### PR TITLE
archive.extracted: Use `user`/`group`, not `archive_user`

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -84,7 +84,6 @@ def _cleanup_destdir(name):
 def extracted(name,
               source,
               archive_format,
-              archive_user=None,
               password=None,
               user=None,
               group=None,
@@ -371,7 +370,7 @@ def extracted(name,
                           .format(name.rstrip('/')))
         return ret
     elif not __salt__['file.directory_exists'](name):
-        __salt__['file.makedirs'](name, user=archive_user)
+        __salt__['file.makedirs'](name, user=user, group=group)
         created_destdir = True
 
     log.debug('Extracting {0} to {1}'.format(filename, name))


### PR DESCRIPTION
### What does this PR do?

Ensure that any created parent directories are made with `user`/`group`
perms, not as the `archive_user` user. This also allows setting the
group for these dirs instead of defaulting to `root`.

The `archive_user` argument to archive.extracted has been deprecated
since version 2014.7.2, and supplanted by the `user` parameter in
2015.8.0, with a logged warning until Boron. Now that 2016.3.0 is out,
complete the deprecation by:
- no longer silently using `archive_user` in `archive.extracted`,
  preferring instead `user` and `group`,
- no longer accepted `archive_user` as an argument.

Also update man page.
### What issues does this PR fix or reference?

Hit this during servo/saltfs#483 when upgrading from 2015.5.8 to 2016.3.3.
### Previous Behavior

Use the (deprecated) `archive_user` argument when making parent directories.
### New Behavior

Use the `user` and `group` arguments to set permissions on created parent directories.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.