### PR TITLE
network.routes should not raise exception if no interface

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -490,7 +490,7 @@ def _netstat_route_sunos():
             'gateway': comps[1],
             'netmask': '',
             'flags': comps[2],
-            'interface': comps[5]})
+            'interface': comps[5] if len(comps) == 6 else ''})
     cmd = 'netstat -f inet6 -rn | tail -n+5'
     out = __salt__['cmd.run'](cmd, python_shell=True)
     for line in out.splitlines():
@@ -501,7 +501,7 @@ def _netstat_route_sunos():
             'gateway': comps[1],
             'netmask': '',
             'flags': comps[2],
-            'interface': comps[5]})
+            'interface': comps[5] if len(comps) == 6 else ''})
     return ret
 
 

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -490,7 +490,7 @@ def _netstat_route_sunos():
             'gateway': comps[1],
             'netmask': '',
             'flags': comps[2],
-            'interface': comps[5] if len(comps) == 6 else ''})
+            'interface': comps[5] if len(comps) >= 6 else ''})
     cmd = 'netstat -f inet6 -rn | tail -n+5'
     out = __salt__['cmd.run'](cmd, python_shell=True)
     for line in out.splitlines():
@@ -501,7 +501,7 @@ def _netstat_route_sunos():
             'gateway': comps[1],
             'netmask': '',
             'flags': comps[2],
-            'interface': comps[5] if len(comps) == 6 else ''})
+            'interface': comps[5] if len(comps) >= 6 else ''})
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?
Not all routes are assigned to an interface, we should not raise an exception due to index out of bounds if this is the case.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Raises exception when route without interface is encoutnered

### New Behavior
Just leaves the interface field empty.

### Tests written?
No

