### PR TITLE
refresh_pillar() should be called always with refresh=True during saltutil.sync_all

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -636,8 +636,7 @@ def sync_all(saltenv=None, refresh=True):
         ret['pillar'] = sync_pillar(saltenv, False)
     if refresh:
         refresh_modules()
-        if __opts__['file_client'] == 'local':
-            refresh_pillar()
+        refresh_pillar()
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?
After merging #25361 and #33833 it looks like the latter changes have overwritten the former and now pillar is refreshed only while running in masterless mode.
This PR aims to restore the behavior specified in #25297
### Tests written?

No
