### PR TITLE
status.uptime - use snaptime if boot_time kstat fails

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -139,8 +139,6 @@ def uptime():
         The uptime function was changed to return a dictionary of easy-to-read
         key/value pairs containing uptime information, instead of the output
         from a ``cmd.run`` call.
-    .. versionchanged:: carbon
-        Fall back to output of `uptime` when /proc/uptime is not available.
 
     CLI Example:
 
@@ -157,6 +155,9 @@ def uptime():
     elif salt.utils.is_sunos():
         cmd = "kstat -p unix:0:system_misc:boot_time | nawk '{printf \"%d\\n\", srand()-$2}'"
         ut_ret['seconds'] = int(__salt__['cmd.shell'](cmd, output_loglevel='trace').strip() or 0)
+        if ut_ret['seconds'] < 0:
+            cmd = "kstat -p unix:0:system_misc:snaptime | nawk '{printf \"%d\\n\", $2}'"
+            ut_ret['seconds'] = int(__salt__['cmd.shell'](cmd, output_loglevel='trace').strip() or 0)
     else:
         raise CommandExecutionError('This platform is not supported')
 


### PR DESCRIPTION
### What does this PR do?

Fall back to snaptime kstat when boot_time kstat fails, this sometimes happen inside zones when they have less priv's than usual.

It also removes the comment about fallback to the uptime binary as this is no longer the case.
### What issues does this PR fix or reference?
#37318
### Previous Behavior

Return negative uptime
### New Behavior

Fall back to the slightly less accurate snaptime kstat.
### Tests written?

No
