### PR TITLE
[yumpkg] Skip test_pkg_upgrade_has_pending_upgrades if there are no upgrades

### DIFF
--- a/tests/integration/modules/pkg.py
+++ b/tests/integration/modules/pkg.py
@@ -276,7 +276,7 @@ class PkgModuleTest(integration.ModuleCase,
             self.assertIn('vim', ret['changes'])
         else:
             ret = self.run_function('pkg.list_updates')
-            if ret == '':
+            if ret == '' or ret == {}:
                 self.skipTest('No updates available for this machine.  Skipping pkg.upgrade test.')
             else:
                 ret = self.run_function(func)


### PR DESCRIPTION
yumpkg.list_upgrades returns an empty dictionary when no upgrades are available.
We need to check for this situation and skip the test if no upgrades are present.

Fixes the test failure on Fedora 24 on Jenkins currently, but also protects against
any potential failures for other RHEL-based distros that aren't currently failing
because "ret" is populated with a dictionary of upgrades.
