### PR TITLE
Add the CLI client and pub_data as class attributes

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -602,7 +602,7 @@ class LocalClient(object):
         :returns: A generator
         '''
         arg = salt.utils.args.condition_input(arg, kwarg)
-        pub_data = self.run_job(
+        self.pub_data = self.run_job(
             tgt,
             fun,
             arg,
@@ -611,13 +611,13 @@ class LocalClient(object):
             timeout,
             **kwargs)
 
-        if not pub_data:
-            yield pub_data
+        if not self.pub_data:
+            yield self.pub_data
         else:
             try:
                 for fn_ret in self.get_cli_event_returns(
-                        pub_data['jid'],
-                        pub_data['minions'],
+                        self.pub_data['jid'],
+                        self.pub_data['minions'],
                         self._get_timeout(timeout),
                         tgt,
                         expr_form,
@@ -630,12 +630,16 @@ class LocalClient(object):
 
                     yield fn_ret
             except KeyboardInterrupt:
-                msg = ('Exiting on Ctrl-C\nThis job\'s jid is:\n{0}\n'
-                       'The minions may not have all finished running and any '
-                       'remaining minions will return upon completion. To '
-                       'look up the return data for this job later run:\n'
-                       'salt-run jobs.lookup_jid {0}').format(pub_data['jid'])
-                raise SystemExit(msg)
+                raise SystemExit(
+                    '\n'
+                    'This job\'s jid is: {0}\n'
+                    'Exiting gracefully on Ctrl-c\n'
+                    'The minions may not have all finished running and any '
+                    'remaining minions will return upon completion. To look '
+                    'up the return data for this job later, run the following '
+                    'command:\n\n'
+                    'salt-run jobs.lookup_jid {0}'.format(self.pub_data['jid'])
+                )
 
     def cmd_iter(
             self,

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -46,9 +46,24 @@ def _handle_signals(client, signum, sigframe):
         hardcrash = client.options.hard_crash
     except (AttributeError, KeyError):
         hardcrash = False
+
+    exit_msg = '\nExiting gracefully on Ctrl-c'
+    try:
+        jid = client.local_client.pub_data['jid']
+        exit_msg += (
+            '\n'
+            'This job\'s jid is: {0}\n'
+            'The minions may not have all finished running and any remaining '
+            'minions will return upon completion. To look up the return data '
+            'for this job later, run the following command:\n\n'
+            'salt-run jobs.lookup_jid {0}'.format(jid)
+        )
+    except (AttributeError, KeyError):
+        pass
+
     _handle_interrupt(
-        SystemExit('\nExiting gracefully on Ctrl-c'),
-        Exception('\nExiting with hard crash Ctrl-c'),
+        SystemExit(exit_msg),
+        Exception('\nExiting with hard crash on Ctrl-c'),
         hardcrash, trace=trace)
 
 

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -47,19 +47,22 @@ def _handle_signals(client, signum, sigframe):
     except (AttributeError, KeyError):
         hardcrash = False
 
-    exit_msg = '\nExiting gracefully on Ctrl-c'
-    try:
-        jid = client.local_client.pub_data['jid']
-        exit_msg += (
-            '\n'
-            'This job\'s jid is: {0}\n'
-            'The minions may not have all finished running and any remaining '
-            'minions will return upon completion. To look up the return data '
-            'for this job later, run the following command:\n\n'
-            'salt-run jobs.lookup_jid {0}'.format(jid)
-        )
-    except (AttributeError, KeyError):
-        pass
+    if signum == signal.SIGINT:
+        exit_msg = '\nExiting gracefully on Ctrl-c'
+        try:
+            jid = client.local_client.pub_data['jid']
+            exit_msg += (
+                '\n'
+                'This job\'s jid is: {0}\n'
+                'The minions may not have all finished running and any remaining '
+                'minions will return upon completion. To look up the return data '
+                'for this job later, run the following command:\n\n'
+                'salt-run jobs.lookup_jid {0}'.format(jid)
+            )
+        except (AttributeError, KeyError):
+            pass
+    else:
+        exit_msg = None
 
     _handle_interrupt(
         SystemExit(exit_msg),


### PR DESCRIPTION
This is necessary to filter up the jid to salt.scripts in order to provide the JID in the `SystemExit` triggered by the handler added in 6569267.

Fixes #36746.

@cachedout, @thatch45 I'd appreciate some feedback on whether or not there may be a better way of handling this. Also, I'm not sure if the `KeyboardInterrupt` needs to be caught anymore in `salt/client/__init__.py` since the handler keeps us from getting to that code. At any rate, I decided to update the `SystemExit` message there to match the one in the handler.