### PR TITLE
fix bug for including loopback addr

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -581,7 +581,7 @@ class CkMinions(object):
                 # Add in possible ip addresses of a locally connected minion
                 addrs.discard('127.0.0.1')
                 addrs.discard('0.0.0.0')
-                addrs.update(set(salt.utils.network.ip_addrs()))
+                addrs.update(set(salt.utils.network.ip_addrs(include_loopback=include_localhost)))
             if subset:
                 search = subset
             else:


### PR DESCRIPTION
### What does this PR do?

fix a bug of includeing loopback addr.
### What issues does this PR fix or reference?
#36669

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

addrs.discard('127.0.0.1') already remove 127.0.0.1 out of addrs, and salt.utils.network.ip_addrs will ignore 127.0.0.1 by default, so the code of line 589 `if ipv4 in addrs` will not works forever, because 127.0.0.1 will never be in addrs.