### PR TITLE
module and state for pdbedit

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -259,6 +259,7 @@ execution modules
     parallels
     parted
     pcs
+    pdbedit
     pecl
     philips_hue
     pillar

--- a/doc/ref/modules/all/salt.modules.pdbedit.rst
+++ b/doc/ref/modules/all/salt.modules.pdbedit.rst
@@ -1,0 +1,6 @@
+====================
+salt.modules.pdbedit
+====================
+
+.. automodule:: salt.modules.pdbedit
+    :members:

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -156,6 +156,7 @@ state modules
     pagerduty_user
     pcs
     pecl
+    pdbedit
     pip_state
     pkg
     pkgbuild

--- a/doc/ref/states/all/salt.states.pdbedit.rst
+++ b/doc/ref/states/all/salt.states.pdbedit.rst
@@ -1,0 +1,6 @@
+===================
+salt.states.pdbedit
+===================
+
+.. automodule:: salt.states.pdbedit
+    :members:

--- a/salt/modules/pdbedit.py
+++ b/salt/modules/pdbedit.py
@@ -17,7 +17,8 @@ __virtualname__ = 'pdbedit'
 
 # Function aliases
 __func_alias__ = {
-    'list_users': 'list'
+    'list_users': 'list',
+    'get_user': 'get',
 }
 
 
@@ -52,7 +53,7 @@ def list_users(verbose=True):
 
     if verbose:
         ## parse detailed user data
-        res = __salt__['cmd.run_all']('pdbedit -L -v')
+        res = __salt__['cmd.run_all']('pdbedit --list --verbose')
 
         if res['retcode'] > 0:
             log.error(res['stderr'] if 'stderr' in res else res['stdout'])
@@ -73,7 +74,7 @@ def list_users(verbose=True):
                 users[user_data['unix username']] = user_data
     else:
         ## list users
-        res = __salt__['cmd.run_all']('pdbedit -L')
+        res = __salt__['cmd.run_all']('pdbedit --list')
 
         if res['retcode'] > 0:
             log.error(res['stderr'] if 'stderr' in res else res['stdout'])
@@ -83,5 +84,21 @@ def list_users(verbose=True):
 
     return users
 
