### PR TITLE
boto3 doesn't want parameters to be None

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -247,21 +247,27 @@ def create(name, allocated_storage, db_instance_class, engine,
 
         taglist = _tag_doc(tags)
 
-        rds = conn.create_db_instance(DBInstanceIdentifier=name,
-                                      AllocatedStorage=allocated_storage,
-                                      DBInstanceClass=db_instance_class,
-                                      Engine=engine,
-                                      MasterUsername=master_username,
-                                      MasterUserPassword=master_user_password,
-                                      VpcSecurityGroupIds=vpc_security_group_ids,
-                                      AvailabilityZone=availability_zone,
-                                      DBSubnetGroupName=db_subnet_group_name,
-                                      PreferredMaintenanceWindow=preferred_maintenance_window,
-                                      DBParameterGroupName=db_parameter_group_name,
-                                      BackupRetentionPeriod=backup_retention_period,
-                                      PreferredBackupWindow=preferred_backup_window,
-                                      StorageType=storage_type, Tags=taglist,
-                                      **kwargs)
+        kwargs['DBInstanceIdentifier'] = name
+        kwargs['AllocatedStorage'] = allocated_storage
+        kwargs['DBInstanceClass'] = db_instance_class
+        kwargs['Engine'] = engine
+        kwargs['MasterUsername'] = master_username
+        kwargs['MasterUserPassword'] = master_user_password
+        kwargs['VpcSecurityGroupIds'] = vpc_security_group_ids
+        kwargs['AvailabilityZone'] = availability_zone
+        kwargs['DBSubnetGroupName'] = db_subnet_group_name
+        kwargs['PreferredMaintenanceWindow'] = preferred_maintenance_window
+        kwargs['DBParameterGroupName'] = db_parameter_group_name
+        kwargs['BackupRetentionPeriod'] = backup_retention_period
+        kwargs['PreferredBackupWindow'] = preferred_backup_window
+        kwargs['StorageType'] = storage_type
+        kwargs['Tags'] = taglist
+
+        # Validation doesn't want parameters that are None
+        # https://github.com/boto/boto3/issues/400
+        kwargs = dict((k, v) for k, v in six.iteritems(kwargs) if v is not None)
+
+        rds = conn.create_db_instance(**kwargs)
 
         if not rds:
             return {'created': False}


### PR DESCRIPTION
### What does this PR do?

In boto_rds.create, remove parameters that are None from being sent to the call into boto
See also https://github.com/boto/boto3/issues/400
### What issues does this PR fix or reference?
- 
### Test Case:

```
production:
  boto_rds.present:
    - allocated_storage: 10
    - db_instance_class: db.t2.micro
    - engine: postgres
    - master_username: wadmin
    - master_user_password: {{ pillar['rds_master_password'] }}
    - region: eu-west-1
```

(note that a lot of optional parameters are omitted)
### Previous Behavior

```
An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/state.py", line 1751, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1704, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/states/boto_rds.py", line 346, in present
    promotion_tier, key, keyid, profile)
  File "/usr/lib/python2.7/site-packages/salt/modules/boto_rds.py", line 264, in create
    **kwargs)
  File "/usr/lib/python2.7/site-packages/botocore/client.py", line 258, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/lib/python2.7/site-packages/botocore/client.py", line 524, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/usr/lib/python2.7/site-packages/botocore/client.py", line 577, in _convert_to_request_dict
    api_params, operation_model)
  File "/usr/lib/python2.7/site-packages/botocore/validate.py", line 270, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
ParamValidationError: Parameter validation failed:
Invalid type for parameter DBParameterGroupName, value: None, type: <type 'NoneType'>, valid types: <type 'basestring'>
Invalid type for parameter AvailabilityZone, value: None, type: <type 'NoneType'>, valid types: <type 'basestring'>
Invalid type for parameter StorageType, value: None, type: <type 'NoneType'>, valid types: <type 'basestring'>
Invalid type for parameter VpcSecurityGroupIds, value: None, type: <type 'NoneType'>, valid types: <type 'list'>, <type 'tuple'>
Invalid type for parameter PreferredBackupWindow, value: None, type: <type 'NoneType'>, valid types: <type 'basestring'>
Invalid type for parameter PreferredMaintenanceWindow, value: None, type: <type 'NoneType'>, valid types: <type 'basestring'>
Invalid type for parameter DBSubnetGroupName, value: None, type: <type 'NoneType'>, valid types: <type 'basestring'>
Invalid type for parameter BackupRetentionPeriod, value: None, type: <type 'NoneType'>, valid types: <type 'int'>, <type 'long'>
```
### New Behavior

State runs without errors.
### Tests written?

No