### PR TITLE
fixed bug where gpg.trust_key calls get_key for current user, not input user

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -819,7 +819,7 @@ def trust_key(keyid=None,
 
     if not fingerprint:
         if keyid:
-            key = get_key(keyid)
+            key = get_key(keyid, user=user)
             if key:
                 if 'fingerprint' not in key:
                     ret['res'] = False


### PR DESCRIPTION
### What does this PR do?

Fixes issue where gpg.trust_key calls get_key for the current user, not the input user. 
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/36451
### Previous Behavior

Remove this section if not relevant
gpg.trust_key called get_key for the current user by not inputting a value for user
### New Behavior

Remove this section if not relevant
trust_key calls get_key for the input user
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
