### PR TITLE
Fix freeipa ldap groups

### DIFF
--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -341,14 +341,14 @@ def groups(username, **kwargs):
                 if 'cn' in entry:
                     group_list.append(entry['cn'][0])
             log.debug('User {0} is a member of groups: {1}'.format(username, group_list))
-            
-        if _config('freeipa'):
+
+        elif _config('freeipa'):
             escaped_username = ldap.filter.escape_filter_chars(username)
             search_base = _config('group_basedn')
             search_string = _render_template(_config('group_filter'), escaped_username)
-            search_results = bind.search_s(search_base, 
-                                           ldap.SCOPE_SUBTREE, 
-                                           search_string, 
+            search_results = bind.search_s(search_base,
+                                           ldap.SCOPE_SUBTREE,
+                                           search_string,
                                            [_config('accountattributename'), 'cn'])
 
             for entry, result in search_results:

--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -341,6 +341,26 @@ def groups(username, **kwargs):
                 if 'cn' in entry:
                     group_list.append(entry['cn'][0])
             log.debug('User {0} is a member of groups: {1}'.format(username, group_list))
+            
+        if _config('freeipa'):
+            escaped_username = ldap.filter.escape_filter_chars(username)
+            search_base = _config('group_basedn')
+            search_string = _render_template(_config('group_filter'), escaped_username)
+            search_results = bind.search_s(search_base, 
+                                           ldap.SCOPE_SUBTREE, 
+                                           search_string, 
+                                           [_config('accountattributename'), 'cn'])
+
+            for entry, result in search_results:
+                for user in result[_config('accountattributename')]:
+                    if username == user.split(',')[0].split('=')[-1]:
+                        group_list.append(entry.split(',')[0].split('=')[-1])
+
+            log.debug('User {0} is a member of groups: {1}'.format(username, group_list))
+
+            if not auth(username, kwargs['password']):
+                log.error('LDAP username and password do not match')
+                return []
         else:
             if _config('groupou'):
                 search_base = 'ou={0},{1}'.format(_config('groupou'), _config('basedn'))


### PR DESCRIPTION
### What does this PR do?

Add support to authenticate an LDAP group via FreeIPA
### What issues does this PR fix or reference?

Issuse #36148
### Previous Behavior

Unable to grant users permissions based on groups when authenticating against FreeIPA
### New Behavior

With the addition of 3 new config options, it is now possible to grant users permissions based on groups.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.