### PR TITLE
remove options from pylint

### DIFF
--- a/.testing.pylintrc
+++ b/.testing.pylintrc
@@ -14,9 +14,6 @@ init-hook="
   aXIsICdTY3JpcHRzJyksICdhY3RpdmF0ZV90aGlzLnB5JykKCiAgICBleGVjZmlsZShhY3RpdmF0 \
   ZV90aGlzLCBkaWN0KF9fZmlsZV9fPWFjdGl2YXRlX3RoaXMpKQo='.decode('base64')"
 
-# Profiled execution.
-profile=no
-
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=CVS
@@ -208,10 +205,6 @@ reports=no
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
-
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
 #msg-template=
@@ -304,10 +297,6 @@ ignored-modules=
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
 
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
-
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
 # expressions are accepted.
@@ -334,9 +323,6 @@ ignore-imports=no
 
 
 [BASIC]
-# Required attributes for module, separated by a comma
-required-attributes=
-
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter,apply,input
 
@@ -439,10 +425,6 @@ spelling-store-unknown-words=no
 
 
 [CLASSES]
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
-
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp
 


### PR DESCRIPTION
## What does this PR do?

These are going to be removed in pylint 1.6, and it doesn't appear that
we are using them, and just causes extra output.
# Previous behavior

```
Warning: option profile is obsolete and it is slated for removal in Pylint 1.6.
Warning: option comment is obsolete and it is slated for removal in Pylint 1.6.
Warning: option required-attributes is obsolete and it is slated for removal in Pylint 1.6.
Warning: option ignore-iface-methods is obsolete and it is slated for removal in Pylint 1.6.
Warning: option zope is obsolete and it is slated for removal in Pylint 1.6.
```

This was printed at the start of each pylint run, and causes popups in IDEs that can use pylint as a plugin
# New Behavior

No more Warning messages.

@s0undt3ch can you review this and make sure I am not wrong?  Thanks!