### PR TITLE
Report the reason that a module did not load to the user via remote-ex

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1337,14 +1337,16 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             raise
         except ImportError as exc:
             if 'magic number' in str(exc):
-                log.warning('Failed to import {0} {1}. Bad magic number. If migrating '
-                        'from Python2 to Python3, remove all .pyc files and try again.'.format(self.tag, name))
+                error_msg = 'Failed to import {0} {1}. Bad magic number. If migrating from Python2 to Python3, remove all .pyc files and try again.'.format(self.tag, name)
+                log.warning(error_msg)
+                self.missing_modules[name] = error_msg
             log.debug(
                 'Failed to import {0} {1}:\n'.format(
                     self.tag, name
                 ),
                 exc_info=True
             )
+            self.missing_modules[name] = exc
             return False
         except Exception as error:
             log.error(
@@ -1354,14 +1356,16 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 ),
                 exc_info=True
             )
+            self.missing_modules[name] = error
             return False
-        except SystemExit:
+        except SystemExit as error:
             log.error(
                 'Failed to import {0} {1} as the module called exit()\n'.format(
                     self.tag, name
                 ),
                 exc_info=True
             )
+            self.missing_modules[name] = error
             return False
         finally:
             sys.path.remove(fpath_dirname)


### PR DESCRIPTION
This gives you feedback on why your module is broken.

Given an intentional syntax error written into `salt.modules.test`:

Old behavior:

```
mp@silver ~/devel/salt/salt/modules
 % sudo salt silver test.ping                                                                                                                                                                                                                      (git)-[develop] 
silver:
    'test.ping' is not available.
```

New behavior:

```
mp@silver ~/devel/salt/salt/modules
 % sudo salt silver test.ping                                                                                   (git)-[develop] 
silver:
    'test' __virtual__ returned False: invalid syntax (test.py, line 36)
```

Closes #27807
