### PR TITLE
Don't stop to failover if all masters not reachable.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -561,6 +561,7 @@ class MinionBase(object):
                     if attempts == tries:
                         # Exhausted all attempts. Return exception.
                         self.connected = False
+                        self.opts['master'] = copy.copy(self.opts['local_masters'])
                         msg = ('No master could be reached or all masters '
                                'denied the minions connection attempt.')
                         log.error(msg)


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with minion stopping and exiting if no master could be reached in multimaster failover mode.
### What issues does this PR fix or reference?
#36135
### Previous Behavior

Minion tries each master then restarts the master connection procedure but stops on the second try with an error.
The problem is that minion saves the original master list in `opts['local_masters']` and sets the currently trying master to `opts['master']`. So on the first connection attempt `opts['master']` contains the list and on the second attempt `opts['master']` contains the last master that is a misconfiguration from the minion viewpoint (master is a string and failover enabled).
### New Behavior

If minion can't connect to any master, set `opts['master']` back to the original list before return.
### Tests written?

No