### PR TITLE
Add support to specify a consul ACL token

### DIFF
--- a/salt/pillar/consul_pillar.py
+++ b/salt/pillar/consul_pillar.py
@@ -186,9 +186,10 @@ def get_conn(opts, profile):
 
     consul_host = conf.get('consul.host', '127.0.0.1')
     consul_port = conf.get('consul.port', 8500)
+    consul_token = conf.get('consul.token', None)
 
     if HAS_CONSUL:
-        return consul.Consul(host=consul_host, port=consul_port)
+        return consul.Consul(host=consul_host, port=consul_port, token=consul_token)
     else:
         raise CommandExecutionError(
             '(unable to import consul, '


### PR DESCRIPTION
### What does this PR do?

This allows the Salt Master to have specific permissions in the consul dataset using the ACL Token
### What issues does this PR fix or reference?

No issues, just adding the option to use fine grained permissions on Consul to the Salt Master using ACL Tokens
### Tests written?

No, but running fine in my Prod environment
