### PR TITLE
Add support for ElasticsearchVersion parameter

### DIFF
--- a/salt/modules/boto_elasticsearch_domain.py
+++ b/salt/modules/boto_elasticsearch_domain.py
@@ -300,8 +300,7 @@ def delete(DomainName, region=None, key=None, keyid=None, profile=None):
 
 def update(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
            AccessPolicies=None, SnapshotOptions=None, AdvancedOptions=None,
-           region=None, key=None, keyid=None, profile=None,
-           ElasticsearchVersion=None):
+           region=None, key=None, keyid=None, profile=None):
     '''
     Update the named domain to the configuration.
 
@@ -327,8 +326,7 @@ def update(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
 
     call_args = {}
     for k in ('ElasticsearchClusterConfig', 'EBSOptions',
-                'AccessPolicies', 'SnapshotOptions', 'AdvancedOptions',
-                'ElasticsearchVersion'):
+                'AccessPolicies', 'SnapshotOptions', 'AdvancedOptions'):
         if locals()[k] is not None:
             val = locals()[k]
             if isinstance(val, six.string_types):
@@ -339,8 +337,6 @@ def update(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
             call_args[k] = val
     if 'AccessPolicies' in call_args:
         call_args['AccessPolicies'] = json.dumps(call_args['AccessPolicies'])
-    if 'ElasticsearchVersion' in call_args:
-        call_args['ElasticsearchVersion'] = str(call_args['ElasticsearchVersion'])
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         domain = conn.update_elasticsearch_domain_config(DomainName=DomainName, **call_args)

--- a/salt/modules/boto_elasticsearch_domain.py
+++ b/salt/modules/boto_elasticsearch_domain.py
@@ -112,7 +112,7 @@ def __virtual__():
     a given version.
     '''
     required_boto_version = '2.8.0'
-    required_boto3_version = '1.2.5'
+    required_boto3_version = '1.4.0'
     # the boto_lambda execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
