### PR TITLE
implement lookup of salt master via dns SRV record

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -58,6 +58,22 @@
 # interval can be set to ping the top master with this interval, in seconds.
 #master_failback_interval: 0
 
+# Query dns server for a SRV entry and use the response to connect
+# to the discovered masters (needs: dig, host, or nslookup binary installed
+# to work).  You can set name in 'master_dns_discovery_name' or it'll default 
+# to 'saltmaster' if unset.
+#master_dns_discovery: False
+
+# Service name to look for with dns srv.  Defaults to 'saltmaster', can be
+# useful if you have a single domain, but may have multiple data centers
+# and separate masters. (optional)
+#master_dns_discovery_name: str
+
+# Domain that is used for dns discovery of salt master via SRV records. Only used
+# if 'master_dns_discovery' is true.  Not required, but if you have dns command
+# output problems, try setting this.
+#master_dns_discovery_domain: str
+
 # Set whether the minion should connect to the master via IPv6:
 #ipv6: False
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -121,9 +121,15 @@ VALID_OPTS = {
     # a master fingerprint with `salt-key -F master`
     'master_finger': str,
 
-    # Query dns server for a SRV entry for 'saltmaster' and use the response to connect
-    # to the discovered masters (needs: dig binary installed to work).
+    # Query dns server for a SRV entry and use the response to connect
+    # to the discovered masters (needs: dig, host, or nslookup binary installed
+    # to work).  You can set name in 'master_dns_discovery_name' or it'll default 
+    # to 'saltmaster' if unset.
     'master_dns_discovery': bool,
+
+    # Service name to look for with dns srv.  Defaults to 'saltmaster', useful if you
+    # have a single domain, but may have multiple data centers and separate masters.
+    'master_dns_discovery_name': str,
 
     # Domain that is used for dns discovery of salt master via SRV records. Only used
     # if 'master_dns_discovery' is true.
@@ -929,6 +935,9 @@ DEFAULT_MINION_OPTS = {
     'master_uri_format': 'default',
     'master_port': 4506,
     'master_finger': '',
+    'master_dns_discovery': False,
+    'master_dns_discovery_name': 'saltmaster',
+    'master_dns_discovery_domain': None,
     'master_shuffle': False,
     'master_alive_interval': 0,
     'master_failback': False,

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -121,6 +121,14 @@ VALID_OPTS = {
     # a master fingerprint with `salt-key -F master`
     'master_finger': str,
 
+    # Query dns server for a SRV entry for 'saltmaster' and use the response to connect
+    # to the discovered masters (needs: dig binary installed to work).
+    'master_dns_discovery': bool,
+
+    # Domain that is used for dns discovery of salt master via SRV records. Only used
+    # if 'master_dns_discovery' is true.
+    'master_dns_discovery_domain': str,
+
     # Selects a random master when starting a minion up in multi-master mode
     'master_shuffle': bool,
 


### PR DESCRIPTION
This PR implements the discovery of  one or multiple salt master via dns SRV records.

This has been asked for here #20275.

I was trying to implement this with the absolute minimum set of changes to not mess anything up. If I was missing obvious things that would cause problems, please let me know so I can implement them.
