### PR TITLE
Make build_pkg.bat work with Python 3.6/3.5/2.7

### DIFF
--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -9,13 +9,36 @@
 Set "CurrDir=%cd%"
 Set "BinDir=%cd%\buildenv\bin"
 Set "InsDir=%cd%\installer"
-Set "PyDir=C:\Python27"
+Set "PyDir27=C:\Python27"
+Set "PyDir35=C:\Program Files\Python35"
+Set "PyDir36=C:\Program Files\Python36"
 
 :: Get the version from git if not passed
 if [%1]==[] (
     for /f "delims=" %%a in ('git describe') do @set "Version=%%a"
 ) else (
     set "Version=%~1"
+)
+
+If Exist "%PyDir36%\python.exe" (
+    Set "PyDir=%PyDir36%"
+    Set "PyVerMajor=3"
+    Set "PyVerMinor=6"
+) Else (
+    If Exist "%PyDir35%\python.exe" (
+        Set "PyDir=%PyDir35%"
+        Set "PyVerMajor=3"
+        Set "PyVerMinor=5"
+    ) Else (
+        If Exist "%PyDir27%\python.exe" (
+            Set "PyDir=%PyDir27%"
+            Set "PyVerMajor=2"
+            Set "PyVerMinor=7"
+        ) Else (
+            @echo Could not find Python on the system
+            exit /b 1
+        )
+    )
 )
 
 :: Find the NSIS Installer
@@ -27,12 +50,12 @@ If Exist "C:\Program Files\NSIS\" (
 Set "PATH=%NSIS%;%PATH%"
 @echo.
 
-@echo Copying C:\Python27 to bin...
+@echo Copying "%PyDir%" to bin...
 @echo ----------------------------------------------------------------------
 :: Check for existing bin directory and remove
 If Exist "%BinDir%\" rd /S /Q "%BinDir%"
 
-:: Copy the Python27 directory to bin
+:: Copy the Python directory to bin
 @echo xcopy /E /Q "%PyDir%" "%BinDir%\"
 xcopy /E /Q "%PyDir%" "%BinDir%\"
 @echo.
@@ -40,11 +63,11 @@ xcopy /E /Q "%PyDir%" "%BinDir%\"
 :: Remove the fixed path in .exe files
 @echo Removing fixed path from .exe files
 @echo ----------------------------------------------------------------------
-%PyDir%\python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\easy_install.exe"
-%PyDir%\python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\easy_install-2.7.exe"
-%PyDir%\python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip.exe"
-%PyDir%\python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip2.7.exe"
-%PyDir%\python "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip2.exe"
+"%PyDir%\python" "%CurrDir%\portable.py" -f "%BinDir%\Scripts\easy_install.exe"
+"%PyDir%\python" "%CurrDir%\portable.py" -f "%BinDir%\Scripts\easy_install-%PyVerMajor%.%PyVerMinor%.exe"
+"%PyDir%\python" "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip.exe"
+"%PyDir%\python" "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip%PyVerMajor%.%PyVerMinor%.exe"
+"%PyDir%\python" "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip%PyVerMajor%.exe"
 @echo.
 
 @echo Cleaning up unused files and directories...

--- a/pkg/windows/portable.py
+++ b/pkg/windows/portable.py
@@ -1,7 +1,10 @@
 #!/usr/bin/python
 from __future__ import print_function
 
-import sys, getopt
+import sys
+import os.path
+import getopt
+
 
 def display_help():
     print('####################################################################')
@@ -23,9 +26,16 @@ def display_help():
     print('####################################################################')
     sys.exit(2)
 
+
 def main(argv):
     target = ''
-    search = 'C:\Python27'
+    python_dir = 'Python{0}{1}'.format(sys.version_info[0], sys.version_info[1])
+    if sys.version_info >= (3, 5):
+        from win32com.shell import shellcon, shell
+        search = shell.SHGetFolderPath(0, shellcon.CSIDL_PROGRAM_FILES, 0, 0)
+        search = os.path.join(search, python_dir)
+    else:
+        search = os.path.join('C:\\', python_dir)
     replace = '..'
     try:
         opts, args = getopt.getopt(argv,"hf:s:r:",["file=","search=", "replace="])
@@ -42,10 +52,15 @@ def main(argv):
             replace = arg
     if target == '':
         display_help()
+
+    if sys.version_info >= (3, 0):
+        search = search.encode('utf-8')
+        replace = replace.encode('utf-8')
     f = open( target, 'rb' ).read()
     f = f.replace( search, replace )
     f = f.replace( search.lower(), replace )
     open( target, 'wb' ).write(f)
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
### What does this PR do?

Make `build_pkg.bat` and associated utility `portable.py`
compatible with Python 3.6, 3.5, and 2.7.

### Tests written?

No

Signed-off-by: Sergey Kizunov <sergey.kizunov@ni.com>