### PR TITLE
Fix parameter handling for boto_rds with boto3

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -76,6 +76,51 @@ except ImportError:
     HAS_BOTO = False
 # pylint: enable=import-error
 
+boto3_param_map = {
+    'allocated_storage': ('AllocatedStorage', lambda val: int(val)),
+    'allow_major_version_upgrade': ('AllowMajorVersionUpgrade', lambda val: bool(val)),
+    'auto_minor_version_upgrade': ('AutoMinorVersionUpgrade', lambda val: bool(val)),
+    'availability_zone': ('AvailabilityZone', lambda val: str(val)),
+    'apply_immediately': ('ApplyImmediately', lambda val: bool(val)),
+    'backup_retention_period': ('BackupRetentionPeriod', lambda val: int(val)),
+    'ca_certificate_identifier': ('CACertificateIdentifier', lambda val: str(val)),
+    'character_set_name': ('CharacterSetName', lambda val: str(val)),
+    'copy_tags_to_snapshot': ('CopyTagsToSnapshot', lambda val: bool(val)),
+    'db_cluster_identifier': ('DBClusterIdentifier', lambda val: str(val)),
+    'db_instance_class': ('DBInstanceClass', lambda val: str(val)),
+    'db_name': ('DBName', lambda val: str(val)),
+    'db_parameter_group_name': ('DBParameterGroupName', lambda val: str(val)),
+    'db_port_number': ('DBPortNumber', lambda val: int(val)),
+    'db_security_groups': ('DBSecurityGroups', lambda val: list(val)),
+    'db_subnet_group_name': ('DBSubnetGroupName', lambda val: str(val)),
+    'db_cluster_identifier': ('DBClusterIdentifier', lambda val: str(val)),
+    'domain': ('Domain', lambda val: str(val)),
+    'domain_iam_role_name': ('DomainIAMRoleName', lambda val: str(val)),
+    'engine': ('Engine', lambda val: str(val)),
+    'engine_version': ('EngineVersion', lambda val: str(val)),
+    'iops': ('Iops', lambda val: int(val)),
+    'kms_key_id': ('KmsKeyId', lambda val: str(val)),
+    'license_model': ('LicenseModel', lambda val: str(val)),
+    'master_user_password': ('MasterUserPassword', lambda val: str(val)),
+    'master_username': ('MasterUsername', lambda val: str(val)),
+    'monitoring_interval': ('MonitoringInterval', lambda val: int(val)),
+    'monitoring_role_arn': ('MonitoringRoleArn', lambda val: str(val)),
+    'multi_az': ('MultiAZ', lambda val: bool(val)),
+    'name': ('DBInstanceIdentifier', lambda val: str(val)),
+    'new_db_instance_identifier': ('NewDBInstanceIdentifier', lambda val: str(val)),
+    'option_group_name': ('OptionGroupName', lambda val: str(val)),
+    'port': ('Port', lambda val: int(val)),
+    'preferred_backup_window': ('PreferredBackupWindow', lambda val: str(val)),
+    'preferred_maintenance_window': ('PreferredMaintenanceWindow', lambda val: str(val)),
+    'promotion_tier': ('PromotionTier', lambda val: int(val)),
+    'publicly_accessible': ('PubliclyAccessible', lambda val: bool(val)),
+    'storage_encrypted': ('StorageEncrypted', lambda val: bool(val)),
+    'storage_type': ('StorageType', lambda val: str(val)),
+    'taglist': ('Tags', lambda val: list(val)),
+    'tde_credential_arn': ('TdeCredentialArn', lambda val: str(val)),
+    'tde_credential_password': ('TdeCredentialPassword', lambda val: str(val)),
+    'vpc_security_group_ids': ('VpcSecurityGroupIds', lambda val: list(val)),
+}
 
 def __virtual__():
     '''
@@ -175,21 +220,21 @@ def subnet_group_exists(name, tags=None, region=None, key=None, keyid=None,
 
 
 def create(name, allocated_storage, db_instance_class, engine,
-           master_username, master_user_password, DBname=None,
-           DBSecurityGroups=None, vpc_security_group_ids=None,
+           master_username, master_user_password, db_name=None,
+           db_security_groups=None, vpc_security_group_ids=None,
            availability_zone=None, db_subnet_group_name=None,
            preferred_maintenance_window=None, db_parameter_group_name=None,
            backup_retention_period=None, preferred_backup_window=None,
-           Port=None, MultiAZ=None, EngineVersion=None,
-           AutoMinorVersionUpgrade=None, LicenseModel=None, Iops=None,
-           OptionGroupName=None, CharacterSetName=None,
-           PubliclyAccessible=None, wait_status=None, tags=None,
-           DBClusterIdentifier=None, storage_type=None,
-           TdeCredentialArn=None, TdeCredentialPassword=None,
-           StorageEncrypted=None, KmsKeyId=None, Domain=None,
-           CopyTagsToSnapshot=None, MonitoringInterval=None,
-           MonitoringRoleArn=None, DomainIAMRoleName=None, region=None,
-           PromotionTier=None, key=None, keyid=None, profile=None):
+           port=None, multi_az=None, engine_version=None,
+           auto_minor_version_upgrade=None, license_model=None, iops=None,
+           option_group_name=None, character_set_name=None,
+           publicly_accessible=None, wait_status=None, tags=None,
+           db_cluster_identifier=None, storage_type=None,
+           tde_credential_arn=None, tde_credential_password=None,
+           storage_encrypted=None, kms_key_id=None, domain=None,
+           copy_tags_to_snapshot=None, monitoring_interval=None,
+           monitoring_role_arn=None, domain_iam_role_name=None, region=None,
+           promotion_tier=None, key=None, keyid=None, profile=None):
     '''
     Create an RDS
 
