### PR TITLE
Fix chocolatey

### DIFF
--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -76,7 +76,7 @@ def _find_chocolatey(context, salt):
     if 'chocolatey._path' in context:
         return context['chocolatey._path']
     choc_defaults = ['C:\\Chocolatey\\bin\\chocolatey.bat',
-                        'C:\\ProgramData\\Chocolatey\\bin\\chocolatey.exe', ]
+                     'C:\\ProgramData\\Chocolatey\\bin\\chocolatey.exe', ]
 
     choc_path = salt['cmd.which']('chocolatey.exe')
     if not choc_path:
@@ -248,11 +248,11 @@ def list_(narrow=None,
     if narrow:
         cmd.append(narrow)
     if salt.utils.is_true(all_versions):
-        cmd.append('-AllVersions')
+        cmd.append('-allversions')
     if salt.utils.is_true(pre_versions):
-        cmd.append('-Prerelease')
+        cmd.append('-prerelease')
     if source:
-        cmd.extend(['-Source', source])
+        cmd.extend(['-source', source])
     if local_only:
         cmd.extend(['-localonly'])
 
@@ -281,6 +281,9 @@ def list_webpi():
     Instructs Chocolatey to pull a full package list from the Microsoft Web PI
     repository.
 
+    Returns:
+        str: List of webpi packages
+
     CLI Example:
 
     .. code-block:: bash
@@ -288,7 +291,7 @@ def list_webpi():
         salt '*' chocolatey.list_webpi
     '''
     choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'list', '-Source', 'webpi']
+    cmd = [choc_path, 'list', '-source', 'webpi']
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if result['retcode'] != 0:
@@ -304,6 +307,9 @@ def list_windowsfeatures():
     Instructs Chocolatey to pull a full package list from the Windows Features
     list, via the Deployment Image Servicing and Management tool.
 
+    Returns:
+        str: List of Windows Features
+
     CLI Example:
 
     .. code-block:: bash
@@ -311,7 +317,7 @@ def list_windowsfeatures():
         salt '*' chocolatey.list_windowsfeatures
     '''
     choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'list', '-Source', 'windowsfeatures']
+    cmd = [choc_path, 'list', '-source', 'windowsfeatures']
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if result['retcode'] != 0:
@@ -334,36 +340,52 @@ def install(name,
     '''
     Instructs Chocolatey to install a package.
 
-    name
-        The name of the package to be installed. Only accepts a single argument.
+    Args:
 
-    version
-        Install a specific version of the package. Defaults to latest version.
+        name (str):
+            The name of the package to be installed. Only accepts a single
+            argument.
 
-    source
-        Chocolatey repository (directory, share or remote URL feed) the package
-        comes from. Defaults to the official Chocolatey feed.
+        version (str):
+            Install a specific version of the package. Defaults to latest
+            version.
 
-    force
-        Reinstall the current version of an existing package.
+        source (str):
+            Chocolatey repository (directory, share or remote URL feed) the
+            package comes from. Defaults to the official Chocolatey feed.
 
-    pre_versions
-        Include pre-release packages. Defaults to False.
+            Alternative Sources:
 
-    install_args
-        A list of install arguments you want to pass to the installation process
-        i.e product key or feature list
+            - cygwin
+            - python
+            - ruby
+            - webpi
+            - windowsfeatures
 
-    override_args
-        Set to true if you want to override the original install arguments (for the native installer)
-         in the package and use your own. When this is set to False install_args will be appended to the end of the
-         default arguments
+        force (bool):
+            Reinstall the current version of an existing package.
 
-    force_x86
-        Force x86 (32bit) installation on 64 bit systems. Defaults to false.
+        pre_versions (bool):
+            Include pre-release packages. Defaults to False.
 
-    package_args
-        A list of arguments you want to pass to the package
+        install_args (str):
+            A list of install arguments you want to pass to the installation
+            process i.e product key or feature list
+
+        override_args (bool):
+            Set to true if you want to override the original install arguments
+            (for the native installer) in the package and use your own. When
+            this is set to False install_args will be appended to the end of the
+            default arguments
+
+        force_x86 (str):
+            Force x86 (32bit) installation on 64 bit systems. Defaults to false.
+
+        package_args (str):
+            A list of arguments you want to pass to the package
+
+    Returns:
+        str: The output of the ``chocolatey`` command
 
     CLI Example:
 
@@ -377,21 +399,21 @@ def install(name,
     # chocolatey helpfully only supports a single package argument
     cmd = [choc_path, 'install', name]
     if version:
-        cmd.extend(['-Version', version])
+        cmd.extend(['-version', version])
     if source:
-        cmd.extend(['-Source', source])
+        cmd.extend(['-source', source])
     if salt.utils.is_true(force):
-        cmd.extend(['-Force'])
+        cmd.append('-force')
     if salt.utils.is_true(pre_versions):
-        cmd.extend(['-PreRelease'])
+        cmd.append('-prerelease')
     if install_args:
-        cmd.extend(['-InstallArguments', install_args])
+        cmd.extend(['-installarguments', install_args])
     if override_args:
-        cmd.extend(['-OverrideArguments'])
+        cmd.append('-overridearguments')
     if force_x86:
-        cmd.extend(['-forcex86'])
+        cmd.append('-forcex86')
     if package_args:
-        cmd.extend(['-PackageParameters', package_args])
+        cmd.extend(['-packageparameters', package_args])
     cmd.extend(_yes(__context__))
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
@@ -399,7 +421,8 @@ def install(name,
         err = 'Running chocolatey failed: {0}'.format(result['stderr'])
         log.error(err)
         raise CommandExecutionError(err)
-    elif name == 'chocolatey':
+
+    if name == 'chocolatey':
         _clear_context(__context__)
 
     return result['stdout']
@@ -428,21 +451,10 @@ def install_cygwin(name, install_args=None, override_args=False):
         salt '*' chocolatey.install_cygwin <package name>
         salt '*' chocolatey.install_cygwin <package name> install_args=<args> override_args=True
     '''
-    choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'cygwin', name]
-    if install_args:
-        cmd.extend(['-InstallArguments', install_args])
-    if override_args:
-        cmd.extend(['-OverrideArguments'])
-    cmd.extend(_yes(__context__))
-    result = __salt__['cmd.run_all'](cmd, python_shell=False)
-
-    if result['retcode'] != 0:
-        err = 'Running chocolatey failed: {0}'.format(result['stderr'])
-        log.error(err)
-        raise CommandExecutionError(err)
-
-    return result['stdout']
+    return install(name,
+                   source='cygwin',
+                   install_args=install_args,
+                   override_args=override_args)
 
 
 def install_gem(name, version=None, install_args=None, override_args=False):
