### PR TITLE
fix accound_id in boto_iam and get_region in boto_sns

### DIFF
--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -1200,6 +1200,7 @@ def get_account_id(region=None, key=None, keyid=None, profile=None):
             # The get_user call returns an user ARN:
             #    arn:aws:iam::027050522557:user/salt-test
             arn = ret['get_user_response']['get_user_result']['user']['arn']
+            account_id = arn.split(':')[4]
         except boto.exception.BotoServerError:
             # If call failed, then let's try to get the ARN from the metadata
             timeout = boto.config.getfloat(
@@ -1208,15 +1209,15 @@ def get_account_id(region=None, key=None, keyid=None, profile=None):
             attempts = boto.config.getint(
                 'Boto', 'metadata_service_num_attempts', 1
             )
-            metadata = boto.utils.get_instance_metadata(
+            identity = boto.utils.get_instance_identity(
                 timeout=timeout, num_retries=attempts
             )
             try:
-                arn = metadata['iam']['info']['InstanceProfileArn']
+                account_id = identity['document']['accountId']
             except KeyError:
-                log.error('Failed to get user or metadata ARN information in'
+                log.error('Failed to get account id from instance_identity in'
                           ' boto_iam.get_account_id.')
-        __context__[cache_key] = arn.split(':')[4]
+        __context__[cache_key] = account_id
     return __context__[cache_key]
 
 

--- a/salt/modules/boto_sns.py
+++ b/salt/modules/boto_sns.py
@@ -199,6 +199,9 @@ def get_arn(name, region=None, key=None, keyid=None, profile=None):
 def _get_region(region=None, profile=None):
     if profile and 'region' in profile:
         return profile['region']
+    if not region and __salt__['config.option'](profile):
+        _profile = __salt__['config.option'](profile)
+        region = _profile.get('region', None)
     if not region and __salt__['config.option']('sns.region'):
         region = __salt__['config.option']('sns.region')
     if not region:


### PR DESCRIPTION
### What does this PR do?

This PR does
- Fixes an error when trying to retrieve the `account_id` from an instance which doesn't have iam profile.
- Fetch region from config_option if the profile is a string
### What issues does this PR fix or reference?
- First issue is that `salt-call boto_iam.get_account_id` doesnt work if the instance doesn't have an iam profile, switched retrieval of the `account_id` from `arn` to `identity_doc`.
- Second issue is that `salt-call boto_sns.get_arn my_alert profile=profile` doesn't fetch the region from `cloud_profile` if the profile is specified, fixed it by fetching the the region from cloud option of the profile as well.
### Tests written?

No
