### PR TITLE
add connected_masters to salt.utils.minion and refactor status.master

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -24,6 +24,7 @@ import salt.config
 import salt.minion
 import salt.utils
 import salt.utils.event
+from salt.utils.minion import connected_masters as _connected_masters
 from salt.utils.network import host_to_ips as _host_to_ips
 from salt.utils.network import remote_port_tcp as _remote_port_tcp
 from salt.ext.six.moves import zip
@@ -1034,28 +1035,24 @@ def master(master=None, connected=True):
 
         salt '*' status.master
     '''
-
-    # the default publishing port
-    port = 4505
     master_ips = None
 
-    if __salt__['config.get']('publish_port') != '':
-        port = int(__salt__['config.get']('publish_port'))
-
-    # Check if we have FQDN/hostname defined as master
-    # address and try resolving it first. _remote_port_tcp
-    # only works with IP-addresses.
-    if master is not None:
+    if master:
         master_ips = _host_to_ips(master)
 
-    master_connection_status = False
-    if master_ips:
-        ips = _remote_port_tcp(port)
-        for master_ip in master_ips:
-            if master_ip in ips:
-                master_connection_status = True
-                break
+    if not master_ips:
+        return
 
+    master_connection_status = False
+    connected_ips = _connected_masters()
+
+    # Get connection status for master
+    for master_ip in master_ips:
+        if master_ip in connected_ips:
+            master_connection_status = True
+            break
+
+    # Connection to master is not as expected
     if master_connection_status is not connected:
         event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)
         if master_connection_status:

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -26,7 +26,6 @@ import salt.utils
 import salt.utils.event
 from salt.utils.minion import connected_masters as _connected_masters
 from salt.utils.network import host_to_ips as _host_to_ips
-from salt.utils.network import remote_port_tcp as _remote_port_tcp
 from salt.ext.six.moves import zip
 from salt.exceptions import CommandExecutionError
 

--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -333,23 +333,25 @@ def master(master=None, connected=True):
     port = 4505
     master_ips = None
 
+    if master:
+        master_ips = _host_to_ips(master)
+
+    if not master_ips:
+        return
+
     if __salt__['config.get']('publish_port') != '':
         port = int(__salt__['config.get']('publish_port'))
 
-    # Check if we have FQDN/hostname defined as master
-    # address and try resolving it first. _remote_port_tcp
-    # only works with IP-addresses.
-    if master is not None:
-        master_ips = _host_to_ips(master)
-
     master_connection_status = False
-    if master_ips:
-        ips = _win_remotes_on(port)
-        for master_ip in master_ips:
-            if master_ip in ips:
-                master_connection_status = True
-                break
+    connected_ips = _win_remotes_on(port)
 
+    # Get connection status for master
+    for master_ip in master_ips:
+        if master_ip in connected_ips:
+            master_connection_status = True
+            break
+
+    # Connection to master is not as expected
     if master_connection_status is not connected:
         event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)
         if master_connection_status:

--- a/salt/utils/minion.py
+++ b/salt/utils/minion.py
@@ -11,6 +11,7 @@ import threading
 # Import Salt Libs
 import salt.utils
 import salt.payload
+from salt.utils.network import remote_port_tcp as _remote_port_tcp
 
 
 def running(opts):
@@ -49,6 +50,22 @@ def cache_jobs(opts, jid, ret):
         os.makedirs(jdir)
     with salt.utils.fopen(fn_, 'w+b') as fp_:
         fp_.write(serial.dumps(ret))
+
+
+def connected_masters():
+    '''
+    Return current connected masters
+    '''
+    # default port
+    port = 4505
+
+    config_port = __salt__['config.get']('publish_port')
+    if config_port:
+        port = config_port
+
+    connected_masters_ips = _remote_port_tcp(port)
+
+    return connected_masters_ips
 
 
 def _read_proc_file(path, opts):


### PR DESCRIPTION
### What does this PR do?
1. add connected_masters to salt.utils.minion, which will be very helpful for multi-master cases
2. refactor status.master to make it concise and use connected_masters

### What issues does this PR fix or reference?

### New Behavior
One more useful util for multi-master setup

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

