### PR TITLE
Various fixes for MacOS X

### DIFF
--- a/tests/integration/shell/master.py
+++ b/tests/integration/shell/master.py
@@ -87,7 +87,7 @@ class MasterTest(integration.ShellCase, testprogram.TestProgramCase, integration
 
         master = testprogram.TestDaemonSaltMaster(
             name='unknown_user',
-            configs={'master': {'map': {'user': 'unknown'}}},
+            configs={'master': {'map': {'user': 'some_unknown_user_xyz'}}},
             parent_dir=self._test_dir,
         )
         # Call setup here to ensure config and script exist

--- a/tests/integration/shell/minion.py
+++ b/tests/integration/shell/minion.py
@@ -283,7 +283,7 @@ class MinionTest(integration.ShellCase, testprogram.TestProgramCase, integration
 
         minion = testprogram.TestDaemonSaltMinion(
             name='unknown_user',
-            configs={'minion': {'map': {'user': 'unknown'}}},
+            configs={'minion': {'map': {'user': 'some_unknown_user_xyz'}}},
             parent_dir=self._test_dir,
         )
         # Call setup here to ensure config and script exist

--- a/tests/integration/shell/proxy.py
+++ b/tests/integration/shell/proxy.py
@@ -46,6 +46,9 @@ class ProxyTest(testprogram.TestProgramCase):
             verbatim_args=True,   # prevents --proxyid from being added automatically
             catch_stderr=True,
             with_retcode=True,
+            # The proxy minion had a bug where it would loop forever
+            # without daemonizing - protect that with a timeout.
+            timeout=60,
         )
         self.assert_exit_status(
             status, 'EX_USAGE',
@@ -62,7 +65,7 @@ class ProxyTest(testprogram.TestProgramCase):
 
         proxy = testprogram.TestDaemonSaltProxy(
             name='proxy-unknown_user',
-            config_base={'user': 'unknown'},
+            config_base={'user': 'some_unknown_user_xyz'},
             parent_dir=self._test_dir,
         )
         # Call setup here to ensure config and script exist

--- a/tests/integration/shell/syndic.py
+++ b/tests/integration/shell/syndic.py
@@ -94,7 +94,7 @@ class SyndicTest(integration.ShellCase, testprogram.TestProgramCase, integration
 
         syndic = testprogram.TestDaemonSaltSyndic(
             name='unknown_user',
-            config_base={'user': 'unknown'},
+            config_base={'user': 'some_unknown_user_xyz'},
             parent_dir=self._test_dir,
         )
         # Call setup here to ensure config and script exist

--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -384,8 +384,9 @@ class TestProgram(six.with_metaclass(TestProgramMeta, object)):
                 for path in sys.path:
                     if path not in env_pypath:
                         env_pypath.append(path)
-                if integration.CODE_DIR not in env_pypath:
-                    env_pypath.append(integration.CODE_DIR)
+            # Always ensure that the test tree is searched first for python modules
+            if integration.CODE_DIR != env_pypath[0]:
+                env_pypath.insert(0, integration.CODE_DIR)
             env_delta['PYTHONPATH'] = ':'.join(env_pypath)
 
         cmd_env = dict(os.environ)


### PR DESCRIPTION
### What does this PR do?

Fixes MacOS X failures
### What issues does this PR fix or reference?

N/A
### Previous Behavior

Failed tests in `tests.integration.shell` under MacOS X
### New Behavior

Successful tests in `tests.integration.shell` under MacOS x
### Tests written?

Yes - we _fixed_ the previously-written tests ;^)

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
- Change "unknown" user to "some_unknown_user_xyz" since "unknown"
  _is_ a valid user
- Add timeout to proxy test_exit_status_no_proxyid() since a known
  failure case is to infinitely loop with an error.
- Always force the source code tree under test to be the first entry
  in PYTHONPATH (excluding verbatim_env)
