### PR TITLE
Add basic sanity checks for env_vars in pip.install function

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -87,7 +87,7 @@ import salt.utils
 import tempfile
 import salt.utils.locales
 import salt.utils.url
-import salt.ext.six
+from salt.ext.six import string_types, iteritems
 from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
 
@@ -213,7 +213,7 @@ def _resolve_requirements_chain(requirements):
 
     chain = []
 
-    if isinstance(requirements, salt.ext.six.string_types):
+    if isinstance(requirements, string_types):
         requirements = [requirements]
 
     for req_file in requirements:
@@ -827,7 +827,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if env_vars:
         if isinstance(env_vars, dict):
-            for k, v in salt.ext.six.iteritems(env_vars):
+            for k, v in iteritems(env_vars):
                 if not isinstance(v, string_types):
                     env_vars[k] = str(v)
             os.environ.update(env_vars)

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -828,7 +828,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
     if env_vars:
         if isinstance(env_vars, dict):
             for k, v in env_vars.iteritems():
-                if not isinstance(v, basestring):
+                if not isinstance(v, string_types):
                     env_vars[k] = str(v)
             os.environ.update(env_vars)
         else:

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -87,7 +87,7 @@ import salt.utils
 import tempfile
 import salt.utils.locales
 import salt.utils.url
-from salt.ext.six import string_types
+from salt.ext.six import string_types, iteritems
 from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
 
@@ -827,7 +827,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if env_vars:
         if isinstance(env_vars, dict):
-            for k, v in env_vars.iteritems():
+            for k, v in iteritems(env_vars):
                 if not isinstance(v, string_types):
                     env_vars[k] = str(v)
             os.environ.update(env_vars)

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -87,7 +87,7 @@ import salt.utils
 import tempfile
 import salt.utils.locales
 import salt.utils.url
-from salt.ext.six import string_types, iteritems
+import salt.ext.six
 from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
 
@@ -213,7 +213,7 @@ def _resolve_requirements_chain(requirements):
 
     chain = []
 
-    if isinstance(requirements, string_types):
+    if isinstance(requirements, salt.ext.six.string_types):
         requirements = [requirements]
 
     for req_file in requirements:
@@ -827,7 +827,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if env_vars:
         if isinstance(env_vars, dict):
-            for k, v in iteritems(env_vars):
+            for k, v in salt.ext.six.iteritems(env_vars):
                 if not isinstance(v, string_types):
                     env_vars[k] = str(v)
             os.environ.update(env_vars)

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -827,6 +827,9 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if env_vars:
         if isinstance(env_vars, dict):
+            for k, v in env_vars.iteritems():
+                if not isinstance(v, basestring):
+                    env_vars[k] = str(v)
             os.environ.update(env_vars)
         else:
             raise CommandExecutionError(


### PR DESCRIPTION
### What does this PR do?

This PR introduces a basic sanity check for values to be passed on to os.environ.update and ensures that they are strings.
### What issues does this PR fix or reference?
#36644
### Previous Behavior

Remove this section if not relevant
### New Behavior

Values were passed on to above mentioned method without sanity checking and could therefore lead to unhandled exceptions.
### Tests written?

No
