### PR TITLE
add functions to parallels execution module

### DIFF
--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -1,8 +1,20 @@
 # -*- coding: utf-8 -*-
 '''
-Manage Parallels Desktop VMs with prlctl
+Manage Parallels Desktop VMs with ``prlctl`` and ``prlsrvctl``.  Only some of
+the prlctl commands implemented so far.  Of those that have been implemented,
+not all of the options may have been provided yet.  For a complete reference,
+see the `Parallels Desktop Reference Guide
+<http://download.parallels.com/desktop/v9/ga/docs/en_US/Parallels%20Command%20Line%20Reference%20Guide.pdf>`_.
 
-http://download.parallels.com/desktop/v9/ga/docs/en_US/Parallels%20Command%20Line%20Reference%20Guide.pdf
+What has not been implemented yet can be accessed through ``parallels.prlctl``
+and ``parallels.prlsrvctl`` (note the preceeding double dash ``--`` as
+necessary):
+
+.. code-block::
+
+    salt '*' parallels.prlctl installtools macvm runas=macdev
+    salt -- '*' parallels.prlctl capture 'macvm --file macvm.display.png' runas=macdev
+    salt -- '*' parallels.prlsrvctl set '--mem-limit auto' runas=macdev
 
 .. versionadded:: 2016.3.0
 '''

--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -48,7 +48,9 @@ def __virtual__():
     Load this module if prlctl is available
     '''
     if not salt.utils.which('prlctl'):
-        return (False, 'Cannot load prlctl module: prlctl utility not available')
+        return (False, 'prlctl utility not available')
+    if not salt.utils.which('prlsrvctl'):
+        return (False, 'prlsrvctl utility not available')
     return __virtualname__
 
 
@@ -88,6 +90,38 @@ def _find_guids(guid_string):
     return sorted(list(set(guids)))
 
 
+def prlsrvctl(sub_cmd, args=None, runas=None):
+    '''
+    Execute a prlsrvctl command
+
+    .. versionadded:: Carbon
+
+    :param str sub_cmd:
+        prlsrvctl subcommand to execute
+
+    :param str args:
+        The arguments supplied to ``prlsrvctl <sub_cmd>``
+
+    :param str runas:
+        The user that the prlsrvctl command will be run as
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.prlsrvctl info runas=macdev
+        salt '*' parallels.prlsrvctl usb list runas=macdev
+        salt -- '*' parallels.prlsrvctl set '--mem-limit auto' runas=macdev
+    '''
+    # Construct command
+    cmd = ['prlsrvctl', sub_cmd]
+    if args:
+        cmd.extend(_normalize_args(args))
+
+    # Execute command and return output
+    return __salt__['cmd.run'](cmd, runas=runas)
+
+
 def prlctl(sub_cmd, args=None, runas=None):
     '''
     Execute a prlctl command
@@ -107,6 +141,7 @@ def prlctl(sub_cmd, args=None, runas=None):
 
         salt '*' parallels.prlctl user list runas=macdev
         salt '*' parallels.prlctl exec 'macvm uname' runas=macdev
+        salt -- '*' parallels.prlctl capture 'macvm --file macvm.display.png' runas=macdev
     '''
     # Construct command
     cmd = ['prlctl', sub_cmd]

--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -209,6 +209,63 @@ def list_vms(name=None, info=False, all=False, args=None, runas=None, template=F
     return prlctl('list', args, runas=runas)
 
 
+def clone(name, new_name, linked=False, template=False, runas=None):
+    '''
+    Clone a VM
+
+    .. versionadded:: Carbon
+
+    :param str name:
+        Name/ID of VM to clone
+
+    :param str new_name:
+        Name of the new VM
+
+    :param bool linked:
+        Create a linked virtual machine.
+
+    :param bool template:
+        Create a virtual machine template instead of a real virtual machine.
+
+    :param str runas:
+        The user that the prlctl command will be run as
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.clone macvm macvm_new runas=macdev
+        salt '*' parallels.clone macvm macvm_templ template=True runas=macdev
+    '''
+    args = [_sdecode(name), '--name', _sdecode(new_name)]
+    if linked:
+        args.append('--linked')
+    if template:
+        args.append('--template')
+    return prlctl('clone', args, runas=runas)
+
+
+def delete(name, runas=None):
+    '''
+    Delete a VM
+
+    .. versionadded:: Carbon
+
+    :param str name:
+        Name/ID of VM to clone
+
+    :param str runas:
+        The user that the prlctl command will be run as
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.exec macvm 'find /etc/paths.d' runas=macdev
+    '''
+    return prlctl('delete', _sdecode(name), runas=runas)
+
+
 def start(name, runas=None):
     '''
     Start a VM

