### PR TITLE
OS grains for SLES Expanded Support

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1047,6 +1047,7 @@ _OS_NAME_MAP = {
     'manjaro': 'Manjaro',
     'antergos': 'Antergos',
     'sles': 'SUSE',
+    'slesexpand': "RES",
     'void': 'Void',
     'linuxmint': 'Mint',
 }
@@ -1070,6 +1071,7 @@ _OS_FAMILY_MAP = {
     'OEL': 'RedHat',
     'XCP': 'RedHat',
     'XenServer': 'RedHat',
+    'RES': 'RedHat',
     'Mandrake': 'Mandriva',
     'ESXi': 'VMware',
     'Mint': 'Debian',

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1047,7 +1047,7 @@ _OS_NAME_MAP = {
     'manjaro': 'Manjaro',
     'antergos': 'Antergos',
     'sles': 'SUSE',
-    'slesexpand': "RES",
+    'slesexpand': 'RES',
     'void': 'Void',
     'linuxmint': 'Mint',
 }


### PR DESCRIPTION
### What does this PR do?

Adds support for `os` and `osfamily` grains for the [SLES ES](https://www.suse.com/products/expandedsupport) product family.
### What issues does this PR fix or reference?

None.
### Previous Behavior

 `os` and `osfamily` grains did not report correct information for SLES ES minions.
### Tests written?

No.
