### PR TITLE
CkMinions.connected_ids fix: continue if cache.fetch raises exception

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -15,7 +15,7 @@ import logging
 import salt.payload
 import salt.utils
 from salt.defaults import DEFAULT_TARGET_DELIM
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, SaltCacheError
 import salt.auth.ldap
 import salt.cache
 import salt.ext.six as six
@@ -580,7 +580,14 @@ class CkMinions(object):
             if subset:
                 search = subset
             for id_ in search:
-                mdata = self.cache.fetch('minions/{0}'.format(id_), 'data')
+                try:
+                    mdata = self.cache.fetch('minions/{0}'.format(id_), 'data')
+                except SaltCacheError:
+                    # If a SaltCacheError is explicitly raised during the fetch operation,
+                    # permission was denied to open the cached data.p file. Continue on as
+                    # in the releases <= 2016.3. (An explicit error raise was added in PR
+                    # #35388. See issue #36867 for more information.
+                    continue
                 if mdata is None:
                     continue
                 grains = mdata.get('grains', {})


### PR DESCRIPTION
In releases <= 2016.3.x, when running the CLI as a non-root user, we
did not explicitly raise an error when the cache files for connected
minions could not be accessed.

In PR #35388, a SaltCacheError is being explicitly raised when the
cache file permissions are denied. This PR restores the behavior to
the non-root CLI user to continue through the minion id loop when
the data file can't be accessed, instead of stack tracing.

Fixes #36867