### PR TITLE
fixes pkgrepo for fedora>22

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -287,7 +287,7 @@ def _get_yum_config():
         # fall back to parsing the config ourselves
         # Look for the config the same order yum does
         fn = None
-        paths = ('/etc/yum/yum.conf', '/etc/yum.conf')
+        paths = ('/etc/yum/yum.conf', '/etc/yum.conf', '/etc/dnf/dnf.conf')
         for path in paths:
             if os.path.exists(path):
                 fn = path


### PR DESCRIPTION
### What does this PR do?

This makes modules.yumpkg completely independent from yum. yum is not
installed in fedora>22, so this will actually fix pkgrepo in fedora.
### What issues does this PR fix or reference?
saltstack/salt#31240
### Previous Behavior

pkgrepo failed with `Failed to examine repo 'dockeriorepo': No suitable yum config file found in ('/etc/yum/yum.conf', '/etc/yum.conf')`
### New Behavior

pkgrepo works
### Tests written?

No