### PR TITLE
Drop log warning level to debug

### DIFF
--- a/salt/utils/dns.py
+++ b/salt/utils/dns.py
@@ -98,7 +98,7 @@ def parse_resolv(src='/etc/resolv.conf'):
             # The domain and search keywords are mutually exclusive.  If more
             # than one instance of these keywords is present, the last instance
             # will override.
-            log.warning('{0}: The domain and search keywords are mutually '
+            log.debug('{0}: The domain and search keywords are mutually '
                         'exclusive.'.format(src))
 
         return {


### PR DESCRIPTION
If we set this to info, it will appear on systems on every grains load. This affects
things like salt-call on every invocation. It's not sensible to throw this warning
in a CLI utility, especially on systems which may have a valid reason for being
configured in this manner. Either way, it shouldn't be the job of Salt to warn
people of this condition.

Refs #33934

Closes #37506