### PR TITLE
Added prefix to tempfile for template

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -189,7 +189,7 @@ def wrap_tmpl_func(render_str):
         else:
             if to_str:  # then render as string
                 return dict(result=True, data=output)
-            with tempfile.NamedTemporaryFile('wb', delete=False) as outf:
+            with tempfile.NamedTemporaryFile('wb', delete=False, prefix=salt.utils.files.TEMPFILE_PREFIX) as outf:
                 outf.write(SLS_ENCODER(output)[0])
                 # Note: If nothing is replaced or added by the rendering
                 #       function, then the contents of the output file will


### PR DESCRIPTION
### What issue does this pull request address
#37541

### What does this PR do?
Add prefix to the creation of tempfiles when rendering templates so that they get cleaned by __clean_tmp() and no longer fill up /tmp with each salt run.

### Tests written?
None, but obviously there are tests needed for this.