### PR TITLE
systemd.py: expose _check_for_unit_changes as "refresh"

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -327,6 +327,9 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
     if 'enabled' in kwargs:
         return _enabled_used_error(ret)
 
+    if 'service.refresh' in __salt__:
+        __salt__['service.refresh'](name)
+
     # Check if the service is available
     try:
         if not _available(name, ret):


### PR DESCRIPTION
This allows for this function to be called from within service states, and alters the service.running state to call this function if present in the `__salt__` dunder.

This pull request is a potential alternative to https://github.com/saltstack/salt/pull/36538.
