### PR TITLE
Revert "Fix integration tests launching - remove redundant "config_dir" argument in call to ShellTestCase.run_run from SaltDaemonScriptBase._wait_until_running"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ htmlcov/
 /*.iml
 *.sublime-project
 *.sublime-workspace
-/.vscode
 
 # ignore ctags file
 tags

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -618,7 +618,7 @@ class SaltDaemonScriptBase(SaltScriptBase, ShellTestCase):
                                 pass
                     del sock
                 elif isinstance(port, str):
-                    joined = self.run_run('manage.joined')
+                    joined = self.run_run('manage.joined', config_dir=self.config_dir)
                     joined = [x.lstrip('- ') for x in joined]
                     if port in joined:
                         check_ports.remove(port)


### PR DESCRIPTION
Reverts saltstack/salt#36875
