### PR TITLE
Update solarisips.list_upgrades refresh default to True

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -11,3 +11,11 @@ Grains Changes
   State files, especially those using a templating language like Jinja
   may need to be adjusted to account for this change.
 - Add ability to specify disk backing mode in the VMWare salt cloud profile.
+
+Execution Module Changes
+========================
+
+- The ``refresh`` kwarg for the ``list_upgrades`` function in the ``solarisips``
+  package module default value has been changed from ``True`` to ``False``. This
+  makes the function more consistent with all of the other package execution
+  modules. All other ``pkg.list_upgrades`` functions already default to ``True``.

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -146,7 +146,7 @@ def upgrade_available(name):
     return ret
 
 
-def list_upgrades(refresh=False, **kwargs):  # pylint: disable=W0613
+def list_upgrades(refresh=True, **kwargs):  # pylint: disable=W0613
     '''
     Lists all packages available for update.
 
@@ -160,15 +160,22 @@ def list_upgrades(refresh=False, **kwargs):  # pylint: disable=W0613
     in the list of upgrades, then the global zone should be updated to get all
     possible updates. Use ``refresh=True`` to refresh the package database.
 
-    refresh : False
-        Set to ``True`` to force a full pkg DB refresh before listing
+    refresh : True
+        Runs a full package database refresh before listing. Set to ``False`` to
+        disable running the refresh.
+
+        .. versionchanged:: Nitrogen
+
+        In previous versions of Salt, ``refresh`` defaulted to ``False``. This was
+        changed to default to ``True`` in the Nitrogen release to make the behavior
+        more consistent with the other package modules, which all default to ``True``.
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' pkg.list_upgrades
-        salt '*' pkg.list_upgrades refresh=True
+        salt '*' pkg.list_upgrades refresh=False
     '''
     if salt.utils.is_true(refresh):
         refresh_db(full=True)


### PR DESCRIPTION
The refresh kwarg defaults to True in all of the other pkg execution
modules. This change updates the solarisips.list_upgrades refresh
kwarg to be True instead of False to be consistent with the other
pkg execution modules.

Fixes #36210