### PR TITLE
Adding Azure Service Principal auth for Azure ARM 

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -201,7 +201,7 @@ def get_conn(Client=None):
             'secret',
             get_configured_provider(), __opts__, search_global=False
         )
-        credentials = ServicePrincipalCredentials(client_id, secret, tenant)
+        credentials = ServicePrincipalCredentials(client_id, secret, tenant=tenant)
     else:
         username = config.get_cloud_config_value(
             'username',

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -13,20 +13,35 @@ The Azure cloud module is used to control access to Microsoft Azure
 :configuration:
     Required provider parameters:
 
+    if using username and password:
     * ``subscription_id``
     * ``username``
     * ``password``
+
+    if using a service principal:
+    * ``subscription_id``
+    * ``tenant``
+    * ``client_id``
+    * ``secret``
 
 Example ``/etc/salt/cloud.providers`` or
 ``/etc/salt/cloud.providers.d/azure.conf`` configuration:
 
 .. code-block:: yaml
 
-    my-azure-config:
+    my-azure-config with username and password:
       driver: azure
       subscription_id: 3287abc8-f98a-c678-3bde-326766fd3617
       username: larry
       password: 123pass
+
+    Or my-azure-config with service principal:
+      driver: azure
+      subscription_id: 3287abc8-f98a-c678-3bde-326766fd3617
+      tenant: ABCDEFAB-1234-ABCD-1234-ABCDEFABCDEF
+      client_id: ABCDEFAB-1234-ABCD-1234-ABCDEFABCDEF
+      secret: XXXXXXXXXXXXXXXXXXXXXXXX
+
 '''
 # pylint: disable=E0102
 
@@ -57,7 +72,10 @@ try:
     import salt.utils.msazure
     from salt.utils.msazure import object_to_dict
     import azure.storage
-    from azure.common.credentials import UserPassCredentials
+    from azure.common.credentials import (
+        UserPassCredentials,
+        ServicePrincipalCredentials,
+    )
     from azure.mgmt.compute import ComputeManagementClient
     from azure.mgmt.compute.models import (
         CachingTypes,
@@ -128,11 +146,19 @@ def get_configured_provider():
     '''
     Return the first configured instance.
     '''
-    return config.is_provider_configured(
+    provider = config.is_provider_configured(
         __opts__,
         __active_provider_name__ or __virtualname__,
-        ('subscription_id', 'username', 'password')
-    )
+        ('subscription_id', 'tenant', 'client_id', 'secret')
+        )
+    if provider is False:
+        return config.is_provider_configured(
+            __opts__,
+            __active_provider_name__ or __virtualname__,
+            ('subscription_id', 'username', 'password')
+        )
+    else:
+        return provider
 
 
 def get_dependencies():
@@ -157,17 +183,32 @@ def get_conn(Client=None):
         get_configured_provider(), __opts__, search_global=False
     )
 
-    username = config.get_cloud_config_value(
-        'username',
+    tenant = config.get_cloud_config_value(
+        'tenant',
         get_configured_provider(), __opts__, search_global=False
     )
 
-    password = config.get_cloud_config_value(
-        'password',
-        get_configured_provider(), __opts__, search_global=False
-    )
+    if tenant is None:
+        username = config.get_cloud_config_value(
+            'username',
+            get_configured_provider(), __opts__, search_global=False
+        )
+        password = config.get_cloud_config_value(
+            'password',
+            get_configured_provider(), __opts__, search_global=False
+        )
+        credentials = UserPassCredentials(username, password)
+    else:
+        client_id = config.get_cloud_config_value(
+            'client_id',
+            get_configured_provider(), __opts__, search_global=False
+        )
+        secret = config.get_cloud_config_value(
+            'secret',
+            get_configured_provider(), __opts__, search_global=False
+        )
+        credentials = ServicePrincipalCredentials(client_id, secret, tenant)
 
-    credentials = UserPassCredentials(username, password)
     client = Client(
         credentials=credentials,
         subscription_id=subscription_id,

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -46,6 +46,7 @@ Example ``/etc/salt/cloud.providers`` or
       az ad sp create-for-rbac -n "http://<yourappname>" --role <role> --scopes <scope>
       For example, this creates a service principal with 'owner' role for the whole subscription:
       az ad sp create-for-rbac -n "http://mysaltapp" --role owner --scopes /subscriptions/3287abc8-f98a-c678-3bde-326766fd3617
+      *Note: review the details of Service Principals. Owner role is more than you normally need, and you can restrict scope to a resource group or individual resources.
 '''
 # pylint: disable=E0102
 

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -42,6 +42,10 @@ Example ``/etc/salt/cloud.providers`` or
       client_id: ABCDEFAB-1234-ABCD-1234-ABCDEFABCDEF
       secret: XXXXXXXXXXXXXXXXXXXXXXXX
 
+      The Service Principal can be created with the new Azure CLI (https://github.com/Azure/azure-cli) with:
+      az ad sp create-for-rbac -n "http://<yourappname>" --role <role> --scopes <scope>
+      For example, this creates a service principal with 'owner' role for the whole subscription:
+      az ad sp create-for-rbac -n "http://mysaltapp" --role owner --scopes /subscriptions/3287abc8-f98a-c678-3bde-326766fd3617
 '''
 # pylint: disable=E0102
 
@@ -187,18 +191,7 @@ def get_conn(Client=None):
         'tenant',
         get_configured_provider(), __opts__, search_global=False
     )
-
-    if tenant is None:
-        username = config.get_cloud_config_value(
-            'username',
-            get_configured_provider(), __opts__, search_global=False
-        )
-        password = config.get_cloud_config_value(
-            'password',
-            get_configured_provider(), __opts__, search_global=False
-        )
-        credentials = UserPassCredentials(username, password)
-    else:
+    if tenant is not None:
         client_id = config.get_cloud_config_value(
             'client_id',
             get_configured_provider(), __opts__, search_global=False
@@ -208,6 +201,16 @@ def get_conn(Client=None):
             get_configured_provider(), __opts__, search_global=False
         )
         credentials = ServicePrincipalCredentials(client_id, secret, tenant)
+    else:
+        username = config.get_cloud_config_value(
+            'username',
+            get_configured_provider(), __opts__, search_global=False
+        )
+        password = config.get_cloud_config_value(
+            'password',
+            get_configured_provider(), __opts__, search_global=False
+        )
+        credentials = UserPassCredentials(username, password)
 
     client = Client(
         credentials=credentials,


### PR DESCRIPTION
### What does this PR do?
Extends the Azure ARM support to allow for [Service Principal authentication](https://docs.microsoft.com/en-us/azure/resource-group-authenticate-service-principal-cli). It allows scoped access to Azure resources without the need to use your own credentials. 

### What issues does this PR fix or reference?
None.

### Previous Behavior
Only Username and Password auth support for Azure ARM.

### New Behavior
Both Username and Password and Service Principal support for Azure ARM.

### Tests written?
No automated test. Has been manually tested.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
