### PR TITLE
Wrap the entire GrainsAppendTestCase class with destructiveTest

### DIFF
--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -133,6 +133,7 @@ class TestModulesGrains(integration.ModuleCase):
                                   msg='grain: {0} is not an int or empty'.format(grain))
 
 
+@destructiveTest
 class GrainsAppendTestCase(integration.ModuleCase):
     '''
     Tests written specifically for the grains.append function.
@@ -140,13 +141,11 @@ class GrainsAppendTestCase(integration.ModuleCase):
     GRAIN_KEY = 'salttesting-grain-key'
     GRAIN_VAL = 'my-grain-val'
 
-    @destructiveTest
     def tearDown(self):
         test_grain = self.run_function('grains.get', [self.GRAIN_KEY])
         if test_grain and test_grain == [self.GRAIN_VAL]:
             self.run_function('grains.remove', [self.GRAIN_KEY, self.GRAIN_VAL])
 
-    @destructiveTest
     def test_grains_append(self):
         '''
         Tests the return of a simple grains.append call.
@@ -154,7 +153,6 @@ class GrainsAppendTestCase(integration.ModuleCase):
         ret = self.run_function('grains.append', [self.GRAIN_KEY, self.GRAIN_VAL])
         self.assertEqual(ret[self.GRAIN_KEY], [self.GRAIN_VAL])
 
-    @destructiveTest
     def test_grains_append_val_already_present(self):
         '''
         Tests the return of a grains.append call when the value is already present in the grains list.
@@ -168,7 +166,6 @@ class GrainsAppendTestCase(integration.ModuleCase):
         ret = self.run_function('grains.append', [self.GRAIN_KEY, self.GRAIN_VAL])
         self.assertEqual(messaging, ret)
 
-    @destructiveTest
     def test_grains_append_val_is_list(self):
         '''
         Tests the return of a grains.append call when val is passed in as a list.
@@ -177,7 +174,6 @@ class GrainsAppendTestCase(integration.ModuleCase):
         ret = self.run_function('grains.append', [self.GRAIN_KEY, [self.GRAIN_VAL, second_grain]])
         self.assertEqual(ret[self.GRAIN_KEY], [self.GRAIN_VAL, second_grain])
 
-    @destructiveTest
     def test_grains_append_call_twice(self):
         '''
         Tests the return of a grains.append call when the value is already present


### PR DESCRIPTION
### What does this PR do?

Since all pieces of the GrainsAppendTestCase are destructive, let's just wrap the whole class test case.

Because the tests themselves as well as the `tearDown` function were wrapped in a @destructiveTest decorator, some test errors were printing in the test output when --run-destructive isn't passed at the CLI.

This fixes those test errors.
### What issues does this PR fix or reference?

None.
### Previous Behavior

When these tests were run but the `--run-destructive` flag wasn't passed, several tests would report as errors and show the following stacktraces:

```
-> integration.modules.grains.GrainsAppendTestCase.test_grains_append_val_is_list  .................................................
       Traceback (most recent call last):
         File "/usr/local/lib/python2.7/dist-packages/salttesting/helpers.py", line 67, in wrap
           cls.skipTest('Destructive tests are disabled')
         File "/usr/lib/python2.7/unittest/case.py", line 406, in skipTest
           raise SkipTest(reason)
       SkipTest: Destructive tests are disabled
```
### New Behavior

No test errors reported and no stracktraces are printed when `--run-destructive` isn't passed at the CLI and the correct messaging occurs:

```
   -> integration.modules.grains.GrainsAppendTestCase.test_grains_append                      ->  Destructive tests are disabled
   -> integration.modules.grains.GrainsAppendTestCase.test_grains_append_call_twice           ->  Destructive tests are disabled
   -> integration.modules.grains.GrainsAppendTestCase.test_grains_append_val_already_present  ->  Destructive tests are disabled
   -> integration.modules.grains.GrainsAppendTestCase.test_grains_append_val_is_list          ->  Destructive tests are disabled
```
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
