### PR TITLE
opkg: Support ignore_epoch argument in version comparisons

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -695,11 +695,16 @@ def upgrade_available(name):
 
 
 @_which('opkg-compare-versions')
-def version_cmp(pkg1, pkg2):
+def version_cmp(pkg1, pkg2, ignore_epoch=False):
     '''
     Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
     pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
     making the comparison.
+
+    ignore_epoch : False
+        Set to ``True`` to ignore the epoch when comparing versions
+
+        .. versionadded:: 2016.3.4
 
     CLI Example:
 
@@ -707,6 +712,10 @@ def version_cmp(pkg1, pkg2):
 
         salt '*' pkg.version_cmp '0.2.4-0' '0.2.4.1-0'
     '''
+    normalize = lambda x: str(x).split(':', 1)[-1] if ignore_epoch else str(x)
+    pkg1 = normalize(pkg1)
+    pkg2 = normalize(pkg2)
+
     cmd_compare = ['opkg-compare-versions']
     for oper, ret in (("<<", -1), ("=", 0), (">>", 1)):
         cmd = cmd_compare[:]


### PR DESCRIPTION
### What does this PR do?

Based on PR #34531. Missed in that PR because it started at
2015.8 and the opkg module was added in 2016.3.

Based on change in that PR to `aptpkg.py`.
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com