### PR TITLE
Don't use os.wait() on subprocesses managed by `multiprocessing`.

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -378,19 +378,12 @@ class ProcessManager(object):
             try:
                 # in case someone died while we were waiting...
                 self.check_children()
-
-                if not salt.utils.is_windows() and not async:
-                    pid, exit_status = os.wait()
-                    if pid not in self._process_map:
-                        log.debug('Process of pid {0} died, not a known'
-                                  ' process, will not restart'.format(pid))
-                        continue
-                    if self._restart_processes is True:
-                        self.restart_process(pid)
-                elif async is True:
+                # The event-based subprocesses management code was removed from here
+                # because os.wait() conflicts with the subprocesses management logic
+                # implemented in `multiprocessing` package. See #35480 for details.
+                if async:
                     yield gen.sleep(10)
-                elif async is False:
-                    # os.wait() is not supported on Windows.
+                else:
                     time.sleep(10)
             # OSError is raised if a signal handler is called (SIGTERM) during os.wait
             except OSError:


### PR DESCRIPTION
### What does this PR do?

Fixes the following error on master shutdown:

``` python
OSError: [Errno 3] No such process
Traceback (most recent call last):
  File "/usr/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/usr/lib/python2.7/multiprocessing/util.py", line 321, in _exit_function
    p._popen.terminate()
  File "/usr/lib/python2.7/multiprocessing/forking.py", line 171, in terminate
    os.kill(self.pid, signal.SIGTERM)
```
### What issues does this PR fix or reference?

Fixes: #35480
### Previous Behavior

Main master process manages subprocesses with ProcessManager. Also it creates a daemon subprocess for logging queue.
If the logging queue is the first process exited during master shutdown the ProcessManager gets its status in the `os.wait()` call that is removed by this PR. Since kernel already passed the process result to the parent process it removes the child info from the parent process and following `waitpid` calls for this process will return `ECHILD` error. So when main master process shuts down and the multiprocessing module performs cleanup it has a record about the logging queue child but gets the `ECHILD` error that `multiprocessing` treats as error and raises the exception.
### New Behavior

Do not mix high-level `multiprocessing` wrappers with destructive low level `os.wait()` calls. Under destructive here I mean calls changing processes states.
### Tests written?

No