### PR TITLE
Fixes routes being installed with wrong interfaces

### DIFF
--- a/salt/templates/debian_ip/route_eth.jinja
+++ b/salt/templates/debian_ip/route_eth.jinja
@@ -1,5 +1,6 @@
 #!/bin/sh
 # {{route_type}}
+test "${IFACE}" = "{{iface}}" || exit 0
 {% for route in routes %}{% if route.name %}# {{route.name}}
 {%endif%}route {{route_type}} -net {% if route.ipaddr %}{{route.ipaddr}}{%endif%} {% if route.netmask %}netmask {{route.netmask}}{%endif%} {% if route.gateway %}gateway {{route.gateway}}{%endif%} dev {{iface}}
 {% endfor %}


### PR DESCRIPTION
### What does this PR do?

This PR ensures that routes installed for a given interface are only executed when that interface is started/stopped and not when other interfaces are coming up or down.
### What issues does this PR fix or reference?

Should fix issue reported on #36208 where `networking` service fails because routes installed for an interface are getting executed multiple times (once for each interface in the system).
### Previous Behavior

Previously the script installed by salt on `/etc/network/if-up.d` would execute and try to install routes everytime an interface would come up.
### New Behavior

The script will now check if the interface that is coming up or going down is the one for which the routes where installed and only if so will it install/remove the routes.
### Tests written?

No