### PR TITLE
Avoid disk hit for renderer generation on pillar instantiation

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -954,7 +954,7 @@ class AESFuncs(object):
         self.mminion = salt.minion.MasterMinion(
             self.opts,
             states=False,
-            rend=False,
+            rend=True,
             ignore_config_errors=True
         )
         self.__setup_fileserver()
@@ -1326,7 +1326,8 @@ class AESFuncs(object):
             load.get('saltenv', load.get('env')),
             ext=load.get('ext'),
             pillar=load.get('pillar_override', {}),
-            pillarenv=load.get('pillarenv'))
+            pillarenv=load.get('pillarenv'),
+            rend=self.mminion.rend)
         data = pillar.compile_pillar(pillar_dirs=pillar_dirs)
         self.fs_.update_opts()
         if self.opts.get('minion_data_cache', False):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -664,14 +664,6 @@ class SMinion(MinionBase):
         '''
         Load all of the modules for the minion
         '''
-        if self.opts.get('master_type') != 'disable':
-            self.opts['pillar'] = salt.pillar.get_pillar(
-                self.opts,
-                self.opts['grains'],
-                self.opts['id'],
-                self.opts['environment'],
-                pillarenv=self.opts.get('pillarenv'),
-            ).compile_pillar()
 
         self.utils = salt.loader.utils(self.opts)
         self.functions = salt.loader.minion_mods(self.opts, utils=self.utils,
@@ -689,6 +681,17 @@ class SMinion(MinionBase):
         self.matcher = Matcher(self.opts, self.functions)
         self.functions['sys.reload_modules'] = self.gen_modules
         self.executors = salt.loader.executors(self.opts)
+
+        if self.opts.get('master_type') != 'disable':
+            self.opts['pillar'] = salt.pillar.get_pillar(
+                self.opts,
+                self.opts['grains'],
+                self.opts['id'],
+                self.opts['environment'],
+                pillarenv=self.opts.get('pillarenv'),
+                funcs=self.functions,
+                rend=self.rend,
+            ).compile_pillar()
 
 
 class MasterMinion(object):

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 
 
 def get_pillar(opts, grains, minion_id, saltenv=None, ext=None, funcs=None,
-               pillar=None, pillarenv=None):
+               pillar=None, pillarenv=None, rend=None):
     '''
     Return the correct pillar driver based on the file_client option
     '''
@@ -48,7 +48,7 @@ def get_pillar(opts, grains, minion_id, saltenv=None, ext=None, funcs=None,
         return PillarCache(opts, grains, minion_id, saltenv, ext=ext, functions=funcs,
                 pillar=pillar, pillarenv=pillarenv)
     return ptype(opts, grains, minion_id, saltenv, ext, functions=funcs,
-                 pillar=pillar, pillarenv=pillarenv)
+                 pillar=pillar, pillarenv=pillarenv, rend=rend)
 
 
 # TODO: migrate everyone to this one!
@@ -123,7 +123,7 @@ class RemotePillar(object):
     Get the pillar from the master
     '''
     def __init__(self, opts, grains, minion_id, saltenv, ext=None, functions=None,
-                 pillar=None, pillarenv=None):
+                 pillar=None, pillarenv=None, *args, **kwargs):
         self.opts = opts
         self.opts['environment'] = saltenv
         self.ext = ext
@@ -259,7 +259,7 @@ class Pillar(object):
     Read over the pillar top files and render the pillar data
     '''
     def __init__(self, opts, grains, minion_id, saltenv, ext=None, functions=None,
-                 pillar=None, pillarenv=None):
+                 pillar=None, pillarenv=None, rend=None):
         self.minion_id = minion_id
         # Store the file_roots path so we can restore later. Issue 5449
         self.actual_file_roots = opts['file_roots']
@@ -281,7 +281,10 @@ class Pillar(object):
             self.functions = functions
 
         self.matcher = salt.minion.Matcher(self.opts, self.functions)
-        self.rend = salt.loader.render(self.opts, self.functions)
+        if rend is None:
+            self.rend = salt.loader.render(self.opts, self.functions)
+        else:
+            self.rend = rend
         ext_pillar_opts = copy.deepcopy(self.opts)
         # Fix self.opts['file_roots'] so that ext_pillars know the real
         # location of file_roots. Issue 5951


### PR DESCRIPTION
Prior to this, both salt-call and MWorkers would hit the disk to pull all of the renderers on each pillar generation. This should provide a marginal peformance increase for both.
