### PR TITLE
[develop] salt.modules.at was hopelessly broken on Solaris-like platforms

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -25,6 +25,7 @@ execution modules
     archive
     artifactory
     at
+    at_solaris
     augeas_cfg
     aws_sqs
     bamboohr

--- a/doc/ref/modules/all/salt.modules.at_solaris.rst
+++ b/doc/ref/modules/all/salt.modules.at_solaris.rst
@@ -1,0 +1,6 @@
+=======================
+salt.modules.at_solaris
+=======================
+
+.. automodule:: salt.modules.at_solaris
+    :members:

--- a/salt/modules/at.py
+++ b/salt/modules/at.py
@@ -4,6 +4,10 @@ Wrapper module for at(1)
 
 Also, a 'tag' feature has been added to more
 easily tag jobs.
+
+:platform:      linux,openbsd,freebsd
+
+.. versionchanged:: nitrogen
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/at.py
+++ b/salt/modules/at.py
@@ -27,14 +27,18 @@ import salt.utils
 # Tested on OpenBSD 5.0
 BSD = ('OpenBSD', 'FreeBSD')
 
+__virtualname__ = 'at'
+
 
 def __virtual__():
     '''
     Most everything has the ability to support at(1)
     '''
-    if salt.utils.is_windows() or salt.utils.which('at') is None:
+    if salt.utils.is_windows() or salt.utils.is_sunos():
+        return (False, 'The at module could not be loaded: unsupported platform')
+    if salt.utils.which('at') is None:
         return (False, 'The at module could not be loaded: at command not found')
-    return True
+    return __virtualname__
 
 
 def _cmd(binary, *args):
@@ -79,15 +83,15 @@ def atq(tag=None):
     if output == '':
         return {'jobs': jobs}
 
+    # Jobs created with at.at() will use the following
+    # comment to denote a tagged job.
+    job_kw_regex = re.compile(r'^### SALT: (\w+)')
+
     # Split each job into a dictionary and handle
     # pulling out tags or only listing jobs with a certain
     # tag
     for line in output.splitlines():
         job_tag = ''
-
-        # Jobs created with at.at() will use the following
-        # comment to denote a tagged job.
-        job_kw_regex = re.compile(r'^### SALT: (\w+)')
 
         # Redhat/CentOS
         if __grains__['os_family'] == 'RedHat':

