### PR TITLE
Strip slashes from gitfs mountpoints

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -243,6 +243,7 @@ class GitProvider(object):
 
         if hasattr(self, 'mountpoint'):
             self.mountpoint = salt.utils.url.strip_proto(self.mountpoint)
+            self.mountpoint = self.mountpoint.strip('/')
         else:
             # For providers which do not use a mountpoint, assume the
             # filesystem is mounted at the root of the fileserver.


### PR DESCRIPTION
This fixes an issue where mountpoints containing a trailing slash result
in all fileclient requests for files from that repo to fail to match.

Resolves #37286.