### PR TITLE
Remove grains type deprecation warning from 2016.3

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1490,7 +1490,6 @@ def os_data():
             osrelease_info[idx] = int(value)
         grains['osrelease_info'] = tuple(osrelease_info)
         grains['osmajorrelease'] = str(grains['osrelease_info'][0])  # This will be an integer in the two releases
-        salt.utils.warn_until('Nitrogen', 'The "osmajorrelease" will be a type of an integer.')
         os_name = grains['os' if grains.get('os') in (
             'FreeBSD', 'OpenBSD', 'NetBSD', 'Mac', 'Raspbian') else 'osfullname']
         grains['osfinger'] = '{0}-{1}'.format(


### PR DESCRIPTION
Fixes saltstack/salt#35972 and Refs saltstack/salt#35637