### PR TITLE
Exposes `ignore_if_missing` to file.replace state module

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2746,7 +2746,8 @@ def replace(name,
             prepend_if_not_found=False,
             not_found_content=None,
             backup='.bak',
-            show_changes=True):
+            show_changes=True,
+            ignore_if_missing=False):
     r'''
     Maintain an edit in a file.
 
@@ -2828,6 +2829,13 @@ def replace(name,
             diff. This may not normally be a concern, but could impact
             performance if used with large files.
 
+    ignore_if_missing : False
+        .. versionadded:: 2016.3.5
+
+        Controls what to do if the file is missing. If set to ``False``, the
+        state will display an error raised by the execution module. If set to
+        ``True``, the state will simply report no changes.
+
     For complex regex patterns, it can be useful to avoid the need for complex
     quoting and escape sequences by making use of YAML's multiline string
     syntax.
@@ -2871,7 +2879,8 @@ def replace(name,
                                        not_found_content=not_found_content,
                                        backup=backup,
                                        dry_run=__opts__['test'],
-                                       show_changes=show_changes)
+                                       show_changes=show_changes,
+                                       ignore_if_missing=ignore_if_missing)
 
     if changes:
         ret['pchanges']['diff'] = changes


### PR DESCRIPTION
### What does this PR do?

Exposes `ignore_if_missing` to file.replace state module
### What issues does this PR fix or reference?

Fixes #36692

No