### PR TITLE
Support running git states / remote exec funcs as a different user in Windows

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -303,6 +303,22 @@ def _run(cmd,
                   'Setting value to an empty string'.format(bad_env_key))
         env[bad_env_key] = ''
 
+    if _check_loglevel(output_loglevel) is not None:
+        # Always log the shell commands at INFO unless quiet logging is
+        # requested. The command output is what will be controlled by the
+        # 'loglevel' parameter.
+        msg = (
+            'Executing command {0}{1}{0} {2}in directory \'{3}\'{4}'.format(
+                '\'' if not isinstance(cmd, list) else '',
+                cmd,
+                'as user \'{0}\' '.format(runas) if runas else '',
+                cwd,
+                '. Executing command in the background, no output will be '
+                'logged.' if bg else ''
+            )
+        )
+        log.info(log_callback(msg))
+
     if runas and salt.utils.is_windows():
         if not password:
             msg = 'password is a required argument for runas on Windows'
@@ -367,21 +383,6 @@ def _run(cmd,
                     runas
                 )
             )
-
-    if _check_loglevel(output_loglevel) is not None:
-        # Always log the shell commands at INFO unless quiet logging is
-        # requested. The command output is what will be controlled by the
-        # 'loglevel' parameter.
-        msg = (
-            'Executing command {0}{1}{0} {2}in directory \'{3}\'{4}'.format(
-                '\'' if not isinstance(cmd, list) else '',
-                cmd,
-                'as user \'{0}\' '.format(runas) if runas else '',
-                cwd,
-                ' in the background, no output will be logged' if bg else ''
-            )
-        )
-        log.info(log_callback(msg))
 
     if reset_system_locale is True:
         if not salt.utils.is_windows():

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -680,6 +680,7 @@ def run(cmd,
         saltenv='base',
         use_vt=False,
         bg=False,
+        password=None,
         **kwargs):
     r'''
     Execute the passed command and return the output as a string
@@ -699,8 +700,8 @@ def run(cmd,
     :param str runas: User to run script as. If running on a Windows minion you
       must also pass a password
 
-    :param str password: Windows only. Pass a password if you specify runas.
-      This parameter will be ignored for other OS's
+    :param str password: Windows only. Required when specifying ``runas``. This
+      parameter will be ignored on non-Windows platforms.
 
       .. versionadded:: 2016.3.0
 
@@ -848,7 +849,7 @@ def run(cmd,
                pillarenv=kwargs.get('pillarenv'),
                pillar_override=kwargs.get('pillar'),
                use_vt=use_vt,
-               password=kwargs.get('password', None),
+               password=password,
                bg=bg)
 
     log_callback = _check_cb(log_callback)
@@ -888,6 +889,7 @@ def shell(cmd,
         saltenv='base',
         use_vt=False,
         bg=False,
+        password=None,
         **kwargs):
     '''
     Execute the passed command and return the output as a string.
