### PR TITLE
Allow alternatives.show_link function to work on Suse distros

### DIFF
--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -76,9 +76,14 @@ def show_link(name):
         salt '*' alternatives.show_link editor
     '''
 
-    path = '/var/lib/dpkg/alternatives/{0}'.format(name)
-    if _get_cmd() == 'alternatives':
-        path = '/var/lib/alternatives/{0}'.format(name)
+    if __grains__['os_family'] == 'RedHat':
+        path = '/var/lib/'
+    elif __grains__['os_family'] == 'Suse':
+        path = '/var/lib/rpm/'
+    else:
+        path = '/var/lib/dpkg/'
+
+    path += 'alternatives/{0}'.format(name)
 
     try:
         with salt.utils.fopen(path, 'rb') as r_file:


### PR DESCRIPTION
This should fix up the failing integration.states.alternatives test
in 2016.3 as well. The alternatives.install state relies on checking
if the output of alternatives.show_link matches the path passed into
the state. Since show_link didn't work on suse correctly, the state
doesn't install the alternative and returns False. This test is only
present on the 2016.3 branch, but I knew the bug was broken in 
this branch as well and it should be fixed in 2015.8.