### PR TITLE
2016.3 solaris grains improvements

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1427,7 +1427,15 @@ def os_data():
             # See https://github.com/joyent/smartos-live/issues/224
             uname_v = os.uname()[3]
             grains['os'] = grains['osfullname'] = 'SmartOS'
-            grains['osrelease'] = uname_v[uname_v.index('_')+1:]
+            # format: joyent_20161101T004406Z
+            # note: YYYY, MM, DD, timestamp
+            grains['osrelease_stamp'] = uname_v[uname_v.index('_')+1:]
+            grains['osrelease'] = ".".join([
+                uname_v[uname_v.index('_')+1:].split('T')[0][0:4],
+                uname_v[uname_v.index('_')+1:].split('T')[0][4:6],
+                uname_v[uname_v.index('_')+1:].split('T')[0][6:8],
+                uname_v[uname_v.index('_')+1:]
+            ])
             if salt.utils.is_smartos_globalzone():
                 grains.update(_smartos_computenode_data())
         elif os.path.isfile('/etc/release'):

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1458,11 +1458,15 @@ def os_data():
                         osname = ' '.join((osname, development))
                     uname_v = os.uname()[3]
                     grains['os'] = grains['osfullname'] = osname
+                    osrelease = []
+                    osrelease.append(osmajorrelease)
+                    if '/' in osminorrelease:
+                        osrelease.append(osminorrelease.split('/')[0])
+                        osrelease.append(osminorrelease.split('/')[1])
+                    else:
+                        osrelease.append(osminorrelease)
+                    grains['osrelease'] = ".".join(osrelease)
                     grains['osrelease_stamp'] = uname_v
-                    grains['osrelease'] = ".".join([
-                        osmajorrelease,
-                        osminorrelease,
-                    ])
 
         grains.update(_sunos_cpudata())
     elif grains['kernel'] == 'VMkernel':

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1443,7 +1443,7 @@ def os_data():
                 rel_data = fp_.read()
                 try:
                     release_re = re.compile(
-                        r'((?:Open)?Solaris|OpenIndiana) (Development)?'
+                        r'((?:Open|Oracle )?Solaris|OpenIndiana) (Development)?'
                         r'\s*(\d+)\s?\D*\s?(\d+\/\d+|oi_\S+|snv_\S+)?'
                     )
                     osname, development, osmajorrelease, osminorrelease = \
@@ -1458,15 +1458,18 @@ def os_data():
                         osname = ' '.join((osname, development))
                     uname_v = os.uname()[3]
                     grains['os'] = grains['osfullname'] = osname
-                    osrelease = []
-                    osrelease.append(osmajorrelease)
-                    if '/' in osminorrelease:
-                        osrelease.append(osminorrelease.split('/')[0])
-                        osrelease.append(osminorrelease.split('/')[1])
+                    if osname in ['Oracle Solaris'] and uname_v.startswith(osmajorrelease):
+                        # Oracla Solars 11 and up have minor version in uname
+                        grains['osrelease'] = uname_v
                     else:
-                        osrelease.append(osminorrelease)
-                    grains['osrelease'] = ".".join(osrelease)
-                    grains['osrelease_stamp'] = uname_v
+                        # Sun Solaris 10 and earlier/comparable
+                        # (OpenIndiana, OmniOS)
+                        osrelease = []
+                        osrelease.append(osmajorrelease)
+                        if osminorrelease:
+                            osrelease.append(osminorrelease)
+                        grains['osrelease'] = ".".join(osrelease)
+                        grains['osrelease_stamp'] = uname_v
 
         grains.update(_sunos_cpudata())
     elif grains['kernel'] == 'VMkernel':

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1425,17 +1425,17 @@ def os_data():
         grains['os_family'] = 'Solaris'
         if salt.utils.is_smartos():
             # See https://github.com/joyent/smartos-live/issues/224
-            uname_v = os.uname()[3]
+            uname_v = os.uname()[3]  # format: joyent_20161101T004406Z
+            uname_v = uname_v[uname_v.index('_')+1:]
             grains['os'] = grains['osfullname'] = 'SmartOS'
-            # format: joyent_20161101T004406Z
-            # note: YYYY, MM, DD, timestamp
-            grains['osrelease_stamp'] = uname_v[uname_v.index('_')+1:]
+            # store a parsed version of YYYY.MM.DD as osrelease
             grains['osrelease'] = ".".join([
-                uname_v[uname_v.index('_')+1:].split('T')[0][0:4],
-                uname_v[uname_v.index('_')+1:].split('T')[0][4:6],
-                uname_v[uname_v.index('_')+1:].split('T')[0][6:8],
-                uname_v[uname_v.index('_')+1:]
+                uname_v.split('T')[0][0:4],
+                uname_v.split('T')[0][4:6],
+                uname_v.split('T')[0][6:8],
             ])
+            # store a untouched copy of the timestamp in osrelease_stamp
+            grains['osrelease_stamp'] = uname_v 
             if salt.utils.is_smartos_globalzone():
                 grains.update(_smartos_computenode_data())
         elif os.path.isfile('/etc/release'):

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1435,7 +1435,7 @@ def os_data():
                 uname_v.split('T')[0][6:8],
             ])
             # store a untouched copy of the timestamp in osrelease_stamp
