### PR TITLE
Salt-cloud vmware driver: Enable specification of parent folder for folders/resourcepools/vapps

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2274,6 +2274,9 @@ def create(vm_):
     folder = config.get_cloud_config_value(
         'folder', vm_, __opts__, default=None
     )
+    parent_folder = config.get_cloud_config_value(
+        'parent', vm_, __opts__, default=None
+    )
     datacenter = config.get_cloud_config_value(
         'datacenter', vm_, __opts__, default=None
     )
@@ -2391,6 +2394,11 @@ def create(vm_):
             log.error("Specified resource pool: '{0}' does not exist".format(resourcepool))
             if not clone_type or clone_type == "template":
                 raise SaltCloudSystemExit('You must specify a resource pool that exists.')
+        elif parent_folder:
+            object_list = salt.utils.vmware.get_mors_with_properties(si, vim.ResourcePool, property_list=['parent'], container_ref=container_ref)
+            for obj in object_list:
+                if obj['parent'] == parent_folder and obj['name'] == resourcepool:
+                    resourcepool_ref = obj['object']
     elif cluster:
         cluster_ref = salt.utils.vmware.get_mor_by_property(si, vim.ClusterComputeResource, cluster, container_ref=container_ref)
         if not cluster_ref:
@@ -2418,6 +2426,11 @@ def create(vm_):
             log.error("Specified folder: '{0}' does not exist".format(folder))
             log.debug("Using folder in which {0} {1} is present".format(clone_type, vm_['clonefrom']))
             folder_ref = object_ref.parent
+        elif parent_folder:
+            object_list = salt.utils.vmware.get_mors_with_properties(si, vim.Folder, property_list=['parent'], container_ref=container_ref)
+            for obj in object_list:
+                if obj['parent'] == parent_folder and obj['name'] == folder:
+                    folder_ref = obj['object']
     elif datacenter:
         if not datacenter_ref:
             log.error("Specified datacenter: '{0}' does not exist".format(datacenter))


### PR DESCRIPTION
I have a particular case where I have many folders with the same name (gold-master cloned vapps that are identical to each other)

Salt-cloud appears to put all newly created VMs into the latest created folder/resourcepool/vApp

This is my attempt to enable the ability to specify the name of the parent container of the folder/resourcepool/vApp specified in the cloud profile

I'm not really sure how or whether this requires an additional unit/integration test. I'm also not really sure how to test this code manually! I hope this is right!