### PR TITLE
Revert change in default value for top_file_merging_strategy

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1242,12 +1242,12 @@ This option has no default value. Set it to an environment name to ensure that
 
 .. note::
     Using this value does not change the merging strategy. For instance, if
-    :conf_minion:`top_file_merging_strategy` is set to ``default``, and
+    :conf_minion:`top_file_merging_strategy` is set to ``merge``, and
     :conf_minion:`state_top_saltenv` is set to ``foo``, then any sections for
     environments other than ``foo`` in the top file for the ``foo`` environment
-    will be ignored. With :conf_minion:`top_file_merging_strategy` set to
-    ``base``, all states from all environments in the ``base`` top file will
-    be applied, while all other top files are ignored. The only way to set
+    will be ignored. With :conf_minion:`state_top_saltenv` set to ``base``, all
+    states from all environments in the ``base`` top file will be applied,
+    while all other top files are ignored. The only way to set
     :conf_minion:`state_top_saltenv` to something other than ``base`` and not
     have the other environments in the targeted top file ignored, would be to
     set :conf_minion:`top_file_merging_strategy` to ``merge_all``.
@@ -1262,28 +1262,25 @@ This option has no default value. Set it to an environment name to ensure that
 -----------------------------
 
 .. versionchanged:: Carbon
-    Default value has been changed from ``merge`` to ``default`` to reflect the
-    fact that states from matching targets in matching environments in multiple
-    top files are not actually being merged. Additonally, the ``merge_all``
-    strategy has been added.
+    A ``merge_all`` strategy has been added.
 
-Default: ``default``
+Default: ``merge``
 
 When no specific fileserver environment (a.k.a. ``saltenv``) has been specified
 for a :ref:`highstate <running-highstate>`, all environments' top files are
 inspected. This config option determines how the SLS targets in those top files
 are handled.
 
-When set to ``default``, the ``base`` environment's top file is evaluated
-first, followed by the other environments' top files. The first target
-expression (e.g. ``'*'``) for a given environment is kept, and when the same
-target expression is used in a different top file evaluated later, it is
-ignored. Because ``base`` is evaluated first, it is authoritative. For
-example, if there is a target for ``'*'`` for the ``foo`` environment in both
-the ``base`` and ``foo`` environment's top files, the one in the ``foo``
-environment would be ignored. The environments will be evaluated in no specific
-order (aside from ``base`` coming first). For greater control over the order in
-which the environments are evaluated, use :conf_minion:`env_order`.
+When set to ``merge``, the ``base`` environment's top file is evaluated first,
+followed by the other environments' top files. The first target expression
+(e.g. ``'*'``) for a given environment is kept, and when the same target
+expression is used in a different top file evaluated later, it is ignored.
+Because ``base`` is evaluated first, it is authoritative. For example, if there
+is a target for ``'*'`` for the ``foo`` environment in both the ``base`` and
+``foo`` environment's top files, the one in the ``foo`` environment would be
+ignored. The environments will be evaluated in no specific order (aside from
+``base`` coming first). For greater control over the order in which the
+environments are evaluated, use :conf_minion:`env_order`.
 
 When set to ``same``, then for each environment, only that environment's top
 file is processed, with the others being ignored. For example, only the ``dev``

--- a/doc/ref/states/top.rst
+++ b/doc/ref/states/top.rst
@@ -428,13 +428,8 @@ If the ``base`` environment were specified, the result would be that only the
 If the ``qa`` environment were specified, the :ref:`highstate
 <running-highstate>` would exit with an error.
 
-Scenario 2 - No Environment Specified, :conf_minion:`top_file_merging_strategy` is "default"
---------------------------------------------------------------------------------------------
-
-.. versionchanged:: Carbon
-    The default merging strategy has been renamed from ``merge`` to
-    ``default`` to reflect the fact that SLS names from identical targets in
-    matching environments from multiple top files are not actually merged.
+Scenario 2 - No Environment Specified, :conf_minion:`top_file_merging_strategy` is "merge"
+------------------------------------------------------------------------------------------
 
 In this scenario, assuming that the ``base`` environment's top file was
 evaluated first, the ``base1``, ``dev1``, and ``qa1`` states would be applied
@@ -463,7 +458,7 @@ the default), then ``qa1`` from the ``qa`` environment will be applied to all
 minions. If :conf_minion:`default_top` were set to ``dev``, then both ``qa1``
 and ``qa2`` from the ``qa`` environment would be applied to all minions.
 
-Scenario 3 - No Environment Specified, :conf_minion:`top_file_merging_strategy` is "merge_all"
+Scenario 4 - No Environment Specified, :conf_minion:`top_file_merging_strategy` is "merge_all"
 ----------------------------------------------------------------------------------------------
 
 .. versionadded:: Carbon

--- a/doc/topics/releases/carbon.rst
+++ b/doc/topics/releases/carbon.rst
@@ -118,9 +118,22 @@ Additional Features
           - source: salt://path/to/myapp
           - dir_mode: 755
           - file_mode: keep
-          
-- The ``junos`` state module is now available. It has all the functions 
+
+- The ``junos`` state module is now available. It has all the functions
   that are present in the ``junos`` execution module.
