### PR TITLE
fixed guestfs mounting for salt virt

### DIFF
--- a/salt/modules/seed.py
+++ b/salt/modules/seed.py
@@ -72,7 +72,7 @@ def _mount(path, ftype, root=None):
         return path
     elif ftype == 'file':
         if 'guestfs.mount' in __salt__:
-            util = 'qemu_nbd'
+            util = 'guestfs'
         elif 'qemu_nbd.init' in __salt__:
             util = 'qemu_nbd'
         else:


### PR DESCRIPTION
### What does this PR do?
Enable guestfs mout for virt

### What issues does this PR fix or reference?
qemu-nbd mount not working correctly.

### Previous Behavior
Previously only qemu-nbd mount possible. 

### Tests written?
No, hope not necessary.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

