### PR TITLE
Integration tests fixes for 2015.8

### DIFF
--- a/tests/integration/cloud/providers/msazure.py
+++ b/tests/integration/cloud/providers/msazure.py
@@ -53,14 +53,15 @@ def __has_required_azure():
     '''
     Returns True/False if the required version of the Azure SDK is installed.
     '''
-    if hasattr(azure, '__version__'):
-        version = LooseVersion(azure.__version__)
-    else:
-        version = LooseVersion(azure.common.__version__)
-    if HAS_AZURE is True and REQUIRED_AZURE <= version:
-        return True
-    else:
-        return False
+    if HAS_AZURE:
+        if hasattr(azure, '__version__'):
+            version = LooseVersion(azure.__version__)
+        else:
+            version = LooseVersion(azure.common.__version__)
+
+        if REQUIRED_AZURE <= version:
+            return True
+    return False
 
 
 @skipIf(HAS_AZURE is False, 'These tests require the Azure Python SDK to be installed.')

--- a/tests/integration/modules/git.py
+++ b/tests/integration/modules/git.py
@@ -36,12 +36,15 @@ log = logging.getLogger(__name__)
 
 
 def _git_version():
-    git_version = subprocess.Popen(
-        ['git', '--version'],
-        shell=False,
-        close_fds=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE).communicate()[0]
+    try:
+        git_version = subprocess.Popen(
+            ['git', '--version'],
+            shell=False,
+            close_fds=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE).communicate()[0]
+    except OSError:
+        return False
     if not git_version:
         log.debug('Git not installed')
         return False

--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -20,6 +20,7 @@ import integration
 import salt.utils
 
 
+@skip_if_binaries_missing('git')
 class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
     '''
     Validate the git state
@@ -310,7 +311,6 @@ class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
-    @skip_if_binaries_missing('git')
     def test_config_set_value_with_space_character(self):
         '''
         git.config


### PR DESCRIPTION
### What does this PR do?

This PR fixes some integration tests failures in `2015.8` if `git` or `azure` are not present:
1. Fix integration tests if azure is not present 
2. Skip git state integration tests if 'git' does not exists
3. Prevent OSError if 'git' command not found during _git_version()

Thanks!