### PR TITLE
add salt-run state.event test

### DIFF
--- a/tests/integration/runners/state.py
+++ b/tests/integration/runners/state.py
@@ -88,6 +88,7 @@ class StateRunnerTest(integration.ShellCase):
 
         server_thread.join()
 
+
 @skipIf(salt.utils.is_windows(), '*NIX-only test')
 class OrchEventTest(integration.ShellCase):
     '''


### PR DESCRIPTION
### What does this PR do?

Adds a test for `salt-run state.event`. This is a test to make sure this does not regress: https://github.com/saltstack/salt/issues/35570 
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/35570

Hoping to get any code improvements on this one. Particularly I want to make sure I'm closing all threads and queues properly. Or maybe there is a better way to get data from a  thread. Thanks
### Tests written?

Yes
