### PR TITLE
Icinga2 module and state draft proposal.

### DIFF
--- a/salt/modules/icinga2.py
+++ b/salt/modules/icinga2.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+'''
+Module to provide icinga2 compatibility to salt.
+
+:depends:   - icinga2 server
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import logging
+import os
+import subprocess
+
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load this module if the mysql libraries exist
+    '''
+    '''TODO: icinga2 check should be os independent and maybe based on package, not binary.'''
+    if os.path.isfile('/usr/sbin/icinga2'):
+        return True
+    return (False, 'Icinga2 not installed.')
+
+
+def _execute(cmd, ret_code=False):
+    process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    if ret_code:
+        return process.wait()
+    output, error = process.communicate()
+    if output:
+        log.debug(output)
+        return output
+    log.debug(error)
+    return error
+
+
+def generate_ticket(domain):
+    '''
+    Generate and save an icinga2 ticket.
+
+    Returns::
+        icinga2 pki ticket --cn domain.tld
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' icinga2.generate_ticket domain.tld
+
+    '''
+    result = _execute(["icinga2", "pki", "ticket", "--cn", domain])
+    return result
+
+
+def generate_cert(domain):
+    '''
+    Generate an icinga2 client certificate and key.
+
+    Returns::
+        icinga2 pki new-cert --cn domain.tld --key /etc/icinga2/pki/domain.tld.key --cert /etc/icinga2/pki/domain.tld.crt
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' icinga2.generate_cert domain.tld
+
+    '''
+    result = _execute(["icinga2", "pki", "new-cert", "--cn", domain, "--key", "/etc/icinga2/pki/{0}.key".format(domain), "--cert", "/etc/icinga2/pki/{0}.crt".format(domain)], ret_code=True)
+    return result
+
+
+def save_cert(domain, master):
+    '''
+    Save the certificate for master icinga2 node.
+
+    Returns::
+        icinga2 pki save-cert --key /etc/icinga2/pki/domain.tld.key --cert /etc/icinga2/pki/domain.tld.crt --trustedcert /etc/icinga2/pki/trusted-master.crt --host master.domain.tld
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' icinga2.save_cert domain.tld master.domain.tld
+
+    '''
+    result = _execute(["icinga2", "pki", "save-cert", "--key", "/etc/icinga2/pki/{0}.key".format(domain), "--cert", "/etc/icinga2/pki/{0}.cert".format(domain), "--trustedcert", \
+                       "/etc/icinga2/pki/trusted-master.crt", "--host", master], ret_code=True)
+    return result
+
+
+def request_cert(domain, master, ticket, port):
+    '''
+    Request CA cert from master icinga2 node.
+
+    Returns::
+        icinga2 pki request --host master.domain.tld --port 5665 --ticket TICKET_ID --key /etc/icinga2/pki/domain.tld.key --cert /etc/icinga2/pki/domain.tld.crt --trustedcert \
+                /etc/icinga2/pki/trusted-master.crt --ca /etc/icinga2/pki/ca.crt
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' icinga2.request_cert domain.tld master.domain.tld TICKET_ID
+
+    '''
+    result = _execute(["icinga2", "pki", "request", "--host", master, "--port", port, "--ticket", ticket, "--key", "/etc/icinga2/pki/{0}.key".format(domain), "--cert", \
+                       "/etc/icinga2/pki/{0}.crt".format(domain), "--trustedcert", "/etc/icinga2/pki/trusted-master.crt", "--ca", "/etc/icinga2/pki/ca.crt"], ret_code=True)
+    return result
+
+
+def node_setup(domain, master, ticket):
+    '''
+    Setup the icinga2 node.
+
+    Returns::
+        icinga2 node setup --ticket TICKET_ID --endpoint master.domain.tld --zone domain.tld --master_host master.domain.tld --trustedcert \
+                /etc/icinga2/pki/trusted-master.crt
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' icinga2.node_setup domain.tld master.domain.tld TICKET_ID
+
+    '''
+    result = _execute(["icinga2", "node", "setup", "--ticket", ticket, "--endpoint", master, "--zone", domain, "--master_host", master, "--trustedcert", "/etc/icinga2/pki/trusted-master.crt"], \
+                       ret_code=True)
+    return result

