### PR TITLE
git.latest Treat an up-to-date checkout with local changes as up-to-date

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -724,30 +724,29 @@ def latest(name,
                 )
                 local_changes = False
 
-            if local_changes:
-                if revs_match:
-                    if force_reset:
-                        msg = (
-                            '{0} is up-to-date, but with local changes. Since '
-                            '\'force_reset\' is enabled, these local changes '
-                            'would be reset.'.format(target)
-                        )
-                        if __opts__['test']:
-                            ret['changes']['forced update'] = True
-                            if comments:
-                                msg += _format_comments(comments)
-                            return _neutral_test(ret, msg)
-                        log.debug(msg.replace('would', 'will'))
-                    else:
-                        log.debug(
-                            '%s has local changes, but is up-to-date. Since '
-                            '\'force_reset\' is disabled, no changes will be '
-                            'made.', target
-                        )
-                        return _uptodate(ret,
-                                         target,
-                                         _format_comments(comments),
-                                         local_changes)
+            if local_changes and revs_match:
+                if force_reset:
+                    msg = (
+                        '{0} is up-to-date, but with local changes. Since '
+                        '\'force_reset\' is enabled, these local changes '
+                        'would be reset.'.format(target)
+                    )
+                    if __opts__['test']:
+                        ret['changes']['forced update'] = True
+                        if comments:
+                            msg += _format_comments(comments)
+                        return _neutral_test(ret, msg)
+                    log.debug(msg.replace('would', 'will'))
+                else:
+                    log.debug(
+                        '%s up-to-date, but with local changes. Since '
+                        '\'force_reset\' is disabled, no changes will be '
+                        'made.', target
+                    )
+                    return _uptodate(ret,
+                                     target,
+                                     _format_comments(comments),
+                                     local_changes)
 
             if remote_rev_type == 'sha1' \
                     and base_rev is not None \

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -138,8 +138,11 @@ def _strip_exc(exc):
     return re.sub(r'^Command [\'"].+[\'"] failed: ', '', exc.strerror)
 
 
-def _uptodate(ret, target, comments=None):
+def _uptodate(ret, target, comments=None, local_changes=False):
     ret['comment'] = 'Repository {0} is up-to-date'.format(target)
+    if local_changes:
+        ret['comment'] += ', but with local changes. Set \'force_reset\' to ' \
+                          'True to purge local changes.'
     if comments:
         # Shouldn't be making any changes if the repo was up to date, but
         # report on them so we are alerted to potential problems with our
@@ -721,6 +724,31 @@ def latest(name,
                 )
                 local_changes = False
 
+            if local_changes:
+                if revs_match:
+                    if force_reset:
+                        msg = (
+                            '{0} is up-to-date, but with local changes. Since '
+                            '\'force_reset\' is enabled, these local changes '
+                            'would be reset.'.format(target)
+                        )
+                        if __opts__['test']:
+                            ret['changes']['forced update'] = True
+                            if comments:
+                                msg += _format_comments(comments)
+                            return _neutral_test(ret, msg)
+                        log.debug(msg.replace('would', 'will'))
+                    else:
+                        log.debug(
+                            '%s has local changes, but is up-to-date. Since '
+                            '\'force_reset\' is disabled, no changes will be '
+                            'made.', target
+                        )
+                        return _uptodate(ret,
+                                         target,
+                                         _format_comments(comments),
+                                         local_changes)
+
             if remote_rev_type == 'sha1' \
                     and base_rev is not None \
                     and base_rev.startswith(remote_rev):
@@ -810,7 +838,7 @@ def latest(name,
                             has_remote_rev = True
 
             # If fast_forward is not boolean, then we don't know if this will
-            # be a fast forward or not, because a fetch is requirde.
+            # be a fast forward or not, because a fetch is required.
             fast_forward = None if not local_changes else False
 
             if has_remote_rev:

--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -174,16 +174,21 @@ class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             # Make sure that we now have uncommitted changes
             self.assertTrue(self.run_function('git.diff', [name, 'HEAD']))
 
-            # Re-run state with force_reset=False, this should fail
+            # Re-run state with force_reset=False
             ret = self.run_state(
                 'git.latest',
                 name='https://{0}/saltstack/salt-test-repo.git'.format(self.__domain),
                 target=name,
                 force_reset=False
             )
-            self.assertSaltFalseReturn(ret)
+            self.assertSaltTrueReturn(ret)
+            self.assertEqual(
+                ret[next(iter(ret))]['comment'],
+                ('Repository {0} is up-to-date, but with local changes. Set '
+                 '\'force_reset\' to True to purge local changes.'.format(name))
+            )
 
-            # Now run the state with force_reset=True, this should succeed
+            # Now run the state with force_reset=True
             ret = self.run_state(
                 'git.latest',
                 name='https://{0}/saltstack/salt-test-repo.git'.format(self.__domain),


### PR DESCRIPTION
Implementation of https://github.com/saltstack/salt/issues/34725 caused
these cases to be seen as non-fast-forward changes, requiring
`force_reset=True` to proceed. This resolves that unintended behavior.

Fixes #36321.