### PR TITLE
Use string.ascii_lowercase

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 import contextlib
 import logging
 import os
+import string
 import shutil
 import ftplib
 from tornado.httputil import parse_response_start_line, HTTPInputError
@@ -465,8 +466,8 @@ class Client(object):
         url_path = os.path.join(
                 url_data.netloc, url_data.path).rstrip(os.sep)
 
-        if url_scheme and url_scheme.lower() in 'abcdefghijklmnopqrstuvwxyz':
-            url_path = ':'.join([url_scheme, url_path])
+        if url_scheme and url_scheme.lower() in string.ascii_lowercase:
+            url_path = ':'.join((url_scheme, url_path))
             url_scheme = 'file'
 
         if url_scheme in ('file', ''):


### PR DESCRIPTION
This is less error-prone than defining a string with all lowercase
letters.

This also uses a tuple for the join as the tuple is a lighter-weight
type and performs the join almost twice as fast as when this is done
with a list, as can be seen below:

```
>>> import timeit
>>> list_timer = timeit.Timer('":".join(["foo", "bar"])')
>>> tuple_timer = timeit.Timer('":".join(("foo", "bar"))')
>>> list_timer.repeat()
[0.18616199493408203, 0.14670491218566895, 0.14609003067016602]
>>> tuple_timer.repeat()
[0.10539507865905762, 0.08876705169677734, 0.08883404731750488]
>>>
```
