### PR TITLE
X509 fixes

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -163,6 +163,9 @@ def _get_csr_extensions(csr):
     if csryaml and 'Requested Extensions' in csryaml['Certificate Request']['Data']:
         csrexts = csryaml['Certificate Request']['Data']['Requested Extensions']
 
+        if not csrexts:
+            return ret
+
         for short_name, long_name in six.iteritems(EXT_NAME_MAPPINGS):
             if long_name in csrexts:
                 ret[short_name] = csrexts[long_name]

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -19,7 +19,6 @@ import yaml
 import re
 import datetime
 import ast
-import pkg_resources
 
 # Import salt libs
 import salt.utils
@@ -674,7 +673,7 @@ def create_private_key(path=None, text=False, bits=2048):
 
 def create_crl(path=None, text=False, signing_private_key=None,
         signing_cert=None, revoked=None, include_expired=False,
-        days_valid=100, digest=""):
+        days_valid=100, digest=''):
     '''
     Create a CRL
 
@@ -780,9 +779,10 @@ def create_crl(path=None, text=False, signing_private_key=None,
     key = OpenSSL.crypto.load_privatekey(OpenSSL.crypto.FILETYPE_PEM,
             get_pem_entry(signing_private_key))
 
-    if digest and pkg_resources.get_distribution("pyopenssl").version >= '0.15':
+    try:
         crltext = crl.export(cert, key, OpenSSL.crypto.FILETYPE_PEM, days=days_valid, digest=bytes(digest))
-    else:
+    except TypeError:
+        log.warning('Error signing crl with specified digest. Are you using pyopenssl 0.15 or newer? The default md5 digest will be used.')
         crltext = crl.export(cert, key, OpenSSL.crypto.FILETYPE_PEM, days=days_valid)
 
     if text:

--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -293,7 +293,7 @@ def csr_managed(name,
 
         /etc/pki/mycert.csr:
           x509.csr_managed:
-             - public_key: /etc/pki/mycert.key
+             - private_key: /etc/pki/mycert.key
              - CN: www.example.com
              - C: US
              - ST: Utah

--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -483,6 +483,7 @@ def crl_managed(name,
                 signing_cert=None,
                 revoked=None,
                 days_valid=100,
+                digest="",
                 days_remaining=30,
                 include_expired=False,
                 backup=False,):
@@ -507,6 +508,10 @@ def crl_managed(name,
 
     days_valid:
         The number of days the certificate should be valid for. Default is 100.
+
+    digest:
+        The digest to use for signing the CRL.
+        This has no effect on versions of pyOpenSSL less than 0.14
 
     days_remaining:
         The crl should be automatically recreated if there are less than ``days_remaining``
@@ -564,7 +569,7 @@ def crl_managed(name,
         current = '{0} does not exist.'.format(name)
 
     new_crl = __salt__['x509.create_crl'](text=True, signing_private_key=signing_private_key,
-            signing_cert=signing_cert, revoked=revoked, days_valid=days_valid, include_expired=include_expired)
+            signing_cert=signing_cert, revoked=revoked, days_valid=days_valid, digest=digest, include_expired=include_expired)
 
     new = __salt__['x509.read_crl'](crl=new_crl)
     new_comp = new.copy()


### PR DESCRIPTION
### What does this PR do?

Fixes #36814 as well as a bug reading CRLs and allows customizing CRL digest.
### What issues does this PR fix or reference?
#36814
### Previous Behavior

Generating CSR's fails on newer versions of OpenSSL. Comparing CRL's fails. And digest for CRLs is only MD5.
### New Behavior

CRL digest can be specified if M2Crypto is new enough. CSRs and CRLs work as expected.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
