### PR TITLE
Fix cloud tests timeout

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1300,12 +1300,13 @@ class ShellCase(AdaptedConfigurationTestCaseMixIn, ShellTestCase):
         arg_str = '--config-dir {0} {1}'.format(self.get_config_dir(), arg_str)
         return self.run_script('salt-call', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr, timeout=30)
 
-    def run_cloud(self, arg_str, catch_stderr=False, timeout=None):
+    def run_cloud(self, arg_str, catch_stderr=False, timeout=15):
         '''
         Execute salt-cloud
         '''
         arg_str = '-c {0} {1}'.format(self.get_config_dir(), arg_str)
-        return self.run_script('salt-cloud', arg_str, catch_stderr, timeout)
+        return self.run_script('salt-cloud', arg_str, catch_stderr,
+                               timeout=timeout)
 
 
 class ShellCaseCommonTestsMixIn(CheckShellBinaryNameAndVersionMixIn):

--- a/tests/integration/cloud/providers/digital_ocean.py
+++ b/tests/integration/cloud/providers/digital_ocean.py
@@ -157,17 +157,17 @@ class DigitalOceanTest(integration.ShellCase):
         try:
             self.assertIn(
                 INSTANCE_NAME,
-                [i.strip() for i in self.run_cloud('-p digitalocean-test {0}'.format(INSTANCE_NAME))]
+                [i.strip() for i in self.run_cloud('-p digitalocean-test {0}'.format(INSTANCE_NAME), timeout=500)]
             )
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
             raise
 
         # delete the instance
         try:
             self.assertIn(
                 'True',
-                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))]
+                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)]
             )
         except AssertionError:
             raise
@@ -176,7 +176,7 @@ class DigitalOceanTest(integration.ShellCase):
         # This was originally in a tearDown function, but that didn't make sense
         # To run this for each test when not all tests create instances.
         if INSTANCE_NAME in [i.strip() for i in self.run_cloud('--query')]:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
 
 
 if __name__ == '__main__':

--- a/tests/integration/cloud/providers/ec2.py
+++ b/tests/integration/cloud/providers/ec2.py
@@ -99,18 +99,18 @@ class EC2Test(integration.ShellCase):
         Tests creating and deleting an instance on EC2 (classic)
         '''
         # create the instance
-        instance = self.run_cloud('-p ec2-test {0}'.format(INSTANCE_NAME))
+        instance = self.run_cloud('-p ec2-test {0}'.format(INSTANCE_NAME), timeout=500)
         ret_str = '{0}:'.format(INSTANCE_NAME)
 
         # check if instance returned with salt installed
         try:
             self.assertIn(ret_str, instance)
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
             raise
 
         # delete the instance
-        delete = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+        delete = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
         ret_str = '                    shutting-down'
 
         # check if deletion was performed appropriately
@@ -128,7 +128,7 @@ class EC2Test(integration.ShellCase):
 
         # if test instance is still present, delete it
         if ret_str in query:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
 
 
 if __name__ == '__main__':

--- a/tests/integration/cloud/providers/gce.py
+++ b/tests/integration/cloud/providers/gce.py
@@ -92,18 +92,18 @@ class GCETest(integration.ShellCase):
         '''
 
         # create the instance
-        instance = self.run_cloud('-p gce-test {0}'.format(self.INSTANCE_NAME))
+        instance = self.run_cloud('-p gce-test {0}'.format(self.INSTANCE_NAME), timeout=500)
         ret_str = '{0}:'.format(self.INSTANCE_NAME)
 
         # check if instance returned with salt installed
         try:
             self.assertIn(ret_str, instance)
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=500)
             raise
 
         # delete the instance
-        delete = self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME))
+        delete = self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=500)
         # example response: ['gce-config:', '----------', '    gce:', '----------', 'cloud-test-dq4e6c:', 'True', '']
         delete_str = ''.join(delete)
 
@@ -127,11 +127,11 @@ class GCETest(integration.ShellCase):
         try:
             self.assertIn(ret_str, instance)
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=500)
             raise
 
         # delete the instance
-        delete = self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME))
+        delete = self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=500)
         # example response: ['gce-config:', '----------', '    gce:', '----------', 'cloud-test-dq4e6c:', 'True', '']
         delete_str = ''.join(delete)
 
@@ -152,7 +152,7 @@ class GCETest(integration.ShellCase):
 
         # if test instance is still present, delete it
         if ret_str in query:
-            self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=500)
 
 
 if __name__ == '__main__':

--- a/tests/integration/cloud/providers/gogrid.py
+++ b/tests/integration/cloud/providers/gogrid.py
@@ -86,17 +86,17 @@ class GoGridTest(integration.ShellCase):
         try:
             self.assertIn(
                 INSTANCE_NAME,
-                [i.strip() for i in self.run_cloud('-p gogrid-test {0}'.format(INSTANCE_NAME))]
+                [i.strip() for i in self.run_cloud('-p gogrid-test {0}'.format(INSTANCE_NAME), timeout=500)]
             )
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
             raise
 
         # delete the instance
         try:
             self.assertIn(
                 INSTANCE_NAME + ':',
-                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))]
+                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)]
             )
         except AssertionError:
             raise
