### PR TITLE
Clarify docs on salt-key events

### DIFF
--- a/doc/topics/event/master_events.rst
+++ b/doc/topics/event/master_events.rst
@@ -43,10 +43,10 @@ Key events
 .. salt:event:: salt/key
 
     Fired when accepting and rejecting minions keys on the Salt master.
+    These happen as a result of actions undertaken by the `salt-key` command.
 
     :var id: The minion ID.
-    :var act: The new status of the minion key: ``accept``, ``pend``,
-              ``reject``.
+    :var act: The new status of the minion key: ``accept``, ``delete``,
 
 .. warning:: If a master is in :conf_master:`auto_accept mode`, ``salt/key`` events
              will not be fired when the keys are accepted.  In addition, pre-seeding


### PR DESCRIPTION
Corrects what may have been a bad cut/paste in the documentation that does not accurately reflect how key events work.

Closes #37448