### PR TITLE
salt.utils.gitfs: Fix ref to self.root

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -404,7 +404,7 @@ class GitProvider(object):
         # No need to pass an environment to self.root() here since per-saltenv
         # configuration is a gitfs-only feature and check_root() is not used
         # for gitfs.
-        root_dir = salt.utils.path_join(self.cachedir, self.root).rstrip(os.sep)
+        root_dir = salt.utils.path_join(self.cachedir, self.root()).rstrip(os.sep)
         if os.path.isdir(root_dir):
             return root_dir
         log.error(


### PR DESCRIPTION
This regressed during a recent merge-forward. See here for more info:

https://github.com/saltstack/salt/commit/2b1ad9e#diff-2c34a66e40db8ce28e251f98de56ce31L406

Resolves #36095.