### PR TITLE
add process_dependency_links flag to virtualenv_mod state

### DIFF
--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -54,7 +54,8 @@ def managed(name,
             env_vars=None,
             no_use_wheel=False,
             pip_upgrade=False,
-            pip_pkgs=None):
+            pip_pkgs=None,
+            process_dependency_links=False):
     '''
     Create a virtualenv and optionally manage it with pip
 
@@ -103,6 +104,9 @@ def managed(name,
     pip_pkgs: None
         As an alternative to `requirements`, pass a list of pip packages that
         should be installed.
+
+    process_dependency_links: False
+        Run pip install with the --process_dependency_links flag.
 
     Also accepts any kwargs that the virtualenv module will. However, some
     kwargs, such as the ``pip`` option, require ``- distribute: True``.
@@ -253,6 +257,7 @@ def managed(name,
         _ret = __salt__['pip.install'](
             pkgs=pip_pkgs,
             requirements=requirements,
+            process_dependency_links=process_dependency_links,
             bin_env=name,
             use_wheel=use_wheel,
             no_use_wheel=no_use_wheel,


### PR DESCRIPTION
### What does this PR do?

Adds ability to pass `--process-dependency-links` flag to `virtualenv.managed` state for pip.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.