### PR TITLE
PY3: Use `enter_context` instead of `push` for `ExitStack`

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1312,9 +1312,9 @@ class Minion(MinionBase):
             )
         else:
             exitstack = contextlib.ExitStack()
-            exitstack.push(self.functions.context_dict.clone())
-            exitstack.push(self.returners.context_dict.clone())
-            exitstack.push(self.executors.context_dict.clone())
+            exitstack.enter_context(self.functions.context_dict.clone())
+            exitstack.enter_context(self.returners.context_dict.clone())
+            exitstack.enter_context(self.executors.context_dict.clone())
             return exitstack
 
     @classmethod


### PR DESCRIPTION
### What does this PR do?

`salt.utils.context.ChildContextDict.__enter__()` was not being
invoked in Python 3 because `ExitStack.push()` only ensures that
`__exit__` is invoked. Switch to `ExitStack.enter_context()` which
is more appropriate.

### Tests written?

No

Signed-off-by: Sergey Kizunov <sergey.kizunov@ni.com>