### PR TITLE
Adding 'dist-upgrade' support to the zypper module

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1126,7 +1126,7 @@ def upgrade(refresh=True,
 
         if novendorchange:
             cmd_update.append('--no-allow-vendor-change')
-            log.info('Disabling changes of vendor')
+            log.info('Disabling vendor changes')
 
     old = list_pkgs()
     __zypper__(systemd_scope=_systemd_scope()).noraise.call(*cmd_update)

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1052,7 +1052,7 @@ def upgrade(refresh=True,
             dist_upgrade=False,
             fromrepo=None,
             novendorchange=False,
-            **kwargs):
+            **kwargs):  # pylint: disable=unused-argument
     '''
     .. versionchanged:: 2015.8.12,2016.3.3,Carbon
         On minions running systemd>=205, `systemd-run(1)`_ is now used to

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1047,7 +1047,12 @@ def install(name=None,
     return salt.utils.compare_dicts(old, new)
 
 
-def upgrade(refresh=True):
+def upgrade(refresh=True,
+            dryrun=False,
+            dist_upgrade=False,
+            fromrepo=None,
+            novendorchange=False,
+            **kwargs):
     '''
     .. versionchanged:: 2015.8.12,2016.3.3,Carbon
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
@@ -1070,6 +1075,19 @@ def upgrade(refresh=True):
         If set to False it depends on zypper if a refresh is
         executed.
 
+    dryrun
+        If set to True, it creates a debug solver log file and then perform
+        a dry-run upgrade (no changes are made). Default: False
+
+    dist_upgrade
+        Perform a system dist-upgrade. Default: False
+
+    fromrepo
+        Specify a package repository to upgrade from. Default: None
+
+    novendorchange
+        If set to True, no allow vendor changes. Default: False
+
     Return a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
@@ -1080,16 +1098,41 @@ def upgrade(refresh=True):
     .. code-block:: bash
 
         salt '*' pkg.upgrade
