### PR TITLE
fix status handling in sysv init scripts

### DIFF
--- a/pkg/rpm/salt-api
+++ b/pkg/rpm/salt-api
@@ -125,6 +125,7 @@ case "$1" in
             echo -n "Checking for service salt-api "
             checkproc $SALTAPI
             rc_status -v
+            RETVAL=$?
         elif [ -f $DEBIAN_VERSION ]; then
             if [ -f $LOCKFILE ]; then
                 RETVAL=0

--- a/pkg/suse/salt-master
+++ b/pkg/suse/salt-master
@@ -108,6 +108,7 @@ case "$1" in
             echo -n "Checking for service salt-master "
             checkproc $SALTMASTER
             rc_status -v
+            RETVAL=$?
         elif [ -f $DEBIAN_VERSION ]; then
             if [ -f $LOCKFILE ]; then
                 RETVAL=0

--- a/pkg/suse/salt-minion
+++ b/pkg/suse/salt-minion
@@ -57,6 +57,7 @@ start() {
     if [ -f $SUSE_RELEASE ]; then
         startproc -p /var/run/$SERVICE.pid $SALTMINION -d $MINION_ARGS
         rc_status -v
+        RETVAL=$?
     elif [ -e $DEBIAN_VERSION ]; then
         if [ -f $LOCKFILE ]; then
             echo -n "already started, lock file found"
@@ -114,6 +115,7 @@ case "$1" in
             echo -n "Checking for service salt-minion "
             checkproc $SALTMINION
             rc_status -v
+            RETVAL=$?
         elif [ -f $DEBIAN_VERSION ]; then
             if [ -f $LOCKFILE ]; then
                 RETVAL=0

--- a/pkg/suse/salt-syndic
+++ b/pkg/suse/salt-syndic
@@ -109,6 +109,7 @@ case "$1" in
             echo -n "Checking for service salt-syndic "
             checkproc $SALTSYNDIC
             rc_status -v
+            RETVAL=$?
         elif [ -f $DEBIAN_VERSION ]; then
             if [ -f $LOCKFILE ]; then
                 RETVAL=0


### PR DESCRIPTION
### What does this PR do?

fix exit codes of SYSV init scripts if used on a SUSE system.

### Previous Behavior

salt-minion not running:

$> service salt-minion status
$> echo $?
0

### New Behavior
salt-minion not running:

$> service salt-minion status
$> echo $?
3

### Tests written?

No