### PR TITLE
Fix pkg.latest_version when latest already installed

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1679,7 +1679,7 @@ def latest(
     targets = {}
     problems = []
     for pkg in desired_pkgs:
-        if not avail[pkg]:
+        if not avail.get(pkg):
             # Package either a) is up-to-date, or b) does not exist
             if not cur[pkg]:
                 # Package does not exist


### PR DESCRIPTION
### What does this PR do?

Fixes pkg.latest_version in case the latest version already installed
### Previous Behavior

```
   {
       "vero_quisquam": {
           "pkg_|-latest-state_|-postfix_|-latest": {
               "comment": "An exception occurred in this state: Traceback (most recent call last):\n  File \"/salt/src/salt-devel/salt/state.py\", line 1733, in call\n    **cdata['kwargs'])\n  File \"/salt/src/salt-devel/salt/loader.py\", line 1651, in wrapper\n    return f(*args, **kwargs)\n  File \"/salt/src/salt-devel/salt/states/pkg.py\", line 1634, in latest\n    if not avail[pkg]:\nKeyError: 'postfix'\n",
               "name": "postfix",
               "start_time": "11:41:28.124873",
               "result": false,
               "duration": 15298.145,
               "__run_num__": 0,
               "changes": {},
               "__id__": "latest-state"
           }
       }
   }
```
### Tests written?

No
