### PR TITLE
Corrected struct value in wtmp/btmp beacons

### DIFF
--- a/salt/beacons/btmp.py
+++ b/salt/beacons/btmp.py
@@ -18,7 +18,7 @@ import salt.utils
 
 __virtualname__ = 'btmp'
 BTMP = '/var/log/btmp'
-FMT = '<hI32s4s32s256siili4l20s'
+FMT = 'hi32s4s32s256shhiii4i20x'
 FIELDS = [
           'type',
           'PID',

--- a/salt/beacons/wtmp.py
+++ b/salt/beacons/wtmp.py
@@ -18,7 +18,7 @@ import salt.utils
 
 __virtualname__ = 'wtmp'
 WTMP = '/var/log/wtmp'
-FMT = '<hI32s4s32s256siili4l20s'
+FMT = 'hi32s4s32s256shhiii4i20x'
 FIELDS = [
           'type',
           'PID',


### PR DESCRIPTION
### Fix incorrect struct values for wtmp/btmp beacons

### Beacons contain invalid usernames with current struct

### Previous Behavior
username was incorrect

### New Behavior
username as expected

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
