### PR TITLE
Bugs/37191 minion hangs

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -798,6 +798,7 @@ def setup_multiprocessing_logging_listener(opts, queue=None):
         target=__process_multiprocessing_logging_queue,
         args=(opts, queue or get_multiprocessing_logging_queue(),)
     )
+    __MP_LOGGING_QUEUE_PROCESS.daemon = True
     __MP_LOGGING_QUEUE_PROCESS.start()
     __MP_LOGGING_LISTENER_CONFIGURED = True
 


### PR DESCRIPTION
### What does this PR do?

This reverts commit c9c45a5d790f9e8ee259650d0b014ea5b498d4dd.
Set the `daemon` flag on MultiprocessingLoggingListener subprocess.
This fixes a number of issues related to minion hang.
The commit was introduced as a part of master shutdown fix. I'm working on another solution.
### What issues does this PR fix or reference?

Fixes: #37191, #37238, #37192.
Breaks: #35480.
This is also needed in _carbon_.
### Tests written?

No