### PR TITLE
No force_yes parameter to pkg.upgrade #21248

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -949,9 +949,17 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
     if salt.utils.systemd.has_scope(__context__) \
             and __salt__['config.get']('systemd.scope', True):
         cmd.extend(['systemd-run', '--scope'])
+        
     cmd.extend(['apt-get', '-q', '-y',
                 '-o', 'DPkg::Options::={0}'.format(force_conf),
                 '-o', 'DPkg::Options::=--force-confdef'])
+                
+    if kwargs.get('force_yes', False):
+        cmd.append('--force-yes')
+        
+    if kwargs.get('skip_verify', False):
+        cmd.append('--allow-unauthenticated')
+        
     cmd.append('dist-upgrade' if dist_upgrade else 'upgrade')
 
     call = __salt__['cmd.run_all'](cmd,

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -948,7 +948,7 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
     if salt.utils.systemd.has_scope(__context__) \
             and __salt__['config.get']('systemd.scope', True):
         cmd.extend(['systemd-run', '--scope'])
-        
+
     cmd.extend(['apt-get', '-q', '-y',
                 '-o', 'DPkg::Options::={0}'.format(force_conf),
                 '-o', 'DPkg::Options::=--force-confdef'])

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -951,7 +951,7 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
         
     cmd.extend(['apt-get', '-q', '-y',
                 '-o', 'DPkg::Options::={0}'.format(force_conf),
-                '-o', 'DPkg::Options::=--force-confdef']
+                '-o', 'DPkg::Options::=--force-confdef'])
 
     if kwargs.get('force_yes', False):
         cmd.append('--force-yes')

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -944,7 +944,6 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
         force_conf = '--force-confnew'
     else:
         force_conf = '--force-confold'
-
     cmd = []
     if salt.utils.systemd.has_scope(__context__) \
             and __salt__['config.get']('systemd.scope', True):
@@ -952,14 +951,13 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
         
     cmd.extend(['apt-get', '-q', '-y',
                 '-o', 'DPkg::Options::={0}'.format(force_conf),
-                '-o', 'DPkg::Options::=--force-confdef'])
-                
+                '-o', 'DPkg::Options::=--force-confdef']
+
     if kwargs.get('force_yes', False):
         cmd.append('--force-yes')
-        
     if kwargs.get('skip_verify', False):
         cmd.append('--allow-unauthenticated')
-        
+
     cmd.append('dist-upgrade' if dist_upgrade else 'upgrade')
 
     call = __salt__['cmd.run_all'](cmd,


### PR DESCRIPTION
### What does this PR do?

Allows for skip_verify and force_yes to work with aptpkg.upgrade module
### What issues does this PR fix or reference?
#21248
### Previous Behavior

```
local:
    ----------
    changes:
        ----------
    comment:
        E: There are problems and -y was used without --force-yesReading package lists...
        Building dependency tree...
        Reading state information...
        The following NEW packages will be installed:
          libevent-1.4-2 linux-headers-3.13.0-95 linux-headers-3.13.0-95-generic
          linux-image-3.13.0-95-generic
        The following packages will be upgraded:
          base-files cloud-init curl dpkg dpkg-dev fontconfig fontconfig-config gnupg
          gpgv grub-common grub-legacy-ec2 grub-pc grub-pc-bin grub2-common
          initramfs-tools initramfs-tools-bin isc-dhcp-client isc-dhcp-common
          libarchive13 libavahi-client3 libavahi-common-data libavahi-common3 libcurl3
          libcurl3-gnutls libdpkg-perl libdrm2 libexpat1 libexpat1-dev libfontconfig1
          libgcrypt11 libharfbuzz0b libidn11 libldap-2.4-2 libmysqlclient18 libpq5
          libxml2 linux-headers-generic linux-headers-virtual linux-image-virtual
          linux-libc-dev linux-virtual mysql-common openssh-client openssh-server
          openssh-sftp-server pollinate python-pip python-pip-whl
          python3-update-manager tmux tzdata update-manager-core
          update-notifier-common wget
        54 upgraded, 4 newly installed, 0 to remove and 0 not upgraded.
        Need to get 39.5 MB of archives.
        After this operation, 120 MB of additional disk space will be used.
        WARNING: The following packages cannot be authenticated!
          tmux
    result:
        False
```
### Tests written?

No
