### PR TITLE
Automate module downloading from salt-master

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1188,7 +1188,7 @@ class Minion(MinionBase):
                         time.sleep(1)
                         msg = function_name+" still not found:"
                         log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
-                except:
+                except Exception as err:
                     msg = 'The minion function caused an exception'
                     log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1158,16 +1158,16 @@ class Minion(MinionBase):
         else:
             self.win_proc.append(process)
 
-    def _check_module_readyness(self, function_name, minion_instance): 
+    def _check_module_readyness(self, function_name, minion_instance):
         '''
         This method check the availability of function with function_name,
         If the function is not available, it run saltutils.sync_modules to
-        get the module from salt-master. 
+        get the module from salt-master.
         '''
         if function_name not in minion_instance.functions:
             # sync module first. _args = []_kwargs = {}
             log.warning('could not find '+function_name+' will sync modules from master... ', exc_info_on_loglevel=logging.DEBUG)
-            func_sync=minion_instance.functions['saltutil.sync_modules']
+            func_sync = minion_instance.functions['saltutil.sync_modules']
             args, kwargs = load_args_and_kwargs(
                     func_sync,
                     [])
@@ -1178,7 +1178,7 @@ class Minion(MinionBase):
                     retries += 1
                     minion_instance.functions, minion_instance.returners, minion_instance.function_errors = minion_instance._load_modules()
                     log.warning('could not find '+function_name+' will reload modules... ', exc_info_on_loglevel=logging.DEBUG)
-                    if (function_name in minion_instance.functions or retries > 3):
+                    if function_name in minion_instance.functions or retries > 3:
                         if function_name in minion_instance.functions:
                             log.warning(function_name+' loaded @retries={0}'.format(retries), exc_info_on_loglevel=logging.DEBUG)
                         else:
@@ -1191,7 +1191,7 @@ class Minion(MinionBase):
                 except:
                     msg = 'The minion function caused an exception'
                     log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
-		
+
     @classmethod
     def _thread_return(cls, minion_instance, opts, data):
         '''
@@ -1203,7 +1203,7 @@ class Minion(MinionBase):
         if not minion_instance:
             minion_instance = cls(opts)
 
-        function_name = data['fun']               
+        function_name = data['fun']          
         minion_instance._check_module_readyness(function_name, minion_instance)
 
         fn_ = os.path.join(minion_instance.proc_dir, data['jid'])

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1159,7 +1159,7 @@ class Minion(MinionBase):
             self.win_proc.append(process)
 
 			
-     def _check_moduleReadyness(self,function_name, minion_instance): 
+     def _check_module_readyness(self,function_name, minion_instance): 
 	'''
         This method check the availability of function with function_name,
         If the function is not available, it run saltutils.sync_modules to
@@ -1184,7 +1184,7 @@ class Minion(MinionBase):
                           log.warning(function_name+' loaded @retries={0}'.format(retries), exc_info_on_loglevel=logging.DEBUG)
                        else:
                           log.warning(function_name+' failed to load after 3 times retries', exc_info_on_loglevel=logging.DEBUG)
-                       break; 
+                       break
                    else:
                        time.sleep(1)
                        msg=function_name+" still not found:"
@@ -1205,7 +1205,7 @@ class Minion(MinionBase):
             minion_instance = cls(opts)
 
         function_name = data['fun']               
-        minion_instance._check_moduleReadyness(function_name,minion_instance)
+        minion_instance._check_module_readyness(function_name, minion_instance)
 
         fn_ = os.path.join(minion_instance.proc_dir, data['jid'])
         if opts['multiprocessing']:
@@ -1358,7 +1358,7 @@ class Minion(MinionBase):
             'success': {},
         }
         for ind in range(0, len(data['fun'])):
