### PR TITLE
Failhard test=True fix

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1809,6 +1809,8 @@ class State(object):
         tag = _gen_tag(low)
         if (low.get('failhard', False) or self.opts['failhard']
                 and tag in running):
+            if running[tag]['result'] is None:
+                return False
             return not running[tag]['result']
         return False
 


### PR DESCRIPTION
When failhard is set test=True causes the changes return to bail out.

Should we disable all failhard when running in test=True mode?

Per #18341
