### PR TITLE
Keep minion schedule when recreate loaders.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1969,7 +1969,11 @@ class Minion(MinionBase):
                         # re-init the subsystems to work with the new master
                         log.info('Re-initialising subsystems for new '
                                  'master {0}'.format(self.opts['master']))
+                        # put the current schedule into the new loaders
+                        self.opts['schedule'] = self.schedule.option('schedule')
                         self.functions, self.returners, self.function_errors, self.executors = self._load_modules()
+                        # make the schedule to use the new 'functions' loader
+                        self.schedule.functions = self.functions
                         self.pub_channel.on_recv(self._handle_payload)
                         self._fire_master_minion_start()
                         log.info('Minion is ready to receive requests!')


### PR DESCRIPTION
### What does this PR do?

Keep the actual schedule in the minion modules lazy loader and update the loader in the schedule object when minion fails over to the next master.
### What issues does this PR fix or reference?
#36134, #36866
### Previous Behavior

The minion schedule is loaded into `opts['schedule']`. Then it's kept up to date in the `minion.functions.opts` because the schedule gets access to the schedule via `config.merge` function.
When minion fails over to the next master it's `functions` lazy loader gets recreated so it's `opts` gets reset to the initial value kept in the `minion.opts`. And `schedule` now has the initial jobs. This breaks minion failover process.
### New Behavior

Get the actual schedule and keep it in `minion.opts`.
Update the schedule functions lazy loader object with the just created actual copy.
### Tests written?

No
