### PR TITLE
log.setup: only assign user if defined

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -930,8 +930,13 @@ def patch_python_logging_handlers():
 def __process_multiprocessing_logging_queue(opts, queue):
     import salt.utils
     salt.utils.appendproctitle('MultiprocessingLoggingQueue')
+
+    # Assign UID/GID of user to proc if set
     from salt.utils.verify import check_user
-    check_user(opts['user'])
+    user = opts.get('user')
+    if user:
+        check_user(user)
+
     if salt.utils.is_windows():
         # On Windows, creating a new process doesn't fork (copy the parent
         # process image). Due to this, we need to setup extended logging

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -184,7 +184,7 @@ class TestDaemon(object):
         '''
         # Setup the multiprocessing logging queue listener
         salt_log_setup.setup_multiprocessing_logging_listener(
-            self.parser.options
+            vars(self.parser.options)
         )
 
         # Set up PATH to mockbin


### PR DESCRIPTION
### What does this PR do?

Fix the stack trace:

``` py
Process Process-1:
Traceback (most recent call last):
  File "/opt/salt/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/opt/salt/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/testing/salt/log/setup.py", line 934, in __process_multiprocessing_logging_queue
    check_user(opts['user'])
AttributeError: Values instance has no attribute '__getitem__'
```
### What issues does this PR fix or reference?
#36203
### Tests written?

No
