### PR TITLE
Fixup alterernatives module

### DIFF
--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -82,7 +82,7 @@ def show_link(name):
 
     try:
         with salt.utils.fopen(path, 'rb') as r_file:
-            return r_file.readlines()[1]
+            return r_file.readlines()[1],rstrip('\n')
     except OSError:
         log.error(
             'alternatives: {0} does not exist'.format(name)

--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -82,7 +82,7 @@ def show_link(name):
 
     try:
         with salt.utils.fopen(path, 'rb') as r_file:
-            return r_file.readlines()[1],rstrip('\n')
+            return r_file.readlines()[1].rstrip('\n')
     except OSError:
         log.error(
             'alternatives: {0} does not exist'.format(name)


### PR DESCRIPTION
This was including the newline which was causing the state modifications present in saltstack/salt#36676 to fail in alternatives integration tests which were introduced in 2016.3