### PR TITLE
allow for closing stuff in beacons

### DIFF
--- a/doc/topics/beacons/index.rst
+++ b/doc/topics/beacons/index.rst
@@ -101,6 +101,12 @@ which point the normal beacon interval will resume.
 
 .. _beacon-example:
 
+.. note::
+    For beacon writers:  If you need extra stuff to happen, like closing file
+    handles for the ``disable_during_state_run`` to actually work, you can add
+    a `close()` function to the beacon to run those extra things. See the
+    `inotify` beacon.
+
 Beacon Example
 ==============
 

--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -86,7 +86,12 @@ class Beacon(object):
                         if re.match('state.*', job['fun']):
                             is_running = True
                     if is_running:
-                        log.info('Skipping beacon {0}. State run in progress.'.format(mod))
+                        close_str = '{0}.close'.format(mod)
+                        if close_str in self.beacons:
+                            log.info('Closing beacon {0}. State run in progress.'.format(mod))
+                            self.beacons[close_str](b_config[mod])
+                        else:
+                            log.info('Skipping beacon {0}. State run in progress.'.format(mod))
                         continue
                 # Fire the beacon!
                 raw = self.beacons[fun_str](b_config[mod])

--- a/salt/beacons/inotify.py
+++ b/salt/beacons/inotify.py
@@ -265,3 +265,9 @@ def beacon(config):
 
     # Return event data
     return ret
+
+
+def close(config):
+    if 'inotify.notifier' in __context__:
+        __context__['inotify.notifier'].stop()
+        del __context__['inotify.notifier']


### PR DESCRIPTION
### What does this PR do?

allow for closing file handlers in the inotify beacon when disable_during_state_run is enabled.