### PR TITLE
Silence warnings about "__prerequired__" being an invalid kwarg when using `prereq` with supervisord states.

### DIFF
--- a/salt/states/supervisord.py
+++ b/salt/states/supervisord.py
@@ -54,7 +54,8 @@ def running(name,
             update=False,
             user=None,
             conf_file=None,
-            bin_env=None):
+            bin_env=None,
+            **kwargs):
     '''
     Ensure the named service is running.
 
@@ -271,7 +272,8 @@ def running(name,
 def dead(name,
          user=None,
          conf_file=None,
-         bin_env=None):
+         bin_env=None,
+         **kwargs):
     '''
     Ensure the named service is dead (not running).
 


### PR DESCRIPTION
### What does this PR do?

Fixes `prereq` requisite behavior with supervisord states, similarly to #29463 .

Example SLS:

```
{% set process_name = 'asdf' %}

asdf-setup:
  pkg.installed:
    - name: supervisor
    - refresh: true
  service.running:
    - name: supervisor
    - enable: true
    - require:
      - pkg: asdf-setup
  file.managed:
    - name: /etc/supervisor/conf.d/{{ process_name }}.conf
    - contents: |
        [program:{{ process_name }}]
        command = /bin/bash -c 'while true; do sleep 15; done'
        autostart = true
        autorestart = true
    - require:
      - pkg: asdf-setup
  cmd.run:  # guarantee an always populated `changes` dict
    - name: lsb_release -a
    - require:
      - file: asdf-setup

asdf-dead:
  supervisord.dead:
    - name: {{ process_name }}
    - prereq:
      - cmd: asdf-setup

asdf-running:
  supervisord.running:
    - name: {{ process_name }}
    - update: true
    - onchanges:
      - cmd: asdf-setup
```
### Previous Behavior

`state.sls` run:

```
ubuntu16:
  Name: supervisor - Function: pkg.installed - Result: Clean
  Name: supervisor - Function: service.running - Result: Clean
  Name: /etc/supervisor/conf.d/asdf.conf - Function: file.managed - Result: Clean
Warnings:
'__prerequired__' is an invalid keyword argument for 'supervisord.dead'. If you were trying to pass additional data to be used in a template context, please populate 'context' with 'key: value' pairs. Your approach will work until Salt Carbon is out. Please update your state files.  Name: asdf - Function: supervisord.dead - Result: Changed
  Name: lsb_release -a - Function: cmd.run - Result: Changed
  Name: asdf - Function: supervisord.running - Result: Changed

Summary for ubuntu16
------------
Succeeded: 6 (changed=3)
Failed:    0
------------
Total states run:     6
```
### New Behavior

`state.sls` run:

```
ubuntu16:
  Name: supervisor - Function: pkg.installed - Result: Clean
  Name: supervisor - Function: service.running - Result: Clean
  Name: /etc/supervisor/conf.d/asdf.conf - Function: file.managed - Result: Clean
  Name: asdf - Function: supervisord.dead - Result: Changed
  Name: lsb_release -a - Function: cmd.run - Result: Changed
  Name: asdf - Function: supervisord.running - Result: Changed

Summary for ubuntu16
------------
Succeeded: 6 (changed=3)
Failed:    0
------------
Total states run:     6
```
### Tests written?

No
