### PR TITLE
Doc cherrypy deemphasize urlencoded

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -125,7 +125,8 @@ Authentication
 Authentication is performed by passing a session token with each request.
 Tokens are generated via the :py:class:`Login` URL.
 
-The token may be sent in one of two ways:
+The token may be sent in one of two ways: as a custom header or as a session
+cookie. The latter is far more convenient for clients that support cookies.
 
 * Include a custom header named :mailheader:`X-Auth-Token`.
 
@@ -178,54 +179,190 @@ The token may be sent in one of two ways:
 Usage
 -----
 
-Commands are sent to a running Salt master via this module by sending HTTP
-requests to the URLs detailed below.
+This interface directly exposes Salt's :ref:`Python API <python-api>`.
+Everything possible at the CLI is possible through the Python API. Commands are
+executed on the Salt Master.
 
-.. admonition:: Content negotiation
+The root URL (``/``) is RPC-like in that it accepts instructions in the request
+body for what Salt functions to execute, and the response contains the result
+of those function calls.
 
-    This REST interface is flexible in what data formats it will accept as well
-    as what formats it will return (e.g., JSON, YAML, x-www-form-urlencoded).
+For example:
 
-    * Specify the format of data in the request body by including the
-      :mailheader:`Content-Type` header.
-    * Specify the desired data format for the response body with the
-      :mailheader:`Accept` header.
+.. code-block:: text
 
-Data sent in :http:method:`post` and :http:method:`put` requests  must be in
-the format of a list of lowstate dictionaries. This allows multiple commands to
-be executed in a single HTTP request. The order of commands in the request
-corresponds to the return for each command in the response.
+    % curl -sSi https://localhost:8000 \
+        -H 'Content-type: application/json' \
+        -d '[{
+            "client": "local",
+            "tgt": "*",
+            "fun": "test.ping"
+        }]'
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+    [...snip...]
 
-Lowstate, broadly, is a dictionary of values that are mapped to a function
-call. This pattern is used pervasively throughout Salt. The functions called
-from netapi modules are described in :ref:`Client Interfaces <netapi-clients>`.
+    {"return": [{"jerry": true}]}
 
-The following example (in JSON format) causes Salt to execute two commands, a
-command sent to minions as well as a runner function on the master::
+The request body must be an array of commands. Use this workflow to build a
+command:
 
-    [{
-        "client": "local",
-        "tgt": "*",
-        "fun": "test.fib",
-        "arg": ["10"]
-    },
+1.  Choose a client interface.
+2.  Choose a function.
+3.  Fill out the remaining parameters needed for the chosen client.
+
+The ``client`` field is a reference to the main Python classes used in Salt's
+Python API. Read the full :ref:`client interfaces <netapi-clients>`
+documentation, but in short:
+
+* "local" uses :py:class:`LocalClient <salt.client.LocalClient>` which sends
+  commands to Minions. Equivalent to the ``salt`` CLI command.
+* "runner" uses :py:class:`RunnerClient <salt.runner.RunnerClient>` which
+  invokes runner modules on the Master. Equivalent to the ``salt-run`` CLI
+  command.
+* "wheel" uses :py:class:`WheelClient <salt.wheel.WheelClient>` which invokes
+  wheel modules on the Master. Wheel modules do not have a direct CLI
+  equivalent but they typically manage Master-side resources such as state
+  files, pillar files, the Salt config files, and the :py:mod:`key wheel module
+  <salt.wheel.key>` exposes similar functionality as the ``salt-key`` CLI
+  command.
+
+Each client requires different arguments and sometimes has different syntax.
+For example, ``LocalClient`` requires the ``tgt`` argument because it forwards
+the command to Minions and the other client interfaces do not. ``LocalClient``
+also takes ``arg`` (array) and ``kwarg`` (dictionary) arguments because these
+values are sent to the Minions and used to execute the requested function
+there. ``RunnerClient`` and ``WheelClient`` are executed directly on the Master
+and thus do not need or accept those arguments.
+
+Read the method signatures in the client documentation linked above, but
+hopefully an example will help illustrate the concept. This example causes Salt
+to execute two functions -- the :py:func:`test.arg execution function
+<salt.modules.test.arg>` using ``LocalClient`` and the :py:func:`test.arg
+runner function <salt.runners.test.arg>` using ``RunnerClient``; note the
+different structure for each command. The results for both are combined and
+returned as one response.
+
+.. code-block:: text
+
+    % curl -b ~/cookies.txt -sSi localhost:8000 \
+        -H 'Content-type: application/json' \
+        -d '
+    [
+        {
+            "client": "local",
+            "tgt": "*",
+            "fun": "test.arg",
+            "arg": ["positional arg one", "positional arg two"],
+            "kwarg": {
+                "keyword arg one": "Hello from a minion",
+                "keyword arg two": "Hello again from a minion"
+            }
+        },
+        {
+            "client": "runner",
+            "fun": "test.arg",
+            "keyword arg one": "Hello from a master",
+            "keyword arg two": "Runners do not support positional args"
+        }
+    ]
+    '
+    HTTP/1.1 200 OK
+    [...snip...]
     {
-        "client": "runner",
-        "fun": "jobs.lookup_jid",
-        "jid": "20130603122505459265"
-    }]
+      "return": [
+        {
+          "jerry": {
+            "args": [
+              "positional arg one",
+              "positional arg two"
+            ],
+            "kwargs": {
+              "keyword arg one": "Hello from a minion",
+              "keyword arg two": "Hello again from a minion",
+              [...snip...]
+            }
+          },
+          [...snip; other minion returns here...]
+        },
+        {
+          "args": [],
+          "kwargs": {
+            "keyword arg two": "Runners do not support positional args",
+            "keyword arg one": "Hello from a master"
+          }
+        }
+      ]
+    }
 
