### PR TITLE
Add test to catch sample config files that are not commented out

### DIFF
--- a/conf/cloud.maps.d/cloud.map
+++ b/conf/cloud.maps.d/cloud.map
@@ -4,17 +4,16 @@
 # Because the location to this file must be explicitly declared when using it,
 # its actual location on disk is up to the user.
 
+#fedora_rs:
+#  - fedora1
+#  - fedora2
+#  - fedora3
+#  - fedora4
+#  - fedora5
 
-fedora_rs:
-  - fedora1
-  - fedora2
-  - fedora3
-  - fedora4
-  - fedora5
-
-ubuntu_rs:
-  - ubuntu1
-  - ubuntu2
-  - ubuntu3
-  - ubuntu4
-  - ubuntu5
+#ubuntu_rs:
+#  - ubuntu1
+#  - ubuntu2
+#  - ubuntu3
+#  - ubuntu4
+#  - ubuntu5

--- a/conf/cloud.profiles
+++ b/conf/cloud.profiles
@@ -1,23 +1,27 @@
-base_ec2:
-  provider: my-ec2-config
-  image: ami-e565ba8c
-  size: t1.micro
-  script: python-bootstrap
-  minion:
-      cheese: edam
+# This file may be used in addition to, or instead of, the files in the
+# cloud.profiles.d/ directory. The format for this file, and all files in that
+# directory, is identical.
 
-ubuntu_rs:
-  provider: my-openstack-rackspace-config
-  image: Ubuntu 12.04 LTS
-  size: 256 server
-  script: Ubuntu
-  minion:
-      cheese: edam
+#base_ec2:
+#  provider: my-ec2-config
+#  image: ami-e565ba8c
+#  size: t1.micro
+#  script: python-bootstrap
+#  minion:
+#      cheese: edam
 
-fedora_rs:
-  provider: my-openstack-rackspace-config
-  image: Fedora 17
-  size: 256 server
-  script: Fedora
-  minion:
-      cheese: edam
+#ubuntu_rs:
+#  provider: my-openstack-rackspace-config
+#  image: Ubuntu 12.04 LTS
+#  size: 256 server
+#  script: Ubuntu
+#  minion:
+#      cheese: edam
+
+#fedora_rs:
+#  provider: my-openstack-rackspace-config
+#  image: Fedora 17
+#  size: 256 server
+#  script: Fedora
+#  minion:
+#      cheese: edam

--- a/conf/cloud.profiles.d/EC2-us-east-1.profiles
+++ b/conf/cloud.profiles.d/EC2-us-east-1.profiles
@@ -2,115 +2,114 @@
 
 # Arch Linux
 # https://wiki.archlinux.org/index.php/Arch_Linux_AMIs_for_Amazon_Web_Services
-arch_ec2:
-  provider: my-ec2-config
-  image: ami-6ee95107
-  size: t1.micro
-  ssh_username: root
-  location: us-east-1
-  minion:
-    grains:
-      cloud: ec2-us-east-1
+#arch_ec2:
+#  provider: my-ec2-config
+#  image: ami-6ee95107
+#  size: t1.micro
+#  ssh_username: root
+#  location: us-east-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-east-1
 
-arch_cloud-init_ec2:
-  provider: my-ec2-config
-  image: ami-596de730
-  size: t1.micro
-  ssh_username: root
-  location: us-east-1
-  minion:
-    grains:
-      cloud: ec2-us-east-1
+#arch_cloud-init_ec2:
+#  provider: my-ec2-config
+#  image: ami-596de730
+#  size: t1.micro
+#  ssh_username: root
+#  location: us-east-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-east-1
 
 # Centos 6, available from ec2 marketplace for no-charge
 # http://wiki.centos.org/Cloud/AWS
-centos_6:
-  provider: my-ec2-config
-  image: ami-86e15bef
-  size: t1.micro
-  ssh_username: root
-  location: us-east-1
-  minion:
-    grains:
-      cloud: ec2-us-east-1
+#centos_6:
+#  provider: my-ec2-config
+#  image: ami-86e15bef
+#  size: t1.micro
+#  ssh_username: root
+#  location: us-east-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-east-1
 
 # official Debian, available at no-charge from ec2 marketplace:
 # http://wiki.debian.org/Cloud/AmazonEC2Image
