### PR TITLE
dev_python*.txt: use current SaltTesting and SaltPyLint modules

### DIFF
--- a/requirements/dev_python27.txt
+++ b/requirements/dev_python27.txt
@@ -3,4 +3,5 @@
 mock
 boto>=2.32.1
 moto>=0.3.6
-SaltTesting==2015.2.16
+SaltTesting
+SaltPyLint

--- a/requirements/dev_python34.txt
+++ b/requirements/dev_python34.txt
@@ -3,4 +3,5 @@
 mock
 boto>=2.32.1
 moto>=0.3.6
-SaltTesting>=2015.2.16
+SaltTesting
+SaltPyLint


### PR DESCRIPTION
### What does this PR do?

Allow `pip` to install a current version of SaltTesting

### What issues does this PR fix or reference?

#34712

By default the SaltTesting module was pinned to version 2015.2.16

### Notes

We could set a minimum version

    SaltTesting>=2016.10.26
    SaltPyLint>=2016.6.25

But this seems more like an annotation than a help.

Include SaltPyLint since anyone doing development work will also want to
run pylint.