### PR TITLE
Add pyOpenSSL to req file for Windows

### DIFF
--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -22,6 +22,7 @@ pycparser==2.14
 pycurl==7.43.0
 PyMySQL==0.7.2
 pypiwin32==219
+pyOpenSSL==16.1.0
 python-dateutil==2.5.3
 python-gnupg==0.3.8
 pyzmq==15.2.0


### PR DESCRIPTION
### What does this PR do?

Adds pyOpenSSL to the req file for the Windows installer. Needed for some of the formulas Tom is working on.
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/973
### Tests written?

NA
