### PR TITLE
Don't overwrite the "key" variable passed in to _listeners_present func

### DIFF
--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -689,12 +689,12 @@ def _listeners_present(
 
     expected_listeners_by_tuple = {}
     for l in listeners:
-        key = __salt__['boto_elb.listener_dict_to_tuple'](l)
-        expected_listeners_by_tuple[key] = l
+        l_key = __salt__['boto_elb.listener_dict_to_tuple'](l)
+        expected_listeners_by_tuple[l_key] = l
     actual_listeners_by_tuple = {}
     for l in lb['listeners']:
-        key = __salt__['boto_elb.listener_dict_to_tuple'](l)
-        actual_listeners_by_tuple[key] = l
+        l_key = __salt__['boto_elb.listener_dict_to_tuple'](l)
+        actual_listeners_by_tuple[l_key] = l
 
     to_delete = []
     to_create = []


### PR DESCRIPTION
Fixes #37665

The `key` variable is used in the function's signature. We don't want to overwrite what we're passing in there with this generated tuple. `key` is used later in the function to other boto_elb modules functions, which should be the normal key string and not a tuple.