### PR TITLE
Document `python` argument in `salt.states.virtualenv_mod`

### DIFF
--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -69,6 +69,9 @@ def managed(name,
     use_wheel: False
         Prefer wheel archives (requires pip >= 1.4).
 
+    python : None
+        Python executable used to build the virtualenv
+
     user: None
         The user under which to run virtualenv and pip.
 


### PR DESCRIPTION
### What does this PR do?

Add missing documentation

### What issues does this PR fix or reference?

related; http://grokbase.com/t/gg/salt-users/15c2fxe65p/specify-specific-python-version-when-create-a-virtualenv