### PR TITLE
Clean up libcloud stack trace

### DIFF
--- a/salt/states/libcloud_dns.py
+++ b/salt/states/libcloud_dns.py
@@ -63,7 +63,7 @@ try:
     import libcloud
     from libcloud.dns.providers import get_driver
     #pylint: enable=unused-import
-    if _LooseVersion(libcloud.__version__) < _LooseVersion(REQUIRED_LIBCLOUD_VERSION):
+    if hasattr(libcloud, '__version__') and _LooseVersion(libcloud.__version__) < _LooseVersion(REQUIRED_LIBCLOUD_VERSION):
         raise ImportError()
     logging.getLogger('libcloud').setLevel(logging.CRITICAL)
     HAS_LIBCLOUD = True


### PR DESCRIPTION
This is the same fix as done in #35658, but for the state module. The test suite logs show the following stacktrace, which will be cleaned up by this fix:

```
21:47:55 21:47:49,951 [salt.loader                                               :1355][ERROR   ] Failed to import states libcloud_dns, this is due most likely to a syntax error:
21:47:55 Traceback (most recent call last):
21:47:55   File "/testing/salt/loader.py", line 1334, in _load_module
21:47:55     ), fn_, fpath, desc)
21:47:55   File "/testing/salt/states/libcloud_dns.py", line 66, in <module>
21:47:55     if _LooseVersion(libcloud.__version__) < _LooseVersion(REQUIRED_LIBCLOUD_VERSION):
21:47:55   File "/usr/local/lib/python2.7/dist-packages/mock.py", line 660, in __getattr__
21:47:55     raise AttributeError(name)
21:47:55 AttributeError: __version__
```
