### PR TITLE
Adds a couple handy jinja filters, `escape_regex` and `unique`

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3164,6 +3164,15 @@ def replace(name,
         A regular expression, to be matched using Python's
         :py:func:`~re.search`.
 
+        ..note::
+            If you need to match a literal string that contains regex special
+            characters, you may want to use salt's custom Jinja filter,
+            ``escape_regex``.
+
+            ..code-block:: jinja
+
+                {{ 'http://example.com?foo=bar%20baz' | escape_regex }}
+
     repl
         The replacement text
 

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 import json
 import pprint
 import logging
+import re
 from os import path
 from functools import wraps
 
@@ -330,11 +331,28 @@ class SerializerExtension(Extension, object):
         {% from "doc1.sls" import var1, var2 as local2 %}
         {{ var1.foo }} {{ local2.bar }}
 
+    ** Escape Filters **
+
+    ..versionadded:: Nitrogen
+
+    Allows escaping of strings so they can be interpreted literally by another
+    function.
+
+    For example:
+
+    .. code-block:: jinja
+
+        escape_regex = {{ 'https://example.com?foo=bar%20baz' | escape_regex }}
+
+    will be rendered as::
+
+        escape_regex = https\\:\\/\\/example\\.com\\?foo\\=bar\\%20baz
+
     .. _`import tag`: http://jinja.pocoo.org/docs/templates/#import
     '''
 
     tags = set(['load_yaml', 'load_json', 'import_yaml', 'import_json',
-                'load_text', 'import_text'])
+                'load_text', 'import_text', 'regex_escape'])
 
     def __init__(self, environment):
         super(SerializerExtension, self).__init__(environment)
@@ -346,6 +364,7 @@ class SerializerExtension(Extension, object):
             'load_yaml': self.load_yaml,
             'load_json': self.load_json,
             'load_text': self.load_text,
+            'regex_escape': self.regex_escape,
         })
 
         if self.environment.finalize is None:
@@ -533,3 +552,6 @@ class SerializerExtension(Extension, object):
             ).set_lineno(lineno)
         ]
     # pylint: enable=E1120,E1121
+
+    def regex_escape(self, value):
+        return re.escape(value)

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -5,6 +5,7 @@ Jinja loading utils to enable a more powerful backend for jinja templates
 
 # Import python libs
 from __future__ import absolute_import
+import collections
 import json
 import pprint
 import logging
@@ -348,11 +349,27 @@ class SerializerExtension(Extension, object):
 
         escape_regex = https\\:\\/\\/example\\.com\\?foo\\=bar\\%20baz
 
+    ** Set Theory Filters **
+
+    ..versionadded:: Nitrogen
+
+    Performs set math using Jinja filters.
+
+    For example:
+
+    .. code-block:: jinja
+
+        unique = {{ ['foo', 'foo', 'bar'] | unique }}
+
+    will be rendered as::
+
+        unique = ['foo', 'bar']
+
     .. _`import tag`: http://jinja.pocoo.org/docs/templates/#import
     '''
 
     tags = set(['load_yaml', 'load_json', 'import_yaml', 'import_json',
-                'load_text', 'import_text', 'regex_escape'])
+                'load_text', 'import_text', 'regex_escape', 'unique'])
 
     def __init__(self, environment):
         super(SerializerExtension, self).__init__(environment)
@@ -365,6 +382,7 @@ class SerializerExtension(Extension, object):
             'load_json': self.load_json,
             'load_text': self.load_text,
             'regex_escape': self.regex_escape,
+            'unique': self.unique,
         })
 
         if self.environment.finalize is None:
@@ -555,3 +573,14 @@ class SerializerExtension(Extension, object):
 
     def regex_escape(self, value):
         return re.escape(value)
+
+    def unique(self, values):
+        ret = None
+        if isinstance(values, collections.Hashable):
+            ret = set(values)
+        else:
+            ret = []
+            for value in values:
+                if value not in ret:
+                    ret.append(value)
+        return ret

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -8,6 +8,7 @@ import tempfile
 import json
 import datetime
 import pprint
+import re
 
 # Import Salt Testing libs
 from salttesting.unit import skipIf, TestCase
@@ -460,6 +461,12 @@ class TestGetTemplate(TestCase):
 
 
 class TestCustomExtensions(TestCase):
+    def test_regex_escape(self):
+        dataset = 'foo?:.*/\\bar'
+        env = Environment(extensions=[SerializerExtension])
+        rendered = env.from_string('{{ dataset|regex_escape }}').render(dataset=dataset)
+        self.assertEqual(rendered, re.escape(dataset))
+
     def test_serialize_json(self):
         dataset = {
             "foo": True,

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -467,6 +467,27 @@ class TestCustomExtensions(TestCase):
         rendered = env.from_string('{{ dataset|regex_escape }}').render(dataset=dataset)
         self.assertEqual(rendered, re.escape(dataset))
 
+    def test_unique_string(self):
+        dataset = 'foo'
+        unique = set(dataset)
+        env = Environment(extensions=[SerializerExtension])
+        rendered = env.from_string('{{ dataset|unique }}').render(dataset=dataset)
+        self.assertEqual(rendered, u"{0}".format(unique))
+
+    def test_unique_tuple(self):
+        dataset = ('foo', 'foo', 'bar')
+        unique = set(dataset)
+        env = Environment(extensions=[SerializerExtension])
+        rendered = env.from_string('{{ dataset|unique }}').render(dataset=dataset)
+        self.assertEqual(rendered, u"{0}".format(unique))
+
+    def test_unique_list(self):
+        dataset = ['foo', 'foo', 'bar']
+        unique = ['foo', 'bar']
+        env = Environment(extensions=[SerializerExtension])
+        rendered = env.from_string('{{ dataset|unique }}').render(dataset=dataset)
+        self.assertEqual(rendered, u"{0}".format(unique))
+
     def test_serialize_json(self):
         dataset = {
             "foo": True,


### PR DESCRIPTION
### What does this PR do?

Adds a couple custom jinja filters:
* `escape_regex` supports escaping literal strings for functions that expect a regex pattern (e.g. `file.replace`)
* `unique` performs a bit of set math to return unique items from a string, list, or tuple

### What issues does this PR fix or reference?

Fixes saltstack/salt#37429

### Tests written?

Yes