### PR TITLE
modules.parallels.delete: allow multiple IDs for same name

### DIFF
--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -291,33 +291,6 @@ def exists(name, runas=None):
     return False
 
 
-def state(name, runas=None):
-    '''
-    Return the state of the VM
-
-    .. versionadded:: Carbon
-
-    :param str name:
-        Name/ID of VM
-
-    :param str runas:
-        The user that the prlctl command will be run as
-
-    Example:
-
-    .. code-block:: bash
-
-        salt '*' parallels.state macvm runas=macdev
-    '''
-    vm_info = list_vms(name, info=True, runas=runas).splitlines()
-    for info_line in vm_info:
-        if 'State: ' in info_line:
-            return info_line.split('State: ')[1]
-
-    log.error('Cannot find state of VM named {0}'.format(name))
-    return ''
-
-
 def start(name, runas=None):
     '''
     Start a VM

--- a/salt/modules/parallels.py
+++ b/salt/modules/parallels.py
@@ -591,12 +591,18 @@ def snapshot_name_to_id(name, snap_name, strict=False, runas=None):
         return named_ids
 
 
-def _validate_snap_name(name, snap_name, runas=None):
+def _validate_snap_name(name, snap_name, strict=True, runas=None):
     '''
     Validate snapshot name and convert to snapshot ID
 
+    :param str name:
+        Name/ID of VM whose snapshot name is being validated
+
     :param str snap_name:
         Name/ID of snapshot
+
+    :param bool strict:
+        Raise an exception if multiple snapshot IDs are found
 
     :param str runas:
         The user that the prlctl command will be run as
@@ -607,7 +613,7 @@ def _validate_snap_name(name, snap_name, runas=None):
     if re.match(GUID_REGEX, snap_name):
         return snap_name.strip('{}')
     else:
-        return snapshot_name_to_id(name, snap_name, strict=True, runas=runas)
+        return snapshot_name_to_id(name, snap_name, strict=strict, runas=runas)
 
 
 def list_snapshots(name, snap_name=None, tree=False, names=False, runas=None):
@@ -711,7 +717,7 @@ def snapshot(name, snap_name=None, desc=None, runas=None):
     return prlctl('snapshot', args, runas=runas)
 
 
-def delete_snapshot(name, snap_name, runas=None):
+def delete_snapshot(name, snap_name, runas=None, all=False):
     '''
     Delete a snapshot
 
@@ -729,21 +735,43 @@ def delete_snapshot(name, snap_name, runas=None):
     :param str runas:
         The user that the prlctl command will be run as
 
+    :param bool all:
+        Delete all snapshots having the name given
+
+        .. versionadded:: Carbon
+
     Example:
 
     .. code-block:: bash
 
         salt '*' parallels.delete_snapshot macvm 'unneeded snapshot' runas=macdev
+        salt '*' parallels.delete_snapshot macvm 'Snapshot for linked clone' all=True runas=macdev
     '''
+    # strict means raise an error if multiple snapshot IDs found for the name given
+    strict = not all
+
     # Validate VM and snapshot names
     name = _sdecode(name)
-    snap_name = _validate_snap_name(name, snap_name, runas=runas)
+    snap_ids = _validate_snap_name(name, snap_name, strict=strict, runas=runas)
+    if isinstance(snap_ids, six.string_types):
+        snap_ids = [snap_ids]
 
-    # Construct argument list
-    args = [name, '--id', snap_name]
+    # Delete snapshot(s)
+    ret = {}
+    for snap_id in snap_ids:
+        snap_id = snap_id.strip('{}')
+        # Construct argument list
+        args = [name, '--id', snap_id]
 
-    # Execute command and return output
-    return prlctl('snapshot-delete', args, runas=runas)
+        # Execute command
+        ret[snap_id] = prlctl('snapshot-delete', args, runas=runas)
+
+    # Return results
+    ret_keys = list(ret.keys())
+    if len(ret_keys) == 1:
+        return ret[ret_keys[0]]
+    else:
+        return ret
 
 
 def revert_snapshot(name, snap_name, runas=None):

--- a/tests/unit/modules/parallels_test.py
+++ b/tests/unit/modules/parallels_test.py
@@ -247,26 +247,6 @@ class ParallelsTestCase(TestCase):
         with patch.object(parallels, 'list_vms', mock_list):
             self.assertFalse(parallels.exists('winvm', runas=runas))
 
