### PR TITLE
Allow overwrite archives extraction

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -502,6 +502,7 @@ def extracted(name,
     overwrite
         If archive was already extracted, then setting this to True will
         extract it all over again.
+        **WARNING: This operation will flush clean all the previous content, if exists!**
 
     **Examples**
 

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -909,7 +909,13 @@ def extracted(name,
     if extraction_needed:
         destination = os.path.join(name, contents['top_level_dirs'][0])
         if os.path.exists(destination):
-            shutil.rmtree(destination)
+            try:
+                shutil.rmtree(destination)
+            except OSError as err:
+                ret['comment'] = 'Error removing destination directory ' \
+                                 '"{0}": {1}'.format(destination, err)
+                ret['result'] = False
+                return ret
 
     try:
         if_missing_path_exists = os.path.exists(if_missing)

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import stat
 import tarfile
 from contextlib import closing
@@ -140,6 +141,7 @@ def extracted(name,
               enforce_toplevel=True,
               enforce_ownership_on=None,
               archive_format=None,
+              overwrite=False,
               **kwargs):
     '''
     .. versionadded:: 2014.1.0
@@ -496,6 +498,10 @@ def extracted(name,
     .. _tarfile: https://docs.python.org/2/library/tarfile.html
     .. _zipfile: https://docs.python.org/2/library/zipfile.html
     .. _xz-utils: http://tukaani.org/xz/
+
+    overwrite
+        If archive was already extracted, then setting this to True will
+        extract it all over again.
 
     **Examples**
 
@@ -897,7 +903,14 @@ def extracted(name,
     # already need to catch an OSError to cover edge cases where the minion is
     # running as a non-privileged user and is trying to check for the existence
     # of a path to which it does not have permission.
-    extraction_needed = False
+
+    extraction_needed = overwrite
+
+    if extraction_needed:
+        destination = os.path.join(name, contents['top_level_dirs'][0])
+        if os.path.exists(destination):
+            shutil.rmtree(destination)
+
     try:
         if_missing_path_exists = os.path.exists(if_missing)
     except TypeError:

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -545,10 +545,9 @@ def extracted(name,
         ret['comment'] = '{0} is not an absolute path'.format(name)
         return ret
     else:
-        if name is None:
-            # Only way this happens is if some doofus specifies "- name: None"
-            # in their SLS file. Prevent tracebacks by failing gracefully.
-            ret['comment'] = 'None is not a valid directory path'
+        if not name:
+            # Empty name, like None, '' etc.
+            ret['comment'] = 'Name of the directory path needs to be specified'
             return ret
         # os.path.isfile() returns False when there is a trailing slash, hence
         # our need for first stripping the slash and then adding it back later.


### PR DESCRIPTION
### What does this PR do?

Add an option `overwrite` to `states.archive`.

### Previous Behavior

If an archive was extracted, newer version was not applied.

### New Behavior

If an archive was extracted, all extracted content is flushed and an archive is extracted again.

### Tests written?

No
