### PR TITLE
fix digital ocean image name in profile

### DIFF
--- a/tests/integration/cloud/providers/digital_ocean.py
+++ b/tests/integration/cloud/providers/digital_ocean.py
@@ -10,7 +10,6 @@ import random
 import string
 
 # Import Salt Testing Libs
-from salttesting import skipIf
 from salttesting.helpers import ensure_in_syspath, expensiveTest
 
 ensure_in_syspath('../../../')
@@ -37,8 +36,6 @@ INSTANCE_NAME = __random_name()
 PROVIDER_NAME = 'digital_ocean'
 
 
-@skipIf(True, 'Valid provider configs are not available for the DigitalOcean v1 API '
-              'in conjunction with the configs needed for v2 API.')
 class DigitalOceanTest(integration.ShellCase):
     '''
     Integration tests for the DigitalOcean cloud provider in Salt-Cloud
@@ -89,7 +86,7 @@ class DigitalOceanTest(integration.ShellCase):
         '''
         image_list = self.run_cloud('--list-images {0}'.format(PROVIDER_NAME))
         self.assertIn(
-            '14.04 x64',
+            '14.04.5 x64',
             [i.strip() for i in image_list]
         )
 

--- a/tests/integration/files/conf/cloud.profiles.d/digital_ocean.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/digital_ocean.conf
@@ -1,5 +1,5 @@
 digitalocean-test:
   provider: digitalocean-config
-  image: 14.04 x64
+  image: 14.04.5 x64
   size: 2GB
   script_args: '-P -Z'


### PR DESCRIPTION
### What does this PR do?

DO changed the name of their Ubuntu14 profile image. Need to update this for the salt cloud tests.
