### PR TITLE
Add "/env/" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ MANIFEST
 #   top of salt such as
 # - /some/path$ git clone https://github.com/thatch45/salt.git
 # - /some/path$ virtualenv --python=/usr/bin/python2.6 salt
+/env/
 /bin/
 /etc/
 /include/


### PR DESCRIPTION
### What does this PR do?

This adds the entry `/env/` to the `.gitignore` file to allow a default named virtualenv to exist without the attention of git.
