### PR TITLE
Fix diff output of test runs for Debian slave interfaces

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1228,6 +1228,10 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
     elif iface_type == 'slave':
         adapters[iface]['master'] = opts['master']
 
+        opts['proto'] = 'manual'
+        iface_data['inet']['addrfam'] = 'inet'
+        iface_data['inet']['master'] = adapters[iface]['master']
+
     elif iface_type == 'vlan':
         iface_data['inet']['vlan_raw_device'] = re.sub(r'\.\d*', '', iface)
 
@@ -1456,12 +1460,6 @@ def _write_file_ifaces(iface, data, **settings):
 
     ifcfg = ''
     for adapter in adapters:
-        if 'type' in adapters[adapter] and adapters[adapter]['type'] == 'slave':
-            # Override values so the interfaces file is correct
-            adapters[adapter]['data']['inet']['addrfam'] = 'inet'
-            adapters[adapter]['data']['inet']['proto'] = 'manual'
-            adapters[adapter]['data']['inet']['master'] = adapters[adapter]['master']
-
         if 'type' in adapters[adapter] and adapters[adapter]['type'] == 'source':
             tmp = source_template.render({'name': adapter, 'data': adapters[adapter]})
         else:


### PR DESCRIPTION
### What does this PR do?

The diff shown after running `salt '*' state.apply test=True` was reporting changes in `network.managed` for slave interfaces on Debian, even though nothing changed in the states/pillars and nothing was going to be changed by `salt '*' state.apply`.
### Previous Behavior

Running `salt '*' state.apply test=True` with a state like this:

```
ens2f1:
  network.managed:
    - type: slave
    - master: bond0
```

showed changes every time:

```
      ID: ens2f1
Function: network.managed
  Result: None
 Comment: Interface ens2f1 is set to be updated:
          ---
          +++
          @@ -1,4 +1,3 @@
           auto ens2f1
          -iface ens2f1 inet manual
          -    bond-master bond0
          +iface ens2f1 inet static
 Started: 09:07:41.719716
Duration: 1.91 ms
 Changes:
```

even though nothing was going to be changed by `salt '*' state.apply`.
### New Behavior

The test run now correctly shows no changes when `salt '*' state.apply` is not going to change anything.
### Tests written?

No
