### PR TITLE
Fix integration tests launching - remove redundant "config_dir" argument in call to ShellTestCase.run_run from SaltDaemonScriptBase._wait_until_running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ htmlcov/
 /*.iml
 *.sublime-project
 *.sublime-workspace
+/.vscode
 
 # ignore ctags file
 tags

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -618,7 +618,7 @@ class SaltDaemonScriptBase(SaltScriptBase, ShellTestCase):
                                 pass
                     del sock
                 elif isinstance(port, str):
-                    joined = self.run_run('manage.joined', config_dir=self.config_dir)
+                    joined = self.run_run('manage.joined')
                     joined = [x.lstrip('- ') for x in joined]
                     if port in joined:
                         check_ports.remove(port)


### PR DESCRIPTION
### What does this PR do?

I was unable to run integration tests, because of [this](https://github.com/saltstack/salt/blob/ee9eb7c4135dbfd4a34b743bb6d4bf4963f48de7/tests/integration/__init__.py#L621) call with non-existent argument. This PR fixes it.

p.s.  
Also there is a commit, that adds Visual Studio Code files to `.gitignore`.
