### PR TITLE
Suse user state test fix

### DIFF
--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -151,7 +151,7 @@ class UserTest(integration.ModuleCase,
         group_name = grp.getgrgid(ret['gid']).gr_name
 
         self.assertTrue(os.path.isdir('/var/lib/salt_test'))
-        if grains['os_family'] in ('SUSE',):
+        if grains['os_family'] in ('Suse',):
             self.assertEqual(group_name, 'users')
         elif grains['os_family'] == 'MacOS':
             self.assertEqual(group_name, 'staff')


### PR DESCRIPTION
### What does this PR do?

Suse os_family grain is Suse not SUSE. This updates test_user_present_gid_from_name_default to correctly use the Suse os_family grain.
### What issues does this PR fix or reference?

Fixes failing test on jenkins. 
### Tests written?

Yes