### PR TITLE
Fixed the changed salt-key output on accept/reject/delete actions.

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -259,10 +259,20 @@ class KeyCLI(object):
                                 veri = 'y'
                     except KeyboardInterrupt:
                         raise SystemExit("\nExiting on CTRL-c")
+                # accept/reject/delete the same keys we're printed to the user
+                self.opts['match_dict'] = ret
+                self.opts.pop('match', None)
+                list_ret = ret
 
             if veri is None or veri.lower().startswith('y'):
                 ret = self._run_cmd(cmd)
-                if isinstance(ret, dict):
+                if cmd in ('accept', 'reject', 'delete'):
+                    if cmd == 'delete':
+                        ret = list_ret
+                    for minions in ret.values():
+                        for minion in minions:
+                            print('Key for minion {0} {1}ed.'.format(minion, cmd))
+                elif isinstance(ret, dict):
                     salt.output.display_output(ret, 'key', opts=self.opts)
                 else:
                     salt.output.display_output({'return': ret}, 'key', opts=self.opts)


### PR DESCRIPTION
### What does this PR do?

Fixes the salt-key output that has been changed by #35015.
### What issues does this PR fix or reference?

Fixes #36081 
Related to #8705, #35015
### Previous Behavior

```
$ salt-key -A -y
The following keys are going to be accepted:
Unaccepted Keys:
alpha
Accepted Keys:
alpha
```
### New Behavior

```
$ salt-key -A -y
The following keys are going to be accepted:
Unaccepted Keys:
alpha
Key for minion alpha accepted.
```
### Tests written?

No
