### PR TITLE
Remove file.check_managed_changes  when not needed (backport of PR #36589 to 2016.3)

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1627,24 +1627,6 @@ def managed(name,
         if not context:
             context = {}
         context['accumulator'] = accum_data[name]
-    if 'file.check_managed_changes' in __salt__:
-        ret['pchanges'] = __salt__['file.check_managed_changes'](
-            name,
-            source,
-            source_hash,
-            user,
-            group,
-            mode,
-            template,
-            context,
-            defaults,
-            __env__,
-            contents,
-            skip_verify,
-            **kwargs
-        )
-    else:
-        ret['pchanges'] = {}
 
     if show_diff is not None:
         show_changes = show_diff
@@ -1656,6 +1638,22 @@ def managed(name,
 
     try:
         if __opts__['test']:
+            if 'file.check_managed_changes' in __salt__:
+                ret['pchanges'] = __salt__['file.check_managed_changes'](
+                    name,
+                    source,
+                    source_hash,
+                    user,
+                    group,
+                    mode,
+                    template,
+                    context,
+                    defaults,
+                    __env__,
+                    contents,
+                    skip_verify,
+                    **kwargs
+                )
             if ret['pchanges']:
                 ret['result'] = None
                 ret['comment'] = 'The file {0} is set to be changed'.format(name)


### PR DESCRIPTION
### What does this PR do?
- Generate pchanges only when `test=True`
- Remove uneeded  `ret['pchanges'] = {}` which is set at top of `managed` function
### What issues does this PR fix or reference?
- Fix for https://github.com/saltstack/salt/issues/36588 for 2016.3
### Previous Behavior
- Jinja templates were being rendered twice during file.managed. Once to generate pchanges (predictive changes) and once to actually generate the file.
### New Behavior
- `pchanges` are only generated when `test=True`
### Tests written?

No

Tested with jinja template and file.managed on 2016.3 branch in Ubuntu 14.04 LTS.
