### PR TITLE
Allow emtpy content for delete mode in file.line as per feature request #37092.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1501,7 +1501,7 @@ def line(path, content=None, match=None, mode=None, location=None,
     modeswithemptycontent = ['delete']
     if mode not in modeswithemptycontent and content is None:
         raise CommandExecutionError('Content can only be empty if mode is {0}'.format(modeswithemptycontent))
-    del(modeswithemptycontent)
+    del modeswithemptycontent
 
     # Before/after has privilege. If nothing defined, match is used by content.
     if before is None and after is None and not match:

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1404,7 +1404,7 @@ def _get_line_indent(src, line, indent):
     return ''.join(idt) + line.strip()
 
 
-def line(path, content, match=None, mode=None, location=None,
+def line(path, content=None, match=None, mode=None, location=None,
          before=None, after=None, show_changes=True, backup=False,
          quiet=False, indent=True):
     '''
@@ -1416,7 +1416,7 @@ def line(path, content, match=None, mode=None, location=None,
         Filesystem path to the file to be edited.
 
     :param content:
-        Content of the line.
+        Content of the line. Allowed to be empty if mode=delete.
 
     :param match:
         Match the target line for an action by
@@ -1495,6 +1495,13 @@ def line(path, content, match=None, mode=None, location=None,
             raise CommandExecutionError('Mode was not defined. How to process the file?')
         else:
             raise CommandExecutionError('Unknown mode: "{0}"'.format(mode))
+
+    # We've set the content to be empty in the function params but we want to make sure
+    # it gets passed when needed. Feature #37092
+    modeswithemptycontent = ['delete']
+    if mode not in modeswithemptycontent and content is None:
+        raise CommandExecutionError('Content can only be empty if mode is {0}'.format(modeswithemptycontent))
+    del(modeswithemptycontent)
 
     # Before/after has privilege. If nothing defined, match is used by content.
     if before is None and after is None and not match:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3118,7 +3118,7 @@ def line(name, content=None, match=None, mode=None, location=None,
     modeswithemptycontent = ['delete']
     if mode not in modeswithemptycontent and content is None:
         return _error(ret, 'Content can only be empty if mode is {0}'.format(modeswithemptycontent))
-    del(modeswithemptycontent)
+    del modeswithemptycontent
 
     changes = __salt__['file.line'](
         name, content, match=match, mode=mode, location=location,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2990,7 +2990,7 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
     return ret
 
 
-def line(name, content, match=None, mode=None, location=None,
+def line(name, content=None, match=None, mode=None, location=None,
          before=None, after=None, show_changes=True, backup=False,
          quiet=False, indent=True, create=False, user=None,
          group=None, file_mode=None):
@@ -3003,7 +3003,7 @@ def line(name, content, match=None, mode=None, location=None,
         Filesystem path to the file to be edited.
 
     :param content:
-        Content of the line.
+        Content of the line. Allowed to be empty if mode=delete.
 
     :param match:
         Match the target line for an action by
@@ -3108,6 +3108,17 @@ def line(name, content, match=None, mode=None, location=None,
     check_res, check_msg = _check_file(name)
     if not check_res:
         return _error(ret, check_msg)
+
+    # We've set the content to be empty in the function params but we want to make sure
+    # it gets passed when needed. Feature #37092
+    mode = mode and mode.lower() or mode
+    if mode is None:
+        return _error(ret, 'Mode was not defined. How to process the file?')
+
+    modeswithemptycontent = ['delete']
+    if mode not in modeswithemptycontent and content is None:
+        return _error(ret, 'Content can only be empty if mode is {0}'.format(modeswithemptycontent))
+    del(modeswithemptycontent)
 
     changes = __salt__['file.line'](
         name, content, match=match, mode=mode, location=location,


### PR DESCRIPTION
### What does this PR do?

This PR allows the user to leave the content empty if the mode is delete when using the file.line function. This updates both states and modules.
### What issues does this PR fix or reference?

Feature #37092
### Previous Behavior

Some random content needed to be passed for delete mode to work.
### New Behavior

If mode is set to delete, the content doesn't need to be passed.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
