### PR TITLE
Fix incorrect reference of __utils__ in salt.utils

### DIFF
--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -97,7 +97,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
         headers['x-amz-server-side-encryption-aws-kms-key-id'] = kms_keyid
 
     if not location:
-        location = __utils__['aws.get_location']()
+        location = salt.utils.aws.get_location()
 
     data = ''
     payload_hash = None


### PR DESCRIPTION
Closes #37388

Unfortunately, the original regression went all the way back into 2015.8 so this might need to get backported there as well. :-/