### PR TITLE
Carbons status uptime

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -169,7 +169,6 @@ def uptime():
     elif salt.utils.is_freebsd() or salt.utils.is_darwin():
         # format: { sec = 1477761334, usec = 664698 } Sat Oct 29 17:15:34 2016
         bt_data = __salt__['sysctl.get']('kern.boottime')
-        res = __salt__['cmd.run_all']('sysctl -n kern.boottime')
         if not bt_data:
             raise CommandExecutionError('Cannot find kern.boottime system parameter')
         data = bt_data.split("{")[-1].split("}")[0].strip().replace(' ', '')

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -155,8 +155,10 @@ def uptime():
             raise CommandExecutionError("File {ut_path} was not found.".format(ut_path=ut_path))
         ut_ret['seconds'] = int(float(open(ut_path).read().strip().split()[0]))
     elif salt.utils.is_sunos():
-        cmd = "kstat -p unix:0:system_misc:boot_time | nawk '{printf \"%d\\n\", srand()-$2}'"
+        cmd = "kstat -p unix:0:system_misc:boot_time | nawk '{printf \"%d\\n\", $2}'"
         ut_ret['seconds'] = int(__salt__['cmd.shell'](cmd, output_loglevel='trace').strip() or 0)
+        if ut_ret['seconds'] > 0:  # convert to seconds (nawk + srand is fails on SmartOS)
+            ut_ret['seconds'] = (int(time.time()) - ut_ret['seconds'])
     else:
         raise CommandExecutionError('This platform is not supported')
 

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -139,8 +139,6 @@ def uptime():
         The uptime function was changed to return a dictionary of easy-to-read
         key/value pairs containing uptime information, instead of the output
         from a ``cmd.run`` call.
-    .. versionchanged:: carbon
-        Fall back to output of `uptime` when /proc/uptime is not available.
 
     CLI Example:
 

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -161,7 +161,7 @@ def uptime():
         if res['retcode'] > 0:
             raise CommandExecutionError('The boot_time kstat was not found.')
         utc_time = datetime.datetime.utcfromtimestamp(float(res['stdout'].split()[1].strip()))
-        ut_ret['seconds'] = int((datetime.datetime.utcnow() - utc_time).total_seconds())
+        ut_ret['seconds'] = int(time.time()-time.mktime(utc_time.timetuple()))
     elif salt.utils.which('uptime'):
         return __salt__['cmd.run']('uptime')
     else:

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -140,7 +140,7 @@ def uptime():
         key/value pairs containing uptime information, instead of the output
         from a ``cmd.run`` call.
     .. versionchanged:: carbon
-        Support for OpenBSD, FreeBSD, and Solaris-like platforms.
+        Support for OpenBSD, FreeBSD, NetBSD, and Solaris-like platforms.
 
     CLI Example:
 
@@ -162,7 +162,7 @@ def uptime():
             raise CommandExecutionError('The boot_time kstat was not found.')
         utc_time = datetime.datetime.utcfromtimestamp(float(res['stdout'].split()[1].strip()))
         ut_ret['seconds'] = int(time.time()-time.mktime(utc_time.timetuple()))
-    elif salt.utils.is_openbsd():
+    elif salt.utils.is_openbsd() or salt.utils.is_netbsd():
         res = __salt__['cmd.run_all']('sysctl -n kern.boottime')
         if res['retcode'] > 0:
             raise CommandExecutionError('The sysctl kern.boottime was not found.')

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -167,14 +167,14 @@ def uptime():
             raise CommandExecutionError('Cannot find kern.boottime system parameter')
         seconds = int(curr_seconds - int(bt_data))
     elif salt.utils.is_freebsd() or salt.utils.is_darwin():
+        # format: { sec = 1477761334, usec = 664698 } Sat Oct 29 17:15:34 2016
         bt_data = __salt__['sysctl.get']('kern.boottime')
         res = __salt__['cmd.run_all']('sysctl -n kern.boottime')
         if not bt_data:
             raise CommandExecutionError('Cannot find kern.boottime system parameter')
