### PR TITLE
[2016.11.0rc1] module.x509 did not handle mine.get output properly

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -419,6 +419,25 @@ def get_pem_entry(text, pem_type=None):
 
     _match = None
 
+    if len(text.splitlines()) == 1 and text.startswith('-----') and text.endswith('-----'):
+        # mine.get returns the PEM on a single line, we fix this
+        pem_fixed = []
+        pem_temp = text
+        while len(pem_temp) > 0:
+            if pem_temp.startswith('-----'):
+                # Grab ----(.*)---- blocks
+                pem_fixed.append(pem_temp[:pem_temp.index('-----', 5)+5])
+                pem_temp = pem_temp[pem_temp.index('-----', 5)+5:]
+            else:
+                # grab base64 chunks
+                if pem_temp[:64].count('-') == 0:
+                    pem_fixed.append(pem_temp[:64])
+                    pem_temp = pem_temp[64:]
+                else:
+                    pem_fixed.append(pem_temp[:pem_temp.index('-')])
+                    pem_temp = pem_temp[pem_temp.index('-'):]
+        text = "\n".join(pem_fixed)
+
     if not pem_type:
         # Find using a regex iterator, pick the first match
         for _match in PEM_RE.finditer(text):


### PR DESCRIPTION
### What does this PR do?

Now that I have found the elusive 2016.11 branch under the code name...

This PR adds an extra check to get_pem_entry to fix mine.get output.
If it detects a single line text block beginning and ending with `-----`,
Inject new lines after the `-----.*-----` blocks and for the base64 data every 64 chars.
### What issues does this PR fix or reference?
#36861
### Previous Behavior

It would error out because it is not a valid PEM format.
### New Behavior

It works as expected, text is valid PEM format after fixing it.
### Tests written?

No
