### PR TITLE
Fix test disabled 2016.3 [DO NOT MERGE FORWARD]

### DIFF
--- a/tests/integration/modules/mac_service.py
+++ b/tests/integration/modules/mac_service.py
@@ -199,13 +199,14 @@ class MacServiceModuleTest(integration.ModuleCase):
         '''
         Test service.disabled
         '''
-        self.assertTrue(self.run_function('service.start', [self.SERVICE_NAME]))
+        SERVICE_NAME = 'com.apple.nfsd'
+        self.assertTrue(self.run_function('service.start', [SERVICE_NAME]))
         self.assertFalse(
-            self.run_function('service.disabled', [self.SERVICE_NAME]))
+            self.run_function('service.disabled', [SERVICE_NAME]))
 
-        self.assertTrue(self.run_function('service.stop', [self.SERVICE_NAME]))
+        self.assertTrue(self.run_function('service.stop', [SERVICE_NAME]))
         self.assertTrue(
-            self.run_function('service.disabled', [self.SERVICE_NAME]))
+            self.run_function('service.disabled', [SERVICE_NAME]))
 
         self.assertTrue(self.run_function('service.disabled', ['spongebob']))
 


### PR DESCRIPTION
### What does this PR do?
Fixes the mac_service test_disabled test. There was a problem using the apsd service. The test would pass or fail intermittently. Using the nfsd service to test disabled works everytime.

@rallytime Please do NOT merge forward.