### PR TITLE
Proxy keepalive feature

### DIFF
--- a/doc/topics/proxyminion/index.rst
+++ b/doc/topics/proxyminion/index.rst
@@ -351,6 +351,13 @@ the keyword ``pass`` if there is no shutdown logic required.
 be defined in the proxymodule. The code for ``ping`` should contact the
 controlled device and make sure it is really available.
 
+``alive(opts)``: Another optional function, it is used together with the
+``proxy_keep_alive`` option (default: ``True``). This function should
+return a boolean value corresponding to the state of the connection.
+If the connection is down, will try to restart (``shutdown``
+followed by ``init``). The polling frequency is controlled using
+the ``proxy_keep_alive_interval`` option, in minutes.
+
 ``grains()``: Rather than including grains in /srv/salt/_grains or in
 the standard install directories for grains, grains can be computed and
 returned by this function.  This function will be called automatically
@@ -404,6 +411,9 @@ and status; "package" installation, and a ping.
         return True
 
 
+    def _complicated_function_that_determines_if_alive():
+        return True
+
     # Every proxy module needs an 'init', though you can
     # just put DETAILS['initialized'] = True here if nothing
     # else needs to be done.
@@ -418,6 +428,16 @@ and status; "package" installation, and a ping.
         # Make sure the REST URL ends with a '/'
         if not DETAILS['url'].endswith('/'):
             DETAILS['url'] += '/'
+
+    def alive(opts):
+        '''
+        This function returns a flag with the connection state.
+        It is very useful when the proxy minion establishes the communication
+        via a channel that requires a more elaborated keep-alive mechanism, e.g.
+        NETCONF over SSH.
+        '''
+        log.debug('rest_sample proxy alive() called...')
+        return _complicated_function_that_determines_if_alive()
 
 
     def initialized():

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -542,6 +542,14 @@ VALID_OPTS = {
     # but this was the default pre 2015.8.2.  This should default to
     # False in 2016.3.0
     'add_proxymodule_to_opts': bool,
+
+    # Poll the connection state with the proxy minion
+    # If enabled, this option requires the function `alive`
+    # to be implemented in the proxy module
+    'proxy_keep_alive': bool,
+
+    # Frequency of the proxy_keep_alive, in minutes
+    'proxy_keep_alive_interval': int,
     'git_pillar_base': str,
     'git_pillar_branch': str,
     'git_pillar_env': str,
@@ -1472,6 +1480,8 @@ DEFAULT_PROXY_MINION_OPTS = {
     'proxy_merge_grains_in_module': True,
     'append_minionid_config_dirs': ['cachedir', 'pidfile'],
     'default_include': 'proxy.d/*.conf',
+    'proxy_keep_alive': True,  # by default will try to keep alive the connection
+    'proxy_keep_alive_interval': 1  # frequency of the proxy keepalive in minutes
 }
 
 # ----- Salt Cloud Configuration Defaults ----------------------------------->

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3196,8 +3196,7 @@ class ProxyMinion(Minion):
                     'maxrunning': 1,
                     'return_job': False,
                     'kwargs': {
-                        'proxy_name': fq_proxyname,
-                        'opts': self.opts
+                        'proxy_name': fq_proxyname
                     }
                 }
             }, persist=True)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3183,23 +3183,20 @@ class ProxyMinion(Minion):
             self.schedule.delete_job(master_event(type='failback'), persist=True)
 
         # proxy keepalive
