### PR TITLE
for 36049, log current connected master and make status module more useful and efficient

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1820,6 +1820,12 @@ class Minion(MinionBase):
         elif package.startswith('fire_master'):
             log.debug('Forwarding master event tag={tag}'.format(tag=data['tag']))
             self._fire_master(data['data'], data['tag'], data['events'], data['pretag'])
+        elif package.startswith('__schedule_return'):
+            # reporting current connection with master
+            if data['schedule'] == '__master_alive':
+                if data['return']:
+                    if data['fun_args'] and type(data['fun_args'][0]) is dict and data['fun_args'][0].get('master', None):
+                        log.debug('Connected to master {0}'.format(data['fun_args'][0]['master']))
         elif package.startswith('__master_disconnected') or package.startswith('__master_failback'):
             # if the master disconnect event is for a different master, raise an exception
             if package.startswith('__master_disconnected') and data['master'] != self.opts['master']:

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -1013,10 +1013,10 @@ def master(master=None, connected=True):
     '''
     .. versionadded:: 2014.7.0
 
-    Fire an event if the minion gets disconnected from its master. This
-    function is meant to be run via a scheduled job from the minion. If
-    master_ip is an FQDN/Hostname, it must be resolvable to a valid IPv4
-    address.
+    Return the connection status with master. Fire an event if the
+    connection to master is not as expected. This function is meant to be
+    run via a scheduled job from the minion. If master_ip is an FQDN/Hostname,
+    it must be resolvable to a valid IPv4 address.
 
     CLI Example:
 
@@ -1041,15 +1041,16 @@ def master(master=None, connected=True):
             master_ip = tmp_ip
 
     ips = _remote_port_tcp(port)
+    master_connection_status = master_ip in ips
 
-    if connected:
-        if master_ip not in ips:
-            event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)
-            event.fire_event({'master': master}, '__master_disconnected')
-    else:
-        if master_ip in ips:
-            event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)
+    if master_connection_status is not connected:
+        event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)
+        if master_connection_status:
             event.fire_event({'master': master}, '__master_connected')
+        else:
+            event.fire_event({'master': master}, '__master_disconnected')
+
+    return master_connection_status
 
 
 def ping_master(master):

--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -345,16 +345,13 @@ def master(master=None, connected=True):
             master_ip = tmp_ip
 
     ips = _win_remotes_on(port)
+    master_connection_status = master_ip in ips
 
-    if connected:
-        if master_ip not in ips:
-            event = salt.utils.event.get_event(
-                'minion', opts=__opts__, listen=False
-            )
-            event.fire_event({'master': master}, '__master_disconnected')
-    else:
-        if master_ip in ips:
-            event = salt.utils.event.get_event(
-                'minion', opts=__opts__, listen=False
-            )
+    if master_connection_status is not connected:
+        event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)
+        if master_connection_status:
             event.fire_event({'master': master}, '__master_connected')
+        else:
+            event.fire_event({'master': master}, '__master_disconnected')
+
+    return master_connection_status


### PR DESCRIPTION
### What does this PR do?

This is for feature request in https://github.com/saltstack/salt/issues/36049. 
More than that, I change module `status` a little bit. Make a return value so that the module itself will not just be a trigger for events but return the master connection info as well. 
Also, refactor module `status` for code optimization and better code efficiency. 

A little bit scrutiny on data because I don't want the code break out just for a line of debug log:)

```
+                if data['return']:
+                    if data['fun_args'] and type(data['fun_args'][0]) is dict and data['fun_args'][0].get('master', None):
+                        log.debug('Connected to master {0}'.format(data['fun_args'][0]['master']))
```
### What issues does this PR fix or reference?
### Previous Behavior

Detailed in https://github.com/saltstack/salt/issues/36049
### New Behavior

```
2016-09-09 22:27:46,629 [salt.minion      ][INFO    ][17978] Connected to master this-is-a-master.com
```
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
