### PR TITLE
Allow highstate outputter to show all results

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -133,9 +133,6 @@ def output(data):
     ret = [
         _format_host(host, hostdata)[0]
         for host, hostdata in six.iteritems(data)
-        # Highstate return data must be a dict, if this is not the case
-        # then this value is likely a retcode.
-        if isinstance(hostdata, dict)
     ]
     if ret:
         return "\n".join(ret)


### PR DESCRIPTION
This regressed here: 82a70e015fbab5decc4ba1176bd066fac0ffa6c2

The above incorrect assumed that all data flowing into the highstate outputter is expected to be a dictionary. However, looking at _format_host() shows that it does expect to receive multiple types and does handle them accordingly.

I believe that the issue reported in #33915 may be fixed by #35559 instead. This should allow the highstate outputter to display all results instead of stopping after the first one. I would like @terminalmage and @mattglv and possibly @Ch3ll to please confirm this before we get this in.

Resolves #35423
