### PR TITLE
Back-port #36246 to 2016.3

### DIFF
--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -11,6 +11,7 @@ import glob
 import shutil
 import logging
 import os
+import sys
 
 # Import salt libs
 import salt.utils
@@ -131,6 +132,9 @@ def create(path,
         venv_bin = __opts__.get('venv_bin') or __pillar__.get('venv_bin')
     # raise CommandNotFoundError if venv_bin is missing
     salt.utils.check_or_die(venv_bin)
+
+    if not os.path.exists(venv_bin):
+        venv_bin = '/'.join([os.path.dirname(sys.executable), venv_bin])
 
     cmd = [venv_bin]
 

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -11,7 +11,6 @@ import glob
 import shutil
 import logging
 import os
-import sys
 
 # Import salt libs
 import salt.utils
@@ -132,9 +131,6 @@ def create(path,
         venv_bin = __opts__.get('venv_bin') or __pillar__.get('venv_bin')
     # raise CommandNotFoundError if venv_bin is missing
     salt.utils.check_or_die(venv_bin)
-
-    if not os.path.exists(venv_bin):
-        venv_bin = '/'.join([os.path.dirname(sys.executable), venv_bin])
 
     cmd = [venv_bin]
 

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -79,9 +79,12 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
 
     @requires_system_grains
     def test_pip_installed_weird_install(self, grains=None):
-        # First, check to see if this is running on CentOS 5. If so, skip this test.
+        # First, check to see if this is running on CentOS 5 or MacOS.
+        # If so, skip this test.
         if grains['os'] in ('CentOS',) and grains['osrelease_info'][0] in (5,):
             self.skipTest('This test does not run reliably on CentOS 5')
+        if grains['os'] in ('MacOS',):
+            self.skipTest('This test does not run reliably on MacOS')
 
         ographite = '/opt/graphite'
         if os.path.isdir(ographite):

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -365,7 +365,6 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             # previously installed
             ret = self.run_function(
                 'pip.install', ['pip==6.0'], upgrade=True,
-                ignore_installed=True,
                 bin_env=venv_dir
             )
             try:
@@ -379,7 +378,7 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                 pprint.pprint(ret)
                 raise
 
-            # Le't make sure we have pip 6.0 installed
+            # Let's make sure we have pip 6.0 installed
             self.assertEqual(
                 self.run_function('pip.list', ['pip'], bin_env=venv_dir),
                 {'pip': '6.0'}


### PR DESCRIPTION
Back-port #36246 to 2016.3

There was an original back-port of this PR that was supposed to go in #36418, however, not all of the commits were grabbed. This back-ports the other commits from the original PR.
