### PR TITLE
Port the 'rabbitmq' module to Windows

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -10,6 +10,8 @@ from __future__ import absolute_import
 import json
 import re
 import logging
+import os
+import os.path
 import random
 import string
 
@@ -28,19 +30,75 @@ def __virtual__():
     '''
     Verify RabbitMQ is installed.
     '''
-    return salt.utils.which('rabbitmqctl') is not None
+    if salt.utils.is_windows():
+        from salt.ext.six.moves import winreg
+        key = None
+        try:
+            key = winreg.OpenKeyEx(
+                winreg.HKEY_LOCAL_MACHINE,
+                'SOFTWARE\\VMware, Inc.\\RabbitMQ Server',
+                0,
+                winreg.KEY_READ | winreg.KEY_WOW64_32KEY
+            )
+            (dir_path, value_type) = winreg.QueryValueEx(
+                key,
+                'Install_Dir'
+            )
+            if value_type != winreg.REG_SZ:
+                raise TypeError('Invalid RabbitMQ Server directory type: {0}'.format(value_type))
+            if not os.path.isdir(dir_path):
+                raise IOError('RabbitMQ directory not found: {0}'.format(dir_path))
+            subdir_match = ''
+            for name in os.listdir(dir_path):
+                if name.startswith('rabbitmq_server-'):
+                    subdir_path = os.path.join(dir_path, name)
+                    # Get the matching entry that is last in ASCII order.
+                    if os.path.isdir(subdir_path) and subdir_path > subdir_match:
+                        subdir_match = subdir_path
+            if not subdir_match:
+                raise IOError('"rabbitmq_server-*" subdirectory not found in: {0}'.format(dir_path))
+            __context__['rabbitmqctl'] = os.path.join(subdir_match, 'sbin', 'rabbitmqctl.bat')
+            __context__['rabbitmq-plugins'] = os.path.join(subdir_match, 'sbin', 'rabbitmq-plugins.bat')
+        except Exception:
+            pass
+        finally:
+            if key is not None:
+                winreg.CloseKey(key)
+    else:
+        __context__['rabbitmqctl'] = salt.utils.which('rabbitmqctl')
+        __context__['rabbitmq-plugins'] = salt.utils.which('rabbitmq-plugins')
+
+    if not __context__.get('rabbitmqctl'):
+        return (False, 'Module rabbitmq: module only works when RabbitMQ is installed')
+    return True
+
+
+def _check_response(response):
+    if isinstance(response, dict):
+        if response['retcode'] != 0 or response['stderr']:
+            raise CommandExecutionError(
+                'RabbitMQ command failed: {0}'.format(response['stderr'])
+            )
+    else:
+        if 'Error' in response:
+            raise CommandExecutionError(
+                'RabbitMQ command failed: {0}'.format(response)
+            )
 
 
 def _format_response(response, msg):
-    error = 'RabbitMQ command failed: {0}'.format(response)
     if isinstance(response, dict):
-        if response['retcode'] != 0:
-            raise CommandExecutionError(error)
+        if response['retcode'] != 0 or response['stderr']:
+            raise CommandExecutionError(
+                'RabbitMQ command failed: {0}'.format(response['stderr'])
+            )
         else:
-            msg = response['stdout']
+            response = response['stdout']
     else:
         if 'Error' in response:
-            raise CommandExecutionError(error)
+            raise CommandExecutionError(
+                'RabbitMQ command failed: {0}'.format(response)
+            )
     return {
         msg: response
     }
@@ -53,13 +111,13 @@ def _get_rabbitmq_plugin():
     This works by taking the rabbitmq-server version and looking for where it
     seems to be hidden in /usr/lib.
     '''
-    rabbitmq = salt.utils.which('rabbitmq-plugins')
+    rabbitmq = __context__.get('rabbitmq-plugins')
 
     if rabbitmq is None:
         version = __salt__['pkg.version']('rabbitmq-server').split('-')[0]
-
         rabbitmq = ('/usr/lib/rabbitmq/lib/rabbitmq_server-{0}'
                     '/sbin/rabbitmq-plugins').format(version)
+        __context__['rabbitmq-plugins'] = rabbitmq
 
     return rabbitmq
 
@@ -93,6 +151,13 @@ def _output_to_dict(cmdoutput, values_mapper=None):
     cmdoutput: string output of rabbitmqctl commands
     values_mapper: function object to process the values part of each line
     '''
