### PR TITLE
Add Amazon Kinesis support via boto3

### DIFF
--- a/salt/modules/boto_kinesis.py
+++ b/salt/modules/boto_kinesis.py
@@ -81,6 +81,10 @@ def _get_basic_stream(stream_name, conn):
     '''
     Stream info from AWS, via describe_stream
     Only returns the first "page" of shards (up to 100); use _get_full_stream() for all shards.
+
+    CLI example::
+
+        salt myminion boto_kinesis._get_basic_stream my_stream existing_conn
     '''
     return _execute_with_retries(conn, "describe_stream", StreamName=stream_name)
 
@@ -88,6 +92,10 @@ def _get_basic_stream(stream_name, conn):
 def _get_full_stream(stream_name, region=None, key=None, keyid=None, profile=None):
     '''
     Get complete stream info from AWS, via describe_stream, including all shards.
+
+    CLI example::
+
+        salt myminion boto_kinesis._get_full_stream my_stream region=us-east-1
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     r = {}
@@ -112,6 +120,10 @@ def get_stream_when_active(stream_name, region=None, key=None, keyid=None, profi
     Get complete stream info from AWS, returning only when the stream is in the ACTIVE state.
     Continues to retry when stream is updating or creating.
     If the stream is deleted during retries, the loop will catch the error and break.
+
+    CLI example::
+
+        salt myminion boto_kinesis.get_stream_when_active my_stream region=us-east-1
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
@@ -138,6 +150,10 @@ def get_stream_when_active(stream_name, region=None, key=None, keyid=None, profi
 def exists(stream_name, region=None, key=None, keyid=None, profile=None):
     '''
     Check if the stream exists. Returns False and the error if it does not.
+
+    CLI example::
+
+        salt myminion boto_kinesis.exists my_stream region=us-east-1
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     r = {}
@@ -155,6 +171,10 @@ def exists(stream_name, region=None, key=None, keyid=None, profile=None):
 def create_stream(stream_name, num_shards, region=None, key=None, keyid=None, profile=None):
     '''
     Create a stream with name stream_name and initial number of shards num_shards.
+
+    CLI example::
+
+        salt myminion boto_kinesis.create_stream my_stream N region=us-east-1
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     r = _execute_with_retries(conn,
@@ -169,6 +189,10 @@ def create_stream(stream_name, num_shards, region=None, key=None, keyid=None, pr
 def delete_stream(stream_name, region=None, key=None, keyid=None, profile=None):
     '''
     Delete the stream with name stream_name. This cannot be undone! All data will be lost!!
