### PR TITLE
Fix error message when ConvertTo-Json not supported [DO NOT MERGE FORWARD]

### DIFF
--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -47,7 +47,16 @@ def _pshell(cmd, cwd=None):
     if 'convertto-json' not in cmd.lower():
         cmd = ' '.join([cmd, '| ConvertTo-Json'])
     log.debug('DSC: {0}'.format(cmd))
-    ret = __salt__['cmd.shell'](cmd, shell='powershell', cwd=cwd)
+    ret = __salt__['cmd.run_all'](cmd, shell='powershell', cwd=cwd,
+            python_shell=True, ignore_retcode=True)
+
+    if ret['retcode']:
+        log.debug('Error running command: {0}'.format(cmd))
+        log.debug(ret)
+        return False
+
+    ret = ret['stdout']
+
     try:
         ret = json.loads(ret, strict=False)
     except ValueError:


### PR DESCRIPTION
[DO NOT MERGE FORWARD]
### What does this PR do?
Uses `cmd.run_all` instead of `cmd.shell` with `ignore_retcode=True` to keep from dumping the PowerShell error when an older version of PowerShell (<3) is installed that doesn't support `ConvertTo-JSON`

### What issues does this PR fix or reference?
Issue found in testing

### Previous Behavior
When running `salt-call --local sys.doc none` on a minion that has PowerShell 2 (default) and hasn't received the update to PowerShell 3 the following was being returned to the master.
```
[ERROR   ] Command '$PSVersionTable.PSVersion.Major | ConvertTo-Json' failed with return code: 1
[ERROR   ] output: The term 'ConvertTo-Json' is not recognized as the name of a cmdlet, function, script file,
 or operable progr
am. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:49
+ $PSVersionTable.PSVersion.Major | ConvertTo-Json <<<<
    + CategoryInfo          : ObjectNotFound: (ConvertTo-Json:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
local:
    ----------
```

### New Behavior
Returns:
```
local:
    ----------
```

### Tests written?
No