### PR TITLE
Address transport test hang

### DIFF
--- a/tests/unit/transport/zeromq_test.py
+++ b/tests/unit/transport/zeromq_test.py
@@ -6,6 +6,7 @@
 # Import python libs
 from __future__ import absolute_import
 import os
+import time
 import threading
 import platform
 
@@ -81,10 +82,18 @@ class BaseZMQReqCase(TestCase):
     def tearDownClass(cls):
         # Attempting to kill the children hangs the test suite.
         # Let the test suite handle this instead.
-        # cls.process_manager.kill_children()
-        # time.sleep(2)  # Give the procs a chance to fully close before we stop the io_loop
+        cls.process_manager.kill_children()
+        time.sleep(2)  # Give the procs a chance to fully close before we stop the io_loop
         cls.io_loop.stop()
         cls.server_channel.close()
+        del cls.server_channel
+
+    @classmethod
+    def _handle_payload(cls, payload):
+        '''
+        TODO: something besides echo
+        '''
+        return payload, {'fun': 'send_clear'}
 
 
 class ClearReqTestCases(BaseZMQReqCase, ReqChannelMixin):


### PR DESCRIPTION
It would appear that if an attribute error is raised when trying to detect a class atter,
that the test suite does not run the class teardown method but continues regardless. This
fixes the class attr error which then allows the teardown to run. Prior to this, if the
teardown did not run, the entire suite would hang out shutdown because it was blocked
on waiting for a ioloop to terminate.