+
+New Top File Merging Strategy for States
+========================================
+
+A new strategy called ``merge_all`` has been added to provide a new way of
+merging top file matches when executing a :ref:`highstate <running-highstate>`.
+See the :conf_master:`top_file_merging_strategy` documentation for further
+information.
+
+In addition, the ``same`` merging strategy was not functioning as documented.
+This has now been corrected. While this is technically a bugfix, we decided to
+hold a change in top file merging until a feature release to minimize user
+impact.
 
 Config Changes
 ==============
@@ -196,7 +209,7 @@ Pillar Changes
   ref:`utility modules <writing-utility-modules>` synced to the correct
   location on the Master so that they are available in execution modules called
   from Pillar SLS files.
-  
+
 Junos Module Changes
 ===================
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -974,7 +974,7 @@ DEFAULT_MINION_OPTS = {
         'base': [salt.syspaths.BASE_FILE_ROOTS_DIR,
                  salt.syspaths.SPM_FORMULA_PATH]
     },
-    'top_file_merging_strategy': 'default',
+    'top_file_merging_strategy': 'merge',
     'env_order': [],
     'default_top': 'base',
     'fileserver_limit_traversal': False,
@@ -1192,7 +1192,7 @@ DEFAULT_MASTER_OPTS = {
     'thorium_roots': {
         'base': [salt.syspaths.BASE_THORIUM_ROOTS_DIR],
         },
-    'top_file_merging_strategy': 'default',
+    'top_file_merging_strategy': 'merge',
     'env_order': [],
     'environment': None,
     'default_top': 'base',

--- a/salt/state.py
+++ b/salt/state.py
@@ -2485,16 +2485,6 @@ class BaseHighState(object):
             opts['file_roots'] = mopts['file_roots']
             opts['top_file_merging_strategy'] = mopts.get('top_file_merging_strategy',
                                                           opts.get('top_file_merging_strategy'))
-            if opts['top_file_merging_strategy'] == 'merge':
-                salt.utils.warn_until(
-                    'Oxygen',
-                    'The top_file_merging_strategy \'merge\' has been renamed '
-                    'to \'default\'. Please comment out the '
-                    '\'top_file_merging_strategy\' line or change it to '
-                    '\'default\'.'
-                )
-                opts['top_file_merging_strategy'] = 'default'
-
             opts['env_order'] = mopts.get('env_order', opts.get('env_order', []))
             opts['default_top'] = mopts.get('default_top', opts.get('default_top'))
             opts['state_events'] = mopts.get('state_events')
@@ -2665,12 +2655,12 @@ class BaseHighState(object):
         except (AttributeError, TypeError):
             log.warning(
                 'Invalid top_file_merging_strategy \'%s\', falling back to '
-                '\'default\'', merging_strategy
+                '\'merge\'', merging_strategy
             )
-            merge_func = self._merge_tops_default
+            merge_func = self._merge_tops_merge
         return merge_func(tops)
 
-    def _merge_tops_default(self, tops):
+    def _merge_tops_merge(self, tops):
         '''
         The default merging strategy. The base env is authoritative, so it is
         checked first, followed by the remaining environments. In top files
@@ -2701,7 +2691,7 @@ class BaseHighState(object):
                         log.debug(
                             'Section for saltenv \'%s\' in the \'%s\' '
                             'saltenv\'s top file will be ignored, as the '
-                            'top_file_merging_strategy is set to \'default\' '
+                            'top_file_merging_strategy is set to \'merge\' '
                             'and the saltenvs do not match',
                             saltenv, cenv
                         )

--- a/tests/unit/state_test.py
+++ b/tests/unit/state_test.py
@@ -202,7 +202,7 @@ class TopFileMergeTestCase(TestCase):
             ret[env].append(tops[env])
         return ret
 
-    def test_merge_tops_default(self):
+    def test_merge_tops_merge(self):
         '''
         Test the default merge strategy for top files, in an instance where the
         base top file contains sections for all envs and the other envs' top
@@ -216,9 +216,10 @@ class TopFileMergeTestCase(TestCase):
 
         self.assertEqual(merged_tops, expected_merge)
 
-    def test_merge_tops_default_limited_base(self):
+    def test_merge_tops_merge_limited_base(self):
         '''
-        Test the default merge strategy for top files when
+        Test the default merge strategy for top files when the base environment
+        only defines states for itself.
         '''
         tops = self.get_tops(tops=self.tops_limited_base)
         merged_tops = self.highstate().merge_tops(tops)
@@ -230,7 +231,7 @@ class TopFileMergeTestCase(TestCase):
 
         self.assertEqual(merged_tops, expected_merge)
 
-    def test_merge_tops_default_state_top_saltenv_base(self):
+    def test_merge_tops_merge_state_top_saltenv_base(self):
         '''
         Test the 'state_top_saltenv' parameter to load states exclusively from
         the 'base' saltenv, with the default merging strategy. This should
@@ -247,7 +248,7 @@ class TopFileMergeTestCase(TestCase):
 
         self.assertEqual(merged_tops, expected_merge)
 
-    def test_merge_tops_default_state_top_saltenv_foo(self):
+    def test_merge_tops_merge_state_top_saltenv_foo(self):
         '''
         Test the 'state_top_saltenv' parameter to load states exclusively from
         the 'foo' saltenv, with the default merging strategy. This should


### PR DESCRIPTION
This causes problems when a Carbon master tries to run states on a
non-Carbon minion.

Fixes #36868.