### PR TITLE
Fix service state for Windows (Carbon)

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -373,6 +373,10 @@ def start(name):
     '''
     Start the specified service
 
+    .. warning::
+        You cannot start a disabled service in Windows. If the service is
+        disabled, it will be changed to ``Manual`` start.
+
     Args:
         name (str): The name of the service to start
 
@@ -387,6 +391,9 @@ def start(name):
     '''
     if status(name):
         return True
+
+    if disabled(name):
+        modify(name, start_type='Manual')
 
     try:
         win32serviceutil.StartService(name)

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -392,6 +392,7 @@ def start(name):
     if status(name):
         return True
 
+    # Set the service to manual if disabled
     if disabled(name):
         modify(name, start_type='Manual')
 


### PR DESCRIPTION
### What does this PR do?

Enable the service before trying to start it. In Windows, you can't start a disabled service.
Supersedes saltstack/salt#36923
### What issues does this PR fix or reference?
#35316
### Previous Behavior

service.start would fail if the service was disabled.
### New Behavior

If the service is disabled, service.start will change it to a manual start type.
### Tests written?

No