### PR TITLE
Switch default filter tag for ONE resources from user only to all resources

### DIFF
--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -62,7 +62,6 @@ to find the IP of the new VM.
 
 # Import Python Libs
 from __future__ import absolute_import
-import distutils
 import logging
 import os
 import pprint
@@ -526,7 +525,6 @@ def get_one_version(kwargs=None, call=None):
     auth = ':'.join([user, password])
 
     return server.one.system.version(auth)[1]
-
 
 
 def get_cluster_id(kwargs=None, call=None):

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -8,7 +8,7 @@ The OpenNebula cloud module is used to control access to an OpenNebula cloud.
 .. versionadded:: 2014.7.0
 
 :depends: lxml
-:depends: OpenNebula installation running version ``4.14``.
+:depends: OpenNebula installation running version ``4.14`` or later.
 
 Use of this module requires the ``xml_rpc``, ``user``, and ``password``
 parameters to be set.
@@ -62,6 +62,7 @@ to find the IP of the new VM.
 
 # Import Python Libs
 from __future__ import absolute_import
+import distutils
 import logging
 import os
 import pprint
@@ -85,6 +86,7 @@ try:
     HAS_XML_LIBS = True
 except ImportError:
     HAS_XML_LIBS = False
+
 
 # Get Logging Started
 log = logging.getLogger(__name__)
@@ -147,7 +149,8 @@ def avail_images(call=None):
 
     server, user, password = _get_xml_rpc()
     auth = ':'.join([user, password])
-    image_pool = server.one.imagepool.info(auth, -1, -1, -1)[1]
+
+    image_pool = server.one.imagepool.info(auth, -2, -1, -1)[1]
 
     images = {}
     for image in _get_xml(image_pool):
@@ -358,7 +361,7 @@ def list_security_groups(call=None):
 
     server, user, password = _get_xml_rpc()
     auth = ':'.join([user, password])
-    secgroup_pool = server.one.secgrouppool.info(auth, -1, -1, -1)[1]
+    secgroup_pool = server.one.secgrouppool.info(auth, -2, -1, -1)[1]
 
     groups = {}
     for group in _get_xml(secgroup_pool):
@@ -386,7 +389,7 @@ def list_templates(call=None):
 
     server, user, password = _get_xml_rpc()
     auth = ':'.join([user, password])
-    template_pool = server.one.templatepool.info(auth, -1, -1, -1)[1]
+    template_pool = server.one.templatepool.info(auth, -2, -1, -1)[1]
 
     templates = {}
     for template in _get_xml(template_pool):
@@ -414,7 +417,7 @@ def list_vns(call=None):
 
     server, user, password = _get_xml_rpc()
     auth = ':'.join([user, password])
-    vn_pool = server.one.vnpool.info(auth, -1, -1, -1)[1]
+    vn_pool = server.one.vnpool.info(auth, -2, -1, -1)[1]
 
     vns = {}
     for v_network in _get_xml(vn_pool):
@@ -496,6 +499,34 @@ def stop(name, call=None):
     log.info('Stopping node {0}'.format(name))
 
     return vm_action(name, kwargs={'action': 'stop'}, call=call)
+
+
+def get_one_version(kwargs=None, call=None):
+    '''
+    Returns the OpenNebula version.
+
+    .. versionadded:: 2016.3.5
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-cloud -f get_one_version one_provider_name
+    '''
+
+    if call == 'action':
+        raise SaltCloudSystemExit(
+            'The get_cluster_id function must be called with -f or --function.'
+        )
+
+    if kwargs is None:
+        kwargs = {}
+
+    server, user, password = _get_xml_rpc()
+    auth = ':'.join([user, password])
+
+    return server.one.system.version(auth)[1]
+
 
 
 def get_cluster_id(kwargs=None, call=None):
@@ -4421,7 +4452,7 @@ def _list_nodes(full=False):
     server, user, password = _get_xml_rpc()
     auth = ':'.join([user, password])
 
-    vm_pool = server.one.vmpool.info(auth, -1, -1, -1, -1)[1]
+    vm_pool = server.one.vmpool.info(auth, -2, -1, -1, -1)[1]
 
     vms = {}
     for vm in _get_xml(vm_pool):


### PR DESCRIPTION
### What does this PR do?

The default filter tag for ONE images, templates, VMs, etc, was set to show only items
that were owned by a user or a user's group.  This PR changes it to show all items.

This PR also adds a function `get_one_version` since I wrote it thinking that to fix this issue
I was going to have to change the filter tags based on the ONE version in use.  There ended up being an easier way, but I didn't want to throw out code that might be useful.

### What issues does this PR fix or reference?

No open issue currently.

### Previous Behavior

Accessible templates or images that could be accessed from the web interface could not
be used with Salt-cloud because Salt-cloud would not see them.