### PR TITLE
zpool grains should just be a list

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2104,36 +2104,9 @@ def _zpool_data(grains):
         return {}
 
     # collect zpool data
-    zpool_grains = {}
-
-    for zpool in __salt__['cmd.run']('zpool list -H -o name,health,size,alloc,free,cap').splitlines():
-        zpool = zpool.split()
-
-        # append zpool information
-        zpool_grains[zpool[0]] = {
-            'health':        zpool[1],
-            'size': {
-                'total':     zpool[2],
-                'free':      zpool[3],
-                'alloc':     zpool[4],
-                'cap_pct':   int(zpool[5][:-1])
-            },
-        }
-
-    # collect addition zpool data
-    if salt.utils.which('zfs'):
-        for zpool in zpool_grains.keys():
-            zpool_type_data = __salt__['cmd.run'](
-                'zfs list -H -t all -o type -r {0}'.format(zpool)
-            ).splitlines()
-            zpool_grains[zpool]['children'] = {
-                'datasets':  zpool_type_data.count('filesystem'),
-                'volumes':   zpool_type_data.count('volume'),
-                'snapshots': zpool_type_data.count('snapshot'),
-            }
-
+    zpool_grains = __salt__['cmd.run']('zpool list -H -o name').splitlines()
     # return grain data
-    if len(zpool_grains.keys()) < 1:
+    if len(zpool_grains) < 1:
         return {}
     return {'zpool': zpool_grains}
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2104,9 +2104,13 @@ def _zpool_data(grains):
         return {}
 
     # collect zpool data
-    zpool_grains = __salt__['cmd.run']('zpool list -H -o name').splitlines()
+    zpool_grains = {}
+    for zpool in __salt__['cmd.run']('zpool list -H -o name,size').splitlines():
+        zpool = zpool.split()
+        zpool_grains[zpool[0]] = zpool[1]
+
     # return grain data
-    if len(zpool_grains) < 1:
+    if len(zpool_grains.keys()) < 1:
         return {}
     return {'zpool': zpool_grains}
 


### PR DESCRIPTION
### What does this PR do?

Follow up on PR#36839
### What issues does this PR fix or reference?
saltstack/salt#36839
### Previous Behavior

List a lot of extra zpool information
### New Behavior

Only list name and size

``` bash
salt core grains.get zpool    
```

``` yaml
core:
    ----------
    archive:
        21.8T
    data:
        1.81T
    zones:
        111G
```
### Tests written?

No