### PR TITLE
Remove --no-compress option from mac_package.install_app function

### DIFF
--- a/salt/modules/mac_package.py
+++ b/salt/modules/mac_package.py
@@ -110,7 +110,7 @@ def install_app(app, target='/Applications/'):
     if not app[-1] == '/':
         app += '/'
 
-    cmd = 'rsync -a --no-compress --delete {0} {1}'.format(app, target)
+    cmd = 'rsync -a --delete {0} {1}'.format(app, target)
     return __salt__['cmd.run'](cmd)
 
 

--- a/tests/unit/modules/mac_package_test.py
+++ b/tests/unit/modules/mac_package_test.py
@@ -57,7 +57,7 @@ class MacPackageTestCase(TestCase):
         mock = MagicMock()
         with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
             macpackage.install_app('/path/to/file.app')
-            mock.assert_called_once_with('rsync -a --no-compress --delete /path/to/file.app/ '
+            mock.assert_called_once_with('rsync -a --delete /path/to/file.app/ '
                                          '/Applications/file.app')
 
     def test_install_app_specify_target(self):
@@ -67,7 +67,7 @@ class MacPackageTestCase(TestCase):
         mock = MagicMock()
         with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
             macpackage.install_app('/path/to/file.app', '/Applications/new.app')
-            mock.assert_called_once_with('rsync -a --no-compress --delete /path/to/file.app/ '
+            mock.assert_called_once_with('rsync -a --delete /path/to/file.app/ '
                                          '/Applications/new.app')
 
     def test_install_app_with_slash(self):
@@ -77,7 +77,7 @@ class MacPackageTestCase(TestCase):
         mock = MagicMock()
         with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
             macpackage.install_app('/path/to/file.app/')
-            mock.assert_called_once_with('rsync -a --no-compress --delete /path/to/file.app/ '
+            mock.assert_called_once_with('rsync -a --delete /path/to/file.app/ '
                                          '/Applications/file.app')
 
     def test_uninstall(self):


### PR DESCRIPTION
The `--no-compress` flag for the rsync command doesn't exist in newer versions of rsync on OSX.

Fixes #36829

FYI @opdude