### PR TITLE
Unbreak _check_cmdline() on SunOS distributions

### DIFF
--- a/salt/utils/minion.py
+++ b/salt/utils/minion.py
@@ -6,11 +6,14 @@ Utility functions for minions
 # Import Python Libs
 from __future__ import absolute_import
 import os
+import logging
 import threading
 
 # Import Salt Libs
 import salt.utils
 import salt.payload
+
+log = logging.getLogger(__name__)
 
 
 def running(opts):
@@ -101,6 +104,11 @@ def _read_proc_file(path, opts):
             return None
 
     if not _check_cmdline(data):
+        pid = data.get('pid')
+        if pid:
+            log.warning(
+                'PID {0} exists but does not appear to be a salt process.'.format(pid)
+            )
         try:
             os.remove(path)
         except IOError:
@@ -113,27 +121,17 @@ def _check_cmdline(data):
     '''
     In some cases where there are an insane number of processes being created
     on a system a PID can get recycled or assigned to a non-Salt process.
-    This fn checks to make sure the PID we are checking on is actually
+    On Linux this fn checks to make sure the PID we are checking on is actually
     a Salt process.
 
-    For non-Linux systems with no procfs style /proc mounted
-    we punt and just return True (assuming that the data has a PID in it)
+    For non-Linux systems we punt and just return True
     '''
+    if not salt.utils.is_linux():
+        return True
     pid = data.get('pid')
     if not pid:
         return False
-    if not os.path.isdir('/proc') or salt.utils.is_windows():
-        return True
-    # Some BSDs have a /proc dir, but procfs is not mounted there.  Since
-    # processes are represented by directories in /proc, if there are no
-    # dirs in proc, this is a non-procfs supporting OS.  In this case
-    # like the one above we just return True
-    dirs_in_proc = False
-    for dirpath, dirnames, files in os.walk('/proc'):
-        if dirnames:
-            dirs_in_proc = True
-            break
-    if not dirs_in_proc:
+    if not os.path.isdir('/proc'):
         return True
     path = os.path.join('/proc/{0}/cmdline'.format(pid))
     if not os.path.isfile(path):


### PR DESCRIPTION
### What does this PR do?

Prevent PID check from failing on SunOS minions
### What issues does this PR fix or reference?
#34872

(PR #37025 also tries to solve this problem)
### Previous Behavior

```
$ salt database1 cmd.run "sleep 20"
database1:
    Minion did not return. [No response]
```
### New Behavior

```
$ salt database1 cmd.run "sleep 20"
database1:
```
### Tests written?

No, tested manually on SmartOS 5.11 (joyent_20160929T030056Z) on using the
following virtualenv setup

```
pkgin install py27-pip zeromq gcc47 git py27-zmq
pkgin upgrade
virtualenv ~/local/saltenv --system-site-packages
```

Also verified on FreeBSD 11.0-RELEASE-p1
