### PR TITLE
Feature :: provide state.show_state_usage call

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1195,6 +1195,40 @@ def show_lowstate(queue=False, **kwargs):
     return ret
 
 
+def show_state_usage(queue=False, **kwargs):
+    '''
+    Retrieve the highstate data from the salt master, analyse used states and unused states
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' state.show_state_usage
+    '''
+    conflict = _check_queue(queue, kwargs)
+    if conflict is not None:
+        return conflict
+    pillar = kwargs.get('pillar')
+    pillar_enc = kwargs.get('pillar_enc')
+    if pillar_enc is None \
+            and pillar is not None \
+            and not isinstance(pillar, dict):
+        raise SaltInvocationError(
+            'Pillar data must be formatted as a dictionary, unless pillar_enc '
+            'is specified.'
+        )
+
+    st_ = salt.state.HighState(__opts__, pillar, pillar_enc=pillar_enc)
+    st_.push_active()
+
+    try:
+        ret = st_.compile_state_usage()
+    finally:
+        st_.pop_active()
+    _set_retcode(ret)
+    return ret
+
+
 def sls_id(
         id_,
         mods,

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1197,7 +1197,9 @@ def show_lowstate(queue=False, **kwargs):
 
 def show_state_usage(queue=False, **kwargs):
     '''
-    Retrieve the highstate data from the salt master, analyse used states and unused states
+    Retrieve the highstate data from the salt master to analyse used and unused states
+
+    Custom Pillar data can be passed with the ``pillar`` kwarg.
 
     CLI Example:
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -3550,7 +3550,7 @@ class BaseHighState(object):
                     env_usage['count_unused'] += 1
                     env_usage['unused'].append(state)
 
-            state_usage[saltenv]= env_usage
+            state_usage[saltenv] = env_usage
 
         return state_usage
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -3516,6 +3516,44 @@ class BaseHighState(object):
 
         return chunks
 
+    def compile_state_usage(self):
+        '''
+        Return all used and unused states for the minion based on the top match data
+        '''
+        err = []
+        top = self.get_top()
+        err += self.verify_tops(top)
+
+        if err:
+            return err
+
+        matches = self.top_matches(top)
+        state_usage = {}
+
+        for saltenv, states in self.avail.items():
+            env_usage = {
+                'used': [],
+                'unused': [],
+                'count_all': 0,
+                'count_used': 0,
+                'count_unused': 0
+            }
+
+            env_matches = matches.get(saltenv)
+
+            for state in states:
+                env_usage['count_all'] += 1
+                if state in env_matches:
+                    env_usage['count_used'] += 1
+                    env_usage['used'].append(state)
+                else:
+                    env_usage['count_unused'] += 1
+                    env_usage['unused'].append(state)
+
+            state_usage[saltenv]= env_usage
+
+        return state_usage
+
 
 class HighState(BaseHighState):
     '''

--- a/tests/unit/modules/state_test.py
+++ b/tests/unit/modules/state_test.py
@@ -191,6 +191,13 @@ class MockState(object):
             return "A"
 
         @staticmethod
+        def compile_state_usage():
+            '''
+                Mock compile_state_usage method
+            '''
+            return "A"
+
+        @staticmethod
         def pop_active():
             '''
                 Mock pop_active method
@@ -566,6 +573,21 @@ class StateTestCase(TestCase):
             self.assertRaises(AssertionError, state.show_lowstate)
 
             self.assertTrue(state.show_lowstate())
+
+    def test_show_state_usage(self):
+        '''
+            Test to list out the state usage that will be applied to this minion
+        '''
+
+        mock = MagicMock(side_effect=["A", None, None])
+        with patch.object(state, '_check_queue', mock):
+            self.assertEqual(state.show_state_usage(), "A")
+
+            self.assertRaises(SaltInvocationError,
+                              state.show_state_usage,
+                              pillar="A")
+
+            self.assertEqual(state.show_state_usage(), "A")
 
     def test_sls_id(self):
         '''

--- a/tests/unit/state_test.py
+++ b/tests/unit/state_test.py
@@ -108,6 +108,34 @@ class HighStateTestCase(TestCase):
                                                    'state2,state3')
         self.assertEqual(matches, {'env': ['state2', 'state3']})
 
+    def test_show_state_usage(self):
+        # monkey patch sub methods
+        self.highstate.avail = {
+            'base': ['state.a', 'state.b','state.c']
+        }
+
+        def verify_tops(*args, **kwargs):
+            return []
+
+        def get_top(*args, **kwargs):
+            return None
+
+        def top_matches(*args, **kwargs):
+            return {'base': ['state.a', 'state.b']}
+
+        self.highstate.verify_tops = verify_tops
+        self.highstate.get_top = get_top
+        self.highstate.top_matches = top_matches
+
+        # get compile_state_usage() result
+        state_usage_dict = self.highstate.compile_state_usage()
+
+        self.assertEqual(state_usage_dict['base']['count_unused'], 1)
+        self.assertEqual(state_usage_dict['base']['count_used'], 2)
+        self.assertEqual(state_usage_dict['base']['count_all'], 3)
+        self.assertEqual(state_usage_dict['base']['used'], ['state.a', 'state.b'])
+        self.assertEqual(state_usage_dict['base']['unused'], ['state.c'])
+
 
 class TopFileMergeTestCase(TestCase):
     '''

--- a/tests/unit/state_test.py
+++ b/tests/unit/state_test.py
@@ -111,7 +111,7 @@ class HighStateTestCase(TestCase):
     def test_show_state_usage(self):
         # monkey patch sub methods
         self.highstate.avail = {
-            'base': ['state.a', 'state.b','state.c']
+            'base': ['state.a', 'state.b', 'state.c']
         }
 
         def verify_tops(*args, **kwargs):


### PR DESCRIPTION
### What does this PR do?

Implement `state.show_state_usage` call
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/36688
### New Behavior

``` sh
salt -c etc/salt '*' state.show_state_usage                                                                  

minion-882m.local:
    ----------
    base:
        ----------
        count_all:
            10
        count_unused:
            2
        count_used:
            8
        unused:
            - state.app.1
            - state.app.5
        used:
            - state.app.2
            - state.app.3
            - state.app.4
            - state.app.6
            - state.app.7
            - state.app.8
            - state.app.9
            - state.app.10
```
### Tests written?

Yes