### PR TITLE
Bugfix for salt-runner and LXC clouds

### DIFF
--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -76,10 +76,12 @@ def _minion_opts(cfg='minion'):
 
 
 def _master_opts(cfg='master'):
+    if 'conf_file' in __opts__:
+        default_dir = os.path.dirname(__opts__['conf_file'])
+    else:
+        default_dir = __opts__['config_dir'],
     cfg = os.environ.get(
-        'SALT_MASTER_CONFIG',
-        __opts__.get('conf_file',
-                     os.path.join(__opts__['config_dir'], cfg)))
+        'SALT_MASTER_CONFIG', os.path.join(default_dir, cfg))
     opts = config.master_config(cfg)
     return opts
 


### PR DESCRIPTION
### What does this PR do?

When I use salt-cloud profile , orchestration and LXC containers , I see this error
          ID: base-lxc
    Function: cloud.profile
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/site-packages/salt/state.py", line 1733, in call
                  *_cdata['kwargs'])
                File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1652, in wrapper
                  return f(_args, **kwargs)
                File "/usr/lib/python2.7/site-packages/salt/states/cloud.py", line 262, in profile
                  instance = _get_instance([name])
                File "/usr/lib/python2.7/site-packages/salt/states/cloud.py", line 62, in _get_instance
                  instance = __salt__['cloud.action'](fun='show_instance', names=names)
                File "/usr/lib/python2.7/site-packages/salt/modules/cloud.py", line 234, in action
                  info = client.action(fun, cloudmap, names, provider, instance, kwargs)
                File "/usr/lib/python2.7/site-packages/salt/cloud/**init**.py", line 468, in action
                  mapper = salt.cloud.Map(self._opts_defaults(action=fun, names=names))
                File "/usr/lib/python2.7/site-packages/salt/cloud/__init__.py", line 1663, in **init**
                  Cloud.**init**(self, opts)
                File "/usr/lib/python2.7/site-packages/salt/cloud/**init**.py", line 501, in **init**
                  self.**filter_non_working_providers()
                File "/usr/lib/python2.7/site-packages/salt/cloud/__init**.py", line 1642, in **filter_non_working_providers
                  if self.clouds[fun]() is False:
                File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/lxc.py", line 552, in get_configured_provider
                  ret = _salt('test.ping', salt_target=data['target'])
                File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/lxc.py", line 153, in _salt
                  conn = _client()
                File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/lxc.py", line 88, in _client
                  return salt.client.get_local_client(mopts=_master_opts())
                File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/lxc.py", line 82, in _master_opts
                  os.path.join(__opts**['config_dir'], cfg)))
              KeyError: 'config_dir'
### What issues does this PR fix or reference?
### Tests written?

No :-(

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.