--- a/salt/modules/icinga2.py
+++ b/salt/modules/icinga2.py
@@ -19,7 +19,7 @@ def __virtual__():
     '''
     Only load this module if the mysql libraries exist
     '''
-    '''TODO: icinga2 check should be os independent and maybe based on package, not binary.'''
+    # TODO: icinga2 check should be os independent and maybe based on package, not binary.
     if os.path.isfile('/usr/sbin/icinga2'):
         return True
     return (False, 'Icinga2 not installed.')
@@ -87,7 +87,7 @@ def save_cert(domain, master):
         salt '*' icinga2.save_cert domain.tld master.domain.tld
 
     '''
-    result = _execute(["icinga2", "pki", "save-cert", "--key", "/etc/icinga2/pki/{0}.key".format(domain), "--cert", "/etc/icinga2/pki/{0}.cert".format(domain), "--trustedcert", \
+    result = _execute(["icinga2", "pki", "save-cert", "--key", "/etc/icinga2/pki/{0}.key".format(domain), "--cert", "/etc/icinga2/pki/{0}.cert".format(domain), "--trustedcert",
                        "/etc/icinga2/pki/trusted-master.crt", "--host", master], ret_code=True)
     return result
 
@@ -107,7 +107,7 @@ def request_cert(domain, master, ticket, port):
         salt '*' icinga2.request_cert domain.tld master.domain.tld TICKET_ID
 
     '''
