### PR TITLE
Ignore states that do not have a numeric jid, i.e. 'req'

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -228,7 +228,11 @@ def _prior_running_states(jid):
     ret = []
     active = __salt__['saltutil.is_running']('state.*')
     for data in active:
-        if int(data['jid']) < int(jid):
+        try:
+            data_jid = int(data['jid'])
+        except ValueError:
+            continue
+        if data_jid < int(jid):
             ret.append(data)
     return ret
 


### PR DESCRIPTION
### What does this PR do?

A state listed by `saltutil.is_running` can have `req` as job id.
### What issues does this PR fix or reference?

in _prior_running_states, the jid is converted into an int for comparison. This obviously fails.
### Previous Behavior

Exception
### New Behavior

Jobs without jid are not considered active.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
