### PR TITLE
Fix pkg.upgrade for zypper

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1120,10 +1120,11 @@ def upgrade(refresh=True, skip_verify=False):
         refresh_db()
     old = list_pkgs()
 
-    to_append = ''
     if skip_verify:
-        to_append = '--no-gpg-checks'
-    __zypper__(systemd_scope=_systemd_scope()).noraise.call('update', '--auto-agree-with-licenses', to_append)
+        __zypper__(systemd_scope=_systemd_scope()).noraise.call('update', '--auto-agree-with-licenses', '--no-gpg-checks')
+    else:
+        __zypper__(systemd_scope=_systemd_scope()).noraise.call('update', '--auto-agree-with-licenses')
+
     if __zypper__.exit_code not in __zypper__.SUCCESS_EXIT_CODES:
         ret['result'] = False
         ret['comment'] = (__zypper__.stdout() + os.linesep + __zypper__.stderr()).strip()


### PR DESCRIPTION
### What does this PR do?

Allows pkg.upgrade to work on SUSE again.
### What issues does this PR fix or reference?

Closes #36491 : pkg.upgrade does not upgrade on Leap 42.1 or Tumbleweed
### Previous Behavior

pkg.upgrade would always return True but would upgrade no packages
### New Behavior

pkg.upgrade works again.