-    result = _execute(["icinga2", "pki", "request", "--host", master, "--port", port, "--ticket", ticket, "--key", "/etc/icinga2/pki/{0}.key".format(domain), "--cert", \
+    result = _execute(["icinga2", "pki", "request", "--host", master, "--port", port, "--ticket", ticket, "--key", "/etc/icinga2/pki/{0}.key".format(domain), "--cert",
                        "/etc/icinga2/pki/{0}.crt".format(domain), "--trustedcert", "/etc/icinga2/pki/trusted-master.crt", "--ca", "/etc/icinga2/pki/ca.crt"], ret_code=True)
     return result
 
@@ -127,6 +127,6 @@ def node_setup(domain, master, ticket):
         salt '*' icinga2.node_setup domain.tld master.domain.tld TICKET_ID
 
     '''
-    result = _execute(["icinga2", "node", "setup", "--ticket", ticket, "--endpoint", master, "--zone", domain, "--master_host", master, "--trustedcert", "/etc/icinga2/pki/trusted-master.crt"], \
+    result = _execute(["icinga2", "node", "setup", "--ticket", ticket, "--endpoint", master, "--zone", domain, "--master_host", master, "--trustedcert", "/etc/icinga2/pki/trusted-master.crt"],
                        ret_code=True)
     return result

--- a/salt/modules/icinga2.py
+++ b/salt/modules/icinga2.py
@@ -8,8 +8,6 @@ Module to provide icinga2 compatibility to salt.
 # Import python libs
 from __future__ import absolute_import
 import logging
-import os
-import subprocess
 
 # Import Salt libs
 import salt.utils
@@ -120,6 +118,5 @@ def node_setup(domain, master, ticket):
         salt '*' icinga2.node_setup domain.tld master.domain.tld TICKET_ID
 
     '''
-    result = __salt__['cmd.run']("icinga2 node setup --ticket {0} --endpoint {1} --zone {2} --master_host {1} --trustedcert /etc/icinga2/pki/trusted-master.crt".format(ticket,  master, domain))
+    result = __salt__['cmd.run']("icinga2 node setup --ticket {0} --endpoint {1} --zone {2} --master_host {1} --trustedcert /etc/icinga2/pki/trusted-master.crt".format(ticket, master, domain))
     return result
-

--- a/salt/states/icinga2.py
+++ b/salt/states/icinga2.py
@@ -1,0 +1,277 @@
+# -*- coding: utf-8 -*-
+'''
+Icinga2 state
+==========================
+
+.. versionadded:: TODO
+
+:depends:   - Icinga2 Python module
+:configuration: See :py:mod:`salt.modules.icinga2` for setup instructions.
+
+The icinga2 module is used to execute commands.
+Its output may be stored in a file or in a grain.
+
+.. code-block:: yaml
+
+    command_id:
+      icinga2.generate_ticket
+        - name: domain.tld
+        - output:  "/tmp/query_id.txt"
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import sys
+import os.path
+
+# Import Salt libs
+import salt.utils
+
+
+def __virtual__():
+    '''
+    Only load if the icinga2 module is available in __salt__
+    '''
+    return 'icinga2.generate_ticket' in __salt__
+
+
+def generate_ticket(name, output=None, grain=None, key=None, overwrite=True):
+    '''
+    Generate an icinga2 ticket on the master.
+
+    name
+        The domain name for which this ticket will be generated
+
+    output
+        grain: output in a grain
+        other: the file to store results
+        None:  output to the result comment (default)
+
+    grain:
+        grain to store the output (need output=grain)
+
+    key:
+        the specified grain will be treated as a dictionary, the result
+        of this state will be stored under the specified key.
+
+    overwrite:
+        The file or grain will be overwritten if it already exists (default)
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    '''Checking if execution is needed.'''
+    if output == 'grain':
+        if grain and not key:
+            if not overwrite and grain in __salt__['grains.ls']():
+                ret['comment'] = 'No execution needed. Grain {0} already set'.format(grain)
+                return ret
+            elif __opts__['test']:
+                ret['result'] = None
+                ret['comment'] = 'Ticket generation would be executed, storing result in grain: {0}'.format(grain)
+                return ret
+        elif grain:
+            if grain in __salt__['grains.ls']():
+                grain_value = __salt__['grains.get'](grain)
+            else:
+                grain_value = {}
+            if not overwrite and key in grain_value:
+                ret['comment'] = 'No execution needed. Grain {0}:{1} already set'.format(grain, key)
+                return ret
+            elif __opts__['test']:
+                ret['result'] = None
+                ret['comment'] = 'Ticket generation would be executed, storing result in grain: {0}:{1}'.format(grain, key)
+                return ret
+        else:
+            ret['result'] = False
+            ret['comment'] = "Error: output type 'grain' needs the grain parameter\n"
+            return ret
+    elif output:
+        if not overwrite and os.path.isfile(output):
+            ret['comment'] = 'No execution needed. File {0} already set'.format(output)
+            return ret
+        elif __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Ticket generation would be executed, storing result in file: '.format(output)
+            return ret
+    elif __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Ticket generation would be executed, not storing result'
+        return ret
+
+    '''Executing the command.'''
+    ticket = __salt__['icinga2.generate_ticket'](name).strip()
+    if ticket:
+        ret['comment'] = str(ticket)
+
+    if output == 'grain':
+        if grain and not key:
+            __salt__['grains.setval'](grain, ticket)
+            ret['changes']['ticket'] = "Executed. Output into grain: {0}".format(grain)
+        elif grain:
+            if grain in __salt__['grains.ls']():
+                grain_value = __salt__['grains.get'](grain)
+            else:
+                grain_value = {}
+            grain_value[key] = ticket
+            __salt__['grains.setval'](grain, grain_value)
+            ret['changes']['ticket'] = "Executed. Output into grain: {0}:{1}".format(grain, key)
+    elif output:
+        ret['changes']['ticket'] = "Executed. Output into {0}".format(output)
+        with salt.utils.fopen(output, 'w') as output_file:
+                output_file.write(str(ticket))
+    else:
+        ret['changes']['ticket'] = "Executed"
+
+    return ret
+
+
+def generate_cert(name):
+    '''
+    Generate an icinga2 certificate and key on the client.
+
+    name
+        The domain name for which this certificate and key will be generated
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+    cert = "/etc/icinga2/pki/{0}.crt".format(name)
+    key = "/etc/icinga2/pki/{0}.key".format(name)
+
+    '''Checking if execution is needed.'''
+    if os.path.isfile(cert) and os.path.isfile(key):
+        ret['comment'] = 'No execution needed. Cert: {0} and key: {1} already generated.'.format(cert, key)
+        return ret
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Certificate and key generation would be executed'
+        return ret
+
+    '''Executing the command.'''
+    cert_save = __salt__['icinga2.generate_cert'](name)
+    if not cert_save:
+        ret['comment'] = "Certificate and key generated"
+        ret['changes']['cert'] = "Executed. Certificate saved: {0}".format(cert)
+        ret['changes']['key'] = "Executed. Key saved: {0}".format(key)
+    return ret
+
+
+def save_cert(name, master):
+    '''
+    Save the certificate on master icinga2 node.
+
+    name
+        The domain name for which this certificate will be saved
+
+    master
+        Icinga2 master node for which this certificate will be saved
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+    cert = "/etc/icinga2/pki/trusted-master.crt"
+
+    '''Checking if execution is needed.'''
+    if os.path.isfile(cert):
+        ret['comment'] = 'No execution needed. Cert: {0} already saved.'.format(cert)
+        return ret
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Certificate save for icinga2 master would be executed'
+        return ret
+
+    '''Executing the command.'''
+    cert_save = __salt__['icinga2.save_cert'](name, master)
+    if not cert_save:
+        ret['comment'] = "Certificate for icinga2 master saved"
+        ret['changes']['cert'] = "Executed. Certificate saved: {0}".format(cert)
+    return ret
+
+
+def request_cert(name, master, ticket, port="5665"):
+    '''
+    Request CA certificate from master icinga2 node.
+
+    name
+        The domain name for which this certificate will be saved
+
+    master
+        Icinga2 master node for which this certificate will be saved
+
+    ticket
+        Authentication ticket generated on icinga2 master
+
+    port
+        Icinga2 port, defaults to 5665
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+    cert = "/etc/icinga2/pki/ca.crt"
+
+    '''Checking if execution is needed.'''
+    if os.path.isfile(cert):
+        ret['comment'] = 'No execution needed. Cert: {0} already exists.'.format(cert)
+        return ret
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Certificate request from icinga2 master would be executed'
+        return ret
+
+    '''Executing the command.'''
+    cert_request = __salt__['icinga2.request_cert'](name, master, ticket, port)
+    if not cert_request:
+        ret['comment'] = "Certificate request from icinga2 master executed"
+        ret['changes']['cert'] = "Executed. Certificate requested: {0}".format(cert)
+        return ret
+
+    ret['comment'] = "FAILED. Certificate requested failed with exit code: {0}".format(cert_request)
+    ret['result'] = False
+    return ret
+
+
+def node_setup(name, master, ticket):
+    '''
+    Setup the icinga2 node.
+
+    name
+        The domain name for which this certificate will be saved
+
+    master
+        Icinga2 master node for which this certificate will be saved
+
+    ticket
+        Authentication ticket generated on icinga2 master
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+    cert = "/etc/icinga2/pki/{0}.crt.orig".format(name)
+    key = "/etc/icinga2/pki/{0}.key.orig".format(name)
+
+    '''Checking if execution is needed.'''
+    if os.path.isfile(cert) and os.path.isfile(cert):
+        ret['comment'] = 'No execution needed. Node already configured.'
+        return ret
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Node setup will be executed.'
+        return ret
+
+    '''Executing the command.'''
+    node_setup = __salt__['icinga2.node_setup'](name, master, ticket)
+    if not node_setup:
+        ret['comment'] = "Node setup executed."
+        ret['changes']['cert'] = "Node setup finished successfully."
+        return ret
+
+    ret['comment'] = "FAILED. Node setup failed with exit code: {0}".format(node_setup)
+    ret['result'] = False
+    return ret

--- a/salt/states/icinga2.py
+++ b/salt/states/icinga2.py
@@ -21,7 +21,6 @@ Its output may be stored in a file or in a grain.
 
 # Import python libs
 from __future__ import absolute_import
-import sys
 import os.path
 
 # Import Salt libs
@@ -62,7 +61,7 @@ def generate_ticket(name, output=None, grain=None, key=None, overwrite=True):
            'result': True,
            'comment': ''}
 
-    '''Checking if execution is needed.'''
+    # Checking if execution is needed.
     if output == 'grain':
         if grain and not key:
             if not overwrite and grain in __salt__['grains.ls']():
@@ -94,14 +93,14 @@ def generate_ticket(name, output=None, grain=None, key=None, overwrite=True):
             return ret
         elif __opts__['test']:
             ret['result'] = None
-            ret['comment'] = 'Ticket generation would be executed, storing result in file: '.format(output)
+            ret['comment'] = 'Ticket generation would be executed, storing result in file: {0}'.format(output)
             return ret
     elif __opts__['test']:
         ret['result'] = None
         ret['comment'] = 'Ticket generation would be executed, not storing result'
         return ret
 
-    '''Executing the command.'''
+    # Executing the command.
     ticket = __salt__['icinga2.generate_ticket'](name).strip()
     if ticket:
         ret['comment'] = str(ticket)
@@ -121,7 +120,7 @@ def generate_ticket(name, output=None, grain=None, key=None, overwrite=True):
     elif output:
         ret['changes']['ticket'] = "Executed. Output into {0}".format(output)
         with salt.utils.fopen(output, 'w') as output_file:
-                output_file.write(str(ticket))
+            output_file.write(str(ticket))
     else:
         ret['changes']['ticket'] = "Executed"
 
@@ -142,7 +141,7 @@ def generate_cert(name):
     cert = "/etc/icinga2/pki/{0}.crt".format(name)
     key = "/etc/icinga2/pki/{0}.key".format(name)
 
-    '''Checking if execution is needed.'''
+    # Checking if execution is needed.
     if os.path.isfile(cert) and os.path.isfile(key):
         ret['comment'] = 'No execution needed. Cert: {0} and key: {1} already generated.'.format(cert, key)
         return ret
@@ -151,7 +150,7 @@ def generate_cert(name):
         ret['comment'] = 'Certificate and key generation would be executed'
         return ret
 
-    '''Executing the command.'''
+    # Executing the command.
     cert_save = __salt__['icinga2.generate_cert'](name)
     if not cert_save:
         ret['comment'] = "Certificate and key generated"
@@ -176,7 +175,7 @@ def save_cert(name, master):
            'comment': ''}
     cert = "/etc/icinga2/pki/trusted-master.crt"
 
