### PR TITLE
Allow specifying a VPC for named security groups

### DIFF
--- a/salt/modules/boto_asg.py
+++ b/salt/modules/boto_asg.py
@@ -592,7 +592,7 @@ def create_launch_configuration(name, image_id, key_name=None,
     # If a VPC is specified, then determine the secgroup id's within that VPC, not
     # within the default VPC. If a security group id is already part of the list,
     # convert_to_group_ids leaves that entry without attempting a lookup on it.
-    if (security_groups and (vpc_id or vpc_name)):
+    if security_groups and (vpc_id or vpc_name):
         security_groups = __salt__['boto_secgroup.convert_to_group_ids'](
                                security_groups,
                                vpc_id=vpc_id, vpc_name=vpc_name,

--- a/salt/modules/boto_asg.py
+++ b/salt/modules/boto_asg.py
@@ -553,6 +553,7 @@ def describe_launch_configuration(name, region=None, key=None, keyid=None,
 
 
 def create_launch_configuration(name, image_id, key_name=None,
+                                vpc_id=None, vpc_name=None,
                                 security_groups=None, user_data=None,
                                 instance_type='m1.small', kernel_id=None,
                                 ramdisk_id=None, block_device_mappings=None,
@@ -587,6 +588,17 @@ def create_launch_configuration(name, image_id, key_name=None,
                     setattr(_block_device, attribute, value)
                 _block_device_map[block_device] = _block_device
         _bdms = [_block_device_map]
+
+    # If a VPC is specified, then determine the secgroup id's within that VPC, not
+    # within the default VPC. If a security group id is already part of the list,
+    # convert_to_group_ids leaves that entry without attempting a lookup on it.
+    if (security_groups and (vpc_id or vpc_name)):
+        security_groups = __salt__['boto_secgroup.convert_to_group_ids'](
+                               security_groups,
+                               vpc_id=vpc_id, vpc_name=vpc_name,
+                               region=region, key=key, keyid=keyid,
+                               profile=profile
+                           )
     lc = autoscale.LaunchConfiguration(
         name=name, image_id=image_id, key_name=key_name,
         security_groups=security_groups, user_data=user_data,

--- a/salt/states/boto_lc.py
+++ b/salt/states/boto_lc.py
@@ -241,9 +241,11 @@ def present(
         raise SaltInvocationError('user_data and cloud_init are mutually'
                                   ' exclusive options.')
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
-    exists = __salt__['boto_asg.launch_configuration_exists'](name, region,
-                                                              key, keyid,
-                                                              profile)
+    exists = __salt__['boto_asg.launch_configuration_exists'](name,
+                                                              region=region,
+                                                              key=key,
+                                                              keyid=keyid,
+                                                              profile=profile)
     if not exists:
         if __opts__['test']:
             msg = 'Launch configuration set to be created.'
@@ -312,16 +314,22 @@ def absent(
         that contains a dict with region, key and keyid.
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
-    exists = __salt__['boto_asg.launch_configuration_exists'](name, region,
-                                                              key, keyid,
-                                                              profile)
+    exists = __salt__['boto_asg.launch_configuration_exists'](name,
+                                                              region=region,
+                                                              key=key,
+                                                              keyid=keyid,
+                                                              profile=profile)
     if exists:
         if __opts__['test']:
             ret['comment'] = 'Launch configuration set to be deleted.'
             ret['result'] = None
             return ret
         deleted = __salt__['boto_asg.delete_launch_configuration'](
-            name, region, key, keyid, profile)
+                                                              name,
+                                                              region=region,
+                                                              key=key,
+                                                              keyid=keyid,
+                                                              profile=profile)
         if deleted:
             ret['changes']['old'] = name
             ret['changes']['new'] = None

--- a/salt/states/boto_lc.py
+++ b/salt/states/boto_lc.py
@@ -113,6 +113,8 @@ def present(
         name,
         image_id,
         key_name=None,
+        vpc_id=None,
+        vpc_name=None,
         security_groups=None,
         user_data=None,
         cloud_init=None,
@@ -142,6 +144,16 @@ def present(
     key_name
         Name of the EC2 key pair to use for instances. Key must exist or
         creation of the launch configuration will fail.
+
+    vpc_id
+        The VPC id where the security groups are defined. Only necessary when
+        using named security groups that exist outside of the default VPC.
+        Mutually exclusive with vpc_name.
+
+    vpc_name
+        Name of the VPC where the security groups are defined. Only Necessary
+        when using named security groups that exist outside of the default VPC.
+        Mutually exclusive with vpc_id.
 
     security_groups
         List of Names or security group id’s of the security groups with which
@@ -246,6 +258,8 @@ def present(
             name,
             image_id,
             key_name=key_name,
+            vpc_id=vpc_id,
+            vpc_name=vpc_name,
             security_groups=security_groups,
             user_data=user_data,
             instance_type=instance_type,


### PR DESCRIPTION
### What does this PR do?
Allows the use of named security groups when creating a launch configuration even when not using the default VPC, by allowing `boto_lc.present` to accept `vpc_id` and `vpc_name`.

### What issues does this PR fix or reference?
None. In the interests of streamlining some states that we have to create launch configurations, we wanted to be able to specify named security groups, and since we extensively use non-default VPCs, this was a requirement.

### Previous Behavior
Previously, if you tried to specify the name of a security group that was _not_ in the default VPC it would fail.

```
[DEBUG   ] BotoServerError: 400 Bad Request
<ErrorResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
  <Error>
    <Type>Sender</Type>
    <Code>ValidationError</Code>
    <Message>The security group 'my-vpc-specific-group' does not exist in default VPC 'vpc-1a2b3c4d'</Message>
  </Error>
  <RequestId>a6e49d10-a104-11e6-9958-4b63824c6fb0</RequestId>
</ErrorResponse>
```

### New Behavior

_If_ you specify the `vpc_id` or `vpc_name` in the call to `boto_lc.present`, it will perform a lookup of the security group names within the desired VPC using `boto_secgroup.convert_to_group_ids` and use the returned security group ids in the creation of the launch configuration.

```yaml
my-launch-config:
    boto_lc.present:
        - vpc_name: my-non-default-vpc
        - security_groups:
            - my-vpc-specific-group
        - instance_type: t2.small
```    

### Tests written?

No