### PR TITLE
Adding check for ignore_if_missing param when calling _check_file.

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3342,7 +3342,10 @@ def replace(name,
 
     check_res, check_msg = _check_file(name)
     if not check_res:
-        return _error(ret, check_msg)
+        if ignore_if_missing and 'file not found' in check_msg:
+            pass
+        else:
+            return _error(ret, check_msg)
 
     changes = __salt__['file.replace'](name,
                                        pattern,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3343,7 +3343,8 @@ def replace(name,
     check_res, check_msg = _check_file(name)
     if not check_res:
         if ignore_if_missing and 'file not found' in check_msg:
-            pass
+            ret['comment'] = 'No changes needed to be made'
+            return ret
         else:
             return _error(ret, check_msg)
 


### PR DESCRIPTION
### What does this PR do?

Checks ignore_if_missing param after calling _check_file in file.replace state module. If _check_file returns false due to file not found error, method returns immediately.

### What issues does this PR fix or reference?

#37741 

### Previous Behavior
----------
          ID: /tmp/test
    Function: file.replace
      Result: False
     Comment: /tmp/test: file not found
     Started: 15:30:55.730533
    Duration: 0.799 ms
     Changes:  

### New Behavior
----------
          ID: /tmp/test
    Function: file.replace
      Result: True
     Comment: No changes needed to be made
     Started: 15:56:11.907440
    Duration: 0.349 ms
     Changes:

### Tests written?

No