### PR TITLE
Add syndic_id=None kwarg to save_minions funcs in returners

### DIFF
--- a/salt/returners/cassandra_cql_return.py
+++ b/salt/returners/cassandra_cql_return.py
@@ -304,7 +304,7 @@ def save_load(jid, load, minions=None):
         raise
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -367,7 +367,7 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -150,7 +150,7 @@ def save_load(jid, load, minions=None):
     )
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/influxdb_return.py
+++ b/salt/returners/influxdb_return.py
@@ -158,7 +158,7 @@ def save_load(jid, load, minions=None):
         log.critical('Failed to store load with InfluxDB returner: {0}'.format(ex))
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -163,7 +163,7 @@ def save_load(jid, load, minions=None):
     _append_list(serv, 'jids', jid)
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -211,7 +211,7 @@ def save_load(jid, load, minions=None):
         mdb.jobs.insert(load.copy())
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -234,7 +234,7 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/multi_returner.py
+++ b/salt/returners/multi_returner.py
@@ -69,7 +69,7 @@ def save_load(jid, clear_load, minions=None):
         _mminion().returners['{0}.save_load'.format(returner_)](jid, clear_load)
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -311,7 +311,7 @@ def save_load(jid, load, minions=None):
             pass
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/odbc.py
+++ b/salt/returners/odbc.py
@@ -226,7 +226,7 @@ def save_load(jid, load, minions=None):
     _close_conn(conn)
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -291,7 +291,7 @@ def save_load(jid, load, minions=None):
             pass
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -208,7 +208,7 @@ def save_load(jid, load, minions=None):
     _close_conn(conn)
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -304,7 +304,7 @@ def save_load(jid, clear_load, minions=None):
     _close_conn(conn)
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -128,7 +128,7 @@ def save_load(jid, load, minions=None):
     serv.setex('load:{0}'.format(jid), json.dumps(load), _get_ttl())
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -193,7 +193,7 @@ def save_load(jid, load, minions=None):
     _close_conn(conn)
 
 
-def save_minions(jid, minions):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Included for API consistency
     '''


### PR DESCRIPTION
### What does this PR do?
Cleans up stack traces when a returner is used that has the `save_minions` function, but is missing the `syndic_id` kwarg. This PR adds this kwarg to functions that are only available for API consistency, but currently don't perform any functionality.

### What issues does this PR fix or reference?
Fixes #35016

### Previous Behavior
If the `save_minions` func is called on a returner that doesn't have the `syndic_id` kwarg, a stacktrace will occur:
```
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/salt/master.py", line 1540, in run_func
    ret = getattr(self, func)(load)
  File "/usr/lib/python2.6/site-packages/salt/master.py", line 1308, in _minion_event
    self._handle_minion_event(load)
  File "/usr/lib/python2.6/site-packages/salt/master.py", line 1334, in _handle_minion_event
    syndic_id=id_)
  File "/usr/lib/python2.6/site-packages/salt/utils/job.py", line 114, in store_minions
    mminion.returners[minions_fstr](jid, minions, syndic_id=syndic_id)
TypeError: save_minions() got an unexpected keyword argument 'syndic_id'
```

### New Behavior
No more stack traces.

Since all of the `save_minions` funcs changed here are implemented strictly for API consistency anyway, adding this kwarg just helps clean up some stacktraces without changing any functionality.

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.