### PR TITLE
[WIP] Handle concurency in salt.utils.schedule.handle_func

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -667,35 +667,35 @@ class Schedule(object):
             jobcount = 0
             for basefilename in os.listdir(salt.minion.get_proc_dir(self.opts['cachedir'])):
                 fn_ = os.path.join(salt.minion.get_proc_dir(self.opts['cachedir']), basefilename)
-                if not os.path.exists(fn_):
-                    log.debug('schedule.handle_func: {0} was processed '
-                              'in another thread, skipping.'.format(
-                                  basefilename))
-                    continue
-                with salt.utils.fopen(fn_, 'rb') as fp_:
-                    job = salt.payload.Serial(self.opts).load(fp_)
-                    if job:
-                        if 'schedule' in job:
-                            log.debug('schedule.handle_func: Checking job against '
-                                      'fun {0}: {1}'.format(ret['fun'], job))
-                            if ret['schedule'] == job['schedule'] and os_is_running(job['pid']):
-                                jobcount += 1
-                                log.debug(
-                                    'schedule.handle_func: Incrementing jobcount, now '
-                                    '{0}, maxrunning is {1}'.format(
-                                        jobcount, data['maxrunning']))
-                                if jobcount >= data['maxrunning']:
+                try:
+                    with salt.utils.flopen(fn_, 'rb') as fp_:
+                        job = salt.payload.Serial(self.opts).load(fp_)
+                        if job:
+                            if 'schedule' in job:
+                                log.debug('schedule.handle_func: Checking job against '
+                                          'fun {0}: {1}'.format(ret['fun'], job))
+                                if ret['schedule'] == job['schedule'] and os_is_running(job['pid']):
+                                    jobcount += 1
                                     log.debug(
-                                        'schedule.handle_func: The scheduled job {0} '
-                                        'was not started, {1} already running'.format(
-                                            ret['schedule'], data['maxrunning']))
-                                    return False
-                    else:
-                        try:
-                            log.info('Invalid job file found.  Removing.')
-                            os.remove(fn_)
-                        except OSError:
-                            log.info('Unable to remove file: {0}.'.format(fn_))
+                                        'schedule.handle_func: Incrementing jobcount, now '
+                                        '{0}, maxrunning is {1}'.format(
+                                            jobcount, data['maxrunning']))
+                                    if jobcount >= data['maxrunning']:
+                                        log.debug(
+                                            'schedule.handle_func: The scheduled job {0} '
+                                            'was not started, {1} already running'.format(
+                                                ret['schedule'], data['maxrunning']))
+                                        return False
+                        else:
+                            try:
+                                log.info('Invalid job file found.  Removing.')
+                                os.remove(fn_)
+                            except OSError:
+                                log.info('Unable to remove file: {0}.'.format(fn_))
+                except IOError:
+                    log.debug('schedule.handle_func: {0} was processed '
+                              'in another thread, skipping.'.format(basefilename))
+                    continue
 
         if multiprocessing_enabled and not salt.utils.is_windows():
             # Reconfigure multiprocessing logging after daemonizing


### PR DESCRIPTION
Instead of checking for a file's existence and immediately opening the file if the
file is supposed to exist, let's try to open the cache file with salt.utils.flopen
to wait for the lock. If the file doesn't exist (IOError), then log the debug message
and continue.

I wasn't able to reproduce the errors reported in #35097, so this should be tested by
those who are hitting this issue.

@cachedout Can you please look over these changes and let me know if there is a more elegant way to handle this particular issue? Note the change from `salt.utils.fopen` to `salt.utils.flopen` in the context manager. I am not certain if this is the right approach, but seems like it would be since we're dealing with multiple threads.
