### PR TITLE
Forgot to update os_family map in #37472

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1074,10 +1074,12 @@ _OS_FAMILY_MAP = {
     'SLES_SAP': 'Suse',
     'Solaris': 'Solaris',
     'SmartOS': 'Solaris',
+    'OmniOS': 'Solaris',
     'OpenIndiana Development': 'Solaris',
     'OpenIndiana': 'Solaris',
     'OpenSolaris Development': 'Solaris',
     'OpenSolaris': 'Solaris',
+    'Oracle Solaris': 'Solaris',
     'Arch ARM': 'Arch',
     'Manjaro': 'Arch',
     'Antergos': 'Arch',
@@ -1422,7 +1424,6 @@ def os_data():
         grains.update(_linux_cpudata())
         grains.update(_linux_gpu_data())
     elif grains['kernel'] == 'SunOS':
-        grains['os_family'] = 'Solaris'
         if salt.utils.is_smartos():
             # See https://github.com/joyent/smartos-live/issues/224
             uname_v = os.uname()[3]  # format: joyent_20161101T004406Z


### PR DESCRIPTION
### What does this PR do?
Update the MAP to figure out os_family to handle ```OmniOS``` and ```Oracle Solaris```

### What issues does this PR fix or reference?
#37472

### Previous Behavior
OmniOS and Oracle Solaris were mapped to os_family = os

### New Behavior
Correctly map both to the Solaris family.

### Tests written?
No

### Forward ports needed
Like #37472, this should end up in 2016.11 and develop

