### PR TITLE
Fix race condition in which files were removed during a file.directory

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3644,6 +3644,10 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
     perms = {}
     cur = stats(name, follow_symlinks=follow_symlinks)
     if not cur:
+        # NOTE: The file.directory state checks the content of the error
+        # message in this exception. Any changes made to the message for this
+        # exception will reflect the file.directory state as well, and will
+        # likely require changes there.
         raise CommandExecutionError('{0} does not exist'.format(name))
     perms['luser'] = cur['user']
     perms['lgroup'] = cur['group']


### PR DESCRIPTION
This resolves a case in which a directory being managed by a
file.directory state was running a sphinx build, and temporary
files/dirs created by the build were present when the initial walk was
performed but were cleaned up by the time the state got around to
enforcing permissions.

Resolves #36831.