### PR TITLE
Revert commit fb763d to unbreak salt-master on non-Linux systems

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -484,7 +484,6 @@ def _virtual(osdata):
     #   virtual
     #   virtual_subtype
     grains = {'virtual': 'physical'}
-    grains.update(_hw_data(grains))
 
     # Skip the below loop on platforms which have none of the desired cmds
     # This is a temporary measure until we can write proper virtual hardware


### PR DESCRIPTION
### Explanation

Commit fb763d91e8189bb73a2c24916093cc06896d251f breaks the salt-master on all non-Linux systems.

Why? `_hw_data(osdata)` is called before `osdata` includes the key 'kernel', resulting
in a KeyError.

### Steps to reproduce

    (saltenv) $ salt-master -l debug

I confirmed that reverting this change restores operation of salt-master on OpenBSD and MacOS