### PR TITLE
New cmd.shell_info. Fixed win_dsc & win_psget  Slowdown of Minion (36252) Add defensive programming to win_dsc & win_psget

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2670,17 +2670,17 @@ def shell_info(shell):
     :codeauthor: Damon Atkins <https://github.com/damon-atkins>
     '''
     regex_shells = {
-        'bash': ['version ([-\\w.]+)', 'bash', '--version'],
-        'bash-test-error': ['versioZ ([-\\w.]+)', 'bash', '--version'],  # used to test a error result
-        'bash-test-env': ['(HOME=.*)', 'bash', '-c', 'declare'],  # used to test a error result
-        'zsh': ['^zsh ([\\d.]+)', 'zsh', '--version'],
-        'tcsh': ['^tcsh ([\\d.]+)', 'tcsh', '--version'],
-        'cmd': ['Version ([\\d.]+)', 'cmd.exe', '/C', 'ver'],
-        'powershell': ['PSVersion\\s+([\\d.]+)', 'powershell', '-NonInteractive', '$PSVersionTable'],
-        'perl': ['^([\\d.]+)', 'perl', '-e', 'printf "%vd\n", $^V;'],
-        'python': ['^Python ([\\d.]+)', 'python', '-V'],
-        'ruby': ['^ruby ([\\d.]+)', 'ruby', '-v'],
-        'php': ['^PHP ([\\d.]+)', 'php', '-v']
+        'bash': [r'version ([-\w.]+)', 'bash', '--version'],
+        'bash-test-error': [r'versioZ ([-\w.]+)', 'bash', '--version'],  # used to test a error result
+        'bash-test-env': [r'(HOME=.*)', 'bash', '-c', 'declare'],  # used to test a error result
+        'zsh': [r'^zsh ([\d.]+)', 'zsh', '--version'],
+        'tcsh': [r'^tcsh ([\d.]+)', 'tcsh', '--version'],
+        'cmd': [r'Version ([\d.]+)', 'cmd.exe', '/C', 'ver'],
+        'powershell': [r'PSVersion\s+([\d.]+)', 'powershell', '-NonInteractive', '$PSVersionTable'],
+        'perl': [r'^([\d.]+)', 'perl', '-e', 'printf "%vd\n", $^V;'],
+        'python': [r'^Python ([\d.]+)', 'python', '-V'],
+        'ruby': [r'^ruby ([\d.]+)', 'ruby', '-v'],
+        'php': [r'^PHP ([\d.]+)', 'php', '-v']
     }
     # Ensure ret['installed'] always as a value of True, False or None (not sure)
     ret = {}

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2663,17 +2663,17 @@ def shell_info(name):
     :codeauthor: Damon Atkins <https://github.com/damon-atkins>
     '''
     regex_shells = {
-        'bash': ['version ([-\w.]+)', 'bash', '--version'],
-        'bash-test-error': ['versioZ ([-\w.]+)', 'bash', '--version'], # used to test a error result
-        'bash-test-env': ['(HOME=.*)', 'bash', '-c', 'declare'], # used to test a error result
-        'zsh': ['^zsh ([\d.]+)', 'zsh', '--version'],
-        'tcsh': ['^tcsh ([\d.]+)', 'tcsh', '--version'],
-        'cmd': ['Version ([\d.]+)', 'cmd.exe', '/C', 'ver'],
-        'powershell': ['PSVersion\s+([\d.]+)', 'powershell', '-NonInteractive', '$PSVersionTable'],
-        'perl': ['^([\d.]+)', 'perl', '-e', 'printf "%vd\n", $^V;'],
-        'python': ['^Python ([\d.]+)', 'python', '-V'],
-        'ruby': ['^ruby ([\d.]+)', 'ruby', '-v'],
-        'php': ['^PHP ([\d.]+)', 'php', '-v']
+        'bash': ['version ([-\\w.]+)', 'bash', '--version'],
+        'bash-test-error': ['versioZ ([-\\w.]+)', 'bash', '--version'],  # used to test a error result
+        'bash-test-env': ['(HOME=.*)', 'bash', '-c', 'declare'],  # used to test a error result
+        'zsh': ['^zsh ([\\d.]+)', 'zsh', '--version'],
+        'tcsh': ['^tcsh ([\\d.]+)', 'tcsh', '--version'],
+        'cmd': ['Version ([\\d.]+)', 'cmd.exe', '/C', 'ver'],
+        'powershell': ['PSVersion\s+([\\d.]+)', 'powershell', '-NonInteractive', '$PSVersionTable'],
+        'perl': ['^([\\d.]+)', 'perl', '-e', 'printf "%vd\n", $^V;'],
+        'python': ['^Python ([\\d.]+)', 'python', '-V'],
+        'ruby': ['^ruby ([\\d.]+)', 'ruby', '-v'],
+        'php': ['^PHP ([\\d.]+)', 'php', '-v']
     }
     # Ensure ret['installed'] always as a value of True, False or None (not sure)
     ret = {}
