### PR TITLE
Create new salt util win_dacl

### DIFF
--- a/salt/modules/win_dacl.py
+++ b/salt/modules/win_dacl.py
@@ -581,6 +581,18 @@ def _ace_to_text(ace, objectType):
 def _set_dacl_inheritance(path, objectType, inheritance=True, copy=True, clear=False):
     '''
     helper function to set the inheritance
+    Args:
+
+        path (str): The path to the object
+
+        objectType (str): The type of object
+
+        inheritance (bool): True enables inheritance, False disables
+
+        copy (bool): Copy inherited ACEs to the DACL before disabling
+        inheritance
+
+        clear (bool): Remove non-inherited ACEs from the DACL
     '''
     ret = {'result': False,
            'comment': '',

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -603,7 +603,7 @@ def win_verify_env(dirs, permissive=False, pki_dir='', skip_extra=False):
                 salt.utils.win_dacl.set_owner(path, 'S-1-5-32-544')
 
                 # Give Admins, System and Owner permissions
-                # Get SIDs for Groups and Users
+                # Get SIDs
                 admins = salt.utils.win_dacl.get_sid('S-1-5-32-544')
                 system = salt.utils.win_dacl.get_sid('S-1-5-18')
                 owner = salt.utils.win_dacl.get_sid('S-1-3-4')
@@ -620,7 +620,7 @@ def win_verify_env(dirs, permissive=False, pki_dir='', skip_extra=False):
                              'full_control')
 
                 # Save the dacl to the object
-                dacl.save(path, 'file', True)
+                dacl.save(dir_, 'file', True)
 
             except CommandExecutionError:
                 msg = 'Unable to securely set the permissions of "{0}".'

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -554,27 +554,25 @@ def win_verify_env(dirs, permissive=False, pki_dir='', skip_extra=False):
 
         if not permissive:
             try:
-                # Get SIDs for Groups and Users
-                admins = salt.utils.win_dacl.get_sid('S-1-5-32-544')
-                system = salt.utils.win_dacl.get_sid('S-1-5-18')
-                owner = salt.utils.win_dacl.get_sid('S-1-3-4')
-                user = salt.utils.win_dacl.get_sid('S-1-5-32-545')
+                # Get a clean dacl by not passing an obj_name
+                dacl = salt.utils.win_dacl.Dacl()
 
