### PR TITLE
A couple fixes for Antergos Linux

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1258,7 +1258,12 @@ def os_data():
                             grains[
                                 'lsb_{0}'.format(match.groups()[0].lower())
                             ] = match.groups()[1].rstrip()
-            if 'lsb_distrib_id' not in grains:
+            if grains.get('lsb_distrib_description', '').lower().startswith('antergos'):
+                # Antergos incorrectly configures their /etc/lsb-release,
+                # setting the DISTRIB_ID to "Arch". This causes the "os" grain
+                # to be incorrectly set to "Arch".
+                grains['osfullname'] = 'Antergos Linux'
+            elif 'lsb_distrib_id' not in grains:
                 if os.path.isfile('/etc/os-release') or os.path.isfile('/usr/lib/os-release'):
                     os_release = _parse_os_release()
                     if 'NAME' in os_release:

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -155,10 +155,17 @@ def list_upgrades(refresh=False, root=None, **kwargs):  # pylint: disable=W0613
         out = call['stdout']
 
     for line in salt.utils.itertools.split(out, '\n'):
-        comps = line.split(' ')
-        if len(comps) != 2:
+        try:
+            pkgname, pkgver = line.split()
+        except ValueError:
             continue
-        upgrades[comps[0]] = comps[1]
+        if pkgname.lower() == 'downloading' and '.db' in pkgver.lower():
+            # Antergos (and possibly other Arch derivatives) add lines when pkg
+            # metadata is being downloaded. Because these lines, when split,
+            # contain two columns (i.e. 'downloading community.db...'), we will
+            # skip this line to keep it from being interpreted as an upgrade.
+            continue
+        upgrades[pkgname] = pkgver
     return upgrades
 
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -36,7 +36,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Arch
     '''
-    if __grains__['os'] in ('Arch', 'Arch ARM', 'Antergos', 'ManjaroLinux'):
+    if __grains__['os_family'] == 'Arch':
         return __virtualname__
     return (False, 'The pacman module could not be loaded: unsupported OS family.')
 


### PR DESCRIPTION
This pull request fixes the following issues affecting Antergos Linux:
1. Antergos incorrectly sets its `/etc/lsb-release`, setting `DISTRIB_ID=Arch`. While this doesn't break things like setting pacman.py as the `pkg` virtual module, it does result in the `os` grain being set to `Arch` when it should be set as `Antergos`.
2. Antergos (at least its ARM variant) seems to be adding lines when it downloads updated package databases, interfering with `pkg.list_upgrades` (see #36388).

Additionally, pacman.py, despite only being assigned to distros in the `Arch` os_family, has its `__virtual__` function checking the `os` grain. This pull request changes this so that it checks that the `os_family` is `Arch`, which should be easier to maintain moving forward.

Fixes #36388.