### PR TITLE
Add delayed start option to minion service

### DIFF
--- a/doc/topics/installation/windows.rst
+++ b/doc/topics/installation/windows.rst
@@ -38,33 +38,64 @@ The 64bit installer has been tested on Windows 7 64bit and Windows Server
 Please file a bug report on our GitHub repo if issues for other platforms are
 found.
 
-The installer will detect previous installations of Salt and ask if you would
-like to remove them. Clicking OK will remove the Salt binaries and related
-files but leave any existing config, cache, and PKI information.
+There are two installers available.
 
-You will next be prompted to choose to install the minion and master. The
-minion check box is checked by default. To also install the master, check the
-appropriate checkbox. To not install the minion, uncheck the checkbox. At least
-one item must be selected for install.
+=============================================  =================================
+Filename                                       Details
+=============================================  =================================
+``Salt-Minion-<version>-<cpuarch>-Setup.exe``  Just the salt Minion
+``Salt-<version>-<cpuarch>-Setup.exe``         Salt Minion and Master
+=============================================  =================================
 
-The installer asks for two additional bits of information to configure the
-minion; the master hostname and the minion name. The installer will update the
-minion config with these options.
+When run, both installers will detect previous installations of Salt and ask if
+you would like to remove them. Clicking OK will remove the Salt binaries and
+related files but leave any existing config, cache, and PKI information.
 
-The final page allows you to select which services to start. Checking the box
-next to master or minion will start that service when the installer exits.
+Salt Minion Only Installation
+=============================
+
+After the Welcome and the License Agreement, the installer asks for two bits of
+information to configure the minion; the master hostname and the minion name.
+The installer will update the minion config with these options. If the installer
+finds an existing minion config file, these fields will be populated with values
+from the existing config.
+
+The final page allows you to start the minion service and optionally change its
+startup type. By default, the minion is set to ``Automatic``. You can change the
+minion start type to ``Automatic (Delayed Start)`` by checking the 'Delayed
+Start' checkbox.
+
+.. note::
+    Highstates that require a reboot may fail after reboot because salt
+    continues the highstate before Windows has finished the booting process.
+    This can be fixed by changing the startup type to 'Automatic (Delayed
+    Start)'. The drawback is that it may increase the time it takes for the
+    'salt-minion' service to actually start.
 
 The ``salt-minion`` service will appear in the Windows Service Manager and can
-be started and stopped there or with the command line program ``sc`` like any
-other Windows service.
+be managed there or from the command line like any other Windows service.
 
 .. code-block:: bat
 
     sc start salt-minion
     net start salt-minion
 
-If the minion won't start, try installing the Microsoft Visual C++ 2008 x64 SP1
-redistributable. Allow all Windows updates to run salt-minion smoothly.
+.. note::
+    If the minion won't start, you may need to install the Microsoft Visual C++
+    2008 x64 SP1 redistributable. Allow all Windows updates to run salt-minion
+    smoothly.
+
+Salt Minion/Master Installation
+===============================
+
+This installer behaves the same as the Minion installer but adds an additional
+installer page. You will be prompted to choose to install the minion and master.
+The minion check box is checked by default. To also install the master, check
+the master checkbox. To install only the master, uncheck the minion checkbox. At
+least one item must be selected.
+
+You will also be prompted on the final page to start the ``salt-master``
+service.
 
 .. _windows-installer-options:
 
@@ -72,36 +103,60 @@ Silent Installer Options
 ========================
 
 The installer can be run silently by providing the ``/S`` option at the command
-line. The installer also accepts the following options for configuring the Salt
+line. Both installers also accept the following options for configuring the Salt
 Minion silently:
 
-- `/master=` A string value to set the IP address or host name of the master. Default value is 'salt'
-- `/minion-name=` A string value to set the minion name. Default is 'hostname'
-- `/start-minion=` Either a 1 or 0. '1' will start the salt-minion service, '0' will not. Default is to start the service after installation.
-- `/start-master=` Either a 1 or 0. '1' will start the salt-master service, '0' will not. Default is to start the service after installation.
-- `/install-master` Will install the master along with the minion. Default is to install minion only
-- `/master-only` Will only install the master.
+=========================  =====================================================
+Option                     Description
+=========================  =====================================================
+``/minion-name=``          A string value to set the minion name. Default is
+                           'hostname'
+``/master=``               A string value to set the IP address or host name of
+                           the master. Default value is 'salt'
+``/start-minion=``         Either a 1 or 0. '1' will start the salt-minion
+                           service, '0' will not. Default is to start the
+                           service after installation.
+``/start-minion-delayed``  Set the minion start type to
+                           ``Automatic (Delayed Start)``
+=========================  =====================================================
+
+The Master/Minion installer also supports the following options:
+
+=========================  =====================================================
+Option                     Description
+=========================  =====================================================
+``/start-master=``         Either a 1 or 0. '1' will start the salt-master
+                           service, '0' will not. Default is to start the
+                           service after installation.
+``/install-master``        Will install the master along with the minion.
+                           Default is to install minion only
+``/master-only``           Will only install the master.
+=========================  =====================================================
 
 .. note::
