### PR TITLE
Including resolution parameters in the Zypper debug-solver call during a dry-run dist-upgrade (2016.3)

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1135,6 +1135,10 @@ def upgrade(refresh=True,
 
     cmd_update = (['dist-upgrade'] if dist_upgrade else ['update']) + ['--auto-agree-with-licenses']
 
+    if skip_verify:
+        # The '--no-gpg-checks' needs to be placed before the Zypper command.
+        cmd_update.insert(0, '--no-gpg-checks')
+
     if refresh:
         refresh_db()
 
@@ -1142,11 +1146,6 @@ def upgrade(refresh=True,
         cmd_update.append('--dry-run')
 
     if dist_upgrade:
-        if dryrun:
-            # Creates a solver test case for debugging.
-            log.info('Executing debugsolver and performing a dry-run dist-upgrade')
-            __zypper__.noraise.call(*cmd_update + ['--debug-solver'])
-
         if fromrepo:
             for repo in fromrepo:
                 cmd_update.extend(['--from', repo])
@@ -1160,8 +1159,10 @@ def upgrade(refresh=True,
             else:
                 log.warn('Disabling vendor changes is not supported on this Zypper version')
 
-    if skip_verify:
-        cmd_update.append('--no-gpg-checks')
+        if dryrun:
+            # Creates a solver test case for debugging.
+            log.info('Executing debugsolver and performing a dry-run dist-upgrade')
+            __zypper__(systemd_scope=_systemd_scope()).noraise.call(*cmd_update + ['--debug-solver'])
 
     old = list_pkgs()
 

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -359,6 +359,13 @@ class ZypperTestCase(TestCase):
                 zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses', '--dry-run')
                 zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses', '--dry-run', '--debug-solver')
 
+            with patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])):
+                ret = zypper.upgrade(dist_upgrade=True, dryrun=True, fromrepo=["Dummy", "Dummy2"], novendorchange=True)
+                self.assertTrue(ret['result'])
+                self.assertDictEqual(ret['changes'], {})
+                zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses', '--dry-run', '--from', "Dummy", '--from', 'Dummy2', '--no-allow-vendor-change')
+                zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses', '--dry-run', '--from', "Dummy", '--from', 'Dummy2', '--no-allow-vendor-change', '--debug-solver')
+
             with patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}])):
                 ret = zypper.upgrade(dist_upgrade=True, fromrepo=["Dummy", "Dummy2"], novendorchange=True)
                 self.assertTrue(ret['result'])


### PR DESCRIPTION
### What does this PR do?
This PR brings the changes from #37353 to the `2016.3` branch:

- Includes the `--no-allow-vendor-change` and `--from` parameters into the zypper `--debug-solver` call in order to set the right resolution while performing a dry-run dist-upgrade.

### Tests written?
Yes

/cc @isbm 