### PR TITLE
Fix traceback when checking command whitelist/blacklist

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -222,7 +222,8 @@ def _check_avail(cmd):
     Check to see if the given command can be run
     '''
     if isinstance(cmd, list):
-        cmd = ' '.join(cmd)
+        cmd = ' '.join([str(x) if not isinstance(x, six.string_types) else x
+                        for x in cmd])
     bret = True
     wret = False
     if __salt__['config.get']('cmd_blacklist_glob'):


### PR DESCRIPTION
When pub kwargs are passed to a cmd.run\* function, we invoke
`_check_avail()` to examine the command to see if it matches the
whitelist/blacklist expression(s). To perform the fnmatch, we join the
list of arguments into a string. When one of the arguments is, for
instance an int, this causes a traceback.

This fixes that traceback by forcing non-string arguments to be strings
in the call to `str.join()`, converting non-string arguments to
strings. This selective conversion to a str preserves elements of the
list that may contain unicode characters from being converted to the
`str` type in Python 2.