### PR TITLE
Do not include "gpg-pubkey" packages, filtering by their name

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -564,6 +564,9 @@ def info(*packages, **attr):
     ret = dict()
     for pkg_data in reversed(sorted(_ret, cmp=lambda a_vrs, b_vrs: version_cmp(a_vrs['edition'], b_vrs['edition']))):
         pkg_name = pkg_data.pop('name')
+        # Filter out GPG public keys packages
+        if pkg_name.startswith('gpg-pubkey'):
+            continue
         if pkg_name not in ret:
             ret[pkg_name] = pkg_data.copy()
             del ret[pkg_name]['edition']


### PR DESCRIPTION
Backport to 2015.8 of https://github.com/saltstack/salt/pull/37884