### PR TITLE
Allow VMs created from scratch to be assigned to a specific host

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2558,7 +2558,7 @@ def create(vm_):
                 task = folder_ref.CreateVM_Task(config_spec, resourcepool_ref, host_ref)
             else:
                 task = folder_ref.CreateVM_Task(config_spec, resourcepool_ref)
-            salt.utils.vmware.wait_for_task(task, vm_name, "create", 5, 'info')
+            salt.utils.vmware.wait_for_task(task, vm_name, "create", 15, 'info')
     except Exception as exc:
         err_msg = 'Error creating {0}: {1}'.format(vm_['name'], exc)
         log.error(
@@ -2571,9 +2571,13 @@ def create(vm_):
     new_vm_ref = salt.utils.vmware.get_mor_by_property(_get_si(), vim.VirtualMachine, vm_name, container_ref=container_ref)
 
     # Find how to power on in CreateVM_Task (if possible), for now this will do
-    if not clone_type and power:
-        task = new_vm_ref.PowerOn()
-        salt.utils.vmware.wait_for_task(task, vm_name, 'power', 5, 'info')
+    try:
+        if not clone_type and power:
+            task = new_vm_ref.PowerOn()
+            salt.utils.vmware.wait_for_task(task, vm_name, 'power', 5, 'info')
+    except Exception as exc:
+        log.info('Powering on the VM threw this exception. Ignoring.')
+        log.info(exc)
 
     # If it a template or if it does not need to be powered on then do not wait for the IP
     out = None

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2919,7 +2919,7 @@ def is_profile_configured(opts, provider, profile_name, vm_=None):
         required_keys.append('image')
         if driver == 'vmware':
             required_keys.append('datastore')
-    elif driver in ['linode', 'virtualbox', 'vmware']:
+    elif driver in ['linode', 'virtualbox']:
         required_keys.append('clonefrom')
     elif driver == 'nova':
         nova_image_keys = ['image', 'block_device_mapping', 'block_device', 'boot_volume']

--- a/tests/unit/cloud/clouds/vmware_test.py
+++ b/tests/unit/cloud/clouds/vmware_test.py
@@ -847,32 +847,6 @@ class VMwareTestCase(ExtendedTestCase):
             self.assertEqual(config.is_profile_configured(vmware.__opts__, 'vcenter01:vmware',
                                                           'base-gold', vm_=vm_), True)
 
-    @patch('salt.config.log')
-    def test_no_clonefrom_or_image_expect_fail(self, log_mock):
-        '''
-        Tests that not including the clonefrom property will result in an invalid profile
-        '''
-
-        profile_additions = {}
-
-        provider_config = deepcopy(PROVIDER_CONFIG)
-        profile = deepcopy(PROFILE)
-        profile['base-gold'].update(profile_additions)
-
-        provider_config_additions = {
-            'profiles': profile
-        }
-        provider_config['vcenter01']['vmware'].update(provider_config_additions)
-        vm_ = {'profile': profile}
-
-        with patch.dict(vmware.__opts__, {'providers': provider_config}, clean=True):
-            self.assertEqual(config.is_profile_configured(vmware.__opts__, 'vcenter01:vmware',
-                                                          'base-gold', vm_=vm_), False)
-            self.assertEqual(log_mock.error.call_args[0][0],
-                              "The required '{0}' configuration setting is missing from "
-                              "the '{1}' profile, which is configured under the '{2}' "
-                              'alias.'.format('clonefrom', 'base-gold', 'vcenter01'))
-
     @patch('salt.cloud.clouds.vmware.randint', return_value=101)
     def test_add_new_ide_controller_helper(self, randint_mock):
         '''


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the VMware driver that prevented non-cloned & non-templated VMs from being assigned to a specific host.  Also catches exception when trying to power on a VM--sometimes this throws a spurious error that is not relevant.
### What issues does this PR fix or reference?

Fixes #37151
### Previous Behavior

"From scratch" VMs in VMware would get assigned a host by vSphere.  The `host` key in the profiles file would be ignored.
### New Behavior

Specified host appears to be honored.
### Tests written?

No