### PR TITLE
Pyobjects renderer: some modules may require utils to be loaded.

### DIFF
--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -305,8 +305,8 @@ def load_states():
     # the loader expects to find pillar & grain data
     __opts__['grains'] = salt.loader.grains(__opts__)
     __opts__['pillar'] = __pillar__
-    lazy_funcs = salt.loader.minion_mods(__opts__)
     lazy_utils = salt.loader.utils(__opts__)
+    lazy_funcs = salt.loader.minion_mods(__opts__, utils=lazy_utils)
     lazy_serializers = salt.loader.serializers(__opts__)
     lazy_states = salt.loader.states(__opts__,
             lazy_funcs,


### PR DESCRIPTION
### What does this PR do?

Make sure that when minion_mods are loaded by pyobjects, __utils__  is available as some modules expect.

Currently, some boto modules are unavailable when using the pyobjects renderer. Note: I only use that renderer for orchestration and I haven't tested if the problem also occurs with states.
### What issues does this PR fix or reference?

\- 
### Previous Behavior

```
[ERROR   ] Exception raised when processing __virtual__ function for boto_cloudwatch. Module will not be loaded 'boto.assign_funcs'
[WARNING ] salt.loaded.int.module.boto_cloudwatch.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new nam
e. If you're the developer of the module 'boto_cloudwatch', please fix this.
[ERROR   ] Exception raised when processing __virtual__ function for boto_dynamodb. Module will not be loaded 'boto.assign_funcs'
[WARNING ] salt.loaded.int.module.boto_dynamodb.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name.
 If you're the developer of the module 'boto_dynamodb', please fix this.
[ERROR   ] Exception raised when processing __virtual__ function for boto_elasticache. Module will not be loaded 'boto.assign_funcs'
[WARNING ] salt.loaded.int.module.boto_elasticache.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new na
me. If you're the developer of the module 'boto_elasticache', please fix this.
[ERROR   ] Exception raised when processing __virtual__ function for boto_secgroup. Module will not be loaded 'boto.assign_funcs'
[WARNING ] salt.loaded.int.module.boto_secgroup.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name.
 If you're the developer of the module 'boto_secgroup', please fix this.
[ERROR   ] Exception raised when processing __virtual__ function for boto_sns. Module will not be loaded 'boto.assign_funcs'
[WARNING ] salt.loaded.int.module.boto_sns.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If y
ou're the developer of the module 'boto_sns', please fix this.
[ERROR   ] Exception raised when processing __virtual__ function for boto_sqs. Module will not be loaded 'boto.assign_funcs'
[WARNING ] salt.loaded.int.module.boto_sqs.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If y
ou're the developer of the module 'boto_sqs', please fix this.
[ERROR   ] Exception raised when processing __virtual__ function for boto_elb. Module will not be loaded 'boto.assign_funcs'
[WARNING ] salt.loaded.int.module.boto_elb.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If y
ou're the developer of the module 'boto_elb', please fix this.
```
### New Behavior

The modules load without error.
### Tests written?

No