### PR TITLE
Change the confirm parameter in commit function

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -240,7 +240,7 @@ def commit():
     commit_ok = conn.cu.commit_check()
     if commit_ok:
         try:
-            conn.cu.commit(confirm=True)
+            conn.cu.commit(confirm=False)
             ret['out'] = True
             ret['message'] = 'Commit Successful.'
         except Exception as exception:


### PR DESCRIPTION
## What does this PR do?
Fixes a bug in commit function of junos module.

## Previous Behavior
The commit requires a confirmation otherwise, the changes are rolled back

## New Behavior
A regular commit goes through

## Tests written?
No