+    if isinstance(cmdoutput, dict):
+        if cmdoutput['retcode'] != 0 or cmdoutput['stderr']:
+            raise CommandExecutionError(
+                'RabbitMQ command failed: {0}'.format(cmdoutput['stderr'])
+            )
+        cmdoutput = cmdoutput['stdout']
+
     ret = {}
     if values_mapper is None:
         values_mapper = lambda string: string.split('\t')
@@ -127,10 +192,13 @@ def list_users(runas=None):
 
         salt '*' rabbitmq.list_users
     '''
-    if runas is None:
+    # Windows runas currently requires a password.
+    # Due to this, don't use a default value for
+    # runas in Windows.
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'list_users'],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'list_users'],
         runas=runas,
         python_shell=False)
 
@@ -150,11 +218,14 @@ def list_vhosts(runas=None):
 
         salt '*' rabbitmq.list_vhosts
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run']('rabbitmqctl list_vhosts -q',
-                              runas=runas).splitlines()
-    return res
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'list_vhosts', '-q'],
+        runas=runas,
+        python_shell=False)
+    _check_response(res)
+    return res['stdout'].splitlines()
 
 
 def user_exists(name, runas=None):
@@ -167,7 +238,7 @@ def user_exists(name, runas=None):
 
         salt '*' rabbitmq.user_exists rabbit_user
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
     user_list = list_users(runas=runas)
     log.debug(user_list)
@@ -185,7 +256,7 @@ def vhost_exists(name, runas=None):
 
         salt '*' rabbitmq.vhost_exists rabbit_host
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
     return name in list_vhosts(runas=runas)
 
@@ -208,24 +279,39 @@ def add_user(name, password=None, runas=None):
         password = ''.join(random.SystemRandom().choice(
             string.ascii_uppercase + string.digits) for x in range(15))
 
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'add_user', name, password],
+
+    if salt.utils.is_windows():
+        # On Windows, if the password contains a special character
+        # such as '|', normal execution will fail. For example:
+        # cmd: rabbitmq.add_user abc "asdf|def"
+        # stderr: 'def' is not recognized as an internal or external
+        #         command,\r\noperable program or batch file.
+        # Work around this by using a shell and a quoted command.
+        python_shell = True
+        cmd = '"{0}" add_user "{1}" "{2}"'.format(
+            __context__['rabbitmqctl'], name, password
+        )
+    else:
+        python_shell = False
+        cmd = [__context__['rabbitmqctl'], 'add_user', name, password]
+
+    res = __salt__['cmd.run_all'](
+        cmd,
         output_loglevel='quiet',
         runas=runas,
-        python_shell=False)
+        python_shell=python_shell)
 
     if clear_pw:
         # Now, Clear the random password from the account, if necessary
-        res2 = clear_password(name, runas)
-
-        if 'Error' in res2:
+        try:
+            clear_password(name, runas)
+        except Exception:
             # Clearing the password failed. We should try to cleanup
             # and rerun and error.
             delete_user(name, runas)
-            msg = 'Error'
-            return _format_response(res2, msg)
+            raise
 
     msg = 'Added'
     return _format_response(res, msg)
@@ -241,10 +327,10 @@ def delete_user(name, runas=None):
 
         salt '*' rabbitmq.delete_user rabbit_user
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'delete_user', name],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'delete_user', name],
         python_shell=False,
         runas=runas)
     msg = 'Deleted'
@@ -262,13 +348,27 @@ def change_password(name, password, runas=None):
 
         salt '*' rabbitmq.change_password rabbit_user password
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'change_password', name, password],
+    if salt.utils.is_windows():
+        # On Windows, if the password contains a special character
+        # such as '|', normal execution will fail. For example:
+        # cmd: rabbitmq.add_user abc "asdf|def"
+        # stderr: 'def' is not recognized as an internal or external
+        #         command,\r\noperable program or batch file.
+        # Work around this by using a shell and a quoted command.
+        python_shell = True
+        cmd = '"{0}" change_password "{1}" "{2}"'.format(
+            __context__['rabbitmqctl'], name, password
+        )
+    else:
+        python_shell = False
+        cmd = [__context__['rabbitmqctl'], 'change_password', name, password]
+    res = __salt__['cmd.run_all'](
+        cmd,
         runas=runas,
         output_loglevel='quiet',
-        python_shell=False)
+        python_shell=python_shell)
     msg = 'Password Changed'
 
     return _format_response(res, msg)
@@ -284,10 +384,10 @@ def clear_password(name, runas=None):
 
         salt '*' rabbitmq.clear_password rabbit_user
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'clear_password', name],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'clear_password', name],
         runas=runas,
         python_shell=False)
     msg = 'Password Cleared'
@@ -309,11 +409,11 @@ def check_password(name, password, runas=None):
     '''
     # try to get the rabbitmq-version - adapted from _get_rabbitmq_plugin
 
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
 
     try:
