### PR TITLE
Disable signal handling while handling signal

### DIFF
--- a/salt/log/handlers/__init__.py
+++ b/salt/log/handlers/__init__.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import
 
 # Import python libs
 import sys
-import atexit
 import logging
 import threading
 import logging.handlers


### PR DESCRIPTION
### What does this PR do?
1. Do not handle TERM/INT signals while already handling the signals.
2. Surround os.kill with try/except to prevent the children killing termination if a child already died.
### What issues does this PR fix or reference?
#35480
### Tests written?

No