### PR TITLE
Allow function privileges to be set

### DIFF
--- a/salt/states/postgres_privileges.py
+++ b/salt/states/postgres_privileges.py
@@ -106,6 +106,7 @@ def present(name,
        - language
        - database
        - group
+       - function
 
     privileges
        List of privileges to grant, from the list below:
@@ -226,6 +227,7 @@ def absent(name,
        - language
        - database
        - group
+       - function
 
     privileges
        Comma separated list of privileges to revoke, from the list below:


### PR DESCRIPTION
### What does this PR do?

Allows permissions to be set for functions
### What issues does this PR fix or reference?
#36765
### Previous Behavior

The postgres module did not allow `EXECUTE` permissions to be granted or revoked on functions.
### New Behavior

Since PG allows functions to be overloaded, the function name must be specified with a list of types separated by commas

```
localharvest:
  postgres_privileges.present:
    - maintenance_db: localharvest
    - user: _postgresql
    - db_user: postgres
    - object_name: first_friday(text)
    - object_type: function
    - privileges:
      - EXECUTE
```

If the function does takes no arguments use empty parens `()`.
