### PR TITLE
Eliminate warning when 'ssl' not set

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -921,7 +921,7 @@ VALID_OPTS = {
     # http://docs.python.org/2/library/ssl.html#ssl.wrap_socket
     # Note: to set enum arguments values like `cert_reqs` and `ssl_version` use constant names
     # without ssl module prefix: `CERT_REQUIRED` or `PROTOCOL_SSLv23`.
-    'ssl': dict,
+    'ssl': (dict, type(None)),
 }
 
 # default configurations


### PR DESCRIPTION
### What does this PR do?

When not specifying 'ssl' in a config file, the following warning
is displayed:

`[WARNING ] Key 'ssl' with value None has an invalid type of NoneType,
a dict is required for this value`

This has been caused by PR #37776.

Fix this by allowing `None` as a valid value for `ssl`.

### Tests written?

No

Signed-off-by: Sergey Kizunov <sergey.kizunov@ni.com>