### PR TITLE
Fix mac non-string arg handling

### DIFF
--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -16,6 +16,7 @@ import os
 import salt.utils
 import salt.utils.timed_subprocess
 import salt.grains.extra
+from salt.ext import six
 from salt.exceptions import CommandExecutionError, SaltInvocationError,\
     TimedProcTimeoutError
 
@@ -49,6 +50,10 @@ def _run_all(cmd):
     '''
     if not isinstance(cmd, list):
         cmd = salt.utils.shlex_split(cmd, posix=False)
+
+    for idx, item in enumerate(cmd):
+        if not isinstance(cmd[idx], six.string_types):
+            cmd[idx] = str(cmd[idx])
 
     cmd = ' '.join(cmd)
 

--- a/tests/integration/modules/mac_service.py
+++ b/tests/integration/modules/mac_service.py
@@ -65,10 +65,10 @@ class MacServiceModuleTest(integration.ModuleCase):
         # Expected Functionality
         self.assertTrue(
             self.run_function('service.launchctl',
-                              ['error', 'bootstrap', '64']))
+                              ['error', 'bootstrap', 64]))
         self.assertEqual(
             self.run_function('service.launchctl',
-                              ['error', 'bootstrap', '64'],
+                              ['error', 'bootstrap', 64],
                               return_stdout=True),
             '64: unknown error code')
 


### PR DESCRIPTION
The mac modules are for some reason using a re-implementation of cmd.run_all, which was causing problem with tests (see [here](https://github.com/saltstack/salt/pull/36176/files#r78154138)).

This reverts the changes made to the tests, and fixes the broken behavior in salt.utils.mac_utils, until such time as this module can be removed altogether.