### PR TITLE
Fix issue where test suite could hang on shutdown

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -704,7 +704,7 @@ class TestDaemon(object):
         self._exit_ssh()
         # Shutdown the multiprocessing logging queue listener
         salt_log_setup.shutdown_multiprocessing_logging()
-        salt_log_setup.shutdown_multiprocessing_logging_listener()
+        salt_log_setup.shutdown_multiprocessing_logging_listener(daemonizing=True)
 
     def pre_setup_minions(self):
         '''


### PR DESCRIPTION
This is most common in the develop branch but could occur here as well. If we don't call with this flag, we'll never get to the logic necessary to actually to the shutdown. The only way to kill it is to have a `KeyboardInterrupt` exception raised.

cc: @s0undt3ch