### PR TITLE
daemon-reload on call to service.avaliable

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -298,7 +298,7 @@ def _untracked_custom_unit_found(name):
     '''
     unit_path = os.path.join('/etc/systemd/system',
                              _canonical_unit_name(name))
-    return os.access(unit_path, os.R_OK) and not available(name)
+    return os.access(unit_path, os.R_OK) and not available(name, False)
 
 
 def _unit_file_changed(name):
@@ -468,7 +468,7 @@ def get_all():
     return sorted(ret)
 
 
-def available(name):
+def available(name, check_units=True):
     '''
     .. versionadded:: 0.10.4
 
@@ -481,6 +481,8 @@ def available(name):
 
         salt '*' service.available sshd
     '''
+    if check_units:
+        _check_for_unit_changes(name)
     out = _systemctl_status(name).lower()
     for line in salt.utils.itertools.split(out, '\n'):
         match = re.match(r'\s+loaded:\s+(\S+)', line)

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -71,6 +71,23 @@ def _canonical_unit_name(name):
     return '%s.service' % name
 
 
+def _check_available(name):
+    '''
+    Returns boolean telling whether or not the named service is available
+    '''
+    out = _systemctl_status(name).lower()
+    for line in salt.utils.itertools.split(out, '\n'):
+        match = re.match(r'\s+loaded:\s+(\S+)', line)
+        if match:
+            ret = match.group(1) != 'not-found'
+            break
+    else:
+        raise CommandExecutionError(
+            'Failed to get information on unit \'%s\'' % name
+        )
+    return ret
+
+
 def _check_for_unit_changes(name):
     '''
     Check for modified/updated unit files, and run a daemon-reload if any are
@@ -298,7 +315,7 @@ def _untracked_custom_unit_found(name):
     '''
     unit_path = os.path.join('/etc/systemd/system',
                              _canonical_unit_name(name))
-    return os.access(unit_path, os.R_OK) and not available(name, False)
+    return os.access(unit_path, os.R_OK) and not _check_available(name)
 
 
 def _unit_file_changed(name):
@@ -468,7 +485,7 @@ def get_all():
     return sorted(ret)
 
 
-def available(name, check_units=True):
+def available(name):
     '''
     .. versionadded:: 0.10.4
 
@@ -481,19 +498,8 @@ def available(name, check_units=True):
 
         salt '*' service.available sshd
     '''
-    if check_units:
-        _check_for_unit_changes(name)
-    out = _systemctl_status(name).lower()
-    for line in salt.utils.itertools.split(out, '\n'):
-        match = re.match(r'\s+loaded:\s+(\S+)', line)
-        if match:
-            ret = match.group(1) != 'not-found'
-            break
-    else:
-        raise CommandExecutionError(
-            'Failed to get information on unit \'%s\'' % name
-        )
-    return ret
+    _check_for_unit_changes(name)
+    return _check_available(name)
 
 
 def missing(name):


### PR DESCRIPTION
### What does this PR do?

Calls _check_for_unit_changes on service.avaliable
### What issues does this PR fix or reference?

Related to #34927, but affecting the service.running with enable=true rather than the service.enable state.
### Previous Behavior

The following state would automatically detect if a unit file existed and execute a daemon-reload if required to make the service available before enabling it.

``` sls
myservice:
  service.enabled: []
```

But this similar state would not.

``` sls
myservice:
  service.running:
    - enable: True
```
### New Behavior

Both states listed above do daemon-reload before trying to enable the service if changes in the unit file are detected.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.