### PR TITLE
Fix retrieval of shadow password for OpenBSD (#36112)

### DIFF
--- a/salt/modules/bsd_shadow.py
+++ b/salt/modules/bsd_shadow.py
@@ -79,7 +79,9 @@ def info(name):
             with salt.utils.fopen('/etc/master.passwd', 'r') as fp_:
                 for line in fp_:
                     if line.startswith('{0}:'.format(name)):
-                        change, expire = line.split(':')[5:7]
+                        key = line.split(':')
+                        change, expire = key[5:7]
+                        ret['passwd'] = str(key[1])
                         break
         except IOError:
             change = expire = None


### PR DESCRIPTION
### What does this PR do?

Trying to fix OpenBSD `shadow` module
### What issues does this PR fix or reference?

See Issue #36112 
### Tests written?

No

Tested with :
- OpenBSD/amd64 5.9
- OpenBSD/amd64 6.0

As the patch is inside the OpenBSD _and_ NetBSD condition, it would be
necessary to test with NetBSD too (which I didn't).