-        res = __salt__['cmd.run'](['rabbitmqctl', 'status'], runas=runas, python_shell=False)
+        res = __salt__['cmd.run']([__context__['rabbitmqctl'], 'status'], runas=runas, python_shell=False)
         server_version = re.search(r'\{rabbit,"RabbitMQ","(.+)"\}', res)
 
         if server_version is None:
@@ -328,21 +428,38 @@ def check_password(name, password, runas=None):
 
     # rabbitmq introduced a native api to check a username and password in version 3.5.7.
     if tuple(version) >= (3, 5, 7):
-        res = __salt__['cmd.run'](
-            ['rabbitmqctl', 'authenticate_user', name, password],
+        if salt.utils.is_windows():
+            # On Windows, if the password contains a special character
+            # such as '|', normal execution will fail. For example:
+            # cmd: rabbitmq.add_user abc "asdf|def"
+            # stderr: 'def' is not recognized as an internal or external
+            #         command,\r\noperable program or batch file.
+            # Work around this by using a shell and a quoted command.
+            python_shell = True
+            cmd = '"{0}" authenticate_user "{1}" "{2}"'.format(
+                __context__['rabbitmqctl'], name, password
+            )
+        else:
+            python_shell = False
+            cmd = [__context__['rabbitmqctl'], 'authenticate_user', name, password]
+
+        res = __salt__['cmd.run_all'](
+            cmd,
             runas=runas,
             output_loglevel='quiet',
-            python_shell=False)
+            python_shell=python_shell)
 
-        return 'Error:' not in res
+        if res['retcode'] != 0 or res['stderr']:
+            return False
+        return True
 
     cmd = ('rabbit_auth_backend_internal:check_user_login'
         '(<<"{0}">>, [{{password, <<"{1}">>}}]).').format(
         name.replace('"', '\\"'),
         password.replace('"', '\\"'))
 
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'eval', cmd],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'eval', cmd],
         runas=runas,
         output_loglevel='quiet',
         python_shell=False)
@@ -367,10 +484,10 @@ def add_vhost(vhost, runas=None):
 
         salt '*' rabbitmq add_vhost '<vhost_name>'
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'add_vhost', vhost],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'add_vhost', vhost],
         runas=runas,
         python_shell=False)
 
@@ -388,10 +505,10 @@ def delete_vhost(vhost, runas=None):
 
         salt '*' rabbitmq.delete_vhost '<vhost_name>'
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'delete_vhost', vhost],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'delete_vhost', vhost],
         runas=runas,
         python_shell=False)
     msg = 'Deleted'
@@ -408,10 +525,10 @@ def set_permissions(vhost, user, conf='.*', write='.*', read='.*', runas=None):
 
         salt '*' rabbitmq.set_permissions 'myvhost' 'myuser'
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'set_permissions', '-p',
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'set_permissions', '-p',
          vhost, user, conf, write, read],
         runas=runas,
         python_shell=False)
@@ -429,10 +546,10 @@ def list_permissions(vhost, runas=None):
 
         salt '*' rabbitmq.list_permissions '/myvhost'
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'list_permissions', '-p', vhost],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'list_permissions', '-p', vhost],
         runas=runas,
         python_shell=False)
 
@@ -449,10 +566,10 @@ def list_user_permissions(name, runas=None):
 
         salt '*' rabbitmq.list_user_permissions 'user'.
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'list_user_permissions', name],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'list_user_permissions', name],
         runas=runas,
         python_shell=False)
 
@@ -468,14 +585,14 @@ def set_user_tags(name, tags, runas=None):
 
         salt '*' rabbitmq.set_user_tags 'myadmin' 'administrator'
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
 
     if tags and isinstance(tags, (list, tuple)):
         tags = ' '.join(tags)
 
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'set_user_tags', name, tags],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'set_user_tags', name, tags],
         runas=runas,
         python_shell=False)
     msg = "Tag(s) set"
@@ -492,13 +609,14 @@ def status(runas=None):
 
         salt '*' rabbitmq.status
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'status'],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'status'],
         runas=runas,
         python_shell=False)