--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -266,6 +266,58 @@ def delete(name, runas=None):
     return prlctl('delete', _sdecode(name), runas=runas)
 
 
+def exists(name, runas=None):
+    '''
+    Query whether a VM exists
+
+    .. versionadded:: Carbon
+
+    :param str name:
+        Name/ID of VM
+
+    :param str runas:
+        The user that the prlctl command will be run as
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.exists macvm runas=macdev
+    '''
+    vm_info = list_vms(name, info=True, runas=runas).splitlines()
+    for info_line in vm_info:
+        if 'Name: {0}'.format(name) in info_line:
+            return True
+    return False
+
+
+def state(name, runas=None):
+    '''
+    Return the state of the VM
+
+    .. versionadded:: Carbon
+
+    :param str name:
+        Name/ID of VM
+
+    :param str runas:
+        The user that the prlctl command will be run as
+
+    Example:
+
+    .. code-block:: bash
+
+        salt '*' parallels.state macvm runas=macdev
+    '''
+    vm_info = list_vms(name, info=True, runas=runas).splitlines()
+    for info_line in vm_info:
+        if 'State: ' in info_line:
+            return info_line.split('State: ')[1]
+
+    log.error('Cannot find state of VM named {0}'.format(name))
+    return ''
+
+
 def start(name, runas=None):
     '''
     Start a VM
@@ -454,7 +506,7 @@ def snapshot_id_to_name(name, snap_id, strict=False, runas=None):
         data = yaml.safe_load(info)
     except yaml.YAMLError as err:
         log.warning(
-            'Could not interpret snapshot data returned from parallels deskop: '
+            'Could not interpret snapshot data returned from prlctl: '
             '{0}'.format(err)
         )
         data = {}
@@ -467,7 +519,7 @@ def snapshot_id_to_name(name, snap_id, strict=False, runas=None):
             snap_name = ''
     else:
         log.warning(
-            u'Could not interpret snapshot data returned from parallels deskop: '
+            u'Could not interpret snapshot data returned from prlctl: '
             u'data is not formed as a dictionary: {0}'.format(data)
         )
         snap_name = ''

--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -152,32 +152,41 @@ def prlctl(sub_cmd, args=None, runas=None):
     return __salt__['cmd.run'](cmd, runas=runas)
 
 
-def list_vms(name=None, info=False, all=False, args=None, runas=None):
+def list_vms(name=None, info=False, all=False, args=None, runas=None, template=False):
     '''
     List information about the VMs
 
     :param str name:
-        Name/ID of VM to list; implies ``info=True``
+        Name/ID of VM to list
+
+        .. versionchanged:: Carbon
+
+            No longer implies ``info=True``
 
     :param str info:
         List extra information
 
     :param bool all:
-        Also list non-running VMs
+        List all non-template VMs
 
     :param tuple args:
-        Additional arguments given to ``prctl list``.  This argument is
-        mutually exclusive with the other arguments
+        Additional arguments given to ``prctl list``
 
     :param str runas:
         The user that the prlctl command will be run as
+
+    :param bool template:
+        List the available virtual machine templates.  The real virtual
+        machines will not be included in the output
+
+        .. versionadded:: Carbon
 
     Example:
 
     .. code-block:: bash
 
         salt '*' parallels.list_vms runas=macdev
