### PR TITLE
Boto apigateway optional stacktrace in response mapping

### DIFF
--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -55,7 +55,6 @@ import hashlib
 import re
 import json
 import yaml
-
 # Import Salt Libs
 import salt.ext.six as six
 import salt.utils
@@ -74,7 +73,7 @@ def present(name, api_name, swagger_file, stage_name, api_key_required,
             lambda_integration_role, lambda_region=None, stage_variables=None,
             region=None, key=None, keyid=None, profile=None,
             lambda_funcname_format='{stage}_{api}_{resource}_{method}',
-            authorization_type='NONE'):
+            authorization_type='NONE', error_response_template=None, response_template=None):
     '''
     Ensure the spcified api_name with the corresponding swaggerfile is deployed to the
     given stage_name in AWS ApiGateway.
@@ -203,6 +202,35 @@ def present(name, api_name, swagger_file, stage_name, api_key_required,
     authorization_type
         This field can be either 'NONE', or 'AWS_IAM'.  This will be applied to all methods in the given
         swagger spec file.  Default is set to 'NONE'
+
+    error_response_template
+        String value that defines the response template mapping that should be applied in cases error occurs.
+        Refer to AWS documentation for details:
+            http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
+        If set to None, the following default value is used:
+            '#set($inputRoot = $input.path(\'$\'))\n'
+            '{\n'
+            '  "errorMessage" : "$inputRoot.errorMessage",\n'
+            '  "errorType" : "$inputRoot.errorType",\n'
+            '  "stackTrace" : [\n'
+            '#foreach($stackTrace in $inputRoot.stackTrace)\n'
+            '    [\n'
+            '#foreach($elem in $stackTrace)\n'
+            '      "$elem"\n'
+            '#if($foreach.hasNext),#end\n'
+            '#end\n'
+            '    ]\n'
+            '#if($foreach.hasNext),#end\n'
+            '#end\n'
+            '  ]\n'
+
+        .. versionadded:: Carbon
+
+    response_template
+        String value that defines the response template mapping applied in case of success (including OPTIONS method)
+        If set to None, empty ({}) template is assumed, which will transfer response from the lambda function as is.
+
+        .. versionadded:: Carbon
     '''
     ret = {'name': name,
            'result': True,
@@ -219,7 +247,9 @@ def present(name, api_name, swagger_file, stage_name, api_key_required,
         # try to open the swagger file and basic validation
         swagger = _Swagger(api_name, stage_name,
                            lambda_funcname_format,
-                           swagger_file, common_args)
+                           swagger_file,
+                           error_response_template, response_template,
+                           common_args)
 
         # retrieve stage variables
         stage_vars = _get_stage_variables(stage_variables)
@@ -362,7 +392,7 @@ def absent(name, api_name, stage_name, nuke_api=False, region=None, key=None, ke
                             ('keyid', keyid),
                             ('profile', profile)])
 
-        swagger = _Swagger(api_name, stage_name, '', None, common_args)
+        swagger = _Swagger(api_name, stage_name, '', None, None, None, common_args)
 
         if not swagger.restApiId:
             ret['comment'] = '[Rest API: {0}] does not exist.'.format(api_name)
@@ -421,7 +451,7 @@ def _name_matches(name, matches):
     for m in matches:
         if name.endswith(m):
             return True
-        if name.lower().endswith('_'+m.lower()):
+        if name.lower().endswith('_' + m.lower()):
             return True
         if name.lower() == m.lower():
             return True
@@ -502,79 +532,77 @@ class _Swagger(object):
     JSON_SCHEMA_DRAFT_4 = 'http://json-schema.org/draft-04/schema#'
 
     # AWS integration templates for normal and options methods
