### PR TITLE
Fix regression in service.dead state

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -431,6 +431,9 @@ def dead(name, enable=None, sig=None, **kwargs):
     # Check if the service is available
     try:
         if not _available(name, ret):
+            # A non-available service is OK here, don't let the state fail
+            # because of it.
+            ret['result'] = True
             return ret
     except CommandExecutionError as exc:
         ret['result'] = False

--- a/tests/unit/states/service_test.py
+++ b/tests/unit/states/service_test.py
@@ -247,6 +247,25 @@ class ServiceTestCase(TestCase):
             ):
                 self.assertDictEqual(service.dead("salt", False), ret[4])
 
+    def test_dead_with_missing_service(self):
+        '''
+        Tests the case in which a service.dead state is executed on a state
+        which does not exist.
+
+        See https://github.com/saltstack/salt/issues/37511
+        '''
+        name = 'thisisnotarealservice'
+        with patch.dict(service.__salt__,
+                        {'service.available': MagicMock(return_value=False)}):
+            ret = service.dead(name=name)
+            self.assertDictEqual(
+                ret,
+                {'changes': {},
+                 'comment': 'The named service {0} is not available'.format(name),
+                 'result': True,
+                 'name': name}
+            )
+
     def test_enabled(self):
         '''
             Test to verify that the service is enabled


### PR DESCRIPTION
### What does this PR do?

Fixes a regression in ``service.dead`` when the specified service is not present

### What issues does this PR fix or reference?

#37511

### Previous Behavior

State would return a ``False`` result

### New Behavior

State now returns a ``True`` result as it did in 2016.3.3 and earlier

### Tests written?

Yes