### PR TITLE
Fix support for extra_mods='six' to add six module to a thin.tgz tarball

### DIFF
--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -19,7 +19,7 @@ import subprocess
 import jinja2
 import yaml
 import msgpack
-import salt.ext.six as six
+import salt.ext.six as _six
 import tornado
 
 # pylint: disable=import-error,no-name-in-module
@@ -107,7 +107,7 @@ def get_tops(extra_mods='', so_mods=''):
             os.path.dirname(msgpack.__file__),
             ]
 
-    tops.append(six.__file__.replace('.pyc', '.py'))
+    tops.append(_six.__file__.replace('.pyc', '.py'))
 
     if HAS_CERTIFI:
         tops.append(os.path.dirname(certifi.__file__))
@@ -196,7 +196,7 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
                 pass
         else:
             return thintar
-    if six.PY3:
+    if _six.PY3:
         # Let's check for the minimum python 2 version requirement, 2.6
         py_shell_cmd = (
             python2_bin + ' -c \'from __future__ import print_function; import sys; '
@@ -222,14 +222,14 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
 
     tops_py_version_mapping = {}
     tops = get_tops(extra_mods=extra_mods, so_mods=so_mods)
-    if six.PY2:
+    if _six.PY2:
         tops_py_version_mapping['2'] = tops
     else:
         tops_py_version_mapping['3'] = tops
 
     # TODO: Consider putting known py2 and py3 compatible libs in it's own sharable directory.
     #       This would reduce the thin size.
-    if six.PY2 and sys.version_info[0] == 2:
+    if _six.PY2 and sys.version_info[0] == 2:
         # Get python 3 tops
         py_shell_cmd = (
             python3_bin + ' -c \'import sys; import json; import salt.utils.thin; '
@@ -244,7 +244,7 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
                 tops_py_version_mapping['3'] = tops
             except ValueError:
                 pass
-    if six.PY3 and sys.version_info[0] == 3:
+    if _six.PY3 and sys.version_info[0] == 3:
         # Get python 2 tops
         py_shell_cmd = (
             python2_bin + ' -c \'from __future__ import print_function; '
@@ -267,7 +267,7 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
     except OSError:
         start_dir = None
     tempdir = None
-    for py_ver, tops in six.iteritems(tops_py_version_mapping):
+    for py_ver, tops in _six.iteritems(tops_py_version_mapping):
         for top in tops:
             base = os.path.basename(top)
             top_dirname = os.path.dirname(top)
@@ -359,7 +359,7 @@ def gen_min(cachedir, extra_mods='', overwrite=False, so_mods='',
                 pass
         else:
             return mintar
-    if six.PY3:
+    if _six.PY3:
         # Let's check for the minimum python 2 version requirement, 2.6
         py_shell_cmd = (
             python2_bin + ' -c \'from __future__ import print_function; import sys; '
@@ -385,14 +385,14 @@ def gen_min(cachedir, extra_mods='', overwrite=False, so_mods='',
 
     tops_py_version_mapping = {}
     tops = get_tops(extra_mods=extra_mods, so_mods=so_mods)
-    if six.PY2:
+    if _six.PY2:
         tops_py_version_mapping['2'] = tops
     else:
         tops_py_version_mapping['3'] = tops
 
     # TODO: Consider putting known py2 and py3 compatible libs in it's own sharable directory.
     #       This would reduce the min size.
-    if six.PY2 and sys.version_info[0] == 2:
+    if _six.PY2 and sys.version_info[0] == 2:
         # Get python 3 tops
         py_shell_cmd = (
             python3_bin + ' -c \'import sys; import json; import salt.utils.thin; '
@@ -407,7 +407,7 @@ def gen_min(cachedir, extra_mods='', overwrite=False, so_mods='',
                 tops_py_version_mapping['3'] = tops
             except ValueError:
                 pass
-    if six.PY3 and sys.version_info[0] == 3:
+    if _six.PY3 and sys.version_info[0] == 3:
         # Get python 2 tops
         py_shell_cmd = (
             python2_bin + ' -c \'from __future__ import print_function; '
@@ -548,7 +548,7 @@ def gen_min(cachedir, extra_mods='', overwrite=False, so_mods='',
         'salt/output/nested.py',
     )
 
-    for py_ver, tops in six.iteritems(tops_py_version_mapping):
+    for py_ver, tops in _six.iteritems(tops_py_version_mapping):
         for top in tops:
             base = os.path.basename(top)
             top_dirname = os.path.dirname(top)


### PR DESCRIPTION
Without this patch, `gen_thin('/tmp', extra_mods='six')` will only include `py2/salt/ext/six.py` to the thin.tgz tarball but not `py2/six.py` (which may be required by other selected extra_mods python modules that need the `six` dependency)