### PR TITLE
Remove tests which no longer apply

### DIFF
--- a/tests/integration/shell/master.py
+++ b/tests/integration/shell/master.py
@@ -69,10 +69,6 @@ class MasterTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
                     pass
         try:
             self.assertFalse(os.path.isdir(os.path.join(config_dir, 'file:')))
-            self.assertIn(
-                'Failed to setup the Syslog logging handler', '\n'.join(ret[1])
-            )
-            self.assertEqual(ret[2], 2)
         finally:
             self.chdir(old_cwd)
             if os.path.isdir(config_dir):

--- a/tests/integration/shell/minion.py
+++ b/tests/integration/shell/minion.py
@@ -66,10 +66,6 @@ class MinionTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
                     pass
         try:
             self.assertFalse(os.path.isdir(os.path.join(config_dir, 'file:')))
-            self.assertIn(
-                'Failed to setup the Syslog logging handler', '\n'.join(ret[1])
-            )
-            self.assertEqual(ret[2], 2)
         finally:
             self.chdir(old_cwd)
             if os.path.isdir(config_dir):

--- a/tests/integration/shell/syndic.py
+++ b/tests/integration/shell/syndic.py
@@ -70,10 +70,6 @@ class SyndicTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
                     pass
         try:
             self.assertFalse(os.path.isdir(os.path.join(config_dir, 'file:')))
-            self.assertIn(
-                'Failed to setup the Syslog logging handler', '\n'.join(ret[1])
-            )
-            self.assertEqual(ret[2], 2)
         finally:
             self.chdir(old_cwd)
             if os.path.isdir(config_dir):


### PR DESCRIPTION
The point of these tests originally was to verify the proper location
of a log file. Checking return codes is just spurious and ties the test
too closely with the shutdown behavior of the daemons which are tracked and tested
in other places more closely and with more accuracy.