### PR TITLE
Properly handle "shared" arg in git.init when it is a bool

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -1718,7 +1718,8 @@ def init(cwd,
             separate_git_dir = str(separate_git_dir)
         command.append('--separate-git-dir={0}'.format(separate_git_dir))
     if shared is not None:
-        if isinstance(shared, six.integer_types):
+        if isinstance(shared, six.integer_types) \
+                and not isinstance(shared, bool):
             shared = '0' + str(shared)
         elif not isinstance(shared, six.string_types):
             # Using lower here because booleans would be capitalized when


### PR DESCRIPTION
Fixes #36881.