### PR TITLE
merge error overwrites correct ssh_host with stale data in ip_address

### DIFF
--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -477,7 +477,6 @@ def create(vm_):
     log.debug('Found public IP address to use for ssh minion bootstrapping: {0}'.format(vm_['ssh_host']))
 
     vm_['key_filename'] = key_filename
-    vm_['ssh_host'] = ip_address
     ret = __utils__['cloud.bootstrap'](vm_, __opts__)
     ret.update(data)
 


### PR DESCRIPTION
### What does this PR do?

Fix a merge error. Effect was salt-cloud correctly saying it would connect to the IPv4 address of a newly created droplet in DigitalOcean and then actually attempting to connect to the IPv6. Probably doesn't even break things if IPv6 is working correctly.
### What issues does this PR fix or reference?
#36308
### Tests written?

No