### PR TITLE
Additional unit tests

### DIFF
--- a/tests/unit/target_test.py
+++ b/tests/unit/target_test.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email: `Mike Place <mp@saltstack.com>`
+
+    tests.unit.target_test
+    ~~~~~~~~~~~~~~~~~~~~~~
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+import sys
+
+# Import Salt libs
+import salt.utils.minions
+import salt.config
+
+# Import Salt Testing libs
+from salttesting import TestCase, skipIf
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class CkMinionTestCase(TestCase):
+
+    def setUp(self):
+        self.ck_ = salt.utils.minions.CkMinions(salt.config.DEFAULT_MASTER_OPTS)
+
+    def tearDown(self):
+        self.ck_ = None
+
+    #TODO This is just a stub for upcoming tests
+
+
+@skipIf(sys.version_info < (2, 7), 'Python 2.7 needed for dictionary equality assertions')
+class TargetParseTestCase(TestCase):
+
+    def test_parse_grains_target(self):
+        '''
+        Ensure proper parsing for grains
+        '''
+        g_tgt = 'G@a:b'
+        ret = salt.utils.minions.parse_target(g_tgt)
+        self.assertDictEqual(ret, {'engine': 'G', 'pattern': 'a:b', 'delimiter': None})
+
+    def test_parse_grains_pcre_target(self):
+        '''
+        Ensure proper parsing for grains PCRE matching
+        '''
+        p_tgt = 'P@a:b'
+        ret = salt.utils.minions.parse_target(p_tgt)
+        self.assertDictEqual(ret, {'engine': 'P', 'pattern': 'a:b', 'delimiter': None})
+
+    def test_parse_pillar_pcre_target(self):
+        '''
+        Ensure proper parsing for pillar PCRE matching
+        '''
+        j_tgt = 'J@a:b'
+        ret = salt.utils.minions.parse_target(j_tgt)
+        self.assertDictEqual(ret, {'engine': 'J', 'pattern': 'a:b', 'delimiter': None})
+
+    def test_parse_list_target(self):
+        '''
+        Ensure proper parsing for list matching
+        '''
+        l_tgt = 'L@a:b'
+        ret = salt.utils.minions.parse_target(l_tgt)
+        self.assertDictEqual(ret, {'engine': 'L', 'pattern': 'a:b', 'delimiter': None})
+
+    def test_parse_nodegroup_target(self):
+        '''
+        Ensure proper parsing for pillar matching
+        '''
+        n_tgt = 'N@a:b'
+        ret = salt.utils.minions.parse_target(n_tgt)
+        self.assertDictEqual(ret, {'engine': 'N', 'pattern': 'a:b', 'delimiter': None})
+
+    def test_parse_subnet_target(self):
+        '''
+        Ensure proper parsing for subnet matching
+        '''
+        s_tgt = 'S@a:b'
+        ret = salt.utils.minions.parse_target(s_tgt)
+        self.assertDictEqual(ret, {'engine': 'S', 'pattern': 'a:b', 'delimiter': None})
+
+    def test_parse_minion_pcre_target(self):
+        '''
+        Ensure proper parsing for minion PCRE matching
+        '''
+        e_tgt = 'E@a:b'
+        ret = salt.utils.minions.parse_target(e_tgt)
+        self.assertDictEqual(ret, {'engine': 'E', 'pattern': 'a:b', 'delimiter': None})
+
+    def test_parse_range_target(self):
+        '''
+        Ensure proper parsing for range matching
+        '''
+        r_tgt = 'R@a:b'
+        ret = salt.utils.minions.parse_target(r_tgt)
+        self.assertDictEqual(ret, {'engine': 'R', 'pattern': 'a:b', 'delimiter': None})
+
+    def test_parse_multiword_target(self):
+        '''
+        Ensure proper parsing for multi-word targets
+
+        Refs https://github.com/saltstack/salt/issues/37231
+        '''
+        mw_tgt = 'G@a:b c'
+        ret = salt.utils.minions.parse_target(mw_tgt)
+        self.assertEqual(ret['pattern'], 'a:b c')
+
+
+class NodegroupCompTest(TestCase):
+    '''
+    Test nodegroup comparisons found in
+    salt.utils.minions.nodgroup_comp()
+    '''
+
+    def test_simple_nodegroup(self):
+        '''
+        Smoke test a very simple nodegroup. No recursion.
+        '''
+        simple_nodegroup = {'group1': 'L@foo.domain.com,bar.domain.com,baz.domain.com or bl*.domain.com'}
+
+        ret = salt.utils.minions.nodegroup_comp('group1', simple_nodegroup)
+        expected_ret = ['L@foo.domain.com,bar.domain.com,baz.domain.com', 'or', 'bl*.domain.com']
+        self.assertListEqual(ret, expected_ret)
+
+    def test_simple_recurse(self):
+        '''
+        Test a case where one nodegroup contains a second nodegroup
+        '''
+        referenced_nodegroups = {
+                'group1': 'L@foo.domain.com,bar.domain.com,baz.domain.com or bl*.domain.com',
+                'group2': 'G@os:Debian and N@group1'
+                }
+
+        ret = salt.utils.minions.nodegroup_comp('group2', referenced_nodegroups)
+        expected_ret = [
+                '(',
+                'G@os:Debian',
+                'and',
+                '(',
+                'L@foo.domain.com,bar.domain.com,baz.domain.com',
+                'or',
+                'bl*.domain.com',
+                ')',
+                ')'
+                ]
+        self.assertListEqual(ret, expected_ret)
+
+    def test_circular_nodegroup_reference(self):
+        '''
+        Test to see what happens if A refers to B
+        and B in turn refers back to A
+        '''
+        referenced_nodegroups = {
+                'group1': 'N@group2',
+                'group2': 'N@group1'
+                }
+
+        # If this works, it should also print an error to the console
+        ret = salt.utils.minions.nodegroup_comp('group1', referenced_nodegroups)
+        self.assertEqual(ret, [])