-    `/start-service` has been deprecated but will continue to function as expected for the time being.
+    ``/start-service`` has been deprecated but will continue to function as
+    expected for the time being.
 
 Here are some examples of using the silent installer:
 
 .. code-block:: bat
 
-    # Will install both minion and master, configure the minion and start both services
+    # install both minion and master
+    # configure the minion and start both services
 
     Salt-2016.9.1-Setup-amd64.exe /S /master=yoursaltmaster /minion-name=yourminionname /install-master
 
 .. code-block:: bat
 
-    # Will install only the master but will NOT start the salt-master service
+    # install only the master but don't start the salt-master service
 
     Salt-2016.9.1-Setup-amd64.exe /S /master-only /start-master=0
 
 .. code-block:: bat
 
-    # Will install the minion and master, will configure the minion to talk to the local master and will start both services
+    # install the minion and master
+    # configure the minion to talk to the local master
+    # start both services
 
     Salt-2016.9.1-Setup-amd64.exe /S /install-master /master=localhost /minion-name=local_minion
 

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -149,8 +149,8 @@ Function pageFinish_Show
     # This command required to bring the checkbox to the front
     System::Call "User32::SetWindowPos(i, i, i, i, i, i, i) b ($CheckBox_Minion, ${HWND_TOP}, 0, 0, 0, 0, ${SWP_NOSIZE}|${SWP_NOMOVE})"
 
-    # Create Start Minion Delayed Checkbox
-    ${NSD_CreateCheckbox} 130u 105u 100% 12u "Startup Type: &Automatic (Delayed Start)"
+    # Create Start Minion Delayed ComboBox
+    ${NSD_CreateCheckbox} 130u 105u 100% 12u "&Delayed Start"
     Pop $CheckBox_Minion_Delayed
     SetCtlColors $CheckBox_Minion_Delayed "" "ffffff"
     # This command required to bring the checkbox to the front

--- a/pkg/windows/installer/Salt-Setup.nsi
+++ b/pkg/windows/installer/Salt-Setup.nsi
@@ -256,7 +256,7 @@ Function pageFinish_Show
     System::Call "User32::SetWindowPos(i, i, i, i, i, i, i) b ($CheckBox_Minion, ${HWND_TOP}, 0, 0, 0, 0, ${SWP_NOSIZE}|${SWP_NOMOVE})"
 
     # Create Start Minion Delayed Checkbox
-    ${NSD_CreateCheckbox} 130u 105u 100% 12u "Startup Type: &Automatic (Delayed Start)"
+    ${NSD_CreateCheckbox} 130u 105u 100% 12u "&Delayed Start"
     Pop $CheckBox_Minion_Delayed
     SetCtlColors $CheckBox_Minion_Delayed "" "ffffff"
     # This command required to bring the checkbox to the front

--- a/pkg/windows/installer/Salt-Setup.nsi
+++ b/pkg/windows/installer/Salt-Setup.nsi
@@ -89,6 +89,7 @@ Var Label
 Var Warning
 Var CheckBox_Minion
 Var CheckBox_Minion_State
+Var CheckBox_Minion_Delayed
 Var CheckBox_Master
 Var CheckBox_Master_State
 Var MasterHost
@@ -96,6 +97,7 @@ Var MasterHost_State
 Var MinionName
 Var MinionName_State
 Var StartMinion
+Var StartMinionDelayed
 Var StartMaster
 
 
@@ -231,10 +233,7 @@ FunctionEnd
 Function pageMinionConfig_Leave
 
     ${NSD_GetText} $MasterHost $MasterHost_State
-    #MessageBox MB_OK "Master Hostname is:$\n$\n$MasterHost_State"
-
     ${NSD_GetText} $MinionName $MinionName_State
