### PR TITLE
raise exception on ipc msg subscriber so we can deal with them

### DIFF
--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -700,11 +700,12 @@ class IPCMessageSubscriber(IPCClient):
                 for framed_msg in self.unpacker:
                     body = framed_msg['body']
                     self.io_loop.spawn_callback(callback, body)
-            except tornado.iostream.StreamClosedError:
+            except tornado.iostream.StreamClosedError as exc:
                 log.trace('Subscriber disconnected from IPC {0}'.format(self.socket_path))
-                break
+                raise exc
             except Exception as exc:
                 log.error('Exception occurred while Subscriber handling stream: {0}'.format(exc))
+                raise exc
 
     @tornado.gen.coroutine
     def read_async(self, callback):

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -702,7 +702,9 @@ class IPCMessageSubscriber(IPCClient):
                     self.io_loop.spawn_callback(callback, body)
             except tornado.iostream.StreamClosedError as exc:
                 log.trace('Subscriber disconnected from IPC {0}'.format(self.socket_path))
-                raise exc
+                if not self._closing:
+                    raise exc
+                break
             except Exception as exc:
                 log.error('Exception occurred while Subscriber handling stream: {0}'.format(exc))
                 raise exc

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -530,7 +530,9 @@ class SaltEvent(object):
             except KeyboardInterrupt:
                 return {'tag': 'salt/event/exit', 'data': {}}
             except (tornado.iostream.StreamClosedError, RuntimeError) as exc:
-                raise exc
+                if not self._closing:
+                    raise exc
+                return None
 
             if not match_func(ret['tag'], tag):
                 # tag not match

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -529,8 +529,8 @@ class SaltEvent(object):
                 ret = {'data': data, 'tag': mtag}
             except KeyboardInterrupt:
                 return {'tag': 'salt/event/exit', 'data': {}}
-            except (tornado.iostream.StreamClosedError, RuntimeError):
-                return None
+            except (tornado.iostream.StreamClosedError, RuntimeError) as exc:
+                raise exc
 
             if not match_func(ret['tag'], tag):
                 # tag not match


### PR DESCRIPTION
When we follow the documentation (https://docs.saltstack.com/en/2015.8/topics/event/index.html#from-python) , in order to listen to the event system, in case we restart the salt-master or if it goes down for whatever reason, this piece of code will hang as we keep on sending the same info whether we have no messages or if the salt-master is down. 

This is because the exceptions never makes it through to the callee and are basically ignored.

This PR intends to fix this.
