### PR TITLE
Windows Perms for file.directory and file.managed

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4411,19 +4411,25 @@ def check_file_meta(
                 else:
                     changes['diff'] = 'Replace binary file with text file'
 
-    if (user is not None
-            and user != lstats['user']
-            and user != lstats['uid']):
-        changes['user'] = user
-    if (group is not None
-            and group != lstats['group']
-            and group != lstats['gid']):
-        changes['group'] = group
-    # Normalize the file mode
-    smode = salt.utils.normalize_mode(lstats['mode'])
-    mode = salt.utils.normalize_mode(mode)
-    if mode is not None and mode != smode:
-        changes['mode'] = mode
+    if not salt.utils.is_windows():
+        # Check owner
+        if (user is not None
+                and user != lstats['user']
+                and user != lstats['uid']):
+            changes['user'] = user
+
+        # Check group
+        if (group is not None
+                and group != lstats['group']
+                and group != lstats['gid']):
+            changes['group'] = group
+
+        # Normalize the file mode
+        smode = salt.utils.normalize_mode(lstats['mode'])
+        mode = salt.utils.normalize_mode(mode)
+        if mode is not None and mode != smode:
+            changes['mode'] = mode
+
     return changes
 
 
@@ -4771,8 +4777,14 @@ def manage_file(name,
                     if mode_list[idx] != '0':
                         mode_list[idx] = str(int(mode_list[idx]) | 1)
                 dir_mode = ''.join(mode_list)
-            makedirs_(name, user=user,
-                      group=group, mode=dir_mode)
+
+            if salt.utils.is_windows():
+                # This function resides in win_file.py and will be available
+                # on Windows
+                makedirs_(name, win_owner, win_perms, win_deny_perms,
+                          win_inheritance)
+            else:
+                makedirs_(name, user=user, group=group, mode=dir_mode)
 
         if source:
             # It is a new file, set the diff accordingly
@@ -4875,7 +4887,16 @@ def manage_file(name,
             os.umask(mask)
             # Calculate the mode value that results from the umask
             mode = oct((0o777 ^ mask) & 0o666)
-        ret, _ = check_perms(name, ret, user, group, mode)
+
+        if salt.utils.is_windows():
+            ret = check_perms(name,
+                              ret,
+                              kwargs.get('win_owner'),
+                              kwargs.get('win_perms'),
+                              kwargs.get('win_deny_perms'),
+                              kwargs.get('win_inheritance'))
+        else:
+            ret, _ = check_perms(name, ret, user, group, mode)
 
         if not ret['comment']:
             ret['comment'] = 'File ' + name + ' updated'
@@ -4886,6 +4907,7 @@ def manage_file(name,
             ret['comment'] = 'File ' + name + ' is in the correct state'
         if sfn:
             __clean_tmp(sfn)
+
         return ret
 
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4746,7 +4746,15 @@ def manage_file(name,
             ret['changes']['diff'] = \
                 'Replace symbolic link with regular file'
 
-        ret, _ = check_perms(name, ret, user, group, mode, follow_symlinks)
+        if salt.utils.is_windows():
+            ret = check_perms(name,
+                              ret,
+                              kwargs.get('win_owner'),
+                              kwargs.get('win_perms'),
+                              kwargs.get('win_deny_perms'),
+                              kwargs.get('win_inheritance'))
+        else:
+            ret, _ = check_perms(name, ret, user, group, mode, follow_symlinks)
 
         if ret['changes']:
             ret['comment'] = 'File {0} updated'.format(name)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4788,9 +4788,14 @@ def manage_file(name,
 
             if salt.utils.is_windows():
                 # This function resides in win_file.py and will be available
-                # on Windows
-                makedirs_(name, win_owner, win_perms, win_deny_perms,
-                          win_inheritance)
+                # on Windows. The local function will be overridden
+                # pylint: disable=E1121
+                makedirs_(name,
+                          kwargs.get('win_owner'),
+                          kwargs.get('win_perms'),
+                          kwargs.get('win_deny_perms'),
+                          kwargs.get('win_inheritance'))
+                # pylint: enable=E1121
             else:
                 makedirs_(name, user=user, group=group, mode=dir_mode)
 

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -55,7 +55,7 @@ except ImportError:
 import salt.utils
 from salt.modules.file import (check_hash,  # pylint: disable=W0611
         directory_exists, get_managed,
-        check_managed, check_managed_changes, check_perms, source_list,
+        check_managed, check_managed_changes, source_list,
         touch, append, contains, contains_regex, get_source_sum,
         contains_glob, find, psed, get_sum, _get_bkroot, _mkstemp_copy,
         get_hash, manage_file, file_exists, get_diff, line, list_backups,
@@ -80,8 +80,8 @@ def __virtual__():
     '''
     if salt.utils.is_windows():
         if HAS_WINDOWS_MODULES:
-            global check_perms, get_managed, makedirs_perms, manage_file
-            global source_list, mkdir, __clean_tmp, makedirs_, file_exists
+            global get_managed, manage_file
+            global source_list, __clean_tmp, file_exists
             global check_managed, check_managed_changes, check_file_meta
             global append, _error, directory_exists, touch, contains
             global contains_regex, contains_glob, get_source_sum
@@ -104,16 +104,12 @@ def __virtual__():
             delete_backup = _namespaced_function(delete_backup, globals())
             extract_hash = _namespaced_function(extract_hash, globals())
             append = _namespaced_function(append, globals())
-            check_perms = _namespaced_function(check_perms, globals())
             get_managed = _namespaced_function(get_managed, globals())
             check_managed = _namespaced_function(check_managed, globals())
             check_managed_changes = _namespaced_function(check_managed_changes, globals())
             check_file_meta = _namespaced_function(check_file_meta, globals())
-            makedirs_perms = _namespaced_function(makedirs_perms, globals())
-            makedirs_ = _namespaced_function(makedirs_, globals())
             manage_file = _namespaced_function(manage_file, globals())
             source_list = _namespaced_function(source_list, globals())
-            mkdir = _namespaced_function(mkdir, globals())
             file_exists = _namespaced_function(file_exists, globals())
             __clean_tmp = _namespaced_function(__clean_tmp, globals())
             directory_exists = _namespaced_function(directory_exists, globals())
@@ -1384,7 +1380,13 @@ def mkdir(path,
 
         # Make the directory
         os.mkdir(path)
-        set_perms(path, owner, grant_perms, deny_perms, inheritance)
+
+        # Set owner
+        if owner:
+            salt.utils.win_dacl.set_owner(path, owner)
+
+        # Set permissions
+        set_perms(path, grant_perms, deny_perms, inheritance)
 
     return True
 
@@ -1562,6 +1564,7 @@ def check_perms(path,
                 owner=None,
                 grant_perms=None,
                 deny_perms=None,
+                applies_to,
                 inheritance=None,
                 follow_symlinks=False):
     path = os.path.expanduser(path)
@@ -1595,18 +1598,130 @@ def check_perms(path,
                         ret['comment'].append(
                             'Failed to change owner to "{0}"'.format(owner))
 
-    # Check permissions
+    # Check permissions# Check perms
+    perms = salt.utils.win_dacl.get_permissions(name)
+
+    # Verify Grant Permissions and Applies to
+    if grant_perms is not None:
+        for user in grant_perms:
+
+            # Check Perms
+            list_grant_perms = []
+            if isinstance(grant_perms[user], six.string_types):
+                if not salt.utils.win_dacl.has_permission(
+                        name, user, grant_perms[user]):
+                    list_grant_perms = grant_perms[user]
+            else:
+                for perm in grant_perms[user]:
+                    if not salt.utils.win_dacl.has_permission(
+                            name, user, perm, exact=False):
+                        list_grant_perms.append(grant_perms[user])
+
+            # Check Applies to
+            user = salt.utils.win_dacl.get_name(user)
+
+            # Get the proper applies_to text
+            at_flag = salt.utils.win_dacl.Flags.ace_prop['file'][win_applies_to]
+            applies_to_text = salt.utils.win_dacl.Flags.ace_prop['file'][at_flag]
+
+            # Get current "applies to" settings from the file
+            new_applies_to = 'this_folder_subfolder_files'
+            for flag in salt.utils.win_dacl.Flags.ace_prop['file']:
+                if salt.utils.win_dacl.Flags.ace_prop['file'][flag] == \
+                    perms[user]['grant']['applies to']:
+                    at_flag = flag
+            for flag in salt.utils.win_dacl.Flags.ace_prop['file']:
+                if salt.utils.win_dacl.Flags.ace_prop['file'][flag] == \
+                    at_flag:
+                    new_applies_to = flag
+
+            # If the applies to settings are different, use the new one
+            if 'grant' in perms[user]:
+                if not perms[user]['grant']['applies to'] == applies_to_text:
+                    new_applies_to = applies_to
+                    if not list_grant_perms:
+                        if __opts__['test'] is True:
+                            ret['changes']['applies_to'] = applies_to_text
+                        else:
+                            try:
+                                salt.utils.win_dacl.set_permissions(
+                                    path, user, perms[user]['grant']['permissions'], 'grant', new_applies_to)
+                                ret['changes']['applies_to'] = applies_to_text
+                            except CommandExecutionError:
+                                ret['result'] = False
+                                ret['comment'].append(
+                                    'Failed to set "applies to" for "{0}" to '
+                                    '{0}'.format(user, applies_to_text))
+
+            if list_grant_perms:
+                if 'grant_perms' not in ret['changes']:
+                    ret['changes']['grant_perms'] = {}
+                if __opts__['test'] is True:
+                    ret['changes']['grant_perms'][user] = list_grant_perms
+                else:
+                    try:
+                        salt.utils.win_dacl.set_permissions(
+                            path, user, grant_perms[user], 'grant', new_applies_to)
+                        ret['changes']['grant_perms'][user] = list_grant_perms
+                    except CommandExecutionError:
+                        ret['result'] = False
+                        ret['comment'].append(
+                            'Failed to grant permissions for "{0}" to '
+                            '{0}'.format(user, grant_perms[user]))
+
+    # Verify Deny Permissions
+    if deny_perms is not None:
+        for user in deny_perms:
+            list_deny_perms = []
+            # Check for permissions
+            if isinstance(deny_perms[user], six.string_types):
+                if not salt.utils.win_dacl.has_permission(
+                        name, user, deny_perms[user], 'deny'):
+                    list_deny_perms = deny_perms[user]
+            else:
+                for perm in deny_perms[user]:
+                    if not salt.utils.win_dacl.has_permission(
+                            name, user, perm, 'deny', exact=False):
+                        list_deny_perms.append(perm)
+
+            if list_deny_perms:
+                if 'deny_perms' not in ret['changes']:
+                    ret['changes']['deny_perms'] = {}
+                ret['changes']['deny_perms'][user] = list_deny_perms
+
+            # Check Applies to
+            user = salt.utils.win_dacl.get_name(user)
+
+            # Get the proper applies_to text
+            at_flag = salt.utils.win_dacl.Flags.ace_prop['file'][win_applies_to]
+            applies_to_text = salt.utils.win_dacl.Flags.ace_prop['file'][at_flag]
+
+            if 'deny' in perms[user]:
+                if not perms[user]['deny']['applies to'] == applies_to_text:
+                    ret['changes']['applies_to'] = applies_to_text
+
+    # Check inheritance
+    if inheritance is not None:
+        if not inheritance == salt.utils.win_dacl.get_inheritance(name):
+            ret['changes']['inheritance'] = inheritance
+
+    # Re-add the Original Comment if defined
+    if isinstance(orig_comment, six.string_types):
+        if orig_comment:
+            ret['comment'].insert(0, orig_comment)
+        ret['comment'] = '; '.join(ret['comment'])
+
+    # Set result for test = True
+    if __opts__['test'] is True and ret['changes']:
+        ret['result'] = None
+
+    return ret, perms
 
 
 def set_perms(path,
-              owner=None,
               grant_perms=None,
               deny_perms=None,
               inheritance=None):
-
-    # Set the owner if passed
-    if owner is not None:
-        salt.utils.win_dacl.set_owner(path, owner)
 
     # Get the DACL for the directory
     dacl = salt.utils.win_dacl.Dacl(path)

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1911,7 +1911,7 @@ def check_perms(path,
                     ret['result'] = False
                     ret['comment'].append(
                         'Failed to grant permissions for "{0}" to '
-                        '{0}'.format(user, changes[user]))
+                        '{1}'.format(user, changes[user]))
 
     # Check inheritance
     if inheritance is not None:

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1330,7 +1330,7 @@ def mkdir(path,
           deny_perms=None,
           inheritance=True):
     '''
-    Ensure that the directory is available.
+    Ensure that the directory is available and permissions are set.
 
     Args:
 
@@ -1340,29 +1340,25 @@ def mkdir(path,
         account that created the directory, likely SYSTEM
 
         grant_perms (dict): A dictionary containing the user/group and the basic
-        permission to grant, ie: ``{'user': 'basic_permission'}``. To set
-        advanced permissions use a dict containing the user/group and a list of
-        advanced permissions to apply, ie:
-        ``{'user': ['adv_perm1', 'adv_perm2']}``
+        permissions to grant, ie: ``{'user': {'perms': 'basic_permission'}}``.
+        You can also set the ``applies_to`` setting here. The default is
+        ``this_folder_subfolders_files``. Specify another ``applies_to`` setting
+        like this:
+
+        .. code-block:: yaml
+
+            {'user': {'perms': 'full_control', 'applies_to': 'this_folder'}}
+
+        To set advanced permissions use a list for the ``perms`` parameter, ie:
+
+        .. code-block:: yaml
+
+            {'user': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder'}}
 
         deny_perms (dict): A dictionary containing the user/group and
-        permissions to deny. Use the same format used for the ``grant_perms``
-        parameter. Remember, deny permissions supersede grant permissions.
-
-        applies_to (str): The objects to which these permissions will apply.
-        Acceptable options are:
-
-            - this_folder_only: Applies only to this object
-            - this_folder_subfolders_files (default): Applies to this object
-              and all sub containers and objects
-            - this_folder_subfolders: Applies to this object and all sub
-              containers, no files
-            - this_folder_files: Applies to this object and all file
-              objects, no containers
-            - subfolders_files: Applies to all containers and objects
-              beneath this object
-            - subfolders_only: Applies to all containers beneath this object
-            - files_only: Applies to all file objects beneath this object
+        permissions to deny along with the ``applies_to`` setting. Use the same
+        format used for the ``grant_perms`` parameter. Remember, deny
+        permissions supersede grant permissions.
 
         inheritance (bool): If True the object will inherit permissions from the
         parent, if False, inheritance will be disabled. Inheritance setting will
@@ -1376,13 +1372,13 @@ def mkdir(path,
     .. code-block:: bash
 
         # To grant the 'Users' group 'read & execute' permissions.
-        salt '*' file.mkdir C:\\Temp\\ Administrators "{'Users': 'read_execute'}"
+        salt '*' file.mkdir C:\\Temp\\ Administrators "{'Users': {'perms': 'read_execute'}}"
 
         # Locally using salt call
-        salt-call file.mkdir C:\\Temp\\ Administrators "{'Users': 'read_execute'}"
+        salt-call file.mkdir C:\\Temp\\ Administrators "{'Users': {'perms': 'read_execute', 'applies_to': 'this_folder_only'}}"
 
         # Specify advanced attributes with a list
-        salt '*' file.mkdir C:\\Temp\\ Administrators "{'jsnuffy': ['read_attributes', 'read_ea']}"
+        salt '*' file.mkdir C:\\Temp\\ Administrators "{'jsnuffy': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder_only'}}"
     '''
     # Make sure the drive is valid
     if not os.path.isdir(os.path.splitdrive(path)[0]):
@@ -1410,7 +1406,6 @@ def makedirs(path,
              owner=None,
              grant_perms=None,
              deny_perms=None,
-             applies_to='this_folder_subfolders_files',
              inheritance=True):
     '''
     Ensure that the parent directory containing this path is available.
@@ -1423,28 +1418,25 @@ def makedirs(path,
         account that created the directly, likely SYSTEM
 
         grant_perms (dict): A dictionary containing the user/group and the basic
-        permission to grant, ie: ``{user: basic_permission}``. To set advanced
-        permissions use a dict containing the user/group and a list of advanced
-        permissions to apply, ie: ``{user: [adv_perm1, adv_perm2]}``
+        permissions to grant, ie: ``{'user': {'perms': 'basic_permission'}}``.
+        You can also set the ``applies_to`` setting here. The default is
+        ``this_folder_subfolders_files``. Specify another ``applies_to`` setting
+        like this:
+
+        .. code-block:: yaml
+
+            {'user': {'perms': 'full_control', 'applies_to': 'this_folder'}}
+
+        To set advanced permissions use a list for the ``perms`` parameter, ie:
+
+        .. code-block:: yaml
+
+            {'user': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder'}}
 
         deny_perms (dict): A dictionary containing the user/group and
-        permissions to deny. Use the same format used for the ``grant_perms``
-        parameter. Remember, deny permissions supersede grant permissions.
-
-        applies_to (str): The objects to which these permissions will apply.
-        Acceptable options are:
-
-            - this_folder_only: Applies only to this object
-            - this_folder_subfolders_files (default): Applies to this object
-              and all sub containers and objects
-            - this_folder_subfolders: Applies to this object and all sub
-              containers, no files
-            - this_folder_files: Applies to this object and all file
-              objects, no containers
-            - subfolders_files: Applies to all containers and objects
-              beneath this object
-            - subfolders_only: Applies to all containers beneath this object
-            - files_only: Applies to all file objects beneath this object
+        permissions to deny along with the ``applies_to`` setting. Use the same
+        format used for the ``grant_perms`` parameter. Remember, deny
+        permissions supersede grant permissions.
 
         inheritance (bool): If True the object will inherit permissions from the
         parent, if False, inheritance will be disabled. Inheritance setting will
@@ -1463,14 +1455,13 @@ def makedirs(path,
     .. code-block:: bash
 
         # To grant the 'Users' group 'read & execute' permissions.
-        salt '*' file.makedirs C:\\Temp\\ Administrators "{'Users': 'read_execute'}"
+        salt '*' file.makedirs C:\\Temp\\ Administrators "{'Users': {'perms': 'read_execute'}}"
 
         # Locally using salt call
-        salt-call file.makedirs C:\\Temp\\ Administrators "{'Users': 'read_execute'}"
+        salt-call file.makedirs C:\\Temp\\ Administrators "{'Users': {'perms': 'read_execute', 'applies_to': 'this_folder_only'}}"
 
         # Specify advanced attributes with a list
-        salt '*' file.makedirs C:\\Temp\\ Administrators "{'jsnuffy': ['read_attributes', 'read_ea']}"
-
+        salt '*' file.makedirs C:\\Temp\\ Administrators "{'jsnuffy': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder_only'}}"
     '''
     path = os.path.expanduser(path)
 
@@ -1511,107 +1502,14 @@ def makedirs(path,
     for directory_to_create in directories_to_create:
         # all directories have the user, group and mode set!!
         log.debug('Creating directory: %s', directory_to_create)
-        mkdir(path, owner, grant_perms, deny_perms, applies_to, inheritance)
+        mkdir(path, owner, grant_perms, deny_perms, inheritance)
 
 
 def makedirs_perms(path,
                    owner=None,
                    grant_perms=None,
                    deny_perms=None,
-                   applies_to='this_folder_subfolders_files',
                    inheritance=True):
-    '''
-    Set owner and permissions for each directory created.
-
-    Args:
-
-        path (str): The full path to the directory.
-
-        owner (str): The owner of the directory. If not passed, it will be the
-        account that created the directory, likely SYSTEM
-
-        grant_perms (dict): A dictionary containing the user/group and the basic
-        permission to grant, ie: ``{'user': 'basic_permission'}``. To set
-        advanced permissions use a dict containing the user/group and a list of
-        advanced permissions to apply, ie:
-        ``{'user': ['adv_perm1', 'adv_perm2']}``
-
-        deny_perms (dict): A dictionary containing the user/group and
-        permissions to deny. Use the same format used for the ``grant_perms``
-        parameter. Remember, deny permissions supersede grant permissions.
-
-        applies_to (str): The objects to which these permissions will apply.
-        Acceptable options are:
-
-            - this_folder_only: Applies only to this object
-            - this_folder_subfolders_files (default): Applies to this object
-              and all sub containers and objects
-            - this_folder_subfolders: Applies to this object and all sub
-              containers, no files
-            - this_folder_files: Applies to this object and all file
-              objects, no containers
-            - subfolders_files: Applies to all containers and objects
-              beneath this object
-            - subfolders_only: Applies to all containers beneath this object
-            - files_only: Applies to all file objects beneath this object
-
-        inheritance (bool): If True the object will inherit permissions from the
-        parent, if False, inheritance will be disabled. Inheritance setting will
-        not apply to parent directories if they must be created
-
-    Returns:
-        bool: True if successful, otherwise raise an error
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        # To grant the 'Users' group 'read & execute' permissions.
-        salt '*' file.makedirs_perms C:\\Temp\\ Administrators "{'Users': 'read_execute'}"
-
-        # Locally using salt call
-        salt-call file.makedirs_perms C:\\Temp\\ Administrators "{'Users': 'read_execute'}"
-
-        # Specify advanced attributes with a list
-        salt '*' file.makedirs_perms C:\\Temp\\ Administrators "{'jsnuffy': ['read_attributes', 'read_ea']}"
-    '''
-    # Expand any environment variables
-    path = os.path.expanduser(path)
-    path = os.path.expandvars(path)
-
-    # Get parent directory (head)
-    head, tail = os.path.split(path)
-
-    # If tail is empty, split head
-    if not tail:
-        head, tail = os.path.split(head)
-
-    # If head and tail are defined and head is not there, recurse
-    if head and tail and not os.path.exists(head):
-        try:
-            # Create the directory here, set inherited True because this is a
-            # parent directory, the inheritance setting will only apply to the
-            # child directory
-            makedirs_perms(head, owner, grant_perms, deny_perms, True)
-        except OSError as exc:
-            # be happy if someone already created the path
-            if exc.errno != errno.EEXIST:
-                raise
-        if tail == os.curdir:  # xxx/newdir/. exists if xxx/newdir exists
-            return {}
-
-    # Make the directory
-    mkdir(path, owner, grant_perms, deny_perms, applies_to, inheritance)
-
-    return True
-
-
-def check_perms(path,
-                ret=None,
-                owner=None,
-                grant_perms=None,
-                deny_perms=None,
-                inheritance=True):
     '''
     Set owner and permissions for each directory created.
 
@@ -1661,7 +1559,98 @@ def check_perms(path,
         salt-call file.makedirs_perms C:\\Temp\\ Administrators "{'Users': {'perms': 'read_execute', 'applies_to': 'this_folder_only'}}"
 
         # Specify advanced attributes with a list
-        salt '*' file.makedirs_perms C:\\Temp\\ Administrators "{'jsnuffy': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'files_only'}}"
+        salt '*' file.makedirs_perms C:\\Temp\\ Administrators "{'jsnuffy': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder_files'}}"
+    '''
+    # Expand any environment variables
+    path = os.path.expanduser(path)
+    path = os.path.expandvars(path)
+
+    # Get parent directory (head)
+    head, tail = os.path.split(path)
+
+    # If tail is empty, split head
+    if not tail:
+        head, tail = os.path.split(head)
+
+    # If head and tail are defined and head is not there, recurse
+    if head and tail and not os.path.exists(head):
+        try:
+            # Create the directory here, set inherited True because this is a
+            # parent directory, the inheritance setting will only apply to the
+            # child directory
+            makedirs_perms(head, owner, grant_perms, deny_perms, True)
+        except OSError as exc:
+            # be happy if someone already created the path
+            if exc.errno != errno.EEXIST:
+                raise
+        if tail == os.curdir:  # xxx/newdir/. exists if xxx/newdir exists
+            return {}
+
+    # Make the directory
+    mkdir(path, owner, grant_perms, deny_perms, applies_to, inheritance)
+
+    return True
+
+
+def check_perms(path,
+                ret=None,
+                owner=None,
+                grant_perms=None,
+                deny_perms=None,
+                inheritance=True):
+    '''
+    Set owner and permissions for each directory created.
+
+    Args:
+
+        path (str): The full path to the directory.
+
+        ret (dict): A dictionary to append changes to and return. If not passed,
+        will create a new dictionary to return.
+
+        owner (str): The owner of the directory. If not passed, it will be the
+        account that created the directory, likely SYSTEM
+
+        grant_perms (dict): A dictionary containing the user/group and the basic
+        permissions to grant, ie: ``{'user': {'perms': 'basic_permission'}}``.
+        You can also set the ``applies_to`` setting here. The default is
+        ``this_folder_subfolders_files``. Specify another ``applies_to`` setting
+        like this:
+
+        .. code-block:: yaml
+
+            {'user': {'perms': 'full_control', 'applies_to': 'this_folder'}}
+
+        To set advanced permissions use a list for the ``perms`` parameter, ie:
+
+        .. code-block:: yaml
+
+            {'user': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder'}}
+
+        deny_perms (dict): A dictionary containing the user/group and
+        permissions to deny along with the ``applies_to`` setting. Use the same
+        format used for the ``grant_perms`` parameter. Remember, deny
+        permissions supersede grant permissions.
+
+        inheritance (bool): If True the object will inherit permissions from the
+        parent, if False, inheritance will be disabled. Inheritance setting will
+        not apply to parent directories if they must be created
+
+    Returns:
+        bool: True if successful, otherwise raise an error
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        # To grant the 'Users' group 'read & execute' permissions.
+        salt '*' file.check_perms C:\\Temp\\ Administrators "{'Users': {'perms': 'read_execute'}}"
+
+        # Locally using salt call
+        salt-call file.check_perms C:\\Temp\\ Administrators "{'Users': {'perms': 'read_execute', 'applies_to': 'this_folder_only'}}"
+
+        # Specify advanced attributes with a list
+        salt '*' file.check_perms C:\\Temp\\ Administrators "{'jsnuffy': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'files_only'}}"
     '''
     path = os.path.expanduser(path)
 
@@ -1684,7 +1673,7 @@ def check_perms(path,
             current_owner = salt.utils.win_dacl.get_owner(path)
             if owner != current_owner:
                 if __opts__['test'] is True:
-                    ret['changes']['owner'] = owner
+                    ret['pchanges']['owner'] = owner
                 else:
                     try:
                         salt.utils.win_dacl.set_owner(path, owner)
@@ -1719,7 +1708,6 @@ def check_perms(path,
                 applies_to = None
 
             if user_name not in cur_perms:
-
                 changes[user] = {'perms': deny_perms[user]['perms']}
                 if applies_to:
                     changes[user]['applies_to'] = applies_to
@@ -1730,11 +1718,6 @@ def check_perms(path,
                 if isinstance(deny_perms[user]['perms'], six.string_types):
                     if not salt.utils.win_dacl.has_permission(
                             path, user, deny_perms[user]['perms'], 'deny'):
-
-                        log.debug('*' * 68)
-                        log.debug(user_name)
-                        log.debug('*' * 68)
-
                         changes[user] = {'perms': deny_perms[user]['perms']}
                 else:
                     for perm in deny_perms[user]['perms']:
@@ -1760,7 +1743,7 @@ def check_perms(path,
             user_name = salt.utils.win_dacl.get_name(user)
 
             if __opts__['test'] is True:
-                ret['changes']['deny_perms'][user] = changes[user]
+                ret['pchanges']['deny_perms'][user] = changes[user]
             else:
                 # Get applies_to
                 applies_to = None
@@ -1954,10 +1937,55 @@ def check_perms(path,
     return ret
 
 
-def set_perms(path,
-              grant_perms=None,
-              deny_perms=None,
-              inheritance=True):
+def set_perms(path, grant_perms=None, deny_perms=None, inheritance=True):
+    '''
+    Set permissions for the given path
+
+    Args:
+
+        path (str): The full path to the directory.
+
+        grant_perms (dict): A dictionary containing the user/group and the basic
+        permissions to grant, ie: ``{'user': {'perms': 'basic_permission'}}``.
+        You can also set the ``applies_to`` setting here. The default is
+        ``this_folder_subfolders_files``. Specify another ``applies_to`` setting
+        like this:
+
+        .. code-block:: yaml
+
+            {'user': {'perms': 'full_control', 'applies_to': 'this_folder'}}
+
+        To set advanced permissions use a list for the ``perms`` parameter, ie:
+
+        .. code-block:: yaml
+
+            {'user': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder'}}
+
+        deny_perms (dict): A dictionary containing the user/group and
+        permissions to deny along with the ``applies_to`` setting. Use the same
+        format used for the ``grant_perms`` parameter. Remember, deny
+        permissions supersede grant permissions.
+
+        inheritance (bool): If True the object will inherit permissions from the
+        parent, if False, inheritance will be disabled. Inheritance setting will
+        not apply to parent directories if they must be created
+
+    Returns:
+        bool: True if successful, otherwise raise an error
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        # To grant the 'Users' group 'read & execute' permissions.
+        salt '*' file.set_perms C:\\Temp\\ "{'Users': {'perms': 'read_execute'}}"
+
+        # Locally using salt call
+        salt-call file.set_perms C:\\Temp\\ "{'Users': {'perms': 'read_execute', 'applies_to': 'this_folder_only'}}"
+
+        # Specify advanced attributes with a list
+        salt '*' file.set_perms C:\\Temp\\ "{'jsnuffy': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder_only'}}"
+    '''
     ret = {}
 
     # Get the DACL for the directory

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2091,10 +2091,10 @@ def managed(name,
                 follow_symlinks,
                 skip_verify,
                 keep_mode,
-                win_owner,
-                win_perms,
-                win_deny_perms,
-                win_inheritance,
+                win_owner=win_owner,
+                win_perms=win_perms,
+                win_deny_perms=win_deny_perms,
+                win_inheritance=win_inheritance,
                 **kwargs)
         except Exception as exc:
             ret['changes'] = {}

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -271,9 +271,10 @@ import salt.utils.dictupdate
 import salt.utils.files
 import salt.utils.templates
 import salt.utils.url
-import salt.utils.win_dacl
 from salt.utils.locales import sdecode
 from salt.exceptions import CommandExecutionError
+if salt.utils.is_windows():
+    import salt.utils.win_dacl
 
 # Import 3rd-party libs
 import salt.ext.six as six

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1263,7 +1263,7 @@ def managed(name,
             win_deny_perms=None,
             win_inheritance=True,
             **kwargs):
-    '''
+    r'''
     Manage a given file, this function allows for a file to be downloaded from
     the salt master and potentially run through a templating system.
 
@@ -2209,7 +2209,7 @@ def directory(name,
               win_deny_perms=None,
               win_inheritance=True,
               **kwargs):
-    '''
+    r'''
     Ensure that a named directory is present and has the right perms
 
     name
@@ -2507,8 +2507,7 @@ def directory(name,
                         return _error(
                             ret, 'Drive {0} is not mapped'.format(drive))
                     __salt__['file.makedirs'](name, win_owner, win_perms,
-                                              win_deny_perms, win_applies_to,
-                                              win_inheritance)
+                                              win_deny_perms, win_inheritance)
                 else:
                     __salt__['file.makedirs'](name, user=user, group=group,
                                               mode=dir_mode)
@@ -2604,7 +2603,7 @@ def directory(name,
                         if salt.utils.is_windows():
                             ret = __salt__['file.check_perms'](
                                 full, ret, win_owner, win_perms, win_deny_perms,
-                                win_applies_to, win_inheritance, follow_symlinks)
+                                win_inheritance)
                         else:
                             ret, _ = __salt__['file.check_perms'](
                                 full, ret, user, group, file_mode, follow_symlinks)
@@ -2619,7 +2618,7 @@ def directory(name,
                         if salt.utils.is_windows():
                             ret = __salt__['file.check_perms'](
                                 full, ret, win_owner, win_perms, win_deny_perms,
-                                win_applies_to, win_inheritance, follow_symlinks)
+                                win_inheritance)
                         else:
                             ret, _ = __salt__['file.check_perms'](
                                 full, ret, user, group, dir_mode, follow_symlinks)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1675,12 +1675,56 @@ def managed(name,
         .. versionadded:: 2016.3.0
 
     win_owner : None
+        The owner of the directory. If this is not passed, user will be used. If
+        user is not passed, the account under which Salt is running will be
+        used.
+        .. versionadded:: Nitrogen
 
     win_perms : None
+        A dictionary containing permissions to grant and their propagation. For
+        example: ``{'Administrators': {'perms': 'full_control'}}`` Can be a
+        single basic perm or a list of advanced perms. ``perms`` must be
+        specified. ``applies_to`` does not apply to file objects.
+        .. versionadded:: Nitrogen
 
     win_deny_perms : None
+        A dictionary containing permissions to deny and their propagation. For
+        example: ``{'Administrators': {'perms': 'full_control'}}`` Can be a
+        single basic perm or a list of advanced perms. ``perms`` must be
+        specified. ``applies_to`` does not apply to file objects.
+        .. versionadded:: Nitrogen
 
     win_inheritance : True
+        True to inherit permissions from the parent directory, False not to
+        inherit permission.
+        .. versionadded:: Nitrogen
+
+    Here's an example using the above ``win_*`` parameters:
+
+    .. code-block:: yaml
+
+        create_config_file:
+          file.managed:
+            - name: C:\config\settings.cfg
+            - source: salt://settings.cfg
+            - win_owner: Administrators
+            - win_perms:
+                # Basic Permissions
+                dev_ops:
+                  perms: full_control
+                # List of advanced permissions
+                appuser:
+                  perms:
+                    - read_attributes
+                    - read_ea
+                    - create_folders
+                    - read_permissions
+                joe_snuffy:
+                  perms: read
+            - win_deny_perms:
+                fred_snuffy:
+                  perms: full_control
+            - win_inheritance: False
     '''
     if 'env' in kwargs:
         salt.utils.warn_until(

--- a/salt/utils/win_dacl.py
+++ b/salt/utils/win_dacl.py
@@ -137,12 +137,14 @@ from salt.ext.six.moves import range
 import salt.ext.six as six
 
 # Import 3rd-party libs
+HAS_WIN32 = False
 try:
     import win32security
     import win32con
     import win32api
     import pywintypes
     import salt.utils.win_functions
+    HAS_WIN32 = True
 except ImportError:
     pass
 

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -581,7 +581,7 @@ class FileTestCase(TestCase):
                          'file.copy': mock_cp,
                          'file.manage_file': mock_ex,
                          'cmd.run_all': mock_cmd_fail}):
-            comt = ('Must provide name to file.exists')
+            comt = ('Must provide name to file.managed')
             ret.update({'comment': comt, 'name': '', 'pchanges': {}})
             self.assertDictEqual(filestate.managed(''), ret)
 


### PR DESCRIPTION
### What does this PR do?
Adds ability to set owner and user/group permissions for ``file.directory`` and ``file.managed``. Also fixes an issue with ``salt.utils.win_dacl.set_owner`` where you couldn't set ownership to a group you weren't a member of or another group. Tried to make minimal changes to the ``file.py`` state module and make changes in ``win_file.py`` execution module where possible.

Adds 4 new parameters to ``file.directory`` and ``file.managed``.

win_owner (str)
win_perms (dict)
win_deny_perms (dict)
win_inheritance (bool)

Ultimately the goal is to implement this into the rest of the state functions in the ``file.py`` state module.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/28920

### Previous Behavior
Permissions settings weren't being set on ``file.directory`` and ``file.managed``

### New Behavior
You can now set permissions for ``file.directory`` and ``file.managed``

### Tests written?
No