--- a/salt/modules/at_solaris.py
+++ b/salt/modules/at_solaris.py
@@ -1,0 +1,326 @@
+# -*- coding: utf-8 -*-
+'''
+Wrapper for at(1) on Solaris-like systems
+
+Output is compatible with the generic at
+module where possible.
+'''
+from __future__ import absolute_import
+
+# Import python libs
+import re
+import time
+import datetime
+import logging
+
+# Import 3rd-party libs
+# pylint: disable=import-error,redefined-builtin
+from salt.ext.six.moves import map
+
+# Import salt libs
+import salt.utils
+
+log = logging.getLogger(__name__)
+__virtualname__ = 'at'
+
+
+def __virtual__():
+    '''
+    We only deal with Solaris' specific version of at
+    '''
+    if not salt.utils.is_sunos():
+        return (False, 'The at module could not be loaded: unsupported platform')
+    if not salt.utils.which('at') or \
+        not salt.utils.which('atq') or \
+        not salt.utils.which('atrm'):
+        return (False, 'The at module could not be loaded: at command not found')
+    return __virtualname__
+
+
+def atq(tag=None):
+    '''
+    List all queued and running jobs or only those with
+    an optional 'tag'.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' at.atq
+        salt '*' at.atq [tag]
+        salt '*' at.atq [job number]
+    '''
+    jobs = []
+
+    res = __salt__['cmd.run_all']('atq')
+
+    if res['retcode'] > 0:
+        return {'error': res['stderr']}
+
+    # No jobs so return
+    if res['stdout'] == 'no files in queue.':
+        return {'jobs': jobs}
+
+    # Jobs created with at.at() will use the following
+    # comment to denote a tagged job.
+    job_kw_regex = re.compile(r'^### SALT: (\w+)')
+
+    # Split each job into a dictionary and handle
+    # pulling out tags or only listing jobs with a certain
+    # tag
+    for line in res['stdout'].splitlines():
+        job_tag = ''
+
+        # skip header
+        if line.startswith(' Rank'):
+            continue
+
+        # parse job output
+        tmp = line.split()
+        timestr = ' '.join(tmp[1:5])
+        job = tmp[6]
+        specs = datetime.datetime(
+            *(time.strptime(timestr, '%b %d, %Y %H:%M')[0:5])
+        ).isoformat().split('T')
+        specs.append(tmp[7])
+        specs.append(tmp[5])
+
+        # make sure job is str
+        job = str(job)
+
+        # search for any tags
+        atjob_file = '/var/spool/cron/atjobs/{job}'.format(
+            job=job
+        )
+        if __salt__['file.file_exists'](atjob_file):
+            with salt.utils.fopen(atjob_file, 'r') as atjob:
+                for line in atjob:
+                    tmp = job_kw_regex.match(line)
+                    if tmp:
+                        job_tag = tmp.groups()[0]
+
+        # filter on tags
+        if not tag:
+            jobs.append({'job': job, 'date': specs[0], 'time': specs[1],
+                'queue': specs[2], 'user': specs[3], 'tag': job_tag})
+        elif tag and tag in [job_tag, job]:
+            jobs.append({'job': job, 'date': specs[0], 'time': specs[1],
+                'queue': specs[2], 'user': specs[3], 'tag': job_tag})
+
+    return {'jobs': jobs}
+
+
+def atrm(*args):
+    '''
+    Remove jobs from the queue.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' at.atrm <jobid> <jobid> .. <jobid>
+        salt '*' at.atrm all
+        salt '*' at.atrm all [tag]
+    '''
+
+    if not args:
+        return {'jobs': {'removed': [], 'tag': None}}
+
+    if args[0] == 'all':
+        if len(args) > 1:
+            opts = list(list(map(str, [j['job'] for j in atq(args[1])['jobs']])))
+            ret = {'jobs': {'removed': opts, 'tag': args[1]}}
+        else:
+            opts = list(list(map(str, [j['job'] for j in atq()['jobs']])))
+            ret = {'jobs': {'removed': opts, 'tag': None}}
+    else:
+        opts = list(list(map(str, [i['job'] for i in atq()['jobs']
+            if i['job'] in args])))
+        ret = {'jobs': {'removed': opts, 'tag': None}}
+
+    # call atrm for each job in ret['jobs']['removed']
+    for job in ret['jobs']['removed']:
+        res_job = __salt__['cmd.run_all']('atrm {job}'.format(
+            job=job
+        ))
+        if res_job['retcode'] > 0:
+            if 'failed' not in ret['jobs']:
+                ret['jobs']['failed'] = {}
+            ret['jobs']['failed'][job] = res_job['stderr']
+
+    # remove failed from list
+    if 'failed' in ret['jobs']:
+        for job in ret['jobs']['failed']:
+            ret['jobs']['removed'].remove(job)
+
+    return ret
+
+
+def at(*args, **kwargs):  # pylint: disable=C0103
+    '''
+    Add a job to the queue.
+
+    The 'timespec' follows the format documented in the
+    at(1) manpage.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' at.at <timespec> <cmd> [tag=<tag>] [runas=<user>]
+        salt '*' at.at 12:05am '/sbin/reboot' tag=reboot
+        salt '*' at.at '3:05am +3 days' 'bin/myscript' tag=nightly runas=jim
+    '''
+
+    # check args
+    if len(args) < 2:
+        return {'jobs': []}
+
+    # build job
+    if 'tag' in kwargs:
+        stdin = '### SALT: {0}\n{1}'.format(kwargs['tag'], ' '.join(args[1:]))
+    else:
+        stdin = ' '.join(args[1:])
+
+    cmd_kwargs = {'stdin': stdin, 'python_shell': False}
+    if 'runas' in kwargs:
+        cmd_kwargs['runas'] = kwargs['runas']
+    res = __salt__['cmd.run_all']('at "{timespec}"'.format(
+        timespec=args[0]
+    ), **cmd_kwargs)
+
+    # verify job creation
+    if res['retcode'] > 0:
+        if 'bad time specification' in res['stderr']:
+            return {'jobs': [], 'error': 'invalid timespec'}
+        return {'jobs': [], 'error': res['stderr']}
+    else:
+        jobid = res['stderr'].splitlines()[1]
+        jobid = str(jobid.split()[1])
+        return atq(jobid)
+
+
+def atc(jobid):
+    '''
+    Print the at(1) script that will run for the passed job
+    id. This is mostly for debugging so the output will
+    just be text.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' at.atc <jobid>
+    '''
+
+    atjob_file = '/var/spool/cron/atjobs/{job}'.format(
+        job=jobid
+    )
+    if __salt__['file.file_exists'](atjob_file):
+        return "".join(salt.utils.fopen(atjob_file, 'r').readlines())
+    else:
+        return {'error': 'invalid job id \'{0}\''.format(jobid)}
+
+
+def _atq(**kwargs):
+    '''
+    Return match jobs list
+    '''
+
+    jobs = []
+
+    runas = kwargs.get('runas', None)
+    tag = kwargs.get('tag', None)
+    hour = kwargs.get('hour', None)
+    minute = kwargs.get('minute', None)
+    day = kwargs.get('day', None)
+    month = kwargs.get('month', None)
+    year = kwargs.get('year', None)
+    if year and len(str(year)) == 2:
+        year = '20{0}'.format(year)
+
+    jobinfo = atq()['jobs']
+    if not jobinfo:
+        return {'jobs': jobs}
+
+    for job in jobinfo:
+
+        if not runas:
+            pass
+        elif runas == job['user']:
+            pass
+        else:
+            continue
+
+        if not tag:
+            pass
+        elif tag == job['tag']:
+            pass
+        else:
+            continue
+
+        if not hour:
+            pass
+        elif '{0:02d}'.format(int(hour)) == job['time'].split(':')[0]:
+            pass
+        else:
+            continue
+
+        if not minute:
+            pass
+        elif '{0:02d}'.format(int(minute)) == job['time'].split(':')[1]:
+            pass
+        else:
+            continue
+
+        if not day:
+            pass
+        elif '{0:02d}'.format(int(day)) == job['date'].split('-')[2]:
+            pass
+        else:
+            continue
+
+        if not month:
+            pass
+        elif '{0:02d}'.format(int(month)) == job['date'].split('-')[1]:
+            pass
+        else:
+            continue
+
+        if not year:
+            pass
+        elif year == job['date'].split('-')[0]:
+            pass
+        else:
+            continue
+
+        jobs.append(job)
+
+    if not jobs:
+        note = 'No match jobs or time format error'
+        return {'jobs': jobs, 'note': note}
+
+    return {'jobs': jobs}
+
+
+def jobcheck(**kwargs):
+    '''
+    Check the job from queue.
+    The kwargs dict include 'hour minute day month year tag runas'
+    Other parameters will be ignored.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' at.jobcheck runas=jam day=13
+        salt '*' at.jobcheck day=13 month=12 year=13 tag=rose
+    '''
+
+    if not kwargs:
+        return {'error': 'You have given a condition'}
+
+    return _atq(**kwargs)
+
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/at_solaris.py
+++ b/salt/modules/at_solaris.py
@@ -2,8 +2,15 @@
 '''
 Wrapper for at(1) on Solaris-like systems
 
-Output is compatible with the generic at
-module where possible.
+.. note::
+    we try to mirror the generic at module
+    where possible
+
+:maintainer:    jorge schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:platform:      solaris,illumos,smartso
+
+.. versionadded:: nitrogen
 '''
 from __future__ import absolute_import
 

