### PR TITLE
handle semodule version >=2.4 (#37732) and fix typo

### DIFF
--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -249,7 +249,7 @@ def list_semod():
     if semodule_version == 'new':
         mdata = __salt__['cmd.run']('semodule -lfull').splitlines()
         ret = {}
-        for line in mdata[1:]:
+        for line in mdata[0:]:
             if not line.strip():
                 continue
             comps = line.split()
@@ -262,7 +262,7 @@ def list_semod():
     else:
         mdata = __salt__['cmd.run']('semodule -l').splitlines()
         ret = {}
-        for line in mdata[1:]:
+        for line in mdata[0:]:
             if not line.strip():
                 continue
             comps = line.split()

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -243,7 +243,7 @@ def list_semod():
     semodule_versioncheck = __salt__['cmd.run']('semodule -h').splitlines()
     semodule_version = ''
     for line in versioncheck[1:]:
-        if line.strip.startswith('full'):
+        if line.strip().startswith('full'):
             semodule_version = 'new'
 
     if semodule_version == 'new':

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -240,16 +240,36 @@ def list_semod():
 
     .. versionadded:: 2016.3.0
     '''
-    mdata = __salt__['cmd.run']('semodule -l').splitlines()
-    ret = {}
-    for line in mdata[1:]:
-        if not line.strip():
-            continue
-        comps = line.split()
-        if len(comps) == 3:
-            ret[comps[0]] = {'Enabled': False,
-                             'Version': comps[1]}
-        else:
-            ret[comps[0]] = {'Enabled': True,
-                             'Version': comps[1]}
+    semodule_versioncheck = __salt__['cmd.run']('semodule -h').splitlines()
+    semodule_version = ''
+    for line in versioncheck[1:]:
+        if line.strip.startswith('full'):
+            semodule_version = 'new'
+
+    if semodule_version == 'new':
+        mdata = __salt__['cmd.run']('semodule -lfull').splitlines()
+        ret = {}
+        for line in mdata[1:]:
+            if not line.strip():
+                continue
+            comps = line.split()
+            if len(comps) == 4:
+                ret[comps[1]] = {'Enabled': False,
+                                 'Version': None}
+            else:
+                ret[comps[1]] = {'Enabled': True,
+                                 'Version': None}
+    else:
+        mdata = __salt__['cmd.run']('semodule -l').splitlines()
+        ret = {}
+        for line in mdata[1:]:
+            if not line.strip():
+                continue
+            comps = line.split()
+            if len(comps) == 3:
+                ret[comps[0]] = {'Enabled': False,
+                                 'Version': comps[1]}
+            else:
+                ret[comps[0]] = {'Enabled': True,
+                                 'Version': comps[1]}
     return ret

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -240,16 +240,16 @@ def list_semod():
 
     .. versionadded:: 2016.3.0
     '''
-    semodule_versioncheck = __salt__['cmd.run']('semodule -h').splitlines()
+    helptext = __salt__['cmd.run']('semodule -h').splitlines()
     semodule_version = ''
-    for line in versioncheck[1:]:
+    for line in helptext:
         if line.strip().startswith('full'):
             semodule_version = 'new'
 
     if semodule_version == 'new':
         mdata = __salt__['cmd.run']('semodule -lfull').splitlines()
         ret = {}
-        for line in mdata[0:]:
+        for line in mdata:
             if not line.strip():
                 continue
             comps = line.split()
@@ -262,7 +262,7 @@ def list_semod():
     else:
         mdata = __salt__['cmd.run']('semodule -l').splitlines()
         ret = {}
-        for line in mdata[0:]:
+        for line in mdata:
             if not line.strip():
                 continue
             comps = line.split()

--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -198,7 +198,8 @@ def module(name, module_state='Enabled', version='any'):
         installed_version = modules[name]['Version']
         if not installed_version == version:
             ret['comment'] = 'Module version is {0} and does not match ' \
-                             'the desired version of {1}'.format(installed_version, version)
+                             'the desired version of {1} or you are ' \
+                             'using semodule >= 2.4'.format(installed_version, version)
             ret['result'] = False
             return ret
     current_module_state = _refine_module_state(modules[name]['Enabled'])
@@ -207,7 +208,7 @@ def module(name, module_state='Enabled', version='any'):
         return ret
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = 'Module {0} is set to be togggled to {1}'.format(
+        ret['comment'] = 'Module {0} is set to be toggled to {1}'.format(
             name, module_state)
         return ret
 


### PR DESCRIPTION
### What does this PR do?
Checks for more recent versions of semodule (v2.4+) and runs semodule differently depending on what side of the version line it's on, storing different results in the dictionary

### What issues does this PR fix or reference?
#37732

### Previous Behavior
errors on any state.apply of a selinux.module state

### New Behavior
no more errors, but no more selinux module versioning for newer versions of the selinux userspace (but that's upstream's choice)

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

