### PR TITLE
Fix cmd.script runas for Windows

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2007,7 +2007,7 @@ def script(source,
     if salt.utils.is_windows() and runas and cwd is None:
         cwd = os.path.join(__opts__['cachedir'], 'wintmp')
         if not os.path.isdir(cwd):
-            __salt__['file.mkdir'](root)
+            __salt__['file.mkdir'](cwd)
         ret = __salt__['win_dacl.add_ace'](
             cwd, 'File', runas, 'READ&EXECUTE', 'ALLOW',
             'FOLDER&SUBFOLDERS&FILES')

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2004,6 +2004,13 @@ def script(source,
         # Backwards compatibility
         saltenv = __env__
 
+    if salt.utils.is_windows() and runas and cwd is None:
+        cwd = os.path.join(__opts__['cachedir'], 'wintmp')
+        if not os.path.isdir(cwd):
+            ret = __salt__['win_dacl.add_ace'](
+                cwd, 'File', runas, 'READ&EXECUTE', 'ALLOW',
+                'FOLDER&SUBFOLDERS&FILES')
+
     path = salt.utils.mkstemp(dir=cwd, suffix=os.path.splitext(source)[1])
 
     if template:

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2007,9 +2007,10 @@ def script(source,
     if salt.utils.is_windows() and runas and cwd is None:
         cwd = os.path.join(__opts__['cachedir'], 'wintmp')
         if not os.path.isdir(cwd):
-            ret = __salt__['win_dacl.add_ace'](
-                cwd, 'File', runas, 'READ&EXECUTE', 'ALLOW',
-                'FOLDER&SUBFOLDERS&FILES')
+            __salt__['file.mkdir'](root)
+        ret = __salt__['win_dacl.add_ace'](
+            cwd, 'File', runas, 'READ&EXECUTE', 'ALLOW',
+            'FOLDER&SUBFOLDERS&FILES')
 
     path = salt.utils.mkstemp(dir=cwd, suffix=os.path.splitext(source)[1])
 


### PR DESCRIPTION
### What does this PR do?

Fixes problem with ``cmd.script` when the runas parameter is set in Windows.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/33761
### Previous Behavior

The default Temp directory for Windows us something like `C:\Users\Joe\AppData\Local\Temp`. The `cmd.script` copies the script down to the temporary folder using a randomized file name. Then it executes the script. The problem is that the `runas` user doesn't have permissions to the **TEMP** directory of the process that cached the file... so it can't run it.
### New Behavior

For Windows, with `runas`, and`cwd`not set, the file will be copied to the file_cache. The folder permissions will be set to allow that user to read and execute within that directory. The`runas`` user can now access the script.
### Tests written?

No