### PR TITLE
Use a default prefix for the mkstemp utils function

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -15,6 +15,7 @@ from contextlib import closing
 import salt.client.ssh.shell
 import salt.client.ssh
 import salt.utils
+import salt.utils.files
 import salt.utils.thin
 import salt.utils.url
 import salt.roster
@@ -128,7 +129,7 @@ def prep_trans_tar(file_client, chunks, file_refs, pillar=None, id_=None):
     data structure
     '''
     gendir = tempfile.mkdtemp()
-    trans_tar = salt.utils.mkstemp()
+    trans_tar = salt.utils.files.mkstemp()
     lowfn = os.path.join(gendir, 'lowstate.json')
     pillarfn = os.path.join(gendir, 'pillar.json')
     sync_refs = [

--- a/salt/client/ssh/wrapper/cp.py
+++ b/salt/client/ssh/wrapper/cp.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 
 # Import salt libs
 import salt.client.ssh
+import salt.utils.files
 import logging
 import os
 from salt.exceptions import CommandExecutionError
@@ -136,7 +137,7 @@ def _render_filenames(path, dest, saltenv, template):
         temp file, rendering that file, and returning the result.
         '''
         # write out path to temp file
-        tmp_path_fn = salt.utils.mkstemp()
+        tmp_path_fn = salt.utils.files.mkstemp()
         with salt.utils.fopen(tmp_path_fn, 'w+') as fp_:
             fp_.write(contents)
         data = salt.utils.templates.TEMPLATE_REGISTRY[template](

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -31,6 +31,7 @@ import salt.client
 import salt.loader
 import salt.utils
 import salt.utils.cloud
+import salt.utils.files
 import salt.syspaths
 from salt.utils import reinit_crypto
 from salt.utils import context
@@ -2092,7 +2093,7 @@ class Map(Cloud):
 
             # Generate the fingerprint of the master pubkey in order to
             # mitigate man-in-the-middle attacks
-            master_temp_pub = salt.utils.mkstemp()
+            master_temp_pub = salt.utils.files.mkstemp()
             with salt.utils.fopen(master_temp_pub, 'w') as mtp:
                 mtp.write(pub)
             master_finger = salt.utils.pem_finger(master_temp_pub, sum_type=self.opts['hash_type'])

--- a/salt/engines/hipchat.py
+++ b/salt/engines/hipchat.py
@@ -42,6 +42,7 @@ except ImportError:
     HAS_HYPCHAT = False
 
 import salt.utils
+import salt.utils.files
 import salt.runner
 import salt.client
 import salt.loader
@@ -225,7 +226,7 @@ def start(token,
                 local = salt.client.LocalClient()
                 ret = local.cmd('{0}'.format(target), cmd, args, kwargs)
 
-            tmp_path_fn = salt.utils.mkstemp()
+            tmp_path_fn = salt.utils.files.mkstemp()
             with salt.utils.fopen(tmp_path_fn, 'w+') as fp_:
                 fp_.write(json.dumps(ret, sort_keys=True, indent=4))
             message_string = '@{0} Results for: {1} {2} {3} on {4}'.format(partner, cmd, args, kwargs, target)

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -14,6 +14,7 @@ import logging
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 from salt.ext.six import string_types, integer_types
 import salt.utils
+import salt.utils.files
 
 # TODO: Check that the passed arguments are correct
 
@@ -760,7 +761,7 @@ def _render_filenames(filenames, zip_file, saltenv, template):
         temp file, rendering that file, and returning the result.
         '''
         # write out path to temp file
-        tmp_path_fn = salt.utils.mkstemp()
+        tmp_path_fn = salt.utils.files.mkstemp()
         with salt.utils.fopen(tmp_path_fn, 'w+') as fp_:
             fp_.write(contents)
         data = salt.utils.templates.TEMPLATE_REGISTRY[template](

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -25,6 +25,7 @@ import tempfile
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.timed_subprocess
 import salt.grains.extra
 import salt.ext.six as six
@@ -137,7 +138,7 @@ def _render_cmd(cmd, cwd, template, saltenv='base', pillarenv=None, pillar_overr
 
     def _render(contents):
         # write out path to temp file
-        tmp_path_fn = salt.utils.mkstemp()
+        tmp_path_fn = salt.utils.files.mkstemp()
         with salt.utils.fopen(tmp_path_fn, 'w+') as fp_:
             fp_.write(contents)
         data = salt.utils.templates.TEMPLATE_REGISTRY[template](
@@ -2067,7 +2068,7 @@ def script(source,
             cwd, 'File', runas, 'READ&EXECUTE', 'ALLOW',
             'FOLDER&SUBFOLDERS&FILES')
 
-    path = salt.utils.mkstemp(dir=cwd, suffix=os.path.splitext(source)[1])
+    path = salt.utils.files.mkstemp(dir=cwd, suffix=os.path.splitext(source)[1])
 
     if template:
         if 'pillarenv' in kwargs or 'pillar' in kwargs:
@@ -2367,9 +2368,9 @@ def exec_code_all(lang, code, cwd=None):
     powershell = lang.lower().startswith("powershell")
 
     if powershell:
-        codefile = salt.utils.mkstemp(suffix=".ps1")
+        codefile = salt.utils.files.mkstemp(suffix=".ps1")
     else:
-        codefile = salt.utils.mkstemp()
+        codefile = salt.utils.files.mkstemp()
 
     with salt.utils.fopen(codefile, 'w+t', binary=False) as fp_:
         fp_.write(code)

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -13,6 +13,7 @@ import fnmatch
 import salt.minion
 import salt.fileclient
 import salt.utils
+import salt.utils.files
 import salt.utils.url
 import salt.crypt
 import salt.transport
@@ -137,7 +138,7 @@ def _render_filenames(path, dest, saltenv, template, **kw):
         temp file, rendering that file, and returning the result.
         '''
         # write out path to temp file
-        tmp_path_fn = salt.utils.mkstemp()
+        tmp_path_fn = salt.utils.files.mkstemp()
         with salt.utils.fopen(tmp_path_fn, 'w+') as fp_:
             fp_.write(contents)
         data = salt.utils.templates.TEMPLATE_REGISTRY[template](

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -15,6 +15,7 @@ import random
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.ext.six.moves import range
 
 
@@ -220,7 +221,7 @@ def _write_cron_lines(user, lines):
     Takes a list of lines to be committed to a user's crontab and writes it
     '''
     appUser = __opts__['user']
-    path = salt.utils.mkstemp()
+    path = salt.utils.files.mkstemp()
     if __grains__.get('os_family') in ('Solaris', 'AIX') and appUser != user:
         # on solaris/aix we change to the user before executing the commands
         with salt.utils.fpopen(path, 'w+', uid=__salt__['file.user_to_uid'](user), mode=0o600) as fp_:

--- a/salt/modules/debconfmod.py
+++ b/salt/modules/debconfmod.py
@@ -11,6 +11,7 @@ import re
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -123,7 +124,7 @@ def set_(package, question, type, value, *extra):
     if extra:
         value = ' '.join((value,) + tuple(extra))
 
-    fd_, fname = salt.utils.mkstemp(prefix="salt-", close_fd=False)
+    fd_, fname = salt.utils.files.mkstemp(prefix="salt-", close_fd=False)
 
     line = "{0} {1} {2} {3}".format(package, question, type, value)
     os.write(fd_, line)

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -171,6 +171,7 @@ import types
 from salt.modules import cmdmod
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 import salt.utils
+import salt.utils.files
 import salt.utils.odict
 
 # Import 3rd-party libs
@@ -2179,7 +2180,7 @@ def _script(status,
                 )
             kwargs.pop('env')
 
-        path = salt.utils.mkstemp(dir=tpath)
+        path = salt.utils.files.mkstemp(dir=tpath)
         if template:
             __salt__['cp.get_template'](
                 source, path, template, saltenv, **kwargs)

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -274,6 +274,7 @@ import salt.ext.six as six
 from salt.ext.six.moves import map  # pylint: disable=import-error,redefined-builtin
 import salt.utils
 import salt.utils.decorators
+import salt.utils.files
 import salt.utils.thin
 import salt.pillar
 import salt.exceptions
@@ -4373,7 +4374,7 @@ def save(name,
             )
 
     if compression:
-        saved_path = salt.utils.mkstemp()
+        saved_path = salt.utils.files.mkstemp()
     else:
         saved_path = path
 
@@ -5131,9 +5132,9 @@ def _script(name,
                 )
             )
 
-    path = salt.utils.mkstemp(dir='/tmp',
-                              prefix='salt',
-                              suffix=os.path.splitext(source)[1])
+    path = salt.utils.files.mkstemp(dir='/tmp',
+                                    prefix='salt',
+                                    suffix=os.path.splitext(source)[1])
     if template:
         fn_ = __salt__['cp.get_template'](source, path, template, saltenv)
         if not fn_:

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -84,7 +84,8 @@ def __clean_tmp(sfn):
     '''
     Clean out a template temp file
     '''
-    if sfn.startswith(tempfile.gettempdir()):
+    if sfn.startswith(os.path.join(tempfile.gettempdir(),
+                                   salt.utils.files.TEMPFILE_PREFIX)):
         # Don't remove if it exists in file_roots (any saltenv)
         all_roots = itertools.chain.from_iterable(
                 six.itervalues(__opts__['file_roots']))
@@ -1282,7 +1283,7 @@ def _mkstemp_copy(path,
     temp_file = None
     # Create the temp file
     try:
-        temp_file = salt.utils.mkstemp()
+        temp_file = salt.utils.files.mkstemp()
     except (OSError, IOError) as exc:
         raise CommandExecutionError(
             "Unable to create temp file. "
@@ -4061,7 +4062,7 @@ def check_file_meta(
 
     if contents is not None:
         # Write a tempfile with the static contents
-        tmp = salt.utils.mkstemp(text=True)
+        tmp = salt.utils.files.mkstemp(text=True)
         if salt.utils.is_windows():
             contents = os.linesep.join(contents.splitlines())
         with salt.utils.fopen(tmp, 'w') as tmp_:
@@ -4331,7 +4332,7 @@ def manage_file(name,
 
         if contents is not None:
             # Write the static contents to a temporary file
-            tmp = salt.utils.mkstemp(text=True)
+            tmp = salt.utils.files.mkstemp(text=True)
             if salt.utils.is_windows():
                 contents = os.linesep.join(contents.splitlines())
             with salt.utils.fopen(tmp, 'w') as tmp_:
@@ -4513,7 +4514,7 @@ def manage_file(name,
 
         if contents is not None:
             # Write the static contents to a temporary file
-            tmp = salt.utils.mkstemp(text=True)
+            tmp = salt.utils.files.mkstemp(text=True)
             if salt.utils.is_windows():
                 contents = os.linesep.join(contents.splitlines())
             with salt.utils.fopen(tmp, 'w') as tmp_:

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -210,7 +210,7 @@ def _git_run(command, cwd=None, user=None, password=None, identity=None,
                 ssh_id_wrapper += '.bat'
                 env['GIT_SSH'] = ssh_id_wrapper
             else:
-                tmp_file = salt.utils.mkstemp()
+                tmp_file = salt.utils.files.mkstemp()
                 salt.utils.files.copyfile(ssh_id_wrapper, tmp_file)
                 os.chmod(tmp_file, 0o500)
                 os.chown(tmp_file, __salt__['file.user_to_uid'](user), -1)

--- a/salt/modules/heat.py
+++ b/salt/modules/heat.py
@@ -48,6 +48,7 @@ import yaml
 # Import salt libs
 import salt.ext.six as six
 import salt.utils
+import salt.utils.files
 from salt.exceptions import SaltInvocationError
 
 # pylint: disable=import-error
@@ -508,7 +509,7 @@ def create_stack(name=None, template_file=None, enviroment=None,
     if not parameters:
         parameters = {}
     if template_file:
-        template_tmp_file = salt.utils.mkstemp()
+        template_tmp_file = salt.utils.files.mkstemp()
         tsfn, source_sum, comment_ = __salt__['file.get_managed'](
             name=template_tmp_file,
             template=None,
@@ -570,7 +571,7 @@ def create_stack(name=None, template_file=None, enviroment=None,
         return ret
     env = {}
     if enviroment:
-        enviroment_tmp_file = salt.utils.mkstemp()
+        enviroment_tmp_file = salt.utils.files.mkstemp()
         esfn, source_sum, comment_ = __salt__['file.get_managed'](
             name=enviroment_tmp_file,
             template=None,
@@ -697,7 +698,7 @@ def update_stack(name=None, template_file=None, enviroment=None,
     if not parameters:
         parameters = {}
     if template_file:
-        template_tmp_file = salt.utils.mkstemp()
+        template_tmp_file = salt.utils.files.mkstemp()
         tsfn, source_sum, comment_ = __salt__['file.get_managed'](
             name=template_tmp_file,
             template=None,
@@ -759,7 +760,7 @@ def update_stack(name=None, template_file=None, enviroment=None,
         return ret
     env = {}
     if enviroment:
-        enviroment_tmp_file = salt.utils.mkstemp()
+        enviroment_tmp_file = salt.utils.files.mkstemp()
         esfn, source_sum, comment_ = __salt__['file.get_managed'](
             name=enviroment_tmp_file,
             template=None,

--- a/salt/modules/incron.py
+++ b/salt/modules/incron.py
@@ -10,6 +10,7 @@ import os
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.ext.six.moves import range
 
 # Set up logging
@@ -100,7 +101,7 @@ def _write_incron_lines(user, lines):
         ret['retcode'] = _write_file(_INCRON_SYSTEM_TAB, 'salt', ''.join(lines))
         return ret
     else:
-        path = salt.utils.mkstemp()
+        path = salt.utils.files.mkstemp()
         with salt.utils.fopen(path, 'w+') as fp_:
             fp_.writelines(lines)
         if __grains__['os_family'] == 'Solaris' and user != "root":

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -49,6 +49,7 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.itertools
 from salt.exceptions import SaltInvocationError
 
@@ -168,7 +169,7 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None):
     if password is None:
         password = __salt__['config.option']('postgres.pass')
     if password is not None:
-        pgpassfile = salt.utils.mkstemp(text=True)
+        pgpassfile = salt.utils.files.mkstemp(text=True)
         with salt.utils.fopen(pgpassfile, 'w') as fp_:
             fp_.write('{0}:{1}:*:{2}:{3}'.format(
                 'localhost' if not host or host.startswith('/') else host,
@@ -222,7 +223,7 @@ def _run_initdb(name,
         cmd.append('--locale={0}'.format(locale))
 
     if password is not None:
-        pgpassfile = salt.utils.mkstemp(text=True)
+        pgpassfile = salt.utils.files.mkstemp(text=True)
         with salt.utils.fopen(pgpassfile, 'w') as fp_:
             fp_.write('{0}'.format(password))
             __salt__['file.chown'](pgpassfile, runas, '')

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -17,6 +17,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError, MinionError
 
 log = logging.getLogger(__name__)
@@ -55,7 +56,7 @@ def _write_adminfile(kwargs):
     basedir = kwargs.get('basedir', 'default')
 
     # Make tempfile to hold the adminfile contents.
-    fd_, adminfile = salt.utils.mkstemp(prefix="salt-", close_fd=False)
+    fd_, adminfile = salt.utils.files.mkstemp(prefix="salt-", close_fd=False)
 
     # Write to file then close it.
     os.write(fd_, 'email={0}\n'.format(email))
@@ -457,7 +458,7 @@ def remove(name=None, pkgs=None, saltenv='base', **kwargs):
         basedir = kwargs.get('basedir', 'default')
 
         # Make tempfile to hold the adminfile contents.
-        fd_, adminfile = salt.utils.mkstemp(prefix="salt-", close_fd=False)
+        fd_, adminfile = salt.utils.files.mkstemp(prefix="salt-", close_fd=False)
 
         # Write to file then close it.
         os.write(fd_, 'email={0}\n'.format(email))

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -14,6 +14,7 @@ import os
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext.six import string_types
 
@@ -547,7 +548,7 @@ def get_resource_content(venv,
 
 def _install_script(source, cwd, python, user, saltenv='base', use_vt=False):
     if not salt.utils.is_windows():
-        tmppath = salt.utils.mkstemp(dir=cwd)
+        tmppath = salt.utils.files.mkstemp(dir=cwd)
     else:
         tmppath = __salt__['cp.cache_file'](source, saltenv)
 

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -144,6 +144,7 @@ import os
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.modules.cron import (
     _needs_change,
     _cron_matched
@@ -472,7 +473,7 @@ def file(name,
     mode = salt.utils.normalize_mode('0600')
     owner, group, crontab_dir = _get_cron_info()
 
-    cron_path = salt.utils.mkstemp()
+    cron_path = salt.utils.files.mkstemp()
     with salt.utils.fopen(cron_path, 'w+') as fp_:
         raw_cron = __salt__['cron.raw_cron'](user)
         if not raw_cron.endswith('\n'):

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -143,6 +143,7 @@ import logging
 # Import salt libs
 from salt.ext.six import string_types
 import salt.utils
+import salt.utils.files
 import salt.ext.six as six
 
 # Enable proper logging
@@ -503,7 +504,7 @@ def loaded(name, tag='latest', source=None, source_hash='', force=False):
         comment = 'Image {0} will be loaded'.format(image_name)
         return _ret_status(name=name, comment=comment)
 
-    tmp_filename = salt.utils.mkstemp()
+    tmp_filename = salt.utils.files.mkstemp()
     __salt__['state.single']('file.managed',
                              name=tmp_filename,
                              source=source,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -268,6 +268,7 @@ import salt.loader
 import salt.payload
 import salt.utils
 import salt.utils.dictupdate
+import salt.utils.files
 import salt.utils.templates
 import salt.utils.url
 from salt.utils.locales import sdecode
@@ -1792,7 +1793,7 @@ def managed(name,
     tmp_filename = None
 
     if check_cmd:
-        tmp_filename = salt.utils.mkstemp()+tmp_ext
+        tmp_filename = salt.utils.files.mkstemp() + tmp_ext
 
         # if exists copy existing file to tmp to compare
         if __salt__['file.file_exists'](name):

--- a/salt/states/heat.py
+++ b/salt/states/heat.py
@@ -39,6 +39,7 @@ import logging
 # Import third party libs
 import salt.ext.six as six
 import salt.utils
+import salt.utils.files
 import salt.exceptions
 import yaml
 # Import python libs
@@ -175,7 +176,7 @@ def deployed(name, template=None, enviroment=None, params=None, poll=5,
         return ret
     if existing_stack['result'] and update:
         if template:
-            template_tmp_file = salt.utils.mkstemp()
+            template_tmp_file = salt.utils.files.mkstemp()
             tsfn, source_sum, comment_ = __salt__['file.get_managed'](
                 name=template_tmp_file,
                 template=None,

--- a/salt/template.py
+++ b/salt/template.py
@@ -13,6 +13,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.utils.odict import OrderedDict
 from salt._compat import string_io
 from salt.ext.six import string_types
@@ -128,7 +129,7 @@ def compile_template_str(template, renderers, default, blacklist, whitelist):
     Take template as a string and return the high data structure
     derived from the template.
     '''
-    fn_ = salt.utils.mkstemp()
+    fn_ = salt.utils.files.mkstemp()
     with salt.utils.fopen(fn_, 'wb') as ofile:
         ofile.write(SLS_ENCODER(template)[0])
     return compile_template(fn_, renderers, default, blacklist, whitelist)

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1585,22 +1585,6 @@ def traverse_dict_and_list(data, key, default, delimiter=DEFAULT_TARGET_DELIM):
     return data
 
 
-def mkstemp(*args, **kwargs):
-    '''
-    Helper function which does exactly what `tempfile.mkstemp()` does but
-    accepts another argument, `close_fd`, which, by default, is true and closes
-    the fd before returning the file path. Something commonly done throughout
-    Salt's code.
-    '''
-    close_fd = kwargs.pop('close_fd', True)
-    fd_, fpath = tempfile.mkstemp(*args, **kwargs)
-    if close_fd is False:
-        return (fd_, fpath)
-    os.close(fd_)
-    del fd_
-    return fpath
-
-
 def clean_kwargs(**kwargs):
     '''
     Return a dict without any of the __pub* keys (or any other keys starting

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -76,7 +76,7 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
         )
     bname = os.path.basename(dest)
     dname = os.path.dirname(os.path.abspath(dest))
-    tgt = salt.utils.mkstemp(prefix=bname, dir=dname)
+    tgt = mkstemp(prefix=bname, dir=dname)
     shutil.copyfile(source, tgt)
     bkroot = ''
     if cachedir:

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -9,6 +9,7 @@ import logging
 import os
 import shutil
 import subprocess
+import tempfile
 import time
 
 # Import salt libs
@@ -20,6 +21,26 @@ from salt.exceptions import CommandExecutionError, FileLockError, MinionError
 from salt.ext import six
 
 log = logging.getLogger(__name__)
+
+TEMPFILE_PREFIX = '__salt.tmp.'
+
+
+def mkstemp(*args, **kwargs):
+    '''
+    Helper function which does exactly what `tempfile.mkstemp()` does but
+    accepts another argument, `close_fd`, which, by default, is true and closes
+    the fd before returning the file path. Something commonly done throughout
+    Salt's code.
+    '''
+    if 'prefix' not in kwargs:
+        kwargs['prefix'] = TEMPFILE_PREFIX
+    close_fd = kwargs.pop('close_fd', True)
+    fd_, fpath = tempfile.mkstemp(*args, **kwargs)
+    if close_fd is False:
+        return (fd_, fpath)
+    os.close(fd_)
+    del fd_
+    return fpath
 
 
 def recursive_copy(source, dest):

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -20,6 +20,7 @@ import jinja2.ext
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.yamlencoding
 import salt.utils.locales
 from salt.exceptions import (
@@ -526,7 +527,7 @@ def py(sfn, string=False, **kwargs):  # pylint: disable=C0103
         if string:
             return {'result': True,
                     'data': data}
-        tgt = salt.utils.mkstemp()
+        tgt = salt.utils.files.mkstemp()
         with salt.utils.fopen(tgt, 'w+') as target:
             target.write(data)
         return {'result': True,

--- a/tests/integration/modules/darwin_sysctl.py
+++ b/tests/integration/modules/darwin_sysctl.py
@@ -11,6 +11,7 @@ import random
 # Import Salt Libs
 import integration
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 # Import Salt Testing Libs
@@ -156,7 +157,7 @@ class DarwinSysctlModuleTest(integration.ModuleCase):
         file will be restored in tearDown
         '''
         # Create new temporary file path and open needed files
-        temp_path = salt.utils.mkstemp()
+        temp_path = salt.utils.files.mkstemp()
         with salt.utils.fopen(CONFIG, 'r') as org_conf:
             with salt.utils.fopen(temp_path, 'w') as temp_sysconf:
                 # write sysctl lines to temp file

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import json
 import pprint
-import tempfile
 
 # Import Salt Testing libs
 from salttesting import skipIf, TestCase
@@ -32,6 +31,7 @@ import salt.serializers.python as pythonserializer
 from salt.exceptions import CommandExecutionError
 import salt
 import salt.utils
+import salt.utils.files
 import os
 import shutil
 
@@ -148,7 +148,7 @@ class FileTestCase(TestCase):
         Test to create a symlink.
         '''
         name = '/tmp/testfile.txt'
-        target = tempfile.mkstemp()[1]
+        target = salt.utils.files.mkstemp()
         test_dir = '/tmp'
         user = 'salt'
 
@@ -656,7 +656,7 @@ class FileTestCase(TestCase):
                                                  (name, user=user, group=group,
                                                   contents='A'), ret)
 
-                            with patch.object(salt.utils, 'mkstemp',
+                            with patch.object(salt.utils.files, 'mkstemp',
                                               return_value=name):
                                 comt = ('Unable to copy file {0} to {1}: '
                                         .format(name, name))


### PR DESCRIPTION
This also moves this function into salt.utils.files so that alongside it can be an attribute (`TEMPFILE_PREFIX`) which can be used to get the default tempfile prefix. This allows for simpler logic for properly cleaning the tempfiles created by the `__clean_tmp()` function in `salt.modules.file`.

Refs: https://github.com/saltstack/salt/issues/37021

This should be merged before https://github.com/saltstack/salt/pull/37023. https://github.com/saltstack/salt/pull/37023 will cause merge conflicts with this PR.

This PR is a better long-term fix for #37021, but touches a lot of files, so I thought the best course of action would be to make the minimal change in the 2015.8 branch, and then make the better long-term change in develop.