### PR TITLE
Fix test_launchctl test in mac_service

### DIFF
--- a/tests/integration/modules/mac_service.py
+++ b/tests/integration/modules/mac_service.py
@@ -15,6 +15,7 @@ ensure_in_syspath('../../')
 import integration
 import salt.utils
 
+
 @skipIf(not salt.utils.is_darwin(), 'Test only available on Mac OS X')
 @skipIf(not salt.utils.which('launchctl'), 'Test requires launchctl binary')
 @skipIf(not salt.utils.which('plutil'), 'Test requires plutil binary')

--- a/tests/integration/modules/mac_service.py
+++ b/tests/integration/modules/mac_service.py
@@ -63,10 +63,11 @@ class MacServiceModuleTest(integration.ModuleCase):
         '''
         # Expected Functionality
         self.assertTrue(
-            self.run_function('service.launchctl', ['error', 'bootstrap', 64]))
+            self.run_function('service.launchctl',
+                              ['error', 'bootstrap', '64']))
         self.assertEqual(
             self.run_function('service.launchctl',
-                              ['error', 'bootstrap', 64],
+                              ['error', 'bootstrap', '64'],
                               return_stdout=True),
             '64: unknown error code')
 


### PR DESCRIPTION
### What does this PR do?

Quote the integers being passed to the service.launchctl command
Use skipIf decorator instead of skipTest in the setUp function so checks aren't run on every test.
### What issues does this PR fix or reference?

https://github.com/saltstack/qa/issues/236
### Previous Behavior

test_launchctl test would fail
### New Behavior

test_launchctl now completes successfully
### Tests written?

NA