### PR TITLE
pkg on Mac OSX: Support full package names

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -625,11 +625,15 @@ def _verify_install(desired, new_pkgs, ignore_epoch=False):
     ok = []
     failed = []
     for pkgname, pkgver in desired.items():
-        # FreeBSD pkg supports `openjdk` and `java/openjdk7` package names
-        origin = bool(re.search('/', pkgname))
+        # FreeBSD pkg supports `openjdk` and `java/openjdk7` package names.
+        # Homebrew for Mac OSX does something similar with tap names
+        # prefixing package names, separated with a slash.
+        has_origin = '/' in pkgname
 
-        if __grains__['os'] == 'FreeBSD' and origin:
+        if __grains__['os'] == 'FreeBSD' and has_origin:
             cver = [k for k, v in six.iteritems(new_pkgs) if v['origin'] == pkgname]
+        elif __grains__['os'] == 'MacOS' and has_origin:
+            cver = new_pkgs.get(pkgname, new_pkgs.get(pkgname.split('/')[-1]))
         elif __grains__['os'] == 'OpenBSD':
             cver = new_pkgs.get(pkgname.split('%')[0])
         elif __grains__['os_family'] == 'Debian':


### PR DESCRIPTION
### What does this PR do?

Supports fully-qualified package names in Homebrew
### What issues does this PR fix or reference?

There is no corresponding issue for this that I can find.

The problem can be trivially reproduced by attempting to use `pkg.installed` to install something from an external homebrew tap.

This DOES NOT fix or address #26414
### Previous Behavior

The package would usually successfully install, but salt would always report a failure and be unable to detect that the package has been installed on future runs.
### New Behavior

As far as I can tell, as expected: installing from a tap will now report success if it succeeded.

This does not fix `pkg.removed` but it's probably a step in the right direction. `pkg.removed` can just use the short name.

I see a potential bug where a package will be reported as installed already even if the installed version came from a different tap, but I'm not sure how important that is as an edge case.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

---

There are probably enough special cases in that block of code now to warrant splitting this out into its respective `modules` files. What do you think?

---

Commit blurb follows

> This makes _verify_install ignore everything up to and including the
> final slash in a package name on Mac OSX, if that is necessary to find
> the correct package.
> 
> This allows specifications to be prefixed with a tap name, like
> "homebrew/science/a5".
