### PR TITLE
set __virtualname__ to 'service'

### DIFF
--- a/salt/modules/daemontools.py
+++ b/salt/modules/daemontools.py
@@ -31,6 +31,8 @@ __func_alias__ = {
 
 log = logging.getLogger(__name__)
 
+__virtualname__ = 'service'
+
 VALID_SERVICE_DIRS = [
     '/service',
     '/var/service',
@@ -46,7 +48,7 @@ for service_dir in VALID_SERVICE_DIRS:
 def __virtual__():
     # Ensure that daemontools is installed properly.
     BINS = frozenset(('svc', 'supervise', 'svok'))
-    return all(salt.utils.which(b) for b in BINS)
+    return __virtualname__ if all(salt.utils.which(b) for b in BINS) else False
 
 
 def _service_path(name):


### PR DESCRIPTION
### What does this PR do?

It sets `__virtualname__` to 'service'.

In the `states/service.py` file the check is made through the `_available` function:

``` python
def _available(name, ret):
    '''
    Check if the service is available
    '''
    avail = False
    if 'service.available' in __salt__:
        avail = __salt__['service.available'](name)
    elif 'service.get_all' in __salt__:
        avail = name in __salt__['service.get_all']()
    if not avail:
        ret['result'] = False
        ret['comment'] = 'The named service {0} is not available'.format(name)
    return avail
```

So currently it doesn't work with the daemontools module as the `__virtualname__` is not `service`

Also: not sure if `provider: daemontools` is still supported as I haven't found any reference in the service state file ... and it is not mentionned in the documentation
### What issues does this PR fix or reference?

None
### Tests written?

No
