### PR TITLE
salt.utils.gitfs: Check for existence of ssh keys

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -426,13 +426,17 @@ class Master(SMaster):
             and not isinstance(x['git'], six.string_types)
         ]
         if non_legacy_git_pillars:
-            new_opts = copy.deepcopy(self.opts)
-            new_opts['ext_pillar'] = non_legacy_git_pillars
             try:
-                # Init any values needed by the git ext pillar
-                salt.utils.gitfs.GitPillar(new_opts)
-            except FileserverConfigError as exc:
-                critical_errors.append(exc.strerror)
+                new_opts = copy.deepcopy(self.opts)
+                from salt.pillar.git_pillar \
+                    import PER_REMOTE_OVERRIDES as overrides
+                for repo in non_legacy_git_pillars:
+                    new_opts['ext_pillar'] = [repo]
+                    try:
+                        git_pillar = salt.utils.gitfs.GitPillar(new_opts)
+                        git_pillar.init_remotes(repo['git'], overrides)
+                    except FileserverConfigError as exc:
+                        critical_errors.append(exc.strerror)
             finally:
                 del new_opts
 


### PR DESCRIPTION
This adds a check for existence of the public and private keys, and
will raise an exception if they do not exist.

The git_pillar preflight checks have also been altered to try to init
the git_pillar repos, instead of just instantiating a GitPillar object.
This will cause invalid git_pillar configuration to keep the master from
starting up like we already do for gitfs.