### PR TITLE
Including resolution parameters in the Zypper debug-solver call during a dry-run dist-upgrade

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1115,11 +1115,6 @@ def upgrade(refresh=True,
         cmd_update.append('--dry-run')
 
     if dist_upgrade:
-        if dryrun:
-            # Creates a solver test case for debugging.
-            log.info('Executing debugsolver and performing a dry-run dist-upgrade')
-            __zypper__.noraise.call(*cmd_update + ['--debug-solver'])
-
         if fromrepo:
             for repo in fromrepo:
                 cmd_update.extend(['--from', repo])
@@ -1132,6 +1127,11 @@ def upgrade(refresh=True,
                 log.info('Disabling vendor changes')
             else:
                 log.warn('Disabling vendor changes is not supported on this Zypper version')
+
+        if dryrun:
+            # Creates a solver test case for debugging.
+            log.info('Executing debugsolver and performing a dry-run dist-upgrade')
+            __zypper__(systemd_scope=_systemd_scope()).noraise.call(*cmd_update + ['--debug-solver'])
 
     old = list_pkgs()
     __zypper__(systemd_scope=_systemd_scope()).noraise.call(*cmd_update)

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -359,6 +359,13 @@ class ZypperTestCase(TestCase):
                 zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses', '--dry-run')
                 zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses', '--dry-run', '--debug-solver')
 
+            with patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])):
+                ret = zypper.upgrade(dist_upgrade=True, dryrun=True, fromrepo=["Dummy", "Dummy2"], novendorchange=True)
+                self.assertTrue(ret['result'])
+                self.assertDictEqual(ret['changes'], {})
+                zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses', '--dry-run', '--from', "Dummy", '--from', 'Dummy2', '--no-allow-vendor-change')
+                zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses', '--dry-run', '--from', "Dummy", '--from', 'Dummy2', '--no-allow-vendor-change', '--debug-solver')
+
             with patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}])):
                 ret = zypper.upgrade(dist_upgrade=True, fromrepo=["Dummy", "Dummy2"], novendorchange=True)
                 self.assertTrue(ret['result'])


### PR DESCRIPTION
### What does this PR do?
This PR includes the `--no-allow-vendor-change` and `--from` parameters into the zypper `--debug-solver` call in order to set the right resolution while performing a dry-run dist-upgrade.

### Tests written?

Yes

/cc @isbm 