### PR TITLE
[carbon] Update salt.utils.cloud references to __utils__ for cache funcs

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -1052,7 +1052,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -1130,7 +1130,7 @@ def create(vm_):
 
     ret.update(data)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),

--- a/salt/cloud/clouds/dimensiondata.py
+++ b/salt/cloud/clouds/dimensiondata.py
@@ -150,7 +150,7 @@ def create(vm_):
     if 'provider' in vm_:
         vm_['driver'] = vm_.pop('provider')
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
@@ -312,7 +312,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -395,7 +395,7 @@ def create_lb(kwargs=None, call=None):
     log.debug('Network Domain: %s', network_domain.id)
     lb_conn.ex_set_current_network_domain(network_domain.id)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'create load_balancer',
         'salt/cloud/loadbalancer/creating',
@@ -408,7 +408,7 @@ def create_lb(kwargs=None, call=None):
         name, port, protocol, algorithm, members
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created load_balancer',
         'salt/cloud/loadbalancer/created',

--- a/salt/cloud/clouds/profitbricks.py
+++ b/salt/cloud/clouds/profitbricks.py
@@ -515,7 +515,7 @@ def list_nodes_full(conn=None, call=None):
 
         ret[node['name']] = node
 
-    salt.utils.cloud.cache_node_list(
+    __utils__['cloud.cache_node_list'](
         ret,
         __active_provider_name__.split(':')[0],
         __opts__
@@ -534,8 +534,11 @@ def show_instance(name, call=None):
         )
 
     nodes = list_nodes_full()
-    salt.utils.cloud.cache_node(nodes[name], __active_provider_name__,
-                                __opts__)
+    __utils__['cloud.cache_node'](
+        nodes[name],
+        __active_provider_name__,
+        __opts__
+    )
     return nodes[name]
 
 
@@ -682,7 +685,7 @@ def create(vm_):
     # Assembla the composite server object.
     server = _get_server(vm_, volumes, nics)
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
@@ -777,7 +780,7 @@ def create(vm_):
         )
     )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
@@ -792,7 +795,7 @@ def create(vm_):
 
     if 'ssh_host' in vm_:
         vm_['key_filename'] = get_key_filename(vm_)
-        ret = salt.utils.cloud.bootstrap(vm_, __opts__)
+        ret = __utils__['cloud.bootstrap'](vm_, __opts__)
         ret.update(data)
         return ret
     else:
@@ -821,7 +824,7 @@ def destroy(name, call=None):
             '-a or --action.'
         )
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
@@ -836,7 +839,7 @@ def destroy(name, call=None):
 
     conn.delete_server(datacenter_id=datacenter_id, server_id=node['id'])
 
-    salt.utils.cloud.fire_event(
+    __utils__['cloud.fire_event'](
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
@@ -846,7 +849,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(
+        __utils__['cloud.delete_minion_cachedir'](
             name,
             __active_provider_name__.split(':')[0],
             __opts__


### PR DESCRIPTION
Follow up to #35483 for carbon branch. Includes the commit in #37057 so I knew I got all of the related utils functions, and would have been merged-forward later anyway.

ping @gtmanfred 
