### PR TITLE
[develop] grains should have some information about zpools if available

### DIFF
--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -30,6 +30,7 @@ from salt.grains import core
 core.__salt__ = {}
 core.__opts__ = {}
 
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class CoreGrainsTestCase(TestCase):
     '''

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -28,7 +28,7 @@ from salt.grains import core
 
 # Globals
 core.__salt__ = {}
-
+core.__opts__ = {}
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class CoreGrainsTestCase(TestCase):


### PR DESCRIPTION
### What does this PR do?

Add information about zpools to grains.
### What issues does this PR fix or reference?

n/a
### Previous Behavior

No grains about zpools present on the system
### New Behavior

Summary information about zpools and children is available

``` bash
root@core /opt/tools/lib/python2.7/site-packages/salt/grains]# salt-call --local grains.get zpool
```

``` yaml
local:
    ----------
    archive:
        ----------
        children:
            ----------
            datasets:
                5
            snapshots:
                35
            volumes:
                0
        health:
            ONLINE
        size:
            ----------
            alloc:
                8.35T
            cap_pct:
                61
            free:
                13.4T
            total:
                21.8T
    data:
        ----------
        children:
            ----------
            datasets:
                13
            snapshots:
                142
            volumes:
                2
        health:
            ONLINE
        size:
            ----------
            alloc:
                1.24T
            cap_pct:
                31
            free:
                586G
            total:
                1.81T
    zones:
        ----------
        children:
            ----------
            datasets:
                31
            snapshots:
                79
            volumes:
                2
        health:
            ONLINE
        size:
            ----------
            alloc:
                64.5G
            cap_pct:
                41
            free:
                46.5G
            total:
                111G
```
### Tests written?

No
### Additional info

Targeting develop branch because this is a new feature, although the patch applies to 2016.3 cleanly too. 