-    REQUEST_TEMPLATE = {'application/json':
-                        '#set($inputRoot = $input.path(\'$\'))\n'
-                        '{\n'
-                        '"header_params" : {\n'
-                        '#set ($map = $input.params().header)\n'
-                        '#foreach( $param in $map.entrySet() )\n'
-                        '"$param.key" : "$param.value" #if( $foreach.hasNext ), #end\n'
-                        '#end\n'
-                        '},\n'
-                        '"query_params" : {\n'
-                        '#set ($map = $input.params().querystring)\n'
-                        '#foreach( $param in $map.entrySet() )\n'
-                        '"$param.key" : "$param.value" #if( $foreach.hasNext ), #end\n'
-                        '#end\n'
-                        '},\n'
-                        '"path_params" : {\n'
-                        '#set ($map = $input.params().path)\n'
-                        '#foreach( $param in $map.entrySet() )\n'
-                        '"$param.key" : "$param.value" #if( $foreach.hasNext ), #end\n'
-                        '#end\n'
-                        '},\n'
-                        '"apigw_context" : {\n'
-                        '"apiId": "$context.apiId",\n'
-                        '"httpMethod": "$context.httpMethod",\n'
-                        '"requestId": "$context.requestId",\n'
-                        '"resourceId": "$context.resourceId",\n'
-                        '"resourcePath": "$context.resourcePath",\n'
-                        '"stage": "$context.stage",\n'
-                        '"identity": {\n'
-                        '  "user":"$context.identity.user",\n'
-                        '  "userArn":"$context.identity.userArn",\n'
-                        '  "userAgent":"$context.identity.userAgent",\n'
-                        '  "sourceIp":"$context.identity.sourceIp",\n'
-                        '  "cognitoIdentityId":"$context.identity.cognitoIdentityId",\n'
-                        '  "cognitoIdentityPoolId":"$context.identity.cognitoIdentityPoolId",\n'
-                        '  "cognitoAuthenticationType":"$context.identity.cognitoAuthenticationType",\n'
-                        '  "cognitoAuthenticationProvider":["$util.escapeJavaScript($context.identity.cognitoAuthenticationProvider)"],\n'
-                        '  "caller":"$context.identity.caller",\n'
-                        '  "apiKey":"$context.identity.apiKey",\n'
-                        '  "accountId":"$context.identity.accountId"\n'
-                        '}\n'
-                        '},\n'
-                        '"body_params" : $input.json(\'$\'),\n'
-                        '"stage_variables": {\n'
-                        '#foreach($variable in $stageVariables.keySet())\n'
-                        '"$variable": "$util.escapeJavaScript($stageVariables.get($variable))"\n'
-                        '#if($foreach.hasNext), #end\n'
-                        '#end\n'
-                        '}\n'
-                        '}'}
+    REQUEST_TEMPLATE = {'application/json': '#set($inputRoot = $input.path(\'$\'))\n'
+                                            '{\n'
+                                            '"header_params" : {\n'
+                                            '#set ($map = $input.params().header)\n'
+                                            '#foreach( $param in $map.entrySet() )\n'
+                                            '"$param.key" : "$param.value" #if( $foreach.hasNext ), #end\n'
+                                            '#end\n'
+                                            '},\n'
+                                            '"query_params" : {\n'
+                                            '#set ($map = $input.params().querystring)\n'
+                                            '#foreach( $param in $map.entrySet() )\n'
+                                            '"$param.key" : "$param.value" #if( $foreach.hasNext ), #end\n'
+                                            '#end\n'
+                                            '},\n'
+                                            '"path_params" : {\n'
+                                            '#set ($map = $input.params().path)\n'
+                                            '#foreach( $param in $map.entrySet() )\n'
+                                            '"$param.key" : "$param.value" #if( $foreach.hasNext ), #end\n'
+                                            '#end\n'
+                                            '},\n'
+                                            '"apigw_context" : {\n'
+                                            '"apiId": "$context.apiId",\n'
+                                            '"httpMethod": "$context.httpMethod",\n'
+                                            '"requestId": "$context.requestId",\n'
+                                            '"resourceId": "$context.resourceId",\n'
+                                            '"resourcePath": "$context.resourcePath",\n'
+                                            '"stage": "$context.stage",\n'
+                                            '"identity": {\n'
+                                            '  "user":"$context.identity.user",\n'
+                                            '  "userArn":"$context.identity.userArn",\n'
+                                            '  "userAgent":"$context.identity.userAgent",\n'
+                                            '  "sourceIp":"$context.identity.sourceIp",\n'
+                                            '  "cognitoIdentityId":"$context.identity.cognitoIdentityId",\n'
+                                            '  "cognitoIdentityPoolId":"$context.identity.cognitoIdentityPoolId",\n'
+                                            '  "cognitoAuthenticationType":"$context.identity.cognitoAuthenticationType",\n'
+                                            '  "cognitoAuthenticationProvider":["$util.escapeJavaScript($context.identity.cognitoAuthenticationProvider)"],\n'
+                                            '  "caller":"$context.identity.caller",\n'
+                                            '  "apiKey":"$context.identity.apiKey",\n'
+                                            '  "accountId":"$context.identity.accountId"\n'
+                                            '}\n'
+                                            '},\n'
+                                            '"body_params" : $input.json(\'$\'),\n'
+                                            '"stage_variables": {\n'
+                                            '#foreach($variable in $stageVariables.keySet())\n'
+                                            '"$variable": "$util.escapeJavaScript($stageVariables.get($variable))"\n'
+                                            '#if($foreach.hasNext), #end\n'
+                                            '#end\n'
+                                            '}\n'
+                                            '}'}
     REQUEST_OPTION_TEMPLATE = {'application/json': '{"statusCode": 200}'}
 
     # AWS integration response template mapping to convert stackTrace part or the error
     # to a uniform format containing strings only. Swagger does not seem to allow defining
     # an array of non-uniform types, to it is not possible to create error model to match
     # exactly what comes out of lambda functions in case of error.
