### PR TITLE
Fix/minion cache publish

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1980,6 +1980,14 @@ class ClearFuncs(object):
             )
             return ''
 
+        # Retrieve the minions list
+        delimiter = clear_load.get('kwargs', {}).get('delimiter', DEFAULT_TARGET_DELIM)
+        minions = self.ckminions.check_minions(
+            clear_load['tgt'],
+            clear_load.get('tgt_type', 'glob'),
+            delimiter
+        )
+
         # Check for external auth calls
         if extra.get('token', False):
             # A token was passed, check it
@@ -2041,7 +2049,8 @@ class ClearFuncs(object):
                 clear_load['fun'],
                 clear_load['arg'],
                 clear_load['tgt'],
-                clear_load.get('tgt_type', 'glob'))
+                clear_load.get('tgt_type', 'glob'),
+                minions=minions)
             if not good:
                 # Accept find_job so the CLI will function cleanly
                 if clear_load['fun'] != 'saltutil.find_job':
@@ -2138,7 +2147,8 @@ class ClearFuncs(object):
                 clear_load['fun'],
                 clear_load['arg'],
                 clear_load['tgt'],
-                clear_load.get('tgt_type', 'glob')
+                clear_load.get('tgt_type', 'glob'),
+                minions=minions
                 )
             if not good:
                 # Accept find_job so the CLI will function cleanly
@@ -2170,7 +2180,8 @@ class ClearFuncs(object):
                                 clear_load['fun'],
                                 clear_load['arg'],
                                 clear_load['tgt'],
-                                clear_load.get('tgt_type', 'glob'))
+                                clear_load.get('tgt_type', 'glob'),
+                                minions=minions)
                     if not good:
                         # Accept find_job so the CLI will function cleanly
                         if clear_load['fun'] != 'saltutil.find_job':
@@ -2215,7 +2226,8 @@ class ClearFuncs(object):
                         clear_load['fun'],
                         clear_load['arg'],
                         clear_load['tgt'],
-                        clear_load.get('tgt_type', 'glob'))
+                        clear_load.get('tgt_type', 'glob'),
+                        minions=minions)
                     if not good:
                         # Accept find_job so the CLI will function cleanly
                         if clear_load['fun'] != 'saltutil.find_job':
@@ -2235,14 +2247,7 @@ class ClearFuncs(object):
                     'Authentication failure of type "other" occurred.'
                 )
                 return ''
-        # FIXME Needs additional refactoring
-        # Retrieve the minions list
-        delimiter = clear_load.get('kwargs', {}).get('delimiter', DEFAULT_TARGET_DELIM)
-        minions = self.ckminions.check_minions(
-            clear_load['tgt'],
-            clear_load.get('tgt_type', 'glob'),
-            delimiter
-        )
+
         # If we order masters (via a syndic), don't short circuit if no minions
         # are found
         if not self.opts.get('order_masters'):

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -652,6 +652,8 @@ class CkMinions(object):
         v_minions = self._expand_matching(valid)
         if minions is None:
             minions = set(self.check_minions(expr, expr_form))
+        else:
+            minions = set(minions)
         d_bool = not bool(minions.difference(v_minions))
         if len(v_minions) == len(minions) and d_bool:
             return True


### PR DESCRIPTION
### What does this PR do?

The publish function in the master was already obtaining a list of minions via check_minions, so use that list to provide it to the auth_check/validate_tgt functions.  I'm not sure if there are unforeseen consequences of moving the check_minions to earlier in the function.
### What issues does this PR fix or reference?

With a large amount of minions and large ACL sets, check_minions starts becoming extremely expensive, as it's called for every ACL within external_auth.  This attempts to alleviate some of that cost.
### Previous Behavior

When a large ACL set is involved ( think ~100 different ACL's for a single group ), it causes check_minions to be called for each set, which in turn then has to parse items from the filesystem.  With a large amount of minions, this parse is slow, so in turn, the authentication slows down tremendously.
### New Behavior

The master's publish function now provides the list of minions ( which is was already obtaining ), to the auth_check function.
### Tests written?

No