### PR TITLE
Allow additional kwargs in states.dockerng.image_present (fixes #31513)

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -474,7 +474,8 @@ def image_present(name,
                   load=None,
                   force=False,
                   insecure_registry=False,
-                  client_timeout=CLIENT_TIMEOUT):
+                  client_timeout=CLIENT_TIMEOUT,
+                  **kwargs):
     '''
     Ensure that an image is present. The image can either be pulled from a
     Docker registry, built from a Dockerfile, or loaded from a saved image.


### PR DESCRIPTION
### What does this PR do?

Allow additional kwargs in states.dockerng.image_present
### What issues does this PR fix or reference?

Fixes #31513
### Tests written?

No
