### PR TITLE
salt.fileserver.Fileserver: Don't try to split a list in _gen_back

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -323,10 +323,11 @@ class Fileserver(object):
         if not back:
             back = self.opts['fileserver_backend']
         else:
-            try:
-                back = back.split(',')
-            except AttributeError:
-                back = six.text_type(back).split(',')
+            if not isinstance(back, list):
+                try:
+                    back = back.split(',')
+                except AttributeError:
+                    back = six.text_type(back).split(',')
 
         ret = []
         if not isinstance(back, list):


### PR DESCRIPTION
This fixes a bug which causes backends passed as a python list to be
converted to a `str` (specifically a `unicode` type in PY2) and then
split, resulting in a backend that will never match anything.

This only affects runner and Salt Python API usage in which the
"backend" param to fileserver runner funcs is passed as a Python list.