### PR TITLE
Add resize2fs unit test from blockdev_test to disk_test

### DIFF
--- a/tests/unit/modules/disk_test.py
+++ b/tests/unit/modules/disk_test.py
@@ -7,13 +7,14 @@
 from __future__ import absolute_import
 
 # Import Salt Testing libs
-from salttesting import TestCase
+from salttesting import skipIf, TestCase
 from salttesting.helpers import ensure_in_syspath
 from salttesting.mock import MagicMock, patch
 ensure_in_syspath('../../')
 
+# Import Salt libs
 from salt.modules import disk
-#usage_size = {'filesystem': None,'1K-blocks':10000,'used':10000,'available':10000,'capacity':10000}
+import salt.utils
 
 STUB_DISK_USAGE = {
                    '/': {'filesystem': None, '1K-blocks': 10000, 'used': 10000, 'available': 10000, 'capacity': 10000},
@@ -129,6 +130,17 @@ class DiskTestCase(TestCase):
                     'blockdev --setra 512 --setfra 512 /dev/sda',
                     python_shell=False
                 )
+
+    @skipIf(not salt.utils.which('resize2fs'), 'resize2fs not found')
+    def test_resize2fs(self):
+        '''
+        unit tests for disk.resize2fs
+        '''
+        device = '/dev/sdX1'
+        mock = MagicMock()
+        with patch.dict(disk.__salt__, {'cmd.run_all': mock}):
+            disk.resize2fs(device)
+            mock.assert_called_once_with('resize2fs {0}'.format(device), python_shell=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The blockdev module is being slowly deprecated and its functions moved to
to the disk module instead. There is a test for resize2fs in the blockdev_test
file in the 2015.8 branch (which matches the resize2fs function in the blockdev
module), but this function was moved to the disk file in 2016.3. The test was
never moved over.

I discovered this during a merge forward in #36344. This PR adds the
test from 2015.8 blockdev_test to the 2016.3 disk_test.py, and is adjusted
to work with the disk module accordingly.