### PR TITLE
allow the file.recurse state to support saltenv

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2396,6 +2396,8 @@ def recurse(name,
     # Check source path relative to fileserver root, make sure it is a
     # directory
     srcpath, senv = salt.utils.url.parse(source)
+    if senv is None:
+        senv = __env__
     master_dirs = __salt__['cp.list_master_dirs'](saltenv=senv)
     if srcpath not in master_dirs \
             and not any((x for x in master_dirs

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2395,15 +2395,15 @@ def recurse(name,
 
     # Check source path relative to fileserver root, make sure it is a
     # directory
-    source_rel = source.partition('://')[2]
-    master_dirs = __salt__['cp.list_master_dirs'](__env__)
-    if source_rel not in master_dirs \
+    srcpath, senv = salt.utils.url.parse(source)
+    master_dirs = __salt__['cp.list_master_dirs'](saltenv=senv)
+    if srcpath not in master_dirs \
             and not any((x for x in master_dirs
-                         if x.startswith(source_rel + '/'))):
+                         if x.startswith(srcpath + '/'))):
         ret['result'] = False
         ret['comment'] = (
             'The directory {0!r} does not exist on the salt fileserver '
-            'in saltenv {1!r}'.format(source, __env__)
+            'in saltenv {1!r}'.format(srcpath, senv)
         )
         return ret
 
@@ -2542,16 +2542,15 @@ def recurse(name,
 
     keep = set()
     vdir = set()
-    srcpath = salt.utils.url.parse(source)[0]
     if not srcpath.endswith('/'):
         # we're searching for things that start with this *directory*.
         # use '/' since #master only runs on POSIX
         srcpath = srcpath + '/'
-    fns_ = __salt__['cp.list_master'](__env__, srcpath)
+    fns_ = __salt__['cp.list_master'](senv, srcpath)
     # If we are instructed to keep symlinks, then process them.
     if keep_symlinks:
         # Make this global so that emptydirs can use it if needed.
-        symlinks = __salt__['cp.list_master_symlinks'](__env__, srcpath)
+        symlinks = __salt__['cp.list_master_symlinks'](senv, srcpath)
         fns_ = process_symlinks(fns_, symlinks)
     for fn_ in fns_:
         if not fn_.strip():
@@ -2590,11 +2589,11 @@ def recurse(name,
             manage_directory(dirname)
             vdir.add(dirname)
 
-        src = salt.utils.url.create(fn_)
+        src = salt.utils.url.create(fn_, saltenv=senv)
         manage_file(dest, src)
 
     if include_empty:
-        mdirs = __salt__['cp.list_master_dirs'](__env__, srcpath)
+        mdirs = __salt__['cp.list_master_dirs'](senv, srcpath)
         for mdir in mdirs:
             if not salt.utils.check_include_exclude(
                     os.path.relpath(mdir, srcpath), include_pat, exclude_pat):

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -675,6 +675,32 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             if os.path.isdir(name):
                 shutil.rmtree(name, ignore_errors=True)
 
+    def test_recurse_specific_env_in_url(self):
+        '''
+        file.recurse passing __env__
+        '''
+        name = os.path.join(integration.TMP, 'recurse_dir_prod_env')
+        ret = self.run_state('file.recurse',
+                             name=name,
+                             source='salt://holy?saltenv=prod')
+        try:
+            self.assertSaltTrueReturn(ret)
+            self.assertTrue(os.path.isfile(os.path.join(name, '32', 'scene')))
+        finally:
+            if os.path.isdir(name):
+                shutil.rmtree(name, ignore_errors=True)
+
+        name = os.path.join(integration.TMP, 'recurse_dir_prod_env')
+        ret = self.run_state('file.recurse',
+                             name=name,
+                             source='salt://holy?saltenv=prod')
+        try:
+            self.assertSaltTrueReturn(ret)
+            self.assertTrue(os.path.isfile(os.path.join(name, '32', 'scene')))
+        finally:
+            if os.path.isdir(name):
+                shutil.rmtree(name, ignore_errors=True)
+
     def test_test_recurse(self):
         '''
         file.recurse test interface

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -874,7 +874,7 @@ class FileTestCase(TestCase):
                 ret.update({'comment': comt})
                 self.assertDictEqual(filestate.recurse(name, source), ret)
 
-                comt = ("The directory 'salt://code/flask' does not exist"
+                comt = ("The directory 'code/flask' does not exist"
                         " on the salt fileserver in saltenv 'base'")
                 ret.update({'comment': comt})
                 self.assertDictEqual(filestate.recurse(name, source), ret)


### PR DESCRIPTION
### What does this PR do?

This pull request allows the file.recurse state to pull directories from other saltenvs
such as salt://example/dir?saltenv=dev
### What issues does this PR fix or reference?
#37123
### Previous Behavior

state with

```
/etc/test:
  file.recurse:
    - source: salt://example/dir?saltenv=dev
```

failed with "The directory 'salt://example/dir?saltenv=dev' does not exist on the salt fileserver in saltenv 'base'"
### New Behavior

Files copied as expected
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.