### PR TITLE
[fix] pkg.installed call on pkg.install for apline apk

### DIFF
--- a/salt/modules/apk.py
+++ b/salt/modules/apk.py
@@ -301,6 +301,12 @@ def install(name=None,
             pkg_to_install = [name]
 
     if pkgs:
+        # We don't support installing specific version for now
+        # so transform the dict in list ignoring version provided
+        pkgs = [
+            p.keys()[0] for p in pkgs
+            if isinstance(p, dict)
+        ]
         pkg_to_install.extend(pkgs)
 
     if not pkg_to_install:


### PR DESCRIPTION
### What does this PR do?

Fix `pkg.install` call from `pkg.installed`
### What issues does this PR fix or reference?

There's no issue opened on the subject, but I can open one if needed

The issue is when `pkg.installed` call `pkg.install` the `pkgs` parameter is list of dict, eg. `[{'foo': '1.0.0', 'bar': None}]`, so an error is raised because the rest of the code base is design to receive a list of string, eg. `['foo', 'bar']`
### Tests written?

No
