### PR TITLE
don't stacktrace on import pwd on Windows

### DIFF
--- a/salt/modules/snapper.py
+++ b/salt/modules/snapper.py
@@ -17,7 +17,10 @@ import logging
 import os
 import time
 import difflib
-from pwd import getpwuid
+try:
+    from pwd import getpwuid
+except ImportError:
+    pass
 
 from salt.exceptions import CommandExecutionError
 import salt.utils

--- a/salt/modules/snapper.py
+++ b/salt/modules/snapper.py
@@ -19,8 +19,9 @@ import time
 import difflib
 try:
     from pwd import getpwuid
+    HAS_PWD = True
 except ImportError:
-    pass
+    HAS_PWD = False
 
 from salt.exceptions import CommandExecutionError
 import salt.utils
@@ -85,6 +86,8 @@ def __virtual__():
         return False, error_msg.format(snapper_error)
     elif not bus:
         return False, error_msg.format(system_bus_error)
+    elif not HAS_PWD:
+        return False, error_msg.format('pwd module not available')
 
     return 'snapper'
 


### PR DESCRIPTION
### What does this PR do?

Stops a stacktrace where pwd was being imported in the snapper module.
Put that in a try/except block
### Tests written?

No
