### PR TITLE
change TIMEZONE on SUSE systems (bsc#1008933)

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -221,7 +221,7 @@ def set_zone(timezone):
             '/etc/sysconfig/clock', '^ZONE=.*', 'ZONE="{0}"'.format(timezone))
     elif 'Suse' in __grains__['os_family']:
         __salt__['file.sed'](
-            '/etc/sysconfig/clock', '^ZONE=.*', 'ZONE="{0}"'.format(timezone))
+            '/etc/sysconfig/clock', '^TIMEZONE=.*', 'TIMEZONE="{0}"'.format(timezone))
     elif 'Debian' in __grains__['os_family']:
         with salt.utils.fopen('/etc/timezone', 'w') as ofh:
             ofh.write(timezone.strip())
@@ -415,7 +415,7 @@ def set_hwclock(clock):
             '/etc/sysconfig/clock', '^ZONE=.*', 'ZONE="{0}"'.format(timezone))
     elif 'Suse' in __grains__['os_family']:
         __salt__['file.sed'](
-            '/etc/sysconfig/clock', '^ZONE=.*', 'ZONE="{0}"'.format(timezone))
+            '/etc/sysconfig/clock', '^TIMEZONE=.*', 'TIMEZONE="{0}"'.format(timezone))
     elif 'Debian' in __grains__['os_family']:
         if clock == 'UTC':
             __salt__['file.sed']('/etc/default/rcS', '^UTC=.*', 'UTC=yes')


### PR DESCRIPTION
### What does this PR do?

fix timezone setting on SUSE systems

### What issues does this PR fix or reference?

None

### Previous Behavior

Try to change ZONE in /etc/sysconfig/clock

### New Behavior

Change the value for "TIMEZONE" in /etc/sysconfig/clock which is the correct name on SUSE systems

### Tests written?

No
