### PR TITLE
Add state.grains.exists and unit tests

### DIFF
--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -18,6 +18,31 @@ import re
 from salt.defaults import DEFAULT_TARGET_DELIM
 
 
+def exists(name, delimiter=DEFAULT_TARGET_DELIM):
+    '''
+    Ensure that a grain is set
+
+    name
+        The grain name
+
+    delimiter
+        A delimiter different from the default can be provided.
+
+    Check whether a grain exists. Does not attempt to check or set the value.
+    '''
+    name = re.sub(delimiter, DEFAULT_TARGET_DELIM, name)
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': 'Grain exists'}
+    _non_existent = object()
+    existing = __salt__['grains.get'](name, _non_existent)
+    if existing is _non_existent:
+        ret['result'] = False
+        ret['comment'] = 'Grain does not exist'
+    return ret
+
+
 def present(name, value, delimiter=DEFAULT_TARGET_DELIM, force=False):
     '''
     Ensure that a grain is set

--- a/tests/unit/states/grains_test.py
+++ b/tests/unit/states/grains_test.py
@@ -78,6 +78,27 @@ class GrainsTestCase(TestCase):
         with open(grains_file, "w+") as grf:
             grf.write(cstr)
 
+    # 'exists' function tests: 2
+
+    def test_exists_missing(self):
+        self.setGrains({'a': 'aval'})
+        ret = grains.exists(
+            name='foo',
+        )
+        self.assertEqual(ret['result'], False)
+        self.assertEqual(ret['comment'], 'Grain does not exist')
+        self.assertEqual(ret['changes'], {})
+
+    def test_exists_found(self):
+        self.setGrains({'a': 'aval', 'foo': 'bar'})
+        # Grain already set
+        ret = grains.exists(
+            name='foo',
+        )
+        self.assertEqual(ret['result'], True)
+        self.assertEqual(ret['comment'], 'Grain exists')
+        self.assertEqual(ret['changes'], {})
+
     # 'present' function tests: 12
 
     def test_present_add(self):


### PR DESCRIPTION
### What does this PR do?
Adds a new method exists() to state.grains to assert a grain exists regardless of the grain's value.

### What issues does this PR fix or reference?
No issues fixed but new functionality added.

### New Behavior
Provides ability to assert in a state run that a grain exists regardless of the grain's value. For example, a state may need a custom grain and you want the state not to be executed if that grain is not present but you do not want to set the grain in this state run as grains.present would do.

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.