-        salt '*' parallels.list_vms name=macvm runas=macdev
+        salt '*' parallels.list_vms name=macvm info=True runas=macdev
         salt '*' parallels.list_vms info=True runas=macdev
         salt '*' parallels.list_vms ' -o uuid,status' all=True runas=macdev
     '''
@@ -188,12 +197,13 @@ def list_vms(name=None, info=False, all=False, args=None, runas=None):
         args = _normalize_args(args)
 
     if name:
-        args.extend(['--info', name])
-    elif info:
+        args.extend([name])
+    if info:
         args.append('--info')
-
     if all:
         args.append('--all')
+    if template:
+        args.append('--template')
 
     # Execute command and return output
     return prlctl('list', args, runas=runas)

--- a/tests/unit/modules/parallels_test.py
+++ b/tests/unit/modules/parallels_test.py
@@ -159,8 +159,16 @@ class ParallelsTestCase(TestCase):
         with patch.object(parallels, 'prlctl', mock_name):
             parallels.list_vms(name='macvm', runas=runas)
             mock_name.assert_called_once_with('list',
-                                              ['--info', 'macvm'],
+                                              ['macvm'],
                                               runas=runas)
+
+        # Validate listing templates
+        mock_templ = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_templ):
+            parallels.list_vms(template=True, runas=runas)
+            mock_templ.assert_called_once_with('list',
+                                               ['--template'],
+                                               runas=runas)
 
         # Validate listing extra info
         mock_info = MagicMock()

--- a/tests/unit/modules/parallels_test.py
+++ b/tests/unit/modules/parallels_test.py
@@ -88,6 +88,33 @@ class ParallelsTestCase(TestCase):
 
         self.assertEqual(parallels._find_guids(guid_str), guids)
 
+    def test_prlsrvctl(self):
+        '''
+        Test parallels.prlsrvctl
+        '''
+        runas = 'macdev'
+
+        # Validate 'prlsrvctl info'
+        info_cmd = ['prlsrvctl', 'info']
+        info_fcn = MagicMock()
+        with patch.dict(parallels.__salt__, {'cmd.run': info_fcn}):
+            parallels.prlsrvctl('info', runas=runas)
+            info_fcn.assert_called_once_with(info_cmd, runas=runas)
+
+        # Validate 'prlsrvctl usb list'
+        usb_cmd = ['prlsrvctl', 'usb', 'list']
+        usb_fcn = MagicMock()
+        with patch.dict(parallels.__salt__, {'cmd.run': usb_fcn}):
+            parallels.prlsrvctl('usb', 'list', runas=runas)
+            usb_fcn.assert_called_once_with(usb_cmd, runas=runas)
+
+        # Validate 'prlsrvctl set "--mem-limit auto"'
+        set_cmd = ['prlsrvctl', 'set', '--mem-limit', 'auto']
+        set_fcn = MagicMock()
+        with patch.dict(parallels.__salt__, {'cmd.run': set_fcn}):
+            parallels.prlsrvctl('set', '--mem-limit auto', runas=runas)
+            set_fcn.assert_called_once_with(set_cmd, runas=runas)
+
     def test_prlctl(self):
         '''
         Test parallels.prlctl
@@ -101,12 +128,19 @@ class ParallelsTestCase(TestCase):
             parallels.prlctl('user', 'list', runas=runas)
             user_fcn.assert_called_once_with(user_cmd, runas=runas)
 
-        # Validate 'prlctl exec macvm uname'
+        # Validate 'prlctl exec "macvm uname"'
         exec_cmd = ['prlctl', 'exec', 'macvm', 'uname']
         exec_fcn = MagicMock()
         with patch.dict(parallels.__salt__, {'cmd.run': exec_fcn}):
             parallels.prlctl('exec', 'macvm uname', runas=runas)
             exec_fcn.assert_called_once_with(exec_cmd, runas=runas)
