### PR TITLE
Avoid Early Convert ret['comment'] to String

### DIFF
--- a/salt/states/gpg.py
+++ b/salt/states/gpg.py
@@ -132,7 +132,7 @@ def present(name,
                 else:
                     ret['comment'].append('Invalid trust level {0}'.format(trust))
 
-        ret['comment'] = '\n'.join(ret['comment'])
+    ret['comment'] = '\n'.join(ret['comment'])
     return ret
 
 
@@ -188,5 +188,5 @@ def absent(name,
                 ret['comment'].append('Deleting {0} from GPG keychain'.format(name))
         else:
             ret['comment'].append('{0} not found in GPG keychain'.format(name))
-        ret['comment'] = '\n'.join(ret['comment'])
+    ret['comment'] = '\n'.join(ret['comment'])
     return ret


### PR DESCRIPTION
### What does this PR do?

Fixes this exception:
```
Traceback (most recent call last):
  File "/var/tmp/.syops_b1274f_salt/py2/salt/state.py", line 1733, in call
    **cdata['kwargs'])
  File "/var/tmp/.syops_b1274f_salt/py2/salt/loader.py", line 1652, in wrapper
    return f(*args, **kwargs)
  File "/var/tmp/.syops_b1274f_salt/py2/salt/states/gpg.py", line 119, in present
    ret['comment'].append('Adding {0} to GPG keychain'.format(name))
AttributeError: 'str' object has no attribute 'append'
```

### What issues does this PR fix or reference?

The code that mutates the `ret['comment']` from a list to a string happens inside a loop. It should happen just before returning.

### Previous Behavior

You can only use the gpg.present state with one key at a time, or it will crash.

### New Behavior
You can now use the gpg state with multiple keys, [as documented](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.gpg.html).

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.