### PR TITLE
Allow ZFS pool names to contain legal upper-case letters

### DIFF
--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -61,7 +61,7 @@ def __virtual__():
     else:
         return (
             False,
-            '{0} state module can only be loaded on illumos, Solaris, SmartOS, FreeBSD, ...'.format(
+            '{0} state module can only be loaded on illumos, Solaris, SmartOS, FreeBSD, Linux, ...'.format(
                 __virtualname__
             )
         )

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -155,7 +155,7 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
 
             zpool create mypool mirror /tmp/vdisk0 /tmp/vdisk1 /tmp/vdisk2
 
-        Creating a 3-way mirror! Why you probably expect it to be mirror root vdev with 2 devices + a root vdev of 1 device!
+        Creating a 3-way mirror! While you probably expect it to be mirror root vdev with 2 devices + a root vdev of 1 device!
 
     '''
     ret = {'name': name,

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -158,7 +158,6 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
         Creating a 3-way mirror! Why you probably expect it to be mirror root vdev with 2 devices + a root vdev of 1 device!
 
     '''
-    name = name.lower()
     ret = {'name': name,
            'changes': {},
            'result': None,
@@ -300,7 +299,6 @@ def absent(name, export=False, force=False):
         force destroy or export
 
     '''
-    name = name.lower()
     ret = {'name': name,
            'changes': {},
            'result': None,

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -30,6 +30,23 @@ Management zpool
               /dev/disk2
               /dev/disk3
 
+    partitionpool:
+      zpool.present:
+        - config:
+            import: false
+            force: true
+        - properties:
+            comment: disk partition salty storage pool
+            ashift: '12'
+            feature@lz4_compress: enabled
+        - filesystem_properties:
+            compression: lz4
+            atime: on
+            relatime: on
+        - layout:
+            disk-0:
+              /dev/disk/by-uuid/3e43ce94-77af-4f52-a91b-6cdbb0b0f41b
+
     simplepool:
       zpool.present:
         - config:

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -73,7 +73,7 @@ def __virtual__():
     else:
         return (
             False,
-            '{0} state module can only be loaded on illumos, Solaris, SmartOS, FreeBSD, ...'.format(
+            '{0} state module can only be loaded on illumos, Solaris, SmartOS, FreeBSD, Linux, ...'.format(
                 __virtualname__
             )
         )

--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -44,8 +44,7 @@ Management zpool
             atime: on
             relatime: on
         - layout:
-            disk-0:
-              /dev/disk/by-uuid/3e43ce94-77af-4f52-a91b-6cdbb0b0f41b
+            - /dev/disk/by-uuid/3e43ce94-77af-4f52-a91b-6cdbb0b0f41b
 
     simplepool:
       zpool.present:
@@ -181,7 +180,7 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
     # parse layout
     if layout:
         for root_dev in layout:
-            if '-' not in root_dev:
+            if root_dev.count('-') != 1:
                 continue
             layout[root_dev] = layout[root_dev].keys() if isinstance(layout[root_dev], OrderedDict) else layout[root_dev].split(' ')
 
@@ -258,7 +257,7 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
                     params = []
                     params.append(name)
                     for root_dev in layout:
-                        if '-' in root_dev:  # special device
+                        if root_dev.count('-') == 1:  # special device
                             # NOTE: accomidate non existing 'disk' vdev
                             if root_dev.split('-')[0] != 'disk':
                                 params.append(root_dev.split('-')[0])  # add the type by stripping the ID


### PR DESCRIPTION
### What does this PR do?

See commit-by-commit explanation below.
### What issues does this PR fix or reference?

N/A
### Tests written?

No
### Commit-by-commit explanation

@sjorge Thanks for your work, I use ZFS on multiple minions and appreciate being able to use SaltStack to manage them all.
#### 43e28d3

I'm using Linux minions so when I first encountered these error messages, I thought Linux wasn't supported.  I had to recheck the docs to make sure.
#### bea1bf9

It took me quite a lot of trial and error before I was able to find the correct values to use.  I hope that these examples will make it easier for future users to work out what values they need to use.
1. `ashift: '12'` is a very common setting and this is made trickier by having to quote the number
2. `filesystem_properties` aren't in the two examples already provided
3. `layout` took a while to figure out for a single partition-based pool, which people may use on laptops, etc.

I was thinking about simply merging these with the prior example for `newpool` but I thought that there was merit in showing a different `layout` at the same time.
#### 317a02f

Examples of ZFS naming requirements:
1. http://docs.oracle.com/cd/E19253-01/819-5461/6n7ht6qtq/
2. https://wiki.openindiana.org/oi/ZFS+naming+conventions

The second reference actually gives examples of valid pool names containing upper-case letters:

> A valid names of a zpool and a ZFS dataset are listed below:
> 
> rpool
> ROOT
> R_:0/level4-4