### PR TITLE
add the ability to verify github webhook hmac signatures

### DIFF
--- a/salt/modules/hashutil.py
+++ b/salt/modules/hashutil.py
@@ -299,3 +299,30 @@ def hmac_signature(string, shared_secret, challenge_hmac):
     hmac_hash = hmac.new(key, msg, hashlib.sha256)
     valid_hmac = base64.b64encode(hmac_hash.digest())
     return valid_hmac == challenge
+
+
+def github_signature(string, shared_secret, challenge_hmac):
+    '''
+    Verify a challenging hmac signature against a string / shared-secret for
+    github webhooks.
+
+    .. versionadded:: Nitrogen
+
+    Returns a boolean if the verification succeeded or failed.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' hashutil.github_signature '{"ref":....} ' 'shared secret' 'sha1=bc6550fc290acf5b42283fa8deaf55cea0f8c206'
+    '''
+    if six.PY3:
+        msg = salt.utils.to_bytes(string)
+        key = salt.utils.to_bytes(shared_secret)
+        hashtype, challenge = salt.utils.to_bytes(challenge_hmac).split('=')
+    else:
+        msg = string
+        key = shared_secret
+        hashtype, challenge = challenge_hmac.split('=')
+    hmac_hash = hmac.new(key, msg, getattr(hashlib, hashtype))
+    return hmac_hash.hexdigest() == challenge

--- a/tests/unit/modules/hashutil_test.py
+++ b/tests/unit/modules/hashutil_test.py
@@ -20,6 +20,7 @@ class HashutilTestCase(ModuleCase):
     the_string_sha256 = 'd49859ccbc854fa68d800b5734efc70d72383e6479d545468bc300263164ff33'
     the_string_sha512 = 'a8c174a7941c64a068e686812a2fafd7624c840fde800f5965fbeca675f2f6e37061ffe41e17728c919bdea290eab7a21e13c04ae71661955a87f2e0e04bb045'
     the_string_hmac = 'eBWf9bstXg+NiP5AOwppB5HMvZiYMPzEM9W5YMm/AmQ='
+    the_string_github = 'sha1=b06aa56bdf4935eec82c4e53e83ed03f03fdb32d'
 
     def setUp(self):
         minion_opts = salt.config.minion_config(os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'minion'))
@@ -50,6 +51,13 @@ class HashutilTestCase(ModuleCase):
                 self.the_string,
                 'shared secret',
                 self.the_string_hmac)
+        self.assertTrue(ret)
+
+    def test_github_signature(self):
+        ret = self.hashutil['hashutil.github_signature'](
+                self.the_string,
+                'shared secret',
+                self.the_string_github)
         self.assertTrue(ret)
 
 


### PR DESCRIPTION
### What does this PR do?

make it easy to verify webhooks in the salt api using the hmac signature

```
{%- if salt.hashutil.hmac_signature(data['body'], 'testhmac', data['headers']['X-Hub-Signature']) %}
highstate_run:
  caller.state.apply:
    - args: []
{%- endif %
```