### PR TITLE
The "assert_called_once" mock testing function is only available in mock 2.0.0 or greater

### DIFF
--- a/tests/unit/cloud/clouds/dimensiondata_test.py
+++ b/tests/unit/cloud/clouds/dimensiondata_test.py
@@ -8,6 +8,8 @@
 
 # Import Python libs
 from __future__ import absolute_import
+from distutils.version import LooseVersion
+import mock
 
 try:
     import libcloud.security
@@ -148,7 +150,8 @@ class DimensionDataTestCase(ExtendedTestCase):
         with patch('salt.config.check_driver_dependencies', return_value=True) as p:
             get_deps = dimensiondata.get_dependencies()
             self.assertEqual(get_deps, True)
-            p.assert_called_once()
+            if LooseVersion(mock.__version__) >= LooseVersion('2.0.0'):
+                p.assert_called_once()
 
     def test_provider_matches(self):
         """

--- a/tests/unit/cloud/clouds/gce_test.py
+++ b/tests/unit/cloud/clouds/gce_test.py
@@ -8,6 +8,8 @@
 
 # Import Python libs
 from __future__ import absolute_import
+from distutils.version import LooseVersion
+import mock
 
 try:
     import libcloud.security
@@ -94,7 +96,8 @@ class GCETestCase(TestCase):
         with patch('salt.config.check_driver_dependencies', return_value=True) as p:
             get_deps = gce.get_dependencies()
             self.assertEqual(get_deps, True)
-            p.assert_called_once()
+            if LooseVersion(mock.__version__) >= LooseVersion('2.0.0'):
+                p.assert_called_once()
 
     def test_provider_matches(self):
         """

--- a/tests/unit/modules/pacman_test.py
+++ b/tests/unit/modules/pacman_test.py
@@ -40,16 +40,17 @@ class PacmanTestCase(TestCase):
         cmdmock = MagicMock(return_value='A 1.0\nB 2.0')
         sortmock = MagicMock()
         stringifymock = MagicMock()
+        mock_ret = {'A': ['1.0'], 'B': ['2.0']}
         with patch.dict(pacman.__salt__, {
                 'cmd.run': cmdmock,
                 'pkg_resource.add_pkg': lambda pkgs, name, version: pkgs.setdefault(name, []).append(version),
                 'pkg_resource.sort_pkglist': sortmock,
                 'pkg_resource.stringify': stringifymock
                 }):
-            self.assertDictEqual(pacman.list_pkgs(), {'A': ['1.0'], 'B': ['2.0']})
+            self.assertDictEqual(pacman.list_pkgs(), mock_ret)
 
-        sortmock.assert_called_once()
-        stringifymock.assert_called_once()
+        sortmock.assert_called_with(mock_ret)
+        stringifymock.assert_called_with(mock_ret)
 
     def test_list_pkgs_as_list(self):
         '''
@@ -58,15 +59,16 @@ class PacmanTestCase(TestCase):
         cmdmock = MagicMock(return_value='A 1.0\nB 2.0')
         sortmock = MagicMock()
         stringifymock = MagicMock()
+        mock_ret = {'A': ['1.0'], 'B': ['2.0']}
         with patch.dict(pacman.__salt__, {
                 'cmd.run': cmdmock,
                 'pkg_resource.add_pkg': lambda pkgs, name, version: pkgs.setdefault(name, []).append(version),
                 'pkg_resource.sort_pkglist': sortmock,
                 'pkg_resource.stringify': stringifymock
                 }):
-            self.assertDictEqual(pacman.list_pkgs(True), {'A': ['1.0'], 'B': ['2.0']})
+            self.assertDictEqual(pacman.list_pkgs(True), mock_ret)
 
-        sortmock.assert_called_once()
+        sortmock.assert_called_with(mock_ret)
         stringifymock.assert_not_called()
 
     def test_group_list(self):


### PR DESCRIPTION
We have a couple of tests using the "assert_called_once" function, however, our salt-jenkins
states pin the version of mock at 1.0.1 (This is the last version that is compatible with
Python 2.6). We either need to use something else that works for all versions of mock or gate
the test.

In the pacman tests, it is possible to use "assert_called_with" instead of "assert_called_once"

In the dimension_data and gce unit tests, we need to gate the assertion behind a mock version check.
This way the tests won't fail if the version of mock installed is less than 2.0.0.

These four tests started failing on CentOS 7 tests at some point yesterday. I am not certain why they were not failing before.

cc @jtand 
