### PR TITLE
Fix test not starting, skip broken functions

### DIFF
--- a/tests/integration/modules/mac_system.py
+++ b/tests/integration/modules/mac_system.py
@@ -35,7 +35,7 @@ SET_SUBNET_NAME = __random_string()
 
 @skipIf(not salt.utils.is_darwin()
         or not salt.utils.which('systemsetup')
-        or salt.utils.get_uid(salt.utils.get_user() != 0), 'Test requirements not met')
+        or salt.utils.get_uid(salt.utils.get_user()) != 0, 'Test requirements not met')
 class MacSystemModuleTest(integration.ModuleCase):
     '''
     Validate the mac_system module
@@ -168,6 +168,7 @@ class MacSystemModuleTest(integration.ModuleCase):
             'Invalid value passed for path.',
             self.run_function('system.set_startup_disk', ['spongebob']))
 
+    @skipIf(True, 'Skip this test until mac fixes it.')
     def test_get_set_restart_delay(self):
         '''
         Test system.get_restart_delay
@@ -184,7 +185,7 @@ class MacSystemModuleTest(integration.ModuleCase):
         # Pass set bad value for seconds
         self.assertIn(
             'Invalid value passed for seconds.',
-            self.run_funcdtion('system.set_restart_delay', [70]))
+            self.run_function('system.set_restart_delay', [70]))
 
     def test_get_set_disable_keyboard_on_lock(self):
         '''
@@ -226,6 +227,7 @@ class MacSystemModuleTest(integration.ModuleCase):
             self.run_function('system.set_disable_keyboard_on_lock',
                               ['spongebob']))
 
+    @skipIf(True, 'Skip this test until mac fixes it.')
     def test_get_set_boot_arch(self):
         '''
         Test system.get_boot_arch


### PR DESCRIPTION
### What does this PR do?

The following functions, though documented in the man for system setup, do not work:
- `systemsetup -setwaitforstartupafterpowerfailure`
- `systemsetup -setkernelbootarchitecture`

Skip these tests.
### What issues does this PR fix or reference?

https://github.com/saltstack/qa/issues/236
### Previous Behavior

Test would fail
### New Behavior

Test now starts and the two tests are skipped.
### Tests written?

Yes
