### PR TITLE
Improve and fix `_check_cache_minions`

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -234,12 +234,12 @@ class CkMinions(object):
         If not 'greedy' return the only minions have cache data and matched by the condition.
         '''
         cache_enabled = self.opts.get('minion_data_cache', False)
+        cdir = os.path.join(self.opts['cachedir'], 'minions')
 
         def list_cached_minions():
-            cdir = os.path.join(self.opts['cachedir'], 'minions')
             if not os.path.isdir(cdir):
                 return []
-            return os.listdir(cdir):
+            return os.listdir(cdir)
 
         if greedy:
             minions = []

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -230,30 +230,41 @@ class CkMinions(object):
                              exact_match=False):
         '''
         Helper function to search for minions in master caches
+        If 'greedy' return accepted minions that matched by the condition or absend in the cache.
+        If not 'greedy' return the only minions have cache data and matched by the condition.
         '''
         cache_enabled = self.opts.get('minion_data_cache', False)
 
-        if greedy:
-            mlist = []
-            for fn_ in salt.utils.isorted(os.listdir(os.path.join(self.opts['pki_dir'], self.acc))):
-                if not fn_.startswith('.') and os.path.isfile(os.path.join(self.opts['pki_dir'], self.acc, fn_)):
-                    mlist.append(fn_)
-            minions = set(mlist)
-        elif cache_enabled:
-            minions = os.listdir(os.path.join(self.opts['cachedir'], 'minions'))
-        else:
-            return list()
-
-        if cache_enabled:
+        def list_cached_minions():
             cdir = os.path.join(self.opts['cachedir'], 'minions')
             if not os.path.isdir(cdir):
-                return list(minions)
-            for id_ in os.listdir(cdir):
-                if not greedy and id_ not in minions:
+                return []
+            return os.listdir(cdir):
+
+        if greedy:
+            minions = []
+            for fn_ in salt.utils.isorted(os.listdir(os.path.join(self.opts['pki_dir'], self.acc))):
+                if not fn_.startswith('.') and os.path.isfile(os.path.join(self.opts['pki_dir'], self.acc, fn_)):
+                    minions.append(fn_)
+        elif cache_enabled:
+            minions = list_cached_minions()
+        else:
+            return []
+
+        if cache_enabled:
+            if greedy:
+                cminions = list_cached_minions()
+            else:
+                cminions = minions
+            if not cminions:
+                return minions
+            minions = set(minions)
+            for id_ in cminions:
+                if greedy and id_ not in minions:
                     continue
                 datap = os.path.join(cdir, id_, 'data.p')
                 if not os.path.isfile(datap):
-                    if not greedy and id_ in minions:
+                    if not greedy:
                         minions.remove(id_)
                     continue
                 search_results = self.serial.load(
@@ -263,9 +274,10 @@ class CkMinions(object):
                                                 expr,
                                                 delimiter=delimiter,
                                                 regex_match=regex_match,
-                                                exact_match=exact_match) and id_ in minions:
+                                                exact_match=exact_match):
                     minions.remove(id_)
-        return list(minions)
+            minions = list(minions)
+        return minions
 
     def _check_grain_minions(self, expr, delimiter, greedy):
         '''


### PR DESCRIPTION
### What does this PR do?

Don't match minion if it's not in the output list.
Don't check the minion existence in the list where we know it's there.
### What issues does this PR fix or reference?

Related to saltstack/salt#32368
### Previous Behavior

If there are a lot of minions in the master cache and the only some of them are accepted at this moment each minion in the cache will be matched before check it's already not in the ret list.
### Tests written?

No

_NOTE_
@cachedout please merge this only if my understanding described in the function comment is truth. If not just close this and let to discuss it after my vacation.

Just to not lose it, I'll keep it here:

Args:
   greedy: Bool
   cache_enabled: Bool

Current behavior:
1. cache_enabled: False
   - greedy = False
     - return empty list
   - greedy = True
     - return all the accepted minions
2. cache_enabled: True
   - greedy = False
     - get a list of all minions in master cache
     - remove from the list minions:
       - not having data cache file
       - not matching the condition
     - return the list
   - greedy = True
     - get a list of all the accepted minions
     - keep minions not having data cache file (this is different from non-greedy behavior)
     - remove non-matching minions
     - return the list