### PR TITLE
Fix couchbase returner and add couple of more features

### DIFF
--- a/salt/returners/couchbase_return.py
+++ b/salt/returners/couchbase_return.py
@@ -3,14 +3,36 @@
 Simple returner for Couchbase. Optional configuration
 settings are listed below, along with sane defaults.
 
-couchbase.host:   'salt'
-couchbase.port:   8091
-couchbase.bucket: 'salt'
-couchbase.skip_verify_views: False
+.. code-block:: yaml
 
-  To use the couchbase returner, append '--return couchbase' to the salt command. ex:
+    couchbase.host:   'salt'
+    couchbase.port:   8091
+    couchbase.bucket: 'salt'
+    couchbase.ttl: 24
+    couchbase.password: 'password'
+    couchbase.skip_verify_views: False
+
+To use the couchbase returner, append '--return couchbase' to the salt command. ex:
+
+.. code-block:: bash
 
     salt '*' test.ping --return couchbase
+
+To use the alternative configuration, append '--return_config alternative' to the salt command.
+
+.. versionadded:: 2015.5.0
+
+.. code-block:: bash
+
+    salt '*' test.ping --return couchbase --return_config alternative
+
+To override individual configuration items, append --return_kwargs '{"key:": "value"}' to the salt command.
+
+.. versionadded:: 2016.3.0
+
+.. code-block:: bash
+
+    salt '*' test.ping --return couchbase --return_kwargs '{"bucket": "another-salt"}'
 
 
 All of the return data will be stored in documents as follows:
@@ -24,10 +46,11 @@ nocache: should we not cache the return data
 JID/MINION_ID
 =============
 return: return_data
-out: out_data
+full_ret: full load of job return
 '''
 from __future__ import absolute_import
 
+import json
 import logging
 
 try:
@@ -70,7 +93,8 @@ def _get_options():
     '''
     return {'host': __opts__.get('couchbase.host', 'salt'),
             'port': __opts__.get('couchbase.port', 8091),
-            'bucket': __opts__.get('couchbase.bucket', 'salt')}
+            'bucket': __opts__.get('couchbase.bucket', 'salt'),
+            'password': __opts__.get('couchbase.password', '')}
 
 
 def _get_connection():
@@ -80,9 +104,16 @@ def _get_connection():
     global COUCHBASE_CONN
     if COUCHBASE_CONN is None:
         opts = _get_options()
-        COUCHBASE_CONN = couchbase.Couchbase.connect(host=opts['host'],
-                                                     port=opts['port'],
-                                                     bucket=opts['bucket'])
+        if opts['password']:
+            COUCHBASE_CONN = couchbase.Couchbase.connect(host=opts['host'],
+                                                         port=opts['port'],
+                                                         bucket=opts['bucket'],
+                                                         password=opts['password'])
+        else:
+            COUCHBASE_CONN = couchbase.Couchbase.connect(host=opts['host'],
+                                                         port=opts['port'],
+                                                         bucket=opts['bucket'])
+
     return COUCHBASE_CONN
 
 
@@ -117,7 +148,7 @@ def _get_ttl():
     '''
     Return the TTL that we should store our objects with
     '''
-    return __opts__['keep_jobs'] * 60 * 60  # keep_jobs is in hours
+    return __opts__.get('couchbase.ttl', 24) * 60 * 60  # keep_jobs is in hours
 
 
 #TODO: add to returner docs-- this is a new one
@@ -150,25 +181,14 @@ def prep_jid(nocache=False, passed_jid=None):
 
 def returner(load):
     '''
-    Return data to the local job cache
+    Return data to couchbase bucket
     '''
     cb_ = _get_connection()
-    try:
-        jid_doc = cb_.get(load['jid'])
-        if jid_doc.value['nocache'] is True:
-            return
-    except couchbase.exceptions.NotFoundError:
-        log.error(
-            'An inconsistency occurred, a job was received with a job id '
-            'that is not present in the local cache: {jid}'.format(**load)
-        )
-        return False
 
     hn_key = '{0}/{1}'.format(load['jid'], load['id'])
     try:
-        ret_doc = {'return': load['return']}
-        if 'out' in load:
-            ret_doc['out'] = load['out']
+        ret_doc = {'return': load['return'],
+                   'full_ret': json.dumps(load)}
 
         cb_.add(hn_key,
                ret_doc,


### PR DESCRIPTION
### What does this PR do?
Fixes:
 1. For external job cache setup, since all the jid return will come directly from salt-minions, there is no need to check the jid exists in couchbase because jid cannot be written into it from salt-master in this scenario.

2. add full_ret to return doc so that the document will be more informative.

3. make ttl as a config attribute because salt-minion does not have keep_jobs attribute. This problem cause the couchbase returner not functional. 

Features:
1. add password into config attribute in case some connections to couchbase bucket need to pass the authentication. 

Docs:
1. Update the docs accordingly. 

### What issues does this PR fix or reference?

### Previous Behavior
Not Working for external job cache setup. 

### New Behavior
External job cache should work properly with authentication and more informative data put into couchbase. 

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
