### PR TITLE
Reauth on string with content 'AES key not found'

### DIFF
--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -110,7 +110,7 @@ class AESReqServerMixin(object):
             return self.crypticle.dumps({})
         except IOError:
             log.error('AES key not found')
-            return 'AES key not found'
+            return {'error': 'AES key not found'}
 
         pret = {}
         cipher = PKCS1_OAEP.new(pub)


### PR DESCRIPTION
### What does this PR do?

ret is a string 'AES key not found', no reauth attempt is made since 'key' is contained in the string (python in keyword)
### What issues does this PR fix or reference?

Reauth when ret is not a dict but string contains 'key'
### Previous Behavior

Broken if string is returned and string contains 'key'
### New Behavior

A check is made if ret is a string type in which case reauth attempt is made too
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.