@@ -222,46 +267,15 @@ def create(name, allocated_storage, db_instance_class, engine,
             return {'results': bool(conn)}
 
         kwargs = {}
-        for key in ('DomainIAMRoleName', 'LicenseModel',
-                    'TdeCredentialArn',
-                    'TdeCredentialPassword', 'DBname', 'Domain',
-                    'EngineVersion', 'OptionGroupName',
-                    'CharacterSetName', 'MonitoringRoleArn',
-                    'DBClusterIdentifier', 'KmsKeyId'):
-            if locals()[key] is not None:
-                kwargs[key] = str(locals()[key])
-
-        for key in ('MonitoringInterval', 'PromotionTier',
-                    'Iops', 'Port'):
-            if locals()[key] is not None:
-                kwargs[key] = int(locals()[key])
-
-        for key in ('CopyTagsToSnapshot', 'MultiAZ',
-                    'AutoMinorVersionUpgrade', 'StorageEncrypted',
-                    'PubliclyAccessible'):
-            if locals()[key] is not None:
-                kwargs[key] = bool(locals()[key])
-
-        if locals()['DBSecurityGroups'] is not None:
-            kwargs['DBSecurityGroups'] = list(locals()['DBSecurityGroups'])
+        boto_params = set(boto3_param_map.keys())
+        keys = set(locals().keys())
+        for key in keys.intersection(boto_params):
+            val = locals()[key]
+            if val is not None:
+                mapped = boto3_param_map[key]
+                kwargs[mapped[0]] = mapped[1](val)
 
         taglist = _tag_doc(tags)
-
-        kwargs['DBInstanceIdentifier'] = name
-        kwargs['AllocatedStorage'] = allocated_storage
-        kwargs['DBInstanceClass'] = db_instance_class
-        kwargs['Engine'] = engine
-        kwargs['MasterUsername'] = master_username
-        kwargs['MasterUserPassword'] = master_user_password
-        kwargs['VpcSecurityGroupIds'] = vpc_security_group_ids
-        kwargs['AvailabilityZone'] = availability_zone
-        kwargs['DBSubnetGroupName'] = db_subnet_group_name
-        kwargs['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        kwargs['DBParameterGroupName'] = db_parameter_group_name
-        kwargs['BackupRetentionPeriod'] = backup_retention_period
-        kwargs['PreferredBackupWindow'] = preferred_backup_window
-        kwargs['StorageType'] = storage_type
-        kwargs['Tags'] = taglist
 
         # Validation doesn't want parameters that are None
         # https://github.com/boto/boto3/issues/400
@@ -788,41 +802,42 @@ def describe_parameters(name, Source=None, MaxRecords=None, Marker=None,
 
 
 def modify_db_instance(name,
-                       AllocatedStorage=None,
-                       DBInstanceClass=None,
-                       DBSecurityGroups=None,
-                       VpcSecurityGroupIds=None,
-                       ApplyImmediately=None,
-                       MasterUserPassword=None,
-                       DBParameterGroupName=None,
-                       BackupRetentionPeriod=None,
-                       PreferredBackupWindow=None,
-                       PreferredMaintenanceWindow=None,
-                       StorageType=None,
-                       DBname=None,
-                       MultiAZ=None,
-                       LicenseModel=None,
-                       EngineVersion=None,
-                       AllowMajorVersionUpgrade=None,
-                       AutoMinorVersionUpgrade=None,
-                       Iops=None,
-                       OptionGroupName=None,
-                       NewDBInstanceIdentifier=None,
-                       TdeCredentialArn=None,
-                       TdeCredentialPassword=None,
-                       CACertificateIdentifier=None,
-                       Domain=None,
-                       CopyTagsToSnapshot=None,
-                       MonitoringInterval=None,
-                       DBPortNumber=None,
-                       DBClusterIdentifier=None,
-                       PubliclyAccessible=None,
-                       MonitoringRoleArn=None,
-                       DomainIAMRoleName=None,
-                       CharacterSetName=None,
-                       KmsKeyId=None,
-                       StorageEncrypted=None,
-                       PromotionTier=None,
+                       allocated_storage=None,
+                       allow_major_version_upgrade=None,
+                       apply_immediately=None,
+                       auto_minor_version_upgrade=None,
+                       backup_retention_period=None,
+                       ca_certificate_identifier=None,
+                       character_set_name=None,
+                       copy_tags_to_snapshot=None,
+                       db_cluster_identifier=None,
+                       db_instance_class=None,
+                       db_name=None,
+                       db_parameter_group_name=None,
+                       db_port_number=None,
+                       db_security_groups=None,
+                       db_subnet_group_name=None,
+                       domain=None,
+                       domain_iam_role_name=None,
+                       engine_version=None,
+                       iops=None,
+                       kms_key_id=None,
+                       license_model=None,
+                       master_user_password=None,
+                       monitoring_interval=None,
+                       monitoring_role_arn=None,
+                       multi_az=None,
+                       new_db_instance_identifier=None,
+                       option_group_name=None,
+                       preferred_backup_window=None,
+                       preferred_maintenance_window=None,
+                       promotion_tier=None,
+                       publicly_accessible=None,
+                       storage_encrypted=None,
+                       storage_type=None,
+                       tde_credential_arn=None,
+                       tde_credential_password=None,
+                       vpc_security_group_ids=None,
                        region=None, key=None, keyid=None, profile=None):
     '''
     Modify settings for a DB instance.
@@ -841,34 +856,14 @@ def modify_db_instance(name,
             return {'modified': False}
 
         kwargs = {}
-        for key in ('DomainIAMRoleName', 'LicenseModel',
-                    'TdeCredentialArn', 'DBInstanceClass',
-                    'TdeCredentialPassword', 'DBname', 'Domain',
-                    'EngineVersion', 'OptionGroupName',
-                    'CharacterSetName', 'MonitoringRoleArn',
-                    'DBClusterIdentifier', 'KmsKeyId',
-                    'NewDBInstanceIdentifier', 'StorageType',
-                    'CACertificateIdentifier', 'MasterUserPassword',
-                    'DBParameterGroupName', 'PreferredBackupWindow',
-                    'Domain', 'PreferredMaintenanceWindow'):
-            if locals()[key] is not None:
-                kwargs[key] = str(locals()[key])
-
-        for key in ('MonitoringInterval', 'PromotionTier',
-                    'Iops', 'DBPortNumber', 'AllocatedStorage'):
-            if locals()[key] is not None:
-                kwargs[key] = int(locals()[key])
-
-        for key in ('CopyTagsToSnapshot', 'MultiAZ',
-                    'AutoMinorVersionUpgrade',
-                    'AllowMajorVersionUpgrade', 'StorageEncrypted',
-                    'ApplyImmediately', 'PubliclyAccessible'):
-            if locals()[key] is not None:
-                kwargs[key] = bool(locals()[key])
-
-        for key in ('DBSecurityGroups', 'VpcSecurityGroupIds'):
-            if locals()[key] is not None:
-                kwargs[key] = list(locals()[key])
+        excluded = {'name'}
+        boto_params = set(boto3_param_map.keys())
+        keys = set(locals().keys())
+        for key in keys.intersection(boto_params).difference(excluded):
+            val = locals()[key]
+            if val is not None:
+                mapped = boto3_param_map[key]
+                kwargs[mapped[0]] = mapped[1](val)
 
         info = conn.modify_db_instance(DBInstanceIdentifier=name, **kwargs)
 

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -675,9 +675,9 @@ def parameter_present(name, db_parameter_group_family, description, parameters=N
            'comment': '',
            'changes': {}
            }
-    exists = __salt__['boto_rds.parameter_group_exists'](name=name, tags=tags, region=region, key=key,
+    res = __salt__['boto_rds.parameter_group_exists'](name=name, tags=tags, region=region, key=key,
                                                          keyid=keyid, profile=profile)
-    if not exists:
+    if not res.get('exists'):
         if __opts__['test']:
             ret['comment'] = 'Parameter group {0} is set to be created.'.format(name)
             ret['result'] = None

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -701,15 +701,14 @@ def parameter_present(name, db_parameter_group_family, description, parameters=N
                 params[k] = value
         logging.debug('Parameters from user are : {0}.'.format(params))
         options = __salt__['boto_rds.describe_parameters'](name=name, region=region, key=key, keyid=keyid, profile=profile)
-        if not options:
+        if not options.get('result'):
             ret['result'] = False
             ret['comment'] = os.linesep.join([ret['comment'], 'Faled to get parameters for group  {0}.'.format(name)])
             return ret
-        options = options['DescribeDBParametersResponse']['DescribeDBParametersResult']['Parameters']
-        for values in options:
-            if values['ParameterName'] in params and str(params.get(values['ParameterName'])) != str(values['ParameterValue']):
-                logging.debug('Values that are being compared are {0}:{1} .'.format(params.get(values['ParameterName']), values['ParameterValue']))
-                changed[values['ParameterName']] = params.get(values['ParameterName'])
+        for parameter in options['parameters'].values():
+            if parameter['ParameterName'] in params and str(params.get(parameter['ParameterName'])) != str(parameter['ParameterValue']):
+                logging.debug('Values that are being compared are {0}:{1} .'.format(params.get(parameter['ParameterName']), parameter['ParameterValue']))
+                changed[parameter['ParameterName']] = params.get(parameter['ParameterName'])
         if len(changed) > 0:
             if __opts__['test']:
                 ret['comment'] = os.linesep.join([ret['comment'], 'Parameters {0} for group {1} are set to be changed.'.format(changed, name)])


### PR DESCRIPTION
### What does this PR do?
Fixes improper handling of parameters in call to create and modify RDS instances using the boto3 library.

### What issues does this PR fix or reference?
#37528

### Previous Behavior
When optional parameters were not defined the call would fail due to passing `None` to parameters that were expecting values of a different type.

### New Behavior
Optional parameters can be properly excluded without causing errors.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

The way that optional parameters are handled forces some of them to be
defined even when that is not necessary. Updated handling to use a
mapping of snake_case to CamelCase names and only include defined
parameters in the call to boto for the `create` and `modify` actions.