### PR TITLE
Fix race condition when returning events from commands

### DIFF
--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -353,6 +353,16 @@ class IPCClient(object):
         if self.stream is not None and not self.stream.closed():
             self.stream.close()
 
+        # Remove the entry from the instance map so
+        # that a closed entry may not be reused.
+        # This forces this operation even if the reference
+        # count of the entry has not yet gone to zero.
+        if self.io_loop in IPCClient.instance_map:
+            loop_instance_map = IPCClient.instance_map[self.io_loop]
+            key = str(self.socket_path)
+            if key in loop_instance_map:
+                del loop_instance_map[key]
+
 
 class IPCMessageClient(IPCClient):
     '''

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -365,6 +365,18 @@ class SaltEvent(object):
             self.cpub = True
         return self.cpub
 
+    def close_pub(self):
+        '''
+        Close the publish connection (if established)
+        '''
+        if not self.cpub:
+            return
+
+        self.subscriber.close()
+        self.subscriber = None
+        self.pending_events = []
+        self.cpub = False
+
     def connect_pull(self, timeout=1):
         '''
         Establish a connection with the event pull socket


### PR DESCRIPTION
### What does this PR do?

It has been observed that when running this command:

```
salt "*" test.ping
```

sometimes the command would return `Minion did not return. [No response]`
for some of the minions even though the minions did indeed respond
(reproduced running Windows salt-master on Python 3 using the TCP
transport).

After investigating this further, it seems that there is a race condition
where if the response via event happens before events are being listened
for, the response is lost. For instance, in
`salt.client.LocalClient.cmd_cli` which is what is invoked in the command
above, it won't start listening for events until `get_cli_event_returns`
which invokes `get_iter_returns` which invokes `get_returns_no_block`
which invokes `self.event.get_event` which will connect to the event bus
if it hasn't connected yet (which is the case the first time it hits
this code). But events may be fired anytime after `self.pub()` is
executed which occurs before this code.

We need to ensure that events are being listened for before it is
possible they return. We also want to avoid issue #31454 which is what
PR #36024 fixed but in turn caused this issue. This is the approach I
have taken to try to tackle this issue:

It doesn't seem possible to generically discern if events can be
returned by a given function that invokes `run_job` and contains an
event searching function such as `get_cli_event_returns`. So for all
such functions that could possibly need to search the event bus, we
do the following:
- Record if the event bus is currently being listened to.
- When invoking `run_job`, ensure that `listen=True` so that `self.pub()`
  will ensure that the event bus is listed to before sending the payload.
- When all possible event bus activities are concluded, if the event
  bus was not originally being listened to, stop listening to it. This is
  designed so that issue #31454 does not reappear. We do this via a
  try/finally block in all instances of such code.
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
