### PR TITLE
fix python26 archive zip module

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -367,7 +367,7 @@ def zip_(zip_file, sources, template=None, cwd=None, runas=None):
     try:
         exc = None
         archived_files = []
-        with zipfile.ZipFile(zip_file, 'w', zipfile.ZIP_DEFLATED) as zfile:
+        with contextlib.closing(zipfile.ZipFile(zip_file, 'w', zipfile.ZIP_DEFLATED)) as zfile:
             for src in sources:
                 if cwd:
                     src = os.path.join(cwd, src)


### PR DESCRIPTION
### What does this PR do?

It fixes the error when attempting to run `archive.zip` on python26 VMs. 
### What issues does this PR fix or reference?

fixes saltstack/salt#36718
### Previous Behavior

```
[root@8de2f6775883 testing]# salt-call --local archive.zip /test.zip /tmp/test/touch1                                                                                       
Error running 'archive.zip': Exception encountered creating zipfile: ZipFile instance has no attribute '__exit__'
```
### New Behavior

```
[root@8d4e467cb005 testing]# salt-call --local archive.zip /test.zip /tmp/test/touch1 
local:
    - tmp/test/touch1
```
### Tests written?

This actually fixes a test that is currently failling: `integration.modules.archive.ArchiveTest.test_zip`