+
+    CLI example::
+
+        salt myminion boto_kinesis.delete_stream my_stream region=us-east-1
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     r = _execute_with_retries(conn,
@@ -183,6 +207,10 @@ def increase_stream_retention_period(stream_name, retention_hours,
                                      region=None, key=None, keyid=None, profile=None):
     '''
     Increase stream retention period to retention_hours
+
+    CLI example::
+
+        salt myminion boto_kinesis.increase_stream_retention_period my_stream N region=us-east-1
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     r = _execute_with_retries(conn,
@@ -198,6 +226,10 @@ def decrease_stream_retention_period(stream_name, retention_hours,
                                      region=None, key=None, keyid=None, profile=None):
     '''
     Decrease stream retention period to retention_hours
+
+    CLI example::
+
+        salt myminion boto_kinesis.decrease_stream_retention_period my_stream N region=us-east-1
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     r = _execute_with_retries(conn,
@@ -213,6 +245,10 @@ def enable_enhanced_monitoring(stream_name, metrics,
                                region=None, key=None, keyid=None, profile=None):
     '''
     Enable enhanced monitoring for the specified shard-level metrics on stream stream_name
+
+    CLI example::
+
+        salt myminion boto_kinesis.enable_enhanced_monitoring my_stream ["metrics", "to", "enable"] region=us-east-1
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     r = _execute_with_retries(conn,
@@ -229,6 +265,10 @@ def disable_enhanced_monitoring(stream_name, metrics,
                                 region=None, key=None, keyid=None, profile=None):
     '''
     Disable enhanced monitoring for the specified shard-level metrics on stream stream_name
+
+    CLI example::
+
+        salt myminion boto_kinesis.disable_enhanced_monitoring my_stream ["metrics", "to", "disable"] region=us-east-1
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     r = _execute_with_retries(conn,
@@ -246,6 +286,10 @@ def get_info_for_reshard(stream_details):
     Collect some data: number of open shards, key range, etc.
     Modifies stream_details to add a sorted list of OpenShards.
     Returns (min_hash_key, max_hash_key, stream_details)
+
+    CLI example::
+
+        salt myminion boto_kinesis.get_info_for_reshard existing_stream_details
     """
     min_hash_key = 0
     max_hash_key = 0
@@ -276,6 +320,10 @@ def long_int(hash_key):
     It's necessary to convert to int/long for comparison operations.
     This helper method handles python 2/3 incompatibility
 
+    CLI example::
+
+        salt myminion boto_kinesis.long_int some_MD5_hash_as_string
+
     :return: long object if python 2.X, int object if python 3.X
     """
     if sys.version_info < (3,):
@@ -290,6 +338,12 @@ def reshard(stream_name, desired_size, force=False,
     Reshard a kinesis stream.  Each call to this function will wait until the stream is ACTIVE,
     then make a single split or merge operation. This function decides where to split or merge
     with the assumption that the ultimate goal is a balanced partition space.
+
+    For safety, user must past in force=True; otherwise, the function will dry run.
+
+    CLI example::
+
+        salt myminion boto_kinesis.reshard my_stream N True region=us-east-1
 
     :return: True if a split or merge was found/performed, False if nothing is needed
     """
@@ -388,6 +442,10 @@ def reshard(stream_name, desired_size, force=False,
 def _get_next_open_shard(stream_details, shard_id):
     '''
     Return the next open shard after shard_id
+
+    CLI example::
+
+        salt myminion boto_kinesis._get_next_open_shard existing_stream_details shard_id
     '''
     found = False
     for shard in stream_details["OpenShards"]:
@@ -417,6 +475,10 @@ def _execute_with_retries(conn, function, **kwargs):
     Returns:
         The result dict with the HTTP response and JSON data if applicable
         as 'result', or an error as 'error'
+
+    CLI example::
+
+        salt myminion boto_kinesis._execute_with_retries existing_conn function_name function_kwargs
 
     '''
     r = {}
@@ -448,5 +510,9 @@ def _execute_with_retries(conn, function, **kwargs):
 def _jittered_backoff(attempt, max_retry_delay):
     '''
     Basic exponential backoff
+
+    CLI example::
+
+        salt myminion boto_kinesis._jittered_backoff current_attempt_number max_delay_in_seconds
     '''
     return min(random.random() * (2 ** attempt), max_retry_delay)

--- a/salt/modules/boto_kinesis.py
+++ b/salt/modules/boto_kinesis.py
@@ -1,0 +1,436 @@
+# -*- coding: utf-8 -*-
+'''
+Connection module for Amazon Kinesis
+
+.. versionadded:: develop
+
+:configuration: This module accepts explicit Kinesis credentials but can also
+    utilize IAM roles assigned to the instance trough Instance Profiles.
+    Dynamic credentials are then automatically obtained from AWS API and no
+    further configuration is necessary. More Information available at:
+
+    .. code-block:: text
+
+        http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file:
+
+    .. code-block:: yaml
+
+        kinesis.keyid: GKTADJGHEIQSXMKKRBJ08H
+        kinesis.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration:
+
+    .. code-block:: yaml
+
+        kinesis.region: us-east-1
+
+    If a region is not specified, the default is us-east-1.
+
+    It's also possible to specify key, keyid and region via a profile, either
+    as a passed in dict, or as a string to pull from pillars or minion config:
+
+    .. code-block:: yaml
+
+        myprofile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+:depends: boto3
+
+'''
+# keep lint from choking on _get_conn
+#pylint: disable=E0602
+
+# Import Python libs
+from __future__ import absolute_import
+import logging
+import time
+import random
+
+# Import third party libs
+# pylint: disable=unused-import
+try:
+    import boto3
+    import botocore
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+# pylint: enable=unused-import
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if boto3 libraries exist.
+    '''
+    if not HAS_BOTO:
+        return False
+    __utils__['boto3.assign_funcs'](__name__, 'kinesis')
+    return True
+
+
+def _get_basic_stream(stream_name, conn):
+    '''
+    Stream info from AWS, via describe_stream
+    Only returns the first "page" of shards (up to 100); use _get_full_stream() for all shards.
+    '''
+    return _execute_with_retries(conn, "describe_stream", StreamName=stream_name)
+
+
+def _get_full_stream(stream_name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Get complete stream info from AWS, via describe_stream, including all shards.
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    r = {}
+    stream = _get_basic_stream(stream_name, conn)['result']
+    full_stream = stream
+
+    # iterate through if there are > 100 shards (max that AWS will return from describe_stream)
+    while stream["StreamDescription"]["HasMoreShards"]:
+        stream = _execute_with_retries(conn,
+                                       "describe_stream",
+                                       StreamName=stream_name,
+                                       ExclusiveStartShardId=stream["StreamDescription"]["Shards"][-1]["ShardId"])
+        stream = stream['result']
+        full_stream["StreamDescription"]["Shards"] += stream["StreamDescription"]["Shards"]
+
+    r['result'] = full_stream
+    return r
+
+
+def get_stream_when_active(stream_name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Get complete stream info from AWS, returning only when the stream is in the ACTIVE state.
+    Continues to retry when stream is updating or creating.
+    If the stream is deleted during retries, the loop will catch the error and break.
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    stream_status = None
+    # only get basic stream until it's active,
+    # so we don't pull the full list of shards repeatedly (in case of very large stream)
+    attempt = 0
+    max_retry_delay = 10
+    while stream_status != "ACTIVE":
+        time.sleep(_jittered_backoff(attempt, max_retry_delay))
+        attempt += 1
+        stream_response = _get_basic_stream(stream_name, conn)
+        if 'error' in stream_response:
+            return stream_response
+        stream_status = stream_response['result']["StreamDescription"]["StreamStatus"]
+
+    # now it's active, get the full stream if necessary
+    if stream_response['result']["StreamDescription"]["HasMoreShards"]:
+        stream_response = _get_full_stream(stream_name, region, key, keyid, profile)
+
+    return stream_response
+
+
+def exists(stream_name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Check if the stream exists. Returns False and the error if it does not.
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    r = {}
+
+    stream = _get_basic_stream(stream_name, conn)
+    if 'error' in stream:
+        r['result'] = False
+        r['error'] = stream['error']
+    else:
+        r['result'] = True
+
+    return r
+
+
+def create_stream(stream_name, num_shards, region=None, key=None, keyid=None, profile=None):
+    '''
+    Create a stream with name stream_name and initial number of shards num_shards.
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    r = _execute_with_retries(conn,
+                              "create_stream",
+                              ShardCount=num_shards,
+                              StreamName=stream_name)
+    if 'error' not in r:
+        r['result'] = True
+    return r
+
+
+def delete_stream(stream_name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Delete the stream with name stream_name. This cannot be undone! All data will be lost!!
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    r = _execute_with_retries(conn,
+                              "delete_stream",
+                              StreamName=stream_name)
+    if 'error' not in r:
+        r['result'] = True
+    return r
+
+
+def increase_stream_retention_period(stream_name, retention_hours,
+                                     region=None, key=None, keyid=None, profile=None):
+    '''
+    Increase stream retention period to retention_hours
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    r = _execute_with_retries(conn,
+                              "increase_stream_retention_period",
+                              StreamName=stream_name,
+                              RetentionPeriodHours=retention_hours)
+    if 'error' not in r:
+        r['result'] = True
+    return r
+
+
+def decrease_stream_retention_period(stream_name, retention_hours,
+                                     region=None, key=None, keyid=None, profile=None):
+    '''
+    Decrease stream retention period to retention_hours
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    r = _execute_with_retries(conn,
+                              "decrease_stream_retention_period",
+                              StreamName=stream_name,
+                              RetentionPeriodHours=retention_hours)
+    if 'error' not in r:
+        r['result'] = True
+    return r
+
+
+def enable_enhanced_monitoring(stream_name, metrics,
+                               region=None, key=None, keyid=None, profile=None):
+    '''
+    Enable enhanced monitoring for the specified shard-level metrics on stream stream_name
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    r = _execute_with_retries(conn,
+                              "enable_enhanced_monitoring",
+                              StreamName=stream_name,
+                              ShardLevelMetrics=metrics)
+
+    if 'error' not in r:
+        r['result'] = True
+    return r
+
+
+def disable_enhanced_monitoring(stream_name, metrics,
+                                region=None, key=None, keyid=None, profile=None):
+    '''
+    Disable enhanced monitoring for the specified shard-level metrics on stream stream_name
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    r = _execute_with_retries(conn,
+                              "disable_enhanced_monitoring",
+                              StreamName=stream_name,
+                              ShardLevelMetrics=metrics)
+
+    if 'error' not in r:
+        r['result'] = True
+    return r
+
+
+def get_info_for_reshard(stream_details):
+    """
+    Collect some data: number of open shards, key range, etc.
+    Modifies stream_details to add a sorted list of OpenShards.
+    Returns (min_hash_key, max_hash_key, stream_details)
+    """
+    min_hash_key = 0
+    max_hash_key = 0
+    stream_details["OpenShards"] = []
+    for shard in stream_details["Shards"]:
+        shard_id = shard["ShardId"]
+        if "EndingSequenceNumber" in shard["SequenceNumberRange"]:
+            # EndingSequenceNumber is null for open shards, so this shard must be closed
+            log.debug("skipping closed shard {}".format(shard_id))
+            continue
+        stream_details["OpenShards"].append(shard)
+        shard["HashKeyRange"]["StartingHashKey"] = long(
+            shard["HashKeyRange"]["StartingHashKey"])
+        shard["HashKeyRange"]["EndingHashKey"] = long(
+            shard["HashKeyRange"]["EndingHashKey"])
+        if shard["HashKeyRange"]["StartingHashKey"] < min_hash_key:
+            min_hash_key = shard["HashKeyRange"]["StartingHashKey"]
+        if shard["HashKeyRange"]["EndingHashKey"] > max_hash_key:
+            max_hash_key = shard["HashKeyRange"]["EndingHashKey"]
+    stream_details["OpenShards"].sort(key=lambda shard: long(
+        shard["HashKeyRange"]["StartingHashKey"]))
+    return min_hash_key, max_hash_key, stream_details
+
+
+def reshard(stream_name, desired_size, force=False,
+            region=None, key=None, keyid=None, profile=None):
+    """
+    Reshard a kinesis stream.  Each call to this function will wait until the stream is ACTIVE,
+    then make a single split or merge operation. This function decides where to split or merge
+    with the assumption that the ultimate goal is a balanced partition space.
+
+    :return: True if a split or merge was found/performed, False if nothing is needed
+    """
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    r = {}
+
+    stream_response = get_stream_when_active(stream_name, region, key, keyid, profile)
+    if 'error' in stream_response:
+        return stream_response
+
+    stream_details = stream_response['result']["StreamDescription"]
+    min_hash_key, max_hash_key, stream_details = get_info_for_reshard(stream_details)
+
+    log.debug("found {} open shards, min_hash_key {} max_hash_key {}".format(
+        len(stream_details["OpenShards"]), min_hash_key, max_hash_key))
+
+    # find the first open shard that doesn't match the desired pattern. When we find it,
+    # either split or merge (depending on if it's too big or too small), and then return.
+    for shard_num, shard in enumerate(stream_details["OpenShards"]):
+        shard_id = shard["ShardId"]
+        if "EndingSequenceNumber" in shard["SequenceNumberRange"]:
+            # something went wrong, there's a closed shard in our open shard list
+            log.debug("this should never happen! closed shard {}".format(shard_id))
+            continue
+
+        starting_hash_key = shard["HashKeyRange"]["StartingHashKey"]
+        ending_hash_key = shard["HashKeyRange"]["EndingHashKey"]
+        # this weird math matches what AWS does when you create a kinesis stream
+        # with an initial number of shards.
+        expected_starting_hash_key = (
+            max_hash_key - min_hash_key) / desired_size * shard_num + shard_num
+        expected_ending_hash_key = (
+            max_hash_key - min_hash_key) / desired_size * (shard_num + 1) + shard_num
+        # fix an off-by-one at the end
+        if expected_ending_hash_key > max_hash_key:
+            expected_ending_hash_key = max_hash_key
+
+        log.debug("Shard {} ({}) should start at {}: {}".format(shard_num, shard_id, expected_starting_hash_key,
+                                                                starting_hash_key == expected_starting_hash_key
+                                                                ))
+        log.debug("Shard {} ({}) should end at {}: {}".format(shard_num, shard_id, expected_ending_hash_key,
+                                                              ending_hash_key == expected_ending_hash_key
+                                                              ))
+
+        if starting_hash_key != expected_starting_hash_key:
+            r['error'] = "starting hash keys mismatch, don't know what to do!"
+            return r
+
+        if ending_hash_key == expected_ending_hash_key:
+            continue
+
+        if ending_hash_key > expected_ending_hash_key + 1:
+            # split at expected_ending_hash_key
+            if force:
+                log.debug("{} should end at {}, actual {}, splitting".format(
+                    shard_id, expected_ending_hash_key, ending_hash_key))
+                r = _execute_with_retries(conn,
+                                          "split_shard",
+                                          StreamName=stream_name,
+                                          ShardToSplit=shard_id,
+                                          NewStartingHashKey=str(expected_ending_hash_key + 1))
+            else:
+                log.debug("{} should end at {}, actual {} would split".format(
+                    shard_id, expected_ending_hash_key, ending_hash_key))
+
+            if 'error' not in r:
+                r['result'] = True
+            return r
+        else:
+            # merge
+            next_shard_id = _get_next_open_shard(stream_details, shard_id)
+            if not next_shard_id:
+                r['error'] = "failed to find next shard after {}".format(shard_id)
+                return r
+            if force:
+                log.debug("{} should continue past {}, merging with {}".format(
+                    shard_id, ending_hash_key, next_shard_id))
+                r = _execute_with_retries(conn,
+                                          "merge_shards",
+                                          StreamName=stream_name,
+                                          ShardToMerge=shard_id,
+                                          AdjacentShardToMerge=next_shard_id)
+            else:
+                log.debug("{} should continue past {}, would merge with {}".format(
+                    shard_id, ending_hash_key, next_shard_id))
+
+            if 'error' not in r:
+                r['result'] = True
+            return r
+
+    log.debug("No split or merge action necessary")
+    r['result'] = False
+    return r
+
+
+def _get_next_open_shard(stream_details, shard_id):
+    '''
+    Return the next open shard after shard_id
+    '''
+    found = False
+    for shard in stream_details["OpenShards"]:
+        current_shard_id = shard["ShardId"]
+        if current_shard_id == shard_id:
+            found = True
+            continue
+        if found:
+            return current_shard_id
+
+
+def _execute_with_retries(conn, function, **kwargs):
+    '''
+    Retry if we're rate limited by AWS or blocked by another call.
+    Give up and return error message if resource not found or argument is invalid.
+
+    conn
+        The connection established by the calling method via _get_conn()
+
+    function
+        The function to call on conn. i.e. create_stream
+
+    **kwargs
+        Any kwargs required by the above function, with their keywords
+        i.e. StreamName=stream_name
+
+    Returns:
+        The result dict with the HTTP response and JSON data if applicable
+        as 'result', or an error as 'error'
+
+    '''
+    r = {}
+    max_attempts = 18
+    max_retry_delay = 10
+    for attempt in range(max_attempts):
+        log.info("attempt: {} function: {}".format(attempt, function))
+        try:
+            fn = getattr(conn, function)
+            r['result'] = fn(**kwargs)
+            return r
+        except botocore.exceptions.ClientError as e:
+            error_code = e.response['Error']['Code']
+            if "LimitExceededException" in error_code or "ResourceInUseException" in error_code:
+                # could be rate limited by AWS or another command is blocking,
+                # retry with exponential backoff
+                log.debug("Retrying due to AWS exception {}".format(e))
+                time.sleep(_jittered_backoff(attempt, max_retry_delay))
+            else:
+                # ResourceNotFoundException or InvalidArgumentException
+                r['error'] = e.response['Error']
+                r['result'] = None
+                return r
+
+    r['error'] = "Tried to execute function {} {} times, but was unable".format(function, max_attempts)
+    return r
+
+
+def _jittered_backoff(attempt, max_retry_delay):
+    '''
+    Basic exponential backoff
+    '''
+    return min(random.random() * (2 ** attempt), max_retry_delay)

--- a/salt/modules/boto_kinesis.py
+++ b/salt/modules/boto_kinesis.py
@@ -43,7 +43,7 @@ Connection module for Amazon Kinesis
 
 '''
 # keep lint from choking on _get_conn
-#pylint: disable=E0602
+# pylint: disable=E0602
 
 # Import Python libs
 from __future__ import absolute_import
@@ -252,7 +252,7 @@ def get_info_for_reshard(stream_details):
         shard_id = shard["ShardId"]
         if "EndingSequenceNumber" in shard["SequenceNumberRange"]:
             # EndingSequenceNumber is null for open shards, so this shard must be closed
-            log.debug("skipping closed shard {}".format(shard_id))
+            log.debug("skipping closed shard {0}".format(shard_id))
             continue
         stream_details["OpenShards"].append(shard)
         shard["HashKeyRange"]["StartingHashKey"] = long(
@@ -287,7 +287,7 @@ def reshard(stream_name, desired_size, force=False,
     stream_details = stream_response['result']["StreamDescription"]
     min_hash_key, max_hash_key, stream_details = get_info_for_reshard(stream_details)
 
-    log.debug("found {} open shards, min_hash_key {} max_hash_key {}".format(
+    log.debug("found {0} open shards, min_hash_key {1} max_hash_key {2}".format(
         len(stream_details["OpenShards"]), min_hash_key, max_hash_key))
 
     # find the first open shard that doesn't match the desired pattern. When we find it,
@@ -296,7 +296,7 @@ def reshard(stream_name, desired_size, force=False,
         shard_id = shard["ShardId"]
         if "EndingSequenceNumber" in shard["SequenceNumberRange"]:
             # something went wrong, there's a closed shard in our open shard list
-            log.debug("this should never happen! closed shard {}".format(shard_id))
+            log.debug("this should never happen! closed shard {0}".format(shard_id))
             continue
 
         starting_hash_key = shard["HashKeyRange"]["StartingHashKey"]
@@ -311,10 +311,10 @@ def reshard(stream_name, desired_size, force=False,
         if expected_ending_hash_key > max_hash_key:
             expected_ending_hash_key = max_hash_key
 
-        log.debug("Shard {} ({}) should start at {}: {}".format(shard_num, shard_id, expected_starting_hash_key,
+        log.debug("Shard {0} ({1}) should start at {2}: {3}".format(shard_num, shard_id, expected_starting_hash_key,
                                                                 starting_hash_key == expected_starting_hash_key
                                                                 ))
-        log.debug("Shard {} ({}) should end at {}: {}".format(shard_num, shard_id, expected_ending_hash_key,
+        log.debug("Shard {0} ({1}) should end at {2}: {3}".format(shard_num, shard_id, expected_ending_hash_key,
                                                               ending_hash_key == expected_ending_hash_key
                                                               ))
 
@@ -328,7 +328,7 @@ def reshard(stream_name, desired_size, force=False,
         if ending_hash_key > expected_ending_hash_key + 1:
             # split at expected_ending_hash_key
             if force:
-                log.debug("{} should end at {}, actual {}, splitting".format(
+                log.debug("{0} should end at {1}, actual {2}, splitting".format(
                     shard_id, expected_ending_hash_key, ending_hash_key))
                 r = _execute_with_retries(conn,
                                           "split_shard",
@@ -336,7 +336,7 @@ def reshard(stream_name, desired_size, force=False,
                                           ShardToSplit=shard_id,
                                           NewStartingHashKey=str(expected_ending_hash_key + 1))
             else:
-                log.debug("{} should end at {}, actual {} would split".format(
+                log.debug("{0} should end at {1}, actual {2} would split".format(
                     shard_id, expected_ending_hash_key, ending_hash_key))
 
             if 'error' not in r:
@@ -346,10 +346,10 @@ def reshard(stream_name, desired_size, force=False,
             # merge
             next_shard_id = _get_next_open_shard(stream_details, shard_id)
             if not next_shard_id:
-                r['error'] = "failed to find next shard after {}".format(shard_id)
+                r['error'] = "failed to find next shard after {0}".format(shard_id)
                 return r
             if force:
-                log.debug("{} should continue past {}, merging with {}".format(
+                log.debug("{0} should continue past {1}, merging with {2}".format(
                     shard_id, ending_hash_key, next_shard_id))
                 r = _execute_with_retries(conn,
                                           "merge_shards",
@@ -357,7 +357,7 @@ def reshard(stream_name, desired_size, force=False,
                                           ShardToMerge=shard_id,
                                           AdjacentShardToMerge=next_shard_id)
             else:
-                log.debug("{} should continue past {}, would merge with {}".format(
+                log.debug("{0} should continue past {1}, would merge with {2}".format(
                     shard_id, ending_hash_key, next_shard_id))
 
             if 'error' not in r:
@@ -407,7 +407,7 @@ def _execute_with_retries(conn, function, **kwargs):
     max_attempts = 18
     max_retry_delay = 10
     for attempt in range(max_attempts):
-        log.info("attempt: {} function: {}".format(attempt, function))
+        log.info("attempt: {0} function: {1}".format(attempt, function))
         try:
             fn = getattr(conn, function)
             r['result'] = fn(**kwargs)
@@ -417,7 +417,7 @@ def _execute_with_retries(conn, function, **kwargs):
             if "LimitExceededException" in error_code or "ResourceInUseException" in error_code:
                 # could be rate limited by AWS or another command is blocking,
                 # retry with exponential backoff
-                log.debug("Retrying due to AWS exception {}".format(e))
+                log.debug("Retrying due to AWS exception {0}".format(e))
                 time.sleep(_jittered_backoff(attempt, max_retry_delay))
             else:
                 # ResourceNotFoundException or InvalidArgumentException
@@ -425,7 +425,7 @@ def _execute_with_retries(conn, function, **kwargs):
                 r['result'] = None
                 return r
 
-    r['error'] = "Tried to execute function {} {} times, but was unable".format(function, max_attempts)
+    r['error'] = "Tried to execute function {0} {1} times, but was unable".format(function, max_attempts)
     return r
 
 

--- a/salt/modules/boto_kinesis.py
+++ b/salt/modules/boto_kinesis.py
@@ -51,6 +51,7 @@ import logging
 import time
 import random
 import sys
+from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
 # Import third party libs
 # pylint: disable=unused-import
@@ -278,7 +279,7 @@ def long_int(hash_key):
     :return: long object if python 2.X, int object if python 3.X
     """
     if sys.version_info < (3,):
-        return long(hash_key)
+        return long(hash_key)  # pylint: disable=incompatible-py3-code
     else:
         return int(hash_key)
 
@@ -327,11 +328,11 @@ def reshard(stream_name, desired_size, force=False,
             expected_ending_hash_key = max_hash_key
 
         log.debug("Shard {0} ({1}) should start at {2}: {3}".format(shard_num, shard_id, expected_starting_hash_key,
-                                                                starting_hash_key == expected_starting_hash_key
-                                                                ))
+                                                                    starting_hash_key == expected_starting_hash_key
+                                                                    ))
         log.debug("Shard {0} ({1}) should end at {2}: {3}".format(shard_num, shard_id, expected_ending_hash_key,
-                                                              ending_hash_key == expected_ending_hash_key
-                                                              ))
+                                                                  ending_hash_key == expected_ending_hash_key
+                                                                  ))
 
         if starting_hash_key != expected_starting_hash_key:
             r['error'] = "starting hash keys mismatch, don't know what to do!"

--- a/salt/modules/boto_kinesis.py
+++ b/salt/modules/boto_kinesis.py
@@ -278,9 +278,9 @@ def long_int(hash_key):
     :return: long object if python 2.X, int object if python 3.X
     """
     if sys.version_info < (3,):
-        return int(hash_key)
-    else:
         return long(hash_key)
+    else:
+        return int(hash_key)
 
 
 def reshard(stream_name, desired_size, force=False,

--- a/salt/states/boto_kinesis.py
+++ b/salt/states/boto_kinesis.py
@@ -1,0 +1,442 @@
+# -*- coding: utf-8 -*-
+'''
+Manage Kinesis Streams
+======================
+
+.. versionadded:: develop
+
+Create and destroy Kinesis streams. Be aware that this interacts with Amazon's
+services, and so may incur charges.
+
+This module uses ``boto3``, which can be installed via package, or pip.
+
+This module accepts explicit Kinesis credentials but can also utilize
+IAM roles assigned to the instance through Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More information available `here
+<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_.
+
+If IAM roles are not used you need to specify them either in a pillar file or
+in the minion's config file:
+
+.. code-block:: yaml
+
+    keyid: GKTADJGHEIQSXMKKRBJ08H
+    key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+    region: us-east-1
+
+It's also possible to specify ``key``, ``keyid`` and ``region`` via a
+profile, either passed in as a dict, or as a string to pull from
+pillars or minion config:
+
+.. code-block:: yaml
+
+    myprofile:
+        keyid: GKTADJGHEIQSXMKKRBJ08H
+        key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+.. code-block:: yaml
+
+    Ensure Kinesis stream does not exist:
+      boto_kinesis.absent:
+        - name: new_stream
+        - keyid: GKTADJGHEIQSXMKKRBJ08H
+        - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+        - region: us-east-1
+
+    Ensure Kinesis stream exists:
+      boto_kinesis.present:
+        - name: new_stream
+        - retention_hours: 168
+        - enhanced_monitoring: ['ALL']
+        - num_shards: 2
+        - keyid: GKTADJGHEIQSXMKKRBJ08H
+        - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+        - region: us-east-1
+'''
+# Import Python libs
+from __future__ import absolute_import
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if boto_kinesis is available.
+    '''
+    ret = 'boto_kinesis' if 'boto_kinesis.exists' in __salt__ else False
+    return ret
+
+
+def present(name,
+            retention_hours=None,
+            enhanced_monitoring=None,
+            num_shards=None,
+            do_reshard=True,
+            region=None,
+            key=None,
+            keyid=None,
+            profile=None):
+    '''
+    Ensure the kinesis stream is properly configured and scaled.
+
+    name (string)
+        Stream name
+
+    retention_hours (int)
+        Retain data for this many hours.
+        AWS allows minimum 24 hours, maximum 168 hours.
+
+    enhanced_monitoring (list of string)
+        Turn on enhanced monitoring for the specified shard-level metrics.
+        Pass in ['ALL'] or True for all metrics, [] or False for no metrics.
+        Turn on individual metrics by passing in a list: ['IncomingBytes', 'OutgoingBytes']
+        Note that if only some metrics are supplied, the remaining metrics will be turned off.
+
+    num_shards (int)
+        Reshard stream (if necessary) to this number of shards
+        !!!!! Resharding is expensive! Each split or merge can take up to 30 seconds,
+        and the reshard method balances the partition space evenly.
+        Resharding from N to N+1 can require 2N operations !!!!!
+
+    do_reshard (boolean)
+        If set to False, this script will NEVER reshard the stream,
+        regardless of other input. Useful for testing.
+
+    region (string)
+        Region to connect to.
+
+    key (string)
+        Secret key to be used.
+
+    keyid (string)
+        Access key to be used.
+
+    profile (dict)
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+    '''
+
+    ret = {'name': name, 'result': (None if __opts__['test'] else True), 'comment': '', 'changes': {}}
+
+    comments = []
+    changes_old = {}
+    changes_new = {}
+
+    # Ensure stream exists
+    exists = __salt__['boto_kinesis.exists'](
+        name,
+        region,
+        key,
+        keyid,
+        profile
+    )
+    if exists['result'] is False:
+        if __opts__['test']:
+            ret['result'] = None
+            comments.append('{} would be created'.format(name))
+            _add_changes(ret, changes_old, changes_new, comments)
+            return ret
+        else:
+            is_created = __salt__['boto_kinesis.create_stream'](
+                name,
+                num_shards,
+                region,
+                key,
+                keyid,
+                profile
+            )
+            if 'error' in is_created:
+                ret['result'] = False
+                comments.append('Failed to create stream {}: {}'.format(name, is_created['error']))
+                _add_changes(ret, changes_old, changes_new, comments)
+                return ret
+
+            comments.append('{}: successfully created'.format(name))
+            changes_new['name'] = name
+            changes_new['num_shards'] = num_shards
+    else:
+        comments.append('{}: already exists'.format(name))
+
+    stream_response = __salt__['boto_kinesis.get_stream_when_active'](
+        name,
+        region,
+        key,
+        keyid,
+        profile
+    )
+    if 'error' in stream_response:
+        ret['result'] = False
+        comments.append('{}: error getting description: {}'
+                        .format(name, stream_response['error']))
+        _add_changes(ret, changes_old, changes_new, comments)
+        return ret
+
+    stream_details = stream_response['result']["StreamDescription"]
+
+    # Configure retention hours
+    if retention_hours is not None:
+        old_retention_hours = stream_details["RetentionPeriodHours"]
+        retention_matches = (old_retention_hours == retention_hours)
+        if not retention_matches:
+            if __opts__['test']:
+                ret['result'] = None
+                comments.append('{}: retention hours would be updated to {}'.format(name, retention_hours))
+            else:
+                if old_retention_hours > retention_hours:
+                    retention_updated = __salt__['boto_kinesis.decrease_stream_retention_period'](
+                        name,
+                        retention_hours,
+                        region,
+                        key,
+                        keyid,
+                        profile
+                    )
+                else:
+                    retention_updated = __salt__['boto_kinesis.increase_stream_retention_period'](
+                        name,
+                        retention_hours,
+                        region,
+                        key,
+                        keyid,
+                        profile
+                    )
+
+                if 'error' in retention_updated:
+                    ret['result'] = False
+                    comments.append('{}: failed to update retention hours: {}'
+                                    .format(name, retention_updated['error']))
+                    _add_changes(ret, changes_old, changes_new, comments)
+                    return ret
+
+                comments.append('{}: retention hours was successfully updated'.format(name))
+                changes_old['retention_hours'] = old_retention_hours
+                changes_new['retention_hours'] = retention_hours
+
+                # wait until active again, otherwise it will log a lot of ResourceInUseExceptions
+                # note that this isn't required below; reshard() will itself handle waiting
+                stream_response = __salt__['boto_kinesis.get_stream_when_active'](
+                    name,
+                    region,
+                    key,
+                    keyid,
+                    profile
+                )
+                if 'error' in stream_response:
+                    ret['result'] = False
+                    comments.append('{}: error getting description: {}'
+                                    .format(name, stream_response['error']))
+                    _add_changes(ret, changes_old, changes_new, comments)
+                    return ret
+
+                stream_details = stream_response['result']["StreamDescription"]
+        else:
+            comments.append('{}: retention hours did not require change, already set at {}'
+                            .format(name, old_retention_hours))
+    else:
+        comments.append('{}: did not configure retention hours'.format(name))
+
+    # Configure enhanced monitoring
+    if enhanced_monitoring is not None:
+        if enhanced_monitoring is True or enhanced_monitoring == ['ALL']:
+            # for ease of comparison; describe_stream will always return the full list of metrics, never 'ALL'
+            enhanced_monitoring = [
+                    "IncomingBytes",
+                    "OutgoingRecords",
+                    "IteratorAgeMilliseconds",
+                    "IncomingRecords",
+                    "ReadProvisionedThroughputExceeded",
+                    "WriteProvisionedThroughputExceeded",
+                    "OutgoingBytes"
+                ]
+        elif enhanced_monitoring is False or enhanced_monitoring == "None":
+            enhanced_monitoring = []
+
+        old_enhanced_monitoring = stream_details.get("EnhancedMonitoring")[0]["ShardLevelMetrics"]
+
+        new_monitoring_set = set(enhanced_monitoring)
+        old_monitoring_set = set(old_enhanced_monitoring)
+
+        matching_metrics = new_monitoring_set.intersection(old_monitoring_set)
+        enable_metrics = list(new_monitoring_set.difference(matching_metrics))
+        disable_metrics = list(old_monitoring_set.difference(matching_metrics))
+
+        if len(enable_metrics) != 0:
+            if __opts__['test']:
+                ret['result'] = None
+                comments.append('{}: would enable enhanced monitoring for {}'.format(name, enable_metrics))
+            else:
+
+                metrics_enabled = __salt__['boto_kinesis.enable_enhanced_monitoring'](
+                    name,
+                    enable_metrics,
+                    region,
+                    key,
+                    keyid,
+                    profile
+                )
+                if 'error' in metrics_enabled:
+                    ret['result'] = False
+                    comments.append('{}: failed to enable enhanced monitoring: {}'
+                                    .format(name, metrics_enabled['error']))
+                    _add_changes(ret, changes_old, changes_new, comments)
+                    return ret
+
+                comments.append('{}: enhanced monitoring was enabled for shard-level metrics {}'
+                                .format(name, enable_metrics))
+
+        if len(disable_metrics) != 0:
+            if __opts__['test']:
+                ret['result'] = None
+                comments.append('{}: would disable enhanced monitoring for {}'.format(name, disable_metrics))
+            else:
+
+                metrics_disabled = __salt__['boto_kinesis.disable_enhanced_monitoring'](
+                    name,
+                    disable_metrics,
+                    region,
+                    key,
+                    keyid,
+                    profile
+                )
+                if 'error' in metrics_disabled:
+                    ret['result'] = False
+                    comments.append('{}: failed to disable enhanced monitoring: {}'
+                                    .format(name, metrics_disabled['error']))
+                    _add_changes(ret, changes_old, changes_new, comments)
+                    return ret
+
+                comments.append('{}: enhanced monitoring was disabled for shard-level metrics {}'
+                                .format(name, disable_metrics))
+
+        if len(disable_metrics) == 0 and len(enable_metrics) == 0:
+            comments.append('{}: enhanced monitoring did not require change, already set at {}'
+                            .format(name, (old_enhanced_monitoring if len(old_enhanced_monitoring) > 0
+                                                  else "None")))
+        elif not __opts__['test']:
+            changes_old['enhanced_monitoring'] = (old_enhanced_monitoring if len(old_enhanced_monitoring) > 0
+                                                  else "None")
+            changes_new['enhanced_monitoring'] = (enhanced_monitoring if len(enhanced_monitoring) > 0
+                                                  else "None")
+    else:
+        comments.append('{}: did not configure enhanced monitoring'.format(name))
+
+    # Reshard stream if necessary
+    min_hash_key, max_hash_key, full_stream_details = __salt__['boto_kinesis.get_info_for_reshard'](
+        stream_details
+    )
+    old_num_shards = len(full_stream_details["OpenShards"])
+
+    if num_shards is not None and do_reshard:
+        num_shards_matches = (old_num_shards == num_shards)
+        if not num_shards_matches:
+            if __opts__['test']:
+                ret['result'] = None
+                comments.append('{}: would be resharded from {} to {} shards'
+                                .format(name, old_num_shards, num_shards))
+            else:
+                log.info("Resharding stream from {} to {} shards, this could take a while"
+                         .format(old_num_shards, num_shards))
+                # reshard returns True when a split/merge action is taken,
+                # or False when no more actions are required
+                continue_reshard = True
+                while continue_reshard:
+                    reshard_response = __salt__['boto_kinesis.reshard'](
+                        name,
+                        num_shards,
+                        do_reshard,
+                        region,
+                        key,
+                        keyid,
+                        profile)
+
+                    if 'error' in reshard_response:
+                        ret['result'] = False
+                        comments.append('Encountered error while resharding {}: {}'
+                                        .format(name, reshard_response['error']))
+                        _add_changes(ret, changes_old, changes_new, comments)
+                        return ret
+
+                    continue_reshard = reshard_response['result']
+
+                comments.append('{}: successfully resharded to {} shards'.format(name, num_shards))
+                changes_old['num_shards'] = old_num_shards
+                changes_new['num_shards'] = num_shards
+        else:
+            comments.append('{}: did not require resharding, remains at {} shards'
+                            .format(name, old_num_shards))
+    else:
+        comments.append('{}: did not reshard, remains at {} shards'.format(name, old_num_shards))
+
+    _add_changes(ret, changes_old, changes_new, comments)
+    return ret
+
+
+def absent(name,
+           region=None,
+           key=None,
+           keyid=None,
+           profile=None):
+    '''
+    Delete the kinesis stream, if it exists.
+
+    name (string)
+        Stream name
+
+    region (string)
+        Region to connect to.
+
+    key (string)
+        Secret key to be used.
+
+    keyid (string)
+        Access key to be used.
+
+    profile (dict)
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    exists = __salt__['boto_kinesis.exists'](
+        name,
+        region,
+        key,
+        keyid,
+        profile
+    )
+    if exists['result'] is False:
+        ret['comment'] = '{}: does not exist'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = '{}: would be deleted'.format(name)
+        ret['result'] = None
+        return ret
+
+    is_deleted = __salt__['boto_kinesis.delete_stream'](
+        name,
+        region,
+        key,
+        keyid,
+        profile
+    )
+    if 'error' in is_deleted:
+        ret['comment'] = 'Failed to delete stream {}: {}'.format(name, is_deleted['error'])
+        ret['result'] = False
+    else:
+        ret['comment'] = 'Deleted stream {}'.format(name)
+        ret['changes'].setdefault('old', 'Stream {} exists'.format(name))
+        ret['changes'].setdefault('new', 'Stream {} deleted'.format(name))
+
+    return ret
+
+
+def _add_changes(ret, changes_old, changes_new, comments):
+    ret['comment'] = ',\n'.join(comments)
+    if changes_old:
+        ret['changes']['old'] = changes_old
+    if changes_new:
+        ret['changes']['new'] = changes_new

--- a/salt/states/boto_kinesis.py
+++ b/salt/states/boto_kinesis.py
@@ -137,7 +137,7 @@ def present(name,
     if exists['result'] is False:
         if __opts__['test']:
             ret['result'] = None
-            comments.append('Kinesis stream {} would be created'.format(name))
+            comments.append('Kinesis stream {0} would be created'.format(name))
             _add_changes(ret, changes_old, changes_new, comments)
             return ret
         else:
@@ -151,15 +151,15 @@ def present(name,
             )
             if 'error' in is_created:
                 ret['result'] = False
-                comments.append('Failed to create stream {}: {}'.format(name, is_created['error']))
+                comments.append('Failed to create stream {0}: {1}'.format(name, is_created['error']))
                 _add_changes(ret, changes_old, changes_new, comments)
                 return ret
 
-            comments.append('Kinesis stream {} successfully created'.format(name))
+            comments.append('Kinesis stream {0} successfully created'.format(name))
             changes_new['name'] = name
             changes_new['num_shards'] = num_shards
     else:
-        comments.append('Kinesis stream {} already exists'.format(name))
+        comments.append('Kinesis stream {0} already exists'.format(name))
 
     stream_response = __salt__['boto_kinesis.get_stream_when_active'](
         name,
@@ -170,7 +170,7 @@ def present(name,
     )
     if 'error' in stream_response:
         ret['result'] = False
-        comments.append('Kinesis stream {}: error getting description: {}'
+        comments.append('Kinesis stream {0}: error getting description: {1}'
                         .format(name, stream_response['error']))
         _add_changes(ret, changes_old, changes_new, comments)
         return ret
@@ -184,7 +184,7 @@ def present(name,
         if not retention_matches:
             if __opts__['test']:
                 ret['result'] = None
-                comments.append('Kinesis stream {}: retention hours would be updated to {}'
+                comments.append('Kinesis stream {0}: retention hours would be updated to {1}'
                                 .format(name, retention_hours))
             else:
                 if old_retention_hours > retention_hours:
@@ -208,12 +208,12 @@ def present(name,
 
                 if 'error' in retention_updated:
                     ret['result'] = False
-                    comments.append('Kinesis stream {}: failed to update retention hours: {}'
+                    comments.append('Kinesis stream {0}: failed to update retention hours: {1}'
                                     .format(name, retention_updated['error']))
                     _add_changes(ret, changes_old, changes_new, comments)
                     return ret
 
-                comments.append('Kinesis stream {}: retention hours was successfully updated'.format(name))
+                comments.append('Kinesis stream {0}: retention hours was successfully updated'.format(name))
                 changes_old['retention_hours'] = old_retention_hours
                 changes_new['retention_hours'] = retention_hours
 
@@ -228,17 +228,17 @@ def present(name,
                 )
                 if 'error' in stream_response:
                     ret['result'] = False
-                    comments.append('Kinesis stream {}: error getting description: {}'
+                    comments.append('Kinesis stream {0}: error getting description: {1}'
                                     .format(name, stream_response['error']))
                     _add_changes(ret, changes_old, changes_new, comments)
                     return ret
 
                 stream_details = stream_response['result']["StreamDescription"]
         else:
-            comments.append('Kinesis stream {}: retention hours did not require change, already set at {}'
+            comments.append('Kinesis stream {0}: retention hours did not require change, already set at {1}'
                             .format(name, old_retention_hours))
     else:
-        comments.append('Kinesis stream {}: did not configure retention hours'.format(name))
+        comments.append('Kinesis stream {0}: did not configure retention hours'.format(name))
 
     # Configure enhanced monitoring
     if enhanced_monitoring is not None:
@@ -268,7 +268,7 @@ def present(name,
         if len(enable_metrics) != 0:
             if __opts__['test']:
                 ret['result'] = None
-                comments.append('Kinesis stream {}: would enable enhanced monitoring for {}'
+                comments.append('Kinesis stream {0}: would enable enhanced monitoring for {1}'
                                 .format(name, enable_metrics))
             else:
 
@@ -282,18 +282,18 @@ def present(name,
                 )
                 if 'error' in metrics_enabled:
                     ret['result'] = False
-                    comments.append('Kinesis stream {}: failed to enable enhanced monitoring: {}'
+                    comments.append('Kinesis stream {0}: failed to enable enhanced monitoring: {1}'
                                     .format(name, metrics_enabled['error']))
                     _add_changes(ret, changes_old, changes_new, comments)
                     return ret
 
-                comments.append('Kinesis stream {}: enhanced monitoring was enabled for shard-level metrics {}'
+                comments.append('Kinesis stream {0}: enhanced monitoring was enabled for shard-level metrics {1}'
                                 .format(name, enable_metrics))
 
         if len(disable_metrics) != 0:
             if __opts__['test']:
                 ret['result'] = None
-                comments.append('Kinesis stream {}: would disable enhanced monitoring for {}'
+                comments.append('Kinesis stream {0}: would disable enhanced monitoring for {1}'
                                 .format(name, disable_metrics))
             else:
 
@@ -307,25 +307,24 @@ def present(name,
                 )
                 if 'error' in metrics_disabled:
                     ret['result'] = False
-                    comments.append('Kinesis stream {}: failed to disable enhanced monitoring: {}'
+                    comments.append('Kinesis stream {0}: failed to disable enhanced monitoring: {1}'
                                     .format(name, metrics_disabled['error']))
                     _add_changes(ret, changes_old, changes_new, comments)
                     return ret
 
-                comments.append('Kinesis stream {}: enhanced monitoring was disabled for shard-level metrics {}'
+                comments.append('Kinesis stream {0}: enhanced monitoring was disabled for shard-level metrics {1}'
                                 .format(name, disable_metrics))
 
         if len(disable_metrics) == 0 and len(enable_metrics) == 0:
-            comments.append('Kinesis stream {}: enhanced monitoring did not require change, already set at {}'
-                            .format(name, (old_enhanced_monitoring if len(old_enhanced_monitoring) > 0
-                                                  else "None")))
+            comments.append('Kinesis stream {0}: enhanced monitoring did not require change, already set at {1}'
+                            .format(name, (old_enhanced_monitoring if len(old_enhanced_monitoring) > 0 else "None")))
         elif not __opts__['test']:
             changes_old['enhanced_monitoring'] = (old_enhanced_monitoring if len(old_enhanced_monitoring) > 0
                                                   else "None")
             changes_new['enhanced_monitoring'] = (enhanced_monitoring if len(enhanced_monitoring) > 0
                                                   else "None")
     else:
-        comments.append('Kinesis stream {}: did not configure enhanced monitoring'.format(name))
+        comments.append('Kinesis stream {0}: did not configure enhanced monitoring'.format(name))
 
     # Reshard stream if necessary
     min_hash_key, max_hash_key, full_stream_details = __salt__['boto_kinesis.get_info_for_reshard'](
@@ -338,10 +337,10 @@ def present(name,
         if not num_shards_matches:
             if __opts__['test']:
                 ret['result'] = None
-                comments.append('Kinesis stream {}: would be resharded from {} to {} shards'
+                comments.append('Kinesis stream {0}: would be resharded from {1} to {2} shards'
                                 .format(name, old_num_shards, num_shards))
             else:
-                log.info("Resharding stream from {} to {} shards, this could take a while"
+                log.info("Resharding stream from {0} to {1} shards, this could take a while"
                          .format(old_num_shards, num_shards))
                 # reshard returns True when a split/merge action is taken,
                 # or False when no more actions are required
@@ -358,21 +357,21 @@ def present(name,
 
                     if 'error' in reshard_response:
                         ret['result'] = False
-                        comments.append('Encountered error while resharding {}: {}'
+                        comments.append('Encountered error while resharding {0}: {1}'
                                         .format(name, reshard_response['error']))
                         _add_changes(ret, changes_old, changes_new, comments)
                         return ret
 
                     continue_reshard = reshard_response['result']
 
-                comments.append('Kinesis stream {}: successfully resharded to {} shards'.format(name, num_shards))
+                comments.append('Kinesis stream {0}: successfully resharded to {1} shards'.format(name, num_shards))
                 changes_old['num_shards'] = old_num_shards
                 changes_new['num_shards'] = num_shards
         else:
-            comments.append('Kinesis stream {}: did not require resharding, remains at {} shards'
+            comments.append('Kinesis stream {0}: did not require resharding, remains at {1} shards'
                             .format(name, old_num_shards))
     else:
-        comments.append('Kinesis stream {}: did not reshard, remains at {} shards'.format(name, old_num_shards))
+        comments.append('Kinesis stream {0}: did not reshard, remains at {1} shards'.format(name, old_num_shards))
 
     _add_changes(ret, changes_old, changes_new, comments)
     return ret
@@ -412,11 +411,11 @@ def absent(name,
         profile
     )
     if exists['result'] is False:
-        ret['comment'] = 'Kinesis stream {} does not exist'.format(name)
+        ret['comment'] = 'Kinesis stream {0} does not exist'.format(name)
         return ret
 
     if __opts__['test']:
-        ret['comment'] = 'Kinesis stream {} would be deleted'.format(name)
+        ret['comment'] = 'Kinesis stream {0} would be deleted'.format(name)
         ret['result'] = None
         return ret
 
@@ -428,12 +427,12 @@ def absent(name,
         profile
     )
     if 'error' in is_deleted:
-        ret['comment'] = 'Failed to delete stream {}: {}'.format(name, is_deleted['error'])
+        ret['comment'] = 'Failed to delete stream {0}: {1}'.format(name, is_deleted['error'])
         ret['result'] = False
     else:
-        ret['comment'] = 'Deleted stream {}'.format(name)
-        ret['changes'].setdefault('old', 'Stream {} exists'.format(name))
-        ret['changes'].setdefault('new', 'Stream {} deleted'.format(name))
+        ret['comment'] = 'Deleted stream {0}'.format(name)
+        ret['changes'].setdefault('old', 'Stream {0} exists'.format(name))
+        ret['changes'].setdefault('new', 'Stream {0} deleted'.format(name))
 
     return ret
 

--- a/salt/states/boto_kinesis.py
+++ b/salt/states/boto_kinesis.py
@@ -136,7 +136,7 @@ def present(name,
     if exists['result'] is False:
         if __opts__['test']:
             ret['result'] = None
-            comments.append('{} would be created'.format(name))
+            comments.append('Kinesis stream {} would be created'.format(name))
             _add_changes(ret, changes_old, changes_new, comments)
             return ret
         else:
@@ -154,11 +154,11 @@ def present(name,
                 _add_changes(ret, changes_old, changes_new, comments)
                 return ret
 
-            comments.append('{}: successfully created'.format(name))
+            comments.append('Kinesis stream {} successfully created'.format(name))
             changes_new['name'] = name
             changes_new['num_shards'] = num_shards
     else:
-        comments.append('{}: already exists'.format(name))
+        comments.append('Kinesis stream {} already exists'.format(name))
 
     stream_response = __salt__['boto_kinesis.get_stream_when_active'](
         name,
@@ -169,7 +169,7 @@ def present(name,
     )
     if 'error' in stream_response:
         ret['result'] = False
-        comments.append('{}: error getting description: {}'
+        comments.append('Kinesis stream {}: error getting description: {}'
                         .format(name, stream_response['error']))
         _add_changes(ret, changes_old, changes_new, comments)
         return ret
@@ -183,7 +183,8 @@ def present(name,
         if not retention_matches:
             if __opts__['test']:
                 ret['result'] = None
-                comments.append('{}: retention hours would be updated to {}'.format(name, retention_hours))
+                comments.append('Kinesis stream {}: retention hours would be updated to {}'
+                                .format(name, retention_hours))
             else:
                 if old_retention_hours > retention_hours:
                     retention_updated = __salt__['boto_kinesis.decrease_stream_retention_period'](
@@ -206,12 +207,12 @@ def present(name,
 
                 if 'error' in retention_updated:
                     ret['result'] = False
-                    comments.append('{}: failed to update retention hours: {}'
+                    comments.append('Kinesis stream {}: failed to update retention hours: {}'
                                     .format(name, retention_updated['error']))
                     _add_changes(ret, changes_old, changes_new, comments)
                     return ret
 
-                comments.append('{}: retention hours was successfully updated'.format(name))
+                comments.append('Kinesis stream {}: retention hours was successfully updated'.format(name))
                 changes_old['retention_hours'] = old_retention_hours
                 changes_new['retention_hours'] = retention_hours
 
@@ -226,17 +227,17 @@ def present(name,
                 )
                 if 'error' in stream_response:
                     ret['result'] = False
-                    comments.append('{}: error getting description: {}'
+                    comments.append('Kinesis stream {}: error getting description: {}'
                                     .format(name, stream_response['error']))
                     _add_changes(ret, changes_old, changes_new, comments)
                     return ret
 
                 stream_details = stream_response['result']["StreamDescription"]
         else:
-            comments.append('{}: retention hours did not require change, already set at {}'
+            comments.append('Kinesis stream {}: retention hours did not require change, already set at {}'
                             .format(name, old_retention_hours))
     else:
-        comments.append('{}: did not configure retention hours'.format(name))
+        comments.append('Kinesis stream {}: did not configure retention hours'.format(name))
 
     # Configure enhanced monitoring
     if enhanced_monitoring is not None:
@@ -266,7 +267,8 @@ def present(name,
         if len(enable_metrics) != 0:
             if __opts__['test']:
                 ret['result'] = None
-                comments.append('{}: would enable enhanced monitoring for {}'.format(name, enable_metrics))
+                comments.append('Kinesis stream {}: would enable enhanced monitoring for {}'
+                                .format(name, enable_metrics))
             else:
 
                 metrics_enabled = __salt__['boto_kinesis.enable_enhanced_monitoring'](
@@ -279,18 +281,19 @@ def present(name,
                 )
                 if 'error' in metrics_enabled:
                     ret['result'] = False
-                    comments.append('{}: failed to enable enhanced monitoring: {}'
+                    comments.append('Kinesis stream {}: failed to enable enhanced monitoring: {}'
                                     .format(name, metrics_enabled['error']))
                     _add_changes(ret, changes_old, changes_new, comments)
                     return ret
 
-                comments.append('{}: enhanced monitoring was enabled for shard-level metrics {}'
+                comments.append('Kinesis stream {}: enhanced monitoring was enabled for shard-level metrics {}'
                                 .format(name, enable_metrics))
 
         if len(disable_metrics) != 0:
             if __opts__['test']:
                 ret['result'] = None
-                comments.append('{}: would disable enhanced monitoring for {}'.format(name, disable_metrics))
+                comments.append('Kinesis stream {}: would disable enhanced monitoring for {}'
+                                .format(name, disable_metrics))
             else:
 
                 metrics_disabled = __salt__['boto_kinesis.disable_enhanced_monitoring'](
@@ -303,16 +306,16 @@ def present(name,
                 )
                 if 'error' in metrics_disabled:
                     ret['result'] = False
-                    comments.append('{}: failed to disable enhanced monitoring: {}'
+                    comments.append('Kinesis stream {}: failed to disable enhanced monitoring: {}'
                                     .format(name, metrics_disabled['error']))
                     _add_changes(ret, changes_old, changes_new, comments)
                     return ret
 
-                comments.append('{}: enhanced monitoring was disabled for shard-level metrics {}'
+                comments.append('Kinesis stream {}: enhanced monitoring was disabled for shard-level metrics {}'
                                 .format(name, disable_metrics))
 
         if len(disable_metrics) == 0 and len(enable_metrics) == 0:
-            comments.append('{}: enhanced monitoring did not require change, already set at {}'
+            comments.append('Kinesis stream {}: enhanced monitoring did not require change, already set at {}'
                             .format(name, (old_enhanced_monitoring if len(old_enhanced_monitoring) > 0
                                                   else "None")))
         elif not __opts__['test']:
@@ -321,7 +324,7 @@ def present(name,
             changes_new['enhanced_monitoring'] = (enhanced_monitoring if len(enhanced_monitoring) > 0
                                                   else "None")
     else:
-        comments.append('{}: did not configure enhanced monitoring'.format(name))
+        comments.append('Kinesis stream {}: did not configure enhanced monitoring'.format(name))
 
     # Reshard stream if necessary
     min_hash_key, max_hash_key, full_stream_details = __salt__['boto_kinesis.get_info_for_reshard'](
@@ -334,7 +337,7 @@ def present(name,
         if not num_shards_matches:
             if __opts__['test']:
                 ret['result'] = None
-                comments.append('{}: would be resharded from {} to {} shards'
+                comments.append('Kinesis stream {}: would be resharded from {} to {} shards'
                                 .format(name, old_num_shards, num_shards))
             else:
                 log.info("Resharding stream from {} to {} shards, this could take a while"
@@ -361,14 +364,14 @@ def present(name,
 
                     continue_reshard = reshard_response['result']
 
-                comments.append('{}: successfully resharded to {} shards'.format(name, num_shards))
+                comments.append('Kinesis stream {}: successfully resharded to {} shards'.format(name, num_shards))
                 changes_old['num_shards'] = old_num_shards
                 changes_new['num_shards'] = num_shards
         else:
-            comments.append('{}: did not require resharding, remains at {} shards'
+            comments.append('Kinesis stream {}: did not require resharding, remains at {} shards'
                             .format(name, old_num_shards))
     else:
-        comments.append('{}: did not reshard, remains at {} shards'.format(name, old_num_shards))
+        comments.append('Kinesis stream {}: did not reshard, remains at {} shards'.format(name, old_num_shards))
 
     _add_changes(ret, changes_old, changes_new, comments)
     return ret
@@ -408,11 +411,11 @@ def absent(name,
         profile
     )
     if exists['result'] is False:
-        ret['comment'] = '{}: does not exist'.format(name)
+        ret['comment'] = 'Kinesis stream {} does not exist'.format(name)
         return ret
 
     if __opts__['test']:
-        ret['comment'] = '{}: would be deleted'.format(name)
+        ret['comment'] = 'Kinesis stream {} would be deleted'.format(name)
         ret['result'] = None
         return ret
 

--- a/salt/states/boto_kinesis.py
+++ b/salt/states/boto_kinesis.py
@@ -55,6 +55,8 @@ pillars or minion config:
         - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
         - region: us-east-1
 '''
+# Keep pylint from chocking on ret
+# pylint: disable=undefined-variable
 # Import Python libs
 from __future__ import absolute_import
 import logging

--- a/salt/states/boto_kinesis.py
+++ b/salt/states/boto_kinesis.py
@@ -119,7 +119,7 @@ def present(name,
         that contains a dict with region, key and keyid.
     '''
 
-    ret = {'name': name, 'result': (None if __opts__['test'] else True), 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     comments = []
     changes_old = {}

--- a/salt/states/boto_kinesis.py
+++ b/salt/states/boto_kinesis.py
@@ -99,7 +99,8 @@ def present(name,
         Reshard stream (if necessary) to this number of shards
         !!!!! Resharding is expensive! Each split or merge can take up to 30 seconds,
         and the reshard method balances the partition space evenly.
-        Resharding from N to N+1 can require 2N operations !!!!!
+        Resharding from N to N+1 can require 2N operations.
+        Resharding is much faster with powers of 2 (e.g. 2^N to 2^N+1) !!!!!
 
     do_reshard (boolean)
         If set to False, this script will NEVER reshard the stream,

--- a/tests/unit/states/boto_kinesis_test.py
+++ b/tests/unit/states/boto_kinesis_test.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import skipIf, TestCase
+from salttesting.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch)
+
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.states import boto_kinesis
+
+boto_kinesis.__salt__ = {}
+boto_kinesis.__opts__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BotoKinesisTestCase(TestCase):
+    '''
+    Test cases for salt.states.boto_kinesis
+    '''
+    # 'present' function tests: 1
+
+    def test_stream_present(self):
+        '''
+        Test to ensure the kinesis stream exists.
+        '''
+        name = 'new_stream'
+
+        ret = {'name': name,
+               'result': True,
+               'changes': {},
+               'comment': ''}
+
+        exists_mock = MagicMock(side_effect=[True, False, False])
+        dict_mock = MagicMock(return_value={})
+        mock_bool = MagicMock(return_value=True)
+        pillar_mock = MagicMock(return_value=[])
+        with patch.dict(boto_kinesis.__salt__,
+                        {'boto_kinesis.exists': exists_mock,
+                         'boto_kinesis.get_stream_when_active': dict_mock,
+                         'config.option': dict_mock,
+                         'pillar.get': pillar_mock,
+                         'boto_kinesis.create_stream': mock_bool}):
+            comt = ('Kinesis stream {0} already exists\n'
+                    'Kinesis stream {0}: retention hours did not require change, already set at {1}\n'
+                    'Kinesis stream {0}: enhanced monitoring did not require change, already set at {2}\n'
+                    'Kinesis stream {0}: did not reshard, remains at {3} shards\n'
+                    .format(name))
+            ret.update({'comment': comt})
+            self.assertDictEqual(boto_kinesis.present(name), ret)
+
+            with patch.dict(boto_kinesis.__opts__, {'test': True}):
+                comt = ('Kinesis stream {0} would be be created\n'
+                        'Kinesis stream {0}: retention hours did not require change, already set at {1}\n'
+                        'Kinesis stream {0}: enhanced monitoring did not require change, already set at {2}\n'
+                        'Kinesis stream {0}: did not reshard, remains at {3} shards\n'
+                        .format(name))
+                ret.update({'comment': comt, 'result': None})
+                self.assertDictEqual(boto_kinesis.present(name), ret)
+
+            changes = {'new': {'global_indexes': None,
+                               'hash_key': None,
+                               'hash_key_data_type': None,
+                               'local_indexes': None,
+                               'range_key': None,
+                               'range_key_data_type': None,
+                               'read_capacity_units': None,
+                               'table': 'new_table',
+                               'write_capacity_units': None}}
+
+            with patch.dict(boto_kinesis.__opts__, {'test': False}):
+                comt = ('DynamoDB table {0} was successfully created,\n'
+                        'DynamoDB table new_table throughput matches,\n'
+                        .format(name))
+                ret.update({'comment': comt, 'result': True,
+                            'changes': changes})
+                self.assertDictEqual(ret, boto_kinesis.present(name))
+
+    # 'absent' function tests: 1
+
+    def test_absent(self):
+        '''
+        Test to ensure the Kinesis stream does not exist.
+        '''
+        name = 'new_stream'
+
+        ret = {'name': name,
+               'result': True,
+               'changes': {},
+               'comment': ''}
+
+        mock = MagicMock(side_effect=[False, True, True])
+        mock_bool = MagicMock(return_value=True)
+        with patch.dict(boto_dynamodb.__salt__,
+                        {'boto_kinesis.exists': mock,
+                         'boto_stream.delete': mock_bool}):
+            comt = ('Kinesis stream {0} does not exist'.format(name))
+            ret.update({'comment': comt})
+            self.assertDictEqual(boto_kinesis.absent(name), ret)
+
+            with patch.dict(boto_kinesis.__opts__, {'test': True}):
+                comt = ('Kinesis stream {0} would be deleted \
+                         '.format(name))
+                ret.update({'comment': comt, 'result': None})
+                self.assertDictEqual(boto_kinesis.absent(name), ret)
+
+            changes = {'new': 'Stream {0} deleted'.format(name),
+                       'old': 'Stream {0} exists'.format(name)}
+
+            with patch.dict(boto_kinesis.__opts__, {'test': False}):
+                comt = ('Deleted stream {0}'.format(name))
+                ret.update({'comment': comt, 'result': True,
+                            'changes': changes})
+                self.assertDictEqual(boto_kinesis.absent(name), ret)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(BotoKinesisTestCase, needs_daemon=False)

--- a/tests/unit/states/boto_kinesis_test.py
+++ b/tests/unit/states/boto_kinesis_test.py
@@ -26,63 +26,63 @@ class BotoKinesisTestCase(TestCase):
     '''
     Test cases for salt.states.boto_kinesis
     '''
-    # 'present' function tests: 1
-
-    def test_stream_present(self):
-        '''
-        Test to ensure the kinesis stream exists.
-        '''
-        name = 'new_stream'
-
-        ret = {'name': name,
-               'result': True,
-               'changes': {},
-               'comment': ''}
-
-        exists_mock = MagicMock(side_effect=[True, False, False])
-        dict_mock = MagicMock(return_value={})
-        mock_bool = MagicMock(return_value=True)
-        pillar_mock = MagicMock(return_value=[])
-        with patch.dict(boto_kinesis.__salt__,
-                        {'boto_kinesis.exists': exists_mock,
-                         'boto_kinesis.get_stream_when_active': dict_mock,
-                         'config.option': dict_mock,
-                         'pillar.get': pillar_mock,
-                         'boto_kinesis.create_stream': mock_bool}):
-            comt = ('Kinesis stream {0} already exists\n'
-                    'Kinesis stream {0}: retention hours did not require change, already set at {1}\n'
-                    'Kinesis stream {0}: enhanced monitoring did not require change, already set at {2}\n'
-                    'Kinesis stream {0}: did not reshard, remains at {3} shards\n'
-                    .format(name))
-            ret.update({'comment': comt})
-            self.assertDictEqual(boto_kinesis.present(name), ret)
-
-            with patch.dict(boto_kinesis.__opts__, {'test': True}):
-                comt = ('Kinesis stream {0} would be be created\n'
-                        'Kinesis stream {0}: retention hours did not require change, already set at {1}\n'
-                        'Kinesis stream {0}: enhanced monitoring did not require change, already set at {2}\n'
-                        'Kinesis stream {0}: did not reshard, remains at {3} shards\n'
-                        .format(name))
-                ret.update({'comment': comt, 'result': None})
-                self.assertDictEqual(boto_kinesis.present(name), ret)
-
-            changes = {'new': {'global_indexes': None,
-                               'hash_key': None,
-                               'hash_key_data_type': None,
-                               'local_indexes': None,
-                               'range_key': None,
-                               'range_key_data_type': None,
-                               'read_capacity_units': None,
-                               'table': 'new_table',
-                               'write_capacity_units': None}}
-
-            with patch.dict(boto_kinesis.__opts__, {'test': False}):
-                comt = ('DynamoDB table {0} was successfully created,\n'
-                        'DynamoDB table new_table throughput matches,\n'
-                        .format(name))
-                ret.update({'comment': comt, 'result': True,
-                            'changes': changes})
-                self.assertDictEqual(ret, boto_kinesis.present(name))
+    # # 'present' function tests: 1
+    #
+    # def test_stream_present(self):
+    #     '''
+    #     Test to ensure the kinesis stream exists.
+    #     '''
+    #     name = 'new_stream'
+    #
+    #     ret = {'name': name,
+    #            'result': True,
+    #            'changes': {},
+    #            'comment': ''}
+    #
+    #     exists_mock = MagicMock(side_effect=[True, False, False])
+    #     dict_mock = MagicMock(return_value={})
+    #     mock_bool = MagicMock(return_value=True)
+    #     pillar_mock = MagicMock(return_value=[])
+    #     with patch.dict(boto_kinesis.__salt__,
+    #                     {'boto_kinesis.exists': exists_mock,
+    #                      'boto_kinesis.get_stream_when_active': dict_mock,
+    #                      'config.option': dict_mock,
+    #                      'pillar.get': pillar_mock,
+    #                      'boto_kinesis.create_stream': mock_bool}):
+    #         comt = ('Kinesis stream {0} already exists\n'
+    #                 'Kinesis stream {0}: retention hours did not require change, already set at {1}\n'
+    #                 'Kinesis stream {0}: enhanced monitoring did not require change, already set at {2}\n'
+    #                 'Kinesis stream {0}: did not reshard, remains at {3} shards\n'
+    #                 .format(name))
+    #         ret.update({'comment': comt})
+    #         self.assertDictEqual(boto_kinesis.present(name), ret)
+    #
+    #         with patch.dict(boto_kinesis.__opts__, {'test': True}):
+    #             comt = ('Kinesis stream {0} would be be created\n'
+    #                     'Kinesis stream {0}: retention hours did not require change, already set at {1}\n'
+    #                     'Kinesis stream {0}: enhanced monitoring did not require change, already set at {2}\n'
+    #                     'Kinesis stream {0}: did not reshard, remains at {3} shards\n'
+    #                     .format(name))
+    #             ret.update({'comment': comt, 'result': None})
+    #             self.assertDictEqual(boto_kinesis.present(name), ret)
+    #
+    #         changes = {'new': {'global_indexes': None,
+    #                            'hash_key': None,
+    #                            'hash_key_data_type': None,
+    #                            'local_indexes': None,
+    #                            'range_key': None,
+    #                            'range_key_data_type': None,
+    #                            'read_capacity_units': None,
+    #                            'table': 'new_table',
+    #                            'write_capacity_units': None}}
+    #
+    #         with patch.dict(boto_kinesis.__opts__, {'test': False}):
+    #             comt = ('DynamoDB table {0} was successfully created,\n'
+    #                     'DynamoDB table new_table throughput matches,\n'
+    #                     .format(name))
+    #             ret.update({'comment': comt, 'result': True,
+    #                         'changes': changes})
+    #             self.assertDictEqual(ret, boto_kinesis.present(name))
 
     # 'absent' function tests: 1
 
@@ -97,18 +97,17 @@ class BotoKinesisTestCase(TestCase):
                'changes': {},
                'comment': ''}
 
-        mock = MagicMock(side_effect=[False, True, True])
-        mock_bool = MagicMock(return_value=True)
-        with patch.dict(boto_dynamodb.__salt__,
+        mock = MagicMock(side_effect=[{'result': False}, {'result': True}, {'result': True}])
+        mock_bool = MagicMock(return_value={'result': True})
+        with patch.dict(boto_kinesis.__salt__,
                         {'boto_kinesis.exists': mock,
-                         'boto_stream.delete': mock_bool}):
+                         'boto_kinesis.delete_stream': mock_bool}):
             comt = ('Kinesis stream {0} does not exist'.format(name))
             ret.update({'comment': comt})
             self.assertDictEqual(boto_kinesis.absent(name), ret)
 
             with patch.dict(boto_kinesis.__opts__, {'test': True}):
-                comt = ('Kinesis stream {0} would be deleted \
-                         '.format(name))
+                comt = ('Kinesis stream {0} would be deleted'.format(name))
                 ret.update({'comment': comt, 'result': None})
                 self.assertDictEqual(boto_kinesis.absent(name), ret)
 

--- a/tests/unit/states/boto_kinesis_test.py
+++ b/tests/unit/states/boto_kinesis_test.py
@@ -26,63 +26,88 @@ class BotoKinesisTestCase(TestCase):
     '''
     Test cases for salt.states.boto_kinesis
     '''
-    # # 'present' function tests: 1
-    #
-    # def test_stream_present(self):
-    #     '''
-    #     Test to ensure the kinesis stream exists.
-    #     '''
-    #     name = 'new_stream'
-    #
-    #     ret = {'name': name,
-    #            'result': True,
-    #            'changes': {},
-    #            'comment': ''}
-    #
-    #     exists_mock = MagicMock(side_effect=[True, False, False])
-    #     dict_mock = MagicMock(return_value={})
-    #     mock_bool = MagicMock(return_value=True)
-    #     pillar_mock = MagicMock(return_value=[])
-    #     with patch.dict(boto_kinesis.__salt__,
-    #                     {'boto_kinesis.exists': exists_mock,
-    #                      'boto_kinesis.get_stream_when_active': dict_mock,
-    #                      'config.option': dict_mock,
-    #                      'pillar.get': pillar_mock,
-    #                      'boto_kinesis.create_stream': mock_bool}):
-    #         comt = ('Kinesis stream {0} already exists\n'
-    #                 'Kinesis stream {0}: retention hours did not require change, already set at {1}\n'
-    #                 'Kinesis stream {0}: enhanced monitoring did not require change, already set at {2}\n'
-    #                 'Kinesis stream {0}: did not reshard, remains at {3} shards\n'
-    #                 .format(name))
-    #         ret.update({'comment': comt})
-    #         self.assertDictEqual(boto_kinesis.present(name), ret)
-    #
-    #         with patch.dict(boto_kinesis.__opts__, {'test': True}):
-    #             comt = ('Kinesis stream {0} would be be created\n'
-    #                     'Kinesis stream {0}: retention hours did not require change, already set at {1}\n'
-    #                     'Kinesis stream {0}: enhanced monitoring did not require change, already set at {2}\n'
-    #                     'Kinesis stream {0}: did not reshard, remains at {3} shards\n'
-    #                     .format(name))
-    #             ret.update({'comment': comt, 'result': None})
-    #             self.assertDictEqual(boto_kinesis.present(name), ret)
-    #
-    #         changes = {'new': {'global_indexes': None,
-    #                            'hash_key': None,
-    #                            'hash_key_data_type': None,
-    #                            'local_indexes': None,
-    #                            'range_key': None,
-    #                            'range_key_data_type': None,
-    #                            'read_capacity_units': None,
-    #                            'table': 'new_table',
-    #                            'write_capacity_units': None}}
-    #
-    #         with patch.dict(boto_kinesis.__opts__, {'test': False}):
-    #             comt = ('DynamoDB table {0} was successfully created,\n'
-    #                     'DynamoDB table new_table throughput matches,\n'
-    #                     .format(name))
-    #             ret.update({'comment': comt, 'result': True,
-    #                         'changes': changes})
-    #             self.assertDictEqual(ret, boto_kinesis.present(name))
+    # 'present' function tests: 1
+
+    maxDiff = None
+
+    def test_stream_present(self):
+        '''
+        Test to ensure the kinesis stream exists.
+        '''
+        name = 'new_stream'
+        retention_hours = 24
+        enhanced_monitoring = ['IteratorAgeMilliseconds']
+        different_enhanced_monitoring = ['IncomingBytes']
+        num_shards = 1
+
+        ret = {'name': name,
+               'result': True,
+               'changes': {},
+               'comment': ''}
+
+        shards = [{'ShardId': 'shardId-000000000000',
+                   'HashKeyRange': {'EndingHashKey': 'big number', 'StartingHashKey': '0'},
+                   'SequenceNumberRange': {'StartingSequenceNumber': 'bigger number'}}]
+        stream_description = {'HasMoreShards': False,
+                              'RetentionPeriodHours': retention_hours,
+                              'StreamName': name,
+                              'Shards': shards,
+                              'StreamARN': "",
+                              'EnhancedMonitoring': [{'ShardLevelMetrics': enhanced_monitoring}],
+                              'StreamStatus': 'ACTIVE'}
+
+        exists_mock = MagicMock(side_effect=[{'result': True}, {'result': False}, {'result': True}, {'result': False}])
+        get_stream_mock = MagicMock(return_value={'result': {'StreamDescription': stream_description}})
+        shard_mock = MagicMock(return_value=[0, 0, {'OpenShards': shards}])
+        dict_mock = MagicMock(return_value={'result': True})
+        mock_bool = MagicMock(return_value=True)
+        with patch.dict(boto_kinesis.__salt__,
+                        {'boto_kinesis.exists': exists_mock,
+                         'boto_kinesis.create_stream': dict_mock,
+                         'boto_kinesis.get_stream_when_active': get_stream_mock,
+                         'boto_kinesis.get_info_for_reshard': shard_mock,
+                         'boto_kinesis.num_shards_matches': mock_bool}):
+            # already present, no change required
+            comt = ('Kinesis stream {0} already exists,\n'
+                    'Kinesis stream {0}: retention hours did not require change, already set at {1},\n'
+                    'Kinesis stream {0}: enhanced monitoring did not require change, already set at {2},\n'
+                    'Kinesis stream {0}: did not require resharding, remains at {3} shards'
+                    .format(name, retention_hours, enhanced_monitoring, num_shards))
+            ret.update({'comment': comt})
+            self.assertDictEqual(boto_kinesis.present(name, retention_hours, enhanced_monitoring, num_shards), ret)
+
+            with patch.dict(boto_kinesis.__opts__, {'test': True}):
+                # not present, test environment (dry run)
+                comt = ('Kinesis stream {0} would be created'
+                        .format(name))
+                ret.update({'comment': comt, 'result': None})
+                self.assertDictEqual(boto_kinesis.present(name, retention_hours, enhanced_monitoring, num_shards), ret)
+
+                # already present, changes required, test environment (dry run)
+                comt = ('Kinesis stream {0} already exists,\n'
+                        'Kinesis stream {0}: retention hours would be updated to {1},\n'
+                        'Kinesis stream {0}: would enable enhanced monitoring for {2},\n'
+                        'Kinesis stream {0}: would disable enhanced monitoring for {3},\n'
+                        'Kinesis stream {0}: would be resharded from {4} to {5} shards'
+                        .format(name, retention_hours+1, different_enhanced_monitoring,
+                                enhanced_monitoring, num_shards, num_shards+1))
+                ret.update({'comment': comt, 'result': None})
+                self.assertDictEqual(boto_kinesis.present(name, retention_hours+1, different_enhanced_monitoring,
+                                                          num_shards+1), ret)
+
+            # not present, create and configure
+            changes = {'new': {'name': name,
+                               'num_shards': num_shards}}
+
+            with patch.dict(boto_kinesis.__opts__, {'test': False}):
+                comt = ('Kinesis stream {0} successfully created,\n'
+                        'Kinesis stream {0}: retention hours did not require change, already set at {1},\n'
+                        'Kinesis stream {0}: enhanced monitoring did not require change, already set at {2},\n'
+                        'Kinesis stream {0}: did not require resharding, remains at {3} shards'
+                        .format(name, retention_hours, enhanced_monitoring, num_shards))
+                ret.update({'comment': comt, 'result': True,
+                            'changes': changes})
+                self.assertDictEqual(ret, boto_kinesis.present(name, retention_hours, enhanced_monitoring, num_shards))
 
     # 'absent' function tests: 1
 


### PR DESCRIPTION
### What does this PR do?

Adds support for kinesis management via boto, in the style of other boto modules (boto_dynamodb, boto_ec2, etc). Includes functionality to create or delete a stream, reshard a stream, change enhanced monitoring, and change retention hours. State file for boto_kinesis.present and boto_kinesis.absent; plus module file for the various useful methods.

One note: this reshards a stream such that the partition space stays balanced, which means the actual reshard process can take a really long time - it could take hours for N -> N+1 shards, but would be minutes for 2^N -> 2^N+1 shards. There are warnings in the documentation here to that effect.

I relied heavily on the existing boto_\* files and tests when writing this (especially boto_dynamodb) and thank those authors for their work.
### What issues does this PR fix or reference?
#37203
### Tests written?

Yes, some unit tests.