--- a/salt/states/at.py
+++ b/salt/states/at.py
@@ -7,12 +7,13 @@ The at state can be add disposable regularly scheduled tasks for your system.
 '''
 from __future__ import absolute_import
 
+# Import Python libs
+import logging
+
 # Import salt libs
-import salt.utils
 from salt.ext.six.moves import map
 
-# Tested on OpenBSD 5.0
-BSD = ('OpenBSD', 'FreeBSD')
+log = logging.getLogger(__name__)
 
 
 def __virtual__():
@@ -22,23 +23,27 @@ def __virtual__():
     return 'at.at' in __salt__
 
 
-def present(name, timespec, tag=None, user=None, job=None):
+def present(name, timespec, tag=None, user=None, job=None, unique_tag=False):
     '''
+    .. versionchanged:: nitrogen
     Add a job to queue.
 
-    job
+    job : string
         Command to run.
 
-    timespec
+    timespec : string
         The 'timespec' follows the format documented in the at(1) manpage.
 
-    tag
+    tag : string
         Make a tag for the job.
 
-    user
+    user : string
         The user to run the at job
-
         .. versionadded:: 2014.1.4
+
+    unique_tag : boolean
+        If set to True job will not be added if a job with the tag exists.
+        .. versionadded:: nitrogen
 
     .. code-block:: yaml
 
