### PR TITLE
Remove "Targeting with Executions" section from docs

### DIFF
--- a/doc/ref/cli/index.rst
+++ b/doc/ref/cli/index.rst
@@ -82,19 +82,6 @@ grains.item salt function:
 more info on using targeting with grains can be found :ref:`here
 <targeting-grains>`.
 
-Targeting with Executions
-`````````````````````````
-
-As of 0.8.8 targeting with executions is still under heavy development and this
-documentation is written to reference the behavior of execution matching in the
-future.
-
-Execution matching allows for a primary function to be executed, and then based
-on the return of the primary function the main function is executed.
-
-Execution matching allows for matching minions based on any arbitrary running
-data on the minions.
-
 Compound Targeting
 ``````````````````
 


### PR DESCRIPTION
This feature was removed long ago and is no longer under development.

Fixes #36906