@@ -2688,10 +2688,10 @@ def shell_info(name):
                 'version': None
             }
         for reg_ver in pw_keys:
-            install_data = __salt__['reg.read_value']('HKEY_LOCAL_MACHINE', 'Software\Microsoft\PowerShell\{0}'.format(reg_ver),'Install')
+            install_data = __salt__['reg.read_value']('HKEY_LOCAL_MACHINE', 'Software\Microsoft\PowerShell\{0}'.format(reg_ver), 'Install')
             if 'vtype' in install_data and install_data['vtype'] == 'REG_DWORD' and install_data['vdata'] == 1:
-                details = __salt__['reg.list_values']('HKEY_LOCAL_MACHINE','Software\Microsoft\PowerShell\{0}\PowerShellEngine'.format(reg_ver))
-                ret = {} # reset data, want the newest version details only as powershell is backwards compatible
+                details = __salt__['reg.list_values']('HKEY_LOCAL_MACHINE', 'Software\Microsoft\PowerShell\{0}\PowerShellEngine'.format(reg_ver))
+                ret = {}  # reset data, want the newest version details only as powershell is backwards compatible
                 ret['installed'] = True
                 ret['path'] = which('powershell.exe')
                 for attribute in details:
@@ -2749,10 +2749,10 @@ def shell_info(name):
                 'installed': False,
                 'version': None
             }
-        ret['stdout'] = proc.stdout
+
         ret['installed'] = True
         ret['path'] = which(shell_data[0])
-        pattern_result = re.search( pattern, proc.stdout, flags=re.IGNORECASE)
+        pattern_result = re.search(pattern, proc.stdout, flags=re.IGNORECASE)
         # only set version if we find it, so code later on can deal with it
         if pattern_result:
             ret['version'] = pattern_result.group(1)
@@ -2760,16 +2760,18 @@ def shell_info(name):
     if 'version' not in ret:
         ret['error'] = 'The version regex pattern for shell {0}, could not find the version string'.format(name)
         ret['version'] = None
+        ret['stdout'] = proc.stdout  # include stdout so they can see the issue
         log.error(ret['error'])
     else:
-        major_result=re.match('(\d+)',ret['version'])
+        major_result=re.match('(\d+)', ret['version'])
         if major_result:
             ret['version_major'] = major_result.group(1)
-            major_minor_result = re.match('(\d+[-.]\d+)',ret['version'])
+            major_minor_result = re.match('(\d+[-.]\d+)', ret['version'])
             if major_minor_result:
                 ret['version_major_minor'] = major_minor_result.group(1)
 
     return ret
