### PR TITLE
Bugs/36093 schedule unpickling failure on windows

### DIFF
--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -206,7 +206,9 @@ def merge(value,
                 ret = list(ret) + list(tmp)
     if ret is None and value in DEFAULTS:
         return DEFAULTS[value]
-    return ret or default
+    if ret is None:
+        return default
+    return ret
 
 
 def get(key, default='', delimiter=':', merge=None):

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -417,6 +417,9 @@ class Schedule(object):
             for prefix in cleanup:
                 self.delete_job_prefix(prefix)
 
+    def __getnewargs__(self):
+        return self.opts, self.functions, self.returners, self.intervals, None
+
     def option(self, opt):
         '''
         Return the schedule data structure


### PR DESCRIPTION
### What does this PR do?
1. Fixes another one schedule issue: properly update the empty schedule.
2. Fixes windows forking related issue: make Schedule pickleable.
### What issues does this PR fix or reference?
#36093
### Previous vs New Behavior
1. If the schedule was empty it hasn't been updated because the `config.merge('schedule', default={})` module function was returning the empty dict instance passed by `default` argument instead of one got from the options dict.
2. The `Schedule` object uses multiprocessing to run the scheduled jobs, so under windows it should be pickleable. After I've made it a singleton, it's `__new__` method expects a number of arguments and can't be unpickled without an advice that is now provided by `__getnewargs__` method.
### Tests written?

No