@@ -211,7 +211,7 @@ def describe(DomainName,
         domain = conn.describe_elasticsearch_domain_config(DomainName=DomainName)
         if domain and 'DomainConfig' in domain:
             domain = domain['DomainConfig']
-            keys = ('ElasticsearchClusterConfig', 'EBSOptions', 'AccessPolicies',
+            keys = ('ElasticsearchVersion', 'ElasticsearchClusterConfig', 'EBSOptions', 'AccessPolicies',
                     'SnapshotOptions', 'AdvancedOptions')
             return {'domain': dict([(k, domain.get(k, {}).get('Options')) for k in keys if k in domain])}
         else:
@@ -222,7 +222,8 @@ def describe(DomainName,
 
 def create(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
            AccessPolicies=None, SnapshotOptions=None, AdvancedOptions=None,
-           region=None, key=None, keyid=None, profile=None):
+           region=None, key=None, keyid=None, profile=None,
+           ElasticsearchVersion=None):
     '''
     Given a valid config, create a domain.
 
@@ -249,7 +250,8 @@ def create(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         kwargs = {}
         for k in ('ElasticsearchClusterConfig', 'EBSOptions',
-                    'AccessPolicies', 'SnapshotOptions', 'AdvancedOptions'):
+                    'AccessPolicies', 'SnapshotOptions', 'AdvancedOptions',
+                    'ElasticsearchVersion'):
             if locals()[k] is not None:
                 val = locals()[k]
                 if isinstance(val, six.string_types):
@@ -260,6 +262,8 @@ def create(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
                 kwargs[k] = val
         if 'AccessPolicies' in kwargs:
             kwargs['AccessPolicies'] = json.dumps(kwargs['AccessPolicies'])
+        if 'ElasticsearchVersion' in kwargs:
+            kwargs['ElasticsearchVersion'] = str(kwargs['ElasticsearchVersion'])
         domain = conn.create_elasticsearch_domain(DomainName=DomainName, **kwargs)
         if domain and 'DomainStatus' in domain:
             return {'created': True}
@@ -295,7 +299,8 @@ def delete(DomainName, region=None, key=None, keyid=None, profile=None):
 
 def update(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
            AccessPolicies=None, SnapshotOptions=None, AdvancedOptions=None,
-           region=None, key=None, keyid=None, profile=None):
+           region=None, key=None, keyid=None, profile=None,
+           ElasticsearchVersion=None):
     '''
     Update the named domain to the configuration.
 
@@ -321,7 +326,8 @@ def update(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
 
     call_args = {}
     for k in ('ElasticsearchClusterConfig', 'EBSOptions',
-                'AccessPolicies', 'SnapshotOptions', 'AdvancedOptions'):
+                'AccessPolicies', 'SnapshotOptions', 'AdvancedOptions',
+                'ElasticsearchVersion'):
         if locals()[k] is not None:
             val = locals()[k]
             if isinstance(val, six.string_types):
@@ -332,6 +338,8 @@ def update(DomainName, ElasticsearchClusterConfig=None, EBSOptions=None,
             call_args[k] = val
     if 'AccessPolicies' in call_args:
         call_args['AccessPolicies'] = json.dumps(call_args['AccessPolicies'])
+    if 'ElasticsearchVersion' in call_args:
+        call_args['ElasticsearchVersion'] = str(call_args['ElasticsearchVersion'])
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         domain = conn.update_elasticsearch_domain_config(DomainName=DomainName, **call_args)

--- a/salt/modules/boto_elasticsearch_domain.py
+++ b/salt/modules/boto_elasticsearch_domain.py
@@ -183,7 +183,8 @@ def status(DomainName,
             domain = domain.get('DomainStatus', {})
             keys = ('Endpoint', 'Created', 'Deleted',
                     'DomainName', 'DomainId', 'EBSOptions', 'SnapshotOptions',
-                    'AccessPolicies', 'Processing', 'AdvancedOptions', 'ARN')
+                    'AccessPolicies', 'Processing', 'AdvancedOptions', 'ARN',
+                    'ElasticsearchVersion')
             return {'domain': dict([(k, domain.get(k)) for k in keys if k in domain])}
         else:
             return {'domain': None}
@@ -211,7 +212,7 @@ def describe(DomainName,
         domain = conn.describe_elasticsearch_domain_config(DomainName=DomainName)
         if domain and 'DomainConfig' in domain:
             domain = domain['DomainConfig']
-            keys = ('ElasticsearchVersion', 'ElasticsearchClusterConfig', 'EBSOptions', 'AccessPolicies',
+            keys = ('ElasticsearchClusterConfig', 'EBSOptions', 'AccessPolicies',
                     'SnapshotOptions', 'AdvancedOptions')
             return {'domain': dict([(k, domain.get(k, {}).get('Options')) for k in keys if k in domain])}
         else:

--- a/salt/states/boto_elasticsearch_domain.py
+++ b/salt/states/boto_elasticsearch_domain.py
@@ -41,6 +41,7 @@ config:
         boto_elasticsearch_domain.present:
             - DomainName: mydomain
             - profile='user-credentials'
+            - ElasticsearchVersion: "2.3"
             - ElasticsearchClusterConfig:
                 InstanceType": "t2.micro.elasticsearch"
                 InstanceCount: 1
@@ -108,7 +109,8 @@ def present(name, DomainName,
             SnapshotOptions=None,
             AdvancedOptions=None,
             Tags=None,
-            region=None, key=None, keyid=None, profile=None):
+            region=None, key=None, keyid=None, profile=None,
+            ElasticsearchVersion="1.5"):
     '''
     Ensure domain exists.
 
@@ -188,6 +190,10 @@ def present(name, DomainName,
     profile
         A dict with region, key and keyid, or a pillar key (string) that
         contains a dict with region, key and keyid.
+
+    ElasticsearchVersion
+        String of format X.Y to specify version for the Elasticsearch domain eg.
+        "1.5" or "2.3".
     '''
     ret = {'name': DomainName,
            'result': True,
@@ -242,6 +248,7 @@ def present(name, DomainName,
                                                      AccessPolicies=AccessPolicies,
                                                      SnapshotOptions=SnapshotOptions,
                                                      AdvancedOptions=AdvancedOptions,
+                                                     ElasticsearchVersion=str(ElasticsearchVersion),
                                                region=region, key=key,
                                                keyid=keyid, profile=profile)
         if not r.get('created'):
@@ -275,7 +282,8 @@ def present(name, DomainName,
                'EBSOptions': EBSOptions,
                'AccessPolicies': AccessPolicies,
                'SnapshotOptions': SnapshotOptions,
-               'AdvancedOptions': AdvancedOptions}
+               'AdvancedOptions': AdvancedOptions,
+               'ElasticsearchVersion': str(ElasticsearchVersion)}
 
     for k, v in six.iteritems(es_opts):
         if not _compare_json(v, _describe[k]):

--- a/salt/states/boto_elasticsearch_domain.py
+++ b/salt/states/boto_elasticsearch_domain.py
@@ -268,6 +268,10 @@ def present(name, DomainName,
     _status = __salt__['boto_elasticsearch_domain.status'](DomainName=DomainName,
                                   region=region, key=key, keyid=keyid,
                                   profile=profile)['domain']
+    if _status.get('ElasticsearchVersion') != str(ElasticsearchVersion):
+        ret['result'] = False
+        ret['comment'] = 'Failed to update domain: version cannot be modified from {0} to {1}.'.format(_status.get('ElasticsearchVersion'), str(ElasticsearchVersion))
+        return ret
     _describe = __salt__['boto_elasticsearch_domain.describe'](DomainName=DomainName,
                                   region=region, key=key, keyid=keyid,
                                   profile=profile)['domain']
@@ -293,11 +297,6 @@ def present(name, DomainName,
             comm_args[k] = v
             ret['changes'].setdefault('new', {})[k] = v
             ret['changes'].setdefault('old', {})[k] = _describe[k]
-    if _status.get('ElasticsearchVersion') != str(ElasticsearchVersion):
-        need_update = True
-        comm_args['ElasticsearchVersion'] = str(ElasticsearchVersion)
-        ret['changes'].setdefault('new', {})['ElasticsearchVersion'] = str(ElasticsearchVersion)
-        ret['changes'].setdefault('old', {})['ElasticsearchVersion'] = _status.get('ElasticsearchVersion')
     if need_update:
         if __opts__['test']:
             msg = 'Domain {0} set to be modified.'.format(DomainName)

--- a/tests/unit/states/boto_elasticsearch_domain_test.py
+++ b/tests/unit/states/boto_elasticsearch_domain_test.py
@@ -88,7 +88,9 @@ if _has_required_boto():
                   EBSOptions={},
                   AccessPolicies={},
                   SnapshotOptions={},
-                  AdvancedOptions={})
+                  AdvancedOptions={},
+                  ElasticsearchVersion='1.5',
+                  )
 
 
 class BotoElasticsearchDomainStateTestCaseBase(TestCase):


### PR DESCRIPTION
### What does this PR do?

Adds support for the ElasticsearchVersion parameter to the module and state modules, to allow creation & management of ES 2.3 clusters.
### What issues does this PR fix or reference?

None
### Tests written?

Covered by existing tests.