+        salt '*' pkg.upgrade dist-upgrade=True fromrepo="MyRepoName" novendorchange=True
+        salt '*' pkg.upgrade dist-upgrade=True dryrun=True
     '''
     ret = {'changes': {},
            'result': True,
            'comment': '',
     }
 
+    cmd_update = ['dist-upgrade'] if dist_upgrade else ['update']
+    cmd_update.extend(['--auto-agree-with-licenses'])
+
     if refresh:
         refresh_db()
+
+    if dryrun:
+        cmd_update.extend(['--dry-run'])
+
+    if dist_upgrade:
+        if dryrun:
+            # Creates a solver test case for debugging.
+            log.info('Executing debugsolver and performing a dry-run dist-upgrade')
+            cmd_debugsolver = cmd_update + ['--debug-solver']
+            __zypper__.noraise.call(*cmd_debugsolver)
+
+        if fromrepo:
+            fromrepoopt = ['--from', fromrepo]
+            log.info('Targeting repo {0!r}'.format(fromrepo))
+            cmd_update.extend(fromrepoopt)
+
+        if novendorchange:
+            log.info('Disabling changes of vendor')
+            cmd_update.extend(['--no-allow-vendor-change'])
+
     old = list_pkgs()
-    __zypper__(systemd_scope=_systemd_scope()).noraise.call('update', '--auto-agree-with-licenses')
+    __zypper__(systemd_scope=_systemd_scope()).noraise.call(*cmd_update)
     if __zypper__.exit_code not in __zypper__.SUCCESS_EXIT_CODES:
         ret['result'] = False
         ret['comment'] = (__zypper__.stdout() + os.linesep + __zypper__.stderr()).strip()

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1106,30 +1106,27 @@ def upgrade(refresh=True,
            'comment': '',
     }
 
-    cmd_update = ['dist-upgrade'] if dist_upgrade else ['update']
-    cmd_update.extend(['--auto-agree-with-licenses'])
+    cmd_update = (['dist-upgrade'] if dist_upgrade else ['update']) + ['--auto-agree-with-licenses']
 
     if refresh:
         refresh_db()
 
     if dryrun:
-        cmd_update.extend(['--dry-run'])
+        cmd_update.append('--dry-run')
 
     if dist_upgrade:
         if dryrun:
             # Creates a solver test case for debugging.
             log.info('Executing debugsolver and performing a dry-run dist-upgrade')
-            cmd_debugsolver = cmd_update + ['--debug-solver']
-            __zypper__.noraise.call(*cmd_debugsolver)
+            __zypper__.noraise.call(*cmd_update + ['--debug-solver'])
 
         if fromrepo:
-            fromrepoopt = ['--from', fromrepo]
+            cmd_update.extend(['--from', fromrepo])
             log.info('Targeting repo {0!r}'.format(fromrepo))
-            cmd_update.extend(fromrepoopt)
 
         if novendorchange:
+            cmd_update.append('--no-allow-vendor-change')
             log.info('Disabling changes of vendor')
-            cmd_update.extend(['--no-allow-vendor-change'])
 
     old = list_pkgs()
     __zypper__(systemd_scope=_systemd_scope()).noraise.call(*cmd_update)

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -330,6 +330,76 @@ class ZypperTestCase(TestCase):
             self.assertEqual(zypper.latest_version('vim'), '7.4.326-2.62')
 
     @patch('salt.modules.zypper.refresh_db', MagicMock(return_value=True))
+    @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
+    def test_upgrade_success(self):
+        '''
+        Test system upgrade and dist-upgrade success.
+
+        :return:
+        '''
+        with patch('salt.modules.zypper.__zypper__.noraise.call', MagicMock()) as zypper_mock:
+            with patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}])):
+                ret = zypper.upgrade()
+                self.assertTrue(ret['result'])
+                self.assertDictEqual(ret['changes'], {"vim": {"old": "1.1", "new": "1.2"}})
+                zypper_mock.assert_any_call('update', '--auto-agree-with-licenses')
+
+            with patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}])):
+                ret = zypper.upgrade(dist_upgrade=True)
+                self.assertTrue(ret['result'])
+                self.assertDictEqual(ret['changes'], {"vim": {"old": "1.1", "new": "1.2"}})
+                zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses')
+
+            with patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])):
+                ret = zypper.upgrade(dist_upgrade=True, dryrun=True)
+                self.assertTrue(ret['result'])
+                self.assertDictEqual(ret['changes'], {})
+                zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses', '--dry-run')
+                zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses', '--dry-run', '--debug-solver')
+
+            with patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}])):
+                ret = zypper.upgrade(dist_upgrade=True, fromrepo="Dummy", novendorchange=True)
+                self.assertTrue(ret['result'])
+                self.assertDictEqual(ret['changes'], {"vim": {"old": "1.1", "new": "1.2"}})
+                zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses', '--from', "Dummy", '--no-allow-vendor-change')
+
+    @patch('salt.modules.zypper.refresh_db', MagicMock(return_value=True))
+    @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
+    def test_upgrade_failure(self):
+        '''
+        Test system upgrade failure.
+
+        :return:
+        '''
+        zypper_out = '''
+Loading repository data...
+Reading installed packages...
+Computing distribution upgrade...
+Use 'zypper repos' to get the list of defined repositories.
+Repository 'DUMMY' not found by its alias, number, or URI.
+'''
+
+        class FailingZypperDummy(object):
+            def __init__(self):
+                self.stdout = MagicMock(return_value=zypper_out)
+                self.stderr = MagicMock(return_value="")
+                self.exit_code = MagicMock(return_value=555)
+                self.noraise = MagicMock()
+                self.SUCCESS_EXIT_CODES = [0]
+
+            def __call__(self, *args, **kwargs):
+                return self
+
+        with patch('salt.modules.zypper.__zypper__', FailingZypperDummy()) as zypper_mock:
+            zypper_mock.noraise.call = MagicMock()
+            with patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])):
+                    ret = zypper.upgrade(dist_upgrade=True, fromrepo="DUMMY")
+                    self.assertFalse(ret['result'])
+                    self.assertEqual(ret['comment'], zypper_out.strip())
+                    self.assertDictEqual(ret['changes'], {})
+                    zypper_mock.noraise.call.assert_called_with('dist-upgrade', '--auto-agree-with-licenses', '--from', 'DUMMY')
+
+    @patch('salt.modules.zypper.refresh_db', MagicMock(return_value=True))
     def test_upgrade_available(self):
         '''
         Test whether or not an upgrade is available for a given package.

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -393,11 +393,11 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         with patch('salt.modules.zypper.__zypper__', FailingZypperDummy()) as zypper_mock:
             zypper_mock.noraise.call = MagicMock()
             with patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])):
-                    ret = zypper.upgrade(dist_upgrade=True, fromrepo="DUMMY")
-                    self.assertFalse(ret['result'])
-                    self.assertEqual(ret['comment'], zypper_out.strip())
-                    self.assertDictEqual(ret['changes'], {})
-                    zypper_mock.noraise.call.assert_called_with('dist-upgrade', '--auto-agree-with-licenses', '--from', 'DUMMY')
+                ret = zypper.upgrade(dist_upgrade=True, fromrepo="DUMMY")
+                self.assertFalse(ret['result'])
+                self.assertEqual(ret['comment'], zypper_out.strip())
+                self.assertDictEqual(ret['changes'], {})
+                zypper_mock.noraise.call.assert_called_with('dist-upgrade', '--auto-agree-with-licenses', '--from', 'DUMMY')
 
     @patch('salt.modules.zypper.refresh_db', MagicMock(return_value=True))
     def test_upgrade_available(self):


### PR DESCRIPTION
### What does this PR do?

This PR adds `dist-upgrade` support for zypper `pkg.upgrade`. It allows you to perform `dryrun` upgrades, and also set `fromrepo` and `novendorchange` options when you're performing a system `dist-upgrade`.

If possible, this changes should also go everywhere :smile:
Thanks!
### Tests written?

Yes

/cc @isbm 
