### PR TITLE
Fix/workaround for issue #37355

### DIFF
--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -292,6 +292,16 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
             if tempdir is not None:
                 shutil.rmtree(tempdir)
                 tempdir = None
+
+        # workaround for backports
+        os.symlink('salt/ext','/tmp/workaround_symlink_backports')
+        tftp_deref_old = tfp.dereference
+        tfp.dereference = False
+        tfp.add('/tmp/workaround_symlink_backports', arcname=os.path.join('py{0}'.format(py_ver), 'backports'))
+        tfp.dereference = tftp_deref_old
+        os.unlink('/tmp/workaround_symlink_backports')
+        # workaround end
+
     os.chdir(thindir)
     tfp.add('salt-call')
     with salt.utils.fopen(thinver, 'w+') as fp_:

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -296,7 +296,7 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
         # symlink for backports directory on old distributions
         tmpbackports = tempfile.mkdtemp(suffix='_backports_workaround',prefix='salt_')
         tmpbackports_symlink = os.path.join(WA,'symlink')
-		os.symlink('salt/ext', tmpbackports_symlink)
+        os.symlink('salt/ext', tmpbackports_symlink)
         tftp_deref_old = tfp.dereference
         tfp.dereference = False
         tfp.add(tmpbackports_symlink, arcname=os.path.join('py{0}'.format(py_ver), 'backports'))

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -293,13 +293,15 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
                 shutil.rmtree(tempdir)
                 tempdir = None
 
-        # workaround for backports
-        os.symlink('salt/ext','/tmp/workaround_symlink_backports')
+        # symlink for backports directory on old distributions
+        tmpbackports = tempfile.mkdtemp(suffix='_backports_workaround',prefix='salt_')
+        tmpbackports_symlink = os.path.join(WA,'symlink')
+		os.symlink('salt/ext', tmpbackports_symlink)
         tftp_deref_old = tfp.dereference
         tfp.dereference = False
-        tfp.add('/tmp/workaround_symlink_backports', arcname=os.path.join('py{0}'.format(py_ver), 'backports'))
+        tfp.add(tmpbackports_symlink, arcname=os.path.join('py{0}'.format(py_ver), 'backports'))
         tfp.dereference = tftp_deref_old
-        os.unlink('/tmp/workaround_symlink_backports')
+        shutil.rmtree(tmpbackports)
         # workaround end
 
     os.chdir(thindir)

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -297,10 +297,10 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
         tmpbackports = tempfile.mkdtemp(suffix='_backports_workaround', prefix='salt_')
         tmpbackports_symlink = os.path.join(tmpbackports, 'symlink')
         os.symlink('salt/ext', tmpbackports_symlink)
-        tftp_deref_old = tfp.dereference
+        tfp_deref_old = tfp.dereference
         tfp.dereference = False
         tfp.add(tmpbackports_symlink, arcname=os.path.join('py{0}'.format(py_ver), 'backports'))
-        tfp.dereference = tftp_deref_old
+        tfp.dereference = tfp_deref_old
         shutil.rmtree(tmpbackports)
         # workaround end
 

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -294,8 +294,8 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
                 tempdir = None
 
         # symlink for backports directory on old distributions
-        tmpbackports = tempfile.mkdtemp(suffix='_backports_workaround',prefix='salt_')
-        tmpbackports_symlink = os.path.join(WA,'symlink')
+        tmpbackports = tempfile.mkdtemp(suffix='_backports_workaround', prefix='salt_')
+        tmpbackports_symlink = os.path.join(tmpbackports, 'symlink')
         os.symlink('salt/ext', tmpbackports_symlink)
         tftp_deref_old = tfp.dereference
         tfp.dereference = False


### PR DESCRIPTION
### What does this PR do?
Add backports symlink to thin.tgz. So included tornado dependencies could import backports.ssl_match_hostname

### What issues does this PR fix or reference?
Fix/Workaround issue 
#37355 
#34600 
#27355

### Tests written?
No


