### PR TITLE
Add the "bash" option to the "code-block"directive.

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -786,7 +786,8 @@ steps to this process:
          #!/usr/bin/env sh
          salt-call event.fire_master update salt/fileserver/gitfs/update
 
-   b. To enable other git users to run the hook after a `push`, use sudo in the hook script: 
+   b. To enable other git users to run the hook after a `push`, use sudo in the hook script:
+
      .. code-block:: bash
 
          #!/usr/bin/env sh
@@ -795,7 +796,7 @@ steps to this process:
 4. If using sudo in the git hook (above), the policy must be changed to permit all users to fire the event.
    Add the following policy to the sudoers file on the git server.
 
-   .. code-block::
+   .. code-block:: bash
 
        Cmnd_Alias SALT_GIT_HOOK = /bin/salt-call event.fire_master update salt/fileserver/gitfs/update
        Defaults!SALT_GIT_HOOK !requiretty


### PR DESCRIPTION
Fixes #36475

By adding the "bash" argument, we avoid the following error and the docs
will display appropriately:

```
/root/SaltStack/salt/doc/topics/tutorials/gitfs.rst:918: ERROR: Error in "code-block" directive:
1 argument(s) required, 0 supplied.

.. code-block::

    Cmnd_Alias SALT_GIT_HOOK = /bin/salt-call event.fire_master update salt/fileserver/gitfs/update
    Defaults!SALT_GIT_HOOK !requiretty
    ALL ALL=(root) NOPASSWD: SALT_GIT_HOOK
```
