### PR TITLE
[carbon] smbios.get should handle missing /dev/mem to not have useless grains

### DIFF
--- a/salt/modules/smbios.py
+++ b/salt/modules/smbios.py
@@ -91,6 +91,10 @@ def get(string, clean=True):
     # Don't.
     val = '\n'.join([v for v in val.split('\n') if not v.startswith('#')])
 
+    # handle missing /dev/mem
+    if val.startswith('/dev/mem'):
+        return None
+
     if not clean or _dmi_isclean(string, val):
         return val
 


### PR DESCRIPTION
### What does this PR do?

Return None for smbios.get if we are missing /dev/mem
### What issues does this PR fix or reference?
#36907
### Previous Behavior

smbios.get returns the value '/dev/mem: No such file or directory'
### New Behavior

smbios.get returns the value None
### Tests written?

No
