### PR TITLE
Added proxy support to elasticsearch using requests backend module

### DIFF
--- a/salt/modules/elasticsearch.py
+++ b/salt/modules/elasticsearch.py
@@ -77,6 +77,7 @@ def _get_instance(hosts=None, profile=None):
     Return the elasticsearch instance
     '''
     es = None
+    proxies = {}
 
     if profile is None:
         profile = 'elasticsearch'
@@ -89,13 +90,13 @@ def _get_instance(hosts=None, profile=None):
         hosts = _profile.get('host', None)
         if not hosts:
             hosts = _profile.get('hosts', None)
+        proxies = _profile.get('proxies', {})
 
     if not hosts:
         hosts = ['127.0.0.1:9200']
     if isinstance(hosts, string_types):
         hosts = [hosts]
     try:
-        proxies = _profile.get('proxies', {})
         if proxies == {}:
             es = elasticsearch.Elasticsearch(hosts)
         else:

--- a/salt/modules/elasticsearch.py
+++ b/salt/modules/elasticsearch.py
@@ -63,6 +63,7 @@ except ImportError:
 
 from salt.ext.six import string_types
 
+
 def __virtual__():
     '''
     Only load if elasticsearch libraries exist.


### PR DESCRIPTION
### What does this PR do?
Add proxy support to modules.elasticsearch using the requests backend module with config options supplied via same config route

### What issues does this PR fix or reference?
None

### Previous Behavior
Proxy had to be set via environment variables

### New Behavior
Proxies can be specified in the elasticsearch config options in the format required by the requests backend. The existence of the "proxies" data causes the requests backed to be used via a custom connection class.

### Tests written?
No tests exist for this module.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.