### PR TITLE
s3.put can't create s3 bucket

### DIFF
--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -133,20 +133,13 @@ def query(key, keyid, method='GET', params=None, headers=None,
     response = None
     if method == 'PUT':
         if local_file:
-            with salt.utils.fopen(local_file, 'r') as data:
-                result = requests.request(method,
-                                          requesturl,
-                                          headers=headers,
-                                          data=data,
-                                          verify=verify_ssl,
-                                          stream=True)
-        else:
-            result = requests.request(method,
-                                      requesturl,
-                                      headers=headers,
-                                      data=data,
-                                      verify=verify_ssl,
-                                      stream=True)
+            data = salt.utils.fopen(local_file, 'r')
+        result = requests.request(method,
+                                  requesturl,
+                                  headers=headers,
+                                  data=data,
+                                  verify=verify_ssl,
+                                  stream=True)
         response = result.content
     elif method == 'GET' and local_file and not return_bin:
         result = requests.request(method,

--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -106,6 +106,9 @@ def query(key, keyid, method='GET', params=None, headers=None,
         if local_file:
             payload_hash = salt.utils.get_hash(local_file, form='sha256')
 
+    if path is None:
+        path = ''
+
     if not requesturl:
         requesturl = 'https://{0}/{1}'.format(endpoint, path)
         headers, requesturl = salt.utils.aws.sig4(


### PR DESCRIPTION
### What does this PR do?

It converts default 'path' variable (value None) into an empty string
Also little code style changes
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/36712
### Previous Behavior

s3.put can't create s3 bucket
### New Behavior

s3.put can create s3 bucket successfully
### Tests written?

No

Closes saltstack/salt#36712