### PR TITLE
Add a kwarg to let people switch on templating for Junos config files

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -355,7 +355,10 @@ def install_config(path=None, **kwargs):
     if 'timeout' in kwargs:
         conn.timeout = kwargs['timeout']
 
-    options = {'path': path}
+    if kwargs['template']:
+        options = {'template_path': path}
+    else:
+        options = {'path': path}
 
     try:
         conn.cu.load(**options)

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -356,7 +356,7 @@ def install_config(path=None, **kwargs):
         conn.timeout = kwargs['timeout']
 
     if kwargs['template']:
-        options = {'template_path': path}
+        options = {'template_path': path, 'template_vars': __pillar__['proxy']}
     else:
         options = {'path': path}
 


### PR DESCRIPTION
### What does this PR do?

Current Junos execution module only allows for loading plain text config files. This PR makes it possible to turn on Jinja interpreting for those files.
### What issues does this PR fix or reference?

None - it's a new feature
### Previous Behavior

Only basic config files using this syntax
salt 'device_name' junos.install_config '/home/user/config.set' timeout=300
### New Behavior

Now you can do Jinja files like this
salt 'device_name' junos.install_config '/home/user/config.set' timeout=300 template=True
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

Just set template=True and pyez will interpret Jinja in the given file