### PR TITLE
Dsc config data

### DIFF
--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -84,7 +84,7 @@ def _pshell(cmd, cwd=None, json_depth=2):
 
 def run_config(path,
                source=None,
-               config=None,
+               config_name=None,
                config_data=None,
                config_data_source=None,
                script_parameters=None,
@@ -109,23 +109,31 @@ def run_config(path,
             locally and then executed. If source is not passed, the config
             script located at ``path`` will be compiled. Optional.
 
-        config (str): The name of the Configuration within the script to apply.
-            the script contains multiple configurations within the file a config
-            must be specified. If the config is not specified, the name of the
-            file will be used as the config to run. Optional.
+        config_name (str): The name of the Configuration within the script to
+            apply. If the script contains multiple configurations within the
+            file a ``config_name`` must be specified. If the ``config_name`` is
+            not specified, the name of the file will be used as the
+            ``config_name`` to run. Optional.
 
         config_data (str): Configuration data in the form of a hash table that
             will be passed to the ``ConfigurationData`` parameter when the
-            configuration script is run. This can be the path to a ``.psd1``
-            file or the PowerShell code to create the hash table.
+            ``config_name`` is compiled. This can be the path to a ``.psd1``
+            file containing the proper hash table or the PowerShell code to
+            create the hash table.
+
+            .. versionadded:: Nitrogen
 
         config_data_source (str): The path to the ``.psd1`` file on
             ``file_roots`` to cache at the location specified by
             ``config_data``. If this is specified, ``config_data`` must be a
             local path instead of a hash table.
 
+            .. versionadded:: Nitrogen
+
         script_parameters (str): Any additional parameters expected by the
             configuration script. These must be defined in the script itself.
+
+            .. versionadded:: Nitrogen
 
         salt_env (str): The salt environment to use when copying the source.
             Default is 'base'
@@ -149,7 +157,7 @@ def run_config(path,
     '''
     ret = compile_config(path=path,
                          source=source,
-                         config=config,
+                         config_name=config_name,
                          config_data=config_data,
                          config_data_source=config_data_source,
                          script_parameters=script_parameters,
@@ -164,7 +172,7 @@ def run_config(path,
 
 def compile_config(path,
                    source=None,
-                   config=None,
+                   config_name=None,
                    config_data=None,
                    config_data_source=None,
                    script_parameters=None,
@@ -183,23 +191,31 @@ def compile_config(path,
             locally and then executed. If source is not passed, the config
             script located at ``path`` will be compiled. Optional.
 
-        config (str): The name of the Configuration within the script to apply.
-            If the script contains multiple configurations within the file a
-            config must be specified. If the config is not specified, the name
-            of the file will be used as the config to run. Optional.
+        config_name (str): The name of the Configuration within the script to
+            apply. If the script contains multiple configurations within the
+            file a ``config_name`` must be specified. If the ``config_name`` is
+            not specified, the name of the file will be used as the
+            ``config_name`` to run. Optional.
 
         config_data (str): Configuration data in the form of a hash table that
             will be passed to the ``ConfigurationData`` parameter when the
-            configuration script is run. This can be the path to a ``.psd1``
-            file or the PowerShell code to create the hash table.
+            ``config_name`` is compiled. This can be the path to a ``.psd1``
+            file containing the proper hash table or the PowerShell code to
+            create the hash table.
+
+            .. versionadded:: Nitrogen
 
         config_data_source (str): The path to the ``.psd1`` file on
             ``file_roots`` to cache at the location specified by
             ``config_data``. If this is specified, ``config_data`` must be a
             local path instead of a hash table.
 
+            .. versionadded:: Nitrogen
+
         script_parameters (str): Any additional parameters expected by the
             configuration script. These must be defined in the script itself.
+
+            .. versionadded:: Nitrogen
 
         salt_env (str): The salt environment to use when copying the source.
             Default is 'base'
@@ -249,9 +265,9 @@ def compile_config(path,
         log.error(error)
         raise CommandExecutionError(error)
 
-    if config is None:
+    if config_name is None:
         # If the name of the config isn't passed, make it the name of the .ps1
-        config = os.path.splitext(os.path.basename(path))[0]
+        config_name = os.path.splitext(os.path.basename(path))[0]
 
     cwd = os.path.dirname(path)
 
@@ -279,7 +295,7 @@ def compile_config(path,
     cmd = ['.', path]
     if script_parameters:
         cmd.append(script_parameters)
-    cmd.extend([';', config])
+    cmd.extend([';', config_name])
     if config_data:
         cmd.append(config_data)
     cmd.append('| Select-Object -Property FullName, Extension, Exists, '
@@ -308,6 +324,7 @@ def apply_config(path, source=None, salt_env='base'):
     folder can be cached from the salt master using the ``source`` option.
 
     Args:
+
         path (str): Local path to the directory that contains the .mof
             configuration file to apply. Required.
 

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -297,22 +297,21 @@ def apply_config(path, source=None, salt_env='base'):
     Run an compiled DSC configuration (a folder containing a .mof file). The
     folder can be cached from the salt master using the ``source`` option.
 
-    :param str path: Local path to the directory that contains the .mof
-    configuration file to apply.
-    Required.
+    Args:
+        path (str): Local path to the directory that contains the .mof
+            configuration file to apply. Required.
 
-    :param str source: Path to the directory that contains the .mof file on the
-    ``file_roots``. The source directory will be copied to the path directory
-    and then executed. If the path and source directories differ, the source
-    directory will be applied. If source is not passed, the config located at
-    ``path`` will be applied.
-    Optional.
+        source (str): Path to the directory that contains the .mof file on the
+            ``file_roots``. The source directory will be copied to the path
+            directory and then executed. If the path and source directories
+            differ, the source directory will be applied. If source is not
+            passed, the config located at ``path`` will be applied. Optional.
 
-    :param str salt_env: The salt environment to use when copying your source.
-    Default is 'base'
+        salt_env (str): The salt environment to use when copying your source.
+            Default is 'base'
 
-    :return: True if successful, otherwise False
-    :rtype: bool
+    Returns:
+        bool: True if successful, otherwise False
 
     CLI Example:
 
@@ -378,8 +377,8 @@ def get_config():
     '''
     Get the current DSC Configuration
 
-    :return: A dictionary representing the DSC Configuration on the machine
-    :rtype: dict
+    Returns:
+        dict: A dictionary representing the DSC Configuration on the machine
 
     CLI Example:
 
@@ -396,8 +395,8 @@ def test_config():
     '''
     Tests the current applied DSC Configuration
 
-    :return: True if successfully applied, otherwise False
-    :rtype: bool
+    Returns:
+        bool: True if successfully applied, otherwise False
 
     CLI Example:
 
@@ -414,9 +413,9 @@ def get_config_status():
     '''
     Get the status of the current DSC Configuration
 
-    :return: A dictionary representing the status of the current DSC
-    Configuration on the machine
-    :rtype: dict
+    Returns:
+        dict: A dictionary representing the status of the current DSC
+            Configuration on the machine
 
     CLI Example:
 
@@ -435,9 +434,9 @@ def get_lcm_config():
     '''
     Get the current Local Configuration Manager settings
 
-    :return: A dictionary representing the Local Configuration Manager settings
-     on the machine
-    :rtype: dict
+    Returns:
+        dict: A dictionary representing the Local Configuration Manager settings
+            on the machine
 
     CLI Example:
 
@@ -465,57 +464,63 @@ def set_lcm_config(config_mode=None,
                    debug_mode=False,
                    status_retention_days=None):
     '''
-
     For detailed descriptions of the parameters see:
     https://msdn.microsoft.com/en-us/PowerShell/DSC/metaConfig
 
-    :param str config_mode: How the LCM applies the configuration. Valid values
-    are:
-    - ApplyOnly
-    - ApplyAndMonitor
-    - ApplyAndAutoCorrect
+    Args:
 
-    :param int config_mode_freq: How often, in minutes, the current
-    configuration is checked and applied. Ignored if config_mode is set to
-    ApplyOnly. Default is 15.
+        config_mode (str): How the LCM applies the configuration. Valid values
+            are:
 
-    :param str refresh_mode: How the LCM gets configurations. Valid values are:
-    - Disabled
-    - Push
-    - Pull
+            - ApplyOnly
+            - ApplyAndMonitor
+            - ApplyAndAutoCorrect
 
-    :param int refresh_freq: How often, in minutes, the LCM checks for updated
-    configurations. (pull mode only) Default is 30.
+        config_mode_freq (int): How often, in minutes, the current configuration
+            is checked and applied. Ignored if config_mode is set to ApplyOnly.
+            Default is 15.
 
-    .. note:: Either `config_mode_freq` or `refresh_freq` needs to be a multiple
-    of the other. See documentation on MSDN for more details.
+        refresh_mode (str): How the LCM gets configurations. Valid values are:
 
-    :param bool reboot_if_needed: Reboot the machine if needed after a
-    configuration is applied. Default is False.
+            - Disabled
+            - Push
+            - Pull
 
-    :param str action_after_reboot: Action to take after reboot. Valid values
-    are:
-    - ContinueConfiguration
-    - StopConfiguration
+        refresh_freq (int): How often, in minutes, the LCM checks for updated
+            configurations. (pull mode only) Default is 30.
 
-    :param guid certificate_id: A GUID that specifies a certificate used to
-    access the configuration: (pull mode)
+        .. note:: Either `config_mode_freq` or `refresh_freq` needs to be a
+            multiple of the other. See documentation on MSDN for more details.
 
-    :param guid configuration_id: A GUID that identifies the config file to get
-    from a pull server. (pull mode)
+        reboot_if_needed (bool): Reboot the machine if needed after a
+            configuration is applied. Default is False.
 
-    :param bool allow_module_overwrite: New configs are allowed to overwrite old
-    ones on the target node.
+        action_after_reboot (str): Action to take after reboot. Valid values
+            are:
 
-    :param str debug_mode: Sets the debug level. Valid values are:
-    - None
-    - ForceModuleImport
-    - All
+            - ContinueConfiguration
+            - StopConfiguration
 
-    :param int status_retention_days: Number of days to keep status of the
-    current config.
+        certificate_id (guid): A GUID that specifies a certificate used to
+            access the configuration: (pull mode)
 
-    Returns (bool): True if successful, otherwise False
+        configuration_id (guid): A GUID that identifies the config file to get
+            from a pull server. (pull mode)
+
+        allow_module_overwrite (bool): New configs are allowed to overwrite old
+            ones on the target node.
+
+        debug_mode (str): Sets the debug level. Valid values are:
+
+            - None
+            - ForceModuleImport
+            - All
+
+        status_retention_days (int): Number of days to keep status of the
+            current config.
+
+    Returns:
+        bool: True if successful, otherwise False
 
     CLI Example:
 

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -5,7 +5,7 @@ Module for working with DSC (Alpha)
 :depends:
     - PowerShell 5.0
 '''
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 # Import python libs
 import logging
@@ -72,7 +72,13 @@ def _pshell(cmd, cwd=None, json_depth=2):
     return ret
 
 
-def run_config(path, source=None, config=None, salt_env='base'):
+def run_config(path,
+               source=None,
+               config=None,
+               config_data=None,
+               config_data_source=None,
+               script_parameters=None,
+               salt_env='base'):
     r'''
     Compile a DSC Configuration in the form of a powershell script (.ps1) and
     apply it. The powershell script can be cached from the master using the
@@ -83,27 +89,39 @@ def run_config(path, source=None, config=None, salt_env='base'):
     This command would be the equivalent of running ``dsc.compile_config`` and
     ``dsc.apply_config`` separately.
 
-    :param str path: The local path to the powershell script that contains the
-    DSC Configuration.
-    Required.
+    Args:
 
-    :param str source: The path to the script on ``file_roots`` to cache at the
-    location specified by ``path``. The source file will be cached locally and
-    then executed. If source is not passed, the config script located at
-    ``path`` will be compiled.
-    Optional.
+        path (str): The local path to the powershell script that contains the
+            DSC Configuration. Required.
 
-    :param str config: The name of the Configuration within the script to apply.
-    If the script contains multiple configurations within the file a config
-    must be specified. If the config is not specified, the name of the file will
-    be used as the config to run.
-    Optional.
+        source (str): The path to the script on ``file_roots`` to cache at the
+            location specified by ``path``. The source file will be cached
+            locally and then executed. If source is not passed, the config
+            script located at ``path`` will be compiled. Optional.
 
-    :param str salt_env: The salt environment to use when copying the source.
-    Default is 'base'
+        config (str): The name of the Configuration within the script to apply.
+            the script contains multiple configurations within the file a config
+            must be specified. If the config is not specified, the name of the
+            file will be used as the config to run. Optional.
 
-    :return: True if successfully compiled and applied, False if not
-    :rtype: bool
+        config_data (str): Configuration data in the form of a hash table that
+            will be passed to the ``ConfigurationData`` parameter when the
+            configuration script is run. This can be the path to a ``.psd1``
+            file or the PowerShell code to create the hash table.
+
+        config_data_source (str): The path to the ``.psd1`` file on
+            ``file_roots`` to cache at the location specified by
+            ``config_data``. If this is specified, ``config_data`` must be a
+            local path instead of a hash table.
+
+        script_parameters (str): Any additional parameters expected by the
+            configuration script. These must be defined in the script itself.
+
+        salt_env (str): The salt environment to use when copying the source.
+            Default is 'base'
+
+    Returns:
+        bool: True if successfully compiled and applied, False if not
 
     CLI Example:
 
@@ -119,7 +137,13 @@ def run_config(path, source=None, config=None, salt_env='base'):
 
         salt '*' dsc.compile_apply_config C:\\DSC\\WebsiteConfig.ps1 salt://dsc/configs/WebsiteConfig.ps1
     '''
-    ret = compile_config(path, source, config, salt_env)
+    ret = compile_config(path=path,
+                         source=source,
+                         config=config,
+                         config_data=config_data,
+                         config_data_source=config_data_source,
+                         script_parameters=script_parameters,
+                         salt_env=salt_env)
 
     if ret.get('Exists'):
         config_path = os.path.dirname(ret['FullName'])
@@ -128,31 +152,50 @@ def run_config(path, source=None, config=None, salt_env='base'):
         return False
 
 
-def compile_config(path, source=None, config=None, salt_env='base'):
+def compile_config(path,
+                   source=None,
+                   config=None,
+                   config_data=None,
+                   config_data_source=None,
+                   script_parameters=None,
+                   salt_env='base'):
     r'''
     Compile a config from a powershell script (``.ps1``)
 
-    :param str path: Path (local) to the script that will create the ``.mof``
-    configuration file. If no source is passed, the file must exist locally.
-    Required.
+    Args:
 
-    :param str source: Path to the script on ``file_roots`` to cache at the
-    location specified by ``path``. The source file will be cached locally and
-    then executed. If source is not passed, the config script located at
-    ``path`` will be compiled.
-    Optional.
+        path (str): Path (local) to the script that will create the ``.mof``
+            configuration file. If no source is passed, the file must exist
+            locally. Required.
 
-    :param str config: The name of the Configuration within the script to apply.
-    If the script contains multiple configurations within the file a config
-    must be specified. If the config is not specified, the name of the file will
-    be used as the config to run.
-    Optional.
+        source (str): Path to the script on ``file_roots`` to cache at the
+            location specified by ``path``. The source file will be cached
+            locally and then executed. If source is not passed, the config
+            script located at ``path`` will be compiled. Optional.
 
-    :param str salt_env: The salt environment to use when copying the source.
-    Default is 'base'
+        config (str): The name of the Configuration within the script to apply.
+            If the script contains multiple configurations within the file a
+            config must be specified. If the config is not specified, the name
+            of the file will be used as the config to run. Optional.
 
-    :return: A dictionary containing the results of the compilation
-    :rtype: dict
+        config_data (str): Configuration data in the form of a hash table that
+            will be passed to the ``ConfigurationData`` parameter when the
+            configuration script is run. This can be the path to a ``.psd1``
+            file or the PowerShell code to create the hash table.
+
+        config_data_source (str): The path to the ``.psd1`` file on
+            ``file_roots`` to cache at the location specified by
+            ``config_data``. If this is specified, ``config_data`` must be a
+            local path instead of a hash table.
+
+        script_parameters (str): Any additional parameters expected by the
+            configuration script. These must be defined in the script itself.
+
+        salt_env (str): The salt environment to use when copying the source.
+            Default is 'base'
+
+    Returns:
+        dict: A dictionary containing the results of the compilation
 
     CLI Example:
 
@@ -179,6 +222,17 @@ def compile_config(path, source=None, config=None, salt_env='base'):
             log.error(error)
             raise CommandExecutionError(error)
 
+    if config_data_source:
+        log.info('Caching {0}'.format(config_data_source))
+        cached_files = __salt__['cp.get_file'](path=config_data_source,
+                                               dest=config_data,
+                                               saltenv=salt_env,
+                                               makedirs=True)
+        if not cached_files:
+            error = 'Failed to cache {0}'.format(config_data_source)
+            log.error(error)
+            raise CommandExecutionError(error)
+
     # Make sure the path exists
     if not os.path.exists(path):
         error = '"{0} not found.'.format(path)
@@ -192,10 +246,16 @@ def compile_config(path, source=None, config=None, salt_env='base'):
     cwd = os.path.dirname(path)
 
     # Run the script and see if the compile command is in the script
-    cmd = '{0} '.format(path)
-    cmd += '| Select-Object -Property FullName, Extension, Exists, ' \
-           '@{Name="LastWriteTime";Expression={Get-Date ($_.LastWriteTime) ' \
-           '-Format g}}'
+    cmd = [path]
+    # Add any script parameters
+    if script_parameters:
+        cmd.append(script_parameters)
+    # Select fields to return
+    cmd.append('| Select-Object -Property FullName, Extension, Exists, '
+               '@{Name="LastWriteTime";Expression={Get-Date ($_.LastWriteTime) '
+               '-Format g}}')
+
+    cmd = ' '.join(cmd)
 
     ret = _pshell(cmd, cwd)
 
@@ -206,10 +266,17 @@ def compile_config(path, source=None, config=None, salt_env='base'):
             return ret
 
     # Run the script and run the compile command
-    cmd = '. {0} ; {1} '.format(path, config)
-    cmd += '| Select-Object -Property FullName, Extension, Exists, ' \
-           '@{Name="LastWriteTime";Expression={Get-Date ($_.LastWriteTime) ' \
-           '-Format g}}'
+    cmd = ['.', path]
+    if script_parameters:
+        cmd.append(script_parameters)
+    cmd.extend([';', config])
+    if config_data:
+        cmd.append(config_data)
+    cmd.append('| Select-Object -Property FullName, Extension, Exists, '
+               '@{Name="LastWriteTime";Expression={Get-Date ($_.LastWriteTime) '
+               '-Format g}}')
+
+    cmd = ' '.join(cmd)
 
     ret = _pshell(cmd, cwd)
 

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -1,6 +1,16 @@
 # -*- coding: utf-8 -*-
 '''
-Module for working with DSC (Alpha)
+This module is Alpha
+
+Module for working with Windows PowerShell DSC (Desired State Configuration)
+
+This module applies DSC Configurations in the form of PowerShell scripts or
+MOF (Managed Object Format) schema files.
+
+Use the ``psget`` module to manage PowerShell resources.
+
+The idea is to leverage Salt to push DSC configuration scripts or MOF files to
+the Minion.
 
 :depends:
     - PowerShell 5.0
@@ -35,18 +45,18 @@ def __virtual__():
     # Verify PowerShell 5.0
     powershell_info = __salt__['cmd.shell_info']('powershell')
     if not powershell_info['installed']:
-        return False, 'Module DSC: Powershell not available'
+        return False, 'Module DSC: PowerShell not available'
 
     if distutils.version.StrictVersion(powershell_info['version']) < \
             distutils.version.StrictVersion('5.0'):
-        return False, 'Module DSC: Requires Powershell 5 or later'
+        return False, 'Module DSC: Requires PowerShell 5 or later'
 
     return __virtualname__
 
 
 def _pshell(cmd, cwd=None, json_depth=2):
     '''
-    Execute the desired powershell command and ensure that it returns data
+    Execute the desired PowerShell command and ensure that it returns data
     in json format and load that into python
     '''
     if 'convertto-json' not in cmd.lower():
@@ -61,13 +71,13 @@ def _pshell(cmd, cwd=None, json_depth=2):
     if 'retcode' not in results or results['retcode'] != 0:
         # run_all logs an error to log.error, fail hard back to the user
         raise CommandExecutionError(
-            'Issue executing powershell {0}'.format(cmd), info=results)
+            'Issue executing PowerShell {0}'.format(cmd), info=results)
 
     try:
         ret = json.loads(results['stdout'], strict=False)
     except ValueError:
         raise CommandExecutionError(
-            'No JSON results from powershell', info=results)
+            'No JSON results from PowerShell', info=results)
 
     return ret
 
@@ -80,9 +90,9 @@ def run_config(path,
                script_parameters=None,
                salt_env='base'):
     r'''
-    Compile a DSC Configuration in the form of a powershell script (.ps1) and
-    apply it. The powershell script can be cached from the master using the
-    ``source`` option. If there is more than one config within the powershell
+    Compile a DSC Configuration in the form of a PowerShell script (.ps1) and
+    apply it. The PowerShell script can be cached from the master using the
+    ``source`` option. If there is more than one config within the PowerShell
     script, the desired configuration can be applied by passing the name in the
     ``config`` option.
 
@@ -91,7 +101,7 @@ def run_config(path,
 
     Args:
 
-        path (str): The local path to the powershell script that contains the
+        path (str): The local path to the PowerShell script that contains the
             DSC Configuration. Required.
 
         source (str): The path to the script on ``file_roots`` to cache at the
@@ -160,7 +170,7 @@ def compile_config(path,
                    script_parameters=None,
                    salt_env='base'):
     r'''
-    Compile a config from a powershell script (``.ps1``)
+    Compile a config from a PowerShell script (``.ps1``)
 
     Args:
 


### PR DESCRIPTION
### What does this PR do?
Adds the ability to pass a hash table of configuration data when compiling a DSC Script. Also the ability to pass parameters to the DSC Script.
Fixes formatting and missing documentation.

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1046

### Previous Behavior
No way to pass parameters or configuration data to the DSC configuration.

### New Behavior
Now you can pass parameters and configuration data to the DSC configuration.

### Tests written?
No