### PR TITLE
Allow the minion test daemons a couple of tries to connect to the master

### DIFF
--- a/tests/integration/files/conf/minion
+++ b/tests/integration/files/conf/minion
@@ -12,6 +12,11 @@ log_file: minion
 #loop_interval: 0.05
 config_dir: /tmp/salt-tests-tmpdir
 
+# Give the minion extra attempts to find the master
+# This is especially needed for the TCP tests as we
+# wait for the master to come up in 2016.3. See #35489.
+master_tries: 5
+
 # module extension
 test.foo: baz
 hosts.file: /tmp/salt-tests-tmpdir/hosts

--- a/tests/integration/files/conf/sub_minion
+++ b/tests/integration/files/conf/sub_minion
@@ -10,6 +10,11 @@ sock_dir: sub_minion_sock
 open_mode: True
 log_file: minion
 
+# Give the minion extra attempts to find the master
+# This is especially needed for the TCP tests as we
+# wait for the master to come up in 2016.3. See #35489.
+master_tries: 5
+
 # module extension
 test.foo: baz
 hosts.file: /tmp/salt-tests-tmpdir/hosts


### PR DESCRIPTION
When running the tests with the tcp transport, we are not as forgiving
with the minion connection process as we are in ZMQ. In ZMQ, we attempt
to connect to the master. If it isn't up yet, we wait and try again. In
TCP, we try to connect to the master once, realize it's not up (because
the master process takes longer to spin up than the minions) and crash
and bail out.

This just gives the master a little more time to come up by having the
minions try to connect a couple more times.
