### PR TITLE
Add version_cmp for FreeBSD pkg.

### DIFF
--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -1670,3 +1670,35 @@ def updating(name,
         python_shell=False,
         output_loglevel='trace'
     )
+
+
+def version_cmp(pkg1, pkg2, ignore_epoch=False):
+    '''
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.version_cmp '2.1.11' '2.1.12'
+    '''
+    # Don't worry about ignore_epoch since we're shelling out to pkg.
+    sym = {
+        '<': -1,
+        '>': 1,
+        '=': 0,
+    }
+    try:
+        cmd = ['pkg', 'version', '--test-version', pkg1, pkg2]
+        ret = __salt__['cmd.run_all'](cmd,
+                                            output_loglevel='trace',
+                                            python_shell=False,
+                                            ignore_retcode=True)
+    except Exception as exc:
+        log.error(exc)
+
+    if ret['stdout'] in sym:
+        return sym[ret['stdout']]
+    return None

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -165,6 +165,10 @@ def _fulfills_version_spec(versions, oper, desired_version,
     otherwise returns False
     '''
     cmp_func = __salt__.get('pkg.version_cmp')
+    # stripping "with_origin" dict wrapper
+    if salt.utils.is_freebsd():
+        if isinstance(versions, dict) and 'version' in versions:
+            versions = versions['version']
     for ver in versions:
         if salt.utils.compare_versions(ver1=ver,
                                        oper=oper,
@@ -1241,10 +1245,14 @@ def installed(
     failed_hold = None
     if targets or to_reinstall:
         reinstall = bool(to_reinstall)
+        force = False
+        if salt.utils.is_freebsd():
+            force = True    # Downgrades need to be forced.
         try:
             pkg_ret = __salt__['pkg.install'](name,
                                               refresh=refresh,
                                               version=version,
+                                              force=force,
                                               fromrepo=fromrepo,
                                               skip_verify=skip_verify,
                                               pkgs=pkgs,


### PR DESCRIPTION
### What does this PR do?

Enable pkg compare_version for FreeBSD.
### What issues does this PR fix or reference?

None I'm aware of.
### Previous Behavior

Seems like it's falling back to a generic salt version_cmp, but doesn't work right for FreeBSD.
### New Behavior

Version comparison works for FreeBSD packages.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