-            grains['osrelease_stamp'] = uname_v 
+            grains['osrelease_stamp'] = uname_v
             if salt.utils.is_smartos_globalzone():
                 grains.update(_smartos_computenode_data())
         elif os.path.isfile('/etc/release'):
@@ -1444,9 +1444,9 @@ def os_data():
                 try:
                     release_re = re.compile(
                         r'((?:Open)?Solaris|OpenIndiana) (Development)?'
-                        r'\s*(\d+ \d+\/\d+|oi_\S+|snv_\S+)?'
+                        r'\s*(\d+)\s?\D*\s?(\d+\/\d+|oi_\S+|snv_\S+)?'
                     )
-                    osname, development, osrelease = \
+                    osname, development, osmajorrelease, osminorrelease = \
                         release_re.search(rel_data).groups()
                 except AttributeError:
                     # Set a blank osrelease grain and fallback to 'Solaris'
@@ -1456,8 +1456,13 @@ def os_data():
                 else:
                     if development is not None:
                         osname = ' '.join((osname, development))
+                    uname_v = os.uname()[3]
                     grains['os'] = grains['osfullname'] = osname
-                    grains['osrelease'] = osrelease
+                    grains['osrelease_stamp'] = uname_v
+                    grains['osrelease'] = ".".join([
+                        osmajorrelease,
+                        osminorrelease,
+                    ])
 
         grains.update(_sunos_cpudata())
     elif grains['kernel'] == 'VMkernel':

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1443,8 +1443,8 @@ def os_data():
                 rel_data = fp_.read()
                 try:
                     release_re = re.compile(
-                        r'((?:Open|Oracle )?Solaris|OpenIndiana) (Development)?'
-                        r'\s*(\d+)\s?\D*\s?(\d+\/\d+|oi_\S+|snv_\S+)?'
+                        r'((?:Open|Oracle )?Solaris|OpenIndiana|OmniOS) (Development)?'
+                        r'\s*(\d+\.?\d*|v\d+)\s?[A-Z]*\s?(r\d+|\d+\/\d+|oi_\S+|snv_\S+)?'
                     )
                     osname, development, osmajorrelease, osminorrelease = \
                         release_re.search(rel_data).groups()
@@ -1461,9 +1461,15 @@ def os_data():
                     if osname in ['Oracle Solaris'] and uname_v.startswith(osmajorrelease):
                         # Oracla Solars 11 and up have minor version in uname
                         grains['osrelease'] = uname_v
+                    elif osname in ['OmniOS']:
+                        # OmniOS
+                        osrelease = []
+                        osrelease.append(osmajorrelease[1:])
+                        osrelease.append(osminorrelease[1:])
+                        grains['osrelease'] = ".".join(osrelease)
+                        grains['osrelease_stamp'] = uname_v
                     else:
                         # Sun Solaris 10 and earlier/comparable
-                        # (OpenIndiana, OmniOS)
                         osrelease = []
                         osrelease.append(osmajorrelease)
                         if osminorrelease:


### PR DESCRIPTION
### What does this PR do?
- SmartOS: parse timestamp into YYYY.MM.DD version tuple, add osrelease_stamp for original value
- OmniOS: updated regex, extra handling to parse version tuple
- Oracle Solaris 11+: updated regex, extra handling to parse version tuple (uses uname -v)
- Sun Solaris 10: cleanup parsing a bit, include osrelease_stamp
- Sun Solaris 8: updated regex to handle this

### What issues does this PR fix or reference?
#37389

### Previous Behavior
```yaml
os:
    Solaris
os_family:
    Solaris
osarch:
    sparcv9
osfinger:
    Solaris-10 9/10
osfullname:
    Solaris
osmajorrelease:
    10
osrelease:
    5.10
osrelease_info:
    - 5
    - 10
```

```yaml
os:
    Solaris
os_family:
    Solaris
osarch:
    sparcv9
osfullname:
    Solaris
osrelease:
    None
```
### New Behavior
(I placed the /etc/release files on my SmartOS machine to test the improved parsing, I have no Solaris10/8 boxes I can play on currently, but the relevant code paths get hit so I'm confident the new regex is working)

```yaml
    os:
        Solaris
    os_family:
        Solaris
    osarch:
        amd64
    osfinger:
        Solaris-10
    osfullname:
        Solaris
    osmajorrelease:
        10
    osrelease:
        10.10.09
    osrelease_info:
        - 10
        - 10
        - 9
    osrelease_stamp:
        Generic_141445-09
```

```yaml
    os:
        Solaris
    os_family:
        Solaris
    osarch:
        amd64
    osfinger:
        Solaris-8
    osfullname:
        Solaris
    osmajorrelease:
        8
    osrelease:
        8.7.03
    osrelease_info:
        - 8
        - 7
        - 3
    osrelease_stamp:
        Generic_Virtual
```

```yaml
    os:
        SmartOS
    os_family:
        Solaris
    osarch:
        amd64
    osfinger:
        SmartOS-2016
    osfullname:
        SmartOS
    osmajorrelease:
        2016
    osrelease:
        2016.11.01
    osrelease_info:
        - 2016
        - 11
        - 1
    osrelease_stamp:
        20161101T004406Z
```

### Tests written?
No

### Forward ports needed
- 2016.11
- develop