### PR TITLE
Certbot support for the acme module/state

### DIFF
--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -120,7 +120,7 @@ def cert(name,
         salt 'gitlab.example.com' acme.cert dev.example.com "[gitlab.example.com]" test_cert=True renew=14 webroot=/opt/gitlab/embedded/service/gitlab-rails/public
     '''
 
-    cmd = [LEA, 'certonly']
+    cmd = [LEA, 'certonly', '--quiet']
 
     cert_file = _cert_file(name, 'cert')
     if not __salt__['file.file_exists'](cert_file):

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -30,7 +30,9 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
-LEA = salt.utils.which_bin(['letsencrypt-auto', '/opt/letsencrypt/letsencrypt-auto'])
+LEA = salt.utils.which_bin(['certbot', 'letsencrypt',
+                            'certbot-auto', 'letsencrypt-auto',
+                            '/opt/letsencrypt/letsencrypt-auto'])
 LE_LIVE = '/etc/letsencrypt/live/'
 
 

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -9,10 +9,6 @@ This module currently uses letsencrypt-auto, which needs to be available in the 
 
 .. note::
 
-    Currently only the webroot authentication is tested/implemented.
-
-.. note::
-
     Installation & configuration of the Let's Encrypt client can for example be done using
     https://github.com/saltstack-formulas/letsencrypt-formula
 
@@ -104,7 +100,7 @@ def cert(name,
     :param name: Common Name of the certificate (DNS name of certificate)
     :param aliases: subjectAltNames (Additional DNS names on certificate)
     :param email: e-mail address for interaction with ACME provider
-    :param webroot: True or full path to webroot used for authentication
+    :param webroot: True or a full path to use to use webroot. Otherwise use standalone mode
     :param test_cert: Request a certificate from the Happy Hacker Fake CA (mutually exclusive with 'server')
     :param renew: True/'force' to force a renewal, or a window of renewal before expiry in days
     :param keysize: RSA key bits
@@ -149,6 +145,8 @@ def cert(name,
         cmd.append('--authenticator webroot')
         if webroot is not True:
             cmd.append('--webroot-path {0}'.format(webroot))
+    else:
+        cmd.append('--authenticator standalone')
 
     if email:
         cmd.append('--email {0}'.format(email))

--- a/salt/states/acme.py
+++ b/salt/states/acme.py
@@ -55,7 +55,7 @@ def cert(name,
     :param name: Common Name of the certificate (DNS name of certificate)
     :param aliases: subjectAltNames (Additional DNS names on certificate)
     :param email: e-mail address for interaction with ACME provider
-    :param webroot: True or full path to webroot used for authentication
+    :param webroot: True or a full path to use to use webroot. Otherwise use standalone mode
     :param test_cert: Request a certificate from the Happy Hacker Fake CA (mutually exclusive with 'server')
     :param renew: True/'force' to force a renewal, or a window of renewal before expiry in days
     :param keysize: RSA key bits


### PR DESCRIPTION
### What does this PR do?

I tried running the acme state/module from develop against an Arch Linux box and hit some snags:
1. Letsencrypt has [renamed the binary to certbot](https://www.eff.org/deeplinks/2016/05/announcing-certbot-new-tls-robot). Its a drop-in replacement.
2. certbot needed the --quiet flag set, otherwise the module failed citing terminal issues (python failed to create a dialog)

I've also took the liberty of adding support for standalone mode, turning it on by default if a webroot isn't set.
### What issues does this PR fix or reference?

Closes saltstack/salt#36638
### New Behavior
- Works with certbot
- Supports standalone mode when webroot is omitted
### Tests written?

No