### PR TITLE
Updated host_to_ip to return all the IPs instead of the first one.

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -24,7 +24,7 @@ import salt.config
 import salt.minion
 import salt.utils
 import salt.utils.event
-from salt.utils.network import host_to_ip as _host_to_ip
+from salt.utils.network import host_to_ips as _host_to_ips
 from salt.utils.network import remote_port_tcp as _remote_port_tcp
 from salt.ext.six.moves import zip
 from salt.exceptions import CommandExecutionError
@@ -1009,7 +1009,7 @@ def master(master=None, connected=True):
 
     # the default publishing port
     port = 4505
-    master_ip = None
+    master_ips = None
 
     if __salt__['config.get']('publish_port') != '':
         port = int(__salt__['config.get']('publish_port'))
@@ -1018,12 +1018,14 @@ def master(master=None, connected=True):
     # address and try resolving it first. _remote_port_tcp
     # only works with IP-addresses.
     if master is not None:
-        tmp_ip = _host_to_ip(master)
-        if tmp_ip is not None:
-            master_ip = tmp_ip
+        master_ips = _host_to_ips(master)
 
     ips = _remote_port_tcp(port)
-    master_connection_status = master_ip in ips
+    master_connection_status = False
+    for master_ip in master_ips:
+        if master_ip in ips:
+            master_connection_status = True
+            break
 
     if master_connection_status is not connected:
         event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)

--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -19,7 +19,7 @@ import salt.utils
 import salt.ext.six as six
 import salt.utils.event
 from salt._compat import subprocess
-from salt.utils.network import host_to_ip as _host_to_ip
+from salt.utils.network import host_to_ips as _host_to_ips
 
 import os
 import ctypes
@@ -331,7 +331,7 @@ def master(master=None, connected=True):
 
     # the default publishing port
     port = 4505
-    master_ip = None
+    master_ips = None
 
     if __salt__['config.get']('publish_port') != '':
         port = int(__salt__['config.get']('publish_port'))
@@ -340,12 +340,14 @@ def master(master=None, connected=True):
     # address and try resolving it first. _remote_port_tcp
     # only works with IP-addresses.
     if master is not None:
-        tmp_ip = _host_to_ip(master)
-        if tmp_ip is not None:
-            master_ip = tmp_ip
+        master_ips = _host_to_ips(master)
 
     ips = _win_remotes_on(port)
-    master_connection_status = master_ip in ips
+    master_connection_status = False
+    for master_ip in master_ips:
+        if master_ip in ips:
+            master_connection_status = True
+            break
 
     if master_connection_status is not connected:
         event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -54,22 +54,24 @@ def isportopen(host, port):
     return out
 
 
-def host_to_ip(host):
+def host_to_ips(host):
     '''
-    Returns the IP address of a given hostname
+    Returns a list of IP addresses of a given hostname or None if not found.
     '''
+    ips = []
     try:
-        family, socktype, proto, canonname, sockaddr = socket.getaddrinfo(
-            host, 0, socket.AF_UNSPEC, socket.SOCK_STREAM)[0]
-
-        if family == socket.AF_INET:
-            ip, port = sockaddr
-        elif family == socket.AF_INET6:
-            ip, port, flow_info, scope_id = sockaddr
-
+        for family, socktype, proto, canonname, sockaddr in socket.getaddrinfo(
+                host, 0, socket.AF_UNSPEC, socket.SOCK_STREAM):
+            if family == socket.AF_INET:
+                ip, port = sockaddr
+            elif family == socket.AF_INET6:
+                ip, port, flow_info, scope_id = sockaddr
+            ips.append(ip)
+        if not ips:
+            ips = None
     except Exception:
-        ip = None
-    return ip
+        ips = None
+    return ips
 
 
 def _generate_minion_id():

--- a/tests/unit/utils/network_test.py
+++ b/tests/unit/utils/network_test.py
@@ -100,9 +100,9 @@ class NetworkTestCase(TestCase):
         ret = network.sanitize_host('10.1./2.$3')
         self.assertEqual(ret, '10.1.2.3')
 
-    def test_host_to_ip(self):
-        ret = network.host_to_ip('www.saltstack.com')
-        self.assertEqual(ret, '104.199.122.13')
+    def test_host_to_ips(self):
+        ret = network.host_to_ips('www.saltstack.com')
+        self.assertEqual(ret, ['104.199.122.13'])
 
     def test_generate_minion_id(self):
         self.assertTrue(network.generate_minion_id())


### PR DESCRIPTION
### What does this PR do?

This fixes the bug #36866 where minion gets __master_disconnected right
after connect because '::1' isn't in the list of connected masters that
is ['127.0.0.1'].
### What issues does this PR fix or reference?
#36866
### New Behavior

Now for 'localhost' master `status.master` gets a list of master ips that are ['::1', '127.0.0.1'], and checks correctly determines that master '127.0.0.1' is connected. 
### Tests written?

No
