### PR TITLE
Make the Salt Proxy environment aware

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2988,7 +2988,7 @@ class ProxyMinion(MinionManager):
         # we can then sync any proxymodules down from the master
         # we do a sync_all here in case proxy code was installed by
         # SPM or was manually placed in /srv/salt/_modules etc.
-        self.functions['saltutil.sync_all'](saltenv='base')
+        self.functions['saltutil.sync_all'](saltenv=self.opts['environment'])
 
         # Then load the proxy module
         self.proxy = salt.loader.proxy(self.opts)
@@ -3083,5 +3083,5 @@ class ProxyMinion(MinionManager):
             self.schedule.delete_job(master_event(type='failback'), persist=True)
 
         #  Sync the grains here so the proxy can communicate them to the master
-        self.functions['saltutil.sync_grains'](saltenv='base')
+        self.functions['saltutil.sync_grains'](saltenv=self.opts['environment'])
         self.grains_cache = self.opts['grains']


### PR DESCRIPTION
The Salt proxy minion is looking for proxy minion modules in
salt://_proxy/. It does so however only in the default "base"
environment. On setups which do not use "base" or shall be executed in a
different environment this breaks:

/etc/salt/master:
...
file_roots:
  noc:
    - /srv/salt
...

$ grep "proxyenabled" /srv/salt/_proxy/junos_manager.py
__proxyenabled__ = ['junos_manager']

$ salt-proxy --proxyid=dev1 -l debug
...
DEBUG   ] rest_sample proxy **virtual**() called...
[INFO    ] ssh_sample proxy **virtual**() called...
[DEBUG   ] Could not LazyLoad junos_manager.grains
[DEBUG   ] Could not LazyLoad junos_manager.init
[ERROR   ] Proxymodule junos_manager is missing an init() or a
shutdown() or both. Check your proxymodule.  Salt-proxy aborted.
[WARNING ] Stopping the Salt Proxy Minion
[ERROR   ] -1
[INFO    ] The proxy minion is shutting down..
[INFO    ] The Salt ProxyMinion is shut down

This is because the loader only looks for _proxy modules in the "base"
environment. This commit fixes this (but might possibly break other
things, though I did not find side-effects)