### PR TITLE
added support for keyword arguments (**kwargs) caching in decorators.…

### DIFF
--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -238,14 +238,20 @@ def memoize(func):
     '''
     Memoize aka cache the return output of a function
     given a specific set of arguments
+
+    .. versionedited:: 2016.3.4
+
+    Added **kwargs support.
     '''
     cache = {}
 
     @wraps(func)
-    def _memoize(*args):
-        if args not in cache:
-            cache[args] = func(*args)
-        return cache[args]
+    def _memoize(*args, **kwargs):
+       args_ = ','.join(list(args) + ['{0}={1}'.format(k, kwargs[k]) for k in sorted(kwargs)])
+       if args_ not in cache:
+           cache[args_] = func(*args, **kwargs)
+       return cache[args_]
+
     return _memoize
 
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -247,10 +247,10 @@ def memoize(func):
 
     @wraps(func)
     def _memoize(*args, **kwargs):
-       args_ = ','.join(list(args) + ['{0}={1}'.format(k, kwargs[k]) for k in sorted(kwargs)])
-       if args_ not in cache:
-           cache[args_] = func(*args, **kwargs)
-       return cache[args_]
+        args_ = ','.join(list(args) + ['{0}={1}'.format(k, kwargs[k]) for k in sorted(kwargs)])
+        if args_ not in cache:
+            cache[args_] = func(*args, **kwargs)
+        return cache[args_]
 
     return _memoize
 


### PR DESCRIPTION
### What does this PR do?

Adds support for keyword arguments (`**kwargs`) caching when using `@decorators.memoize`.
### What issues does this PR fix or reference?
saltstack/salt#36970
### Previous Behavior

`@decorators.memoize` only cached positional arguments.
### New Behavior

`@decorators.memoize` now supports both positional and keyword arguments' caching.
### Tests written?

No