### PR TITLE
Fixed arguments to VPC peering function

### DIFF
--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -1480,7 +1480,7 @@ def accept_vpc_peering_connection(name=None, conn_id=None, conn_name=None,
     log.debug('Called state to accept VPC peering connection')
     pending = __salt__['boto_vpc.is_peering_connection_pending'](
         conn_id=conn_id,
-        name=conn_name,
+        conn_name=conn_name,
         region=region,
         key=key,
         keyid=keyid,


### PR DESCRIPTION
### What does this PR do?

Fix a bug in the keyword arguments used for `is_peering_connection_pending` in the state function `accept_vpc_peering_connection`.
### What issues does this PR fix or reference?

None
### Previous Behavior

When using the `accept_vpc_peering_connection` state function it would result in the following stacktrace:

```
               An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1744, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1704, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/boto_vpc.py", line 1487, in accept_vpc_peering_connection
                  profile=profile
              TypeError: is_peering_connection_pending() got an unexpected keyword argument 'name'
```
### New Behavior

An exception is not raised.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
