### PR TITLE
pygit2: Prevent traceback on initial gitfs setup

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1213,7 +1213,7 @@ class Pygit2(GitProvider):
                 self.repo.config.set_multivar(
                     'http.sslVerify',
                     '',
-                    self.ssl_verify
+                    str(self.ssl_verify).lower()
                 )
             except os.error:
                 # This exception occurs when two processes are trying to write


### PR DESCRIPTION
Newer pygit2 releases require that this value be a string, they will not
accept a bool here.
