### PR TITLE
Create paths.d directory

### DIFF
--- a/pkg/osx/pkg-scripts/postinstall
+++ b/pkg/osx/pkg-scripts/postinstall
@@ -46,6 +46,9 @@ ln -sf /opt/salt/bin/salt-config.sh /usr/local/sbin/salt-config
 # Add salt to paths.d
 ###############################################################################
 # echo "Path: Adding salt to the path..." >> /tmp/postinstall.txt
+if [ ! -d "/etc/paths.d" ]; then
+    mkdir /etc/paths.d
+fi
 sh -c 'echo "/opt/salt/bin" > /etc/paths.d/salt'
 sh -c 'echo "/usr/local/sbin" >> /etc/paths.d/salt'
 


### PR DESCRIPTION
### What does this PR do?
Fixes a problem with the installer if the `/etc/paths.d` directory does not exist.

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1025

### Previous Behavior
The `/etc/paths.d` directory doesn't exist on fresh mac installs. The postinstall script would fail because it couldn't write to `/etc/paths.d/salt`.

### New Behavior
The postinstall script checks for `/etc/paths.d` and creates it if it doesn't exist.

### Tests written?
NA