### PR TITLE
Prefer archive.cmd_unzip

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -6,6 +6,7 @@ A module to wrap (non-Windows) archive calls
 '''
 from __future__ import absolute_import
 import os
+import logging
 import contextlib  # For < 2.7 compat
 
 # Import salt libs
@@ -19,6 +20,8 @@ import salt.utils
 __func_alias__ = {
     'zip_': 'zip'
 }
+
+log = logging.getLogger(__name__)
 
 
 HAS_ZIPFILE = False
@@ -518,6 +521,12 @@ def unzip(zip_file, dest, excludes=None,
 
         salt '*' archive.unzip /tmp/zipfile.zip /home/strongbad/ password='BadPassword'
     '''
+    # https://bugs.python.org/issue15795
+    log.warning('Due to bug 15795 in python\'s zip lib, the permissions of the'
+                ' extracted files may not be preserved when using archive.unzip')
+    log.warning('To preserve the permissions of extracted files, use'
+                ' archive.cmd_unzip')
+
     if not excludes:
         excludes = []
     if runas:

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -374,7 +374,16 @@ def extracted(name,
 
     log.debug('Extracting {0} to {1}'.format(filename, name))
     if archive_format == 'zip':
-        files = __salt__['archive.unzip'](filename, name, trim_output=trim_output, password=password)
+        if password is None and salt.utils.which('unzip'):
+            files = __salt__['archive.cmd_unzip'](filename, name, trim_output=trim_output)
+        else:
+            # https://bugs.python.org/issue15795
+            if password is not None:
+                log.warning('Password supplied: using archive.unzip')
+            if not salt.utils.which('unzip'):
+                log.warning('Cannot find unzip command for archive.cmd_unzip:'
+                            ' using archive.unzip instead')
+            files = __salt__['archive.unzip'](filename, name, trim_output=trim_output, password=password)
     elif archive_format == 'rar':
         files = __salt__['archive.unrar'](filename, name, trim_output=trim_output)
     else:


### PR DESCRIPTION
### What does this PR do?

Prefer `archive.cmd_unzip` when possible as the python zip module [does not preserve](https://bugs.python.org/issue15795) some file attributes.
### What issues does this PR fix or reference?
- ZD 966 - `archive.extracted` with zip archive does not preserve perms or mtimes
- #25128 - original fix
- #27764 - accidental revert by merge forward
- #27317 - revert to use `archive.unzip` for when `unzip` cmd is not present (windows)
- #31116 - add password support to state
- #33906 - better fix; @rallytime, this may cause a conflict in the merge forward.
### Tests written?

I have manually tested all permutations of the changes but  have not written automated tests yet.  I plan on adding integration tests for the archive module and expanding the testing for the archive state in saltstack/qa#252
