### PR TITLE
use versionadded and deprecated warnings in apache_module

### DIFF
--- a/salt/states/apache_module.py
+++ b/salt/states/apache_module.py
@@ -91,6 +91,8 @@ def disabled(name):
     '''
     Ensure an Apache module is disabled.
 
+    .. versionadded:: 2016.3.0
+    
     name
         Name of the Apache module
     '''
@@ -125,9 +127,7 @@ def disable(name):
     '''
     Ensure an Apache module is disabled.
 
-    .. warning::
-
-        This function is deprecated and will be removed in Salt Nitrogen.
+    .. deprecated:: 2016.3.0
 
     name
         Name of the Apache module

--- a/salt/states/apache_module.py
+++ b/salt/states/apache_module.py
@@ -92,7 +92,7 @@ def disabled(name):
     Ensure an Apache module is disabled.
 
     .. versionadded:: 2016.3.0
-    
+
     name
         Name of the Apache module
     '''


### PR DESCRIPTION
### What does this PR do?

Updates documentation for the apache_module state to use the standard deprecated and versionadded warnings.
