### PR TITLE
fix thin argument for `lvm.lvcreate'

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -280,7 +280,7 @@ def lvcreate(lvname, vgname, size=None, extents=None, snapshot=None, pv=None, **
              'monitor', 'ignoremonitoring', 'permission', 'poolmetadatasize',
              'readahead', 'regionsize', 'thin', 'thinpool', 'type', 'virtualsize',
              'zero',)
-    no_parameter = ('noudevsync', 'ignoremonitoring', )
+    no_parameter = ('noudevsync', 'ignoremonitoring', 'thin', )
 
     extra_arguments = []
     if kwargs:


### PR DESCRIPTION
### What does this PR do?

This adds `thin` to the list of parameters without arguments when calling `lvcreate`.
### What issues does this PR fix or reference?
#36604
### Tests written?

No