-    RESPONSE_TEMPLATE = {'application/json':
-                         '#set($inputRoot = $input.path(\'$\'))\n'
-                         '{\n'
-                         '  "errorMessage" : "$inputRoot.errorMessage",\n'
-                         '  "errorType" : "$inputRoot.errorType",\n'
-                         '  "stackTrace" : [\n'
-                         '#foreach($stackTrace in $inputRoot.stackTrace)\n'
-                         '    [\n'
-                         '#foreach($elem in $stackTrace)\n'
-                         '      "$elem"\n'
-                         '#if($foreach.hasNext),#end\n'
-                         '#end\n'
-                         '    ]\n'
-                         '#if($foreach.hasNext),#end\n'
-                         '#end\n'
-                         '  ]\n'
-                         '}'}
+    RESPONSE_TEMPLATE = {'application/json': '#set($inputRoot = $input.path(\'$\'))\n'
+                                             '{\n'
+                                             '  "errorMessage" : "$inputRoot.errorMessage",\n'
+                                             '  "errorType" : "$inputRoot.errorType",\n'
+                                             '  "stackTrace" : [\n'
+                                             '#foreach($stackTrace in $inputRoot.stackTrace)\n'
+                                             '    [\n'
+                                             '#foreach($elem in $stackTrace)\n'
+                                             '      "$elem"\n'
+                                             '#if($foreach.hasNext),#end\n'
+                                             '#end\n'
+                                             '    ]\n'
+                                             '#if($foreach.hasNext),#end\n'
+                                             '#end\n'
+                                             '  ]\n'
+                                             '}'}
     RESPONSE_OPTION_TEMPLATE = {}
 
     # This string should not be modified, every API created by this state will carry the description
@@ -637,6 +665,7 @@ class _Swagger(object):
         '''
         Helper class for Swagger Method Response Object
         '''
+
         def __init__(self, r):
             self._r = r
 
@@ -662,13 +691,15 @@ class _Swagger(object):
             return _headers
 
     def __init__(self, api_name, stage_name, lambda_funcname_format,
-                 swagger_file_path, common_aws_args):
+                 swagger_file_path, error_response_template, response_template, common_aws_args):
         self._api_name = api_name
         self._stage_name = stage_name
         self._lambda_funcname_format = lambda_funcname_format
         self._common_aws_args = common_aws_args
         self._restApiId = ''
         self._deploymentId = ''
+        self._error_response_template = error_response_template
+        self._response_template = response_template
 
         if swagger_file_path is not None:
             if os.path.exists(swagger_file_path) and os.path.isfile(swagger_file_path):
@@ -738,6 +769,10 @@ class _Swagger(object):
                                          'be used'.format(modelname))
 
     def _validate_lambda_funcname_format(self):
