### PR TITLE
Add a runner function to clear fileserver list caches

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1363,6 +1363,36 @@ is impacted.
 
     fileserver_limit_traversal: False
 
+.. conf_master:: fileserver_list_cache_time
+
+``fileserver_list_cache_time``
+------------------------------
+
+.. versionadded:: 2014.1.0
+.. versionchanged:: Carbon
+    The default was changed from ``30`` seconds to ``20``.
+
+Default: ``20``
+
+Salt caches the list of files/symlinks/directories for each fileserver backend
+and environment as they are requested, to guard against a performance
+bottleneck at scale when many minions all ask the fileserver which files are
+available simultaneously. This configuration parameter allows for the max age
+of that cache to be altered.
+
+Set this value to ``0`` to disable use of this cache altogether, but keep in
+mind that this may increase the CPU load on the master when running a highstate
+on a large number of minions.
+
+.. note::
+    Rather than altering this configuration parameter, it may be advisable to
+    use the :mod:`fileserver.clear_list_cache
+    <salt.runners.fileserver.clear_list_cache>` runner to clear these caches.
+
+.. code-block:: yaml
+
+    fileserver_list_cache_time: 5
+
 .. conf_master:: hash_type
 
 ``hash_type``

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -122,8 +122,8 @@ def check_file_list_cache(opts, form, list_cache, w_lock):
                     age = time.time() - cache_stat.st_mtime
                 else:
                     # if filelist does not exists yet, mark it as expired
