### PR TITLE
Whitespace bugfix in linux acl.getfacl

### DIFF
--- a/salt/modules/linux_acl.py
+++ b/salt/modules/linux_acl.py
@@ -180,7 +180,7 @@ def wipefacls(*args, **kwargs):
     if recursive:
         cmd += ' -R'
     for dentry in args:
-        cmd += ' {0}'.format(dentry)
+        cmd += ' "{0}"'.format(dentry)
     __salt__['cmd.run'](cmd, python_shell=False)
     return True
 
@@ -227,7 +227,7 @@ def modfacl(acl_type, acl_name='', perms='', *args, **kwargs):
     cmd = '{0} {1}:{2}:{3}'.format(cmd, _acl_prefix(acl_type), acl_name, perms)
 
     for dentry in args:
-        cmd += ' {0}'.format(dentry)
+        cmd += ' "{0}"'.format(dentry)
     __salt__['cmd.run'](cmd, python_shell=False)
     return True
 
@@ -259,6 +259,6 @@ def delfacl(acl_type, acl_name='', *args, **kwargs):
     cmd = '{0} {1}:{2}'.format(cmd, _acl_prefix(acl_type), acl_name)
 
     for dentry in args:
-        cmd += ' {0}'.format(dentry)
+        cmd += ' "{0}"'.format(dentry)
     __salt__['cmd.run'](cmd, python_shell=False)
     return True

--- a/salt/modules/linux_acl.py
+++ b/salt/modules/linux_acl.py
@@ -63,7 +63,7 @@ def getfacl(*args, **kwargs):
     if recursive:
         cmd += ' -R'
     for dentry in args:
-        cmd += ' {0}'.format(dentry)
+        cmd += ' "{0}"'.format(dentry)
     out = __salt__['cmd.run'](cmd, python_shell=False).splitlines()
     dentry = ''
     for line in out:

--- a/tests/unit/modules/linux_acl_test.py
+++ b/tests/unit/modules/linux_acl_test.py
@@ -21,7 +21,9 @@ class LinuxAclTestCase(TestCase):
         linux_acl.__salt__ = {'cmd.run': MagicMock()}
         self.cmdrun = linux_acl.__salt__['cmd.run']
         self.file = '/tmp/file'
-        self.files = ['/tmp/file1', '/tmp/file2']
+        self.quoted_file = '"/tmp/file"'
+        self.files = ['/tmp/file1', '/tmp/file2', '/tmp/file3 with whitespaces']
+        self.quoted_files = [ '"{0}"'.format(f) for f in self.files]
         self.u_acl = ['u', 'myuser', 'rwx']
         self.user_acl = ['user', 'myuser', 'rwx']
         self.user_acl_cmd = 'u:myuser:rwx'
@@ -42,30 +44,30 @@ class LinuxAclTestCase(TestCase):
 
     def test_getfacl_w_single_arg(self):
         linux_acl.getfacl(self.file)
-        self.cmdrun.assert_called_once_with('getfacl --absolute-names ' + self.file, python_shell=False)
+        self.cmdrun.assert_called_once_with('getfacl --absolute-names ' + self.quoted_file, python_shell=False)
 
     def test_getfacl_w_multiple_args(self):
         linux_acl.getfacl(*self.files)
