### PR TITLE
corrected OS Name in openbsd_sysctl module load error message

### DIFF
--- a/salt/modules/openbsd_sysctl.py
+++ b/salt/modules/openbsd_sysctl.py
@@ -20,7 +20,7 @@ def __virtual__():
     if __grains__['os'] == 'OpenBSD':
         return __virtualname__
     return (False, 'The openbsd_sysctl execution module cannot be loaded: '
-            'only available on FreeBSD systems.')
+            'only available on OpenBSD systems.')
 
 
 def show(config_file=False):


### PR DESCRIPTION
### What does this PR do?

It does print out the correct OS name when log level is set to debug for the openbsd_sysctl execution module.
### What issues does this PR fix or reference?

No issue opened for this.
### Previous Behavior

Debug log level entry before:

```
[DEBUG   ] Error loading module.openbsd_sysctl: The openbsd_sysctl execution module cannot be loaded: only available on FreeBSD systems.
```
### New Behavior

Debug log level entry after:

```
[DEBUG   ] Error loading module.openbsd_sysctl: The openbsd_sysctl execution module cannot be loaded: only available on OpenBSD systems.
```
### Tests written?

No