@@ -50,133 +55,192 @@ def present(name, timespec, tag=None, user=None, job=None):
             - user: jam
 
     '''
-    if job:
-        name = job
     ret = {'name': name,
            'changes': {},
            'result': True,
-           'comment': 'job {0} is add and will run on {1}'.format(name,
-                                                                  timespec)}
+           'comment': ''}
 
-    binary = salt.utils.which('at')
+    # if job is missing, use name
+    if not job:
+        job = name
 
+    # quick return on test=True
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = 'job {0} is add and will run on {1}'.format(name,
-                                                                     timespec)
+        ret['comment'] = 'job {0} added and will run on {1}'.format(
+            job,
+            timespec,
+        )
         return ret
 
-    if tag:
-        stdin = '### SALT: {0}\n{1}'.format(tag, name)
-    else:
-        stdin = name
-    cmd = '{0} {1}'.format(binary, timespec)
+    # quick return if unique_tag and job exists
+    if unique_tag:
+        if not tag:
+            ret['result'] = False
+            ret['comment'] = 'no tag provided and unique_tag is set to True'
+            return ret
+        elif len(__salt__['at.jobcheck'](tag=tag)['jobs']) > 0:
+            ret['comment'] = 'atleast one job with tag {tag} exists.'.format(
+                tag=tag
+            )
+            return ret
 
+    # create job
     if user:
         luser = __salt__['user.info'](user)
         if not luser:
-            ret['comment'] = 'User: {0} is not exists'.format(user)
             ret['result'] = False
+            ret['comment'] = 'user {0} does not exists'.format(user)
             return ret
-        ret['comment'] = __salt__['cmd.run'](cmd, stdin=stdin, runas=user)
+        ret['comment'] = 'job {0} added and will run as {1} on {2}'.format(
+            job,
+            user,
+            timespec,
+        )
+        res = __salt__['at.at'](
+            timespec,
+            job,
+            tag=tag,
+            runas=user,
+        )
     else:
-        ret['comment'] = __salt__['cmd.run'](cmd, stdin=stdin)
+        ret['comment'] = 'job {0} added and will run on {1}'.format(
+            job,
+            timespec,
+        )
+        res = __salt__['at.at'](
+            timespec,
+            job,
+            tag=tag,
+        )
+
+    # set ret['changes']
+    if 'jobs' in res and len(res['jobs']) > 0:
+        ret['changes'] = res['jobs'][0]
+    if 'error' in res:
+        ret['result'] = False
+        ret['comment'] = res['error']
 
     return ret
 
 
 def absent(name, jobid=None, **kwargs):
     '''
