### PR TITLE
Infrastructure testing

### DIFF
--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -457,7 +457,7 @@ Testing Custom Modules
 ~~~~~~~~~~~~~~~~~~~~~~
 
 It is possible to test custom Salt states and modules using the full power of the Salt
-test framework. This enables teams that have invested heavily in customized module
+test framework. This enables teams that have invested heavily in customized modules
 for Salt to have access to a full testing and acceptance framework, including
 support for integration tests with a running Salt master and minion.
 

--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -474,4 +474,14 @@ To include custom tests in a full run of all of Salt's functionality, simply pas
 ``--customdir`` flag. For example, to include tests present in `/tmp/mytests`, pass
 ``-customdir=/tmp/mytests``.
 
-To test *only* custom modules, pass both the ``--customdir=`` flag and the ``--custom`` flag.
+To run *only* custom tests, pass both the ``--customdir=`` flag and the ``--custom`` flag.
+
+This capability isn't useful for much withou the ability to add custom modules. To do so,
+create a `ext/` directory below the directory specified by `customdir`.
+
+Inside that directory, one can add all modular subsystems available to salt and they will
+be automatically copied to to the appropriate locations in the master/minion configurations.
+
+As always, you can view these configurations by running the test suite with ``--no-clean``
+and examining the daemon configurations present in the `salt-tests-tmpdir` directory.
+

--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -465,7 +465,7 @@ To test custom modules, place the tests in a directory anywhere on the filesyste
 
 .. note::
     
-    All directories must be structered as Python packages. This means that each directory,
+    All directories must be structured as Python packages. This means that each directory,
     including the top-level directory for tests, must contain an `__init__.py` file. This
     file may be empty. Any directories which do not contain this file will not be searched
     for tests.

--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -472,7 +472,7 @@ To test custom modules, place the tests in a directory anywhere on the filesyste
 
 To include custom tests in a full run of all of Salt's functionality, simply pass the 
 ``--customdir`` flag. For example, to include tests present in `/tmp/mytests`, pass
-``-customdir=/tmp/mytests``.
+``--customdir=/tmp/mytests``.
 
 To run *only* custom tests, pass both the ``--customdir=`` flag and the ``--custom`` flag.
 

--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -452,3 +452,26 @@ See implementation details in `salttesting.helpers` for details.
 
 `@with_system_user_and_group` -- Creates and optionally destroys a system user and group
 within a test case.  See implementation details in `salttesting.helpers` for details.
+
+Testing Custom Modules
+~~~~~~~~~~~~~~~~~~~~~~
+
+It is possible to test custom Salt states and modules using the full power of the Salt
+test framework. This enables teams that have invested heavily in customized module
+for Salt to have access to a full testing and acceptance framework, including
+support for integration tests with a running Salt master and minion.
+
+To test custom modules, place the tests in a directory anywhere on the filesystem.
+
+.. note::
+    
+    All directories must be structered as Python packages. This means that each directory,
+    including the top-level directory for tests, must contain an `__init__.py` file. This
+    file may be empty. Any directories which do not contain this file will not be searched
+    for tests.
+
+To include custom tests in a full run of all of Salt's functionality, simply pass the 
+``--customdir`` flag. For example, to include tests present in `/tmp/mytests`, pass
+``-customdir=/tmp/mytests``.
+
+To test *only* custom modules, pass both the ``--customdir=`` flag and the ``--custom`` flag.

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -352,7 +352,7 @@ def run_tests(*test_cases, **kwargs):
             transport = None
             if needs_daemon:
                 transport = self.options.transport
-            TestDaemon.transplant_configs(transport=transport)
+            TestDaemon.transplant_configs(transport=transport, ext=self.options.customdir)
 
         def run_testcase(self, testcase, needs_daemon=True):  # pylint: disable=W0221
             if needs_daemon:
@@ -1044,7 +1044,7 @@ class TestDaemon(object):
         return RUNTIME_CONFIGS['runtime_client']
 
     @classmethod
-    def transplant_configs(cls, transport='zeromq'):
+    def transplant_configs(cls, transport='zeromq', ext=None):
         if os.path.isdir(TMP_CONF_DIR):
             shutil.rmtree(TMP_CONF_DIR)
         os.makedirs(TMP_CONF_DIR)
@@ -1087,6 +1087,7 @@ class TestDaemon(object):
         minion_opts['pki_dir'] = os.path.join(TMP, 'rootdir', 'pki')
         minion_opts['hosts.file'] = os.path.join(TMP, 'rootdir', 'hosts')
         minion_opts['aliases.file'] = os.path.join(TMP, 'rootdir', 'aliases')
+        minion_opts['module_dirs'] = [os.path.join(ext, 'ext', 'modules')]
 
         # This sub_minion also connects to master
         sub_minion_opts = salt.config._read_conf_file(os.path.join(CONF_DIR, 'sub_minion'))
@@ -1097,6 +1098,7 @@ class TestDaemon(object):
         sub_minion_opts['pki_dir'] = os.path.join(TMP, 'rootdir-sub-minion', 'pki', 'minion')
         sub_minion_opts['hosts.file'] = os.path.join(TMP, 'rootdir', 'hosts')
         sub_minion_opts['aliases.file'] = os.path.join(TMP, 'rootdir', 'aliases')
