### PR TITLE
Check for Server os before checking [DO NOT MERGE FORWARD]

### DIFF
--- a/salt/modules/win_servermanager.py
+++ b/salt/modules/win_servermanager.py
@@ -47,6 +47,9 @@ def _check_server_manager():
 
     Returns: True if import is successful, otherwise returns False
     '''
+    if 'Server' not in __grains__['osrelease']:
+        return False
+
     return not __salt__['cmd.retcode']('Import-Module ServerManager',
                                        shell='powershell',
                                        python_shell=True)


### PR DESCRIPTION
************* DO NOT MERGE FORWARD **************
This issue is fixed in Carbon

### What does this PR do?
Fixes problem with Powershell Module import failure on non-server Windows OSs. There were too many conflicts with backporting https://github.com/saltstack/salt/pull/36983

### What issues does this PR fix or reference?
Related to:
https://github.com/saltstack/salt/issues/36252

### Previous Behavior
Returns an ugly debug if you run `salt-call --local sys.doc none` on Non-Server Windows
```
[ERROR   ] Command 'Import-Module ServerManager' failed with return code: 1
[ERROR   ] output: Import-Module : The specified module 'ServerManager' was not loaded because no valid module file was found in any
module directory.
At line:1 char:1
+ Import-Module ServerManager
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ResourceUnavailable: (ServerManager:String) [Import-Module], FileNotFoundException
    + FullyQualifiedErrorId : Modules_ModuleNotFound,Microsoft.PowerShell.Commands.ImportModuleCommand
local:
    ----------
```

### New Behavior
Checks the `osrelease` grain for the word `Server`. If not found, simply returns false instead of failing to import ServerManager.

### Tests written?
NA