### PR TITLE
2016.3

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1038,6 +1038,7 @@ _OS_NAME_MAP = {
     'manjaro': 'Manjaro',
     'antergos': 'Antergos',
     'sles': 'SUSE',
+    'slesexpand': "RES",
     'linuxmint': 'Mint',
 }
 
@@ -1057,6 +1058,7 @@ _OS_FAMILY_MAP = {
     'OEL': 'RedHat',
     'XCP': 'RedHat',
     'XenServer': 'RedHat',
+    'RES': 'RedHat',
     'Mandrake': 'Mandriva',
     'ESXi': 'VMWare',
     'Mint': 'Debian',

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1038,7 +1038,7 @@ _OS_NAME_MAP = {
     'manjaro': 'Manjaro',
     'antergos': 'Antergos',
     'sles': 'SUSE',
-    'slesexpand': "RES",
+    'slesexpand': 'RES',
     'linuxmint': 'Mint',
 }
 

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -953,7 +953,8 @@ def _image_wrapper(attr, *args, **kwargs):
                     creds['username'],
                     password=creds['password'],
                     email=creds.get('email'),
-                    registry=registry)
+                    registry=registry,
+                    reauth=cred.get('reauth', False))
         except KeyError:
             raise SaltInvocationError(
                 err.format('Incomplete', ' for registry {0}'.format(registry))

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -68,7 +68,11 @@ For example:
         username: foo
 
 Reauth is an optional parameter that forces the docker login to reauthorize using
-the credentials passed in the pillar data. Defaults to false. For example:
+the credentials passed in the pillar data. Defaults to false.
+
+.. versionadded:: 2016.3.5,2016.11.1
+
+For example:
 
 .. code-block:: yaml
 

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -55,6 +55,7 @@ be used, it is recommended to place this configuration in :ref:`Pillar
         email: <email_address>
         password: <password>
         username: <username>
+        reauth: <boolean>
 
 For example:
 
@@ -65,6 +66,18 @@ For example:
         email: foo@foo.com
         password: s3cr3t
         username: foo
+
+Reauth is an optional parameter that forces the docker login to reauthorize using
+the credentials passed in the pillar data. Defaults to false. For example:
+
+.. code-block:: yaml
+
+    docker-registries:
+      https://index.docker.io/v1/:
+        email: foo@foo.com
+        password: s3cr3t
+        username: foo
+        reauth: True
 
 Mulitiple registries can be configured. This can be done in one of two ways.
 The first way is to configure each registry under the ``docker-registries``
@@ -954,7 +967,7 @@ def _image_wrapper(attr, *args, **kwargs):
                     password=creds['password'],
                     email=creds.get('email'),
                     registry=registry,
-                    reauth=cred.get('reauth', False))
+                    reauth=creds.get('reauth', False))
         except KeyError:
             raise SaltInvocationError(
                 err.format('Incomplete', ' for registry {0}'.format(registry))

--- a/salt/modules/linux_acl.py
+++ b/salt/modules/linux_acl.py
@@ -250,9 +250,11 @@ def delfacl(acl_type, acl_name='', *args, **kwargs):
 
     _raise_on_no_files(*args)
 
-    cmd = 'setfacl -x'
+    cmd = 'setfacl'
     if recursive:
         cmd += ' -R'
+
+    cmd += ' -x'
 
     cmd = '{0} {1}:{2}'.format(cmd, _acl_prefix(acl_type), acl_name)
 

--- a/salt/modules/nacl.py
+++ b/salt/modules/nacl.py
@@ -78,6 +78,30 @@ Or do something interesting with grains like:
         '{{ opts['id'] }}':
             - {{ role }}
         {%- endif %}
+
+Multi-line text items like certificates require a bit of extra work. You have to strip the new lines
+and replace them with '/n' characters. Certificates specifically require some leading white space when
+calling nacl.enc so that the '--' in the first line (commonly -----BEGIN CERTIFICATE-----) doesn't get
+interpreted as an argument to nacl.enc. For instance if you have a certificate file that lives in cert.crt:
+
+.. code-block:: bash
+
+    cert=$(cat cert.crt |awk '{printf "%s\\n",$0} END {print ""}'); salt-run nacl.enc "  $cert"
+
+Pillar data should look the same, even though the secret will be quite long. However, when calling
+multiline encrypted secrets from pillar in a state, use the following format to avoid issues with /n
+creating extra whitespace at the beginning of each line in the cert file:
+
+.. code-block:: yaml
+    secret.txt:
+        file.managed:
+            - template: jinja
+            - user: user
+            - group: group
+            - mode: 700
+            - contents: "{{- salt['pillar.get']('secret') }}"
+
+The '{{-' will tell jinja to strip the whitespace from the beginning of each of the new lines.
 '''
 
 from __future__ import absolute_import

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1679,7 +1679,7 @@ def latest(
     targets = {}
     problems = []
     for pkg in desired_pkgs:
-        if not avail[pkg]:
+        if not avail.get(pkg):
             # Package either a) is up-to-date, or b) does not exist
             if not cur[pkg]:
                 # Package does not exist

--- a/tests/unit/modules/linux_acl_test.py
+++ b/tests/unit/modules/linux_acl_test.py
@@ -193,4 +193,4 @@ class LinuxAclTestCase(TestCase):
 
     def test_delfacl__recursive_w_multiple_args(self):
         linux_acl.delfacl(*(self.default_user_acl[:-1] + self.files), recursive=True)
-        self.cmdrun.assert_called_once_with('setfacl -x -R ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.files), python_shell=False)
+        self.cmdrun.assert_called_once_with('setfacl -R -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.files), python_shell=False)


### PR DESCRIPTION
### What does this PR do?
Fixes return value when running salt with test=True

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/37870

### Previous Behavior
Any salt state that uses augeas.changes returns None instead of True regardless of whether there is a difference between the desired state and the current state for a given target

### New Behavior
This change returns True by default. The current code also says what augeas commands will be run and this gives the end user an idea of what would happen if the state was run. Ideally a check would run to find out if a change would be generated but a default of None is incorrect but returning True is at least correct.

### Tests written?

No. The change is literally changing None -> True for the code where 'test' has been detected.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