-        self.cmdrun.assert_called_once_with('getfacl --absolute-names ' + ' '.join(self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('getfacl --absolute-names ' + ' '.join(self.quoted_files), python_shell=False)
 
     def test_getfacl__recursive_w_multiple_args(self):
         linux_acl.getfacl(*self.files, recursive=True)
-        self.cmdrun.assert_called_once_with('getfacl --absolute-names -R ' + ' '.join(self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('getfacl --absolute-names -R ' + ' '.join(self.quoted_files), python_shell=False)
 
     def test_wipefacls_wo_args(self):
         self.assertRaises(CommandExecutionError, linux_acl.wipefacls)
 
     def test_wipefacls_w_single_arg(self):
         linux_acl.wipefacls(self.file)
-        self.cmdrun.assert_called_once_with('setfacl -b ' + self.file, python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -b ' + self.quoted_file, python_shell=False)
 
     def test_wipefacls_w_multiple_args(self):
         linux_acl.wipefacls(*self.files)
-        self.cmdrun.assert_called_once_with('setfacl -b ' + ' '.join(self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -b ' + ' '.join(self.quoted_files), python_shell=False)
 
     def test_wipefacls__recursive_w_multiple_args(self):
         linux_acl.wipefacls(*self.files, recursive=True)
-        self.cmdrun.assert_called_once_with('setfacl -b -R ' + ' '.join(self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -b -R ' + ' '.join(self.quoted_files), python_shell=False)
 
     def test_modfacl_wo_args(self):
         for acl in [self.u_acl, self.user_acl, self.g_acl, self.group_acl]:
@@ -73,63 +75,63 @@ class LinuxAclTestCase(TestCase):
 
     def test_modfacl__u_w_single_arg(self):
         linux_acl.modfacl(*(self.u_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.user_acl_cmd, self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.user_acl_cmd, self.quoted_file]), python_shell=False)
 
     def test_modfacl__u_w_multiple_args(self):
         linux_acl.modfacl(*(self.u_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.user_acl_cmd] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.user_acl_cmd] + self.quoted_files), python_shell=False)
 
     def test_modfacl__user_w_single_arg(self):
         linux_acl.modfacl(*(self.user_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.user_acl_cmd, self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.user_acl_cmd, self.quoted_file]), python_shell=False)
 
     def test_modfacl__user_w_multiple_args(self):
         linux_acl.modfacl(*(self.user_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.user_acl_cmd] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.user_acl_cmd] + self.quoted_files), python_shell=False)
 
     def test_modfacl__g_w_single_arg(self):
         linux_acl.modfacl(*(self.g_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.group_acl_cmd, self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.group_acl_cmd, self.quoted_file]), python_shell=False)
 
     def test_modfacl__g_w_multiple_args(self):
         linux_acl.modfacl(*(self.g_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.group_acl_cmd] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.group_acl_cmd] + self.quoted_files), python_shell=False)
 
     def test_modfacl__group_w_single_arg(self):
         linux_acl.modfacl(*(self.group_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.group_acl_cmd, self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.group_acl_cmd, self.quoted_file]), python_shell=False)
 
     def test_modfacl__group_w_multiple_args(self):
         linux_acl.modfacl(*(self.group_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.group_acl_cmd] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.group_acl_cmd] + self.quoted_files), python_shell=False)
 
     def test_modfacl__d_u_w_single_arg(self):
         linux_acl.modfacl(*(self.d_u_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd, self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd, self.quoted_file]), python_shell=False)
 
     def test_modfacl__d_u_w_multiple_args(self):
         linux_acl.modfacl(*(self.d_u_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd] + self.quoted_files), python_shell=False)
 
     def test_modfacl__d_user_w_single_arg(self):
         linux_acl.modfacl(*(self.d_user_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd, self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd, self.quoted_file]), python_shell=False)
 
     def test_modfacl__d_user_w_multiple_args(self):
         linux_acl.modfacl(*(self.d_user_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd] + self.quoted_files), python_shell=False)
 
     def test_modfacl__default_user_w_single_arg(self):
         linux_acl.modfacl(*(self.default_user_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd, self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd, self.quoted_file]), python_shell=False)
 
     def test_modfacl__default_user_w_multiple_args(self):
         linux_acl.modfacl(*(self.default_user_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd] + self.quoted_files), python_shell=False)
 
     def test_modfacl__recursive_w_multiple_args(self):
         linux_acl.modfacl(*(self.user_acl + self.files), recursive=True)
