### PR TITLE
FEAT: put back support for Maverick in OS X installer.

### DIFF
--- a/pkg/osx/distribution.xml.dist
+++ b/pkg/osx/distribution.xml.dist
@@ -5,7 +5,7 @@
     <!-- Define minimum system requirements -->
     <volume-check>
         <allowed-os-versions>
-            <os-version min="10.11" />
+            <os-version min="10.9" />
         </allowed-os-versions>
     </volume-check>
     <options rootVolumeOnly="true"

--- a/pkg/osx/pkg-scripts/postinstall
+++ b/pkg/osx/pkg-scripts/postinstall
@@ -55,25 +55,59 @@ sh -c 'echo "/usr/local/sbin" >> /etc/paths.d/salt'
 ###############################################################################
 # Register Salt as a service
 ###############################################################################
+setup_services_maverick() {
+    echo "Using old (< 10.10) launchctl interface" >> /tmp/postinstall.txt
+    if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
+        echo "Stop running service..a." >> /tmp/postinstall.txt
+        launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist
+    fi;
+    launchctl load -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist || return 1
+
+    echo "Service start: Successful" >> /tmp/postinstall.txt
+
+    echo "Service disable: Disabling Master, Syndic, and API" >> /tmp/postinstall.txt
+
+    launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.api.plist
+    launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.master.plist
+    launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.syndic.plist
+
+    return 0
+}
+
+setup_services_yosemite_and_later() {
+    echo "Using new (>= 10.10) launchctl interface" >> /tmp/postinstall.txt
+    launchctl enable system/com.saltstack.salt.minion
+    echo "Service start: Bootstrapping service..." >> /tmp/postinstall.txt
+    launchctl bootstrap system /Library/LaunchDaemons/com.saltstack.salt.minion.plist
+
+    if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
+        echo "Service is running" >> /tmp/postinstall.txt
+    else
+        echo "Service start: Kickstarting service..." >> /tmp/postinstall.txt
+        launchctl kickstart -kp system/com.saltstack.salt.minion
+    fi
+
+    echo "Service start: Successful" >> /tmp/postinstall.txt
+
+    echo "Service disable: Disabling Master, Syndic, and API" >> /tmp/postinstall.txt
+
+    launchctl disable system/com.saltstack.salt.master
+    launchctl disable system/com.saltstack.salt.syndic
+    launchctl disable system/com.saltstack.salt.api
+}
+
+OSX_VERSION=$(sw_vers | grep ProductVersion | cut -f 2 -d: | tr -d '[:space:]')
+MINOR=$(echo ${OSX_VERSION} | cut -f 2 -d.)
+
 echo "Service start: Enabling service..." >> /tmp/postinstall.txt
-launchctl enable system/com.saltstack.salt.minion
-echo "Service start: Bootstrapping service..." >> /tmp/postinstall.txt
-launchctl bootstrap system /Library/LaunchDaemons/com.saltstack.salt.minion.plist
-
-if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-    echo "Service is running" >> /tmp/postinstall.txt
-else
-    echo "Service start: Kickstarting service..." >> /tmp/postinstall.txt
-    launchctl kickstart -kp system/com.saltstack.salt.minion
-fi
-
-echo "Service start: Successful" >> /tmp/postinstall.txt
-
-echo "Service disable: Disabling Master, Syndic, and API" >> /tmp/postinstall.txt
-
-launchctl disable system/com.saltstack.salt.master
-launchctl disable system/com.saltstack.salt.syndic
-launchctl disable system/com.saltstack.salt.api
+case $MINOR in
+        9 )
+                setup_services_maverick;
+                ;;
+        * )
+                setup_services_yosemite_and_later;
+                ;;
+esac
 
 echo "Post install completed successfully" >> /tmp/postinstall.txt
 

