### PR TITLE
Mercurial Module: Pass the identity_path portion as own arg

### DIFF
--- a/salt/modules/hg.py
+++ b/salt/modules/hg.py
@@ -23,7 +23,7 @@ def __virtual__():
 
 
 def _ssh_flag(identity_path):
-    return '--ssh "ssh -i {0}"'.format(identity_path)
+    return ['--ssh', 'ssh -i {0}'.format(identity_path)]
 
 
 def revision(cwd, rev='tip', short=False, user=None):
@@ -181,7 +181,7 @@ def pull(cwd, opts=None, user=None, identity=None, repository=None):
     '''
     cmd = ['hg', 'pull']
     if identity:
-        cmd.append(_ssh_flag(identity))
+        cmd.extend(_ssh_flag(identity))
     if opts:
         for opt in opts.split():
             cmd.append(opt)
@@ -250,7 +250,7 @@ def clone(cwd, repository, opts=None, user=None, identity=None):
         for opt in opts.split():
             cmd.append('{0}'.format(opt))
     if identity:
-        cmd.append(_ssh_flag(identity))
+        cmd.extend(_ssh_flag(identity))
     return __salt__['cmd.run'](cmd, runas=user, python_shell=False)
 
 


### PR DESCRIPTION
### What does this PR do?

When we pass in an identity file to use with the `--ssh` option in the `hg.py` execution module, the `ssh -i <identity file>` portion needs to be passed along as its own arg in the list of command args passed `cmd.run`.
### What issues does this PR fix or reference?

Fixes #36514
### Previous Behavior

When using the mercurial sate with the `identity` option set, the state would fail because the `--ssh "ssh -i /indentity/file"` way of passing the command was tripping up the `cmd.run` call:

```
local:
----------
          ID: mercurial
    Function: hg.latest
        Name: ssh://hg@bitbucket.org/nickwilliams/influx-salt
      Result: False
     Comment: hg clone: invalid arguments
              hg clone [OPTION]... SOURCE [DEST]

              make a copy of an existing repository

              options:

               -U --noupdate          the clone will include an empty working copy (only a
                                      repository)
               -u --updaterev REV     revision, tag or branch to check out
               -r --rev REV [+]       include the specified changeset
               -b --branch BRANCH [+] clone only the specified branch
                  --pull              use pull protocol to copy metadata
                  --uncompressed      use uncompressed transfer (fast over LAN)
               -e --ssh CMD           specify ssh command to use
                  --remotecmd CMD     specify hg command to run on the remote side
                  --insecure          do not verify server certificate (ignoring web.cacerts
                                      config)

              [+] marked option can be specified multiple times

              use "hg help clone" to show the full help text
     Started: 21:55:07.034511
    Duration: 114.811 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
```
### New Behavior

The list of args are passed correctly to the `cmd.run` function and we no longer have an error.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.