### PR TITLE
Wait for task update gh

### DIFF
--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -386,6 +386,13 @@ class VMwareSaltError(CommandExecutionError):
     '''
 
 
+class VMwareRuntimeError(VMwareSaltError):
+    '''
+    Used when a runtime error is encountered when communicating with the
+    vCenter
+    '''
+
+
 class VMwareConnectionError(VMwareSaltError):
     '''
     Used when the client fails to connect to a either a VMware vCenter server or
@@ -395,5 +402,11 @@ class VMwareConnectionError(VMwareSaltError):
 
 class VMwareApiError(VMwareSaltError):
     '''
-    Used when a VMware object cannot be retrieved
+    Used when representing a generic VMware API error
+    '''
+
+
+class VMwareSystemError(VMwareSaltError):
+    '''
+    Used when representing a generic VMware system error
     '''

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -900,7 +900,15 @@ def wait_for_task(task, instance_name, task_type, sleep_seconds=1, log_level='de
     '''
     time_counter = 0
     start_time = time.time()
-    while task.info.state == 'running' or task.info.state == 'queued':
+    log.trace('task = {0}, task_type = {1}'.format(task,
+                                                   task.__class__.__name__))
+    try:
+        task_info = task.info
+    except vim.fault.VimFault as exc:
+        raise salt.exceptions.VMwareApiError(exc.msg)
+    except vmodl.RuntimeFault as exc:
+        raise salt.exceptions.VMwareRuntimeError(exc.msg)
+    while task_info.state == 'running' or task_info.state == 'queued':
         if time_counter % sleep_seconds == 0:
             msg = '[ {0} ] Waiting for {1} task to finish [{2} s]'.format(
                 instance_name, task_type, time_counter)
@@ -910,9 +918,13 @@ def wait_for_task(task, instance_name, task_type, sleep_seconds=1, log_level='de
                 log.debug(msg)
         time.sleep(1.0 - ((time.time() - start_time) % 1.0))
         time_counter += 1
-    log.trace('task = {0}, task_type = {1}'.format(task,
-                                                   task.__class__.__name__))
-    if task.info.state == 'success':
+        try:
+            task_info = task.info
+        except vim.fault.VimFault as exc:
+            raise salt.exceptions.VMwareApiError(exc.msg)
+        except vmodl.RuntimeFault as exc:
+            raise salt.exceptions.VMwareRuntimeError(exc.msg)
+    if task_info.state == 'success':
         msg = '[ {0} ] Successfully completed {1} task in {2} seconds'.format(
             instance_name, task_type, time_counter)
         if log_level == 'info':
@@ -920,7 +932,12 @@ def wait_for_task(task, instance_name, task_type, sleep_seconds=1, log_level='de
         else:
             log.debug(msg)
         # task is in a successful state
-        return task.info.result
+        return task_info.result
     else:
         # task is in an error state
-        raise task.info.error
+        try:
+            raise task_info.error
+        except vim.fault.VimFault as exc:
+            raise salt.exceptions.VMwareApiError(exc.msg)
+        except vmodl.fault.SystemError as exc:
+            raise salt.exceptions.VMwareSystemError(exc.msg)

--- a/tests/unit/utils/vmware_test/common_test.py
+++ b/tests/unit/utils/vmware_test/common_test.py
@@ -14,11 +14,12 @@ from salttesting import TestCase, skipIf
 from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock, \
         PropertyMock
 
+import salt.exceptions as excs
 # Import Salt libraries
 import salt.utils.vmware
 # Import Third Party Libs
 try:
-    from pyVmomi import vim
+    from pyVmomi import vim, vmodl
     HAS_PYVMOMI = True
 except ImportError:
     HAS_PYVMOMI = False
@@ -34,9 +35,59 @@ log = logging.getLogger(__name__)
 class WaitForTaskTestCase(TestCase):
     '''Tests for salt.utils.vmware.wait_for_task'''
 
-    def test_info_state_running(self):
+    def test_first_task_info_raise_vim_fault(self):
+        exc = vim.fault.VimFault()
+        exc.msg = 'VimFault msg'
         mock_task = MagicMock()
+        type(mock_task).info = PropertyMock(side_effect=exc)
+        with self.assertRaises(excs.VMwareApiError) as excinfo:
+            salt.utils.vmware.wait_for_task(mock_task,
+                                            'fake_instance_name',
+                                            'task_type')
+        self.assertEqual(excinfo.exception.strerror, 'VimFault msg')
+
+    def test_first_task_info_raise_runtime_fault(self):
+        exc = vmodl.RuntimeFault()
+        exc.msg = 'RuntimeFault msg'
+        mock_task = MagicMock()
+        type(mock_task).info = PropertyMock(side_effect=exc)
+        with self.assertRaises(excs.VMwareRuntimeError) as excinfo:
+            salt.utils.vmware.wait_for_task(mock_task,
+                                            'fake_instance_name',
+                                            'task_type')
+        self.assertEqual(excinfo.exception.strerror, 'RuntimeFault msg')
+
+    def test_inner_loop_task_info_raise_vim_fault(self):
+        exc = vim.fault.VimFault()
+        exc.msg = 'VimFault msg'
+        mock_task = MagicMock()
+        mock_info1 = MagicMock()
+        type(mock_task).info = PropertyMock(
+            side_effect=[mock_info1, exc])
+        type(mock_info1).state = PropertyMock(side_effect=['running', 'bad'])
+        with self.assertRaises(excs.VMwareApiError) as excinfo:
+            salt.utils.vmware.wait_for_task(mock_task,
+                                            'fake_instance_name',
+                                            'task_type')
+        self.assertEqual(excinfo.exception.strerror, 'VimFault msg')
+
+    def test_inner_loop_task_info_raise_runtime_fault(self):
+        exc = vmodl.RuntimeFault()
+        exc.msg = 'RuntimeFault msg'
+        mock_task = MagicMock()
+        mock_info1 = MagicMock()
+        type(mock_task).info = PropertyMock(
+            side_effect=[mock_info1, exc])
+        type(mock_info1).state = PropertyMock(side_effect=['running', 'bad'])
+        with self.assertRaises(excs.VMwareRuntimeError) as excinfo:
+            salt.utils.vmware.wait_for_task(mock_task,
+                                            'fake_instance_name',
+                                            'task_type')
+        self.assertEqual(excinfo.exception.strerror, 'RuntimeFault msg')
+
+    def test_info_state_running(self):
         # The 'bad' values are invalid in the while loop
+        mock_task = MagicMock()
         prop_mock_state = PropertyMock(side_effect=['running', 'bad', 'bad',
                                                     'success'])
         prop_mock_result = PropertyMock()
@@ -48,11 +99,27 @@ class WaitForTaskTestCase(TestCase):
         self.assertEqual(prop_mock_state.call_count, 4)
         self.assertEqual(prop_mock_result.call_count, 1)
 
-    def test_info_state_queued(self):
+    def test_info_state_running_continues_loop(self):
         mock_task = MagicMock()
-        # The 'bad' values are invalid in the while loop
-        prop_mock_state = PropertyMock(side_effect=['bad', 'queued', 'bad',
-                                                    'bad', 'success'])
+        # The 'fake' values are required to match all the lookups and end the
+        # loop
+        prop_mock_state = PropertyMock(side_effect=['running', 'fake', 'fake',
+                                                    'success'])
+        prop_mock_result = PropertyMock()
+        type(mock_task.info).state = prop_mock_state
+        type(mock_task.info).result = prop_mock_result
+        salt.utils.vmware.wait_for_task(mock_task,
+                                        'fake_instance_name',
+                                        'task_type')
+        self.assertEqual(prop_mock_state.call_count, 4)
+        self.assertEqual(prop_mock_result.call_count, 1)
+
+    def test_info_state_queued_continues_loop(self):
+        mock_task = MagicMock()
+        # The 'fake' values are required to match all the lookups and end the
+        # loop
+        prop_mock_state = PropertyMock(side_effect=['fake', 'queued', 'fake',
+                                                    'fake', 'success'])
         prop_mock_result = PropertyMock()
         type(mock_task.info).state = prop_mock_state
         type(mock_task.info).result = prop_mock_result
@@ -74,9 +141,8 @@ class WaitForTaskTestCase(TestCase):
         self.assertEqual(prop_mock_state.call_count, 3)
         self.assertEqual(prop_mock_result.call_count, 1)
 
-    def test_info_state_different_no_error_attr(self):
+    def test_info_error_exception(self):
         mock_task = MagicMock()
-        # The 'bad' values are invalid in the while loop
         prop_mock_state = PropertyMock(return_value='error')
         prop_mock_error = PropertyMock(side_effect=Exception('error exc'))
         type(mock_task.info).state = prop_mock_state
@@ -85,9 +151,35 @@ class WaitForTaskTestCase(TestCase):
             salt.utils.vmware.wait_for_task(mock_task,
                                             'fake_instance_name',
                                             'task_type')
-        self.assertEqual(prop_mock_state.call_count, 3)
-        self.assertEqual(prop_mock_error.call_count, 1)
-        self.assertEqual('error exc', excinfo.exception.message)
+        self.assertEqual(excinfo.exception.message, 'error exc')
+
+    def test_info_error_vim_fault(self):
+        exc = vim.fault.VimFault()
+        exc.msg = 'VimFault msg'
+        mock_task = MagicMock()
+        prop_mock_state = PropertyMock(return_value='error')
+        prop_mock_error = PropertyMock(side_effect=exc)
+        type(mock_task.info).state = prop_mock_state
+        type(mock_task.info).error = prop_mock_error
+        with self.assertRaises(excs.VMwareApiError) as excinfo:
+            salt.utils.vmware.wait_for_task(mock_task,
+                                            'fake_instance_name',
+                                            'task_type')
+        self.assertEqual(excinfo.exception.strerror, 'VimFault msg')
+
+    def test_info_error_system_fault(self):
+        exc = vmodl.fault.SystemError()
+        exc.msg = 'SystemError msg'
+        mock_task = MagicMock()
+        prop_mock_state = PropertyMock(return_value='error')
+        prop_mock_error = PropertyMock(side_effect=exc)
+        type(mock_task.info).state = prop_mock_state
+        type(mock_task.info).error = prop_mock_error
+        with self.assertRaises(excs.VMwareSystemError) as excinfo:
+            salt.utils.vmware.wait_for_task(mock_task,
+                                            'fake_instance_name',
+                                            'task_type')
+        self.assertEqual(excinfo.exception.strerror, 'SystemError msg')
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)


### PR DESCRIPTION
### What does this PR do?

improved logic in salt.utils.vmware.wait_for_task to:
-  do less RPC calls to the vCenter
- encapsulated the calls to the vCenter to handle errors
- task errors now raise salt errors and not vcenter ones
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
