### PR TITLE
Don't subscribe to events if not sure it would read them.

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1493,10 +1493,6 @@ class LocalClient(object):
                                                  master_uri=master_uri)
 
         try:
-            # Ensure that the event subscriber is connected.
-            # If not, we won't get a response, so error out
-            if not self.event.connect_pub(timeout=timeout):
-                raise SaltReqTimeoutError()
             payload = channel.send(payload_kwargs, timeout=timeout)
         except SaltReqTimeoutError:
             raise SaltReqTimeoutError(


### PR DESCRIPTION
### What does this PR do?

Reactor uses LocalClient to send message but do not read events that
produces memory leak in EventPublisher: sent messages are collected
there in the IOStream class.

If there are any issues with no-receiving answer because the client is not subscribed to the bus we should change the logic there to subscribe to it implicitly or explicitly, but we shouldn't do this if not sure we'll read them.
### What issues does this PR fix or reference?
saltstack/salt#31454
### Tests written?

No