### PR TITLE
Add the option to skip updating the head for a hg latest state

### DIFF
--- a/salt/states/hg.py
+++ b/salt/states/hg.py
@@ -47,7 +47,8 @@ def latest(name,
            user=None,
            identity=None,
            force=False,
-           opts=False):
+           opts=False,
+           update_head=True):
     '''
     Make sure the repository is cloned to the given directory and is up to date
 
@@ -78,6 +79,9 @@ def latest(name,
 
     opts
         Include additional arguments and options to the hg command line
+
+    update_head
+        Should we update the head if new changes are found? Defaults to True
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
@@ -89,7 +93,7 @@ def latest(name,
             os.path.isdir('{0}/.hg'.format(target)))
 
     if is_repository:
-        ret = _update_repo(ret, name, target, clean, user, identity, rev, opts)
+        ret = _update_repo(ret, name, target, clean, user, identity, rev, opts, update_head)
     else:
         if os.path.isdir(target):
             fail = _handle_existing(ret, target, force)
@@ -108,7 +112,7 @@ def latest(name,
     return ret
 
 
-def _update_repo(ret, name, target, clean, user, identity, rev, opts):
+def _update_repo(ret, name, target, clean, user, identity, rev, opts, update_head):
     '''
     Update the repo to a given revision. Using clean passes -C to the hg up
     '''
@@ -136,6 +140,14 @@ def _update_repo(ret, name, target, clean, user, identity, rev, opts):
     except CommandExecutionError as err:
         ret['result'] = False
         ret['comment'] = err
+        return ret
+
+    if update_head is False:
+        changes = 'no changes found' not in pull_out
+        if changes:
+            ret['comment'] = 'Update is probably required but update_head=False so we will skip updating.'
+        else:
+            ret['comment'] = 'No changes found and update_head=False so will skip updating.'
         return ret
 
     if rev:


### PR DESCRIPTION
### What does this PR do?

Adds the option of skipping updating the head of a mercurial repo
### Tests written?

Yes
