### PR TITLE
Add 'refresh' option to 'pkg.list_pkgs'

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1244,6 +1244,7 @@ def _clean_pkglist(pkgs):
 def list_pkgs(versions_as_list=False,
               removed=False,
               purge_desired=False,
+              refresh=False,
               **kwargs):  # pylint: disable=W0613
     '''
     List the packages currently installed in a dict::
@@ -1265,6 +1266,13 @@ def list_pkgs(versions_as_list=False,
             Packages in this state now correctly show up in the output of this
             function.
 
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
+
     .. note:: External dependencies
 
         Virtual package resolution requires the ``dctrl-tools`` package to be
@@ -1281,7 +1289,7 @@ def list_pkgs(versions_as_list=False,
     removed = salt.utils.is_true(removed)
     purge_desired = salt.utils.is_true(purge_desired)
 
-    if 'pkg.list_pkgs' in __context__:
+    if not refresh and 'pkg.list_pkgs' in __context__:
         if removed:
             ret = copy.deepcopy(__context__['pkg.list_pkgs']['removed'])
         else:

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -363,11 +363,18 @@ def porttree_matches(name):
     return matches
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):
     '''
     List the packages currently installed in a dict::
 
         {'<package_name>': '<version>'}
+
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -381,7 +388,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
 
-    if 'pkg.list_pkgs' in __context__:
+    if not refresh and 'pkg.list_pkgs' in __context__:
         if versions_as_list:
             return __context__['pkg.list_pkgs']
         else:

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -249,7 +249,7 @@ def refresh_db():
     return True
 
 
-def list_pkgs(versions_as_list=False, with_origin=False, **kwargs):
+def list_pkgs(versions_as_list=False, with_origin=False, refresh=False, **kwargs):
     '''
     List the packages currently installed as a dict::
 
@@ -260,6 +260,13 @@ def list_pkgs(versions_as_list=False, with_origin=False, **kwargs):
         for each installed package.
 
         .. versionadded:: 2014.1.0
+
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -273,7 +280,7 @@ def list_pkgs(versions_as_list=False, with_origin=False, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
 
-    if 'pkg.list_pkgs' in __context__:
+    if not refresh and 'pkg.list_pkgs' in __context__:
         ret = copy.deepcopy(__context__['pkg.list_pkgs'])
         if not versions_as_list:
             __salt__['pkg_resource.stringify'](ret)

--- a/salt/modules/mac_brew.py
+++ b/salt/modules/mac_brew.py
@@ -91,11 +91,18 @@ def _call_brew(cmd, failhard=True):
     return result
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):
     '''
     List the packages currently installed in a dict::
 
         {'<package_name>': '<version>'}
+
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -109,7 +116,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
 
-    if 'pkg.list_pkgs' in __context__:
+    if not refresh and 'pkg.list_pkgs' in __context__:
         if versions_as_list:
             return __context__['pkg.list_pkgs']
         else:

--- a/salt/modules/mac_ports.py
+++ b/salt/modules/mac_ports.py
@@ -79,11 +79,18 @@ def _list(query=''):
     return ret
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):
     '''
     List the packages currently installed in a dict::
 
         {'<package_name>': '<version>'}
+
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -97,7 +104,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
 
-    if 'pkg.list_pkgs' in __context__:
+    if not refresh and 'pkg.list_pkgs' in __context__:
         if versions_as_list:
             return __context__['pkg.list_pkgs']
         else:

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -52,11 +52,18 @@ def __virtual__():
             'only available on OpenBSD systems.')
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):
     '''
     List the packages currently installed as a dict::
 
         {'<package_name>': '<version>'}
+
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -70,7 +77,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
 
-    if 'pkg.list_pkgs' in __context__:
+    if not refresh and 'pkg.list_pkgs' in __context__:
         if versions_as_list:
             return __context__['pkg.list_pkgs']
         else:

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -691,11 +691,18 @@ def _set_state(pkg, state):
     return ret
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):
     '''
     List the packages currently installed in a dict::
 
         {'<package_name>': '<version>'}
+
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -710,7 +717,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
 
-    if 'pkg.list_pkgs' in __context__:
+    if not refresh and 'pkg.list_pkgs' in __context__:
         if versions_as_list:
             return __context__['pkg.list_pkgs']
         else:

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -185,11 +185,18 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):
     '''
     List the packages currently installed as a dict::
 
         {'<package_name>': '<version>'}
+
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -203,7 +210,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
 
-    if 'pkg.list_pkgs' in __context__:
+    if not refresh and 'pkg.list_pkgs' in __context__:
         if versions_as_list:
             return __context__['pkg.list_pkgs']
         else:

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -239,12 +239,19 @@ def refresh_db():
     return True
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):
     '''
     .. versionchanged: 2016.3.0
     List the packages currently installed as a dict::
 
         {'<package_name>': '<version>'}
+
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -258,7 +265,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
 
-    if 'pkg.list_pkgs' in __context__:
+    if not refresh and 'pkg.list_pkgs' in __context__:
         if versions_as_list:
             return __context__['pkg.list_pkgs']
         else:

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -346,6 +346,7 @@ def list_pkgs(versions_as_list=False,
               chroot=None,
               root=None,
               with_origin=False,
+              refresh=False,
               **kwargs):
     '''
     List the packages currently installed as a dict::