-debian_squeeze_ec2:
-  provider: my-ec2-config
-  image: ami-a121a6c8
-  size: t1.micro
-  ssh_username: admin
-  location: us-east-1
-  minion:
-    grains:
-      cloud: ec2-us-east-1
+#debian_squeeze_ec2:
+#  provider: my-ec2-config
+#  image: ami-a121a6c8
+#  size: t1.micro
+#  ssh_username: admin
+#  location: us-east-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-east-1
 
 # Fedora project cloud images
 # https://fedoraproject.org/wiki/Cloud_images
-fedora_17_ec2:
-  provider: my-ec2-config
-  image: ami-2ea50247
-  size: t1.micro
-  ssh_username: ec2-user
-  location: us-east-1
-  minion:
-    grains:
-      cloud: ec2-us-east-1
+#fedora_17_ec2:
+#  provider: my-ec2-config
+#  image: ami-2ea50247
+#  size: t1.micro
+#  ssh_username: ec2-user
+#  location: us-east-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-east-1
 
-fedora_18_ec2:
-  provider: my-ec2-config
-  image: ami-6145cc08
-  size: t1.micro
-  ssh_username: ec2-user
-  location: us-east-1
-  minion:
-    grains:
-      cloud: ec2-us-east-1
+#fedora_18_ec2:
+#  provider: my-ec2-config
+#  image: ami-6145cc08
+#  size: t1.micro
+#  ssh_username: ec2-user
+#  location: us-east-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-east-1
 
 # FreeBSD 9.1
 # http://www.daemonology.net/freebsd-on-ec2/
 
 # this t1.micro instance does not auto-populate SSH keys see above link
-freebsd_91_ec2:
-  provider: my-ec2-config
-  image: ami-5339bb3a
-  size: t1.micro
-  ssh_username: ec2-user
-  location: us-east-1
-  minion:
-    grains:
-      cloud: ec2-us-east-1
+#freebsd_91_ec2:
+#  provider: my-ec2-config
+#  image: ami-5339bb3a
+#  size: t1.micro
+#  ssh_username: ec2-user
+#  location: us-east-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-east-1
 
-freebsd_91_4XL_ec2:
-  provider: my-ec2-config
-  image: ami-79088510
-  size: Cluster Compute 4XL
-  ssh_username: ec2-user
-  location: us-east-1
-  minion:
-    grains:
-      cloud: ec2-us-east-1
+#freebsd_91_4XL_ec2:
+#  provider: my-ec2-config
+#  image: ami-79088510
+#  size: Cluster Compute 4XL
+#  ssh_username: ec2-user
+#  location: us-east-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-east-1
 
 # Canonical Ubuntu LTS images
 # http://cloud-images.ubuntu.com/releases/
-ubuntu_lucid_ec2:
-  provider: my-ec2-config
-  image: ami-21e47148
-  size: t1.micro
-  ssh_username: ubuntu
-  location: us-east-1
-  minion:
-    grains:
-      cloud: ec2-us-east-1
+#ubuntu_lucid_ec2:
+#  provider: my-ec2-config
+#  image: ami-21e47148
+#  size: t1.micro
+#  ssh_username: ubuntu
+#  location: us-east-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-east-1
 
-ubuntu_precise_ec2:
-  provider: my-ec2-config
-  image: ami-0145d268
-  size: t1.micro
-  ssh_username: ubuntu
-  location: us-east-1
-  minion:
-    grains:
-      cloud: ec2-us-east-1
-
+#ubuntu_precise_ec2:
+#  provider: my-ec2-config
+#  image: ami-0145d268
+#  size: t1.micro
+#  ssh_username: ubuntu
+#  location: us-east-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-east-1

--- a/conf/cloud.profiles.d/EC2-us-west-1.profiles
+++ b/conf/cloud.profiles.d/EC2-us-west-1.profiles
@@ -2,105 +2,104 @@
 
 # Arch Linux
 # https://wiki.archlinux.org/index.php/Arch_Linux_AMIs_for_Amazon_Web_Services
-arch_ec2:
-  provider: my-ec2-config
-  image: ami-337d5b76
-  size: t1.micro
-  ssh_username: root
-  location: us-west-1
-  minion:
-    grains:
-      cloud: ec2-us-west-1
+#arch_ec2:
+#  provider: my-ec2-config
+#  image: ami-337d5b76
+#  size: t1.micro
+#  ssh_username: root
+#  location: us-west-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-1
 
