### PR TITLE
cp.get_file_str: do not fail if file not found

### DIFF
--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -341,6 +341,8 @@ def get_file_str(path, saltenv='base', env=None):
     '''
     Return the contents of a file from a URL
 
+    Returns ``False`` if Salt was unable to cache a file from a URL.
+
     CLI Example:
 
     .. code-block:: bash
@@ -357,9 +359,11 @@ def get_file_str(path, saltenv='base', env=None):
         saltenv = env
 
     fn_ = cache_file(path, saltenv)
-    with salt.utils.fopen(fn_, 'r') as fp_:
-        data = fp_.read()
-    return data
+    if isinstance(fn_, six.string_types):
+        with salt.utils.fopen(fn_, 'r') as fp_:
+            data = fp_.read()
+        return data
+    return fn_
 
 
 def cache_file(path, saltenv='base', env=None):


### PR DESCRIPTION
### What does this PR do?

It removes misleading exception message when `cp.get_file_str` function tries to display non-existent file:

```
Passed invalid arguments: coercing to Unicode: need string or buffer, bool found.
```

Instead, the function will simply return the result given by `cache_file` function which does the real job.

This becomes especially useful in Jinja templates.
### Previous Behavior

``` console
# salt-call cp.get_file_str salt://files/test2
[ERROR   ] Unable to cache file u'salt://files/test2' from saltenv 'base'.

Passed invalid arguments: coercing to Unicode: need string or buffer, bool found.

Usage:

    Return the contents of a file from a URL

    CLI Example:

    .. code-block:: bash

        salt '*' cp.get_file_str salt://my/file

```
### New Behavior

``` console
# salt-call cp.get_file_str salt://files/test2
[ERROR   ] Unable to cache file u'salt://files/test2' from saltenv 'base'.
local:
    False
```
### Tests written?

No