### PR TITLE
Update parameter for building with mock for rpms

### DIFF
--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -156,7 +156,7 @@ def _get_deps(deps, tree_base, saltenv='base'):
         else:
             shutil.copy(deprpm, dest)
 
-        deps_list += ' --install {0}'.format(dest)
+        deps_list += ' {0}'.format(dest)
 
     return deps_list
 
@@ -250,9 +250,10 @@ def build(runas,
             __salt__['cmd.run']('chown {0} -R {1}'.format(runas, results_dir))
             cmd = 'mock --root={0} --resultdir={1} --init'.format(tgt, results_dir)
             __salt__['cmd.run'](cmd, runas=runas)
-            if deps_list:
+            if deps_list and not deps_list.isspace():
                 cmd = 'mock --root={0} --resultdir={1} --install {2} {3}'.format(tgt, results_dir, deps_list, noclean)
                 __salt__['cmd.run'](cmd, runas=runas)
+                noclean += ' --no-clean'
 
             cmd = 'mock --root={0} --resultdir={1} {2} {3} {4}'.format(
                 tgt,


### PR DESCRIPTION
### What does this PR do?
Fix building on Redhat 5 and 6 for packages with dependencies

### What issues does this PR fix or reference?
Fix building on Redhat 5 and 6 for packages with dependencies

### Previous Behavior
Some dependencies were not saved in mock's chroot, causing some package builds to fail on a clean system, for example: Redhat 6 and python-pyzmq

### New Behavior
Dependencies now saved correctly in mock's chroot, now all package builds succeed on a clean system, for example: Redhat 6 and python-pyzmq

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