-arch_cloud-init_ec2:
-  provider: my-ec2-config
-  image: ami-6a5f7c2f
-  size: t1.micro
-  ssh_username: root
-  location: us-west-1
-  minion:
-    grains:
-      cloud: ec2-us-west-1
+#arch_cloud-init_ec2:
+#  provider: my-ec2-config
+#  image: ami-6a5f7c2f
+#  size: t1.micro
+#  ssh_username: root
+#  location: us-west-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-1
 
 # Centos 6, available from ec2 marketplace for no-charge
 # http://wiki.centos.org/Cloud/AWS
-centos_6:
-  provider: my-ec2-config
-  image: ami-f61630b3
-  size: t1.micro
-  ssh_username: root
-  location: us-west-1
-  minion:
-    grains:
-      cloud: ec2-us-west-1
+#centos_6:
+#  provider: my-ec2-config
+#  image: ami-f61630b3
+#  size: t1.micro
+#  ssh_username: root
+#  location: us-west-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-1
 
 # official Debian, available at no-charge from ec2 marketplace:
 # http://wiki.debian.org/Cloud/AmazonEC2Image
-debian_squeeze_ec2:
-  provider: my-ec2-config
-  image: ami-2c735269
-  size: t1.micro
-  ssh_username: admin
-  location: us-west-1
-  minion:
-    grains:
-      cloud: ec2-us-west-1
+#debian_squeeze_ec2:
+#  provider: my-ec2-config
+#  image: ami-2c735269
+#  size: t1.micro
+#  ssh_username: admin
+#  location: us-west-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-1
 
 # Fedora project cloud images
 # https://fedoraproject.org/wiki/Cloud_images
-fedora_17_ec2:
-  provider: my-ec2-config
-  image: ami-877e24c2
-  size: t1.micro
-  ssh_username: ec2-user
-  location: us-west-1
-  minion:
-    grains:
-      cloud: ec2-us-west-1
+#fedora_17_ec2:
+#  provider: my-ec2-config
+#  image: ami-877e24c2
+#  size: t1.micro
+#  ssh_username: ec2-user
+#  location: us-west-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-1
 
-fedora_18_ec2:
-  provider: my-ec2-config
-  image: ami-0899b94d
-  size: t1.micro
-  ssh_username: ec2-user
-  location: us-west-1
-  minion:
-    grains:
-      cloud: ec2-us-west-1
+#fedora_18_ec2:
+#  provider: my-ec2-config
+#  image: ami-0899b94d
+#  size: t1.micro
+#  ssh_username: ec2-user
+#  location: us-west-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-1
 
 # FreeBSD 9.1
 # http://www.daemonology.net/freebsd-on-ec2/
 
 # this t1.micro instance does not auto-populate SSH keys see above link
-freebsd_91_ec2:
-  provider: my-ec2-config
-  image: ami-4c8baa09
-  size: t1.micro
-  ssh_username: ec2-user
-  location: us-west-1
-  minion:
-    grains:
-      cloud: ec2-us-west-1
+#freebsd_91_ec2:
+#  provider: my-ec2-config
+#  image: ami-4c8baa09
+#  size: t1.micro
+#  ssh_username: ec2-user
+#  location: us-west-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-1
 
 # Canonical Ubuntu LTS images
 # http://cloud-images.ubuntu.com/releases/
-ubuntu_lucid_ec2:
-  provider: my-ec2-config
-  image: ami-e63013a3
-  size: t1.micro
-  ssh_username: ubuntu
-  location: us-west-1
-  minion:
-    grains:
-      cloud: ec2-us-west-1
+#ubuntu_lucid_ec2:
+#  provider: my-ec2-config
+#  image: ami-e63013a3
+#  size: t1.micro
+#  ssh_username: ubuntu
+#  location: us-west-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-1
 
-ubuntu_precise_ec2:
-  provider: my-ec2-config
-  image: ami-3ed8fb7b
-  size: t1.micro
-  ssh_username: ubuntu
-  location: us-west-1
-  minion:
-    grains:
-      cloud: ec2-us-west-1
-
+#ubuntu_precise_ec2:
+#  provider: my-ec2-config
+#  image: ami-3ed8fb7b
+#  size: t1.micro
+#  ssh_username: ubuntu
+#  location: us-west-1
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-1

