### PR TITLE
win_wua state and util

### DIFF
--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -135,22 +135,22 @@ def available(software=True,
     .. code-block:: bash
 
         # Normal Usage (list all software updates)
-        salt '*' win_wua.list_updates
+        salt '*' win_wua.available
 
         # List all updates with categories of Critical Updates and Drivers
-        salt '*' win_wua.list_updates categories=['Critical Updates','Drivers']
+        salt '*' win_wua.available categories=['Critical Updates','Drivers']
 
         # List all Critical Security Updates
-        salt '*' win_wua.list_updates categories=['Security Updates'] severities=['Critical']
+        salt '*' win_wua.available categories=['Security Updates'] severities=['Critical']
 
         # List all updates with a severity of Critical
-        salt '*' win_wua.list_updates severities=['Critical']
+        salt '*' win_wua.available severities=['Critical']
 
         # A summary of all available updates
-        salt '*' win_wua.list_updates summary=True
+        salt '*' win_wua.available summary=True
 
         # A summary of all Feature Packs and Windows 8.1 Updates
-        salt '*' win_wua.list_updates categories=['Feature Packs','Windows 8.1'] summary=True
+        salt '*' win_wua.available categories=['Feature Packs','Windows 8.1'] summary=True
     '''
 
     # Create a Windows Update Agent instance
@@ -168,7 +168,7 @@ def available(software=True,
         return updates.list()
 
 
-def list_update(name=None, download=False, install=False):
+def list_update(name, download=False, install=False):
     '''
     Returns details for all updates that match the search criteria
 
@@ -943,13 +943,4 @@ def get_needs_reboot():
         salt '*' win_wua.get_needs_reboot
 
     '''
-    # Initialize the PyCom system
-    pythoncom.CoInitialize()
-
-    # Create an AutoUpdate object
-    obj_sys = win32com.client.Dispatch('Microsoft.Update.SystemInfo')
-
-    if obj_sys.RebootRequired:
-        return True
-    else:
-        return False
+    return salt.utils.win_update.WindowsUpdateAgent.needs_reboot()

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -162,10 +162,7 @@ def available(software=True,
                             severities)
 
     # Return results as Summary or Details
-    if summary:
-        return updates.summary()
-    else:
-        return updates.list()
+    return updates.summary() if summary else updates.list()
 
 
 def list_update(name, download=False, install=False):
@@ -249,10 +246,7 @@ def list_update(name, download=False, install=False):
     if install:
         ret['Install'] = wua.install(updates.updates)
 
-    if not ret:
-        return updates.list()
-
-    return ret
+    return ret if ret else updates.list()
 
 
 def list_updates(software=True,
@@ -393,10 +387,7 @@ def list_updates(software=True,
         ret['Install'] = wua.install(updates.updates)
 
     if not ret:
-        if summary:
-            return updates.summary()
-        else:
-            return updates.list()
+        return updates.summary() if summary else updates.list()
 
     return ret
 
@@ -435,7 +426,7 @@ def download_update(name):
         raise CommandExecutionError('No updates found')
 
     if updates.count() > 1:
-        raise CommandExecutionError('More than one update found')
+        raise CommandExecutionError('Multiple updates found, narrow your search')
 
     return wua.download(updates.updates)
 
@@ -507,7 +498,7 @@ def install_update(name):
         raise CommandExecutionError('No updates found')
 
     if updates.count() > 1:
-        raise CommandExecutionError('More than one update found')
+        raise CommandExecutionError('Multiple updates found, narrow your search')
 
     return wua.install(updates.updates)
 
@@ -579,7 +570,7 @@ def uninstall(name):
         raise CommandExecutionError('No updates found')
 
     if updates.count() > 1:
-        raise CommandExecutionError('More than one update found')
+        raise CommandExecutionError('Multiple updates found, narrow your search')
 
     return wua.uninstall(updates.updates)
 
@@ -943,4 +934,4 @@ def get_needs_reboot():
         salt '*' win_wua.get_needs_reboot
 
     '''
-    return salt.utils.win_update.WindowsUpdateAgent.needs_reboot()
+    return salt.utils.win_update.needs_reboot()

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Module for managing Windows Updates using the Windows Update Agent.
 
 .. versionadded:: 2015.8.0
 
 :depends:
-        - win32com
-        - pythoncom
-"""
+        - salt.utils.win_wua
+'''
 from __future__ import absolute_import
 
 # Import Python libs
@@ -15,277 +14,90 @@ import logging
 
 # Import Salt libs
 from salt.ext import six
-from salt.ext.six.moves import range  # pylint: disable=no-name-in-module,redefined-builtin
-import salt.utils.win_wua
-
-# Import 3rd-party libs
-try:
-    import win32com.client
-    import pythoncom
-
-    HAS_DEPENDENCIES = True
-except ImportError:
-    HAS_DEPENDENCIES = False
-
-# Import salt libs
 import salt.utils
+import salt.utils.win_wua
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    """
-    Only works on Windows systems
-    """
-    if salt.utils.is_windows() and HAS_DEPENDENCIES:
-        return True
-    return (False, "Module win_wua: module has failed dependencies or is not on Windows client")
+    '''
+    Only works on Windows systems with PyWin32
+    '''
+    if not salt.utils.is_windows():
+        return False, 'WUA: Only available on Window systems'
+
+    if not salt.utils.win_wua.HAS_PYWIN32:
+        return False, 'WUA: Requires PyWin32 libraries'
+
+    return True
 
 
-def _wua_search(skip_hidden=True,
-                skip_installed=True,
-                skip_present=False,
-                skip_reboot=False,
-                software_updates=True,
-                driver_updates=True):
-    # Build the search string
-    search_string = ''
-    search_params = []
+def available(software=True,
+              drivers=True,
+              summary=False,
+              skip_installed=True,
+              skip_hidden=True,
+              skip_mandatory=False,
+              skip_reboot=False,
+              categories=None,
+              severities=None,
+              ):
+    '''
+    List updates that match the passed criteria.
 
-    if skip_hidden:
-        search_params.append('IsHidden=0')
+    Args:
 
-    if skip_installed:
-        search_params.append('IsInstalled=0')
+        software (bool): Include software updates in the results (default is
+        True)
 
-    if skip_present:
-        search_params.append('IsPresent=0')
+        drivers (bool): Include driver updates in the results (default is False)
 
-    if skip_reboot:
-        search_params.append('RebootRequired=0')
+        summary (bool):
+        - True: Return a summary of updates available for each category.
+        - False (default): Return a detailed list of available updates.
 
-    for i in search_params:
-        search_string += '{0} and '.format(i)
+        skip_installed (bool): Skip updates that are already installed. Default
+        is False.
 
-    if software_updates and driver_updates:
-        search_string += 'Type=\'Software\' or Type=\'Driver\''
-    elif software_updates:
-        search_string += 'Type=\'Software\''
-    elif driver_updates:
-        search_string += 'Type=\'Driver\''
-    else:
-        log.debug('Neither Software nor Drivers included in search. Results will be empty.')
-        return False
+        skip_hidden (bool): Skip updates that have been hidden. Default is True.
 
-    # Initialize the PyCom system
-    pythoncom.CoInitialize()
+        skip_mandatory (bool): Skip mandatory updates. Default is False.
 
-    # Create a session with the Windows Update Agent
-    wua_session = win32com.client.Dispatch('Microsoft.Update.Session')
+        skip_reboot (bool): Skip updates that require a reboot. Default is
+        False.
 
-    # Create a searcher object
-    wua_searcher = wua_session.CreateUpdateSearcher()
+        categories (list): Specify the categories to list. Must be passed as a
+        list. All categories returned by default.
 
-    # Search for updates
-    try:
-        log.debug('Searching for updates: {0}'.format(search_string))
-        results = wua_searcher.Search(search_string)
-        log.debug('Search completed successfully')
-        return results.Updates
-    except Exception as exc:
-        log.info('Search for updates failed. {0}'.format(exc))
-        return exc
+            Categories include the following:
 
+            * Critical Updates
+            * Definition Updates
+            * Drivers (make sure you set drivers=True)
+            * Feature Packs
+            * Security Updates
+            * Update Rollups
+            * Updates
+            * Update Rollups
+            * Windows 7
+            * Windows 8.1
+            * Windows 8.1 drivers
+            * Windows 8.1 and later drivers
+            * Windows Defender
 
-def _filter_list_by_category(updates, categories=None):
-    # This function filters the updates list based on Category
+        severities (list): Specify the severities to include. Must be passed as
+        a list. All severities returned by default.
 
-    if not updates:
-        return 'No updates found'
+            Severities include the following:
 
-    update_list = win32com.client.Dispatch('Microsoft.Update.UpdateColl')
+            * Critical
+            * Important
 
-    for update in updates:
+    Returns:
 
-        category_match = False
-
-        # If no categories were passed, return all categories
-        # Set categoryMatch to True
-        if categories is None:
-            category_match = True
-        else:
-            # Loop through each category found in the update
-            for category in update.Categories:
-                # If the update category exists in the list of categories
-                # passed, then set categoryMatch to True
-                if category.Name in categories:
-                    category_match = True
-
-        if category_match:
-            update_list.Add(update)
-
-    return update_list
-
-
-def _filter_list_by_severity(updates, severities=None):
-    # This function filters the updates list based on Category
-
-    if not updates:
-        return 'No updates found'
-
-    update_list = win32com.client.Dispatch('Microsoft.Update.UpdateColl')
-
-    for update in updates:
-
-        severity_match = False
-
-        # If no severities were passed, return all categories
-        # Set severity_match to True
-        if severities is None:
-            severity_match = True
-        else:
-            # If the severity exists in the list of severities passed, then set
-            # severity_match to True
-            if update.MsrcSeverity in severities:
-                severity_match = True
-
-        if severity_match:
-            update_list.Add(update)
-
-    return update_list
-
-
-def _list_updates_build_summary(updates):
-    if updates.Count == 0:
-        return 'Nothing to return'
-
-    results = {}
-
-    log.debug('Building update summary')
-
-    # Build a dictionary containing a summary of updates available
-    results['Total'] = 0
-    results['Available'] = 0
-    results['Downloaded'] = 0
-    results['Installed'] = 0
-    results['Categories'] = {}
-    results['Severity'] = {}
-
-    for update in updates:
-
-        # Count the total number of updates available
-        results['Total'] += 1
-
-        # Updates available for download
-        if not update.IsDownloaded and not update.IsInstalled:
-            results['Available'] += 1
-
-        # Updates downloaded awaiting install
-        if update.IsDownloaded and not update.IsInstalled:
-            results['Downloaded'] += 1
-
-        # Updates installed
-        if update.IsInstalled:
-            results['Installed'] += 1
-
-        # Add Categories and increment total for each one
-        # The sum will be more than the total because each update can have
-        # multiple categories
-        for category in update.Categories:
-            if category.Name in results['Categories']:
-                results['Categories'][category.Name] += 1
-            else:
-                results['Categories'][category.Name] = 1
-
-        # Add Severity Summary
-        if update.MsrcSeverity:
-            if update.MsrcSeverity in results['Severity']:
-                results['Severity'][update.MsrcSeverity] += 1
-            else:
-                results['Severity'][update.MsrcSeverity] = 1
-
-    return results
-
-
-def _list_updates_build_report(updates):
-    if updates.Count == 0:
-        return 'Nothing to return'
-
-    results = {}
-
-    log.debug('Building a detailed report of the results.')
-
-    # Build a dictionary containing details for each update
-
-    for update in updates:
-
-        guid = update.Identity.UpdateID
-        results[guid] = {}
-        results[guid]['guid'] = guid
-        title = update.Title
-        results[guid]['Title'] = title
-        kb = ""
-        if "KB" in title:
-            kb = title[title.find("(") + 1: title.find(")")]
-        results[guid]['KB'] = kb
-        results[guid]['Description'] = update.Description
-        results[guid]['Downloaded'] = str(update.IsDownloaded)
-        results[guid]['Installed'] = str(update.IsInstalled)
-        results[guid]['Mandatory'] = str(update.IsMandatory)
-        results[guid]['UserInput'] = str(update.InstallationBehavior.CanRequestUserInput)
-        results[guid]['EULAAccepted'] = str(update.EulaAccepted)
-
-        # Severity of the Update
-        # Can be: Critical, Important, Low, Moderate, <unspecified or empty>
-        results[guid]['Severity'] = str(update.MsrcSeverity)
-
-        # This value could easily be confused with the Reboot Behavior value
-        # This is stating whether or not the INSTALLED update is awaiting
-        # reboot
-        results[guid]['NeedsReboot'] = str(update.RebootRequired)
-
-        # Interpret the RebootBehavior value
-        # This value is referencing an update that has NOT been installed
-        rb = {0: 'Never Requires Reboot',
-              1: 'Always Requires Reboot',
-              2: 'Can Require Reboot'}
-        results[guid]['RebootBehavior'] = rb[update.InstallationBehavior.RebootBehavior]
-
-        # Add categories (nested list)
-        results[guid]['Categories'] = []
-        for category in update.Categories:
-            results[guid]['Categories'].append(category.Name)
-
-    return results
-
-
-def list_update(name=None,
-                download=False,
-                install=False):
-    """
-    Returns details for all updates that match the search criteria
-
-    :param str name:
-        The name of the update you're searching for. This can be the GUID
-        (preferred), a KB number, or the full name of the update. Run list_updates
-        to get the GUID for the update you're looking for.
-
-    :param bool download:
-        Download the update returned by this function. Run this function first
-        to see if the update exists, then set download=True to download the
-        update.
-
-    :param bool install:
-        Install the update returned by this function. Run this function first
-        to see if the update exists, then set install=True to install the
-        update. This will override download=True
-
-    :return:
-        Returns a dict containing a list of updates that match the name if
-        download and install are both set to False. Should usually be a single
-        update, but can return multiple if a partial name is given. If download or
-        install is set to true it will return the results of
-        win_wua.download_updates:
+        dict: Returns a dict containing either a summary or a list of updates:
 
         .. code-block:: cfg
 
@@ -293,175 +105,6 @@ def list_update(name=None,
             {'<GUID>': {'Title': <title>,
                         'KB': <KB>,
                         'GUID': <the globally unique identifier for the update>
-                        'Description': <description>,
-                        'Downloaded': <has the update been downloaded>,
-                        'Installed': <has the update been installed>,
-                        'Mandatory': <is the update mandatory>,
-                        'UserInput': <is user input required>,
-                        'EULAAccepted': <has the EULA been accepted>,
-                        'Severity': <update severity>,
-                        'NeedsReboot': <is the update installed and awaiting reboot>,
-                        'RebootBehavior': <will the update require a reboot>,
-                        'Categories': [ '<category 1>',
-                                        '<category 2>',
-                                        ...]
-                        }
-            }
-
-    :return type: dict
-
-    CLI Examples:
-
-    .. code-block:: bash
-
-        # Recommended Usage using GUID without braces
-        # Use this to find the status of a specific update
-        salt '*' win_wua.list_update 12345678-abcd-1234-abcd-1234567890ab
-
-        # Use the following if you don't know the GUID:
-
-        # Using a KB number (could possibly return multiple results)
-        # Not all updates have an associated KB
-        salt '*' win_wua.list_update KB3030298
-
-        # Using part or all of the name of the update
-        # Could possibly return multiple results
-        # Not all updates have an associated KB
-        salt '*' win_wua.list_update 'Microsoft Camera Codec Pack'
-
-    """
-    if name is None:
-        return 'Nothing to list'
-
-    # Initialize the PyCom system
-    pythoncom.CoInitialize()
-
-    # Create a session with the Windows Update Agent
-    wua_session = win32com.client.Dispatch('Microsoft.Update.Session')
-
-    # Create the searcher
-    wua_searcher = wua_session.CreateUpdateSearcher()
-
-    # Create the found update collection
-    wua_found = win32com.client.Dispatch('Microsoft.Update.UpdateColl')
-
-    # Try searching for the GUID first
-    search_string = 'UpdateID=\'{0}\''.format(name)
-
-    log.debug('Searching for update: {0}'.format(search_string.lower()))
-    try:
-        found_using_guid = False
-        wua_search_result = wua_searcher.Search(search_string.lower())
-        if wua_search_result.Updates.Count > 0:
-            found_using_guid = True
-        else:
-            return "No update found"
-    except Exception:
-        log.debug('GUID not found, searching Title: {0}'.format(name))
-        search_string = 'Type=\'Software\' or Type=\'Driver\''
-        wua_search_result = wua_searcher.Search(search_string)
-
-    # Populate wua_found
-    if found_using_guid:
-        # Found using GUID so there should only be one
-        # Add it to the collection
-        for update in wua_search_result.Updates:
-            wua_found.Add(update)
-    else:
-        # Not found using GUID
-        # Try searching the title for the Name or KB
-        for update in wua_search_result.Updates:
-            if name in update.Title:
-                wua_found.Add(update)
-
-    if install:
-        guid_list = []
-        for update in wua_found:
-            guid_list.append(update.Identity.UpdateID)
-        return install_updates(guid_list)
-
-    if download:
-        guid_list = []
-        for update in wua_found:
-            guid_list.append(update.Identity.UpdateID)
-        return download_updates(guid_list)
-
-    return _list_updates_build_report(wua_found)
-
-
-def list_updates(software=True,
-                 drivers=False,
-                 summary=False,
-                 installed=False,
-                 categories=None,
-                 severities=None,
-                 download=False,
-                 install=False):
-    """
-    Returns a detailed list of available updates or a summary
-
-    :param bool software:
-        Include software updates in the results (default is True)
-
-    :param bool drivers:
-        Include driver updates in the results (default is False)
-
-    :param bool summary:
-        True: Return a summary of updates available for each category.\
-        False (default): Return a detailed list of available updates.
-
-    :param bool installed:
-        Include installed updates in the results (default if False)
-
-    :param bool download:
-        (Overrides reporting functionality) Download the list of updates
-        returned by this function. Run this function first to see what will be
-        installed, then set download=True to download the updates.
-
-    :param bool install:
-        (Overrides reporting functionality) Install the list of updates
-        returned by this function. Run this function first to see what will be
-        installed, then set install=True to install the updates. This will
-        override download=True
-
-    :param list categories:
-        Specify the categories to list. Must be passed as a list. All
-        categories returned by default.
-
-        Categories include the following:
-
-        * Critical Updates
-        * Definition Updates
-        * Drivers (make sure you set drivers=True)
-        * Feature Packs
-        * Security Updates
-        * Update Rollups
-        * Updates
-        * Update Rollups
-        * Windows 7
-        * Windows 8.1
-        * Windows 8.1 drivers
-        * Windows 8.1 and later drivers
-        * Windows Defender
-
-    :param list severities:
-        Specify the severities to include. Must be passed as a list. All
-        severities returned by default.
-
-        Severities include the following:
-
-        * Critical
-        * Important
-
-    :return:
-        Returns a dict containing either a summary or a list of updates:
-
-        .. code-block:: cfg
-
-            List of Updates:
-            {'<GUID>': {'Title': <title>,
-                        'KB': <KB>,
-                        'GUID': <the globally uinique identifier for the update>
                         'Description': <description>,
                         'Downloaded': <has the update been downloaded>,
                         'Installed': <has the update been installed>,
@@ -486,7 +129,6 @@ def list_updates(software=True,
                              <category 2>: <total for category 2>,
                              ... }
             }
-    :return type: dict
 
     CLI Examples:
 
@@ -509,53 +151,270 @@ def list_updates(software=True,
 
         # A summary of all Feature Packs and Windows 8.1 Updates
         salt '*' win_wua.list_updates categories=['Feature Packs','Windows 8.1'] summary=True
+    '''
 
-    """
-    # Get the list of updates
-    updates = _wua_search(software_updates=software,
-                          driver_updates=drivers,
-                          skip_installed=not installed)
+    # Create a Windows Update Agent instance
+    wua = salt.utils.win_wua.WindowsUpdateAgent()
 
-    # Filter the list of updates
-    updates = _filter_list_by_category(updates=updates,
-                                       categories=categories)
+    # Look for available
+    updates = wua.available(skip_hidden, skip_installed, skip_mandatory,
+                            skip_reboot, software, drivers, categories,
+                            severities)
 
-    updates = _filter_list_by_severity(updates=updates,
-                                       severities=severities)
-
-    # If the list is empty after filtering, return a message
-    if not updates:
-        return 'No updates found. Check software and drivers parameters. One ' \
-               'must be true.'
-
-    if install:
-        guid_list = []
-        for update in updates:
-            guid_list.append(update.Identity.UpdateID)
-        return install_updates(guid_list)
-
-    if download:
-        guid_list = []
-        for update in updates:
-            guid_list.append(update.Identity.UpdateID)
-        return download_updates(guid_list)
-
+    # Return results as Summary or Details
     if summary:
-        return _list_updates_build_summary(updates)
+        return updates.summary()
     else:
-        return _list_updates_build_report(updates)
+        return updates.list()
 
 
-def download_update(guid=None):
-    """
-    Downloads a single update
+def list_update(name=None, download=False, install=False):
+    '''
+    Returns details for all updates that match the search criteria
 
-    :param guid: str
-        A GUID for the update to be downloaded
+    Args:
+        name (str): The name of the update you're searching for. This can be the
+        GUID (preferred), a KB number, or any part of the name of the update.
+        Run ``list_updates`` to get the GUID for the update you're looking for.
 
-    :return:
-        A dictionary containing the status, a message, and a list of updates
-        that were downloaded.
+        download (bool): Download the update returned by this function. Run this
+        function first to see if the update exists, then set ``download=True``
+        to download the update.
+
+        install (bool): Install the update returned by this function. Run this
+        function first to see if the update exists, then set ``install=True`` to
+        install the update.
+
+    Returns:
+        dict: Returns a dict containing a list of updates that match the name if
+        download and install are both set to False. Should usually be a single
+        update, but can return multiple if a partial name is given.
+
+        If download or install is set to true it will return the results of the
+        operation.
+
+        .. code-block:: cfg
+
+            List of Updates:
+            {'<GUID>': {'Title': <title>,
+                        'KB': <KB>,
+                        'GUID': <the globally unique identifier for the update>
+                        'Description': <description>,
+                        'Downloaded': <has the update been downloaded>,
+                        'Installed': <has the update been installed>,
+                        'Mandatory': <is the update mandatory>,
+                        'UserInput': <is user input required>,
+                        'EULAAccepted': <has the EULA been accepted>,
+                        'Severity': <update severity>,
+                        'NeedsReboot': <is the update installed and awaiting reboot>,
+                        'RebootBehavior': <will the update require a reboot>,
+                        'Categories': [ '<category 1>',
+                                        '<category 2>',
+                                        ...]
+                        }
+            }
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        # Recommended Usage using GUID without braces
+        # Use this to find the status of a specific update
+        salt '*' win_wua.list_update 12345678-abcd-1234-abcd-1234567890ab
+
+        # Use the following if you don't know the GUID:
+
+        # Using a KB number (could possibly return multiple results)
+        # Not all updates have an associated KB
+        salt '*' win_wua.list_update KB3030298
+
+        # Using part or all of the name of the update
+        # Could possibly return multiple results
+        # Not all updates have an associated KB
+        salt '*' win_wua.list_update 'Microsoft Camera Codec Pack'
+    '''
+    # Create a Windows Update Agent instance
+    wua = salt.utils.win_wua.WindowsUpdateAgent()
+
+    # Search for Update
+    updates = wua.search(name)
+
+    ret = {}
+
+    # Download
+    if download or install:
+        ret['Download'] = wua.download(updates.updates)
+
+    # Install
+    if install:
+        ret['Install'] = wua.install(updates.updates)
+
+    if not ret:
+        return updates.list()
+
+    return ret
+
+
+def list_updates(software=True,
+                 drivers=False,
+                 summary=False,
+                 skip_installed=True,
+                 categories=None,
+                 severities=None,
+                 download=False,
+                 install=False):
+    '''
+    Returns a detailed list of available updates or a summary. If download or
+    install is True the same list will be downloaded and/or installed.
+
+    Args:
+        software (bool): Include software updates in the results (default is
+        True)
+
+        drivers (bool): Include driver updates in the results (default is False)
+
+        summary (bool):
+        - True: Return a summary of updates available for each category.
+        - False (default): Return a detailed list of available updates.
+
+        skip_installed (bool): Skip installed updates in the results (default is
+        False)
+
+        download (bool): (Overrides reporting functionality) Download the list
+        of updates returned by this function. Run this function first with
+        ``download=False`` to see what will be downloaded, then set
+        ``download=True`` to download the updates.
+
+        install (bool): (Overrides reporting functionality) Install the list of
+        updates returned by this function. Run this function first with
+        ``install=False`` to see what will be installed, then set
+        ``install=True`` to install the updates.
+
+        categories (list): Specify the categories to list. Must be passed as a
+        list. All categories returned by default.
+
+            Categories include the following:
+
+            * Critical Updates
+            * Definition Updates
+            * Drivers (make sure you set drivers=True)
+            * Feature Packs
+            * Security Updates
+            * Update Rollups
+            * Updates
+            * Update Rollups
+            * Windows 7
+            * Windows 8.1
+            * Windows 8.1 drivers
+            * Windows 8.1 and later drivers
+            * Windows Defender
+
+        severities (list): Specify the severities to include. Must be passed as
+        a list. All severities returned by default.
+
+            Severities include the following:
+
+            * Critical
+            * Important
+
+    Returns:
+
+        dict: Returns a dict containing either a summary or a list of updates:
+
+        .. code-block:: cfg
+
+            List of Updates:
+            {'<GUID>': {'Title': <title>,
+                        'KB': <KB>,
+                        'GUID': <the globally unique identifier for the update>
+                        'Description': <description>,
+                        'Downloaded': <has the update been downloaded>,
+                        'Installed': <has the update been installed>,
+                        'Mandatory': <is the update mandatory>,
+                        'UserInput': <is user input required>,
+                        'EULAAccepted': <has the EULA been accepted>,
+                        'Severity': <update severity>,
+                        'NeedsReboot': <is the update installed and awaiting reboot>,
+                        'RebootBehavior': <will the update require a reboot>,
+                        'Categories': [ '<category 1>',
+                                        '<category 2>',
+                                        ...]
+                        }
+            }
+
+            Summary of Updates:
+            {'Total': <total number of updates returned>,
+             'Available': <updates that are not downloaded or installed>,
+             'Downloaded': <updates that are downloaded but not installed>,
+             'Installed': <updates installed (usually 0 unless installed=True)>,
+             'Categories': { <category 1>: <total for that category>,
+                             <category 2>: <total for category 2>,
+                             ... }
+            }
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        # Normal Usage (list all software updates)
+        salt '*' win_wua.list_updates
+
+        # List all updates with categories of Critical Updates and Drivers
+        salt '*' win_wua.list_updates categories=['Critical Updates','Drivers']
+
+        # List all Critical Security Updates
+        salt '*' win_wua.list_updates categories=['Security Updates'] severities=['Critical']
+
+        # List all updates with a severity of Critical
+        salt '*' win_wua.list_updates severities=['Critical']
+
+        # A summary of all available updates
+        salt '*' win_wua.list_updates summary=True
+
+        # A summary of all Feature Packs and Windows 8.1 Updates
+        salt '*' win_wua.list_updates categories=['Feature Packs','Windows 8.1'] summary=True
+    '''
+    # Create a Windows Update Agent instance
+    wua = salt.utils.win_wua.WindowsUpdateAgent()
+
+    # Search for Update
+    updates = wua.available(skip_installed=skip_installed, software=software,
+                            drivers=drivers, categories=categories,
+                            severities=severities)
+
+    ret = {}
+
+    # Download
+    if download or install:
+        ret['Download'] = wua.download(updates.updates)
+
+    # Install
+    if install:
+        ret['Install'] = wua.install(updates.updates)
+
+    if not ret:
+        if summary:
+            return updates.summary()
+        else:
+            return updates.list()
+
+    return ret
+
+
+def download_update(name):
+    '''
+    Downloads a single update.
+
+    Args:
+
+        name (str): The name of the update to download. This can be a GUID, a KB
+        number, or any part of the name. To ensure a single item is matched the
+        GUID is preferred.
+
+        .. note:: If more than one result is returned an error will be raised.
+
+    Returns:
+        dict: A dictionary containing the results of the download
 
     CLI Examples:
 
@@ -563,169 +422,72 @@ def download_update(guid=None):
 
         salt '*' win_wua.download_update 12345678-abcd-1234-abcd-1234567890ab
 
-    """
-    return download_updates([guid])
+        salt '*' win_wua.download_update KB12312321
+
+    '''
+    # Create a Windows Update Agent instance
+    wua = salt.utils.win_wua.WindowsUpdateAgent()
+
+    # Search for Update
+    updates = wua.search(name)
+
+    if updates.count() == 0:
+        raise CommandExecutionError('No updates found')
+
+    if updates.count() > 1:
+        raise CommandExecutionError('More than one update found')
+
+    return wua.download(updates.updates)
 
 
-def download_updates(guid=None):
-    """
-    Downloads updates that match the list of passed GUIDs. It's easier to use
-    this function by using list_updates and setting install=True.
+def download_updates(names):
+    '''
+    Downloads updates that match the list of passed identifiers. It's easier to
+    use this function by using list_updates and setting install=True.
 
-    :param guid:
-        A list of GUIDs to be downloaded
+    Args:
 
-    :return:
-        A dictionary containing the status, a message, and a list of updates
-        that were downloaded.
+        names (list): A list of updates to download. This can be any combination
+        of GUIDs, KB numbers, or names. GUIDs or KBs are preferred.
+
+    Returns:
+
+        dict: A dictionary containing the details about the downloaded updates
 
     CLI Examples:
 
     .. code-block:: bash
 
         # Normal Usage
-        salt '*' win_wua.download_updates \
-                guid=['12345678-abcd-1234-abcd-1234567890ab',\
-                      '87654321-dcba-4321-dcba-ba0987654321']
-    """
-    # Check for empty GUID
-    if guid is None:
-        return "No GUID Specified"
+        salt '*' win_wua.download_updates guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB2131233']
+    '''
+    # Create a Windows Update Agent instance
+    wua = salt.utils.win_wua.WindowsUpdateAgent()
 
-    # Initialize the PyCom system
-    pythoncom.CoInitialize()
+    # Search for Update
+    updates = wua.search(names)
 
-    # Create a session with the Windows Update Agent
-    wua_session = win32com.client.Dispatch('Microsoft.Update.Session')
-    wua_session.ClientApplicationID = 'Salt: Install Update'
+    if updates.count() == 0:
+        raise CommandExecutionError('No updates found')
 
-    # Create the Searcher, Downloader, Installer, and Collections
-    wua_searcher = wua_session.CreateUpdateSearcher()
-    wua_download_list = win32com.client.Dispatch('Microsoft.Update.UpdateColl')
-    wua_downloader = wua_session.CreateUpdateDownloader()
-
-    ret = {}
-
-    # Searching for the GUID
-    search_string = ''
-    search_list = ''
-    log.debug('Searching for updates:')
-    for ident in guid:
-        log.debug('{0}'.format(ident))
-        if search_string == '':
-            search_string = 'UpdateID=\'{0}\''.format(ident.lower())
-            search_list = '{0}'.format(ident.lower())
-        else:
-            search_string += ' or UpdateID=\'{0}\''.format(ident.lower())
-            search_list += '\n{0}'.format(ident.lower())
-
-    try:
-        wua_search_result = wua_searcher.Search(search_string)
-        if wua_search_result.Updates.Count == 0:
-            log.debug('No Updates found for:\n\t\t{0}'.format(search_list))
-            ret['Success'] = False
-            ret['Details'] = 'No Updates found: {0}'.format(search_list)
-            return ret
-    except Exception:
-        log.debug('Invalid Search String: {0}'.format(search_string))
-        return 'Invalid Search String: {0}'.format(search_string)
-
-    # List updates found
-    log.debug('Found the following updates:')
-    ret['Updates'] = {}
-    for update in wua_search_result.Updates:
-        # Check to see if the update is already installed
-        ret['Updates'][update.Identity.UpdateID] = {}
-        ret['Updates'][update.Identity.UpdateID]['Title'] = update.Title
-        if update.IsInstalled:
-            log.debug('Already Installed: {0}'.format(update.Identity.UpdateID))
-            log.debug(u'\tTitle: {0}'.format(update.Title))
-            ret['Updates'][update.Identity.UpdateID]['AlreadyInstalled'] = True
-        # Make sure the EULA has been accepted
-        if not update.EulaAccepted:
-            log.debug(u'Accepting EULA: {0}'.format(update.Title))
-            update.AcceptEula()  # pylint: disable=W0104
-        # Add to the list of updates that need to be downloaded
-        if update.IsDownloaded:
-            log.debug('Already Downloaded: {0}'.format(update.Identity.UpdateID))
-            log.debug(u'\tTitle: {0}'.format(update.Title))
-            ret['Updates'][update.Identity.UpdateID]['AlreadyDownloaded'] = True
-        else:
-            log.debug('To Be Downloaded: {0}'.format(update.Identity.UpdateID))
-            log.debug(u'\tTitle: {0}'.format(update.Title))
-            ret['Updates'][update.Identity.UpdateID]['AlreadyDownloaded'] = False
-            wua_download_list.Add(update)
-
-    # Check the download list
-    if wua_download_list.Count == 0:
-        # Not necessarily a failure, perhaps the update has been downloaded
-        log.debug('No updates to download')
-        ret['Success'] = False
-        ret['Message'] = 'No updates to download'
-        return ret
-
-    # Download the updates
-    log.debug('Downloading...')
-    wua_downloader.Updates = wua_download_list
-
-    try:
-        result = wua_downloader.Download()
-
-    except Exception as error:
-
-        ret['Success'] = False
-        ret['Result'] = format(error)
-
-        hr, msg, exc, arg = error.args  # pylint: disable=W0633
-        # Error codes found at the following site:
-        # https://msdn.microsoft.com/en-us/library/windows/desktop/hh968413(v=vs.85).aspx
-        fc = {-2145124316: 'No Updates: 0x80240024',
-              -2145124284: 'Access Denied: 0x8024044'}
-        try:
-            failure_code = fc[exc[5]]
-        except KeyError:
-            failure_code = 'Unknown Failure: {0}'.format(error)
-
-        log.debug('Download Failed: {0}'.format(failure_code))
-        ret['error_msg'] = failure_code
-        ret['location'] = 'Download Section of download_updates'
-        ret['file'] = 'win_wua.py'
-
-        return ret
-
-    log.debug('Download Complete')
-
-    rc = {0: 'Download Not Started',
-          1: 'Download In Progress',
-          2: 'Download Succeeded',
-          3: 'Download Succeeded With Errors',
-          4: 'Download Failed',
-          5: 'Download Aborted'}
-    log.debug(rc[result.ResultCode])
-
-    if result.ResultCode in [2, 3]:
-        ret['Success'] = True
-    else:
-        ret['Success'] = False
-
-    ret['Message'] = rc[result.ResultCode]
-
-    for i in range(wua_download_list.Count):
-        uid = wua_download_list.Item(i).Identity.UpdateID
-        ret['Updates'][uid]['Result'] = rc[result.GetUpdateResult(i).ResultCode]
-
-    return ret
+    return wua.download(updates.updates)
 
 
-def install_update(guid=None):
-    """
+def install_update(name):
+    '''
     Installs a single update
 
-    :param guid: str
-        A GUID for the update to be installed
+    Args:
 
-    :return: dict
-        A dictionary containing the details about the installed update
+        name (str): The name of the update to install. This can be a GUID, a KB
+        number, or any part of the name. To ensure a single item is matched the
+        GUID is preferred.
+
+        .. note:: If no results or more than one result is returned an error
+           will be raised.
+
+    Returns:
+        dict: A dictionary containing the results of the install
 
     CLI Examples:
 
@@ -733,206 +495,125 @@ def install_update(guid=None):
 
         salt '*' win_wua.install_update 12345678-abcd-1234-abcd-1234567890ab
 
-    """
-    return install_updates([guid])
+        salt '*' win_wua.install_update KB12312231
+    '''
+    # Create a Windows Update Agent instance
+    wua = salt.utils.win_wua.WindowsUpdateAgent()
+
+    # Search for Update
+    updates = wua.search(name)
+
+    if updates.count() == 0:
+        raise CommandExecutionError('No updates found')
+
+    if updates.count() > 1:
+        raise CommandExecutionError('More than one update found')
+
+    return wua.install(updates.updates)
 
 
-def install_updates(guid=None):
-    """
-    Installs updates that match the passed criteria. It may be easier to use the
-    list_updates function and set install=True.
+def install_updates(names):
+    '''
+    Installs updates that match the list of identifiers. It may be easier to use
+    the list_updates function and set install=True.
 
-    :param guid: list
-        A list of GUIDs to be installed
+    Args:
 
-    :return: dict
-        A dictionary containing the details about the installed updates
+        names (list): A list of updates to install. This can be any combination
+        of GUIDs, KB numbers, or names. GUIDs or KBs are preferred.
+
+    Returns:
+
+        dict: A dictionary containing the details about the installed updates
 
     CLI Examples:
 
     .. code-block:: bash
 
         # Normal Usage
-        salt '*' win_wua.install_updates
-         guid=['12345678-abcd-1234-abcd-1234567890ab',
-         '87654321-dcba-4321-dcba-ba0987654321']
-    """
-    # Check for empty GUID
-    if guid is None:
-        return 'No GUID Specified'
+        salt '*' win_wua.install_updates guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB12323211']
+    '''
+    # Create a Windows Update Agent instance
+    wua = salt.utils.win_wua.WindowsUpdateAgent()
 
-    # Initialize the PyCom system
-    pythoncom.CoInitialize()
+    # Search for Updates
+    updates = wua.search(names)
 
-    # Create a session with the Windows Update Agent
-    wua_session = win32com.client.Dispatch('Microsoft.Update.Session')
-    wua_session.ClientApplicationID = 'Salt: Install Update'
+    if updates.count() == 0:
+        raise CommandExecutionError('No updates found')
 
-    # Create the Searcher, Downloader, Installer, and Collections
-    wua_searcher = wua_session.CreateUpdateSearcher()
-    wua_download_list = win32com.client.Dispatch('Microsoft.Update.UpdateColl')
-    wua_downloader = wua_session.CreateUpdateDownloader()
-    wua_install_list = win32com.client.Dispatch('Microsoft.Update.UpdateColl')
-    wua_installer = wua_session.CreateUpdateInstaller()
+    return wua.install(updates.updates)
 
-    ret = {}
 
-    # Searching for the GUID
-    search_string = ''
-    search_list = ''
-    log.debug('Searching for updates:')
-    for ident in guid:
-        log.debug('{0}'.format(ident))
-        if search_string == '':
-            search_string = 'UpdateID=\'{0}\''.format(ident.lower())
-            search_list = '{0}'.format(ident.lower())
-        else:
-            search_string += ' or UpdateID=\'{0}\''.format(ident.lower())
-            search_list += '\n{0}'.format(ident.lower())
+def uninstall(name):
+    '''
+    Uninstalls a single update
 
-    try:
-        wua_search_result = wua_searcher.Search(search_string)
-        if wua_search_result.Updates.Count == 0:
-            log.debug('No Updates found for:\n\t\t{0}'.format(search_list))
-            ret['Success'] = False
-            ret['Details'] = 'No Updates found: {0}'.format(search_list)
-            return ret
-    except Exception:
-        log.debug('Invalid Search String: {0}'.format(search_string))
-        return 'Invalid Search String: {0}'.format(search_string)
+    Args:
 
-    # List updates found
-    log.debug('Found the following update:')
-    ret['Updates'] = {}
-    for update in wua_search_result.Updates:
-        # Check to see if the update is already installed
-        ret['Updates'][update.Identity.UpdateID] = {}
-        ret['Updates'][update.Identity.UpdateID]['Title'] = update.Title
-        if update.IsInstalled:
-            log.debug('Already Installed: {0}'.format(update.Identity.UpdateID))
-            log.debug(u'\tTitle: {0}'.format(update.Title))
-            ret['Updates'][update.Identity.UpdateID]['AlreadyInstalled'] = True
-        # Make sure the EULA has been accepted
-        if not update.EulaAccepted:
-            log.debug(u'Accepting EULA: {0}'.format(update.Title))
-            update.AcceptEula()  # pylint: disable=W0104
-        # Add to the list of updates that need to be downloaded
-        if update.IsDownloaded:
-            log.debug('Already Downloaded: {0}'.format(update.Identity.UpdateID))
-            log.debug(u'\tTitle: {0}'.format(update.Title))
-            ret['Updates'][update.Identity.UpdateID]['AlreadyDownloaded'] = True
-        else:
-            log.debug('To Be Downloaded: {0}'.format(update.Identity.UpdateID))
-            log.debug(u'\tTitle: {0}'.format(update.Title))
-            ret['Updates'][update.Identity.UpdateID]['AlreadyDownloaded'] = False
-            wua_download_list.Add(update)
+        name (str): The name of the update to uninstall. This can be a GUID, a
+        KB number, or any part of the name. To ensure a single item is matched
+        the GUID is preferred.
 
-    # Download the updates
-    if wua_download_list.Count == 0:
-        # Not necessarily a failure, perhaps the update has been downloaded
-        # but not installed
-        log.debug('No updates to download')
-    else:
-        # Otherwise, download the update
-        log.debug('Downloading...')
-        wua_downloader.Updates = wua_download_list
+        .. note:: If no results or more than one result is returned an error
+           will be raised.
 
-        try:
-            wua_downloader.Download()
-            log.debug('Download Complete')
+    Returns:
+        dict: A dictionary containing the results of the uninstall
 
-        except Exception as error:
+    CLI Examples:
 
-            ret['Success'] = False
-            ret['Result'] = format(error)
+    .. code-block:: bash
 
-            hr, msg, exc, arg = error.args  # pylint: disable=W0633
-            # Error codes found at the following site:
-            # https://msdn.microsoft.com/en-us/library/windows/desktop/hh968413(v=vs.85).aspx
-            fc = {-2145124316: 'No Updates: 0x80240024',
-                  -2145124284: 'Access Denied: 0x8024044'}
-            try:
-                failure_code = fc[exc[5]]
-            except KeyError:
-                failure_code = 'Unknown Failure: {0}'.format(error)
+        salt '*' win_wua.uninstall 12345678-abcd-1234-abcd-1234567890ab
 
-            log.debug('Download Failed: {0}'.format(failure_code))
-            ret['error_msg'] = failure_code
-            ret['location'] = 'Download Section of install_updates'
-            ret['file'] = 'win_wua.py'
+        salt '*' win_wua.uninstall KB12312233
+    '''
+    # Create a Windows Update Agent instance
+    wua = salt.utils.win_wua.WindowsUpdateAgent()
 
-            return ret
+    # Search for Update
+    updates = wua.search(name)
 
-    # Install the updates
-    for update in wua_search_result.Updates:
-        # Make sure the update has actually been downloaded
-        if update.IsDownloaded:
-            log.debug(u'To be installed: {0}'.format(update.Title))
-            wua_install_list.Add(update)
+    if updates.count() == 0:
+        raise CommandExecutionError('No updates found')
 
-    if wua_install_list.Count == 0:
-        # There are not updates to install
-        # This would only happen if there was a problem with the download
-        # If this happens often, perhaps some error checking for the download
-        log.debug('No updates to install')
-        ret['Success'] = False
-        ret['Message'] = 'No Updates to install'
-        return ret
+    if updates.count() > 1:
+        raise CommandExecutionError('More than one update found')
 
-    wua_installer.Updates = wua_install_list
+    return wua.uninstall(updates.updates)
 
-    # Try to run the installer
-    try:
-        result = wua_installer.Install()
 
-    except Exception as error:
+def uninstall_list(names):
+    '''
+    Uninstalls updates that match the list of identifiers.
 
-        # See if we know the problem, if not return the full error
-        ret['Success'] = False
-        ret['Result'] = format(error)
+    Args:
 
-        hr, msg, exc, arg = error.args  # pylint: disable=W0633
-        # Error codes found at the following site:
-        # https://msdn.microsoft.com/en-us/library/windows/desktop/hh968413(v=vs.85).aspx
-        fc = {-2145124316: 'No Updates: 0x80240024',
-              -2145124284: 'Access Denied: 0x8024044'}
-        try:
-            failure_code = fc[exc[5]]
-        except KeyError:
-            failure_code = 'Unknown Failure: {0}'.format(error)
+        names (list): A list of updates to uninstall. This can be any
+        combination of GUIDs, KB numbers, or names. GUIDs or KBs are preferred.
 
-        log.debug('Download Failed: {0}'.format(failure_code))
-        ret['error_msg'] = failure_code
-        ret['location'] = 'Install Section of install_updates'
-        ret['file'] = 'win_wua.py'
+    Returns:
 
-        return ret
+        dict: A dictionary containing the details about the uninstalled updates
 
-    rc = {0: 'Installation Not Started',
-          1: 'Installation In Progress',
-          2: 'Installation Succeeded',
-          3: 'Installation Succeeded With Errors',
-          4: 'Installation Failed',
-          5: 'Installation Aborted'}
-    log.debug(rc[result.ResultCode])
+    CLI Examples:
 
-    if result.ResultCode in [2, 3]:
-        ret['Success'] = True
-        ret['NeedsReboot'] = result.RebootRequired
-        log.debug('NeedsReboot: {0}'.format(result.RebootRequired))
-    else:
-        ret['Success'] = False
+    .. code-block:: bash
 
-    ret['Message'] = rc[result.ResultCode]
-    rb = {0: 'Never Reboot',
-          1: 'Always Reboot',
-          2: 'Poss Reboot'}
-    for i in range(wua_install_list.Count):
-        uid = wua_install_list.Item(i).Identity.UpdateID
-        ret['Updates'][uid]['Result'] = rc[result.GetUpdateResult(i).ResultCode]
-        ret['Updates'][uid]['RebootBehavior'] = rb[wua_install_list.Item(i).InstallationBehavior.RebootBehavior]
+        # Normal Usage
+        salt '*' win_wua.uninstall_updates guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB1231231']
+    '''
+    # Create a Windows Update Agent instance
+    wua = salt.utils.win_wua.WindowsUpdateAgent()
 
-    return ret
+    # Search for Updates
+    updates = wua.search(name)
+
+    if updates.count() == 0:
+        raise CommandExecutionError('No updates found')
+
+    return wua.install(updates.updates)
 
 
 def set_wu_settings(level=None,

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -240,11 +240,11 @@ def list_update(name, download=False, install=False):
 
     # Download
     if download or install:
-        ret['Download'] = wua.download(updates.updates)
+        ret['Download'] = wua.download(updates)
 
     # Install
     if install:
-        ret['Install'] = wua.install(updates.updates)
+        ret['Install'] = wua.install(updates)
 
     return ret if ret else updates.list()
 

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -185,8 +185,8 @@ def list_update(name, download=False, install=False):
 
     Args:
         name (str): The name of the update you're searching for. This can be the
-        GUID, a KB number, or any part of the name of the update. GUID's and
-        KB's are preferred. Run ``list_updates`` to get the GUID for the update
+        GUID, a KB number, or any part of the name of the update. GUIDs and
+        KBs are preferred. Run ``list_updates`` to get the GUID for the update
         you're looking for.
 
         download (bool): Download the update returned by this function. Run this
@@ -260,8 +260,8 @@ def get(name, download=False, install=False):
 
     Args:
         name (str): The name of the update you're searching for. This can be the
-        GUID, a KB number, or any part of the name of the update. GUID's and
-        KB's are preferred. Run ``list`` to get the GUID for the update
+        GUID, a KB number, or any part of the name of the update. GUIDs and
+        KBs are preferred. Run ``list`` to get the GUID for the update
         you're looking for.
 
         download (bool): Download the update returned by this function. Run this

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -45,6 +45,8 @@ def available(software=True,
               severities=None,
               ):
     '''
+    .. versionadded:: nitrogen
+
     List updates that match the passed criteria.
 
     Args:
@@ -167,12 +169,15 @@ def available(software=True,
 
 def list_update(name, download=False, install=False):
     '''
+    .. deprecated:: nitrogen
+       Use :func:`get` instead
     Returns details for all updates that match the search criteria
 
     Args:
         name (str): The name of the update you're searching for. This can be the
-        GUID (preferred), a KB number, or any part of the name of the update.
-        Run ``list_updates`` to get the GUID for the update you're looking for.
+        GUID, a KB number, or any part of the name of the update. GUID's and
+        KB's are preferred. Run ``list_updates`` to get the GUID for the update
+        you're looking for.
 
         download (bool): Download the update returned by this function. Run this
         function first to see if the update exists, then set ``download=True``
@@ -230,6 +235,81 @@ def list_update(name, download=False, install=False):
         # Not all updates have an associated KB
         salt '*' win_wua.list_update 'Microsoft Camera Codec Pack'
     '''
+    salt.utils.warn_until(
+        'Oxygen',
+        'This function is replaced by \'get\' as of Salt Nitrogen. This'
+        'warning will be removed in Salt Oxygen')
+    return get(name, download, install)
+
+
+def get(name, download=False, install=False):
+    '''
+    .. versionadded:: nitrogen
+
+    Returns details for all updates that match the search criteria
+
+    Args:
+        name (str): The name of the update you're searching for. This can be the
+        GUID, a KB number, or any part of the name of the update. GUID's and
+        KB's are preferred. Run ``list`` to get the GUID for the update
+        you're looking for.
+
+        download (bool): Download the update returned by this function. Run this
+        function first to see if the update exists, then set ``download=True``
+        to download the update.
+
+        install (bool): Install the update returned by this function. Run this
+        function first to see if the update exists, then set ``install=True`` to
+        install the update.
+
+    Returns:
+        dict: Returns a dict containing a list of updates that match the name if
+        download and install are both set to False. Should usually be a single
+        update, but can return multiple if a partial name is given.
+
+        If download or install is set to true it will return the results of the
+        operation.
+
+        .. code-block:: cfg
+
+            List of Updates:
+            {'<GUID>': {'Title': <title>,
+                        'KB': <KB>,
+                        'GUID': <the globally unique identifier for the update>
+                        'Description': <description>,
+                        'Downloaded': <has the update been downloaded>,
+                        'Installed': <has the update been installed>,
+                        'Mandatory': <is the update mandatory>,
+                        'UserInput': <is user input required>,
+                        'EULAAccepted': <has the EULA been accepted>,
+                        'Severity': <update severity>,
+                        'NeedsReboot': <is the update installed and awaiting reboot>,
+                        'RebootBehavior': <will the update require a reboot>,
+                        'Categories': [ '<category 1>',
+                                        '<category 2>',
+                                        ...]
+                        }
+            }
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        # Recommended Usage using GUID without braces
+        # Use this to find the status of a specific update
+        salt '*' win_wua.get 12345678-abcd-1234-abcd-1234567890ab
+
+        # Use the following if you don't know the GUID:
+
+        # Using a KB number
+        # Not all updates have an associated KB
+        salt '*' win_wua.get KB3030298
+
+        # Using part or all of the name of the update
+        # Could possibly return multiple results
+        # Not all updates have an associated KB
+        salt '*' win_wua.get 'Microsoft Camera Codec Pack'
+    '''
     # Create a Windows Update Agent instance
     wua = salt.utils.win_update.WindowsUpdateAgent()
 
@@ -258,6 +338,138 @@ def list_updates(software=True,
                  download=False,
                  install=False):
     '''
+    .. deprecated:: nitrogen
+       Use :func:`list` instead
+
+    Returns a detailed list of available updates or a summary. If download or
+    install is True the same list will be downloaded and/or installed.
+
+    Args:
+        software (bool): Include software updates in the results (default is
+        True)
+
+        drivers (bool): Include driver updates in the results (default is False)
+
+        summary (bool):
+        - True: Return a summary of updates available for each category.
+        - False (default): Return a detailed list of available updates.
+
+        skip_installed (bool): Skip installed updates in the results (default is
+        False)
+
+        download (bool): (Overrides reporting functionality) Download the list
+        of updates returned by this function. Run this function first with
+        ``download=False`` to see what will be downloaded, then set
+        ``download=True`` to download the updates.
+
+        install (bool): (Overrides reporting functionality) Install the list of
+        updates returned by this function. Run this function first with
+        ``install=False`` to see what will be installed, then set
+        ``install=True`` to install the updates.
+
+        categories (list): Specify the categories to list. Must be passed as a
+        list. All categories returned by default.
+
+            Categories include the following:
+
+            * Critical Updates
+            * Definition Updates
+            * Drivers (make sure you set drivers=True)
+            * Feature Packs
+            * Security Updates
+            * Update Rollups
+            * Updates
+            * Update Rollups
+            * Windows 7
+            * Windows 8.1
+            * Windows 8.1 drivers
+            * Windows 8.1 and later drivers
+            * Windows Defender
+
+        severities (list): Specify the severities to include. Must be passed as
+        a list. All severities returned by default.
+
+            Severities include the following:
+
+            * Critical
+            * Important
+
+    Returns:
+
+        dict: Returns a dict containing either a summary or a list of updates:
+
+        .. code-block:: cfg
+
+            List of Updates:
+            {'<GUID>': {'Title': <title>,
+                        'KB': <KB>,
+                        'GUID': <the globally unique identifier for the update>
+                        'Description': <description>,
+                        'Downloaded': <has the update been downloaded>,
+                        'Installed': <has the update been installed>,
+                        'Mandatory': <is the update mandatory>,
+                        'UserInput': <is user input required>,
+                        'EULAAccepted': <has the EULA been accepted>,
+                        'Severity': <update severity>,
+                        'NeedsReboot': <is the update installed and awaiting reboot>,
+                        'RebootBehavior': <will the update require a reboot>,
+                        'Categories': [ '<category 1>',
+                                        '<category 2>',
+                                        ...]
+                        }
+            }
+
+            Summary of Updates:
+            {'Total': <total number of updates returned>,
+             'Available': <updates that are not downloaded or installed>,
+             'Downloaded': <updates that are downloaded but not installed>,
+             'Installed': <updates installed (usually 0 unless installed=True)>,
+             'Categories': { <category 1>: <total for that category>,
+                             <category 2>: <total for category 2>,
+                             ... }
+            }
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        # Normal Usage (list all software updates)
+        salt '*' win_wua.list_updates
+
+        # List all updates with categories of Critical Updates and Drivers
+        salt '*' win_wua.list_updates categories=['Critical Updates','Drivers']
+
+        # List all Critical Security Updates
+        salt '*' win_wua.list_updates categories=['Security Updates'] severities=['Critical']
+
+        # List all updates with a severity of Critical
+        salt '*' win_wua.list_updates severities=['Critical']
+
+        # A summary of all available updates
+        salt '*' win_wua.list_updates summary=True
+
+        # A summary of all Feature Packs and Windows 8.1 Updates
+        salt '*' win_wua.list_updates categories=['Feature Packs','Windows 8.1'] summary=True
+    '''
+    salt.utils.warn_until(
+        'Oxygen',
+        'This function is replaced by \'list\' as of Salt Nitrogen. This'
+        'warning will be removed in Salt Oxygen')
+    return list(software, drivers, summary, skip_installed, categories,
+                severities, download, install)
+
+
+def list(software=True,
+         drivers=False,
+         summary=False,
+         skip_installed=True,
+         categories=None,
+         severities=None,
+         download=False,
+         install=False):
+    '''
+    .. versionadded:: nitrogen
+
     Returns a detailed list of available updates or a summary. If download or
     install is True the same list will be downloaded and/or installed.
 
@@ -394,6 +606,9 @@ def list_updates(software=True,
 
 def download_update(name):
     '''
+    .. deprecated:: oxygen
+       Use :func:`download` instead
+
     Downloads a single update.
 
     Args:
@@ -416,23 +631,18 @@ def download_update(name):
         salt '*' win_wua.download_update KB12312321
 
     '''
-    # Create a Windows Update Agent instance
-    wua = salt.utils.win_update.WindowsUpdateAgent()
-
-    # Search for Update
-    updates = wua.search(name)
-
-    if updates.count() == 0:
-        raise CommandExecutionError('No updates found')
-
-    if updates.count() > 1:
-        raise CommandExecutionError('Multiple updates found, narrow your search')
-
-    return wua.download(updates.updates)
+    salt.utils.warn_until(
+        'Oxygen',
+        'This function is replaced by \'download\' as of Salt Nitrogen. This'
+        'warning will be removed in Salt Oxygen')
+    return download(name)
 
 
 def download_updates(names):
     '''
+    .. deprecated:: oxygen
+       Use :func:`download` instead
+
     Downloads updates that match the list of passed identifiers. It's easier to
     use this function by using list_updates and setting install=True.
 
@@ -450,7 +660,37 @@ def download_updates(names):
     .. code-block:: bash
 
         # Normal Usage
-        salt '*' win_wua.download_updates guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB2131233']
+        salt '*' win_wua.download guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB2131233']
+    '''
+    salt.utils.warn_until(
+        'Oxygen',
+        'This function is replaced by \'download\' as of Salt Nitrogen. This'
+        'warning will be removed in Salt Oxygen')
+    return download(names)
+
+
+def download(names):
+    '''
+    .. versionadded:: nitrogen
+    Downloads updates that match the list of passed identifiers. It's easier to
+    use this function by using list_updates and setting install=True.
+
+    Args:
+
+        names (str, list): A single update or a list of updates to download.
+        This can be any combination of GUIDs, KB numbers, or names. GUIDs or KBs
+        are preferred.
+
+    Returns:
+
+        dict: A dictionary containing the details about the downloaded updates
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        # Normal Usage
+        salt '*' win_wua.download guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB2131233']
     '''
     # Create a Windows Update Agent instance
     wua = salt.utils.win_update.WindowsUpdateAgent()
@@ -461,11 +701,18 @@ def download_updates(names):
     if updates.count() == 0:
         raise CommandExecutionError('No updates found')
 
-    return wua.download(updates.updates)
+    if updates.count() > len(names):
+        raise CommandExecutionError('Multiple updates found, names need to be '
+                                    'more specific')
+
+    return wua.download(updates)
 
 
 def install_update(name):
     '''
+    .. deprecated:: oxygen
+       Use :func:`install` instead
+
     Installs a single update
 
     Args:
@@ -488,23 +735,18 @@ def install_update(name):
 
         salt '*' win_wua.install_update KB12312231
     '''
-    # Create a Windows Update Agent instance
-    wua = salt.utils.win_update.WindowsUpdateAgent()
-
-    # Search for Update
-    updates = wua.search(name)
-
-    if updates.count() == 0:
-        raise CommandExecutionError('No updates found')
-
-    if updates.count() > 1:
-        raise CommandExecutionError('Multiple updates found, narrow your search')
-
-    return wua.install(updates.updates)
+    salt.utils.warn_until(
+        'Oxygen',
+        'This function is replaced by \'install\' as of Salt Nitrogen. This'
+        'warning will be removed in Salt Oxygen')
+    return install(name)
 
 
 def install_updates(names):
     '''
+    .. deprecated:: oxygen
+       Use :func:`install` instead
+
     Installs updates that match the list of identifiers. It may be easier to use
     the list_updates function and set install=True.
 
@@ -512,6 +754,37 @@ def install_updates(names):
 
         names (list): A list of updates to install. This can be any combination
         of GUIDs, KB numbers, or names. GUIDs or KBs are preferred.
+
+    Returns:
+
+        dict: A dictionary containing the details about the installed updates
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        # Normal Usage
+        salt '*' win_wua.install_updates guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB12323211']
+    '''
+    salt.utils.warn_until(
+        'Oxygen',
+        'This function is replaced by \'install\' as of Salt Nitrogen. This'
+        'warning will be removed in Salt Oxygen')
+    return install(names)
+
+
+def install(names):
+    '''
+    .. versionadded:: nitrogen
+
+    Installs updates that match the list of identifiers. It may be easier to use
+    the list_updates function and set install=True.
+
+    Args:
+
+        names (str, list): A single update or a list of updates to install.
+        This can be any combination of GUIDs, KB numbers, or names. GUIDs or KBs
+        are preferred.
 
     Returns:
 
@@ -533,56 +806,24 @@ def install_updates(names):
     if updates.count() == 0:
         raise CommandExecutionError('No updates found')
 
-    return wua.install(updates.updates)
+    if updates.count() > len(names):
+        raise CommandExecutionError('Multiple updates found, names need to be '
+                                    'more specific')
+
+    return wua.install(updates)
 
 
-def uninstall(name):
+def uninstall(names):
     '''
-    Uninstalls a single update
+    .. versionadded:: nitrogen
+
+    Uninstall updates.
 
     Args:
 
-        name (str): The name of the update to uninstall. This can be a GUID, a
-        KB number, or any part of the name. To ensure a single item is matched
-        the GUID is preferred.
-
-        .. note:: If no results or more than one result is returned an error
-           will be raised.
-
-    Returns:
-        dict: A dictionary containing the results of the uninstall
-
-    CLI Examples:
-
-    .. code-block:: bash
-
-        salt '*' win_wua.uninstall 12345678-abcd-1234-abcd-1234567890ab
-
-        salt '*' win_wua.uninstall KB12312233
-    '''
-    # Create a Windows Update Agent instance
-    wua = salt.utils.win_update.WindowsUpdateAgent()
-
-    # Search for Update
-    updates = wua.search(name)
-
-    if updates.count() == 0:
-        raise CommandExecutionError('No updates found')
-
-    if updates.count() > 1:
-        raise CommandExecutionError('Multiple updates found, narrow your search')
-
-    return wua.uninstall(updates.updates)
-
-
-def uninstall_list(names):
-    '''
-    Uninstalls updates that match the list of identifiers.
-
-    Args:
-
-        names (list): A list of updates to uninstall. This can be any
-        combination of GUIDs, KB numbers, or names. GUIDs or KBs are preferred.
+        names (str, list): A single update or a list of updates to uninstall.
+        This can be any combination of GUIDs, KB numbers, or names. GUIDs or KBs
+        are preferred.
 
     Returns:
 
@@ -593,7 +834,10 @@ def uninstall_list(names):
     .. code-block:: bash
 
         # Normal Usage
-        salt '*' win_wua.uninstall_updates guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB1231231']
+        salt '*' win_wua.uninstall KB3121212
+
+        # As a list
+        salt '*' win_wua.uninstall guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB1231231']
     '''
     # Create a Windows Update Agent instance
     wua = salt.utils.win_update.WindowsUpdateAgent()
@@ -604,7 +848,7 @@ def uninstall_list(names):
     if updates.count() == 0:
         raise CommandExecutionError('No updates found')
 
-    return wua.install(updates.updates)
+    return wua.uninstall(updates)
 
 
 def set_wu_settings(level=None,

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -17,10 +17,9 @@ import salt.utils
 import salt.utils.win_update
 from salt.exceptions import CommandExecutionError
 
-# Import 3rd Party libs
+# Import 3rd-party libs
 try:
     import pythoncom
-    import pywintypes
     import win32com.client
     HAS_PYWIN32 = True
 except ImportError:

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -16,6 +16,7 @@ import logging
 # Import Salt libs
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=no-name-in-module,redefined-builtin
+import salt.utils.win_wua
 
 # Import 3rd-party libs
 try:

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -623,7 +623,7 @@ def set_wu_settings(level=None,
                     msupdate=None,
                     day=None,
                     time=None):
-    """
+    '''
     Change Windows Update settings. If no parameters are passed, the current
     value will be returned.
 
@@ -674,7 +674,7 @@ def set_wu_settings(level=None,
 
         salt '*' win_wua.set_wu_settings level=4 recommended=True featured=False
 
-    """
+    '''
     ret = {}
     ret['Success'] = True
 
@@ -817,10 +817,13 @@ def set_wu_settings(level=None,
 
 
 def get_wu_settings():
-    """
+    '''
     Get current Windows Update settings.
 
-    :return:
+    Returns:
+
+        dict: A dictionary of Windows Update settings:
+
         Featured Updates:
             Boolean value that indicates whether to display notifications for
             featured updates.
@@ -860,7 +863,7 @@ def get_wu_settings():
     .. code-block:: bash
 
         salt '*' win_wua.get_wu_settings
-    """
+    '''
     ret = {}
 
     day = ['Every Day',
@@ -904,10 +907,10 @@ def get_wu_settings():
 
 
 def _get_msupdate_status():
-    """
+    '''
     Check to see if Microsoft Update is Enabled
     Return Boolean
-    """
+    '''
     # To get the status of Microsoft Update we actually have to check the
     # Microsoft Update Service Manager
     # Create a ServiceManager Object
@@ -926,11 +929,12 @@ def _get_msupdate_status():
 
 
 def get_needs_reboot():
-    """
+    '''
     Determines if the system needs to be rebooted.
 
-    :return: bool
-        True if the system requires a reboot, False if not
+    Returns:
+
+        bool: True if the system requires a reboot, False if not
 
     CLI Examples:
 
@@ -938,7 +942,7 @@ def get_needs_reboot():
 
         salt '*' win_wua.get_needs_reboot
 
-    """
+    '''
     # Initialize the PyCom system
     pythoncom.CoInitialize()
 

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -7,9 +7,8 @@ Module for managing Windows Updates using the Windows Update Agent.
 :depends:
         - salt.utils.win_update
 '''
-from __future__ import absolute_import
-
 # Import Python libs
+from __future__ import absolute_import
 import logging
 
 # Import Salt libs
@@ -17,6 +16,15 @@ from salt.ext import six
 import salt.utils
 import salt.utils.win_update
 from salt.exceptions import CommandExecutionError
+
+# Import 3rd Party libs
+try:
+    import pythoncom
+    import pywintypes
+    import win32com.client
+    HAS_PYWIN32 = True
+except ImportError:
+    HAS_PYWIN32 = False
 
 log = logging.getLogger(__name__)
 
@@ -28,8 +36,11 @@ def __virtual__():
     if not salt.utils.is_windows():
         return False, 'WUA: Only available on Window systems'
 
-    if not salt.utils.win_update.HAS_PYWIN32:
+    if not HAS_PYWIN32:
         return False, 'WUA: Requires PyWin32 libraries'
+
+    if not salt.utils.win_update.HAS_PYWIN32:
+        return False, 'WUA: Missing Libraries required by salt.utils.win_update'
 
     return True
 

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -524,7 +524,8 @@ def list_updates(software=True,
 
     # If the list is empty after filtering, return a message
     if not updates:
-        return 'No updates found. Check software and drivers parameters. One must be true.'
+        return 'No updates found. Check software and drivers parameters. One ' \
+               'must be true.'
 
     if install:
         guid_list = []

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -5,7 +5,7 @@ Module for managing Windows Updates using the Windows Update Agent.
 .. versionadded:: 2015.8.0
 
 :depends:
-        - salt.utils.win_wua
+        - salt.utils.win_update
 '''
 from __future__ import absolute_import
 
@@ -15,7 +15,7 @@ import logging
 # Import Salt libs
 from salt.ext import six
 import salt.utils
-import salt.utils.win_wua
+import salt.utils.win_update
 from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
@@ -28,7 +28,7 @@ def __virtual__():
     if not salt.utils.is_windows():
         return False, 'WUA: Only available on Window systems'
 
-    if not salt.utils.win_wua.HAS_PYWIN32:
+    if not salt.utils.win_update.HAS_PYWIN32:
         return False, 'WUA: Requires PyWin32 libraries'
 
     return True
@@ -154,7 +154,7 @@ def available(software=True,
     '''
 
     # Create a Windows Update Agent instance
-    wua = salt.utils.win_wua.WindowsUpdateAgent()
+    wua = salt.utils.win_update.WindowsUpdateAgent()
 
     # Look for available
     updates = wua.available(skip_hidden, skip_installed, skip_mandatory,
@@ -234,7 +234,7 @@ def list_update(name=None, download=False, install=False):
         salt '*' win_wua.list_update 'Microsoft Camera Codec Pack'
     '''
     # Create a Windows Update Agent instance
-    wua = salt.utils.win_wua.WindowsUpdateAgent()
+    wua = salt.utils.win_update.WindowsUpdateAgent()
 
     # Search for Update
     updates = wua.search(name)
@@ -375,7 +375,7 @@ def list_updates(software=True,
         salt '*' win_wua.list_updates categories=['Feature Packs','Windows 8.1'] summary=True
     '''
     # Create a Windows Update Agent instance
-    wua = salt.utils.win_wua.WindowsUpdateAgent()
+    wua = salt.utils.win_update.WindowsUpdateAgent()
 
     # Search for Update
     updates = wua.available(skip_installed=skip_installed, software=software,
@@ -426,7 +426,7 @@ def download_update(name):
 
     '''
     # Create a Windows Update Agent instance
-    wua = salt.utils.win_wua.WindowsUpdateAgent()
+    wua = salt.utils.win_update.WindowsUpdateAgent()
 
     # Search for Update
     updates = wua.search(name)
@@ -462,7 +462,7 @@ def download_updates(names):
         salt '*' win_wua.download_updates guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB2131233']
     '''
     # Create a Windows Update Agent instance
-    wua = salt.utils.win_wua.WindowsUpdateAgent()
+    wua = salt.utils.win_update.WindowsUpdateAgent()
 
     # Search for Update
     updates = wua.search(names)
@@ -498,7 +498,7 @@ def install_update(name):
         salt '*' win_wua.install_update KB12312231
     '''
     # Create a Windows Update Agent instance
-    wua = salt.utils.win_wua.WindowsUpdateAgent()
+    wua = salt.utils.win_update.WindowsUpdateAgent()
 
     # Search for Update
     updates = wua.search(name)
@@ -534,7 +534,7 @@ def install_updates(names):
         salt '*' win_wua.install_updates guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB12323211']
     '''
     # Create a Windows Update Agent instance
-    wua = salt.utils.win_wua.WindowsUpdateAgent()
+    wua = salt.utils.win_update.WindowsUpdateAgent()
 
     # Search for Updates
     updates = wua.search(names)
@@ -570,7 +570,7 @@ def uninstall(name):
         salt '*' win_wua.uninstall KB12312233
     '''
     # Create a Windows Update Agent instance
-    wua = salt.utils.win_wua.WindowsUpdateAgent()
+    wua = salt.utils.win_update.WindowsUpdateAgent()
 
     # Search for Update
     updates = wua.search(name)
@@ -605,10 +605,10 @@ def uninstall_list(names):
         salt '*' win_wua.uninstall_updates guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB1231231']
     '''
     # Create a Windows Update Agent instance
-    wua = salt.utils.win_wua.WindowsUpdateAgent()
+    wua = salt.utils.win_update.WindowsUpdateAgent()
 
     # Search for Updates
-    updates = wua.search(name)
+    updates = wua.search(names)
 
     if updates.count() == 0:
         raise CommandExecutionError('No updates found')

--- a/salt/states/win_wua.py
+++ b/salt/states/win_wua.py
@@ -1,5 +1,52 @@
 # -*- coding: utf-8 -*-
+'''
+Installation of Windows Updates using the Windows Update Agent
 
+Salt can manage Windows updates via the "wua" state module. Updates can be
+installed and removed. Update management declarations are as follows:
+
+For installation:
+
+.. code-block:: yaml
+
+    # Install a single update using the KB
+    KB3194343:
+      wua.installed
+
+    # Install a single update using the name parameter
+    install_update:
+      wua.installed:
+        - name: KB3194343
+
+    # Install multiple updates using the updates parameter and a combination of
+    # KB number and GUID
+    install_updates:
+      wua.installed:
+       - updates:
+         - KB3194343
+         - bb1dbb26-3fb6-45fd-bb05-e3c8e379195c
+
+For removal:
+
+.. code-block:: yaml
+
+    # Remove a single update using the KB
+    KB3194343:
+      wua.removed
+
+    # Remove a single update using the name parameter
+    remove_update:
+      wua.removed:
+        - name: KB3194343
+
+    # Remove multiple updates using the updates parameter and a combination of
+    # KB number and GUID
+    remove_updates:
+      wua.removed:
+       - updates:
+         - KB3194343
+         - bb1dbb26-3fb6-45fd-bb05-e3c8e379195c
+'''
 # Import python libs
 from __future__ import absolute_import
 import logging

--- a/salt/states/win_wua.py
+++ b/salt/states/win_wua.py
@@ -47,11 +47,11 @@ For removal:
          - KB3194343
          - bb1dbb26-3fb6-45fd-bb05-e3c8e379195c
 '''
-# Import python libs
+# Import Python libs
 from __future__ import absolute_import
 import logging
 
-# Import salt libs
+# Import Salt libs
 from salt.ext import six
 import salt.utils
 import salt.utils.win_update

--- a/salt/states/win_wua.py
+++ b/salt/states/win_wua.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import
+import logging
+
+# Import salt libs
+import salt.utils
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'wua'
+
+
+def __virtual__():
+    '''
+    Only valid on Windows machines
+    '''
+    if not salt.utils.is_windows():
+        return False, 'wua state module failed to load: ' \
+                      'Only available on Window systems'
+
+    return __virtualname__
+
+
+def installed(name):
+    '''
+    Ensure a single Microsoft Update is installed.
+
+    Args:
+
+        name (str): Can be the GUID, the KB number, or any part of the Title of
+            Microsoft update. GUID is the preferred method to ensure you're
+            installing the correct update.
+
+        .. warning:: Using a partial KB number or a partial Title could result
+            in more than one update being applied.
+
+    Returns:
+        dict: A dictionary containing the results of the update
+
+    CLI Example:
+
+    .. code-block:: yaml
+
+        # using a GUID
+        install_update:
+          wua.installed:
+            - name: 28cf1b09-2b1a-458c-9bd1-971d1b26b211
+
+        # using a KB:
+        install_update:
+          wua.installed:
+            - name: KB3194343
+
+        # using the full Title
+        install_update:
+          wua.installed:
+            - name: Security Update for Adobe Flash Player for Windows 10 Version 1607 (for x64-based Systems) (KB3194343)
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    # Get pre update info
+    pre_info = __salt__['win_wua.list_update'](name)
+
+    # No updates found
+    if len(pre_info) == 0:
+        ret['comment'] = 'No updates found'
+        return ret
+
+    # List of updates to install
+    install = dict()
+    for item in pre_info:
+        if not salt.utils.is_true(pre_info[item]['Installed']):
+            install[item] = pre_info[item]['Title']
+
+    if not install:
+        ret['comment'] = 'Update {0} already installed'.format(name)
+        return ret
+
+    # Return comment of changes if test.
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Updates will be installed:'
+        for item in install:
+            ret['comment'] += '\n'
+            ret['comment'] += ': '.join([item, install[item]])
+        return ret
+
+    # Install the update
+    result = __salt__['win_wua.install_updates'](pre_info.keys())
+    print('*' * 68)
+    print(result)
+    print('*' * 68)
+
+    # Get post update info
+    post_info = __salt__['win_wua.list_update'](name)
+
+    # Verify the installation
+
+    for item in install:
+        if not salt.utils.is_true(post_info[item]['Installed']):
+            ret['changes']['failed'] = {
+                item: {'Title': post_info[item]['Title']}
+            }
+            ret['result'] = False
+        else:
+            ret['changes']['installed'] = {
+                item: {'Title': post_info[item]['Title'],
+                       'NeedsReboot': post_info[item]['NeedsReboot']}
+            }
+            ret['comment'] = 'Update {0} was installed'.format(name)
+
+    return ret

--- a/salt/states/win_wua.py
+++ b/salt/states/win_wua.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import logging
 
 # Import salt libs
+from salt.ext import six
 import salt.utils
 import salt.utils.win_update
 from salt.exceptions import CommandExecutionError
@@ -27,18 +28,24 @@ def __virtual__():
     return __virtualname__
 
 
-def installed(name):
+def installed(name, updates=None):
     '''
-    Ensure Microsoft Updates are installed.
+    Ensure Microsoft Updates are installed. Updates will be downloaded if
+    needed.
 
     Args:
 
-        name (str): Can be the GUID, the KB number, or any part of the
-        Title of Microsoft update. GUID is the preferred method to ensure you're
-        installing the correct update. Can also be a list of identifiers.
+        name (str): The identifier of a single update to install.
 
-        .. warning:: Using a partial KB number or a partial Title could result
-           in more than one update being applied.
+        updates (list): A list of identifiers for updates to be installed.
+        Overrides ``name``. Default is None.
+
+    .. note:: Identifiers can be the GUID, the KB number, or any part of the
+       Title of the Microsoft update. GUID's and KB's are the preferred method
+       to ensure you're installing the correct update.
+
+    .. warning:: Using a partial KB number or a partial Title could result in
+       more than one update being installed.
 
     Returns:
         dict: A dictionary containing the results of the update
@@ -69,11 +76,11 @@ def installed(name):
               - KB3194343
               - 28cf1b09-2b1a-458c-9bd1-971d1b26b211
     '''
-    if isinstance(name, list) and len(name) == 0:
-        return {'name': name,
-                'changes': {},
-                'result': True,
-                'comment': 'No updates provided'}
+    if isinstance(updates, six.string_types):
+        updates = [updates]
+
+    if not updates:
+        updates = name
 
     ret = {'name': name,
            'changes': {},
@@ -83,7 +90,7 @@ def installed(name):
     wua = salt.utils.win_update.WindowsUpdateAgent()
 
     # Search for updates
-    install_list = wua.search(name)
+    install_list = wua.search(updates)
 
     # No updates found
     if install_list.count() == 0:
@@ -98,12 +105,16 @@ def installed(name):
 
     # List of updates to install
     install = salt.utils.win_update.Updates()
+    installed_updates = []
     for item in install_list.updates:
         if not salt.utils.is_true(item.IsInstalled):
             install.updates.Add(item)
+        else:
+            installed_updates.extend('KB' + kb for kb in item.KBArticleIDs)
 
     if install.count() == 0:
-        ret['comment'] = 'Updates already installed'
+        ret['comment'] = 'Updates already installed: '
+        ret['comment'] += '\n - '.join(installed_updates)
         return ret
 
     # Return comment of changes if test.
@@ -117,10 +128,10 @@ def installed(name):
         return ret
 
     # Download updates
-    wua.download(download.updates)
+    wua.download(download)
 
     # Install updates
-    wua.install(install.updates)
+    wua.install(install)
 
     # Refresh windows update info
     wua.refresh()
@@ -130,20 +141,142 @@ def installed(name):
     for item in install.list():
         if not salt.utils.is_true(post_info[item]['Installed']):
             ret['changes']['failed'] = {
-                item: {'Title': post_info[item]['Title']}
+                item: {'Title': post_info[item]['Title'][:40] + '...',
+                       'KBs': post_info[item]['KBs']}
             }
             ret['result'] = False
-            failed.append(item)
         else:
             ret['changes']['installed'] = {
-                item: {'Title': post_info[item]['Title'],
-                       'NeedsReboot': post_info[item]['NeedsReboot']}
+                item: {'Title': post_info[item]['Title'][:40] + '...',
+                       'NeedsReboot': post_info[item]['NeedsReboot'],
+                       'KBs': post_info[item]['KBs']}
             }
-            succeeded.append(item)
 
     if ret['changes'].get('failed', False):
-        ret['comment'] = 'Some updates failed'
+        ret['comment'] = 'Updates failed'
     else:
-        ret['comment'] = 'Updates completed successfully'
+        ret['comment'] = 'Updates installed successfully'
+
+    return ret
+
+
+def removed(name, updates=None):
+    '''
+    Ensure Microsoft Updates are uninstalled.
+
+    Args:
+
+        name (str): The identifier of a single update to uninstall.
+
+        updates (list): A list of identifiers for updates to be removed.
+        Overrides ``name``. Default is None.
+
+    .. note:: Identifiers can be the GUID, the KB number, or any part of the
+       Title of the Microsoft update. GUID's and KB's are the preferred method
+       to ensure you're uninstalling the correct update.
+
+    .. warning:: Using a partial KB number or a partial Title could result in
+       more than one update being removed.
+
+    Returns:
+        dict: A dictionary containing the results of the removal
+
+    CLI Example:
+
+    .. code-block:: yaml
+
+        # using a GUID
+        uninstall_update:
+          wua.removed:
+            - name: 28cf1b09-2b1a-458c-9bd1-971d1b26b211
+
+        # using a KB
+        uninstall_update:
+          wua.removed:
+            - name: KB3194343
+
+        # using the full Title
+        uninstall_update:
+          wua.removed:
+            - name: Security Update for Adobe Flash Player for Windows 10 Version 1607 (for x64-based Systems) (KB3194343)
+
+        # Install multiple updates
+        uninstall_updates:
+          wua.removed:
+            - updates:
+              - KB3194343
+              - 28cf1b09-2b1a-458c-9bd1-971d1b26b211
+    '''
+    if isinstance(updates, six.string_types):
+        updates = [updates]
+
+    if not updates:
+        updates = name
+
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    wua = salt.utils.win_update.WindowsUpdateAgent()
+
+    # Search for updates
+    updates = wua.search(updates)
+
+    # No updates found
+    if updates.count() == 0:
+        ret['comment'] = 'No updates found'
+        return ret
+
+    # List of updates to uninstall
+    uninstall = salt.utils.win_update.Updates()
+    removed_updates = []
+    for item in updates.updates:
+        if salt.utils.is_true(item.IsInstalled):
+            uninstall.updates.Add(item)
+        else:
+            removed_updates.extend('KB' + kb for kb in item.KBArticleIDs)
+
+    if uninstall.count() == 0:
+        ret['comment'] = 'Updates already removed: '
+        ret['comment'] += '\n - '.join(removed_updates)
+        return ret
+
+    # Return comment of changes if test.
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Updates will be removed:'
+        for update in uninstall.updates:
+            ret['comment'] += '\n'
+            ret['comment'] += ': '.join(
+                [update.Identity.UpdateID, update.Title])
+        return ret
+
+    # Install updates
+    wua.uninstall(uninstall)
+
+    # Refresh windows update info
+    wua.refresh()
+    post_info = wua.updates().list()
+
+    # Verify the installation
+    for item in uninstall.list():
+        if salt.utils.is_true(post_info[item]['Installed']):
+            ret['changes']['failed'] = {
+                item: {'Title': post_info[item]['Title'][:40] + '...',
+                       'KBs': post_info[item]['KBs']}
+            }
+            ret['result'] = False
+        else:
+            ret['changes']['removed'] = {
+                item: {'Title': post_info[item]['Title'][:40] + '...',
+                       'NeedsReboot': post_info[item]['NeedsReboot'],
+                       'KBs': post_info[item]['KBs']}
+            }
+
+    if ret['changes'].get('failed', False):
+        ret['comment'] = 'Updates failed'
+    else:
+        ret['comment'] = 'Updates removed successfully'
 
     return ret

--- a/salt/states/win_wua.py
+++ b/salt/states/win_wua.py
@@ -87,7 +87,7 @@ def installed(name, updates=None):
         Overrides ``name``. Default is None.
 
     .. note:: Identifiers can be the GUID, the KB number, or any part of the
-       Title of the Microsoft update. GUID's and KB's are the preferred method
+       Title of the Microsoft update. GUIDs and KBs are the preferred method
        to ensure you're installing the correct update.
 
     .. warning:: Using a partial KB number or a partial Title could result in
@@ -218,7 +218,7 @@ def removed(name, updates=None):
         Overrides ``name``. Default is None.
 
     .. note:: Identifiers can be the GUID, the KB number, or any part of the
-       Title of the Microsoft update. GUID's and KB's are the preferred method
+       Title of the Microsoft update. GUIDs and KBs are the preferred method
        to ensure you're uninstalling the correct update.
 
     .. warning:: Using a partial KB number or a partial Title could result in

--- a/salt/states/win_wua.py
+++ b/salt/states/win_wua.py
@@ -55,7 +55,6 @@ import logging
 from salt.ext import six
 import salt.utils
 import salt.utils.win_update
-from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/win_update.py
+++ b/salt/utils/win_update.py
@@ -1,8 +1,19 @@
 # -*- coding: utf-8 -*-
+'''
+Classes for working with Windows Update Agent
+'''
+# Import Python libs
 from __future__ import absolute_import
 import logging
 import subprocess
 
+# Import Salt libs
+import salt.utils
+from salt.ext import six
+from salt.ext.moves import range
+from salt.exceptions import CommandExecutionError
+
+# Import 3rd Party libs
 try:
     import win32com.client
     import pythoncom
@@ -10,10 +21,6 @@ try:
     HAS_PYWIN32 = True
 except ImportError:
     HAS_PYWIN32 = False
-
-import salt.utils
-from salt.ext import six
-from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -330,8 +337,8 @@ class WindowsUpdateAgent(object):
         try:
             results = searcher.Search(search_string)
             if results.Updates.Count == 0:
-                log.debug('No Updates found for:\n\t\t{0}'.format(search_list))
-                return 'No Updates found: {0}'.format(search_list)
+                log.debug('No Updates found for:\n\t\t{0}'.format(search_string))
+                return 'No Updates found: {0}'.format(search_string)
         except pywintypes.com_error as error:
             # Something happened, raise an error
             hr, msg, exc, arg = error.args  # pylint: disable=W0633
@@ -341,7 +348,7 @@ class WindowsUpdateAgent(object):
                 failure_code = 'Unknown Failure: {0}'.format(error)
 
             log.error('Search Failed: {0}\n\t\t{1}'.format(
-                failure_code, search_list))
+                failure_code, search_string))
             raise CommandExecutionError(failure_code)
 
         self._updates = results.Updates
@@ -449,7 +456,7 @@ class WindowsUpdateAgent(object):
                 continue
 
             if categories is not None:
-                match = false
+                match = False
                 for category in update.Categories:
                     if category.Name in categories:
                         match = True

--- a/salt/utils/win_update.py
+++ b/salt/utils/win_update.py
@@ -531,7 +531,7 @@ class WindowsUpdateAgent(object):
                 # Populate the return dictionary
                 ret['Success'] = True
                 ret['Message'] = 'Uninstalled using WUSA'
-                ret['NeedsReboot'] = self.needs_reboot()
+                ret['NeedsReboot'] = needs_reboot()
                 log.debug('NeedsReboot: {0}'.format(ret['NeedsReboot']))
 
                 # Refresh the Updates Table
@@ -589,21 +589,25 @@ class WindowsUpdateAgent(object):
 
         return ret
 
-    def needs_reboot():
-        '''
-        Determines if the system needs to be rebooted.
 
-        Returns:
+def needs_reboot():
+    '''
+    Determines if the system needs to be rebooted.
 
-            bool: True if the system requires a reboot, False if not
+    Returns:
 
-        CLI Examples:
+        bool: True if the system requires a reboot, False if not
 
-        .. code-block:: bash
+    CLI Examples:
 
-            salt '*' win_wua.get_needs_reboot
+    .. code-block:: bash
 
-        '''
-        # Create an AutoUpdate object
-        obj_sys = win32com.client.Dispatch('Microsoft.Update.SystemInfo')
-        return salt.utils.is_true(obj_sys.RebootRequired)
+        salt '*' win_wua.get_needs_reboot
+
+    '''
+    # Initialize the PyCom system
+    pythoncom.CoInitialize()
+
+    # Create an AutoUpdate object
+    obj_sys = win32com.client.Dispatch('Microsoft.Update.SystemInfo')
+    return salt.utils.is_true(obj_sys.RebootRequired)

--- a/salt/utils/win_update.py
+++ b/salt/utils/win_update.py
@@ -759,7 +759,8 @@ class WindowsUpdateAgent(object):
         .. note:: Starting with Windows 10 the Windows Update Agent is unable to
         uninstall updates. An ``Uninstall Not Allowed`` error is returned. If
         this error is encountered this function will instead attempt to use
-        ``dism.exe`` to perform the uninstallation.
+        ``dism.exe`` to perform the uninstallation. ``dism.exe`` may fail to
+        to find the KB number for the package. In that case, removal will fail.
 
         Args:
 

--- a/salt/utils/win_update.py
+++ b/salt/utils/win_update.py
@@ -10,10 +10,10 @@ import subprocess
 # Import Salt libs
 import salt.utils
 from salt.ext import six
-from salt.ext.moves import range
+from salt.ext.six.moves import range
 from salt.exceptions import CommandExecutionError
 
-# Import 3rd Party libs
+# Import 3rd-party libs
 try:
     import win32com.client
     import pythoncom

--- a/salt/utils/win_update.py
+++ b/salt/utils/win_update.py
@@ -473,7 +473,7 @@ class WindowsUpdateAgent(object):
 
     def search(self, search_string):
         '''
-        Search for either a single update or a specific list of updates. GUID's
+        Search for either a single update or a specific list of updates. GUIDs
         are searched first, then KB numbers, and finally Titles.
 
         Args:

--- a/salt/utils/win_wua.py
+++ b/salt/utils/win_wua.py
@@ -1,0 +1,365 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import logging
+
+import win32com.client
+import pythoncom
+import pywintypes
+
+import salt.utils
+from salt.ext import six
+from salt.exceptions import CommandExecutionError
+
+log = logging.getLogger(__name__)
+
+
+class WindowsUpdateAgent:
+    # Error codes found at the following site:
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/hh968413(v=vs.85).aspx
+    fail_codes = {-2145124300: 'Download failed: 0x80240034',
+                  -2145124302: 'Invalid search criteria: 0x80240032',
+                  -2145124305: 'Cancelled by policy: 0x8024002F',
+                  -2145124307: 'Missing source: 0x8024002D',
+                  -2145124308: 'Missing source: 0x8024002C',
+                  -2145124315: 'Prevented by policy: 0x80240025',
+                  -2145124316: 'No Updates: 0x80240024',
+                  -2145124322: 'Service being shutdown: 0x8024001E',
+                  -2145124325: 'Self Update in Progress: 0x8024001B',
+                  -2145124327: 'Exclusive Install Conflict: 0x80240019',
+                  -2145124330: 'Install not allowed: 0x80240016',
+                  -2145124333: 'Duplicate item: 0x80240013',
+                  -2145124341: 'Operation cancelled: 0x8024000B',
+                  -2145124343: 'Operation in progress: 0x80240009',
+                  -2145124284: 'Access Denied: 0x8024044',
+                  -2145124283: 'Unsupported search scope: 0x80240045',
+                  -2149843018: 'Setup in progress: 0x8024004A',
+                  -4292599787: 'Install still pending: 0x00242015',
+                  -4292607992: 'Already downloaded: 0x00240008',
+                  -4292607993: 'Already uninstalled: 0x00240007',
+                  -4292607994: 'Already installed: 0x00240006',
+                  -4292607995: 'Reboot required: 0x00240005'}
+    update_types = {1: 'Software',
+                    2: 'Driver'}
+    reboot_behavior = {0: 'Never Requires Reboot',
+                       1: 'Always Requires Reboot',
+                       2: 'Can Require Reboot'}
+
+    def __init__(self):
+        # Initialize the PyCom system
+        pythoncom.CoInitialize()
+
+        # Create a session with the Windows Update Agent
+        self._session = win32com.client.Dispatch('Microsoft.Update.Session')
+
+        # Create Collection for Updates
+        self._updates = win32com.client.Dispatch('Microsoft.Update.UpdateColl')
+        self._found = win32com.client.Dispatch('Microsoft.Update.UpdateColl')
+        self._download = win32com.client.Dispatch('Microsoft.Update.UpdateColl')
+        self._install = win32com.client.Dispatch('Microsoft.Update.UpdateColl')
+
+        self._load_all_updates()
+
+    def _load_all_updates(self):
+        # Load all updates
+        search_string = 'Type=\'Software\' or ' \
+                        'Type=\'Driver\''
+
+        # Create searcher object
+        searcher = self._session.CreateUpdateSearcher()
+        self._session.ClientApplicationID = 'Salt: Load Updates'
+
+        # Load all updates into the updates collection
+        try:
+            results = searcher.Search(search_string)
+            if results.Updates.Count == 0:
+                log.debug('No Updates found for:\n\t\t{0}'.format(search_list))
+                return 'No Updates found: {0}'.format(search_list)
+        except pywintypes.com_error as error:
+            # Something happened, raise an error
+            hr, msg, exc, arg = error.args  # pylint: disable=W0633
+            try:
+                failure_code = self.fail_codes[exc[5]]
+            except KeyError:
+                failure_code = 'Unknown Failure: {0}'.format(error)
+
+            log.error('Search Failed: {0}\n\t\t{1}'.format(
+                failure_code, search_list))
+            raise CommandExecutionError(failure_code)
+
+        self._updates = results.Updates
+
+    def search(self, search_string):
+
+        found = win32com.client.Dispatch('Microsoft.Update.UpdateColl')
+
+        if self._updates.Count == 0:
+            self._load_all_updates()
+
+        if isinstance(search_string, six.string_types):
+            search_string = [search_string]
+
+        for update in self._updates:
+
+            for find in search_string:
+
+                # Search by GUID
+                if find == update.Identity.UpdateID:
+                    found.Add(update)
+                    continue
+
+                # Search by KB
+                if find in ['KB' + item for item in update.KBArticleIDs]:
+                    found.Add(update)
+                    continue
+
+                # Search by KB without the KB in front
+                if find in [item for item in update.KBArticleIDs]:
+                    found.Add(update)
+                    continue
+
+                # Search by Title
+                if find in update.Title:
+                    found.Add(update)
+                    continue
+
+        self._found = found
+
+    def updates_details(self):
+        return self._details(self._updates)
+
+    def found_details(self):
+        return self._details(self._found)
+
+    def _details(self, updates):
+
+        if updates.Count == 0:
+            return 'Nothing to return'
+
+        log.debug('Building a detailed report of the results.')
+
+        # Build a dictionary containing details for each update
+        results = {}
+        for update in updates:
+
+            results[update.Identity.UpdateID] = {
+                'guid': update.Identity.UpdateID,
+                'Title': str(update.Title),
+                'Type': self.update_types[update.Type],
+                'Description': update.Description,
+                'Downloaded': bool(update.IsDownloaded),
+                'Installed': bool(update.IsInstalled),
+                'Mandatory': bool(update.IsMandatory),
+                'EULAAccepted': bool(update.EulaAccepted),
+                'NeedsReboot': bool(update.RebootRequired),
+                'Severity': str(update.MsrcSeverity),
+                'UserInput':
+                    bool(update.InstallationBehavior.CanRequestUserInput),
+                'RebootBehavior':
+                    self.reboot_behavior[update.InstallationBehavior.RebootBehavior],
+                'KB': ['KB' + item for item in update.KBArticleIDs],
+                'Categories': [item.Name for item in update.Categories]
+            }
+
+        return results
+
+    def updates_summary(self):
+        return self._summary(self._updates)
+
+    def found_summary(self):
+        return self._summary(self._found)
+
+    def _summary(self, updates):
+
+        if updates.Count == 0:
+            return 'Nothing to return'
+
+        # Build a dictionary containing a summary of updates available
+        results = {'Total': 0,
+                   'Available': 0,
+                   'Downloaded': 0,
+                   'Installed': 0,
+                   'Categories': {},
+                   'Severity': {}}
+
+        for update in updates:
+
+            # Count the total number of updates available
+            results['Total'] += 1
+
+            # Updates available for download
+            if not salt.utils.is_true(update.IsDownloaded)\
+                    and not salt.utils.is_true(update.IsInstalled):
+                results['Available'] += 1
+
+            # Updates downloaded awaiting install
+            if salt.utils.is_true(update.IsDownloaded)\
+                    and not salt.utils.is_true(update.IsInstalled):
+                results['Downloaded'] += 1
+
+            # Updates installed
+            if salt.utils.is_true(update.IsInstalled):
+                results['Installed'] += 1
+
+            # Add Categories and increment total for each one
+            # The sum will be more than the total because each update can have
+            # multiple categories
+            for category in update.Categories:
+                if category.Name in results['Categories']:
+                    results['Categories'][category.Name] += 1
+                else:
+                    results['Categories'][category.Name] = 1
+
+            # Add Severity Summary
+            if update.MsrcSeverity:
+                if update.MsrcSeverity in results['Severity']:
+                    results['Severity'][update.MsrcSeverity] += 1
+                else:
+                    results['Severity'][update.MsrcSeverity] = 1
+
+        return results
+
+    def download_updates(self):
+        return self._download(self._updates)
+
+    def download_found(self):
+        return self._download(self._found)
+
+    def _download(self, updates):
+        # Lookup dictionaries
+        result_code = {0: 'Download Not Started',
+                       1: 'Download In Progress',
+                       2: 'Download Succeeded',
+                       3: 'Download Succeeded With Errors',
+                       4: 'Download Failed',
+                       5: 'Download Aborted'}
+
+        # Check for empty list
+        if updates.Count == 0:
+            return 'Nothing to download'
+
+        # Initialize the downloader object and list collection
+        downloader = self._session.CreateUpdateDownloader()
+        self._session.ClientApplicationID = 'Salt: Download Update'
+        download_list = win32com.client.Dispatch('Microsoft.Update.UpdateColl')
+
+        # Check for updates that aren't already downloaded
+        for update in updates.Updates:
+            if not salt.utils.is_true(update.IsDownloaded):
+                download_list.Add(update)
+
+        # Check the download list
+        if download_list.Count == 0:
+            return 'Nothing to download'
+
+        # Send the list to the downloader
+        downloader.Updates = download_list
+
+        # Download the list
+        try:
+            result = downloader.Download()
+        except pywintypes.com_error as error:
+            # Something happened, raise an error
+            hr, msg, exc, arg = error.args  # pylint: disable=W0633
+            try:
+                failure_code = self.fail_codes[exc[5]]
+            except KeyError:
+                failure_code = 'Unknown Failure: {0}'.format(error)
+
+            log.error('Download Failed: {0}'.format(failure_code))
+            raise CommandExecutionError(failure_code)
+
+        log.debug('Download Complete')
+        log.debug(result_code[result.ResultCode])
+
+        # Was the download successful?
+        if result.ResultCode in [2, 3]:
+            ret['Success'] = True
+        else:
+            ret['Success'] = False
+
+        ret['Message'] = result_code[result.ResultCode]
+
+        # Report results for each update
+        for i in range(download_list.Count):
+            uid = download_list.Item(i).Identity.UpdateID
+            ret['Updates'][uid]['Result'] = \
+                result_code[result.GetUpdateResult(i).ResultCode]
+
+        return ret
+
+    def install_updates(self):
+        return self._install(self._updates)
+
+    def install_found(self):
+        return self._install(self._found)
+
+    def _install(self, updates):
+        if updates.Count == 0:
+            return 'Nothing to install'
+
+        installer = self._session.CreateUpdateInstaller()
+        self._session.ClientApplicationID = 'Salt: Install Update'
+        install_list = win32com.client.Dispatch('Microsoft.Update.UpdateColl')
+
+        # Install the updates
+        for update in updates:
+            # Make sure the update has actually been downloaded
+            if not salt.utils.is_true(update.IsInstalled):
+                install_list.Add(update)
+
+        if install_list.Count == 0:
+            return 'Nothing to install'
+
+        installer.Updates = install_list
+
+        # Try to run the installer
+        try:
+            result = installer.Install()
+
+        except pywintypes.com_error as error:
+            # Something happened, raise an error
+            hr, msg, exc, arg = error.args  # pylint: disable=W0633
+            try:
+                failure_code = self.fail_codes[exc[5]]
+            except KeyError:
+                failure_code = 'Unknown Failure: {0}'.format(error)
+
+            log.error('Install Failed: {0}'.format(failure_code))
+            raise CommandExecutionError(failure_code)
+
+        result_code = {0: 'Installation Not Started',
+                       1: 'Installation In Progress',
+                       2: 'Installation Succeeded',
+                       3: 'Installation Succeeded With Errors',
+                       4: 'Installation Failed',
+                       5: 'Installation Aborted'}
+
+        log.debug('Install Complete')
+        log.debug(result_code[result.ResultCode])
+
+        if result.ResultCode in [2, 3]:
+            ret['Success'] = True
+            ret['NeedsReboot'] = result.RebootRequired
+            log.debug('NeedsReboot: {0}'.format(result.RebootRequired))
+        else:
+            ret['Success'] = False
+
+        ret['Message'] = result_code[result.ResultCode]
+        reboot = {0: 'Never Reboot',
+                  1: 'Always Reboot',
+                  2: 'Poss Reboot'}
+        for i in range(wua_install_list.Count):
+            uid = wua_install_list.Item(i).Identity.UpdateID
+            ret['Updates'][uid]['Result'] = \
+                result_code[result.GetUpdateResult(i).ResultCode]
+            ret['Updates'][uid]['RebootBehavior'] = \
+                reboot[wua_install_list.Item(i).InstallationBehavior.RebootBehavior]
+
+        return ret
+
+wua = WUA()
+wua.search('28cf1b09-2b1a-458c-9bd1-971d1b26b211')
+print(wua.list_found())
+print(wua.summary_found())
+# print(wua.download())
+# print(wua.install())


### PR DESCRIPTION
### What does this PR do?

https://github.com/saltstack/salt/issues/32830

Creates a win_wua state module.
- `wua.installed`
- `wua.removed`

Moves repetitive code to a salt util (win_update).

Starts a deprecation path for renaming some module functions (win_wua).
Adds:
`win_wua.available`
`win_wua.get`
`win_wua.list`
`win_wua.download`
`win_wua.install`
`win_wua.uninstall`

Deprecation path:
`win_wua.list_update` -> `win_wua.get`
`win_wua.list_updates` -> `win_wua.list`
`win_wua.download_update` -> `win_wua.download`
`win_wua.download_updates` -> `win_wua.download`
`win_wua.install_update` -> `win_wua.install`
`win_wua.install_updates` -> `win_wua.install`
### Tests written?

No