### PR TITLE
Safely shutdown the minion in minion test

### DIFF
--- a/tests/unit/minion_test.py
+++ b/tests/unit/minion_test.py
@@ -70,10 +70,13 @@ class MinionTestCase(TestCase):
         mock_data = {'fun': 'foo.bar',
                      'jid': 123}
         mock_jid_queue = [123]
-        minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue))
-        ret = minion._handle_decoded_payload(mock_data)
-        self.assertEqual(minion.jid_queue, mock_jid_queue)
-        self.assertIsNone(ret)
+        try:
+            minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue))
+            ret = minion._handle_decoded_payload(mock_data)
+            self.assertEqual(minion.jid_queue, mock_jid_queue)
+            self.assertIsNone(ret)
+        finally:
+            minion.destroy()
 
     @patch('salt.minion.Minion.ctx', MagicMock(return_value={}))
     @patch('salt.utils.process.SignalHandlingMultiprocessingProcess.start', MagicMock(return_value=True))
@@ -90,18 +93,21 @@ class MinionTestCase(TestCase):
         mock_data = {'fun': 'foo.bar',
                      'jid': mock_jid}
         mock_jid_queue = [123, 456]
-        minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue))
+        try:
+            minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue))
 
-        # Assert that the minion's jid_queue attribute matches the mock_jid_queue as a baseline
-        # This can help debug any test failures if the _handle_decoded_payload call fails.
-        self.assertEqual(minion.jid_queue, mock_jid_queue)
+            # Assert that the minion's jid_queue attribute matches the mock_jid_queue as a baseline
+            # This can help debug any test failures if the _handle_decoded_payload call fails.
+            self.assertEqual(minion.jid_queue, mock_jid_queue)
 
-        # Call the _handle_decoded_payload function and update the mock_jid_queue to include the new
-        # mock_jid. The mock_jid should have been added to the jid_queue since the mock_jid wasn't
-        # previously included. The minion's jid_queue attribute and the mock_jid_queue should be equal.
-        minion._handle_decoded_payload(mock_data)
-        mock_jid_queue.append(mock_jid)
-        self.assertEqual(minion.jid_queue, mock_jid_queue)
+            # Call the _handle_decoded_payload function and update the mock_jid_queue to include the new
+            # mock_jid. The mock_jid should have been added to the jid_queue since the mock_jid wasn't
+            # previously included. The minion's jid_queue attribute and the mock_jid_queue should be equal.
+            minion._handle_decoded_payload(mock_data)
+            mock_jid_queue.append(mock_jid)
+            self.assertEqual(minion.jid_queue, mock_jid_queue)
+        finally:
+            minion.destroy()
 
     @patch('salt.minion.Minion.ctx', MagicMock(return_value={}))
     @patch('salt.utils.process.SignalHandlingMultiprocessingProcess.start', MagicMock(return_value=True))
@@ -117,17 +123,20 @@ class MinionTestCase(TestCase):
         mock_data = {'fun': 'foo.bar',
                      'jid': 789}
         mock_jid_queue = [123, 456]
-        minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue))
+        try:
+            minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue))
 
-        # Assert that the minion's jid_queue attribute matches the mock_jid_queue as a baseline
-        # This can help debug any test failures if the _handle_decoded_payload call fails.
-        self.assertEqual(minion.jid_queue, mock_jid_queue)
+            # Assert that the minion's jid_queue attribute matches the mock_jid_queue as a baseline
+            # This can help debug any test failures if the _handle_decoded_payload call fails.
+            self.assertEqual(minion.jid_queue, mock_jid_queue)
 
-        # Call the _handle_decoded_payload function and check that the queue is smaller by one item
-        # and contains the new jid
-        minion._handle_decoded_payload(mock_data)
-        self.assertEqual(len(minion.jid_queue), 2)
-        self.assertEqual(minion.jid_queue, [456, 789])
+            # Call the _handle_decoded_payload function and check that the queue is smaller by one item
+            # and contains the new jid
+            minion._handle_decoded_payload(mock_data)
+            self.assertEqual(len(minion.jid_queue), 2)
+            self.assertEqual(minion.jid_queue, [456, 789])
+        finally:
+            minion.destroy()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The test is racing the callback in the minion init.

cc: @rallytime