### PR TITLE
Allow zabbix_host state to assign templates

### DIFF
--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -319,13 +319,13 @@ def assign_templates(host, templates, **kwargs):
 
     # Set comments
     comment_host_templates_updated = 'Templates updated.'
-    comment_host_templates_notupdated = 'Unable to update templates on host: {0}. '.format(host)
+    comment_host_templates_notupdated = 'Unable to update templates on host: {0}.'.format(host)
     comment_host_templates_in_sync = 'Templates already synced.'
 
     update_host_templates = False
     curr_template_ids = list()
     requested_template_ids = list()
-    hostid = ""
+    hostid = ''
 
     host_exists = __salt__['zabbix.host_exists'](host)
 
@@ -354,7 +354,7 @@ def assign_templates(host, templates, **kwargs):
             requested_template_ids.append(template_id)
         except TypeError:
             ret['result'] = False
-            ret['comment'] = 'Unable to find template: {0}. '.format(template)
+            ret['comment'] = 'Unable to find template: {0}.'.format(template)
             return ret
 
     # remove any duplications

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -309,7 +309,7 @@ def assign_templates(host, templates, **kwargs):
 
         add_zabbix_templates_to_host:
             zabbix_host.assign_templates:
-                - host: TestHostWithInterfaces
+                - host: TestHost
                     - templates:
                         - "Template OS Linux"
                         - "Template App MySQL"
@@ -359,10 +359,7 @@ def assign_templates(host, templates, **kwargs):
             return ret
 
     # remove any duplications
-    log.info("XXX BEFORE {0}".format(requested_template_ids))
     requested_template_ids = list(set(requested_template_ids))
-    log.info("XXX AFTER {0}".format(requested_template_ids))
-
 
     if set(curr_template_ids) != set(requested_template_ids):
         update_host_templates = True

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -292,3 +292,106 @@ def absent(name):
             ret['comment'] = comment_host_notdeleted + str(host_delete['error'])
 
     return ret
+
+
+def assign_templates(host, templates, **kwargs):
+    '''
+    Ensures that templates are assigned to the host.
+
+    .. versionadded:: Carbon
+
+    :param host: technical name of the host
+    :param _connection_user: Optional - zabbix user (can also be set in opts or pillar, see module's docstring)
+    :param _connection_password: Optional - zabbix password (can also be set in opts or pillar, see module's docstring)
+    :param _connection_url: Optional - url of zabbix frontend (can also be set in opts, pillar, see module's docstring)
+
+    .. code-block:: yaml
+
+        add_zabbix_templates_to_host:
+            zabbix_host.assign_templates:
+                - host: TestHostWithInterfaces
+                    - templates:
+                        - "Template OS Linux"
+                        - "Template App MySQL"
+
+    '''
+    ret = {'name': host, 'changes': {}, 'result': False, 'comment': ''}
+
+    # Set comments
+    comment_host_templates_updated = 'Templates updated.'
+    comment_host_templates_notupdated = 'Unable to update templates on host: {0}. '.format(host)
+    comment_host_templates_in_sync = 'Templates already synced.'
+
+    update_host_templates = False
+    curr_template_ids = list()
+    requested_template_ids = list()
+    hostid = ""
+
+    host_exists = __salt__['zabbix.host_exists'](host)
+
+    # Fail out if host does not exist
+    if not host_exists:
+        ret['result'] = False
+        ret['comment'] = comment_host_templates_notupdated
+        return ret
+
+    host_info = __salt__['zabbix.host_get'](name=host)[0]
+    hostid = host_info['hostid']
+
+    if not templates:
+        templates = list()
+
+    # Get current templateids for host
+    host_templates = __salt__['zabbix.host_get'](hostids=hostid,
+                                                 output='[{"hostid"}]', selectParentTemplates='["templateid"]')
+    for template_id in host_templates[0]['parentTemplates']:
+        curr_template_ids.append(template_id['templateid'])
+
+
+    # Get requested templateids
+    for template in templates:
+        try:
+            template_id = __salt__['zabbix.template_get'](host=template)[0]['templateid']
+            requested_template_ids.append(template_id)
+        except TypeError:
+            ret['result'] = False
+            ret['comment'] = 'Unable to find template: {0}. '.format(template)
+            return ret
+
+    # remove any duplications
+    log.info("XXX BEFORE {0}".format(requested_template_ids))
+    requested_template_ids = list(set(requested_template_ids))
+    log.info("XXX AFTER {0}".format(requested_template_ids))
+
+
+    if set(curr_template_ids) != set(requested_template_ids):
+        update_host_templates = True
+
+    # Set change output
+    changes_host_templates_modified = {host: {'old': 'Host templates: ' + ", ".join(curr_template_ids),
+                                              'new': 'Host templates: ' + ', '.join(requested_template_ids)} }
+
+    # Dry run, test=true mode
+    if __opts__['test']:
+        if update_host_templates:
+            ret['result'] = None
+            ret['comment'] = comment_host_templates_updated
+        else:
+            ret['result'] = True
+            ret['comment'] = comment_host_templates_in_sync
+        return ret
+
+    # Attempt to perform update
+    ret['result'] = True
+    if update_host_templates:
+        update_output = __salt__['zabbix.host_update'](hostid, templates=(requested_template_ids))
+        if update_output is False:
+            ret['result'] = False
+            ret['comment'] = comment_host_templates_notupdated
+            return ret
+        ret['comment'] = comment_host_templates_updated
+        ret['changes'] = changes_host_templates_modified
+    else:
+        ret['comment'] = comment_host_templates_in_sync
+
+    return ret

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -347,7 +347,6 @@ def assign_templates(host, templates, **kwargs):
     for template_id in host_templates[0]['parentTemplates']:
         curr_template_ids.append(template_id['templateid'])
 
-
     # Get requested templateids
     for template in templates:
         try:
@@ -366,7 +365,7 @@ def assign_templates(host, templates, **kwargs):
 
     # Set change output
     changes_host_templates_modified = {host: {'old': 'Host templates: ' + ", ".join(curr_template_ids),
-                                              'new': 'Host templates: ' + ', '.join(requested_template_ids)} }
+                                              'new': 'Host templates: ' + ', '.join(requested_template_ids)}}
 
     # Dry run, test=true mode
     if __opts__['test']:


### PR DESCRIPTION
### What does this PR do?

Adds functionality to zabbix_host state to assign a host to templates in the zabbix system. 
### What issues does this PR fix or reference?

New functionality
### New Behavior

``` json
add_zabbix_templates_to_host: 
  zabbix_host.assign_templates:
    - host: TestHostWithInterfaces
      - templates:
        - "Template OS Linux"
        - "Template App MySQL"
```

Defines a new zabbix_host.assign_templates function which ensures the specified templates are in sync on a zabbix server. Between this and the already existing zabbix_host.present, salt is now capable of idempotently managing hosts in the zabbix monitoring environment.
### Tests written?

No

@jirikotlin