### PR TITLE
gitfs: Return None when find_file identifies the path as a directory

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -874,6 +874,9 @@ class GitPython(GitProvider):
                     path = salt.utils.path_join(os.path.dirname(path), link_tgt)
                 else:
                     blob = file_blob
+                    if isinstance(blob, git.Tree):
+                        # Path is a directory, not a file.
+                        blob = None
                     break
             except KeyError:
                 # File not found or repo_path points to a directory
@@ -1417,6 +1420,9 @@ class Pygit2(GitProvider):
                 else:
                     oid = tree[path].oid
                     blob = self.repo[oid]
+                    if isinstance(blob, pygit2.Tree):
+                        # Path is a directory, not a file.
+                        blob = None
                     break
             except KeyError:
                 blob = None
@@ -1792,6 +1798,9 @@ class Dulwich(GitProvider):  # pylint: disable=abstract-method
                     path = salt.utils.path_join(os.path.dirname(path), link_tgt)
                 else:
                     blob = self.repo.get_object(oid)
+                    if isinstance(blob, dulwich.objects.Tree):
+                        # Path is a directory, not a file.
+                        blob = None
                     break
             except KeyError:
                 blob = None


### PR DESCRIPTION
This fixes a traceback in the LocalClient when you try to use
cp.cache_file on a directory instead of a file.