-                    age = opts.get('fileserver_list_cache_time', 30) + 1
-                if age < opts.get('fileserver_list_cache_time', 30):
+                    age = opts.get('fileserver_list_cache_time', 20) + 1
+                if age < opts.get('fileserver_list_cache_time', 20):
                     # Young enough! Load this sucker up!
                     with salt.utils.fopen(list_cache, 'rb') as fp_:
                         log.trace('Returning file_lists cache data from '

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -5,6 +5,7 @@ File server pluggable modules and generic backend functions
 
 # Import python libs
 from __future__ import absolute_import
+import collections
 import errno
 import fnmatch
 import logging
@@ -325,10 +326,18 @@ class Fileserver(object):
         if not back:
             back = self.opts['fileserver_backend']
         else:
-            try:
-                back = back.split(',')
-            except AttributeError:
-                back = six.text_type(back).split(',')
+            if not isinstance(back, list):
+                try:
+                    back = back.split(',')
+                except AttributeError:
+                    back = six.text_type(back).split(',')
+
+        if isinstance(back, collections.Sequence):
+            # The test suite uses an ImmutableList type (based on
+            # collections.Sequence) for lists, which breaks this function in
+            # the test suite. This normalizes the value from the opts into a
+            # list if it is based on collections.Sequence.
+            back = list(back)
 
         ret = []
         if not isinstance(back, list):

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -335,7 +335,8 @@ def _file_lists(load, form):
                     dir_rel_fn = dir_rel_fn.replace('\\', '/')
                 ret['dirs'].append(dir_rel_fn)
                 if len(dirs) == 0 and len(files) == 0:
-                    if not salt.fileserver.is_file_ignored(__opts__, dir_rel_fn):
+                    if dir_rel_fn not in ('.', '..') \
+                            and not salt.fileserver.is_file_ignored(__opts__, dir_rel_fn):
                         ret['empty_dirs'].append(dir_rel_fn)
                 for fname in files:
                     is_link = os.path.islink(os.path.join(root, fname))

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -39,6 +39,114 @@ def envs(backend=None, sources=False):
     return fileserver.envs(back=backend, sources=sources)
 
 
+def clear_file_list_cache(saltenv=None, backend=None):
+    '''
+    .. versionadded:: Carbon
+
+    The Salt fileserver caches the files/directories/symlinks for each
+    fileserver backend and environment as they are requested. This is done to
+    help the fileserver scale better. Without this caching, when
+    hundreds/thousands of minions simultaneously ask the master what files are
+    available, this would cause the master's CPU load to spike as it obtains
+    the same information separately for each minion.
+
+    saltenv
+        By default, this runner will clear the file list caches for all
+        environments. This argument allows for a list of environments to be
+        passed, to clear more selectively. This list can be passed either as a
+        comma-separated string, or a Python list.
+
+    backend
+        Similar to the ``saltenv`` parameter, this argument will restrict the
+        cache clearing to specific fileserver backends (the default behavior is
+        to clear from all enabled fileserver backends). This list can be passed
+        either as a comma-separated string, or a Python list.
+
+    .. note:
+        The maximum age for the cached file lists (i.e. the age at which the
+        cache will be disregarded and rebuilt) is defined by the
+        :conf_master:`fileserver_list_cache_time` configuration parameter.
+
+    Since the ability to clear these caches is often required by users writing
+    custom runners which add/remove files, this runner can easily be called
+    from within a custom runner using any of the following examples:
+
+    .. code-block:: python
+
+        # Clear all file list caches
+        __salt__['fileserver.clear_file_list_cache']()
+        # Clear just the 'base' saltenv file list caches
+        __salt__['fileserver.clear_file_list_cache'](saltenv='base')
+        # Clear just the 'base' saltenv file list caches from just the 'roots'
+        # fileserver backend
+        __salt__['fileserver.clear_file_list_cache'](saltenv='base', backend='roots')
+        # Clear all file list caches from the 'roots' fileserver backend
+        __salt__['fileserver.clear_file_list_cache'](backend='roots')
+
+    .. note::
+        In runners, the ``__salt__`` dictionary will likely be renamed to
+        ``__runner__`` in a future Salt release to distinguish runner functions
+        from remote execution functions. See `this GitHub issue`_ for
+        discussion/updates on this.
+
+    .. _`this GitHub issue`: https://github.com/saltstack/salt/issues/34958
+
+    If using Salt's Python API (not a runner), the following examples are
+    equivalent to the ones above:
+
+    .. code-block:: python
+
+        import salt.config
+        import salt.runner
+
+        opts = salt.config.master_config('/etc/salt/master')
+        opts['fun'] = 'fileserver.clear_file_list_cache'
+
+        # Clear all file list_caches
+        opts['arg'] = []  # No arguments
+        runner = salt.runner.Runner(opts)
+        cleared = runner.run()
+
+        # Clear just the 'base' saltenv file list caches
+        opts['arg'] = ['base', None]
+        runner = salt.runner.Runner(opts)
+        cleared = runner.run()
+
+        # Clear just the 'base' saltenv file list caches from just the 'roots'
+        # fileserver backend
+        opts['arg'] = ['base', 'roots']
+        runner = salt.runner.Runner(opts)
+        cleared = runner.run()
+
+        # Clear all file list caches from the 'roots' fileserver backend
+        opts['arg'] = [None, 'roots']
+        runner = salt.runner.Runner(opts)
+        cleared = runner.run()
+
+
+    This function will return a dictionary showing a list of environments which
+    were cleared for each backend. An empty return dictionary means that no
+    changes were made.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        # Clear all file list caches
+        salt-run fileserver.clear_file_list_cache
+        # Clear just the 'base' saltenv file list caches
+        salt-run fileserver.clear_file_list_cache saltenv=base
+        # Clear just the 'base' saltenv file list caches from just the 'roots'
+        # fileserver backend
+        salt-run fileserver.clear_file_list_cache saltenv=base backend=roots
+        # Clear all file list caches from the 'roots' fileserver backend
+        salt-run fileserver.clear_file_list_cache backend=roots
+    '''
+    fileserver = salt.fileserver.Fileserver(__opts__)
+    load = {'saltenv': saltenv, 'fsbackend': backend}
+    return fileserver.clear_file_list_cache(load=load)
+
+
 def file_list(saltenv='base', backend=None):
     '''
     Return a list of files from the salt fileserver

--- a/tests/integration/runners/fileserver.py
+++ b/tests/integration/runners/fileserver.py
@@ -4,6 +4,7 @@ Tests for the fileserver runner
 '''
 # Import Python libs
 from __future__ import absolute_import
+import contextlib
 
 # Import Salt Testing libs
 from salttesting.helpers import ensure_in_syspath
@@ -13,7 +14,7 @@ ensure_in_syspath('../../')
 import integration
 
 
-class ManageTest(integration.ShellCase):
+class FileserverTest(integration.ShellCase):
     '''
     Test the fileserver runner
     '''
@@ -70,6 +71,70 @@ class ManageTest(integration.ShellCase):
         ret = self.run_run_plus(fun='fileserver.envs', backend=['roots'])
         self.assertIsInstance(ret['return'], list)
 
+    def test_clear_file_list_cache(self):
+        '''
+        fileserver.clear_file_list_cache
+
+        If this test fails, then something may have changed in the test suite
+        and we may have more than just "roots" configured in the fileserver
+        backends. This assert will need to be updated accordingly.
+        '''
+        @contextlib.contextmanager
+        def gen_cache():
+            '''
+            Create file_list cache so we have something to clear
+            '''
+            self.run_run_plus(fun='fileserver.file_list')
+            yield
+
+        # Test with no arguments
+        with gen_cache():
+            ret = self.run_run_plus(fun='fileserver.clear_file_list_cache')
+            self.assertEqual(ret['return'], {'roots': ['base']})
+
+        # Test with backend passed as string
+        with gen_cache():
+            ret = self.run_run_plus(fun='fileserver.clear_file_list_cache',
+                                    backend='roots')
+            self.assertEqual(ret['return'], {'roots': ['base']})
+
+        # Test with backend passed as list
+        with gen_cache():
+            ret = self.run_run_plus(fun='fileserver.clear_file_list_cache',
+                                    backend=['roots'])
+            self.assertEqual(ret['return'], {'roots': ['base']})
+
+        # Test with backend passed as string, but with a nonsense backend
+        with gen_cache():
+            ret = self.run_run_plus(fun='fileserver.clear_file_list_cache',
+                                    backend='notarealbackend')
+            self.assertEqual(ret['return'], {})
+
+        # Test with saltenv passed as string
+        with gen_cache():
+            ret = self.run_run_plus(fun='fileserver.clear_file_list_cache',
+                                    saltenv='base')
+            self.assertEqual(ret['return'], {'roots': ['base']})
+
+        # Test with saltenv passed as list
+        with gen_cache():
+            ret = self.run_run_plus(fun='fileserver.clear_file_list_cache',
+                                    saltenv=['base'])
+            self.assertEqual(ret['return'], {'roots': ['base']})
+
+        # Test with saltenv passed as string, but with a nonsense saltenv
+        with gen_cache():
+            ret = self.run_run_plus(fun='fileserver.clear_file_list_cache',
+                                    saltenv='notarealsaltenv')
+            self.assertEqual(ret['return'], {})
+
+        # Test with both backend and saltenv passed
+        with gen_cache():
+            ret = self.run_run_plus(fun='fileserver.clear_file_list_cache',
+                                    backend='roots',
+                                    saltenv='base')
+            self.assertEqual(ret['return'], {'roots': ['base']})
+
     def test_file_list(self):
         '''
         fileserver.file_list
@@ -117,4 +182,4 @@ class ManageTest(integration.ShellCase):
 
 if __name__ == '__main__':
     from integration import run_tests
-    run_tests(ManageTest)
+    run_tests(FileserverTest)

--- a/tests/integration/runners/fileserver.py
+++ b/tests/integration/runners/fileserver.py
@@ -24,18 +24,17 @@ class FileserverTest(integration.ShellCase):
         '''
         ret = self.run_run_plus(fun='fileserver.dir_list')
         self.assertIsInstance(ret['return'], list)
+        self.assertTrue('_modules' in ret['return'])
 
         # Backend submitted as a string
-        ret = self.run_run_plus(
-            fun='fileserver.dir_list',
-            backend='roots')
+        ret = self.run_run_plus(fun='fileserver.dir_list', backend='roots')
         self.assertIsInstance(ret['return'], list)
+        self.assertTrue('_modules' in ret['return'])
 
         # Backend submitted as a list
-        ret = self.run_run_plus(
-            fun='fileserver.dir_list',
-            backend=['roots'])
+        ret = self.run_run_plus(fun='fileserver.dir_list', backend=['roots'])
         self.assertIsInstance(ret['return'], list)
+        self.assertTrue('_modules' in ret['return'])
 
     def test_empty_dir_list(self):
         '''
@@ -43,18 +42,21 @@ class FileserverTest(integration.ShellCase):
         '''
         ret = self.run_run_plus(fun='fileserver.empty_dir_list')
         self.assertIsInstance(ret['return'], list)
+        self.assertEqual(ret['return'], [])
 
         # Backend submitted as a string
         ret = self.run_run_plus(
             fun='fileserver.empty_dir_list',
             backend='roots')
         self.assertIsInstance(ret['return'], list)
+        self.assertEqual(ret['return'], [])
 
         # Backend submitted as a list
         ret = self.run_run_plus(
             fun='fileserver.empty_dir_list',
             backend=['roots'])
         self.assertIsInstance(ret['return'], list)
+        self.assertEqual(ret['return'], [])
 
     def test_envs(self):
         '''
@@ -141,14 +143,17 @@ class FileserverTest(integration.ShellCase):
         '''
         ret = self.run_run_plus(fun='fileserver.file_list')
         self.assertIsInstance(ret['return'], list)
+        self.assertTrue('grail/scene33' in ret['return'])
 
         # Backend submitted as a string
         ret = self.run_run_plus(fun='fileserver.file_list', backend='roots')
         self.assertIsInstance(ret['return'], list)
+        self.assertTrue('grail/scene33' in ret['return'])
 
         # Backend submitted as a list
         ret = self.run_run_plus(fun='fileserver.file_list', backend=['roots'])
         self.assertIsInstance(ret['return'], list)
+        self.assertTrue('grail/scene33' in ret['return'])
 
     def test_symlink_list(self):
         '''
@@ -156,14 +161,17 @@ class FileserverTest(integration.ShellCase):
         '''
         ret = self.run_run_plus(fun='fileserver.symlink_list')
         self.assertIsInstance(ret['return'], dict)
+        self.assertTrue('dest_sym' in ret['return'])
 
         # Backend submitted as a string
         ret = self.run_run_plus(fun='fileserver.symlink_list', backend='roots')
         self.assertIsInstance(ret['return'], dict)
+        self.assertTrue('dest_sym' in ret['return'])
 
         # Backend submitted as a list
         ret = self.run_run_plus(fun='fileserver.symlink_list', backend=['roots'])
         self.assertIsInstance(ret['return'], dict)
+        self.assertTrue('dest_sym' in ret['return'])
 
     def test_update(self):
         '''


### PR DESCRIPTION
Resolves #36150.

In the process of writing integration tests for this new runner function, I discovered two bugs that were not caught by our existing fileserver integration tests. These have been addressed in #36244 and #36245 (both of which were opened against the `2015.8` release branch), but both fixes are also included in this PR as well (as I needed them in place to ensure that my new tests would pass.

I also took the liberty of beefing up the existing fileserver runner integration tests to check the content of the return as well as the type. I may yet backport these fixes into 2015.8, but I'll need to confirm that they'll work as expected before I try this, as some recent changes to salt-testing (and `tests/integration/__init__.py`) uncovered some deficiencies in the `run_run_plus` helper which we use to obtain return data from runner functions in the test suite. Not to mention that both #36244 and #36245 will need to be merged before I can backport the tests in the first place.
