### PR TITLE
clean up pylint in virtualenvs

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -9,7 +9,7 @@ import copy
 import logging
 import os
 import re
-from distutils.version import LooseVersion as _LooseVersion
+from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=no-name-in-module
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -11,7 +11,7 @@ Module for the management of MacOS systems that use launchd/launchctl
 :depends:   - plistlib Python module
 '''
 from __future__ import absolute_import
-from distutils.version import LooseVersion
+from distutils.version import LooseVersion  # pylint: disable=no-name-in-module
 
 # Import python libs
 import logging

--- a/salt/modules/mac_assistive.py
+++ b/salt/modules/mac_assistive.py
@@ -11,7 +11,7 @@ This module allows you to manage assistive access on OS X minions with 10.9+
 
 # Import Python Libs
 from __future__ import absolute_import
-from distutils.version import LooseVersion
+from distutils.version import LooseVersion  # pylint: disable=no-name-in-module
 import re
 import logging
 

--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 import os
 import re
 import plistlib
-from distutils.version import LooseVersion
+from distutils.version import LooseVersion  # pylint: disable=no-name-in-module
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -5,7 +5,7 @@ Execute puppet routines
 
 # Import python libs
 from __future__ import absolute_import
-from distutils import version
+from distutils import version  # pylint: disable=no-name-in-module
 import logging
 import os
 import datetime

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, unicode_literals
 import logging
 import json
 import os
-import distutils.version
+import distutils.version  # pylint: disable=no-name-in-module
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/win_psget.py
+++ b/salt/modules/win_psget.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import, unicode_literals
 import copy
 import logging
 import json
-import distutils.version
+import distutils.version  # pylint: disable=no-name-in-module
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 import logging
 import socket
 import json
-from distutils.version import LooseVersion
+from distutils.version import LooseVersion  # pylint: disable=no-name-in-module
 
 # Import salt libs
 import salt.utils

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -5,7 +5,7 @@ Nova class
 
 # Import Python libs
 from __future__ import absolute_import, with_statement
-from distutils.version import LooseVersion
+from distutils.version import LooseVersion  # pylint: disable=no-name-in-module,import-error
 import time
 import inspect
 import logging


### PR DESCRIPTION
### What does this PR do?
In virtualenvs distutils.version is not available.  So ignore those errors so that the pylint can be run successfully in the virtualenv.

```
(saltpylint) ~github salt ➤ pylint --rcfile=.testing.pylintrc --disable=W1307,E1322 salt/
************* Module salt.modules.git
salt/modules/git.py:12: [E0611(no-name-in-module), ] No name 'version' in module 'distutils'
************* Module salt.modules.launchctl
salt/modules/launchctl.py:14: [E0611(no-name-in-module), ] No name 'version' in module 'distutils'
************* Module salt.modules.mac_assistive
salt/modules/mac_assistive.py:14: [E0611(no-name-in-module), ] No name 'version' in module 'distutils'
************* Module salt.modules.mac_service
salt/modules/mac_service.py:12: [E0611(no-name-in-module), ] No name 'version' in module 'distutils'
************* Module salt.modules.puppet
salt/modules/puppet.py:8: [E0611(no-name-in-module), ] No name 'version' in module 'distutils'
************* Module salt.modules.win_dsc
salt/modules/win_dsc.py:14: [E0611(no-name-in-module), ] No name 'version' in module 'distutils'
************* Module salt.modules.win_psget
salt/modules/win_psget.py:17: [E0611(no-name-in-module), ] No name 'version' in module 'distutils'
************* Module salt.modules.zabbix
salt/modules/zabbix.py:31: [E0611(no-name-in-module), ] No name 'version' in module 'distutils'
************* Module salt.states.git
salt/states/git.py:21: [E0611(no-name-in-module), ] No name 'version' in module 'distutils'
************* Module salt.states.mac_assistive
salt/states/mac_assistive.py:17: [E0611(no-name-in-module), ] No name 'version' in module 'distutils'
************* Module salt.utils.openstack.nova
salt/utils/openstack/nova.py:8: [E0611(no-name-in-module), ] No name 'version' in module 'distutils'
salt/utils/openstack/nova.py:8: [E0401(import-error), ] Unable to import 'distutils.version'
```