### PR TITLE
Preserve the merge order specified in env_order

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2488,18 +2488,12 @@ class BaseHighState(object):
         client_envs = self.client.envs()
         if env_order and client_envs:
             env_intersection = set(env_order).intersection(client_envs)
-            final_list = []
-            for ord_env in env_order:
-                if ord_env in env_intersection:
-                    final_list.append(ord_env)
-            return final_list
+            return [env for env in env_order if env in env_intersection]
 
         elif env_order:
             return env_order
         else:
-            for cenv in client_envs:
-                if cenv not in envs:
-                    envs.append(cenv)
+            envs.extend([env for env in client_envs if env not in envs])
             return envs
 
     def get_tops(self):

--- a/salt/state.py
+++ b/salt/state.py
@@ -2482,7 +2482,8 @@ class BaseHighState(object):
         '''
         envs = ['base']
         if 'file_roots' in self.opts:
-            envs.extend(list(self.opts['file_roots']))
+            envs.extend([x for x in list(self.opts['file_roots'])
+                         if x not in envs])
         env_order = self.opts.get('env_order', [])
         client_envs = self.client.envs()
         if env_order and client_envs:
@@ -2491,15 +2492,15 @@ class BaseHighState(object):
             for ord_env in env_order:
                 if ord_env in env_intersection:
                     final_list.append(ord_env)
-            return set(final_list)
+            return final_list
 
         elif env_order:
-            return set(env_order)
+            return env_order
         else:
             for cenv in client_envs:
                 if cenv not in envs:
                     envs.append(cenv)
-            return set(envs)
+            return envs
 
     def get_tops(self):
         '''
@@ -2574,7 +2575,7 @@ class BaseHighState(object):
                     else:
                         tops[saltenv].append({})
                         log.debug('No contents loaded for env: {0}'.format(saltenv))
-            if found > 1:
+            if found > 1 and not self.opts.get('env_order', None):
                 log.warning(
                     'top_file_merging_strategy is set to \'merge\' and '
                     'multiple top files were found. Merging order is not '

--- a/salt/state.py
+++ b/salt/state.py
@@ -2483,12 +2483,10 @@ class BaseHighState(object):
         envs = ['base']
         if 'file_roots' in self.opts:
             envs.extend(list(self.opts['file_roots']))
-        client_envs = self.client.envs()
         env_order = self.opts.get('env_order', [])
         client_envs = self.client.envs()
         if env_order and client_envs:
-            client_env_list = self.client.envs()
-            env_intersection = set(env_order).intersection(client_env_list)
+            env_intersection = set(env_order).intersection(client_envs)
             final_list = []
             for ord_env in env_order:
                 if ord_env in env_intersection:


### PR DESCRIPTION
### What does this PR do?

According to the documentation, the `env_order` config option allows one to explicitly define the order in which top files are evaluated, when `top_file_merging_strategy` is set to merge, and no environment is specified for a highstate.

Despite honoring the environment order specified in `env_order` in `BaseHighState._get_envs()` in the beginning, this function converts the perfectly ordered environment list into a set (to remove duplicates) and thus destroys the order and the purpose of this configuration option.

Thus change `_get_envs()` to return a list instead of a set and remove duplicate entries before returning the list. All three users of this internal function just iterate over the envs (and therefore just require an iterable type as response).

In addition, remove duplicate code and simplify `_get_envs()` by using list comprehensions.
### What issues does this PR fix or reference?

This PR fixes #29104
### Tests written?

No
