### PR TITLE
PY3: Fix broken minion

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1877,7 +1877,7 @@ class Minion(MinionBase):
         elif tag.startswith('fire_master'):
             log.debug('Forwarding master event tag={tag}'.format(tag=data['tag']))
             self._fire_master(data['data'], data['tag'], data['events'], data['pretag'])
-        elif package.startswith('__schedule_return'):
+        elif tag.startswith('__schedule_return'):
             # reporting current connection with master
             if data['schedule'].startswith(master_event(type='alive', master='')):
                 if data['return']:
@@ -1932,7 +1932,7 @@ class Minion(MinionBase):
                         master, self.pub_channel = yield self.eval_master(
                                                             opts=self.opts,
                                                             failed=True,
-                                                            failback=package.startswith(master_event(type='failback')))
+                                                            failback=tag.startswith(master_event(type='failback')))
                     except SaltClientError:
                         pass
 


### PR DESCRIPTION
### What does this PR do?

The following error occurs when the salt-minion runs using Python 3:

```
  File "...\bin\lib\site-packages\salt\minion.py", line 1880,
    in handle_event
      elif package.startswith('__schedule_return'):
      TypeError: startswith first arg must be bytes or a tuple of bytes,
      not str
```

Use `tag` instead of `package` when reading the tag names just like
every other case.

Broken by PR #36202.
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
