### PR TITLE
Check for Ign/Hit membership instead of == in aptpkg.refresh_db

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -361,9 +361,9 @@ def refresh_db():
             # Strip filesize from end of line
             ident = re.sub(r' \[.+B\]$', '', ident)
             ret[ident] = True
-        elif cols[0] == 'Ign':
+        elif 'Ign' in cols[0]:
             ret[ident] = False
-        elif cols[0] == 'Hit':
+        elif 'Hit' in cols[0]:
             ret[ident] = None
     return ret
 


### PR DESCRIPTION
### What does this PR do?

Ubuntu 16 lists the first "column" of data differently than previous versions of Ubuntu. Instead of check for `Hit` or `Ign` explicitly with `==`, we should use `in` instead to make sure display the `Hit` and `Ign` returns.

Ubuntu 16 looks like this:

```
Hit:1 http://repo.saltstack.com/apt/ubuntu/16.04/amd64/latest xenial InRelease
Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [95.7 kB]
Get:4 http://archive.ubuntu.com/ubuntu xenial-security InRelease [94.5 kB]
```

Ubuntu 14 looks like this:

```
Hit http://repo.saltstack.com trusty InRelease
Ign http://archive.ubuntu.com trusty InRelease
Get:1 http://archive.ubuntu.com trusty-updates InRelease [65.9 kB]
Get:2 http://archive.ubuntu.com trusty-security InRelease [65.9 kB]
```
### What issues does this PR fix or reference?

This should clear up the `integration.modules.pkg.PkgModuleTest.test_refresh_db` test failures on Ubuntu 16, as it should now be unlikely that a `{}` will be returned if no `Get`s are in the `apt-get -q update` return: 

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/salttesting/helpers.py", line 547, in wrapper
    return func(cls)
  File "/usr/local/lib/python2.7/dist-packages/salttesting/helpers.py", line 68, in wrap
    return caller(cls)
  File "/testing/tests/integration/modules/pkg.py", line 198, in test_refresh_db
    self.assertNotEqual(ret, {})
AssertionError: {} == {}
```
### Tests written?

Yes - there is already a test written for this which found this change in behavior.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
