### PR TITLE
file.line with mode=replace on an empty file should return False, not stacktrace

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1513,7 +1513,7 @@ def line(path, content, match=None, mode=None, location=None,
 
     elif mode == 'replace':
         if os.stat(path).st_size == 0:
-            log.debug('Cannot find text to replace. File \'{0}\' is empty.'.format(path))
+            log.warning('Cannot find text to replace. File \'{0}\' is empty.'.format(path))
             body = ''
         else:
             body = os.linesep.join([(_get_line_indent(file_line, content, indent)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1512,9 +1512,13 @@ def line(path, content, match=None, mode=None, location=None,
         body = os.linesep.join([line for line in body.split(os.linesep) if line.find(match) < 0])
 
     elif mode == 'replace':
-        body = os.linesep.join([(_get_line_indent(line, content, indent)
-                                if (line.find(match) > -1 and not line == content) else line)
-                                for line in body.split(os.linesep)])
+        if os.stat(path).st_size == 0:
+            log.debug('Cannot find text to replace. File \'{0}\' is empty.'.format(path))
+            body = ''
+        else:
+            body = os.linesep.join([(_get_line_indent(file_line, content, indent)
+                                    if (file_line.find(match) > -1 and not file_line == content) else file_line)
+                                    for file_line in body.split(os.linesep)])
     elif mode == 'insert':
         if not location and not before and not after:
             raise CommandExecutionError('On insert must be defined either "location" or "before/after" conditions.')

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -571,6 +571,32 @@ class FileModuleTestCase(TestCase):
             saltenv='base')
         self.assertEqual(ret, 'This is a templated file.')
 
+    def test_replace_line_in_empty_file(self):
+        '''
+        Tests that when calling file.line with ``mode=replace``,
+        the function doesn't stack trace if the file is empty.
+        Should return ``False``.
+
+        See Issue #31135.
+        '''
+        # Create an empty temporary named file
+        empty_file = tempfile.NamedTemporaryFile(delete=False,
+                                                 mode='w+')
+
+        # Assert that the file was created and is empty
+        self.assertEqual(os.stat(empty_file.name).st_size, 0)
+
+        # Now call the function on the empty file and assert
+        # the return is False instead of stack-tracing
+        self.assertFalse(filemod.line(empty_file.name,
+                                      content='foo',
+                                      match='bar',
+                                      mode='replace'))
+
+        # Close and remove the file
+        empty_file.close()
+        os.remove(empty_file.name)
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Fixes #31135

If a file exists but is empty, we are stack tracing on a call to
the body.split(os.linesep) function. This fix sets the body variable
to an empty string instead of stack tracing when the file is empty.

This allows the function to return ``False``, since no match can be
found in an empty file.

I also adjusted one of the ``line`` variables in the ``replace`` block
because it was shadowing the outer line function scope.

Also wrote a unit test first before fixing this function.