### PR TITLE
Don't insert __pub* keys into dnsmasq config file with set_config function

### DIFF
--- a/tests/unit/modules/dnsmasq_test.py
+++ b/tests/unit/modules/dnsmasq_test.py
@@ -58,6 +58,23 @@ class DnsmasqTestCase(TestCase):
             with patch.object(os, 'listdir', mock):
                 self.assertDictEqual(dnsmasq.set_config(), {})
 
+    @patch('salt.modules.dnsmasq.get_config', MagicMock(return_value={'conf-dir': 'A'}))
+    def test_set_config_filter_pub_kwargs(self):
+        '''
+        Test that the kwargs returned from running the set_config function
+        do not contain the __pub that may have been passed through in **kwargs.
+        '''
+        mock_domain = 'local'
+        mock_address = '/some-test-address.local/8.8.4.4'
+        with patch.dict(dnsmasq.__salt__, {'file.append': MagicMock()}):
+            ret = dnsmasq.set_config(follow=False,
+                                     domain=mock_domain,
+                                     address=mock_address,
+                                     __pub_pid=8184,
+                                     __pub_jid=20161101194639387946,
+                                     __pub_tgt='salt-call')
+        self.assertEqual(ret, {'domain': mock_domain, 'address': mock_address})
+
     def test_get_config(self):
         '''
         test to dumps all options from the config file.

--- a/tests/unit/modules/dnsmasq_test.py
+++ b/tests/unit/modules/dnsmasq_test.py
@@ -16,6 +16,7 @@ from salttesting.mock import (
 )
 
 # Import Salt Libs
+from salt.exceptions import CommandExecutionError
 from salt.modules import dnsmasq
 
 # Import python libs
@@ -85,6 +86,14 @@ class DnsmasqTestCase(TestCase):
             with patch.object(os, 'listdir', mock):
                 self.assertDictEqual(dnsmasq.get_config(), {'conf-dir': 'A'})
 
+    def test_parse_dnsmasq_no_file(self):
+        '''
+        Tests that a CommandExecutionError is when a filename that doesn't exist is
+        passed in.
+        '''
+        self.assertRaises(CommandExecutionError, dnsmasq._parse_dnamasq, 'filename')
+
+    @patch('os.path.isfile', MagicMock(return_value=True))
     def test_parse_dnamasq(self):
         '''
         test for generic function for parsing dnsmasq files including includes.


### PR DESCRIPTION
### What does this PR do?
Filters out the `__pub*` key/value pairs from the `**kwargs` dictionary when calling the `dnsmasq.set_config` execution module function.

### What issues does this PR fix or reference?
Fixes #34263

### Previous Behavior
When running the `dnsmasq.set_config` function, the `__pub*` keys would be passed along with the other key/value pairs, and would add these key value pairs to the config file. Here's an example:
```
# salt-call --local dnsmasq.set_config 'config_file=/tmp/dnsmasq.conf' domain=local address='/vern.test.local/8.8.4.4'
local:
    ----------
    __pub_fun:
        dnsmasq.set_config
    __pub_jid:
        20161101194639387946
    __pub_pid:
        16672
    __pub_tgt:
        salt-call
    address:
        /vern.test.local/8.8.4.4
    domain:
        local
```
With the contents of the file being:
```
# cat /tmp/dnsmasq.conf
domain=local
__pub_pid=16672
__pub_fun=dnsmasq.set_config
__pub_jid=20161101194639387946
__pub_tgt=salt-call
address=/vern.test.local/8.8.4.4
```

### New Behavior
With this fix, we don't include the `__pub*` key/value pairs in the config file, or the command return:
```
# salt-call --local dnsmasq.set_config config_file=/tmp/dnsmasq.conf domain=local address='/vern.test.local/8.8.4.4'
local:
    ----------
    address:
        /vern.test.local/8.8.4.4
    domain:
        local
# cat /tmp/dnsmasq.conf
domain=local
address=/vern.test.local/8.8.4.4
```

This change also adds a check in the `_parse_dnamasq` function to check if the file exists before trying to open it. (I hit an IOError when attempting to test this on a file that didn't exist yet.) If the file doesn't exist, we raise an error instead.

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
