### PR TITLE
timezone: Don't assume /etc/timezone exists

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -127,8 +127,15 @@ def _get_zone_etc_localtime():
 
 
 def _get_zone_etc_timezone():
-    with salt.utils.fopen('/etc/timezone', 'r') as fp_:
-        return fp_.read().strip()
+    tzfile = '/etc/timezone'
+    try:
+        with salt.utils.fopen(tzfile, 'r') as fp_:
+            return fp_.read().strip()
+    except IOError as exc:
+        raise CommandExecutionError(
+            'Problem reading timezone file {0}: {1}'
+            .format(tzfile, exc.strerror)
+        )
 
 
 def get_zone():


### PR DESCRIPTION
### What does this PR do?

/etc/timezone might not exist on some Gentoo systems, especially if they are not fully configured.
https://wiki.gentoo.org/wiki/Handbook:AMD64/Full/Installation#Timezone
### What issues does this PR fix or reference?

If the file does not exist it hides the IOError and provides a nicer user-visible error.
### Previous Behavior

IOError: [Errno 2] No such file or directory: '/etc/timezone'
### New Behavior

ERROR: Problem reading timezone file /etc/timezone: No such file or directory
### Tests written?

No