### PR TITLE
Add a section to the manual for the sqlite3 state that hints to module.run

### DIFF
--- a/salt/states/sqlite3.py
+++ b/salt/states/sqlite3.py
@@ -77,6 +77,19 @@ Here is an example of removing a row from a table:
         - where_sql: email="john.doe@companyabc.com"
         - require:
           - sqlite3: users
+          
+Note that there is no explicit state to perform random queries, however, this 
+can be approximated sqlite3's module functions and module.run:
+
+  .. code-block:: yaml
+  
+    zone-delete:
+      module.run:
+        - name: sqlite3.modify
+        - db: {{ db }}
+        - sql: "DELETE FROM records WHERE id > {{ count[0] }} AND domain_id = {{ domain_id }}"
+        - watch:
+          - sqlite3: zone-insert-12
 """
 
 # Import Python libs

--- a/salt/states/sqlite3.py
+++ b/salt/states/sqlite3.py
@@ -77,12 +77,12 @@ Here is an example of removing a row from a table:
         - where_sql: email="john.doe@companyabc.com"
         - require:
           - sqlite3: users
-          
-Note that there is no explicit state to perform random queries, however, this 
+
+Note that there is no explicit state to perform random queries, however, this
 can be approximated with sqlite3's module functions and module.run:
 
   .. code-block:: yaml
-  
+
     zone-delete:
       module.run:
         - name: sqlite3.modify

--- a/salt/states/sqlite3.py
+++ b/salt/states/sqlite3.py
@@ -79,7 +79,7 @@ Here is an example of removing a row from a table:
           - sqlite3: users
           
 Note that there is no explicit state to perform random queries, however, this 
-can be approximated sqlite3's module functions and module.run:
+can be approximated with sqlite3's module functions and module.run:
 
   .. code-block:: yaml
   


### PR DESCRIPTION
### What does this PR do?

Adds to the documentation,  to give a hint how to run random queries. The state module only supports adding/deleting single rows, so you're a bit hampered if you want to clean a table out. If you don't know about module.run you're out of luck.

