### PR TITLE
Fix service state for Windows (DO NOT MERGE FORWARD)

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -157,7 +157,18 @@ def get_service_name(*args):
 
 def start(name):
     '''
-    Start the specified service
+    Start the specified service.
+
+    .. warning::
+        You cannot start a disabled service in Windows. If the service is
+        disabled, it will be changed to ``Manual`` start.
+
+    Args:
+
+        name (str): The name of the service to start
+
+    Returns:
+        bool: True if successful, otherwise False
 
     CLI Example:
 
@@ -165,6 +176,11 @@ def start(name):
 
         salt '*' service.start <service name>
     '''
+    # Set the service to manual if disabled
+    if disabled(name):
+        cmd = ['sc', 'config', name, 'start=demand']
+        __salt__['cmd.retcode'](cmd, python_shell=False)
+
     cmd = ['net', 'start', '/y', name]
     return not __salt__['cmd.retcode'](cmd, python_shell=False)
 

--- a/tests/unit/modules/win_service_test.py
+++ b/tests/unit/modules/win_service_test.py
@@ -94,9 +94,11 @@ class WinServiceTestCase(TestCase):
         '''
             Test to start the specified service
         '''
-        mock = MagicMock(return_value=False)
-        with patch.dict(win_service.__salt__, {'cmd.retcode': mock}):
-            self.assertTrue(win_service.start("salt"))
+        mock_retcode = MagicMock(side_effect=[False, False])
+        mock_run = MagicMock(return_value='Auto')
+        with patch.dict(win_service.__salt__, {'cmd.retcode': mock_retcode}):
+            with patch.dict(win_service.__salt__, {'cmd.run': mock_run}):
+                self.assertTrue(win_service.start("salt"))
 
     def test_stop(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Enable the service before trying to start it. In Windows, you can't start a disabled service.
Supersedes #36923 

DO NOT MERGE FORWARD. There will be another PR for Carbon branch as the service module changed significantly.
### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/35316
### Previous Behavior

`service.start` would fail if the service was disabled.
### New Behavior

If the service is disabled, `service.start` will change it to a `manual` start type.
### Tests written?

No
