### PR TITLE
respect trailing dot in ddns name parameter

### DIFF
--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -152,7 +152,12 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', replace=False,
         salt ns1 ddns.update example.com host1 60 A 10.0.0.1
     '''
     name = str(name)
-    fqdn = '{0}.{1}'.format(name, zone)
+
+    if name[-1:] == '.':
+        fqdn = name
+    else:
+        fqdn = '{0}.{1}'.format(name, zone)
+
     request = dns.message.make_query(fqdn, rdtype)
     answer = dns.query.udp(request, nameserver)
 
@@ -198,9 +203,13 @@ def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1', **kwargs)
         salt ns1 ddns.delete example.com host1 A
     '''
     name = str(name)
-    fqdn = '{0}.{1}'.format(name, zone)
-    request = dns.message.make_query(fqdn, (rdtype or 'ANY'))
 
+    if name[-1:] == '.':
+        fqdn = name
+    else:
+        fqdn = '{0}.{1}'.format(name, zone)
+
+    request = dns.message.make_query(fqdn, (rdtype or 'ANY'))
     answer = dns.query.udp(request, nameserver)
     if not answer.answer:
         return None

--- a/salt/states/ddns.py
+++ b/salt/states/ddns.py
@@ -37,8 +37,9 @@ def present(name, zone, ttl, data, rdtype='A', **kwargs):
 
     name
         The host portion of the DNS record, e.g., 'webserver'. Name and zone
-        are concatenated when the entry is created, so make sure that
-        information is not duplicated in these two arguments.
+        are concatenated when the entry is created unless name includes a
+        trailing dot, so make sure that information is not duplicated in these
+        two arguments.
 
     zone
         The zone to check/update
@@ -95,8 +96,9 @@ def absent(name, zone, data=None, rdtype=None, **kwargs):
 
     name
         The host portion of the DNS record, e.g., 'webserver'. Name and zone
-        are concatenated when the entry is created, so make sure that
-        information is not duplicated in these two arguments.
+        are concatenated when the entry is created unless name includes a
+        trailing dot, so make sure that information is not duplicated in these
+        two arguments.
 
     zone
         The zone to check


### PR DESCRIPTION
### What does this PR do?
In modules.ddns, when checking if a record exists, only append zone to record name if record name does not end in a trailing dot. 

### What issues does this PR fix or reference?
#37287 

### Previous Behavior
Previously the zone was always appended to the name.

### Tests written?
No