### PR TITLE
[2016.3] Remove "Targeting with Executions" section from docs

### DIFF
--- a/doc/topics/targeting/index.rst
+++ b/doc/topics/targeting/index.rst
@@ -51,19 +51,6 @@ grains.item salt function:
 more info on using targeting with grains can be found :ref:`here
 <targeting-grains>`.
 
-Targeting with Executions
-=========================
-
-As of 0.8.8 targeting with executions is still under heavy development and this
-documentation is written to reference the behavior of execution matching in the
-future.
-
-Execution matching allows for a primary function to be executed, and then based
-on the return of the primary function the main function is executed.
-
-Execution matching allows for matching minions based on any arbitrary running
-data on the minions.
-
 Compound Targeting
 ==================
 


### PR DESCRIPTION
The targeting docs were refactored in the 2016.3 branch compared to
the 2015.8 branch. This fixes #36906 for the 2016.3 branch and newer.

Refs saltstack/salt#36925