### PR TITLE
Add run_on_start to SCHEDULE_CONF

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -55,7 +55,8 @@ SCHEDULE_CONF = [
         'until',
         'after',
         'return_config',
-        'return_kwargs'
+        'return_kwargs',
+        'run_on_start'
 ]
 
 


### PR DESCRIPTION
### What does this PR do?

Fix #37037 by adding run_on_start to SCHEDULE_CONF in schedule.py
### What issues does this PR fix or reference?
#37037
### Tests written?

No
