### PR TITLE
fileclient: Change queryarg comparison from None to simple boolean check

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -803,7 +803,7 @@ class Client(object):
         elif not os.path.isabs(cachedir):
             cachedir = os.path.join(self.opts['cachedir'], cachedir)
 
-        if url_data.query is not None:
+        if url_data.query:
             file_name = '-'.join([url_data.path, url_data.query])
         else:
             file_name = url_data.path


### PR DESCRIPTION
When there are no queryargs, the `query` attribute is an empty string,
not `None`.

Fixes #36804 