--- a/conf/cloud.profiles.d/EC2-us-west-2.profiles
+++ b/conf/cloud.profiles.d/EC2-us-west-2.profiles
@@ -2,115 +2,114 @@
 
 # Arch Linux
 # https://wiki.archlinux.org/index.php/Arch_Linux_AMIs_for_Amazon_Web_Services
-arch_ec2:
-  provider: my-ec2-config
-  image: ami-bcf77e8c
-  size: t1.micro
-  ssh_username: root
-  location: us-west-2
-  minion:
-    grains:
-      cloud: ec2-us-west-2
+#arch_ec2:
+#  provider: my-ec2-config
+#  image: ami-bcf77e8c
+#  size: t1.micro
+#  ssh_username: root
+#  location: us-west-2
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-2
 
-arch_cloud-init_ec2:
-  provider: my-ec2-config
-  image: ami-6a5f7c2f
-  size: t1.micro
-  ssh_username: root
-  location: us-west-2
-  minion:
-    grains:
-      cloud: ec2-us-west-2
+#arch_cloud-init_ec2:
+#  provider: my-ec2-config
+#  image: ami-6a5f7c2f
+#  size: t1.micro
+#  ssh_username: root
+#  location: us-west-2
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-2
 
 # Centos 6, available from ec2 marketplace for no-charge
 # http://wiki.centos.org/Cloud/AWS
-centos_6:
-  provider: my-ec2-config
-  image: ami-de5bd2ee
-  size: t1.micro
-  ssh_username: root
-  location: us-west-2
-  minion:
-    grains:
-      cloud: ec2-us-west-2
+#centos_6:
+#  provider: my-ec2-config
+#  image: ami-de5bd2ee
+#  size: t1.micro
+#  ssh_username: root
+#  location: us-west-2
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-2
 
 # official Debian, available at no-charge from ec2 marketplace:
 # http://wiki.debian.org/Cloud/AmazonEC2Image
-debian_squeeze_ec2:
-  provider: my-ec2-config
-  image: ami-e4da52d4
-  size: t1.micro
-  ssh_username: admin
-  location: us-west-2
-  minion:
-    grains:
-      cloud: ec2-us-west-2
+#debian_squeeze_ec2:
+#  provider: my-ec2-config
+#  image: ami-e4da52d4
+#  size: t1.micro
+#  ssh_username: admin
+#  location: us-west-2
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-2
 
 # Fedora project cloud images
 # https://fedoraproject.org/wiki/Cloud_images
-fedora_17_ec2:
-  provider: my-ec2-config
-  image: ami-8e69e5be
-  size: t1.micro
-  ssh_username: ec2-user
-  location: us-west-2
-  minion:
-    grains:
-      cloud: ec2-us-west-2
+#fedora_17_ec2:
+#  provider: my-ec2-config
+#  image: ami-8e69e5be
+#  size: t1.micro
+#  ssh_username: ec2-user
+#  location: us-west-2
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-2
 
-fedora_18_ec2:
-  provider: my-ec2-config
-  image: ami-0266ed32
-  size: t1.micro
-  ssh_username: ec2-user
-  location: us-west-2
-  minion:
-    grains:
-      cloud: ec2-us-west-2
+#fedora_18_ec2:
+#  provider: my-ec2-config
+#  image: ami-0266ed32
+#  size: t1.micro
+#  ssh_username: ec2-user
+#  location: us-west-2
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-2
 
 # FreeBSD 9.1
 # http://www.daemonology.net/freebsd-on-ec2/
 
 # this t1.micro instance does not auto-populate SSH keys see above link
-freebsd_91_ec2:
-  provider: my-ec2-config
-  image: ami-aa09819a
-  size: t1.micro
-  ssh_username: ec2-user
-  location: us-west-2
-  minion:
-    grains:
-      cloud: ec2-us-west-2
+#freebsd_91_ec2:
+#  provider: my-ec2-config
+#  image: ami-aa09819a
+#  size: t1.micro
+#  ssh_username: ec2-user
+#  location: us-west-2
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-2
 
-freebsd_91_4XL_ec2:
-  provider: my-ec2-config
-  image: ami-66169e56
-  size: Cluster Compute 4XL
-  ssh_username: ec2-user
-  location: us-west-2
-  minion:
-    grains:
-      cloud: ec2-us-west-2
+#freebsd_91_4XL_ec2:
+#  provider: my-ec2-config
+#  image: ami-66169e56
+#  size: Cluster Compute 4XL
+#  ssh_username: ec2-user
+#  location: us-west-2
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-2
 
 # Canonical Ubuntu LTS images
 # http://cloud-images.ubuntu.com/releases/
