### PR TITLE
Get managed object name gh

### DIFF
--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -803,6 +803,18 @@ def get_properties_of_managed_object(mo_ref, properties):
     return items[0]
 
 
+def get_managed_object_name(mo_ref):
+    '''
+    Returns the name of a managed object.
+    If the name wasn't found, it returns None.
+
+    mo_ref
+        The managed object reference.
+    '''
+    props = get_properties_of_managed_object(mo_ref, ['name'])
+    return props.get('name')
+
+
 def get_network_adapter_type(adapter_type):
     '''
     Return the network adapter type.

--- a/tests/unit/utils/vmware_test/common_test.py
+++ b/tests/unit/utils/vmware_test/common_test.py
@@ -456,6 +456,34 @@ class GetPropertiesOfManagedObjectTestCase(TestCase):
                          'retrieved', excinfo.exception.strerror)
 
 
+@patch('salt.utils.vmware.get_properties_of_managed_object',
+       MagicMock(return_value={'key': 'value'}))
+class GetManagedObjectName(TestCase):
+    '''Tests for salt.utils.get_managed_object_name'''
+
+    def setUp(self):
+        self.mock_mo_ref = MagicMock()
+
+    def test_get_properties_of_managed_object_call(self):
+        mock_get_properties_of_managed_object = MagicMock()
+        with patch('salt.utils.vmware.get_properties_of_managed_object',
+                   mock_get_properties_of_managed_object):
+            salt.utils.vmware.get_managed_object_name(self.mock_mo_ref)
+        mock_get_properties_of_managed_object.assert_called_once_with(
+            self.mock_mo_ref, ['name'])
+
+    def test_no_name_in_property_dict(self):
+        ret = salt.utils.vmware.get_managed_object_name(self.mock_mo_ref)
+        self.assertIsNone(ret)
+
+    def test_return_managed_object_name(self):
+        mock_get_properties_of_managed_object = MagicMock()
+        with patch('salt.utils.vmware.get_properties_of_managed_object',
+                   MagicMock(return_value={'name': 'fake_name'})):
+            ret = salt.utils.vmware.get_managed_object_name(self.mock_mo_ref)
+        self.assertEqual(ret, 'fake_name')
+
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
 @patch('salt.utils.vmware.get_root_folder', MagicMock())
@@ -663,5 +691,6 @@ if __name__ == '__main__':
     run_tests(WaitForTaskTestCase, needs_daemon=False)
     run_tests(GetMorsWithPropertiesTestCase, needs_daemon=False)
     run_tests(GetPropertiesOfManagedObjectTestCase, needs_daemon=False)
+    run_tests(GetManagedObjectName, needs_daemon=False)
     run_tests(GetContentTestCase, needs_daemon=False)
     run_tests(GetRootFolderTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

Added get_managed_object_name to optimally retrieve a managed object's name
### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.