### PR TITLE
Fix trust key 2015.8

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -811,7 +811,10 @@ def trust_key(keyid=None,
 
     if not fingerprint:
         if keyid:
-            key = get_key(keyid, user=user)
+            if user:
+                key = get_key(keyid, user=user)
+            else:
+                key = get_key(keyid)
             if key:
                 if 'fingerprint' not in key:
                     ret['res'] = False

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -811,7 +811,7 @@ def trust_key(keyid=None,
 
     if not fingerprint:
         if keyid:
-            key = get_key(keyid)
+            key = get_key(keyid, user=user)
             if key:
                 if 'fingerprint' not in key:
                     ret['res'] = False


### PR DESCRIPTION
### What does this PR do?

Fixes issue where gpg.trust_key calls get_key for the current user, not the input user.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/36451

Previous Behavior

Remove this section if not relevant
gpg.trust_key called get_key for the current user by not inputting a value for user

New Behavior

Remove this section if not relevant
trust_key calls get_key for the input user

Tests written?

No
