### PR TITLE
Be explicit about the salt.utils.templates import

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -47,10 +47,11 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+import salt.utils.atomicfile
 import salt.utils.find
 import salt.utils.filebuffer
 import salt.utils.files
-import salt.utils.atomicfile
+import salt.utils.templates
 import salt.utils.url
 from salt.exceptions import CommandExecutionError, SaltInvocationError, get_error_message as _get_error_message
 


### PR DESCRIPTION
When poking around in the file.py execution module, I noticed that we're not import salt.utils.templates, but we're referencing salt.utils.templates.TEMPLATE_REGISTRY all over the place. Let's be explicit about that import.
