### PR TITLE
Fix for #37238 salt hang on master restart

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -46,7 +46,8 @@ class SaltCMD(parsers.SaltCMDOptionParser):
 
             self.local_client = salt.client.get_local_client(
                 self.get_config_file_path(),
-                skip_perm_errors=skip_perm_errors)
+                skip_perm_errors=skip_perm_errors,
+                auto_reconnect=True)
         except SaltClientError as exc:
             self.exit(2, '{0}\n'.format(exc))
             return

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -112,7 +112,7 @@ TAGS = {
 
 def get_event(
         node, sock_dir=None, transport='zeromq',
-        opts=None, listen=True, io_loop=None, keep_loop=False):
+        opts=None, listen=True, io_loop=None, keep_loop=False, raise_errors=False):
     '''
     Return an event object suitable for the named transport
 
@@ -125,8 +125,19 @@ def get_event(
     # TODO: AIO core is separate from transport
     if transport in ('zeromq', 'tcp'):
         if node == 'master':
-            return MasterEvent(sock_dir, opts, listen=listen, io_loop=io_loop, keep_loop=keep_loop)
-        return SaltEvent(node, sock_dir, opts, listen=listen, io_loop=io_loop, keep_loop=keep_loop)
+            return MasterEvent(sock_dir,
+                               opts,
+                               listen=listen,
+                               io_loop=io_loop,
+                               keep_loop=keep_loop,
+                               raise_errors=raise_errors)
+        return SaltEvent(node,
+                         sock_dir,
+                         opts,
+                         listen=listen,
+                         io_loop=io_loop,
+                         keep_loop=keep_loop,
+                         raise_errors=raise_errors)
     elif transport == 'raet':
         import salt.utils.raetevent
         return salt.utils.raetevent.RAETEvent(node,
@@ -135,13 +146,13 @@ def get_event(
                                               opts=opts)
 
 
-def get_master_event(opts, sock_dir, listen=True, io_loop=None):
+def get_master_event(opts, sock_dir, listen=True, io_loop=None, raise_errors=False):
     '''
     Return an event object suitable for the named transport
     '''
     # TODO: AIO core is separate from transport
     if opts['transport'] in ('zeromq', 'tcp'):
-        return MasterEvent(sock_dir, opts, listen=listen, io_loop=io_loop)
+        return MasterEvent(sock_dir, opts, listen=listen, io_loop=io_loop, raise_errors=raise_errors)
     elif opts['transport'] == 'raet':
         import salt.utils.raetevent
         return salt.utils.raetevent.MasterEvent(
@@ -177,7 +188,8 @@ class SaltEvent(object):
     '''
     def __init__(
             self, node, sock_dir=None,
-            opts=None, listen=True, io_loop=None, keep_loop=False):
+            opts=None, listen=True, io_loop=None,
+            keep_loop=False, raise_errors=False):
         '''
         :param IOLoop io_loop: Pass in an io_loop if you want asynchronous
                                operation for obtaining events. Eg use of
@@ -200,6 +212,7 @@ class SaltEvent(object):
         self.cpush = False
         self.subscriber = None
         self.pusher = None
+        self.raise_errors = raise_errors
 
         if opts is None:
             opts = {}
@@ -505,7 +518,12 @@ class SaltEvent(object):
                 ret = {'data': data, 'tag': mtag}
             except KeyboardInterrupt:
                 return {'tag': 'salt/event/exit', 'data': {}}
-            except (tornado.iostream.StreamClosedError, RuntimeError):
+            except tornado.iostream.StreamClosedError:
+                if self.raise_errors:
+                    raise
+                else:
+                    return None
+            except RuntimeError:
                 return None
 
             if not match_func(ret['tag'], tag):
@@ -773,14 +791,16 @@ class MasterEvent(SaltEvent):
             opts=None,
             listen=True,
             io_loop=None,
-            keep_loop=False):
+            keep_loop=False,
+            raise_errors=False):
         super(MasterEvent, self).__init__(
             'master',
             sock_dir,
             opts,
             listen=listen,
             io_loop=io_loop,
-            keep_loop=keep_loop)
+            keep_loop=keep_loop,
+            raise_errors=raise_errors)
 
 
 class LocalClientEvent(MasterEvent):
@@ -813,10 +833,11 @@ class MinionEvent(SaltEvent):
     RAET compatible
     Create a master event management object
     '''
-    def __init__(self, opts, listen=True, io_loop=None):
+    def __init__(self, opts, listen=True, io_loop=None, raise_errors=False):
         super(MinionEvent, self).__init__(
             'minion', sock_dir=opts.get('sock_dir'),
-            opts=opts, listen=listen, io_loop=io_loop)
+            opts=opts, listen=listen, io_loop=io_loop,
+            raise_errors=raise_errors)
 
 
 class AsyncEventPublisher(object):


### PR DESCRIPTION
### What does this PR do?
Auto reconnect `salt` to master if the connection was lost.
    
1. Re-raise `StreamClosedError` in the `SaltEvent` if the event was created with `raise_errors=True`.
2. Handle `StreamClosedError` in the client if the client was created with `auto_reconnect=True`.

### What issues does this PR fix or reference?
Fixes #37238, #37018.

### Previous Behavior
`SaltEvent.get_event` was silently ignoring the `StreamClosedError` so `salt` command was hanging if master was restarted during `salt` execution.

### New Behavior
`salt` command gets the results and exits correctly because it reconnects to master.

### Tests written?
No