### PR TITLE
Add lxml to deps for Windows (used by win_lgpo)

### DIFF
--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -13,6 +13,7 @@ ioloop==0.1a0
 ipaddress==1.0.16
 Jinja2==2.8
 libnacl==1.4.5
+lxml==3.6.0
 Mako==1.0.4
 MarkupSafe==0.23
 msgpack-python==0.4.8


### PR DESCRIPTION
### What does this PR do?

Adds 'lxml' (BSD license) to the dependencies to be packaged with Windows
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/21485#issuecomment-250475907
### Tests written?

NA
