### PR TITLE
Allow VMware salt-cloud driver to list objects again

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1848,6 +1848,7 @@ class Minion(MinionBase):
         '''
         Handle an event from the epull_sock (all local minion events)
         '''
+        log.debug('handle_event ----------------------- ')
         if not self.ready:
             raise tornado.gen.Return()
         tag, data = salt.utils.event.SaltEvent.unpack(package)
@@ -2944,7 +2945,8 @@ class ProxyMinion(MinionManager):
         '''
         log.debug("subclassed _post_master_init")
 
-        self.opts['master'] = master
+        if self.connected:
+            self.opts['master'] = master
 
         self.opts['pillar'] = yield salt.pillar.get_async_pillar(
             self.opts,
@@ -3067,5 +3069,6 @@ class ProxyMinion(MinionManager):
             self.schedule.delete_job(master_event(type='failback'), persist=True)
 
         #  Sync the grains here so the proxy can communicate them to the master
-        self.functions['saltutil.sync_grains'](saltenv='base')
+        # self.functions['saltutil.sync_grains'](saltenv='base')
         self.grains_cache = self.opts['grains']
+        self.ready = True

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3068,6 +3068,6 @@ class ProxyMinion(MinionManager):
             self.schedule.delete_job(master_event(type='failback'), persist=True)
 
         #  Sync the grains here so the proxy can communicate them to the master
-        self.functions['saltutil.sync_grains'](saltenv='base')
+        # self.functions['saltutil.sync_grains'](saltenv='base')
         self.grains_cache = self.opts['grains']
         self.ready = True

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3070,4 +3070,3 @@ class ProxyMinion(MinionManager):
         #  Sync the grains here so the proxy can communicate them to the master
         # self.functions['saltutil.sync_grains'](saltenv='base')
         self.grains_cache = self.opts['grains']
-        self.ready = True

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1848,7 +1848,6 @@ class Minion(MinionBase):
         '''
         Handle an event from the epull_sock (all local minion events)
         '''
-        log.debug('handle_event ----------------------- ')
         if not self.ready:
             raise tornado.gen.Return()
         tag, data = salt.utils.event.SaltEvent.unpack(package)
@@ -3069,6 +3068,6 @@ class ProxyMinion(MinionManager):
             self.schedule.delete_job(master_event(type='failback'), persist=True)
 
         #  Sync the grains here so the proxy can communicate them to the master
-        # self.functions['saltutil.sync_grains'](saltenv='base')
+        self.functions['saltutil.sync_grains'](saltenv='base')
         self.grains_cache = self.opts['grains']
         self.ready = True

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -601,7 +601,7 @@ def get_content(service_instance, obj_type, property_list=None,
         traversal_spec = vmodl.query.PropertyCollector.TraversalSpec(
             name='traverseEntities',
             path='view',
-            skip=True,
+            skip=False,
             type=vim.view.ContainerView
         )
 
@@ -615,7 +615,7 @@ def get_content(service_instance, obj_type, property_list=None,
     # Create object spec to navigate content
     obj_spec = vmodl.query.PropertyCollector.ObjectSpec(
         obj=obj_ref,
-        skip=False,
+        skip=True,
         selectSet=[traversal_spec] if not local_properties else None
     )
 

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -615,7 +615,7 @@ def get_content(service_instance, obj_type, property_list=None,
     # Create object spec to navigate content
     obj_spec = vmodl.query.PropertyCollector.ObjectSpec(
         obj=obj_ref,
-        skip=True,
+        skip=True if not local_properties else False,
         selectSet=[traversal_spec] if not local_properties else None
     )
 

--- a/tests/unit/utils/vmware_test/common_test.py
+++ b/tests/unit/utils/vmware_test/common_test.py
@@ -403,11 +403,11 @@ class GetContentTestCase(TestCase):
         self.create_container_view_mock.assert_called_once_with(
             self.root_folder_mock, [self.obj_type_mock], True)
         self.traversal_spec_mock.assert_called_once_with(
-            name='traverseEntities', path='view', skip=True,
+            name='traverseEntities', path='view', skip=False,
             type=vim.view.ContainerView)
         self.obj_spec_mock.assert_called_once_with(
             obj=self.container_view_mock,
-            skip=False,
+            skip=True,
             selectSet=[self.traversal_spec_ret_mock])
         # check destroy is called
         self.assertEqual(self.destroy_mock.call_count, 1)
@@ -423,7 +423,7 @@ class GetContentTestCase(TestCase):
                     traversal_spec=traversal_spec_obj_mock)
         self.obj_spec_mock.assert_called_once_with(
             obj=self.root_folder_mock,
-            skip=False,
+            skip=True,
             selectSet=[traversal_spec_obj_mock])
         # Check local traversal methods are not called
         self.assertEqual(self.create_container_view_mock.call_count, 0)
@@ -441,12 +441,12 @@ class GetContentTestCase(TestCase):
                             self.si_mock,
                             self.obj_type_mock)
         self.traversal_spec_mock.assert_called_once_with(
-            name='traverseEntities', path='view', skip=True,
+            name='traverseEntities', path='view', skip=False,
             type=vim.view.ContainerView)
         self.property_spec_mock.assert_called_once_with(
             type=self.obj_type_mock, all=True, pathSet=None)
         self.obj_spec_mock.assert_called_once_with(
-            obj=self.container_view_mock, skip=False,
+            obj=self.container_view_mock, skip=True,
             selectSet=[self.traversal_spec_ret_mock])
         self.retrieve_contents_mock.assert_called_once_with(
             [self.filter_spec_ret_mock])
@@ -464,7 +464,7 @@ class GetContentTestCase(TestCase):
                         local_properties=True)
         self.assertEqual(self.traversal_spec_mock.call_count, 0)
         self.obj_spec_mock.assert_called_once_with(
-            obj=container_ref_mock, skip=False, selectSet=None)
+            obj=container_ref_mock, skip=True, selectSet=None)
 
 
 if __name__ == '__main__':

--- a/tests/unit/utils/vmware_test/common_test.py
+++ b/tests/unit/utils/vmware_test/common_test.py
@@ -464,7 +464,7 @@ class GetContentTestCase(TestCase):
                         local_properties=True)
         self.assertEqual(self.traversal_spec_mock.call_count, 0)
         self.obj_spec_mock.assert_called_once_with(
-            obj=container_ref_mock, skip=True, selectSet=None)
+            obj=container_ref_mock, skip=False, selectSet=None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Current VMware driver in Carbon does not list images or allow new VMs to be created.
### What issues does this PR fix or reference?

Closes #36301 
### Previous Behavior

`salt-cloud --list-images vsphere01` (with properly configured provider/profile files) would return

```
vsphere01:
    ----------
    vmware:
        ----------
```
### New Behavior

--list-images and other salt-cloud switches work again.
### Tests written?

No

@alexbleotu Feedback requested.
