### PR TITLE
[PY3] Change log.warn statements to log.warning

### DIFF
--- a/salt/beacons/inotify.py
+++ b/salt/beacons/inotify.py
@@ -218,7 +218,7 @@ def beacon(config):
                                 if re.search(exclude.keys()[0], event.pathname):
                                     _append = False
                             except Exception:
-                                log.warn('Failed to compile regex: {0}'.format(exclude.keys()[0]))
+                                log.warning('Failed to compile regex: {0}'.format(exclude.keys()[0]))
                         else:
                             exclude = exclude.keys()[0]
                     elif '*' in exclude:

--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -76,7 +76,7 @@ def updated(bank, key):
     '''
     key_file = os.path.join(__opts__['cachedir'], os.path.normpath(bank), '{0}.p'.format(key))
     if not os.path.isfile(key_file):
-        log.warn('Cache file "%s" does not exist', key_file)
+        log.warning('Cache file "%s" does not exist', key_file)
         return None
     try:
         return int(os.path.getmtime(key_file))

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -218,7 +218,7 @@ def _cache(bank, key, fun, **kwargs):
         try:
             item_list = fun(**kwargs)
         except CloudError as exc:
-            log.warn('There was a cloud error calling {0} with kwargs {1}: {2}'.format(fun, kwargs, exc))
+            log.warning('There was a cloud error calling {0} with kwargs {1}: {2}'.format(fun, kwargs, exc))
         for item in item_list:
             items[item.name] = object_to_dict(item)
         cache.store(bank, key, items)
@@ -1024,8 +1024,8 @@ def request_instance(call=None, kwargs=None):  # pylint: disable=unused-argument
     try:
         poller.wait()
     except CloudError as exc:
-        log.warn('There was a cloud error: {0}'.format(exc))
-        log.warn('This may or may not indicate an actual problem')
+        log.warning('There was a cloud error: {0}'.format(exc))
+        log.warning('This may or may not indicate an actual problem')
 
     try:
         return show_instance(vm_['name'], call='action')
@@ -1100,7 +1100,7 @@ def create(vm_):
         )
     except (SaltCloudExecutionTimeout, SaltCloudExecutionFailure, SaltCloudSystemExit) as exc:
         try:
-            log.warn(exc)
+            log.warning(exc)
         finally:
             raise SaltCloudSystemExit(str(exc))
 

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -404,7 +404,7 @@ def show_instance(name, call=None):
     try:
         __utils__['cloud.cache_node'](nodes[name], __active_provider_name__, __opts__)
     except TypeError:
-        log.warn('Unable to show cache node data; this may be because the node has been deleted')
+        log.warning('Unable to show cache node data; this may be because the node has been deleted')
     return nodes[name]
 
 

--- a/salt/modules/boto_elasticsearch_domain.py
+++ b/salt/modules/boto_elasticsearch_domain.py
@@ -460,7 +460,7 @@ def list_tags(DomainName=None, ARN=None,
             raise SaltInvocationError('One (but not both) of ARN or '
                          'domain must be specified.')
         ret = conn.list_tags(ARN=ARN)
-        log.warn(ret)
+        log.warning(ret)
         tlist = ret.get('TagList', [])
         tagdict = {}
         for tag in tlist:

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -2616,7 +2616,7 @@ def _maybe_set_dns(conn, vpcid, dns_support, dns_hostnames):
 def _maybe_name_route_table(conn, vpcid, vpc_name):
     route_tables = conn.get_all_route_tables(filters={'vpc_id': vpcid})
     if not route_tables:
-        log.warn('no default route table found')
+        log.warning('no default route table found')
         return
     default_table = None
     for table in route_tables:
@@ -2625,7 +2625,7 @@ def _maybe_name_route_table(conn, vpcid, vpc_name):
                 default_table = table
                 break
     if not default_table:
-        log.warn('no default route table found')
+        log.warning('no default route table found')
         return
 
     name = '{0}-default-table'.format(vpc_name)

--- a/salt/modules/k8s.py
+++ b/salt/modules/k8s.py
@@ -535,7 +535,7 @@ def _is_valid_secret_file(filename):
     if os.path.exists(filename) and os.path.isfile(filename):
         log.debug("File: {0} is valid secret file".format(filename))
         return True
-    log.warn("File: {0} does not exists or not file".format(filename))
+    log.warning("File: {0} does not exists or not file".format(filename))
     return False
 
 
@@ -607,7 +607,7 @@ def _source_encode(source, saltenv):
             # The source is a file on a server
             filename = __salt__['cp.cache_file'](source, saltenv)
             if not filename:
-                log.warn("Source file: {0} can not be retrieved".format(source))
+                log.warning("Source file: {0} can not be retrieved".format(source))
                 return "", ""
             return os.path.basename(filename), _file_encode(filename)
     return "", ""

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -149,7 +149,7 @@ def delete(name, remove=False, force=False):
 
     # force is added for compatibility with user.absent state function
     if force:
-        log.warn('force option is unsupported on MacOS, ignoring')
+        log.warning('force option is unsupported on MacOS, ignoring')
 
     # remove home directory from filesystem
     if remove:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1163,7 +1163,7 @@ def upgrade(refresh=True,
                 cmd_update.append('--no-allow-vendor-change')
                 log.info('Disabling vendor changes')
             else:
-                log.warn('Disabling vendor changes is not supported on this Zypper version')
+                log.warning('Disabling vendor changes is not supported on this Zypper version')
 
         if dryrun:
             # Creates a solver test case for debugging.

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -776,8 +776,8 @@ def bootstrap(version='develop',
             salt.client.ssh.SSH(client_opts).run()
         except SaltSystemExit as exc:
             if 'No hosts found with target' in str(exc):
-                log.warn('The host {0} was not found in the Salt SSH roster '
-                         'system. Attempting to log in without Salt SSH.')
+                log.warning('The host {0} was not found in the Salt SSH roster '
+                            'system. Attempting to log in without Salt SSH.')
                 salt.utils.warn_until('Oxygen', dep_warning)
                 ret = subprocess.call([
                     'ssh',

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -121,7 +121,7 @@ def _generate_minion_id():
                 if len(a_nfo) > 3:
                     hosts.append(a_nfo[3])
         except socket.gaierror:
-            log.warn('Cannot resolve address {addr} info via socket: {message}'.format(
+            log.warning('Cannot resolve address {addr} info via socket: {message}'.format(
                 addr=hosts.first(), message=socket.gaierror)
             )
     # Universal method for everywhere (Linux, Slowlaris, Windows etc)

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -519,7 +519,7 @@ def verify_log(opts):
     level = LOG_LEVELS.get(opts.get('log_level').lower(), logging.NOTSET)
 
     if level < logging.INFO:
-        log.warn('Insecure logging configuration detected! Sensitive data may be logged.')
+        log.warning('Insecure logging configuration detected! Sensitive data may be logged.')
 
 
 def win_verify_env(dirs, user, permissive=False, pki_dir='', skip_extra=False):

--- a/salt/utils/virtualbox.py
+++ b/salt/utils/virtualbox.py
@@ -514,7 +514,7 @@ def vb_xpcom_to_attribute_dict(xpcom,
         m = re.search(r"XPCOM.+implementing {0}".format(interface_name), str(xpcom))
         if not m:
             # TODO maybe raise error here?
-            log.warn("Interface %s is unknown and cannot be converted to dict", interface_name)
+            log.warning("Interface %s is unknown and cannot be converted to dict", interface_name)
             return dict()
 
     interface_attributes = set(attributes or XPCOM_ATTRIBUTES.get(interface_name, []))

--- a/tests/integration/cloud/providers/virtualbox.py
+++ b/tests/integration/cloud/providers/virtualbox.py
@@ -283,7 +283,7 @@ class VirtualboxProviderHeavyTests(VirtualboxCloudTestCase):
                 vb_stop_vm(INSTANCE_NAME)
                 vb_destroy_machine(INSTANCE_NAME)
             except Exception as e:
-                log.warn("Possibly dirty state after exception", exc_info=True)
+                log.warning("Possibly dirty state after exception", exc_info=True)
 
     def test_deploy(self):
         machines = self.run_cloud('-p {0} {1} --log-level=debug'.format(DEPLOY_PROFILE_NAME, INSTANCE_NAME))

--- a/tests/unit/modules/boto_elasticsearch_domain_test.py
+++ b/tests/unit/modules/boto_elasticsearch_domain_test.py
@@ -187,7 +187,7 @@ class BotoElasticsearchDomainTestCase(BotoElasticsearchDomainTestCaseBase, BotoE
 
         result = boto_elasticsearch_domain.describe(DomainName=domain_ret['DomainName'], **conn_parameters)
 
-        log.warn(result)
+        log.warning(result)
         desired_ret = copy.copy(domain_ret)
         desired_ret.pop('DomainName')
         self.assertEqual(result, {'domain': desired_ret})

--- a/tests/unit/states/boto_iot_test.py
+++ b/tests/unit/states/boto_iot_test.py
@@ -363,7 +363,7 @@ class BotoIoTPolicyTestCase(BotoIoTStateTestCaseBase, BotoIoTTestCaseMixin):
         self.conn.list_principal_policies.return_value = {'policies': [policy_ret]}
         result = salt_states['boto_iot.policy_detached']('test', policy_ret['policyName'], principal)
         self.assertTrue(result['result'])
-        log.warn(result)
+        log.warning(result)
         self.assertFalse(result['changes']['new']['attached'])
 
     def test_detached_when_policy_detached(self):

--- a/tests/unit/utils/verify_test.py
+++ b/tests/unit/utils/verify_test.py
@@ -230,17 +230,17 @@ class TestVerify(TestCase):
         message = 'Insecure logging configuration detected! Sensitive data may be logged.'
 
         mock_cheese = MagicMock()
-        with patch.object(log, 'warn', mock_cheese):
+        with patch.object(log, 'warning', mock_cheese):
             verify_log({'log_level': 'cheeseshop'})
             mock_cheese.assert_called_once_with(message)
 
         mock_trace = MagicMock()
-        with patch.object(log, 'warn', mock_trace):
+        with patch.object(log, 'warning', mock_trace):
             verify_log({'log_level': 'trace'})
             mock_trace.assert_called_once_with(message)
 
         mock_info = MagicMock()
-        with patch.object(log, 'warn', mock_info):
+        with patch.object(log, 'warning', mock_info):
             verify_log({'log_level': 'info'})
             mock_info.assert_not_called()
 


### PR DESCRIPTION
`log.warn` is deprecated in Python 3. This change removes the occurrence of deprecation warnings for using `log.warn`. For example:

```
17:24:23 [WARNING ] /testing/salt/utils/verify.py:522: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
17:24:23   log.warn('Insecure logging configuration detected! Sensitive data may be logged.')
17:24:23
17:24:23 [WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
```