-        self.cmdrun.assert_called_once_with('setfacl -R -m ' + ' '.join([self.user_acl_cmd] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -R -m ' + ' '.join([self.user_acl_cmd] + self.quoted_files), python_shell=False)
 
     def test_delfacl_wo_args(self):
         for acl in [self.u_acl, self.user_acl, self.g_acl, self.group_acl]:
@@ -137,60 +139,60 @@ class LinuxAclTestCase(TestCase):
 
     def test_delfacl__u_w_single_arg(self):
         linux_acl.delfacl(*(self.u_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.user_acl_cmd.rpartition(':')[0], self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.user_acl_cmd.rpartition(':')[0], self.quoted_file]), python_shell=False)
 
     def test_delfacl__u_w_multiple_args(self):
         linux_acl.delfacl(*(self.u_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.user_acl_cmd.rpartition(':')[0]] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.user_acl_cmd.rpartition(':')[0]] + self.quoted_files), python_shell=False)
 
     def test_delfacl__user_w_single_arg(self):
         linux_acl.delfacl(*(self.user_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.user_acl_cmd.rpartition(':')[0], self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.user_acl_cmd.rpartition(':')[0], self.quoted_file]), python_shell=False)
 
     def test_delfacl__user_w_multiple_args(self):
         linux_acl.delfacl(*(self.user_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.user_acl_cmd.rpartition(':')[0]] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.user_acl_cmd.rpartition(':')[0]] + self.quoted_files), python_shell=False)
 
     def test_delfacl__g_w_single_arg(self):
         linux_acl.delfacl(*(self.g_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.group_acl_cmd.rpartition(':')[0], self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.group_acl_cmd.rpartition(':')[0], self.quoted_file]), python_shell=False)
 
     def test_delfacl__g_w_multiple_args(self):
         linux_acl.delfacl(*(self.g_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.group_acl_cmd.rpartition(':')[0]] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.group_acl_cmd.rpartition(':')[0]] + self.quoted_files), python_shell=False)
 
     def test_delfacl__group_w_single_arg(self):
         linux_acl.delfacl(*(self.group_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.group_acl_cmd.rpartition(':')[0], self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.group_acl_cmd.rpartition(':')[0], self.quoted_file]), python_shell=False)
 
     def test_delfacl__group_w_multiple_args(self):
         linux_acl.delfacl(*(self.group_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.group_acl_cmd.rpartition(':')[0]] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.group_acl_cmd.rpartition(':')[0]] + self.quoted_files), python_shell=False)
 
     def test_delfacl__d_u_w_single_arg(self):
         linux_acl.delfacl(*(self.d_u_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0], self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0], self.quoted_file]), python_shell=False)
 
     def test_delfacl__d_u_w_multiple_args(self):
         linux_acl.delfacl(*(self.d_u_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.quoted_files), python_shell=False)
 
     def test_delfacl__d_user_w_single_arg(self):
         linux_acl.delfacl(*(self.d_user_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0], self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0], self.quoted_file]), python_shell=False)
 
     def test_delfacl__d_user_w_multiple_args(self):
         linux_acl.delfacl(*(self.d_user_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.quoted_files), python_shell=False)
 
     def test_delfacl__default_user_w_single_arg(self):
         linux_acl.delfacl(*(self.default_user_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0], self.file]), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0], self.quoted_file]), python_shell=False)
 
     def test_delfacl__default_user_w_multiple_args(self):
         linux_acl.delfacl(*(self.default_user_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.quoted_files), python_shell=False)
 
     def test_delfacl__recursive_w_multiple_args(self):
         linux_acl.delfacl(*(self.default_user_acl[:-1] + self.files), recursive=True)
-        self.cmdrun.assert_called_once_with('setfacl -R -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -R -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.quoted_files), python_shell=False)

--- a/tests/unit/modules/linux_acl_test.py
+++ b/tests/unit/modules/linux_acl_test.py
@@ -23,7 +23,7 @@ class LinuxAclTestCase(TestCase):
         self.file = '/tmp/file'
         self.quoted_file = '"/tmp/file"'
         self.files = ['/tmp/file1', '/tmp/file2', '/tmp/file3 with whitespaces']
-        self.quoted_files = [ '"{0}"'.format(f) for f in self.files]
+        self.quoted_files = ['"{0}"'.format(f) for f in self.files]
         self.u_acl = ['u', 'myuser', 'rwx']
         self.user_acl = ['user', 'myuser', 'rwx']
         self.user_acl_cmd = 'u:myuser:rwx'


### PR DESCRIPTION
### What does this PR do?

bugfix: Whitespace in linux_acl.getfacl
### What issues does this PR fix or reference?
### Previous Behavior

```
[root@saltmaster ~]# salt minion file.touch '/tmp/acl issue'
minion:
    True
[root@saltmaster ~]# salt minion file.stats '/tmp/acl issue'
minion:
    ----------
    atime:
        1475773217.09
    ctime:
        1475773217.09
    gid:
        0
    group:
        root
    inode:
        279473
    mode:
        0644
    mtime:
        1475773217.09
    size:
        0
    target:
        /tmp/acl issue
    type:
        file
    uid:
        0
    user:
        root
[root@saltmaster ~]# salt minion acl.getfacl '/tmp/acl issue'
minion:
    ----------
ERROR: Minions returned with non-zero exit code
```
### New Behavior

```
[root@saltmaster ~]# salt minion saltutil.sync_modules
minion:
    - modules.linux_acl

[root@saltmaster ~]# salt minion acl.getfacl '/tmp/acl issue'
minion:
    ----------
    /tmp/acl issue:
        ----------
        comment:
            ----------
            file:
                /tmp/acl issue
            group:
                root
            owner:
                root
        group:
            |_
              ----------
              root:
                  ----------
                  octal:
                      4
                  permissions:
                      ----------
                      execute:
                          False
                      read:
                          True
                      write:
                          False
        other:
            |_
              ----------
              :
                  ----------
                  octal:
                      4
                  permissions:
                      ----------
                      execute:
                          False
                      read:
                          True
                      write:
                          False
        user:
            |_
              ----------
              root:
                  ----------
                  octal:
                      6
                  permissions:
                      ----------
                      execute:
                          False
                      read:
                          True
                      write:
                          True
```
### Tests written?

Updated existing tests

It is a trivial fix