### PR TITLE
Update references to future default value change that was reverted

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1047,9 +1047,9 @@ This option has no default value. Set it to an environment name to ensure that
     :conf_minion:`top_file_merging_strategy` is left at its default, and
     :conf_minion:`state_top_saltenv` is set to ``foo``, then any sections for
     environments other than ``foo`` in the top file for the ``foo`` environment
-    will be ignored. With :conf_minion:`top_file_merging_strategy` set to
-    ``base``, all states from all environments in the ``base`` top file will
-    be applied, while all other top files are ignored.
+    will be ignored. With :conf_minion:`state_top_saltenv` set to ``base``, all
+    states from all environments in the ``base`` top file will be applied,
+    while all other top files are ignored.
 
 .. code-block:: yaml
 

--- a/doc/ref/states/top.rst
+++ b/doc/ref/states/top.rst
@@ -429,11 +429,6 @@ If the ``qa`` environment were specified, the :ref:`highstate
 Scenario 2 - No Environment Specified, :conf_minion:`top_file_merging_strategy` is "merge"
 ------------------------------------------------------------------------------------------
 
-.. versionchanged:: Carbon
-    The default merging strategy has been renamed from ``merge`` to
-    ``default`` to reflect the fact that SLS names from identical targets in
-    matching environments from multiple top files are not actually merged.
-
 In this scenario, assuming that the ``base`` environment's top file was
 evaluated first, the ``base1``, ``dev1``, and ``qa1`` states would be applied
 to all minions. If, for instance, the ``qa`` environment is not defined in


### PR DESCRIPTION
This was reverted in https://github.com/saltstack/salt/pull/36922, so remove the references to it. Also fix an incorrect parameter name elsewhere in the minion config file docs.