### PR TITLE
Fix for 35681: sdb paths are truncated.

### DIFF
--- a/salt/utils/sdb.py
+++ b/salt/utils/sdb.py
@@ -54,11 +54,11 @@ def sdb_set(uri, value, opts):
     indx = uri.find('/', sdlen)
 
     if (indx == -1) or len(uri[(indx+1):]) == 0:
-        return uri
+        return False
 
     profile = opts.get(uri[sdlen:indx], {})
     if 'driver' not in profile:
-        return uri
+        return False
 
     fun = '{0}.set'.format(profile['driver'])
     query = uri[indx+1:]
@@ -77,17 +77,17 @@ def sdb_delete(uri, opts):
         return False
 
     if not uri.startswith('sdb://'):
-        return uri
+        return False
 
     sdlen = len('sdb://')
     indx = uri.find('/', sdlen)
 
     if (indx == -1) or len(uri[(indx+1):]) == 0:
-        return uri
+        return False
 
     profile = opts.get(uri[sdlen:indx], {})
     if 'driver' not in profile:
-        return uri
+        return False
 
     fun = '{0}.delete'.format(profile['driver'])
     query = uri[indx+1:]

--- a/salt/utils/sdb.py
+++ b/salt/utils/sdb.py
@@ -21,17 +21,18 @@ def sdb_get(uri, opts):
     if not uri.startswith('sdb://'):
         return uri
 
-    comps = uri.replace('sdb://', '').split('/', 1)
+    sdlen = len('sdb://')
+    indx = uri.find('/', sdlen)
 
-    if len(comps) < 2:
+    if (indx == -1) or len(uri[(indx+1):])==0:
         return uri
 
-    profile = opts.get(comps[0], {})
+    profile = opts.get(uri[sdlen:indx], {})
     if 'driver' not in profile:
         return uri
 
     fun = '{0}.get'.format(profile['driver'])
-    query = comps[1]
+    query = uri[indx+1:]
 
     loaded_db = salt.loader.sdb(opts, fun)
     return loaded_db[fun](query, profile=profile)
@@ -49,17 +50,18 @@ def sdb_set(uri, value, opts):
     if not uri.startswith('sdb://'):
         return False
 
-    comps = uri.replace('sdb://', '').split('/', 1)
+    sdlen = len('sdb://')
+    indx = uri.find('/', sdlen)
 
-    if len(comps) < 2:
-        return False
+    if (indx == -1) or len(uri[(indx+1):])==0:
+        return uri
 
-    profile = opts.get(comps[0], {})
+    profile = opts.get(uri[sdlen:indx], {})
     if 'driver' not in profile:
-        return False
+        return uri
 
     fun = '{0}.set'.format(profile['driver'])
-    query = comps[1]
+    query = uri[indx+1:]
 
     loaded_db = salt.loader.sdb(opts, fun)
     return loaded_db[fun](query, value, profile=profile)
@@ -75,19 +77,20 @@ def sdb_delete(uri, opts):
         return False
 
     if not uri.startswith('sdb://'):
-        return False
+        return uri
 
-    comps = uri.replace('sdb://', '').split('/', 1)
+    sdlen = len('sdb://')
+    indx = uri.find('/', sdlen)
 
-    if len(comps) < 2:
-        return False
+    if (indx == -1) or len(uri[(indx+1):])==0:
+        return uri
 
-    profile = opts.get(comps[0], {})
+    profile = opts.get(uri[sdlen:indx], {})
     if 'driver' not in profile:
-        return False
+        return uri
 
-    fun = '{0}.delete'.format(profile['driver'])
-    query = comps[1]
+    fun = '{0}.get'.format(profile['driver'])
+    query = uri[indx+1:]
 
     loaded_db = salt.loader.sdb(opts, fun)
     return loaded_db[fun](query, profile=profile)

--- a/salt/utils/sdb.py
+++ b/salt/utils/sdb.py
@@ -24,7 +24,7 @@ def sdb_get(uri, opts):
     sdlen = len('sdb://')
     indx = uri.find('/', sdlen)
 
-    if (indx == -1) or len(uri[(indx+1):])==0:
+    if (indx == -1) or len(uri[(indx+1):]) == 0:
         return uri
 
     profile = opts.get(uri[sdlen:indx], {})
@@ -53,7 +53,7 @@ def sdb_set(uri, value, opts):
     sdlen = len('sdb://')
     indx = uri.find('/', sdlen)
 
-    if (indx == -1) or len(uri[(indx+1):])==0:
+    if (indx == -1) or len(uri[(indx+1):]) == 0:
         return uri
 
     profile = opts.get(uri[sdlen:indx], {})
@@ -82,14 +82,14 @@ def sdb_delete(uri, opts):
     sdlen = len('sdb://')
     indx = uri.find('/', sdlen)
 
-    if (indx == -1) or len(uri[(indx+1):])==0:
+    if (indx == -1) or len(uri[(indx+1):]) == 0:
         return uri
 
     profile = opts.get(uri[sdlen:indx], {})
     if 'driver' not in profile:
         return uri
 
-    fun = '{0}.get'.format(profile['driver'])
+    fun = '{0}.delete'.format(profile['driver'])
     query = uri[indx+1:]
 
     loaded_db = salt.loader.sdb(opts, fun)


### PR DESCRIPTION
This is a proposed fix for 35681. Currently a split() is used to retrieve the profile and get the path to pass to the driver (once found). However this truncates the rest of the path. This change uses find() instead of split() to preserve the path
