### PR TITLE
Skip cmd_unzip test if salt.utils.which('zip') isn't available

### DIFF
--- a/tests/integration/modules/archive.py
+++ b/tests/integration/modules/archive.py
@@ -189,6 +189,7 @@ class ArchiveTest(integration.ModuleCase):
 
         self._tear_down()
 
+    @skipIf(not salt.utils.which('zip'), 'Cannot find zip executable')
     @skipIf(not salt.utils.which('unzip'), 'Cannot find unzip executable')
     def test_cmd_unzip(self):
         '''


### PR DESCRIPTION
This test relies on running archive.cmd_zip in order to have something
to test running archive.cmd_unzip against. Some distros will have the
unzip binary available, but not the zip binary. We need to protect this
test against both so we don't have a false failure on trying to run
archive.cmd_zip.