### PR TITLE
Catch loader error on returners without save_load

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -2304,7 +2304,7 @@ class ClearFuncs(object):
                             self.opts['ext_job_cache']
                         )
                     )
-            except AttributeError:
+            except (AttributeError, KeyError):
                 save_load_func = False
                 log.critical(
                     'The specified returner used for the external job cache '


### PR DESCRIPTION
Prevents a msgpack error from occurring.

Refs #36713