### PR TITLE
Fix example signing policy in salt.states.x509 docs

### DIFF
--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -110,7 +110,7 @@ can define a restricted list of minons which are allowed to remotely invoke this
         - ST: Utah
         - L: Salt Lake City
         - basicConstraints: "critical CA:false"
-        - keyUsage: "critical cRLSign, keyCertSign"
+        - keyUsage: "critical keyEncipherment"
         - subjectKeyIdentifier: hash
         - authorityKeyIdentifier: keyid,issuer:always
         - days_valid: 90


### PR DESCRIPTION
### What does this PR do?

The example "www" signing policy has keyUsage set to "critical cRLSign, keyCertSign". These values are correct for a CA but not a SSL server certificate. With some SSL implementations this causes Firefox to throw SEC_ERROR_INADEQUATE_KEY_USAGE when the generated certificate is used on a web server. The correct value is "critical keyEncipherment".
