### PR TITLE
iptables changes for match recent

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -207,8 +207,9 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
             match_value = match_value.split(',')
         for match in match_value:
             rule.append('-m {0}'.format(match))
-            if 'name' in kwargs and match.strip() in ('pknock', 'quota2', 'recent'):
-                rule.append('--name {0}'.format(kwargs['name']))
+            if '_name' in kwargs and match.strip() in ('pknock', 'quota2', 'recent'):
+                rule.append('--name {0}'.format(kwargs['_name']))
+		del kwargs['_name']
         del kwargs['match']
 
     if 'match-set' in kwargs:
@@ -416,9 +417,15 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
     for item in kwargs:
         rule.append(maybe_add_negation(item))
         if len(item) == 1:
-            rule.append('-{0} {1}'.format(item, kwargs[item]))
+	    if kwargs[item] in (None, ''):
+                rule.append('-{0}'.format(item))
+            else:
+                rule.append('-{0} {1}'.format(item, kwargs[item]))
         else:
-            rule.append('--{0} {1}'.format(item, kwargs[item]))
+            if kwargs[item] in (None, ''):
+                rule.append('--{0}'.format(item))
+            else:
+                rule.append('--{0} {1}'.format(item, kwargs[item]))
 
     rule += after_jump
 

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -209,7 +209,7 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
             rule.append('-m {0}'.format(match))
             if '_name' in kwargs and match.strip() in ('pknock', 'quota2', 'recent'):
                 rule.append('--name {0}'.format(kwargs['_name']))
-		del kwargs['_name']
+                del kwargs['_name']
         del kwargs['match']
 
     if 'match-set' in kwargs:
@@ -417,7 +417,7 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
     for item in kwargs:
         rule.append(maybe_add_negation(item))
         if len(item) == 1:
-	    if kwargs[item] in (None, ''):
+            if kwargs[item] in (None, ''):
                 rule.append('-{0}'.format(item))
             else:
                 rule.append('-{0} {1}'.format(item, kwargs[item]))

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -207,9 +207,9 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
             match_value = match_value.split(',')
         for match in match_value:
             rule.append('-m {0}'.format(match))
-            if '_name' in kwargs and match.strip() in ('pknock', 'quota2', 'recent'):
-                rule.append('--name {0}'.format(kwargs['_name']))
-                del kwargs['_name']
+            if 'name_' in kwargs and match.strip() in ('pknock', 'quota2', 'recent'):
+                rule.append('--name {0}'.format(kwargs['name_']))
+                del kwargs['name_']
         del kwargs['match']
 
     if 'match-set' in kwargs:
@@ -414,18 +414,11 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
                 after_jump.append('--{0} {1}'.format(after_jump_argument, value))
             del kwargs[after_jump_argument]
 
-    for item in kwargs:
-        rule.append(maybe_add_negation(item))
-        if len(item) == 1:
-            if kwargs[item] in (None, ''):
-                rule.append('-{0}'.format(item))
-            else:
-                rule.append('-{0} {1}'.format(item, kwargs[item]))
-        else:
-            if kwargs[item] in (None, ''):
-                rule.append('--{0}'.format(item))
-            else:
-                rule.append('--{0} {1}'.format(item, kwargs[item]))
+    for key, value in kwargs.items():
+        negation = maybe_add_negation(key)
+        flag = '-' if len(key) == 1 else '--'
+        value = '' if value in (None, '') else ' {0}'.format(value)
+        rule.append('{0}{1}{2}{3}'.format(negation, flag, key, value))
 
     rule += after_jump
 

--- a/tests/unit/modules/iptables_test.py
+++ b/tests/unit/modules/iptables_test.py
@@ -156,6 +156,14 @@ class IptablesTestCase(TestCase):
         self.assertEqual(iptables.build_rule(**{'match-set': match_sets}),
                          '-m set --match-set src1 flag -m set ! --match-set src2 flag2')
 
+        # should allow escaped name
+        self.assertEqual(iptables.build_rule(**{'match': 'recent', 'name_': 'SSH'}),
+                         '-m recent --name SSH')
+
+        # should allow empty arguments 
+        self.assertEqual(iptables.build_rule(**{'match': 'recent', 'update': None}),
+                         '-m recent --update')
+
         # Should allow the --save jump option to CONNSECMARK
         #self.assertEqual(iptables.build_rule(jump='CONNSECMARK',
         #                                     **{'save': ''}),

--- a/tests/unit/modules/iptables_test.py
+++ b/tests/unit/modules/iptables_test.py
@@ -160,7 +160,7 @@ class IptablesTestCase(TestCase):
         self.assertEqual(iptables.build_rule(**{'match': 'recent', 'name_': 'SSH'}),
                          '-m recent --name SSH')
 
-        # should allow empty arguments 
+        # should allow empty arguments
         self.assertEqual(iptables.build_rule(**{'match': 'recent', 'update': None}),
                          '-m recent --update')
 


### PR DESCRIPTION
Hi,

this change allows for iptables to have more options for match recent.
Recent can be used for example to rate limit access like SSH:

iptables -I INPUT -p tcp --dport 22 -i eth0 -m state --state NEW -m recent --set --name SSH
iptables -I INPUT -p tcp --dport 22 -i eth0 -m state --state NEW -m recent  --update --name SSH --seconds 60 --hitcount 4 -j DROP

This only allows 3 connections every 60 seconds from a host.

Currently this is not possible with Salt since:

a) a single argument is not allowed for iptables but recent requires set, update
b) a name for the list where the tracking should happen is not possible.
this was actually discussed in #30013 

This commit adds a check to allow single arguments for iptables and picks up the discussion to add a variable _name for name when the argument is recent.

Please let me know what you think.

Best
Sven