+
 
 def powershell(cmd,
         cwd=None,

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -20,6 +20,7 @@ import time
 import traceback
 import fnmatch
 import base64
+import re
 
 # Import salt libs
 import salt.utils
@@ -2633,6 +2634,140 @@ def shells():
             log.error("File '{0}' was not found".format(shells_fn))
     return ret
 
+
+def shell_info(name):
+    '''
+    Provides information about a shell or languages often use #!
+    The values returned are dependant on the shell or languages all return
+    the ``version`` ``version_major`` and ``version_major_minor`` e.g. 5.0 or 6-3.
+    The shell must be within the exeuctable search path.
+
+    :param str name: Name of the shell.
+    Support are bash, cmd, perl, php, powershell, python, ruby and zsh
+    :return: Properies of the shell specifically its version and stdout
+    and other information if available.
+    :rtype: dict
+    .. code-block:: cfg
+        {'version': '<version string>
+         'version_major': '<version string'
+         'version_minor': '<version string>'
+         '<attribute>': '<attribute value>'}
+
+    .. versionadded:: 2016.9.0
+
+    CLI Example::
+    .. code-block:: bash
+        salt '*' cmd.shell bash
+        salt '*' cmd.shell powershell
+
+    :codeauthor: Damon Atkins <https://github.com/damon-atkins>
+    '''
+    regex_shells = {
+        'bash': ['version ([-\w.]+)','bash', '--version'],
+        'bash-test-error': ['versioZ ([-\w.]+)','bash', '--version'], # used to test a error result
+        'bash-test-env': ['(HOME=.*)','bash', '-c', 'declare'], # used to test a error result
+        'zsh': ['^zsh ([\d.]+)','zsh', '--version'],
+        'tcsh': ['^tcsh ([\d.]+)','tcsh', '--version'],
+        'cmd': ['Version ([\d.]+)', 'cmd.exe', '/C', 'ver'],
+        'powershell': ['PSVersion\s+([\d.]+)', 'powershell', '-NonInteractive', '$PSVersionTable'],
+        'perl': ['^([\d.]+)', 'perl', '-e', 'printf "%vd\n", $^V;'],
+        'python': ['^Python ([\d.]+)', 'python', '-V'],
+        'ruby': ['^ruby ([\d.]+)', 'ruby', '-v'],
+        'php': ['^PHP ([\d.]+)', 'php', '-v']
+    }
+    ret = {}
+    if salt.utils.is_windows() and name == 'powershell':
+       pw_keys=__salt__['reg.list_keys']('HKEY_LOCAL_MACHINE','Software\Microsoft\PowerShell')
+       pw_keys.sort(key=int)
+       if len(pw_keys) == 0:
+           return {
+                'error': 'Unable to locate \'powershell\' Reason: Cannot be found in registry.',
+                'installed': False,
+                'version': None
+           }
+       for reg_ver in pw_keys:
+          install_data=__salt__['reg.read_value']('HKEY_LOCAL_MACHINE','Software\Microsoft\PowerShell\{0}'.format(reg_ver),'Install')
+          if 'vtype' in install_data and install_data['vtype'] == 'REG_DWORD' and install_data['vdata'] == 1:
+             details=__salt__['reg.list_values']('HKEY_LOCAL_MACHINE','Software\Microsoft\PowerShell\{0}\PowerShellEngine'.format(reg_ver))
+             ret={} # reset data, want the newest version details only as powershell is backwards compatible
+             ret['installed'] = True
+             ret['path'] = which('powershell.exe')
+             for attribute in details:
+                 if attribute['vname'].lower() == '(default)':
+                     continue
+                 elif attribute['vname'].lower() == 'powershellversion':
+                     ret['psversion']=attribute['vdata']
+                     ret['version']=attribute['vdata']
+                 elif attribute['vname'].lower() == 'runtimeversion':
+                     ret['crlversion']=attribute['vdata']
+                     if ret['crlversion'][0] == 'v' or ret['crlversion'][0] == 'V':
+                         ret['crlversion']=ret['crlversion'][1::]
+                 elif attribute['vname'].lower() == 'pscompatibleversion':
+                     # reg attribute does not end in s, the powershell attibute does
+                     ret['pscompatibleversions']=attribute['vdata']
+                 else:
+                     # keys are lower case as python is case sensitive the registry is not
+                     ret[attribute['vname'].lower()]=attribute['vdata']
+    else:
+        if name not in regex_shells:
+           return {
+               'error': 'Salt does not know how to get the version number for {0}'.format(name),
+               'installed': None
+           }
+        shell_data = regex_shells[name]
+        pattern = shell_data.pop(0)
+        # We need to make sure HOME set, so shells work correctly
+        # salt-call will general have home set, the salt-minion service may not
+        # We need to assume ports of unix shells to windows will look after themselves
+        # in setting HOME as they do it in many different ways
+        newenv=os.environ
+        if ('HOME' not in newenv) and (not salt.utils.is_windows()):
+          newenv['HOME'] = os.path.expanduser('~')
+          log.error('HOME environment set to {0}'.format(newenv['HOME']))
+        try:
+            proc = salt.utils.timed_subprocess.TimedProc(
+                shell_data,
+                stdin=None,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=10,
+                env=newenv
+                )
+        except (OSError, IOError) as exc:
+            return {
+                'error': 'Unable to run command \'{0}\' Reason: {1}'.format(' '.join(shell_data), exc),
+                'installed': False,
+                'version': None
+            }
+        try:
+            proc.run()
+        except TimedProcTimeoutError as exc:
+            return {
+                'error': 'Unable to run command \'{0}\' Reason: Timed out.'.format(' '.join(shell_data)),
+                'installed': False,
+                'version': None
+            }
+        ret['stdout'] = proc.stdout
+        ret['installed'] = True
+        ret['path'] = which(shell_data[0])
+        pattern_result=re.search( pattern, proc.stdout, flags=re.IGNORECASE)
+        # only set version if we find it, so code later on can deal with it
+        if pattern_result:
+           ret['version']=pattern_result.group(1)
+
+    if 'version' not in ret:
+        ret['error'] = 'The version regex pattern for shell {0}, could not find the version string'.format(name)
+        ret['version'] = None
+        log.error(ret['error'])
+    else:
+       major_result=re.match('(\d+)',ret['version'])
+       if major_result:
+           ret['version_major']=major_result.group(1)
+           major_minor_result=re.match('(\d+[-.]\d+)',ret['version'])
+           if major_minor_result:
+               ret['version_major_minor']=major_minor_result.group(1)
+
+    return ret
 
 def powershell(cmd,
         cwd=None,

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2669,7 +2669,7 @@ def shell_info(name):
         'zsh': ['^zsh ([\\d.]+)', 'zsh', '--version'],
         'tcsh': ['^tcsh ([\\d.]+)', 'tcsh', '--version'],
         'cmd': ['Version ([\\d.]+)', 'cmd.exe', '/C', 'ver'],
-        'powershell': ['PSVersion\s+([\\d.]+)', 'powershell', '-NonInteractive', '$PSVersionTable'],
+        'powershell': ['PSVersion\\s+([\\d.]+)', 'powershell', '-NonInteractive', '$PSVersionTable'],
         'perl': ['^([\\d.]+)', 'perl', '-e', 'printf "%vd\n", $^V;'],
         'python': ['^Python ([\\d.]+)', 'python', '-V'],
         'ruby': ['^ruby ([\\d.]+)', 'ruby', '-v'],
@@ -2679,7 +2679,7 @@ def shell_info(name):
     ret = {}
     ret['installed'] = None
     if salt.utils.is_windows() and name == 'powershell':
-        pw_keys = __salt__['reg.list_keys']('HKEY_LOCAL_MACHINE', 'Software\Microsoft\PowerShell')
+        pw_keys = __salt__['reg.list_keys']('HKEY_LOCAL_MACHINE', 'Software\\Microsoft\\PowerShell')
         pw_keys.sort(key=int)
         if len(pw_keys) == 0:
             return {
@@ -2688,9 +2688,9 @@ def shell_info(name):
                 'version': None
             }
         for reg_ver in pw_keys:
-            install_data = __salt__['reg.read_value']('HKEY_LOCAL_MACHINE', 'Software\Microsoft\PowerShell\{0}'.format(reg_ver), 'Install')
+            install_data = __salt__['reg.read_value']('HKEY_LOCAL_MACHINE', 'Software\\Microsoft\\PowerShell\\{0}'.format(reg_ver), 'Install')
             if 'vtype' in install_data and install_data['vtype'] == 'REG_DWORD' and install_data['vdata'] == 1:
-                details = __salt__['reg.list_values']('HKEY_LOCAL_MACHINE', 'Software\Microsoft\PowerShell\{0}\PowerShellEngine'.format(reg_ver))
+                details = __salt__['reg.list_values']('HKEY_LOCAL_MACHINE', 'Software\\Microsoft\\PowerShell\\{0}\\PowerShellEngine'.format(reg_ver))
                 ret = {}  # reset data, want the newest version details only as powershell is backwards compatible
                 ret['installed'] = True
                 ret['path'] = which('powershell.exe')
@@ -2698,12 +2698,12 @@ def shell_info(name):
                     if attribute['vname'].lower() == '(default)':
                         continue
                     elif attribute['vname'].lower() == 'powershellversion':
-                        ret['psversion']=attribute['vdata']
-                        ret['version']=attribute['vdata']
+                        ret['psversion'] = attribute['vdata']
+                        ret['version'] = attribute['vdata']
                     elif attribute['vname'].lower() == 'runtimeversion':
-                        ret['crlversion']=attribute['vdata']
+                        ret['crlversion'] = attribute['vdata']
                         if ret['crlversion'][0] == 'v' or ret['crlversion'][0] == 'V':
-                            ret['crlversion']=ret['crlversion'][1::]
+                            ret['crlversion'] = ret['crlversion'][1::]
                     elif attribute['vname'].lower() == 'pscompatibleversion':
                         # reg attribute does not end in s, the powershell attibute does
                         ret['pscompatibleversions'] = attribute['vdata']
@@ -2763,10 +2763,10 @@ def shell_info(name):
         ret['stdout'] = proc.stdout  # include stdout so they can see the issue
         log.error(ret['error'])
     else:
-        major_result=re.match('(\d+)', ret['version'])
+        major_result = re.match('(\\d+)', ret['version'])
         if major_result:
             ret['version_major'] = major_result.group(1)
-            major_minor_result = re.match('(\d+[-.]\d+)', ret['version'])
+            major_minor_result = re.match('(\\d+[-.]\\d+)', ret['version'])
             if major_minor_result:
                 ret['version_major_minor'] = major_minor_result.group(1)
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2638,20 +2638,27 @@ def shells():
 def shell_info(name):
     '''
     Provides information about a shell or languages often use #!
-    The values returned are dependant on the shell or languages all return
-    the ``version`` ``version_major`` and ``version_major_minor`` e.g. 5.0 or 6-3.
+    The values returned are dependant on the shell or languages all return the
+    ``installed``, ``path``, ``version``, ``version_major`` and
+    ``version_major_minor`` e.g. 5.0 or 6-3.
     The shell must be within the exeuctable search path.
 
     :param str name: Name of the shell.
     Support are bash, cmd, perl, php, powershell, python, ruby and zsh
-    :return: Properies of the shell specifically its version and stdout
-    and other information if available.
+    :return: Properies of the shell specifically its and other information if
+    available.
     :rtype: dict
+       
     .. code-block:: cfg
-        {'version': '<version string>
-         'version_major': '<version string'
-         'version_minor': '<version string>'
+        {'version': '<version string>',
+         'version_major': '<version string',
+         'version_minor': '<version string>',
+         'path': '<full path to binary>',
+         'installed': <True, False or None>,
          '<attribute>': '<attribute value>'}
+
+    ``installed`` is always returned, if None or False also returns error and
+     may also return stdout for diagnostics.
 
     .. versionadded:: 2016.9.0
 
@@ -2725,7 +2732,7 @@ def shell_info(name):
         newenv = os.environ
         if ('HOME' not in newenv) and (not salt.utils.is_windows()):
             newenv['HOME'] = os.path.expanduser('~')
-            log.error('HOME environment set to {0}'.format(newenv['HOME']))
+            log.debug('HOME environment set to {0}'.format(newenv['HOME']))
         try:
             proc = salt.utils.timed_subprocess.TimedProc(
                 shell_data,

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2635,7 +2635,7 @@ def shells():
     return ret
 
 
-def shell_info(name):
+def shell_info(shell):
     '''
     Provides information about a shell or languages often use #!
     The values returned are dependant on the shell or languages all return the
@@ -2643,7 +2643,7 @@ def shell_info(name):
     ``version_major_minor`` e.g. 5.0 or 6-3.
     The shell must be within the exeuctable search path.
 
-    :param str name: Name of the shell.
+    :param str shell: Name of the shell.
     Support are bash, cmd, perl, php, powershell, python, ruby and zsh
     :return: Properies of the shell specifically its and other information if
     available.
@@ -2685,7 +2685,7 @@ def shell_info(name):
     # Ensure ret['installed'] always as a value of True, False or None (not sure)
     ret = {}
     ret['installed'] = None
-    if salt.utils.is_windows() and name == 'powershell':
+    if salt.utils.is_windows() and shell == 'powershell':
         pw_keys = __salt__['reg.list_keys']('HKEY_LOCAL_MACHINE', 'Software\\Microsoft\\PowerShell')
         pw_keys.sort(key=int)
         if len(pw_keys) == 0:
@@ -2718,12 +2718,12 @@ def shell_info(name):
                         # keys are lower case as python is case sensitive the registry is not
                         ret[attribute['vname'].lower()] = attribute['vdata']
     else:
-        if name not in regex_shells:
+        if shell not in regex_shells:
             return {
-                'error': 'Salt does not know how to get the version number for {0}'.format(name),
+                'error': 'Salt does not know how to get the version number for {0}'.format(shell),
                 'installed': None
             }
-        shell_data = regex_shells[name]
+        shell_data = regex_shells[shell]
         pattern = shell_data.pop(0)
         # We need to make sure HOME set, so shells work correctly
         # salt-call will general have home set, the salt-minion service may not
@@ -2765,7 +2765,7 @@ def shell_info(name):
             ret['version'] = pattern_result.group(1)
 
     if 'version' not in ret:
-        ret['error'] = 'The version regex pattern for shell {0}, could not find the version string'.format(name)
+        ret['error'] = 'The version regex pattern for shell {0}, could not find the version string'.format(shell)
         ret['version'] = None
         ret['stdout'] = proc.stdout  # include stdout so they can see the issue
         log.error(ret['error'])

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2648,7 +2648,7 @@ def shell_info(shell):
     :return: Properies of the shell specifically its and other information if
     available.
     :rtype: dict
-       
+
     .. code-block:: cfg
         {'version': '<version string>',
          'version_major': '<version string',

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -45,13 +45,13 @@ def __virtual__():
     return __virtualname__
 
 
-def _pshell(cmd, cwd=None):
+def _pshell(cmd, cwd=None, json_depth=2):
     '''
     Execute the desired powershell command and ensure that it returns data
     in json format and load that into python
     '''
     if 'convertto-json' not in cmd.lower():
-        cmd = ' '.join([cmd, '| ConvertTo-Json -Depth 2147483647'])
+        cmd = '{0} | ConvertTo-Json -Depth {1}'.format(cmd, json_depth)
     log.debug('DSC: {0}'.format(cmd))
     results = __salt__['cmd.run_all'](cmd, shell='powershell', cwd=cwd, python_shell=True)
 

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -36,7 +36,7 @@ def __virtual__():
 
     powershell_info = __salt__['cmd.shell_info']('powershell')
     if (
-           (powershell_info['installed'] == True) and
+           powershell_info['installed'] and
            ('version_major' in powershell_info) and
            (distutils.version.LooseVersion(powershell_info['version_major']) < distutils.version.LooseVersion('5'))
         ):
@@ -122,7 +122,7 @@ def psversion():
         'replaced by \'cmd.shell_info\'.'
     )
     powershell_info = __salt__['cmd.shell_info']('powershell')
-    if powershell_info['installed'] == True and 'version_major' in powershell_info:
+    if powershell_info['installed'] and 'version_major' in powershell_info:
         try:
             return int(powershell_info['version_major'])
         except ValueError:

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -7,13 +7,14 @@ Module for managing PowerShell modules
 
 Support for PowerShell
 '''
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 # Import python libs
 import copy
 import logging
 import json
 import os
+import distutils.version
 
 # Import salt libs
 import salt.utils
@@ -33,8 +34,13 @@ def __virtual__():
     if not salt.utils.is_windows():
         return (False, 'Module DSC: Module only works on Windows systems ')
 
-    if psversion() < 5:
-        return (False, 'Module DSC: Module only works with PowerShell 5 or later.')
+    powershell_info = __salt__['cmd.shell_info']('powershell')
+    if (
+           (powershell_info['installed'] == True) and
+           ('version_major' in powershell_info) and
+           (distutils.version.LooseVersion(powershell_info['version_major']) < distutils.version.LooseVersion('5'))
+       ):
+       return (False, 'Module DSC: Module only works with PowerShell 5 or newer.')
 
     return __virtualname__
 
@@ -45,13 +51,23 @@ def _pshell(cmd, cwd=None):
     in json format and load that into python
     '''
     if 'convertto-json' not in cmd.lower():
-        cmd = ' '.join([cmd, '| ConvertTo-Json'])
+        cmd = ' '.join([cmd, '| ConvertTo-Json -Depth 2147483647'])
     log.debug('DSC: {0}'.format(cmd))
-    ret = __salt__['cmd.shell'](cmd, shell='powershell', cwd=cwd)
+    results = __salt__['cmd.run_all'](cmd, shell='powershell', cwd=cwd, python_shell=True)
+
+    if 'pid' in results:
+        del results['pid']
+
+    if 'retcode' not in results or results['retcode'] != 0:
+        error='Issue executing powershell {0}'.format(cmd)
+        # run_all logs an error to log.error, fail hard back to the user
+        raise CommandExecutionError(error,info=results)
+
     try:
-        ret = json.loads(ret, strict=False)
+        ret = json.loads(results['stdout'], strict=False)
     except ValueError:
-        log.debug('Json not returned')
+        raise CommandExecutionError('No JSON results from powershell',info=results)
+
     return ret
 
 
@@ -92,15 +108,27 @@ def psversion():
     '''
     Returns the Powershell version
 
+    This has been deprecated and has been replaced by ``cmd.shell_info`` Note
+    the minimum version return is 5 as ``dsc`` is not available for version
+    less than 5.  This function will be removed in 'Nitrogen' release.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt 'win01' dsc.psversion
     '''
-    cmd = '$PSVersionTable.PSVersion.Major'
-    ret = _pshell(cmd)
-    return ret
+    salt.utils.warn_until('Nitrogen',
+        'The \'psversion\' has been deprecated and has been '
+        'replaced by \'cmd.shell_info\'.'
+    )
+    powershell_info = __salt__['cmd.shell_info']('powershell')
+    if powershell_info['installed'] == True and 'version_major' in powershell_info:
+        try:
+            return int(powershell_info['version_major'])
+        except ValueError:
+            pass
+    return 0
 
 
 def avail_modules(desc=False):

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -39,8 +39,8 @@ def __virtual__():
            (powershell_info['installed'] == True) and
            ('version_major' in powershell_info) and
            (distutils.version.LooseVersion(powershell_info['version_major']) < distutils.version.LooseVersion('5'))
-       ):
-       return (False, 'Module DSC: Module only works with PowerShell 5 or newer.')
+        ):
+        return (False, 'Module DSC: Module only works with PowerShell 5 or newer.')
 
     return __virtualname__
 
