### PR TITLE
do not load libvirt pillar if certtool is unavailable

### DIFF
--- a/salt/pillar/libvirt.py
+++ b/salt/pillar/libvirt.py
@@ -15,6 +15,10 @@ import subprocess
 import salt.utils
 
 
+def __virtual__():
+    return salt.utils.which('certtool') is not None
+
+
 def ext_pillar(minion_id,
                pillar,  # pylint: disable=W0613
                command):  # pylint: disable=W0613


### PR DESCRIPTION
### What issues does this PR fix or reference?

closes saltstack/salt#36788