### PR TITLE
Fix for new integration test for fileserver.clear_file_list_cache

### DIFF
--- a/tests/integration/runners/fileserver.py
+++ b/tests/integration/runners/fileserver.py
@@ -81,30 +81,36 @@ class FileserverTest(integration.ShellCase):
         and we may have more than just "roots" configured in the fileserver
         backends. This assert will need to be updated accordingly.
         '''
+        saltenvs = sorted(self.run_run_plus(fun='fileserver.envs')['return'])
+
         @contextlib.contextmanager
         def gen_cache():
             '''
             Create file_list cache so we have something to clear
             '''
-            self.run_run_plus(fun='fileserver.file_list')
+            for saltenv in saltenvs:
+                self.run_run_plus(fun='fileserver.file_list', saltenv=saltenv)
             yield
 
         # Test with no arguments
         with gen_cache():
             ret = self.run_run_plus(fun='fileserver.clear_file_list_cache')
-            self.assertEqual(ret['return'], {'roots': ['base']})
+            ret['return']['roots'].sort()
+            self.assertEqual(ret['return'], {'roots': saltenvs})
 
         # Test with backend passed as string
         with gen_cache():
             ret = self.run_run_plus(fun='fileserver.clear_file_list_cache',
                                     backend='roots')
-            self.assertEqual(ret['return'], {'roots': ['base']})
+            ret['return']['roots'].sort()
+            self.assertEqual(ret['return'], {'roots': saltenvs})
 
         # Test with backend passed as list
         with gen_cache():
             ret = self.run_run_plus(fun='fileserver.clear_file_list_cache',
                                     backend=['roots'])
-            self.assertEqual(ret['return'], {'roots': ['base']})
+            ret['return']['roots'].sort()
+            self.assertEqual(ret['return'], {'roots': saltenvs})
 
         # Test with backend passed as string, but with a nonsense backend
         with gen_cache():


### PR DESCRIPTION
The test suite actually has a `prod` env, but this test only considers
the `base` env. If a test is run which requests a file (or just the
file/dir/symlink/... list) from the `prod` env, then this will result
in the `prod` env's file list caches being present, and they will be
removed when the `fileserver.clear_file_list_cache` runner is
executed, showing up in the return data and causing the test to fail.

This tweak to the test ensures that we will always have a file list
cache for `prod` present, and adjusts the necessary asserts in the
test to expect the `prod` env in the return data from the runner.