### PR TITLE
Fix versions report for Windows Server platforms

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -645,8 +645,8 @@ def system_information():
     release = platform.release()
     if platform.win32_ver()[0]:
         import win32api
-        if ((sys.version_info.major == 2 and sys.version_info >= (2,7,12)) or
-                (sys.version_info.major == 3 and sys.version_info >= (3,5,2))):
+        if ((sys.version_info.major == 2 and sys.version_info >= (2, 7, 12)) or
+                (sys.version_info.major == 3 and sys.version_info >= (3, 5, 2))):
             if win32api.GetVersionEx(1)[8] > 1:
                 server = {'Vista': '2008Server',
                           '7': '2008ServerR2',

--- a/salt/version.py
+++ b/salt/version.py
@@ -641,12 +641,29 @@ def system_information():
         else:
             return ''
 
+    version = system_version()
+    release = platform.release()
+    if platform.win32_ver()[0]:
+        import win32api
+        if ((sys.version_info.major == 2 and sys.version_info >= (2,7,12)) or
+                (sys.version_info.major == 3 and sys.version_info >= (3,5,2))):
+            if win32api.GetVersionEx(1)[8] > 1:
+                server = {'Vista': '2008Server',
+                          '7': '2008ServerR2',
+                          '8': '2012Server',
+                          '8.1': '2012ServerR2',
+                          '10': '2016Server'}
+                release = server.get(platform.release(),
+                                     'UNKServer')
+                _, ver, sp, extra = platform.win32_ver()
+                version = ' '.join([release, ver, sp, extra])
+
     system = [
         ('system', platform.system()),
         ('dist', ' '.join(platform.dist())),
-        ('release', platform.release()),
+        ('release', release),
         ('machine', platform.machine()),
-        ('version', system_version()),
+        ('version', version),
     ]
 
     for name, attr in system:


### PR DESCRIPTION
### What does this PR do?
Python 2.7.12 and 3.5.2 changed the return values for reporting version numbers on Server versions of Windows. As a result, Server 2008 gets reported as Vista, 2008R2 as 7, 2012 as 8, 2012R2 as 8.1, etc...
This issue was addressed for grains (https://github.com/saltstack/salt/issues/36307), but we didn't consider versions-report.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/37620

### Previous Behavior
The Workstation version was being reported instead of the Server version.

### New Behavior
Mimics the old behavior.

### Tests written?
No