### PR TITLE
Fix breakage from updates to __utils__

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -473,7 +473,7 @@ def show_instance(name, resource_group=None, call=None):  # pylint: disable=unus
     data['network_profile']['network_interfaces'] = ifaces
     data['resource_group'] = resource_group
 
-    salt.utils.cloud.cache_node(
+    __utils__['cloud.cache_node'](
         salt.utils.simple_types_filter(data),
         __active_provider_name__,
         __opts__
@@ -1118,7 +1118,7 @@ def create(vm_):
     vm_['password'] = config.get_cloud_config_value(
         'ssh_password', vm_, __opts__
     )
-    ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 
     data = show_instance(vm_['name'], call='action')
     log.info('Created Cloud VM \'{0[name]}\''.format(vm_))
@@ -1179,7 +1179,7 @@ def destroy(name, conn=None, call=None, kwargs=None):  # pylint: disable=unused-
     result.wait()
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
+        __utils__['cloud.delete_minion_cachedir'](name, __active_provider_name__.split(':')[0], __opts__)
 
     cleanup_disks = config.get_cloud_config_value(
         'cleanup_disks',

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2607,13 +2607,16 @@ def delete_minion_cachedir(minion_id, provider, opts, base=None):
     all cachedirs to find the minion's cache file.
     Needs `update_cachedir` set to True.
     '''
-    if opts.get('update_cachedir', False) is False:
+    if isinstance(opts, dict):
+        __opts__.update(opts)
+
+    if __opts__.get('update_cachedir', False) is False:
         return
 
     if base is None:
         base = __opts__['cachedir']
 
-    driver = next(six.iterkeys(opts['providers'][provider]))
+    driver = next(six.iterkeys(__opts__['providers'][provider]))
     fname = '{0}.p'.format(minion_id)
     for cachedir in 'requested', 'active':
         path = os.path.join(base, cachedir, driver, provider, fname)
@@ -2839,7 +2842,10 @@ def cache_node(node, provider, opts):
 
     .. versionadded:: 2014.7.0
     '''
-    if 'update_cachedir' not in opts or not opts['update_cachedir']:
+    if isinstance(opts, dict):
+        __opts__.update(opts)
+
+    if 'update_cachedir' not in __opts__ or not __opts__['update_cachedir']:
         return
 
     if not os.path.exists(os.path.join(__opts__['cachedir'], 'active')):


### PR DESCRIPTION
### What does this PR do?

The updates to `__utils__` in Salt Cloud cased `__opts__` to show up in unexpected places, which caused tracebacks with `__opts__` not being defined.
### Tests written?

No.
