### PR TITLE
Handle lack of exception class in older git backends

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -370,7 +370,9 @@ class _LegacyGitPillar(object):
                       'initializing the repo: {0}. Maybe '
                       'git is not available.'.format(exc))
         except Exception as exc:
-            log.exception('Undefined exception in git pillar')
+            log.exception('Undefined exception in git pillar. '
+                    'This may be a bug should be reported to the '
+                    'SaltStack developers.')
 
         # Git directory we are working on
         # Should be the same as self.repo.working_dir

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -363,13 +363,12 @@ class _LegacyGitPillar(object):
         if not os.path.isdir(rp_):
             os.makedirs(rp_)
         try:
-            try:
-                self.repo = git.Repo.init(rp_)
-            except (git.exc.NoSuchPathError,
-                    git.exc.InvalidGitRepositoryError) as exc:
-                log.error('GitPython exception caught while '
-                          'initializing the repo: {0}. Maybe '
-                          'git is not available.'.format(exc))
+            self.repo = git.Repo.init(rp_)
+        except (git.exc.NoSuchPathError,
+                git.exc.InvalidGitRepositoryError) as exc:
+            log.error('GitPython exception caught while '
+                      'initializing the repo: {0}. Maybe '
+                      'git is not available.'.format(exc))
         except Exception as exc:
             log.exception('Undefined exception in git pillar')
 

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -362,14 +362,16 @@ class _LegacyGitPillar(object):
 
         if not os.path.isdir(rp_):
             os.makedirs(rp_)
-
         try:
-            self.repo = git.Repo.init(rp_)
-        except (git.exc.NoSuchPathError,
-                git.exc.InvalidGitRepositoryError) as exc:
-            log.error('GitPython exception caught while '
-                      'initializing the repo: {0}. Maybe '
-                      'git is not available.'.format(exc))
+            try:
+                self.repo = git.Repo.init(rp_)
+            except (git.exc.NoSuchPathError,
+                    git.exc.InvalidGitRepositoryError) as exc:
+                log.error('GitPython exception caught while '
+                          'initializing the repo: {0}. Maybe '
+                          'git is not available.'.format(exc))
+        except Exception as exc:
+            log.exception('Undefined exception in git pillar')
 
         # Git directory we are working on
         # Should be the same as self.repo.working_dir


### PR DESCRIPTION
Some older gitbackends do not have the required exception handling classes. Handle this by logging a general exception.