### PR TITLE
Fix mac_package wildcard install error on mac

### DIFF
--- a/salt/modules/mac_package.py
+++ b/salt/modules/mac_package.py
@@ -63,7 +63,7 @@ def install(pkg, target='LocalSystem', store=False, allow_untrusted=False):
     if '*.' not in pkg:
         # If we use wildcards, we cannot use quotes
         pkg = _quote(pkg)
-    
+
     target = _quote(target)
 
     cmd = 'installer -pkg {0} -target {1}'.format(pkg, target)

--- a/salt/modules/mac_package.py
+++ b/salt/modules/mac_package.py
@@ -60,7 +60,10 @@ def install(pkg, target='LocalSystem', store=False, allow_untrusted=False):
 
         salt '*' macpackage.install test.pkg
     '''
-    pkg = _quote(pkg)
+    if '*.' not in pkg:
+        # If we use wildcards, we cannot use quotes
+        pkg = _quote(pkg)
+    
     target = _quote(target)
 
     cmd = 'installer -pkg {0} -target {1}'.format(pkg, target)

--- a/tests/unit/modules/mac_package_test.py
+++ b/tests/unit/modules/mac_package_test.py
@@ -38,7 +38,7 @@ class MacPackageTestCase(TestCase):
         mock = MagicMock()
         with patch.dict(macpackage.__salt__, {'cmd.run_all': mock}):
             macpackage.install('/path/to/*.pkg')
-            mock.assert_called_once_with('installer -pkg \'/path/to/*.pkg\' -target LocalSystem', python_shell=True)
+            mock.assert_called_once_with('installer -pkg /path/to/*.pkg -target LocalSystem', python_shell=True)
 
     def test_install_with_extras(self):
         '''


### PR DESCRIPTION
### What does this PR do?

In mac_package, do not add quote around wildcard. The wildcard need to be expanded by bash. Adding quote will cause it not being expanded by the shell.
### What issues does this PR fix or reference?

On a mac, the mac_package state will result in the following error if the wildcard filename is not expanded. The following example illustrate how it failed.

`sudo installer -pkg '/private/tmp/test/*.pkg' -target LocalSystem`
`installer: Error the package path specified was invalid: '/private/tmp/test/*.pkg'.`
### Tests written?

Updated existing test.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.