### PR TITLE
salt-cloud vmware driver: allow selection by id

### DIFF
--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -715,7 +715,7 @@ def get_mor_by_property(service_instance, object_type, property_value, property_
     object_list = get_mors_with_properties(service_instance, object_type, property_list=[property_name], container_ref=container_ref)
 
     for obj in object_list:
-        if obj[property_name] == property_value:
+        if obj[property_name] == property_value or property_value in str(obj.get('object', '')):
             return obj['object']
 
     return None


### PR DESCRIPTION
### What does this PR do?

Allows users to specify the id of objects in vmware (folders, clusters, resourcepools, vapps, etc) instead of by name.

Example:

    ...
    resourcepool: vim.ResourcePool:resgroup-v92131
    ...

When duplicate named objects exist in a provider, salt-cloud will pick the first object that matches, which may not be the correct one.

In my example, we clone test environments (vApps). Each vApp has several nested vApps which share the same name as the master vApp. Since the cloned vApps have a later creation date than the master, it's not possible to create VMs into the master vApp by name.

### Previous Behavior
When getting an object (such as a folder or resourcepool), salt-cloud checks if the name matches the string provided

### New Behavior
When getting an object, salt-cloud checks if the name OR object (converted to string) matches the string provided

### Tests written?

No.

Not sure if this is really required, since it's a relatively small change.
