### PR TITLE
add global 'retry' option to state processing

### DIFF
--- a/tests/integration/files/file/base/retry/create_file.sls
+++ b/tests/integration/files/file/base/retry/create_file.sls
@@ -1,0 +1,8 @@
+wait_thirty:
+  module.run:
+    - name: test.sleep
+    - length: 30 
+
+{{ salt['runtests_helpers.get_salt_temp_dir_for_path']('retry_file') }}:
+  file:
+    - touch

--- a/tests/integration/files/file/base/retry/retry_custom.sls
+++ b/tests/integration/files/file/base/retry/retry_custom.sls
@@ -1,0 +1,8 @@
+file_test:
+  file.exists:
+    - name: /path/to/a/non-existent/file.txt
+    - retry:
+        until: True
+        attempts: 5
+        interval: 10
+        splay: 0

--- a/tests/integration/files/file/base/retry/retry_defaults.sls
+++ b/tests/integration/files/file/base/retry/retry_defaults.sls
@@ -1,0 +1,4 @@
+file_test:
+  file.exists:
+    - name: /path/to/a/non-existent/file.txt
+    - retry: True

--- a/tests/integration/files/file/base/retry/retry_success.sls
+++ b/tests/integration/files/file/base/retry/retry_success.sls
@@ -1,0 +1,12 @@
+{{ salt['runtests_helpers.get_salt_temp_dir_for_path']('retry_file') }}:
+  file:
+    - touch
+
+file_test:
+  file.exists:
+    - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('retry_file') }} 
+    - retry:
+        until: True
+        attempts: 5
+        interval: 10
+        splay: 0

--- a/tests/integration/files/file/base/retry/retry_success2.sls
+++ b/tests/integration/files/file/base/retry/retry_success2.sls
@@ -1,0 +1,7 @@
+file_test:
+  file.exists:
+    - name: {{ salt['runtests_helpers.get_salt_temp_dir_for_path']('retry_file') }} 
+    - retry:
+        until: True
+        attempts: 20
+        interval: 5

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import
 import os
 import shutil
 import textwrap
+import threading
+import time
 
 # Import Salt Testing libs
 from salttesting import skipIf
@@ -1139,6 +1141,90 @@ class StateModuleTest(integration.ModuleCase,
         self.assertIn(bar_state, state_run)
         self.assertEqual(state_run[bar_state]['comment'],
                          'Command "echo bar" run')
+
+    def test_retry_option_defaults(self):
+        '''
+        test the retry option on a simple state with defaults
+        ensure comment is as expected
+        ensure state duration is greater than default retry_interval (30 seconds)
+        '''
+        state_run = self.run_function(
+            'state.sls',
+            mods='retry.retry_defaults'
+        )
+        retry_state = 'file_|-file_test_|-/path/to/a/non-existent/file.txt_|-exists'
+        expected_comment = ('Attempt 1: Returned a result of "False", with the following '
+                'comment: "Specified path /path/to/a/non-existent/file.txt does not exist"\n'
+                'Specified path /path/to/a/non-existent/file.txt does not exist')
+        self.assertEqual(state_run[retry_state]['comment'], expected_comment)
+        self.assertTrue(state_run[retry_state]['duration'] > 30)
+        self.assertEqual(state_run[retry_state]['result'], False)
+
+    def test_retry_option_custom(self):
+        '''
+        test the retry option on a simple state with custom retry values
+        ensure comment is as expected
+        ensure state duration is greater than custom defined interval * (retries - 1)
+        '''
+        state_run = self.run_function(
+            'state.sls',
+            mods='retry.retry_custom'
+        )
+        retry_state = 'file_|-file_test_|-/path/to/a/non-existent/file.txt_|-exists'
+        expected_comment = ('Attempt 1: Returned a result of "False", with the following '
+                'comment: "Specified path /path/to/a/non-existent/file.txt does not exist"\n'
+                'Attempt 2: Returned a result of "False", with the following comment: "Specified'
+                ' path /path/to/a/non-existent/file.txt does not exist"\nAttempt 3: Returned'
+                ' a result of "False", with the following comment: "Specified path'
+                ' /path/to/a/non-existent/file.txt does not exist"\nAttempt 4: Returned a'
+                ' result of "False", with the following comment: "Specified path'
+                ' /path/to/a/non-existent/file.txt does not exist"\nSpecified path'
+                ' /path/to/a/non-existent/file.txt does not exist')
+        self.assertEqual(state_run[retry_state]['comment'], expected_comment)
+        self.assertTrue(state_run[retry_state]['duration'] > 40)
+        self.assertEqual(state_run[retry_state]['result'], False)
+
+    def test_retry_option_success(self):
+        '''
+        test a state with the retry option that should return True immedietly (i.e. no retries)
+        '''
+        testfile = os.path.join(integration.TMP, 'retry_file')
+        state_run = self.run_function(
+            'state.sls',
+            mods='retry.retry_success'
+        )
+        os.unlink(testfile)
+        retry_state = 'file_|-file_test_|-{0}_|-exists'.format(testfile)
+        self.assertNotIn('Attempt', state_run[retry_state]['comment'])
+
+    def run_create(self):
+        '''
+        helper function to wait 30 seconds and then create the temp retry file
+        '''
+        testfile = os.path.join(integration.TMP, 'retry_file')
+        time.sleep(30)
+        open(testfile, 'a').close()
+
+    def test_retry_option_eventual_success(self):
+        '''
+        test a state with the retry option that should return True after at least 4 retry attmempt
+        but never run 15 attempts
+        '''
+        testfile = os.path.join(integration.TMP, 'retry_file')
+        create_thread = threading.Thread(target=self.run_create)
+        create_thread.start()
+        state_run = self.run_function(
+            'state.sls',
+            mods='retry.retry_success2'
+        )
+        retry_state = 'file_|-file_test_|-{0}_|-exists'.format(testfile)
+        self.assertIn('Attempt 1:', state_run[retry_state]['comment'])
+        self.assertIn('Attempt 2:', state_run[retry_state]['comment'])
+        self.assertIn('Attempt 3:', state_run[retry_state]['comment'])
+        self.assertIn('Attempt 4:', state_run[retry_state]['comment'])
+        self.assertNotIn('Attempt 15:', state_run[retry_state]['comment'])
+        self.assertEqual(state_run[retry_state]['result'], True)
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?

adds a global "retry" option to state processing, allow states to be retried some number of times with a specified interval until the desired result is returned or the maximum number of retry attempts is met
### What issues does this PR fix or reference?
#31051
### Previous Behavior

No state retry option
### New Behavior

A state can be retried until the desired result or maximum attempts is achieved

The retry parameter accepts a dict with the following configurable values:

```
  retry:
    until: Bool # define the result that is required to stop retrying (i.e. True/False), default=True
    attempts:  Int # number of attempts at running the state, default=2
    interval: Int # number of seconds between attempts, default=30
    splay: Int # splay the attempts by this number of seconds, default=0
```

for example, wait until a file is created (say if a service startup creates the file) before proceeding.  The following would retry the file.exists state 15 times with 30 seconds between attempts.  The file.exists state would be retried until file.exists returned True or the 15 attempts were made

```
wait_for_file:
  file.exists:
    - name: /path/to/some/file
    - retry:
        attempts: 15
        interval: 30
```

or retry installing a package, the following would retry pkg.installed 3 times with 60 seconds between attempts while also splaying the 60 seconds by up to 15 seconds.  If pkg.installed succeeded on the first attempt, it would not be retried

```
elasticsearch:
  pkg.installed:
    - retry:
        attempts: 3
        interval: 60
        splay: 15
```
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
