### PR TITLE
cp.get_url: fix `dest=None` behaviour with `salt://` URL

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -556,12 +556,13 @@ class Client(object):
             return url_data.path
 
         if url_data.scheme == 'salt':
-            cached = self.get_file(url, dest, makedirs, saltenv, cachedir=cachedir)
-            if dest is None:
-                with salt.utils.fopen(cached, 'r') as fp_:
+            result = self.get_file(url, dest, makedirs, saltenv, cachedir=cachedir)
+            if result and dest is None:
+                with salt.utils.fopen(result, 'r') as fp_:
                     data = fp_.read()
                 return data
-            return cached
+            return result
+
         if dest:
             destdir = os.path.dirname(dest)
             if not os.path.isdir(destdir):

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -556,8 +556,12 @@ class Client(object):
             return url_data.path
 
         if url_data.scheme == 'salt':
-            return self.get_file(
-                url, dest, makedirs, saltenv, cachedir=cachedir)
+            cached = self.get_file(url, dest, makedirs, saltenv, cachedir=cachedir)
+            if dest is None:
+                with salt.utils.fopen(cached, 'r') as fp_:
+                    data = fp_.read()
+                return data
+            return cached
         if dest:
             destdir = os.path.dirname(dest)
             if not os.path.isdir(destdir):

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -553,6 +553,10 @@ class Client(object):
                 raise CommandExecutionError(
                     'Path {0!r} is not absolute'.format(url_data.path)
                 )
