### PR TITLE
joyent: Handle error if deployment fails

### DIFF
--- a/tests/unit/cloud/clouds/joyent_test.py
+++ b/tests/unit/cloud/clouds/joyent_test.py
@@ -129,7 +129,7 @@ class JoyentTestCase(TestCase):
         })
         self.assertEqual(http_mock.call_args[1]['header_dict']['Content-Type'],
             'application/json')
-        self.assertEqual(result, False) # Deploy failed
+        self.assertEqual(result, False)  # Deploy failed
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/cloud/clouds/joyent_test.py
+++ b/tests/unit/cloud/clouds/joyent_test.py
@@ -5,12 +5,18 @@
 
 # Import Salt Libs
 from __future__ import absolute_import
+import json
 
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
 from salttesting.helpers import ensure_in_syspath
-from salttesting.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON
-
+from salttesting.mock import (
+    MagicMock,
+    mock_open,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
 
 # Import Salt Libs
 from salt.cloud.clouds import joyent
@@ -42,14 +48,24 @@ class JoyentTestCase(TestCase):
     Unit TestCase for the salt.cloud.clouds.joyent module
     '''
     joyent.__utils__ = {
-        'cloud.fire_event': MagicMock()
+        'cloud.fire_event': MagicMock(),
+        'cloud.bootstrap': MagicMock()
     }
     joyent.__opts__ = {
         'sock_dir': True,
         'transport': True,
-        'providers': {'my_joyent': {}}
+        'providers': {'my_joyent': {}},
+        'profiles': {'my_joyent': {}}
     }
-    vm_ = {'name': 'vm3', 'driver': 'joyent'}
+    vm_ = {
+        'profile': 'my_joyent',
+        'name': 'vm3',
+        'driver': 'joyent',
+        'size': 'k4-highcpu-kvm-750M',
+        'image': 'freebsd10',
+        'location': 'us-east-1'
+    }
+    joyent.__active_provider_name__ = 'my_joyent:joyent'
 
     @patch('salt.utils.cloud.wait_for_ip', fake_wait_for_ip)
     def test_query_instance_init(self):
@@ -85,6 +101,35 @@ class JoyentTestCase(TestCase):
         self.assertTrue(joyent.__utils__['cloud.fire_event'].called_once())
         self.assertEqual(result, '1.1.1.1')
 
+    @patch('salt.config.is_profile_configured', MagicMock(return_value=True))
+    @patch('salt.utils.fopen', mock_open())
+    @patch('Crypto.PublicKey.RSA.importKey', MagicMock())
+    @patch('Crypto.Signature.PKCS1_v1_5.new', MagicMock())
+    @patch('base64.b64encode', MagicMock())
+    def test_create_fail(self):
+        '''
+        Test behavior when node creation failed because of an invalid profile
+        option
+        '''
+        image = {'name': '39a87f12-034c-11e6-84f5-4316cc1fcaa0'}
+        size = {'name': 'k4-highcpu-kvm-750M'}
+        show_reply = {}
+        query_ret = {'error': 'Unable to create machine', 'status': 0}
+        with patch.object(joyent, 'get_image', return_value=image):
+            with patch.object(joyent, 'get_size', return_value=size):
+                with patch.object(joyent, 'show_instance', return_value=show_reply):
+                    with patch('salt.utils.http.query', return_value=query_ret) as http_mock:
+                        result = joyent.create(self.vm_)
+        self.assertEqual(http_mock.call_args[0],
+            ('https://us-east-1.api.joyentcloud.com//my/machines', 'POST'))
+        self.assertDictEqual(json.loads(http_mock.call_args[1]['data']), {
+            'image': '39a87f12-034c-11e6-84f5-4316cc1fcaa0',
+            'name': 'vm3',
+            'package': 'k4-highcpu-kvm-750M'
+        })
+        self.assertEqual(http_mock.call_args[1]['header_dict']['Content-Type'],
+            'application/json')
+        self.assertEqual(result, False) # Deploy failed
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?

Try to handle errors during the provisioning of new VMs on Joyent.

### Previous Behavior

If VM creation failed a confusing traceback ending with the following would be printed:

    TypeError: 'NoneType' object has no attribute '__getitem__'

The code path was set up to handle exceptions, but if a failure occurred an exception was not raised. Instead interpret the return values.

### New Behavior

If a parameter in the profile is not correct the following error is logged:

    Error: There was a profile error: Failed to deploy VM

### Tests written?

Yes. The heavy use of mocks can be reduced by relocating RSA key processing to a helper function.

Also fix up some pylint warnings.
