### PR TITLE
Fix pillar merging when ext_pillar_first is enabled

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -791,8 +791,8 @@ class Pillar(object):
                 self.opts['pillar'], errors = self.ext_pillar({}, pillar_dirs)
                 matches = self.top_matches(top)
                 pillar, errors = self.render_pillar(matches, errors=errors)
-                pillar = merge(pillar,
-                               self.opts['pillar'],
+                pillar = merge(self.opts['pillar'],
+                               pillar,
                                self.merge_strategy,
                                self.opts.get('renderer', 'yaml'),
                                self.opts.get('pillar_merge_lists', False))


### PR DESCRIPTION
ext_pillar was being merged into pillar, when it should have been the
other way around. This means that when ext_pillar_first was enabled,
pillar keys with the same name as ones defined in ext_pillar were being
lost instead of overriding ext_pillar.

Fixes #36723,