### PR TITLE
modules.win_system.py: Fix flag disabling AD Computer objects

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -759,7 +759,7 @@ def unjoin_domain(username=None,
     if username and password is None:
         return 'Must specify a password if you pass a username'
 
-    NETSETUP_ACCT_DELETE = 0x2  # pylint: disable=invalid-name
+    NETSETUP_ACCT_DELETE = 0x4  # pylint: disable=invalid-name
 
     unjoin_options = 0x0
     if disable:


### PR DESCRIPTION
### What does this PR do?

This fixes an incorrect flag, `NETSETUP_ACCT_DELETE = 0x2` and replaces it with `0x4` in the module win_system.py, which is used to disable a computer account object in Active Directory upon leaving a domain with `system.unjoin_domain disable=True`. 
### What issues does this PR fix or reference?

This fixes issue [#37132](https://github.com/saltstack/salt/issues/37132)
### Previous Behavior

After running the `system.unjoin_domain` module function with `disable=True`, the following error is returned:

```
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
Traceback (most recent call last):
  File "C:\salt\bin\Scripts\salt-call", line 11, in <module>
    salt_call()
  File "C:\salt\bin\lib\site-packages\salt\scripts.py", line 345, in salt_call
    client.run()
  File "C:\salt\bin\lib\site-packages\salt\cli\call.py", line 58, in run
    caller.run()
  File "C:\salt\bin\lib\site-packages\salt\cli\caller.py", line 134, in run
    ret = self.call()
  File "C:\salt\bin\lib\site-packages\salt\cli\caller.py", line 197, in call
    ret['return'] = func(*args, **kwargs)
  File "C:\salt\bin\lib\site-packages\salt\modules\win_system.py", line 688, in unjoin_domain
    log.error(_lookup_error(err[0]))
  File "C:\salt\bin\lib\site-packages\salt\modules\win_system.py", line 504, in _lookup_error
    return return_values[number]
KeyError: 1004
```
### Tests written?

No
