### PR TITLE
Isolate sun IPv6 fix to Sun OS only

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -589,7 +589,10 @@ def _interfaces_ifconfig(out):
                     if not salt.utils.is_sunos():
                         ipv6scope = mmask6.group(3) or mmask6.group(4)
                         addr_obj['scope'] = ipv6scope.lower() if ipv6scope is not None else ipv6scope
-                if addr_obj['address'] != '::' and addr_obj['prefixlen'] != 0:  # SunOS sometimes has ::/0 as inet6 addr when using addrconf
+                if salt.utils.is_sunos():
+                    if addr_obj['address'] != '::' and addr_obj['prefixlen'] != 0:  # SunOS sometimes has ::/0 as inet6 addr when using addrconf
+                        data['inet6'].append(addr_obj)
+                else:
                     data['inet6'].append(addr_obj)
         data['up'] = updown
         if iface in ret:

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -589,10 +589,10 @@ def _interfaces_ifconfig(out):
                     if not salt.utils.is_sunos():
                         ipv6scope = mmask6.group(3) or mmask6.group(4)
                         addr_obj['scope'] = ipv6scope.lower() if ipv6scope is not None else ipv6scope
-                if salt.utils.is_sunos():
-                    if addr_obj['address'] != '::' and addr_obj['prefixlen'] != 0:  # SunOS sometimes has ::/0 as inet6 addr when using addrconf
-                        data['inet6'].append(addr_obj)
-                else:
+                # SunOS sometimes has ::/0 as inet6 addr when using addrconf
+                if not salt.utils.is_sunos() \
+                        or addr_obj['address'] != '::' \
+                        and addr_obj['prefixlen'] != 0:
                     data['inet6'].append(addr_obj)
         data['up'] = updown
         if iface in ret:


### PR DESCRIPTION
### What does this PR do?

Fixes Sun Os test for valid Ipv6 packet to only occur if on Sun Os
### What issues does this PR fix or reference?

On AIX IPv6 packets were causing KeyErrors since 'prefixlen' index was being utilized without it having been defined, on a test for a confdition which occurs on Sun Os. Added check for Sun OS before executing test oitherwise execute original code.
### Previous Behavior

KeyError due to use of undefined index 'prefixlen' with some IPv6 packets
### New Behavior

Remove cause of KeyError by only testing after 'prefixlen' index has been defined
### Tests written?

No, debugged on AIX

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
