### PR TITLE
Add `str.replace` to query if we use encryption

### DIFF
--- a/salt/pillar/mysql.py
+++ b/salt/pillar/mysql.py
@@ -117,6 +117,14 @@ class MySQLExtPillar(SqlBaseExtPillar):
             This function normalizes the config block into a set of queries we
             can use.  The return is a list of consistently laid out dicts.
         '''
+        
+        '''
+            If we have an encryption key in master config, read it and replace in our query string for each ext_pillar
+        '''
+        for ext_pillar_item in kwargs.keys():
+            if 'encryption_key' in kwargs[ext_pillar_item]:
+                kwargs[ext_pillar_item]['query'] = kwargs[ext_pillar_item]['query'].replace('REPLACEWITHREALKEYVALUE', kwargs[ext_pillar_item]['encryption_key'])
+                
         return super(MySQLExtPillar, self).extract_queries(args, kwargs)
 
 


### PR DESCRIPTION
### What does this PR do?

Add the ability to manage an encryption key via a master config value (encryption_key) for an external pillar which uses a query with field level encryption
### What issues does this PR fix or reference?

None
### New Behavior

If `encryption_key` is found in `ext_pillar` configuration, will attempt a str.replace of `REPLACEWITHREALKEYVALUE` with value found in `encryption_key` master config option.

e.g. 
`ext_pillar:`
&nbsp;&nbsp;`- mysql:`
&nbsp;&nbsp;&nbsp;&nbsp;`custom_pillar:`
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`encryption_key: somereallylongpassworddata`
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`query: 'SELECT AES_DECRYPT(table.key_field, "REPLACEWITHREALKEYVALUE") AS key, AES_DECRYPT(table.value, "REPLACEWITHREALKEYVALUE") AS value FROM table WHERE tabel.minion_id LIKE AES_ENCRYPT(%s, "REPLACEWITHREALKEYVALUE")'
`
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

If `encryption_key` master config argument is found in the section for `ext_pillar`, allow for a `str.replace` to make it easier to manage a common encryption key in SQL `query` for field level encryption.

e.g. `SELECT AES_DECRYPT(table.key, "REPLACEWITHREALKEYVALUE") AS somekey AES_DECRYPT(table.value, "REPLACEWITHREALKEYVALUE") AS somevalue FROM table WHERE table.minion_id LIKE AES_ENCRYPT(%s, "REPLACEWITHREALKEYVALUE")`