@@ -59,14 +59,13 @@ def _pshell(cmd, cwd=None):
         del results['pid']
 
     if 'retcode' not in results or results['retcode'] != 0:
-        error='Issue executing powershell {0}'.format(cmd)
         # run_all logs an error to log.error, fail hard back to the user
-        raise CommandExecutionError(error,info=results)
+        raise CommandExecutionError('Issue executing powershell {0}'.format(cmd), info=results)
 
     try:
         ret = json.loads(results['stdout'], strict=False)
     except ValueError:
-        raise CommandExecutionError('No JSON results from powershell',info=results)
+        raise CommandExecutionError('No JSON results from powershell', info=results)
 
     return ret
 

--- a/salt/modules/win_psget.py
+++ b/salt/modules/win_psget.py
@@ -45,13 +45,13 @@ def __virtual__():
     return __virtualname__
 
 
-def _pshell(cmd, cwd=None):
+def _pshell(cmd, cwd=None, json_depth=2):
     '''
     Execute the desired powershell command and ensure that it returns data
     in json format and load that into python
     '''
     if 'convertto-json' not in cmd.lower():
-        cmd = ' '.join([cmd, '| ConvertTo-Json -Depth 2147483647'])
+        cmd = '{0} | ConvertTo-Json -Depth {1}'.format(cmd, json_depth)
     log.debug('DSC: {0}'.format(cmd))
     results = __salt__['cmd.run_all'](cmd, shell='powershell', cwd=cwd, python_shell=True)
 

