### PR TITLE
pkg.install: enable OpenBSD branch and flavor specifications

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -580,6 +580,8 @@ def _verify_install(desired, new_pkgs, ignore_epoch=False):
 
         if __grains__['os'] == 'FreeBSD' and origin:
             cver = [k for k, v in six.iteritems(new_pkgs) if v['origin'] == pkgname]
+        elif __grains__['os'] == 'OpenBSD':
+            cver = new_pkgs.get(pkgname.split('%')[0])
         elif __grains__['os_family'] == 'Debian':
             cver = new_pkgs.get(pkgname.split('=')[0])
         else:

--- a/tests/unit/modules/openbsdpkg_test.py
+++ b/tests/unit/modules/openbsdpkg_test.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Eric Radman <ericshane@eradman.com>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    call,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt Libs
+from salt.modules import openbsdpkg
+
+# Globals
+openbsdpkg.__grains__ = dict()
+openbsdpkg.__salt__ = dict()
+openbsdpkg.__context__ = dict()
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class OpenbsdpkgTestCase(TestCase):
+    '''
+    Test cases for salt.modules.openbsdpkg
+    '''
+
+    def test_list_pkgs(self):
+        '''
+        Test for listing installed packages.
+        '''
+        def _add_data(data, key, value):
+            data[key] = value
+
+        pkg_info_out = [
+            'png-1.6.23',
+            'vim-7.4.1467p1-gtk2',  # vim--gtk2
+            'ruby-2.3.1p1'  # ruby%2.3
+        ]
+        run_stdout_mock = MagicMock(return_value='\n'.join(pkg_info_out))
+        patches = {
+            'cmd.run_stdout': run_stdout_mock,
+            'pkg_resource.add_pkg': _add_data,
+            'pkg_resource.sort_pkglist': MagicMock(),
+            'pkg_resource.stringify': MagicMock(),
+        }
+        with patch.dict(openbsdpkg.__salt__, patches):
+            pkgs = openbsdpkg.list_pkgs()
+            self.assertDictEqual(pkgs, {
+                'png': '1.6.23',
+                'vim--gtk2': '7.4.1467p1',
+                'ruby': '2.3.1p1'})
+        run_stdout_mock.assert_called_once_with('pkg_info -q -a',
+                                                output_loglevel='trace')
+
+    def test_install_pkgs(self):
+        '''
+        Test package install behavior for the following conditions:
+        - only base package name is given ('png')
+        - a flavor is specified ('vim--gtk2')
+        - a branch is specified ('ruby%2.3')
+        '''
+        class ListPackages(object):
+            def __init__(self):
+                self._iteration = 0
+
+            def __call__(self):
+                pkg_lists = [
+                     {'vim': '7.4.1467p1-gtk2'},
+                     {'png': '1.6.23', 'vim': '7.4.1467p1-gtk2', 'ruby': '2.3.1p1'}
+                ]
+                pkgs = pkg_lists[self._iteration]
+                self._iteration += 1
+                return pkgs
+
+        parsed_targets = (
+            {'vim--gtk2': None, 'png': None, 'ruby%2.3': None},
+            "repository"
+        )
+        cmd_out = {
+            'retcode': 0,
+            'stdout': 'quirks-2.241 signed on 2016-07-26T16:56:10Z',
+            'stderr': ''
+        }
+        run_all_mock = MagicMock(return_value=cmd_out)
+        patches = {
+            'cmd.run_all': run_all_mock,
+            'pkg_resource.parse_targets': MagicMock(return_value=parsed_targets),
+            'pkg_resource.stringify': MagicMock(),
+            'pkg_resource.sort_pkglist': MagicMock(),
+        }
+
+        with patch.dict(openbsdpkg.__salt__, patches):
+            with patch('salt.modules.openbsdpkg.list_pkgs', ListPackages()):
+                added = openbsdpkg.install()
+                expected = {
+                    'png': {'new': '1.6.23', 'old': ''},
+                    'ruby': {'new': '2.3.1p1', 'old': ''}
+                }
+                self.assertDictEqual(added, expected)
+        expected_calls = [
+            call('pkg_add -x -I png--%', output_loglevel='trace', python_shell=False),
+            call('pkg_add -x -I ruby--%2.3', output_loglevel='trace', python_shell=False),
+            call('pkg_add -x -I vim--gtk2%', output_loglevel='trace', python_shell=False),
+        ]
+        run_all_mock.assert_has_calls(expected_calls, any_order=True)
+        self.assertEqual(run_all_mock.call_count, 3)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(OpenbsdpkgTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

More completely support OpenBSD package specifications:

by _branch_

```
- ruby%2.3
```

by _flavor_

```
- vim--gtk2
```

While Salt package management is based on package versions (e.g. 7.4.1467p1), this concern is mostly orthogonal to package management on OpenBSD since a release is an and OS base plus a signed set of packages.
### What issues does this PR fix or reference?

Previously there was no way to install an alternate branch of a package (Python 2.7 vs. 3.4 for example)
### Previous Behavior

Package install would fail if a branch was specified in the package name
### New Behavior

Packages names can be formatted in conformity to OpenBSD's [pkg_add(1)](http://man.openbsd.org/OpenBSD-current/man1/pkg_add.1)
### Tests written?

Yes
