### PR TITLE
Fix lineterminator on kapacitor diffs

### DIFF
--- a/salt/states/kapacitor.py
+++ b/salt/states/kapacitor.py
@@ -92,6 +92,7 @@ def task_present(name,
         ret['changes']['TICKscript diff'] = '\n'.join(difflib.unified_diff(
             old_script.splitlines(),
             new_script.splitlines(),
+            lineterm=''
         ))
         comments.append('Task script updated')
 


### PR DESCRIPTION
Small fix to the diff the kapacitor state will output. Spacing of the header was wrong. e.g:

```
TICKscript diff:
    --- 

    +++ 

    @@ -1,7 +1,6 @@

    stream
        |from()
    ....
```
