### PR TITLE
Creates `filter_by` as a utils function

### DIFF
--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -361,3 +361,63 @@ def file_exists(path, saltenv=None):
 
 # Provide a jinja function call compatible get aliased as fetch
 fetch = get
+
+
+def filter_by(lookup_dict,
+              pillar,
+              merge=None,
+              default='default',
+              base=None):
+    '''
+    .. versionadded:: Nitrogen
+
+    Look up the given pillar in a given dictionary and return the result
+
+    :param lookup_dict: A dictionary, keyed by a pillar, containing a value or
+        values relevant to systems matching that pillar. For example, a key
+        could be a pillar for a role and the value could the name of a package
+        on that particular OS.
+
+        The dictionary key can be a globbing pattern. The function will return
+        the corresponding ``lookup_dict`` value where the pilalr value matches
+        the  pattern. For example:
+
+        .. code-block:: bash
+
+            # this will render 'got some salt' if ``role`` begins with 'salt'
+            salt '*' pillar.filter_by '{salt*: got some salt, default: salt is not here}' role
+
+    :param pillar: The name of a pillar to match with the system's pillar. For
+        example, the value of the "role" pillar could be used to pull values
+        from the ``lookup_dict`` dictionary.
+
+        The pillar value can be a list. The function will return the
+        ``lookup_dict`` value for a first found item in the list matching
+        one of the ``lookup_dict`` keys.
+
+    :param merge: A dictionary to merge with the results of the pillar
+        selection from ``lookup_dict``. This allows another dictionary to
+        override the values in the ``lookup_dict``.
+
+    :param default: default lookup_dict's key used if the pillar does not exist
+        or if the pillar value has no match on lookup_dict.  If unspecified
+        the value is "default".
+
+    :param base: A lookup_dict key to use for a base dictionary.  The
+        pillar-selected ``lookup_dict`` is merged over this and then finally
+        the ``merge`` dictionary is merged.  This allows common values for
+        each case to be collected in the base and overridden by the pillar
+        selection dictionary and the merge dictionary.  Default is unset.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pillar.filter_by '{web: Serve it up, db: I query, default: x_x}' role
+    '''
+    return salt.utils.filter_by(lookup_dict=lookup_dict,
+                                lookup=pillar,
+                                traverse=__pillar__,
+                                merge=merge,
+                                default=default,
+                                base=base)


### PR DESCRIPTION
### What does this PR do?

Moves the `filter_by()` function to the `utils` module and changes the function in the `grains` module to be a wrapper around `utils.filter_by()`. Also adds a similar wrapper to create a `pillar.filter_by()` function.

### What issues does this PR fix or reference?

Fixes saltstack/salt#18836 

### New Behavior

A nifty new `pillar.filter_by()` function that supports the same functionality as the prior `grains.filter_by()` function, but operates on pillar data rather than grains.

### Tests written?

No. I looked at the existing tests in `tests/modules/grains_tests.py` and `tests/modules/pillar_tests.py`, but it wasn't clear to me how to proceed. I'm happy to add tests if someone can give me a pointer or example.