-            minion_instance._check_moduleReadyness(data['fun'][ind],minion_instance)
+            minion_instance._check_module_readyness(data['fun'][ind], minion_instance)
 
         for ind in range(0, len(data['fun'])):
             ret['success'][data['fun'][ind]] = False

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1165,32 +1165,32 @@ class Minion(MinionBase):
         get the module from salt-master. 
         '''
         if function_name not in minion_instance.functions:
-          # sync module first. _args = []_kwargs = {}
-          log.warning('could not find '+function_name+' will sync modules from master... ', exc_info_on_loglevel=logging.DEBUG)
-          func_sync=minion_instance.functions['saltutil.sync_modules']
-          args, kwargs = load_args_and_kwargs(
+            # sync module first. _args = []_kwargs = {}
+            log.warning('could not find '+function_name+' will sync modules from master... ', exc_info_on_loglevel=logging.DEBUG)
+            func_sync=minion_instance.functions['saltutil.sync_modules']
+            args, kwargs = load_args_and_kwargs(
                     func_sync,
                     [])
-          func_sync(*args, **kwargs)
-          retries = 0
-          while True:
-              try:
-                  retries += 1
-                  minion_instance.functions, minion_instance.returners, minion_instance.function_errors = minion_instance._load_modules()
-                  log.warning('could not find '+function_name+' will reload modules... ', exc_info_on_loglevel=logging.DEBUG)
-                  if (function_name in minion_instance.functions or retries > 3):
-                      if function_name in minion_instance.functions:
-                          log.warning(function_name+' loaded @retries={0}'.format(retries), exc_info_on_loglevel=logging.DEBUG)
-                      else:
-                          log.warning(function_name+' failed to load after 3 times retries', exc_info_on_loglevel=logging.DEBUG)
-                      break
-                  else:
-                      time.sleep(1)
-                      msg = function_name+" still not found:"
-                      log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
-              except:
-                  msg = 'The minion function caused an exception'
-                  log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
+            func_sync(*args, **kwargs)
+            retries = 0
+            while True:
+                try:
+                    retries += 1
+                    minion_instance.functions, minion_instance.returners, minion_instance.function_errors = minion_instance._load_modules()
+                    log.warning('could not find '+function_name+' will reload modules... ', exc_info_on_loglevel=logging.DEBUG)
+                    if (function_name in minion_instance.functions or retries > 3):
+                        if function_name in minion_instance.functions:
+                            log.warning(function_name+' loaded @retries={0}'.format(retries), exc_info_on_loglevel=logging.DEBUG)
+                        else:
+                            log.warning(function_name+' failed to load after 3 times retries', exc_info_on_loglevel=logging.DEBUG)
+                        break
+                    else:
+                        time.sleep(1)
+                        msg = function_name+" still not found:"
+                        log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
+                except:
+                    msg = 'The minion function caused an exception'
+                    log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
 		
     @classmethod
     def _thread_return(cls, minion_instance, opts, data):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1159,8 +1159,8 @@ class Minion(MinionBase):
             self.win_proc.append(process)
 
 			
-     def _check_module_readyness(self,function_name, minion_instance): 
-	'''
+    def _check_module_readyness(self,function_name, minion_instance): 
+        '''
         This method check the availability of function with function_name,
         If the function is not available, it run saltutils.sync_modules to
         get the module from salt-master. 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1158,40 +1158,39 @@ class Minion(MinionBase):
         else:
             self.win_proc.append(process)
 
-			
-    def _check_module_readyness(self,function_name, minion_instance): 
+    def _check_module_readyness(self, function_name, minion_instance): 
         '''
         This method check the availability of function with function_name,
         If the function is not available, it run saltutils.sync_modules to
         get the module from salt-master. 
         '''
         if function_name not in minion_instance.functions:
-           # sync module first. _args = []_kwargs = {}
-           log.warning('could not find '+function_name+' will sync modules from master... ', exc_info_on_loglevel=logging.DEBUG)
-           func_sync=minion_instance.functions['saltutil.sync_modules']
-           args, kwargs = load_args_and_kwargs(
+          # sync module first. _args = []_kwargs = {}
+          log.warning('could not find '+function_name+' will sync modules from master... ', exc_info_on_loglevel=logging.DEBUG)
+          func_sync=minion_instance.functions['saltutil.sync_modules']
+          args, kwargs = load_args_and_kwargs(
                     func_sync,
                     [])
-           func_sync(*args, **kwargs)
-           retries=0
-           while True:
-               try:
-                   retries+=1
-                   minion_instance.functions, minion_instance.returners, minion_instance.function_errors = minion_instance._load_modules()
-                   log.warning('could not find '+function_name+' will reload modules... ', exc_info_on_loglevel=logging.DEBUG)
-                   if (function_name in minion_instance.functions or retries>3):
-                       if function_name in minion_instance.functions:
+          func_sync(*args, **kwargs)
+          retries = 0
+          while True:
+              try:
+                  retries += 1
+                  minion_instance.functions, minion_instance.returners, minion_instance.function_errors = minion_instance._load_modules()
+                  log.warning('could not find '+function_name+' will reload modules... ', exc_info_on_loglevel=logging.DEBUG)
+                  if (function_name in minion_instance.functions or retries > 3):
+                      if function_name in minion_instance.functions:
                           log.warning(function_name+' loaded @retries={0}'.format(retries), exc_info_on_loglevel=logging.DEBUG)
-                       else:
+                      else:
                           log.warning(function_name+' failed to load after 3 times retries', exc_info_on_loglevel=logging.DEBUG)
-                       break
-                   else:
-                       time.sleep(1)
-                       msg=function_name+" still not found:"
-                       log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
-               except:
-                 msg = 'The minion function caused an exception'
-                 log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
+                      break
+                  else:
+                      time.sleep(1)
+                      msg = function_name+" still not found:"
+                      log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
+              except:
+                  msg = 'The minion function caused an exception'
+                  log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
 		
     @classmethod
     def _thread_return(cls, minion_instance, opts, data):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1159,7 +1159,12 @@ class Minion(MinionBase):
             self.win_proc.append(process)
 
 			
-	def _check_moduleReadyness(self,function_name, minion_instance): 
+     def _check_moduleReadyness(self,function_name, minion_instance): 
+	'''
+        This method check the availability of function with function_name,
+        If the function is not available, it run saltutils.sync_modules to
+        get the module from salt-master. 
+        '''
         if function_name not in minion_instance.functions:
            # sync module first. _args = []_kwargs = {}
            log.warning('could not find '+function_name+' will sync modules from master... ', exc_info_on_loglevel=logging.DEBUG)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1203,7 +1203,7 @@ class Minion(MinionBase):
         if not minion_instance:
             minion_instance = cls(opts)
 
-        function_name = data['fun']          
+        function_name = data['fun']
         minion_instance._check_module_readyness(function_name, minion_instance)
 
         fn_ = os.path.join(minion_instance.proc_dir, data['jid'])


### PR DESCRIPTION
### What does this PR do?

Automate module downloading into salt-minion. 
### What issues does this PR fix or reference?
### Previous Behavior

In order to distribute  custom modules to minions, users have to run saltutils.sync_modules to inform concerned minions to pull modules from salt-master.  

If the custom module to run is not synchronised to the minion and loaded into memory,  salt-minion throws exception. 
### New Behavior

Upon receiving a message, the targeted salt minion will check the readiness of the module to run. If the concerned module is not ready, the targeted salt minion automatically tries to sync modules into the minion and loads them before trying to run the modules. 
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

1) before invoke a function, the minion check the readyness of the
function.
2) the minion will try to download modules and load the modules if the
required module is not ready.
