### PR TITLE
Prevent theoretically possible None from being processed by getaddrinfo

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -117,13 +117,13 @@ def _generate_minion_id():
     hosts = DistinctList().append(socket.getfqdn()).append(platform.node()).append(socket.gethostname())
     if not hosts:
         try:
-            for a_nfo in socket.getaddrinfo(hosts.first(), None, socket.AF_INET,
+            for a_nfo in socket.getaddrinfo(hosts.first() or 'localhost', None, socket.AF_INET,
                                             socket.SOCK_RAW, socket.IPPROTO_IP, socket.AI_CANONNAME):
                 if len(a_nfo) > 3:
                     hosts.append(a_nfo[3])
         except socket.gaierror:
             log.warn('Cannot resolve address {addr} info via socket: {message}'.format(
-                addr=hosts.first(), message=socket.gaierror)
+                addr=hosts.first() or 'localhost (N/A)', message=socket.gaierror)
             )
     # Universal method for everywhere (Linux, Slowlaris, Windows etc)
     for f_name in ['/etc/hostname', '/etc/nodename', '/etc/hosts',


### PR DESCRIPTION
### What does this PR do?

Addresses https://github.com/saltstack/salt/pull/37402

### What issues does this PR fix or reference?

References https://github.com/saltstack/salt/issues/37395

### Previous Behavior

Function does what it should.

### New Behavior

Function still does what it should. Just eliminated _theoretical_ possibility of `None` being processed as a hostname. In reality that won't happen, as three first calls on host name resolution always return something.

### Tests written?

Yes
