### PR TITLE
salt.modules.gpg: allow getting keys by short key ID

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 '''
-Manage a GPG keychains, add keys, create keys, retrieve keys
-from keyservers.  Sign, encrypt and sign & encrypt text and files.
+Manage a GPG keychains, add keys, create keys, retrieve keys from keyservers.
+Sign, encrypt and sign plus encrypt text and files.
 
 .. versionadded:: 2015.5.0
 
 .. note::
-    The ``python-gnupg`` library and gpg binary are
-    required to be installed.
+
+    The ``python-gnupg`` library and ``gpg`` binary are required to be
+    installed.
 
 '''
 
@@ -31,10 +32,6 @@ try:
     from shlex import quote as _cmd_quote  # pylint: disable=E0611
 except ImportError:
     from pipes import quote as _cmd_quote
-
-from salt.exceptions import (
-    SaltInvocationError
-)
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -562,7 +559,7 @@ def get_key(keyid=None, fingerprint=None, user=None, gnupghome=None):
     Get a key from the GPG keychain
 
     keyid
-        The keyid of the key to be retrieved.
+        The key ID (short or long) of the key to be retrieved.
 
     fingerprint
         The fingerprint of the key to be retrieved.
@@ -588,7 +585,9 @@ def get_key(keyid=None, fingerprint=None, user=None, gnupghome=None):
     '''
     tmp = {}
     for _key in _list_keys(user, gnupghome):
-        if _key['fingerprint'] == fingerprint or _key['keyid'] == keyid:
+        if (_key['fingerprint'] == fingerprint or
+                _key['keyid'] == keyid or
+                _key['keyid'][8:] == keyid):
             tmp['keyid'] = _key['keyid']
             tmp['fingerprint'] = _key['fingerprint']
             tmp['uids'] = _key['uids']
@@ -619,7 +618,7 @@ def get_secret_key(keyid=None, fingerprint=None, user=None, gnupghome=None):
     Get a key from the GPG keychain
 
     keyid
-        The keyid of the key to be retrieved.
+        The key ID (short or long) of the key to be retrieved.
 
     fingerprint
         The fingerprint of the key to be retrieved.
@@ -645,7 +644,9 @@ def get_secret_key(keyid=None, fingerprint=None, user=None, gnupghome=None):
     '''
     tmp = {}
     for _key in _list_keys(user, gnupghome, secret=True):
-        if _key['fingerprint'] == fingerprint or _key['keyid'] == keyid:
+        if (_key['fingerprint'] == fingerprint or
+                _key['keyid'] == keyid or
+                _key['keyid'][8:] == keyid):
             tmp['keyid'] = _key['keyid']
             tmp['fingerprint'] = _key['fingerprint']
             tmp['uids'] = _key['uids']
@@ -672,23 +673,23 @@ def get_secret_key(keyid=None, fingerprint=None, user=None, gnupghome=None):
 
 
 @_restore_ownership
-def import_key(user=None,
-               text=None,
+def import_key(text=None,
                filename=None,
+               user=None,
                gnupghome=None):
     r'''
     Import a key from text or file
-
-    user
-        Which user's keychain to access, defaults to user Salt is running as.
-        Passing the user as ``salt`` will set the GnuPG home directory to the
-        ``/etc/salt/gpgkeys``.
 
     text
         The text containing to import.
 
     filename
         The filename containing the key to import.
+
+    user
+        Which user's keychain to access, defaults to user Salt is running as.
+        Passing the user as ``salt`` will set the GnuPG home directory to the
+        ``/etc/salt/gpgkeys``.
 
     gnupghome
         Specify the location where GPG keyring and related files are stored.
@@ -702,9 +703,9 @@ def import_key(user=None,
 
     '''
     ret = {
-           'res': True,
-           'message': ''
-          }
+        'res': True,
+        'message': ''
+        }
 
     gpg = _create_gpg(user, gnupghome)
 
@@ -752,12 +753,13 @@ def export_key(keyids=None, secret=False, user=None, gnupghome=None):
     Export a key from the GPG keychain
 
     keyids
-        The keyid(s) of the key(s) to be exported.  Can be specified as a comma
-        separated string or a list.  Anything which GnuPG itself accepts to
-        identify a key - for example, the keyid or the fingerprint could be used.
+        The key ID(s) of the key(s) to be exported. Can be specified as a comma
+        separated string or a list. Anything which GnuPG itself accepts to
+        identify a key - for example, the key ID or the fingerprint could be
+        used.
 
     secret
-        Export the secret key identified by the keyid information passed.
+        Export the secret key identified by the ``keyids`` information passed.
 
     user
         Which user's keychain to access, defaults to user Salt is running as.
@@ -775,7 +777,7 @@ def export_key(keyids=None, secret=False, user=None, gnupghome=None):
 
         salt '*' gpg.export_key keyids=3FAD9F1E secret=True
 
-        salt '*' gpg.export_key keyid="['3FAD9F1E','3FBD8F1E']" user=username
+        salt '*' gpg.export_key keyids="['3FAD9F1E','3FBD8F1E']" user=username
 
     '''
     gpg = _create_gpg(user, gnupghome)


### PR DESCRIPTION
### What does this PR do?

It restores the ability of the `gpg` exec module to handle short GnuPG key IDs (last 8 chars of the fingerprint) in such functions as `get_key`, `get_secret_key`, `delete_key` and `trust_key`. Also, fixed some docstrings.
### What issues does this PR fix or reference?

Modern versions of `python-gnupg` module always return _long_ key ID (16 chars) as a result of calling `list_keys()` method. But the documentation for the Salt `gpg` module clearly says that you're able to use short key IDs in the example sections. This PR allows to use both short and long key ID as an argument for the functions mentioned above.
### Previous Behavior

I've imported public key into my keyring.

``` yaml
# salt-call gpg.list_keys
local:
    |_
      ----------
      created:
          2011-10-13
      expires:
          2019-07-02
      fingerprint:
          B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
      keyLength:
          4096
      keyid:
          7FCC7D46ACCC4CF8
      ownerTrust:
          Unknown
      trust:
          Unknown
      uids:
          - PostgreSQL Debian Repository
```

But, unfortunately, I can't get information about it directly.

``` yaml
# salt-call gpg.get_key ACCC4CF8
local:
    False
```
### New Behavior

Now `gpg` module supports short key IDs as well:

``` yaml
# salt-call gpg.get_key ACCC4CF8
local:
    ----------
    created:
        2011-10-13
    expires:
        2019-07-02
    fingerprint:
        B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
    keyLength:
        4096
    keyid:
        7FCC7D46ACCC4CF8
    ownerTrust:
        Unknown
    trust:
        Unknown
    uids:
        - PostgreSQL Debian Repository
```
### Tests written?

No