+            if dest is None:
+                with salt.utils.fopen(url_data.path, 'r') as fp_:
+                    data = fp_.read()
+                return data
             return url_data.path
 
         if url_data.scheme == 'salt':

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -309,11 +309,11 @@ def get_dir(path, dest, saltenv='base', template=None, gzip=None, env=None, **kw
 
 def get_url(path, dest, saltenv='base', env=None):
     '''
-    Used to get a single file from a URL.
+    Used to get a single file from a URL
 
-    The default behaviuor is to write the fetched file to the given
-    destination path. To simply return the text contents instead, set destination to
-    None.
+    The default behaviour is to write the fetched file to the given
+    destination path. To simply return the file contents instead, set
+    destination to ``None``.
 
     CLI Example:
 
@@ -331,7 +331,7 @@ def get_url(path, dest, saltenv='base', env=None):
         # Backwards compatibility
         saltenv = env
 
-    if dest:
+    if isinstance(dest, str):
         return _client().get_url(path, dest, False, saltenv)
     else:
         return _client().get_url(path, None, False, saltenv, no_cache=True)

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -315,6 +315,8 @@ def get_url(path, dest, saltenv='base', env=None):
     destination path. To simply return the file contents instead, set
     destination to ``None``.
 
+    Returns ``False`` if Salt was unable to fetch a file from a URL.
+
     CLI Example:
 
     .. code-block:: bash
@@ -331,10 +333,17 @@ def get_url(path, dest, saltenv='base', env=None):
         # Backwards compatibility
         saltenv = env
 
-    if isinstance(dest, str):
-        return _client().get_url(path, dest, False, saltenv)
+    if isinstance(dest, six.string_type):
+        result = _client().get_url(path, dest, False, saltenv)
     else:
-        return _client().get_url(path, None, False, saltenv, no_cache=True)
+        result = _client().get_url(path, None, False, saltenv, no_cache=True)
+    if not result:
+        log.error(
+            'Unable to fetch file {0!r} from saltenv {1!r}.'.format(
+                path, saltenv
+            )
+        )
+    return result
 
 
 def get_file_str(path, saltenv='base', env=None):

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -307,21 +307,32 @@ def get_dir(path, dest, saltenv='base', template=None, gzip=None, env=None, **kw
     return _client().get_dir(path, dest, saltenv, gzip)
 
 
-def get_url(path, dest, saltenv='base', env=None):
+def get_url(path, dest='', saltenv='base', env=None):
     '''
     Used to get a single file from a URL
 
-    The default behaviour is to write the fetched file to the given
-    destination path. To simply return the file contents instead, set
-    destination to ``None``.
+    path
+        A URL to download a file from. Supported URL schemes are: ``salt://``,
+        ``http://``, ``https://``, ``ftp://``, ``s3://`` and ``swift://``.
+        The function returns ``False`` if Salt was unable to fetch a file from
+        a ``salt://`` URL.
 
-    Returns ``False`` if Salt was unable to fetch a file from a URL.
+    dest
+        The default behaviour is to write the fetched file to the given
+        destination path. If this parameter is omitted or set as empty string
+        (``''``), the function places the file on the local filesystem inside
+        the Minion cache directory and will return the path to that file.
+        To simply return the file contents instead, set destination to ``None``.
+
+    saltenv : base
+        Salt fileserver envrionment from which to retrieve the file. Ignored if
+        ``path`` is not a ``salt://`` URL.
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' cp.get_url salt://my/file /tmp/mine
+        salt '*' cp.get_url salt://my/file /tmp/this_file_is_mine
         salt '*' cp.get_url http://www.slashdot.org /tmp/index.html
     '''
     if env is not None:

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -333,7 +333,7 @@ def get_url(path, dest, saltenv='base', env=None):
         # Backwards compatibility
         saltenv = env
 
-    if isinstance(dest, six.string_type):
+    if isinstance(dest, six.string_types):
         result = _client().get_url(path, dest, False, saltenv)
     else:
         result = _client().get_url(path, None, False, saltenv, no_cache=True)

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -313,22 +313,26 @@ def get_url(path, dest='', saltenv='base', env=None):
 
     path
         A URL to download a file from. Supported URL schemes are: ``salt://``,
-        ``http://``, ``https://``, ``ftp://``, ``s3://`` and ``swift://``.
+        ``http://``, ``https://``, ``ftp://``, ``s3://``, ``swift://`` and
+        ``file://`` (local filesystem). If no scheme was specified, this is
+        equivalent of using ``file://``.
+        If a ``file://`` URL is given, the function just returns absolute path
+        to that file on a local filesystem.
         The function returns ``False`` if Salt was unable to fetch a file from
         a ``salt://`` URL.
 
     dest
         The default behaviour is to write the fetched file to the given
         destination path. If this parameter is omitted or set as empty string
-        (``''``), the function places the file on the local filesystem inside
-        the Minion cache directory and will return the path to that file.
+        (``''``), the function places the remote file on the local filesystem
+        inside the Minion cache directory and returns the path to that file.
 
         .. note::
 
             To simply return the file contents instead, set destination to
-            ``None``. This works with ``salt://``, ``http://`` and ``https://``
-            URLs. The files fetched by ``http://`` and ``https://`` will not be
-            cached.
+            ``None``. This works with ``salt://``, ``http://``, ``https://``
+            and ``file://`` URLs. The files fetched by ``http://`` and
+            ``https://`` will not be cached.
 
     saltenv : base
         Salt fileserver envrionment from which to retrieve the file. Ignored if

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -322,7 +322,13 @@ def get_url(path, dest='', saltenv='base', env=None):
         destination path. If this parameter is omitted or set as empty string
         (``''``), the function places the file on the local filesystem inside
         the Minion cache directory and will return the path to that file.
-        To simply return the file contents instead, set destination to ``None``.
+
+        .. note::
+
+            To simply return the file contents instead, set destination to
+            ``None``. This works with ``salt://``, ``http://`` and ``https://``
+            URLs. The files fetched by ``http://`` and ``https://`` will not be
+            cached.
 
     saltenv : base
         Salt fileserver envrionment from which to retrieve the file. Ignored if

--- a/tests/integration/modules/cp.py
+++ b/tests/integration/modules/cp.py
@@ -146,7 +146,7 @@ class CPModuleTest(integration.ModuleCase):
 
     def test_get_url(self):
         '''
-        cp.get_url with salt:// source
+        cp.get_url with salt:// source given
         '''
         tgt = os.path.join(integration.TMP, 'scene33')
         self.run_function(
@@ -162,14 +162,12 @@ class CPModuleTest(integration.ModuleCase):
 
     def test_get_url_dest_empty(self):
         '''
-        cp.get_url with salt:// source and destination set as empty string: ''
+        cp.get_url with salt:// source given and destination omitted.
         '''
-        tgt = ''
         ret = self.run_function(
             'cp.get_url',
             [
                 'salt://grail/scene33',
-                tgt,
             ])
         with salt.utils.fopen(ret, 'r') as scene:
             data = scene.read()
@@ -180,7 +178,7 @@ class CPModuleTest(integration.ModuleCase):
 
     def test_get_url_no_dest(self):
         '''
-        cp.get_url with salt:// source and destination set as None
+        cp.get_url with salt:// source given and destination set as None
         '''
         tgt = None
         ret = self.run_function(
@@ -193,7 +191,7 @@ class CPModuleTest(integration.ModuleCase):
 
     def test_get_url_nonexistent_source(self):
         '''
-        cp.get_url with nonexistent salt:// source
+        cp.get_url with nonexistent salt:// source given
         '''
         tgt = None
         ret = self.run_function(
@@ -206,7 +204,7 @@ class CPModuleTest(integration.ModuleCase):
 
     def test_get_url_https(self):
         '''
-        cp.get_url with https:// source
+        cp.get_url with https:// source given
         '''
         tgt = os.path.join(integration.TMP, 'test_get_url_https')
         self.run_function(

--- a/tests/integration/modules/cp.py
+++ b/tests/integration/modules/cp.py
@@ -174,8 +174,6 @@ class CPModuleTest(integration.ModuleCase):
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
 
-        self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
-
     def test_get_url_no_dest(self):
         '''
         cp.get_url with salt:// source given and destination set as None
@@ -220,6 +218,22 @@ class CPModuleTest(integration.ModuleCase):
             self.assertIn('Windows', data)
             self.assertNotIn('AYBABTU', data)
 
+    def test_get_url_https_dest_empty(self):
+        '''
+        cp.get_url with https:// source given and destination omitted.
+        '''
+        ret = self.run_function(
+            'cp.get_url',
+            [
+                'https://repo.saltstack.com/index.html',
+            ])
+        with salt.utils.fopen(ret, 'r') as instructions:
+            data = instructions.read()
+            self.assertIn('Bootstrap', data)
+            self.assertIn('Debian', data)
+            self.assertIn('Windows', data)
+            self.assertNotIn('AYBABTU', data)
+
     def test_get_url_https_no_dest(self):
         '''
         cp.get_url with https:// source given and destination set as None
@@ -235,6 +249,38 @@ class CPModuleTest(integration.ModuleCase):
         self.assertIn('Debian', ret)
         self.assertIn('Windows', ret)
         self.assertNotIn('AYBABTU', ret)
+
+    def test_get_url_file(self):
+        '''
+        cp.get_url with file:// source given
+        '''
+        tgt = ''
+        src = os.path.join('file://', integration.FILES, 'file/base/file.big')
+        ret = self.run_function(
+            'cp.get_url',
+            [
+                src,
+                tgt,
+            ])
+        with salt.utils.fopen(ret, 'r') as scene:
+            data = scene.read()
+            self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
+            self.assertNotIn('bacon', data)
+
+    def test_get_url_file_no_dest(self):
+        '''
+        cp.get_url with file:// source given and destination set as None
+        '''
+        tgt = None
+        src = os.path.join('file://', integration.FILES, 'file/base/file.big')
+        ret = self.run_function(
+            'cp.get_url',
+            [
+                src,
+                tgt,
+            ])
+        self.assertIn('KNIGHT:  They\'re nervous, sire.', ret)
+        self.assertNotIn('bacon', ret)
 
     def test_cache_file(self):
         '''

--- a/tests/integration/modules/cp.py
+++ b/tests/integration/modules/cp.py
@@ -220,6 +220,22 @@ class CPModuleTest(integration.ModuleCase):
             self.assertIn('Windows', data)
             self.assertNotIn('AYBABTU', data)
 
+    def test_get_url_https_no_dest(self):
+        '''
+        cp.get_url with https:// source given and destination set as None
+        '''
+        tgt = None
+        ret = self.run_function(
+            'cp.get_url',
+            [
+                'https://repo.saltstack.com/index.html',
+                tgt,
+            ])
+        self.assertIn('Bootstrap', ret)
+        self.assertIn('Debian', ret)
+        self.assertIn('Windows', ret)
+        self.assertNotIn('AYBABTU', ret)
+
     def test_cache_file(self):
         '''
         cp.cache_file

--- a/tests/integration/modules/cp.py
+++ b/tests/integration/modules/cp.py
@@ -150,15 +150,59 @@ class CPModuleTest(integration.ModuleCase):
         '''
         tgt = os.path.join(integration.TMP, 'scene33')
         self.run_function(
-                'cp.get_url',
-                [
-                    'salt://grail/scene33',
-                    tgt,
-                ])
+            'cp.get_url',
+            [
+                'salt://grail/scene33',
+                tgt,
+            ])
         with salt.utils.fopen(tgt, 'r') as scene:
             data = scene.read()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