-    return res
+    _check_response(res)
+    return res['stdout']
 
 
 def cluster_status(runas=None):
@@ -511,14 +629,14 @@ def cluster_status(runas=None):
 
         salt '*' rabbitmq.cluster_status
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'cluster_status'],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'cluster_status'],
         runas=runas,
         python_shell=False)
-
-    return res
+    _check_response(res)
+    return res['stdout']
 
 
 def join_cluster(host, user='rabbit', ram_node=None, runas=None):
@@ -531,15 +649,15 @@ def join_cluster(host, user='rabbit', ram_node=None, runas=None):
 
         salt '*' rabbitmq.join_cluster 'rabbit.example.com' 'rabbit'
     '''
-    cmd = ['rabbitmqctl', 'join_cluster']
+    cmd = [__context__['rabbitmqctl'], 'join_cluster']
     if ram_node:
         cmd.append('--ram')
     cmd.append('{0}@{1}'.format(user, host))
 
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
     stop_app(runas)
-    res = __salt__['cmd.run'](cmd, runas=runas, python_shell=False)
+    res = __salt__['cmd.run_all'](cmd, runas=runas, python_shell=False)
     start_app(runas)
 
     return _format_response(res, 'Join')
@@ -555,12 +673,14 @@ def stop_app(runas=None):
 
         salt '*' rabbitmq.stop_app
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    return __salt__['cmd.run'](
-        ['rabbitmqctl', 'stop_app'],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'stop_app'],
         runas=runas,
         python_shell=False)
+    _check_response(res)
+    return res['stdout']
 
 
 def start_app(runas=None):
@@ -573,12 +693,14 @@ def start_app(runas=None):
 
         salt '*' rabbitmq.start_app
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    return __salt__['cmd.run'](
-        ['rabbitmqctl', 'start_app'],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'start_app'],
         runas=runas,
         python_shell=False)
+    _check_response(res)
+    return res['stdout']
 
 
 def reset(runas=None):
@@ -591,12 +713,14 @@ def reset(runas=None):
 
         salt '*' rabbitmq.reset
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    return __salt__['cmd.run'](
-        ['rabbitmqctl', 'reset'],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'reset'],
         runas=runas,
         python_shell=False)
+    _check_response(res)
+    return res['stdout']
 
 
 def force_reset(runas=None):
@@ -609,12 +733,14 @@ def force_reset(runas=None):
 
         salt '*' rabbitmq.force_reset
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    return __salt__['cmd.run'](
-        ['rabbitmqctl', 'force_reset'],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'force_reset'],
         runas=runas,
         python_shell=False)
+    _check_response(res)
+    return res['stdout']
 
 
 def list_queues(runas=None, *args):
@@ -627,11 +753,13 @@ def list_queues(runas=None, *args):
 
         salt '*' rabbitmq.list_queues messages consumers
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    cmd = ['rabbitmqctl', 'list_queues']
+    cmd = [__context__['rabbitmqctl'], 'list_queues']
     cmd.extend(args)
-    return __salt__['cmd.run'](cmd, runas=runas, python_shell=False)
+    res = __salt__['cmd.run_all'](cmd, runas=runas, python_shell=False)
+    _check_response(res)
+    return res['stdout']
 
 
 def list_queues_vhost(vhost, runas=None, *args):
@@ -647,11 +775,13 @@ def list_queues_vhost(vhost, runas=None, *args):
 
         salt '*' rabbitmq.list_queues messages consumers
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    cmd = ['rabbitmqctl', 'list_queues', '-p', vhost]
+    cmd = [__context__['rabbitmqctl'], 'list_queues', '-p', vhost]
     cmd.extend(args)
-    return __salt__['cmd.run'](cmd, runas=runas, python_shell=False)
+    res = __salt__['cmd.run_all'](cmd, runas=runas, python_shell=False)
+    _check_response(res)
+    return res['stdout']
 
 
 def list_policies(vhost="/", runas=None):
@@ -668,12 +798,14 @@ def list_policies(vhost="/", runas=None):
         salt '*' rabbitmq.list_policies'
     '''
     ret = {}
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    output = __salt__['cmd.run'](
-        ['rabbitmqctl', 'list_policies', '-p', vhost],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'list_policies', '-p', vhost],
         runas=runas,
         python_shell=False)
+    _check_response(res)
+    output = res['stdout']
     for line in salt.utils.itertools.split(output, '\n'):
         if '...' not in line:
             parts = line.split('\t')
