### PR TITLE
Remove unnecessary unpack

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1941,7 +1941,6 @@ class Minion(MinionBase):
             log.debug('Forwarding salt error event tag={tag}'.format(tag=tag))
             self._fire_master(data, tag)
         elif package.startswith('salt/auth/creds'):
-            tag, data = salt.utils.event.MinionEvent.unpack(package)
             key = tuple(data['key'])
             log.debug('Updating auth data for {0}: {1} -> {2}'.format(
                     key, salt.crypt.AsyncAuth.creds_map.get(key), data['creds']))


### PR DESCRIPTION
This was causing msgpack stacktraces everywhere because it would effectively try to unpack an empty msg.

Closes #36094

@rallytime This needs to go fwd to the Carbon branch, please.
