### PR TITLE
Close open socket on freebsd

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -270,14 +270,17 @@ def get_unused_localhost_port():
         usock.close()
         return port
 
-    if sys.platform.startswith('darwin') and port in _RUNTESTS_PORTS:
+    DARWIN = True if sys.platform.startswith('darwin') else False
+    BSD = True if 'bsd' in sys.platform else False
+
+    if DARWIN and port in _RUNTESTS_PORTS:
         port = get_unused_localhost_port()
         usock.close()
         return port
 
     _RUNTESTS_PORTS[port] = usock
 
-    if sys.platform.startswith('darwin'):
+    if DARWIN or BSD:
         usock.close()
 
     return port


### PR DESCRIPTION
### What does this PR do?

Freebsd will bind the port, which wont allow the test suite to work properly. This closes the socket so the test suite can run. 

@cachedout 
### What issues does this PR fix or reference?

Allows the test suite to run on carbon and develop
### Tests written?

No