### PR TITLE
Prune obsolete code from integration test harness

### DIFF
--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -11,6 +11,7 @@ import time
 # Import Salt Testing libs
 from salttesting import skipIf
 from salttesting.helpers import ensure_in_syspath
+from salttesting.mixins import SaltReturnAssertsMixIn
 ensure_in_syspath('../../')
 
 # Import salt libs
@@ -22,8 +23,7 @@ from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES
 import salt.ext.six as six
 
 
-class StateModuleTest(integration.ModuleCase,
-                      integration.SaltReturnAssertsMixIn):
+class StateModuleTest(integration.ModuleCase, SaltReturnAssertsMixIn):
     '''
     Validate the state module
     '''


### PR DESCRIPTION
### What does this PR do?

Removes obsolete code from integration test harness that is implemented in the [SaltTesting](https://github.com/saltstack/salt-testing) module.

### Details

These following are implemented by the SaltTesting modules:

    SyndicCase
    ShellCase
    ShellCaseCommonTestsMixIn
    SSHCase
    SaltReturnAssertsMixIn

The class prototypes are still required, but the member functions are obsolete and incorrect which can make troubleshooting a failure in the test harness very confusing.

If the SaltTesting module is not installed, an error is raised when attempting to start the integration tests:

ImportError: No module named salttesting
