### PR TITLE
Skip rest of loop on failed func match

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -789,6 +789,7 @@ class CkMinions(object):
                     # so this fn is permitted by all minions
                     if self.match_check(auth_list_entry, fun):
                         return True
+                continue
             if isinstance(auth_list_entry, dict):
                 if len(auth_list_entry) != 1:
                     log.info('Malformed ACL: {0}'.format(auth_list_entry))


### PR DESCRIPTION
### What does this PR do?

When auth_check_expanded tries to match against direct functions, it
needs to skip the rest of the loop if no match is found.  The rest of
the loop assumes the auth_list_entry is a dict, not a string, and will
throw an exception when trying to get keys()
