### PR TITLE
Option to update htpasswd only if changed

### DIFF
--- a/salt/modules/htpasswd.py
+++ b/salt/modules/htpasswd.py
@@ -147,7 +147,7 @@ def verify(pwfile, user, password, opts='', runas=None):
     password matches.
 
     pwfile
-        Path to htpasswd file
+        Fully qualified path to htpasswd file
 
     user
         User name

--- a/salt/modules/htpasswd.py
+++ b/salt/modules/htpasswd.py
@@ -139,3 +139,46 @@ def userdel(pwfile, user, runas=None):
     out = __salt__['cmd.run'](cmd, runas=runas,
                               python_shell=False).splitlines()
     return out
+
+
+def verify(pwfile, user, password, opts='', runas=None):
+    '''
+    Return True if the htpasswd file exists, the user has an entry, and their
+    password matches.
+
+    pwfile
+        Path to htpasswd file
+
+    user
+        User name
+
+    password
+        User password
+
+    opts
+        Valid options that can be passed are:
+
+            - `m`  Force MD5 encryption of the password (default).
+            - `d`  Force CRYPT encryption of the password.
+            - `p`  Do not encrypt the password (plaintext).
+            - `s`  Force SHA encryption of the password.
+
+    runas
+        The system user to run htpasswd command with
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' webutil.verify /etc/httpd/htpasswd larry maybepassword
+        salt '*' webutil.verify /etc/httpd/htpasswd larry maybepassword opts=ns
+    '''
+    if not os.path.exists(pwfile):
+        return False
+
+    cmd = ['htpasswd', '-bv{0}'.format(opts), pwfile, user, password]
+    ret = __salt__['cmd.run_all'](cmd, runas=runas, python_shell=False)
+    log.debug('Result of verifying htpasswd for user {0}: {1}'.format(
+        user, ret))
+
+    return ret['retcode'] == 0

--- a/salt/states/htpasswd.py
+++ b/salt/states/htpasswd.py
@@ -30,7 +30,7 @@ def __virtual__():
 
 
 def user_exists(name, password=None, htpasswd_file=None, options='',
-                force=False, runas=None):
+                force=False, runas=None, update=False):
     '''
     Make sure the user is inside the specified htpasswd file
 
@@ -52,15 +52,26 @@ def user_exists(name, password=None, htpasswd_file=None, options='',
     runas
         The system user to run htpasswd command with
 
+    update
+        Update an existing user's password if it's different from what's in
+        the htpasswd file (unlike force, which updates regardless)
+
     '''
     ret = {'name': name,
            'changes': {},
            'comment': '',
            'result': None}
 
-    grep = __salt__['file.grep']
-    grep_ret = grep(htpasswd_file, name)
-    if grep_ret['retcode'] != 0 or force:
+    exists = __salt__['file.grep'](htpasswd_file, name)['retcode'] == 0
+
+    # If user exists, but we're supposed to update the password, find out if
+    # it's changed, but not if we're forced to update the file regardless.
+    password_changed = False
+    if exists and update and not force:
+        password_changed = not __salt__['webutil.verify'](
+            htpasswd_file, name, password, opts=options, runas=runas)
+
+    if not exists or password_changed or force:
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = ('User \'{0}\' is set to be added to htpasswd '


### PR DESCRIPTION
### What does this PR do?

Adds a boolean flag called `update` to `webutil.user_exists` to make it update a user's password if it has changed.
### What issues does this PR fix or reference?

Fixes #35445
### Previous Behavior

The file is not updated if the user exists in the file at all. There exists a `force` option, but that updates the file regardless of whether the password has changed or not, which makes it difficult to have other things happen on changes to this, like bouncing nginx or whatnot. So previously, you could either never update the file, or always update the file.
### New Behavior

The file (and state) changes if the password input is different from what's in the file.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
