### PR TITLE
added jail and chroot functionality in modules.freebsdservice #36675

### DIFF
--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -40,36 +40,75 @@ def __virtual__():
 
 
 @decorators.memoize
-def _cmd():
+def _cmd(jail=None):
     '''
     Return full path to service command
+
+    .. versionchanged:: 2016.3.4
+
+    Support for jail (representing jid or jail name) keyword argument in kwargs
     '''
     service = salt.utils.which('service')
     if not service:
         raise CommandNotFoundError('\'service\' command not found')
+    if jail:
+        jexec = salt.utils.which('jexec')
+        if not jexec:
+            raise CommandNotFoundError('\'jexec\' command not found')
+        service = '{0} {1} {2}'.format(jexec, jail, service)
     return service
 
 
-def _get_rcscript(name):
+def _get_jail_path(jail):
+    '''
+    .. versionadded:: 2016.3.4
+
+    Return the jail's root directory (path) as shown in jls
+
+    jail
+        The jid or jail name
+    '''
+    jls = salt.utils.which('jls')
+    if not jls:
+        raise CommandNotFoundError('\'jls\' command not found')
+    jails = __salt__['cmd.run_stdout']('{0} -n jid name path'.format(jls))
+    for j in jails.splitlines():
+        jid, jname, path = (x.split('=')[1].strip() for x in j.split())
+        if jid == jail or jname == jail:
+            return path.rstrip('/')
+    # XΧΧ, TODO, not sure how to handle nonexistent jail
+    return ''
+
+
+def _get_rcscript(name, jail=None):
     '''
     Return full path to service rc script
+
+    .. versionchanged:: 2016.3.4
+
+    Support for jail (representing jid or jail name) keyword argument in kwargs
     '''
-    cmd = '{0} -r'.format(_cmd())
+    cmd = '{0} -r'.format(_cmd(jail))
+    prf = _get_jail_path(jail) if jail else ''
     for line in __salt__['cmd.run_stdout'](cmd, python_shell=False).splitlines():
         if line.endswith('{0}{1}'.format(os.path.sep, name)):
-            return line
+            return os.path.join(prf, line.lstrip(os.path.sep))
     return None
 
 
-def _get_rcvar(name):
+def _get_rcvar(name, jail=None):
     '''
     Return rcvar
+
+    .. versionchanged:: 2016.3.4
+
+    Support for jail (representing jid or jail name) keyword argument in kwargs
     '''
-    if not available(name):
+    if not available(name, jail):
         log.error('Service {0} not found'.format(name))
         return False
 
-    cmd = '{0} {1} rcvar'.format(_cmd(), name)
+    cmd = '{0} {1} rcvar'.format(_cmd(jail), name)
 
     for line in __salt__['cmd.run_stdout'](cmd, python_shell=False).splitlines():
         if '_enable="' not in line:
@@ -80,9 +119,13 @@ def _get_rcvar(name):
     return None
 
 
-def get_enabled():
+def get_enabled(jail=None):
     '''
     Return what services are set to run on boot
+
+    .. versionchanged:: 2016.3.4
+
+    Support for jail (representing jid or jail name) keyword argument in kwargs
 
     CLI Example:
 
@@ -91,25 +134,30 @@ def get_enabled():
         salt '*' service.get_enabled
     '''
     ret = []
-    service = _cmd()
+    service = _cmd(jail)
+    prf = _get_jail_path(jail) if jail else ''
     for svc in __salt__['cmd.run']('{0} -e'.format(service)).splitlines():
         ret.append(os.path.basename(svc))
 
     # This is workaround for bin/173454 bug
-    for svc in get_all():
+    for svc in get_all(jail):
         if svc in ret:
             continue
-        if not os.path.exists('/etc/rc.conf.d/{0}'.format(svc)):
+        if not os.path.exists('{0}/etc/rc.conf.d/{1}'.format(prf, svc)):
             continue
-        if enabled(svc):
+        if enabled(svc, jail=jail):
             ret.append(svc)
 
     return sorted(ret)
 
 
-def get_disabled():
+def get_disabled(jail=None):
     '''
     Return what services are available but not enabled to start at boot
+
+    .. versionchanged:: 2016.3.4
+
+    Support for jail (representing jid or jail name) keyword argument in kwargs
 
     CLI Example:
 
@@ -117,8 +165,8 @@ def get_disabled():
 
         salt '*' service.get_disabled
     '''