@@ -474,23 +486,11 @@ def install_gem(name, version=None, install_args=None, override_args=False):
         salt '*' chocolatey.install_gem <package name> version=<package version>
         salt '*' chocolatey.install_gem <package name> install_args=<args> override_args=True
     '''
-    choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'gem', name]
-    if version:
-        cmd.extend(['-Version', version])
-    if install_args:
-        cmd.extend(['-InstallArguments', install_args])
-    if override_args:
-        cmd.extend(['-OverrideArguments'])
-    cmd.extend(_yes(__context__))
-    result = __salt__['cmd.run_all'](cmd, python_shell=False)
-
-    if result['retcode'] != 0:
-        err = 'Running chocolatey failed: {0}'.format(result['stderr'])
-        log.error(err)
-        raise CommandExecutionError(err)
-
-    return result['stdout']
+    return install(name,
+                   version=version,
+                   source='ruby',
+                   install_args=install_args,
+                   override_args=override_args)
 
 
 def install_missing(name, version=None, source=None):
@@ -529,9 +529,9 @@ def install_missing(name, version=None, source=None):
     # chocolatey helpfully only supports a single package argument
     cmd = [choc_path, 'installmissing', name]
     if version:
-        cmd.extend(['-Version', version])
+        cmd.extend(['-version', version])
     if source:
-        cmd.extend(['-Source', source])
+        cmd.extend(['-source', source])
     # Shouldn't need this as this code should never run on v0.9.9 and newer
     cmd.extend(_yes(__context__))
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
@@ -572,23 +572,11 @@ def install_python(name, version=None, install_args=None, override_args=False):
         salt '*' chocolatey.install_python <package name> version=<package version>
         salt '*' chocolatey.install_python <package name> install_args=<args> override_args=True
     '''
-    choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'python', name]
-    if version:
-        cmd.extend(['-Version', version])
-    if install_args:
-        cmd.extend(['-InstallArguments', install_args])
-    if override_args:
-        cmd.extend(['-OverrideArguments'])
-    cmd.extend(_yes(__context__))
-    result = __salt__['cmd.run_all'](cmd, python_shell=False)
-
-    if result['retcode'] != 0:
-        err = 'Running chocolatey failed: {0}'.format(result['stderr'])
-        log.error(err)
-        raise CommandExecutionError(err)
-
-    return result['stdout']
+    return install(name,
+                   version=version,
+                   source='python',
+                   install_args=install_args,
+                   override_args=override_args)
 
 
 def install_windowsfeatures(name):
