### PR TITLE
Update RST and release notes for Carbon release

### DIFF
--- a/doc/topics/releases/2016.11.0.rst
+++ b/doc/topics/releases/2016.11.0.rst
@@ -182,6 +182,25 @@ Additionally, the following changes have been made to the :mod:`archive
   :py:func:`archive.unzip <salt.modules.archive.unzip>` has been changed to
   ``True``.
 
+Improved Checksum Handling in :py:func:`file.managed <salt.states.file.managed>`, :py:func:`archive.extracted <salt.states.archive.extracted>` States
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+
+When the ``source_hash`` argument for these states refers to a file containing
+checksums, Salt now looks for checksums matching the name of the source URI, as
+well as the file being managed. Prior releases only looked for checksums
+matching the filename being managed. Additionally, a new argument
+(``source_hash_name``) has been added, which allows the user to disambiguate
+ambiguous matches when more than one matching checksum is found in the
+``source_hash`` file.
+
+A more detailed explanation of this functionality can be found in the
+:py:func:`file.managed <salt.states.file.managed>` documentation, in the
+section for the new ``source_hash_name`` argument.
+
+.. note::
+    This improved functionality is also available in the ``2016.3`` (Boron)
+    release cycle, starting with the 2016.3.5 release.
+
 Config Changes
 ==============
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -554,7 +554,7 @@ def get_source_sum(file_name='',
         Optional file name being managed, for matching with
         :py:func:`file.extract_hash <salt.modules.file.extract_hash>`.
 
-        .. versionadded:: 2016.11.1
+        .. versionadded:: 2016.11.0
 
     source
         Source file, as used in :py:mod:`file <salt.states.file>` and other
@@ -574,7 +574,7 @@ def get_source_sum(file_name='',
         Specific file name to look for when ``source_hash`` refers to a remote
         file, used to disambiguate ambiguous matches.
 
-        .. versionadded:: 2016.11.1
+        .. versionadded:: 2016.11.0
 
     saltenv : base
         Salt fileserver environment from which to retrive the source_hash. This
@@ -3810,7 +3810,7 @@ def extract_hash(hash_fn,
         takes precedence over both the ``file_name`` and ``source``. When it is
         not specified, ``file_name`` takes precedence over ``source``. This
         allows for better capability for matching hashes.
-    .. versionchanged:: 2016.11.1
+    .. versionchanged:: 2016.11.0
         File name and source URI matches are no longer disregarded when
         ``source_hash_name`` is specified. They will be used as fallback
         matches if there is no match to the ``source_hash_name`` value.

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -304,7 +304,7 @@ def extracted(name,
             for multiple files that have the same basename. So, in the
             example above, simply using ``foo.txt`` would not match.
 
-        .. versionadded:: 2016.11.1
+        .. versionadded:: 2016.11.0
 
     source_hash_update
         Set this to ``True`` if archive should be extracted if source_hash has

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1284,7 +1284,7 @@ def managed(name,
             for multiple files that have the same basename. So, in the
             example above, simply using ``foo.txt`` would not match.
 
-        .. versionadded:: 2016.3.5,2016.11.1
+        .. versionadded:: 2016.3.5
 
     user
         The user to own the file, this defaults to the user salt is running as


### PR DESCRIPTION
Since v2016.11.0rc2 will not become v2016.11.0, the docs needed to be
updated regarding a bugfix that was originally slated for 2016.11.1
since it came after RC2 was cut.