--- a/tests/unit/utils/cache_mods/cache_mod.py
+++ b/tests/unit/utils/cache_mods/cache_mod.py
@@ -1,0 +1,18 @@
+import salt.utils.cache
+
+'''
+This is a module used in
+unit.utils.cache to test
+the context wrapper functions.
+'''
+
+def __virtual__():
+    return True
+
+@salt.utils.cache.context_cache
+def test_context_module():
+    if 'called' in __context__:
+        __context__['called'] += 1
+    else:
+        __context__['called'] = 0
+    return __context__

--- a/tests/unit/utils/cache_test.py
+++ b/tests/unit/utils/cache_test.py
@@ -8,7 +8,10 @@
 
 # Import python libs
 from __future__ import absolute_import
+import os
 import time
+import tempfile
+import shutil
 
 # Import Salt Testing libs
 from salttesting import TestCase
@@ -16,6 +19,8 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import salt libs
+import salt.config
+import salt.loader
 from salt.utils import cache
 
 
@@ -45,6 +50,52 @@ class CacheDictTestCase(TestCase):
 
         # make sure that a get would get a regular old key error
         self.assertRaises(KeyError, cd.__getitem__, 'foo')
+
+class CacheContextTestCase(TestCase):
+
+    def setUp(self):
+        context_dir = os.path.join(tempfile.gettempdir(), 'context') 
+        if os.path.exists(context_dir):
+            shutil.rmtree(os.path.join(tempfile.gettempdir(), 'context'))
+
+    def test_smoke_context(self):
+        '''
+        Smoke test the context cache
+        '''
+        if os.path.exists(os.path.join(tempfile.gettempdir(), 'context')):
+                self.skipTest('Context dir already exists')
+        else:
+            opts = salt.config.DEFAULT_MINION_OPTS
+            opts['cachedir'] = tempfile.gettempdir()
+            context_cache = cache.ContextCache(opts, 'cache_test')
+
+            context_cache.cache_context({'a': 'b'})
+
+            ret = context_cache.get_cache_context()
+
+            self.assertDictEqual({'a': 'b'}, ret)
+
+
+    def test_context_wrapper(self):
+        '''
+        Test to ensure that a module which decorates itself
+        with a context cache can store and retreive its contextual
+        data
+        '''
+        opts = salt.config.DEFAULT_MINION_OPTS
+        opts['cachedir'] = tempfile.gettempdir()
+
+        ll_ = salt.loader.LazyLoader(
+                [os.path.join(os.path.dirname(os.path.realpath(__file__)), 'cache_mods')],
+                tag='rawmodule',
+                virtual_enable=False,
+                opts=opts)
+
+        cache_test_func = ll_['cache_mod.test_context_module']
+
+        self.assertEqual(cache_test_func()['called'], 0)
+        self.assertEqual(cache_test_func()['called'], 1)
+
 
 
 if __name__ == '__main__':

--- a/tests/unit/utils/cache_test.py
+++ b/tests/unit/utils/cache_test.py
@@ -51,10 +51,11 @@ class CacheDictTestCase(TestCase):
         # make sure that a get would get a regular old key error
         self.assertRaises(KeyError, cd.__getitem__, 'foo')
 
+
 class CacheContextTestCase(TestCase):
 
     def setUp(self):
-        context_dir = os.path.join(tempfile.gettempdir(), 'context') 
+        context_dir = os.path.join(tempfile.gettempdir(), 'context')
         if os.path.exists(context_dir):
             shutil.rmtree(os.path.join(tempfile.gettempdir(), 'context'))
 
@@ -63,7 +64,7 @@ class CacheContextTestCase(TestCase):
         Smoke test the context cache
         '''
         if os.path.exists(os.path.join(tempfile.gettempdir(), 'context')):
-                self.skipTest('Context dir already exists')
+            self.skipTest('Context dir already exists')
         else:
             opts = salt.config.DEFAULT_MINION_OPTS
             opts['cachedir'] = tempfile.gettempdir()
@@ -74,7 +75,6 @@ class CacheContextTestCase(TestCase):
             ret = context_cache.get_cache_context()
 
             self.assertDictEqual({'a': 'b'}, ret)
-
 
     def test_context_wrapper(self):
         '''
@@ -95,7 +95,6 @@ class CacheContextTestCase(TestCase):
 
         self.assertEqual(cache_test_func()['called'], 0)
         self.assertEqual(cache_test_func()['called'], 1)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Although there are already extensive integration tests for the targeting code, this begins work on unit testing the same area. Because this code can take such a wide range of input, I think it's much easier to do in-depth testing here without having to involve running daemons. This also lays the groundwork for TDD on #37231.

Also added testing for the context cache, which I'd like to start using more in execution modules but needs tests and documentation before it's fully ready to go. This is mostly scratching a long-standing itch. ;]