### PR TITLE
Pull request for Bug #37118

### DIFF
--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -360,7 +360,7 @@ class GroupOption(Option):
                 self.gids.add(int(name))
             else:
                 try:
-                    self.gids.add(grp.getgrnam(value).gr_gid)
+                    self.gids.add(grp.getgrnam(name).gr_gid)
                 except KeyError:
                     raise ValueError('no such group "{0}"'.format(name))
 


### PR DESCRIPTION
### What does this PR do?
Fix bug #37118
### What issues does this PR fix or reference?
Bug saltstack/salt#37118
### Previous Behavior
Comma separated groups in file.find wasn't working as expected because the wrong variable was being used for the comparison. 

### New Behavior
Now comma separated groups will work as intended.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.