### PR TITLE
Fix shadowed builtins

### DIFF
--- a/salt/modules/mac_xattr.py
+++ b/salt/modules/mac_xattr.py
@@ -16,7 +16,11 @@ import salt.utils.mac_utils
 from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
+
 __virtualname__ = "xattr"
+__func_alias__ = {
+    'list_': 'list',
+}
 
 
 def __virtual__():
@@ -28,7 +32,7 @@ def __virtual__():
     return False
 
 
-def list(path, hex=False):
+def list_(path, **kwargs):
     '''
     List all of the extended attributes on the given file/directory
 
@@ -49,7 +53,12 @@ def list(path, hex=False):
         salt '*' xattr.list /path/to/file
         salt '*' xattr.list /path/to/file hex=True
     '''
-    cmd = 'xattr "{0}"'.format(path)
+    kwargs = salt.utils.clean_kwargs(**kwargs)
+    hex_ = kwargs.pop('hex', False)
+    if kwargs:
+        salt.utils.invalid_kwargs(kwargs)
+
+    cmd = ['xattr', path]
     try:
         ret = salt.utils.mac_utils.execute_return_result(cmd)
     except CommandExecutionError as exc:
@@ -63,13 +72,13 @@ def list(path, hex=False):
     attrs_ids = ret.split("\n")
     attrs = {}
 
-    for id in attrs_ids:
-        attrs[id] = read(path, id, hex)
+    for id_ in attrs_ids:
+        attrs[id_] = read(path, id_, **{'hex': hex_})
 
     return attrs
 
 
-def read(path, attribute, hex=False):
+def read(path, attribute, **kwargs):
     '''
     Read the given attributes on the given file/directory
 
@@ -92,11 +101,15 @@ def read(path, attribute, hex=False):
         salt '*' xattr.read /path/to/file com.test.attr
         salt '*' xattr.read /path/to/file com.test.attr hex=True
     '''
-    hex_flag = ""
-    if hex:
-        hex_flag = "-x"
+    kwargs = salt.utils.clean_kwargs(**kwargs)
+    hex_ = kwargs.pop('hex', False)
+    if kwargs:
+        salt.utils.invalid_kwargs(kwargs)
 
-    cmd = 'xattr -p {0} "{1}" "{2}"'.format(hex_flag, attribute, path)
+    cmd = ['xattr', '-p']
+    if hex_:
+        cmd.append('-x')
+    cmd.extend([attribute, path])
 
     try:
         ret = salt.utils.mac_utils.execute_return_result(cmd)
@@ -110,7 +123,7 @@ def read(path, attribute, hex=False):
     return ret
 
 
-def write(path, attribute, value, hex=False):
+def write(path, attribute, value, **kwargs):
     '''
     Causes the given attribute name to be assigned the given value
 
@@ -134,11 +147,16 @@ def write(path, attribute, value, hex=False):
         salt '*' xattr.write /path/to/file "com.test.attr" "value"
 
     '''
-    hex_flag = ""
-    if hex:
-        hex_flag = "-x"
+    kwargs = salt.utils.clean_kwargs(**kwargs)
+    hex_ = kwargs.pop('hex', False)
+    if kwargs:
+        salt.utils.invalid_kwargs(kwargs)
 
-    cmd = 'xattr -w {0} "{1}" "{2}" "{3}"'.format(hex_flag, attribute, value, path)
+    cmd = ['xattr', '-w']
+    if hex_:
+        cmd.append('-x')
+    cmd.extend([attribute, value, path])
+
     try:
         salt.utils.mac_utils.execute_return_success(cmd)
     except CommandExecutionError as exc:
@@ -146,7 +164,7 @@ def write(path, attribute, value, hex=False):
             raise CommandExecutionError('File not found: {0}'.format(path))
         raise CommandExecutionError('Unknown Error: {0}'.format(exc.strerror))
 
-    return read(path, attribute, hex) == value
+    return read(path, attribute, **{'hex': hex_}) == value
 
 
 def delete(path, attribute):
