### PR TITLE
Backend config: Propagate usage, deprecate requests_lib

### DIFF
--- a/doc/topics/cloud/azure.rst
+++ b/doc/topics/cloud/azure.rst
@@ -710,7 +710,7 @@ set in the master's configuration file:
 
 .. code-block:: bash
 
-    requests_lib: True
+    backend: requests
 
 The following functions are available.
 

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -14,7 +14,7 @@ The Azure cloud module is used to control access to Microsoft Azure
     * ``apikey``
     * ``certificate_path``
     * ``subscription_id``
-    * ``requests_lib``
+    * ``backend``
 
     A Management Certificate (.pem and .crt files) must be created and the .pem
     file placed on the same machine that salt-cloud is run from. Information on
@@ -23,7 +23,7 @@ The Azure cloud module is used to control access to Microsoft Azure
 
     http://www.windowsazure.com/en-us/develop/python/how-to-guides/service-management/
 
-    For users with Python < 2.7.9, requests_lib must currently be set to True.
+    For users with Python < 2.7.9, ``backend`` must currently be set to ``requests``.
 
 Example ``/etc/salt/cloud.providers`` or
 ``/etc/salt/cloud.providers.d/azure.conf`` configuration:
@@ -3398,6 +3398,14 @@ def query(path, method='GET', data=None, params=None, header_dict=None, decode=T
         'requests_lib',
         get_configured_provider(), __opts__, search_global=False
     )
+    if requests_lib is not None:
+        salt.utils.warn_until('Oxygen', '"requests_lib:True" has been replaced by "backend:requests", '
+                                        'please change your config')
+
+    backend = config.get_cloud_config_value(
+        'backend',
+        get_configured_provider(), __opts__, search_global=False
+    )
     url = 'https://{management_host}/{subscription_id}/{path}'.format(
         management_host=management_host,
         subscription_id=subscription_id,
@@ -3419,6 +3427,7 @@ def query(path, method='GET', data=None, params=None, header_dict=None, decode=T
         text=True,
         cert=certificate_path,
         requests_lib=requests_lib,
+        backend=backend,
         decode=decode,
         decode_type='xml',
     )

--- a/salt/sdb/rest.py
+++ b/salt/sdb/rest.py
@@ -22,7 +22,7 @@ requires very little. In the example:
         url: https://api.github.com/
       keys:
         url: https://api.github.com/users/{{user}}/keys
-        requests_lib: True
+        backend: requests
 
 The ``driver`` refers to the REST module, and must be set to ``rest`` in order
 to use this driver. Each of the other items inside this block refers to a

--- a/salt/states/stormpath_account.py
+++ b/salt/states/stormpath_account.py
@@ -9,6 +9,9 @@ Support for Stormpath.
 from __future__ import absolute_import
 import pprint
 
+# Import salt libs
+import salt.utils
+
 
 def __virtual__():
     '''
@@ -54,10 +57,18 @@ def present(name, **kwargs):
         Optional. Must be specified as a dict.
     '''
     # Because __opts__ is not available outside of functions
-    if __opts__.get('requests_lib', False):
+    backend = __opts__.get('backend', False)
+    if not backend and __opts__.get('requests_lib', False):
+        salt.utils.warn_until('Oxygen', '"requests_lib:True" has been replaced by "backend:requests", '
+                                            'please change your config')
+        backend = 'requests'
+
+    if backend == 'requests':
         from requests.exceptions import HTTPError
-    else:
+    elif backend == 'urrlib2':
         from urllib2 import HTTPError
+    else:
+        from tornado.httpclient import HTTPError
 
     ret = {'name': name,
            'changes': {},
@@ -136,10 +147,18 @@ def absent(name, directory_id=None):
         performance of this state.
     '''
     # Because __opts__ is not available outside of functions
-    if __opts__.get('requests_lib', False):
+    backend = __opts__.get('backend', False)
+    if not backend and __opts__.get('requests_lib', False):
+        salt.utils.warn_until('Oxygen', '"requests_lib:True" has been replaced by "backend:requests", '
+                                            'please change your config')
+        backend = 'requests'
+
+    if backend == 'requests':
         from requests.exceptions import HTTPError
-    else:
+    elif backend == 'urrlib2':
         from urllib2 import HTTPError
+    else:
+        from tornado.httpclient import HTTPError
 
     ret = {'name': name,
            'changes': {},

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -157,7 +157,7 @@ def query(url,
             salt.utils.warn_until('Nitrogen', '"requests_lib:True" has been replaced by "backend:requests"')
             if 'backend' in opts:
                 backend = opts['backend']
-            elif requests_lib or opts.get('request_lib', False):
+            elif requests_lib or opts.get('requests_lib', False):
                 backend = 'requests'
             else:
                 backend = 'tornado'

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -154,7 +154,9 @@ def query(url,
 
     if not backend:
         if requests_lib is not None or 'requests_lib' in opts:
-            salt.utils.warn_until('Nitrogen', '"requests_lib:True" has been replaced by "backend:requests"')
+            salt.utils.warn_until('Oxygen', '"requests_lib:True" has been replaced by "backend:requests", '
+                                            'please change your config')
+            # beware the named arg above
             if 'backend' in opts:
                 backend = opts['backend']
             elif requests_lib or opts.get('requests_lib', False):


### PR DESCRIPTION
### What does this PR do?
After testing #37524 revealed a few documentation and components still referencing the `requests_lib` setting. 

* Adjusted documentation
* Fixed Cloud Azure (but is the reference there still relevant in the Tornado world?) 
* Fixed StormPath Account state (also for Tornado apparently, but it's not nice what's in there considering the idea behind a setting like `backend`)

### What issues does this PR fix or reference?
Follow-up on saltstack/salt#37524