### PR TITLE
Remove possible race between grains dumps in test

### DIFF
--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -417,8 +417,6 @@ class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
             stat3 = os.stat(output_file)
             # Mode must have changed since we're creating a new log file
             self.assertNotEqual(stat1.st_mode, stat3.st_mode)
-            # Data was appended to file
-            self.assertEqual(stat1.st_size, stat3.st_size)
         finally:
             if os.path.exists(output_file):
                 os.unlink(output_file)


### PR DESCRIPTION
It's not always reasonable assume that grains will be the same byte-for-byte between invocations. Remove that assumption since it isn't related to the what's under test here anyhow.