@@ -180,7 +198,7 @@ def delete(path, attribute):
             raise CommandExecutionError('Attribute not found: {0}'.format(attribute))
         raise CommandExecutionError('Unknown Error: {0}'.format(exc.strerror))
 
-    return attribute not in list(path)
+    return attribute not in list_(path)
 
 
 def clear(path):
@@ -207,4 +225,4 @@ def clear(path):
             raise CommandExecutionError('File not found: {0}'.format(path))
         raise CommandExecutionError('Unknown Error: {0}'.format(exc.strerror))
 
-    return list(path) == {}
+    return list_(path) == {}

--- a/tests/unit/modules/mac_xattr_test.py
+++ b/tests/unit/modules/mac_xattr_test.py
@@ -55,8 +55,10 @@ class XAttrTestCase(TestCase):
         '''
         with patch.object(salt.utils.mac_utils, 'execute_return_result',
                           MagicMock(return_value='expected results')) as mock:
-            self.assertEqual(xattr.read('/path/to/file', 'com.attr', True),
-                             'expected results')
+            self.assertEqual(
+                xattr.read('/path/to/file', 'com.attr', **{'hex': True}),
+                'expected results'
+            )
             mock.assert_called_once_with('xattr -p -x "com.attr" "/path/to/file"')
 
     @patch('salt.utils.mac_utils.execute_return_result',

--- a/tests/unit/modules/mac_xattr_test.py
+++ b/tests/unit/modules/mac_xattr_test.py
@@ -30,7 +30,7 @@ class XAttrTestCase(TestCase):
                     'squidward': 'patrick'}
         with patch.object(xattr, 'read', MagicMock(side_effect=['squarepants',
                                                                 'patrick'])):
-            self.assertEqual(xattr.list('path/to/file'), expected)
+            self.assertEqual(xattr.list_('path/to/file'), expected)
 
     @patch('salt.utils.mac_utils.execute_return_result',
            MagicMock(side_effect=CommandExecutionError('No such file')))
@@ -38,7 +38,7 @@ class XAttrTestCase(TestCase):
         '''
         Test listing attributes of a missing file
         '''
-        self.assertRaises(CommandExecutionError, xattr.list, '/path/to/file')
+        self.assertRaises(CommandExecutionError, xattr.list_, '/path/to/file')
 
     @patch('salt.utils.mac_utils.execute_return_result',
            MagicMock(return_value='expected results'))
@@ -59,7 +59,8 @@ class XAttrTestCase(TestCase):
                 xattr.read('/path/to/file', 'com.attr', **{'hex': True}),
                 'expected results'
             )
-            mock.assert_called_once_with('xattr -p -x "com.attr" "/path/to/file"')
+            mock.assert_called_once_with(
+                ['xattr', '-p', '-x', 'com.attr', '/path/to/file'])
 
     @patch('salt.utils.mac_utils.execute_return_result',
            MagicMock(side_effect=CommandExecutionError('No such file')))
@@ -103,7 +104,7 @@ class XAttrTestCase(TestCase):
         Test deleting a specific attribute from a file
         '''
         mock_cmd = MagicMock(return_value={'spongebob': 'squarepants'})
-        with patch.object(xattr, 'list', mock_cmd):
+        with patch.object(xattr, 'list_', mock_cmd):
             self.assertTrue(xattr.delete('/path/to/file', 'attribute'))
 
     @patch('salt.utils.mac_utils.execute_return_success',
@@ -124,7 +125,7 @@ class XAttrTestCase(TestCase):
         Test clearing all attributes on a file
         '''
         mock_cmd = MagicMock(return_value={})
-        with patch.object(xattr, 'list', mock_cmd):
+        with patch.object(xattr, 'list_', mock_cmd):
             self.assertTrue(xattr.clear('/path/to/file'))
 
     @patch('salt.utils.mac_utils.execute_return_success',


### PR DESCRIPTION
`id`, `hex`, and `list` were all shadowed, this PR fixes that.