### PR TITLE
Avoid duplicate data and tag keys in event json

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -2063,7 +2063,7 @@ class Events(object):
                     transport=self.opts['transport'],
                     opts=self.opts,
                     listen=True)
-            stream = event.iter_events(full=True, auto_reconnect=True)
+            stream = event.iter_events(full=False, auto_reconnect=True)
 
             yield u'retry: {0}\n'.format(400)
 


### PR DESCRIPTION
### What does this PR do?
"data" and "tag" keys are duplicated in the response returned by salt-api for an event.

### What issues does this PR fix or reference?
It tries to unify the structure of the json returned by salt-api and terminal for an event.

### Previous Behavior
- manually fired event: `salt-call -l quiet event.send "my/event/test" "{test: True}"` on minion
    - terminal:
            {u'_stamp': u'2016-11-18T14:31:35.753645',
             u'cmd': u'_minion_event',
             u'data': {u'__pub_fun': u'event.send',
                       u'__pub_jid': u'20161118143135746909',
                       u'__pub_pid': 107,
                       u'__pub_tgt': u'salt-call',
                       u'test': True},
             u'id': u'id_Wbhrh',
             u'tag': u'my/event/test'}
    - api:
            {u'data': {u'_stamp': u'2016-11-18T14:31:54.311178',
                       u'cmd': u'_minion_event',
                       u'data': {u'__pub_fun': u'event.send',
                                 u'__pub_jid': u'20161118143154305220',
                                 u'__pub_pid': 191,
                                 u'__pub_tgt': u'salt-call',
                                 u'test': True},
                       u'id': u'id_Wbhrh',
                       u'tag': u'my/event/test'},
             u'tag': u'my/event/test'}

- beacon event: using `load` beacon
    - terminal:
            {u'_stamp': u'2016-11-18T14:33:09.283822',
             u'data': {u'15m': 4.8,
                       u'1m': 8.53,
                       u'5m': 8.71,
                       u'id': u'id_Wbhrh'},
             u'tag': u'salt/beacon/id_Wbhrh/load/'}
    - api:
            {u'data': {u'_stamp': u'2016-11-18T14:33:45.283318',
                       u'data': {u'15m': 4.67,
                                 u'1m': 5.39,
                                 u'5m': 7.89,
                                 u'id': u'id_Wbhrh'},
                       u'tag': u'salt/beacon/id_Wbhrh/load/'},
             u'tag': u'salt/beacon/id_Wbhrh/load/'}

### New Behavior
- manually fired event: `salt-call -l quiet event.send "my/event/test" "{test: True}"` on minion
    - terminal:
            {u'_stamp': u'2016-11-18T14:31:35.753645',
             u'cmd': u'_minion_event',
             u'data': {u'__pub_fun': u'event.send',
                       u'__pub_jid': u'20161118143135746909',
                       u'__pub_pid': 107,
                       u'__pub_tgt': u'salt-call',
                       u'test': True},
             u'id': u'id_Wbhrh',
             u'tag': u'my/event/test'}
    - api:
            {u'_stamp': u'2016-11-18T14:31:54.311178',
             u'cmd': u'_minion_event',
             u'data': {u'__pub_fun': u'event.send',
                        u'__pub_jid': u'20161118143154305220',
                        u'__pub_pid': 191,
                        u'__pub_tgt': u'salt-call',
                        u'test': True},
             u'id': u'id_Wbhrh',
             u'tag': u'my/event/test'}
- beacon event: using `load` beacon
    - terminal:
            {u'_stamp': u'2016-11-18T14:33:09.283822',
             u'data': {u'15m': 4.8,
                       u'1m': 8.53,
                       u'5m': 8.71,
                       u'id': u'id_Wbhrh'},
             u'tag': u'salt/beacon/id_Wbhrh/load/'}
    - api:
            {u'_stamp': u'2016-11-18T14:33:45.283318',
             u'data': {u'15m': 4.67,
                       u'1m': 5.39,
                       u'5m': 7.89,
                       u'id': u'id_Wbhrh'},
             u'tag': u'salt/beacon/id_Wbhrh/load/'}

### Tests written?

No

