### PR TITLE
fix list_snapshots when the vm doesn't have a snapshot

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1903,6 +1903,9 @@ def list_snapshots(kwargs=None, call=None):
                 return {vm["name"]: _get_snapshots(vm["snapshot"].rootSnapshotList)}
             else:
                 ret[vm["name"]] = _get_snapshots(vm["snapshot"].rootSnapshotList)
+        else:
+            if kwargs and kwargs.get('name') == vm["name"]:
+                return {}
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix: saltstack/salt#37427

### Previous Behavior
if the vmname does't have any snapshot,it will return all snapshots on all vm that have snapshots

### New Behavior
return none

### Tests written?

No

if the vmname does't have any snapshot,it will return all snapshots on all vm that with snapshots. but it should return none.fix it