### PR TITLE
[2016.11.0rc1] (re)introduce minimal weighing to get_fqhostname

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -180,6 +180,26 @@ def get_fqhostname():
     except socket.gaierror:
         pass
 
+    # remove empty elements
+    l = [h for h in l if h]
+
+    # apply minimal weighting
+    def _weighted_hostname(e):
+        # favor hostnames w/o spaces
+        if ' ' in e:
+            first = 1
+        else:
+            first = -1
+
+        # favor hosts with more dots
+        second = -(e.count('.'))
+
+        # favor longest fqdn
+        third = -(len(e))
+
+        return (first, second, third)
+    l = sorted(l, key=_weighted_hostname)
+
     return l and l[0] or None
 
 


### PR DESCRIPTION
### What does this PR do?

Introduces minimal weighing to get_fqhostname,
Solaris-like platforms seem to have the nodename as first entry in ai_canonname.
### What issues does this PR fix or reference?
saltstack/salt#36869
### Previous Behavior

Pick first entry
### New Behavior
1. strips out useless '' entries
2. applies minimal weighing to the list

This is based on the old _sort_hostname function, keeping only what made sense in this usecase.
### Tests written?

No