### PR TITLE
Import "salt.ext.six" instead of "six"

### DIFF
--- a/salt/modules/cisconso.py
+++ b/salt/modules/cisconso.py
@@ -9,8 +9,8 @@ for :doc:`salt.proxy.cisconso</ref/proxy/all/salt.proxy.cisconso>`.
 '''
 from __future__ import absolute_import
 
-import six
 import salt.utils
+import salt.ext.six as six
 
 __proxyenabled__ = ['cisconso']
 __virtualname__ = 'cisconso'

--- a/salt/returners/sentry_return.py
+++ b/salt/returners/sentry_return.py
@@ -45,10 +45,10 @@ from __future__ import absolute_import
 
 # Import Python libs
 import logging
-import six
 
 # Import Salt libs
 import salt.utils.jid
+import salt.ext.six as six
 
 try:
     from raven import Client

--- a/salt/returners/syslog_return.py
+++ b/salt/returners/syslog_return.py
@@ -88,7 +88,6 @@ To override individual configuration items, append
 '''
 from __future__ import absolute_import
 import logging
-import six
 
 # Import python libs
 import json
@@ -101,6 +100,7 @@ except ImportError:
 # Import Salt libs
 import salt.utils.jid
 import salt.returners
+import salt.ext.six as six
 
 log = logging.getLogger(__name__)
 # Define the module's virtual name


### PR DESCRIPTION
### What does this PR do?

The Windows distribution doesn't come with `six` as a pre-installed
python package. Since `salt.ext.six` already exists, it makes sense
to use that instead of adding `six` to the Windows distribution.
### Tests written?

No
