### PR TITLE
doc: document what the argument of salt --subset means

### DIFF
--- a/doc/ref/cli/salt.rst
+++ b/doc/ref/cli/salt.rst
@@ -56,7 +56,7 @@ Options
 
     Execute the routine on a random subset of the targeted minions.  The
     minions will be verified that they have the named function before
-    executing.
+    executing. The SUBSET argument is the count of the minions to target.
 
 .. option:: -v VERBOSE, --verbose
 


### PR DESCRIPTION
### What does this PR do?

Documents the meaning of the required argument of salt --subset option.
### Tests written?

No
