### PR TITLE
elasticsearch_returner remove dot in filed names before sending message to elasticsearch

### DIFF
--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -130,7 +130,7 @@ def returner(ret):
         def dst(self, dt):
             return timedelta(0)
 
-    if type({}) == type(ret['return']):
+    if isinstance(ret['return'], dict):
         sk = ""
         for k in ret['return'].keys():
             sk = k.replace('.', '_')

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -130,10 +130,11 @@ def returner(ret):
         def dst(self, dt):
             return timedelta(0)
 
-    sk = ""
-    for k in ret['return'].keys():
-        sk = k.replace('.', '_')
-        ret['return'][sk] = ret['return'].pop(k)
+    if type({}) == type(ret['return']):
+        sk = ""
+        for k in ret['return'].keys():
+            sk = k.replace('.', '_')
+            ret['return'][sk] = ret['return'].pop(k)
 
     utc = UTC()
     data = {

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -130,8 +130,12 @@ def returner(ret):
         def dst(self, dt):
             return timedelta(0)
 
-    utc = UTC()
+    sk = ""
+    for k in ret['return'].keys():
+        sk = k.replace('.', '_')
+        ret['return'][sk] = ret['return'].pop(k)
 
+    utc = UTC()
     data = {
         '@timestamp': datetime.now(utc).isoformat(),
         'success': job_success,


### PR DESCRIPTION
### What issues does this PR fix or reference?

Related issue: https://github.com/saltstack/salt/issues/36331
### Previous Behavior

Field name containing '.' was pushed to elasticsearch and refused if elasticsearch version > 2.0
### New Behavior

Replace '.' with '_' in field names before sending to elasticsearch

Edit:
Closes #36331
