### PR TITLE
FreeBSD sysctl module now handels config_file parameter in show method

### DIFF
--- a/salt/modules/freebsd_sysctl.py
+++ b/salt/modules/freebsd_sysctl.py
@@ -56,17 +56,31 @@ def show(config_file=False):
     )
     cmd = 'sysctl -ae'
     ret = {}
-    out = __salt__['cmd.run'](cmd, output_loglevel='trace')
     comps = ['']
-    for line in out.splitlines():
-        if any([line.startswith('{0}.'.format(root)) for root in roots]):
-            comps = line.split('=', 1)
-            ret[comps[0]] = comps[1]
-        elif comps[0]:
-            ret[comps[0]] += '{0}\n'.format(line)
-        else:
-            continue
-    return ret
+
+    if config_file:
+        try:
+            with salt.utils.fopen(config_file, 'r') as f:
+                for line in f.readlines():
+                    l = line.strip()
+                    if l != "" and not l.startswith("#"):
+                        comps = line.split('=', 1)
+                        ret[comps[0]] = comps[1]
+            return ret
+        except (OSError, IOError):
+            log.error('Could not open sysctl config file')
+            return None
+    else:
+        out = __salt__['cmd.run'](cmd, output_loglevel='trace')
+        for line in out.splitlines():
+            if any([line.startswith('{0}.'.format(root)) for root in roots]):
+                comps = line.split('=', 1)
+                ret[comps[0]] = comps[1]
+            elif comps[0]:
+                ret[comps[0]] += '{0}\n'.format(line)
+            else:
+                 continue
+        return ret
 
 
 def get(name):


### PR DESCRIPTION
### What does this PR do?

This PR adds the possibility to read sysctl key/values from a given config_file on FreeBSD. The sysctl state module did already pass the `config_file` parameter to the FreeBSD execution module although it never got handled there. The fact that the module now collects currently configured sysctl values directly from file and not via `cmd.run` is reducing the execution time on FreeBSD by approx 50%.
### What issues does this PR fix or reference?

This PR is just one part of #36707 which can be back ported to existing versions.
I will open another PR for the same bug later on that adds additional features.
### Previous Behavior

Total execution time of 3 randomly picked sysctl states against a FreeBSD 10.3 salt minion:

```
  Name: vfs.nfs.no_ac_reset_on_bioread - Function: sysctl.present - Result: Clean Started: - 14:54:46.023393 Duration: 5169.115 ms
  Name: kern.minvnodes - Function: sysctl.present - Result: Clean Started: - 14:54:51.193271 Duration: 5243.769 ms
  Name: vfs.wantfreevnodes - Function: sysctl.present - Result: Clean Started: - 14:54:56.437922 Duration: 5318.865 ms
```
### New Behavior

Total execution time of the same 3 sysctl states against a FreeBSD 10.3 salt minion:

```
  Name: vfs.nfs.no_ac_reset_on_bioread - Function: sysctl.present - Result: Clean Started: - 14:57:04.635905 Duration: 2946.115 ms
  Name: kern.minvnodes - Function: sysctl.present - Result: Clean Started: - 14:57:07.583596 Duration: 2936.763 ms
  Name: vfs.wantfreevnodes - Function: sysctl.present - Result: Clean Started: - 14:57:10.521124 Duration: 2737.78 ms
```

Duration for each State is now ~2.8 seconds compared to ~5.2 seconds before.
### Tests written?

No