+    .. versionchanged:: nitrogen
     Remove a job from queue
-    The 'kwargs' can include hour. minute. day. month. year
 
-    limit
-        Target range
+    jobid: string|int
+        Specific jobid to remove
 
-    tag
+    tag : string
         Job's tag
 
-    runas
+    runas : string
         Runs user-specified jobs
+
+    **kwags : *
+        Addition kwargs can be provided to filter jobs.
+        See output of `at.jobcheck` for more.
 
     .. code-block:: yaml
 
         example1:
           at.absent:
-            - limit: all
+
+    .. warning::
+        this will remove all jobs!
 
     .. code-block:: yaml
 
         example2:
           at.absent:
-            - limit: all
             - year: 13
 
     .. code-block:: yaml
 
         example3:
           at.absent:
-            - limit: all
             - tag: rose
-            - runas: jim
 
     .. code-block:: yaml
 
         example4:
           at.absent:
-            - limit: all
             - tag: rose
             - day: 13
             - hour: 16
+
+    .. code-block:: yaml
+
+        example5:
+          at.absent:
+            - jobid: 4
+
+    .. note:
+        all other filters are ignored and only job with id 4 is removed
     '''
-    if 'limit' in kwargs:
-        name = kwargs['limit']
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': ''}
 
-    binary = salt.utils.which('at')
-
-    if __opts__['test']:
-        ret['result'] = None
-        ret['comment'] = 'Remove jobs()'
-        return ret
-
-    if name != 'all':
+    # limit was never support
+    if 'limit' in kwargs:
         ret['comment'] = 'limit parameter not supported {0}'.format(name)
         ret['result'] = False
         return ret
 
-    #if jobid:
-    #    output = __salt__['cmd.run']('{0} -d {1}'.format(binary, jobid))
-    #    if i in map(str, [j['job'] for j in __salt__['at.atq']()['jobs']]):
-    #        ret['result'] = False
-    #        return ret
-    #    ret['comment'] = 'Remove job({0}) from queue'.format(' '.join(opts))
-    #    return ret
-
-    if kwargs:
-        opts = list(list(map(str, [j['job'] for j in __salt__['at.jobcheck'](**kwargs)['jobs']])))
-    else:
-        opts = list(list(map(str, [j['job'] for j in __salt__['at.atq']()['jobs']])))
-
-    if not opts:
-        ret['result'] = False
-        ret['comment'] = 'No match jobs or time format error'
+    # quick return on test=True
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'removed ? job(s)'
         return ret
 
-    __salt__['cmd.run']('{0} -d {1}'.format(binary, ' '.join(opts)))
-    fail = []
-    for i in opts:
-        if i in list(list(map(str, [j['job'] for j in __salt__['at.atq']()['jobs']]))):
-            fail.append(i)
+    # remove specific job
+    if jobid:
+        jobs = __salt__['at.atq'](jobid)
+        if 'jobs' in jobs and len(jobs['jobs']) == 0:
+            ret['result'] = True
+            ret['comment'] = 'job with id {jobid} not present'.format(
+                jobid=jobid
+            )
+            return ret
+        elif 'jobs' in jobs and len(jobs['jobs']) == 1:
+            if 'job' in jobs['jobs'][0] and jobs['jobs'][0]['job']:
+                res = __salt__['at.atrm'](jobid)
+                ret['result'] = jobid in res['jobs']['removed']
+                if ret['result']:
+                    ret['comment'] = 'job with id {jobid} was removed'.format(
+                        jobid=jobid
+                    )
+                else:
+                    ret['comment'] = 'failed to remove job with id {jobid}'.format(
+                        jobid=jobid
+                    )
+                ret['changes']['removed'] = res['jobs']['removed']
+                return ret
+        else:
+            ret['result'] = False
+            ret['comment'] = 'more than one job was return for job with id {jobid}'.format(
+                jobid=jobid
+            )
+            return ret
 
-    if fail:
-        ret['comment'] = 'Remove job({0}) from queue but ({1}) fail'.format(
-            ' '.join(opts), fail
-       )
+    # remove jobs based on filter
+    if kwargs:
+        # we pass kwargs to at.jobcheck
+        opts = list(list(map(str, [j['job'] for j in __salt__['at.jobcheck'](**kwargs)['jobs']])))
+        res = __salt__['at.atrm'](*opts)
     else:
-        ret['comment'] = 'Remove job({0}) from queue'.format(' '.join(opts))
+        # arguments to filter with, removing everything!
+        res = __salt__['at.atrm']('all')
 
+    if len(res['jobs']['removed']) > 0:
+        ret['changes']['removed'] = res['jobs']['removed']
+    ret['comment'] = 'removed {count} job(s)'.format(
+        count=len(res['jobs']['removed'])
+    )
     return ret
+
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/states/at.py
+++ b/salt/states/at.py
@@ -243,4 +243,68 @@ def absent(name, jobid=None, **kwargs):
     return ret
 
 
+def watch(name, timespec, tag=None, user=None, job=None, unique_tag=False):
+    '''
+    .. versionadded:: nitrogen
+    Add an at job if trigger by watch
+
+    job : string
+        Command to run.
+
+    timespec : string
+        The 'timespec' follows the format documented in the at(1) manpage.
+
+    tag : string
+        Make a tag for the job.
+
+    user : string
+        The user to run the at job
+        .. versionadded:: 2014.1.4
+
+    unique_tag : boolean
+        If set to True job will not be added if a job with the tag exists.
+        .. versionadded:: nitrogen
+
+    .. code-block:: yaml
+
+        minion_restart:
+          at.watch:
+            - job: 'salt-call --local service.restart salt-minion'
+            - timespec: 'now +1 min'
+            - tag: minion_restart
+            - unique_tag: trye
+            - watch:
+                - file: /etc/salt/minion
+
+    '''
+    return {
+        'name': name,
+        'changes': {},
+        'result': True,
+        'comment': ''
+    }
+
+
+def mod_watch(name, **kwargs):
+    '''
+    The at watcher, called to invoke the watch command.
+
+    name
+        The name of the atjob
+
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if kwargs['sfun'] == 'watch':
+        for p in ['sfun', '__reqs__']:
+            del kwargs[p]
+        kwargs['name'] = name
+        ret = present(**kwargs)
+
+    return ret
+
+
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/tests/unit/states/at_test.py
+++ b/tests/unit/states/at_test.py
@@ -36,34 +36,72 @@ class AtTestCase(TestCase):
         '''
         Test to add a job to queue.
         '''
