### PR TITLE
acl.delfacl: fix position of -X option to setfacl

### DIFF
--- a/salt/modules/linux_acl.py
+++ b/salt/modules/linux_acl.py
@@ -250,9 +250,11 @@ def delfacl(acl_type, acl_name='', *args, **kwargs):
 
     _raise_on_no_files(*args)
 
-    cmd = 'setfacl -x'
+    cmd = 'setfacl'
     if recursive:
         cmd += ' -R'
+
+    cmd += ' -x'
 
     cmd = '{0} {1}:{2}'.format(cmd, _acl_prefix(acl_type), acl_name)
 

--- a/tests/unit/modules/linux_acl_test.py
+++ b/tests/unit/modules/linux_acl_test.py
@@ -193,4 +193,4 @@ class LinuxAclTestCase(TestCase):
 
     def test_delfacl__recursive_w_multiple_args(self):
         linux_acl.delfacl(*(self.default_user_acl[:-1] + self.files), recursive=True)
-        self.cmdrun.assert_called_once_with('setfacl -x -R ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -R -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.files), python_shell=False)


### PR DESCRIPTION
### What does this PR do?

Fix wrong order of options to `setfacl` for `acl.delfacl` of `linux_acl.py` for `recursive=True`
### Previous Behavior

 `setfacl` called by `acl.delfacl recursive=True` complains about the wrong `-R` parameter to the `-x` option:

```
$ salt-call acl.delfacl user jr rwx /root/acl-test recursive=True
[INFO    ] Executing command 'setfacl -x -R u:jr rwx /root/acl-test' in directory '/root'
[ERROR   ] Command 'setfacl -x -R u:jr rwx /root/acl-test' failed with return code: 2
[ERROR   ] output: setfacl: Option -x: Invalid argument near character 1
local:
   True
$
```
### New Behavior

The call to setfacl succeeds.

```
 $ salt-call acl.delfacl user jr rwx /root/acl-test recursive=True
[INFO    ] Executing command 'setfacl -R -x u:jr rwx /root/acl-test' in directory '/root'
local:
    True
$ 
```
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
