### PR TITLE
Update orchestrate runner file.copy doc example

### DIFF
--- a/doc/topics/orchestrate/orchestrate_runner.rst
+++ b/doc/topics/orchestrate/orchestrate_runner.rst
@@ -104,7 +104,7 @@ can specify the "name" argument to avoid conflicting IDs:
           - /path/to/file
           - /tmp/copy_of_file
         - kwarg:
-          - remove_existing: true
+            remove_existing: true
 
 State
 ^^^^^


### PR DESCRIPTION
The kwarg arguments should be a dictionary, and not a list.

Fixes #37383