### PR TITLE
Remove the `v` from the tag reference

### DIFF
--- a/doc/topics/releases/releasecandidate.rst
+++ b/doc/topics/releases/releasecandidate.rst
@@ -126,4 +126,4 @@ Then install salt using the following command:
 
 .. code-block:: bash
 
-    sudo pip install salt==v2016.11.0rc2
+    sudo pip install salt==2016.11.0rc2


### PR DESCRIPTION
When installing with pip, we just need the package version. No `v`.