### PR TITLE
Don't skip pillar compilation when master_type=='disable'

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -673,14 +673,13 @@ class SMinion(MinionBase):
         '''
         Load all of the modules for the minion
         '''
-        if self.opts.get('master_type') != 'disable':
-            self.opts['pillar'] = salt.pillar.get_pillar(
-                self.opts,
-                self.opts['grains'],
-                self.opts['id'],
-                self.opts['environment'],
-                pillarenv=self.opts.get('pillarenv'),
-            ).compile_pillar()
+        self.opts['pillar'] = salt.pillar.get_pillar(
+            self.opts,
+            self.opts['grains'],
+            self.opts['id'],
+            self.opts['environment'],
+            pillarenv=self.opts.get('pillarenv'),
+        ).compile_pillar()
 
         self.utils = salt.loader.utils(self.opts)
         self.functions = salt.loader.minion_mods(self.opts, utils=self.utils)


### PR DESCRIPTION
This was broken in pull #32521. The community member who opened that PR
was apparently unaware of the fact that masterless minions will use the
Pillar instead of RemotePillar class, so skipping the Pillar compilation
here results in the packed pillar dunder being completely empty.

This PR fixes that by removing the check for master_type and allowing
local pillar data to be compiled.

Refs: #37713