### PR TITLE
Add some unit tests for the jid_queue functionality in minion.py

### DIFF
--- a/tests/unit/minion_test.py
+++ b/tests/unit/minion_test.py
@@ -5,12 +5,13 @@
 
 # Import python libs
 from __future__ import absolute_import
+import copy
 import os
 
 # Import Salt Testing libs
 from salttesting import TestCase, skipIf
 from salttesting.helpers import ensure_in_syspath
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
 
 # Import salt libs
 from salt import minion
@@ -51,6 +52,82 @@ class MinionTestCase(TestCase):
             except SaltSystemExit:
                 result = False
         self.assertTrue(result)
+
+    # Tests for _handle_decoded_payload in the salt.minion.Minion() class: 3
+
+    def test_handle_decoded_payload_jid_match_in_jid_queue(self):
+        '''
+        Tests that the _handle_decoded_payload function returns when a jid is given that is already present
+        in the jid_queue.
+
+        Note: This test doesn't contain all of the patch decorators above the function like the other tests
+        for _handle_decoded_payload below. This is essential to this test as the call to the function must
+        return None BEFORE any of the processes are spun up because we should be avoiding firing duplicate
+        jobs.
+        '''
+        mock_opts = {'cachedir': '',
+                     'extension_modules': ''}
+        mock_data = {'fun': 'foo.bar',
+                     'jid': 123}
+        mock_jid_queue = [123]
+        minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue))
+        ret = minion._handle_decoded_payload(mock_data)
+        self.assertEqual(minion.jid_queue, mock_jid_queue)
+        self.assertIsNone(ret)
+
+    @patch('salt.minion.Minion.ctx', MagicMock(return_value={}))
+    @patch('salt.utils.process.SignalHandlingMultiprocessingProcess.start', MagicMock(return_value=True))
+    @patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True))
+    def test_handle_decoded_payload_jid_queue_addition(self):
+        '''
+        Tests that the _handle_decoded_payload function adds a jid to the minion's jid_queue when the new
+        jid isn't already present in the jid_queue.
+        '''
+        mock_jid = 11111
+        mock_opts = {'cachedir': '',
+                     'extension_modules': '',
+                     'minion_jid_queue_hwm': 100}
+        mock_data = {'fun': 'foo.bar',
+                     'jid': mock_jid}
+        mock_jid_queue = [123, 456]
+        minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue))
+
+        # Assert that the minion's jid_queue attribute matches the mock_jid_queue as a baseline
+        # This can help debug any test failures if the _handle_decoded_payload call fails.
+        self.assertEqual(minion.jid_queue, mock_jid_queue)
+
+        # Call the _handle_decoded_payload function and update the mock_jid_queue to include the new
+        # mock_jid. The mock_jid should have been added to the jid_queue since the mock_jid wasn't
+        # previously included. The minion's jid_queue attribute and the mock_jid_queue should be equal.
+        minion._handle_decoded_payload(mock_data)
+        mock_jid_queue.append(mock_jid)
+        self.assertEqual(minion.jid_queue, mock_jid_queue)
+
+    @patch('salt.minion.Minion.ctx', MagicMock(return_value={}))
+    @patch('salt.utils.process.SignalHandlingMultiprocessingProcess.start', MagicMock(return_value=True))
+    @patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True))
+    def test_handle_decoded_payload_jid_queue_reduced_minion_jid_queue_hwm(self):
+        '''
+        Tests that the _handle_decoded_payload function removes a jid from the minion's jid_queue when the
+        minion's jid_queue high water mark (minion_jid_queue_hwm) is hit.
+        '''
+        mock_opts = {'cachedir': '',
+                     'extension_modules': '',
+                     'minion_jid_queue_hwm': 2}
+        mock_data = {'fun': 'foo.bar',
+                     'jid': 789}
+        mock_jid_queue = [123, 456]
+        minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue))
+
+        # Assert that the minion's jid_queue attribute matches the mock_jid_queue as a baseline
+        # This can help debug any test failures if the _handle_decoded_payload call fails.
+        self.assertEqual(minion.jid_queue, mock_jid_queue)
+
+        # Call the _handle_decoded_payload function and check that the queue is smaller by one item
+        # and contains the new jid
+        minion._handle_decoded_payload(mock_data)
+        self.assertEqual(len(minion.jid_queue), 2)
+        self.assertEqual(minion.jid_queue, [456, 789])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

A new `jid_queue` option was added to `minion.py` to fix issue #28785, as well as a new minion config option, `minion_jid_queue_hwm`. This PR adds unit tests for the section of code that was affected by #35172 to make sure that we're not re-running duplicate jids when the `_handle_decoded_payload` function is called in the Minion class.
### What issues does this PR fix or reference?

Refs #35172 and #28785
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
