### PR TITLE
consul: fix formatting of consul.agent_join

### DIFF
--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -609,11 +609,10 @@ def agent_join(consul_url=None, address=None, **kwargs):
                  query_params=query_params)
     if res['res']:
         ret['res'] = True
-        ret['message'] = ('Agent maintenance mode '
-                          '{0}ed.'.format(kwargs['enable']))
+        ret['message'] = 'Agent joined the cluster'
     else:
         ret['res'] = False
-        ret['message'] = 'Unable to change maintenance mode for agent.'
+        ret['message'] = 'Unable to join the cluster.'
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?

This patch removes the wrong copy/paste and the usage of the undefined `enable` argument.
### What issues does this PR fix or reference?

None
### Previous Behavior

Using the `consul.agent_join` function raises a `KeyError: 'enable'` message, cf. the code in https://github.com/saltstack/salt/blob/develop/salt/modules/consul.py#L612
- there's no reference to `enable` anywhere, and it is not documented anywhere
- actually, the message formatted which causes this error is completely unrelated to the "join" function of Consul, and looks to be a copy/paste from the `agent_maintenance` function
### Tests written?

No