### PR TITLE
Skip test_resize2fs unit test when resize2fs does not exists

### DIFF
--- a/tests/unit/modules/blockdev_test.py
+++ b/tests/unit/modules/blockdev_test.py
@@ -86,6 +86,7 @@ class TestBlockdevModule(TestCase):
         with patch.dict(blockdev.__salt__, {'cmd.run': mock}):
             self.assertEqual(blockdev.fstype(device), fs_type)
 
+    @skipIf(not salt.utils.which('resize2fs'), 'resize2fs not found')
     def test_resize2fs(self):
         '''
         unit tests for blockdev.resize2fs


### PR DESCRIPTION
### What does this PR do?

This PR skips `TestBlockdevModule::test_resize2fs` if `resize2fs` does not exists to prevent test fail.