### PR TITLE
Add support for specifying a datastore for new disks.

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -277,7 +277,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
             controller as well as the hard disk at the same time.
         datastore
             The name of a valid datastore should you wish the new disk to be in
-            a datastore other than the default for the VM
+            a datastore other than the default for the VM.
 
     network
         Enter the network adapter specification here. If the network adapter doesn\'t

--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -129,6 +129,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
           Hard disk 3:
             size: 5
             controller: SCSI controller 3
+            datastore: smalldiskdatastore
         network:
           Network adapter 1:
             name: 10.20.30-400-Test
@@ -274,6 +275,9 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
             Specify the SCSI controller label to which this disk should be attached.
             This should be specified only when creating both the specified SCSI
             controller as well as the hard disk at the same time.
+        datastore
+            The name of a valid datastore should you wish the new disk to be in
+            a datastore other than the default for the VM
 
     network
         Enter the network adapter specification here. If the network adapter doesn\'t

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -297,7 +297,6 @@ def _add_new_hard_disk_helper(disk_label, size_gb, unit_number, controller_key=1
     disk_spec.device.deviceInfo.label = disk_label
     disk_spec.device.deviceInfo.summary = "{0} GB".format(size_gb)
 
-
     disk_spec.device.backing = vim.vm.device.VirtualDisk.FlatVer2BackingInfo()
     disk_spec.device.backing.thinProvisioned = thin_provision
     disk_spec.device.backing.diskMode = 'persistent'

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -281,7 +281,8 @@ def _edit_existing_hard_disk_mode_helper(disk, mode):
     return disk_spec
 
 
-def _add_new_hard_disk_helper(disk_label, size_gb, unit_number, controller_key=1000, thin_provision=False):
+def _add_new_hard_disk_helper(disk_label, size_gb, unit_number, controller_key=1000, thin_provision=False, datastore=None, vm_name=None):
+
     random_key = randint(-2099, -2000)
 
     size_kb = int(size_gb * 1024.0 * 1024.0)
@@ -295,9 +296,19 @@ def _add_new_hard_disk_helper(disk_label, size_gb, unit_number, controller_key=1
     disk_spec.device.deviceInfo = vim.Description()
     disk_spec.device.deviceInfo.label = disk_label
     disk_spec.device.deviceInfo.summary = "{0} GB".format(size_gb)
+
+
     disk_spec.device.backing = vim.vm.device.VirtualDisk.FlatVer2BackingInfo()
     disk_spec.device.backing.thinProvisioned = thin_provision
     disk_spec.device.backing.diskMode = 'persistent'
+    if datastore:
+        ds_ref = salt.utils.vmware.get_datastore_ref(_get_si(), datastore)
+        if not ds_ref:
+            raise SaltCloudSystemExit('Requested {0} disk in datastore {1}, but no such datastore found.'.format(disk_label, datastore))
+        datastore_path = '[' + str(ds_ref.name) + '] ' + vm_name
+        disk_spec.device.backing.fileName = datastore_path + '/' + disk_label + '.vmdk'
+        disk_spec.device.backing.datastore = ds_ref
+
     disk_spec.device.controllerKey = controller_key
     disk_spec.device.unitNumber = unit_number
     disk_spec.device.capacityInKB = size_kb
@@ -601,7 +612,7 @@ def _set_network_adapter_mapping(adapter_specs):
     return adapter_mapping
 
 
-def _manage_devices(devices, vm=None, container_ref=None):
+def _manage_devices(devices, vm=None, container_ref=None, new_vm_name=None):
     unit_number = 0
     bus_number = 0
     device_specs = []
@@ -748,7 +759,8 @@ def _manage_devices(devices, vm=None, container_ref=None):
             # create the disk
             size_gb = float(devices['disk'][disk_label]['size'])
             thin_provision = bool(devices['disk'][disk_label]['thin_provision']) if 'thin_provision' in devices['disk'][disk_label] else False
-            disk_spec = _add_new_hard_disk_helper(disk_label, size_gb, unit_number, thin_provision=thin_provision)
+            datastore = devices['disk'][disk_label].get('datastore', None)
+            disk_spec = _add_new_hard_disk_helper(disk_label, size_gb, unit_number, thin_provision=thin_provision, datastore=datastore, vm_name=new_vm_name)
 
             # when creating both SCSI controller and Hard disk at the same time we need the randomly
             # assigned (temporary) key of the newly created SCSI controller
@@ -2482,7 +2494,7 @@ def create(vm_):
         config_spec.memoryMB = memory_mb
 
     if devices:
-        specs = _manage_devices(devices, object_ref)
+        specs = _manage_devices(devices, vm=object_ref, new_vm_name=vm_['name'])
         config_spec.deviceChange = specs['device_specs']
 
     if extra_config:

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -267,6 +267,25 @@ def _get_service_instance(host, username, password, protocol,
     return service_instance
 
 
+def get_datastore_ref(si, datastore_name):
+    '''
+    Get a reference to a VMware datastore for the purposes of adding/removing disks
+
+    si
+        ServiceInstance for the vSphere or ESXi server (see get_service_instance)
+
+    datastore_name
+        Name of the datastore
+
+    '''
+    inventory = get_inventory(si)
+    container = inventory.viewManager.CreateContainerView(inventory.rootFolder, [vim.Datastore], True)
+    for item in container.view:
+        if item.name == datastore_name:
+            return item
+    return None
+
+
 def get_service_instance(host, username=None, password=None, protocol=None,
                          port=None, mechanism='userpass', principal=None,
                          domain=None):
@@ -601,7 +620,7 @@ def get_content(service_instance, obj_type, property_list=None,
         traversal_spec = vmodl.query.PropertyCollector.TraversalSpec(
             name='traverseEntities',
             path='view',
-            skip=True,
+            skip=False,
             type=vim.view.ContainerView
         )
 
@@ -615,7 +634,7 @@ def get_content(service_instance, obj_type, property_list=None,
     # Create object spec to navigate content
     obj_spec = vmodl.query.PropertyCollector.ObjectSpec(
         obj=obj_ref,
-        skip=False,
+        skip=True if not local_properties else False,
         selectSet=[traversal_spec] if not local_properties else None
     )
 

--- a/tests/unit/utils/vmware_test/common_test.py
+++ b/tests/unit/utils/vmware_test/common_test.py
@@ -403,11 +403,11 @@ class GetContentTestCase(TestCase):
         self.create_container_view_mock.assert_called_once_with(
             self.root_folder_mock, [self.obj_type_mock], True)
         self.traversal_spec_mock.assert_called_once_with(
-            name='traverseEntities', path='view', skip=True,
+            name='traverseEntities', path='view', skip=False,
             type=vim.view.ContainerView)
         self.obj_spec_mock.assert_called_once_with(
             obj=self.container_view_mock,
-            skip=False,
+            skip=True,
             selectSet=[self.traversal_spec_ret_mock])
         # check destroy is called
         self.assertEqual(self.destroy_mock.call_count, 1)
@@ -423,7 +423,7 @@ class GetContentTestCase(TestCase):
                     traversal_spec=traversal_spec_obj_mock)
         self.obj_spec_mock.assert_called_once_with(
             obj=self.root_folder_mock,
-            skip=False,
+            skip=True,
             selectSet=[traversal_spec_obj_mock])
         # Check local traversal methods are not called
         self.assertEqual(self.create_container_view_mock.call_count, 0)
@@ -441,12 +441,12 @@ class GetContentTestCase(TestCase):
                             self.si_mock,
                             self.obj_type_mock)
         self.traversal_spec_mock.assert_called_once_with(
-            name='traverseEntities', path='view', skip=True,
+            name='traverseEntities', path='view', skip=False,
             type=vim.view.ContainerView)
         self.property_spec_mock.assert_called_once_with(
             type=self.obj_type_mock, all=True, pathSet=None)
         self.obj_spec_mock.assert_called_once_with(
-            obj=self.container_view_mock, skip=False,
+            obj=self.container_view_mock, skip=True,
             selectSet=[self.traversal_spec_ret_mock])
         self.retrieve_contents_mock.assert_called_once_with(
             [self.filter_spec_ret_mock])


### PR DESCRIPTION
### What does this PR do?

Adds a 'datastore' parameter for defining additional disks for a VM.  Setting this parameter allows extra disks to be located in a datastore other than the VM's default.
]
