### PR TITLE
Do not generate pchanges in file.managed unless test=True

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1722,28 +1722,26 @@ def managed(name,
         if not context:
             context = {}
         context['accumulator'] = accum_data[name]
-    if 'file.check_managed_changes' in __salt__:
-        ret['pchanges'] = __salt__['file.check_managed_changes'](
-            name,
-            source,
-            source_hash,
-            user,
-            group,
-            mode,
-            template,
-            context,
-            defaults,
-            __env__,
-            contents,
-            skip_verify,
-            keep_mode,
-            **kwargs
-        )
-    else:
-        ret['pchanges'] = {}
 
     try:
         if __opts__['test']:
+            if 'file.check_managed_changes' in __salt__:
+                ret['pchanges'] = __salt__['file.check_managed_changes'](
+                    name,
+                    source,
+                    source_hash,
+                    user,
+                    group,
+                    mode,
+                    template,
+                    context,
+                    defaults,
+                    __env__,
+                    contents,
+                    skip_verify,
+                    keep_mode,
+                    **kwargs
+                )
             if isinstance(ret['pchanges'], tuple):
                 ret['result'], ret['comment'] = ret['pchanges']
             elif ret['pchanges']:


### PR DESCRIPTION
### What does this PR do?

Fix rendering of file.managed for pchanges calculation using file.check_managed_changes to only be done when `test=True` to prevent jinja templates from being rendered two times per file.mangages
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/36588
### Previous Behavior

file.managed renders templates twice.  Once for pchanges and once to write the file
### New Behavior

Disable double rendering of changes of files in file.managed by changing pchanges to be calculated only when test=True
### Tests written?

No
### Notes

Noticed that file.managed was rendering all of our templates twice because of calculation of pchanges value.  Moved the file.check_managed_changes inside of the `if __opts__['test']:` section so this pchanges are only ran when `test=True`.