-ubuntu_lucid_ec2:
-  provider: my-ec2-config
-  image: ami-6ec8425e
-  size: t1.micro
-  ssh_username: ubuntu
-  location: us-west-2
-  minion:
-    grains:
-      cloud: ec2-us-west-2
+#ubuntu_lucid_ec2:
+#  provider: my-ec2-config
+#  image: ami-6ec8425e
+#  size: t1.micro
+#  ssh_username: ubuntu
+#  location: us-west-2
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-2
 
-ubuntu_precise_ec2:
-  provider: my-ec2-config
-  image: ami-e0941ed0
-  size: t1.micro
-  ssh_username: ubuntu
-  location: us-west-2
-  minion:
-    grains:
-      cloud: ec2-us-west-2
-
+#ubuntu_precise_ec2:
+#  provider: my-ec2-config
+#  image: ami-e0941ed0
+#  size: t1.micro
+#  ssh_username: ubuntu
+#  location: us-west-2
+#  minion:
+#    grains:
+#      cloud: ec2-us-west-2

--- a/conf/minion
+++ b/conf/minion
@@ -415,7 +415,7 @@
 # Note that this is a very large hammer and it can be quite difficult to keep the minion working
 # the way you think it should since Salt uses many modules internally itself.  At a bare minimum
 # you need the following enabled or else the minion won't start.
-whitelist_modules:
+#whitelist_modules:
 #  - cmdmod
 #  - test
 #  - config

--- a/tests/unit/conf_test.py
+++ b/tests/unit/conf_test.py
@@ -134,6 +134,60 @@ class ConfTest(TestCase):
             )
         )
 
