### PR TITLE
Some improvements for Zypper `dist-upgrade`

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1083,7 +1083,7 @@ def upgrade(refresh=True,
         Perform a system dist-upgrade. Default: False
 
     fromrepo
-        Specify a package repository to upgrade from. Default: None
+        Specify a list of package repositories to upgrade from. Default: None
 
     novendorchange
         If set to True, no allow vendor changes. Default: False
@@ -1098,7 +1098,7 @@ def upgrade(refresh=True,
     .. code-block:: bash
 
         salt '*' pkg.upgrade
-        salt '*' pkg.upgrade dist-upgrade=True fromrepo="MyRepoName" novendorchange=True
+        salt '*' pkg.upgrade dist-upgrade=True fromrepo='["MyRepoName"]' novendorchange=True
         salt '*' pkg.upgrade dist-upgrade=True dryrun=True
     '''
     ret = {'changes': {},
@@ -1121,8 +1121,9 @@ def upgrade(refresh=True,
             __zypper__.noraise.call(*cmd_update + ['--debug-solver'])
 
         if fromrepo:
-            cmd_update.extend(['--from', fromrepo])
-            log.info('Targeting repo {0!r}'.format(fromrepo))
+            for repo in fromrepo:
+                cmd_update.extend(['--from', repo])
+            log.info('Targeting repos: {0!r}'.format(fromrepo))
 
         if novendorchange:
             cmd_update.append('--no-allow-vendor-change')

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1127,7 +1127,7 @@ def upgrade(refresh=True,
 
         if novendorchange:
             # TODO: Grains validation should be moved to Zypper class
-            if __grains__['osrelease_info'][0] != 11:
+            if __grains__['osrelease_info'][0] > 11:
                 cmd_update.append('--no-allow-vendor-change')
                 log.info('Disabling vendor changes')
             else:

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -332,7 +332,7 @@ class ZypperTestCase(TestCase):
 
     @patch('salt.modules.zypper.refresh_db', MagicMock(return_value=True))
     @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
-    @patch.dict('salt.modules.zypper.__grains__', {'osrelease_info': [12,1]})
+    @patch.dict('salt.modules.zypper.__grains__', {'osrelease_info': [12, 1]})
     def test_upgrade_success(self):
         '''
         Test system upgrade and dist-upgrade success.
@@ -367,7 +367,7 @@ class ZypperTestCase(TestCase):
 
     @patch('salt.modules.zypper.refresh_db', MagicMock(return_value=True))
     @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
-    @patch.dict('salt.modules.zypper.__grains__', {'osrelease_info': [12,1]})
+    @patch.dict('salt.modules.zypper.__grains__', {'osrelease_info': [12, 1]})
     def test_upgrade_failure(self):
         '''
         Test system upgrade failure.


### PR DESCRIPTION
### What does this PR do?

This PR adds a few extra improvements for the zypper `pkg.upgrade`.
1. `fromrepo` now accepts multiple repositories
2. `dryrun` returns the zypper output
3. `novendorchange` is not supported in SLE11 zypper version.
### Tests written?

Yes

/cc @isbm 
