### PR TITLE
Windows: Fix module "file.check_file_meta" incorrect diff

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4061,6 +4061,8 @@ def check_file_meta(
     if contents is not None:
         # Write a tempfile with the static contents
         tmp = salt.utils.mkstemp(text=True)
+        if salt.utils.is_windows():
+            contents = os.linesep.join(contents.splitlines())
         with salt.utils.fopen(tmp, 'wb') as tmp_:
             tmp_.write(salt.utils.to_bytes(str(contents)))
         # Compare the static contents with the named file

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4063,8 +4063,8 @@ def check_file_meta(
         tmp = salt.utils.mkstemp(text=True)
         if salt.utils.is_windows():
             contents = os.linesep.join(contents.splitlines())
-        with salt.utils.fopen(tmp, 'wb') as tmp_:
-            tmp_.write(salt.utils.to_bytes(str(contents)))
+        with salt.utils.fopen(tmp, 'w') as tmp_:
+            tmp_.write(str(contents))
         # Compare the static contents with the named file
         with salt.utils.fopen(tmp, 'r') as src:
             slines = src.readlines()


### PR DESCRIPTION
### What does this PR do?

On Windows, the module function `file.check_file_meta` would always
return a diff even when the files are identical. For instance, the files
are identical but this is returned:

```
"pchanges": {
  "diff": "--- \n+++ \n@@ -1 +1 @@\n
    -{\"Skyline.ExchangeName\":\"niskyline\",\"Skyline.Host\":\"127.0.0.1\",
      \"Skyline.Password\":\"Y5{9()*Dy:x(d&m:FKnmPFb+b5!!!Ya)\",
      \"Skyline.User\":\"niskyline\"}
    +{\"Skyline.ExchangeName\":\"niskyline\",\"Skyline.Host\":\"127.0.0.1\",
      \"Skyline.Password\":\"Y5{9()*Dy:x(d&m:FKnmPFb+b5!!!Ya)\",
      \"Skyline.User\":\"niskyline\"}\n"
}
```

This type of issue was already fixed within similar logic in
`file.manage_file` by using:

```
if salt.utils.is_windows():
    contents = os.linesep.join(contents.splitlines())
```

Add this exact same logic to `file.check_file_meta`.
### Tests written?

No
Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
