### PR TITLE
Quote postgres privilege target names

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -2871,16 +2871,16 @@ def privileges_grant(name,
 
     if grant_option:
         if object_type == 'group':
-            query = 'GRANT {0} TO {1} WITH ADMIN OPTION'.format(
+            query = 'GRANT {0} TO "{1}" WITH ADMIN OPTION'.format(
                 object_name, name)
         else:
-            query = 'GRANT {0} ON {1} {2} TO {3} WITH GRANT OPTION'.format(
+            query = 'GRANT {0} ON {1} {2} TO "{3}" WITH GRANT OPTION'.format(
                 _grants, object_type.upper(), on_part, name)
     else:
         if object_type == 'group':
-            query = 'GRANT {0} TO {1}'.format(object_name, name)
+            query = 'GRANT {0} TO "{1}"'.format(object_name, name)
         else:
-            query = 'GRANT {0} ON {1} {2} TO {3}'.format(
+            query = 'GRANT {0} ON {1} {2} TO "{3}"'.format(
                 _grants, object_type.upper(), on_part, name)
 
     ret = _psql_prepare_and_run(['-c', query],

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -2865,9 +2865,9 @@ def privileges_grant(name,
     _grants = ','.join(_privs)
 
     if object_type in ['table', 'sequence']:
-        on_part = '{0}.{1}'.format(prepend, object_name)
+        on_part = '{0}."{1}"'.format(prepend, object_name)
     else:
-        on_part = object_name
+        on_part = '"{0}"'.format(object_name)
 
     if grant_option:
         if object_type == 'group':

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -1240,7 +1240,7 @@ class PostgresTestCase(TestCase):
                    password='testpassword'
                 )
 
-                query = 'GRANT ALL ON TABLE public.awl TO baruwa WITH GRANT OPTION'
+                query = 'GRANT ALL ON TABLE public."awl" TO baruwa WITH GRANT OPTION'
 
                 postgres._run_psql.assert_called_once_with(
                     ['/usr/bin/pgsql', '--no-align', '--no-readline',
@@ -1267,7 +1267,7 @@ class PostgresTestCase(TestCase):
                    password='testpassword'
                 )
 
-                query = 'GRANT ALL ON TABLE public.awl TO baruwa'
+                query = 'GRANT ALL ON TABLE public."awl" TO baruwa'
 
                 postgres._run_psql.assert_called_once_with(
                     ['/usr/bin/pgsql', '--no-align', '--no-readline',

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -1240,7 +1240,7 @@ class PostgresTestCase(TestCase):
                    password='testpassword'
                 )
 
-                query = 'GRANT ALL ON TABLE public."awl" TO baruwa WITH GRANT OPTION'
+                query = 'GRANT ALL ON TABLE public."awl" TO "baruwa" WITH GRANT OPTION'
 
                 postgres._run_psql.assert_called_once_with(
                     ['/usr/bin/pgsql', '--no-align', '--no-readline',
@@ -1267,7 +1267,7 @@ class PostgresTestCase(TestCase):
                    password='testpassword'
                 )
 
-                query = 'GRANT ALL ON TABLE public."awl" TO baruwa'
+                query = 'GRANT ALL ON TABLE public."awl" TO "baruwa"'
 
                 postgres._run_psql.assert_called_once_with(
                     ['/usr/bin/pgsql', '--no-align', '--no-readline',
@@ -1298,7 +1298,7 @@ class PostgresTestCase(TestCase):
                    password='testpassword'
                 )
 
-                query = 'GRANT admins TO baruwa WITH ADMIN OPTION'
+                query = 'GRANT admins TO "baruwa" WITH ADMIN OPTION'
 
                 postgres._run_psql.assert_called_once_with(
                     ['/usr/bin/pgsql', '--no-align', '--no-readline',
@@ -1324,7 +1324,7 @@ class PostgresTestCase(TestCase):
                    password='testpassword'
                 )
 
-                query = 'GRANT admins TO baruwa'
+                query = 'GRANT admins TO "baruwa"'
 
                 postgres._run_psql.assert_called_once_with(
                     ['/usr/bin/pgsql', '--no-align', '--no-readline',


### PR DESCRIPTION
### What does this PR do?

Quotes privilege update target names and role names in salt.states.postgres_privileges.
You can put certain characters in your table/database/role names which PostgreSQL
allows but then requires you to quote.  So we should always quote these.
### What issues does this PR fix or reference?

None
### Previous Behavior

Privilege target and role names were not quoted, this results in exceptions when you have a table, database, or role name which contains odd characters, such as a dash.
### New Behavior

Quotes things which need to be quoted.
### Tests written?

Unit tests have been updated.