### PR TITLE
fix tiny typo in itfff state docs

### DIFF
--- a/salt/states/ifttt.py
+++ b/salt/states/ifttt.py
@@ -48,7 +48,7 @@ def trigger_event(name,
             - event: TestEvent
             - value1: 'A value that we want to send.'
             - value2: 'A second value that we want to send.'
-            - value3: 'A third value that wen want to send.'
+            - value3: 'A third value that we want to send.'
 
     The following parameters are required:
 


### PR DESCRIPTION
### What does this PR do?

See above, I noticed it when I mistype 'web' as 'wen' when searching the docs for something.
### What issues does this PR fix or reference?

N/A
### Tests written?

No
