### PR TITLE
Fix glance.image_present state

### DIFF
--- a/salt/states/glance.py
+++ b/salt/states/glance.py
@@ -49,26 +49,26 @@ def _find_image(name):
         - False, 'Found more than one image with given name'
     '''
     try:
-        images_dict = __salt__['glance.image_list'](name=name)
+        images = __salt__['glance.image_list'](name=name)
     except kstone_Unauthorized:
         return False, 'keystoneclient: Unauthorized'
     except glance_Unauthorized:
         return False, 'glanceclient: Unauthorized'
-    log.debug('Got images_dict: {0}'.format(images_dict))
+    log.debug('Got images: {0}'.format(images))
 
     warn_until('Carbon', 'Starting with Carbon '
         '\'glance.image_list\' is not supposed to return '
         'the images wrapped in a separate dict anymore.')
-    if len(images_dict) == 1 and 'images' in images_dict:
-        images_dict = images_dict['images']
+    if type(images) is dict and len(images) == 1 and 'images' in images:
+        images = images['images']
 
-    # I /think/ this will still work when glance.image_list
-    # starts returning a list instead of a dictionary...
-    if len(images_dict) == 0:
+    images_list = images.values() if type(images) is dict else images
+
+    if len(images_list) == 0:
         return None, 'No image with name "{0}"'.format(name)
-    elif len(images_dict) == 1:
-        return images_dict.values()[0], 'Found image {0}'.format(name)
-    elif len(images_dict) > 1:
+    elif len(images_list) == 1:
+        return images_list[0], 'Found image {0}'.format(name)
+    elif len(images_list) > 1:
         return False, 'Found more than one image with given name'
     else:
         raise NotImplementedError

--- a/salt/states/glance.py
+++ b/salt/states/glance.py
@@ -13,13 +13,23 @@ from salt.utils import warn_until
 
 # Import OpenStack libs
 try:
-    from keystoneclient.apiclient.exceptions import \
+    from keystoneclient.exceptions import \
         Unauthorized as kstone_Unauthorized
+    HAS_KEYSTONE = True
+except ImportError:
+    try:
+        from keystoneclient.apiclient.exceptions import \
+            Unauthorized as kstone_Unauthorized
+        HAS_KEYSTONE = True
+    except ImportError:
+        HAS_KEYSTONE = False
+
+try:
     from glanceclient.exc import \
         HTTPUnauthorized as glance_Unauthorized
-    HAS_DEPENDENCIES = True
+    HAS_GLANCE = True
 except ImportError:
-    HAS_DEPENDENCIES = False
+    HAS_GLANCE = False
 
 log = logging.getLogger(__name__)
 
@@ -28,7 +38,7 @@ def __virtual__():
     '''
     Only load if dependencies are loaded
     '''
-    return HAS_DEPENDENCIES
+    return HAS_KEYSTONE and HAS_GLANCE
 
 
 def _find_image(name):


### PR DESCRIPTION
### What does this PR do?

Fix a dependency import error and a stack trace in the `glance` state.
### Previous Behavior

The `glance` state failed to load with keystoneclient >=2.1.0:

```
2016-10-05 13:39:33,216 [salt.state       ][ERROR   ][30596] State 'glance.image_present' was not found in SLS 'openstack'
Reason: 'glance' __virtual__ returned False
```

and when that was fixed, it threw the following exception:

```
An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1733, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1652, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/states/glance.py", line 155, in image_present
    image, msg = _find_image(name)
  File "/usr/lib/python2.7/dist-packages/salt/states/glance.py", line 60, in _find_image
    return images_dict.values()[0], 'Found image {0}'.format(name)
AttributeError: 'list' object has no attribute 'values'
```
### New Behavior

The `glance` state loads successfully, and `glance.image_present` works properly.
### Tests written?

No
