### PR TITLE
Don't completely replace grains dict when getting virtual data

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -482,6 +482,7 @@ def _virtual(osdata):
     #   virtual
     #   virtual_subtype
     grains = {'virtual': 'physical'}
+    grains.update(_hw_data(grains))
 
     # Skip the below loop on platforms which have none of the desired cmds
     # This is a temporary measure until we can write proper virtual hardware


### PR DESCRIPTION
Fixes #35381

Replaces #37535 - moved this change to the develop branch as suggested by @cachedout 