### PR TITLE
vmware: optionally allow network interface MAC to be set

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -142,6 +142,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
             name: 10.30.40-500-Dev-DHCP
             adapter_type: e1000
             switch_type: distributed
+            mac: '00:16:3e:e8:19:0f'
           Network adapter 3:
             name: 10.40.50-600-Prod
             adapter_type: vmxnet3
@@ -315,6 +316,10 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
         domain
             Enter the domain to be used with the network adapter. If the network
             specified is DHCP enabled, you do not have to specify this.
+
+        mac
+            Enter the MAC for this network adapter. If not specified an address
+            will be selected automatically.
 
     scsi
         Enter the SCSI controller specification here. If the SCSI controller doesn\'t exist,

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -376,7 +376,7 @@ def _edit_existing_network_adapter(network_adapter, new_network_name, adapter_ty
     return network_spec
 
 
-def _add_new_network_adapter_helper(network_adapter_label, network_name, adapter_type, switch_type, container_ref=None):
+def _add_new_network_adapter_helper(network_adapter_label, network_name, adapter_type, switch_type, mac, container_ref=None):
     random_key = randint(-4099, -4000)
 
     adapter_type.strip().lower()
@@ -422,6 +422,9 @@ def _add_new_network_adapter_helper(network_adapter_label, network_name, adapter
                                                                                           switch_type)
         raise SaltCloudSystemExit(err_msg)
 
+    if mac != '':
+        network_spec.device.addressType = 'assigned'
+        network_spec.device.macAddress = mac
     network_spec.device.key = random_key
     network_spec.device.deviceInfo = vim.Description()
     network_spec.device.deviceInfo.label = network_adapter_label
@@ -738,8 +741,9 @@ def _manage_devices(devices, vm=None, container_ref=None, new_vm_name=None):
             network_name = devices['network'][network_adapter_label]['name']
             adapter_type = devices['network'][network_adapter_label]['adapter_type'] if 'adapter_type' in devices['network'][network_adapter_label] else ''
             switch_type = devices['network'][network_adapter_label]['switch_type'] if 'switch_type' in devices['network'][network_adapter_label] else ''
+            mac = devices['network'][network_adapter_label]['mac'] if 'mac' in devices['network'][network_adapter_label] else ''
             # create the network adapter
-            network_spec = _add_new_network_adapter_helper(network_adapter_label, network_name, adapter_type, switch_type, container_ref)
+            network_spec = _add_new_network_adapter_helper(network_adapter_label, network_name, adapter_type, switch_type, mac, container_ref)
             adapter_mapping = _set_network_adapter_mapping(devices['network'][network_adapter_label])
             device_specs.append(network_spec)
             nics_map.append(adapter_mapping)


### PR DESCRIPTION
### What issues does this PR fix or reference?

saltstack/salt#34035

### New Behavior

The `mac` can optionally be specified on any network interface:

    network:
      Network Adapter 1:
        mac: '00:16:3e:e8:19:0f'
        name: vlan25
        switch_type: standard

This takes effect as soon as the VM is initialized, so PXE-booting can
take advantage of this.

### Tests written?

No, tested manually with vSphere 6.0