### PR TITLE
fix git init --shared

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -1898,12 +1898,12 @@ def init(cwd,
             separate_git_dir = str(separate_git_dir)
         command.append('--separate-git-dir={0}'.format(separate_git_dir))
     if shared is not None:
-        if isinstance(shared, six.integer_types):
-            shared = '0' + str(shared)
-        elif not isinstance(shared, six.string_types):
+        if not isinstance(shared, six.string_types):
             # Using lower here because booleans would be capitalized when
             # converted to a string.
             shared = str(shared).lower()
+        elif isinstance(shared, six.integer_types):
+            shared = '0' + str(shared)
         command.append('--shared={0}'.format(shared))
     command.extend(_format_opts(opts))
     command.append(cwd)


### PR DESCRIPTION
### What does this PR do?
### What issues does this PR fix or reference?

closes #36881 
### Previous Behavior

Possible values for `shared`-parameter on commandline:
- strings (but in python booleans): true/false
- strings: umask/group/all/world/everybody
- octal number: any octal number representing a valid umask

As yaml-values like `false` and `true` get evaluated to booleans, and booleans are instances of integers, the code believes the `shared`-parameter is an integer, but in fact it's a string.
### New Behavior

Check at first if it's a string and at second, if it's an integer.
### Tests written?

No
