### PR TITLE
modules.service: Do not default to OpenRC on Gentoo, also allow systemd

### DIFF
--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -13,6 +13,9 @@ to the correct service manager
 # Import Python libs
 from __future__ import absolute_import
 
+# Import Salt modules
+import salt.utils.systemd
+
 # Define the module's virtual name
 __virtualname__ = 'service'
 
@@ -21,7 +24,8 @@ def __virtual__():
     '''
     Only work on systems which default to systemd
     '''
-    if __grains__['os'] == 'Gentoo':
+    if __grains__['os'] == 'Gentoo' \
+            and not salt.utils.systemd.booted(__context__):
         return __virtualname__
     return (False, 'The gentoo_service execution module cannot be loaded: '
             'only available on Gentoo systems.')


### PR DESCRIPTION
### What does this PR do?

It fixes a bad behaviour of `modules.service` on Gentoo when running `systemd` for service management instead of the default `OpenRC`.
### What issues does this PR fix or reference?

None
### Previous Behavior

Managing services would fail on Gentoo systems running `systemd`:

```
          ID: systemd-networkd
    Function: service.running
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib64/python2.7/site-packages/salt/state.py", line 1723, in call
                  **cdata['kwargs'])
                File "/usr/lib64/python2.7/site-packages/salt/loader.py", line 1650, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib64/python2.7/site-packages/salt/states/service.py", line 599, in mod_watch
                  result = func(name)
                File "/usr/lib64/python2.7/site-packages/salt/modules/gentoo_service.py", line 155, in restart
                  return not __salt__['cmd.retcode'](cmd, python_shell=False)
                File "/usr/lib64/python2.7/site-packages/salt/modules/cmdmod.py", line 1794, in retcode
                  password=kwargs.get('password', None))
                File "/usr/lib64/python2.7/site-packages/salt/modules/cmdmod.py", line 475, in _run
                  'reason: {2}'.format(cmd, kwargs, exc)
              CommandExecutionError: Unable to run command '['/etc/init.d/systemd-networkd', 'restart']' with the context '{'timeout'
: None, 'with_communicate': True, 'shell': False, 'bg': False, 'stderr': -2, 'env': {'LC_NUMERIC': 'C', 'LESS': '-R -M --shift 5', 'L
C_MEASUREMENT': 'C', 'LC_COLLATE': 'C', 'LESSOPEN': '|lesspipe %s', 'HUSHLOGIN': 'FALSE', 'LOGNAME': 'root', 'USER': 'root', 'HOME': 
'/root', 'LC_PAPER': 'C', 'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin:/usr/x86_64-pc-linux-gnu/gcc
-bin/4.9.3', 'UCF_FORCE_CONFFOLD': '1', 'LANG': 'en_US.UTF-8', 'INFOPATH': '/usr/share/info:/usr/share/gcc-data/x86_64-pc-linux-gnu/4
.9.3/info:/usr/share/binutils-data/x86_64-pc-linux-gnu/2.25.1/info', 'TERM': 'vt220', 'SHELL': '/bin/zsh', 'SHLVL': '1', 'CONFIG_PROT
ECT_MASK': '/etc/gentoo-release /etc/sandbox.d /etc/terminfo /etc/ca-certificates.conf', '_': '/usr/bin/salt-call', 'MANPATH': '/usr/
local/share/man:/usr/share/man:/usr/share/gcc-data/x86_64-pc-linux-gnu/4.9.3/man:/usr/share/binutils-data/x86_64-pc-linux-gnu/2.25.1/
man', 'EDITOR': '/bin/nano', 'XDG_RUNTIME_DIR': '/run/user/0', 'LC_ADDRESS': 'C', 'DEBIAN_FRONTEND': 'noninteractive', 'GCC_SPECS': '
', 'LC_CTYPE': 'C', 'MANPAGER': 'manpager', 'MULTIOSDIRS': '../lib64:../lib32', 'XDG_SESSION_ID': 'c1', 'APT_LISTCHANGES_FRONTEND': '
none', 'LC_IDENTIFICATION': 'C', 'LC_MESSAGES': 'C', 'OLDPWD': '/root', 'LC_TELEPHONE': 'C', 'LC_MONETARY': 'C', 'PWD': '/root', 'LC_
NAME': 'C', 'MAIL': '/var/mail/root', 'LC_TIME': 'C', 'PAGER': '/usr/bin/less', 'APT_LISTBUGS_FRONTEND': 'none', 'XDG_SEAT': 'seat0'}
, 'stdout': -1, 'close_fds': True, 'stdin': None, 'cwd': '/root'}', reason: [Errno 2] No such file or directory
     Started: 21:31:51.859009
    Duration: 21.647 ms
     Changes:   
```
### New Behavior

Services management works now as expected on Gentoo systems running `systemd`.
### Tests written?

No