### PR TITLE
Deb systemd should use control-group default for killmode

### DIFF
--- a/pkg/deb/salt-api.service
+++ b/pkg/deb/salt-api.service
@@ -8,7 +8,6 @@ LimitNOFILE=8192
 Type=simple
 NotifyAccess=all
 ExecStart=/usr/bin/salt-api
-KillMode=process
 Restart=$RESTART
 
 [Install]

--- a/pkg/deb/salt-master.service
+++ b/pkg/deb/salt-master.service
@@ -8,7 +8,6 @@ LimitNOFILE=16384
 Type=simple
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master
-KillMode=process
 Restart=$RESTART
 
 [Install]

--- a/pkg/deb/salt-minion.service
+++ b/pkg/deb/salt-minion.service
@@ -7,7 +7,6 @@ EnvironmentFile=/etc/default/salt-minion
 Type=simple
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
-KillMode=process
 Restart=$RESTART
 
 [Install]


### PR DESCRIPTION
### What does this PR do?

Fix deb systemd service files to not use `KillMode=process` and instead use the default (KillMode=control-group)
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/33665

The above issue includes commits to fix the `salt-master` in the `develop` branch but Im seeing this issue on the salt-minion service in debian 8 on the `2016.3` branch as well. Im assuming this affects any salt service.
### Previous Behavior

With a salt-\* service running, issue a `systemctl stop salt-{minion, master}`. That service will hang for around a minute then systemd force kills it:

On the minion:

```
(salt) root@:vagrant # systemctl status salt-minion
● salt-minion.service - The Salt Minion daemon
   Loaded: loaded (/lib/systemd/system/salt-minion.service; enabled)
   Active: failed (Result: signal) since Wed 2016-10-05 18:13:39 GMT; 19s ago
  Process: 13492 ExecStart=/usr/lib/virtualenvs/salt/bin/salt-minion (code=killed, signal=KILL)
 Main PID: 13492 (code=killed, signal=KILL)

Oct 05 18:12:08 saltmaster systemd[1]: Stopping The Salt Minion daemon...
Oct 05 18:12:08 saltmaster salt-minion[13492]: [WARNING ] Minion received a SIGTERM. Exiting.
Oct 05 18:13:39 saltmaster systemd[1]: salt-minion.service stop-sigterm timed out. Killing.
Oct 05 18:13:39 saltmaster systemd[1]: salt-minion.service: main process exited, code=killed, status=9/KILL
Oct 05 18:13:39 saltmaster systemd[1]: Stopped The Salt Minion daemon.
Oct 05 18:13:39 saltmaster systemd[1]: Unit salt-minion.service entered failed state.
Oct 05 18:13:41 saltmaster salt-minion[13492]: The salt minion is shutdown. Minion received a SIGTERM. Exited.[ERROR   ] Minion process encountered exception: [Errno 3] No such process
```

On the master:

```
● salt-master.service - The Salt Master daemon
   Loaded: loaded (/lib/systemd/system/salt-master.service; enabled)
   Active: failed (Result: signal) since Wed 2016-10-05 18:18:04 GMT; 41s ago
  Process: 13547 ExecStart=/usr/lib/virtualenvs/salt/bin/salt-master (code=killed, signal=KILL)
 Main PID: 13547 (code=killed, signal=KILL)

Oct 05 18:16:33 saltmaster systemd[1]: Stopping The Salt Master daemon...
Oct 05 18:16:33 saltmaster salt-master[13547]: [WARNING ] Master received a SIGTERM. Exiting.
Oct 05 18:18:04 saltmaster systemd[1]: salt-master.service stop-sigterm timed out. Killing.
Oct 05 18:18:04 saltmaster systemd[1]: salt-master.service: main process exited, code=killed, status=9/KILL
Oct 05 18:18:04 saltmaster systemd[1]: Stopped The Salt Master daemon.
Oct 05 18:18:04 saltmaster systemd[1]: Unit salt-master.service entered failed state.
```
### New Behavior

With the changes `systemctl stop salt-{minion, master}` no longer hangs and seems to correct stop.

On the minion:

```
● salt-minion.service - The Salt Minion daemon
   Loaded: loaded (/lib/systemd/system/salt-minion.service; enabled)
   Active: inactive (dead) since Wed 2016-10-05 20:23:03 GMT; 1s ago
  Process: 15439 ExecStart=/usr/lib/virtualenvs/salt/bin/salt-minion (code=exited, status=0/SUCCESS)
 Main PID: 15439 (code=exited, status=0/SUCCESS)

Oct 05 20:23:03 saltmaster systemd[1]: Stopping The Salt Minion daemon...
Oct 05 20:23:03 saltmaster salt-minion[15439]: [WARNING ] Minion received a SIGTERM. Exiting.
Oct 05 20:23:03 saltmaster salt-minion[15439]: The salt minion is shutdown. Minion received a SIGTERM. Exited.
Oct 05 20:23:03 saltmaster systemd[1]: Stopped The Salt Minion daemon.
```

On the master:

```
● salt-master.service - The Salt Master daemon
   Loaded: loaded (/lib/systemd/system/salt-master.service; enabled)
   Active: inactive (dead) since Wed 2016-10-05 20:21:25 GMT; 5s ago
  Process: 15156 ExecStart=/usr/lib/virtualenvs/salt/bin/salt-master (code=exited, status=0/SUCCESS)
 Main PID: 15156 (code=exited, status=0/SUCCESS)

Oct 05 20:21:24 saltmaster systemd[1]: Stopping The Salt Master daemon...
Oct 05 20:21:24 saltmaster salt-master[13547]: The salt master is shutdown. Master received a SIGTERM. Exited.
Oct 05 20:21:24 saltmaster salt-master[14448]: The salt master is shutdown. Master received a SIGTERM. Exited.
Oct 05 20:21:24 saltmaster salt-master[15156]: [WARNING ] Master received a SIGTERM. Exiting.
Oct 05 20:21:25 saltmaster salt-master[15156]: The salt master is shutdown. Master received a SIGTERM. Exited.
Oct 05 20:21:25 saltmaster systemd[1]: Stopped The Salt Master daemon.
```
### Tests written?

No, manually tested against vagrant instance.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

```
salt --versions
Salt Version:
           Salt: 2016.3.3-172-g8ff69bf

Dependency Versions:
           cffi: Not Installed
       cherrypy: Not Installed
       dateutil: 2.5.3
          gitdb: 0.6.4
      gitpython: 2.0.2
          ioflo: Not Installed
         Jinja2: 2.8
        libgit2: Not Installed
        libnacl: Not Installed
       M2Crypto: Not Installed
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.4.8
   mysql-python: Not Installed
      pycparser: Not Installed
       pycrypto: 2.6.1
         pygit2: Not Installed
         Python: 2.7.9 (default, Jun 29 2016, 13:08:31)
   python-gnupg: Not Installed
         PyYAML: 3.12
          PyZMQ: 15.4.0
           RAET: Not Installed
          smmap: 0.9.0
        timelib: Not Installed
        Tornado: 4.4.2
            ZMQ: 4.1.5

System Versions:
           dist: debian 8.2 
        machine: x86_64
        release: 3.16.0-4-amd64
         system: Linux
        version: debian 8.2 
```

Let me know what you think,

~Rob