-    def test_state(self):
-        '''
-        Test parallels.state
-        '''
-        name = 'macvm'
-        runas = 'macdev'
-
-        # Validate state
-        mock_list = MagicMock(return_value='Name: {0}\nState: cantering'.format(name))
-        with patch.object(parallels, 'list_vms', mock_list):
-            self.assertEqual(parallels.state(name, runas=runas), 'cantering')
-
-        # Validate cannot find state
-        mock_list = MagicMock(return_value='Name: {0}\nFavorite Color: unknown'.format(name))
-        mock_log_error = MagicMock()
-        with patch.object(parallels, 'list_vms', mock_list):
-            with patch.object(parallels.log, 'error', mock_log_error):
-                self.assertEqual(parallels.state(name, runas=runas), '')
-                mock_log_error.assert_called_once_with('Cannot find state of VM named {0}'.format(name))
-
     def test_start(self):
         '''
         Test parallels.start

--- a/tests/unit/modules/parallels_test.py
+++ b/tests/unit/modules/parallels_test.py
@@ -477,6 +477,12 @@ class ParallelsTestCase(TestCase):
             self.assertEqual(parallels._validate_snap_name(name, '3.14159'), snap_id)
             mock_snap_numb.assert_called_once_with(name, u'3.14159', strict=True, runas=None)
 
+        # Validate not strict (think neutrino oscillation)
+        mock_snap_non_strict = MagicMock(return_value=snap_id)
+        with patch.object(parallels, 'snapshot_name_to_id', mock_snap_non_strict):
+            self.assertEqual(parallels._validate_snap_name(name, u'e_ν', strict=False), snap_id)
+            mock_snap_non_strict.assert_called_once_with(name, u'e_ν', strict=False, runas=None)
+
     def test_list_snapshots(self):
         '''
         Test parallels.list_snapshots
@@ -561,18 +567,44 @@ class ParallelsTestCase(TestCase):
         '''
         Test parallels.delete_snapshot
         '''
+        delete_message = ('Delete the snapshot...\n'
+                          'The snapshot has been successfully deleted.')
+
+        # Validate single ID
         name = 'macvm'
         snap_name = 'kaon'
         snap_id = 'c2eab062-a635-4ccd-b9ae-998370f898b5'
 
         mock_snap_name = MagicMock(return_value=snap_id)
         with patch.object(parallels, '_validate_snap_name', mock_snap_name):
-            mock_delete = MagicMock(return_value='')
+            mock_delete = MagicMock(return_value=delete_message)
             with patch.object(parallels, 'prlctl', mock_delete):
-                parallels.delete_snapshot(name, snap_name)
+                ret = parallels.delete_snapshot(name, snap_name)
+                self.assertEqual(ret, delete_message)
                 mock_delete.assert_called_once_with('snapshot-delete',
                                                     [name, '--id', snap_id],
                                                     runas=None)
+
+        # Validate multiple IDs
+        name = 'macvm'
+        snap_name = 'higgs doublet'
+        snap_ids = ['c2eab062-a635-4ccd-b9ae-998370f898b5',
+                    '8aca07c5-a0e1-4dcb-ba75-cb154d46d516']
+
+        mock_snap_ids = MagicMock(return_value=snap_ids)
+        with patch.object(parallels, '_validate_snap_name', mock_snap_ids):
+            mock_delete = MagicMock(return_value=delete_message)
+            with patch.object(parallels, 'prlctl', mock_delete):
+                ret = parallels.delete_snapshot(name, snap_name, all=True)
+                mock_ret = {snap_ids[0]: delete_message,
+                            snap_ids[1]: delete_message}
+                self.assertDictEqual(ret, mock_ret)
+                mock_delete.assert_any_call('snapshot-delete',
+                                            [name, '--id', snap_ids[0]],
+                                            runas=None)
+                mock_delete.assert_any_call('snapshot-delete',
+                                            [name, '--id', snap_ids[1]],
+                                            runas=None)
 
     def test_revert_snapshot(self):
         '''


### PR DESCRIPTION
### What does this PR do?

When parallels creates linked clones, it generates a new snapshot on the
cloned VM with the name 'Snapshot for linked clone', which when used
with jenkins results in hundreds of unneeded snapshots per week.

Also remove redundant `state` function as parallels provides `status` natively.
### What issues does this PR fix or reference?
#36042
### Tests written?

Yes
