### PR TITLE
Get datacenter gh

### DIFF
--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -400,6 +400,12 @@ class VMwareConnectionError(VMwareSaltError):
     '''
 
 
+class VMwareObjectRetrievalError(VMwareSaltError):
+    '''
+    Used when a VMware object cannot be retrieved
+    '''
+
+
 class VMwareApiError(VMwareSaltError):
     '''
     Used when representing a generic VMware API error

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -801,6 +801,27 @@ def list_datacenters(service_instance):
     return list_objects(service_instance, vim.Datacenter)
 
 
+def get_datacenter(service_instance, datacenter_name):
+    '''
+    Returns a vim.Datacenter managed object.
+
+    service_instance
+        The Service Instance Object from which to obtain datacenter.
+
+    datacenter_name
+        The datacenter name
+    '''
+    items = [i['object'] for i in
+             get_mors_with_properties(service_instance,
+                                      vim.Datacenter,
+                                      property_list=['name'])
+            if i['name'] == datacenter_name]
+    if not items:
+        raise salt.exceptions.VMwareObjectRetrievalError(
+            'Datacenter \'{0}\' was not found'.format(datacenter_name))
+    return items[0]
+
+
 def list_clusters(service_instance):
     '''
     Returns a list of clusters associated with a given service instance.

--- a/tests/unit/utils/vmware_test/datacenter_test.py
+++ b/tests/unit/utils/vmware_test/datacenter_test.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+'''
+:codeauthor: :email:`Alexandru Bleotu <alexandru.bleotu@morganstanley.com>`
+
+Tests for datacenter related functions in salt.utils.vmware
+'''
+
+# Import python libraries
+from __future__ import absolute_import
+import logging
+# Import Salt testing libraries
+from salttesting import TestCase, skipIf
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
+
+from salt.exceptions import VMwareObjectRetrievalError
+
+# Import Salt libraries
+import salt.utils.vmware as vmware
+# Import Third Party Libs
+try:
+    from pyVmomi import vim
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+# Get Logging Started
+log = logging.getLogger(__name__)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
+@patch('salt.utils.vmware.get_mors_with_properties',
+       MagicMock(return_value=[{'name': 'fake_dc', 'object': MagicMock()}]))
+class GetDatacenterTestCase(TestCase):
+    '''Tests for salt.utils.vmware.get_datacenter'''
+
+    def setUp(self):
+        self.mock_si = MagicMock()
+        self.mock_properties = [MagicMock()]
+        self.mock_dc1 = MagicMock()
+        self.mock_dc2 = MagicMock()
+        self.mock_entries = [{'name': 'fake_dc1',
+                              'object': self.mock_dc1},
+                             {'name': 'fake_dc2',
+                              'object': self.mock_dc2}]
+
+    def test_get_mors_with_properties_call(self):
+        mock_get_mors_with_properties = MagicMock(
+            return_value=[{'name': 'fake_dc', 'object': MagicMock()}])
+        with patch('salt.utils.vmware.get_mors_with_properties',
+                   mock_get_mors_with_properties):
+            vmware.get_datacenter(self.mock_si, 'fake_dc')
+        mock_get_mors_with_properties.assert_called_once_with(
+            self.mock_si, vim.Datacenter, property_list=['name'])
+
+    def test_get_mors_with_properties_returns_empty_array(self):
+        with patch('salt.utils.vmware.get_mors_with_properties',
+                   MagicMock(return_value=[])):
+            with self.assertRaises(VMwareObjectRetrievalError) as excinfo:
+                vmware.get_datacenter(self.mock_si, 'fake_dc')
+        self.assertEqual(excinfo.exception.strerror,
+                         'Datacenter \'fake_dc\' was not found')
+
+    def test_datastore_not_found(self):
+        with patch('salt.utils.vmware.get_mors_with_properties',
+                   MagicMock(return_value=self.mock_entries)):
+            with self.assertRaises(VMwareObjectRetrievalError) as excinfo:
+                vmware.get_datacenter(self.mock_si, 'fake_dc')
+        self.assertEqual(excinfo.exception.strerror,
+                         'Datacenter \'fake_dc\' was not found')
+
+    def test_datastore_found(self):
+        with patch('salt.utils.vmware.get_mors_with_properties',
+                   MagicMock(return_value=self.mock_entries)):
+            res = vmware.get_datacenter(self.mock_si, 'fake_dc2')
+        self.assertEqual(res, self.mock_dc2)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(GetDatacenterTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

Added salt.utils.get_datacenter that returns a datacenter managed object
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.