### PR TITLE
modules.archive.unzip: zipfile is stdlib

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -492,7 +492,6 @@ def cmd_unzip(zip_file, dest, excludes=None,
     return _trim_files(files, trim_output)
 
 
-@salt.utils.decorators.depends('zipfile', fallback_function=cmd_unzip)
 def unzip(zip_file, dest, excludes=None,
           template=None, runas=None, trim_output=False, password=None):
     '''


### PR DESCRIPTION
### What does this PR do?

Remove the decorator check because zipfile is in the stdlib.
### What issues does this PR fix or reference?
- #36648
- @terminalmage
### Tests written?

No
