### PR TITLE
PY3: Fix exception when handling connect exception in TCP transport

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -497,7 +497,7 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
         except KeyboardInterrupt:
             raise
         except Exception as exc:
-            if '-|RETRY|-' not in exc:
+            if '-|RETRY|-' not in str(exc):
                 raise SaltClientError('Unable to sign_in to master: {0}'.format(exc))  # TODO: better error message
 
     def on_recv(self, callback):


### PR DESCRIPTION
### What does this PR do?

When `self.auth.authenticate()` would throw this exception:
`raise SaltClientError(
'Attempt to authenticate with the salt master failed with timeout error')`

The code would throw an additional exception dealing with the original
exception as follows:

```
  File "...\salt\transport\tcp.py", line 500, in connect
      if '-|RETRY|-' not in exc:
      TypeError: argument of type 'SaltClientError' is not iterable
```

And since the final exception being thrown is `TypeError` instead of
`SaltClientError`, caller code would not correctly deal with this
case and the salt-minion would terminate.

Fix this by using Python 3 friendly `str(exc)` instead of plain
`exc` when doing a string search.

### Tests written?

No

Signed-off-by: Sergey Kizunov <sergey.kizunov@ni.com>