### PR TITLE
tests.integration.__init__: except psutil error

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -164,7 +164,11 @@ except ImportError:
                         if not kill and child.status() == psutil.STATUS_ZOMBIE:
                             # Zombie processes will exit once child processes also exit
                             continue
-                        cmdline = child.cmdline()
+                        try:
+                            cmdline = child.cmdline()
+                        except psutil.AccessDenied as err:
+                            log.debug('Cannot obtain child process cmdline: %s', err)
+                            cmdline = ''
                         if not cmdline:
                             cmdline = child.as_dict()
                         if kill:


### PR DESCRIPTION
### What does this PR do?

Except a `psutil.AccessDenied` error that is occasionally hanging the test suite on MacOS.

``` py
AccessDenied: psutil.AccessDenied (pid=1373)
Traceback (most recent call last):
  File "/testing/tests/runtests.py", line 624, in <module>
    main()
  File "/testing/tests/runtests.py", line 609, in main
    status = parser.run_integration_tests()
  File "/testing/tests/runtests.py", line 549, in run_integration_tests
    status.append(self.run_integration_suite(**TEST_SUITES[suite]))
  File "/testing/tests/integration/__init__.py", line 1286, in __exit__
    self.minion_process.terminate()
  File "/testing/tests/integration/__init__.py", line 565, in terminate
    terminate_process_pid(self._process.pid)
  File "/testing/tests/integration/__init__.py", line 184, in terminate_process_pid
    kill_children(children)
  File "/testing/tests/integration/__init__.py", line 167, in kill_children
    cmdline = child.cmdline()
  File "/opt/salt/lib/python2.7/site-packages/psutil/__init__.py", line 622, in cmdline
    return self._proc.cmdline()
  File "/opt/salt/lib/python2.7/site-packages/psutil/_psosx.py", line 252, in wrapper
    raise AccessDenied(self.pid, self._name)
psutil.AccessDenied: psutil.AccessDenied (pid=1373)
```
### What issues does this PR fix or reference?

Similar to:
-  #36431
- saltstack/qa#244
### Tests written?

No
