### PR TITLE
EC2 support for SubnetName and securityGroupName

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -1048,6 +1048,12 @@ the network interfaces of your virtual machines, for example:-
           # to accept IP packets with destinations other than itself.
           # SourceDestCheck: False
 
+        - DeviceIndex: 1
+          subnetname: XXXXXXXX-Subnet
+          securitygroupname:
+            - XXXXXXXX-SecurityGroup
+            - YYYYYYYY-SecurityGroup
+
 Note that it is an error to assign a 'subnetid', 'subnetname', 'securitygroupid'
 or 'securitygroupname' to a profile where the interfaces are manually configured
 like this. These are both really properties of each network interface, not of


### PR DESCRIPTION
### What does this PR do?
Added support for subnetname and securitygroupname for EC2 network_interfaces

### Previous Behavior
Only subnetid and securitygroupid were supported

### New Behavior
`subnetname` or `securitygroupname` can be used for EC2 network_interfaces in cloud profiles:
```
myProfile:
  extends: baseProfile
    network_interfaces:
    - DeviceIndex: 0
      allocate_new_eip: true
#    securitygroupid:
#    - sg-xxxxxxxx
#    - sg-yyyyyyyy
    securitygroupname:
    - sgLinuxBase
    - sgAppserverLinux
    # subnetid: subnet-xxxxxxxx
    subnetname: public.us-west-1a
```

### Tests written?
No


This is an improvement on https://github.com/saltstack/salt/pull/31724