### PR TITLE
Update the extend.py and extend_test.py imports

### DIFF
--- a/salt/utils/extend.py
+++ b/salt/utils/extend.py
@@ -12,25 +12,26 @@ This tool is accessed using `salt-extend`
 
     :codeauthor: :email:`Anthony Shaw <anthonyshaw@apache.org>`
 '''
+
+# Import Python libs
 from __future__ import absolute_import
 from __future__ import print_function
 
 from datetime import date
+import logging
 import tempfile
 import os
 import sys
 import shutil
 from jinja2 import Template
 
-# zip compat for PY2/3
+# Import Salt libs
 from salt.serializers.yaml import deserialize
 from salt.ext.six.moves import zip
-from salt.utils import fopen
 from salt.utils.odict import OrderedDict
-
+import salt.utils
 import salt.version
 
-import logging
 log = logging.getLogger(__name__)
 
 try:
@@ -55,7 +56,7 @@ def _get_template(path, option_key):
     :returns: Details about the template
     :rtype: ``tuple``
     '''
-    with fopen(path, "r") as template_f:
+    with salt.utils.fopen(path, "r") as template_f:
         template = deserialize(template_f)
         info = (option_key, template.get('description', ''), template)
     return info
@@ -137,10 +138,10 @@ def _mergetreejinja(src, dst, context):
             if item != TEMPLATE_FILE_NAME:
                 d = Template(d).render(context)
                 log.info("Copying file {0} to {1}".format(s, d))
-                with fopen(s, 'r') as source_file:
+                with salt.utils.fopen(s, 'r') as source_file:
                     src_contents = source_file.read()
                     dest_contents = Template(src_contents).render(context)
-                with fopen(d, 'w') as dest_file:
+                with salt.utils.fopen(d, 'w') as dest_file:
                     dest_file.write(dest_contents)
 
 
@@ -300,7 +301,7 @@ def run(extension=None, name=None, description=None, salt_dir=None, merge=False,
         _mergetree(temp_dir, salt_dir)
         path = salt_dir
 
-    print('New module stored in {0}'.format(path))
+    log.info('New module stored in {0}'.format(path))
     return path
 
 if __name__ == '__main__':

--- a/tests/unit/utils/extend_test.py
+++ b/tests/unit/utils/extend_test.py
@@ -13,17 +13,17 @@ import os
 import shutil
 from datetime import date
 
-# Import salt libs
-import salt.utils.extend
-from salt.utils import fopen
-import integration
-
 # Import Salt Testing libs
 from salttesting import TestCase
 from salttesting.helpers import ensure_in_syspath
 from salttesting.mock import MagicMock, patch
 
 ensure_in_syspath('../../')
+
+# Import salt libs
+import salt.utils.extend
+import integration
+import salt.utils
 
 
 class ExtendTestCase(TestCase):
@@ -44,7 +44,7 @@ class ExtendTestCase(TestCase):
         self.assertFalse(os.path.exists(os.path.join(out, 'template.yml')))
         self.assertTrue(os.path.exists(os.path.join(out, 'directory')))
         self.assertTrue(os.path.exists(os.path.join(out, 'directory', 'test.py')))
-        with fopen(os.path.join(out, 'directory', 'test.py'), 'r') as test_f:
+        with salt.utils.fopen(os.path.join(out, 'directory', 'test.py'), 'r') as test_f:
             self.assertEqual(test_f.read(), year)
 
 if __name__ == '__main__':


### PR DESCRIPTION
When using `fopen`, we need to import all of salt.utils. We should also be explicit about calling salt.utils.fopen.

This also cleans up the ordering of the salttesting vs salt libs to be consistent with other files and conform with `ensure_is_syspath`.

Also changes a print statement to a log.info.

I am hoping this will clear up the `unit.utils.extend_test.ExtendTestCase.test_run` test failure that is currently happening on Ubuntu 12. If it doesn't clear up that failure, then it may have something to do with the self.out file that is used in the `setUp` and `tearDown` functions.