### PR TITLE
fix cron.absent by identifier on test mode

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -389,7 +389,7 @@ def absent(name,
            'comment': ''}
 
     if __opts__['test']:
-        status = _check_cron(user, name)
+        status = _check_cron(user, name, identifier=identifier)
         ret['result'] = None
         if status == 'absent':
             ret['result'] = True

--- a/tests/unit/states/cron_test.py
+++ b/tests/unit/states/cron_test.py
@@ -187,6 +187,25 @@ class CronTestCase(TestCase):
     @patch('salt.modules.cron._write_cron_lines',
            new=MagicMock(side_effect=write_crontab))
     def test_remove(self):
+        cron.__opts__['test'] = True
+        set_crontab(
+            '# Lines below here are managed by Salt, do not edit\n'
+            '# SALT_CRON_IDENTIFIER:1\n'
+            '* 1 * * * foo')
+        result = cron.absent(name='bar', identifier='1')
+        self.assertEqual(
+            result,
+            {'changes': {},
+             'comment': 'Cron bar is set to be removed',
+             'name': 'bar',
+             'result': None}
+        )
+        self.assertEqual(
+            get_crontab(),
+            '# Lines below here are managed by Salt, do not edit\n'
+            '# SALT_CRON_IDENTIFIER:1\n'
+            '* 1 * * * foo')
+        cron.__opts__['test'] = False
         set_crontab(
             '# Lines below here are managed by Salt, do not edit\n'
             '# SALT_CRON_IDENTIFIER:1\n'


### PR DESCRIPTION
### What does this PR do?

It fixes the test mode for removal of a cronjob via its identifier
### What issues does this PR fix or reference?c
#19213
### Previous Behavior

Test mode show no change for a cronjob that would be removed based on its identifier
### New Behavior

Test mode show the change for a cronjob that would be removed based on its identifier
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
