### PR TITLE
Fix memory leak for 0mq transport in case of TCP DDOS

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -144,6 +144,7 @@ class Serial(object):
                          'This often happens when trying to read a file not in binary mode'
                          'To see message payload, enable debug logging and retry. Exception: {0}'.format(exc))
             log.debug('Msgpack deserialization failure on message: {0}'.format(msg))
+            gc.collect()
             raise
         finally:
             gc.enable()


### PR DESCRIPTION
### What does this PR do?

In case anyone is trying to "DDOS" zeromq transport with TCP messages,
we've got ZeroMQPubServerChannel process utilized more than 8GB of RAM.
With this patch, we have got ZeroMQPubServerChannel stabilized at 300MB
for > 500 nodes, with no performance penalties. It doesn't affect performance of 0mq minions, as it perform gc.collect only in case of exception.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/36612
### Tests written?

No