### PR TITLE
Test shutdown

### DIFF
--- a/salt/utils/nb_popen.py
+++ b/salt/utils/nb_popen.py
@@ -96,25 +96,6 @@ class NonBlockingPopen(subprocess.Popen):
             args if logging_command is None else logging_command
         )
 
-    def poll(self, flag=os.WNOHANG):
-        if self.returncode is None:
-            notintr = False
-            while not notintr:
-                try: 
-                    pid, sts = os.waitpid(self.pid, flag)
-                    notintr = True
-                except OSError as exc:
-                    if exc.errno != errno.EINTR:
-                        raise exc
-                if pid == self.pid:
-                    if os.WIFSIGNALED(sts):
-                        self.returncode = -os.WTERMSIG(sts)
-                    else:
-                        assert os.WIFEXITED(sts)
-                        self.returncode = os.WEXITSTATUS(sts)
-                return self.returncode
-
-
     def recv(self, maxsize=None):
         return self._recv('stdout', maxsize)
 

--- a/salt/utils/nb_popen.py
+++ b/salt/utils/nb_popen.py
@@ -96,6 +96,25 @@ class NonBlockingPopen(subprocess.Popen):
             args if logging_command is None else logging_command
         )
 
+    def poll(self, flag=os.WNOHANG):
+        if self.returncode is None:
+            notintr = False
+            while notintr:
+                try: 
+                    pid, sts = os.waitpid(self.pid, flag)
+                    notintr = True
+                except OSError as exc:
+                    if exc.errno != errno.EINTR:
+                        raise exc
+                if pid == self.pid:
+                    if os.WIFSIGNALED(sts):
+                        self.returncode = -os.WTERMSIG(sts)
+                    else:
+                        assert os.WIFEXITED(sts)
+                        self.returncode = os.WEXITSTATUS(sts)
+                return self.returncode
+
+
     def recv(self, maxsize=None):
         return self._recv('stdout', maxsize)
 

--- a/salt/utils/nb_popen.py
+++ b/salt/utils/nb_popen.py
@@ -99,7 +99,7 @@ class NonBlockingPopen(subprocess.Popen):
     def poll(self, flag=os.WNOHANG):
         if self.returncode is None:
             notintr = False
-            while notintr:
+            while not notintr:
                 try: 
                     pid, sts = os.waitpid(self.pid, flag)
                     notintr = True

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -692,6 +692,11 @@ class SignalHandlingMultiprocessingProcess(MultiprocessingProcess):
             msg += 'SIGTERM'
         msg += '. Exiting'
         log.debug(msg)
+        if HAS_PSUTIL:
+            process = psutil.Process(self.pid)
+            if hasattr(process, 'children'):
+                for child in process.children(recursive=True):
+                    child.terminate()
         sys.exit(salt.defaults.exitcodes.EX_OK)
 
     def start(self):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1641,6 +1641,9 @@ class SaltMinionEventAssertsMixIn(object):
         cls.fetch_proc.start()
         return object.__new__(cls)
 
+    def __exit__(self, *args, **kwargs):
+        self.fetch_proc.join()
+
     @staticmethod
     def _fetch(q):
         '''
@@ -1651,7 +1654,6 @@ class SaltMinionEventAssertsMixIn(object):
             while not q.empty():
                 queue_item = q.get()
                 queue_item.task_done()
-            self.fetch_proc.join()
 
         atexit.register(_clean_queue)
         a_config = AdaptedConfigurationTestCaseMixIn()

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -543,7 +543,7 @@ class SaltDaemonScriptBase(SaltScriptBase, ShellTestCase):
             pass
 
         terminate_process_pid(terminal.pid)
-        terminal.communicate()
+#        terminal.communicate()
 
     def terminate(self):
         '''
@@ -554,7 +554,7 @@ class SaltDaemonScriptBase(SaltScriptBase, ShellTestCase):
         self._connectable.clear()
         time.sleep(0.0125)
         terminate_process_pid(self._process.pid)
-        self._process.join()
+#        self._process.join()
         log.info('%s %s DAEMON terminated', self.display_name, self.__class__.__name__)
 
     def wait_until_running(self, timeout=None):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1651,6 +1651,7 @@ class SaltMinionEventAssertsMixIn(object):
             while not q.empty():
                 queue_item = q.get()
                 queue_item.task_done()
+            self.fetch_proc.join()
 
         atexit.register(_clean_queue)
         a_config = AdaptedConfigurationTestCaseMixIn()


### PR DESCRIPTION
This still isn't 100% complete but it does make some improvements.

This modified our implementation of Popen to kill child procs if they are found. This obviates the need to collect child procs in the caller and kill them.

Secondly, this implements a customized version of the multiprocess poller, which is more understanding about processes which may have been reaped underneath it. This is somewhat of a stopgap measure.

 Finally, this removes the need to send a `.communicate()` to the process, since we aren't processing the output anyhow. 

cc: @s0undt3ch 
