### PR TITLE
Enable policy_document from pillars

### DIFF
--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -47,7 +47,6 @@ import yaml
 import salt.ext.six as six
 import salt.utils.compat
 import salt.utils.odict as odict
-import salt.utils.boto
 
 # Import third party libs
 # pylint: disable=unused-import
@@ -1739,7 +1738,7 @@ def delete_policy(policy_name,
         conn.delete_policy(policy_arn)
         log.info('Deleted {0} policy.'.format(policy_name))
     except boto.exception.BotoServerError as e:
-        aws = salt.utils.boto.get_error(e)
+        aws = __utils__['boto.get_error'](e)
         log.debug(aws)
         msg = 'Failed to delete {0} policy: {1}.'
         log.error(msg.format(policy_name, aws.get('message')))
@@ -1761,7 +1760,7 @@ def list_policies(region=None, key=None, keyid=None, profile=None):
 
     try:
         policies = []
-        for ret in salt.utils.boto.paged_call(conn.list_policies):
+        for ret in __utils__['boto.paged_call'](conn.list_policies):
             policies.append(ret.get('list_policies_response', {}).get('list_policies_result', {}).get('policies'))
         return policies
     except boto.exception.BotoServerError as e:
@@ -1844,7 +1843,7 @@ def create_policy_version(policy_name, policy_document, set_as_default=None,
         log.debug(e)
         msg = 'Failed to create {0} policy version.'
         log.error(msg.format(policy_name))
-        return {'created': False, 'error': salt.utils.boto.get_error(e)}
+        return {'created': False, 'error': __utils__['boto.get_error'](e)}
 
 
 def delete_policy_version(policy_name, version_id,
@@ -1867,7 +1866,7 @@ def delete_policy_version(policy_name, version_id,
         conn.delete_policy_version(policy_arn, version_id)
         log.info('Deleted {0} policy version {1}.'.format(policy_name, version_id))
     except boto.exception.BotoServerError as e:
-        aws = salt.utils.boto.get_error(e)
+        aws = __utils__['boto.get_error'](e)
         log.debug(aws)
         msg = 'Failed to delete {0} policy version {1}: {2}'
         log.error(msg.format(policy_name, version_id, aws.get('message')))
@@ -1917,7 +1916,7 @@ def set_default_policy_version(policy_name, version_id,
         conn.set_default_policy_version(policy_arn, version_id)
         log.info('Set {0} policy to version {1}.'.format(policy_name, version_id))
     except boto.exception.BotoServerError as e:
-        aws = salt.utils.boto.get_error(e)
+        aws = __utils__['boto.get_error'](e)
         log.debug(aws)
         msg = 'Failed to set {0} policy to version {1}: {2}'
         log.error(msg.format(policy_name, version_id, aws.get('message')))
@@ -2100,7 +2099,7 @@ def list_entities_for_policy(policy_name, path_prefix=None, entity_filter=None,
           'policy_users': [],
           'policy_roles': [],
         }
-        for ret in salt.utils.boto.paged_call(conn.list_entities_for_policy, policy_arn=policy_arn, **params):
+        for ret in __utils__['boto.paged_call'](conn.list_entities_for_policy, policy_arn=policy_arn, **params):
             for k, v in six.iteritems(allret):
                 v.extend(ret.get('list_entities_for_policy_response', {}).get('list_entities_for_policy_result', {}).get(k))
         return allret
@@ -2132,7 +2131,7 @@ def list_attached_user_policies(user_name, path_prefix=None, entity_filter=None,
     try:
         # Using conn.get_response is a bit of a hack, but it avoids having to
         # rewrite this whole module based on boto3
-        for ret in salt.utils.boto.paged_call(conn.get_response, 'ListAttachedUserPolicies', params, list_marker='AttachedPolicies'):
+        for ret in __utils__['boto.paged_call'](conn.get_response, 'ListAttachedUserPolicies', params, list_marker='AttachedPolicies'):
             policies.extend(ret.get('list_attached_user_policies_response', {}).get('list_attached_user_policies_result', {}
                                    ).get('attached_policies', []))
         return policies
@@ -2164,7 +2163,7 @@ def list_attached_group_policies(group_name, path_prefix=None, entity_filter=Non
     try:
         # Using conn.get_response is a bit of a hack, but it avoids having to
         # rewrite this whole module based on boto3
-        for ret in salt.utils.boto.paged_call(conn.get_response, 'ListAttachedGroupPolicies', params, list_marker='AttachedPolicies'):
+        for ret in __utils__['boto.paged_call'](conn.get_response, 'ListAttachedGroupPolicies', params, list_marker='AttachedPolicies'):
             policies.extend(ret.get('list_attached_group_policies_response', {}).get('list_attached_group_policies_result', {}
                                    ).get('attached_policies', []))
         return policies
@@ -2196,7 +2195,7 @@ def list_attached_role_policies(role_name, path_prefix=None, entity_filter=None,
     try:
         # Using conn.get_response is a bit of a hack, but it avoids having to
         # rewrite this whole module based on boto3
-        for ret in salt.utils.boto.paged_call(conn.get_response, 'ListAttachedRolePolicies', params, list_marker='AttachedPolicies'):
+        for ret in __utils__['boto.paged_call'](conn.get_response, 'ListAttachedRolePolicies', params, list_marker='AttachedPolicies'):
             policies.extend(ret.get('list_attached_role_policies_response', {}).get('list_attached_role_policies_result', {}
                                    ).get('attached_policies', []))
         return policies
@@ -2224,7 +2223,7 @@ def create_saml_provider(name, saml_metadata_document, region=None, key=None, ke
         log.info(msg.format(name))
         return True
     except boto.exception.BotoServerError as e:
-        aws = salt.utils.boto.get_error(e)
+        aws = __utils__['boto.get_error'](e)
         log.debug(aws)
         msg = 'Failed to create SAML provider {0}.'
         log.error(msg.format(name))
@@ -2249,7 +2248,7 @@ def get_saml_provider_arn(name, region=None, key=None, keyid=None, profile=None)
                 return saml_provider['arn']
         return False
     except boto.exception.BotoServerError as e:
-        aws = salt.utils.boto.get_error(e)
+        aws = __utils__['boto.get_error'](e)
         log.debug(aws)
         msg = 'Failed to get ARN of SAML provider {0}.'
         log.error(msg.format(name))
@@ -2278,7 +2277,7 @@ def delete_saml_provider(name, region=None, key=None, keyid=None, profile=None):
         log.info(msg.format(name))
         return True
     except boto.exception.BotoServerError as e:
-        aws = salt.utils.boto.get_error(e)
+        aws = __utils__['boto.get_error'](e)
         log.debug(aws)
         msg = 'Failed to delete {0} SAML provider.'
         log.error(msg.format(name))
@@ -2303,7 +2302,7 @@ def list_saml_providers(region=None, key=None, keyid=None, profile=None):
             providers.append(arn['arn'].rsplit('/', 1)[1])
         return providers
     except boto.exception.BotoServerError as e:
-        aws = salt.utils.boto.get_error(e)
+        aws = __utils__['boto.get_error'](e)
         log.debug(aws)
         msg = 'Failed to get list of SAML providers.'
         log.error(msg)
@@ -2325,7 +2324,7 @@ def get_saml_provider(name, region=None, key=None, keyid=None, profile=None):
         provider = conn.get_saml_provider(name)
         return provider['get_saml_provider_response']['get_saml_provider_result']['saml_metadata_document']
     except boto.exception.BotoServerError as e:
-        aws = salt.utils.boto.get_error(e)
+        aws = __utils__['boto.get_error'](e)
         log.debug(aws)
         msg = 'Failed to get SAML provider document.'
         log.error(msg)
@@ -2353,7 +2352,7 @@ def update_saml_provider(name, saml_metadata_document, region=None, key=None, ke
             return True
         return False
     except boto.exception.BotoServerError as e:
-        aws = salt.utils.boto.get_error(e)
+        aws = __utils__['boto.get_error'](e)
         log.debug(aws)
         msg = 'Failed to update of SAML provider.'
         log.error(msg.format(name))

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -967,13 +967,15 @@ def create_role(name, policy_document=None, path=None, region=None, key=None,
 
     if role_exists(name, region, key, keyid, profile):
         return True
+    if not policy_document:
+        policy_document = None
     try:
         conn.create_role(name, assume_role_policy_document=policy_document,
                          path=path)
         log.info('Created {0} iam role.'.format(name))
         return True
     except boto.exception.BotoServerError as e:
-        log.debug(e)
+        log.error(e)
         msg = 'Failed to create {0} iam role.'
         log.error(msg.format(name))
         return False
@@ -1180,7 +1182,7 @@ def create_role_policy(role_name, policy_name, policy, region=None, key=None,
         log.info(msg.format(policy_name, role_name))
         return True
     except boto.exception.BotoServerError as e:
-        log.debug(e)
+        log.error(e)
         msg = 'Failed to {0} {1} policy for role {2}.'
         log.error(msg.format(mode, policy_name, role_name))
         return False
@@ -1239,7 +1241,7 @@ def update_assume_role_policy(role_name, policy_document, region=None,
         log.info(msg.format(role_name))
         return True
     except boto.exception.BotoServerError as e:
-        log.debug(e)
+        log.error(e)
         msg = 'Failed to update assume role policy for role {0}.'
         log.error(msg.format(role_name))
         return False

--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -104,6 +104,7 @@ def __virtual__():
 def present(
         name,
         policy_document=None,
+        policy_document_from_pillars='boto_iam_role_policy_document',
         path=None,
         policies=None,
         policies_from_pillars=None,
@@ -122,6 +123,11 @@ def present(
 
     policy_document
         The policy that grants an entity permission to assume the role. (See https://boto.readthedocs.io/en/latest/ref/iam.html#boto.iam.connection.IAMConnection.create_role)
+
+    policy_document_from_pillars
+        A pillar key that contains a role policy document. The statements
+        defined here will be appended with the policy document statements
+        defined in the policy_document argument.
 
     path
         The path to the role/instance profile. (See https://boto.readthedocs.io/en/latest/ref/iam.html#boto.iam.connection.IAMConnection.create_role)
@@ -166,8 +172,22 @@ def present(
         .. versionadded:: 2015.8.0
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
-    _ret = _role_present(name, policy_document, path, region, key, keyid,
+    # Build up _policy_document
+    _policy_document = {}
+    if policy_document_from_pillars:
+        from_pillars = __salt__['pillar.get'](policy_document_from_pillars)
+        if from_pillars:
+            _policy_document['Version'] = from_pillars['Version']
+            _policy_document.setdefault('Statement', [])
+            _policy_document['Statement'].extend(from_pillars['Statement'])
+    if policy_document:
+        _policy_document['Version'] = policy_document['Version']
+        _policy_document.setdefault('Statement', [])
+        _policy_document['Statement'].extend(policy_document['Statement'])
+    _ret = _role_present(name, _policy_document, path, region, key, keyid,
                          profile)
+
+    # Build up _policies
     if not policies:
         policies = {}
     if not policies_from_pillars:

--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -104,7 +104,7 @@ def __virtual__():
 def present(
         name,
         policy_document=None,
-        policy_document_from_pillars='boto_iam_role_policy_document',
+        policy_document_from_pillars=None,
         path=None,
         policies=None,
         policies_from_pillars=None,


### PR DESCRIPTION
### What does this PR do?
- Changed some log.debugs to log.errors
- Add another parameter to boto_iam_role.present to retrieve policy documents from pillars.
### What issues does this PR fix or reference?

N/A
### New Behavior

Users can manage an iam role policy document using pillars.
### Tests written?

No