### PR TITLE
Fix test hang

### DIFF
--- a/tests/unit/transport/zeromq_test.py
+++ b/tests/unit/transport/zeromq_test.py
@@ -80,7 +80,9 @@ class BaseZMQReqCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.process_manager.kill_children()
+        # Attempting to kill the children hangs the test suite.
+        # Let the test suite handle this instead.
+#        cls.process_manager.kill_children()
         time.sleep(2)  # Give the procs a chance to fully close before we stop the io_loop
         cls.io_loop.stop()
         cls.server_channel.close()

--- a/tests/unit/transport/zeromq_test.py
+++ b/tests/unit/transport/zeromq_test.py
@@ -83,7 +83,7 @@ class BaseZMQReqCase(TestCase):
         # Attempting to kill the children hangs the test suite.
         # Let the test suite handle this instead.
 #        cls.process_manager.kill_children()
-        time.sleep(2)  # Give the procs a chance to fully close before we stop the io_loop
+#        time.sleep(2)  # Give the procs a chance to fully close before we stop the io_loop
         cls.io_loop.stop()
         cls.server_channel.close()
 


### PR DESCRIPTION
We don't need to clean up here since the test suite will handle it for us. This unblocks the deployment of the newest version of salttesting.
