### PR TITLE
Remove loop from dsc.apply_config

### DIFF
--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -439,7 +439,7 @@ def apply_config(path, source=None, salt_env='base'):
     if ret is False:
         raise CommandExecutionError('Apply Config Failed: {0}'.format(path))
 
-    cmd = '$status = Get-DscConfigurationStatus; $status.Status'.format(config)
+    cmd = '$status = Get-DscConfigurationStatus; $status.Status'
     ret = _pshell(cmd)
     log.info('DSC Apply Config: {0}'.format(ret))
 

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -401,6 +401,9 @@ def apply_config(path, source=None, salt_env='base'):
         salt '*' dsc.run_config C:\\DSC\\WebSiteConfiguration salt://dsc/configs/WebSiteConfiguration
 
     '''
+    # If you're getting an error along the lines of "The client cannot connect
+    # to the destination specified in the request.", try the following:
+    # Enable-PSRemoting -SkipNetworkProfileCheck
     config = path
     if source:
         # Make sure the folder names match
@@ -430,16 +433,17 @@ def apply_config(path, source=None, salt_env='base'):
 
     # Run the DSC Configuration
     # Putting quotes around the parameter protects against command injection
-    cmd = '$job = Start-DscConfiguration -Path "{0}"; '.format(config)
-    cmd += 'Do{ } While ($job.State -notin \'Completed\', \'Failed\'); ' \
-           'return $job.State'
+    cmd = 'Start-DscConfiguration -Path "{0}" -Wait -Force'.format(config)
+    ret = _pshell(cmd)
+
+    if ret is False:
+        raise CommandExecutionError('Apply Config Failed: {0}'.format(path))
+
+    cmd = '$status = Get-DscConfigurationStatus; $status.Status'.format(config)
     ret = _pshell(cmd)
     log.info('DSC Apply Config: {0}'.format(ret))
 
-    if ret == 'Completed':
-        return True
-    else:
-        return False
+    return ret == 'Success'
 
 
 def get_config():
@@ -475,10 +479,7 @@ def test_config():
     '''
     cmd = 'Test-DscConfiguration *>&1'
     ret = _pshell(cmd)
-    if ret == 'True':
-        return True
-    else:
-        return False
+    return ret == 'True'
 
 
 def get_config_status():


### PR DESCRIPTION
### What does this PR do?
Removes the job loop from the apply_config function. It was hanging if no .mof files existed in the target directory.

### What issues does this PR fix or reference?
#35799 

### Previous Behavior
The function would get stuck in an endless loop if no .mof file existed in the directory.

### New Behavior
Run the command and check the application status instead of looping until success or failure. If there is any error, such as no .mof file, a CommandExecutionError will be raised.

### Tests written?
No