### PR TITLE
add mock for `status.uptime` unit test

### DIFF
--- a/tests/unit/modules/status_test.py
+++ b/tests/unit/modules/status_test.py
@@ -25,7 +25,7 @@ class StatusTestCase(TestCase):
     '''
     test modules.status functions
     '''
-
+    @patch('salt.utils.is_linux', MagicMock(return_value=True))
     def test_uptime(self):
         '''
         Test modules.status.uptime function, new version


### PR DESCRIPTION
### What does this PR do?

Fix the intermittent stack trace from the `status.uptime` unit test on macOS.

``` py
Traceback (most recent call last):
  File "/testing/tests/unit/modules/status_test.py", line 45, in test_uptime
    u_time = status.uptime()
  File "/testing/salt/utils/decorators/__init__.py", line 579, in _decorate
    return self._call_function(kwargs)
  File "/testing/salt/utils/decorators/__init__.py", line 314, in _call_function
    raise error
CommandExecutionError: This platform is not supported
```
### What issues does this PR fix or reference?
#37157.  @rallytime, this change should not be included in a merge to develop if/when #37157 is merged.
### Tests written?

Yes
