### PR TITLE
Fix #36461, AttributeError because of .lower()

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -516,7 +516,7 @@ def verify_log(opts):
     '''
     If an insecre logging configuration is found, show a warning
     '''
-    level = LOG_LEVELS.get(opts.get('log_level').lower(), logging.NOTSET)
+    level = LOG_LEVELS.get(str(opts.get('log_level')).lower(), logging.NOTSET)
 
     if level < logging.INFO:
         log.warn('Insecure logging configuration detected! Sensitive data may be logged.')

--- a/tests/unit/utils/verify_test.py
+++ b/tests/unit/utils/verify_test.py
@@ -239,6 +239,11 @@ class TestVerify(TestCase):
             verify_log({'log_level': 'trace'})
             mock_trace.assert_called_once_with(message)
 
+        mock_none = MagicMock()
+        with patch.object(log, 'warn', mock_none):
+            verify_log({})
+            mock_none.assert_called_once_with(message)
+
         mock_info = MagicMock()
         with patch.object(log, 'warn', mock_info):
             verify_log({'log_level': 'info'})


### PR DESCRIPTION
### What does this PR do?

It applies an `str()` call to the `LOG_LEVELS.get()` call to ensure that even an empty `opts` argument validates to an `logging.NOTSET` loglevel.
### What issues does this PR fix or reference?
#36461
