### PR TITLE
fix __opts__ and provider being None in salt.utils.aws:get_location

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -577,8 +577,10 @@ def get_location(opts=None, provider=None):
         DEFAULT_LOCATION
     '''
     if opts is None:
-        opts = __opts__
-    ret = opts.get('location', provider.get('location'))
+        opts = {}
+    ret = opts.get('location')
+    if ret is None and provider is not None:
+        ret = provider.get('location')
     if ret is None:
         ret = get_region_from_metadata()
     if ret is None:


### PR DESCRIPTION
### What does this PR do?
Fixes usage of __opts__ and checks for provider being none in `salt.utils.aws:get_location`.

### What issues does this PR fix or reference?
#37628 

### Tests written?
No
