### PR TITLE
Add options for SSL connection

### DIFF
--- a/salt/pillar/mysql.py
+++ b/salt/pillar/mysql.py
@@ -30,6 +30,10 @@ Complete example
       user: 'salt'
       pass: 'super_secret_password'
       db: 'salt_db'
+      port: 3306
+      ssl:
+        cert: /etc/mysql/client-cert.pem
+        key: /etc/mysql/client-key.pem
 
     ext_pillar:
       - mysql:
@@ -83,7 +87,8 @@ class MySQLExtPillar(SqlBaseExtPillar):
                     'user': 'salt',
                     'pass': 'salt',
                     'db': 'salt',
-                    'port': 3306}
+                    'port': 3306,
+                    'ssl': {}}
         _options = {}
         _opts = __opts__.get('mysql', {})
         for attr in defaults:
@@ -103,7 +108,8 @@ class MySQLExtPillar(SqlBaseExtPillar):
         conn = MySQLdb.connect(host=_options['host'],
                                user=_options['user'],
                                passwd=_options['pass'],
-                               db=_options['db'], port=_options['port'])
+                               db=_options['db'], port=_options['port'],
+                               ssl=_options['ssl'])
         cursor = conn.cursor()
         try:
             yield cursor


### PR DESCRIPTION
### What does this PR do?

Add ability to use SSL client connection feature in MySQLdb module.
### What issues does this PR fix or reference?

None
### Previous Behavior

Could only support non-encrypted connection to MySQL Server
### New Behavior

Connect to MySQL Server via SSL
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

Add `ssl` option to allow for Secure Socket Layer client connection to DB server.  Need to update master config to include `ssl` dictionary with `cert` and `key` path definitions
