### PR TITLE
PY3: Fix error when applying salt state

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1150,6 +1150,8 @@ class RemoteClient(Client):
                     data = salt.utils.gzip_util.uncompress(data['data'])
                 else:
                     data = data['data']
+                if six.PY3 and isinstance(data, str):
+                    data = data.encode()
                 fn_.write(data)
             except (TypeError, KeyError) as exc:
                 try:


### PR DESCRIPTION
### What does this PR do?

In Python 3, a command such as:

```
salt-call state.apply mystate
```

On certain SLS files (in my case a `py` rendered file) could yield an
error such as:

```
[ERROR   ] Data transport is broken, got: #!py
---SLS file contents here---
, type: str, exception: a bytes-like object is required, not 'str',
retry attempts exhausted
```

Change `RemoteClient.get_file` to ensure the `data` passed to `write` is
a `bytes` type in Python 3.
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
