### PR TITLE
Saltstack PPA is no longer maintained - update docs

### DIFF
--- a/doc/topics/installation/ubuntu.rst
+++ b/doc/topics/installation/ubuntu.rst
@@ -17,7 +17,7 @@ Instructions are at https://repo.saltstack.com/#ubuntu.
 Installation from the Community-Maintained Repository
 =====================================================
 
-The PPA is no longer maintained, and shouldn't be used, please use the Official 
+The PPA is no longer maintained, and shouldn't be used. Please use the Official 
 Salt Stack repository instead.
 
 Install Packages

--- a/doc/topics/installation/ubuntu.rst
+++ b/doc/topics/installation/ubuntu.rst
@@ -17,59 +17,8 @@ Instructions are at https://repo.saltstack.com/#ubuntu.
 Installation from the Community-Maintained Repository
 =====================================================
 
-Packages for Ubuntu are also published in the saltstack PPA. If you have
-the ``add-apt-repository`` utility, you can add the repository and import the
-key in one step:
-
-.. code-block:: bash
-
-    sudo add-apt-repository ppa:saltstack/salt
-
-In addition to the main repository, there are secondary repositories for each
-individual major release. These repositories receive security and point
-releases but will not upgrade to any subsequent major release.  There are
-currently several available repos: salt16, salt17, salt2014-1, salt2014-7,
-salt2015-5. For example to follow 2015.5.x releases:
-
-.. code-block:: bash
-
-    sudo add-apt-repository ppa:saltstack/salt2015-5
-
-.. admonition:: add-apt-repository: command not found?
-
-    The ``add-apt-repository`` command is not always present on Ubuntu systems.
-    This can be fixed by installing `python-software-properties`:
-
-    .. code-block:: bash
-
-        sudo apt-get install python-software-properties
-
-    The following may be required as well:
-
-    .. code-block:: bash
-
-        sudo apt-get install software-properties-common
-
-    Note that since Ubuntu 12.10 (Raring Ringtail), ``add-apt-repository`` is
-    found in the `software-properties-common` package, and is part of the base
-    install. Thus, ``add-apt-repository`` should be able to be used
-    out-of-the-box to add the PPA.
-
-Alternately, manually add the repository and import the PPA key with these
-commands:
-
-.. code-block:: bash
-
-    echo deb http://ppa.launchpad.net/saltstack/salt/ubuntu `lsb_release -sc` main | sudo tee /etc/apt/sources.list.d/saltstack.list
-    wget -q -O- "http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0x4759FA960E27C0A6" | sudo apt-key add -
-
-After adding the repository, update the package management database:
-
-.. code-block:: bash
-
-    sudo apt-get update
-
-.. _ubuntu-install-pkgs:
+The PPA is no longer maintained, and shouldn't be used, please use the Official 
+Salt Stack repository instead.
 
 Install Packages
 ================


### PR DESCRIPTION
### What does this PR do?

Corrects the confusion in the docs that arise from mentioning the PPA, which is no longer maintained

### What issues does this PR fix or reference?

Documentation

### Tests written?

No