### PR TITLE
Use __utils__ instead of salt.utils.cloud in opennebula driver

### DIFF
--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -61,10 +61,7 @@ from salt.exceptions import (
     SaltCloudNotFound,
     SaltCloudSystemExit
 )
-from salt.utils import is_true
-
-# Import Salt Cloud Libs
-import salt.utils.cloud
+import salt.utils
 
 # Import Third Party Libs
 try:
@@ -322,7 +319,7 @@ def list_nodes_select(call=None):
             'The list_nodes_full function must be called with -f or --function.'
         )
 
-    return salt.utils.cloud.list_nodes_select(
+    return __utils__['cloud.list_nodes_select'](
         list_nodes_full('function'), __opts__['query.selection'], call,
     )
 
@@ -913,7 +910,7 @@ def create(vm_):
             return node_data
 
     try:
-        data = salt.utils.cloud.wait_for_ip(
+        data = __utils__['cloud.wait_for_ip'](
             __query_node_data,
             update_args=(vm_['name'],),
             timeout=config.get_cloud_config_value(
@@ -953,7 +950,7 @@ def create(vm_):
     vm_['key_filename'] = key_filename
     vm_['ssh_host'] = private_ip
 
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 
     ret['id'] = data['id']
     ret['image'] = vm_['image']
@@ -1028,7 +1025,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(
+        __utils__['cloud.delete_minion_cachedir'](
             name,
             __active_provider_name__.split(':')[0],
             __opts__
@@ -1373,7 +1370,7 @@ def image_persistent(call=None, kwargs=None):
 
     server, user, password = _get_xml_rpc()
     auth = ':'.join([user, password])
-    response = server.one.image.persistent(auth, int(image_id), is_true(persist))
+    response = server.one.image.persistent(auth, int(image_id), salt.utils.is_true(persist))
 
     data = {
         'action': 'image.persistent',
@@ -1720,7 +1717,7 @@ def show_instance(name, call=None):
         )
 
     node = _get_node(name)
-    salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
+    __utils__['cloud.cache_node'](node, __active_provider_name__, __opts__)
 
     return node
 
@@ -2586,7 +2583,7 @@ def vm_allocate(call=None, kwargs=None):
 
     server, user, password = _get_xml_rpc()
     auth = ':'.join([user, password])
-    response = server.one.vm.allocate(auth, data, is_true(hold))
+    response = server.one.vm.allocate(auth, data, salt.utils.is_true(hold))
 
     ret = {
         'action': 'vm.allocate',
@@ -2816,7 +2813,7 @@ def vm_deploy(name, kwargs=None, call=None):
     response = server.one.vm.deploy(auth,
                                     int(vm_id),
                                     int(host_id),
-                                    is_true(capacity_maintained),
+                                    salt.utils.is_true(capacity_maintained),
                                     int(datastore_id))
 
     data = {
@@ -3285,8 +3282,8 @@ def vm_migrate(name, kwargs=None, call=None):
     response = server.one.vm.migrate(auth,
                                      vm_id,
                                      int(host_id),
-                                     is_true(live_migration),
-                                     is_true(capacity_maintained),
+                                     salt.utils.is_true(live_migration),
+                                     salt.utils.is_true(capacity_maintained),
                                      int(datastore_id))
 
     data = {
@@ -3404,7 +3401,7 @@ def vm_resize(name, kwargs=None, call=None):
     server, user, password = _get_xml_rpc()
     auth = ':'.join([user, password])
     vm_id = int(get_vm_id(kwargs={'name': name}))
-    response = server.one.vm.resize(auth, vm_id, data, is_true(capacity_maintained))
+    response = server.one.vm.resize(auth, vm_id, data, salt.utils.is_true(capacity_maintained))
 
     ret = {
         'action': 'vm.resize',

--- a/tests/unit/cloud/clouds/opennebula_test.py
+++ b/tests/unit/cloud/clouds/opennebula_test.py
@@ -20,6 +20,8 @@ from salt.exceptions import SaltCloudSystemExit, SaltCloudNotFound
 # Global Variables
 opennebula.__active_provider_name__ = ''
 opennebula.__opts__ = {}
+opennebula.__utils__ = {}
+opennebula.__utils__['cloud.cache_node'] = MagicMock()
 VM_NAME = 'my-vm'
 
 
@@ -761,7 +763,6 @@ class OpenNebulaTestCase(TestCase):
 
     @patch('salt.cloud.clouds.opennebula._get_node',
            MagicMock(return_value={'my-vm': {'name': 'my-vm', 'id': 0}}))
-    @patch('salt.utils.cloud.cache_node', MagicMock())
     def test_show_instance_success(self):
         '''
         Tests that the node was found successfully.


### PR DESCRIPTION
### What does this PR do?

In #35483, we switched to using `__utils__['cloud.some_function']` instead of `salt.utils.cloud.some_function`. Some of the references were missed in the opennebula cloud driver. This PR fixes those references.

It also fixes up the `from salt.utils import is_true` references. Whenever we are using functions from `salt.utils.__init__.py` we need to import the whole module and reference functions explicitly. This PR changes the `is_true` references to `salt.utils.is_true` to match the `salt.utils.fopen` calls.
### What issues does this PR fix or reference?

Fixes #36057
### Previous Behavior

```
[ERROR   ] There was a profile error: global name '__opts__' is not defined
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/cloud/cli.py", line 284, in run
    self.config.get('names')
  File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1451, in run_profile
    ret[name] = self.create(vm_)
  File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1281, in create
    output = self.clouds[func](vm_)
  File "/usr/lib/python2.7/dist-packages/salt/cloud/clouds/opennebula.py", line 956, in create
    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
  File "/usr/lib/python2.7/dist-packages/salt/utils/cloud.py", line 514, in bootstrap
    transport=opts.get('transport', 'zeromq')
  File "/usr/lib/python2.7/dist-packages/salt/utils/cloud.py", line 1721, in fire_event
    sock_dir = os.path.join(__opts__['sock_dir'], 'master')
NameError: global name '__opts__' is not defined
```
### New Behavior

Cleans up the stack trace and fixes the problem.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
