### PR TITLE
Fix #167 - Add logrotate state module

### DIFF
--- a/salt/states/logrotate.py
+++ b/salt/states/logrotate.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+'''
+Module for managing logrotate.
+'''
+
+# Import python libs
+from __future__ import absolute_import
+
+
+_DEFAULT_CONF = '/etc/logrotate.conf'
+
+# Define the module's virtual name
+__virtualname__ = 'logrotate'
+
+# Define a function alias in order not to shadow built-in's
+__func_alias__ = {
+    'set_': 'set'
+}
+
+
+def __virtual__():
+    '''
+    Load only on minions that have the logrotate module.
+    '''
+    if 'logrotate.show_conf' in __salt__:
+        return __virtualname__
+    return False
+
+
+def _convert_if_int(value):
+    '''
+    Convert to an int if necessary.
+
+    :param str value: The value to check/convert.
+
+    :return: The converted or passed value.
+    :rtype: bool|int|str
+    '''
+    try:
+        value = int(str(value))
+    except ValueError:
+        pass
+    return value
+
+
+def set_(name, key, value, setting=None, conf_file=_DEFAULT_CONF):
+    '''
+    Set a new value for a specific configuration line.
+
+    :param str key: The command or block to configure.
+    :param str value: The command value or command of the block specified by the key parameter.
+    :param str setting: The command value for the command specified by the value parameter.
+    :param str conf_file: The logrotate configuration file.
+
+    Example of usage with only the required arguments:
+
+    .. code-block:: yaml
+
+        logrotate-rotate:
+            logrotate.set:
+                - key: rotate
+                - value: 2
+
+    Example of usage specifying all available arguments:
+
+    .. code-block:: yaml
+
+        logrotate-wtmp-rotate:
+            logrotate.set:
+                - key: /var/log/wtmp
+                - value: rotate
+                - setting: 2
+                - conf_file: /etc/logrotate.conf
+    '''
+    ret = {'name': name,
+           'changes': dict(),
+           'comment': str(),
+           'result': None}
+
+    try:
+        if setting is None:
+            current_value = __salt__['logrotate.get'](key=key, conf_file=conf_file)
+        else:
+            current_value = __salt__['logrotate.get'](key=key, value=value, conf_file=conf_file)
+    except (AttributeError, KeyError):
+        current_value = False
+
+    if setting is None:
+        value = _convert_if_int(value)
+
+        if current_value == value:
+            ret['comment'] = "Command '{0}' already has value: {1}".format(key, value)
+            ret['result'] = True
+        elif __opts__['test']:
+            ret['comment'] = "Command '{0}' will be set to value: {1}".format(key, value)
+            ret['changes'] = {'old': current_value,
+                              'new': value}
+        else:
+            ret['changes'] = {'old': current_value,
+                              'new': value}
+            ret['result'] = __salt__['logrotate.set'](key=key, value=value, conf_file=conf_file)
+            if ret['result']:
+                ret['comment'] = "Set command '{0}' value: {1}".format(key, value)
+            else:
+                ret['comment'] = "Unable to set command '{0}' value: {1}".format(key, value)
+        return ret
+
+    setting = _convert_if_int(setting)
+
+    if current_value == setting:
+        ret['comment'] = "Block '{0}' command '{1}' already has value: {2}".format(key, value, setting)
+        ret['result'] = True
+    elif __opts__['test']:
+        ret['comment'] = "Block '{0}' command '{1}' will be set to value: {2}".format(key, value, setting)
+        ret['changes'] = {'old': current_value,
+                          'new': setting}
+    else:
+        ret['changes'] = {'old': current_value,
+                          'new': setting}
+        ret['result'] = __salt__['logrotate.set'](key=key, value=value, setting=setting,
+                                                  conf_file=conf_file)
+        if ret['result']:
+            ret['comment'] = "Set block '{0}' command '{1}' value: {2}".format(key, value, setting)
+        else:
+            ret['comment'] = "Unable to set block '{0}' command '{1}' value: {2}".format(key, value, setting)
+    return ret

--- a/tests/unit/modules/logrotate_test.py
+++ b/tests/unit/modules/logrotate_test.py
@@ -29,9 +29,9 @@ PARSE_CONF = {
     'include files': {
         'rsyslog': ['/var/log/syslog']
     },
-    'rotate': '1',
+    'rotate': 1,
     '/var/log/wtmp': {
-        'rotate': '1'
+        'rotate': 1
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

- Adds logrotate state module.
- Fixed issue that prevented the removal of existing keys that did not have a value (missingok, compress, etc).
- Adds function to get single value to the execution module.
- Makes _parse_conf return integer values/settings as integers instead of strings.
- Improves docstrings of existing functions.

### What issues does this PR fix or reference?

- #167

### Previous Behavior

- A logrotate state module did not previously exist.
- Attempt to remove existing keys that did not have a value (missingok, compress, etc) would fail.
- Function to get single value did not previously exist.
- _parse_conf returned integer values/settings as strings, making comparisons with parameter values difficult/confusing.
- Docstrings of existing functions did not fully explain usage and expected results.

### New Behavior

- See above.

### Tests written?

No