### PR TITLE
add explicit reference to grains['id'] as a 'safe' grain for pillars

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -361,6 +361,8 @@ files on the local system, grains are considered less secure than other
 identifiers in Salt. Use caution when targeting sensitive operations or setting
 pillar values based on grain data.
 
+The only grain which can be safely used is ``grains['id']`` which contains the Minion ID.
+
 When possible, you should target sensitive operations and data using the Minion
 ID. If the Minion ID of a system changes, the Salt Minion's public key must be
 re-accepted by an administrator on the Salt Master, making it less vulnerable


### PR DESCRIPTION
### What does this PR do?

The documentation is a bit vague concerning the safe way to target
a specific minion inside pillars.

This commit explicitly mention grains['id'] as safe (according to PR
https://github.com/saltstack/salt/pull/12128)
### What issues does this PR fix or reference?

NA
### Previous Behavior

NA
### Tests written?

No
