### PR TITLE
yumpkg.list_repo_pkgs always shows duplicates

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -703,7 +703,7 @@ def list_repo_pkgs(*args, **kwargs):
             version_list.add(pkg.version)
 
     if _no_repository_packages():
-        cmd_prefix = ['yum', '--quiet', 'list']
+        cmd_prefix = ['yum', '--quiet', 'list', '--showduplicates']
         for pkg_src in ('installed', 'available'):
             # Check installed packages first
             out = __salt__['cmd.run_all'](

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -706,7 +706,7 @@ def list_repo_pkgs(*args, **kwargs):
             )
             if out['retcode'] == 0:
                 _parse_output(out['stdout'], strict=True)
-    # The --showduplicates option is added in 3.2.13, but the 
+    # The --showduplicates option is added in 3.2.13, but the
     # repository-packages subcommand is only in 3.4.3 and newer
     elif yum_version and yum_version < _LooseVersion('3.4.3'):
         cmd_prefix = ['yum', '--quiet', 'list', '--showduplicates']


### PR DESCRIPTION
### What does this PR do?
yumpkg.list_repo_pkgs should always show duplicates

### What issues does this PR fix or reference?

### Previous Behavior
On yum versions < 3.4.3, yumpkg.list_repo_pkgs was not showing duplicates

### New Behavior
yumpkg.list_repo_pkgs always shows duplicates, even when yum versions < 3.4.3

### Tests written?
No