### PR TITLE
Download spm package from remote repository and save it to cache

### DIFF
--- a/salt/spm/__init__.py
+++ b/salt/spm/__init__.py
@@ -428,7 +428,7 @@ class SPMClient(object):
                 else:
                     response = http.query(dl_path, text=True)
                     with salt.utils.fopen(out_file, 'w') as outf:
-                        outf.write(response.get("text"))
+                        outf.write(response.get('text'))
 
                 self._local_install((None, out_file), package)
                 return

--- a/salt/spm/__init__.py
+++ b/salt/spm/__init__.py
@@ -426,7 +426,9 @@ class SPMClient(object):
                     dl_path = dl_path.replace('file://', '')
                     shutil.copyfile(dl_path, out_file)
                 else:
-                    http.query(dl_path, text_out=out_file)
+                    response = http.query(dl_path, text=True)
+                    with salt.utils.fopen(out_file, 'w') as outf:
+                        outf.write(response.get("text"))
 
                 self._local_install((None, out_file), package)
                 return


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue that packages downloaded from remote repositories were only downloaded if a file with the same name already existed in the cache.
### What issues does this PR fix or reference?

This PR fixes #37138 
### Tests written?

No
