### PR TITLE
Remove whitespace from string commands

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -280,6 +280,10 @@ def _run(cmd,
         raise CommandExecutionError('VT not available on windows')
 
     if shell.lower().strip() == 'powershell':
+        # Strip whitespace
+        if isinstance(cmd, six.string_types):
+            cmd = cmd.strip()
+
         # If we were called by script(), then fakeout the Windows
         # shell to run a Powershell script.
         # Else just run a Powershell command.
@@ -289,9 +293,9 @@ def _run(cmd,
         # The last item in the list [-1] is the current method.
         # The third item[2] in each tuple is the name of that method.
         if stack[-2][2] == 'script':
-            cmd = 'Powershell -NonInteractive -ExecutionPolicy Bypass -File ' + cmd
+            cmd = 'Powershell -NonInteractive -NoProfile -ExecutionPolicy Bypass -File ' + cmd
         else:
-            cmd = 'Powershell -NonInteractive "{0}"'.format(cmd.replace('"', '\\"'))
+            cmd = 'Powershell -NonInteractive -NoProfile "{0}"'.format(cmd.replace('"', '\\"'))
 
     # munge the cmd and cwd through the template
     (cmd, cwd) = _render_cmd(cmd, cwd, template, saltenv, pillarenv, pillar_override)


### PR DESCRIPTION
### What does this PR do?

Strips whitespace from string commands.
Adds -NoProfile switch to powershell commands
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/34054
https://github.com/saltstack/salt/issues/16872
### Previous Behavior

Commands that had a hard return at the end were producing erroneous quoting. This specifically applies to state files using multiline commands.
PowerShell commands and scripts were loading local powershell profiles. Individualized settings are stored in powershell profiles and can introduce unexpected items into the powershell environment.
### New Behavior

Whitespace is removed if the cmd is a string.
Powershell Profiles are not loaded.
### Tests written?

No