### PR TITLE
Set logging level to 'info' for message about init system detection

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1250,8 +1250,8 @@ def os_data():
                     elif salt.utils.which('supervisord') in init_cmdline:
                         grains['init'] = 'supervisord'
                     else:
-                        log.error(
-                            'Could not determine init location from command line: ({0})'
+                        log.info(
+                            'Could not determine init system from command line: ({0})'
                             .format(' '.join(init_cmdline))
                         )
 


### PR DESCRIPTION
### What does this PR do?

This PR stops Salt complaining about it was unable to detect the init system on Linux each time when Grain data is going to be refreshed.

In case if you're using Salt to build or provision containers (where PID 1 could be virtually anything, even Salt itself!) or you've moved to other not so popular init replacements such as `monit` or `runit`, then this message becomes very annoying:

```
[ERROR   ] Could not determine init location from command line: (/my_init)
```

Since Salt, called interactively, outputs errors to `stderr` by default, and it is generally a bad practice to disable error logging at all, I think it would be better to put the message above to the 'info' loglevel.
### Tests written?

No