### PR TITLE
Fix htpasswd checking for existing user

### DIFF
--- a/salt/states/htpasswd.py
+++ b/salt/states/htpasswd.py
@@ -62,7 +62,8 @@ def user_exists(name, password=None, htpasswd_file=None, options='',
            'comment': '',
            'result': None}
 
-    exists = __salt__['file.grep'](htpasswd_file, name)['retcode'] == 0
+    exists = __salt__['file.grep'](
+        htpasswd_file, '^{0}:'.format(name))['retcode'] == 0
 
     # If user exists, but we're supposed to update the password, find out if
     # it's changed, but not if we're forced to update the file regardless.


### PR DESCRIPTION
### What does this PR do?

Fixes how the `webutil.user_exists` state checks if a user exists already by making the regex pattern match against the entire username portion of a line in the file, rather than anywhere in the line.
### What issues does this PR fix or reference?

Fixes saltstack/salt#28166
### Previous Behavior

If a user like `notadmin` existed in the file, then a user like `admin` would not be added, because the grep pattern would match that other user.
### New Behavior

Users that partially match existing users will still be added.
### Tests written?

No