### PR TITLE
Begin deprecating default setting dns entries in the lxc module

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -287,7 +287,7 @@ def cloud_init_interface(name, vm_=None, **kwargs):
     config
         any extra argument for the salt minion config
     dnsservers
-        list of dns servers to set inside the container
+        list of DNS servers to set inside the container
         (Defaults to 8.8.8.8 and 4.4.4.4 until Oxygen release)
     dns_via_dhcp
         do not set the dns servers, let them be set by the dhcp.

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -287,7 +287,11 @@ def cloud_init_interface(name, vm_=None, **kwargs):
     config
         any extra argument for the salt minion config
     dnsservers
-        dns servers to set inside the container
+        list of dns servers to set inside the container
+        (Defaults to 8.8.8.8 and 4.4.4.4 until Oxygen release)
+    dns_via_dhcp
+        do not set the dns servers, let them be set by the dhcp.
+        (Defaults to False until Oxygen release)
     autostart
         autostart the container at boot time
     password
@@ -400,7 +404,12 @@ def cloud_init_interface(name, vm_=None, **kwargs):
     snapshot = _cloud_get('snapshot', False)
     autostart = bool(_cloud_get('autostart', True))
     dnsservers = _cloud_get('dnsservers', [])
-    if not dnsservers:
+    dns_via_dhcp = _cloud_get('dns_via_dhcp', False)
+    if not dnsservers and not dns_via_dhcp:
+        salt.utils.warn_until('Oxygen', (
+            'dnsservers will stop defaulting to 8.8.8.8 and 4.4.4.4 '
+            'in Oxygen.  Please set your dnsservers.'
+        ))
         dnsservers = ['8.8.8.8', '4.4.4.4']
     password = _cloud_get('password', 's3cr3t')
     password_encrypted = _cloud_get('password_encrypted', False)


### PR DESCRIPTION
### What does this PR do?

We shouldn't be setting defaults for this.  They should have to be
explicitly set because they could also be set by dhcp.

Fixes saltstack/salt#37381