### PR TITLE
salt-ssh: Try "command -v" before falling back to "which"

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -151,7 +151,7 @@ do
         py_cmd_path=`"$py_cmd" -c \
                    'from __future__ import print_function;
                    import sys; print(sys.executable);'`
-        cmdpath=$(which $py_cmd 2>&1)
+        cmdpath=$(command -v $py_cmd 2>/dev/null || which $py_cmd 2>/dev/null)
         if file $cmdpath | grep "shell script" > /dev/null
         then
             ex_vars="'PATH', 'LD_LIBRARY_PATH', 'MANPATH', \


### PR DESCRIPTION
This makes salt-ssh work better on minimal installs such as the CentOS 7
container images from linuxcontainers.org.
