### PR TITLE
Adding autogeneration for datadisk name

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -965,7 +965,7 @@ def request_instance(call=None, kwargs=None):  # pylint: disable=unused-argument
         if isinstance(volume, six.string_types):
             volume = {'name': volume}
 
-       # Creating the name of the datadisk if missing in the configuration of the minion
+        # Creating the name of the datadisk if missing in the configuration of the minion
         # If the "name: name_of_my_disk" entry then we create it with the same logic than the os disk
         volume.setdefault(
             'name', volume.get(

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -962,8 +962,19 @@ def request_instance(call=None, kwargs=None):  # pylint: disable=unused-argument
     lun = 0
     luns = []
     for volume in volumes:
-        if isinstance(volume, six.string_types):
-            volume = {'name': volume}
+
+       # Creating the name of the datadisk if missing in the configuration of the minion
+        # If the "name: name_of_my_disk" entry then we create it with the same logic than the os disk
+        volume.setdefault(
+            'name', volume.get(
+                'name', volume.get('name', '{0}-datadisk{1}'.format(
+                    vm_['name'],
+                    str(lun),
+                    ),
+                )
+            )
+        )
+
         # Use the size keyword to set a size, but you can use either the new
         # azure name (disk_size_gb) or the old (logical_disk_size_in_gb)
         # instead. If none are set, the disk has size 100GB.

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -962,6 +962,8 @@ def request_instance(call=None, kwargs=None):  # pylint: disable=unused-argument
     lun = 0
     luns = []
     for volume in volumes:
+        if isinstance(volume, six.string_types):
+            volume = {'name': volume}
 
        # Creating the name of the datadisk if missing in the configuration of the minion
         # If the "name: name_of_my_disk" entry then we create it with the same logic than the os disk


### PR DESCRIPTION
### What does this PR do?
If { name : "name_of_disk" } is missing in the profile file we autogenerate the name and pass it to azure.  

### What issues does this PR fix or reference?

### Previous Behavior
If the "name" attribute is missing in the minion configuration file, the deployment would fail.

### New Behavior
The new behavior will generate a name based on the vm name and the lun of the datadisk if the "name" attribute is missing.

### Tests written?
No automated test were written but manual testing has been done.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

If { name : "name_of_the_disk" } of the disk is not present we generate it based on the vm name and lun.