### PR TITLE
Raet internal client reference fix

### DIFF
--- a/salt/transport/client.py
+++ b/salt/transport/client.py
@@ -105,7 +105,7 @@ class AsyncReqChannel(AsyncChannel):
             return salt.transport.zeromq.AsyncZeroMQReqChannel(opts, **kwargs)
         elif ttype == 'raet':
             import salt.transport.raet
-            return salt.transport.raet.AsyncRAETReqChannel(opts, **kwargs)
+            return salt.transport.raet.RAETReqChannel(opts, **kwargs)
         elif ttype == 'tcp':
             if not cls._resolver_configured:
                 # TODO: add opt to specify number of resolver threads


### PR DESCRIPTION
Only merge this when I have customer confirmation that it fixes the issue:

```
return: "Traceback (most recent call last):\n File \"/usr/lib/python2.7/site-packages/salt/netapi/rest_cherrypy/app.py\"\ 
, line 534, in hypermedia_handler\n ret = cherrypy.serving.request._hypermedia_inner_handler(*args,\ 
\ **kwargs)\n File \"/usr/lib/python2.7/site-packages/cherrypy/_cpdispatch.py\"\ 
, line 34, in __call__\n return self.callable(*self.args, **self.kwargs)\n File\ 
\ \"/usr/lib/python2.7/site-packages/salt/netapi/rest_cherrypy/app.py\", line 1526,\ 
\ in POST\n token = self.auth.mk_token(creds)\n File \"/usr/lib/python2.7/site-packages/salt/auth/__init__.py\"\ 
, line 461, in mk_token\n tdata = self._send_token_request(load)\n File \"/usr/lib/python2.7/site-packages/salt/auth/__init__.py\"\ 
, line 397, in _send_token_request\n channel = salt.transport.client.ReqChannel.factory(self.opts)\n\ 
\ File \"/usr/lib/python2.7/site-packages/salt/transport/client.py\", line 22,\ 
\ in factory\n sync = SyncWrapper(AsyncReqChannel.factory, (opts,), kwargs)\n\ 
\ File \"/usr/lib/python2.7/site-packages/salt/utils/async.py\", line 60, in __init__\n\ 
\ self.async = method(*args, **kwargs)\n File \"/usr/lib/python2.7/site-packages/salt/transport/client.py\"\ 
, line 108, in factory\n return salt.transport.raet.AsyncRAETReqChannel(opts,\ 
\ **kwargs)\nAttributeError: 'module' object has no attribute 'AsyncRAETReqChannel'\n" 
status: 500
```