### PR TITLE
Prevent source files in /tmp from being deleted by file.managed states

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -84,7 +84,8 @@ def __clean_tmp(sfn):
     '''
     Clean out a template temp file
     '''
-    if sfn.startswith(tempfile.gettempdir()):
+    if sfn.startswith(os.path.join(tempfile.gettempdir(),
+                                   salt.utils.files.TEMPFILE_PREFIX)):
         # Don't remove if it exists in file_roots (any saltenv)
         all_roots = itertools.chain.from_iterable(
                 six.itervalues(__opts__['file_roots']))
@@ -1274,7 +1275,7 @@ def _mkstemp_copy(path,
     temp_file = None
     # Create the temp file
     try:
-        temp_file = salt.utils.mkstemp()
+        temp_file = salt.utils.mkstemp(prefix=salt.utils.files.TEMPFILE_PREFIX)
     except (OSError, IOError) as exc:
         raise CommandExecutionError(
             "Unable to create temp file. "
@@ -3957,7 +3958,8 @@ def check_file_meta(
 
     if contents is not None:
         # Write a tempfile with the static contents
-        tmp = salt.utils.mkstemp(text=True)
+        tmp = salt.utils.mkstemp(prefix=salt.utils.files.TEMPFILE_PREFIX,
+                                 text=True)
         with salt.utils.fopen(tmp, 'wb') as tmp_:
             tmp_.write(str(contents))
         # Compare the static contents with the named file
@@ -4191,7 +4193,8 @@ def manage_file(name,
 
         if contents is not None:
             # Write the static contents to a temporary file
-            tmp = salt.utils.mkstemp(text=True)
+            tmp = salt.utils.mkstemp(prefix=salt.utils.files.TEMPFILE_PREFIX,
+                                     text=True)
             if salt.utils.is_windows():
                 contents = os.linesep.join(contents.splitlines())
             with salt.utils.fopen(tmp, 'w') as tmp_:
@@ -4365,7 +4368,8 @@ def manage_file(name,
 
         if contents is not None:
             # Write the static contents to a temporary file
-            tmp = salt.utils.mkstemp(text=True)
+            tmp = salt.utils.mkstemp(prefix=salt.utils.files.TEMPFILE_PREFIX,
+                                     text=True)
             if salt.utils.is_windows():
                 contents = os.linesep.join(contents.splitlines())
             with salt.utils.fopen(tmp, 'w') as tmp_:

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -21,6 +21,8 @@ from salt.ext import six
 
 log = logging.getLogger(__name__)
 
+TEMPFILE_PREFIX = '__salt.tmp.'
+
 
 def recursive_copy(source, dest):
     '''


### PR DESCRIPTION
Due to how the `__clean_tmp()` function works, if you use a source
file that is local to the minion but within the system's temp dir (e.g.
/tmp/foo.txt), it will be removed by the file.managed state. This stops
that by creating temp files with a specific prefix, and then only
cleaning files that match that prefix.

Fixes #37021.

This should be merged after https://github.com/saltstack/salt/pull/37022, and then merged forward, where it will conflict in develop. See the PR message for https://github.com/saltstack/salt/pull/37022 for more information on why this approach was taken.