+        sub_minion_opts['module_dirs'] = [os.path.join(ext, 'ext', 'modules')]
 
         # This is the master of masters
         syndic_master_opts = salt.config._read_conf_file(os.path.join(CONF_DIR, 'syndic_master'))
@@ -1159,7 +1161,13 @@ class TestDaemon(object):
                     ),
                     new_extension_modules_path
                 )
-            opts_dict['extension_modules'] = os.path.join(opts_dict['root_dir'], 'extension_modules')
+                if ext:
+                    ext_dir = os.path.join(ext, 'ext')
+                    for dir in os.listdir(ext_dir):
+                        print('Copying {0} to {1}'.format(os.path.join(ext_dir, dir), os.path.join(new_extension_modules_path, dir)))
+                        shutil.copytree(os.path.join(ext_dir, dir), os.path.join(new_extension_modules_path, dir))
+                opts_dict['extension_modules'] = os.path.join(opts_dict['root_dir'], 'extension_modules')
+
 
         # Point the config values to the correct temporary paths
         for name in ('hosts', 'aliases'):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1168,7 +1168,6 @@ class TestDaemon(object):
                         shutil.copytree(os.path.join(ext_dir, dir), os.path.join(new_extension_modules_path, dir))
                 opts_dict['extension_modules'] = os.path.join(opts_dict['root_dir'], 'extension_modules')
 
-
         # Point the config values to the correct temporary paths
         for name in ('hosts', 'aliases'):
             optname = '{0}.file'.format(name)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -124,12 +124,18 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
         Return a set of all test suites except unit and cloud provider tests
         unless requested
         '''
+        if self.options.custom:
+           if not self.options.customdir:
+                   raise Exception('Since the `custom` flag has been set, please pass `customdir` as well')
+           if not os.path.exists(self.options.customdir):
+                   raise OSError('Could not find custom test directory: {0}'.format(self.options.customdir))
+           TEST_SUITES['custom'] = {'display_name': 'Custom',
+                   'path': self.options.customdir}
         suites = set(TEST_SUITES.keys())
         if not include_unit:
             suites -= set(['unit'])
         if not include_cloud_provider:
             suites -= set(['cloud_provider'])
-
         return suites
 
     def _check_enabled_suites(self, include_unit=False, include_cloud_provider=False):
@@ -170,6 +176,17 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             default=False,
             action='store_true',
             help='Do not run any tests. Simply start the daemons.'
+        )
+        self.add_option(
+            '--custom',
+            default=False,
+            action='store_true',
+            help='Addtional directories to scan for tests'
+        )
+        self.add_option(
+            '--customdir',
+            default='',
+            help='Directory to scan for additional tests. (Requires that --custom also be set)'
         )
         self.output_options_group.add_option(
             '--no-colors',
@@ -387,8 +404,12 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
         '''
         Run an integration test suite
         '''
-        full_path = os.path.join(TEST_DIR, path)
-        return self.run_suite(full_path, display_name)
+        # If the path is full-qualified, it's not a part of the main suite
+        if os.path.isabs(path):
+            full_path = path
+        else:
+            full_path = os.path.join(TEST_DIR, path)
+        return self.run_suite(full_path, display_name, additional_test_dirs=[self.options.customdir])
 
     def start_daemons_only(self):
         if not salt.utils.is_windows():

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -125,12 +125,12 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
         unless requested
         '''
         if self.options.custom:
-           if not self.options.customdir:
-                   raise Exception('Since the `custom` flag has been set, please pass `customdir` as well')
-           if not os.path.exists(self.options.customdir):
-                   raise OSError('Could not find custom test directory: {0}'.format(self.options.customdir))
-           TEST_SUITES['custom'] = {'display_name': 'Custom',
-                   'path': self.options.customdir}
+            if not self.options.customdir:
+                raise Exception('Since the `custom` flag has been set, please pass `customdir` as well')
+            if not os.path.exists(self.options.customdir):
+                raise OSError('Could not find custom test directory: {0}'.format(self.options.customdir))
+            TEST_SUITES['custom'] = {'display_name': 'Custom',
+                'path': self.options.customdir}
         suites = set(TEST_SUITES.keys())
         if not include_unit:
             suites -= set(['unit'])

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -188,6 +188,11 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             default='',
             help='Directory to scan for additional tests. (Requires that --custom also be set)'
         )
+        self.add_option(
+            '--customroot',
+            default='',
+            help='Additional directories to append to Salt file roots for master/minion'
+        )
         self.output_options_group.add_option(
             '--no-colors',
             '--no-colours',
@@ -393,7 +398,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
         )
 
         # Transplant configuration
-        TestDaemon.transplant_configs(transport=self.options.transport)
+        TestDaemon.transplant_configs(transport=self.options.transport, ext=self.options.customdir)
 
     def post_execution_cleanup(self):
         SaltCoverageTestingParser.post_execution_cleanup(self)


### PR DESCRIPTION
This is the beginning of a project to allow a user to use Salt's own elaborate test suite to test their _own_ modules, states, etc.

The idea here is that with this change, users can now maintain their own repository of tests which are entirely independent of the tests which are shipped with Salt, but still have access to all of the functionality of Salt's test system to perform validation and acceptance testing for their Salt deployments.

The next step will be to fully round out the Docker/LXC support for salt-testing so that using this functionality, it will be easy to quickly model an infrastructure, write tests against that infrastructure and plug the entire thing into a CI/CD pipeline. Onward!
