### PR TITLE
Fix the case both DNS count and order changes in Windows

### DIFF
--- a/salt/states/win_dns_client.py
+++ b/salt/states/win_dns_client.py
@@ -55,7 +55,7 @@ def dns_exists(name, servers=None, interface='Local Area Connection', replace=Fa
     for i, server in enumerate(servers):
         if __opts__['test']:
             if server in configured_list:
-                if configured_list[i] != server:
+                if configured_list.index(server) != i:
                     ret['changes']['Servers Reordered'].append(server)
             else:
                 ret['changes']['Servers Added'].append(server)
@@ -69,7 +69,7 @@ def dns_exists(name, servers=None, interface='Local Area Connection', replace=Fa
                 return ret
             else:
                 if server in configured_list:
-                    if configured_list[i] != server:
+                    if configured_list.index(server) != i:
                         ret['changes']['Servers Reordered'].append(server)
                 else:
                     ret['changes']['Servers Added'].append(server)


### PR DESCRIPTION
### What does this PR do?
Fix the win_dns_client state for the case both number of DNS servers and their order changes

### What issues does this PR fix or reference?
In case both number of DNS servers and their order changes, while checking for the order, we will get
`IndexError: list index out of range`

### Tests written?
No