-        proxy_alive_fn = self.proxy[fq_proxyname+'.alive']
-        proxy_shutdown_fn = self.proxy[fq_proxyname+'.shutdown']
-        if proxy_alive_fn and 'status.proxy_reconnect' in self.functions and 'proxy_keep_alive' not in self.opts or \
-           ('proxy_keep_alive' in self.opts and self.opts['proxy_keep_alive']):
+        proxy_alive_fn = fq_proxyname+'.alive'
+        if proxy_alive_fn in self.proxy and 'status.proxy_reconnect' in self.functions and \
+           ('proxy_keep_alive' not in self.opts or ('proxy_keep_alive' in self.opts and self.opts['proxy_keep_alive'])):
             # if `proxy_keep_alive` is either not specified, either set to False does not retry reconnecting
             self.schedule.add_job({
                 '__proxy_keepalive':
                 {
                     'function': 'status.proxy_reconnect',
-                    'minutes': self.opts.get('proxy_keep_alive_interval', 1),  # check once per minute
+                    'minutes': self.opts.get('proxy_keep_alive_interval', 1),  # by default, check once per minute
                     'jid_include': True,
                     'maxrunning': 1,
                     'return_job': False,
                     'kwargs': {
-                        'alive_fun': proxy_alive_fn,
-                        'init_fun': proxy_init_fn,
-                        'shutdown_fun': proxy_shutdown_fn,
+                        'proxy_name': fq_proxyname,
                         'opts': self.opts
                     }
                 }

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3182,6 +3182,31 @@ class ProxyMinion(Minion):
             self.schedule.delete_job(master_event(type='alive', master=self.opts['master']), persist=True)
             self.schedule.delete_job(master_event(type='failback'), persist=True)
 
+        # proxy keepalive
+        proxy_alive_fn = self.proxy[fq_proxyname+'.alive']
+        proxy_shutdown_fn = self.proxy[fq_proxyname+'.shutdown']
+        if proxy_alive_fn and 'status.proxy_reconnect' in self.functions and 'proxy_keep_alive' not in self.opts or \
+           ('proxy_keep_alive' in self.opts and self.opts['proxy_keep_alive']):
+            # if `proxy_keep_alive` is either not specified, either set to False does not retry reconnecting
+            self.schedule.add_job({
+                '__proxy_keepalive':
+                {
+                    'function': 'status.proxy_reconnect',
+                    'minutes': self.opts.get('proxy_keep_alive_interval', 1),  # check once per minute
+                    'jid_include': True,
+                    'maxrunning': 1,
+                    'return_job': False,
+                    'kwargs': {
+                        'alive_fun': proxy_alive_fn,
+                        'init_fun': proxy_init_fn,
+                        'shutdown_fun': proxy_shutdown_fn,
+                        'opts': self.opts
+                    }
+                }
+            }, persist=True)
+        else:
+            self.schedule.delete_job('__proxy_keepalive', persist=True)
+
         #  Sync the grains here so the proxy can communicate them to the master
         self.functions['saltutil.sync_grains'](saltenv=self.opts['environment'])
         self.grains_cache = self.opts['grains']

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -29,6 +29,9 @@ from salt.utils.network import host_to_ips as _host_to_ips
 from salt.ext.six.moves import zip
 from salt.exceptions import CommandExecutionError
 
+import logging
+log = logging.getLogger(__name__)
+
 __virtualname__ = 'status'
 __opts__ = {}
 
@@ -1129,8 +1132,19 @@ def proxy_reconnect(proxy_name, opts=None):
 
     is_alive = __proxy__[proxy_keepalive_fn](opts)
     if not is_alive:
+        minion_id = opts.get('proxyid', '') or opts.get('id', '')
+        log.info('{minion_id} ({proxy_name} proxy) is down. Restarting.'.format(
+                minion_id=minion_id,
+                proxy_name=proxy_name
+            )
+        )
         __proxy__[proxy_name+'.shutdown'](opts)  # safely close connection
         __proxy__[proxy_name+'.init'](opts)  # reopen connection
+        log.debug('Restarted {minion_id} ({proxy_name} proxy)!'.format(
+                minion_id=minion_id,
+                proxy_name=proxy_name
+            )
+        )
 
     return True  # success
 

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -1106,16 +1106,33 @@ def ping_master(master):
     return result
 
 
-def proxy_reconnect(alive_fun, init_fun, shutdown_fun, opts):
+def proxy_reconnect(proxy_name, opts=None):
     '''
     Forces proxy minion reconnection when not alive.
+
+    proxy_name
+        The virtual name of the proxy module.
+
+    opts: None
+        Opts dictionary.
     '''
 
-    is_alive = alive_fun(opts)
+    if not opts:
+        opts = __opts__
 
+    if not 'proxy' in opts:
+        return False  # fail
+
+    proxy_keepalive_fn = proxy_name+'.alive'
+    if proxy_keepalive_fn not in __proxy__:
+        return False  # fail
+
+    is_alive = __proxy__[proxy_keepalive_fn](opts)
     if not is_alive:
-        shutdown_fun(opts)  # safely close connection
-        init_fun(opts)  # reopen connection
+        __proxy__[proxy_name+'.shutdown'](opts)  # safely close connection
+        __proxy__[proxy_name+'.init'](opts)  # reopen connection
+
+    return True  # success
 
 
 def time_(format='%A, %d. %B %Y %I:%M%p'):

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -1120,7 +1120,7 @@ def proxy_reconnect(proxy_name, opts=None):
     if not opts:
         opts = __opts__
 
-    if not 'proxy' in opts:
+    if 'proxy' not in opts:
         return False  # fail
 
     proxy_keepalive_fn = proxy_name+'.alive'

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -1106,6 +1106,18 @@ def ping_master(master):
     return result
 
 
+def proxy_reconnect(alive_fun, init_fun, shutdown_fun, opts):
+    '''
+    Forces proxy minion reconnection when not alive.
+    '''
+
+    is_alive = alive_fun(opts)
+
+    if not is_alive:
+        shutdown_fun(opts)  # safely close connection
+        init_fun(opts)  # reopen connection
+
+
 def time_(format='%A, %d. %B %Y %I:%M%p'):
     '''
     .. versionadded:: 2016.3.0


### PR DESCRIPTION
### What does this PR do?

Opening this PR to discuss the implementation for the proxy keepalive feature.

Ping @cro

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/32918


Not sure if possible to send the functions as kvargs. At the same time, not sure if the object ```__proxy___``` is available in the ```status``` module at that point to execute from there the functions as ```__proxy__['<proxy_name>.alive']()```. What would you suggest?