--- a/salt/modules/win_psget.py
+++ b/salt/modules/win_psget.py
@@ -36,7 +36,7 @@ def __virtual__():
 
     powershell_info = __salt__['cmd.shell_info']('powershell')
     if (
-           (powershell_info['installed'] == True) and
+           powershell_info['installed'] and
            ('version_major' in powershell_info) and
            (distutils.version.LooseVersion(powershell_info['version_major']) < distutils.version.LooseVersion('5'))
        ):
@@ -61,12 +61,12 @@ def _pshell(cmd, cwd=None):
     if 'retcode' not in results or results['retcode'] != 0:
         error='Issue executing powershell {0}'.format(cmd)
         # run_all logs an error to log.error, fail hard back to the user
-        raise CommandExecutionError(error,info=results)
+        raise CommandExecutionError(error, info=results)
 
     try:
         ret = json.loads(results['stdout'], strict=False)
     except ValueError:
-        raise CommandExecutionError('No JSON results from powershell',info=results)
+        raise CommandExecutionError('No JSON results from powershell', info=results)
 
     return ret
 
@@ -91,7 +91,7 @@ def psversion():
         'replaced by \'cmd.shell_info\'.'
     )
     powershell_info = __salt__['cmd.shell_info']('powershell')
-    if powershell_info['installed'] == True and 'version_major' in powershell_info:
+    if powershell_info['installed'] and 'version_major' in powershell_info:
         try:
             return int(powershell_info['version_major'])
         except ValueError:

