### PR TITLE
Add pre_versions to chocolatey.installed

### DIFF
--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -31,8 +31,9 @@ def install(*args, **kwargs):
     installed(*args, **kwargs)
 
 
-def installed(name, version=None, source=None, force=False, install_args=None,
-            override_args=False, force_x86=False, package_args=None):
+def installed(name, version=None, source=None, force=False, pre_versions=False,
+              install_args=None, override_args=False, force_x86=False,
+              package_args=None):
     '''
     Installs a package if not already installed
 
@@ -48,6 +49,9 @@ def installed(name, version=None, source=None, force=False, install_args=None,
 
     force
       Reinstall the current version of an existing package. Default is false.
+
+    pre_versions
+      Include pre-release packages. Default is False.
 
     install_args
       A list of install arguments you want to pass to the installation
@@ -97,13 +101,9 @@ def installed(name, version=None, source=None, force=False, install_args=None,
         return ret
 
     # Install the package
-    ret['changes'] = {name: __salt__['chocolatey.install'](name, version,
-                                                             source,
-                                                             force,
-                                                             install_args,
-                                                             override_args,
-                                                             force_x86,
-                                                             package_args)}
+    ret['changes'] = {name: __salt__['chocolatey.install'](
+        name, version, source, force, pre_versions, install_args, override_args,
+        force_x86, package_args)}
 
     if 'Running chocolatey failed' not in ret['changes']:
         ret['result'] = True

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -102,8 +102,10 @@ def installed(name, version=None, source=None, force=False, pre_versions=False,
 
     # Install the package
     ret['changes'] = {name: __salt__['chocolatey.install'](
-        name, version, source, force, pre_versions, install_args, override_args,
-        force_x86, package_args)}
+        name=name, version=version, source=source, force=force,
+        pre_versions=pre_versions, install_args=install_args,
+        override_args=override_args, force_x86=force_x86,
+        package_args=package_args)}
 
     if 'Running chocolatey failed' not in ret['changes']:
         ret['result'] = True


### PR DESCRIPTION
### What does this PR do?
Adds ``pre_version`` argument to the ``chocolatey.installed`` state. It looks like this was an oversight.

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1061

### Previous Behavior
This parameter was not available. Additionally, the call to ``chocolatey.install`` used positional arguments and didn't account for the ``pre_versions`` parameter between ``force`` and ``install_args``, so the ``chocolatey.install`` paramaters were being shifted down one after force, ``pre_versions`` was getting ``install_args``, ``install_args`` was getting ``override_args``, etc.

### New Behavior
Parameter now available. Arguments line up correctly.

### Tests written?
No