### PR TITLE
Use ip route instead of the deprecated route

### DIFF
--- a/salt/templates/debian_ip/route_eth.jinja
+++ b/salt/templates/debian_ip/route_eth.jinja
@@ -2,5 +2,5 @@
 # {{route_type}}
 test "${IFACE}" = "{{iface}}" || exit 0
 {% for route in routes %}{% if route.name %}# {{route.name}}
-{%endif%}route {{route_type}} -net {% if route.ipaddr %}{{route.ipaddr}}{%endif%} {% if route.netmask %}netmask {{route.netmask}}{%endif%} {% if route.gateway %}gateway {{route.gateway}}{%endif%} dev {{iface}}
+{%endif%}ip route {{route_type}} {% if route.ipaddr %}{{route.ipaddr}}{%endif%}{% if route.netmask %}/{{route.netmask}}{%endif%} {% if route.gateway %}via {{route.gateway}}{%endif%} dev {{iface}}
 {% endfor %}


### PR DESCRIPTION
### What does this PR do?

route and ifconfig (provided in debian by package net-tools) are deprecated since 2009.[[1](https://linux.die.net/man/8/route)][[2](https://wiki.linuxfoundation.org/networking/iproute2)] The same functionality is now provided by the ip command (in the iproute2 package). This commit changes the script that salt installs in if-up.d to use ip (from iproute2) rather than route (from net-tools).
### What issues does this PR fix or reference?

None
### Previous Behavior

Routes would get installed using the route command (deprecated as of 2009).
### New Behavior

Routes get installed using the ip command (from iproute2 package).
### Tests written?

No