+
+def get_user(login):
+    '''
+    Get user account details
+
+    login : string
+        login name
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pdbedit.get kaylee
+    '''
+    users = list_users()
+    return users[login] if login in users else {}
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/pdbedit.py
+++ b/salt/modules/pdbedit.py
@@ -309,9 +309,9 @@ def modify(
 
     ## update password
     if password:
-        ret = create(login, password, password_hashed)
-        if ret[login] not in ['updated', 'created', 'unchanged']:
-            return ret
+        ret = create(login, password, password_hashed)[login]
+        if ret not in ['updated', 'created', 'unchanged']:
+            return {login: ret}
     elif login not in list_users(False):
         return {login: 'absent'}
 

--- a/salt/modules/pdbedit.py
+++ b/salt/modules/pdbedit.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
-Module for Samba's pdbedit tool
+Manage accounts in Samba's passdb using pdbedit
+
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:platform:      posix
+
+.. versionadded:: nitrogen
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/pdbedit.py
+++ b/salt/modules/pdbedit.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+'''
+Module for Samba's pdbedit tool
+'''
+from __future__ import absolute_import
+
+# Import Python libs
+import logging
+
+# Import Salt libs
+import salt.utils
+
+log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'pdbedit'
+
+# Function aliases
+__func_alias__ = {
+    'list_users': 'list'
+}
+
+
+def __virtual__():
+    '''
+    Provides pdbedit if available
+    '''
+    if salt.utils.which('pdbedit'):
+        return __virtualname__
+    return (
+        False,
+        '{0} module can only be loaded when pdbedit is available'.format(
+            __virtualname__
+        )
+    )
+
+
+def list_users(verbose=True):
+    '''
+    List user accounts
+
+    verbose : boolean
+        return all information
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pdbedit.list
+    '''
+    users = {} if verbose else []
+
+    if verbose:
+        ## parse detailed user data
+        res = __salt__['cmd.run_all']('pdbedit -L -v')
+
+        if res['retcode'] > 0:
+            log.error(res['stderr'] if 'stderr' in res else res['stdout'])
+        else:
+            user_data = {}
+            for user in res['stdout'].splitlines():
+                if user.startswith('-'):
+                    if len(user_data) > 0:
+                        users[user_data['unix username']] = user_data
+                    user_data = {}
+                else:
+                    label = user[:user.index(':')].strip().lower()
+                    data = user[(user.index(':')+1):].strip()
+                    if len(data) > 0:
+                        user_data[label] = data
+
+            if len(user_data) > 0:
+                users[user_data['unix username']] = user_data
+    else:
+        ## list users
+        res = __salt__['cmd.run_all']('pdbedit -L')
+
+        if res['retcode'] > 0:
+            log.error(res['stderr'] if 'stderr' in res else res['stdout'])
+        else:
+            for user in res['stdout'].splitlines():
+                users.append(user.split(':')[0])
+
+    return users
+
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/pdbedit.py
+++ b/salt/modules/pdbedit.py
@@ -212,6 +212,7 @@ def modify(
     drive=None, homedir=None, fullname=None,
     account_desc=None, account_control=None,
     machine_sid=None, user_sid=None,
+    reset_login_hours=False, reset_bad_password_count=False,
 ):
     '''
     Modify user account
@@ -250,6 +251,10 @@ def modify(
             - H: Home directory required
             - L: Automatic Locking
             - X: Password does not expire
+    reset_login_hours : boolean
+        reset the users allowed logon hours
+    reset_bad_password_count : boolean
+        reset the stored bad login counter
 
     CLI Example:
 
@@ -318,13 +323,18 @@ def modify(
             if val is not None and key in current and current[key] != val:
                 changes[key] = val
 
-    if len(changes) > 0:
+    ## apply changes
+    if len(changes) > 0 or reset_login_hours or reset_bad_password_count:
         cmds = []
         for change in changes:
             cmds.append('{flag}{value}'.format(
                 flag=flags[change],
                 value=_quote_args(changes[change]),
             ))
+        if reset_login_hours:
+            cmds.append('--logon-hours-reset')
+        if reset_bad_password_count:
+            cmds.append('--bad-password-count-reset')
 
         res = __salt__['cmd.run_all'](
             'pdbedit --modify --user {login} {changes}'.format(

--- a/salt/states/pdbedit.py
+++ b/salt/states/pdbedit.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+'''
+Manage accounts in Samba's passdb using pdbedit
+
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:depends:       pdbedit
+:platform:      posix
+
+.. versionadded:: nitrogen
+
+.. code-block:: yaml
+
+    wash:
+      pdbedit.absent
+
+    kaylee:
+      pdbedit.managed:
+        - password: A70C708517B5DD0EDB67714FE25336EB
+        - password_hashed: True
+        - drive: 'X:'
+        - homedir: '\\\\serenity\\mechanic\\profile'
+'''
+from __future__ import absolute_import
+
+# Import Python libs
+import logging
+
+# Import Salt libs
+import salt.utils
+
+log = logging.getLogger(__name__)
+
+# Define the state's virtual name
+__virtualname__ = 'pdbedit'
+
+
+def __virtual__():
+    '''
+    Provides pdbedit when available
+    '''
+    if 'pdbedit.create' in __salt__:
+        return True
+    else:
+        return (
+            False,
+            '{0} state module can only be loaded when the pdbedit module is available'.format(
+                __virtualname__
+            )
+        )
+
+
+def absent(name):
+    '''
+    Ensure user account is absent
+
+    name : string
+        username
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    ## remove if needed
+    if name in __salt__['pdbedit.list'](False):
+        res = __salt__['pdbedit.delete'](name)
+        if res[name] in ['deleted']:  # check if we need to update changes
+            ret['changes'].update(res)
+        elif res[name] not in ['absent']:  # oops something went wrong
+            ret['result'] = False
+    else:
+        ret['comment'] = 'account {login} is absent'.format(login=name)
+
+    return ret
+
+
+def managed(name, **kwargs):
+    '''
+    Manage user account
+
+    login : string
+        login name
+    password : string
+        password
+    password_hashed : boolean
+        set if password is a nt hash instead of plain text
+    domain : string
+        users domain
+    profile : string
+        profile path
+    script : string
+        logon script
+    drive : string
+        home drive
+    homedir : string
+        home directory
+    fullname : string
+        full name
+    account_desc : string
+        account description
+    machine_sid : string
+        specify the machines new primary group SID or rid
+    user_sid : string
+        specify the users new primary group SID or rid
+    account_control : string
+        specify user account control properties
+
+        .. note::
+            Only the follwing can be set:
+            - N: No password required
+            - D: Account disabled
+            - H: Home directory required
+            - L: Automatic Locking
+            - X: Password does not expire
+    reset_login_hours : boolean
+        reset the users allowed logon hours
+    reset_bad_password_count : boolean
+        reset the stored bad login counter
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    ## save state
+    saved = __salt__['pdbedit.list'](hashes=True)
+    saved = saved[name] if name in saved else {}
+
+    ## call pdbedit.modify
+    kwargs['login'] = name
+    res = __salt__['pdbedit.modify'](**kwargs)
+
+    ## calculate changes
+    if res[name] in ['created']:
+        ret['changes'] = res
+    elif res[name] in ['updated']:
+        ret['changes'][name] = salt.utils.compare_dicts(
+            saved,
+            __salt__['pdbedit.list'](hashes=True)[name],
+        )
+    elif res[name] not in ['unchanged']:
+        ret['result'] = False
+        ret['comment'] = res[name]
+
+    return ret
+
+
+def present(name, **kwargs):
+    '''
+    Alias for pdbedit.managed
+    '''
+    return managed(name, **kwargs)
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
### What does this PR do?

Allow manipulation of samba's passdb using the pdbedit tool

(I was never happy with using cmd.run with plaintext passwords, just hashes left now 👍)

I had hoped to have this finished before carbon, but other stuff got in the way. Nitrogen it is then :)
### What issues does this PR fix or reference?

N/A
### Previous Behavior

Ugly cmd.run's to pdbedit or smbpasswd which leaked paswords: e.g.
https://github.com/saltstack-formulas/samba-formula/blob/master/samba/users.sls
### New Behavior

A simple clean state with a NTHASH (or plain text if you really want to)
As a bonus some addition stuff can be set like a drive letter and custom home.

``` yaml
    kaylee:
      pdbedit.managed:
        - password: A70C708517B5DD0EDB67714FE25336EB
        - password_hashed: True
        - drive: 'X:'
        - homedir: '\\\\serenity\\mechanic\\profile'
```

Comes with docs, this time I did not forget to enable doc-generation either ;)
### Tests written?

No