@@ -605,17 +593,7 @@ def install_windowsfeatures(name):
 
         salt '*' chocolatey.install_windowsfeatures <package name>
     '''
-    choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'windowsfeatures', name]
-    cmd.extend(_yes(__context__))
-    result = __salt__['cmd.run_all'](cmd, python_shell=False)
-
-    if result['retcode'] != 0:
-        err = 'Running chocolatey failed: {0}'.format(result['stderr'])
-        log.error(err)
-        raise CommandExecutionError(err)
-
-    return result['stdout']
+    return install(name, source='windowsfeatures')
 
 
 def install_webpi(name, install_args=None, override_args=False):
@@ -641,21 +619,10 @@ def install_webpi(name, install_args=None, override_args=False):
         salt '*' chocolatey.install_webpi <package name>
         salt '*' chocolatey.install_webpi <package name> install_args=<args> override_args=True
     '''
-    choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'webpi', name]
-    if install_args:
-        cmd.extend(['-InstallArguments', install_args])
-    if override_args:
-        cmd.extend(['-OverrideArguments'])
-    cmd.extend(_yes(__context__))
-    result = __salt__['cmd.run_all'](cmd, python_shell=False)
-
-    if result['retcode'] != 0:
-        err = 'Running chocolatey failed: {0}'.format(result['stderr'])
-        log.error(err)
-        raise CommandExecutionError(err)
-
-    return result['stdout']
+    return install(name,
+                   source='webpi',
+                   install_args=install_args,
+                   override_args=override_args)
 
 
 def uninstall(name, version=None, uninstall_args=None, override_args=False):
@@ -690,11 +657,11 @@ def uninstall(name, version=None, uninstall_args=None, override_args=False):
     # chocolatey helpfully only supports a single package argument
     cmd = [choc_path, 'uninstall', name]
     if version:
-        cmd.extend(['-Version', version])
+        cmd.extend(['-version', version])
     if uninstall_args:
-        cmd.extend(['-UninstallArguments', uninstall_args])
+        cmd.extend(['-uninstallarguments', uninstall_args])
     if override_args:
-        cmd.extend(['-OverrideArguments'])
+        cmd.extend(['-overridearguments'])
     cmd.extend(_yes(__context__))
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
@@ -706,7 +673,15 @@ def uninstall(name, version=None, uninstall_args=None, override_args=False):
     return result['stdout']
 
 
-def upgrade(name, source=None, pre_versions=False):
+def upgrade(name,
+            version=None,
+            source=None,
+            force=False,
+            pre_versions=False,
+            install_args=None,
+            override_args=False,
+            force_x86=False,
+            package_args=None):
     '''
     .. version-added:: 2016.3.4
 
@@ -719,15 +694,38 @@ def upgrade(name, source=None, pre_versions=False):
             The name of the package to update, or "all" to update everything
             installed on the system.
 
+        version (str):
+            Install a specific version of the package. Defaults to latest
+            version.
+
         source (str):
             Chocolatey repository (directory, share or remote URL feed) the
             package comes from. Defaults to the official Chocolatey feed.
 
+        force (bool):
+            Reinstall the **same** version already installed
+
         pre_versions (bool):
             Include pre-release packages in comparison. Defaults to False.
 
+        install_args (str):
+            A list of install arguments you want to pass to the installation
+            process i.e product key or feature list
+
+        override_args (str):
+            Set to true if you want to override the original install arguments
+            (for the native installer) in the package and use your own. When
+            this is set to False install_args will be appended to the end of the
+            default arguments
+
+        force_x86
+            Force x86 (32bit) installation on 64 bit systems. Defaults to false.
+
+        package_args
+            A list of arguments you want to pass to the package
+
     Returns:
-        str: Results of the Chocolatey command
+        str: Results of the ``chocolatey`` command
 
     CLI Example:
 
@@ -739,14 +737,27 @@ def upgrade(name, source=None, pre_versions=False):
     # chocolatey helpfully only supports a single package argument
     choc_path = _find_chocolatey(__context__, __salt__)
     cmd = [choc_path, 'upgrade', name]
+    if version:
+        cmd.extend(['-version', version])
     if source:
         cmd.extend(['-source', source])
+    if salt.utils.is_true(force):
+        cmd.append('-force')
     if salt.utils.is_true(pre_versions):
         cmd.append('-prerelease')
+    if install_args:
+        cmd.extend(['-installarguments', install_args])
+    if override_args:
+        cmd.append('-overridearguments')
+    if force_x86:
+        cmd.append('-forcex86')
+    if package_args:
+        cmd.extend(['-packageparameters', package_args])
     cmd.extend(_yes(__context__))
+
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
-    if result['retcode'] != 0:
+    if result['retcode'] not in [0, 1605, 1614, 1641, 3010]:
         err = 'Running chocolatey failed: {0}'.format(result['stderr'])
         log.error(err)
         raise CommandExecutionError(err)
@@ -778,11 +789,15 @@ def update(name, source=None, pre_versions=False):
     '''
     # chocolatey helpfully only supports a single package argument
     choc_path = _find_chocolatey(__context__, __salt__)
