### PR TITLE
Add "none" as a pillar merging strategy

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -694,9 +694,9 @@
 #pillar_safe_render_error: True
 
 # The pillar_source_merging_strategy option allows you to configure merging strategy
-# between different sources. It accepts four values: recurse, aggregate, overwrite,
-# or smart. Recurse will merge recursively mapping of data. Aggregate instructs
-# aggregation of elements between sources that use the #!yamlex renderer. Overwrite
+# between different sources. It accepts five values: none, recurse, aggregate, overwrite,
+# or smart. None will not do any merging at all. Recurse will merge recursively mapping of data.
+# Aggregate instructs aggregation of elements between sources that use the #!yamlex renderer. Overwrite
 # will overwrite elements according the order in which they are processed. This is
 # behavior of the 2014.1 branch and earlier. Smart guesses the best strategy based
 # on the "renderer" setting and is the default value.

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2791,6 +2791,9 @@ Default: ``smart``
 The pillar_source_merging_strategy option allows you to configure merging
 strategy between different sources. It accepts 4 values:
 
+* ``none``:
+  it will not do any merging at all and only parse the pillar data from the passed environment and 'base' if no environment was specified.
+
 * ``recurse``:
 
   it will merge recursively mapping of data. For example, theses 2 sources:

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2792,7 +2792,7 @@ The pillar_source_merging_strategy option allows you to configure merging
 strategy between different sources. It accepts 4 values:
 
 * ``none``:
-  it will not do any merging at all and only parse the pillar data from the passed environment and 'base' if no environment was specified.
+  It will not do any merging at all and only parse the pillar data from the passed environment and 'base' if no environment was specified.
 
 * ``recurse``:
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2789,7 +2789,7 @@ Pillar Merging Options
 Default: ``smart``
 
 The pillar_source_merging_strategy option allows you to configure merging
-strategy between different sources. It accepts 4 values:
+strategy between different sources. It accepts 5 values:
 
 * ``none``:
   It will not do any merging at all and only parse the pillar data from the passed environment and 'base' if no environment was specified.

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -379,8 +379,10 @@ class Pillar(object):
                         ]
             else:
                 for saltenv in self._get_envs():
-                    if self.opts.get('pillar_source_merging_strategy', None) == "none":
-                        if self.saltenv and saltenv is not self.saltenv:
+                    if self.opts['pillar_source_merging_strategy'] == "none":
+                        if self.saltenv and saltenv != self.saltenv:
+                            continue
+                        if not self.saltenv and not saltenv == 'base':
                             continue
                     top = self.client.cache_file(
                             self.opts['state_top'],

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -265,6 +265,7 @@ class Pillar(object):
         self.actual_file_roots = opts['file_roots']
         # use the local file client
         self.opts = self.__gen_opts(opts, grains, saltenv=saltenv, ext=ext, pillarenv=pillarenv)
+        self.saltenv = saltenv
         self.client = salt.fileclient.get_file_client(self.opts, True)
 
         if opts.get('file_client', '') == 'local':
@@ -378,6 +379,9 @@ class Pillar(object):
                         ]
             else:
                 for saltenv in self._get_envs():
+                    if self.opts['pillar_source_merging_strategy'].lower() == "none":
+                        if saltenv is not self.saltenv:
+                            continue
                     top = self.client.cache_file(
                             self.opts['state_top'],
                             saltenv

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -379,7 +379,7 @@ class Pillar(object):
                         ]
             else:
                 for saltenv in self._get_envs():
-                    if self.opts['pillar_source_merging_strategy'].lower() == "none":
+                    if self.opts.get('pillar_source_merging_strategy', None) == "none":
                         if saltenv is not self.saltenv:
                             continue
                     top = self.client.cache_file(

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -379,7 +379,7 @@ class Pillar(object):
                         ]
             else:
                 for saltenv in self._get_envs():
-                    if self.opts['pillar_source_merging_strategy'] == "none":
+                    if self.opts.get('pillar_source_merging_strategy', None) == "none":
                         if self.saltenv and saltenv != self.saltenv:
                             continue
                         if not self.saltenv and not saltenv == 'base':

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -380,7 +380,7 @@ class Pillar(object):
             else:
                 for saltenv in self._get_envs():
                     if self.opts.get('pillar_source_merging_strategy', None) == "none":
-                        if saltenv is not self.saltenv:
+                        if self.saltenv and saltenv is not self.saltenv:
                             continue
                     top = self.client.cache_file(
                             self.opts['state_top'],

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -109,6 +109,10 @@ def merge(obj_a, obj_b, strategy='smart', renderer='yaml', merge_lists=False):
         merged = merge_aggregate(obj_a, obj_b)
     elif strategy == 'overwrite':
         merged = merge_overwrite(obj_a, obj_b, merge_lists)
+    elif strategy == 'none':
+        # If we do not want to merge, there is only one pillar passed, so we can safely use the default recurse,
+        # we just do not want to log an error
+        merged = merge_recurse(obj_a, obj_b)
     else:
         log.warning('Unknown merging strategy \'{0}\', '
                     'fallback to recurse'.format(strategy))


### PR DESCRIPTION
### What does this PR do?

Add "none" option to the pillar merging strategy to prevent merging of pillar data altogether, which is referenced in #29421
### What issues does this PR fix or reference?
#29421
### New Behavior

When pillar_source_merging_strategy is set to "none", no pillar merging is done and only the pillar data of the environment that is called is used
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
