### PR TITLE
status.master: don't fail if host_to_ips returns None

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -1020,12 +1020,13 @@ def master(master=None, connected=True):
     if master is not None:
         master_ips = _host_to_ips(master)
 
-    ips = _remote_port_tcp(port)
     master_connection_status = False
-    for master_ip in master_ips:
-        if master_ip in ips:
-            master_connection_status = True
-            break
+    if master_ips:
+        ips = _remote_port_tcp(port)
+        for master_ip in master_ips:
+            if master_ip in ips:
+                master_connection_status = True
+                break
 
     if master_connection_status is not connected:
         event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)

--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -342,12 +342,13 @@ def master(master=None, connected=True):
     if master is not None:
         master_ips = _host_to_ips(master)
 
-    ips = _win_remotes_on(port)
     master_connection_status = False
-    for master_ip in master_ips:
-        if master_ip in ips:
-            master_connection_status = True
-            break
+    if master_ips:
+        ips = _win_remotes_on(port)
+        for master_ip in master_ips:
+            if master_ip in ips:
+                master_connection_status = True
+                break
 
     if master_connection_status is not connected:
         event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)


### PR DESCRIPTION
### What does this PR do?

A minor bugfix: correctly handle the case if the given master name couldn't be resolved to IP.
### What issues does this PR fix or reference?

A part of #37117
Related to #36866 
### Tests written?

No
