### PR TITLE
cache query args with url as well

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -803,12 +803,17 @@ class Client(object):
         elif not os.path.isabs(cachedir):
             cachedir = os.path.join(self.opts['cachedir'], cachedir)
 
+        if url_data.query is not None:
+            file_name = '-'.join([url_data.path, url_data.query])
+        else:
+            file_name = url_data.path
+
         return salt.utils.path_join(
             cachedir,
             'extrn_files',
             saltenv,
             netloc,
-            url_data.path
+            file_name
         )
 
 


### PR DESCRIPTION
### What does this PR do?

Closes #36371

We do not cache based on query args at all, so if you have any you could end up with the same file even though the query args should change it.  Also lets query args be used with the source_hash of the file.
### Previous Behavior

Both of the states below would put the same file in place.

```
/opt/model.standard:
  file.managed:
    - source: http://localhost:8080/table
    - source_hash: http://localhost:8080/table?hash=true
    - skip_verify: True

/opt/model.higgs:
  file.managed:
    - source: http://localhost:8080/table?model=higgs
    - source_hash: http://localhost:8080/table?model=higgs&hash=true
    - skip_verify: True
```

This would fail on the source_hash, because it is checking the /table file for a sha= sum, but is getting the actual file instead of the hash that is returned when the hash=true query arg is passed.

```
/opt/model.standard:
  file.managed:
    - source: http://localhost:8080/table
    - source_hash: http://localhost:8080/table?hash=true

/opt/model.higgs:
  file.managed:
    - source: http://localhost:8080/table?model=higgs
    - source_hash: http://localhost:8080/table?model=higgs&hash=true
```

Getting this

```
[ERROR   ] Source hash http://localhost:8080/table?hash=true format is invalid. It must be in the format <hash type>=<hash>, or it must be a supported protocol: salt, file, http, https, ftp, swift, s3
[ERROR   ] Source hash http://localhost:8080/table?model=higgs&hash=true format is invalid. It must be in the format <hash type>=<hash>, or it must be a supported protocol: salt, file, http, https, ftp, swift, s3
local:
----------
          ID: /opt/model.standard
    Function: file.managed
      Result: False
     Comment: Source hash http://localhost:8080/table?hash=true format is invalid. It must be in the format <hash type>=<hash>, or it must be a supported protocol: salt, file, http, https, ftp, swift, s3
     Started: 20:14:21.806227
    Duration: 54.01 ms
     Changes:
----------
          ID: /opt/model.higgs
    Function: file.managed
      Result: False
     Comment: Source hash http://localhost:8080/table?model=higgs&hash=true format is invalid. It must be in the format <hash type>=<hash>, or it must be a supported protocol: salt, file, http, https, ftp, swift, s3
     Started: 20:14:21.860520
    Duration: 24.797 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    2
------------
Total states run:     2
```
### New Behavior

Fixes the above errors
### Tests written?

No