### PR TITLE
Expand/improve win_iis_test tests

### DIFF
--- a/tests/unit/modules/win_iis_test.py
+++ b/tests/unit/modules/win_iis_test.py
@@ -117,7 +117,7 @@ LIST_VDIRS_SRVMGR = {
 CONTAINER_SETTING = {
     'retcode': 0,
     'stdout': json.dumps([{
-        'managedPipelineMode':'Integrated'
+        'managedPipelineMode': 'Integrated'
     }])
 }
 

--- a/tests/unit/modules/win_iis_test.py
+++ b/tests/unit/modules/win_iis_test.py
@@ -42,6 +42,13 @@ APP_LIST = {
     }
 }
 
+APPPOOL_LIST = {
+    'MyTestPool': {
+        'applications': ['MyTestSite'],
+        'state': 'Started'
+    }
+}
+
 BINDING_LIST = {
     '*:80:': {
         'certificatehash': None,
@@ -49,6 +56,15 @@ BINDING_LIST = {
         'hostheader': None,
         'ipaddress': '*', 'port': 80,
         'protocol': 'http',
+        'sslflags': 0
+    },
+    '*:443:mytestsite.local': {
+        'certificatehash': '9988776655443322111000AAABBBCCCDDDEEEFFF',
+        'certificatestorename': 'My',
+        'hostheader': 'mytestsite.local',
+        'ipaddress': '*',
+        'port': 443,
+        'protocol': 'https',
         'sslflags': 0
     }
 }
@@ -59,6 +75,12 @@ SITE_LIST = {
         'bindings': BINDING_LIST,
         'id': 1, 'sourcepath': r'C:\inetpub\wwwroot',
         'state': 'Started'
+    }
+}
+
+VDIR_LIST = {
+    'TestVdir': {
+        'sourcepath': r'C:\inetpub\vdirs\TestVdir'
     }
 }
 
@@ -92,6 +114,15 @@ LIST_VDIRS_SRVMGR = {
     }])
 }
 
+CONTAINER_SETTING = {
+    'retcode': 0,
+    'stdout': json.dumps([{
+        'managedPipelineMode':'Integrated'
+    }])
+}
+
+CERT_BINDING_INFO = '*:443:mytestsite.local'
+
 
 @skipIf(not HAS_IIS, 'This test case runs only on Windows systems')
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -118,7 +149,7 @@ class WinIisTestCase(TestCase):
         Test - List all configured IIS application pools.
         '''
         with patch.dict(win_iis.__salt__):
-            self.assertIsInstance(win_iis.list_apppools(), dict)
+            self.assertEqual(win_iis.list_apppools(), APPPOOL_LIST)
 
     @patch('salt.modules.win_iis._srvmgr',
            MagicMock(return_value={'retcode': 0}))
@@ -207,7 +238,7 @@ class WinIisTestCase(TestCase):
         Test - Get all configured IIS applications for the specified site.
         '''
         with patch.dict(win_iis.__salt__):
-            self.assertIsInstance(win_iis.list_apps('MyTestSite'), dict)
+            self.assertEqual(win_iis.list_apps('MyTestSite'), APP_LIST)
 
     @patch('salt.modules.win_iis._srvmgr',
            MagicMock(return_value={'retcode': 0}))
