### PR TITLE
Make helper funcs private

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -39,7 +39,7 @@ def __virtual__():
         return False
 
 
-def updateChecksum(fname, target, checksum):
+def _update_checksum(fname, target, checksum):
     lines = []
     compare_string = '{0}:{1}'.format(target, checksum)
     if os.path.exists(fname):
@@ -53,7 +53,7 @@ def updateChecksum(fname, target, checksum):
             f.write(line)
 
 
-def compareChecksum(fname, target, checksum):
+def _compare_checksum(fname, target, checksum):
     if os.path.exists(fname):
         compare_string = '{0}:{1}'.format(target, checksum)
         with salt.utils.fopen(fname, 'r') as f:
@@ -284,7 +284,7 @@ def extracted(name,
                             'files',
                             __env__,
                             source_file)
-        if compareChecksum(hash_fname, name, hash[1]):
+        if _compare_checksum(hash_fname, name, hash[1]):
             ret['result'] = True
             ret['comment'] = 'Hash {0} has not changed'.format(hash[1])
             return ret
@@ -511,7 +511,7 @@ def extracted(name,
         if not keep:
             os.unlink(filename)
         if source_hash and source_hash_update:
-            updateChecksum(hash_fname, name, hash[1])
+            _update_checksum(hash_fname, name, hash[1])
 
     else:
         __salt__['file.remove'](if_missing)


### PR DESCRIPTION
This keeps them from being included in the docs and, more importantly,
hides them from the loader and keeps them out of the `__salt__`
dunder.