### PR TITLE
Add requirement for PowerShell 3 on Windows

### DIFF
--- a/doc/topics/installation/windows.rst
+++ b/doc/topics/installation/windows.rst
@@ -53,6 +53,14 @@ other Windows service.
 If the minion won't start, try installing the Microsoft Visual C++ 2008 x64 SP1
 redistributable. Allow all Windows updates to run salt-minion smoothly.
 
+Installation Prerequisites
+--------------------------
+
+Most Salt functionality should work just fine right out of the box. A few Salt
+modules rely on PowerShell. The minimum version of PowerShell required for Salt
+is version 3. If you intend to work with DSC then Powershell version 5 is the
+minimum.
+
 .. _windows-installer-options:
 
 Silent Installer Options


### PR DESCRIPTION
### What does this PR do?
Adds a note o the Windows Installation page denoting the requirement for at least PowerShell 3. Also noted that for DSC, PowerShell 5 is required.

### What issues does this PR fix or reference?
Found in testing. Some of the Windows modules use PowerShell and require the `ConvertTo-JSON` function which became available in PowerShell 3. This has been a requirement for some time but has not been documented.

### Previous Behavior
No declaration of the required version of PowerShell

### New Behavior
Now denotes version 3 as the required minimum PowerShell version on Windows.

### Tests written?
NA