-    '''Checking if execution is needed.'''
+    # Checking if execution is needed.
     if os.path.isfile(cert):
         ret['comment'] = 'No execution needed. Cert: {0} already saved.'.format(cert)
         return ret
@@ -185,7 +184,7 @@ def save_cert(name, master):
         ret['comment'] = 'Certificate save for icinga2 master would be executed'
         return ret
 
-    '''Executing the command.'''
+    # Executing the command.
     cert_save = __salt__['icinga2.save_cert'](name, master)
     if not cert_save:
         ret['comment'] = "Certificate for icinga2 master saved"
@@ -215,7 +214,7 @@ def request_cert(name, master, ticket, port="5665"):
            'comment': ''}
     cert = "/etc/icinga2/pki/ca.crt"
 
-    '''Checking if execution is needed.'''
+    # Checking if execution is needed.
     if os.path.isfile(cert):
         ret['comment'] = 'No execution needed. Cert: {0} already exists.'.format(cert)
         return ret
@@ -224,7 +223,7 @@ def request_cert(name, master, ticket, port="5665"):
         ret['comment'] = 'Certificate request from icinga2 master would be executed'
         return ret
 
-    '''Executing the command.'''
+    # Executing the command.
     cert_request = __salt__['icinga2.request_cert'](name, master, ticket, port)
     if not cert_request:
         ret['comment'] = "Certificate request from icinga2 master executed"
