### PR TITLE
Some unit tests fixes

### DIFF
--- a/salt/modules/boto_elb.py
+++ b/salt/modules/boto_elb.py
@@ -57,6 +57,7 @@ log = logging.getLogger(__name__)
 # Import third party libs
 try:
     import boto
+    import boto.ec2  # pylint: enable=unused-import
     # connection settings were added in 2.33.0
     required_boto_version = '2.33.0'
     if (_LooseVersion(boto.__version__) <
@@ -64,7 +65,6 @@ try:
         msg = 'boto_elb requires boto {0}.'.format(required_boto_version)
         logging.debug(msg)
         raise ImportError()
-    import boto.ec2
     from boto.ec2.elb import HealthCheck
     from boto.ec2.elb.attributes import AccessLogAttribute
     from boto.ec2.elb.attributes import ConnectionDrainingAttribute

--- a/tests/unit/modules/boto_secgroup_test.py
+++ b/tests/unit/modules/boto_secgroup_test.py
@@ -23,6 +23,7 @@ import salt.loader
 from salt.ext.six.moves import range  # pylint: disable=redefined-builtin
 try:
     import boto
+    import boto.ec2  # pylint: enable=unused-import
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False

--- a/tests/unit/modules/mount_test.py
+++ b/tests/unit/modules/mount_test.py
@@ -100,7 +100,8 @@ class MountTestCase(TestCase):
         '''
         mock = MagicMock(return_value={})
         with patch.object(mount, 'fstab', mock):
-            self.assertTrue(mount.rm_fstab('name', 'device'))
+            with patch('salt.utils.fopen', mock_open()) as m_open:
+                self.assertTrue(mount.rm_fstab('name', 'device'))
 
         mock_fstab = MagicMock(return_value={'name': 'name'})
         with patch.object(mount, 'fstab', mock_fstab):

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -925,6 +925,7 @@ class FileTestCase(TestCase):
 
     # 'comment' function tests: 1
 
+    @patch.object(os.path, 'exists', MagicMock(return_value=True))
     def test_comment(self):
         '''
         Test to comment out specified lines in a file.
@@ -981,6 +982,7 @@ class FileTestCase(TestCase):
 
     # 'uncomment' function tests: 1
 
+    @patch.object(os.path, 'exists', MagicMock(return_value=True))
     def test_uncomment(self):
         '''
         Test to uncomment specified commented lines in a file


### PR DESCRIPTION
### What does this PR do?

This PR fixes some unit tests and prevents errors in some cases:

In cases where `/etc/fstab` does not exists:

```
unit/modules/mount_test.py::MountTestCase::test_rm_fstab FAILED
salt/modules/mount.py:333: CommandExecutionError: Couldn't read from /etc/fstab: [Errno 2] No such file or directory: '/etc/fstab'
...
tests/unit/states/file_test.py::FileTestCase::test_comment FAILED
tests/unit/states/file_test.py:956: AssertionError: {'comment': '/etc/fstab: file not found', 'changes': {[36 chars]alse} != {'comment': 'Pattern already commented', 'name': '/etc[34 chars]True}
tests/unit/states/file_test.py:1015: AssertionError: {'comment': '/etc/fstab: file not found', 'changes': {[36 chars]alse} != {'comment': 'Pattern already uncommented', 'name': '/e[36 chars]True}
```

Sometimes `HAS_BOTO` wrongly responses `True` even if boto module does not exists. I think it's because `from __future__ import absolute_import` causes that when doing `import boto` it does not raise ImportError as it imports `utils/boto.py`:

```
ERROR collecting unit/modules/boto_secgroup_test.py
salt-2015.8.7/tests/unit/modules/boto_secgroup_test.py:96: in <module>
    @skipIf(_has_required_boto() is False, 'The boto module must be greater than'
salt-2015.8.7/tests/unit/modules/boto_secgroup_test.py:87: in _has_required_boto
    elif LooseVersion(boto.__version__) < LooseVersion(required_boto_version):
E   AttributeError: 'module' object has no attribute '__version__'
```

This changes should be also included in `2016.3` and `develop`
Thanks!