+
+    def test_get_url_dest_empty(self):
+        '''
+        cp.get_url with salt:// source and destination set as empty string: ''
+        '''
+        tgt = ''
+        ret = self.run_function(
+            'cp.get_url',
+            [
+                'salt://grail/scene33',
+                tgt,
+            ])
+        with salt.utils.fopen(ret, 'r') as scene:
+            data = scene.read()
+            self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
+            self.assertNotIn('bacon', data)
+
+        self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
+
+    def test_get_url_no_dest(self):
+        '''
+        cp.get_url with salt:// source and destination set as None
+        '''
+        tgt = None
+        ret = self.run_function(
+            'cp.get_url',
+            [
+                'salt://grail/scene33',
+                tgt,
+            ])
+        self.assertIn('KNIGHT:  They\'re nervous, sire.', ret)
+
+    def test_get_url_nonexistent_source(self):
+        '''
+        cp.get_url with nonexistent salt:// source
+        '''
+        tgt = None
+        ret = self.run_function(
+            'cp.get_url',
+            [
+                'salt://grail/nonexistent_scene',
+                tgt,
+            ])
+        self.assertEqual(ret, False)
 
     def test_get_url_https(self):
         '''
@@ -166,11 +210,11 @@ class CPModuleTest(integration.ModuleCase):
         '''
         tgt = os.path.join(integration.TMP, 'test_get_url_https')
         self.run_function(
-                'cp.get_url',
-                [
-                    'https://repo.saltstack.com/index.html',
-                    tgt,
-                ])
+            'cp.get_url',
+            [
+                'https://repo.saltstack.com/index.html',
+                tgt,
+            ])
         with salt.utils.fopen(tgt, 'r') as instructions:
             data = instructions.read()
             self.assertIn('Bootstrap', data)


### PR DESCRIPTION
### What does this PR do?

It makes `cp.get_url` function behave according to the docstring.
### What issues does this PR fix or reference?

The issue is following: the function doc says that passing `dest=None` will return file contents, but this doesn't work with `salt://` URL. See example below.
### Previous Behavior

``` yaml
# salt-call cp.get_url salt://files/test None
local:
    /var/cache/salt/minion/files/base/files/test
```
### New Behavior

``` yaml
# salt-call cp.get_url salt://files/test None
local:
    This is a test
```
### Tests written?

Yes! Added integration tests.