### PR TITLE
if vm state is not ACTIVE, it will fail

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -710,7 +710,7 @@ def request_instance(vm_=None, call=None):
         try:
             salt.utils.cloud.wait_for_ip(
                 __query_node_data,
-                update_args = (vm_,)
+                update_args=(vm_,)
             )
         except (SaltCloudExecutionTimeout, SaltCloudExecutionFailure) as exc:
             try:

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -682,8 +682,47 @@ def request_instance(vm_=None, call=None):
                 break
         if floating_ip is None:
             floating_ip = conn.floating_ip_create(pool)['ip']
+
+        def __query_node_data(vm_):
+            try:
+                node = show_instance(vm_['name'], 'action')
+                log.debug(
+                    'Loaded node data for {0}:\n{1}'.format(
+                        vm_['name'],
+                        pprint.pformat(node)
+                    )
+                )
+            except Exception as err:
+                log.error(
+                    'Failed to get nodes list: {0}'.format(
+                        err
+                    ),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info_on_loglevel=logging.DEBUG
+                )
+                # Trigger a failure in the wait for IP function
+                return False
+            return node['state'] == 'ACTIVE' or None
+
+        # if we associate the floating ip here,then we will fail.
+        # As if we attempt to associate a floating IP before the Nova instance has completed building,
+        # it will fail.So we should associate it after the Nova instance has completed building.
         try:
-            conn.floating_ip_associate(kwargs['name'], floating_ip)
+            salt.utils.cloud.wait_for_ip(
+                __query_node_data,
+                update_args = (vm_,)
+            )
+        except (SaltCloudExecutionTimeout, SaltCloudExecutionFailure) as exc:
+            try:
+                # It might be already up, let's destroy it!
+                destroy(vm_['name'])
+            except SaltCloudSystemExit:
+                pass
+            finally:
+                raise SaltCloudSystemExit(str(exc))
+
+        try:
+            conn.floating_ip_associate(vm_['name'], floating_ip)
             vm_['floating_ip'] = floating_ip
         except Exception as exc:
             raise SaltCloudSystemExit(
@@ -693,6 +732,7 @@ def request_instance(vm_=None, call=None):
                     vm_['name'], exc
                 )
             )
+
     if not vm_.get('password', None):
         vm_['password'] = data.extra.get('password', '')
 


### PR DESCRIPTION
### What does this PR do?

I need associate floating ip to vm when create it with salt-cloud -p openstack-ip test,and i set
floating_ip:
auto_assign: true
pool: admin_floating_net

in my profile file.
but it fails.So i read the code,and update it,it will work.

### What issues does this PR fix or reference?  #33093

### Previous Behavior

associate floating ip to vm will fail

### New Behavior

associate floating ip to it will success

### Tests written?

Yes/No
I have test it in my enviroment and it work fine