-    en_ = get_enabled()
-    all_ = get_all()
+    en_ = get_enabled(jail)
+    all_ = get_all(jail)
     return sorted(set(all_) - set(en_))
 
 
@@ -127,23 +175,37 @@ def _switch(name,                   # pylint: disable=C0103
             **kwargs):
     '''
     Switch on/off service start at boot.
+
+    .. versionchanged:: 2016.3.4
+
+    Support for jail (representing jid or jail name) and chroot keyword argument
+    in kwargs. chroot should be used when jail's /etc is mounted read-only and
+    should point to a root directory where jail's /etc is mounted read-write.
     '''
-    if not available(name):
+    jail = kwargs.get('jail', '')
+    chroot = kwargs.get('chroot', '').rstrip('/')
+    if not available(name, jail):
         return False
 
-    rcvar = _get_rcvar(name)
+    rcvar = _get_rcvar(name, jail)
     if not rcvar:
         log.error('rcvar for service {0} not found'.format(name))
         return False
 
+    if jail and not chroot:
+        # prepend the jail's path in config paths when referring to a jail, when
+        # chroot is not provided. chroot should be provided when the jail's /etc
+        # is mounted read-only
+        chroot = _get_jail_path(jail)
+
     config = kwargs.get('config',
                         __salt__['config.option']('service.config',
-                                                  default='/etc/rc.conf'
+                                                  default='{0}/etc/rc.conf'.format(chroot)
                                                   )
                         )
 
     if not config:
-        rcdir = '/etc/rc.conf.d'
+        rcdir = '{0}/etc/rc.conf.d'.format(chroot)
         if not os.path.exists(rcdir) or not os.path.isdir(rcdir):
             log.error('{0} not exists'.format(rcdir))
             return False
@@ -192,6 +254,14 @@ def enable(name, **kwargs):
 
         Also service.config variable can be used to change default.
 
+    .. versionchanged:: 2016.3.4
+
+    jail (optional keyword argument)
+        the jail's id or name
+
+    chroot (optional keyword argument)
+        the jail's chroot, if the jail's /etc is not mounted read-write
+
     CLI Example:
 
     .. code-block:: bash
@@ -206,6 +276,14 @@ def disable(name, **kwargs):
     Disable the named service to start at boot
 
     Arguments the same as for enable()
+
+    .. versionchanged:: 2016.3.4
+
+    jail (optional keyword argument)
+        the jail's id or name
+
+    chroot (optional keyword argument)
+        the jail's chroot, if the jail's /etc is not mounted read-write
 
     CLI Example:
 
@@ -223,17 +301,22 @@ def enabled(name, **kwargs):
     name
         Service name
 
+    .. versionchanged:: 2016.3.4
+
+    Support for jail (representing jid or jail name) keyword argument in kwargs
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' service.enabled <service name>
     '''
-    if not available(name):
+    jail = kwargs.get('jail', '')
+    if not available(name, jail):
         log.error('Service {0} not found'.format(name))
         return False
 
-    cmd = '{0} {1} rcvar'.format(_cmd(), name)
+    cmd = '{0} {1} rcvar'.format(_cmd(jail), name)
 
     for line in __salt__['cmd.run_stdout'](cmd, python_shell=False).splitlines():
         if '_enable="' not in line:
@@ -245,7 +328,7 @@ def enabled(name, **kwargs):
     return False
 
 
-def disabled(name):
+def disabled(name, **kwargs):
     '''
     Return True if the named service is enabled, false otherwise
 
@@ -255,12 +338,16 @@ def disabled(name):
 
         salt '*' service.disabled <service name>
     '''
-    return not enabled(name)
+    return not enabled(name, **kwargs)
 
 
-def available(name):
+def available(name, jail=None):
     '''
     Check that the given service is available.
+
+    .. versionchanged:: 2016.3.4
+
+    jail: optional jid or jail name
 
     CLI Example:
 
@@ -268,14 +355,18 @@ def available(name):
 
         salt '*' service.available sshd
     '''
-    return name in get_all()
+    return name in get_all(jail)
 
 
-def missing(name):
+def missing(name, jail=None):
     '''
     The inverse of service.available.
     Returns ``True`` if the specified service is not available, otherwise returns
     ``False``.
