### PR TITLE
Adapt MinionManager for Proxy Minions.

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -408,7 +408,6 @@ class ProxyMinion(parsers.ProxyMinionOptionParser, DaemonsMixin):  # pylint: dis
         self.minion.stop(signum)
         super(ProxyMinion, self)._handle_signals(signum, sigframe)
 
-
     # pylint: disable=no-member
     def prepare(self):
         '''

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -184,7 +184,7 @@ VALID_OPTS = {
 
     # Append minion_id to these directories.  Helps with
     # multiple proxies and minions running on the same machine.
-    # Allowed elements in the list: pki_dir, cachedir, extension_modules
+    # Allowed elements in the list: pki_dir, cachedir, extension_modules, pidfile
     'append_minionid_config_dirs': list,
 
     # Flag to cache jobs locally.
@@ -1436,7 +1436,7 @@ DEFAULT_PROXY_MINION_OPTS = {
     'log_file': os.path.join(salt.syspaths.LOGS_DIR, 'proxy'),
     'add_proxymodule_to_opts': False,
     'proxy_merge_grains_in_module': False,
-    'append_minionid_config_dirs': ['cachedir'],
+    'append_minionid_config_dirs': ['cachedir', 'pidfile'],
     'default_include': 'proxy.d/*.conf',
 }
 
@@ -3078,7 +3078,7 @@ def apply_minion_config(overrides=None,
         opts['id'] = _append_domain(opts)
 
     for directory in opts.get('append_minionid_config_dirs', []):
-        if directory in ['pki_dir', 'cachedir', 'extension_modules']:
+        if directory in ['pki_dir', 'cachedir', 'extension_modules', 'pidfile']:
             newdirectory = os.path.join(opts[directory], opts['id'])
             opts[directory] = newdirectory
 

--- a/tests/unit/daemons_test.py
+++ b/tests/unit/daemons_test.py
@@ -160,9 +160,10 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
             '''
             obj = daemons.ProxyMinion()
             obj.config = {'user': 'dummy', 'hash_type': alg}
-            for attr in ['minion', 'start_log_info', 'prepare', 'shutdown']:
+            for attr in ['minion', 'start_log_info', 'prepare', 'shutdown', 'tune_in']:
                 setattr(obj, attr, MagicMock())
 
+            obj.minion.restart = False
             return obj
 
         _logger = LoggerMock()


### PR DESCRIPTION
### What does this PR do?

Adapt MinionManager for Proxy Minions.  

Also default location of proxy minion PID files to include the minion_id in the directory path. (It's much more common to run multiple proxy minions on a machine and by default the proxy would abort because of pidfile collision.)
### What issues does this PR fix or reference?

Fixes #36748
### Previous Behavior

Many proxy minion functions would stacktrace because the `proxy` key was not getting properly installed in `__opts__`.  This was an artifact of making `class ProxyMinion` a subclass of `MinionManager` not `Minion`.

Example:

```
salt p8000 test.ping
p8000:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.7/site-packages/salt/minion.py", line 1378, in _thread_return
        return_data = executor.execute()
      File "/usr/lib/python2.7/site-packages/salt/executors/direct_call.py", line 28, in execute
        return self.func(*self.args, **self.kwargs)
      File "/usr/lib/python2.7/site-packages/salt/modules/test.py", line 117, in ping
        ping_cmd = __opts__['proxy']['proxytype'] + '.ping'
    KeyError: 'proxy'
```
### New Behavior

Proxy functions work again.

ping @cachedout -- I think I did this all correctly but your well-trained eye upon it is appreciated.
