### PR TITLE
Add repr to namespacedict

### DIFF
--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -177,6 +177,9 @@ class NamespacedDictWrapper(collections.MutableMapping, dict):
             r = r[k]
         return r
 
+    def __repr__(self):
+        return repr(self._dict())
+
     def __setitem__(self, key, val):
         self._dict()[key] = val
 


### PR DESCRIPTION
Fixes #35813

The problem here was that we would pack `__grains__` into modules
using a `NamespacedDictWrapper` which would normally work fine because
the typical use case was to either retrieve a particular item or to
iterate over the items. However, in cases where we returned the `__grains__`
dictionary entirely, it would be represented as an empty dictionary.
