### PR TITLE
Fix test not to rely on external resources

### DIFF
--- a/tests/integration/files/file/base/issue-2068-template-str-no-dot.sls
+++ b/tests/integration/files/file/base/issue-2068-template-str-no-dot.sls
@@ -1,14 +1,9 @@
-{{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-2068-template-str') }}:
-  virtualenv:
-    - managed
-    - system_site_packages: False
-    - distribute: True
+required_state:
+  test:
+    - succeed_without_changes
 
-pep8-pip:
-  pip:
-    - installed
-    - name: pep8
-    - bin_env: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-2068-template-str') }}
-    - mirrors: http://testpypi.python.org/pypi
+requiring_state:
+  test:
+    - succeed_without_changes
     - require:
-      - virtualenv: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-2068-template-str') }}
+      - test: required_state

--- a/tests/integration/files/file/base/issue-2068-template-str.sls
+++ b/tests/integration/files/file/base/issue-2068-template-str.sls
@@ -1,12 +1,6 @@
-{{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-2068-template-str') }}:
-  virtualenv.managed:
-    - system_site_packages: False
-    - distribute: True
+required_state: test.succeed_without_changes
 
-pep8-pip:
-  pip.installed:
-    - name: pep8
-    - bin_env: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-2068-template-str') }}
-    - mirrors: http://testpypi.python.org/pypi
+requiring_state:
+  test.succeed_without_changes:
     - require:
-      - virtualenv: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('issue-2068-template-str') }}
+      - test: required_state

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -326,38 +326,22 @@ class StateModuleTest(integration.ModuleCase,
 
         with salt.utils.fopen(template_path, 'r') as fp_:
             template = fp_.read()
-        try:
             ret = self.run_function(
                 'state.template_str', [template], timeout=120
             )
             self.assertSaltTrueReturn(ret)
 
-            self.assertTrue(
-                os.path.isfile(os.path.join(venv_dir, 'bin', 'pep8'))
-            )
-        finally:
-            if os.path.isdir(venv_dir):
-                shutil.rmtree(venv_dir)
-
         # Now using state.template
-        try:
-            ret = self.run_function(
-                'state.template', [template_path], timeout=120
-            )
-            self.assertSaltTrueReturn(ret)
-        finally:
-            if os.path.isdir(venv_dir):
-                shutil.rmtree(venv_dir)
+        ret = self.run_function(
+            'state.template', [template_path], timeout=120
+        )
+        self.assertSaltTrueReturn(ret)
 
         # Now the problematic #2068 including dot's
-        try:
-            ret = self.run_function(
-                'state.sls', mods='issue-2068-template-str', timeout=120
-            )
-            self.assertSaltTrueReturn(ret)
-        finally:
-            if os.path.isdir(venv_dir):
-                shutil.rmtree(venv_dir)
+        ret = self.run_function(
+            'state.sls', mods='issue-2068-template-str', timeout=120
+        )
+        self.assertSaltTrueReturn(ret)
 
         # Let's load the template from the filesystem. If running this state
         # with state.sls works, so should using state.template_str
@@ -368,28 +352,16 @@ class StateModuleTest(integration.ModuleCase,
 
         with salt.utils.fopen(template_path, 'r') as fp_:
             template = fp_.read()
-        try:
-            ret = self.run_function(
-                'state.template_str', [template], timeout=120
-            )
-            self.assertSaltTrueReturn(ret)
-
-            self.assertTrue(
-                os.path.isfile(os.path.join(venv_dir, 'bin', 'pep8'))
-            )
-        finally:
-            if os.path.isdir(venv_dir):
-                shutil.rmtree(venv_dir)
+        ret = self.run_function(
+            'state.template_str', [template], timeout=120
+        )
+        self.assertSaltTrueReturn(ret)
 
         # Now using state.template
-        try:
-            ret = self.run_function(
-                'state.template', [template_path], timeout=120
-            )
-            self.assertSaltTrueReturn(ret)
-        finally:
-            if os.path.isdir(venv_dir):
-                shutil.rmtree(venv_dir)
+        ret = self.run_function(
+            'state.template', [template_path], timeout=120
+        )
+        self.assertSaltTrueReturn(ret)
 
     def test_template_invalid_items(self):
         TEMPLATE = textwrap.dedent('''\


### PR DESCRIPTION
We can still model the original issue without needing to call all the way out to pypi to do it.