### PR TITLE
Use existing VM's VDD size if not specified in the cloud profile

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -657,5 +657,4 @@ can be set in the cloud profile as shown in example below:
             size: 42
 
           Hard disk 2:
-            size: 15
             mode: 'independent_nonpersistent'

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -616,21 +616,22 @@ def _manage_devices(devices, vm=None, container_ref=None):
                     # there is at least one disk specified to be created/configured
                     unit_number += 1
                     existing_disks_label.append(device.deviceInfo.label)
-                    # log.info('all = %s', str(devices['disk'].keys()))
                     if device.deviceInfo.label in list(devices['disk'].keys()):
                         disk_spec = None
-
                         if 'size' in devices['disk'][device.deviceInfo.label]:
                             disk_spec = _get_size_spec(device, devices)
-                            size_gb = float(devices['disk'][device.deviceInfo.label]['size'])
+                            size_kb = float(
+                                devices['disk'][device.deviceInfo.label]['size']
+                            ) * 1024 * 1024
                         else:
-                            raise SaltCloudSystemExit(
-                                'Please specify a size'
-                                ' for the disk "{0}" in'
-                                ' your cloud profile'
-                                ''.format(device.deviceInfo.label))
+                            # User didn't specify disk size
+                            # in the cloud profile
+                            # so use the existing disk size
+                            log.info('Virtual disk size was not'
+                                     ' specified in the cloud profile.'
+                                     ' Using existing disk size.')
+                            size_kb = device.capacityInKB
 
-                        size_kb = int(size_gb * 1024 * 1024)
                         if device.capacityInKB < size_kb:
                             # expand the disk
                             disk_spec = _edit_existing_hard_disk_helper(device, size_kb)


### PR DESCRIPTION
### What does this PR do?
If the user doesn't specify a virtual disk or a virtual disk size in the cloud profile (while cloning), then use the size of the virtual disk from the existing VM that we're cloning from.

### What issues does this PR fix or reference?
ZH 926

### Previous Behavior
Used to throw an error

### New Behavior
Uses the older VM size and does not throw an error

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

