### PR TITLE
modules/apk.py - pkg.list_upgrades: Prevent error and only process lines containing 'Upgrading'

### DIFF
--- a/salt/modules/apk.py
+++ b/salt/modules/apk.py
@@ -511,7 +511,7 @@ def list_upgrades(refresh=True):
         out = call['stdout']
 
     for line in out.splitlines():
-        if not line.startswith('OK:'):
+        if 'Upgrading' in line:
             name = line.split(' ')[2]
             _oldversion = line.split(' ')[3].strip('(')
             newversion = line.split(' ')[5].strip(')')


### PR DESCRIPTION
### What does this PR do?

Prevent error and only process lines containing 'Upgrading' for pkg.list_upgrades function
### Previous Behavior

Could crash if packages would be installed or purged on upgrade
