### PR TITLE
Adding some fixes to the consul module to address #36994 & #36995

### DIFF
--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -253,13 +253,21 @@ def put(consul_url=None, key=None, value=None, **kwargs):
     if not key:
         raise SaltInvocationError('Required argument "key" is missing.')
 
+    # Invalid to specified these together
+    conflicting_args = ['cas', 'release', 'acquire']
+    for _l1 in conflicting_args:
+        for _l2 in conflicting_args:
+            if _l1 in kwargs and _l2 in kwargs and _l1 != _l2:
+                raise SaltInvocationError('Using arguments `{0}` and `{1}`'
+                                          ' together is invalid.'.format(_l1, _l2))
+
     query_params = {}
 
     available_sessions = session_list(consul_url=consul_url, return_list=True)
     _current = get(consul_url=consul_url, key=key)
 
     if 'flags' in kwargs:
-        if not kwargs['flags'] >= 0 and not kwargs['flags'] <= 2**64:
+        if kwargs['flags'] >= 0 and kwargs['flags'] <= 2**64:
             query_params['flags'] = kwargs['flags']
 
     if 'cas' in kwargs:
@@ -281,8 +289,6 @@ def put(consul_url=None, key=None, value=None, **kwargs):
                               'CAS argument can not be used.'.format(key))
             ret['res'] = False
             return ret
-    else:
-        log.error('Key {0} does not exist. Skipping release.')
 
     if 'acquire' in kwargs:
         if kwargs['acquire'] not in available_sessions:


### PR DESCRIPTION
### What does this PR do?

Adding some fixes to the consul module to address #36994 & #36995
### What issues does this PR fix or reference?
#36994 & #36995
### Previous Behavior

Flags were not being set properly and a rogue error message was being displayed on each run.

The consul.put also allowed the use of three conflicting arguments simultaneously. 
### New Behavior

Flags are now set correctly and the error message is not displayed.

This PR adds a check to ensure that conflicting arguments are not all in use simultaneously.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