--- a/pkg/osx/pkg-scripts/postinstall
+++ b/pkg/osx/pkg-scripts/postinstall
@@ -58,7 +58,7 @@ sh -c 'echo "/usr/local/sbin" >> /etc/paths.d/salt'
 setup_services_maverick() {
     echo "Using old (< 10.10) launchctl interface" >> /tmp/postinstall.txt
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-        echo "Stop running service..a." >> /tmp/postinstall.txt
+        echo "Stop running service..." >> /tmp/postinstall.txt
         launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist
     fi;
     launchctl load -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist || return 1

--- a/pkg/osx/pkg-scripts/postinstall
+++ b/pkg/osx/pkg-scripts/postinstall
@@ -15,13 +15,12 @@
 #     This script is run as a part of the OSX Salt Installation
 #
 ###############################################################################
-LOG_OUTPUT=/tmp/postinstall.txt
-echo "Post install started on:" > "${LOG_OUTPUT}"
-date >> "${LOG_OUTPUT}"
+echo "Post install started on:" > /tmp/postinstall.txt
+date >> /tmp/postinstall.txt
 trap 'quit_on_error $LINENO $BASH_COMMAND' ERR
 
 quit_on_error() {
-    echo "$(basename $0) caught error on line : $1 command was: $2" >> "${LOG_OUTPUT}"
+    echo "$(basename $0) caught error on line : $1 command was: $2" >> /tmp/postinstall.txt
     exit -1
 }
 
@@ -29,15 +28,15 @@ quit_on_error() {
 # Check for existing minion config, copy if it doesn't exist
 ###############################################################################
 if [ ! -f /etc/salt/minion ]; then
-    echo "Config copy: Started..." >> "${LOG_OUTPUT}"
+    echo "Config copy: Started..." >> /tmp/postinstall.txt
     cp /etc/salt/minion.dist /etc/salt/minion
-    echo "Config copy: Successful" >> "${LOG_OUTPUT}"
+    echo "Config copy: Successful" >> /tmp/postinstall.txt
 fi
 
 ###############################################################################
 # Create symlink to salt-config.sh
 ###############################################################################
-# echo "Symlink: Creating symlink for salt-config..." >> "${LOG_OUTPUT}"
+# echo "Symlink: Creating symlink for salt-config..." >> /tmp/postinstall.txt
 if [ ! -d "/usr/local/sbin" ]; then
     mkdir /usr/local/sbin
 fi
@@ -46,7 +45,7 @@ ln -sf /opt/salt/bin/salt-config.sh /usr/local/sbin/salt-config
 ###############################################################################
 # Add salt to paths.d
 ###############################################################################
-# echo "Path: Adding salt to the path..." >> "${LOG_OUTPUT}"
+# echo "Path: Adding salt to the path..." >> /tmp/postinstall.txt
 if [ ! -d "/etc/paths.d" ]; then
     mkdir /etc/paths.d
 fi
@@ -57,16 +56,16 @@ sh -c 'echo "/usr/local/sbin" >> /etc/paths.d/salt'
 # Register Salt as a service
 ###############################################################################
 setup_services_maverick() {
-    echo "Using old (< 10.10) launchctl interface" >> "${LOG_OUTPUT}"
+    echo "Using old (< 10.10) launchctl interface" >> /tmp/postinstall.txt
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-        echo "Stop running service..." >> "${LOG_OUTPUT}"
+        echo "Stop running service..." >> /tmp/postinstall.txt
         launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist
     fi;
     launchctl load -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist || return 1
 
-    echo "Service start: Successful" >> "${LOG_OUTPUT}"
+    echo "Service start: Successful" >> /tmp/postinstall.txt
 
-    echo "Service disable: Disabling Master, Syndic, and API" >> "${LOG_OUTPUT}"
+    echo "Service disable: Disabling Master, Syndic, and API" >> /tmp/postinstall.txt
 
     launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.api.plist
     launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.master.plist
@@ -76,21 +75,21 @@ setup_services_maverick() {
 }
 
 setup_services_yosemite_and_later() {
-    echo "Using new (>= 10.10) launchctl interface" >> "${LOG_OUTPUT}"
+    echo "Using new (>= 10.10) launchctl interface" >> /tmp/postinstall.txt
     launchctl enable system/com.saltstack.salt.minion
-    echo "Service start: Bootstrapping service..." >> "${LOG_OUTPUT}"
+    echo "Service start: Bootstrapping service..." >> /tmp/postinstall.txt
     launchctl bootstrap system /Library/LaunchDaemons/com.saltstack.salt.minion.plist
 
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-        echo "Service is running" >> "${LOG_OUTPUT}"
+        echo "Service is running" >> /tmp/postinstall.txt
     else
-        echo "Service start: Kickstarting service..." >> "${LOG_OUTPUT}"
+        echo "Service start: Kickstarting service..." >> /tmp/postinstall.txt
         launchctl kickstart -kp system/com.saltstack.salt.minion
     fi
 
-    echo "Service start: Successful" >> "${LOG_OUTPUT}"
+    echo "Service start: Successful" >> /tmp/postinstall.txt
 
-    echo "Service disable: Disabling Master, Syndic, and API" >> "${LOG_OUTPUT}"
+    echo "Service disable: Disabling Master, Syndic, and API" >> /tmp/postinstall.txt
 
     launchctl disable system/com.saltstack.salt.master
     launchctl disable system/com.saltstack.salt.syndic
@@ -100,7 +99,7 @@ setup_services_yosemite_and_later() {
 OSX_VERSION=$(sw_vers | grep ProductVersion | cut -f 2 -d: | tr -d '[:space:]')
 MINOR=$(echo ${OSX_VERSION} | cut -f 2 -d.)
 
-echo "Service start: Enabling service..." >> "${LOG_OUTPUT}"
+echo "Service start: Enabling service..." >> /tmp/postinstall.txt
 case $MINOR in
         9 )
                 setup_services_maverick;
@@ -110,6 +109,6 @@ case $MINOR in
                 ;;
 esac
 
-echo "Post install completed successfully" >> "${LOG_OUTPUT}"
+echo "Post install completed successfully" >> /tmp/postinstall.txt
 
 exit 0

--- a/pkg/osx/pkg-scripts/postinstall
+++ b/pkg/osx/pkg-scripts/postinstall
@@ -15,12 +15,13 @@
 #     This script is run as a part of the OSX Salt Installation
 #
 ###############################################################################
-echo "Post install started on:" > /tmp/postinstall.txt
-date >> /tmp/postinstall.txt
+LOG_OUTPUT=/tmp/postinstall.txt
+echo "Post install started on:" > "${LOG_OUTPUT}"
+date >> "${LOG_OUTPUT}"
 trap 'quit_on_error $LINENO $BASH_COMMAND' ERR
 
 quit_on_error() {
-    echo "$(basename $0) caught error on line : $1 command was: $2" >> /tmp/postinstall.txt
+    echo "$(basename $0) caught error on line : $1 command was: $2" >> "${LOG_OUTPUT}"
     exit -1
 }
 
@@ -28,15 +29,15 @@ quit_on_error() {
 # Check for existing minion config, copy if it doesn't exist
 ###############################################################################
 if [ ! -f /etc/salt/minion ]; then
-    echo "Config copy: Started..." >> /tmp/postinstall.txt
+    echo "Config copy: Started..." >> "${LOG_OUTPUT}"
     cp /etc/salt/minion.dist /etc/salt/minion
-    echo "Config copy: Successful" >> /tmp/postinstall.txt
+    echo "Config copy: Successful" >> "${LOG_OUTPUT}"
 fi
 
 ###############################################################################
 # Create symlink to salt-config.sh
 ###############################################################################
-# echo "Symlink: Creating symlink for salt-config..." >> /tmp/postinstall.txt
+# echo "Symlink: Creating symlink for salt-config..." >> "${LOG_OUTPUT}"
 if [ ! -d "/usr/local/sbin" ]; then
     mkdir /usr/local/sbin
 fi
@@ -45,7 +46,7 @@ ln -sf /opt/salt/bin/salt-config.sh /usr/local/sbin/salt-config
 ###############################################################################
 # Add salt to paths.d
 ###############################################################################
-# echo "Path: Adding salt to the path..." >> /tmp/postinstall.txt
+# echo "Path: Adding salt to the path..." >> "${LOG_OUTPUT}"
 if [ ! -d "/etc/paths.d" ]; then
     mkdir /etc/paths.d
 fi
@@ -56,16 +57,16 @@ sh -c 'echo "/usr/local/sbin" >> /etc/paths.d/salt'
 # Register Salt as a service
 ###############################################################################
 setup_services_maverick() {
-    echo "Using old (< 10.10) launchctl interface" >> /tmp/postinstall.txt
+    echo "Using old (< 10.10) launchctl interface" >> "${LOG_OUTPUT}"
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-        echo "Stop running service..." >> /tmp/postinstall.txt
+        echo "Stop running service..." >> "${LOG_OUTPUT}"
         launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist
     fi;
     launchctl load -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist || return 1
 
-    echo "Service start: Successful" >> /tmp/postinstall.txt
+    echo "Service start: Successful" >> "${LOG_OUTPUT}"
 
-    echo "Service disable: Disabling Master, Syndic, and API" >> /tmp/postinstall.txt
+    echo "Service disable: Disabling Master, Syndic, and API" >> "${LOG_OUTPUT}"
 
     launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.api.plist
     launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.master.plist
@@ -75,21 +76,21 @@ setup_services_maverick() {
 }
 
 setup_services_yosemite_and_later() {
-    echo "Using new (>= 10.10) launchctl interface" >> /tmp/postinstall.txt
+    echo "Using new (>= 10.10) launchctl interface" >> "${LOG_OUTPUT}"
     launchctl enable system/com.saltstack.salt.minion
-    echo "Service start: Bootstrapping service..." >> /tmp/postinstall.txt
+    echo "Service start: Bootstrapping service..." >> "${LOG_OUTPUT}"
     launchctl bootstrap system /Library/LaunchDaemons/com.saltstack.salt.minion.plist
 
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-        echo "Service is running" >> /tmp/postinstall.txt
+        echo "Service is running" >> "${LOG_OUTPUT}"
     else
-        echo "Service start: Kickstarting service..." >> /tmp/postinstall.txt
+        echo "Service start: Kickstarting service..." >> "${LOG_OUTPUT}"
         launchctl kickstart -kp system/com.saltstack.salt.minion
     fi
 
-    echo "Service start: Successful" >> /tmp/postinstall.txt
+    echo "Service start: Successful" >> "${LOG_OUTPUT}"
 
-    echo "Service disable: Disabling Master, Syndic, and API" >> /tmp/postinstall.txt
+    echo "Service disable: Disabling Master, Syndic, and API" >> "${LOG_OUTPUT}"
 
     launchctl disable system/com.saltstack.salt.master
     launchctl disable system/com.saltstack.salt.syndic
@@ -99,7 +100,7 @@ setup_services_yosemite_and_later() {
 OSX_VERSION=$(sw_vers | grep ProductVersion | cut -f 2 -d: | tr -d '[:space:]')
 MINOR=$(echo ${OSX_VERSION} | cut -f 2 -d.)
 
-echo "Service start: Enabling service..." >> /tmp/postinstall.txt
+echo "Service start: Enabling service..." >> "${LOG_OUTPUT}"
 case $MINOR in
         9 )
                 setup_services_maverick;
@@ -109,6 +110,6 @@ case $MINOR in
                 ;;
 esac
 
-echo "Post install completed successfully" >> /tmp/postinstall.txt
+echo "Post install completed successfully" >> "${LOG_OUTPUT}"
 
 exit 0

--- a/pkg/osx/pkg-scripts/preinstall
+++ b/pkg/osx/pkg-scripts/preinstall
@@ -27,27 +27,25 @@ quit_on_error() {
 OSX_VERSION=$(sw_vers | grep ProductVersion | cut -f 2 -d: | tr -d '[:space:]')
 MINOR=$(echo ${OSX_VERSION} | cut -f 2 -d.)
 
-LOG_OUTPUT=/tmp/preinstall.txt
-
 ###############################################################################
 # Stop the service
 ###############################################################################
 stop_service_maverick() {
-    echo "Using old (< 10.10) launchctl interface" >> "${LOG_OUTPUT}"
+    echo "Using old (< 10.10) launchctl interface" >> /tmp/postinstall.txt
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-        echo "Stop service: Started..." >> "${LOG_OUTPUT}"
+        echo "Stop service: Started..." >> /tmp/preinstall.txt
         launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist
-        echo "Stop service: Successful" >> "${LOG_OUTPUT}"
+        echo "Stop service: Successful" >> /tmp/preinstall.txt
     fi
 }
 
 stop_service_yosemite_and_later() {
-    echo "Using new (>= 10.10) launchctl interface" >> "${LOG_OUTPUT}"
+    echo "Using new (>= 10.10) launchctl interface" >> /tmp/postinstall.txt
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-        echo "Stop service: Started..." >> "${LOG_OUTPUT}"
+        echo "Stop service: Started..." >> /tmp/preinstall.txt
         launchctl disable system/com.saltstack.salt.minion
         launchctl bootout system /Library/LaunchDaemons/com.saltstack.salt.minion.plist
-        echo "Stop service: Successful" >> "${LOG_OUTPUT}"
+        echo "Stop service: Successful" >> /tmp/preinstall.txt
     fi
 }
 
@@ -59,6 +57,6 @@ case $MINOR in
                 stop_service_yosemite_and_later;
                 ;;
 esac
-echo "Preinstall Completed Successfully" >> "${LOG_OUTPUT}"
+echo "Preinstall Completed Successfully" >> /tmp/preinstall.txt
 
 exit 0

--- a/pkg/osx/pkg-scripts/preinstall
+++ b/pkg/osx/pkg-scripts/preinstall
@@ -34,7 +34,7 @@ stop_service_maverick() {
     echo "Using old (< 10.10) launchctl interface" >> /tmp/postinstall.txt
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
         echo "Stop service: Started..." >> /tmp/preinstall.txt
-        launchctl unload /Library/LaunchDaemons/com.saltstack.salt.minion.plist
+        launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist
         echo "Stop service: Successful" >> /tmp/preinstall.txt
     fi
 }

--- a/pkg/osx/pkg-scripts/preinstall
+++ b/pkg/osx/pkg-scripts/preinstall
@@ -27,25 +27,27 @@ quit_on_error() {
 OSX_VERSION=$(sw_vers | grep ProductVersion | cut -f 2 -d: | tr -d '[:space:]')
 MINOR=$(echo ${OSX_VERSION} | cut -f 2 -d.)
 
+LOG_OUTPUT=/tmp/preinstall.txt
+
 ###############################################################################
 # Stop the service
 ###############################################################################
 stop_service_maverick() {
-    echo "Using old (< 10.10) launchctl interface" >> /tmp/postinstall.txt
+    echo "Using old (< 10.10) launchctl interface" >> "${LOG_OUTPUT}"
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-        echo "Stop service: Started..." >> /tmp/preinstall.txt
+        echo "Stop service: Started..." >> "${LOG_OUTPUT}"
         launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist
-        echo "Stop service: Successful" >> /tmp/preinstall.txt
+        echo "Stop service: Successful" >> "${LOG_OUTPUT}"
     fi
 }
 
 stop_service_yosemite_and_later() {
-    echo "Using new (>= 10.10) launchctl interface" >> /tmp/postinstall.txt
+    echo "Using new (>= 10.10) launchctl interface" >> "${LOG_OUTPUT}"
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-        echo "Stop service: Started..." >> /tmp/preinstall.txt
+        echo "Stop service: Started..." >> "${LOG_OUTPUT}"
         launchctl disable system/com.saltstack.salt.minion
         launchctl bootout system /Library/LaunchDaemons/com.saltstack.salt.minion.plist
-        echo "Stop service: Successful" >> /tmp/preinstall.txt
+        echo "Stop service: Successful" >> "${LOG_OUTPUT}"
     fi
 }
 
@@ -57,6 +59,6 @@ case $MINOR in
                 stop_service_yosemite_and_later;
                 ;;
 esac
-echo "Preinstall Completed Successfully" >> /tmp/preinstall.txt
+echo "Preinstall Completed Successfully" >> "${LOG_OUTPUT}"
 
 exit 0

--- a/pkg/osx/pkg-scripts/preinstall
+++ b/pkg/osx/pkg-scripts/preinstall
@@ -31,7 +31,7 @@ MINOR=$(echo ${OSX_VERSION} | cut -f 2 -d.)
 # Stop the service
 ###############################################################################
 stop_service_maverick() {
-    echo "Using old (< 10.10) launchctl interface" >> /tmp/postinstall.txt
+    echo "Using old (< 10.10) launchctl interface" >> /tmp/preinstall.txt
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
         echo "Stop service: Started..." >> /tmp/preinstall.txt
         launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist
@@ -40,7 +40,7 @@ stop_service_maverick() {
 }
 
 stop_service_yosemite_and_later() {
-    echo "Using new (>= 10.10) launchctl interface" >> /tmp/postinstall.txt
+    echo "Using new (>= 10.10) launchctl interface" >> /tmp/preinstall.txt
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
         echo "Stop service: Started..." >> /tmp/preinstall.txt
         launchctl disable system/com.saltstack.salt.minion

--- a/pkg/osx/pkg-scripts/preinstall
+++ b/pkg/osx/pkg-scripts/preinstall
@@ -24,17 +24,39 @@ quit_on_error() {
     exit -1
 }
 
+OSX_VERSION=$(sw_vers | grep ProductVersion | cut -f 2 -d: | tr -d '[:space:]')
+MINOR=$(echo ${OSX_VERSION} | cut -f 2 -d.)
+
 ###############################################################################
 # Stop the service
 ###############################################################################
-if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-    echo "Stop service: Started..." >> /tmp/preinstall.txt
-#    /bin/launchctl unload "/Library/LaunchDaemons/com.saltstack.salt.minion.plist"
-    launchctl disable system/com.saltstack.salt.minion
-    launchctl bootout system /Library/LaunchDaemons/com.saltstack.salt.minion.plist
-    echo "Stop service: Successful" >> /tmp/preinstall.txt
-fi
+stop_service_maverick() {
+    echo "Using old (< 10.10) launchctl interface" >> /tmp/postinstall.txt
+    if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
+        echo "Stop service: Started..." >> /tmp/preinstall.txt
+        launchctl unload /Library/LaunchDaemons/com.saltstack.salt.minion.plist
+        echo "Stop service: Successful" >> /tmp/preinstall.txt
+    fi
+}
 
+stop_service_yosemite_and_later() {
+    echo "Using new (>= 10.10) launchctl interface" >> /tmp/postinstall.txt
+    if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
+        echo "Stop service: Started..." >> /tmp/preinstall.txt
+        launchctl disable system/com.saltstack.salt.minion
+        launchctl bootout system /Library/LaunchDaemons/com.saltstack.salt.minion.plist
+        echo "Stop service: Successful" >> /tmp/preinstall.txt
+    fi
+}
+
+case $MINOR in
+        9 )
+                stop_service_maverick;
+                ;;
+        * )
+                stop_service_yosemite_and_later;
+                ;;
+esac
 echo "Preinstall Completed Successfully" >> /tmp/preinstall.txt
 
 exit 0


### PR DESCRIPTION
### What does this PR do?

Add support for OS X 10.9 in salt installers, while keeping compatibility for 10.11

### What issues does this PR fix or reference?

The current installer only works on 10.11

### Tests written?

No (did not find a way to test installers, let me know if there is one)

We are using salt to manage a build farm, which includes OS X VMs running on vmware vsphere. For backward compatibility reasons, we build on older OS X versions, and the latest OS X installers for salt don't work anymore.

AFAICS, the only requirement for 10.11 in the current installer is the pre/post install scripts that use the new launchctl CLI interface. To add support for 10.9, I simply check for the OS X version, execute the current code for 10.10 and above, and use a slightly modified version of the older versions of those scripts for 10.9.

Tested on Maverick (10.9.5). If that can help getting this accepted, I would be happy to test on 10.10 and 10.11. 