### PR TITLE
modules/apk.py: Ensure we don't error on version extraction

### DIFF
--- a/salt/modules/apk.py
+++ b/salt/modules/apk.py
@@ -202,7 +202,7 @@ def latest_version(*names, **kwargs):
             newversion = line.split(' ')[5].strip(')')
             if name in names:
                 ret[name] = newversion
-        except ValueError:
+        except (ValueError, IndexError):
             pass
 
     # If version is empty, package may not be installed


### PR DESCRIPTION
### What does this PR do?

This fixes pkg.latest_version error when "apk upgrade -s" contains line different than "Upgrading...."
### What issues does this PR fix or reference?

```
# apk upgrade -s
(1/6) Installing libressl2.4-libcrypto@edge (2.4.3-r1)
(2/6) Upgrading borgbackup (1.0.7-r0 -> 1.0.7-r1)
(3/6) Upgrading linux-virtgrsec (4.7.6-r0 -> 4.7.7-r0)
(4/6) Installing libressl2.4-libssl@edge (2.4.3-r1)
(5/6) Upgrading python2@edge (2.7.12-r3 -> 2.7.12-r4)
(6/6) Upgrading py2-pygit2 (0.24.1-r2 -> 0.24.1-r3)
OK: 285 MiB in 101 packages
```

1 and 4 would make pkg.latest_version crash
