### PR TITLE
Detect VC++ for Python on Win32

### DIFF
--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -39,6 +39,7 @@ Function Get-Settings {
         # Location of programs on 32 bit Windows
         $32bitPaths = @{
             "NSISDir" = "C:\Program Files\NSIS"
+            "VCforPythonDir" = "C:\Program Files\Common Files\Microsoft\Visual C++ for Python\9.0"
         }
         $ini.Add("32bitPaths", $32bitPaths)
 


### PR DESCRIPTION
### What does this PR do?
Detects existing installation of VC++ for Python on Win32. Functionality already there for 64 bit, just missing the 32 bit check.