### PR TITLE
Add '/y' switch to the net stop and start commands

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -165,7 +165,7 @@ def start(name):
 
         salt '*' service.start <service name>
     '''
-    cmd = ['net', 'start', name]
+    cmd = ['net', 'start', '/y', name]
     return not __salt__['cmd.retcode'](cmd, python_shell=False)
 
 
@@ -183,7 +183,7 @@ def stop(name):
     # up if the service takes too long to stop with a misleading
     # "service could not be stopped" message and RC 0.
 
-    cmd = ['net', 'stop', name]
+    cmd = ['net', 'stop', '/y', name]
     res = __salt__['cmd.run'](cmd, python_shell=False)
     if 'service was stopped' in res:
         return True


### PR DESCRIPTION
### What does this PR do?

Adds '/y' switch to the net stop and start commands
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/959
### Previous Behavior

Services with dependencies would prompt the user to press 'y' to start or stop a service with dependencies... causing salt to hang.
### New Behavior

The net command now uses the '/y' switch
### Tests written?

No