### PR TITLE
[potential bugfix] salt-cloud vmware driver: more specific matching of object id

### DIFF
--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -715,7 +715,8 @@ def get_mor_by_property(service_instance, object_type, property_value, property_
     object_list = get_mors_with_properties(service_instance, object_type, property_list=[property_name], container_ref=container_ref)
 
     for obj in object_list:
-        if obj[property_name] == property_value or property_value in str(obj.get('object', '')):
+        obj_id = str(obj.get('object', '')).strip('\'"')
+        if obj[property_name] == property_value or property_value == obj_id:
             return obj['object']
 
     return None


### PR DESCRIPTION
### What does this PR do?

Fixes a potential issue that can occur when matching folders/resourcepools by object id instead of name.

The issue is, if the object id is partially matched, it will obtain the wrong object id.
Example: `'vim.ResourcePool:resgroup-v1' in '\'vim.ResourcePool:resgroup-v12345\'" == True`,

This PR makes the match more specific by doing a comparison of equality rather than membership.

The vmware object id needs to be explicitly converted to a string to avoid invoking custom pyvmomi dunder methods (`__eq__`) on the string on the right side of the comparison operator.

Since it is explicitly converted to a string, there are some leftover quotation marks that we need to strip out. I've moved this operation to above the comparison for neatness.

### What issues does this PR fix or reference?

PR #37505

### Previous Behavior
Do a `str in str` check for the object id

### New Behavior
Strip quotation marks from the object id
Do a `str == str` check for the object id

### Tests written?

No