-                # Get a clean dacl
-                dacl = salt.utils.win_dacl.Dacl(obj_type='file')
-
-                # Add aces to the dacl for the above groups
-                dacl.add_ace(admins, 'grant', 'this_folder_subfolders_files',
+                # Add aces to the dacl, use the GUID (locale non-specific)
+                dacl.add_ace('S-1-5-32-544',  # Administrators Group
+                             'grant', 'this_folder_subfolders_files',
                              'full_control')
-                dacl.add_ace(system, 'grant', 'this_folder_subfolders_files',
+                dacl.add_ace('S-1-5-18',  # System Account
+                             'grant', 'this_folder_subfolders_files',
                              'full_control')
-                dacl.add_ace(owner, 'grant', 'this_folder_subfolders_files',
+                dacl.add_ace('S-1-3-4',  # Owner
+                             'grant', 'this_folder_subfolders_files',
                              'full_control')
-                dacl.add_ace(user, 'grant', 'this_folder_subfolders_files',
+                dacl.add_ace('S-1-5-32-545',  # Users group
+                             'grant', 'this_folder_subfolders_files',
                              'read_execute')
 
                 # Save the dacl to the object
-                dacl.save(path, 'file', True)
+                dacl.save(path, True)
 
             except CommandExecutionError:
                 msg = 'Unable to securely set the permissions of ' \
@@ -603,24 +601,22 @@ def win_verify_env(dirs, permissive=False, pki_dir='', skip_extra=False):
                 salt.utils.win_dacl.set_owner(path, 'S-1-5-32-544')
 
                 # Give Admins, System and Owner permissions
-                # Get SIDs
-                admins = salt.utils.win_dacl.get_sid('S-1-5-32-544')
-                system = salt.utils.win_dacl.get_sid('S-1-5-18')
-                owner = salt.utils.win_dacl.get_sid('S-1-3-4')
+                # Get a clean dacl by not passing an obj_name
+                dacl = salt.utils.win_dacl.Dacl()
 
-                # Get a clean dacl
-                dacl = salt.utils.win_dacl.Dacl(obj_type='file')
-
-                # Add aces to the dacl for the above groups
-                dacl.add_ace(admins, 'grant', 'this_folder_subfolders_files',
+                # Add aces to the dacl, use the GUID (locale non-specific)
+                dacl.add_ace('S-1-5-32-544',  # Administrators Group
+                             'grant', 'this_folder_subfolders_files',
                              'full_control')
-                dacl.add_ace(system, 'grant', 'this_folder_subfolders_files',
+                dacl.add_ace('S-1-5-18',  # System User
+                             'grant', 'this_folder_subfolders_files',
                              'full_control')
-                dacl.add_ace(owner, 'grant', 'this_folder_subfolders_files',
+                dacl.add_ace('S-1-3-4',  # Owner
+                             'grant', 'this_folder_subfolders_files',
                              'full_control')
 
                 # Save the dacl to the object
-                dacl.save(dir_, 'file', True)
+                dacl.save(dir_, True)
 
             except CommandExecutionError:
                 msg = 'Unable to securely set the permissions of "{0}".'

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -558,18 +558,18 @@ def win_verify_env(dirs, permissive=False, pki_dir='', skip_extra=False):
                 dacl = salt.utils.win_dacl.Dacl()
 
                 # Add aces to the dacl, use the GUID (locale non-specific)
-                dacl.add_ace('S-1-5-32-544',  # Administrators Group
-                             'grant', 'this_folder_subfolders_files',
-                             'full_control')
-                dacl.add_ace('S-1-5-18',  # System Account
-                             'grant', 'this_folder_subfolders_files',
-                             'full_control')
-                dacl.add_ace('S-1-3-4',  # Owner
-                             'grant', 'this_folder_subfolders_files',
-                             'full_control')
-                dacl.add_ace('S-1-5-32-545',  # Users group
-                             'grant', 'this_folder_subfolders_files',
-                             'read_execute')
+                # Administrators Group
+                dacl.add_ace('S-1-5-32-544', 'grant', 'full_control',
+                             'this_folder_subfolders_files')
+                # System
+                dacl.add_ace('S-1-5-18', 'grant', 'full_control',
+                             'this_folder_subfolders_files')
+                # Owner
+                dacl.add_ace('S-1-3-4', 'grant', 'full_control',
+                             'this_folder_subfolders_files')
+                # Users Group
+                dacl.add_ace('S-1-5-32-545', 'grant', 'read_execute',
+                             'this_folder_subfolders_files')
 
                 # Save the dacl to the object
                 dacl.save(path, True)
@@ -605,15 +605,15 @@ def win_verify_env(dirs, permissive=False, pki_dir='', skip_extra=False):
                 dacl = salt.utils.win_dacl.Dacl()
 
                 # Add aces to the dacl, use the GUID (locale non-specific)
-                dacl.add_ace('S-1-5-32-544',  # Administrators Group
-                             'grant', 'this_folder_subfolders_files',
-                             'full_control')
-                dacl.add_ace('S-1-5-18',  # System User
-                             'grant', 'this_folder_subfolders_files',
-                             'full_control')
-                dacl.add_ace('S-1-3-4',  # Owner
-                             'grant', 'this_folder_subfolders_files',
-                             'full_control')
+                # Administrators Group
+                dacl.add_ace('S-1-5-32-544', 'grant', 'full_control',
+                             'this_folder_subfolders_files')
+                # System
+                dacl.add_ace('S-1-5-18', 'grant', 'full_control',
+                             'this_folder_subfolders_files')
+                # Owner
+                dacl.add_ace('S-1-3-4', 'grant', 'full_control',
+                             'this_folder_subfolders_files')
 
                 # Save the dacl to the object
                 dacl.save(dir_, True)

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -197,9 +197,7 @@ def verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
     can shake the salt
     '''
     if salt.utils.is_windows():
-        from salt.utils.win_functions import get_current_user
-        return win_verify_env(
-            dirs, get_current_user(), permissive, pki_dir, skip_extra)
+        return win_verify_env(dirs, permissive, pki_dir, skip_extra)
     import pwd  # after confirming not running Windows
     try:
         pwnam = pwd.getpwnam(user)
@@ -522,12 +520,13 @@ def verify_log(opts):
         log.warn('Insecure logging configuration detected! Sensitive data may be logged.')
 
 
-def win_verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
+def win_verify_env(dirs, permissive=False, pki_dir='', skip_extra=False):
     '''
     Verify that the named directories are in place and that the environment
     can shake the salt
     '''
     import salt.utils.win_functions
+    import salt.utils.win_dacl
 
     # Get the root path directory where salt is installed
     path = dirs[0]
@@ -542,10 +541,12 @@ def win_verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
     current_user = salt.utils.win_functions.get_current_user()
     if salt.utils.win_functions.is_admin(current_user):
         try:
-            salt.utils.win_functions.set_path_owner(path)
+            # Make the Administrators group owner
+            # Use the SID to be locale agnostic
+            salt.utils.win_dacl.set_owner(path, 'S-1-5-32-544')
+
         except CommandExecutionError:
-            msg = 'Unable to securely set the owner of "{0}".'
-            msg = msg.format(path)
+            msg = 'Unable to securely set the owner of "{0}".'.format(path)
             if is_console_configured():
                 log.critical(msg)
             else:
@@ -553,10 +554,31 @@ def win_verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
 
         if not permissive:
             try:
-                salt.utils.win_functions.set_path_permissions(path)
+                # Get SIDs for Groups and Users
+                admins = salt.utils.win_dacl.get_sid('S-1-5-32-544')
+                system = salt.utils.win_dacl.get_sid('S-1-5-18')
+                owner = salt.utils.win_dacl.get_sid('S-1-3-4')
+                user = salt.utils.win_dacl.get_sid('S-1-5-32-545')
+
+                # Get a clean dacl
+                dacl = salt.utils.win_dacl.Dacl(obj_type='file')
+
+                # Add aces to the dacl for the above groups
+                dacl.add_ace(admins, 'grant', 'this_folder_subfolders_files',
+                             'full_control')
+                dacl.add_ace(system, 'grant', 'this_folder_subfolders_files',
+                             'full_control')
+                dacl.add_ace(owner, 'grant', 'this_folder_subfolders_files',
+                             'full_control')
+                dacl.add_ace(user, 'grant', 'this_folder_subfolders_files',
+                             'read_execute')
+
+                # Save the dacl to the object
+                dacl.save(path, 'file', True)
+
             except CommandExecutionError:
-                msg = 'Unable to securely set the permissions of "{0}".'
-                msg = msg.format(path)
+                msg = 'Unable to securely set the permissions of ' \
+                      '"{0}".'.format(path)
                 if is_console_configured():
                     log.critical(msg)
                 else:
@@ -574,10 +596,32 @@ def win_verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):
                 sys.stderr.write(msg.format(dir_, err))
                 sys.exit(err.errno)
 
+        # The PKI dir gets its own permissions
         if dir_ == pki_dir:
             try:
-                salt.utils.win_functions.set_path_owner(dir_)
-                salt.utils.win_functions.set_path_permissions(dir_)
+                # Make Administrators group the owner
+                salt.utils.win_dacl.set_owner(path, 'S-1-5-32-544')
+
+                # Give Admins, System and Owner permissions
+                # Get SIDs for Groups and Users
+                admins = salt.utils.win_dacl.get_sid('S-1-5-32-544')
+                system = salt.utils.win_dacl.get_sid('S-1-5-18')
+                owner = salt.utils.win_dacl.get_sid('S-1-3-4')
+
+                # Get a clean dacl
+                dacl = salt.utils.win_dacl.Dacl(obj_type='file')
+
+                # Add aces to the dacl for the above groups
+                dacl.add_ace(admins, 'grant', 'this_folder_subfolders_files',
+                             'full_control')
+                dacl.add_ace(system, 'grant', 'this_folder_subfolders_files',
+                             'full_control')
+                dacl.add_ace(owner, 'grant', 'this_folder_subfolders_files',
+                             'full_control')
+
+                # Save the dacl to the object
+                dacl.save(path, 'file', True)
+
             except CommandExecutionError:
                 msg = 'Unable to securely set the permissions of "{0}".'
                 msg = msg.format(dir_)

--- a/salt/utils/win_dacl.py
+++ b/salt/utils/win_dacl.py
@@ -1,16 +1,53 @@
 # -*- coding: utf-8 -*-
 '''
-Functions for setting permissions to objects in windows
+============
+Windows DACL
+============
+This salt utility contains objects and functions for setting permissions to
+objects in Windows. You can use the built in functions or access the objects
+directly to create your own custom functionality. There are two objects, Flags
+and Dacl.
+
+If you need access only to flags, use the Flags object.
+
+.. code-block:: python
+
+    import salt.utils.win_dacl
+    flags = salt.utils.win_dacl.Flags()
+    flag_full_control = flags.ace_perms['file']['basic']['full_control']
+
+The Dacl object inherits Flags. To use the Dacl object:
+
+..code-block:: python
+
+    import salt.utils.win_dacl
+    dacl = salt.utils.win_dacl.Dacl(obj_type='file')
+    dacl.add_ace('Administrators', 'grant',
+
+Object types are used by setting the `obj_type` parameter to a valid Windows
+object. Valid object types are as follows:
+
+- file
+- service
+- printer
+- registry
+- registry32 (for WOW64)
+- share
+
+
+
 '''
 # Import Python libs
 from __future__ import absolute_import
 
 # Import Salt libs
 from salt.exceptions import CommandExecutionError, SaltInvocationError
+from salt.ext.six.moves import range
+import salt.ext.six as six
+
 
 # Import 3rd-party libs
 try:
-    import ntsecuritycon
     import win32security
     import pywintypes
     import salt.utils.win_functions
@@ -23,113 +60,238 @@ class Flags(object):
     Object containing all the flags for dealing with Windows permissions
     '''
     # Flag Dicts
+    ace_perms = {
+        'file': {
+            'basic': {
+                0x1f01ff: 'Full control',
+                0x1301bf: 'Modify',
+                0x1201bf: 'Read & execute with write',
+                0x1200a9: 'Read & execute',
+                0x120089: 'Read',
+                0x100116: 'Write',
+                'full_control': 0x1f01ff,
+                'modify': 0x1301bf,
+                'read_execute': 0x1200a9,
+                'read': 0x120089,
+                'write': 0x100116,
+            },
+            'advanced': {
+                # Advanced
+                0x0001: 'List folder / read data',
+                0x0002: 'Create files / write data',
+                0x0004: 'Create folders / append data',
+                0x0008: 'Read extended attributes',
+                0x0010: 'Write extended attributes',
+                0x0020: 'Traverse folder / execute file',
+                0x0040: 'Delete subfolders and files',
+                0x0080: 'Read attributes',
+                0x0100: 'Write attributes',
+                0x10000: 'Delete',
+                0x20000: 'Read permissions',
+                0x40000: 'Change permissions',
+                0x80000: 'Take ownership',
+                # 0x100000: 'SYNCHRONIZE',  # This is in all of them
+                'list_folder': 0x0001,
+                'read_data': 0x0001,
+                'create_files': 0x0002,
+                'write_data': 0x0002,
+                'create_folders': 0x0004,
+                'append_data': 0x0004,
+                'read_ea': 0x0008,
+                'write_ea': 0x0010,
+                'traverse_folder': 0x0020,
+                'execute_file': 0x0020,
+                'delete_subfolders_files': 0x0040,
+                'read_attributes': 0x0080,
+                'write_attributes': 0x0100,
+                'delete': 0x10000,
+                'read_permissions': 0x20000,
+                'change_permissions': 0x40000,
+                'take_ownership': 0x80000,
+            },
+        },
+        'registry': {
+            'basic': {
+                0xf003f: 'Full Control',
+                0x20019: 'Read',
+                0x20006: 'Write',
+                # Generic Values (These sometimes get hit)
+                0x10000000: 'Full Control',
+                0x20000000: 'Execute',
+                0x40000000: 'Write',
+                0xffffffff80000000: 'Read',
+                'full_control': 0xf003f,
+                'read': 0x20019,
+                'write': 0x20006,
+            },
+            'advanced': {
+                # Advanced
+                0x0001: 'Query Value',
+                0x0002: 'Set Value',
+                0x0004: 'Create Subkey',
+                0x0008: 'Enumerate Subkeys',
+                0x0010: 'Notify',
+                0x0020: 'Create Link',
+                0x10000: 'Delete',
+                0x20000: 'Read Control',
+                0x40000: 'Write DAC',
+                0x80000: 'Write Owner',
+                'query_value': 0x0001,
+                'set_value': 0x0002,
+                'create_subkey': 0x0004,
+                'enum_subkeys': 0x0008,
+                'notify': 0x0010,
+                'create_link': 0x0020,
+                'delete': 0x10000,
+                'read_control': 0x20000,
+                'write_dac': 0x40000,
+                'write_owner': 0x80000,
+            },
+        },
+        'share': {
+            'basic': {
+                0x1f01ff: 'Full control',
+                0x1301bf: 'Change',
+                0x1200a9: 'Read',
+                'full_control': 0x1f01ff,
+                'change': 0x1301bf,
+                'read': 0x1200a9,
+            },
+            'advanced': {},  # No 'advanced' for shares, needed for dict lookup
+        },
+        'printer': {
+            'basic': {
+                0x20008: 'Print',
+                0xf000c: 'Manage this printer',
+                0xf0030: 'Manage documents',
+                'print': 0x20008,
+                'manage_printer': 0xf000c,
+                'manage_documents': 0xf0030,
+            },
+            'advanced': {
+                # Advanced
+                0x10004: 'Manage this printer',
+                0x0008: 'Print',
+                0x20000: 'Read permissions',
+                0x40000: 'Change permissions',
+                0x80000: 'Take ownership',
+                'manage_printer': 0x10004,
+                'print': 0x0008,
+                'read_permissions': 0x20000,
+                'change_permissions': 0x40000,
+                'take_ownership': 0x80000,
+            },
+        },
+        'service': {
+            'basic': {
+                0xf01ff: 'Full Control',
+                0x2008f: 'Read & Write',
+                0x2018d: 'Read',
+                0x20002: 'Write',
+                'full_control': 0xf01ff,
+                'read_write': 0x2008f,
+                'read': 0x2018d,
+                'write': 0x20002,
+            },
+            'advanced': {
+                0x0001: 'Query Config',
+                0x0002: 'Change Config',
+                0x0004: 'Query Status',
+                0x0008: 'Enumerate Dependents',
+                0x0010: 'Start',
+                0x0020: 'Stop',
+                0x0040: 'Pause/Resume',
+                0x0080: 'Interrogate',
+                0x0100: 'User-Defined Control',
+                # 0x10000: 'Delete',  # Not visible in the GUI
+                0x20000: 'Read Permissions',
+                0x40000: 'Change Permissions',
+                0x80000: 'Change Owner',
+                'query_config': 0x0001,
+                'change_config': 0x0002,
+                'query_status': 0x0004,
+                'enum_dependents': 0x0008,
+                'start': 0x0010,
+                'stop': 0x0020,
+                'pause_resume': 0x0040,
+                'interrogate': 0x0080,
+                'user_defined': 0x0100,
+                'read_permissions': 0x20000,
+                'change_permissions': 0x40000,
+                'change_owner': 0x80000,
+            },
+        }
+    }
+
+    ace_prop = {
+        'file': {
+            # for report
+            0x0000: 'Not Inherited (file)',
+            0x0001: 'This folder and files',
+            0x0002: 'This folder and subfolders',
+            0x0003: 'This folder, subfolders and files',
+            0x0006: 'This folder only',
+            0x0009: 'Files only',
+            0x000a: 'Subfolders only',
+            0x000b: 'Subfolders and files only',
+            0x0010: 'Inherited (file)',
+            # for setting
+            'this_folder_only': 0x0006,
+            'this_folder_subfolders_files': 0x0003,
+            'this_folder_subfolders': 0x0002,
+            'this_folder_files': 0x0001,
+            'subfolders_files': 0x000b,
+            'subfolders_only': 0x000a,
+            'files_only': 0x0009,
+        },
+        'registry': {
+            0x0000: 'Not Inherited',
+            0x0002: 'This key and subkeys',
+            0x0006: 'This key only',
+            0x000a: 'Subkeys only',
+            0x0010: 'Inherited',
+            'this_key_only': 0x0006,
+            'this_key_subkeys': 0x0002,
+            'subkeys_only': 0x000a,
+        },
+        'registry32': {
+            0x0000: 'Not Inherited',
+            0x0002: 'This key and subkeys',
+            0x0006: 'This key only',
+            0x000a: 'Subkeys only',
+            0x0010: 'Inherited',
+            'this_key_only': 0x0006,
+            'this_key_subkeys': 0x0002,
+            'subkeys_only': 0x000a,
+        },
+    }
+
+    ace_type = {
+        'grant': win32security.ACCESS_ALLOWED_ACE_TYPE,
+        'deny': win32security.ACCESS_DENIED_ACE_TYPE,
+        win32security.ACCESS_ALLOWED_ACE_TYPE: 'grant',
+        win32security.ACCESS_DENIED_ACE_TYPE: 'deny',
+    }
+
+    element = {
+        'dacl': win32security.DACL_SECURITY_INFORMATION,
+        'group': win32security.GROUP_SECURITY_INFORMATION,
+        'owner': win32security.OWNER_SECURITY_INFORMATION,
+    }
+
+    inheritance = {
+        'protected': win32security.PROTECTED_DACL_SECURITY_INFORMATION,
+        'unprotected': win32security.UNPROTECTED_DACL_SECURITY_INFORMATION,
+    }
+
     obj_type = {
         'file': win32security.SE_FILE_OBJECT,
         'service': win32security.SE_SERVICE,
         'printer': win32security.SE_PRINTER,
         'registry': win32security.SE_REGISTRY_KEY,
         'registry32': win32security.SE_REGISTRY_WOW64_32KEY,
-        'share': win32security.SE_LMSHARE}
-
-    element = {
-        'dacl': win32security.DACL_SECURITY_INFORMATION,
-        'group': win32security.GROUP_SECURITY_INFORMATION,
-        'owner': win32security.OWNER_SECURITY_INFORMATION}
-
-    inheritance = {
-        'protected': win32security.PROTECTED_DACL_SECURITY_INFORMATION,
-        'unprotected': win32security.UNPROTECTED_DACL_SECURITY_INFORMATION}
-
-    access = {
-        'full_control':
-            ntsecuritycon.GENERIC_ALL,
-        'modify':
-            ntsecuritycon.GENERIC_READ |
-            ntsecuritycon.GENERIC_WRITE |
-            ntsecuritycon.GENERIC_EXECUTE |
-            ntsecuritycon.DELETE,
-        'read_execute':
-            ntsecuritycon.GENERIC_READ |
-            ntsecuritycon.GENERIC_EXECUTE,
-        'read':
-            ntsecuritycon.GENERIC_READ,
-        'write':
-            ntsecuritycon.GENERIC_WRITE}
-
-    applies_to = {
-        'this_folder_only':
-            win32security.CONTAINER_INHERIT_ACE |
-            win32security.NO_PROPAGATE_INHERIT_ACE,
-        'this_folder_subfolders_files':
-            win32security.CONTAINER_INHERIT_ACE |
-            win32security.OBJECT_INHERIT_ACE,
-        'this_folder_subfolders':
-            win32security.CONTAINER_INHERIT_ACE,
-        'this_folder_files':
-            win32security.OBJECT_INHERIT_ACE,
-        'subfolders_files':
-            win32security.CONTAINER_INHERIT_ACE |
-            win32security.OBJECT_INHERIT_ACE |
-            win32security.INHERIT_ONLY_ACE,
-        'subfolders_only':
-            win32security.CONTAINER_INHERIT_ACE |
-            win32security.INHERIT_ONLY_ACE,
-        'files_only':
-            win32security.OBJECT_INHERIT_ACE |
-            win32security.INHERIT_ONLY_ACE}
-
-    def type_flags(self, name):
-        '''
-        Get the flag that designates the type of object passed
-        '''
-        try:
-            return self.obj_type[name.lower()]
-        except KeyError:
-            raise CommandExecutionError(
-                'Invalid object type: {0}'.format(name))
-
-    def element_flags(self, name):
-        '''
-        Get the flag for the element of the security information object to be
-        returned/set
-        '''
-        try:
-            return self.element[name.lower()]
-        except KeyError:
-            raise CommandExecutionError(
-                'Invalid security info element: {0}'.format(name))
-
-    def inheritance_flags(self, name):
-        '''
-        Get the flag that determines whether the object will inherit parent
-        permissions
-        '''
-        try:
-            return self.inheritance[name.lower()]
-        except KeyError:
-            raise CommandExecutionError(
-                'Invalid inheritance: {0}'.format(name))
-
-    def permission_flags(self, name):
-        '''
-        Get the flags that correspond to the desired permissions
-        '''
-        try:
-            return self.access[name.lower()]
-        except KeyError:
-            raise CommandExecutionError(
-                'Invalid access: {0}'.format(name))
-
-    def applies_to_flags(self, name):
-        '''
-        Get the flags that determine the type of objects to which the DACL
-        applies
-        '''
-        try:
-            return self.applies_to[name.lower()]
-        except KeyError:
-            raise CommandExecutionError(
-                'Invalid applies_to: {0}'.format(name))
+        'share': win32security.SE_LMSHARE,
+    }
 
 
 class Dacl(Flags):
@@ -170,22 +332,113 @@ class Dacl(Flags):
         if obj_name is None:
             self.dacl = win32security.ACL()
         else:
+            if obj_type.lower() in ['registry', 'registry32']:
+                obj_name = self.get_reg_name(obj_name)
+
             sd = win32security.GetNamedSecurityInfo(
-                obj_name, self.type_flags(obj_type), self.element_flags('dacl'))
+                obj_name, self.obj_type[obj_type], self.element['dacl'])
             self.dacl = sd.GetSecurityDescriptorDacl()
             if self.dacl is None:
                 self.dacl = win32security.ACL()
 
-    def add_ace(self, sid, access_mode, applies_to, permission):
+            self.dacl_type = obj_type
+
+    def get_reg_name(self, obj_name):
+        '''
+        Take the obj_name and convert the hive to a valid registry hive.
+
+        Args:
+
+            obj_name (str): The full path to the registry key including the
+            hive, eg: ``HKLM\\SOFTWARE\\salt``. Valid options for the hive are:
+
+            - HKEY_LOCAL_MACHINE
+            - MACHINE
+            - HKLM
+            - HKEY_USERS
+            - USERS
+            - HKU
+            - HKEY_CURRENT_USER
+            - CURRENT_USER
+            - HKCU
+            - HKEY_CLASSES_ROOT
+            - CLASSES_ROOT
+            - HKCR
+
+        Returns:
+            str: The full path to the registry key in the format expected by
+            the Windows API
+
+        Usage:
+
+        .. code-block:: python
+
+            import salt.utils.win_dacl
+            dacl = salt.utils.win_dacl.Dacl()
+            valid_key = dacl.get_reg_name('HKLM\\SOFTWARE\\salt')
+
+            # Returns: MACHINE\\SOFTWARE\\salt
+        '''
+        # Make sure the hive is correct
+        # Should be MACHINE, USERS, CURRENT_USER, or CLASSES_ROOT
+        hives = {
+            # MACHINE
+            'HKEY_LOCAL_MACHINE': 'MACHINE',
+            'MACHINE': 'MACHINE',
+            'HKLM': 'MACHINE',
+            # USERS
+            'HKEY_USERS': 'USERS',
+            'USERS': 'USERS',
+            'HKU': 'USERS',
+            # CURRENT_USER
+            'HKEY_CURRENT_USER': 'CURRENT_USER',
+            'CURRENT_USER': 'CURRENT_USER',
+            'HKCU': 'CURRENT_USER',
+            # CLASSES ROOT
+            'HKEY_CLASSES_ROOT': 'CLASSES_ROOT',
+            'CLASSES_ROOT': 'CLASSES_ROOT',
+            'HKCR': 'CLASSES_ROOT',
+        }
+        reg = obj_name.split('\\')
+        passed_hive = reg.pop(0)
+
+        try:
+            valid_hive = hives[passed_hive.upper()]
+        except KeyError:
+            raise CommandExecutionError(
+                'Invalid Registry Hive: {0}'.format(passed_hive))
+
+        reg.insert(0, valid_hive)
+        return r'\\'.join(reg)
+
+    def add_ace(self, principal, access_mode, permission, applies_to):
         '''
         Add an ACE to the DACL
 
         Args:
 
-            sid (str): The sid of the user/group to for the ACE
+            principal (str): The sid of the user/group to for the ACE
 
             access_mode (str): Determines the type of ACE to add. Must be either
             ``grant`` or ``deny``.
+
+            permission (str): The type of permissions to grant/deny the user.
+            Valid options by obj_type are:
+
+                ================  ====  ========  =====  =======  =======
+                Permissions       File  Registry  Share  Printer  Service
+                ================  ====  ========  =====  =======  =======
+                full_control      X     X         X               X
+                modify            X
+                read_execute      X
+                read              X     X         X               X
+                write             X     X                         X
+                read_write                                        X
+                change                            X
+                print                                    X
+                manage_printer                           X
+                manage_documents                         X
+                ================  ====  ========  =====  =======  =======
 
             applies_to (str): The objects to which these permissions will apply.
             Not all these options apply to all object types. Valid options are:
@@ -198,17 +451,8 @@ class Dacl(Flags):
                 - subfolders_only
                 - files_only
 
-            permission (str): The type of permissions to grant/deny the user.
-            Valid options:
-
-                - full_control
-                - modify
-                - read_execute
-                - read
-                - write
-
         Returns:
-            bool: True if successful
+            bool: True if successful, otherwise False
 
         Usage:
 
@@ -216,26 +460,28 @@ class Dacl(Flags):
 
             dacl = Dacl(obj_type=obj_type)
             dacl.add_ace(sid, access_mode, applies_to, permission)
-            dacl.save(obj_name, obj_type, protected)
+            dacl.save(obj_name, protected)
         '''
+        sid = get_sid(principal)
+
         if self.dacl is None:
             raise SaltInvocationError(
-                'You must load the DACL before adding and ACE')
+                'You must load the DACL before adding an ACE')
 
         # Add ACE to the DACL
-        # Grand or Deny
+        # Grant or Deny
         try:
             if access_mode.lower() == 'grant':
                 self.dacl.AddAccessAllowedAceEx(
                     win32security.ACL_REVISION_DS,
-                    self.applies_to_flags(applies_to),
-                    self.permission_flags(permission),
+                    self.ace_prop[self.dacl_type][applies_to],
+                    self.ace_perms[self.dacl_type]['basic'][permission],
                     sid)
             elif access_mode.lower() == 'deny':
                 self.dacl.AddAccessDeniedAceEx(
                     win32security.ACL_REVISION_DS,
-                    self.applies_to_flags(applies_to),
-                    self.permission_flags(permission),
+                    self.ace_prop[self.dacl_type][applies_to],
+                    self.ace_perms[self.dacl_type]['basic'][permission],
                     sid)
             else:
                 raise SaltInvocationError(
@@ -245,15 +491,20 @@ class Dacl(Flags):
 
         return True
 
-    def get_ace(self, principal):
+    def get_ace(self, principal, return_obj=False):
         '''
-        Get the ACE for the DACL. Used to work with an existing ACE.
+        Get the ACE for a specific principal.
 
-        principal (str): The name of the user or group for which to get the ace.
-        Can also be a SID.
+        Args:
+
+            principal (str): The name of the user or group for which to get the
+            ace. Can also be a SID.
+
+            return_obj (bool): Return the ACE object instead of a dict. Will
+            return the first ACE that matches the principal.
 
         Returns:
-            dict: A dictionary containing the ACE for the object
+            dict: A dictionary containing the ACEs found for the principal
 
         Usage:
 
@@ -262,10 +513,199 @@ class Dacl(Flags):
             dacl = Dacl(obj_type=obj_type)
             dacl.get_ace()
         '''
-        # TODO: Return the ace by name, currently only returns the first ace
-        return self.dacl.GetAce(0)
+        sid = get_sid(principal)
 
-    def save(self, obj_name, obj_type, protected=None):
+        ret = {}
+
+        for i in range(0, self.dacl.GetAceCount()):
+            ace = self.dacl.GetAce(i)
+
+            # Parse the ACE to text if it matches the passed SID or if
+            if ace[2] == sid:
+                # Return the ACE if it matches the passed SID
+                if return_obj:
+                    return ace
+                user, a_type, a_prop, a_perms, inh = \
+                    self._ace_to_dict(ace)
+                if user in ret:
+                    if a_type in ret[user]:
+                        if a_prop and a_prop not in ret[user][a_type]['applies to']:
+                            if ret[user][a_type]['applies to'] == 'Not Inherited':
+                                ret[user][a_type]['applies to'] = a_prop
+                            else:
+                                a_prop = ':{0}'.format(a_prop)
+                                ret[user][a_type]['applies to'] += a_prop
+                        for perm in a_perms:
+                            if perm and perm not in ret[user][a_type]['permissions']:
+                                ret[user][a_type]['permissions'].extend(a_perms)
+                else:
+                    ret.update(
+                        {user: {
+                            a_type: {
+                                'applies to': a_prop,
+                                'inherited': inh,
+                                'permissions': a_perms,
+                            }}}
+                    )
+
+        return ret
+
+    def list_aces(self):
+        '''
+        List all Entries in the dacl.
+
+        Returns:
+            dict: A dictionary containing the ACEs for the object
+
+        Usage:
+
+        .. code-block:: python
+
+            dacl = Dacl('C:\\Temp')
+            dacl.list_aces()
+        '''
+        ret = {}
+
+        # loop through each ACE in the DACL
+        for i in range(0, self.dacl.GetAceCount()):
+            ace = self.dacl.GetAce(i)
+
+            # Get ACE Elements
+            user, a_type, a_prop, a_perms, inh = self._ace_to_dict(ace)
+
+            # Check for existing entries in the return
+            if user in ret and a_type in ret[user]:
+
+                # Check for an existing applies to entry
+                if a_prop and a_prop not in ret[user][a_type]['applies to']:
+                    if ret[user][a_type]['applies to'] == 'Not Inherited':
+                        ret[user][a_type]['applies to'] = a_prop
+                    else:
+                        a_prop = ':{0}'.format(a_prop)
+                        ret[user][a_type]['applies to'] += a_prop
+
+                # Go through each permission
+                for perm in a_perms:
+                    # If the permission is not in the ret, add it
+                    if perm and perm not in ret[user][a_type]['permissions']:
+                        ret[user][a_type]['permissions'].extend(a_perms)
+
+                # Set inherited bit
+                if inh and not ret[user][a_type]['inherited']:
+                    ret[user][a_type]['inherited'] = inh
+
+            else:
+                # First time through
+                ret.update(
+                    {user: {
+                        a_type: {
+                            'applies to': a_prop,
+                            'inherited': inh,
+                            'permissions': a_perms,
+                        }}}
+                )
+
+        return ret
+
+    def _ace_to_dict(self, ace):
+        '''
+        Helper function for creating the ACE return dictionary
+        '''
+        # Get the principal from the sid (object sid)
+        sid = win32security.ConvertSidToStringSid(ace[2])
+        principal = get_name(sid)
+
+        # Get the ace type
+        ace_type = self.ace_type[ace[0][0]]
+
+        # Is the inherited ace flag present
+        inherited = ace[0][1] & win32security.INHERITED_ACE == 16
+
+        # Ace Propagation
+        ace_prop = 'NA'
+
+        # Get the ace propagation properties
+        if self.dacl_type in ['file', 'registry', 'registry32']:
+
+            ace_prop = ace[0][1]
+
+            # Remove the inherited ace flag and get propagation
+            if inherited:
+                ace_prop = ace[0][1] ^ win32security.INHERITED_ACE
+
+            # Lookup the propagation
+            try:
+                ace_prop = self.ace_prop[self.obj_type][ace_prop]
+            except KeyError:
+                ace_prop = 'Unknown propagation'
+
+        # Get the object type
+        obj_type = 'registry' if self.dacl_type.lower() == 'registry32' \
+            else self.dacl_type.lower()
+
+        # Get the ace permissions
+        # Check basic permissions first
+        ace_perms = [self.ace_perms[obj_type]['basic'].get(ace[1], [])]
+
+        # If it didn't find basic perms, check advanced permissions
+        if not ace_perms[0]:
+            ace_perms = []
+            for perm in self.ace_perms[obj_type]['advanced']:
+                if ace[1] & perm == perm:
+                    ace_perms.append(
+                        self.ace_perms[obj_type]['advanced'][perm])
+
+        # If still nothing, it must be undefined
+        if not ace_perms[0]:
+            ace_perms = ['Undefined Permission: {0}'.format(ace[1])]
+
+        return principal, ace_type, ace_prop, ace_perms, inherited
+
+    def rm_ace(self, principal, ace_type='all'):
+        '''
+        Remove a specific ACE from the DACL.
+
+        Args:
+
+            principal (str): The user whose ACE to remove. Can be the user name
+            or a SID.
+
+            ace_type (str): The type of ACE to remove. If not specified, all
+            ACEs will be removed. Default is 'all'. Valid options are:
+
+                - 'grant'
+                - 'deny'
+                - 'all'
+
+        Returns:
+            list: List of removed aces
+
+        Usage:
+
+        .. code-block:: python
+
+            dacl = Dacl(obj_name='C:\\temp', obj_type='file')
+            dacl.rm_ace('Users')
+            dacl.save(obj_name='C:\\temp')
+        '''
+        sid = get_sid(principal)
+        offset = 0
+        ret = []
+        for i in range(0, self.dacl.GetAceCount()):
+            ace = self.dacl.GetAce(i - offset)
+            if ace[2] == sid:
+                if self.ace_type[ace[0][0]] == ace_type.lower() or \
+                        ace_type == 'all':
+                    self.dacl.DeleteAce(i - offset)
+                    ret.append(self._ace_to_dict(ace))
+                    offset += 1
+
+        if not ret:
+            ret = ['ACE not found for {0}'.format(principal)]
+
+        return ret
+
+    def save(self, obj_name, protected=None):
         '''
         Save the DACL
 
@@ -274,16 +714,6 @@ class Dacl(Flags):
         information about how to format the name see:
 
         https://msdn.microsoft.com/en-us/library/windows/desktop/aa379593(v=vs.85).aspx
-
-        obj_type (str): The type of object for which to set permissions. Valid
-        objects are as follows:
-
-            - file (default): This is a file or directory
-            - service
-            - printer
-            - registry
-            - registry32 (for WOW64)
-            - share
 
         protected (Optional[bool]): True will disable inheritance for the
         object. False will enable inheritance. None will make no change. Default
@@ -297,19 +727,23 @@ class Dacl(Flags):
         .. code-block:: python
 
             dacl = Dacl(obj_type='file')
-            dacl.save('C:\\Temp', 'file', True)
+            dacl.save('C:\\Temp', True)
         '''
-        sec_info = self.element_flags('dacl')
+        sec_info = self.element['dacl']
+
         if protected is not None:
             if protected:
-                sec_info = sec_info | self.inheritance_flags('protected')
+                sec_info = sec_info | self.inheritance['protected']
             else:
-                sec_info = sec_info | self.inheritance_flags('unprotected')
+                sec_info = sec_info | self.inheritance['unprotected']
+
+        if obj_type.lower() in ['registry', 'registry32']:
+            obj_name = self.get_reg_name(obj_name)
 
         try:
             win32security.SetNamedSecurityInfo(
                 obj_name,
-                self.type_flags(obj_type),
+                self.obj_type[self.dacl_type],
                 sec_info,
                 None, None, self.dacl, None)
         except pywintypes.error as exc:
@@ -321,7 +755,8 @@ class Dacl(Flags):
 
 def get_sid(principal):
     '''
-    Converts a username to a sid, or verifies a sid.
+    Converts a username to a sid, or verifies a sid. Required for working with
+    the DACL.
 
     Args:
 
@@ -329,7 +764,7 @@ def get_sid(principal):
         username.
 
     Returns:
-        str: A sid
+        PySID Object: A sid
 
     Usage:
 
@@ -353,8 +788,43 @@ def get_sid(principal):
     except pywintypes.error:
         raise CommandExecutionError(
             'Invalid user/group or sid: {0}'.format(principal))
+    except TypeError:
+        raise CommandExecutionError
 
     return sid
+
+
+def get_sid_string(principal):
+    '''
+    Converts a PySID object to a string SID.
+
+    Args:
+
+        principal(str): The principal to lookup the sid. Must be a PySID object.
+
+    Returns:
+        str: A sid
+
+    Usage:
+
+    .. code-block:: python
+
+        # Get a PySID object
+        py_sid = salt.utils.win_dacl.get_sid('jsnuffy')
+
+        # Get the string version of the SID
+        salt.utils.win_dacl.get_sid_string(py_sid)
+    '''
+    try:
+        return win32security.ConvertSidToStringSid(principal)
+    except TypeError:
+        # Not a PySID object
+        principal = get_sid(principal)
+
+    try:
+        return win32security.ConvertSidToStringSid(principal)
+    except pywintypes.error:
+        raise CommandExecutionError('Invalid principal {0}'.format(principal))
 
 
 def get_name(sid):
@@ -397,7 +867,7 @@ def get_owner(obj_name):
 
     .. code-block:: python
 
-        salt.utils.win_dacl.get_owner('c:\file')
+        salt.utils.win_dacl.get_owner('c:\\file')
     '''
     # Return owner
     security_descriptor = win32security.GetFileSecurity(
@@ -450,8 +920,8 @@ def set_owner(obj_name, principal, obj_type='file'):
     try:
         win32security.SetNamedSecurityInfo(
             obj_name,
-            flags.type_flags(obj_type),
-            flags.element_flags('owner'),
+            flags.obj_type[obj_type],
+            flags.element['owner'],
             sid,
             None, None, None)
     except pywintypes.error as exc:
@@ -468,8 +938,7 @@ def set_permissions(obj_name,
                     reset_perms=False,
                     obj_type='file',
                     protected=None,
-                    applies_to='this_folder_subfolders_files',
-                    propagate=False):
+                    applies_to='this_folder_subfolders_files'):
     '''
     Set the permissions of an object. This can be a file, folder, registry key,
     printer, service, etc...
@@ -496,13 +965,22 @@ def set_permissions(obj_name,
         permissions. Can also pass a SID.
 
         permission (str): The type of permissions to grant/deny the user. Valid
-        options:
+        options by obj_type are:
 
-            - full_control
-            - modify
-            - read_execute
-            - read
-            -  write
+            ================  ====  ========  =====  =======  =======
+            Permissions       File  Registry  Share  Printer  Service
+            ================  ====  ========  =====  =======  =======
+            full_control      X     X         X               X
+            modify            X
+            read_execute      X
+            read              X     X         X               X
+            write             X     X                         X
+            read_write                                        X
+            change                            X
+            print                                    X
+            manage_printer                           X
+            manage_documents                         X
+            ================  ====  ========  =====  =======  =======
 
         access_mode (Optional[str]): Whether to grant or deny user the access.
         Valid options are:
@@ -518,20 +996,34 @@ def set_permissions(obj_name,
         is None.
 
         applies_to (Optional[str]): The objects to which these permissions will
-        apply. Not all these options apply to all object types. Valid options
-        are:
+        apply. Not all these options apply to all object types. Valid options:
 
-            - this_folder_only: Applies only to this object
-            - this_folder_subfolders_files (default): Applies to this object and
-              all sub containers and objects
-            - this_folder_subfolders: Applies to this object and all sub
-              containers.
-            - this_folder_files: Applies to this object and all sub-objects,
-              minus containers.
-            - subfolders_files: Applies to all containers and objects beneath
-              this object
-            - subfolders_only: Applies to all containers beneath the this object
-            - files_only: Applies to all objects beneath this object
+            *File types:*
+
+                - this_folder_only: Applies only to this object
+                - this_folder_subfolders_files (default): Applies to this object
+                  and all sub containers and objects
+                - this_folder_subfolders: Applies to this object and all sub
+                  containers, no files
+                - this_folder_files: Applies to this object and all file
+                  objects, no containers
+                - subfolders_files: Applies to all containers and objects
+                  beneath this object
+                - subfolders_only: Applies to all containers beneath this object
+                - files_only: Applies to all file objects beneath this object
+
+            *Registry types:*
+
+                - this_key_only: Applies only to this key
+                - this_key_subkeys: Applies to this key and all subkeys
+                - subkeys_only: Applies to all subkeys beneath this object
+
+            *Service types:* Does not apply
+
+            *Printer types:* Does not apply (Defaults to ``This object only``)
+
+            *Share types:* Does not apply
+
 
         propagate (Optional[bool]): Apply these permissions to all
         sub-containers and objects. Not yet implemented. Would only apply to
@@ -547,28 +1039,91 @@ def set_permissions(obj_name,
         salt.utils.win_dacl.set_permissions(
             'C:\\Temp', 'file', 'jsnuffy', 'full_control')
     '''
-    sid = get_sid(principal)
-
     # If you don't pass `obj_name` it will create a blank DACL
     # Otherwise, it will grab the existing DACL and add to it
     if reset_perms:
         dacl = Dacl(obj_type=obj_type)
     else:
         dacl = Dacl(obj_name, obj_type)
+        dacl.rm_ace(principal, access_mode)
 
-    dacl.add_ace(sid, access_mode, applies_to, permission)
-    dacl.save(obj_name, obj_type, protected)
+    dacl.add_ace(principal, access_mode, applies_to, permission)
+    dacl.save(obj_name, protected)
 
     return True
 
 
-def get_permissions(obj_name, principal):
+def rm_permissions(obj_name,
+                   principal,
+                   ace_type='all',
+                   obj_type='file'):
+    '''
+    Remove a user's ACE from an object. This can be a file, folder, registry
+    key, printer, service, etc...
+
+    Args:
+
+        obj_name (str): The object from which to remove the ace. This can be the
+        path to a file or folder, a registry key, printer, etc. For more
+        information about how to format the name see:
+
+        https://msdn.microsoft.com/en-us/library/windows/desktop/aa379593(v=vs.85).aspx
+
+        principal (str): The name of the user or group for which to set
+        permissions. Can also pass a SID.
+
+        ace_type(Optional[str]): The type of ace to remove. There are two types
+        of ACEs, 'grant' and 'deny'. 'all' will remove all ACEs for the user.
+
+        obj_type (Optional[str]): The type of object for which to set
+        permissions. Valid objects are as follows:
+
+            - file (default): This is a file or directory
+            - service
+            - printer
+            - registry
+            - registry32 (for WOW64)
+            - share
+
+    Returns:
+        bool: True if successful, raises an error otherwise
+
+    Usage:
+
+    .. code-block:: python
+
+        # Remove jsnuffy's grant ACE from C:\Temp
+        salt.utils.win_dacl.rm_permissions(
+            'C:\\Temp', 'jsnuffy', 'grant', 'file')
+
+        # Remove all ACEs for jsnuffy from C:\Temp
+        salt.utils.win_dacl.rm_permissions('C:\\Temp', 'jsnuffy')
+    '''
+    dacl = Dacl(obj_name, obj_type)
+
+    dacl.rm_ace(principal, ace_type)
+    dacl.save(obj_name)
+
+    return True
+
+
+def get_permissions(obj_name, principal=None, obj_type='file'):
     '''
     Get the permissions for the passed object
 
     Args:
 
         obj_name (str): The name of or path to the object.
+
+        obj_type (str): The type of object for which to get permissions. Valid
+        objects are as follows:
+
+            - file (default): This is a file or directory
+            - service
+            - printer
+            - registry
+            - registry32 (for WOW64)
+            - share
 
         principal (str): The name of the user or group for which to get
         permissions. Can also pass a SID.
@@ -582,6 +1137,249 @@ def get_permissions(obj_name, principal):
 
         salt.utils.win_dacl.get_permissions('C:\\Temp')
     '''
-    # TODO: Return a human readable ace in a dict
-    dacl = Dacl(obj_name)
+    dacl = Dacl(obj_name, obj_type)
+
+    if principal is None:
+        return dacl.list_aces()
+
     return dacl.get_ace(principal)
+
+
+def has_permission(obj_name,
+                   obj_type,
+                   principal,
+                   permission,
+                   access_mode='grant',
+                   exact=True):
+    '''
+    Check if the object has a permission
+
+    Args:
+
+        obj_name (str): The name of or path to the object.
+
+        obj_type (str): The type of object for which to check permissions. Valid
+        objects are as follows:
+
+            - file: This is a file or directory
+            - service
+            - printer
+            - registry
+            - registry32 (for WOW64)
+            - share
+
+        principal (str): The name of the user or group for which to get
+        permissions. Can also pass a SID.
+
+        permission (str): The permission to verify. Valid options depend on the
+        obj_type. Valid options are:
+
+            **Basic Permissions**
+
+            ================  ====  ========  =====  =======  =======
+            Permissions       File  Registry  Share  Printer  Service
+            ================  ====  ========  =====  =======  =======
+            full_control      X     X         X               X
+            modify            X
+            read_execute      X
+            read              X     X         X               X
+            write             X     X                         X
+            read_write                                        X
+            change                            X
+            print                                    X
+            manage_printer                           X
+            manage_documents                         X
+            ================  ====  ========  =====  =======  =======
+
+            **Advanced Permissions**
+
+            =======================  ====  ========  =======  =======
+            Permissions              File  Registry  Printer  Service
+            =======================  ====  ========  =======  =======
+            list_folder              X
+            read_data                X
+            create_files             X
+            write_data               X
+            create_folders           X
+            append_data              X
+            read_ea                  X
+            write_ea                 X
+            traverse_folder          X
+            execute_file             X
+            delete_subfolders_files  X
+            read_attributes          X
+            write_attributes         X
+            delete                   X     X
+            read_permissions         X               X        X
+            change_permissions       X               X        X
+            take_ownership           X               X
+            query_value                    X
+            set_value                      X
+            create_subkey                  X
+            enum_subkeys                   X
+            notify                         X
+            create_link                    X
+            read_control                   X
+            write_dac                      X
+            write_owner                    X
+            manage_printer                           X
+            print                                    X
+            query_config                                      X
+            change_config                                     X
+            query_status                                      X
+            enum_dependents                                   X
+            start                                             X
+            stop                                              X
+            pause_resume                                      X
+            interrogate                                       X
+            user_defined                                      X
+            change_owner                                      X
+            =======================  ====  ========  =======  =======
+
+        access_mode (Optional[str]): The access mode to check. Default is
+        'grant'. Valid options are:
+
+            - grant
+            - deny
+
+        exact (bool): True for an exact match, otherwise check to see if the
+        permission is included in the ACE
+
+    Returns:
+        bool: True if the object has the permission, otherwise False
+
+    Usage:
+
+    .. code-block:: python
+
+        # Does Joe have read permissions to C:\Temp
+        salt.utils.win_dacl.has_permission('C:\\Temp', 'file', 'joe', 'read', 'grant', False)
+
+        # Does Joe have Full Control of C:\Temp
+        salt.utils.win_dacl.has_permission('C:\\Temp', 'file', 'joe', 'full_control', 'grant')
+    '''
+    # Validate obj_type
+    if obj_type.lower() not in ['file', 'service', 'printer', 'registry',
+                                'registry32', 'share']:
+        raise SaltInvocationError(
+            'Invalid "obj_type" passed: {0}'.format(obj_type))
+    obj_type = obj_type.lower()
+
+    # Validate inherited
+    # Validate access_mode
+    if access_mode.lower() not in ['grant', 'deny']:
+        raise SaltInvocationError(
+            'Invalid "access_mode" passed: {0}'.format(access_mode))
+    access_mode = access_mode.lower()
+
+    # Get the DACL
+    dacl = Dacl(obj_name, obj_type)
+
+    # Get a PySID object
+    sid = get_sid(principal)
+
+    # Get the passed permission flag, check basic first
+    chk_flag = dacl.ace_perms[obj_type]['basic'].get(
+        permission.lower(),
+        dacl.ace_perms[obj_type]['advanced'].get(permission.lower(), False))
+    if not chk_flag:
+        raise SaltInvocationError(
+            'Invalid "permission" passed: {0}'.format(permission))
+
+    # Check each ace for sid and type
+    cur_flag = None
+    for i in range(0, dacl.dacl.GetAceCount()):
+        ace = dacl.dacl.GetAce(i)
+        if ace[2] == sid and dacl.ace_type[ace[0][0]] == access_mode:
+            cur_flag = ace[1]
+
+    # If the ace is empty, return false
+    if not cur_flag:
+        return False
+
+    # Check for the exact permission in the ACE
+    if exact:
+        return chk_flag == cur_flag
+
+    # Check if the ACE contains the permission
+    return cur_flag & chk_flag == chk_flag
+
+
+def set_inheritance(obj_name, enabled, obj_type='file', clear=False):
+    '''
+    Enable or disable an objects inheritance.
+
+    Args:
+
+        obj_name (str): The name of the object
+
+        enabled (bool): True to enable inheritance, False to disable
+
+        obj_type (Optional[str]): The type of object. Valid objects are:
+
+            - file (default): This is a file or directory
+            - registry
+            - registry32 (for WOW64)
+
+        clear (Optional[bool]): True to clear existing ACEs, False to keep
+        existing ACEs
+
+    Returns:
+        bool: True if successful, otherwise an Error
+
+    Usage:
+
+    .. code-block:: python
+
+        salt.utils.win_dacl.set_inheritance('C:\\Temp', False)
+    '''
+    if obj_type not in ['file', 'registry', 'registry32']:
+        raise SaltInvocationError(
+            'obj_type called with incorrect parameter: {0}'.format(obj_name))
+
+    if clear:
+        dacl = Dacl(obj_type=obj_type)
+    else:
+        dacl = Dacl(obj_name, obj_type)
+
+    return dacl.save(obj_name, not enabled)
+
+
+def get_inheritance(obj_name, obj_type='file'):
+    '''
+    Get an objects inheritance.
+
+    Args:
+
+        obj_name (str): The name of the object
+
+        obj_type (Optional[str]): The type of object. Valid objects are:
+
+            - file (default): This is a file or directory
+            - registry
+            - registry32 (for WOW64)
+
+            The following should return False as there is no inheritance:
+
+            - service
+            - printer
+            - share
+
+    Returns:
+        bool: True if enabled, otherwise False
+
+    Usage:
+
+    .. code-block:: python
+
+        salt.utils.win_dacl.get_inheritance('HKLM\\SOFTWARE\\salt', 'registry')
+    '''
+    dacl = Dacl(obj_name, obj_type)
+    inherited = win32security.INHERITED_ACE
+
+    for i in range(0, dacl.dacl.GetAceCount()):
+        ace = dacl.dacl.GetAce(i)
+        if ace[0][1] & inherited == inherited:
+            return True
+
+    return False

--- a/salt/utils/win_dacl.py
+++ b/salt/utils/win_dacl.py
@@ -635,7 +635,7 @@ class Dacl(Flags):
 
             # Lookup the propagation
             try:
-                ace_prop = self.ace_prop[self.obj_type][ace_prop]
+                ace_prop = self.ace_prop[self.dacl_type][ace_prop]
             except KeyError:
                 ace_prop = 'Unknown propagation'
 
@@ -651,6 +651,9 @@ class Dacl(Flags):
         if not ace_perms[0]:
             ace_perms = []
             for perm in self.ace_perms[obj_type]['advanced']:
+                # Don't match against the string perms
+                if isinstance(perm, six.string_types):
+                    continue
                 if ace[1] & perm == perm:
                     ace_perms.append(
                         self.ace_perms[obj_type]['advanced'][perm])
@@ -1047,7 +1050,7 @@ def set_permissions(obj_name,
         dacl = Dacl(obj_name, obj_type)
         dacl.rm_ace(principal, access_mode)
 
-    dacl.add_ace(principal, access_mode, applies_to, permission)
+    dacl.add_ace(principal, access_mode, permission, applies_to)
     dacl.save(obj_name, protected)
 
     return True

--- a/salt/utils/win_dacl.py
+++ b/salt/utils/win_dacl.py
@@ -329,10 +329,10 @@ class Dacl(Flags):
             # Load the DACL of the named object
             dacl = Dacl(obj_name, obj_type)
         '''
+        self.dacl_type = obj_type.lower()
         if obj_name is None:
             self.dacl = win32security.ACL()
         else:
-            self.dacl_type = obj_type.lower()
             if self.dacl_type in ['registry', 'registry32']:
                 obj_name = self.get_reg_name(obj_name)
 

--- a/salt/utils/win_dacl.py
+++ b/salt/utils/win_dacl.py
@@ -1057,7 +1057,7 @@ def rm_permissions(obj_name,
                    principal,
                    ace_type='all',
                    obj_type='file'):
-    '''
+    r'''
     Remove a user's ACE from an object. This can be a file, folder, registry
     key, printer, service, etc...
 
@@ -1136,7 +1136,7 @@ def has_permission(obj_name,
                    permission,
                    access_mode='grant',
                    exact=True):
-    '''
+    r'''
     Check if the object has a permission
 
     Args:

--- a/salt/utils/win_dacl.py
+++ b/salt/utils/win_dacl.py
@@ -296,8 +296,8 @@ class Dacl(Flags):
 
         .. code-block:: python
 
-            dacl = Dacl(obj_type=obj_type)
-            dacl.save(obj_name, obj_type, protected)
+            dacl = Dacl(obj_type='file')
+            dacl.save('C:\\Temp', 'file', True)
         '''
         sec_info = self.element_flags('dacl')
         if protected is not None:

--- a/salt/utils/win_dacl.py
+++ b/salt/utils/win_dacl.py
@@ -332,16 +332,15 @@ class Dacl(Flags):
         if obj_name is None:
             self.dacl = win32security.ACL()
         else:
-            if obj_type.lower() in ['registry', 'registry32']:
+            self.dacl_type = obj_type.lower()
+            if self.dacl_type in ['registry', 'registry32']:
                 obj_name = self.get_reg_name(obj_name)
 
             sd = win32security.GetNamedSecurityInfo(
-                obj_name, self.obj_type[obj_type], self.element['dacl'])
+                obj_name, self.obj_type[self.dacl_type], self.element['dacl'])
             self.dacl = sd.GetSecurityDescriptorDacl()
             if self.dacl is None:
                 self.dacl = win32security.ACL()
-
-            self.dacl_type = obj_type
 
     def get_reg_name(self, obj_name):
         '''
@@ -409,6 +408,7 @@ class Dacl(Flags):
                 'Invalid Registry Hive: {0}'.format(passed_hive))
 
         reg.insert(0, valid_hive)
+
         return r'\\'.join(reg)
 
     def add_ace(self, principal, access_mode, permission, applies_to):
@@ -640,8 +640,8 @@ class Dacl(Flags):
                 ace_prop = 'Unknown propagation'
 
         # Get the object type
-        obj_type = 'registry' if self.dacl_type.lower() == 'registry32' \
-            else self.dacl_type.lower()
+        obj_type = 'registry' if self.dacl_type == 'registry32' \
+            else self.dacl_type
 
         # Get the ace permissions
         # Check basic permissions first
@@ -737,7 +737,7 @@ class Dacl(Flags):
             else:
                 sec_info = sec_info | self.inheritance['unprotected']
 
-        if obj_type.lower() in ['registry', 'registry32']:
+        if self.dacl_type in ['registry', 'registry32']:
             obj_name = self.get_reg_name(obj_name)
 
         try:

--- a/salt/utils/win_dacl.py
+++ b/salt/utils/win_dacl.py
@@ -1,0 +1,540 @@
+# -*- coding: utf-8 -*-
+'''
+Functions for setting permissions to objects in windows
+'''
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt libs
+from salt.exceptions import CommandExecutionError, SaltInvocationError
+
+# Import 3rd-party libs
+try:
+    import ntsecuritycon
+    import win32security
+    import pywintypes
+    import salt.utils.win_functions
+except ImportError:
+    pass
+
+
+class Flags(object):
+    '''
+    Object containing all the flags for dealing with Windows permissions
+    '''
+    # Flag Dicts
+    obj_type = {
+        'file': win32security.SE_FILE_OBJECT,
+        'service': win32security.SE_SERVICE,
+        'printer': win32security.SE_PRINTER,
+        'registry': win32security.SE_REGISTRY_KEY,
+        'registry32': win32security.SE_REGISTRY_WOW64_32KEY,
+        'share': win32security.SE_LMSHARE}
+
+    element = {
+        'dacl': win32security.DACL_SECURITY_INFORMATION,
+        'group': win32security.GROUP_SECURITY_INFORMATION,
+        'owner': win32security.OWNER_SECURITY_INFORMATION}
+
+    dacl_inheritance = {
+        'protected': win32security.PROTECTED_DACL_SECURITY_INFORMATION,
+        'unprotected': win32security.UNPROTECTED_DACL_SECURITY_INFORMATION}
+
+    access = {
+        'full_control':
+            ntsecuritycon.GENERIC_ALL,
+        'modify':
+            ntsecuritycon.GENERIC_READ |
+            ntsecuritycon.GENERIC_WRITE |
+            ntsecuritycon.GENERIC_EXECUTE |
+            ntsecuritycon.DELETE,
+        'read_execute':
+            ntsecuritycon.GENERIC_READ |
+            ntsecuritycon.GENERIC_EXECUTE,
+        'read':
+            ntsecuritycon.GENERIC_READ,
+        'write':
+            ntsecuritycon.GENERIC_WRITE}
+
+    applies_to = {
+        'this_folder_only':
+            win32security.CONTAINER_INHERIT_ACE |
+            win32security.NO_PROPAGATE_INHERIT_ACE,
+        'this_folder_subfolders_files':
+            win32security.CONTAINER_INHERIT_ACE |
+            win32security.OBJECT_INHERIT_ACE,
+        'this_folder_subfolders':
+            win32security.CONTAINER_INHERIT_ACE,
+        'this_folder_files':
+            win32security.OBJECT_INHERIT_ACE,
+        'subfolders_files':
+            win32security.CONTAINER_INHERIT_ACE |
+            win32security.OBJECT_INHERIT_ACE |
+            win32security.INHERIT_ONLY_ACE,
+        'subfolders_only':
+            win32security.CONTAINER_INHERIT_ACE |
+            win32security.INHERIT_ONLY_ACE,
+        'files_only':
+            win32security.OBJECT_INHERIT_ACE |
+            win32security.INHERIT_ONLY_ACE}
+
+    def type_flags(self, name):
+        '''
+        Get the flag that designates the type of object passed
+        '''
+        try:
+            return self.obj_type[name.lower()]
+        except KeyError:
+            raise CommandExecutionError(
+                'Invalid object type: {0}'.format(name))
+
+    def element_flags(self, name):
+        '''
+        Get the flag for the element of the security information object to be
+        returned/set
+        '''
+        try:
+            return self.element[name.lower()]
+        except KeyError:
+            raise CommandExecutionError(
+                'Invalid security info element: {0}'.format(name))
+
+    def dacl_inheritance_flags(self, name):
+        '''
+        Get the flag that determines whether the object will inherit parent
+        permissions
+        '''
+        try:
+            return self.dacl_inheritance[name.lower()]
+        except KeyError:
+            raise CommandExecutionError(
+                'Invalid inheritance: {0}'.format(name))
+
+    def permission_flags(self, name):
+        '''
+        Get the flags that correspond to the desired permissions
+        '''
+        try:
+            return self.access[name.lower()]
+        except KeyError:
+            raise CommandExecutionError(
+                'Invalid access: {0}'.format(name))
+
+    def applies_to_flags(self, name):
+        '''
+        Get the flags that determine the type of objects to which the DACL
+        applies
+        '''
+        try:
+            return self.applies_to[name.lower()]
+        except KeyError:
+            raise CommandExecutionError(
+                'Invalid applies_to: {0}'.format(name))
+
+
+class Dacl(Flags):
+    '''
+    DACL Object
+    '''
+    def __init__(self, obj_name=None, obj_type='file'):
+        '''
+        Either load the DACL from the passed object or create an empty DACL. If
+        `obj_name` is not passed, an empty DACL is created.
+
+        Args:
+            obj_name (str):
+                The full path to the object. If None, a blank DACL will be
+                created
+
+            obj_type (Optional[str]):
+                The type of object. Valid options are:
+
+                - file (default): This is a file or directory
+                - service
+                - printer
+                - registry
+                - registry32 (for WOW64)
+                - share
+
+        Returns:
+            obj: A DACL object
+
+        Usage:
+
+            # Create an Empty DACL
+            dacl = DACL(obj_type=obj_type)
+
+            # Load the DACL of the named object
+            dacl = DACL(obj_name, obj_type)
+        '''
+        if obj_name is None:
+            self.dacl = win32security.ACL()
+        else:
+            sd = win32security.GetNamedSecurityInfo(
+                obj_name, self.type_flags(obj_type), self.element_flags('dacl'))
+            self.dacl = sd.GetSecurityDescriptorDacl()
+            if self.dacl is None:
+                self.dacl = win32security.ACL()
+
+    def add_ace(self, sid, access_mode, applies_to, permission):
+        '''
+        Add an ACE to the DACL
+
+        Args:
+
+            sid (str):
+                The sid of the user/group to for the ACE
+
+            access_mode (str):
+                Determines the type of ACE to add. Must be either `grant` or
+                `deny`.
+
+            applies_to (str):
+                The objects to which these permissions will apply. Not all these
+                options apply to all object types. Valid options are:
+
+                - this_folder_only
+                - this_folder_subfolders_files
+                - this_folder_subfolders
+                - this_folder_files
+                - subfolders_files
+                - subfolders_only
+                - files_only
+
+            permission (str):
+                The type of permissions to grant/deny the user. Valid options:
+
+                - full_control
+                - modify
+                - read_execute
+                - read
+                - write
+
+        Returns:
+            bool: True if successful
+
+        Usage:
+
+            dacl = DACL(obj_type=obj_type)
+            dacl.add_ace(sid, access_mode, applies_to, permission)
+            dacl.save(obj_name, obj_type, protected)
+        '''
+        if self.dacl is None:
+            raise SaltInvocationError(
+                'You must load the DACL before adding and ACE')
+
+        # Add ACE to the DACL
+        # Grand or Deny
+        try:
+            if access_mode.lower() == 'grant':
+                self.dacl.AddAccessAllowedAceEx(
+                    win32security.ACL_REVISION_DS,
+                    self.applies_to_flags(applies_to),
+                    self.permission_flags(permission),
+                    sid)
+            elif access_mode.lower() == 'deny':
+                self.dacl.AddAccessDeniedAceEx(
+                    win32security.ACL_REVISION_DS,
+                    self.applies_to_flags(applies_to),
+                    self.permission_flags(permission),
+                    sid)
+            else:
+                raise SaltInvocationError(
+                    'Invalid access mode: {0}'.format(access_mode))
+        except Exception as exc:
+            return False, 'Error: {0}'.format(str(exc))
+
+        return True
+
+    def get_ace(self):
+        '''
+        Get the ACE for the DACL
+
+        Returns:
+            dict: A dictionary containing the ACE for the object
+        Usage:
+
+            dacl = DACL(obj_type=obj_type)
+            dacl.get_ace()
+        '''
+        return self.dacl.GetAce(0)
+
+    def save(self, obj_name, obj_type, protected=None):
+        '''
+        Save the dacl
+
+        obj_name (str):
+            The object for which to set permissions. This can be the path to a
+            file or folder, a registry key, printer, etc. For more information
+            about how to format the name see:
+            https://msdn.microsoft.com/en-us/library/windows/desktop/aa379593(v=vs.85).aspx
+
+        obj_type (str):
+            The type of object for which to set permissions. Valid objects are
+            as follows:
+
+            - file (default): This is a file or directory
+            - service
+            - printer
+            - registry
+            - registry32 (for WOW64)
+            - share
+
+        protected (Optional[bool]):
+            True will disable inheritance for the object. False will enable
+            inheritance. None will make no change. Default is None.
+
+        Returns:
+            bool: True if successful, Otherwise raises an exception
+
+        Usage:
+            dacl = DACL(obj_type=obj_type)
+            dacl.save(obj_name, obj_type, protected)
+        '''
+        sec_info = self.element_flags('dacl')
+        if protected is not None:
+            if protected:
+                sec_info = sec_info | self.dacl_inheritance_flags('protected')
+            else:
+                sec_info = sec_info | self.dacl_inheritance_flags('unprotected')
+
+        try:
+            win32security.SetNamedSecurityInfo(
+                obj_name,
+                self.type_flags(obj_type),
+                sec_info,
+                None, None, self.dacl, None)
+        except pywintypes.error as exc:
+            raise CommandExecutionError(
+                'Failed to set permissions: {0}'.format(exc[2]))
+
+        return True
+
+
+def get_sid(principal):
+    '''
+    Converts a username to a sid, or verifies a sid.
+
+    Args:
+        principal(str):
+            The principal to lookup the sid. Can be a sid or a username.
+
+    Returns:
+        str: A sid
+
+    Usage:
+        salt.utils.dacl.get_sid('jsnuffy')
+    '''
+    # Test if the user passed a sid or a name
+    try:
+        sid = salt.utils.win_functions.get_sid_from_name(principal)
+    except CommandExecutionError:
+        sid = principal
+
+    # Test if the SID is valid
+    try:
+        sid = win32security.ConvertStringSidToSid(sid)
+    except pywintypes.error:
+        raise CommandExecutionError(
+            'Invalid user/group or sid: {0}'.format(principal))
+
+    return sid
+
+
+def get_name(sid):
+    '''
+    Gets the name from the specified SID. Opposite of get_sid
+
+    Args:
+        sid (str): The SID for which to find the name
+
+    Returns:
+        str: The name that corresponds to the passed SID
+    '''
+    try:
+        sid_obj = win32security.ConvertStringSidToSid(sid)
+        name = win32security.LookupAccountSid(None, sid_obj)[0]
+    except pywintypes.error as exc:
+        raise CommandExecutionError(
+            'User {0} found: {1}'.format(sid, exc[2]))
+
+    return name
+
+
+def get_owner(obj_name):
+    '''
+    Gets the owner of the passed object
+
+    Args:
+        obj_name (str): The path for which to obtain owner information
+
+    Returns:
+        str: The owner (group or user)
+    '''
+    # Return owner
+    security_descriptor = win32security.GetFileSecurity(
+        obj_name, win32security.OWNER_SECURITY_INFORMATION)
+    owner_sid = security_descriptor.GetSecurityDescriptorOwner()
+
+    return get_name(win32security.ConvertSidToStringSid(owner_sid))
+
+
+def set_owner(obj_name, principal, obj_type='file'):
+    '''
+    Set the owner of an object. This can be a file, folder, registry key,
+    printer, service, etc...
+
+    Args:
+
+        obj_name (str):
+            The object for which to set owner. This can be the path to a file or
+            folder, a registry key, printer, etc. For more information about how
+            to format the name see:
+            https://msdn.microsoft.com/en-us/library/windows/desktop/aa379593(v=vs.85).aspx
+
+        principal (str):
+            The name of the user or group to make owner of the object. Can also
+            pass a SID.
+
+        obj_type (Optional[str]):
+            The type of object for which to set the owner. Valid objects are as
+            follows:
+
+            - file (default): This is a file or directory
+            - service
+            - printer
+            - registry
+            - registry32 (for WOW64)
+            - share
+
+    Returns:
+        bool: True if successful, raises an error otherwise
+
+    Usage:
+        salt.utils.dacl.set_owner('C:\\MyDirectory', 'jsnuffy', 'file')
+    '''
+    sid = get_sid(principal)
+
+    flags = Flags()
+
+    # Set the user
+    try:
+        win32security.SetNamedSecurityInfo(
+            obj_name,
+            flags.type_flags(obj_type),
+            flags.element_flags('owner'),
+            sid,
+            None, None, None)
+    except pywintypes.error as exc:
+        raise CommandExecutionError(
+            'Failed to set owner: {0}'.format(exc[2]))
+
+    return True
+
+
+def set_permissions(obj_name,
+                    principal,
+                    permission,
+                    access_mode='grant',
+                    reset_perms=False,
+                    obj_type='file',
+                    protected=None,
+                    applies_to='this_folder_subfolders_files',
+                    propagate=False):
+    '''
+    Set the permissions of an object. This can be a file, folder, registry key,
+    printer, service, etc...
+
+    Args:
+
+        obj_name (str):
+            The object for which to set permissions. This can be the path to a
+            file or folder, a registry key, printer, etc. For more information
+            about how to format the name see:
+            https://msdn.microsoft.com/en-us/library/windows/desktop/aa379593(v=vs.85).aspx
+
+        obj_type (Optional[str]):
+            The type of object for which to set permissions. Valid objects are
+            as follows:
+
+            - file (default): This is a file or directory
+            - service
+            - printer
+            - registry
+            - registry32 (for WOW64)
+            - share
+
+        principal (str):
+            The name of the user or group for which to set permissions. Can also
+            pass a SID.
+
+        permission (str):
+            The type of permissions to grant/deny the user. Valid options:
+
+            - full_control
+            - modify
+            - read_execute
+            - read
+            -  write
+
+        access_mode(Optional[str]):
+            Whether to grant or deny user the access. Valid options are:
+
+            - grant (default): Grants the user access
+            - deny: Denies the user access
+
+        reset_perms (Optional[bool]):
+            True will overwrite the permissions on the specified object. False
+            will append the permissions. Default is False
+
+        protected (Optional[bool]):
+            True will disable inheritance for the object. False will enable
+            inheritance. None will make no change. Default is None.
+
+        applies_to (Optional[str]):
+            The objects to which these permissions will apply. Not all these
+            options apply to all object types. Valid options are:
+
+            - this_folder_only: Applies only to this object
+            - this_folder_subfolders_files (default): Applies to this object and
+              all sub containers and objects
+            - this_folder_subfolders: Applies to this object and all sub
+              containers.
+            - this_folder_files: Applies to this object and all sub-objects,
+              minus containers.
+            - subfolders_files: Applies to all containers and objects beneath
+              this object
+            - subfolders_only: Applies to all containers beneath the this object
+            - files_only: Applies to all objects beneath this object
+
+        propagate (Optional[bool]):
+            Apply these permissions to all sub-containers and objects. Not yet
+            implemented. Would only apply to file type objects.
+
+    Returns:
+        bool: True if successful, raises an error otherwise
+
+    Usage:
+        salt.utils.dacl.set_permissions(
+            'C:\\Temp', 'file', 'jsnuffy', 'full_control')
+    '''
+    sid = get_sid(principal)
+
+    # If you don't pass `obj_name` it will create a blank DACL
+    # Otherwise, it will grab the existing DACL and add to it
+    if reset_perms:
+        dacl = Dacl(obj_type=obj_type)
+    else:
+        dacl = Dacl(obj_name, obj_type)
+
+    dacl.add_ace(sid, access_mode, applies_to, permission)
+    dacl.save(obj_name, obj_type, protected)
+
+    return True
+
+
+def get_permissions(obj_name):
+    dacl = Dacl(obj_name)
+    return dacl.get_ace()
+
+


### PR DESCRIPTION
### What does this PR do?
Creates `/salt/utils/win_dacl.py` for working with file permissions and ownership. We will eventually modify the `win_dacl.py` execution module to use the salt util instead. Verify uses this when minion and master start to set directory ownership and permission. Will be used by other modules that need to modify file perms in windows such as the file module where it's currently not configured.

https://github.com/saltstack/zh/issues/1008

### Tests written?
No