### PR TITLE
Fix archive.extracted remote source_hash verification

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3530,6 +3530,7 @@ def get_managed(
         '''
         return {'hsum': get_hash(path, form='sha256'), 'hash_type': 'sha256'}
 
+    source_hash_name = kwargs.pop('source_hash_name', None)
     # If we have a source defined, let's figure out what the hash is
     if source:
         urlparsed_source = _urlparse(source)
@@ -3570,7 +3571,8 @@ def get_managed(
                         if not hash_fn:
                             return '', {}, ('Source hash file {0} not found'
                                             .format(source_hash))
-                        source_sum = extract_hash(hash_fn, '', name)
+                        source_sum = extract_hash(
+                            hash_fn, '', source_hash_name or name)
                         if source_sum is None:
                             return _invalid_source_hash_format()
 

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -16,6 +16,7 @@ from contextlib import closing
 # Import 3rd-party libs
 import salt.ext.six as six
 from salt.ext.six.moves import shlex_quote as _cmd_quote
+from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=no-name-in-module
 
 # Import salt libs
 import salt.utils
@@ -275,19 +276,47 @@ def extracted(name,
     if not name.endswith('/'):
         name += '/'
 
+    if __opts__['test']:
+        source_match = source
+    else:
+        try:
+            source_match = __salt__['file.source_list'](source,
+                                                        source_hash,
+                                                        __env__)[0]
+        except CommandExecutionError as exc:
+            ret['result'] = False
+            ret['comment'] = exc.strerror
+            return ret
+
+    urlparsed_source = _urlparse(source_match)
+    source_hash_name = urlparsed_source.path or urlparsed_source.netloc
+
     if if_missing is None:
         if_missing = name
     if source_hash and source_hash_update:
-        hash = source_hash.split("=")
-        source_file = '{0}.{1}'.format(os.path.basename(source), hash[0])
-        hash_fname = os.path.join(__opts__['cachedir'],
-                            'files',
-                            __env__,
-                            source_file)
-        if _compare_checksum(hash_fname, name, hash[1]):
-            ret['result'] = True
-            ret['comment'] = 'Hash {0} has not changed'.format(hash[1])
+        if urlparsed_source.scheme != '':
+            ret['result'] = False
+            ret['comment'] = (
+                '\'source_hash_update\' is not yet implemented for a remote '
+                'source_hash'
+            )
             return ret
+        else:
+            try:
+                hash_type, hsum = source_hash.split('=')
+            except ValueError:
+                ret['result'] = False
+                ret['comment'] = 'Invalid source_hash format'
+                return ret
+            source_file = '{0}.{1}'.format(os.path.basename(source), hash_type)
+            hash_fname = os.path.join(__opts__['cachedir'],
+                                'files',
+                                __env__,
+                                source_file)
+            if _compare_checksum(hash_fname, name, hsum):
+                ret['result'] = True
+                ret['comment'] = 'Hash {0} has not changed'.format(hsum)
+                return ret
     elif (
         __salt__['file.directory_exists'](if_missing)
         or __salt__['file.file_exists'](if_missing)
@@ -303,18 +332,6 @@ def extracted(name,
                             '{0}.{1}'.format(re.sub('[:/\\\\]', '_', if_missing),
                                              archive_format))
 
-    if __opts__['test']:
-        source_match = source
-    else:
-        try:
-            source_match = __salt__['file.source_list'](source,
-                                                        source_hash,
-                                                        __env__)[0]
-        except CommandExecutionError as exc:
-            ret['result'] = False
-            ret['comment'] = exc.strerror
-            return ret
-
     if not os.path.exists(filename):
         if __opts__['test']:
             ret['result'] = None
@@ -327,13 +344,15 @@ def extracted(name,
             return ret
 
         log.debug('%s is not in cache, downloading it', source_match)
+
         file_result = __salt__['state.single']('file.managed',
                                                filename,
-                                               source=source,
+                                               source=source_match,
                                                source_hash=source_hash,
                                                makedirs=True,
                                                skip_verify=skip_verify,
-                                               saltenv=__env__)
+                                               saltenv=__env__,
+                                               source_hash_name=source_hash_name)
         log.debug('file.managed: {0}'.format(file_result))
         # get value of first key
         try:


### PR DESCRIPTION
When `file.managed` is invoked within an archive.extracted state to
pull down the source archive, `file.extract_hash` is invoked with
the unique name we created for it, rather than the actual source
filename. This causes hash extraction to fail, or only return a partial
match. Either of these cases causes the `archive.extracted` state to
fail.

This commit adds a new optional kwarg to `file.get_managed` which can
be used to override which filename we pass to `file.extract_hash`, and
then passes this kwarg to the `file.managed` we invoke from within the
`archive.extracted` state.

Fixes #37001.
