### PR TITLE
Feature/2016.3 better postgresql grants

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -2875,7 +2875,7 @@ def privileges_grant(name,
                 object_name, name)
         elif (object_type in ('table', 'sequence') and
                 object_name.upper() == 'ALL'):
-            query = 'GRANT {0} ON ALL {1}S IN SCHEMA {2} TO ' + \
+            query = 'GRANT {0} ON ALL {1}S IN SCHEMA {2} TO ' \
                     '"{3}" WITH GRANT OPTION'.format(
                 _grants, object_type.upper(), prepend, name)
         else:

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -2873,12 +2873,21 @@ def privileges_grant(name,
         if object_type == 'group':
             query = 'GRANT {0} TO "{1}" WITH ADMIN OPTION'.format(
                 object_name, name)
+        elif (object_type in ('table', 'sequence') and
+                object_name.upper() == 'ALL'):
+            query = 'GRANT {0} ON ALL {1}S IN SCHEMA {2} TO ' + \
+                    '"{3}" WITH GRANT OPTION'.format(
+                _grants, object_type.upper(), prepend, name)
         else:
             query = 'GRANT {0} ON {1} {2} TO "{3}" WITH GRANT OPTION'.format(
                 _grants, object_type.upper(), on_part, name)
     else:
         if object_type == 'group':
             query = 'GRANT {0} TO "{1}"'.format(object_name, name)
+        elif (object_type in ('table', 'sequence') and
+                object_name.upper() == 'ALL'):
+            query = 'GRANT {0} ON ALL {1}S IN SCHEMA {2} TO "{3}"'.format(
+                _grants, object_type.upper(), prepend, name)
         else:
             query = 'GRANT {0} ON {1} {2} TO "{3}"'.format(
                 _grants, object_type.upper(), on_part, name)

--- a/salt/states/postgres_privileges.py
+++ b/salt/states/postgres_privileges.py
@@ -93,7 +93,8 @@ def present(name,
         Name of the role to which privileges should be granted
 
     object_name
-       Name of the object on which the grant is to be performed
+       Name of the object on which the grant is to be performed.
+       'ALL' may be used for objects of type 'table' or 'sequence'.
 
     object_type
        The object type, which can be one of the following:

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -1277,6 +1277,34 @@ class PostgresTestCase(TestCase):
                     host='testhost', port='testport',
                     password='testpassword', user='testuser', runas='user')
 
+        # Test grant on all tables
+        with patch('salt.modules.postgres._run_psql',
+            Mock(return_value={'retcode': 0})):
+            with patch('salt.modules.postgres.has_privileges',
+                    Mock(return_value=False)):
+                ret = postgres.privileges_grant(
+                   'baruwa',
+                   'ALL',
+                   'table',
+                   'SELECT',
+                   maintenance_db='db_name',
+                   runas='user',
+                   host='testhost',
+                   port='testport',
+                   user='testuser',
+                   password='testpassword'
+                )
+
+                query = 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "baruwa"'
+
+                postgres._run_psql.assert_called_once_with(
+                    ['/usr/bin/pgsql', '--no-align', '--no-readline',
+                     '--no-password', '--username', 'testuser', '--host',
+                     'testhost', '--port', 'testport', '--dbname', 'db_name',
+                     '-c', query],
+                    host='testhost', port='testport',
+                    password='testpassword', user='testuser', runas='user')
+
     def test_privileges_grant_group(self):
         '''
         Test granting privileges on group


### PR DESCRIPTION
### What does this PR do?

Allow granting privileges for ALL tables or sequences in state.postgres_privileges.
### What issues does this PR fix or reference?

Closes issue #36279 
### Tests written?

Yes.
### NOTE

This is based on the code in pull request #36249 - you'll want that first, since that fixes a grant bug.  I wasn't sure the best way to do this, but this feature seemed separate than fixing that bug.
