### PR TITLE
Fix test_issue_6833_pip_upgrade_pip test on OS X

### DIFF
--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -11,6 +11,7 @@ import glob
 import shutil
 import logging
 import os
+import sys
 
 # Import salt libs
 import salt.utils
@@ -129,6 +130,9 @@ def create(path,
     '''
     if venv_bin is None:
         venv_bin = __opts__.get('venv_bin') or __pillar__.get('venv_bin')
+
+    if not os.path.exists(venv_bin):
+        venv_bin = '/'.join([os.path.dirname(sys.executable), venv_bin])
 
     cmd = [venv_bin]
 

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -11,7 +11,6 @@ import glob
 import shutil
 import logging
 import os
-import sys
 
 # Import salt libs
 import salt.utils
@@ -130,9 +129,6 @@ def create(path,
     '''
     if venv_bin is None:
         venv_bin = __opts__.get('venv_bin') or __pillar__.get('venv_bin')
-
-    if not os.path.exists(venv_bin):
-        venv_bin = '/'.join([os.path.dirname(sys.executable), venv_bin])
 
     cmd = [venv_bin]
 

--- a/tests/integration/files/file/base/pip-installed-weird-install.sls
+++ b/tests/integration/files/file/base/pip-installed-weird-install.sls
@@ -1,12 +1,36 @@
-{{ salt['runtests_helpers.get_sys_temp_dir_for_path']('pip-installed-weird-install') }}:
+{%- set virtualenv_base = salt['runtests_helpers.get_salt_temp_dir_for_path']('virtualenv-12-base') -%}
+{%- set virtualenv_test = salt['runtests_helpers.get_salt_temp_dir_for_path']('pip-installed-weird-install') -%}
+
+{{ virtualenv_base }}:
   virtualenv.managed:
     - system_site_packages: False
     - distribute: True
+
+install_older_venv:
+  pip.installed:
+    - name: 'virtualenv < 13.0'
+    - bin_env: {{ virtualenv_base }}
+    - require:
+      - virtualenv: {{ virtualenv_base }}
+
+# For this test we need to make sure that the virtualenv used in the
+# 'carbon-weird-setup' pip.installed state below was created using
+# virtualenv < 13.0. virtualenvs created using later versions make
+# packages with custom setuptools prefixes relative to the virtualenv
+# itself, which makes the 'weird' behavior we are trying to confirm
+# obsolete. Thus, the two states above ensure that the 'base' venv has
+# a version old enough to exhibit the behavior we want to test.
+
+setup_test_virtualenv:
+  cmd.run:
+    - name: {{ virtualenv_base }}/bin/virtualenv {{ virtualenv_test }}
+    - onchanges:
+      - pip: install_older_venv
 
 carbon-weird-setup:
   pip.installed:
     - name: carbon
     - no_deps: True
-    - bin_env: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('pip-installed-weird-install') }}
-    - require:
-      - virtualenv: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('pip-installed-weird-install') }}
+    - bin_env: {{ virtualenv_test }}
+    - onchanges:
+      - cmd: setup_test_virtualenv

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -361,7 +361,6 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             # previously installed
             ret = self.run_function(
                 'pip.install', ['pip==6.0'], upgrade=True,
-                ignore_installed=True,
                 bin_env=venv_dir
             )
             try:
@@ -375,7 +374,7 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                 pprint.pprint(ret)
                 raise
 
-            # Le't make sure we have pip 6.0 installed
+            # Let's make sure we have pip 6.0 installed
             self.assertEqual(
                 self.run_function('pip.list', ['pip'], bin_env=venv_dir),
                 {'pip': '6.0'}

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -78,9 +78,12 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
 
     @requires_system_grains
     def test_pip_installed_weird_install(self, grains=None):
-        # First, check to see if this is running on CentOS 5. If so, skip this test.
+        # First, check to see if this is running on CentOS 5 or MacOS.
+        # If so, skip this test.
         if grains['os'] in ('CentOS',) and grains['osrelease_info'][0] in (5,):
             self.skipTest('This test does not run reliably on CentOS 5')
+        if grains['os'] in ('MacOS',):
+            self.skipTest('This test does not run reliably on MacOS')
 
         ographite = '/opt/graphite'
         if os.path.isdir(ographite):

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -9,6 +9,7 @@
 
 # Import python libs
 from __future__ import absolute_import
+import errno
 import os
 import pwd
 import glob
@@ -82,8 +83,6 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         # If so, skip this test.
         if grains['os'] in ('CentOS',) and grains['osrelease_info'][0] in (5,):
             self.skipTest('This test does not run reliably on CentOS 5')
-        if grains['os'] in ('MacOS',):
-            self.skipTest('This test does not run reliably on MacOS')
 
         ographite = '/opt/graphite'
         if os.path.isdir(ographite):
@@ -94,7 +93,7 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         try:
             os.makedirs(ographite)
         except OSError as err:
-            if err.errno == 13:
+            if err.errno == errno.EACCES:
                 # Permission denied
                 self.skipTest(
                     'You don\'t have the required permissions to run this test'
@@ -103,10 +102,12 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             if os.path.isdir(ographite):
                 shutil.rmtree(ographite)
 
-        venv_dir = os.path.join(
-            integration.SYS_TMP_DIR, 'pip-installed-weird-install'
-        )
+        venv_dir = os.path.join(integration.TMP, 'pip-installed-weird-install')
         try:
+            # We may be able to remove this, I had to add it because the custom
+            # modules from the test suite weren't available in the jinja
+            # context when running the call to state.sls that comes after.
+            self.run_function('saltutil.sync_modules')
             # Since we don't have the virtualenv created, pip.installed will
             # thrown and error.
             ret = self.run_function(
@@ -118,16 +119,17 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             # some of the state return parts
             for key in six.iterkeys(ret):
                 self.assertTrue(ret[key]['result'])
-                if ret[key]['comment'] == 'Created new virtualenv':
+                if ret[key]['name'] != 'carbon':
                     continue
                 self.assertEqual(
                     ret[key]['comment'],
                     'There was no error installing package \'carbon\' '
                     'although it does not show when calling \'pip.freeze\'.'
                 )
+                break
+            else:
+                raise Exception('Expected state did not run')
         finally:
-            if os.path.isdir(venv_dir):
-                shutil.rmtree(venv_dir)
             if os.path.isdir('/opt/graphite'):
                 shutil.rmtree('/opt/graphite')
 


### PR DESCRIPTION
### What does this PR do?

Fixes a problem with the test_issue_6833_pip_upgrade_pip test failure on OS X. Skips the `test_pip_installed_weird_install` test on OS X... can't duplicate the problem on OS X.
### What issues does this PR fix or reference?

https://github.com/saltstack/qa/issues/236
### Previous Behavior

The `ignore_installed` option was corrupting the pip environment causing the following`pip.list` function to fail.
### New Behavior

The `ignore_installed` option is not used (nor needed).
### Tests written?

NA