--- a/salt/modules/win_psget.py
+++ b/salt/modules/win_psget.py
@@ -59,9 +59,8 @@ def _pshell(cmd, cwd=None):
         del results['pid']
 
     if 'retcode' not in results or results['retcode'] != 0:
-        error='Issue executing powershell {0}'.format(cmd)
         # run_all logs an error to log.error, fail hard back to the user
-        raise CommandExecutionError(error, info=results)
+        raise CommandExecutionError('Issue executing powershell {0}'.format(cmd), info=results)
 
     try:
         ret = json.loads(results['stdout'], strict=False)
@@ -69,7 +68,6 @@ def _pshell(cmd, cwd=None):
         raise CommandExecutionError('No JSON results from powershell', info=results)
 
     return ret
-
 
 
 def psversion():


### PR DESCRIPTION
### What does this PR do?
1. Issue:  Carbon Release Fix for #36252 `win_dsc` & `win_psget` both called powershell binary to find out the version number of powershell. Powershell on windows as a large startup overhead. Also output a lot of errors when running salt-call
   Solution:  Add cmd.shell_info to check the windows registry and return powershell version and other information, changed `win_dsc` & `win_psget`  to use  `cmd.shell_info('powershell')`
2. Issue: `win_dsc` & `win_psget` `_pshell` function called `cmd.shell` which just provides `stdout`and not error reporting or stderr.
   Solution:  Change to use `cmd.run_all` and if a non zero return code is return raise an error and report back stdout, stderr and returncode.  Update  JSON Conversion depth from the default of 2 to 2147483647 (max 32bit int)