@@ -256,7 +255,7 @@ def node_setup(name, master, ticket):
     cert = "/etc/icinga2/pki/{0}.crt.orig".format(name)
     key = "/etc/icinga2/pki/{0}.key.orig".format(name)
 
-    '''Checking if execution is needed.'''
+    # Checking if execution is needed.
     if os.path.isfile(cert) and os.path.isfile(cert):
         ret['comment'] = 'No execution needed. Node already configured.'
         return ret
@@ -265,7 +264,7 @@ def node_setup(name, master, ticket):
         ret['comment'] = 'Node setup will be executed.'
         return ret
 
-    '''Executing the command.'''
+    # Executing the command.
     node_setup = __salt__['icinga2.node_setup'](name, master, ticket)
     if not node_setup:
         ret['comment'] = "Node setup executed."


### PR DESCRIPTION
### What does this PR do?
1. Low level logic behind this state and module:
```
# On master
icinga2 pki ticket --cn client.domain.tld
 
# On client
icinga2 pki new-cert --cn client.domain.tld --key /etc/icinga2/pki/client.domain.tld.key --cert /etc/icinga2/pki/client.domain.tld.crt
icinga2 pki save-cert --key /etc/icinga2/pki/client.domain.tld.key --cert /etc/icinga2/pki/client.domain.tld.crt --trustedcert /etc/icinga2/pki/trusted-master.crt --host icinga-server.domain.tld
icinga2 pki request --host icinga-server.domain.tld --port 5665 --ticket 9c298a17409d274ad9d2f17234ce7f5aca30e3f0 --key /etc/icinga2/pki/client.domain.tld.key --cert /etc/icinga2/pki/client.domain.tld.crt --trustedcert /etc/icinga2/pki/trusted-master.crt --ca /etc/icinga2/pki/ca.crt
icinga2 node setup --ticket 9c298a17409d274ad9d2f17234ce7f5aca30e3f0 --endpoint icinga-server.domain.tld --zone client.domain.tld --master_host icinga-server.domain.tld --trustedcert /etc/icinga2/pki/trusted-master.crt
 
# Update files on client:
constants.conf
zones.conf
features-available/api.conf
```
I know there is at least one more way of configuring icinga2 master and client but I chose to use this one.

