### PR TITLE
Update pyzmq to 15.3.0 for 2016.3 [DO NOT MERGE FORWARD]

### DIFF
--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -25,7 +25,7 @@ pypiwin32==219
 pyOpenSSL==16.1.0
 python-dateutil==2.5.3
 python-gnupg==0.3.8
-pyzmq==15.2.0
+pyzmq==15.3.0
 requests==2.10.0
 singledispatch==3.4.0.3
 six==1.10.0


### PR DESCRIPTION
### What does this PR do?
Updates the pyzmq req to 15.3.0. Pyzmq version 15.2.0 uses libzmq 4.1.2 which is has a bug dealing with IPv6. This was fixed in libzmq 4.1.3 and above. pyzmq 15.3.0 uses libzmq 4.1.5. Future builds of salt will ship with a version of pyzmq that works with IPv6.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/37597