+
+        # input variables
         name = 'jboss'
         timespec = '9:09 11/04/15'
         tag = 'love'
         user = 'jam'
 
-        ret = {'name': name,
-               'result': True,
-               'changes': {},
-               'comment': ''}
+        # mock for at.at module call
+        mock_atat = {
+            'jobs': [
+                {
+                    'date': '2015-11-04',
+                    'job': '1476031633.a',
+                    'queue': 'a',
+                    'tag': tag,
+                    'time': '09:09:00',
+                    'user': user,
+                },
+            ],
+        }
 
+        # normale return
+        ret = {
+            'name': name,
+            'result': True,
+            'changes': {
+                'date': '2015-11-04',
+                'job': '1476031633.a',
+                'queue': 'a',
+                'tag': 'love',
+                'time': '09:09:00',
+                'user': 'jam',
+            },
+            'comment': 'job {name} added and will run on {timespec}'.format(
+                name=name,
+                timespec=timespec
+            ),
+        }
+
+        # unknown user return
+        ret_user = {}
+        ret_user.update(ret)
+        ret_user.update({
+            'result': False,
+            'changes': {},
+            'comment': 'user {0} does not exists'.format(user),
+        })
+
+        # add a job
+        mock = MagicMock(return_value=mock_atat)
+        with patch.dict(at.__opts__, {'test': False}):
+            with patch.dict(at.__salt__, {'at.at': mock}):
+                self.assertDictEqual(at.present(name, timespec, tag), ret)
+
+        # add a job with a non-existing user
         mock = MagicMock(return_value=False)
         with patch.dict(at.__opts__, {'test': False}):
