### PR TITLE
Fix test disabled

### DIFF
--- a/tests/integration/modules/mac_service.py
+++ b/tests/integration/modules/mac_service.py
@@ -194,13 +194,14 @@ class MacServiceModuleTest(integration.ModuleCase):
         '''
         Test service.disabled
         '''
-        self.assertTrue(self.run_function('service.start', [self.SERVICE_NAME]))
+	SERVICE_NAME = 'com.apple.nfsd'
+        self.assertTrue(self.run_function('service.start', [SERVICE_NAME]))
         self.assertFalse(
-            self.run_function('service.disabled', [self.SERVICE_NAME]))
+            self.run_function('service.disabled', [SERVICE_NAME]))
 
-        self.assertTrue(self.run_function('service.stop', [self.SERVICE_NAME]))
+        self.assertTrue(self.run_function('service.stop', [SERVICE_NAME]))
         self.assertTrue(
-            self.run_function('service.disabled', [self.SERVICE_NAME]))
+            self.run_function('service.disabled', [SERVICE_NAME]))
 
         self.assertTrue(self.run_function('service.disabled', ['spongebob']))
 

--- a/tests/integration/modules/mac_service.py
+++ b/tests/integration/modules/mac_service.py
@@ -194,7 +194,7 @@ class MacServiceModuleTest(integration.ModuleCase):
         '''
         Test service.disabled
         '''
-	SERVICE_NAME = 'com.apple.nfsd'
+        SERVICE_NAME = 'com.apple.nfsd'
         self.assertTrue(self.run_function('service.start', [SERVICE_NAME]))
         self.assertFalse(
             self.run_function('service.disabled', [SERVICE_NAME]))


### PR DESCRIPTION
### What does this PR do?
Fixes the mac_service test_disabled test. There was a problem using the apsd service. The test would pass or fail intermittently. Using the nfsd service to test disabled works everytime.