### PR TITLE
Skip config type checking for sdb values

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1500,6 +1500,11 @@ def _validate_opts(opts):
             if isinstance(val, VALID_OPTS[key]):
                 continue
 
+            # We don't know what data type sdb will return at run-time so we
+            # simply cannot check it for correctness here at start-time.
+            if isinstance(val, str) and val.startswith('sdb://'):
+                continue
+
             if hasattr(VALID_OPTS[key], '__call__'):
                 try:
                     VALID_OPTS[key](val)


### PR DESCRIPTION
### What does this PR do?

Short-circuits the Salt config type checking behavior for sdb URIs.

### What issues does this PR fix or reference?

#37554 (indirectly).

### Previous Behavior

Salt will throw warnings for config values that are sdb URIs because it cannot know what type/value that _will_ eventually resolve to.

E.g.: `nodegroups: sdb://mysqlite/nodegroups` will throw
```
[WARNING ] Key 'nodegroups' with value sdb://mysqlite/nodegroups has an invalid type of str, a dict is required for this value
```

### New Behavior
Skip the type checks for values that look like sdb URIs.

### Tests written?

No