-        # format: { sec = 1477761334, usec = 664698 } Sat Oct 29 17:15:34 2016
-        # note: sec -> unixtimestamp
-        sec_data, usec_data = bt_data.split('}')[0].strip(' {').split(', ')
-        seconds = int(curr_seconds - int(sec_data.split('sec = ')[1]))
+        data = bt_data.split("{")[-1].split("}")[0].strip().replace(' ', '')
+        uptime = dict([(k, int(v,)) for k, v in [p.strip().split('=') for p in data.split(',')]])
+        seconds = int(curr_seconds - uptime['sec'])
     else:
         raise CommandExecutionError('This platform is not supported')
 

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -139,6 +139,8 @@ def uptime():
         The uptime function was changed to return a dictionary of easy-to-read
         key/value pairs containing uptime information, instead of the output
         from a ``cmd.run`` call.
+    .. versionchanged:: carbon
+        Fall back to output of `uptime` when /proc/uptime is not available.
 
     CLI Example:
 
@@ -160,6 +162,8 @@ def uptime():
             raise CommandExecutionError('The boot_time kstat was not found.')
         utc_time = datetime.datetime.utcfromtimestamp(float(res['stdout'].split()[1].strip()))
         ut_ret['seconds'] = int((datetime.datetime.utcnow() - utc_time).total_seconds())
+    elif salt.utils.which('uptime'):
+        return __salt__['cmd.run']('uptime')
     else:
         raise CommandExecutionError('This platform is not supported')
 

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -157,6 +157,8 @@ def uptime():
             raise CommandExecutionError("File {ut_path} was not found.".format(ut_path=ut_path))
         seconds = int(float(salt.utils.fopen(ut_path).read().split()[0]))
     elif salt.utils.is_sunos():
+        # note: some flavors/vesions report the host uptime inside a zone
+        #       https://support.oracle.com/epmos/faces/BugDisplay?id=15611584
         res = __salt__['cmd.run_all']('kstat -p unix:0:system_misc:boot_time')
         if res['retcode'] > 0:
             raise CommandExecutionError('The boot_time kstat was not found.')

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -163,7 +163,6 @@ def uptime():
     else:
         raise CommandExecutionError('This platform is not supported')
 
-    utc_time = datetime.datetime.utcfromtimestamp(time.time() - ut_ret['seconds'])
     ut_ret['since_iso'] = utc_time.isoformat()
     ut_ret['since_t'] = time.mktime(utc_time.timetuple())
     ut_ret['days'] = ut_ret['seconds'] // 60 // 60 // 24

--- a/tests/unit/modules/status_test.py
+++ b/tests/unit/modules/status_test.py
@@ -105,8 +105,7 @@ class StatusTestCase(TestCase):
         m = self._set_up_test_uptime()
         m2 = self._set_up_test_uptime_sunos()
 
-        with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value="1\n2\n3"),
-                                          'cmd.run_all': MagicMock(return_value=m2)}):
+        with patch.dict(status.__salt__, {'cmd.run_all': MagicMock(return_value=m2.ret)}):
             with patch('time.time', MagicMock(return_value=m.now)):
                 ret = status.uptime()
                 self.assertDictEqual(ret, m.ret)

--- a/tests/unit/modules/status_test.py
+++ b/tests/unit/modules/status_test.py
@@ -105,7 +105,8 @@ class StatusTestCase(TestCase):
         m = self._set_up_test_uptime()
         m2 = self._set_up_test_uptime_sunos()
 
-        with patch.dict(status.__salt__, {'cmd.run_all': MagicMock(return_value=m2.ret)}):
+        with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value="1\n2\n3"),
+                                          'cmd.run_all': MagicMock(return_value=m2.ret)}):
             with patch('time.time', MagicMock(return_value=m.now)):
                 ret = status.uptime()
                 self.assertDictEqual(ret, m.ret)

