### PR TITLE
Fix traceback on salt-ssh -h

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2849,7 +2849,7 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
             dest='regen_thin',
             default=False,
             action='store_true',
-            help=('Trigger a thin tarball regeneration. This is needed if',
+            help=('Trigger a thin tarball regeneration. This is needed if '
                   'custom grains/modules/states have been added or updated.'))
         self.add_option(
             '--python2-bin',


### PR DESCRIPTION
This code was originally added to the option parser in 423a356. It was
probably intended to be a single string continued onto multiple lines
via parenthesis, but the use of a comma turns this into a tuple, which
causes a traceback when `salt-ssh -h` is run.
