### PR TITLE
fix regression for bucket creation

### DIFF
--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -140,6 +140,13 @@ def query(key, keyid, method='GET', params=None, headers=None,
                                           data=data,
                                           verify=verify_ssl,
                                           stream=True)
+        else:
+            result = requests.request(method,
+                                      requesturl,
+                                      headers=headers,
+                                      data=data,
+                                      verify=verify_ssl,
+                                      stream=True)
         response = result.content
     elif method == 'GET' and local_file and not return_bin:
         result = requests.request(method,


### PR DESCRIPTION
### What does this PR do?

Right now on the s3 module if we use s3.put to create a bucket nothing happens as no call is performed. It must be a regression because it was working in 2015.8.1 which was my latest production environment.

Anyway this fixes it now.

Cheers,