@@ -369,6 +370,13 @@ def list_pkgs(versions_as_list=False,
 
         .. versionadded:: 2014.1.0
 
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
+
     CLI Example:
 
     .. code-block:: bash
@@ -386,7 +394,7 @@ def list_pkgs(versions_as_list=False,
     contextkey_pkg = _contextkey(jail, chroot, root)
     contextkey_origins = _contextkey(jail, chroot, root, prefix='pkg.origin')
 
-    if contextkey_pkg in __context__:
+    if not refresh and contextkey_pkg in __context__:
         ret = copy.deepcopy(__context__[contextkey_pkg])
         if not versions_as_list:
             __salt__['pkg_resource.stringify'](ret)

--- a/salt/modules/rest_package.py
+++ b/salt/modules/rest_package.py
@@ -28,7 +28,7 @@ def __virtual__():
     return (False, 'The rest_package execution module failed to load: only works on a rest_sample proxy minion.')
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):
     return __proxy__['rest_sample.package_list']()
 
 

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -232,11 +232,18 @@ def upgrade(refresh=False, **kwargs):
     return ret
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):
     '''
     List the currently installed packages as a dict::
 
         {'<package_name>': '<version>'}
+
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -249,7 +256,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
         for x in ('removed', 'purge_desired')]):
         return {}
 
-    if 'pkg.list_pkgs' in __context__:
+    if not refresh and 'pkg.list_pkgs' in __context__:
         if versions_as_list:
             return __context__['pkg.list_pkgs']
         else:

--- a/salt/modules/ssh_package.py
+++ b/salt/modules/ssh_package.py
@@ -30,7 +30,7 @@ def __virtual__():
     return (False, 'The ssh_package execution module failed to load: only works on an ssh_sample proxy minion.')
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):
     return __proxy__['ssh_sample.package_list']()
 
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -303,7 +303,7 @@ def version(*names, **kwargs):
     return ret
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):
     '''
     List the packages currently installed in a dict::
 
@@ -312,6 +312,13 @@ def list_pkgs(versions_as_list=False, **kwargs):
     :param bool refresh: Refresh package metadata. Default ``False`.
 
         {'<package_name>': '<version>'}
+
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -326,7 +333,6 @@ def list_pkgs(versions_as_list=False, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
     saltenv = kwargs.get('saltenv', 'base')
-    refresh = salt.utils.is_true(kwargs.get('refresh', False))
     _refresh_db_conditional(saltenv, force=refresh)
 
     ret = {}

--- a/salt/modules/xbpspkg.py
+++ b/salt/modules/xbpspkg.py
@@ -75,11 +75,18 @@ def _rehash():
         __salt__['cmd.run']('rehash', output_loglevel='trace')
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):  # pylint: disable=unused-argument
     '''
     List the packages currently installed as a dict::
 
         {'<package_name>': '<version>'}
+
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -94,6 +101,8 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
     cmd = 'xbps-query -l'
     ret = {}
+    # The current implementation always refreshes the installed packages
+    # cache. Due to this, 'refresh' is ignored.
     out = __salt__['cmd.run'](cmd, output_loglevel='trace')
     for line in out.splitlines():
         if not line:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -544,11 +544,18 @@ def version_cmp(pkg1, pkg2, ignore_epoch=False):
     return __salt__['lowpkg.version_cmp'](pkg1, pkg2, ignore_epoch=ignore_epoch)
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):
     '''
     List the packages currently installed in a dict::
 
         {'<package_name>': '<version>'}
+
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -562,7 +569,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
 
-    if 'pkg.list_pkgs' in __context__:
+    if not refresh and 'pkg.list_pkgs' in __context__:
         if versions_as_list:
             return __context__['pkg.list_pkgs']
         else:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -582,7 +582,7 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
     return __salt__['lowpkg.version_cmp'](ver1, ver2, ignore_epoch=ignore_epoch)
 
 
-def list_pkgs(versions_as_list=False, **kwargs):
+def list_pkgs(versions_as_list=False, refresh=False, **kwargs):
     '''
     List the packages currently installed as a dict with versions
     as a comma separated string::
@@ -600,6 +600,13 @@ def list_pkgs(versions_as_list=False, **kwargs):
     purge_desired:
         not supported
 
+    refresh
+        Whether to refresh the installed packages cache (internal to Salt)
+        if it exists.
+        Default: False.
+
+        .. versionadded:: Nitrogen
+
     CLI Example:
 
     .. code-block:: bash
@@ -612,7 +619,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
 
-    if 'pkg.list_pkgs' in __context__:
+    if not refresh and 'pkg.list_pkgs' in __context__:
         if versions_as_list:
             return __context__['pkg.list_pkgs']
         else:


### PR DESCRIPTION
### What does this PR do?

Add a `refresh` option to `pkg.list_pkgs` for all modules that
have virtual name `pkg`. The option is documented as follows:

refresh: Whether to refresh the installed packages cache (internal to
         Salt) if it exists.
         Default: False.

The reason for why such an option is desirable is that if a package is
installed or removed after the installed package list is cached by means
outside of Salt (eg via native package command line), the installed
package list returned will be out of date. This option ensures that
the package list returned is current regardless of external influences.
### Tests written?

No

Signed-off-by: Sergey Kizunov sergey.kizunov@ni.com
