### PR TITLE
add default roster options to the master config

### DIFF
--- a/doc/topics/ssh/roster.rst
+++ b/doc/topics/ssh/roster.rst
@@ -61,6 +61,21 @@ The information which can be stored in a roster ``target`` is the following:
         cmd_umask:   # umask to enforce for the salt-call command. Should be in
                      # octal (so for 0o077 in YAML you would do 0077, or 63)
 
+Target Defaults
+---------------
+
+The `roster_defaults` dictionary in the master config is used to set the
+default login variables for minions in the roster so that the same arguments do
+not need to be passed with commandline arguments.
+
+.. code-block:: yaml
+
+    roster_defaults:
+        user: daniel
+        sudo: True
+        priv: /root/.ssh/id_rsa
+        tty: True
+
 thin_dir
 --------
 

--- a/salt/roster/cache.py
+++ b/salt/roster/cache.py
@@ -38,7 +38,8 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
     cached_data = __runner__['cache.grains'](tgt=tgt, expr_form=tgt_type)
     ret = {}
     for server, grains in cached_data.items():
-        ret[server] = {'host': extract_ipv4(roster_order, grains.get('ipv4', []))}
+        ret[server] = __opts__.get('roster_defaults', {}).copy()
+        ret[server].update({'host': extract_ipv4(roster_order, grains.get('ipv4', []))})
     return ret
 
 

--- a/salt/roster/cloud.py
+++ b/salt/roster/cloud.py
@@ -85,9 +85,8 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
     ))
     preferred_ip = extract_ipv4(roster_order, ip_list)
 
-    ret['tgt'] = {
-        'host': preferred_ip,
-    }
+    ret['tgt'] = __opts__.get('roster_defaults', {})
+    ret['tgt'].update({'host': preferred_ip})
 
     cloud_opts = salt.config.cloud_config('/etc/salt/cloud')
     ssh_username = salt.utils.cloud.ssh_usernames({}, cloud_opts)

--- a/salt/roster/clustershell.py
+++ b/salt/roster/clustershell.py
@@ -43,6 +43,7 @@ def targets(tgt, tgt_type='glob', **kwargs):
 
     for host, addr in host_addrs.items():
         addr = str(addr)
+        ret[addr] = __opts__.get('roster_defaults', {}).copy()
         for port in ports:
             try:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -50,7 +51,7 @@ def targets(tgt, tgt_type='glob', **kwargs):
                 sock.connect((addr, port))
                 sock.shutdown(socket.SHUT_RDWR)
                 sock.close()
-                ret[host] = {'host': host, 'port': port}
+                ret[host].update({'host': host, 'port': port})
             except socket.error:
                 pass
     return ret

--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -142,10 +142,13 @@ class RosterMatcher(object):
         '''
         Return the configured ip
         '''
+        ret = __opts__.get('roster_defaults', {})
         if isinstance(self.raw[minion], string_types):
-            return {'host': self.raw[minion]}
-        if isinstance(self.raw[minion], dict):
-            return self.raw[minion]
+            ret.update({'host': self.raw[minion]})
+            return ret
+        elif isinstance(self.raw[minion], dict):
+            ret.update(self.raw[minion])
+            return ret
         return False
 
 

--- a/salt/roster/range.py
+++ b/salt/roster/range.py
@@ -66,8 +66,21 @@ def targets(tgt, tgt_type='range', **kwargs):
 
 
 def target_range(tgt, hosts):
-    return dict((host, {'host': host, 'user': __opts__['ssh_user']}) for host in hosts)
+    ret = {}
+    for host in hosts:
+        ret[host] = __opts__.get('roster_defaults', {}).copy()
+        ret[host].update({'host': host})
+        if __opts__.get('ssh_user'):
+            ret[host].update({'user': __opts__['ssh_user']})
+    return ret
 
 
 def target_glob(tgt, hosts):
-    return dict((host, {'host': host, 'user': __opts__['ssh_user']}) for host in hosts if fnmatch.fnmatch(tgt, host))
+    ret = {}
+    for host in hosts:
+        if fnmatch.fnmatch(tgt, host):
+            ret[host] = __opts__.get('roster_defaults', {}).copy()
+            ret[host].update({'host': host})
+            if __opts__.get('ssh_user'):
+                ret[host].update({'user': __opts__['ssh_user']})
+    return ret

--- a/salt/roster/scan.py
+++ b/salt/roster/scan.py
@@ -55,6 +55,7 @@ class RosterMatcher(object):
                 pass
         for addr in addrs:
             addr = str(addr)
+            ret[addr] = __opts__.get('roster_defaults', {}).copy()
             log.trace('Scanning host: {0}'.format(addr))
             for port in ports:
                 log.trace('Scanning port: {0}'.format(port))
@@ -64,7 +65,7 @@ class RosterMatcher(object):
                     sock.connect((addr, port))
                     sock.shutdown(socket.SHUT_RDWR)
                     sock.close()
-                    ret[addr] = {'host': addr, 'port': port}
+                    ret[addr].update({'host': addr, 'port': port})
                 except socket.error:
                     pass
         return ret


### PR DESCRIPTION
### What does this PR do?
Allow setting defaults for targets in the roster in the master config.  Useful for the cache and cloud roster, but added to them all.

Should go in after https://github.com/saltstack/salt/pull/37320