### PR TITLE
Bugs/35480 master shutdown

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -798,7 +798,6 @@ def setup_multiprocessing_logging_listener(opts, queue=None):
         target=__process_multiprocessing_logging_queue,
         args=(opts, queue or get_multiprocessing_logging_queue(),)
     )
-    __MP_LOGGING_QUEUE_PROCESS.daemon = True
     __MP_LOGGING_QUEUE_PROCESS.start()
     __MP_LOGGING_LISTENER_CONFIGURED = True
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -533,7 +533,8 @@ class Master(SMaster):
                                       'reload': salt.crypt.Crypticle.generate_key_string
                                      }
             log.info('Creating master process manager')
-            self.process_manager = salt.utils.process.ProcessManager()
+            # Since there are children having their own ProcessManager we should wait for kill more time.
+            self.process_manager = salt.utils.process.ProcessManager(wait_for_kill=5)
             pub_channels = []
             log.info('Creating master publisher process')
             for transport, opts in iter_transport_opts(self.opts):
@@ -687,7 +688,9 @@ class ReqServer(SignalHandlingMultiprocessingProcess):
             except os.error:
                 pass
 
-        self.process_manager = salt.utils.process.ProcessManager(name='ReqServer_ProcessManager')
+        # Wait for kill should be less then parent's ProcessManager.
+        self.process_manager = salt.utils.process.ProcessManager(name='ReqServer_ProcessManager',
+                                                                 wait_for_kill=1)
 
         req_channels = []
         tcp_only = True


### PR DESCRIPTION
### What does this PR do?

The second couple of fixes for master shutdown:
1) Don't run Logging Queue with the daemon flag, because it's shutdown is already under the control of the ProcessManager and it shuts the Logging Queue faster than Python internals, so there is an error occurs in the python code.

```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/usr/lib/python2.7/multiprocessing/util.py", line 322, in _exit_function
    p._popen.terminate()
  File "/usr/lib/python2.7/multiprocessing/forking.py", line 172, in terminate
    os.kill(self.pid, signal.SIGTERM)
OSError: [Errno 3] No such process
```

2) Give the main `ProcessManager` more time to wait before kill because there is a child running a `ProcessManager` too (`ReqServer_ProcessManager`) so it needs more time to kill all subprocesses.
### What issues does this PR fix or reference?
#35480
### Tests written?

No
