### PR TITLE
Fixed state.salt.runner() reporting success on exceptions

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -638,7 +638,6 @@ def runner(name, **kwargs):
           salt.runner:
             - name: manage.up
     '''
-    ret = {'name': name, 'result': False, 'changes': {}, 'comment': ''}
     try:
         jid = __orchestration_jid__
     except NameError:
@@ -651,19 +650,25 @@ def runner(name, **kwargs):
                                       __env__=__env__,
                                       **kwargs)
 
+    runner_return = out.get('return')
     if 'success' in out and not out['success']:
-        ret['result'] = False
+        ret = {
+            'name': name,
+            'result': False,
+            'changes': {},
+            'comment': runner_return if runner_return else "Runner function '{0}' failed without comment.".format(name)
+        }
     else:
-        ret['result'] = True
-    ret['comment'] = "Runner function '{0}' executed.".format(name)
+        ret = {
+            'name': name,
+            'result': True,
+            'changes': runner_return if runner_return else {},
+            'comment': "Runner function '{0}' executed.".format(name)
+        }
 
     ret['__orchestration__'] = True
     if 'jid' in out:
         ret['__jid__'] = out['jid']
-
-    runner_return = out.get('return')
-    if runner_return:
-        ret['changes'] = runner_return
 
     return ret
 

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -651,7 +651,10 @@ def runner(name, **kwargs):
                                       __env__=__env__,
                                       **kwargs)
 
-    ret['result'] = True
+    if 'success' in out and not out['success']:
+        ret['result'] = False
+    else:
+        ret['result'] = True
     ret['comment'] = "Runner function '{0}' executed.".format(name)
 
     ret['__orchestration__'] = True


### PR DESCRIPTION
### What does this PR do?

Fix a bug where states.salt.runner() would always report success, even if the runner that was called raises an exception.

### How to reproduce the issue

Create a simple test runner (`/srv/salt/_runner/testrunner.py`):
```python
def test():
    rasie Exception('This is an exception')
```

Now create a state that calls the runner (`/srv/salt/teststate.sls`):
```salt
testrunner.test:
  salt.runner
```

Now execute the state with `salt-run state.orch teststate`

### Old behavior

The orchestrator will report 1 successful state and 0 failures and display the error message as the changes of the "successful" state. (It will also report, that the changes are invalid, because the error message is not a dictionary, but it will show it nethertheless.)

### New behavior

The state will now be marked as failed and the error message will be displayed as the comment if an exception is thrown from the runner. (Exceptions are already caught and the fail saved in 
`_low()` in https://github.com/saltstack/salt/blob/develop/salt/client/mixins.py but the value is currently ignored by salt.states.salt.runner())

### Backporting issues

This fix can't be backported directly, as information about successful execution is only passed to the function since carbon, because `low()` in salt.client.mixins (e.g. https://github.com/saltstack/salt/blob/2015.8/salt/client/mixins.py) only returns `data['return']` before carbon. Since carbon `data` is returned completely and `data['success']` can be checked to determine if any exceptions where raised by the runner. (see https://github.com/saltstack/salt/blob/carbon/salt/client/mixins.py)

To backport an argument like `full_return` with default value `False` could be added to the functions salt.runner.cmd() and salt.client.mixins.low() (like there is now since carbon), which can then be set to `True` when calling the first function in salt.modules.saltutil.runner() and the function then returns the complete `data` dictionary.

### Functions called when calling salt.states.salt.runner()

- states.salt.runner() = states.saltmod.runner()
- runner() in https://github.com/saltstack/salt/blob/develop/salt/states/saltmod.py calls `saltutil.runner`
- runner() in https://github.com/saltstack/salt/blob/develop/salt/modules/saltutil.py calls `salt.runner.RunnerClient.cmd()`
- cmd() in https://github.com/saltstack/salt/blob/develop/salt/runner.py calls `super().cmd()` (inherited from `mixins.SyncClientMixins`)
- cmd() in https://github.com/saltstack/salt/blob/develop/salt/client/mixins.py calls `self.low()`

Before carbon:
- low() executes the runner and returns only `data['result']` (=the return value of the runner). `data['success']` is set but never used

Since carbon:
- low() calls _low() which returns `data` completely if the parameter `full_return` is `True` (Which is the case if the runner is called with `states.salt.runner()`, see `runner()` in https://github.com/saltstack/salt/blob/develop/salt/modules/saltutil.py: it calls/returns `rclient.cmd()` with `full_return=True`)

### What issues does this PR fix or reference?

This probably also fixes #36204, but I didn't test it.