2. Server side implementation, generates a grains file (would be a lot better to use the grains state or even better come up with an alternative):
```
{% for host, hostinfo in salt['mine.get']('*', 'grains.items').items() %}
  {%- if 'icinga-server.domain.tld' != host %}
icinga_client_{{ host }}:
  file.managed:
    - name: /etc/icinga2/hosts.d/{{ host }}.conf
    - source: salt://icinga2-server/files/host.conf.jinja
    - template: jinja
    - mode: 644
    - context:
        host: {{ host }}
        host_ip: {{ hostinfo.fqdn_ip4 }}
        host_os_family: {{ hostinfo.os_family }}

icinga_client_ticket_{{ host }}:
  icinga2.generate_ticket:
    - name: {{ hostinfo.fqdn }}
    - output: grain
    - grain: icinga2
    - key: {{ hostinfo.fqdn }}
  {%- endif %}
{%- endfor %}

icinga_server_service:
  service.running:
    - name: icinga2
    - enable: True
    - watch:
      - file: /etc/icinga2/hosts.d/*
```

3. Client side implementation:
```
{% set master = "icinga-server.domain.tld" -%}

icinga-pki-perms:
  file.directory:
    - name: /etc/icinga2/pki
    - user: {{ map.icinga_user }}
    - group: {{ map.icinga_group }}
    - mode: 755
    - makedirs: True

icinga-cert:
  icinga2.generate_cert:
    - name: {{ grains['fqdn'] }}
    - require:
      - file: icinga-pki-perms

icinga-save-master-cert:
  icinga2.save_cert:
    - name: {{ grains['fqdn'] }}
    - master: {{ master }}
    - require:
      - icinga2: icinga-cert

{% for host, hostinfo in salt['mine.get'](master, 'grains.items').items() %}
  {%- for fqdn, ticket in hostinfo.icinga2.items() %}
    {%- if fqdn == grains['fqdn'] %}
icinga-ca-request:
  icinga2.request_cert:
    - name: {{ grains['fqdn'] }}
    - master: {{ master }}
    - ticket: {{ ticket }}
    - require:
      - icinga2: icinga-save-master-cert

icinga-node-setup:
  icinga2.node_setup:
    - name: {{ grains['fqdn'] }}
    - master: {{ master }}
    - ticket: {{ ticket }}
    - require:
      - icinga2: icinga-ca-request
    {%- endif %}
  {%- endfor %}
{%- endfor %}

icinga-services-conf:
  file.managed:
    - name: /etc/icinga2/conf.d/services.conf
    - source: salt://icinga2-client/files/services.conf.jinja
    - template: jinja
    - require:
      - icinga2: icinga-node-setup

icinga-hosts-conf:
  file.managed:
    - name: /etc/icinga2/conf.d/hosts.conf
    - source: salt://icinga2-client/files/hosts.conf.jinja
    - template: jinja
    - require:
      - icinga2: icinga-node-setup

icinga-service-restart:
  service.running:
    - name: {{ map.service }}
    - enable: True
    - require:
      - file: icinga-node-conf
    - watch:
      - pkg: icinga2
      - file: icinga-services-conf
```

The above states were trimmed/cleaned a bit, the purpose is to show how it can be used. I am not sure if points 2 and 3 should be documented since there are various ways of achieving them. So the easiest option was to include them in this PR.

As a last note, this was written a while ago so the code should be reviewed and maybe improved. I just did not have the time to create a PR and I am not sure if any one is interested in this kind of functionality.

### What issues does this PR fix or reference?
None.

### Previous Behavior
None.

### New Behavior
Adds support for icinga2.

### Tests written?
No


