### PR TITLE
Fix cmd batch raw

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -194,8 +194,9 @@ class Batch(object):
                                 break
                             continue
                         if self.opts.get('raw'):
-                            parts.update({part['id']: part})
-                            minion_tracker[queue]['minions'].remove(part['id'])
+                            parts.update({part['data']['id']: part})
+                            if part['data']['id'] in minion_tracker[queue]['minions']:
+                                minion_tracker[queue]['minions'].remove(part['data']['id'])
                         else:
                             parts.update(part)
                             for id in part.keys():

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -224,6 +224,7 @@ class Batch(object):
                     if bwait:
                         wait.append(datetime.now() + timedelta(seconds=bwait))
                 if self.opts.get('raw'):
+                    ret[minion] = data
                     yield data
                 elif self.opts.get('failhard'):
                     # When failhard is passed, we need to return all data to include

--- a/tests/integration/client/standard.py
+++ b/tests/integration/client/standard.py
@@ -85,6 +85,29 @@ class StdTest(integration.ModuleCase):
                 continue
             self.assertTrue(ret['minion'])
 
+    def test_batch(self):
+        '''
+        test cmd_batch
+        '''
+        cmd_batch = self.client.cmd_batch(
+            'minion',
+            'test.ping',
+        )
+        for ret in cmd_batch:
+            self.assertTrue(ret['minion'])
+
+    def test_batch_raw(self):
+        '''
+        test cmd_batch with raw option
+        '''
+        cmd_batch = self.client.cmd_batch(
+            'minion',
+            'test.ping',
+            raw=True,
+        )
+        for ret in cmd_batch:
+            self.assertTrue(ret['data']['success'])
+
     def test_full_returns(self):
         '''
         test cmd_iter


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

At the moment when we use salt.client.LocalClient.cmd_batch with the raw kwargs set to True we receive an exception as the result of the minion is trying to access a key in the part dictionnary that does not exist. 

The ret dictionary is not updated either causing the main loop to iterate forever (https://github.com/jeanpralo/salt/blob/ead47e4bba6d8addd0717b28b81251e3a4a22647/salt/cli/batch.py#L133)


### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
