### PR TITLE
Fix signal handling

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -504,8 +504,9 @@ class ProcessManager(object):
                     continue
                 log.trace('Killing pid {0}: {1}'.format(pid, p_map['Process']))
                 try:
-                    os.kill(signal.SIGKILL, pid)
-                except OSError:
+                    os.kill(pid, signal.SIGKILL)
+                except OSError as exc:
+                    log.exception(exc)
                     # in case the process has since decided to die, os.kill returns OSError
                     if not p_map['Process'].is_alive():
                         # The process is no longer alive, remove it from the process map dictionary

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -128,7 +128,6 @@ except ImportError:
                     cmdline = process.as_dict()
                 except psutil.NoSuchProcess as exc:
                     log.debug('No such process found. Stacktrace: {0}'.format(exc))
-
             log.info('Sending %s to process: %s', sigint_name, cmdline)
             process.send_signal(sigint)
             try:
@@ -641,8 +640,9 @@ class SaltMaster(SaltDaemonScriptBase):
     def get_check_ports(self):
         #return set([self.config['runtests_conn_check_port']])
         return set([self.config['ret_port'],
-                    self.config['publish_port'],
-                    self.config['runtests_conn_check_port']])
+                    self.config['publish_port'],])
+        # Disabled along with Pytest config until fixed.
+#                    self.config['runtests_conn_check_port']])
 
     def get_script_args(self):
         #return ['-l', 'debug']
@@ -1151,21 +1151,21 @@ class TestDaemon(object):
             syndic_opts[optname] = optname_path
             syndic_master_opts[optname] = optname_path
 
-        master_opts['runtests_conn_check_port'] = get_unused_localhost_port()
-        minion_opts['runtests_conn_check_port'] = get_unused_localhost_port()
-        sub_minion_opts['runtests_conn_check_port'] = get_unused_localhost_port()
-        syndic_opts['runtests_conn_check_port'] = get_unused_localhost_port()
-        syndic_master_opts['runtests_conn_check_port'] = get_unused_localhost_port()
+#        master_opts['runtests_conn_check_port'] = get_unused_localhost_port()
+#        minion_opts['runtests_conn_check_port'] = get_unused_localhost_port()
+#        sub_minion_opts['runtests_conn_check_port'] = get_unused_localhost_port()
+#        syndic_opts['runtests_conn_check_port'] = get_unused_localhost_port()
+#        syndic_master_opts['runtests_conn_check_port'] = get_unused_localhost_port()
 
         for conf in (master_opts, minion_opts, sub_minion_opts, syndic_opts, syndic_master_opts):
-            if 'engines' not in conf:
-                conf['engines'] = []
-            conf['engines'].append({'salt_runtests': {}})
+#            if 'engines' not in conf:
+#                conf['engines'] = []
+#            conf['engines'].append({'salt_runtests': {}})
 
-            if 'engines_dirs' not in conf:
-                conf['engines_dirs'] = []
-
-            conf['engines_dirs'].insert(0, ENGINES_DIR)
+#            if 'engines_dirs' not in conf:
+#                conf['engines_dirs'] = []
+#
+#            conf['engines_dirs'].insert(0, ENGINES_DIR)
 
             if 'log_handlers_dirs' not in conf:
                 conf['log_handlers_dirs'] = []

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -640,7 +640,7 @@ class SaltMaster(SaltDaemonScriptBase):
     def get_check_ports(self):
         #return set([self.config['runtests_conn_check_port']])
         return set([self.config['ret_port'],
-                    self.config['publish_port'],])
+                    self.config['publish_port']])
         # Disabled along with Pytest config until fixed.
 #                    self.config['runtests_conn_check_port']])
 
@@ -1151,22 +1151,7 @@ class TestDaemon(object):
             syndic_opts[optname] = optname_path
             syndic_master_opts[optname] = optname_path
 
-#        master_opts['runtests_conn_check_port'] = get_unused_localhost_port()
-#        minion_opts['runtests_conn_check_port'] = get_unused_localhost_port()
-#        sub_minion_opts['runtests_conn_check_port'] = get_unused_localhost_port()
-#        syndic_opts['runtests_conn_check_port'] = get_unused_localhost_port()
-#        syndic_master_opts['runtests_conn_check_port'] = get_unused_localhost_port()
-
         for conf in (master_opts, minion_opts, sub_minion_opts, syndic_opts, syndic_master_opts):
-#            if 'engines' not in conf:
-#                conf['engines'] = []
-#            conf['engines'].append({'salt_runtests': {}})
-
-#            if 'engines_dirs' not in conf:
-#                conf['engines_dirs'] = []
-#
-#            conf['engines_dirs'].insert(0, ENGINES_DIR)
-
             if 'log_handlers_dirs' not in conf:
                 conf['log_handlers_dirs'] = []
             conf['log_handlers_dirs'].insert(0, LOG_HANDLERS_DIR)


### PR DESCRIPTION
We had a little mix-up with the args ordering for our signal handling.

This sends the proper signal to processes on cleanup.

I have also temporarily disabled the pytest engines because they werecausing the minions to try to to connect to a master IPC socket which could not be found.

This put the minions into a continual futex state which was not playing well with kill sigs.

The engines should be safe to re-enable as soon as they are either no longer attached to the minions or the issue with the socket not being found is fixed. (I originally located it using strace, FWIW.)
