### PR TITLE
add option to force a reauth for a docker registry

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -1031,7 +1031,8 @@ def _image_wrapper(attr, *args, **kwargs):
                     creds['username'],
                     password=creds['password'],
                     email=creds.get('email'),
-                    registry=registry)
+                    registry=registry,
+                    reauth=cred.get('reauth', False))
         except KeyError:
             raise SaltInvocationError(
                 err.format('Incomplete', ' for registry {0}'.format(registry))

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -60,6 +60,7 @@ The configuration schema is as follows:
         email: <email_address>
         password: <password>
         username: <username>
+        reauth: <boolean>
 
 For example:
 
@@ -70,6 +71,18 @@ For example:
         email: foo@foo.com
         password: s3cr3t
         username: foo
+
+Reauth is an optional parameter that forces the docker login to reauthorize using
+the credentials passed in the pillar data. Defaults to false. For example:
+
+.. code-block:: yaml
+
+    docker-registries:
+      https://index.docker.io/v1/:
+        email: foo@foo.com
+        password: s3cr3t
+        username: foo
+        reauth: True
 
 Mulitiple registries can be configured. This can be done in one of two ways.
 The first way is to configure each registry under the ``docker-registries``
@@ -1032,7 +1045,7 @@ def _image_wrapper(attr, *args, **kwargs):
                     password=creds['password'],
                     email=creds.get('email'),
                     registry=registry,
-                    reauth=cred.get('reauth', False))
+                    reauth=creds.get('reauth', False))
         except KeyError:
             raise SaltInvocationError(
                 err.format('Incomplete', ' for registry {0}'.format(registry))


### PR DESCRIPTION
### What does this PR do?

Adds ability to specify reauth in the docker-registry pillar data structure to specify the reauth kwarg passed to docker-py login call. If not specified it defaults to old behavior of False. 

This makes credentials in the .docker/config.json file used by docker-py, which are possibly out of date or have been manually modified, to not interfere with credentials passed in pillar data without having to mange the config file via salt.
### What issues does this PR fix or reference?

Fixes #32829
### Previous Behavior

Retains old behavior of default reauth=False when calling docker login through docker-py
### New Behavior

Ability to specify if a reauth is done during docker login call
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

Fixes #32829. Adds ability to specify reauth in the docker-registry pillar data structure to specify the reauth kwarg to docker-py login call. If not specified it defaults to old behaviour of False