--- a/tests/unit/modules/status_test.py
+++ b/tests/unit/modules/status_test.py
@@ -13,6 +13,7 @@ from salttesting.helpers import ensure_in_syspath
 from salttesting.mock import (
     MagicMock,
     patch,
+    mock_open,
 )
 
 ensure_in_syspath('../../')
@@ -26,38 +27,126 @@ class StatusTestCase(TestCase):
     '''
     test modules.status functions
     '''
-    @patch('salt.utils.is_linux', MagicMock(return_value=True))
-    def test_uptime(self):
+    def _set_up_test_uptime(self):
         '''
-        Test modules.status.uptime function, new version
-        :return:
+        Define common mock data for status.uptime tests
         '''
-        class ProcUptime(object):
-            def __init__(self, *args, **kwargs):
-                self.data = "773865.18 1003405.46"
+        class MockData(object):
+            '''
+            Store mock data
+            '''
 
-            def read(self):
-                return self.data
+        m = MockData()
+        m.now = 1477004312
+        m.ut = 1540154.00
+        m.idle = 3047777.32
+        m.ret = {
+            'users': 3,
+            'seconds': 1540154,
+            'since_t': 1475464158,
+            'days': 17,
+            'since_iso': '2016-10-03T03:09:18',
+            'time': '19:49',
+        }
+
+        return m
+
+    def _set_up_test_uptime_sunos(self):
+        '''
+        Define common mock data for cmd.run_all for status.uptime on SunOS
+        '''
+        class MockData(object):
+            '''
+            Store mock data
+            '''
+
+        m = MockData()
+        m.ret = {
+            'retcode': 0,
+            'stdout': 'unix:0:system_misc:boot_time    1475464158',
+        }
+
+        return m
+
+    @patch('salt.utils.is_linux', MagicMock(return_value=True))
+    @patch('salt.utils.is_sunos', MagicMock(return_value=False))
+    @patch('salt.utils.is_darwin', MagicMock(return_value=False))
+    @patch('salt.utils.is_freebsd', MagicMock(return_value=False))
+    @patch('salt.utils.is_openbsd', MagicMock(return_value=False))
+    @patch('salt.utils.is_netbsd', MagicMock(return_value=False))
+    def test_uptime_linux(self):
+        '''
+        Test modules.status.uptime function for Linux
+        '''
+        m = self._set_up_test_uptime()
 
         with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value="1\n2\n3")}):
-            with patch('os.path.exists', MagicMock(return_value=True)):
-                with patch('time.time', MagicMock(return_value=1458821523.72)):
-                    status.open = ProcUptime
-                    u_time = status.uptime()
-                    self.assertEqual(u_time['users'], 3)
-                    self.assertEqual(u_time['seconds'], 773865)
-                    self.assertEqual(u_time['days'], 8)
-                    self.assertEqual(u_time['time'], '22:57')
+            with patch('time.time', MagicMock(return_value=m.now)):
+                with patch('os.path.exists', MagicMock(return_value=True)):
+                    proc_uptime = '{0} {1}'.format(m.ut, m.idle)
+                    with patch('salt.utils.fopen', mock_open(read_data=proc_uptime)):
+                        ret = status.uptime()
+                        self.assertDictEqual(ret, m.ret)
 
-    def test_uptime_failure(self):
+                with patch('os.path.exists', MagicMock(return_value=False)):
+                    with self.assertRaises(CommandExecutionError):
+                        status.uptime()
+
+    @patch('salt.utils.is_linux', MagicMock(return_value=False))
+    @patch('salt.utils.is_sunos', MagicMock(return_value=True))
+    @patch('salt.utils.is_darwin', MagicMock(return_value=False))
+    @patch('salt.utils.is_freebsd', MagicMock(return_value=False))
+    @patch('salt.utils.is_openbsd', MagicMock(return_value=False))
+    @patch('salt.utils.is_netbsd', MagicMock(return_value=False))
+    def test_uptime_sunos(self):
         '''
-        Test modules.status.uptime function should raise an exception if /proc/uptime does not exists.
-        :return:
+        Test modules.status.uptime function for SunOS
         '''
