### PR TITLE
`alternatives.install` state: detect `alternatives` command failed

### DIFF
--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -10,6 +10,10 @@ from __future__ import absolute_import
 import os
 import logging
 
+# Import Salt libs
+import salt.utils
+
+
 __outputter__ = {
     'display': 'txt',
     'install': 'txt',
@@ -57,6 +61,39 @@ def display(name):
     if out['retcode'] > 0 and out['stderr'] != '':
         return out['stderr']
     return out['stdout']
+
+
+def show_link(name):
+    '''
+    Display master link for the alternative
+
+    .. versionadded:: 2015.8.13,2016.3.4,Carbon
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' alternatives.show_link editor
+    '''
+
+    path = '/var/lib/dpkg/alternatives/{0}'.format(name)
+    if _get_cmd() == 'alternatives':
+        path = '/var/lib/alternatives/{0}'.format(name)
+
+    try:
+        with salt.utils.fopen(path, 'rb') as r_file:
+            return r_file.readlines()[1]
+    except OSError:
+        log.error(
+            'alternatives: {0} does not exist'.format(name)
+        )
+    except (IOError, IndexError) as exc:
+        log.error(
+            'alternatives: unable to get master link for {0}. '
+            'Exception: {1}'.format(name, exc)
+        )
+
+    return False
 
 
 def show_current(name):

--- a/tests/unit/modules/alternatives_test.py
+++ b/tests/unit/modules/alternatives_test.py
@@ -37,7 +37,7 @@ class AlternativesTestCase(TestCase):
                     python_shell=False
                 )
 
-        with patch.dict(alternatives.__grains__, {'os_family': 'Ubuntu'}):
+        with patch.dict(alternatives.__grains__, {'os_family': 'Suse'}):
             mock = MagicMock(
                 return_value={'retcode': 0, 'stdout': 'undoubtedly-salt'}
             )


### PR DESCRIPTION
### What does this PR do?

It enables Salt to correctly detect `alternatives.install` state failure (RedHat specific issue).
### What issues does this PR fix or reference?

The issue is following. There is a significant difference in how `alternatives --install` command (RedHat) and `update-alternatives --install` command (Debian, Suse) working:
- `update-alternatives --install` allows to change alternative master link, but
- `alternatives --install` doesn't have such ability and will exit with error code. Unfortunately, Salt is unable to detect that.

See the example below.
### Previous Behavior

Here is the state:

``` yaml
install-zookeeper-dist:
  alternatives.install:
    - name: zookeeper-home-link
    - link: /usr/lib/zookeeper
    - path: /usr/lib/zookeeper-3.4.9
    - priority: 30
```

Previously, master link for `zookeeper-home-link` was set to `/usr/local/zookeeper`.

And that's how Salt processes it:

```
[DEBUG   ] LazyLoaded alternatives.install
[INFO    ] Running state [zookeeper-home-link] at time 08:39:32.878733
[INFO    ] Executing state alternatives.install for zookeeper-home-link
[DEBUG   ] LazyLoaded alternatives.check_installed
[INFO    ] Executing command ['alternatives', '--install', '/usr/lib/zookeeper', 'zookeeper-home-link', '/usr/lib/zookeeper-3.4.9', '30'] in directory '/root'
[ERROR   ] Command '['alternatives', '--install', '/usr/lib/zookeeper', 'zookeeper-home-link', '/usr/lib/zookeeper-3.4.9', '30']' failed with return code: 2
[ERROR   ] stderr: the primary link for zookeeper-home-link must be /usr/local/zookeeper
[ERROR   ] retcode: 2
[INFO    ] {'priority': 30, 'path': '/usr/lib/zookeeper-3.4.9', 'link': '/usr/lib/zookeeper', 'name': 'zookeeper-home-link'}
[INFO    ] Completed state [zookeeper-home-link] at time 08:39:32.948467 duration_in_ms=69.734
```

``` yaml
----------
          ID: install-zookeeper-dist
    Function: alternatives.install
        Name: zookeeper-home-link
      Result: True
     Comment: Setting alternative for zookeeper-home-link to /usr/lib/zookeeper-3.4.9 with priority 30
     Started: 08:39:32.878733
    Duration: 69.734 ms
     Changes:   
              ----------
              link:
                  /usr/lib/zookeeper
              name:
                  zookeeper-home-link
              path:
                  /usr/lib/zookeeper-3.4.9
              priority:
                  30
```

Salt mistakenly thinks that the alternative was installed successfully, but the log clearly says it is not.
### New Behavior

Salt is able to detect that command was failed:

``` yaml
----------
          ID: install-zookeeper-dist
    Function: alternatives.install
        Name: zookeeper-home-link
      Result: False
     Comment: Alternative for zookeeper-home-link not installed: the primary link for zookeeper-home-link must be /usr/local/zookeeper
     Started: 13:44:29.279222
    Duration: 71.012 ms
     Changes:   
```

Need to say, that `alternatives` command also doesn't provide the option to get master link path for already installed alternative.
To be able to get a master link by directly reading alternatives database, the `alternatives.show_link` exec module function has been implemented. `alternatives.install` state relies on it to verify that alternative master link and path were actually updated.
### Tests written?

Yes. Added negative test case for `alternatives.install` state function.