### PR TITLE
pkgbuild.repo: fix GPG signing with `use_passphrase=False`

### DIFF
--- a/salt/modules/debbuild.py
+++ b/salt/modules/debbuild.py
@@ -526,8 +526,8 @@ def make_repo(repodir,
         .. versionadded:: 2016.3.0
 
         Use a passphrase with the signing key presented in ``keyid``.
-        Passphrase is received from Pillar data which has been passed on
-        the command line. For example:
+        Passphrase is received from Pillar data which could be passed on the
+        command line with ``pillar`` parameter. For example:
 
         .. code-block:: bash
 
@@ -579,6 +579,7 @@ def make_repo(repodir,
 
     local_fingerprint = None
     local_keyid = None
+    phrase = ''
 
     # preset passphase and interaction with gpg-agent
     gpg_info_file = '{0}/gpg-agent-info-salt'.format(gnupghome)

--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -369,8 +369,8 @@ def make_repo(repodir,
         .. versionadded:: 2016.3.0
 
         Use a passphrase with the signing key presented in ``keyid``.
-        Passphrase is received from Pillar data which has been passed on
-        the command line. For example:
+        Passphrase is received from Pillar data which could be passed on the
+        command line with ``pillar`` parameter. For example:
 
         .. code-block:: bash
 
@@ -405,9 +405,10 @@ def make_repo(repodir,
     '''
     SIGN_PROMPT_RE = re.compile(r'Enter pass phrase: ', re.M)
 
-    local_keyid = None
     define_gpg_name = ''
+    local_keyid = None
     local_uids = None
+    phrase = ''
 
     if keyid is not None:
         ## import_keys

--- a/salt/states/pkgbuild.py
+++ b/salt/states/pkgbuild.py
@@ -336,8 +336,8 @@ def repo(name,
         .. versionadded:: 2016.3.0
 
         Use a passphrase with the signing key presented in ``keyid``.
-        Passphrase is received from Pillar data which has been passed on
-        the command line. For example:
+        Passphrase is received from Pillar data which could be passed on the
+        command line with ``pillar`` parameter. For example:
 
         .. code-block:: bash
 


### PR DESCRIPTION
### What does this PR do?

It fixes the default behavior for `pkgbuild.repo` state and exec module function when you wish to sign the repository with "bare" private key which is not protected with a passphrase.
### What issues does this PR fix or reference?

This state fill fail:

``` yaml
Create YUM repo in /srv/repo:
  pkgbuild.repo:
    - name: /srv/repo
    - runas: root
    - keyid: 1122AABB
    - use_passphrase: False
```
### Previous Behavior

...because of:

``` yaml
----------
          ID: Create YUM repo in /srv/repo
    Function: pkgbuild.repo
        Name: /srv/repo
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1733, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1653, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/pkgbuild.py", line 391, in repo
                  res = __salt__[func](name, keyid, env, use_passphrase, gnupghome, runas, timeout)
                File "/usr/lib/python2.7/dist-packages/salt/modules/rpmbuild.py", line 479, in make_repo
                  proc.sendline(phrase)
              UnboundLocalError: local variable 'phrase' referenced before assignment
     Started: 07:44:37.711373
    Duration: 1449.938 ms
     Changes:   
```
### New Behavior

After the fix applied:

``` yaml
----------
          ID: Create YUM repo in /srv/repo
    Function: pkgbuild.repo
        Name: /srv/repo
      Result: True
     Comment: Spawning worker 0 with 1 pkgs
              Workers Finished
              Saving Primary metadata
              Saving file lists metadata
              Saving other metadata
              Generating sqlite DBs
              Sqlite DBs complete
     Started: 07:49:52.909716
    Duration: 3439.387 ms
     Changes:   
              ----------
              refresh:
                  True
```
### Tests written?

No
