### PR TITLE
Add jenkins.run

### DIFF
--- a/salt/modules/jenkins.py
+++ b/salt/modules/jenkins.py
@@ -76,6 +76,26 @@ def _connect():
                            password=jenkins_password)
 
 
+def run(script):
+    '''
+    .. versionadded:: Carbon
+
+    Execute a groovy script on the jenkins master
+
+    :param script: The groovy script
+
+    CLI Example:
+
+    .. code-block::
+
+        salt '*' jenkins.run 'Jenkins.instance.doSafeRestart()'
+
+    '''
+
+    server = _connect()
+    return server.run_script(script)
+
+
 def get_version():
     '''
     Return version of Jenkins


### PR DESCRIPTION
Add's a new method to the jenkins module: `jenkins.run`. It allows a user to run arbitrary Groovy code on Jenkins.

This gives me room to try and write some richer salt modules/states around Jenkins. I want to get salt to the point where I can orchestrate Jenkins, some executors, credentials and tie them all together, which is all currently lacking.

For example, with installing plugins, you need a sufficiently recent version of jenkins python api, more recent than what's in the CentOS 7 repo, and even then, it seems like it doesn't properly do it synchronously. So it might be better to just forgo the dependency on python-jenkins (ansible-modules-extra Jenkin's support also seems to do something similar, not using python-jenkins).