3. Added new function `cmd.shell_info`. This returns version information for various shells and `#!`. It includes support for bash, cmd, perl, php, powershell, python, ruby and zsh. The reported data includes  installed True or False (i.e. found),  version str, major version str, and major minor version str. If an issue happens it will also report error and stdout (which includes stderr)
4. Both `win_dsc` & `win_psget` provided a `psversion` function this has been depreciated. As `win_dsc` & `win_psget` are not available unless  Powershell 5+ is installed.
### What issues does this PR fix or reference?
#36252 Windows Slow Down win_psget & win_dsc determine version is costly, Change to Registry
### Previous Behavior

Windows Slow Down win_psget & win_dsc determine version is costly, Change to Registry

```
C:\salt>salt-call -l info dsc.psversion
[INFO    ] cmdmod._run Executing command 'Powershell -NonInteractive "$PSVersionTable.PSVersion.Major | ConvertTo-Json"' in directory 'C:\Users\djatkins'
[INFO    ] cmdmod._run Executing command 'Powershell -NonInteractive "$PSVersionTable.PSVersion.Major | ConvertTo-Json"' in directory 'C:\Users\djatkins'
local:
    5
```
### New Behavior

```
C:\salt>salt-call -l info psget.psversion
[WARNING ] __init__.warn_until C:\salt\bin\lib\site-packages\salt\modules\win_psget.py:90: DeprecationWarning: The 'psversion' has been deprecated and has been replaced by 'cmd.shell_info'.

local:
    5
```

