### PR TITLE
Protect the dbus import for a loader stacktrace in avahi_announce beacon

### DIFF
--- a/salt/beacons/avahi_announce.py
+++ b/salt/beacons/avahi_announce.py
@@ -1,6 +1,14 @@
 # -*- coding: utf-8 -*-
 '''
- Beacon to announce via avahi (zeroconf)
+Beacon to announce via avahi (zeroconf)
+
+.. versionadded:: Carbon
+
+Dependencies
+============
+
+- python-avahi
+- dbus-python
 
 '''
 # Import Python libs
@@ -14,7 +22,12 @@ try:
     HAS_PYAVAHI = True
 except ImportError:
     HAS_PYAVAHI = False
-import dbus
+
+try:
+    import dbus
+    HAS_DBUS = True
+except ImportError:
+    HAS_DBUS = False
 
 log = logging.getLogger(__name__)
 
@@ -30,8 +43,12 @@ GROUP = dbus.Interface(BUS.get_object(avahi.DBUS_NAME, SERVER.EntryGroupNew()),
 
 def __virtual__():
     if HAS_PYAVAHI:
-        return __virtualname__
-    return False
+        if HAS_DBUS:
+            return __virtualname__
+        return False, 'The {0} beacon cannot be loaded. The ' \
+                      '\'python-dbus\' dependency is missing.'.format(__virtualname__)
+    return False, 'The {0} beacon cannot be loaded. The ' \
+                  '\'python-avahi\' dependency is missing.'.format(__virtualname__)
 
 
 def __validate__(config):


### PR DESCRIPTION
### What does this PR do?

When the minion starts on `carbon`, the loader spits out the following stacktrace if dbus isn't installed on the minion. We need to protect this beacon module better in the import section and provider more helpful error returns in the `__virtual__()` function when dependencies aren't met:

```
[DEBUG   ] Failed to import beacons avahi_announce:
Traceback (most recent call last):
  File "/root/SaltStack/salt/salt/loader.py", line 1299, in _load_module
    ), fn_, fpath, desc)
  File "/root/SaltStack/salt/salt/beacons/avahi_announce.py", line 17, in <module>
ImportError: No module named dbus
```
### What issues does this PR fix or reference?

None.
### Previous Behavior

Stacktraces in minion log.
### New Behavior

No more stacktraces.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.