### PR TITLE
Cast ip_protocol rule as a str() in boto_secgroup.present

### DIFF
--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -326,7 +326,7 @@ def _get_rule_changes(rules, _rules):
     # 2. determine if rule exists in existing security group rules
     for rule in rules:
         try:
-            ip_protocol = rule.get('ip_protocol')
+            ip_protocol = str(rule.get('ip_protocol'))
         except KeyError:
             raise SaltInvocationError('ip_protocol, to_port, and from_port are'
                                       ' required arguments for security group'


### PR DESCRIPTION
Fixes saltstack/salt#36961

Protects against a stacktrace lower in the function where we call ip_protocol.isdigit(), which expects a string.