@@ -110,7 +110,7 @@ class GoGridTest(integration.ShellCase):
 
         # if test instance is still present, delete it
         if ret_str in query:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
 
 
 if __name__ == '__main__':

--- a/tests/integration/cloud/providers/joyent.py
+++ b/tests/integration/cloud/providers/joyent.py
@@ -86,17 +86,17 @@ class JoyentTest(integration.ShellCase):
         try:
             self.assertIn(
                 INSTANCE_NAME,
-                [i.strip() for i in self.run_cloud('-p joyent-test {0}'.format(INSTANCE_NAME))]
+                [i.strip() for i in self.run_cloud('-p joyent-test {0}'.format(INSTANCE_NAME), timeout=500)]
             )
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
             raise
 
         # delete the instance
         try:
             self.assertIn(
                 INSTANCE_NAME + ':',
-                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))]
+                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)]
             )
         except AssertionError:
             raise
@@ -110,7 +110,7 @@ class JoyentTest(integration.ShellCase):
 
         # if test instance is still present, delete it
         if ret_str in query:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
 
 
 if __name__ == '__main__':

--- a/tests/integration/cloud/providers/linode.py
+++ b/tests/integration/cloud/providers/linode.py
@@ -84,17 +84,17 @@ class LinodeTest(integration.ShellCase):
         try:
             self.assertIn(
                 INSTANCE_NAME,
-                [i.strip() for i in self.run_cloud('-p linode-test {0}'.format(INSTANCE_NAME))]
+                [i.strip() for i in self.run_cloud('-p linode-test {0}'.format(INSTANCE_NAME), timeout=500)]
             )
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
             raise
 
         # delete the instance
         try:
             self.assertIn(
                 INSTANCE_NAME + ':',
-                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))]
+                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)]
             )
         except AssertionError:
             raise
@@ -108,7 +108,7 @@ class LinodeTest(integration.ShellCase):
 
         # if test instance is still present, delete it
         if ret_str in query:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
 
 
 if __name__ == '__main__':

--- a/tests/integration/cloud/providers/profitbricks.py
+++ b/tests/integration/cloud/providers/profitbricks.py
@@ -96,11 +96,11 @@ class ProfitBricksTest(integration.ShellCase):
             self.assertIn(
                 INSTANCE_NAME,
                 [i.strip() for i in self.run_cloud(
-                    '-p profitbricks-test {0}'.format(INSTANCE_NAME)
+                    '-p profitbricks-test {0}'.format(INSTANCE_NAME), timeout=500
                 )]
             )
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
             raise
 
         # delete the instance
@@ -108,7 +108,7 @@ class ProfitBricksTest(integration.ShellCase):
             self.assertIn(
                 INSTANCE_NAME + ':',
                 [i.strip() for i in self.run_cloud(
-                    '-d {0} --assume-yes'.format(INSTANCE_NAME)
+                    '-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500
                 )]
             )
         except AssertionError:
@@ -123,7 +123,7 @@ class ProfitBricksTest(integration.ShellCase):
 
         # if test instance is still present, delete it
         if ret in query:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
 
 
 if __name__ == '__main__':

--- a/tests/integration/cloud/providers/rackspace.py
+++ b/tests/integration/cloud/providers/rackspace.py
@@ -94,17 +94,17 @@ class RackspaceTest(integration.ShellCase):
         try:
             self.assertIn(
                 INSTANCE_NAME,
-                [i.strip() for i in self.run_cloud('-p rackspace-test {0}'.format(INSTANCE_NAME))]
+                [i.strip() for i in self.run_cloud('-p rackspace-test {0}'.format(INSTANCE_NAME), timeout=500)]
             )
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
             raise
 
         # delete the instance
         try:
             self.assertIn(
                 INSTANCE_NAME + ':',
-                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))]
+                [i.strip() for i in self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)]
             )
         except AssertionError:
             raise
@@ -118,7 +118,7 @@ class RackspaceTest(integration.ShellCase):
 
         # if test instance is still present, delete it
         if ret in query:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
 
 
 if __name__ == '__main__':

--- a/tests/integration/cloud/providers/vultr.py
+++ b/tests/integration/cloud/providers/vultr.py
@@ -160,16 +160,16 @@ class VultrTest(integration.ShellCase):
         try:
             self.assertIn(
                 INSTANCE_NAME,
-                [i.strip() for i in self.run_cloud('-p vultr-test {0}'.format(INSTANCE_NAME))]
+                [i.strip() for i in self.run_cloud('-p vultr-test {0}'.format(INSTANCE_NAME), timeout=500)]
             )
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
             raise
 
         # Vultr won't let us delete an instance less than 5 minutes old.
         time.sleep(420)
         # delete the instance
-        results = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+        results = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
         try:
             self.assertIn(
                 'True',
@@ -185,7 +185,7 @@ class VultrTest(integration.ShellCase):
         # If we exceed 6 minutes and the instance is still there, quit
         ct = 0
         while ct < 12 and INSTANCE_NAME in [i.strip() for i in self.run_cloud('--query')]:
-            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
             time.sleep(30)
             ct = ct + 1
 


### PR DESCRIPTION
### What does this PR do?

The cloud tests kept running into this error: `Process took more than 15 seconds to complete. Process Killed!` due to a default timeout of 15 seconds. Increasing the timeout so the cloud tests can run correctly.