### PR TITLE
Fix source_hash when target basename is different than source basename

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3578,7 +3578,7 @@ def get_managed(
                     return '', {}, ('Source hash file {0} not found'
                                     .format(source_hash))
                 source_sum = extract_hash(
-                    hash_fn, '', source_hash_name or name)
+                    hash_fn, '', source_hash_name or urlparsed_source.path)
                 if source_sum is None:
                     return _invalid_source_hash_format()
 


### PR DESCRIPTION
### What does this PR do?
Attempt to solve the numerous `source_hash` problems that exist out there for `file.managed`

### What issues does this PR fix or reference?
#20681
#26981
#27397
#29010
#32933

### Previous Behavior
`file.get_managed` always passes on the *target* filename to the hash extract function.

### New Behavior
Give the path as it is known on the remote side.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
