### PR TITLE
SPM-METADATA are now loaded as yaml from remote URLs

### DIFF
--- a/salt/spm/__init__.py
+++ b/salt/spm/__init__.py
@@ -323,7 +323,7 @@ class SPMClient(object):
                     metadata = yaml.safe_load(rpm)
             else:
                 response = http.query(dl_path, text=True)
-                metadata = response.get('text', {})
+                metadata = yaml.safe_load(response.get('text', '{}'))
             cache_path = '{0}/{1}.p'.format(
                 self.opts['spm_cache_dir'],
                 repo


### PR DESCRIPTION
### What does this PR do?

This PR fixes the undesired behaviour of `spm update_repo` not parsing remote SPM-METADATA as yaml, compared to local `file:///` URLS.
### What issues does this PR fix or reference?

This PR fixes #37095.
### Tests written?

No
