### PR TITLE
Use 'driver' instead of 'provider' in test cloud configs

### DIFF
--- a/tests/integration/files/conf/cloud.providers.d/azure.conf
+++ b/tests/integration/files/conf/cloud.providers.d/azure.conf
@@ -1,5 +1,5 @@
 azure-config:
-  provider: azure
+  driver: azure
   subscription_id: ''
   certificate_path: ''
   cleanup_disks: True

--- a/tests/integration/files/conf/cloud.providers.d/digital_ocean.conf
+++ b/tests/integration/files/conf/cloud.providers.d/digital_ocean.conf
@@ -1,5 +1,5 @@
 digitalocean-config:
-  provider: digital_ocean
+  driver: digital_ocean
   personal_access_token: ''
   ssh_key_file: ''
   ssh_key_name: ''

--- a/tests/integration/files/conf/cloud.providers.d/ec2.conf
+++ b/tests/integration/files/conf/cloud.providers.d/ec2.conf
@@ -1,5 +1,5 @@
 ec2-config:
-  provider: ec2
+  driver: ec2
   id: ''
   key: ''
   keyname: ''

--- a/tests/integration/files/conf/cloud.providers.d/gce.conf
+++ b/tests/integration/files/conf/cloud.providers.d/gce.conf
@@ -1,5 +1,5 @@
 gce-config:
-  provider: gce
+  driver: gce
   project: ''
   service_account_email_address: ''
   service_account_private_key: ''

--- a/tests/integration/files/conf/cloud.providers.d/gogrid.conf
+++ b/tests/integration/files/conf/cloud.providers.d/gogrid.conf
@@ -1,4 +1,4 @@
 gogrid-config:
   apikey: ''
   sharedsecret: ''
-  provider: gogrid
+  driver: gogrid

--- a/tests/integration/files/conf/cloud.providers.d/joyent.conf
+++ b/tests/integration/files/conf/cloud.providers.d/joyent.conf
@@ -1,5 +1,5 @@
 joyent-config:
-  provider: joyent
+  driver: joyent
   user: ''
   password: ''
   private_key: ''

--- a/tests/integration/files/conf/cloud.providers.d/linode.conf
+++ b/tests/integration/files/conf/cloud.providers.d/linode.conf
@@ -1,4 +1,4 @@
 linode-config:
   apikey: ''
   password: ''
-  provider: linode
+  driver: linode

--- a/tests/integration/files/conf/cloud.providers.d/rackspace.conf
+++ b/tests/integration/files/conf/cloud.providers.d/rackspace.conf
@@ -6,4 +6,4 @@ rackspace-config:
   user: ''
   tenant: ''
   apikey: ''
-  provider: openstack
+  driver: openstack

--- a/tests/integration/files/conf/cloud.providers.d/vultr.conf
+++ b/tests/integration/files/conf/cloud.providers.d/vultr.conf
@@ -1,5 +1,5 @@
 vultr-config:
-  provider: vultr
+  driver: vultr
   api_key: asdfhlkasdjfklsdfj;slkdfjas;dlkj
   ssh_key_file: '/root/.ssh/vultr_test.pub'
   ssh_key_name: 'vultr_test'


### PR DESCRIPTION
### What does this PR do?

Clean up warnings (soon to be errors) when running unit and integration tests by replacing deprecated key `provider` with `driver` in provider configuration files.