### PR TITLE
Add wrapper to AWS functions to make it compatible with the cloud module

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -3865,6 +3865,14 @@ def register_image(kwargs=None, call=None):
     return r_data
 
 
+def volume_create(**kwargs):
+    '''
+    Wrapper around create_volume.
+    Here just to ensure the compatibility with the cloud module.
+    '''
+    return create_volume(kwargs, 'function')
+
+
 def create_volume(kwargs=None, call=None, wait_to_finish=False):
     '''
     Create a volume
@@ -4081,6 +4089,14 @@ def delete_volume(name=None, kwargs=None, instance_id=None, call=None):
                      opts=__opts__,
                      sigver='4')
     return data
+
+
+def volume_list(**kwargs):
+    '''
+    Wrapper around describe_volumes.
+    Here just to ensure the compatibility with the cloud module.
+    '''
+    return describe_volumes(kwargs, 'function')
 
 
 def describe_volumes(kwargs=None, call=None):


### PR DESCRIPTION
### What does this PR do?

Enable someone to call volume.create from a salt state, simply by naming correctly function already present in the EC2 module.
### Previous Behavior

Not working
### New Behavior

The EC2 module has better compatibility with the cloud state.
### Tests written?

No
