### PR TITLE
win_pkg.py: fix traceback in list_pkgs(), fix lint error

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -386,7 +386,8 @@ def _get_reg_software():
                    'WIC',
                    'Not Found',
                    '(value not set)',
-                   '']
+                   '',
+                   None]
     #encoding = locale.getpreferredencoding()
     reg_software = {}
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1523,7 +1523,7 @@ def get_repo_data(saltenv='base'):
     if repo_details.winrepo_age == -1:
         # no repo meta db
         log.debug('No winrepo.p cache file. Refresh pkg db now.')
-        _refresh_db_conditional(saltenv=saltenv)
+        refresh_db(saltenv=saltenv)
 
     if 'winrepo.data' in __context__:
         log.trace('get_repo_data returning results from __context__')

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1521,9 +1521,9 @@ def get_repo_data(saltenv='base'):
     # but they will call refresh if they need too.
     repo_details = _get_repo_details(saltenv)
     if repo_details.winrepo_age == -1:
-	# no repo meta db
-	log.debug('No winrepo.p cache file. Refresh pkg db now.')
-	_refresh_db_conditional(saltenv=saltenv)
+        # no repo meta db
+        log.debug('No winrepo.p cache file. Refresh pkg db now.')
+        _refresh_db_conditional(saltenv=saltenv)
 
     if 'winrepo.data' in __context__:
         log.trace('get_repo_data returning results from __context__')


### PR DESCRIPTION
This fixes a lint error I introduced in #36222, as well as an unrelated traceback that occurs when Salt cannot find a registry key containing the version of the package.