+    def test_conf_cloud_profiles_d_files_are_commented(self):
+        '''
+        All cloud profile sample configs in salt/conf/cloud.profiles.d/* must be completely
+        commented out. This test loops through all of the files in that directory to check
+        for any lines that are not commented or blank.
+        '''
+        cloud_sample_files = os.listdir(SAMPLE_CONF_DIR + 'cloud.profiles.d/')
+        for conf_file in cloud_sample_files:
+            profile_conf = SAMPLE_CONF_DIR + 'cloud.profiles.d/' + conf_file
+            ret = salt.config._read_conf_file(profile_conf)
+            self.assertEqual(
+                ret,
+                {},
+                'Sample config file \'{0}\' must be commented out.'.format(
+                    conf_file
+                )
+            )
+
+    def test_conf_cloud_providers_d_files_are_commented(self):
+        '''
+        All cloud profile sample configs in salt/conf/cloud.providers.d/* must be completely
+        commented out. This test loops through all of the files in that directory to check
+        for any lines that are not commented or blank.
+        '''
+        cloud_sample_files = os.listdir(SAMPLE_CONF_DIR + 'cloud.providers.d/')
+        for conf_file in cloud_sample_files:
+            provider_conf = SAMPLE_CONF_DIR + 'cloud.providers.d/' + conf_file
+            ret = salt.config._read_conf_file(provider_conf)
+            self.assertEqual(
+                ret,
+                {},
+                'Sample config file \'{0}\' must be commented out.'.format(
+                    conf_file
+                )
+            )
+
+    def test_conf_cloud_maps_d_files_are_commented(self):
+        '''
+        All cloud profile sample configs in salt/conf/cloud.maps.d/* must be completely
+        commented out. This test loops through all of the files in that directory to check
+        for any lines that are not commented or blank.
+        '''
+        cloud_sample_files = os.listdir(SAMPLE_CONF_DIR + 'cloud.maps.d/')
+        for conf_file in cloud_sample_files:
+            map_conf = SAMPLE_CONF_DIR + 'cloud.maps.d/' + conf_file
+            ret = salt.config._read_conf_file(map_conf)
+            self.assertEqual(
+                ret,
+                {},
+                'Sample config file \'{0}\' must be commented out.'.format(
+                    conf_file
+                )
+            )
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/conf_test.py
+++ b/tests/unit/conf_test.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+'''
+Unit tests for the files in the salt/conf directory.
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+import os
+
+# Import Salt Testing libs
+from salttesting import skipIf, TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+)
+
+ensure_in_syspath('../')
+
+# Import Salt libs
+import salt.config
+
+SAMPLE_CONF_DIR = os.path.dirname(os.path.realpath(__file__)).split('tests')[0] + 'conf/'
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class ConfTest(TestCase):
+    '''
+    Validate files in the salt/conf directory.
+    '''
+
+    def test_conf_master_sample_is_commented(self):
+        '''
+        The sample config file located in salt/conf/master must be completely
+        commented out. This test checks for any lines that are not commented or blank.
+        '''
+        master_config = SAMPLE_CONF_DIR + 'master'
+        ret = salt.config._read_conf_file(master_config)
+        self.assertEqual(
+            ret,
+            {},
+            'Sample config file \'{0}\' must be commented out.'.format(
+                master_config
+            )
+        )
+
+    def test_conf_minion_sample_is_commented(self):
+        '''
+        The sample config file located in salt/conf/minion must be completely
+        commented out. This test checks for any lines that are not commented or blank.
+        '''
+        minion_config = SAMPLE_CONF_DIR + 'minion'
+        ret = salt.config._read_conf_file(minion_config)
+        self.assertEqual(
+            ret,
+            {},
+            'Sample config file \'{0}\' must be commented out.'.format(
+                minion_config
+            )
+        )
+
+    def test_conf_cloud_sample_is_commented(self):
+        '''
+        The sample config file located in salt/conf/cloud must be completely
+        commented out. This test checks for any lines that are not commented or blank.
+        '''
+        cloud_config = SAMPLE_CONF_DIR + 'cloud'
+        ret = salt.config._read_conf_file(cloud_config)
+        self.assertEqual(
+            ret,
+            {},
+            'Sample config file \'{0}\' must be commented out.'.format(
+                cloud_config
+            )
+        )
+
+    def test_conf_cloud_profiles_sample_is_commented(self):
+        '''
+        The sample config file located in salt/conf/cloud.profiles must be completely
+        commented out. This test checks for any lines that are not commented or blank.
+        '''
+        cloud_profiles_config = SAMPLE_CONF_DIR + 'cloud.profiles'
+        ret = salt.config._read_conf_file(cloud_profiles_config)
+        self.assertEqual(
+            ret,
+            {},
+            'Sample config file \'{0}\' must be commented out.'.format(
+                cloud_profiles_config
+            )
+        )
+
+    def test_conf_cloud_providers_sample_is_commented(self):
+        '''
+        The sample config file located in salt/conf/cloud.providers must be completely
+        commented out. This test checks for any lines that are not commented or blank.
+        '''
+        cloud_providers_config = SAMPLE_CONF_DIR + 'cloud.providers'
+        ret = salt.config._read_conf_file(cloud_providers_config)
+        self.assertEqual(
+            ret,
+            {},
+            'Sample config file \'{0}\' must be commented out.'.format(
+                cloud_providers_config
+            )
+        )
+
+    def test_conf_proxy_sample_is_commented(self):
+        '''
+        The sample config file located in salt/conf/proxy must be completely
+        commented out. This test checks for any lines that are not commented or blank.
+        '''
+        proxy_config = SAMPLE_CONF_DIR + 'proxy'
+        ret = salt.config._read_conf_file(proxy_config)
+        self.assertEqual(
+            ret,
+            {},
+            'Sample config file \'{0}\' must be commented out.'.format(
+                proxy_config
+            )
+        )
+
+    def test_conf_roster_sample_is_commented(self):
+        '''
+        The sample config file located in salt/conf/roster must be completely
+        commented out. This test checks for any lines that are not commented or blank.
+        '''
+        roster_config = SAMPLE_CONF_DIR + 'roster'
+        ret = salt.config._read_conf_file(roster_config)
+        self.assertEqual(
+            ret,
+            {},
+            'Sample config file \'{0}\' must be commented out.'.format(
+                roster_config
+            )
+        )
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(ConfTest, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

Adds some unit tests to read in the files in the `salt/conf` directory to make sure all of the lines in those files are commented out. It's easy to miss commenting out a line when adding docs for new options, but when we forget the `#`, we run into problems in #36045.
### What issues does this PR fix or reference?

Fixes #36045
### Previous Behavior

```
[WARNING ] Key 'whitelist_modules' with value None has an invalid type of NoneType, a list is required for this value
```
### New Behavior

No more warnings.
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
