### PR TITLE
Have salt-cloud clean up tmp files

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1813,90 +1813,91 @@ def scp_file(dest_path, contents=None, kwargs=None, local_file=None):
 
     tmpfh, tmppath = tempfile.mkstemp()
 
-    if local_file is not None:
-        file_to_upload = local_file
-        if os.path.isdir(local_file):
-            ssh_args.append('-r')
-    elif contents is not None:
-        file_to_upload = tmppath
-        with salt.utils.fopen(tmppath, 'w') as tmpfile:
-            tmpfile.write(contents)
-    else:
-        raise SaltCloudException('Must provide either contents or local_file')
+    try:
+        if local_file is not None:
+            file_to_upload = local_file
+            if os.path.isdir(local_file):
+                ssh_args.append('-r')
+        elif contents is not None:
+            file_to_upload = tmppath
+            with salt.utils.fopen(tmppath, 'w') as tmpfile:
+                tmpfile.write(contents)
+        else:
+            raise SaltCloudException('Must provide either contents or local_file')
 
-    if 'key_filename' in kwargs:
-        # There should never be both a password and an ssh key passed in, so
-        ssh_args.extend([
-            # tell SSH to skip password authentication
-            '-oPasswordAuthentication=no',
-            '-oChallengeResponseAuthentication=no',
-            # Make sure public key authentication is enabled
-            '-oPubkeyAuthentication=yes',
-            # do only use the provided identity file
-            '-oIdentitiesOnly=yes',
-            # No Keyboard interaction!
-            '-oKbdInteractiveAuthentication=no',
-            # Also, specify the location of the key file
-            '-i {0}'.format(kwargs['key_filename'])
-        ])
+        if 'key_filename' in kwargs:
+            # There should never be both a password and an ssh key passed in, so
+            ssh_args.extend([
+                # tell SSH to skip password authentication
+                '-oPasswordAuthentication=no',
+                '-oChallengeResponseAuthentication=no',
+                # Make sure public key authentication is enabled
+                '-oPubkeyAuthentication=yes',
+                # do only use the provided identity file
+                '-oIdentitiesOnly=yes',
+                # No Keyboard interaction!
+                '-oKbdInteractiveAuthentication=no',
+                # Also, specify the location of the key file
+                '-i {0}'.format(kwargs['key_filename'])
+            ])
 
-    if 'port' in kwargs:
-        ssh_args.append('-oPort={0}'.format(kwargs['port']))
+        if 'port' in kwargs:
+            ssh_args.append('-oPort={0}'.format(kwargs['port']))
 
-    if 'ssh_gateway' in kwargs:
-        ssh_gateway = kwargs['ssh_gateway']
-        ssh_gateway_port = 22
-        ssh_gateway_key = ''
-        ssh_gateway_user = 'root'
-        if ':' in ssh_gateway:
-            ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
-        if 'ssh_gateway_port' in kwargs:
-            ssh_gateway_port = kwargs['ssh_gateway_port']
-        if 'ssh_gateway_key' in kwargs:
-            ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key'])
-        if 'ssh_gateway_user' in kwargs:
-            ssh_gateway_user = kwargs['ssh_gateway_user']
+        if 'ssh_gateway' in kwargs:
+            ssh_gateway = kwargs['ssh_gateway']
+            ssh_gateway_port = 22
+            ssh_gateway_key = ''
+            ssh_gateway_user = 'root'
+            if ':' in ssh_gateway:
+                ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
+            if 'ssh_gateway_port' in kwargs:
+                ssh_gateway_port = kwargs['ssh_gateway_port']
+            if 'ssh_gateway_key' in kwargs:
+                ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key'])
+            if 'ssh_gateway_user' in kwargs:
+                ssh_gateway_user = kwargs['ssh_gateway_user']
 