Powershell on windows reports some extra info

```
C:\salt>salt-call cmd.shell_info powershell
local:
    ----------
    applicationbase:
        C:\Windows\System32\WindowsPowerShell\v1.0
    consolehostassemblyname:
        Microsoft.PowerShell.ConsoleHost, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, ProcessorArchitecture=msil
    consolehostmodulename:
        C:\Windows\System32\WindowsPowerShell\v1.0\Microsoft.PowerShell.ConsoleHost.dll
    crlversion:
        4.0.30319
    installed:
        True
    path:
        C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe
    pscompatibleversions:
        1.0, 2.0, 3.0, 4.0, 5.0
    pspluginwkrmodulename:
        C:\Windows\System32\WindowsPowerShell\v1.0\system.management.automation.dll
    psversion:
        5.0.10586.0
    version:
        5.0.10586.0
    version_major:
        5
    version_major_minor:
        5.0
```

The following is example of the more standard output for shells etc.

```
C:\salt>salt-call cmd.shell_info cmd
local:
    ----------
    installed:
        True
    path:
        C:\WINDOWS\system32\cmd.exe
    version:
        10.0.10586
    version_major:
        10
    version_major_minor:
        10.0
```

```
windowsNEW:
    ERROR: Issue executing powershell Find-Module | ConvertTo-Json -Depth 2147483647. Additional info follows:

    retcode:
        1
    stderr:
        Exception calling "ShouldContinue" with "2" argument(s): "Windows PowerShell
        is in NonInteractive mode. Read and Prompt functionality is not available."
        At C:\Program
        Files\WindowsPowerShell\Modules\PowerShellGet\1.0.0.1\PSModule.psm1:5908 char:8
        +     if($Force -or $PSCmdlet.ShouldContinue($shouldContinueQueryMessag ...
        +        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
            + FullyQualifiedErrorId : PSInvalidOperationException

        Find-Module : NuGet provider is required to interact with NuGet-based
        repositories. Please ensure that '2.8.5.201' or newer version of NuGet
        provider is installed.
        At line:1 char:1
        + Find-Module | ConvertTo-Json -Depth 2147483647
        + ~~~~~~~~~~~
            + CategoryInfo          : InvalidOperation: (:) [Find-Module], InvalidOper
           ationException
            + FullyQualifiedErrorId : CouldNotInstallNuGetProvider,Find-Module
    stdout:

WindowsOLD:
    Passed invalid arguments to dsc.avail_modules: string indices must be integers, not str

        List available modules in registered Powershell module repositories.

        desc : False
             If ``True``, the verbose description will be returned.

        CLI Example:

        .. code-block:: bash

            salt 'win01' dsc.avail_modules
            salt 'win01' dsc.avail_modules desc=True

```
### Tests written?

No.  Original Author should test the code. i.e. win_psget @tonybaloney and win_dsc @twangboy or @UtahDave 
