### PR TITLE
Skip random.org tests for any communication failure

### DIFF
--- a/tests/integration/modules/random_org_test.py
+++ b/tests/integration/modules/random_org_test.py
@@ -28,8 +28,11 @@ def check_status():
     '''
     Check the status of random.org
     '''
-    ret = salt.utils.http.query('https://api.random.org/', status=True)
-    return ret['status'] == 200
+    try:
+        ret = salt.utils.http.query('https://api.random.org/', status=True)
+        return ret['status'] == 200
+    except:  # pylint: disable=W0702
+        return False
 
 
 @skipIf(not check_status(), 'random.org is not available')


### PR DESCRIPTION
### Description 

This test connects to random.org, which may throws the following error
on one network I manage:

ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)

Other errors are possible, such as `socket.error`.  Since it is
difficult to anticipate the failure mode, skip these tests if https
communication provokes any exception.

Also, this is not a unit test--it's more of a system test. My
recommendation that we recategorize this as an integration test where
global IPv4 routing can more reasonably expected.