### PR TITLE
Fix versionadded for base64_decodefile

### DIFF
--- a/salt/modules/hashutil.py
+++ b/salt/modules/hashutil.py
@@ -204,7 +204,7 @@ def base64_decodefile(instr, outfile):
     r'''
     Decode a base64-encoded string and write the result to a file
 
-    .. versionadded:: 2015.2.0
+    .. versionadded:: 2016.3.0
 
     CLI Example:
 


### PR DESCRIPTION
### What does this PR do?

Fixes documentation version for base64_decodefile
### What issues does this PR fix or reference?
### Tests written?

No

When `base64_decodefile` was added the versionadded was pointing to 2015.2, commit https://github.com/saltstack/salt/commit/29ac54d19fd06b4db662ff6567265b5d300e196c updated `base64_encodefile` but missed `base64_decodefile`.
