### PR TITLE
Don't pass the vpc id to boto.vpc.create_internet_gateway func

### DIFF
--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -184,7 +184,7 @@ class BotoVpcTestCaseMixin(object):
         if not self.conn:
             self.conn = boto.vpc.connect_to_region(region)
 
-        igw = self.conn.create_internet_gateway(vpc_id)
+        igw = self.conn.create_internet_gateway()
         _maybe_set_name_tag(name, igw)
         _maybe_set_tags(tags, igw)
         return igw

--- a/tests/unit/states/boto_vpc_test.py
+++ b/tests/unit/states/boto_vpc_test.py
@@ -307,11 +307,12 @@ class BotoVpcRouteTableTestCase(BotoVpcStateTestCaseBase, BotoVpcResourceTestCas
         vpc = self._create_vpc(name='test')
         igw = self._create_internet_gateway(name='test', vpc_id=vpc.id)
 
-        route_table_present_result = salt_states['boto_vpc.route_table_present'](
-                name='test', vpc_name='test', routes=[{'destination_cidr_block': '0.0.0.0/0',
-                                                       'gateway_id': igw.id},
-                                                      {'destination_cidr_block': '10.0.0.0/24',
-                                                       'gateway_id': 'local'}])
+        with patch.dict('salt.utils.boto.__salt__', funcs):
+            route_table_present_result = salt_states['boto_vpc.route_table_present'](
+                    name='test', vpc_name='test', routes=[{'destination_cidr_block': '0.0.0.0/0',
+                                                           'gateway_id': igw.id},
+                                                          {'destination_cidr_block': '10.0.0.0/24',
+                                                           'gateway_id': 'local'}])
         routes = [x['gateway_id'] for x in route_table_present_result['changes']['new']['routes']]
 
         self.assertEqual(set(routes), set(['local', igw.id]))


### PR DESCRIPTION
That function's namespace looks like this:
```
def create_internet_gateway(self, dry_run=False):
```
So when we pass in the vpc_id object in the test, the check later
in the function sets `dry_run=True` since the vpc_id object exists:
```
        params = {}
        if dry_run:
            params['DryRun'] = 'true'
        return self.get_object('CreateInternetGateway', params, InternetGateway)
```

This later throws JSONResponseErrors because the `DryRun` flag is
set. This error raising functionality was added in the most recent
version of moto, which exposed this bug:
```
def is_not_dryrun(self, action):
    if 'true' in self.querystring.get('DryRun', ['false']):
        raise JSONResponseError(400, 'DryRunOperation', body={'message': 'An error occurred (DryRunOperation) when calling the %s operation: Request would have succeeded, but DryRun flag is set' % action})
    return True
```

This fixes the three boto_vpc_test unit state tests. We'll see if
other tests need to be addressed in other files on a full test run.

The version of moto that exposes this bug is `0.4.29`, which was released yesterday. The change that exposes this JSONResponseError is here: https://github.com/spulec/moto/pull/735.