### PR TITLE
Properly gate dbus definitions

### DIFF
--- a/salt/beacons/avahi_announce.py
+++ b/salt/beacons/avahi_announce.py
@@ -25,8 +25,16 @@ except ImportError:
 
 try:
     import dbus
+    from dbus import DBusException
+    BUS = dbus.SystemBus()
+    SERVER = dbus.Interface(BUS.get_object(avahi.DBUS_NAME, avahi.DBUS_PATH_SERVER),
+                            avahi.DBUS_INTERFACE_SERVER)
+    GROUP = dbus.Interface(BUS.get_object(avahi.DBUS_NAME, SERVER.EntryGroupNew()),
+                           avahi.DBUS_INTERFACE_ENTRY_GROUP)
     HAS_DBUS = True
 except ImportError:
+    HAS_DBUS = False
+except DBusException:
     HAS_DBUS = False
 
 log = logging.getLogger(__name__)
@@ -34,11 +42,6 @@ log = logging.getLogger(__name__)
 __virtualname__ = 'avahi_announce'
 
 LAST_GRAINS = {}
-BUS = dbus.SystemBus()
-SERVER = dbus.Interface(BUS.get_object(avahi.DBUS_NAME, avahi.DBUS_PATH_SERVER),
-                        avahi.DBUS_INTERFACE_SERVER)
-GROUP = dbus.Interface(BUS.get_object(avahi.DBUS_NAME, SERVER.EntryGroupNew()),
-                       avahi.DBUS_INTERFACE_ENTRY_GROUP)
 
 
 def __virtual__():


### PR DESCRIPTION
### What does this PR do?
As it says.

### What issues does this PR fix or reference?
None known.

### Previous Behavior
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1332, in _load_module
    ), fn_, fpath, desc)
  File "/usr/lib/python2.7/site-packages/salt/beacons/avahi_announce.py", line 38, in <module>
    SERVER = dbus.Interface(BUS.get_object(avahi.DBUS_NAME, avahi.DBUS_PATH_SERVER),
  File "/usr/lib/python2.7/site-packages/dbus/bus.py", line 241, in get_object
    follow_name_owner_changes=follow_name_owner_changes)
  File "/usr/lib/python2.7/site-packages/dbus/proxies.py", line 248, in __init__
    self._named_service = conn.activate_name_owner(bus_name)
  File "/usr/lib/python2.7/site-packages/dbus/bus.py", line 180, in activate_name_owner
    self.start_service_by_name(bus_name)
  File "/usr/lib/python2.7/site-packages/dbus/bus.py", line 278, in start_service_by_name
    'su', (bus_name, flags)))
  File "/usr/lib/python2.7/site-packages/dbus/connection.py", line 651, in call_blocking
    message, timeout)
DBusException: org.freedesktop.systemd1.NoSuchUnit: Unit dbus-org.freedesktop.Avahi.service not found.
```

### Tests written?
No