### PR TITLE
[WIP] Test ZMQ badload fix

### DIFF
--- a/tests/unit/transport/zeromq_test.py
+++ b/tests/unit/transport/zeromq_test.py
@@ -74,7 +74,7 @@ class BaseZMQReqCase(TestCase):
         cls.server_channel.pre_fork(cls.process_manager)
 
         cls.io_loop = zmq.eventloop.ioloop.ZMQIOLoop()
-        cls.io_loop.make_current()
+#        cls.io_loop.make_current()
         cls.server_channel.post_fork(cls._handle_payload, io_loop=cls.io_loop)
 
         cls.server_thread = threading.Thread(target=cls.io_loop.start)


### PR DESCRIPTION
I can't prove this but I suspect this might be zmq contexts clashing
as the new thread inherits the context from the old thread. This is an
experiment to see if this helps at all.

**DO NOT MERGE THIS.**
