### PR TITLE
Create cluster gh

### DIFF
--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -948,6 +948,31 @@ def get_cluster(dc_ref, cluster):
     return items[0]
 
 
+def create_cluster(dc_ref, cluster_name, cluster_spec):
+    '''
+    Creates a cluster in a datacenter.
+
+    dc_ref
+        The parent datacenter reference.
+
+    cluster_name
+        The cluster name.
+
+    cluster_spec
+        The cluster spec (vim.ClusterConfigSpecEx).
+        Defaults to None.
+    '''
+    dc_name = get_managed_object_name(dc_ref)
+    log.trace('Creating cluster \'{0}\' in datacenter \'{1}\''
+              ''.format(cluster_name, dc_name))
+    try:
+        dc_ref.hostFolder.CreateClusterEx(cluster_name, cluster_spec)
+    except vim.fault.VimFault as exc:
+        raise salt.exceptions.VMwareApiError(exc.msg)
+    except vmodl.RuntimeFault as exc:
+        raise salt.exceptions.VMwareRuntimeError(exc.msg)
+
+
 def update_cluster(cluster_ref, cluster_spec):
     '''
     Updates a cluster in a datacenter.

--- a/tests/unit/utils/vmware_test/cluster_test.py
+++ b/tests/unit/utils/vmware_test/cluster_test.py
@@ -140,6 +140,51 @@ class GetClusterTestCase(TestCase):
         self.assertEqual(res, self.mock_cluster2)
 
 
+@patch('salt.utils.vmware.get_managed_object_name', MagicMock())
+class CreateClusterTestCase(TestCase):
+    '''Tests for salt.utils.vmware.create_cluster'''
+
+    def setUp(self):
+        self.mock_create_cluster_ex = MagicMock()
+        self.mock_dc = MagicMock(
+            hostFolder=MagicMock(CreateClusterEx=self.mock_create_cluster_ex))
+        self.mock_cluster_spec = MagicMock()
+
+    def test_get_managed_object_name(self):
+        mock_get_managed_object_name = MagicMock()
+        with patch('salt.utils.vmware.get_managed_object_name',
+                   mock_get_managed_object_name):
+            vmware.create_cluster(self.mock_dc, 'fake_cluster',
+                                  self.mock_cluster_spec)
+        mock_get_managed_object_name.assert_called_once_with(self.mock_dc)
+
+    def test_create_cluster_call(self):
+        vmware.create_cluster(self.mock_dc, 'fake_cluster',
+                              self.mock_cluster_spec)
+        self.mock_create_cluster_ex.assert_called_once_with(
+           'fake_cluster', self.mock_cluster_spec)
+
+    def test_create_cluster_raise_vim_fault(self):
+        exc = vim.fault.VimFault()
+        exc.msg = 'VimFault msg'
+        self.mock_dc.hostFolder.CreateClusterEx = MagicMock(
+            side_effect=exc)
+        with self.assertRaises(VMwareApiError) as excinfo:
+            vmware.create_cluster(self.mock_dc, 'fake_cluster',
+                                  self.mock_cluster_spec)
+        self.assertEqual(excinfo.exception.strerror, 'VimFault msg')
+
+    def test_create_cluster_raise_runtime_fault(self):
+        exc = vmodl.RuntimeFault()
+        exc.msg = 'RuntimeFault msg'
+        self.mock_dc.hostFolder.CreateClusterEx = MagicMock(
+            side_effect=exc)
+        with self.assertRaises(VMwareRuntimeError) as excinfo:
+            vmware.create_cluster(self.mock_dc, 'fake_cluster',
+                                  self.mock_cluster_spec)
+        self.assertEqual(excinfo.exception.strerror, 'RuntimeFault msg')
+
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
 @patch('salt.utils.vmware.get_managed_object_name', MagicMock())
@@ -199,4 +244,5 @@ class UpdateClusterTestCase(TestCase):
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(GetClusterTestCase, needs_daemon=False)
+    run_tests(CreateClusterTestCase, needs_daemon=False)
     run_tests(UpdateClusterTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

Added utils.vmware.create_clusterd
    
- creates a cluster in a datacenter based on a cluster spec

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.