### PR TITLE
[2016.3] Merge forward from 2015.8 to 2016.3

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -976,3 +976,10 @@
 ############################################
 # Default match type for filtering events tags: startswith, endswith, find, regex, fnmatch
 #event_match_type: startswith
+
+# Permanently include any available Python 3rd party modules into Salt Thin
+# when they are generated for Salt-SSH or other purposes.
+# The modules should be named by the names they are actually imported inside the Python.
+# The value of the parameters can be either one module or a comma separated list of them.
+#thin_extra_mods: foo,bar
+

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -696,6 +696,15 @@ overridden on a per-minion basis in the roster (``minion_opts``)
     minion_opts:
       gpg_keydir: /root/gpg
 
+``thin_extra_mods``
+-------------------
+
+Default: None
+
+List of additional modules, needed to be included into the Salt Thin.
+Pass a list of importable Python modules that are typically located in
+the `site-packages` Python directory so they will be also always included
+into the Salt Thin, once generated.
 
 Master Security Settings
 ========================

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -252,7 +252,7 @@ class SSH(object):
         self.serial = salt.payload.Serial(opts)
         self.returners = salt.loader.returners(self.opts, {})
         self.fsclient = salt.fileclient.FSClient(self.opts)
-        self.thin = salt.utils.thin.gen_thin(self.opts['cachedir'])
+        self.thin = salt.utils.thin.gen_thin(self.opts['cachedir'], extra_mods=self.opts.get('thin_extra_mods'))
         self.mods = mod_data(self.fsclient)
 
     def get_pubkey(self):

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -295,7 +295,7 @@ class SSH(object):
         self.returners = salt.loader.returners(self.opts, {})
         self.fsclient = salt.fileclient.FSClient(self.opts)
         self.thin = salt.utils.thin.gen_thin(self.opts['cachedir'],
-					     extra_mods=self.opts.get('thin_extra_mods'),
+                                             extra_mods=self.opts.get('thin_extra_mods'),
                                              python2_bin=self.opts['python2_bin'],
                                              python3_bin=self.opts['python3_bin'])
         self.mods = mod_data(self.fsclient)

--- a/salt/config.py
+++ b/salt/config.py
@@ -784,6 +784,9 @@ VALID_OPTS = {
 
     # Delay in seconds before executing bootstrap (salt cloud)
     'bootstrap_delay': int,
+
+    # Extra modules for Salt Thin
+    'thin_extra_mods': str,
 }
 
 # default configurations
@@ -1240,6 +1243,7 @@ DEFAULT_MASTER_OPTS = {
     'dummy_pub': False,
     'http_request_timeout': 1 * 60 * 60.0,  # 1 hour
     'http_max_body': 100 * 1024 * 1024 * 1024,  # 100GB
+    'thin_extra_mods': '',
 }
 
 

--- a/salt/runners/thin.py
+++ b/salt/runners/thin.py
@@ -30,4 +30,8 @@ def generate(extra_mods='', overwrite=False, so_mods=''):
         salt-run thin.generate mako,wempy 1
         salt-run thin.generate overwrite=1
     '''
+    conf_mods = __opts__.get('thin_extra_mods')
+    if conf_mods:
+        extra_mods = ','.join([conf_mods, extra_mods])
+
     return salt.utils.thin.gen_thin(__opts__['cachedir'], extra_mods, overwrite, so_mods)

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2476,6 +2476,12 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
             help='Pass in extra files to include in the state tarball'
         )
         self.add_option(
+            '--thin-extra-modules',
+            dest='thin_extra_mods',
+            default=None,
+            help='One or comma-separated list of extra Python modules'
+                 'to be included into Thin Salt.')
+        self.add_option(
             '-v', '--verbose',
             default=False,
             action='store_true',


### PR DESCRIPTION
Conflicts:
- salt/client/ssh/**init**.py
- salt/config/**init**.py
- salt/runners/thin.py