### PR TITLE
Allow function privileges to be set

### DIFF
--- a/salt/states/postgres_privileges.py
+++ b/salt/states/postgres_privileges.py
@@ -106,6 +106,7 @@ def present(name,
        - language
        - database
        - group
+       - function
 
     privileges
        List of privileges to grant, from the list below:
@@ -226,6 +227,7 @@ def absent(name,
        - language
        - database
        - group
+       - function
 
     privileges
        Comma separated list of privileges to revoke, from the list below:


### PR DESCRIPTION
### What does this PR do?

This is a first cut at fixing #36557

Setting function permissions is difficult because PG allows functions to be overloaded:
https://www.postgresql.org/docs/current/static/sql-createfunction.html

Example config:

```
localharvest:
  postgres_privileges.present:
    - maintenance_db: localharvest
    - user: _postgresql
    - db_user: postgres
    - object_name: first_friday
    - object_type: function
    - privileges:
      - EXECUTE
    - grant_option: False
```
