### PR TITLE
Change Carbon references in develop to Nitrogen

### DIFF
--- a/salt/modules/boto_apigateway.py
+++ b/salt/modules/boto_apigateway.py
@@ -1408,17 +1408,15 @@ def describe_usage_plans(name=None, plan_id=None, region=None, key=None, keyid=N
     '''
     Returns a list of existing usage plans, optionally filtered to match a given plan name
 
+    .. versionadded:: Nitrogen
+
     CLI Example:
 
     .. code-block:: bash
 
         salt myminion boto_apigateway.describe_usage_plans
-
         salt myminion boto_apigateway.describe_usage_plans name='usage plan name'
-
         salt myminion boto_apigateway.describe_usage_plans plan_id='usage plan id'
-
-    .. versionadded:: Carbon
 
     '''
     try:
@@ -1462,6 +1460,8 @@ def create_usage_plan(name, description=None, throttle=None, quota=None, region=
     '''
     Creates a new usage plan with throttling and quotas optionally applied
 
+    .. versionadded:: Nitrogen
+
     name
         Name of the usage plan
 
@@ -1492,8 +1492,6 @@ def create_usage_plan(name, description=None, throttle=None, quota=None, region=
 
         salt myminion boto_apigateway.create_usage_plan name='usage plan name' throttle='{"rateLimit": 10.0, "burstLimit": 10}'
 
-    .. versionadded:: Carbon
-
     '''
     try:
         _validate_throttle(throttle)
@@ -1519,6 +1517,8 @@ def create_usage_plan(name, description=None, throttle=None, quota=None, region=
 def update_usage_plan(plan_id, throttle=None, quota=None, region=None, key=None, keyid=None, profile=None):
     '''
     Updates an existing usage plan with throttling and quotas
+
+    .. versionadded:: Nitrogen
 
     plan_id
         Id of the created usage plan
@@ -1549,8 +1549,6 @@ def update_usage_plan(plan_id, throttle=None, quota=None, region=None, key=None,
     .. code-block:: bash
 
         salt myminion boto_apigateway.update_usage_plan plan_id='usage plan id' throttle='{"rateLimit": 10.0, "burstLimit": 10}'
-
-    .. versionadded:: Carbon
 
     '''
     try:
@@ -1594,13 +1592,13 @@ def delete_usage_plan(plan_id, region=None, key=None, keyid=None, profile=None):
     '''
     Deletes usage plan identified by plan_id
 
+    .. versionadded:: Nitrogen
+
     CLI Example:
 
     .. code-block:: bash
 
         salt myminion boto_apigateway.delete_usage_plan plan_id='usage plan id'
-
-    .. versionadded:: Carbon
 
     '''
     try:
@@ -1657,6 +1655,8 @@ def attach_usage_plan_to_apis(plan_id, apis, region=None, key=None, keyid=None, 
     '''
     Attaches given usage plan to each of the apis provided in a list of apiId and stage values
 
+    .. versionadded:: Nitrogen
+
     apis
         a list of dictionaries, where each dictionary contains the following:
 
@@ -1672,8 +1672,6 @@ def attach_usage_plan_to_apis(plan_id, apis, region=None, key=None, keyid=None, 
 
         salt myminion boto_apigateway.attach_usage_plan_to_apis plan_id='usage plan id' apis='[{"apiId": "some id 1", "stage": "some stage 1"}]'
 
-    .. versionadded:: Carbon
-
     '''
     return _update_usage_plan_apis(plan_id, apis, 'add', region=region, key=key, keyid=keyid, profile=profile)
 
@@ -1681,6 +1679,8 @@ def attach_usage_plan_to_apis(plan_id, apis, region=None, key=None, keyid=None, 
 def detach_usage_plan_from_apis(plan_id, apis, region=None, key=None, keyid=None, profile=None):
     '''
     Detaches given usage plan from each of the apis provided in a list of apiId and stage value
+
+    .. versionadded:: Nitrogen
 
     apis
         a list of dictionaries, where each dictionary contains the following:
@@ -1696,8 +1696,6 @@ def detach_usage_plan_from_apis(plan_id, apis, region=None, key=None, keyid=None
     .. code-block:: bash
 
         salt myminion boto_apigateway.detach_usage_plan_to_apis plan_id='usage plan id' apis='[{"apiId": "some id 1", "stage": "some stage 1"}]'
-
-    .. versionadded:: Carbon
 
     '''
     return _update_usage_plan_apis(plan_id, apis, 'remove', region=region, key=key, keyid=keyid, profile=profile)

--- a/salt/pillar/vmware_pillar.py
+++ b/salt/pillar/vmware_pillar.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 '''
-.. versionadded:: Carbon
+Pillar data from vCenter or an ESXi host
+
+.. versionadded:: Nitrogen
 
 :depends: - pyVmomi
-
-Pillar data from vCenter or an ESXi host
 
 This external pillar can pull attributes from objects in vCenter or an ESXi host and provide those attributes
 as pillar data to minions.  This can allow for pillar based targeting of minions on ESXi host, Datastore, VM

--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
 Manage Apigateway Rest APIs
-=================
+===========================
 
 .. versionadded:: 2016.11.0
 
@@ -224,13 +224,13 @@ def present(name, api_name, swagger_file, stage_name, api_key_required,
             '#end\n'
             '  ]\n'
 
-        .. versionadded:: Carbon
+        .. versionadded:: Nitrogen
 
     response_template
         String value that defines the response template mapping applied in case of success (including OPTIONS method)
         If set to None, empty ({}) template is assumed, which will transfer response from the lambda function as is.
 
-        .. versionadded:: Carbon
+        .. versionadded:: Nitrogen
     '''
     ret = {'name': name,
            'result': True,
@@ -1670,6 +1670,8 @@ def usage_plan_present(name, plan_name, description=None, throttle=None, quota=N
     '''
     Ensure the spcifieda usage plan with the corresponding metrics is deployed
 
+    .. versionadded:: Nitrogen
+
     name
         name of the state
 
@@ -1700,19 +1702,18 @@ def usage_plan_present(name, plan_name, description=None, throttle=None, quota=N
             [Required] period to which quota applies. Must be DAY, WEEK or MONTH
 
     .. code-block:: yaml
-        UsagePlanPresent:
-            boto_apigateway.usage_plan_present:
-                - plan_name: my_usage_plan
-                - throttle:
-                    rateLimit: 70
-                    burstLimit: 100
-                - quota:
-                    limit: 1000
-                    offset: 0
-                    period: DAY
-                - profile: my_profile
 
-    .. versionadded:: Carbon
+        UsagePlanPresent:
+          boto_apigateway.usage_plan_present:
+            - plan_name: my_usage_plan
+            - throttle:
+                rateLimit: 70
+                burstLimit: 100
+            - quota:
+                limit: 1000
+                offset: 0
+                period: DAY
+            - profile: my_profile
 
     '''
     func_params = locals()
@@ -1809,6 +1810,8 @@ def usage_plan_absent(name, plan_name, region=None, key=None, keyid=None, profil
     '''
     Ensures usage plan identified by name is no longer present
 
+    .. versionadded:: Nitrogen
+
     name
         name of the state
 
@@ -1816,12 +1819,11 @@ def usage_plan_absent(name, plan_name, region=None, key=None, keyid=None, profil
         name of the plan to remove
 
     .. code-block:: yaml
-        usage plan absent:
-            boto_apigateway.usage_plan_absent:
-                - plan_name: my_usage_plan
-                - profile: my_profile
 
-    .. versionadded:: Carbon
+        usage plan absent:
+          boto_apigateway.usage_plan_absent:
+            - plan_name: my_usage_plan
+            - profile: my_profile
 
     '''
     ret = {'name': name,
@@ -1874,6 +1876,8 @@ def usage_plan_association_present(name, plan_name, api_stages, region=None, key
     '''
     Ensures usage plan identified by name is added to provided api_stages
 
+    .. versionadded:: Nitrogen
+
     name
         name of the state
 
@@ -1890,6 +1894,7 @@ def usage_plan_association_present(name, plan_name, api_stages, region=None, key
             stage name of the api to attach usage plan to
 
     .. code-block:: yaml
+
         UsagePlanAssociationPresent:
           boto_apigateway.usage_plan_association_present:
             - plan_name: my_plan
@@ -1899,8 +1904,6 @@ def usage_plan_association_present(name, plan_name, api_stages, region=None, key
               - apiId: l9v7o2aj90
                 stage: my_stage
             - profile: my_profile
-
-    .. versionadded:: Carbon
 
     '''
     ret = {'name': name,
@@ -1966,7 +1969,9 @@ def usage_plan_association_absent(name, plan_name, api_stages, region=None, key=
     '''
     Ensures usage plan identified by name is removed from provided api_stages
     If a plan is associated to stages not listed in api_stages parameter,
-    those associations remain intact
+    those associations remain intact.
+
+    .. versionadded:: Nitrogen
 
     name
         name of the state
@@ -1984,6 +1989,7 @@ def usage_plan_association_absent(name, plan_name, api_stages, region=None, key=
             stage name of the api to detach usage plan from
 
     .. code-block:: yaml
+
         UsagePlanAssociationAbsent:
           boto_apigateway.usage_plan_association_absent:
             - plan_name: my_plan
@@ -1993,8 +1999,6 @@ def usage_plan_association_absent(name, plan_name, api_stages, region=None, key=
               - apiId: l9v7o2aj90
                 stage: my_stage
             - profile: my_profile
-
-    .. versionadded:: Carbon
 
     '''
     ret = {'name': name,

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -298,7 +298,7 @@ def assign_templates(host, templates, **kwargs):
     '''
     Ensures that templates are assigned to the host.
 
-    .. versionadded:: Carbon
+    .. versionadded:: Nitrogen
 
     :param host: technical name of the host
     :param _connection_user: Optional - zabbix user (can also be set in opts or pillar, see module's docstring)


### PR DESCRIPTION
Several new additions to the develop branch have come in recently
where the `versionadded` directives point to "Carbon", but they
should say "Nitrogen". The 2016.11 branch is now the numbered branch
for the Carbon release.