### PR TITLE
Skip /etc/adjtime check if RTC is N/A (#4983)

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -61,6 +61,22 @@ def _get_zone_solaris():
     raise CommandExecutionError('Unable to get timezone from ' + tzfile)
 
 
+def _get_adjtime_timezone():
+    '''
+    Return the timezone in /etc/adjtime of the system clock
+    '''
+    adjtime_file = '/etc/adjtime'
+    if os.path.exists(adjtime_file):
+        cmd = ['tail', '-n', '1', adjtime_file]
+        return __salt__['cmd.run'](cmd, python_shell=False)
+    elif os.path.exists('/etc/rtc'):
+        raise CommandExecutionError(
+            'Unable to get hwclock timezone from ' + adjtime_file
+        )
+    else:
+        # There is no RTC.
+        return None
+
 def _get_zone_sysconfig():
     tzfile = '/etc/sysconfig/clock'
     with salt.utils.fopen(tzfile, 'r') as fp_:
@@ -316,8 +332,7 @@ def get_hwclock():
         os_family = __grains__['os_family']
         for family in ('RedHat', 'SUSE'):
             if family in os_family:
-                cmd = ['tail', '-n', '1', '/etc/adjtime']
-                return __salt__['cmd.run'](cmd, python_shell=False)
+                return _get_adjtime_timezone()
 
         if 'Debian' in __grains__['os_family']:
             # Original way to look up hwclock on Debian-based systems
@@ -335,8 +350,7 @@ def get_hwclock():
             except IOError as exc:
                 pass
             # Since Wheezy
-            cmd = ['tail', '-n', '1', '/etc/adjtime']
-            return __salt__['cmd.run'](cmd, python_shell=False)
+            return _get_adjtime_timezone()
 
         if 'Gentoo' in __grains__['os_family']:
             if not os.path.exists('/etc/adjtime'):
@@ -360,8 +374,7 @@ def get_hwclock():
                         'Problem reading offset file {0}: {1}'
                         .format(offset_file, exc.strerror)
                     )
-            cmd = ['tail', '-n', '1', '/etc/adjtime']
-            return __salt__['cmd.run'](cmd, python_shell=False)
+            return _get_adjtime_timezone()
 
         if 'Solaris' in __grains__['os_family']:
             offset_file = '/etc/rtc_config'


### PR DESCRIPTION
### What does this PR do?

Avoids unnecessary calls to `/etc/adjtime` since it may not be available.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/pull/4983 (already closed, but the solution was incomplete and basically created this issue)
### Previous Behavior

```
[ERROR   ] Command '['tail', '-n', '1', '/etc/adjtime']' failed with return code: 1
[ERROR   ] output: tail: cannot open '/etc/adjtime' for reading: No such file or directory
```
### New Behavior

Depends. If `/etc/rtc` is not available, we probably shouldn't be looking in `/etc/adjtime` and just return `None` (which is what this does). If /etc/adjtime is unavailable but `/etc/rtc` exists, we raise an error.
### Tests written?

No. Not sure how best to write a test for this. This functionality was never well tested with test cases.