-        with patch('os.path.exists', MagicMock(return_value=False)):
-            with patch.dict(status.__grains__, {'kernel': 'Linux'}):
-                with self.assertRaises(CommandExecutionError):
-                    status.uptime()
+        m = self._set_up_test_uptime()
+        m2 = self._set_up_test_uptime_sunos()
+
+        with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value="1\n2\n3"),
+                                          'cmd.run_all': MagicMock(return_value=m2)}):
+            with patch('time.time', MagicMock(return_value=m.now)):
+                ret = status.uptime()
+                self.assertDictEqual(ret, m.ret)
+
+    @patch('salt.utils.is_linux', MagicMock(return_value=False))
+    @patch('salt.utils.is_sunos', MagicMock(return_value=False))
+    @patch('salt.utils.is_darwin', MagicMock(return_value=True))
+    @patch('salt.utils.is_freebsd', MagicMock(return_value=False))
+    @patch('salt.utils.is_openbsd', MagicMock(return_value=False))
+    @patch('salt.utils.is_netbsd', MagicMock(return_value=False))
+    def test_uptime_macos(self):
+        '''
+        Test modules.status.uptime function for macOS
+        '''
+        m = self._set_up_test_uptime()
+
+        kern_boottime = ('{{ sec = {0}, usec = {1:0<6} }} Mon Oct 03 03:09:18.23 2016'
+                         ''.format(*str(m.now - m.ut).split('.')))
+        with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value="1\n2\n3"),
+                                          'sysctl.get': MagicMock(return_value=kern_boottime)}):
+            with patch('time.time', MagicMock(return_value=m.now)):
+                ret = status.uptime()
+                self.assertDictEqual(ret, m.ret)
+
+        with patch.dict(status.__salt__, {'sysctl.get': MagicMock(return_value='')}):
+            with self.assertRaises(CommandExecutionError):
+                status.uptime()
+
+    @patch('salt.utils.is_linux', MagicMock(return_value=False))
+    @patch('salt.utils.is_sunos', MagicMock(return_value=False))
+    @patch('salt.utils.is_darwin', MagicMock(return_value=False))
+    @patch('salt.utils.is_freebsd', MagicMock(return_value=False))
+    @patch('salt.utils.is_openbsd', MagicMock(return_value=False))
+    @patch('salt.utils.is_netbsd', MagicMock(return_value=False))
+    def test_uptime_return_success_not_supported(self):
+        '''
+        Test modules.status.uptime function for other platforms
+        '''
+        with self.assertRaises(CommandExecutionError):
+            status.uptime()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Fixes status.uptime inside SmartOS zones.
### What issues does this PR fix or reference?
saltstack/salt#37318
### Previous Behavior

Used nawk' srand to get the current unixtimestamp, this was used to get the uptime in seconds instead of the unixtimestamp of the system's boot_time.

This failed inside a SmartOS zone
### New Behavior

We use time.time() to get a unixtimestamp instead.
### Tests written?

No
### test data

``` yaml
cronos:
    ----------
    days:
        1
    seconds:
        108374
    since_iso:
        2016-10-27T17:08:05.494677
    since_t:
        1477580885.0
    time:
        6:6
    users:
        1
mantle:
    ----------
    days:
        1
    seconds:
        108508
    since_iso:
        2016-10-27T17:05:54.715199
    since_t:
        1477587954.0
    time:
        6:8
    users:
        1
```

mantle is the hardware host, cronos is the zone that was booted a couple of minutes later.