### PR TITLE
fix return of boto_ec2.instance_present if test=True

### DIFF
--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -917,7 +917,10 @@ def instance_present(name, instance_name=None, instance_id=None, image_id=None,
     if __opts__['test']:
         if changed_attrs:
             ret['changes']['new'] = changed_attrs
-        ret['result'] = None
+            ret['result'] = None
+        else:
+            ret['comment'] = 'Instance {0} is in the correct state'.format(instance_name if instance_name else name)
+            ret['result'] = True
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?

Add correct return in boto_ec2.instance_present state if running in test mode.
### What issues does this PR fix or reference?

Fix return of boto_ec2.instance_present if run with test=True option.
### Previous Behavior

Example return before this commit:

```
----------
          ID: test-instance
    Function: boto_ec2.instance_present
        Name: test-instance
      Result: None
     Comment:
     Started: 13:15:20.790506
    Duration: 218.224 ms
     Changes:
----------
```
### New Behavior

Example return after this commit:

```
----------
          ID: test-instance
    Function: boto_ec2.instance_present
        Name: test-instance
      Result: True
     Comment: Instance test-instance already present.
     Started: 13:18:32.013133
    Duration: 235.952 ms
     Changes:
----------
```
### Tests written?

No
