### PR TITLE
Check for test=True in salt.wait_for_event orchestration events

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -502,6 +502,12 @@ def wait_for_event(
     '''
     ret = {'name': name, 'changes': {}, 'comment': '', 'result': False}
 
+    if __opts__.get('test'):
+        ret['comment'] = \
+            'Orchestration would wait for event \'{0}\''.format(name)
+        ret['result'] = None
+        return ret
+
     sevent = salt.utils.event.get_event(
             'master',
             __opts__['sock_dir'],


### PR DESCRIPTION
This prevents a wait_for_event from hanging the orchestration job when
test=True.
