### PR TITLE
vm state is not ACTIVE,associate floating ip to it will fail

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -735,7 +735,7 @@ def request_instance(vm_=None, call=None):
             )
 
     if not vm_.get('password', None):
-        vm_['password'] = data.extra.get('password', '')            
+        vm_['password'] = data.extra.get('password', '')
 
     return data, vm_
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -683,9 +683,59 @@ def request_instance(vm_=None, call=None):
         if floating_ip is None:
             floating_ip = conn.floating_ip_create(pool)['ip']
 
-    vm_['floating_ip'] = floating_ip
+        def __query_node_data(vm_):
+            try:
+                node = show_instance(vm_['name'], 'action')
+                log.debug(
+                    'Loaded node data for {0}:\n{1}'.format(
+                        vm_['name'],
+                        pprint.pformat(node)
+                    )
+                )
+            except Exception as err:
+                log.error(
+                    'Failed to get nodes list: {0}'.format(
+                        err
+                    ),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info_on_loglevel=logging.DEBUG
+                )
+                # Trigger a failure in the wait for IP function
+                return False
+        
+            return node['state'] == 'ACTIVE' or None
 
-    vm_['password'] = data.extra.get('password', '')
+        # if we associate the floating ip directly,we will fail.
+        # As if we attempt to associate a floating IP before the Nova instance has completed building,
+        # it will fail.So we should associate it after the Nova instance has completed building.
+        try:
+            salt.utils.cloud.wait_for_ip(
+                __query_node_data,
+                update_args = (vm_,)
+            )
+        except (SaltCloudExecutionTimeout, SaltCloudExecutionFailure) as exc:
+            try:
+                # It might be already up, let's destroy it!
+                destroy(vm_['name'])
+            except SaltCloudSystemExit:
+                pass
+            finally:
+                raise SaltCloudSystemExit(str(exc))
+
+        try:
+            conn.floating_ip_associate(vm_['name'], floating_ip)
+            vm_['floating_ip'] = floating_ip
+        except Exception as exc:
+            raise SaltCloudSystemExit(
+                'Error assigning floating_ip for {0} on Nova\n\n'
+                'The following exception was thrown by libcloud when trying to '
+                'assing a floating ip: {1}\n'.format(
+                    vm_['name'], exc
+                )
+            )
+
+    if not vm_.get('password', None):
+        vm_['password'] = data.extra.get('password', '')            
 
     return data, vm_
 
@@ -786,7 +836,7 @@ def create(vm_):
             return
 
         # set vm state is ACTIVE here,or it will be BUILD or other when final return
-        data.state = 'ACTIVE'        
+        data.state = 'ACTIVE'
         
         if rackconnect(vm_) is True:
             extra = node.get('extra', {})
@@ -912,24 +962,7 @@ def create(vm_):
             data.private_ips = result
             if ssh_interface(vm_) == 'private_ips':
                 return data
-        
-        # if the vm already associated with a floating ip,we should skip it.
-        if not floating:
-            log.debug('associate floating ip {0} to vm {1}'.format(vm_['floating_ip'], vm_['name']))
-            try:
-                # we should associate floating ip to vm after it's state is ACTIVE.
-                conn.floating_ip_associate(vm_['name'], vm_['floating_ip'])
-            except Exception as exc:
-                raise SaltCloudSystemExit(
-                    'Error assigning floating_ip for {0} on Nova\n\n'
-                    'The following exception was thrown by libcloud when trying to '
-                    'assing a floating ip: {1}\n'.format(
-                        vm_['name'], exc
-                    )
-                )
-        else:
-            log.debug('skip floating_ip_associate')
-            
+
     try:
         data = salt.utils.cloud.wait_for_ip(
             __query_node_data,


### PR DESCRIPTION
### What does this PR do?
I need associate floating ip to vm when create it with  salt-cloud -p openstack-ip test,and i set 
  floating_ip:
    auto_assign: true
    pool: admin_floating_net

in my profile file.
but it fails.So i read the code,and update it,it will work.

And when the cmd finished, the state is BUILD,obviously it's not.it it RUNNING,at least it should be ACTIVE.
So i add data.state = 'ACTIVE'  to it.
### What issues does this PR fix or reference?

### Previous Behavior
associate floating ip to vm will fail
### New Behavior
associate floating ip to it will success

### Tests written?
Yes/No
I have test it in my enviroment and it work fine