### PR TITLE
Fix wait_status in boto_rds.create()

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -279,15 +279,15 @@ def create(name, allocated_storage, db_instance_class, engine,
             log.info('Waiting 10 secs...')
             sleep(10)
             _describe = describe(name=name, tags=tags, region=region, key=key,
-                                 keyid=keyid, profile=profile)
+                                 keyid=keyid, profile=profile)['rds']
             if not _describe:
                 return {'created': True}
-            if _describe['db_instance_status'] == wait_status:
+            if _describe['DBInstanceStatus'] == wait_status:
                 return {'created': True, 'message':
                         'Created RDS {0} with current status '
-                        '{1}'.format(name, _describe['db_instance_status'])}
+                        '{1}'.format(name, _describe['DBInstanceStatus'])}
 
-            log.info('Current status: {0}'.format(_describe['db_instance_status']))
+            log.info('Current status: {0}'.format(_describe['DBInstanceStatus']))
 
     except ClientError as e:
         return {'error': salt.utils.boto3.get_error(e)}
@@ -526,7 +526,7 @@ def describe(name, tags=None, region=None, key=None, keyid=None,
                     'CopyTagsToSnapshot', 'MonitoringInterval',
                     'MonitoringRoleArn', 'PromotionTier',
                     'DomainMemberships')
-            return {'rds': dict([(k, rds.get(k)) for k in keys])}
+            return {'rds': dict([(k, rds.get('DBInstances', [{}])[0].get(k)) for k in keys])}
         else:
             return {'rds': None}
     except ClientError as e:


### PR DESCRIPTION
### What does this PR do?

The return value of the boto_rds.describe() function - used to get the current status - has changed, and therefore the status is ignored even if you give wait_status parameter.

```
wait_status
    Wait for the RDS instance to reach a desired status before finishing the state. Available states: available, modifying, backing-up
```

### What issues does this PR fix or reference?

\- 

### Previous Behavior
The RDS is created and the function returns immediately, regardless of what you give as wait_status.

### New Behavior
The RDS is created and the function doesn't return until the RDS has the status you specified in the wait_status parameter.

### Tests written?

No