-.. admonition:: x-www-form-urlencoded
+One more example, this time with more commonly used functions:
 
-    Sending JSON or YAML in the request body is simple and most flexible,
-    however sending data in urlencoded format is also supported with the
-    caveats below. It is the default format for HTML forms, many JavaScript
-    libraries, and the :command:`curl` command.
+.. code-block:: text
 
-    For example, the equivalent to running ``salt '*' test.ping`` is sending
-    ``fun=test.ping&arg&client=local&tgt=*`` in the HTTP request body.
+    curl -b /tmp/cookies.txt -sSi localhost:8000 \
+        -H 'Content-type: application/json' \
+        -d '
+    [
+        {
+            "client": "local",
+            "tgt": "*",
+            "fun": "state.sls",
+            "kwarg": {
+                "mods": "apache",
+                "pillar": {
+                    "lookup": {
+                        "wwwdir": "/srv/httpd/htdocs"
+                    }
+                }
+            }
+        },
+        {
+            "client": "runner",
+            "fun": "cloud.create",
+            "provider": "my-ec2-provider",
+            "instances": "my-centos-6",
+            "image": "ami-1624987f",
+            "delvol_on_destroy", true
+        }
+    ]
+    '
+    HTTP/1.1 200 OK
+    [...snip...]
+    {
+      "return": [
+        {
+          "jerry": {
+            "pkg_|-install_apache_|-httpd_|-installed": {
+                [...snip full state return here...]
+            }
+          }
+          [...snip other minion returns here...]
+        },
+        {
+            [...snip full salt-cloud output here...]
+        }
+      ]
+    }
 
-    Caveats:
+Content negotiation
+-------------------
+
+This REST interface is flexible in what data formats it will accept as well
+as what formats it will return (e.g., JSON, YAML, urlencoded).
+
+* Specify the format of data in the request body by including the
+  :mailheader:`Content-Type` header.
+* Specify the desired data format for the response body with the
+  :mailheader:`Accept` header.
+
+We recommend the JSON format for most HTTP requests. urlencoded data is simple
+and cannot express complex data structures -- and that is often required for
+some Salt commands, such as starting a state run that uses Pillar data. Salt's
+CLI tool can reformat strings passed in at the CLI into complex data
+structures, and that behavior also works via salt-api, but that can be brittle
+and since salt-api can accept JSON it is best just to send JSON.
+
+.. admonition:: urlencoded data caveats
 
     * Only a single command may be sent per HTTP request.
     * Repeating the ``arg`` parameter multiple times will cause those
@@ -236,6 +373,19 @@ command sent to minions as well as a runner function on the master::
       parameters. E.g., ``arg=one``, ``arg=two`` will be sent as ``arg[]=one``,
       ``arg[]=two``. This is not supported; send JSON or YAML instead.
 
+    A note about ``curl``
+
+    The ``-d`` flag to curl does *not* automatically urlencode data which can
+    affect passwords and other data that contains characters that must be
+    encoded. Use the ``--data-urlencode`` flag instead. E.g.:
+
+    .. code-block:: bash
+
+        curl -ksi http://localhost:8000/login \\
+        -H "Accept: application/json" \\
+        -d username='myapiuser' \\
+        --data-urlencode password='1234+' \\
+        -d eauth='pam'
 
 .. |req_token| replace:: a session token from :py:class:`~Login`.
 .. |req_accept| replace:: the desired response format.
@@ -247,21 +397,6 @@ command sent to minions as well as a runner function on the master::
 .. |200| replace:: success
 .. |401| replace:: authentication required
 .. |406| replace:: requested Content-Type not available
-
-A Note About Curl
-=================
-
-When sending passwords and data that might need to be urlencoded, you must set
-the ``-d`` flag to indicate the content type, and the ``--data-urlencode`` flag
-to urlencode the input.
-
-.. code-block:: bash
-
-    curl -ksi http://localhost:8000/login \\
-    -H "Accept: application/json" \\
-    -d username='myapiuser' \\
-    --data-urlencode password='1234+' \\
-    -d eauth='pam'
 
 '''
 # We need a custom pylintrc here...

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -227,6 +227,10 @@ documentation, but in short:
   <salt.wheel.key>` exposes similar functionality as the ``salt-key`` CLI
   command.
 
+Most clients have variants like synchronous or asyncronous execution as well as
+others like batch execution. See the :ref:`full list of client interfaces
+<netapi-clients>`.
+
 Each client requires different arguments and sometimes has different syntax.
 For example, ``LocalClient`` requires the ``tgt`` argument because it forwards
 the command to Minions and the other client interfaces do not. ``LocalClient``


### PR DESCRIPTION
This puts salt-api usage right at the top of the doc instead of scattering the docs across the various endpoints. This also adds details on the perennial `arg`/`kwarg` and client confusion. Finally this replaces all the examples that send urlencoded data with sending JSON. If we want people to use JSON we should show it.