### PR TITLE
`postgres_extension` state: small corrections in docstrings

### DIFF
--- a/salt/states/postgres_extension.py
+++ b/salt/states/postgres_extension.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
-Management of PostgreSQL extensions (e.g.: postgis)
-===================================================
+Management of PostgreSQL extensions
+===================================
 
-The postgres_extensions module is used to create and manage Postgres extensions.
+A module used to install and manage PostgreSQL extensions.
 
 .. code-block:: yaml
 
@@ -44,14 +44,20 @@ def present(name,
             db_port=None):
     '''
     Ensure that the named extension is present.
-    For more information about all of these options see `CREATE EXTENSION` SQL
+
+    .. note::
+
+        Before you can use the state to load an extension into a database, the
+        extension's supporting files must be already installed.
+
+    For more information about all of these options see ``CREATE EXTENSION`` SQL
     command reference in the PostgreSQL documentation.
 
     name
-        The name of the extension to manage
+        The name of the extension to be installed
 
     if_not_exists
-        Add an `IF NOT EXISTS` parameter to the DDL statement
+        Add an ``IF NOT EXISTS`` parameter to the DDL statement
 
     schema
         Schema to install the extension into
@@ -174,10 +180,10 @@ def absent(name,
         Database to act on
 
     db_user
-        database username if different from config or default
+        Database username if different from config or default
 
     db_password
-        user password if any password for a specified user
+        User password if any password for a specified user
 
     db_host
         Database host if different from config or default

--- a/salt/states/postgres_tablespace.py
+++ b/salt/states/postgres_tablespace.py
@@ -45,7 +45,8 @@ def present(name,
             db_user=None):
     '''
     Ensure that the named tablespace is present with the specified properties.
-    For more information about all of these options see man `create_tablespace`(7).
+    For more information about all of these options see man
+    ``create_tablespace``(7).
 
     name
         The name of the tablespace to create/manage.


### PR DESCRIPTION
### What does this PR do?
- Adds note to the `postgres_extension.present` state
- Fixes formatting
- Corrects state and option descriptions
