### PR TITLE
remove unnecessary call of _get_defaults_from_image

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -1647,7 +1647,6 @@ def running(name,
         _validate_input(create_kwargs,
                         validate_ip_addrs=validate_ip_addrs)
 
-        defaults_from_image = _get_defaults_from_image(image_id)
         if create_kwargs.get('binds') is not None:
             # Be smart and try to provide `volumes` argument derived from the
             # "binds" configuration.


### PR DESCRIPTION
### What does this PR do?

remove an unused call of _get_defaults_from_image
it is later called when needed
### What issues does this PR fix or reference?

none
### Tests written?

No