@@ -906,15 +908,16 @@ def shell(cmd,
     :param str runas: User to run script as. If running on a Windows minion you
       must also pass a password
 
-    :param str password: Windows only. Pass a password if you specify runas.
-      This parameter will be ignored for other OS's
+    :param str password: Windows only. Required when specifying ``runas``. This
+      parameter will be ignored on non-Windows platforms.
 
       .. versionadded:: 2016.3.0
 
     :param int shell: Shell to execute under. Defaults to the system default
       shell.
 
-    :param bool bg: If True, run command in background and do not await or deliver it's results
+    :param bool bg: If True, run command in background and do not await or
+      deliver its results
 
     :param list env: A list of environment variables to be set prior to
       execution.
@@ -1053,6 +1056,7 @@ def shell(cmd,
                use_vt=use_vt,
                python_shell=python_shell,
                bg=bg,
+               password=password,
                **kwargs)
 
 
@@ -1074,6 +1078,7 @@ def run_stdout(cmd,
                ignore_retcode=False,
                saltenv='base',
                use_vt=False,
+               password=None,
                **kwargs):
     '''
     Execute a command, and only return the standard out
@@ -1090,8 +1095,8 @@ def run_stdout(cmd,
     :param str runas: User to run script as. If running on a Windows minion you
       must also pass a password
 
-    :param str password: Windows only. Pass a password if you specify runas.
-      This parameter will be ignored for other OS's
+    :param str password: Windows only. Required when specifying ``runas``. This
+      parameter will be ignored on non-Windows platforms.
 
       .. versionadded:: 2016.3.0
 
@@ -1212,6 +1217,7 @@ def run_stdout(cmd,
                pillarenv=kwargs.get('pillarenv'),
                pillar_override=kwargs.get('pillar'),
                use_vt=use_vt,
+               password=password,
                **kwargs)
 
     log_callback = _check_cb(log_callback)
@@ -1255,6 +1261,7 @@ def run_stderr(cmd,
                ignore_retcode=False,
                saltenv='base',
                use_vt=False,
+               password=None,
                **kwargs):
     '''
     Execute a command and only return the standard error
@@ -1271,8 +1278,8 @@ def run_stderr(cmd,
     :param str runas: User to run script as. If running on a Windows minion you
       must also pass a password
 
-    :param str password: Windows only. Pass a password if you specify runas.
-      This parameter will be ignored for other OS's
+    :param str password: Windows only. Required when specifying ``runas``. This
+      parameter will be ignored on non-Windows platforms.
 
       .. versionadded:: 2016.3.0
 
@@ -1394,7 +1401,7 @@ def run_stderr(cmd,
                saltenv=saltenv,
                pillarenv=kwargs.get('pillarenv'),
                pillar_override=kwargs.get('pillar'),
-               password=kwargs.get('password', None))
+               password=password)
 
     log_callback = _check_cb(log_callback)
 
@@ -1438,6 +1445,7 @@ def run_all(cmd,
             saltenv='base',
             use_vt=False,
             redirect_stderr=False,
+            password=None,
             **kwargs):
     '''
     Execute the passed command and return a dict of return data
@@ -1454,8 +1462,8 @@ def run_all(cmd,
     :param str runas: User to run script as. If running on a Windows minion you
       must also pass a password
 
-    :param str password: Windows only. Pass a password if you specify runas.
-      This parameter will be ignored for other OS's
+    :param str password: Windows only. Required when specifying ``runas``. This
+      parameter will be ignored on non-Windows platforms.
 
       .. versionadded:: 2016.3.0
 
@@ -1587,7 +1595,7 @@ def run_all(cmd,
                pillarenv=kwargs.get('pillarenv'),
                pillar_override=kwargs.get('pillar'),
                use_vt=use_vt,
-               password=kwargs.get('password', None))
+               password=password)
 
     log_callback = _check_cb(log_callback)
 
@@ -1629,6 +1637,7 @@ def retcode(cmd,
             ignore_retcode=False,
             saltenv='base',
             use_vt=False,
+            password=None,
             **kwargs):
     '''
     Execute a shell command and return the command's return code.
@@ -1645,8 +1654,8 @@ def retcode(cmd,
     :param str runas: User to run script as. If running on a Windows minion you
       must also pass a password
 
-    :param str password: Windows only. Pass a password if you specify runas.
-      This parameter will be ignored for other OS's
+    :param str password: Windows only. Required when specifying ``runas``. This
+      parameter will be ignored on non-Windows platforms.
 
       .. versionadded:: 2016.3.0
 
@@ -1770,7 +1779,7 @@ def retcode(cmd,
                pillarenv=kwargs.get('pillarenv'),
                pillar_override=kwargs.get('pillar'),
                use_vt=use_vt,
-               password=kwargs.get('password', None))
+               password=password)
 
     log_callback = _check_cb(log_callback)
 
@@ -1807,6 +1816,7 @@ def _retcode_quiet(cmd,
                    ignore_retcode=False,
                    saltenv='base',
                    use_vt=False,
+                   password=None,
                    **kwargs):
     '''
     Helper for running commands quietly for minion startup.
@@ -1829,6 +1839,7 @@ def _retcode_quiet(cmd,
                    ignore_retcode=ignore_retcode,
                    saltenv=saltenv,
                    use_vt=use_vt,
+                   password=password,
                    **kwargs)
 
 
@@ -1851,6 +1862,7 @@ def script(source,
            saltenv='base',
            use_vt=False,
            bg=False,
+           password=None,
            **kwargs):
     '''
     Download a script from a remote location and execute the script locally.
@@ -1879,8 +1891,8 @@ def script(source,
     :param str runas: User to run script as. If running on a Windows minion you
       must also pass a password
 
-    :param str password: Windows only. Pass a password if you specify runas.
-      This parameter will be ignored for other OS's
+    :param str password: Windows only. Required when specifying ``runas``. This
+      parameter will be ignored on non-Windows platforms.
 
       .. versionadded:: 2016.3.0
 
@@ -2038,8 +2050,8 @@ def script(source,
                pillarenv=kwargs.get('pillarenv'),
                pillar_override=kwargs.get('pillar'),
                use_vt=use_vt,
-               password=kwargs.get('password', None),
-               bg=bg)
+               bg=bg,
+               password=password)
     _cleanup_tempfile(path)
     return ret
 
@@ -2061,6 +2073,7 @@ def script_retcode(source,
                    output_loglevel='debug',
                    log_callback=None,
                    use_vt=False,
+                   password=None,
                    **kwargs):
     '''
     Download a script from a remote location and execute the script locally.
@@ -2093,8 +2106,8 @@ def script_retcode(source,
     :param str runas: User to run script as. If running on a Windows minion you
       must also pass a password
 
-    :param str password: Windows only. Pass a password if you specify runas.
-      This parameter will be ignored for other OS's
+    :param str password: Windows only. Required when specifying ``runas``. This
+      parameter will be ignored on non-Windows platforms.
 
       .. versionadded:: 2016.3.0
 
@@ -2201,6 +2214,7 @@ def script_retcode(source,
                   output_loglevel=output_loglevel,
                   log_callback=log_callback,
                   use_vt=use_vt,
+                  password=password,
                   **kwargs)['retcode']
 
 
@@ -2348,10 +2362,10 @@ def run_chroot(root,
     This function runs :mod:`cmd.run_all <salt.modules.cmdmod.run_all>` wrapped
     within a chroot, with dev and proc mounted in the chroot
 
-    root:
+    root
         Path to the root of the jail to use.
 
-    cmd:
+    cmd
         The command to run. ex: 'ls -lart /home'
 
     cwd
@@ -2586,6 +2600,7 @@ def powershell(cmd,
         ignore_retcode=False,
         saltenv='base',
         use_vt=False,
+        password=None,
         **kwargs):
     '''
     Execute the passed PowerShell command and return the output as a string.
@@ -2613,8 +2628,8 @@ def powershell(cmd,
     :param str runas: User to run script as. If running on a Windows minion you
       must also pass a password
 
-    :param str password: Windows only. Pass a password if you specify runas.
-      This parameter will be ignored for other OS's
+    :param str password: Windows only. Required when specifying ``runas``. This
+      parameter will be ignored on non-Windows platforms.
 
       .. versionadded:: 2016.3.0
 
@@ -2727,6 +2742,7 @@ def powershell(cmd,
                    saltenv=saltenv,
                    use_vt=use_vt,
                    python_shell=python_shell,
+                   password=password,
                    **kwargs)
 
     try:
@@ -2749,7 +2765,9 @@ def run_bg(cmd,
         output_loglevel='debug',
         log_callback=None,
         reset_system_locale=True,
+        ignore_retcode=False,
         saltenv='base',
+        password=None,
         **kwargs):
     r'''
     .. versionadded: 2016.3.0
@@ -2770,6 +2788,11 @@ def run_bg(cmd,
 
     :param str runas: User to run script as. If running on a Windows minion you
       must also pass a password
+
+    :param str password: Windows only. Required when specifying ``runas``. This
+      parameter will be ignored on non-Windows platforms.
+
+      .. versionadded:: 2016.3.0
 
     :param str shell: Shell to execute under. Defaults to the system default
       shell.
@@ -2896,12 +2919,11 @@ def run_bg(cmd,
                log_callback=log_callback,
                timeout=timeout,
                reset_system_locale=reset_system_locale,
-               # ignore_retcode=ignore_retcode,
+               ignore_retcode=ignore_retcode,
                saltenv=saltenv,
                pillarenv=kwargs.get('pillarenv'),
                pillar_override=kwargs.get('pillar'),
-               # password=kwargs.get('password', None),
-               )
+               password=password)
 
     return {
         'pid': res['pid']

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -93,7 +93,7 @@ def _config_getter(get_opt,
         command.append(value_regex)
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode,
                     failhard=False)
@@ -146,7 +146,7 @@ def _format_opts(opts):
     return opts
 
 
-def _git_run(command, cwd=None, runas=None, password=None, identity=None,
+def _git_run(command, cwd=None, user=None, password=None, identity=None,
              ignore_retcode=False, failhard=True, redirect_stderr=False,
              saltenv='base', **kwargs):
     '''
@@ -213,7 +213,7 @@ def _git_run(command, cwd=None, runas=None, password=None, identity=None,
                 tmp_file = salt.utils.mkstemp()
                 salt.utils.files.copyfile(ssh_id_wrapper, tmp_file)
                 os.chmod(tmp_file, 0o500)
-                os.chown(tmp_file, __salt__['file.user_to_uid'](runas), -1)
+                os.chown(tmp_file, __salt__['file.user_to_uid'](user), -1)
                 env['GIT_SSH'] = tmp_file
 
             if 'salt-call' not in _salt_cli \
@@ -235,7 +235,7 @@ def _git_run(command, cwd=None, runas=None, password=None, identity=None,
                 result = __salt__['cmd.run_all'](
                     command,
                     cwd=cwd,
-                    runas=runas,
+                    runas=user,
                     password=password,
                     env=env,
                     python_shell=False,
@@ -276,7 +276,7 @@ def _git_run(command, cwd=None, runas=None, password=None, identity=None,
         result = __salt__['cmd.run_all'](
             command,
             cwd=cwd,
-            runas=runas,
+            runas=user,
             password=password,
             env=env,
             python_shell=False,
@@ -311,7 +311,7 @@ def _get_toplevel(path, user=None, password=None):
     return _git_run(
         ['git', 'rev-parse', '--show-toplevel'],
         cwd=path,
-        runas=user,
+        user=user,
         password=password)['stdout']
 
 
@@ -412,7 +412,7 @@ def add(cwd,
     command.extend(['--', filename])
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -556,7 +556,7 @@ def archive(cwd,
     command.extend(['--output', output, rev])
     _git_run(command,
              cwd=cwd,
-             runas=user,
+             user=user,
              password=password,
              ignore_retcode=ignore_retcode)
     # No output (unless --verbose is used, and we don't want all files listed
@@ -635,7 +635,7 @@ def branch(cwd,
         command.append(name)
     _git_run(command,
              cwd=cwd,
-             runas=user,
+             user=user,
              password=password,
              ignore_retcode=ignore_retcode)
     return True
@@ -722,7 +722,7 @@ def checkout(cwd,
     # Checkout message goes to stderr
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode,
                     redirect_stderr=True)['stdout']
@@ -868,7 +868,7 @@ def clone(cwd,
         clone_cwd = '/tmp' if not salt.utils.is_windows() else None
     _git_run(command,
              cwd=clone_cwd,
-             runas=user,
+             user=user,
              password=password,
              identity=identity,
              ignore_retcode=ignore_retcode,
@@ -951,7 +951,7 @@ def commit(cwd,
         command.extend(['--', filename])
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -1265,7 +1265,7 @@ def config_set(key,
         command.extend([key, value])
         _git_run(command,
                  cwd=cwd,
-                 runas=user,
+                 user=user,
                  password=password,
                  ignore_retcode=ignore_retcode)
     else:
@@ -1278,7 +1278,7 @@ def config_set(key,
             command.extend([key, target])
             _git_run(command,
                      cwd=cwd,
-                     runas=user,
+                     user=user,
                      password=password,
                      ignore_retcode=ignore_retcode)
     return config_get(key,
@@ -1372,7 +1372,7 @@ def config_unset(key,
         command.append(value_regex)
     ret = _git_run(command,
                    cwd=cwd if cwd != 'global' else None,
-                   runas=user,
+                   user=user,
                    password=password,
                    ignore_retcode=ignore_retcode,
                    failhard=False)
@@ -1445,7 +1445,7 @@ def current_branch(cwd,
     command = ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -1500,7 +1500,7 @@ def describe(cwd,
     command.append(rev)
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -1645,7 +1645,7 @@ def diff(cwd,
 
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode,
                     failhard=failhard,
@@ -1777,7 +1777,7 @@ def fetch(cwd,
         command.extend(refspec_list)
     output = _git_run(command,
                       cwd=cwd,
-                      runas=user,
+                      user=user,
                       password=password,
                       identity=identity,
                       ignore_retcode=ignore_retcode,
@@ -1908,7 +1908,7 @@ def init(cwd,
     command.extend(_format_opts(opts))
     command.append(cwd)
     return _git_run(command,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -2023,7 +2023,7 @@ def list_branches(cwd,
                'refs/{0}/'.format('heads' if not remote else 'remotes')]
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout'].splitlines()
 
@@ -2068,7 +2068,7 @@ def list_tags(cwd,
                'refs/tags/']
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout'].splitlines()
 
@@ -2149,7 +2149,7 @@ def list_worktrees(cwd,
         '''
         return _git_run(['git', 'tag', '--points-at', rev],
                         cwd=cwd,
-                        runas=user,
+                        user=user,
                         password=password)['stdout'].splitlines()
 
     def _desired(is_stale, all_, stale):
@@ -2186,7 +2186,7 @@ def list_worktrees(cwd,
     if has_native_list_subcommand:
         out = _git_run(['git', 'worktree', 'list', '--porcelain'],
                        cwd=cwd,
-                       runas=user,
+                       user=user,
                        password=password)
         if out['retcode'] != 0:
             msg = 'Failed to list worktrees'
@@ -2494,7 +2494,7 @@ def ls_remote(cwd=None,
         command.extend([ref])
     output = _git_run(command,
                       cwd=cwd,
-                      runas=user,
+                      user=user,
                       password=password,
                       identity=identity,
                       ignore_retcode=ignore_retcode,
@@ -2594,7 +2594,7 @@ def merge(cwd,
         command.append(rev)
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -2778,7 +2778,7 @@ def merge_base(cwd,
             command.append(str(ref))
     result = _git_run(command,
                       cwd=cwd,
-                      runas=user,
+                      user=user,
                       password=password,
                       ignore_retcode=ignore_retcode,
                       failhard=False if is_ancestor else True)
@@ -2858,7 +2858,7 @@ def merge_tree(cwd,
     command.extend([base, ref1, ref2])
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -2941,7 +2941,7 @@ def pull(cwd,
     command.extend(_format_opts(opts))
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     identity=identity,
                     ignore_retcode=ignore_retcode,
@@ -3070,7 +3070,7 @@ def push(cwd,
     command.extend([remote, ref])
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     identity=identity,
                     ignore_retcode=ignore_retcode,
@@ -3138,7 +3138,7 @@ def rebase(cwd,
     command.extend(salt.utils.shlex_split(rev))
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -3299,7 +3299,7 @@ def remote_refs(url,
     except ValueError as exc:
         raise SaltInvocationError(exc.__str__())
     output = _git_run(command,
-                      runas=user,
+                      user=user,
                       password=password,
                       identity=identity,
                       ignore_retcode=ignore_retcode,
@@ -3396,7 +3396,7 @@ def remote_set(cwd,
         command = ['git', 'remote', 'rm', remote]
         _git_run(command,
                  cwd=cwd,
-                 runas=user,
+                 user=user,
                  password=password,
                  ignore_retcode=ignore_retcode)
     # Add remote
@@ -3414,7 +3414,7 @@ def remote_set(cwd,
     command = ['git', 'remote', 'add', remote, url]
     _git_run(command,
              cwd=cwd,
-             runas=user,
+             user=user,
              password=password,
              ignore_retcode=ignore_retcode)
     if push_url:
@@ -3430,7 +3430,7 @@ def remote_set(cwd,
         command = ['git', 'remote', 'set-url', '--push', remote, push_url]
         _git_run(command,
                  cwd=cwd,
-                 runas=user,
+                 user=user,
                  password=password,
                  ignore_retcode=ignore_retcode)
     return remote_get(cwd=cwd,
@@ -3492,7 +3492,7 @@ def remotes(cwd,
     ret = {}
     output = _git_run(command,
                       cwd=cwd,
-                      runas=user,
+                      user=user,
                       password=password,
                       ignore_retcode=ignore_retcode)['stdout']
     for remote_line in salt.utils.itertools.split(output, '\n'):
@@ -3570,7 +3570,7 @@ def reset(cwd,
     command.extend(_format_opts(opts))
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -3642,7 +3642,7 @@ def rev_parse(cwd,
         command.append(rev)
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -3696,7 +3696,7 @@ def revision(cwd,
     command.append(rev)
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -3761,7 +3761,7 @@ def rm_(cwd,
     command.extend(['--', filename])
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -3822,7 +3822,7 @@ def stash(cwd,
     command.extend(_format_opts(opts))
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -3874,7 +3874,7 @@ def status(cwd,
     command = ['git', 'status', '-z', '--porcelain']
     output = _git_run(command,
                       cwd=cwd,
-                      runas=user,
+                      user=user,
                       password=password,
                       ignore_retcode=ignore_retcode)['stdout']
     for line in output.split('\0'):
@@ -4012,7 +4012,7 @@ def submodule(cwd,
     cmd.extend(_format_opts(opts))
     return _git_run(cmd,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     identity=identity,
                     ignore_retcode=ignore_retcode,
@@ -4092,7 +4092,7 @@ def symbolic_ref(cwd,
         command.extend(value)
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 
@@ -4269,7 +4269,7 @@ def worktree_add(cwd,
     # Checkout message goes to stderr
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode,
                     redirect_stderr=True)['stdout']
@@ -4360,7 +4360,7 @@ def worktree_prune(cwd,
     command.extend(_format_opts(opts))
     return _git_run(command,
                     cwd=cwd,
-                    runas=user,
+                    user=user,
                     password=password,
                     ignore_retcode=ignore_retcode)['stdout']
 

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
-Implements the ability to run processes as another user in Windows for salt
+Run processes as a different user in Windows
+
+Based on a solution from http://stackoverflow.com/questions/29566330
 '''
 from __future__ import absolute_import
 


### PR DESCRIPTION
This adds support for Windows minions to run git states and remote execution functions as a user other than the default. It does so by adding a `password` parameter wherever the `user` param is supported.
