### PR TITLE
jinja: fix YAML terminator removal in Jinja's "yaml" filter

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -384,8 +384,8 @@ class SerializerExtension(Extension, object):
     def format_yaml(self, value, flow_style=True):
         yaml_txt = yaml.dump(value, default_flow_style=flow_style,
                              Dumper=OrderedDictDumper).strip()
-        if yaml_txt.endswith('\n...\n'):
-            yaml_txt = yaml_txt[:len(yaml_txt-5)]
+        if yaml_txt.endswith('\n...'):
+            yaml_txt = yaml_txt[:len(yaml_txt)-4]
         return Markup(yaml_txt)
 
     def format_python(self, value):

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -477,6 +477,12 @@ class TestCustomExtensions(TestCase):
         rendered = env.from_string('{{ dataset|yaml }}').render(dataset=dataset)
         self.assertEqual(dataset, yaml.load(rendered))
 
+    def test_serialize_yaml_str(self):
+        dataset = "str value"
+        env = Environment(extensions=[SerializerExtension])
+        rendered = env.from_string('{{ dataset|yaml }}').render(dataset=dataset)
+        self.assertEqual(dataset, rendered)
+
     def test_serialize_python(self):
         dataset = {
             "foo": True,


### PR DESCRIPTION
The following pillar file:

``` yaml
{% set foo = "bla" %}
test: {{ foo | yaml }}
foo: bar
```

fails with:

```
$ salt "minion" saltutil.refresh_pillar
minion:
    True

$ tail /var/log/salt/master
2016-09-27 19:02:59,063 [salt.pillar      ][CRITICAL][1377] Rendering SLS 'test' failed, render error:
expected '<document start>', but found '<block mapping start>'
  in "<unicode string>", line 4, column 1:
    foo: bar
    ^
2016-09-27 19:02:59,113 [salt.pillar      ][CRITICAL][1377] Pillar render error: Rendering SLS 'test' failed. Please see master log for details.
```

Debugging the whole thing shows that the Jinja file rendered, before the YAML parser has a chance to kick in is (literally):

``` yaml
test: bla
...
foo: bar
```

Relevant commits: e6acf7bf5359081d19aeb688cf9c4b2322048ab0 and a7dd113a960a56bacaa942f1258704f1bd6a60b2

This is wrong in many ways:
- the `yaml_txt` value is `strip()`-ed so it will not finish by a `\n` as the test added in e6acf7bf5359081d19aeb688cf9c4b2322048ab0 expects. So, I guess this warning never show up.
- the second commit is even worse, as the subtraction is done on the string object, not on the `len()` call
- ... and I'm so sad to find such bugs in Salt :/