### PR TITLE
Fix shell_info docstring example

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2694,8 +2694,8 @@ def shell_info(shell):
 
     .. code-block:: bash
 
-        salt '*' cmd.shell bash
-        salt '*' cmd.shell powershell
+        salt '*' cmd.shell_info bash
+        salt '*' cmd.shell_info powershell
 
     ..
 


### PR DESCRIPTION
### What does this PR do?
- Fixes shell_info CLI Example usage lines in docstring.
### What issues does this PR fix or reference?
- None
### Previous Behavior
- Docstring displayed `cmd.shell` instead of `cmd.shell_info`.
### New Behavior
- Docstring displays `cmd.shell_info`.
### Tests written?

No