+        '''
+        Checks if the lambda function name format contains only known elements
+        :return: True on success, ValueError raised on error
+        '''
         try:
             if self._lambda_funcname_format:
                 known_kwargs = dict(stage='',
@@ -1436,6 +1471,15 @@ class _Swagger(object):
         patterns = self._find_patterns(model)
         return patterns[0] if patterns else defaultPattern
 
+    def _get_response_template(self, method_name, http_status):
+        if method_name == 'options' or not self._is_http_error_rescode(http_status):
+            response_templates = {'application/json': self._response_template} \
+                if self._response_template else self.RESPONSE_OPTION_TEMPLATE
+        else:
+            response_templates = {'application/json': self._error_response_template} \
+                if self._error_response_template else self.RESPONSE_TEMPLATE
+        return response_templates
+
     def _parse_method_response(self, method_name, method_response, httpStatus):
         '''
         Helper function to construct the method response params, models, and integration_params
@@ -1456,10 +1500,7 @@ class _Swagger(object):
             method_integration_response_params[response_header] = (
                 "'{0}'".format(header_data.get('default')) if 'default' in header_data else "'*'")
 
-        if method_name == 'options' or not self._is_http_error_rescode(httpStatus):
-            response_templates = _Swagger.RESPONSE_OPTION_TEMPLATE
-        else:
-            response_templates = _Swagger.RESPONSE_TEMPLATE
+        response_templates = self._get_response_template(method_name, httpStatus)
 
         return {'params': method_response_params,
                 'models': method_response_models,
@@ -1551,27 +1592,27 @@ class _Swagger(object):
                                                               _Swagger.SwaggerMethodResponse(response_data), httpStatus)
 
                 mr = __salt__['boto_apigateway.create_api_method_response'](
-                                                                restApiId=self.restApiId,
-                                                                resourcePath=resource_path,
-                                                                httpMethod=method_name.upper(),
-                                                                statusCode=httpStatus,
-                                                                responseParameters=method_response.get('params'),
-                                                                responseModels=method_response.get('models'),
-                                                                **self._common_aws_args)
+                    restApiId=self.restApiId,
+                    resourcePath=resource_path,
+                    httpMethod=method_name.upper(),
+                    statusCode=httpStatus,
+                    responseParameters=method_response.get('params'),
+                    responseModels=method_response.get('models'),
+                    **self._common_aws_args)
                 if not mr.get('created'):
                     ret = _log_error_and_abort(ret, mr)
                     return ret
                 ret = _log_changes(ret, '_deploy_method.create_api_method_response', mr)
 
                 mir = __salt__['boto_apigateway.create_api_integration_response'](
-                                                restApiId=self.restApiId,
-                                                resourcePath=resource_path,
-                                                httpMethod=method_name.upper(),
-                                                statusCode=httpStatus,
-                                                selectionPattern=method_response.get('pattern'),
-                                                responseParameters=method_response.get('integration_params'),
-                                                responseTemplates=method_response.get('response_templates'),
-                                                **self._common_aws_args)
+                    restApiId=self.restApiId,
+                    resourcePath=resource_path,
+                    httpMethod=method_name.upper(),
+                    statusCode=httpStatus,
+                    selectionPattern=method_response.get('pattern'),
+                    responseParameters=method_response.get('integration_params'),
+                    responseTemplates=method_response.get('response_templates'),
+                    **self._common_aws_args)
                 if not mir.get('created'):
                     ret = _log_error_and_abort(ret, mir)
                     return ret
@@ -1617,7 +1658,8 @@ class _Swagger(object):
         return ret
 
 
-def usage_plan_present(name, plan_name, description=None, throttle=None, quota=None, region=None, key=None, keyid=None, profile=None):
+def usage_plan_present(name, plan_name, description=None, throttle=None, quota=None, region=None, key=None, keyid=None,
+                       profile=None):
     '''
     Ensure the spcifieda usage plan with the corresponding metrics is deployed
 
@@ -1896,7 +1938,9 @@ def usage_plan_association_present(name, plan_name, api_stages, region=None, key
 
         result = __salt__['boto_apigateway.attach_usage_plan_to_apis'](plan_id, stages_to_add, **common_args)
         if 'error' in result:
-            ret['comment'] = 'Failed to associate a usage plan {0} to the apis {1}, {2}'.format(plan_name, stages_to_add, result['error'])
+            ret['comment'] = 'Failed to associate a usage plan {0} to the apis {1}, {2}'.format(plan_name,
+                                                                                                stages_to_add,
+                                                                                                result['error'])
             ret['result'] = False
             return ret
 
@@ -1992,7 +2036,9 @@ def usage_plan_association_absent(name, plan_name, api_stages, region=None, key=
 
         result = __salt__['boto_apigateway.detach_usage_plan_from_apis'](plan_id, stages_to_remove, **common_args)
         if 'error' in result:
-            ret['comment'] = 'Failed to disassociate a usage plan {0} from the apis {1}, {2}'.format(plan_name, stages_to_remove, result['error'])
+            ret['comment'] = 'Failed to disassociate a usage plan {0} from the apis {1}, {2}'.format(plan_name,
+                                                                                                     stages_to_remove,
+                                                                                                     result['error'])
             ret['result'] = False
             return ret
 

--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -709,7 +709,7 @@ class _Swagger(object):
         if swagger_file_path is not None:
             if os.path.exists(swagger_file_path) and os.path.isfile(swagger_file_path):
                 self._swagger_file = swagger_file_path
-                self._md5_filehash = _gen_md5_filehash(self._swagger_file, 
+                self._md5_filehash = _gen_md5_filehash(self._swagger_file,
                                                        error_response_template,
                                                        response_template)
                 with salt.utils.fopen(self._swagger_file, 'rb') as sf:

--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -424,14 +424,19 @@ def absent(name, api_name, stage_name, nuke_api=False, region=None, key=None, ke
 
 
 # Helper Swagger Class for swagger version 2.0 API specification
-def _gen_md5_filehash(fname):
+def _gen_md5_filehash(fname, *args):
     '''
     helper function to generate a md5 hash of the swagger definition file
+    any extra argument passed to the function is converted to a string
+    and participates in the hash calculation
     '''
     _hash = hashlib.md5()
     with salt.utils.fopen(fname, 'rb') as f:
         for chunk in iter(lambda: f.read(4096), b''):
             _hash.update(chunk)
+
+    for extra_arg in args:
+        _hash.update(str(extra_arg))
     return _hash.hexdigest()
 
 
@@ -704,7 +709,9 @@ class _Swagger(object):
         if swagger_file_path is not None:
             if os.path.exists(swagger_file_path) and os.path.isfile(swagger_file_path):
                 self._swagger_file = swagger_file_path
-                self._md5_filehash = _gen_md5_filehash(self._swagger_file)
+                self._md5_filehash = _gen_md5_filehash(self._swagger_file, 
+                                                       error_response_template,
+                                                       response_template)
                 with salt.utils.fopen(self._swagger_file, 'rb') as sf:
                     self._cfg = yaml.load(sf)
                 self._swagger_version = ''

--- a/tests/unit/states/boto_apigateway_test.py
+++ b/tests/unit/states/boto_apigateway_test.py
@@ -236,7 +236,7 @@ deployment1_ret = dict(createdDate=datetime.datetime(2015, 11, 17, 16, 33, 50),
                        description=(u'{\n'
                                     u'    "api_name": "unit test api",\n'
                                     u'    "swagger_file": "temp-swagger-sample.yaml",\n'
-                                    u'    "swagger_file_md5sum": "4fb17e43bab3a96e7f2410a1597cd0a5",\n'
+                                    u'    "swagger_file_md5sum": "99cd44f491f25a8e8bb468b0a8e23a0a",\n'
                                     u'    "swagger_info_object": {\n'
                                     u'        "description": "salt boto apigateway unit test service",\n'
                                     u'        "title": "salt boto apigateway unit test service",\n'


### PR DESCRIPTION
### What does this PR do?
Allows user to optionally specify response template mappings

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Previous behavior always used predefined response template mappings
(which should still be good for vast majority of cases)

### New Behavior
If response template mappings are not provided, existing default mappings
will be used like in previous versions. If response template mappings are provided,
those will be used instead

### Tests written?
Manually tested against AWS Apigateway

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
