### PR TITLE
add rpad_ipv4_network

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -5,6 +5,7 @@ Define some generic socket functions for network modules
 
 # Import python libs
 from __future__ import absolute_import
+import itertools
 import os
 import re
 import socket
@@ -240,6 +241,17 @@ def natural_ipv4_netmask(ip, fmt='prefixlen'):
         return cidr_to_ipv4_netmask(mask)
     else:
         return '/' + mask
+
+
+def rpad_ipv4_network(ip):
+    '''
+    Returns an IP network address padded with zeros.
+
+    Ex: '192.168.3' -> '192.168.3.0'
+        '10.209' -> '10.209.0.0'
+    '''
+    return '.'.join(itertools.islice(itertools.chain(ip.split('.'), '0000'), 0,
+                                     4))
 
 
 def cidr_to_ipv4_netmask(cidr_bits):


### PR DESCRIPTION
### What does this PR do?

Add a `def rpad_ipv4_network(ip)` function to `salt.utils.network`.

This function returns the original ip padded with zeros.

There are a lot of places where a "short" notation of a **network** ip address is found, and it can sometimes be useful (for example to validate through `salt._compat.ipaddress.ip_network`) to have the "full" version of the address.
### What issues does this PR fix or reference?

None
### Tests written?

No
