### PR TITLE
Make possible to reference previous pillars from subsequent pillars, as they specified in the top file

### DIFF
--- a/doc/topics/pillar/index.rst
+++ b/doc/topics/pillar/index.rst
@@ -263,6 +263,51 @@ Since both pillar SLS files contained a ``bind`` key which contained a nested
 dictionary, the pillar dictionary's ``bind`` key contains the combined contents
 of both SLS files' ``bind`` keys.
 
+
+Referencing Other Pillars
+=========================
+
+.. versionadded:: Nitrogen
+
+It is possible to reference pillar values that are defined in other
+pillar files. To do this, place any pillar SLS files with referenced pillar
+values *before* referencing SLS files in the Top file.
+
+For example with such Top file:
+
+.. code-block:: yaml
+
+    base:
+      '*':
+        - settings
+        - postgres
+
+And such ``settings.sls`` file:
+
+.. code-block:: yaml
+
+    db:
+      name: qux
+      user: baz
+      password: supersecret
+
+Values from ``settings`` can be referenced from ``postgres`` like that:
+
+.. code-block:: yaml
+
+    postgres:
+      users:
+        {{ salt['pillar.get']('db:user', 'bar') }}:
+          ensure: present
+          password: {{ salt['pillar.get']('db:password', 'secret') }}
+      databases:
+        {{ salt['pillar.get']('db:name', 'foo') }}:
+          owner: '{{ salt['pillar.get']('db:user', 'bar') }}'
+          template: 'template0'
+          lc_ctype: 'en_US.UTF-8'
+          lc_collate: 'en_US.UTF-8'
+
+
 Including Other Pillars
 =======================
 

--- a/tests/integration/files/pillar/base/sub.sls
+++ b/tests/integration/files/pillar/base/sub.sls
@@ -1,1 +1,9 @@
 sub: sub_minion
+lowercase_knights:
+{% for knight in pillar.get('knights') %}
+  - {{ knight|lower }}
+{% endfor %}
+uppercase_knights:
+{% for knight in salt['pillar.get']('knights') %}
+  - {{ knight|upper }}
+{% endfor %}

--- a/tests/integration/modules/test_pillar.py
+++ b/tests/integration/modules/test_pillar.py
@@ -61,3 +61,17 @@ class PillarModuleTest(ModuleCase):
         self.assertDictContainsSubset(
             {'knights': ['Lancelot', 'Galahad', 'Bedevere', 'Robin']},
             get_items)
+
+    def test_referencing_preceding_pillars(self):
+        '''
+        Pillars, that come first in the top file can be referenced from
+        the subsequent pillars.
+        '''
+        items = self.run_function('pillar.items', minion_tgt='sub_minion')
+        self.assertDictContainsSubset(
+            {'lowercase_knights': ['lancelot', 'galahad',
+                                   'bedevere', 'robin'],
+             'uppercase_knights': ['LANCELOT', 'GALAHAD',
+                                   'BEDEVERE', 'ROBIN']},
+            items
+        )


### PR DESCRIPTION
### What does this PR do?

It implements [proposal](https://github.com/saltstack/salt/issues/6955#issuecomment-45918224) of @jberkus to make possible to reference previous pillars from the ones that are subsequent in the top file.

Even if core developers have own plans for solving #6955, this feature does not prevent any other solution from being implemented and would just give a developer another way to set up his system.

### What issues does this PR fix or reference?
#6955
### Previous Behavior

Previously order in which regular pillars are loaded (and become reference-able by other pillars) was undefined. 
### New Behavior

Now user can reference pillars, that come before current pillar in the top file.
### Tests written?

Yes. I would ask core devs to advise if and what additional tests are needed.
