### PR TITLE
Add 'resolve_dns_fallback' option to config

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -432,6 +432,9 @@ VALID_OPTS = {
     # salt master
     'retry_dns': float,
 
+    # In the case when the resolve of the salt master hostname fails, fall back to localhost
+    'resolve_dns_fallback': bool,
+
     # set the zeromq_reconnect_ivl option on the minion.
     # http://lists.zeromq.org/pipermail/zeromq-dev/2011-January/008845.html
     'recon_max': float,
@@ -1077,6 +1080,7 @@ DEFAULT_MINION_OPTS = {
     'update_url': False,
     'update_restart_services': [],
     'retry_dns': 30,
+    'resolve_dns_fallback': True,
     'recon_max': 10000,
     'recon_default': 1000,
     'recon_randomize': True,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -513,6 +513,7 @@ class MinionBase(object):
 
         tries = opts.get('master_tries', 1)
         attempts = 0
+        resolve_dns_fallback = opts.get('resolve_dns_fallback', False)
 
         # if we have a list of masters, loop through them and be
         # happy with the first one that allows us to connect
@@ -537,7 +538,14 @@ class MinionBase(object):
                 for master in opts['local_masters']:
                     opts['master'] = master
                     opts.update(prep_ip_port(opts))
-                    opts.update(resolve_dns(opts))
+                    try:
+                        opts.update(resolve_dns(opts, fallback=resolve_dns_fallback))
+                    except SaltClientError as exc:
+                        last_exc = exc
+                        msg = ('Master hostname: \'{0}\' not found. Trying '
+                               'next master (if any)'.format(opts['master']))
+                        log.info(msg)
+                        continue
 
                     # on first run, update self.opts with the whole master list
                     # to enable a minion to re-use old masters if they get fixed
@@ -589,8 +597,8 @@ class MinionBase(object):
                               '(infinite attempts)'.format(attempts)
                     )
                 opts.update(prep_ip_port(opts))
-                opts.update(resolve_dns(opts))
                 try:
+                    opts.update(resolve_dns(opts, fallback=resolve_dns_fallback))
                     if self.opts['transport'] == 'detect':
                         self.opts['detect_mode'] = True
                         for trans in ('zeromq', 'tcp'):


### PR DESCRIPTION
### What does this PR do?

By default, the salt-minion will fall back to localhost (127.0.0.1) if
the DNS resolve fails on the salt-master hostname. There are some cases
where that is not desirable, such as when using a master failover list
and there is a master running locally that we don't want to connect to.

Add a boolean config option called `resolve_dns_fallback` which
defaults to True but will disable the fall back behavior if set to
False.

Now that `salt.minion.resolve_dns()` may be invoked with `fallback=False`,
that function is more likely to throw a `SaltClientError` exception
instead of reacting to the error condition internally. Due to this, made
sure the callers will be able to catch that exception and react
appropriately.
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com