@@ -254,7 +285,7 @@ class WinIisTestCase(TestCase):
         Test - Get all configured IIS bindings for the specified site.
         '''
         with patch.dict(win_iis.__salt__):
-            self.assertIsInstance(win_iis.list_bindings('MyTestSite'), dict)
+            self.assertEqual(win_iis.list_bindings('MyTestSite'), BINDING_LIST)
 
     @patch('salt.modules.win_iis._srvmgr',
            MagicMock(return_value={'retcode': 0}))
@@ -264,10 +295,25 @@ class WinIisTestCase(TestCase):
         '''
         Test - Remove an IIS binding.
         '''
-        kwargs = {'site': 'MyTestSite', 'hostheader': 'mytestsite.local',
+        kwargs = {'site': 'MyTestSite', 'hostheader': 'myothertestsite.local',
                   'ipaddress': '*', 'port': 443}
         with patch.dict(win_iis.__salt__):
             self.assertTrue(win_iis.remove_binding(**kwargs))
+
+    @patch('os.path.isdir',
+           MagicMock(return_value=True))
+    @patch('salt.modules.win_iis._srvmgr',
+           MagicMock(return_value={'retcode': 0}))
+    @patch('salt.modules.win_iis.list_vdirs',
+           MagicMock(return_value=VDIR_LIST))
+    def test_create_vdir(self):
+        '''
+        Test - Create an IIS virtual directory.
+        '''
+        kwargs = {'name': 'TestVdir', 'site': 'MyTestSite',
+                  'sourcepath': r'C:\inetpub\vdirs\TestVdir'}
+        with patch.dict(win_iis.__salt__):
+            self.assertTrue(win_iis.create_vdir(**kwargs))
 
     @patch('salt.modules.win_iis._srvmgr',
            MagicMock(return_value=LIST_VDIRS_SRVMGR))
@@ -283,6 +329,85 @@ class WinIisTestCase(TestCase):
         with patch.dict(win_iis.__salt__):
             self.assertEqual(win_iis.list_vdirs('MyTestSite'), vdirs)
 
+    @patch('salt.modules.win_iis._srvmgr',
+           MagicMock(return_value={'retcode': 0}))
+    @patch('salt.modules.win_iis.list_vdirs',
+           MagicMock(return_value=VDIR_LIST))
+    def test_remove_vdir(self):
+        '''
+        Test - Remove an IIS virtual directory.
+        '''
+        kwargs = {'name': 'TestOtherVdir', 'site': 'MyTestSite'}
+        with patch.dict(win_iis.__salt__):
+            self.assertTrue(win_iis.remove_vdir(**kwargs))
+
+    @patch('salt.modules.win_iis._list_certs',
+           MagicMock(return_value={'9988776655443322111000AAABBBCCCDDDEEEFFF': None}))
+    @patch('salt.modules.win_iis._srvmgr',
+           MagicMock(return_value={'retcode': 0}))
+    @patch('salt.modules.win_iis.list_bindings',
+           MagicMock(return_value=BINDING_LIST))
+    @patch('salt.modules.win_iis.list_cert_bindings',
+           MagicMock(return_value={CERT_BINDING_INFO: BINDING_LIST[CERT_BINDING_INFO]}))
+    def test_create_cert_binding(self):
+        '''
+        Test - Assign a certificate to an IIS binding.
+        '''
+        kwargs = {'name': '9988776655443322111000AAABBBCCCDDDEEEFFF',
+                  'site': 'MyTestSite', 'hostheader': 'mytestsite.local',
+                  'ipaddress': '*', 'port': 443}
+        with patch.dict(win_iis.__salt__):
+            self.assertTrue(win_iis.create_cert_binding(**kwargs))
+
+    @patch('salt.modules.win_iis.list_sites',
+           MagicMock(return_value=SITE_LIST))
+    def test_list_cert_bindings(self):
+        '''
+        Test - List certificate bindings for an IIS site.
+        '''
+        key = '*:443:mytestsite.local'
+        with patch.dict(win_iis.__salt__):
+            self.assertEqual(win_iis.list_cert_bindings('MyTestSite'),
+                             {key: BINDING_LIST[key]})
+
+    @patch('salt.modules.win_iis._srvmgr',
+           MagicMock(return_value={'retcode': 0}))
+    @patch('salt.modules.win_iis.list_cert_bindings',
+           MagicMock(return_value={CERT_BINDING_INFO: BINDING_LIST[CERT_BINDING_INFO]}))
+    def test_remove_cert_binding(self):
+        '''
+        Test - Remove a certificate from an IIS binding.
+        '''
+        kwargs = {'name': 'FFFEEEDDDCCCBBBAAA0001112233445566778899',
+                  'site': 'MyOtherTestSite', 'hostheader': 'myothertestsite.local',
+                  'ipaddress': '*', 'port': 443}
+        with patch.dict(win_iis.__salt__):
+            self.assertTrue(win_iis.remove_cert_binding(**kwargs))
+
+    @patch('salt.modules.win_iis._srvmgr',
+           MagicMock(return_value=CONTAINER_SETTING))
+    def test_get_container_setting(self):
+        '''
+        Test - Get the value of the setting for the IIS container.
+        '''
+        kwargs = {'name': 'MyTestSite', 'container': 'AppPools',
+                  'settings': ['managedPipelineMode']}
+        with patch.dict(win_iis.__salt__):
+            self.assertEqual(win_iis.get_container_setting(**kwargs),
+                             {'managedPipelineMode': 'Integrated'})
+
+    @patch('salt.modules.win_iis._srvmgr',
+           MagicMock(return_value={'retcode': 0}))
+    @patch('salt.modules.win_iis.get_container_setting',
+           MagicMock(return_value={'managedPipelineMode': 'Integrated'}))
+    def test_set_container_setting(self):
+        '''
+        Test - Set the value of the setting for an IIS container.
+        '''
+        kwargs = {'name': 'MyTestSite', 'container': 'AppPools',
+                  'settings': {'managedPipelineMode': 'Integrated'}}
+        with patch.dict(win_iis.__salt__):
+            self.assertTrue(win_iis.set_container_setting(**kwargs))
 
 if __name__ == '__main__':
     from integration import run_tests  # pylint: disable=import-error


### PR DESCRIPTION
### What does this PR do?
- Adds execution module tests for vdir creation/removal, certificate binding creation/removal, and container settings getting/setting.
- Improves tests that had previously only checked instance types.
### What issues does this PR fix or reference?
- None
### Previous Behavior
- Aforementioned new tests did not yet exist.
- Some tests used assertIsInstance, where assertEqual would have been better.
### New Behavior
- Adds execution module tests for vdir creation/removal, certificate binding creation/removal, and container settings getting/setting.
- Improves tests that had previously only checked instance types.
### Tests written?

Yes