### PR TITLE
please tell me where is the “error: 'dict' object has no …”

### DIFF
--- a/salt/template.py
+++ b/salt/template.py
@@ -85,7 +85,7 @@ def compile_template(template,
             try:
                 input_data.seek(0)
             except Exception as exp:
-                log.error('error: {0}'.format(exp))
+                log.error('error while compiling template={1}: {0}'.format(exp,template))
 
         render_kwargs = dict(renderers=renderers, tmplpath=template)
         render_kwargs.update(kwargs)

--- a/salt/template.py
+++ b/salt/template.py
@@ -85,7 +85,7 @@ def compile_template(template,
             try:
                 input_data.seek(0)
             except Exception as exp:
-                log.error('error while compiling template={1}: {0}'.format(exp,template))
+                log.error('error while compiling template \'{0}\': {1}'.format(template, exp))
 
         render_kwargs = dict(renderers=renderers, tmplpath=template)
         render_kwargs.update(kwargs)


### PR DESCRIPTION
### What does this PR do?

Tell me where the "error: 'dict' object has no attribute 'seek'" is so I can go fix it. It makes no attempt to resolve the error, just gives me a hint about what broke.

### What issues does this PR fix or reference?

#29028 and possibly others.

### Previous Behavior
complain uselessly to the minion log

### New Behavior
complain usefully to the minion log

### Tests written?

no

