### PR TITLE
Fix service state for Windows

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -519,7 +519,7 @@ def dead(name, enable=None, sig=None, **kwargs):
         ret['result'] = False
         ret['comment'] = 'Service {0} failed to die'.format(name)
     else:
-        ret['comment'] = 'Service {0} was killed'.format(name)
+        ret['comment'] = 'Killed Service {0}'.format(name)
 
     # add enable/disable status
     if before_toggle_enable_status != after_toggle_enable_status:

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -347,18 +347,13 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
     # Run the tests
     if __opts__['test']:
         ret['result'] = None
+        ret['comment'] = 'Service {0} is already started'.format(name)
         if not before_toggle_status:
             ret['comment'] = 'Service {0} is set to start'.format(name)
         if enable is True and not before_toggle_enable_status:
-            if ret['comment']:
-                ret['comment'] += ' and will be enabled'
-            else:
-                ret['comment'] = 'Service {0} is set to be enabled'.format(name)
+            ret['comment'] += ' and will be enabled'
         if enable is False and before_toggle_enable_status:
-            if ret['comment']:
-                ret['comment'] += ' and will be disabled'
-            else:
-                ret['comment'] = 'Service {0} is set to be disabled'.format(name)
+            ret['comment'] += ' and will be disabled'
         return ret
 
     # Enable the service
@@ -453,18 +448,13 @@ def dead(name, enable=None, sig=None, **kwargs):
     # Run the tests
     if __opts__['test']:
         ret['result'] = None
+        ret['comment'] = 'Service {0} is already stopped'.format(name)
         if before_toggle_status:
-            ret['comment'] = 'Service {0} is set to killed'.format(name)
+            ret['comment'] = 'Service {0} is set to be killed'.format(name)
         if enable is True and not before_toggle_enable_status:
-            if ret['comment']:
-                ret['comment'] += ' and will be enabled'
-            else:
-                ret['comment'] = 'Service {0} is set to be enabled'.format(name)
+            ret['comment'] += ' and will be enabled'
         if enable is False and before_toggle_enable_status:
-            if ret['comment']:
-                ret['comment'] += ' and will be disabled'
-            else:
-                ret['comment'] = 'Service {0} is set to be disabled'.format(name)
+            ret['comment'] += ' and will be disabled'
         return ret
 
     # Enable/Disable service

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -346,14 +346,17 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
 
     # Run the tests
     if __opts__['test']:
-        ret['result'] = None
+        ret['result'] = True
         ret['comment'] = 'Service {0} is already started'.format(name)
         if not before_toggle_status:
             ret['comment'] = 'Service {0} is set to start'.format(name)
+            ret['result'] = None
         if enable is True and not before_toggle_enable_status:
             ret['comment'] += ' and will be enabled'
+            ret['result'] = None
         if enable is False and before_toggle_enable_status:
             ret['comment'] += ' and will be disabled'
+            ret['result'] = None
         return ret
 
     # Enable the service
@@ -464,13 +467,16 @@ def dead(name, enable=None, sig=None, **kwargs):
 
     # Run the tests
     if __opts__['test']:
-        ret['result'] = None
+        ret['result'] = True
         ret['comment'] = 'Service {0} is already stopped'.format(name)
         if before_toggle_status:
+            ret['result'] = None
             ret['comment'] = 'Service {0} is set to be killed'.format(name)
         if enable is True and not before_toggle_enable_status:
+            ret['result'] = None
             ret['comment'] += ' and will be enabled'
         if enable is False and before_toggle_enable_status:
+            ret['result'] = None
             ret['comment'] += ' and will be disabled'
         return ret
 

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -363,7 +363,10 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
         ret.update(_disable(name, before_toggle_status, **kwargs))
 
     # Check the status of the change
-    after_toggle_status = __salt__['service.status'](name)
+    if 'service.enabled' in __salt__:
+        after_toggle_enable_status = __salt__['service.enabled'](name)
+    else:
+        after_toggle_enable_status = True
 
     # See if the service is already running
     if before_toggle_status:
@@ -384,14 +387,13 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
         ret['comment'] = 'Service {0} failed to start'.format(name)
         return ret
 
+    # Check the status of the service
+    after_toggle_status = __salt__['service.status'](name)
+
     if init_delay:
         time.sleep(init_delay)
 
     # only force a change state if we have explicitly detected them
-    if 'service.enabled' in __salt__:
-        after_toggle_enable_status = __salt__['service.enabled'](name)
-    else:
-        after_toggle_enable_status = True
     if (
             (before_toggle_enable_status != after_toggle_enable_status) or
             (before_toggle_status != after_toggle_status)
@@ -479,7 +481,10 @@ def dead(name, enable=None, sig=None, **kwargs):
         ret.update(_disable(name, None, **kwargs))
 
     # Check the status of the change
-    after_toggle_status = __salt__['service.status'](name)
+    if 'service.enabled' in __salt__:
+        after_toggle_enable_status = __salt__['service.enabled'](name)
+    else:
+        after_toggle_enable_status = True
 
     # See if the service is already dead
     if not before_toggle_status:
@@ -499,11 +504,10 @@ def dead(name, enable=None, sig=None, **kwargs):
         ret['comment'] = 'Service {0} failed to die'.format(name)
         return ret
 
+    # Check the status of the service
+    after_toggle_status = __salt__['service.status'](name)
+
     # only force a change state if we have explicitly detected them
-    if 'service.enabled' in __salt__:
-        after_toggle_enable_status = __salt__['service.enabled'](name)
-    else:
-        after_toggle_enable_status = True
     if (
             (before_toggle_enable_status != after_toggle_enable_status) or
             (before_toggle_status != after_toggle_status)

--- a/tests/unit/states/service_test.py
+++ b/tests/unit/states/service_test.py
@@ -5,7 +5,6 @@
 
 # Import Python Libs
 from __future__ import absolute_import
-import contextlib
 
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
@@ -159,7 +158,6 @@ class ServiceTestCase(TestCase):
                                      MagicMock(side_effect=[False, False]),
                                  'service.status': fmock}):
                     self.assertDictEqual(service.running("salt"), ret)
-
 
     def test_dead(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Changes the order a little bit. In Windows, you can't start a disabled service. So, if you set `enabled: True` it should enable the service before it tries to start it. The order doesn't seem to matter in Linux (anyone?).

NOTE: Please look at this one closely as I'm not a Linux guy. The changes I made were tested on Ubuntu 16.04 as well as windows. The unit tests probably aren't a good gauge for whether this will actually work on other OS'es.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/35316
### Previous Behavior

The service state would start the service, then enable/disable the service if you passed the `enable` option.
Additionally, the enable/disable actions were happening prior to the `test=True` check and would, therefore, happen even if the user passed `test=True`
### New Behavior

Now the enable/disable behavior happens before the service is started.
No modifications will be made with `test=True`
### Tests written?

Yes
