### PR TITLE
Fix regression in output for Ctrl-c'ed CLI jobs

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -613,7 +613,7 @@ class LocalClient(object):
         was_listening = self.event.cpub
 
         try:
-            pub_data = self.run_job(
+            self.pub_data = self.run_job(
                 tgt,
                 fun,
                 arg,
@@ -623,13 +623,13 @@ class LocalClient(object):
                 listen=True,
                 **kwargs)
 
-            if not pub_data:
-                yield pub_data
+            if not self.pub_data:
+                yield self.pub_data
             else:
                 try:
                     for fn_ret in self.get_cli_event_returns(
-                            pub_data['jid'],
-                            pub_data['minions'],
+                            self.pub_data['jid'],
+                            self.pub_data['minions'],
                             self._get_timeout(timeout),
                             tgt,
                             expr_form,
@@ -642,12 +642,16 @@ class LocalClient(object):
 
                         yield fn_ret
                 except KeyboardInterrupt:
-                    msg = ('Exiting on Ctrl-C\nThis job\'s jid is:\n{0}\n'
-                           'The minions may not have all finished running and any '
-                           'remaining minions will return upon completion. To '
-                           'look up the return data for this job later run:\n'
-                           'salt-run jobs.lookup_jid {0}').format(pub_data['jid'])
-                    raise SystemExit(msg)
+                    raise SystemExit(
+                        '\n'
+                        'This job\'s jid is: {0}\n'
+                        'Exiting gracefully on Ctrl-c\n'
+                        'The minions may not have all finished running and any '
+                        'remaining minions will return upon completion. To look '
+                        'up the return data for this job later, run the following '
+                        'command:\n\n'
+                        'salt-run jobs.lookup_jid {0}'.format(self.pub_data['jid'])
+                    )
         finally:
             if not was_listening:
                 self.event.close_pub()


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/37115 backported a fix from develop into 2016.3 and inadvertently broke a fix that I had initially submitted in https://github.com/saltstack/salt/pull/36750. This commit corrects this regression.