### PR TITLE
pass __proxy__ in state.sls_id

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1122,7 +1122,10 @@ def sls_id(
     opts['test'] = _get_test_value(test, **kwargs)
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
-    st_ = salt.state.HighState(opts, proxy=__proxy__)
+    try:
+        st_ = salt.state.HighState(opts, proxy=__proxy__)
+    except NameError:
+        st_ = salt.state.HighState(opts)
     if isinstance(mods, six.string_types):
         split_mods = mods.split(',')
     st_.push_active()

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1122,7 +1122,7 @@ def sls_id(
     opts['test'] = _get_test_value(test, **kwargs)
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
-    st_ = salt.state.HighState(opts)
+    st_ = salt.state.HighState(opts, proxy=__proxy__)
     if isinstance(mods, six.string_types):
         split_mods = mods.split(',')
     st_.push_active()


### PR DESCRIPTION
### What does this PR do?

Allows state.sls_id to be called on proxy minions.
### What issues does this PR fix or reference?

Fixes saltstack/salt#32490 

Previously functions executed under `state.sls_id` would not have access to `__proxy__`.