### PR TITLE
Update remaining Carbon references to 2016.11.0

### DIFF
--- a/conf/proxy
+++ b/conf/proxy
@@ -28,7 +28,7 @@
 # dictionary.  Otherwise it is assumed that the module calls the grains
 # function in a custom way and returns the data elsewhere
 #
-# Default to False for 2016.3 and Carbon.  Switch to True for Nitrogen.
+# Default to False for 2016.3 and 2016.11.  Switch to True for Nitrogen.
 # proxy_merge_grains_in_module: False
 
 # If multiple masters are specified in the 'master' setting, the default behavior

--- a/doc/topics/releases/2016.11.0.rst
+++ b/doc/topics/releases/2016.11.0.rst
@@ -1,13 +1,14 @@
 :orphan:
 
-====================================
-Salt Release Notes - Codename Carbon
-====================================
+==============================================
+Salt 2016.11.0 Release Notes - Codename Carbon
+==============================================
 
 Release Candidate
 =================
 
-See :ref:`Installing/Testing a Salt Release Candidate <release-candidate>` for instructions to install the latest release candidate.
+See :ref:`Installing/Testing a Salt Release Candidate <release-candidate>` for instructions to install the
+latest release candidate.
 
 Release Candidate Known Issues
 ------------------------------
@@ -25,7 +26,7 @@ New Features
 Docker Introspection and Configuration
 --------------------------------------
 
-Major additions have been made to the Docker support in Carbon. The new
+Major additions have been made to the Docker support in 2016.11.0. The new
 addition allows Salt to be executed within a Docker container without a
 minion running or installed in the container. This allows states to
 be run inside a container, but also all of Salt's remote execution
@@ -151,7 +152,7 @@ Grains Changes
   is the `official capitalization <https://www.vmware.com>`_.  Additionally,
   all references to ``VMWare`` in the documentation have been changed to
   ``VMware`` :issue:`30807`.  Environments using versions of Salt before and
-  after Salt Carbon should employ case-insensitive grain matching on these
+  after Salt 2016.11.0 should employ case-insensitive grain matching on these
   grains.
 
   .. code-block:: jinja
@@ -374,7 +375,7 @@ General Deprecations
 - ``env`` to ``saltenv``
 
   All occurrences of ``env`` and some occurrences of ``__env__`` marked for
-  deprecation in Salt Carbon have been removed.  The new way to use the salt
+  deprecation in Salt 2016.11.0 have been removed.  The new way to use the salt
   environment setting is with a variable called ``saltenv``:
 
   .. code-block:: python

--- a/doc/topics/releases/index.rst
+++ b/doc/topics/releases/index.rst
@@ -16,13 +16,11 @@ Latest Branch Release
 Previous Releases
 =================
 
-.. after carbon releases, remove carbon from the list below:
-
 .. releasestree::
     :maxdepth: 1
     :glob:
 
-    carbon
+    2016.11.*
     2016.3.*
     2015.8.*
     2015.5.*

--- a/doc/topics/releases/version_numbers.rst
+++ b/doc/topics/releases/version_numbers.rst
@@ -28,8 +28,9 @@ Assigned codenames:
 - Lithium: ``2015.5.0``
 - Beryllium: ``2015.8.0``
 - Boron: ``2016.3.0``
-- Carbon: ``TBD``
+- Carbon: ``2016.11.0``
 - Nitrogen: ``TBD``
+- Oxygen: ``TBD``
 
 Example
 -------

--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -2,7 +2,7 @@
 '''
 Cache data in filesystem.
 
-.. versionadded:: carbon
+.. versionadded:: 2016.11.0
 
 Expirations can be set in the relevant config file (``/etc/salt/master`` for
 the master, ``/etc/salt/cloud`` for Salt Cloud, etc).

--- a/salt/modules/boto_cloudwatch_event.py
+++ b/salt/modules/boto_cloudwatch_event.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon CloudWatch Events
 
-.. versionadded:: carbon
+.. versionadded:: 2016.11.0
 
 :configuration: This module accepts explicit credentials but can also utilize
     IAM roles assigned to the instance through Instance Profiles. Dynamic

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -669,7 +669,7 @@ def get_all_instance_profiles(path_prefix='/', region=None, key=None,
     '''
     Get and return all IAM instance profiles, starting at the optional path.
 
-    .. versionadded:: carbon
+    .. versionadded:: 2016.11.0
 
     CLI Example:
 
@@ -693,7 +693,7 @@ def list_instance_profiles(path_prefix='/', region=None, key=None,
     '''
     List all IAM instance profiles, starting at the optional path.
 
-    .. versionadded:: carbon
+    .. versionadded:: 2016.11.0
 
     CLI Example:
 

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -139,7 +139,8 @@ def uptime():
         The uptime function was changed to return a dictionary of easy-to-read
         key/value pairs containing uptime information, instead of the output
         from a ``cmd.run`` call.
-    .. versionchanged:: carbon
+
+    .. versionchanged:: 2016.11.0
         Fall back to output of `uptime` when /proc/uptime is not available.
 
     CLI Example:

--- a/salt/states/boto_cloudwatch_event.py
+++ b/salt/states/boto_cloudwatch_event.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
 Manage CloudTrail Objects
-=================
+=========================
 
-.. versionadded:: carbon
+.. versionadded:: 2016.11.0
 
 Create and destroy CloudWatch event rules. Be aware that this interacts with Amazon's services,
 and so may incur charges.

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -1553,7 +1553,7 @@ def running(name,
             This option requires Docker 1.9.0 or newer and
             docker-py 1.7.0 or newer.
 
-        .. versionadded:: carbon
+        .. versionadded:: 2016.11.0
     '''
     ret = {'name': name,
            'changes': {},

--- a/salt/version.py
+++ b/salt/version.py
@@ -86,11 +86,11 @@ class SaltStackVersion(object):
         'Lithium'       : (2015, 5),
         'Beryllium'     : (2015, 8),
         'Boron'         : (2016, 3),
-        'Carbon'        : (MAX_SIZE - 103, 0),
+        'Carbon'        : (2016, 11),
         'Nitrogen'      : (MAX_SIZE - 102, 0),
         'Oxygen'        : (MAX_SIZE - 101, 0),
+        'Fluorine'      : (MAX_SIZE - 100, 0),
         # pylint: disable=E8265
-        #'Fluorine'     : (MAX_SIZE - 100, 0),
         #'Neon'         : (MAX_SIZE - 99 , 0),
         #'Sodium'       : (MAX_SIZE - 98 , 0),
         #'Magnesium'    : (MAX_SIZE - 97 , 0),


### PR DESCRIPTION
- Cleanup "carbon" refs and replace with 2016.11.0
- Officially update version.py for carbon to be 2016.11.0
- Prep release notes for 2016.11