### PR TITLE
make a centralized master_event func, replace the hardcoded ones across the codebase

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -358,6 +358,21 @@ def eval_master_func(opts):
         log.info('Evaluated master from module: {0}'.format(mod_fun))
 
 
+def master_event(type, master=None):
+    '''
+    Centralized master event function which will return event type based on event_map
+    '''
+    event_map = {'connected': '__master_connected',
+                 'disconnected': '__master_disconnected',
+                 'failback': '__master_failback',
+                 'alive': '__master_alive'}
+
+    if type == 'alive' and master is not None:
+        return '{0}_{1}'.format(event_map.get(type), master)
+
+    return event_map.get(type, None)
+
+
 class MinionBase(object):
     def __init__(self, opts):
         self.opts = opts
@@ -990,7 +1005,7 @@ class Minion(MinionBase):
             self.opts,
             self.functions,
             self.returners,
-            cleanup=['__master_alive'])
+            cleanup=[master_event(type='alive')])
 
         # add default scheduling jobs to the minions scheduler
         if self.opts['mine_enabled'] and 'mine.update' in self.functions:
@@ -1013,7 +1028,7 @@ class Minion(MinionBase):
                 self.opts['master_alive_interval'] > 0 and
                 self.connected):
             self.schedule.add_job({
-                '__master_alive_{0}'.format(self.opts['master']):
+                master_event(type='alive', master=self.opts['master']):
                 {
                     'function': 'status.master',
                     'seconds': self.opts['master_alive_interval'],
@@ -1028,7 +1043,7 @@ class Minion(MinionBase):
                     'master_list' in self.opts and \
                     self.opts['master'] != self.opts['master_list'][0]:
                 self.schedule.add_job({
-                    '__master_failback':
+                    master_event(type='failback'):
                     {
                         'function': 'status.ping_master',
                         'seconds': self.opts['master_failback_interval'],
@@ -1039,10 +1054,10 @@ class Minion(MinionBase):
                     }
                 }, persist=True)
             else:
-                self.schedule.delete_job('__master_failback', persist=True)
+                self.schedule.delete_job(master_event(type='failback'), persist=True)
         else:
-            self.schedule.delete_job('__master_alive_{0}'.format(self.opts['master']), persist=True)
-            self.schedule.delete_job('__master_failback', persist=True)
+            self.schedule.delete_job(master_event(type='alive', master=self.opts['master']), persist=True)
+            self.schedule.delete_job(master_event(type='failback'), persist=True)
 
         self.grains_cache = self.opts['grains']
         self.ready = True
@@ -1863,15 +1878,15 @@ class Minion(MinionBase):
             self._fire_master(data['data'], data['tag'], data['events'], data['pretag'])
         elif package.startswith('__schedule_return'):
             # reporting current connection with master
-            if data['schedule'].startswith('__master_alive_'):
+            if data['schedule'].startswith(master_event(type='alive', master='')):
                 if data['return']:
-                    log.debug('Connected to master {0}'.format(data['schedule'].split('__master_alive_')[1]))
-        elif tag.startswith('__master_disconnected') or tag.startswith('__master_failback'):
+                    log.debug('Connected to master {0}'.format(data['schedule'].split(master_event(type='alive', master=''))[1]))
+        elif tag.startswith(master_event(type='disconnected')) or tag.startswith(master_event(type='failback')):
             # if the master disconnect event is for a different master, raise an exception
-            if tag.startswith('__master_disconnected') and data['master'] != self.opts['master']:
+            if tag.startswith(master_event(type='disconnected')) and data['master'] != self.opts['master']:
                 # not mine master, ignore
                 return
-            if tag.startswith('__master_failback'):
+            if tag.startswith(master_event(type='failback')):
                 # if the master failback event is not for the top master, raise an exception
                 if data['master'] != self.opts['master_list'][0]:
                     raise SaltException('Bad master \'{0}\' when mine failback is \'{1}\''.format(
@@ -1894,7 +1909,7 @@ class Minion(MinionBase):
                        'kwargs': {'master': self.opts['master'],
                                   'connected': False}
                     }
-                    self.schedule.modify_job(name='__master_alive_{0}'.format(self.opts['master']),
+                    self.schedule.modify_job(name=master_event(type='alive', master=self.opts['master']),
                                              schedule=schedule)
 
                 log.info('Connection to master {0} lost'.format(self.opts['master']))
@@ -1916,7 +1931,7 @@ class Minion(MinionBase):
                         master, self.pub_channel = yield self.eval_master(
                                                             opts=self.opts,
                                                             failed=True,
-                                                            failback=package.startswith('__master_failback'))
+                                                            failback=package.startswith(master_event(type='failback')))
                     except SaltClientError:
                         pass
 
@@ -1942,7 +1957,7 @@ class Minion(MinionBase):
                                'kwargs': {'master': self.opts['master'],
                                           'connected': True}
                             }
-                            self.schedule.modify_job(name='__master_alive_{0}'.format(self.opts['master']),
+                            self.schedule.modify_job(name=master_event(type='alive', master=self.opts['master']),
                                                      schedule=schedule)
 
                             if self.opts['master_failback'] and 'master_list' in self.opts:
@@ -1955,15 +1970,15 @@ class Minion(MinionBase):
                                        'return_job': False,
                                        'kwargs': {'master': self.opts['master_list'][0]}
                                     }
-                                    self.schedule.modify_job(name='__master_failback',
+                                    self.schedule.modify_job(name=master_event(type='failback'),
                                                              schedule=schedule)
                                 else:
-                                    self.schedule.delete_job(name='__master_failback', persist=True)
+                                    self.schedule.delete_job(name=master_event(type='failback'), persist=True)
                     else:
                         self.restart = True
                         self.io_loop.stop()
 
-        elif tag.startswith('__master_connected'):
+        elif tag.startswith(master_event(type='connected')):
             # handle this event only once. otherwise it will pollute the log
             if not self.connected:
                 log.info('Connection to master {0} re-established'.format(self.opts['master']))
@@ -1981,7 +1996,7 @@ class Minion(MinionBase):
                                   'connected': True}
                     }
 
-                    self.schedule.modify_job(name='__master_alive_{0}'.format(self.opts['master']),
+                    self.schedule.modify_job(name=master_event(type='alive', master=self.opts['master']),
                                              schedule=schedule)
         elif tag.startswith('__schedule_return'):
             self._return_pub(data, ret_cmd='_return', sync=False)
@@ -3019,7 +3034,7 @@ class ProxyMinion(Minion):
         if (self.opts['transport'] != 'tcp' and
                 self.opts['master_alive_interval'] > 0):
             self.schedule.add_job({
-                '__master_alive_{0}'.format(self.opts['master']):
+                master_event(type='alive', master=self.opts['master']):
                     {
                         'function': 'status.master',
                         'seconds': self.opts['master_alive_interval'],
@@ -3034,7 +3049,7 @@ class ProxyMinion(Minion):
                     'master_list' in self.opts and \
                     self.opts['master'] != self.opts['master_list'][0]:
                 self.schedule.add_job({
-                    '__master_failback':
+                    master_event(type='failback'):
                     {
                         'function': 'status.ping_master',
                         'seconds': self.opts['master_failback_interval'],
@@ -3045,10 +3060,10 @@ class ProxyMinion(Minion):
                     }
                 }, persist=True)
             else:
-                self.schedule.delete_job('__master_failback', persist=True)
+                self.schedule.delete_job(master_event(type='failback'), persist=True)
         else:
-            self.schedule.delete_job('__master_alive_{0}'.format(self.opts['master']), persist=True)
-            self.schedule.delete_job('__master_failback', persist=True)
+            self.schedule.delete_job(master_event(type='alive', master=self.opts['master']), persist=True)
+            self.schedule.delete_job(master_event(type='failback'), persist=True)
 
         #  Sync the grains here so the proxy can communicate them to the master
         self.functions['saltutil.sync_grains'](saltenv='base')

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -1028,9 +1028,9 @@ def master(master=None, connected=True):
     if master_connection_status is not connected:
         event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)
         if master_connection_status:
-            event.fire_event({'master': master}, '__master_connected')
+            event.fire_event({'master': master}, salt.minion.master_event(type='connected'))
         else:
-            event.fire_event({'master': master}, '__master_disconnected')
+            event.fire_event({'master': master}, salt.minion.master_event(type='disconnected'))
 
     return master_connection_status
 
@@ -1039,7 +1039,7 @@ def ping_master(master):
     '''
     .. versionadded:: 2016.3.0
 
-    Sends ping request to the given master. Fires '__master_alive' event on success.
+    Sends ping request to the given master. Fires '__master_failback' event on success.
     Returns bool result.
 
     CLI Example:
@@ -1074,7 +1074,7 @@ def ping_master(master):
 
     if result:
         event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)
-        event.fire_event({'master': master}, '__master_failback')
+        event.fire_event({'master': master}, salt.minion.master_event(type='failback'))
 
     return result
 

--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -350,8 +350,8 @@ def master(master=None, connected=True):
     if master_connection_status is not connected:
         event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)
         if master_connection_status:
-            event.fire_event({'master': master}, '__master_connected')
+            event.fire_event({'master': master}, salt.minion.master_event(type='connected'))
         else:
-            event.fire_event({'master': master}, '__master_disconnected')
+            event.fire_event({'master': master}, salt.minion.master_event(type='disconnected'))
 
     return master_connection_status


### PR DESCRIPTION
### What does this PR do?
### What issues does this PR fix or reference?

Centralized the master event types of minions in a function so that no need to hard code them over the code base. 

This is not only an improvement of code structure, but can be easily added more event types later by not reaching to every corner of the downstream hardcoded dependencies. 
### Previous Behavior

No behavior change. 
### New Behavior

No behavior change.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
