### PR TITLE
send event on minion event stream if masterless

### DIFF
--- a/salt/modules/event.py
+++ b/salt/modules/event.py
@@ -226,4 +226,7 @@ def send(tag,
     if isinstance(data, collections.Mapping):
         data_dict.update(data)
 
-    return fire_master(data_dict, tag, preload=preload)
+    if __opts__.get('file_client') == 'local':
+        return fire(data_dict, tag)
+    else:
+        return fire_master(data_dict, tag, preload=preload)


### PR DESCRIPTION
### What does this PR do?

When the file_client is local, we should fire events onto the minion event stream.  This makes running engines on masterless minions a bit better, which can use **salt**['event.send'] and have it used correctly for the reactor.
### Tests written?

No