### PR TITLE
Add -V option to work with --versions-report

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -236,7 +236,9 @@ class OptionParser(optparse.OptionParser, object):
     def _add_version_option(self):
         optparse.OptionParser._add_version_option(self)
         self.add_option(
-            '--versions-report', action='store_true',
+            '--versions-report',
+            '-V',
+            action='store_true',
             help='Show program\'s dependencies version number and exit.'
         )
 


### PR DESCRIPTION
Fixes saltstack/salt#36364

```
root@rallytime:~# salt-master -V
Salt Version:
           Salt: 2016.9.0-62-g2a77316

Dependency Versions:
           cffi: 1.7.0
       cherrypy: 5.0.1
       dateutil: 2.5.3
          gitdb: 0.6.4
      gitpython: 1.0.1
          ioflo: 1.5.5
         Jinja2: 2.8
        libgit2: Not Installed
        libnacl: Not Installed
       M2Crypto: 0.21.1
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.4.6
   mysql-python: 1.2.3
      pycparser: 2.10
       pycrypto: 2.6.1
         pygit2: Not Installed
         Python: 2.7.6 (default, Jun 22 2015, 17:58:13)
   python-gnupg: 0.3.8
         PyYAML: 3.10
          PyZMQ: 14.5.0
           RAET: Not Installed
          smmap: 0.9.0
        timelib: 0.2.4
        Tornado: 4.2.1
            ZMQ: 4.0.5

System Versions:
           dist: Ubuntu 14.04 trusty
        machine: x86_64
        release: 4.6.5-x86_64-linode71
         system: Linux
        version: Ubuntu 14.04 trusty
```