### PR TITLE
Adding a get_fqdn method to the network module

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -941,8 +941,7 @@ def get_hostname():
         salt '*' network.get_hostname
     '''
 
-    from socket import gethostname
-    return gethostname()
+    return socket.gethostname()
 
 
 def get_fqdn():
@@ -956,8 +955,7 @@ def get_fqdn():
         salt '*' network.get_fqdn
     '''
 
-    from socket import getfqdn
-    return getfqdn()
+    return socket.getfqdn()
 
 
 def mod_hostname(hostname):

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -945,6 +945,21 @@ def get_hostname():
     return gethostname()
 
 
+def get_fqdn():
+    '''
+    Get fully qualified domain name
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' network.get_fqdn
+    '''
+
+    from socket import getfqdn
+    return getfqdn()
+
+
 def mod_hostname(hostname):
     '''
     Modify hostname


### PR DESCRIPTION
### What does this PR do?

Adds a `get_fqdn` to the network module - allowing quick and easy lookup of a host's fully qualified domain name.
### What issues does this PR fix or reference?

Did a quick search, didn't find any.
### Tests written?

No (it's super simple code though)