### PR TITLE
Fix set_restart_freeze function

### DIFF
--- a/salt/modules/mac_power.py
+++ b/salt/modules/mac_power.py
@@ -446,6 +446,7 @@ def set_restart_freeze(enabled):
     return salt.utils.mac_utils.confirm_updated(
         state,
         get_restart_freeze,
+        True
     )
 
 

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -204,7 +204,7 @@ def validate_enabled(enabled):
 
 def confirm_updated(value, check_fun, normalize_ret=False, wait=5):
     '''
-    Wait upto ``wait`` seconds for a system parameter to be changed before
+    Wait up to ``wait`` seconds for a system parameter to be changed before
     deciding it hasn't changed.
 
     :param str value: The value indicating a successful change


### PR DESCRIPTION
### What does this PR do?
A new function was created in salt.util.mac_utils for handling change validation. The mac_power module was migrated to use that function (`confirm_updated`). The function allows you to normalize the return. This is needed for the `set_restart_freeze` function to work correctly.

### What issues does this PR fix or reference?
Failing tests on OSX

### Previous Behavior
Test failure

### New Behavior
Test now passes

### Tests written?
oui