-            with patch.dict(at.__grains__, {'os_family': 'Redhat'}):
-                with patch.dict(at.__salt__, {'cmd.run': mock}):
-                    ret.update({'comment': False})
-                    self.assertDictEqual(at.present(name, timespec, tag),
-                                         ret)
+            with patch.dict(at.__salt__, {'user.info': mock}):
+                self.assertDictEqual(at.present(name, timespec, tag, user), ret_user)
 
-                with patch.dict(at.__salt__, {'user.info': mock}):
-                    comt = 'User: {0} is not exists'.format(user)
-                    ret.update({'comment': comt, 'result': False})
-                    self.assertDictEqual(at.present(name, timespec, tag, user),
-                                         ret)
-
+        # add a job with test=True
         with patch.dict(at.__opts__, {'test': True}):
-            comt = 'job {0} is add and will run on {1}'.format(name, timespec)
-            ret.update({'comment': comt, 'result': None})
-            self.assertDictEqual(at.present(name, timespec, tag, user), ret)
+            ret_test = {}
+            ret_test.update(ret)
+            ret_test.update({'result': None, 'changes': {}})
+            self.assertDictEqual(at.present(name, timespec, tag, user), ret_test)
 
     # 'absent' function tests: 1
 
@@ -71,37 +109,113 @@ class AtTestCase(TestCase):
         '''
         Test to remove a job from queue
         '''
+        # input variables
         name = 'jboss'
+        tag = 'rose'
+        user = 'jam'
 
-        ret = {'name': name,
-               'result': None,
-               'changes': {},
-               'comment': ''}
+        # mock for at.atrm module call
+        mock_atatrm = {
+            'jobs': {
+                'removed': ['1476033859.a', '1476033855.a'],
+                'tag': None,
+             },
+        }
 
+        # mock for at.jobcheck module call
+        mock_atjobcheck = {
+            'jobs': [
+                {
+                    'date': '2015-11-04',
+                    'job': '1476031633.a',
+                    'queue': 'a',
+                    'tag': tag,
+                    'time': '09:09:00',
+                    'user': user,
+                },
+            ],
+        }
+
+        # normal return
+        ret = {
+            'name': name,
+            'result': True,
+            'changes': {
+                'removed': ['1476033859.a', '1476033855.a'],
+             },
+            'comment': 'removed 2 job(s)',
+        }
+
+        # remove a job with test=True
         with patch.dict(at.__opts__, {'test': True}):
-            ret.update({'comment': 'Remove jobs()'})
-            self.assertDictEqual(at.absent(name), ret)
+            ret_test = {}
+            ret_test.update(ret)
+            ret_test.update({
+                'result': None,
+                'changes': {},
+                'comment': 'removed ? job(s)'
+            })
+            self.assertDictEqual(at.absent(name), ret_test)
 
+        # remove a job and pass limit parameter
         with patch.dict(at.__opts__, {'test': False}):
-            comt = 'limit parameter not supported {0}'.format(name)
-            ret.update({'comment': comt, 'result': False})
-            self.assertDictEqual(at.absent(name), ret)
+            ret_limit = {}
+            ret_limit.update(ret)
+            ret_limit.update({
+                'result': False,
+                'changes': {},
+                'comment': 'limit parameter not supported {0}'.format(name),
+            })
+            self.assertDictEqual(at.absent(name, limit='all'), ret_limit)
 
