### PR TITLE
Allow OmniOS and OpenIndiana to find libcrypto

### DIFF
--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -29,8 +29,10 @@ def _load_libcrypto():
             'libcrypto.so*'))[0])
     else:
         lib = find_library('crypto')
-        if not lib and salt.utils.is_smartos():
-            # smartos does not have libraries in std location
+        if not lib and salt.utils.is_sunos():
+            # Solaris-like distribution that use pkgsrc have
+            # libraries in a non standard location.
+            # (SmartOS, OmniOS, OpenIndiana, ...)
             lib = glob.glob(os.path.join(
                 '/opt/local/lib',
                 'libcrypto.so*'))


### PR DESCRIPTION
### What does this PR do?
Like SmartOS. OmniOS and OpenIndiana can use pkgsrc for packages.
A non standard path is used for libraries when using pkgsrc, this makes the exception for SmartOS apply to all Solaris like platforms.

Resulting in salt working out of the box even when installed via PIP.

### What issues does this PR fix or reference?
N/a

### Previous Behavior
Fails to load libcrypto and raises exception.

### New Behavior
Correctly locate and load libcrypto on OmniOS and OpenIndiana.

### Tests written?
No

@cachedout 2016.11 branch it is, might as well grab and fix the low hanging fruits I found fixing the grain support.