+    if _LooseVersion(chocolatey_version()) >= _LooseVersion('0.9.8.24'):
+        log.warning('update is deprecated, using upgrade')
+        return upgrade(name, source=source, pre_versions=pre_versions)
+
     cmd = [choc_path, 'update', name]
     if source:
-        cmd.extend(['-Source', source])
+        cmd.extend(['-source', source])
     if salt.utils.is_true(pre_versions):
-        cmd.append('-PreRelease')
+        cmd.append('-prerelease')
     cmd.extend(_yes(__context__))
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
@@ -828,11 +843,11 @@ def version(name, check_remote=False, source=None, pre_versions=False):
 
     cmd = [choc_path, 'list', name]
     if not salt.utils.is_true(check_remote):
-        cmd.append('-LocalOnly')
+        cmd.append('-localonly')
     if salt.utils.is_true(pre_versions):
-        cmd.append('-Prerelease')
+        cmd.append('-prerelease')
     if source:
-        cmd.extend(['-Source', source])
+        cmd.extend(['-source', source])
 
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
@@ -880,7 +895,7 @@ def add_source(name, source_location, username=None, password=None):
 
     '''
     choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'sources', 'Add', '-Name', name, "-Source", source_location]
+    cmd = [choc_path, 'sources', 'add', '-name', name, "-source", source_location]
     if username:
         cmd.extend(['-u', username])
     if password:
@@ -907,7 +922,7 @@ def _change_source_state(name, state):
 
     '''
     choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'source', state, "-Name", name]
+    cmd = [choc_path, 'source', state, "-name", name]
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if result['retcode'] != 0:

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -417,7 +417,7 @@ def install(name,
     cmd.extend(_yes(__context__))
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
-    if result['retcode'] not in [0, 1605, 1614, 1641, 3010]:
+    if result['retcode'] not in [0, 1641, 3010]:
         err = 'Running chocolatey failed: {0}'.format(result['stderr'])
         log.error(err)
         raise CommandExecutionError(err)
@@ -665,7 +665,7 @@ def uninstall(name, version=None, uninstall_args=None, override_args=False):
     cmd.extend(_yes(__context__))
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
-    if result['retcode'] != 0:
+    if result['retcode'] not in [0, 1605, 1614, 1641]:
         err = 'Running chocolatey failed: {0}'.format(result['stderr'])
         log.error(err)
         raise CommandExecutionError(err)
@@ -757,7 +757,7 @@ def upgrade(name,
 
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
-    if result['retcode'] not in [0, 1605, 1614, 1641, 3010]:
+    if result['retcode'] not in [0, 1641, 3010]:
         err = 'Running chocolatey failed: {0}'.format(result['stderr'])
         log.error(err)
         raise CommandExecutionError(err)
@@ -801,7 +801,7 @@ def update(name, source=None, pre_versions=False):
     cmd.extend(_yes(__context__))
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
-    if result['retcode'] != 0:
+    if result['retcode'] not in [0, 1641, 3010]:
         err = 'Running chocolatey failed: {0}'.format(result['stderr'])
         log.error(err)
         raise CommandExecutionError(err)


### PR DESCRIPTION
### What does this PR do?

Updates documentation
Add's deprecation notice for Chocolatey function update, along with replacement function upgrade. Looks like they're bringing it in line with other package managers. Update will be used to update package indexes.
Fixes problem where software that installed/uninstalled correctly but required a reboot, or was already installed, etc... was being reported as failed.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/34099
### Previous Behavior

Still using deprecated functions.
Installs requiring reboot were reporting back as failed (`retcode = 3010`)
### New Behavior

Added upgrade function to replace deprecated update function
Returns success on the following retcodes for install/upgrade:

```
====  ===============================================
0     Successful
1641  The installer has initiated a restart. This message is indicative of a success.
3010  A restart is required to complete the install. This message is indicative of a success. This does not include installs where the ForceReboot action is run.
====  ===============================================
```

Returns success on the following retcodes for uninstall

```
====  ===============================================
0     Successful
1605  This action is only valid for products that are currently installed.
1614  The product is uninstalled.
1641  The installer has initiated a restart. This message is indicative of a success.
====  ===============================================
```
### Tests written?

No
