### PR TITLE
Fix arguments to add_team_repo in github state

### DIFF
--- a/salt/states/github.py
+++ b/salt/states/github.py
@@ -682,8 +682,8 @@ def repo_present(
                     ret['result'] = None
                 else:
                     result = __salt__['github.add_team_repo'](name, team_name,
-                                                              permission,
-                                                              profile=profile)
+                                                              profile=profile,
+                                                              permission=permission)
                     if result:
                         ret['changes'][team_name] = team_change
                     else:


### PR DESCRIPTION
@rallytime
### What does this PR do?

I accidentally snuck a bug in after addressing comments in #36361. `permission` was being used as a positional arg but this isn't backwards-compatible.
