### PR TITLE
Update debian systemd unit files to use default KillMode, Type=notify

### DIFF
--- a/pkg/deb/salt-api.service
+++ b/pkg/deb/salt-api.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 EnvironmentFile=/etc/default/salt-api
 LimitNOFILE=8192
-Type=simple
+Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/salt-api
 Restart=$RESTART

--- a/pkg/deb/salt-api.service
+++ b/pkg/deb/salt-api.service
@@ -3,12 +3,10 @@ Description=REST API for Salt
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/default/salt-api
 LimitNOFILE=8192
 Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/salt-api
-Restart=$RESTART
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/deb/salt-api.service
+++ b/pkg/deb/salt-api.service
@@ -8,7 +8,6 @@ LimitNOFILE=8192
 Type=simple
 NotifyAccess=all
 ExecStart=/usr/bin/salt-api
-KillMode=process
 Restart=$RESTART
 
 [Install]

--- a/pkg/deb/salt-master.service
+++ b/pkg/deb/salt-master.service
@@ -3,12 +3,10 @@ Description=The Salt Master daemon
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/default/salt-master
 LimitNOFILE=16384
 Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master
-Restart=$RESTART
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/deb/salt-master.service
+++ b/pkg/deb/salt-master.service
@@ -8,7 +8,6 @@ LimitNOFILE=16384
 Type=simple
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master
-KillMode=process
 Restart=$RESTART
 
 [Install]

--- a/pkg/deb/salt-master.service
+++ b/pkg/deb/salt-master.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 EnvironmentFile=/etc/default/salt-master
 LimitNOFILE=16384
-Type=simple
+Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master
 Restart=$RESTART

--- a/pkg/deb/salt-minion.service
+++ b/pkg/deb/salt-minion.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=notify
+NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
 

--- a/pkg/deb/salt-minion.service
+++ b/pkg/deb/salt-minion.service
@@ -3,11 +3,9 @@ Description=The Salt Minion daemon
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/default/salt-minion
 Type=notify
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
-Restart=$RESTART
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/deb/salt-minion.service
+++ b/pkg/deb/salt-minion.service
@@ -7,7 +7,6 @@ EnvironmentFile=/etc/default/salt-minion
 Type=simple
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
-KillMode=process
 Restart=$RESTART
 
 [Install]

--- a/pkg/deb/salt-minion.service
+++ b/pkg/deb/salt-minion.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=/etc/default/salt-minion
-Type=simple
+Type=notify
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
 Restart=$RESTART

--- a/pkg/deb/salt-syndic.service
+++ b/pkg/deb/salt-syndic.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=notify
+NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-syndic
 

--- a/pkg/deb/salt-syndic.service
+++ b/pkg/deb/salt-syndic.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=/etc/default/salt-syndic
-Type=simple
+Type=notify
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-syndic
 Restart=$RESTART

--- a/pkg/deb/salt-syndic.service
+++ b/pkg/deb/salt-syndic.service
@@ -3,11 +3,9 @@ Description=The Salt Syndic daemon
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/default/salt-syndic
 Type=notify
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-syndic
-Restart=$RESTART
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/salt-api.service
+++ b/pkg/salt-api.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=notify
+NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-api
 TimeoutStopSec=3

--- a/pkg/salt-minion.service
+++ b/pkg/salt-minion.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=notify
+NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
 

--- a/pkg/salt-syndic.service
+++ b/pkg/salt-syndic.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=notify
+NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-syndic
 


### PR DESCRIPTION
This was done for the rest of the unit files in https://github.com/saltstack/salt/pull/35577 but I did not realize we maintain separate unit files for Debian.

This incorporates #36806 from @l2ol33rt (which removes the use of `KillMode=process`), and also changes the unit type to `notify`.

@rallytime This will need to be backported to the 2015.8 branch.
