### PR TITLE
check count of columns after split

### DIFF
--- a/salt/modules/extfs.py
+++ b/salt/modules/extfs.py
@@ -245,6 +245,8 @@ def dump(device, args=None):
             elif line.startswith('Group') and not line.startswith('Group descriptor size'):
                 mode = 'blocks'
             else:
+                if len(comps) < 2:
+                    continue
                 ret['attributes'][comps[0]] = comps[1].strip()
 
         if mode == 'blocks':


### PR DESCRIPTION
If called on a device w/o extfs, a unhandled exception will be raise.
After add this check, is implies that attributes will be empty if the
device's filesystem is not extfs.