### PR TITLE
Issue #37187 Do not parse first /proc/1/cmdline binary if it's not *b…

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1218,7 +1218,7 @@ def os_data():
                 with salt.utils.fopen('/proc/1/cmdline') as fhr:
                     init_cmdline = fhr.read().replace('\x00', ' ').split()
                     init_bin = salt.utils.which(init_cmdline[0])
-                    if init_bin is not None:
+                    if init_bin is not None and init_bin.endswith('bin/init'):
                         supported_inits = (six.b('upstart'), six.b('sysvinit'), six.b('systemd'))
                         edge_len = max(len(x) for x in supported_inits) - 1
                         try:
@@ -1247,6 +1247,8 @@ def os_data():
                                 'Unable to read from init_bin ({0}): {1}'
                                 .format(init_bin, exc)
                             )
+                    elif salt.utils.which('supervisord') in init_cmdline:
+                        grains['init'] = 'supervisord'
                     else:
                         log.error(
                             'Could not determine init location from command line: ({0})'


### PR DESCRIPTION
### What does this PR do?

Do not attempt to determine the grains 'init' if the first binary used in /proc/1/cmdline is not ending with 'bin/init'
Also set 'supervisord' for this grains if supervisord is used.
### What issues does this PR fix or reference?
#37187
### Previous Behavior

The minion would attempt to read the first binary in /proc/1/cmdline. In the case of supervisord, that would be /usr/bin/python, which surprisingly lead to 'systemd' in grains['init']
### New Behavior

Return 'supervisord' if it's the init system.
Do not try to read the first binary if not ending with "bin/init"
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
