### PR TITLE
Fix #36671: check for new output format from systemctl status

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -521,6 +521,8 @@ def available(name):
         salt '*' service.available sshd
     '''
     out = _systemctl_status(name).lower()
+    if 'could not be found.' in out:
+        return False
     for line in salt.utils.itertools.split(out, '\n'):
         match = re.match(r'\s+loaded:\s+(\S+)', line)
         if match:


### PR DESCRIPTION
### What does this PR do?

Adds compatibility for the latest version of systemd (`systemctl status` output changed).
### What issues does this PR fix or reference?
#36671
### Previous Behavior

```
# salt-call service.available bogus.service
[INFO    ] Executing command ['systemctl', 'status', 'bogus.service', '-n', '0'] in directory '/root'
Error running 'service.available': Failed to get information on unit 'bogus.service'
```
### New Behavior

```
Missing service:

# salt-call service.available bogus.service
[INFO    ] Determining pillar cache
[INFO    ] Executing command ['systemctl', 'status', 'bogus.service', '-n', '0'] in directory '/root'
local:
    False

Available service:

# salt-call service.available sshd.service
[INFO    ] Determining pillar cache
[INFO    ] Executing command ['systemctl', 'status', 'sshd.service', '-n', '0'] in directory '/root'
local:
    True
```
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