-    #MessageBox MB_OK "Minion name is:$\n$\n$MinionName_State"
 
 FunctionEnd
 
@@ -256,8 +255,15 @@ Function pageFinish_Show
     # This command required to bring the checkbox to the front
     System::Call "User32::SetWindowPos(i, i, i, i, i, i, i) b ($CheckBox_Minion, ${HWND_TOP}, 0, 0, 0, 0, ${SWP_NOSIZE}|${SWP_NOMOVE})"
 
+    # Create Start Minion Delayed Checkbox
+    ${NSD_CreateCheckbox} 130u 105u 100% 12u "Startup Type: &Automatic (Delayed Start)"
+    Pop $CheckBox_Minion_Delayed
+    SetCtlColors $CheckBox_Minion_Delayed "" "ffffff"
+    # This command required to bring the checkbox to the front
+    System::Call "User32::SetWindowPos(i, i, i, i, i, i, i) b ($CheckBox_Minion_Delayed, ${HWND_TOP}, 0, 0, 0, 0, ${SWP_NOSIZE}|${SWP_NOMOVE})"
+
     # Create Start Master Checkbox
-    ${NSD_CreateCheckbox} 120u 105u 100% 12u "&Start salt-master"
+    ${NSD_CreateCheckbox} 120u 120u 100% 12u "Start salt-&master"
     Pop $CheckBox_Master
     SetCtlColors $CheckBox_Master "" "ffffff"
     # This command required to bring the checkbox to the front
@@ -268,9 +274,14 @@ Function pageFinish_Show
         ${If} $StartMinion == 1
             ${NSD_Check} $CheckBox_Minion
         ${EndIf}
+        ${If} $StartMinionDelayed == 1
+            ${NSD_Check} $CheckBox_Minion_Delayed
+        ${EndIf}
     ${Else}
         EnableWindow $CheckBox_Minion 0
+        EnableWindow $CheckBox_Minion_Delayed 0
         ${NSD_UnCheck} $CheckBox_Minion
+        ${NSD_UnCheck} $CheckBox_Minion_Delayed
     ${EndIf}
 
     # Load current settings for Master
@@ -290,6 +301,7 @@ Function pageFinish_Leave
 
     # Assign the current checkbox states
     ${NSD_GetState} $CheckBox_Minion $StartMinion
+    ${NSD_GetState} $CheckBox_Minion_Delayed $StartMinionDelayed
     ${NSD_GetState} $CheckBox_Master $StartMaster
 
 FunctionEnd
@@ -427,6 +439,7 @@ Section -Post
         nsExec::Exec "nssm.exe install salt-minion $INSTDIR\bin\python.exe $INSTDIR\bin\Scripts\salt-minion -c $INSTDIR\conf -l quiet"
         nsExec::Exec "nssm.exe set salt-minion AppEnvironmentExtra PYTHONHOME="
         nsExec::Exec "nssm.exe set salt-minion Description Salt Minion from saltstack.com"
+        nsExec::Exec "nssm.exe set salt-minion Start SERVICE_AUTO_START"
 
     ${Else}
 
@@ -481,6 +494,11 @@ SectionEnd
 
 
 Function .onInstSuccess
+
+    ; If StartMinionDelayed is 1, then set the service to start delayed
+    ${If} $StartMinionDelayed == 1
+        nsExec::Exec "nssm.exe set salt-minion Start SERVICE_DELAYED_AUTO_START"
+    ${EndIf}
 
     ; If start-minion is 1, then start the service
     ${If} $StartMinion == 1
@@ -932,6 +950,12 @@ Function parseCommandLineSwitches
         ; Otherwise default to 1
         StrCpy $StartMinion 1
     ${EndIf}
+
+    # Service: Startup Type Delayed
+    ${GetOptions} $R0 "/start-minion-delayed" $R1
+    IfErrors start_minion_delayed_not_found
+        StrCpy $StartMinionDelayed 1
+    start_minion_delayed_not_found:
 
     # Service: Start Salt Master
     ${GetOptions} $R0 "/start-master=" $R1


### PR DESCRIPTION
### What does this PR do?

Adds the option to change the minion service start type to "Automatic (Delayed Start)". Adds a switch to do it from the command line (`/start-minion-delayed`). Update docs.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/36316
### Previous Behavior

Automatic start was the only option. This caused problems with the Minion trying to do stuff before Windows was completely up after a reboot.
### Tests written?

NA