+
+    .. versionchanged:: 2016.3.4
+
+    jail: optional jid or jail name
 
     CLI Example:
 
@@ -283,12 +374,16 @@ def missing(name):
 
         salt '*' service.missing sshd
     '''
-    return name not in get_all()
+    return name not in get_all(jail)
 
 
-def get_all():
+def get_all(jail=None):
     '''
     Return a list of all available services
+
+    .. versionchanged:: 2016.3.4
+
+    jail: optional jid or jail name
 
     CLI Example:
 
@@ -297,16 +392,20 @@ def get_all():
         salt '*' service.get_all
     '''
     ret = []
-    service = _cmd()
+    service = _cmd(jail)
     for srv in __salt__['cmd.run']('{0} -l'.format(service)).splitlines():
         if not srv.isupper():
             ret.append(srv)
     return sorted(ret)
 
 
-def start(name):
+def start(name, jail=None):
     '''
     Start the specified service
+
+    .. versionchanged:: 2016.3.4
+
+    jail: optional jid or jail name
 
     CLI Example:
 
@@ -314,13 +413,17 @@ def start(name):
 
         salt '*' service.start <service name>
     '''
-    cmd = '{0} {1} onestart'.format(_cmd(), name)
+    cmd = '{0} {1} onestart'.format(_cmd(jail), name)
     return not __salt__['cmd.retcode'](cmd, python_shell=False)
 
 
-def stop(name):
+def stop(name, jail=None):
     '''
     Stop the specified service
+
+    .. versionchanged:: 2016.3.4
+
+    jail: optional jid or jail name
 
     CLI Example:
 
@@ -328,13 +431,17 @@ def stop(name):
 
         salt '*' service.stop <service name>
     '''
-    cmd = '{0} {1} onestop'.format(_cmd(), name)
+    cmd = '{0} {1} onestop'.format(_cmd(jail), name)
     return not __salt__['cmd.retcode'](cmd, python_shell=False)
 
 
-def restart(name):
+def restart(name, jail=None):
     '''
     Restart the named service
+
+    .. versionchanged:: 2016.3.4
+
+    jail: optional jid or jail name
 
     CLI Example:
 
@@ -342,13 +449,17 @@ def restart(name):
 
         salt '*' service.restart <service name>
     '''
-    cmd = '{0} {1} onerestart'.format(_cmd(), name)
+    cmd = '{0} {1} onerestart'.format(_cmd(jail), name)
     return not __salt__['cmd.retcode'](cmd, python_shell=False)
 
 
-def reload_(name):
+def reload_(name, jail=None):
     '''
     Restart the named service
+
+    .. versionchanged:: 2016.3.4
+
+    jail: optional jid or jail name
 
     CLI Example:
 
@@ -356,16 +467,20 @@ def reload_(name):
 
         salt '*' service.reload <service name>
     '''
-    cmd = '{0} {1} onereload'.format(_cmd(), name)
+    cmd = '{0} {1} onereload'.format(_cmd(jail), name)
     return not __salt__['cmd.retcode'](cmd, python_shell=False)
 
 
-def status(name, sig=None):
+def status(name, sig=None, jail=None):
     '''
     Return the status for a service (True or False).
 
     name
         Name of service
+
+    .. versionchanged:: 2016.3.4
+
+    jail: optional jid or jail name
 
     CLI Example:
 
@@ -375,7 +490,7 @@ def status(name, sig=None):
     '''
     if sig:
         return bool(__salt__['status.pid'](sig))
-    cmd = '{0} {1} onestatus'.format(_cmd(), name)
+    cmd = '{0} {1} onestatus'.format(_cmd(jail), name)
     return not __salt__['cmd.retcode'](cmd,
                                        python_shell=False,
                                        ignore_retcode=True)


### PR DESCRIPTION
### What does this PR do?

It adds jail and chroot functionality on modules.freebsdservice
### What issues does this PR fix or reference?
saltstack/salt#36675
### Previous Behavior

freebsdservice module's functions were unaware of jails and chroots
### New Behavior

Now freebsdservice module's functions are aware of jails and chroots and can handle service management within jails.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.