-        ssh_args.append(
-            # Setup ProxyCommand
-            '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} nc -q0 %h %p"'.format(
-                # Don't add new hosts to the host key database
-                '-oStrictHostKeyChecking=no',
-                # Set hosts key database path to /dev/null, i.e., non-existing
-                '-oUserKnownHostsFile=/dev/null',
-                # Don't re-use the SSH connection. Less failures.
-                '-oControlPath=none',
-                ssh_gateway_key,
-                ssh_gateway_user,
-                ssh_gateway,
-                ssh_gateway_port
+            ssh_args.append(
+                # Setup ProxyCommand
+                '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} nc -q0 %h %p"'.format(
+                    # Don't add new hosts to the host key database
+                    '-oStrictHostKeyChecking=no',
+                    # Set hosts key database path to /dev/null, i.e., non-existing
+                    '-oUserKnownHostsFile=/dev/null',
+                    # Don't re-use the SSH connection. Less failures.
+                    '-oControlPath=none',
+                    ssh_gateway_key,
+                    ssh_gateway_user,
+                    ssh_gateway,
+                    ssh_gateway_port
+                )
+            )
+
+        try:
+            if socket.inet_pton(socket.AF_INET6, kwargs['hostname']):
+                ipaddr = '[{0}]'.format(kwargs['hostname'])
+            else:
+                ipaddr = kwargs['hostname']
+        except socket.error:
+            ipaddr = kwargs['hostname']
+
+        cmd = (
+            'scp {0} {1} {2[username]}@{4}:{3} || '
+            'echo "put {1} {3}" | sftp {0} {2[username]}@{4} || '
+            'rsync -avz -e "ssh {0}" {1} {2[username]}@{2[hostname]}:{3}'.format(
+                ' '.join(ssh_args), file_to_upload, kwargs, dest_path, ipaddr
             )
         )
 
-    try:
-        if socket.inet_pton(socket.AF_INET6, kwargs['hostname']):
-            ipaddr = '[{0}]'.format(kwargs['hostname'])
-        else:
-            ipaddr = kwargs['hostname']
-    except socket.error:
-        ipaddr = kwargs['hostname']
-
-    cmd = (
-        'scp {0} {1} {2[username]}@{4}:{3} || '
-        'echo "put {1} {3}" | sftp {0} {2[username]}@{4} || '
-        'rsync -avz -e "ssh {0}" {1} {2[username]}@{2[hostname]}:{3}'.format(
-            ' '.join(ssh_args), file_to_upload, kwargs, dest_path, ipaddr
-        )
-    )
-
-    log.debug('SCP command: \'{0}\''.format(cmd))
-    retcode = _exec_ssh_cmd(cmd,
-                            error_msg='Failed to upload file \'{0}\': {1}\n{2}',
-                            password_retries=3,
-                            **kwargs)
-
-    # Clean up after ourselves
-    os.remove(tmppath)
+        log.debug('SCP command: \'{0}\''.format(cmd))
+        retcode = _exec_ssh_cmd(cmd,
+                                error_msg='Failed to upload file \'{0}\': {1}\n{2}',
+                                password_retries=3,
+                                **kwargs)
+    finally:
+        # Clean up after ourselves
+        os.remove(tmppath)
 
     return retcode
 
@@ -1922,95 +1923,96 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
 
     tmpfh, tmppath = tempfile.mkstemp()
 
-    if local_file is not None:
-        file_to_upload = local_file
-        if os.path.isdir(local_file):
-            put_args = ['-r']
-    elif contents is not None:
-        file_to_upload = tmppath
-        with salt.utils.fopen(tmppath, 'w') as tmpfile:
-            tmpfile.write(contents)
-    else:
-        raise SaltCloudException('Must provide either contents or local_file')
-
-    log.debug('Uploading {0} to {1} (sftp)'.format(dest_path, kwargs.get('hostname')))
-
-    ssh_args = [
-        # Don't add new hosts to the host key database
-        '-oStrictHostKeyChecking=no',
-        # Set hosts key database path to /dev/null, i.e., non-existing
-        '-oUserKnownHostsFile=/dev/null',
-        # Don't re-use the SSH connection. Less failures.
-        '-oControlPath=none'
-    ]
-    if 'key_filename' in kwargs:
-        # There should never be both a password and an ssh key passed in, so
-        ssh_args.extend([
-            # tell SSH to skip password authentication
-            '-oPasswordAuthentication=no',
-            '-oChallengeResponseAuthentication=no',
-            # Make sure public key authentication is enabled
-            '-oPubkeyAuthentication=yes',
-            # do only use the provided identity file
-            '-oIdentitiesOnly=yes',
-            # No Keyboard interaction!
-            '-oKbdInteractiveAuthentication=no',
-            # Also, specify the location of the key file
-            '-oIdentityFile={0}'.format(kwargs['key_filename'])
-        ])
-
-    if 'port' in kwargs:
-        ssh_args.append('-oPort={0}'.format(kwargs['port']))
-
-    if 'ssh_gateway' in kwargs:
-        ssh_gateway = kwargs['ssh_gateway']
-        ssh_gateway_port = 22
-        ssh_gateway_key = ''
-        ssh_gateway_user = 'root'
-        if ':' in ssh_gateway:
-            ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
-        if 'ssh_gateway_port' in kwargs:
-            ssh_gateway_port = kwargs['ssh_gateway_port']
-        if 'ssh_gateway_key' in kwargs:
-            ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key'])
-        if 'ssh_gateway_user' in kwargs:
-            ssh_gateway_user = kwargs['ssh_gateway_user']
-
-        ssh_args.append(
-            # Setup ProxyCommand
-            '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} nc -q0 %h %p"'.format(
-                # Don't add new hosts to the host key database
-                '-oStrictHostKeyChecking=no',
-                # Set hosts key database path to /dev/null, i.e., non-existing
-                '-oUserKnownHostsFile=/dev/null',
-                # Don't re-use the SSH connection. Less failures.
-                '-oControlPath=none',
-                ssh_gateway_key,
-                ssh_gateway_user,
-                ssh_gateway,
-                ssh_gateway_port
-            )
-        )
-
     try:
-        if socket.inet_pton(socket.AF_INET6, kwargs['hostname']):
-            ipaddr = '[{0}]'.format(kwargs['hostname'])
+        if local_file is not None:
+            file_to_upload = local_file
+            if os.path.isdir(local_file):
+                put_args = ['-r']
+        elif contents is not None:
+            file_to_upload = tmppath
+            with salt.utils.fopen(tmppath, 'w') as tmpfile:
+                tmpfile.write(contents)
         else:
+            raise SaltCloudException('Must provide either contents or local_file')
+
+        log.debug('Uploading {0} to {1} (sftp)'.format(dest_path, kwargs.get('hostname')))
+
+        ssh_args = [
+            # Don't add new hosts to the host key database
+            '-oStrictHostKeyChecking=no',
+            # Set hosts key database path to /dev/null, i.e., non-existing
+            '-oUserKnownHostsFile=/dev/null',
+            # Don't re-use the SSH connection. Less failures.
+            '-oControlPath=none'
+        ]
+        if 'key_filename' in kwargs:
+            # There should never be both a password and an ssh key passed in, so
+            ssh_args.extend([
+                # tell SSH to skip password authentication
+                '-oPasswordAuthentication=no',
+                '-oChallengeResponseAuthentication=no',
+                # Make sure public key authentication is enabled
+                '-oPubkeyAuthentication=yes',
+                # do only use the provided identity file
+                '-oIdentitiesOnly=yes',
+                # No Keyboard interaction!
+                '-oKbdInteractiveAuthentication=no',
+                # Also, specify the location of the key file
+                '-oIdentityFile={0}'.format(kwargs['key_filename'])
+            ])
+
+        if 'port' in kwargs:
+            ssh_args.append('-oPort={0}'.format(kwargs['port']))
+
+        if 'ssh_gateway' in kwargs:
+            ssh_gateway = kwargs['ssh_gateway']
+            ssh_gateway_port = 22
+            ssh_gateway_key = ''
+            ssh_gateway_user = 'root'
+            if ':' in ssh_gateway:
+                ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
+            if 'ssh_gateway_port' in kwargs:
+                ssh_gateway_port = kwargs['ssh_gateway_port']
+            if 'ssh_gateway_key' in kwargs:
+                ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key'])
+            if 'ssh_gateway_user' in kwargs:
+                ssh_gateway_user = kwargs['ssh_gateway_user']
+
+            ssh_args.append(
+                # Setup ProxyCommand
+                '-oProxyCommand="ssh {0} {1} {2} {3} {4}@{5} -p {6} nc -q0 %h %p"'.format(
+                    # Don't add new hosts to the host key database
+                    '-oStrictHostKeyChecking=no',
+                    # Set hosts key database path to /dev/null, i.e., non-existing
+                    '-oUserKnownHostsFile=/dev/null',
+                    # Don't re-use the SSH connection. Less failures.
+                    '-oControlPath=none',
+                    ssh_gateway_key,
+                    ssh_gateway_user,
+                    ssh_gateway,
+                    ssh_gateway_port
+                )
+            )
+
+        try:
+            if socket.inet_pton(socket.AF_INET6, kwargs['hostname']):
+                ipaddr = '[{0}]'.format(kwargs['hostname'])
+            else:
+                ipaddr = kwargs['hostname']
+        except socket.error:
             ipaddr = kwargs['hostname']
-    except socket.error:
-        ipaddr = kwargs['hostname']
 
-    cmd = 'echo "put {0} {1} {2}" | sftp {3} {4[username]}@{5}'.format(
-        ' '.join(put_args), file_to_upload, dest_path, ' '.join(ssh_args), kwargs, ipaddr
-    )
-    log.debug('SFTP command: \'{0}\''.format(cmd))
-    retcode = _exec_ssh_cmd(cmd,
-                            error_msg='Failed to upload file \'{0}\': {1}\n{2}',
-                            password_retries=3,
-                            **kwargs)
-
-    # Clean up after ourselves
-    os.remove(tmppath)
+        cmd = 'echo "put {0} {1} {2}" | sftp {3} {4[username]}@{5}'.format(
+            ' '.join(put_args), file_to_upload, dest_path, ' '.join(ssh_args), kwargs, ipaddr
+        )
+        log.debug('SFTP command: \'{0}\''.format(cmd))
+        retcode = _exec_ssh_cmd(cmd,
+                                error_msg='Failed to upload file \'{0}\': {1}\n{2}',
+                                password_retries=3,
+                                **kwargs)
+    finally:
+        # Clean up after ourselves
+        os.remove(tmppath)
 
     return retcode
 


### PR DESCRIPTION
### What does this PR do?

We ran in to an issue with our root partition filling up due to thousands of tmp files being left behind by salt-cloud.
### What issues does this PR fix or reference?

none
### Previous Behavior

~5 `tmp*` files were left in the `/tmp` directory for every host launched with salt-cloud
### New Behavior

tmp files in `/tmp` are cleaned up by salt-cloud
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
