### PR TITLE
Configure thin/min modules permanently

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -1056,3 +1056,10 @@
 # use OS defaults, typically 75 seconds on Linux, see
 # /proc/sys/net/ipv4/tcp_keepalive_intvl.
 #tcp_keepalive_intvl: -1
+
+# Permanently include any available Python 3rd party modules into thin and minimal Salt
+# when they are generated for Salt-SSH or other purposes.
+# The modules should be named by the names they are actually imported inside the Python.
+# The value of the parameters can be either one module or a comma separated list of them.
+#thin_extra_mods: foo,bar
+#min_extra_mods: foo,bar,baz

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -746,6 +746,24 @@ authentication with minions
 
     ssh_use_home_key: False
 
+``thin_extra_mods``
+-------------------
+
+Default: None
+
+List of additional modules, needed to be included into the Salt Thin.
+Pass a list of importable Python modules that are typically located in
+the `site-packages` Python directory so they will be also always included
+into the Salt Thin, once generated.
+
+
+``min_extra_mods``
+------------------
+
+Default: None
+
+Identical as `thin_extra_mods`, only applied to the Salt Minimal.
+
 Master Security Settings
 ========================
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -305,6 +305,7 @@ class SSH(object):
         self.returners = salt.loader.returners(self.opts, {})
         self.fsclient = salt.fileclient.FSClient(self.opts)
         self.thin = salt.utils.thin.gen_thin(self.opts['cachedir'],
+                                             extra_mods=self.opts.get('thin_extra_mods'),
                                              overwrite=self.opts['regen_thin'],
                                              python2_bin=self.opts['python2_bin'],
                                              python3_bin=self.opts['python3_bin'])

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -913,6 +913,10 @@ VALID_OPTS = {
 
     # Minion data cache driver (one of satl.cache.* modules)
     'cache': str,
+
+    # Thin and minimal Salt extra modules
+    'thin_extra_mods': str,
+    'min_extra_mods': str,
 }
 
 # default configurations
@@ -1422,6 +1426,8 @@ DEFAULT_MASTER_OPTS = {
     'python2_bin': 'python2',
     'python3_bin': 'python3',
     'cache': 'localfs',
+    'thin_extra_mods': '',
+    'min_extra_mods': '',
 }
 
 

--- a/salt/runners/thin.py
+++ b/salt/runners/thin.py
@@ -31,6 +31,10 @@ def generate(extra_mods='', overwrite=False, so_mods='',
         salt-run thin.generate mako,wempy 1
         salt-run thin.generate overwrite=1
     '''
+    conf_mods = __opts__.get('thin_extra_mods')
+    if conf_mods:
+        extra_mods = ','.join([conf_mods, extra_mods])
+
     return salt.utils.thin.gen_thin(__opts__['cachedir'],
                                     extra_mods,
                                     overwrite,

--- a/salt/runners/thin.py
+++ b/salt/runners/thin.py
@@ -56,6 +56,10 @@ def generate_min(extra_mods='', overwrite=False, so_mods='',
 
         salt-run thin.generate_min
     '''
+    conf_mods = __opts__.get('min_extra_mods')
+    if conf_mods:
+        extra_mods = ','.join([conf_mods, extra_mods])
+
     return salt.utils.thin.gen_min(__opts__['cachedir'],
                                    extra_mods,
                                    overwrite,

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2814,6 +2814,14 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
             default=None,
             help='Pass in extra files to include in the state tarball.'
         )
+        self.add_option('--thin-extra-modules',
+                        dest='thin_extra_mods', default=None,
+                        help='One or comma-separated list of extra Python modules'
+                             'to be included into Thin Salt.')
+        self.add_option('--min-extra-modules',
+                        dest='min_extra_mods', default=None,
+                        help='One or comma-separated list of extra Python modules'
+                             'to be included into Minimal Salt.')
         self.add_option(
             '-v', '--verbose',
             default=False,


### PR DESCRIPTION
### What does this PR do?

Feature: configure extra modules that has to be included in the thin or minimal Salt on the permanent basis. Example:

```
/etc/salt/master:

-------------------8<----------------------
thin_extra_mods: mako,wempy
min_extra_mods: mako,wempy
-------------------8<----------------------
```
### Tests written?

No