-            mock = MagicMock(return_value={'jobs': []})
-            mock_bool = MagicMock(return_value=False)
-            with patch.dict(at.__salt__, {'at.atq': mock,
-                                          'cmd.run': mock_bool}):
-                comt = 'No match jobs or time format error'
-                ret.update({'comment': comt, 'result': False, 'name': 'all'})
-                self.assertDictEqual(at.absent('all'), ret)
+        # remove all jobs (2 jobs found)
+        mock = MagicMock(return_value=mock_atatrm)
+        with patch.dict(at.__salt__, {'at.atrm': mock}):
+            with patch.dict(at.__opts__, {'test': False}):
+                self.assertDictEqual(at.absent(name), ret)
 
-            mock = MagicMock(return_value={'jobs': [{'job': 'rose'}]})
-            mock_bool = MagicMock(return_value=False)
-            with patch.dict(at.__salt__, {'at.atq': mock,
-                                          'cmd.run': mock_bool}):
-                comt = "Remove job(rose) from queue but (['rose']) fail"
-                ret.update({'comment': comt, 'result': True})
-                self.assertDictEqual(at.absent('all'), ret)
+        # remove all jobs (0 jobs found)
+        mock_atatrm_nojobs = {}
+        mock_atatrm_nojobs.update(mock_atatrm)
+        mock_atatrm_nojobs.update({
+            'jobs': {
+                'removed': [],
+            },
+        })
+        mock = MagicMock(return_value=mock_atatrm_nojobs)
+        with patch.dict(at.__salt__, {'at.atrm': mock}):
+            with patch.dict(at.__opts__, {'test': False}):
+                ret_nojobs = {}
+                ret_nojobs.update(ret)
+                ret_nojobs.update({
+                    'changes': {},
+                    'comment': ret['comment'].replace('2', '0'),
+                })
+                self.assertDictEqual(at.absent(name), ret_nojobs)
+
+        # remove all tagged jobs (1 jobs found)
+        mock_atatrm_tag = {}
+        mock_atatrm_tag.update(mock_atatrm)
+        mock_atatrm_tag.update({
+            'jobs': {
+                'removed': ['1476031633.a'],
+                'tag': 'rose',
+            },
+        })
+        mock = MagicMock(return_value=mock_atatrm_tag)
+        with patch.dict(at.__salt__, {'at.atrm': mock}):
+            mock = MagicMock(return_value=mock_atjobcheck)
+            with patch.dict(at.__salt__, {'at.jobcheck': mock}):
+                with patch.dict(at.__opts__, {'test': False}):
+                    ret_tag = {}
+                    ret_tag.update(ret)
+                    ret_tag.update({
+                        'changes': {
+                            'removed': ['1476031633.a'],
+                        },
+                        'comment': ret['comment'].replace('2', '1'),
+                    })
+                    self.assertDictEqual(at.absent(name, tag=tag), ret_tag)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?
- update salt.modules.at to use **virtualname**
- update salt.modules.at virtual() to return false on SunOS platform
- improve salt.modules.at to only compute the regex once in atq
- create salt.modules.at_solaris with **virtualname** of at
- update salt.states.at to use new salt.module.at calls
- cleanup salt.states.at
- added unique_tag property to at.present*
- added mod_watch to salt.states.at, because I really want this*

salt.modules.at_solaris is compatible in output with salt.modules.at

Some cleanup happened along the way, that could probably also happen to salt.modules.at
### What issues does this PR fix or reference?

N/A
### Previous Behavior

All at.\* calls would raise exceptions on Solaris-like platforms.
### New Behavior

All at.\* calls now work fine on Solaris-like platforms (tested on Solaris 10, OmniOS and SmartOS)

Although the Solaris 10 box got minimal testing, it was a prod box from work down for maintenance -- why I could test in the first place.
### Tests written?

Yes
- this will be **sweet** in combination with watching the salt-minion config for changes and doing a delayed restart! Which to be honest was the whole reason for me taking a look at this.
