### PR TITLE
Mitigate case of starting an existing supervisord process group success reported as failure.

### DIFF
--- a/salt/states/supervisord.py
+++ b/salt/states/supervisord.py
@@ -26,9 +26,11 @@ def _check_error(result, success_message):
     ret = {}
 
     if 'ERROR' in result:
-        if 'already started' in result:
-            ret['comment'] = success_message
-        elif 'not running' in result:
+        if any(substring in result for substring in [
+            'already started',
+            'not running',
+            'process group already active'
+        ]):
             ret['comment'] = success_message
         else:
             ret['comment'] = result
@@ -151,25 +153,14 @@ def running(name,
 
     changes = []
     just_updated = False
-    if to_add:
-        comment = 'Adding service: {0}'.format(name)
-        __salt__['supervisord.reread'](
-            user=user,
-            conf_file=conf_file,
-            bin_env=bin_env
-        )
-        result = __salt__['supervisord.add'](
-            name,
-            user=user,
-            conf_file=conf_file,
-            bin_env=bin_env
-        )
 
-        ret.update(_check_error(result, comment))
-        changes.append(comment)
-        log.debug(comment)
-
-    elif update:
+    if update:
+        # If the state explicitly asks to update, we don't care if the process
+        # is being added or not, since it'll take care of this for us,
+        # so give this condition priority in order
+        #
+        # That is, unless `to_add` somehow manages to contain processes
+        # we don't want running, in which case adding them may be a mistake
         comment = 'Updating supervisor'
         result = __salt__['supervisord.update'](
             user=user,
@@ -181,6 +172,27 @@ def running(name,
 
         if '{0}: updated'.format(name) in result:
             just_updated = True
+    elif to_add:
+        # Not sure if this condition is precise enough.
+        comment = 'Adding service: {0}'.format(name)
+        __salt__['supervisord.reread'](
+            user=user,
+            conf_file=conf_file,
+            bin_env=bin_env
+        )
+        # Causes supervisorctl to throw `ERROR: process group already active`
+        # if process group exists. At this moment, I'm not sure how to handle
+        # this outside of grepping out the expected string in `_check_error`.
+        result = __salt__['supervisord.add'](
+            name,
+            user=user,
+            conf_file=conf_file,
+            bin_env=bin_env
+        )
+
+        ret.update(_check_error(result, comment))
+        changes.append(comment)
+        log.debug(comment)
 
     is_stopped = None
 


### PR DESCRIPTION
### What does this PR do?

Fixes a situation where attempts at starting an existing supervisord process group succeed, but report failure.
### What issues does this PR fix or reference?

No reported issue at this time.

Reference SLS:

```
asdf-task-setup:
  pkg.installed:
    - name: supervisor
    - refresh: true
  service.running:
    - name: supervisor
    - enable: true
    - require:
      - pkg: asdf-task-setup
  file.managed:
    - name: /etc/supervisor/conf.d/asdf.conf
    - contents: |
        [program:asdf]
        command = /bin/bash -c 'while true; do sleep 15; done'
        autostart = true
        autorestart = true
        numprocs = 2
        process_name = %(program_name)s_%(process_num)s
    - require:
      - pkg: asdf-task-setup
  module.run:
    - name: supervisord.update
    - require:
      - service: asdf-task-setup

asdf-task-stop:
  supervisord.dead:
    - name: 'asdf:'
    - require:
      - module: asdf-task-setup

asdf-task-start:
  supervisord.running:
    - name: 'asdf:'
    - update: true
    - require:
      - supervisord: asdf-task-stop
```
### Previous Behavior

Minion log:

```
2016-10-13 05:33:52,233 [salt.loaded.int.module.cmdmod][INFO    ][31522] Executing command ['/usr/bin/supervisorctl', 'reread'] in directory '/root'
2016-10-13 05:33:52,382 [salt.loaded.int.module.cmdmod][INFO    ][31522] Executing command ['/usr/bin/supervisorctl', 'add', 'asdf'] in directory '/root'
2016-10-13 05:33:52,506 [salt.loaded.int.module.cmdmod][DEBUG   ][31522] stdout: ERROR: process group already active
2016-10-13 05:33:52,507 [salt.loaded.int.states.supervisord][DEBUG   ][31522] Adding service: asdf:
2016-10-13 05:33:52,508 [salt.loaded.int.states.supervisord][DEBUG   ][31522] Starting: asdf:
2016-10-13 05:33:52,509 [salt.loaded.int.module.cmdmod][INFO    ][31522] Executing command ['/usr/bin/supervisorctl', 'start', 'asdf:'] in directory '/root'
2016-10-13 05:33:54,227 [salt.loaded.int.module.cmdmod][DEBUG   ][31522] stdout: asdf: started
2016-10-13 05:33:54,228 [salt.loaded.int.states.supervisord][DEBUG   ][31522] asdf: started
2016-10-13 05:33:54,228 [salt.state       ][ERROR   ][31522] Starting: asdf:
2016-10-13 05:33:54,229 [salt.state       ][INFO    ][31522] Completed state [asdf:] at time 05:33:54.228637 duration_in_ms=2136.438
```

SLS run output:

```
ubuntu16:
  Name: supervisor - Function: pkg.installed - Result: Clean
  Name: supervisor - Function: service.running - Result: Clean
  Name: /etc/supervisor/conf.d/asdf.conf - Function: file.managed - Result: Clean
  Name: supervisord.update - Function: module.run - Result: Changed
  Name: asdf: - Function: supervisord.dead - Result: Changed
----------
          ID: asdf-task-start
    Function: supervisord.running
        Name: asdf:
      Result: False
     Comment: Starting: asdf:
     Started: 09:31:11.083948
    Duration: 2226.972 ms
     Changes:
```
### New Behavior

SLS run output:

```
ubuntu16:
  Name: supervisor - Function: pkg.installed - Result: Clean
  Name: supervisor - Function: service.running - Result: Clean
  Name: /etc/supervisor/conf.d/asdf.conf - Function: file.managed - Result: Clean
  Name: supervisord.update - Function: module.run - Result: Changed
  Name: asdf: - Function: supervisord.dead - Result: Changed
  Name: asdf: - Function: supervisord.running - Result: Changed
```
### Tests written?

No
