### PR TITLE
Skip extra traversals of minion cache for auth

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1939,6 +1939,14 @@ class ClearFuncs(object):
             )
             return ''
 
+        # Retrieve the minions list
+        delimiter = clear_load.get('kwargs', {}).get('delimiter', DEFAULT_TARGET_DELIM)
+        minions = self.ckminions.check_minions(
+            clear_load['tgt'],
+            clear_load.get('tgt_type', 'glob'),
+            delimiter
+        )
+
         # Check for external auth calls
         if extra.get('token', False):
             # A token was passed, check it
@@ -1998,7 +2006,8 @@ class ClearFuncs(object):
                 clear_load['fun'],
                 clear_load['arg'],
                 clear_load['tgt'],
-                clear_load.get('tgt_type', 'glob'))
+                clear_load.get('tgt_type', 'glob'),
+                minions=minions)
             if not good:
                 # Accept find_job so the CLI will function cleanly
                 if clear_load['fun'] != 'saltutil.find_job':
@@ -2093,7 +2102,8 @@ class ClearFuncs(object):
                 clear_load['fun'],
                 clear_load['arg'],
                 clear_load['tgt'],
-                clear_load.get('tgt_type', 'glob')
+                clear_load.get('tgt_type', 'glob'),
+                minions=minions
                 )
             if not good:
                 # Accept find_job so the CLI will function cleanly
@@ -2122,7 +2132,8 @@ class ClearFuncs(object):
                                 clear_load['fun'],
                                 clear_load['arg'],
                                 clear_load['tgt'],
-                                clear_load.get('tgt_type', 'glob'))
+                                clear_load.get('tgt_type', 'glob'),
+                                minions=minions)
                     if not good:
                         # Accept find_job so the CLI will function cleanly
                         if clear_load['fun'] != 'saltutil.find_job':
@@ -2164,7 +2175,8 @@ class ClearFuncs(object):
                         clear_load['fun'],
                         clear_load['arg'],
                         clear_load['tgt'],
-                        clear_load.get('tgt_type', 'glob'))
+                        clear_load.get('tgt_type', 'glob'),
+                        minions=minions)
                     if not good:
                         # Accept find_job so the CLI will function cleanly
                         if clear_load['fun'] != 'saltutil.find_job':
@@ -2184,14 +2196,7 @@ class ClearFuncs(object):
                     'Authentication failure of type "other" occurred.'
                 )
                 return ''
-        # FIXME Needs additional refactoring
-        # Retrieve the minions list
-        delimiter = clear_load.get('kwargs', {}).get('delimiter', DEFAULT_TARGET_DELIM)
-        minions = self.ckminions.check_minions(
-            clear_load['tgt'],
-            clear_load.get('tgt_type', 'glob'),
-            delimiter
-        )
+
         # If we order masters (via a syndic), don't short circuit if no minions
         # are found
         if not self.opts.get('order_masters'):


### PR DESCRIPTION
With a large amount of minions and large ACL sets, check_minions starts
to become rather expensive.  The master's publish was already obtaining
this list ( albeit later in execution ), but by moving it up and passing
it to CkMinion's auth_check, it allows CkMinion's validate_tgt to skip a
cache traversal per ACL check.  Previously, the CkMinion validate_tgt
had to perform a check_minions for both the ACL and the user specified
target.

This does incur a penalty to authentication failures now, since the check
is done before failures are determined.

Related to #33948
### Tests written?

No