@@ -709,7 +841,7 @@ def set_policy(vhost, name, pattern, definition, priority=None, runas=None):
 
         salt '*' rabbitmq.set_policy / HA '.*' '{"ha-mode":"all"}'
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
     if isinstance(definition, dict):
         definition = json.dumps(definition)
@@ -717,12 +849,12 @@ def set_policy(vhost, name, pattern, definition, priority=None, runas=None):
         raise SaltInvocationError(
             'The \'definition\' argument must be a dictionary or JSON string'
         )
-    cmd = ['rabbitmqctl', 'set_policy', '-p', vhost]
+    cmd = [__context__['rabbitmqctl'], 'set_policy', '-p', vhost]
     if priority:
         cmd.extend(['--priority', priority])
     cmd.extend([name, pattern, definition])
-    res = __salt__['cmd.run'](cmd, runas=runas, python_shell=False)
-    log.debug('Set policy: {0}'.format(res))
+    res = __salt__['cmd.run_all'](cmd, runas=runas, python_shell=False)
+    log.debug('Set policy: {0}'.format(res['stdout']))
     return _format_response(res, 'Set')
 
 
@@ -738,13 +870,13 @@ def delete_policy(vhost, name, runas=None):
 
         salt '*' rabbitmq.delete_policy / HA'
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'clear_policy', '-p', vhost, name],
+    res = __salt__['cmd.run_all'](
+        [__context__['rabbitmqctl'], 'clear_policy', '-p', vhost, name],
         runas=runas,
         python_shell=False)
-    log.debug('Delete policy: {0}'.format(res))
+    log.debug('Delete policy: {0}'.format(res['stdout']))
     return _format_response(res, 'Deleted')
 
 
@@ -760,7 +892,7 @@ def policy_exists(vhost, name, runas=None):
 
         salt '*' rabbitmq.policy_exists / HA
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
     policies = list_policies(runas=runas)
     return bool(vhost in policies and name in policies[vhost])
@@ -776,14 +908,11 @@ def plugin_is_enabled(name, runas=None):
 
         salt '*' rabbitmq.plugin_is_enabled foo
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
     cmd = [_get_rabbitmq_plugin(), 'list', '-m', '-e']
     ret = __salt__['cmd.run_all'](cmd, python_shell=False, runas=runas)
-    if ret['retcode'] != 0:
-        raise CommandExecutionError(
-            'RabbitMQ command failed: {0}'.format(ret['stderr'])
-        )
+    _check_response(ret)
     return bool(name in ret['stdout'])
 
 
@@ -797,7 +926,7 @@ def enable_plugin(name, runas=None):
 
         salt '*' rabbitmq.enable_plugin foo
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
     cmd = [_get_rabbitmq_plugin(), 'enable', name]
     ret = __salt__['cmd.run_all'](cmd, runas=runas, python_shell=False)
@@ -814,7 +943,7 @@ def disable_plugin(name, runas=None):
 
         salt '*' rabbitmq.disable_plugin foo
     '''
-    if runas is None:
+    if runas is None and not salt.utils.is_windows():
         runas = salt.utils.get_user()
     cmd = [_get_rabbitmq_plugin(), 'disable', name]
     ret = __salt__['cmd.run_all'](cmd, runas=runas, python_shell=False)


### PR DESCRIPTION
### What does this PR do?

The following changes are necessary for the port:
- On Windows, `rabbitmqctl.bat` and `rabbitmq-plugins.bat` are not found
  in a system path. Created an algorithm to find the correct path to these
  files which is run in `__virtual__()` and the result is saved in
  `__context__`.
- Windows `runas` currently requires a password. Due to this, don't use a
  default value if `runas` is initially set to `None` in Windows.
- Switched from `cmd.run` to `cmd.run_all` because many errors don't
  contain the word 'Error' in the output. So we check both the return value
  and if `stderr` is not empty (on Windows the return value is 0 even on
  some errors because it is calling a batch file `rabbitmqctl.bat` which
  doesn't properly propogate error codes).
- Created a `_check_response()` function to facilitate this type of error
  checking in functions that don't call `_output_to_dict()` or
  `_format_response()` (these two functions have also been updated for this
  type of error checking).
- On Windows, `cmd.run` and `cmd.run_all` in non-shell mode do not
  properly propogate a password that contains a special character such as
  '|' to `rabbitmqctl.bat`. Work around this by using shell mode and
  quoting. More details in the code comments.
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com