### PR TITLE
Remove invalid JSON for Mac OS X

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -181,10 +181,19 @@ def _extract_json(npm_output):
     log.error(lines)
 
     # Strip all lines until JSON output starts
-    while lines and not lines[0].startswith('{') and not lines[0].startswith('['):
-        lines = lines[1:]
-    while lines and not lines[-1].startswith('}') and not lines[-1].startswith(']'):
-        lines = lines[:-1]
+    # Mac OSX (or maybe it's NPM 3.10) includes the following line in the return
+    # when a new module is installed which is invalid JSON:
+    #     [fsevents] Success: "..."
+    if salt.utils.is_darwin():
+        while lines and not lines[0].startswith('{'):
+            lines = lines[1:]
+        while lines and not lines[-1].startswith('}'):
+            lines = lines[:-1]
+    else:
+        while lines and not lines[0].startswith('{') and not lines[0].startswith('['):
+            lines = lines[1:]
+        while lines and not lines[-1].startswith('}') and not lines[-1].startswith(']'):
+            lines = lines[:-1]
     try:
         return json.loads(''.join(lines))
     except ValueError:

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -181,19 +181,15 @@ def _extract_json(npm_output):
     log.error(lines)
 
     # Strip all lines until JSON output starts
-    # Mac OSX (or maybe it's NPM 3.10) includes the following line in the return
+    while lines and not lines[0].startswith('{') and not lines[0].startswith('['):
+        lines = lines[1:]
+    while lines and not lines[-1].startswith('}') and not lines[-1].startswith(']'):
+        lines = lines[:-1]
+    # Mac OSX with fsevents includes the following line in the return
     # when a new module is installed which is invalid JSON:
     #     [fsevents] Success: "..."
-    if salt.utils.is_darwin():
-        while lines and not lines[0].startswith('{'):
-            lines = lines[1:]
-        while lines and not lines[-1].startswith('}'):
-            lines = lines[:-1]
-    else:
-        while lines and not lines[0].startswith('{') and not lines[0].startswith('['):
-            lines = lines[1:]
-        while lines and not lines[-1].startswith('}') and not lines[-1].startswith(']'):
-            lines = lines[:-1]
+    while lines and lines[0].startswith('[fsevents]'):
+        lines = lines[1:]
     try:
         return json.loads(''.join(lines))
     except ValueError:


### PR DESCRIPTION
### What does this PR do?

Fixes a problem with the npm module on OS X. An extra line is being added to the return that is not valid JSON but is not being removed by the `_extract_json` function because it starts with a `[`.
### What issues does this PR fix or reference?

https://github.com/saltstack/qa/issues/236
### Previous Behavior

The npm.install function would return the raw return data instead of a dictionary, which would break the npm.installed state.
### New Behavior

Remove's the offending line and returns a proper dictionary.
### Tests written?

This fixes the npm.installed state test on OS X