### PR TITLE
Add --set-metadata option to salt-call

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -138,7 +138,7 @@ class BaseCaller(object):
                                                         '/tmp/stats'),
                                stop=True)
             out = ret.get('out', 'nested')
-            if self.opts['metadata']:
+            if self.opts['print_metadata']:
                 print_ret = ret
                 out = 'nested'
             else:
@@ -171,12 +171,17 @@ class BaseCaller(object):
             else:
                 sys.stderr.write('\n')
             sys.exit(-1)
+        metadata = self.opts.get('metadata')
+        if metadata is not None:
+            metadata = salt.utils.args.yamlify_arg(metadata)
         try:
             sdata = {
                 'fun': fun,
                 'pid': os.getpid(),
                 'jid': ret['jid'],
                 'tgt': 'salt-call'}
+            if metadata is not None:
+                sdata['metadata'] = metadata
             args, kwargs = salt.minion.load_args_and_kwargs(
                 self.minion.functions[fun],
                 salt.utils.args.parse_input(self.opts['arg']),
@@ -237,6 +242,8 @@ class BaseCaller(object):
             ret['id'] = self.opts['id']
             ret['fun'] = fun
             ret['fun_args'] = self.opts['arg']
+            if metadata is not None:
+                ret['metadata'] = metadata
 
         for returner in returners:
             if not returner:  # if we got an empty returner somehow, skip
@@ -349,7 +356,7 @@ class RAETCaller(BaseCaller):
                 self.stack.server.close()
                 salt.transport.jobber_stack = None
 
-            if self.opts['metadata']:
+            if self.opts['print_metadata']:
                 print_ret = ret
             else:
                 print_ret = ret.get('return', {})

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2559,11 +2559,18 @@ class SaltCallOptionParser(six.with_metaclass(OptionParserMeta,
         self.add_option(
             '--metadata',
             default=False,
-            dest='metadata',
+            dest='print_metadata',
             action='store_true',
             help=('Print out the execution metadata as well as the return. '
                   'This will print out the outputter data, the return code, '
                   'etc.')
+        )
+        self.add_option(
+            '--set-metadata',
+            dest='metadata',
+            default=None,
+            metavar='METADATA',
+            help=('Pass metadata into Salt, used to search jobs.')
         )
         self.add_option(
             '--id',


### PR DESCRIPTION
### What does this PR do?

Works the same as the `--metadata` option in the `salt` command.
Since `--metadata` was already taken in `salt-call` to mean
something else, went with `--set-metadata` for `salt-call`.

### Tests written?

No

Signed-off-by: Sergey Kizunov <sergey.kizunov@ni.com>