### PR TITLE
Fix windows osrelease grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -866,15 +866,17 @@ def _windows_platform_data():
         os_release = platform.release()
         info = salt.utils.win_osinfo.get_os_version_info()
 
-        # Starting with Python 2.7.12 and 3.5.2 python started reporting the
-        # Server version the OS as the Desktop version, so we need to look
-        # those up
+        # Starting with Python 2.7.12 and 3.5.2 the `platform.uname()` function
+        # started reporting the Desktop version instead of the Server version on
+        # Server versions of Windows, so we need to look those up
+        # Check for Python >=2.7.12 or >=3.5.2
         ver = pythonversion()['pythonversion']
         if ((six.PY2 and
                 salt.utils.compare_versions(ver, '>=', [2, 7, 12, 'final', 0]))
             or
             (six.PY3 and
                 salt.utils.compare_versions(ver, '>=', [3, 5, 2, 'final', 0]))):
+            # (Product Type 1 is Desktop, Everything else is Server)
             if info['ProductType'] > 1:
                 server = {'Vista': '2008Server',
                           '7': '2008ServerR2',

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -845,21 +845,21 @@ def _windows_platform_data():
     with salt.utils.winapi.Com():
         wmi_c = wmi.WMI()
         # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394102%28v=vs.85%29.aspx
-        system_info = wmi_c.Win32_ComputerSystem()[0]
+        systeminfo = wmi_c.Win32_ComputerSystem()[0]
         # https://msdn.microsoft.com/en-us/library/aa394239(v=vs.85).aspx
-        os_info = wmi_c.Win32_OperatingSystem()[0]
+        osinfo = wmi_c.Win32_OperatingSystem()[0]
         # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394077(v=vs.85).aspx
-        bios_info = wmi_c.Win32_BIOS()[0]
+        biosinfo = wmi_c.Win32_BIOS()[0]
         # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394498(v=vs.85).aspx
-        time_info = wmi_c.Win32_TimeZone()[0]
+        timeinfo = wmi_c.Win32_TimeZone()[0]
 
         # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394072(v=vs.85).aspx
         motherboard = {'product': None,
                        'serial': None}
         try:
-            motherboard_info = wmi_c.Win32_BaseBoard()[0]
-            motherboard['product'] = motherboard_info.Product
-            motherboard['serial'] = motherboard_info.SerialNumber
+            motherboardinfo = wmi_c.Win32_BaseBoard()[0]
+            motherboard['product'] = motherboardinfo.Product
+            motherboard['serial'] = motherboardinfo.SerialNumber
         except IndexError:
             log.debug('Motherboard info not available on this system')
 
@@ -893,20 +893,20 @@ def _windows_platform_data():
             service_pack = ''.join(['SP', str(info['ServicePackMajor'])])
 
         grains = {
-            'kernelrelease': os_info.Version,
-            'osversion': os_info.Version,
+            'kernelrelease': osinfo.Version,
+            'osversion': osinfo.Version,
             'osrelease': os_release,
             'osservicepack': service_pack,
-            'osmanufacturer': os_info.Manufacturer,
-            'manufacturer': system_info.Manufacturer,
-            'productname': system_info.Model,
+            'osmanufacturer': osinfo.Manufacturer,
+            'manufacturer': systeminfo.Manufacturer,
+            'productname': systeminfo.Model,
             # bios name had a bunch of whitespace appended to it in my testing
             # 'PhoenixBIOS 4.0 Release 6.0     '
-            'biosversion': bios_info.Name.strip(),
-            'serialnumber': bios_info.SerialNumber,
-            'osfullname': os_info.Caption,
-            'timezone': time_info.Description,
-            'windowsdomain': system_info.Domain,
+            'biosversion': biosinfo.Name.strip(),
+            'serialnumber': biosinfo.SerialNumber,
+            'osfullname': osinfo.Caption,
+            'timezone': timeinfo.Description,
+            'windowsdomain': systeminfo.Domain,
             'motherboard': {
                 'productname': motherboard['product'],
                 'serialnumber': motherboard['serial'],
@@ -915,19 +915,19 @@ def _windows_platform_data():
 
         # test for virtualized environments
         # I only had VMware available so the rest are unvalidated
-        if 'VRTUAL' in bios_info.Version:  # (not a typo)
+        if 'VRTUAL' in biosinfo.Version:  # (not a typo)
             grains['virtual'] = 'HyperV'
-        elif 'A M I' in bios_info.Version:
+        elif 'A M I' in biosinfo.Version:
             grains['virtual'] = 'VirtualPC'
-        elif 'VMware' in system_info.Model:
+        elif 'VMware' in systeminfo.Model:
             grains['virtual'] = 'VMware'
-        elif 'VirtualBox' in system_info.Model:
+        elif 'VirtualBox' in systeminfo.Model:
             grains['virtual'] = 'VirtualBox'
-        elif 'Xen' in bios_info.Version:
+        elif 'Xen' in biosinfo.Version:
             grains['virtual'] = 'Xen'
-            if 'HVM domU' in system_info.Model:
+            if 'HVM domU' in systeminfo.Model:
                 grains['virtual_subtype'] = 'HVM domU'
-        elif 'OpenStack' in system_info.Model:
+        elif 'OpenStack' in systeminfo.Model:
             grains['virtual'] = 'OpenStack'
 
     return grains

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -873,7 +873,7 @@ def _windows_platform_data():
             osrelease = server[osrelease]
 
         if info['ServicePackMajor'] > 0:
-            service_pack = ''.join(['SP', info['ServicePackMajor']])
+            service_pack = ''.join(['SP', str(info['ServicePackMajor'])])
             osrelease = ' '.join([osrelease, service_pack])
 
         grains = {

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -863,13 +863,18 @@ def _windows_platform_data():
         # location. For example:
         # 'Microsoft Windows Server 2008 R2 Standard |C:\\Windows|\\Device\\Harddisk0\\Partition2'
         osrelease = platform.release()
-        if salt.utils.win_osinfo.get_os_version_info()['ProductType'] > 1:
-            server = {'Vista': '2008',
-                      '7': '2008R2',
-                      '8': '2012',
-                      '8.1': '2012R2',
-                      '10': '2016'}
+        info = salt.utils.win_osinfo.get_os_version_info()
+        if info['ProductType'] > 1:
+            server = {'Vista': 'Server 2008',
+                      '7': 'Server 2008 R2',
+                      '8': 'Server 2012',
+                      '8.1': 'Server 2012 R2',
+                      '10': 'Server 2016'}
             osrelease = server[osrelease]
+
+        if info['ServicePackMajor'] > 0:
+            service_pack = ''.join('SP', info['ServicePackMajor'])
+            osrelease = ' '.join([osrelease, service_pack])
 
         grains = {
             'osversion': osinfo.Version,

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1080,7 +1080,6 @@ def os_data():
         'gpus': [],
         }
 
-    # Python 2.7.8 Returns
     # Windows Server 2008 64-bit
     # ('Windows', 'MINIONNAME', '2008ServerR2', '6.1.7601', 'AMD64',
     #  'Intel64 Fam ily 6 Model 23 Stepping 6, GenuineIntel')

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -869,9 +869,12 @@ def _windows_platform_data():
         # Starting with Python 2.7.12 and 3.5.2 python started reporting the
         # Server version the OS as the Desktop version, so we need to look
         # those up
-        ver = pythonversion()
-        if salt.utils.compare_versions(ver, '>=', [2, 7, 12, 'final', 0]) \
-                or salt.utils.compare_versions(ver, '>=', [3, 5, 2, 'final', 0]):
+        ver = pythonversion()['pythonversion']
+        if ((six.PY2 and
+                salt.utils.compare_versions(ver, '>=', [2, 7, 12, 'final', 0]))
+            or
+            (six.PY3 and
+                salt.utils.compare_versions(ver, '>=', [3, 5, 2, 'final', 0]))):
             if info['ProductType'] > 1:
                 server = {'Vista': '2008Server',
                           '7': '2008ServerR2',

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -863,21 +863,25 @@ def _windows_platform_data():
         except IndexError:
             log.debug('Motherboard info not available on this system')
 
-        # the name of the OS comes with a bunch of other data about the install
-        # location. For example:
-        # 'Microsoft Windows Server 2008 R2 Standard |C:\\Windows|\\Device\\Harddisk0\\Partition2'
         os_release = platform.release()
         info = salt.utils.win_osinfo.get_os_version_info()
-        if info['ProductType'] > 1:
-            server = {'Vista': '2008Server',
-                      '7': '2008ServerR2',
-                      '8': '2012Server',
-                      '8.1': '2012ServerR2',
-                      '10': '2016Server'}
-            os_release = server.get(os_release,
-                                   'Grain not found. Update lookup table in the '
-                                   '`_window_platform_data` function in '
-                                   '`grains\\core.py`')
+
+        # Starting with Python 2.7.12 and 3.5.2 python started reporting the
+        # Server version the OS as the Desktop version, so we need to look
+        # those up
+        ver = pythonversion()
+        if salt.utils.compare_versions(ver, '>=', [2, 7, 12, 'final', 0]) \
+                or salt.utils.compare_versions(ver, '>=', [3, 5, 2, 'final', 0]):
+            if info['ProductType'] > 1:
+                server = {'Vista': '2008Server',
+                          '7': '2008ServerR2',
+                          '8': '2012Server',
+                          '8.1': '2012ServerR2',
+                          '10': '2016Server'}
+                os_release = server.get(os_release,
+                                       'Grain not found. Update lookup table in '
+                                       'the `_window_platform_data` function in '
+                                       '`grains\\core.py`')
 
         service_pack = None
         if info['ServicePackMajor'] > 0:

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -873,7 +873,7 @@ def _windows_platform_data():
             osrelease = server[osrelease]
 
         if info['ServicePackMajor'] > 0:
-            service_pack = ''.join('SP', info['ServicePackMajor'])
+            service_pack = ''.join(['SP', info['ServicePackMajor']])
             osrelease = ' '.join([osrelease, service_pack])
 
         grains = {

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -884,9 +884,9 @@ def _windows_platform_data():
                           '8.1': '2012ServerR2',
                           '10': '2016Server'}
                 os_release = server.get(os_release,
-                                       'Grain not found. Update lookup table in '
-                                       'the `_window_platform_data` function in '
-                                       '`grains\\core.py`')
+                                        'Grain not found. Update lookup table '
+                                        'in the `_windows_platform_data` '
+                                        'function in `grains\\core.py`')
 
         service_pack = None
         if info['ServicePackMajor'] > 0:

--- a/salt/utils/win_osinfo.py
+++ b/salt/utils/win_osinfo.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+'''
+Get Versioning information from Windows
+'''
+# http://stackoverflow.com/questions/32300004/python-ctypes-getting-0-with-getversionex-function
+import ctypes
+from ctypes.wintypes import BYTE, WORD, DWORD, WCHAR
+
+kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+
+class OSVERSIONINFO(ctypes.Structure):
+    _fields_ = (('dwOSVersionInfoSize', DWORD),
+                ('dwMajorVersion',      DWORD),
+                ('dwMinorVersion',      DWORD),
+                ('dwBuildNumber',       DWORD),
+                ('dwPlatformId',        DWORD),
+                ('szCSDVersion',        WCHAR * 128))
+    def __init__(self, *args, **kwds):
+        super(OSVERSIONINFO, self).__init__(*args, **kwds)
+        self.dwOSVersionInfoSize = ctypes.sizeof(self)
+        kernel32.GetVersionExW(ctypes.byref(self))
+
+class OSVERSIONINFOEX(OSVERSIONINFO):
+    _fields_ = (('wServicePackMajor', WORD),
+                ('wServicePackMinor', WORD),
+                ('wSuiteMask',        WORD),
+                ('wProductType',      BYTE),
+                ('wReserved',         BYTE))
+
+def errcheck_bool(result, func, args):
+    if not result:
+        raise ctypes.WinError(ctypes.get_last_error())
+    return args
+
+kernel32.GetVersionExW.errcheck = errcheck_bool
+kernel32.GetVersionExW.argtypes = (ctypes.POINTER(OSVERSIONINFO),)
+
+def get_os_version_info():
+    info = OSVERSIONINFOEX()
+    ret = {'MajorVersion': info.dwMajorVersion,
+           'MinorVersion': info.dwMinorVersion,
+           'BuildNumber': info.dwBuildNumber,
+           'PlatformID': info.dwPlatformId,
+           'ServicePackMajor': info.wServicePackMajor,
+           'ServicePackMinor': info.wServicePackMinor,
+           'SuiteMask': info.wSuiteMask,
+           'ProductType': info.wProductType}
+
+    return ret

--- a/salt/utils/win_osinfo.py
+++ b/salt/utils/win_osinfo.py
@@ -3,29 +3,35 @@
 Get Versioning information from Windows
 '''
 # http://stackoverflow.com/questions/32300004/python-ctypes-getting-0-with-getversionex-function
+from __future__ import absolute_import
+
 import ctypes
 from ctypes.wintypes import BYTE, WORD, DWORD, WCHAR
 
 kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
 
+
 class OSVERSIONINFO(ctypes.Structure):
     _fields_ = (('dwOSVersionInfoSize', DWORD),
-                ('dwMajorVersion',      DWORD),
-                ('dwMinorVersion',      DWORD),
-                ('dwBuildNumber',       DWORD),
-                ('dwPlatformId',        DWORD),
-                ('szCSDVersion',        WCHAR * 128))
+                ('dwMajorVersion', DWORD),
+                ('dwMinorVersion', DWORD),
+                ('dwBuildNumber', DWORD),
+                ('dwPlatformId', DWORD),
+                ('szCSDVersion', WCHAR * 128))
+
     def __init__(self, *args, **kwds):
         super(OSVERSIONINFO, self).__init__(*args, **kwds)
         self.dwOSVersionInfoSize = ctypes.sizeof(self)
         kernel32.GetVersionExW(ctypes.byref(self))
 
+
 class OSVERSIONINFOEX(OSVERSIONINFO):
     _fields_ = (('wServicePackMajor', WORD),
                 ('wServicePackMinor', WORD),
-                ('wSuiteMask',        WORD),
-                ('wProductType',      BYTE),
-                ('wReserved',         BYTE))
+                ('wSuiteMask', WORD),
+                ('wProductType', BYTE),
+                ('wReserved', BYTE))
+
 
 def errcheck_bool(result, func, args):
     if not result:
@@ -34,6 +40,7 @@ def errcheck_bool(result, func, args):
 
 kernel32.GetVersionExW.errcheck = errcheck_bool
 kernel32.GetVersionExW.argtypes = (ctypes.POINTER(OSVERSIONINFO),)
+
 
 def get_os_version_info():
     info = OSVERSIONINFOEX()


### PR DESCRIPTION
### What does this PR do?

Properly gets the osrelease grain for Server versions of Windows. 
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/36307
### Previous Behavior

OS name was removed in the python command platform.uname(). Python version 2.7.8 would return a value of "2008ServerR2" for Windows Server 2008 R2. We moved to Python 2.7.11 and later to 2.7.12 which both report the Desktop version of 7 instead of the server name of 2008ServerR2.
### New Behavior

Properly detect windows server os release grain along with any applied service packs.
### Tests written?

No