+
+        # Validate 'prlctl capture "macvm --file macvm.display.png"'
+        cap_cmd = ['prlctl', 'capture', 'macvm', '--file', 'macvm.display.png']
+        cap_fcn = MagicMock()
+        with patch.dict(parallels.__salt__, {'cmd.run': cap_fcn}):
+            parallels.prlctl('capture', 'macvm --file macvm.display.png', runas=runas)
+            cap_fcn.assert_called_once_with(cap_cmd, runas=runas)
 
     def test_list_vms(self):
         '''

--- a/tests/unit/modules/parallels_test.py
+++ b/tests/unit/modules/parallels_test.py
@@ -230,6 +230,43 @@ class ParallelsTestCase(TestCase):
             parallels.delete(name, runas=runas)
             mock_delete.assert_called_once_with('delete', name, runas=runas)
 
+    def test_exists(self):
+        '''
+        Test parallels.exists
+        '''
+        name = 'macvm'
+        runas = 'macdev'
+
+        # Validate exists
+        mock_list = MagicMock(return_value='Name: {0}\nState: running'.format(name))
+        with patch.object(parallels, 'list_vms', mock_list):
+            self.assertTrue(parallels.exists(name, runas=runas))
+
+        # Validate not exists
+        mock_list = MagicMock(return_value='Name: {0}\nState: running'.format(name))
+        with patch.object(parallels, 'list_vms', mock_list):
+            self.assertFalse(parallels.exists('winvm', runas=runas))
+
+    def test_state(self):
+        '''
+        Test parallels.state
+        '''
+        name = 'macvm'
+        runas = 'macdev'
+
+        # Validate state
+        mock_list = MagicMock(return_value='Name: {0}\nState: cantering'.format(name))
+        with patch.object(parallels, 'list_vms', mock_list):
+            self.assertEqual(parallels.state(name, runas=runas), 'cantering')
+
+        # Validate cannot find state
+        mock_list = MagicMock(return_value='Name: {0}\nFavorite Color: unknown'.format(name))
+        mock_log_error = MagicMock()
+        with patch.object(parallels, 'list_vms', mock_list):
+            with patch.object(parallels.log, 'error', mock_log_error):
+                self.assertEqual(parallels.state(name, runas=runas), '')
+                mock_log_error.assert_called_once_with('Cannot find state of VM named {0}'.format(name))
+
     def test_start(self):
         '''
         Test parallels.start

--- a/tests/unit/modules/parallels_test.py
+++ b/tests/unit/modules/parallels_test.py
@@ -186,6 +186,50 @@ class ParallelsTestCase(TestCase):
                                                  ['-o', 'uuid,status', '--all'],
                                                  runas=runas)
 
+    def test_clone(self):
+        '''
+        Test parallels.clone
+        '''
+        name = 'macvm'
+        runas = 'macdev'
+
+        # Validate clone
+        mock_clone = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_clone):
+            parallels.clone(name, 'macvm_new', runas=runas)
+            mock_clone.assert_called_once_with('clone',
+                                               [name, '--name', 'macvm_new'],
+                                               runas=runas)
+
+        # Validate linked clone
+        mock_linked = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_linked):
+            parallels.clone(name, 'macvm_link', linked=True, runas=runas)
+            mock_linked.assert_called_once_with('clone',
+                                                [name, '--name', 'macvm_link', '--linked'],
+                                                runas=runas)
+
+        # Validate template clone
+        mock_template = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_template):
+            parallels.clone(name, 'macvm_templ', template=True, runas=runas)
+            mock_template.assert_called_once_with('clone',
+                                                  [name, '--name', 'macvm_templ', '--template'],
+                                                  runas=runas)
+
+    def test_delete(self):
+        '''
+        Test parallels.delete
+        '''
+        name = 'macvm'
+        runas = 'macdev'
+
+        # Validate delete
+        mock_delete = MagicMock()
+        with patch.object(parallels, 'prlctl', mock_delete):
+            parallels.delete(name, runas=runas)
+            mock_delete.assert_called_once_with('delete', name, runas=runas)
+
     def test_start(self):
         '''
         Test parallels.start


### PR DESCRIPTION
### What does this PR do?

Add `prlsrvctl`, `clone`, `delete`, `exists`, and `state` functions to parallels execution module and add an arg to `parallels.list_vms`.
### What issues does this PR fix or reference?

saltstack/salt-testing#86
### Tests written?

Yes
