### PR TITLE
Add ability to specify disk backing mode for VMware cloud profile

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -685,7 +685,7 @@ Example of a complete profile:
 Specifying disk backing mode
 ============================
 
-.. versionadded:: Carbon
+.. versionadded:: Nitrogen
 
 Disk backing mode can now be specified when cloning a VM. This option
 can be set in the cloud profile as shown in example below:

--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -663,6 +663,7 @@ Example of a complete profile:
           Hard disk 0:
             controller: 'SCSI controller 0'
             size: 20
+            mode: 'independent_nonpersistent'
         cd:
           CD/DVD drive 0:
             controller: 'IDE 0'
@@ -679,3 +680,30 @@ Example of a complete profile:
     be available. In such cases, the closest match to another ``image`` should
     be used. In the example above, a Debian 8 VM is created using the image
     ``debian7_64Guest`` which is for a Debian 7 guest.
+
+
+Specifying disk backing mode
+============================
+
+.. versionadded:: Carbon
+
+Disk backing mode can now be specified when cloning a VM. This option
+can be set in the cloud profile as shown in example below:
+
+.. code-block:: yaml
+
+    my-vm:
+      provider: esx01
+      datastore: esx01-datastore
+      resourcepool: Resources
+      folder: vm
+
+
+      devices:
+        disk:
+          Hard disk 1:
+            mode: 'independent_nonpersistent'
+
+          Hard disk 2:
+            size: 15
+            mode: 'independent_nonpersistent'

--- a/doc/topics/releases/2016.3.4.rst
+++ b/doc/topics/releases/2016.3.4.rst
@@ -8,3 +8,4 @@ Version 2016.3.4 is a bugfix release for :doc:`2016.3.0
 - The `disk.wipe` execution module function has been modified
   so that it correctly wipes a disk.
 - Add ability to clone from a snapshot to the VMWare salt-cloud driver.
+- Add ability to specify disk backing mode in the VMWare salt cloud profile.

--- a/doc/topics/releases/2016.3.4.rst
+++ b/doc/topics/releases/2016.3.4.rst
@@ -8,4 +8,3 @@ Version 2016.3.4 is a bugfix release for :doc:`2016.3.0
 - The `disk.wipe` execution module function has been modified
   so that it correctly wipes a disk.
 - Add ability to clone from a snapshot to the VMWare salt-cloud driver.
-- Add ability to specify disk backing mode in the VMWare salt cloud profile.

--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -10,3 +10,4 @@ Grains Changes
 - The ``os_release`` grain has been changed from a string to an integer.
   State files, especially those using a templating language like Jinja
   may need to be adjusted to account for this change.
+- Add ability to specify disk backing mode in the VMWare salt cloud profile.


### PR DESCRIPTION
### What does this PR do?

We're now able to specify a virtual disk backing mode in the cloud profile. This is applicable to the VMware (salt cloud) related functionality.
### What issues does this PR fix or reference?

ZH 926
### Previous Behavior

We could specify size and the sata controller for virtual disk.
### New Behavior

We can now specify the mode as well
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.