### PR TITLE
Change return value for salt/states/augeas.py to be True instead of N…

### DIFF
--- a/salt/states/augeas.py
+++ b/salt/states/augeas.py
@@ -265,7 +265,7 @@ def change(name, context=None, changes=None, lens=None,
         filename = re.sub('^/files|/$', '', context)
 
     if __opts__['test']:
-        ret['result'] = None
+        ret['result'] = True
         ret['comment'] = 'Executing commands'
         if context:
             ret['comment'] += ' in file "{0}":\n'.format(context)

--- a/tests/unit/states/augeas_test.py
+++ b/tests/unit/states/augeas_test.py
@@ -84,7 +84,7 @@ class AugeasTestCase(TestCase):
         comt = ('Executing commands in file "/files/etc/services":\n'
                 'ins service-name after service-name[last()]'
                 '\nset service-name[last()] zabbix-agent')
-        self.ret.update({'comment': comt, 'result': None})
+        self.ret.update({'comment': comt, 'result': True})
 
         with patch.dict(augeas.__opts__, {'test': True}):
             self.assertDictEqual(


### PR DESCRIPTION
### What does this PR do?
Fixes return value for augeas.changes from None to True when salt is run with test=True

### What issues does this PR fix or reference?
#37870

### Previous Behavior
salt-call state.apply my.augeas.state test=True returns 'None' with the list of commands to be run.

### New Behavior
salt-call state.apply my.augeas.state test=True returns 'True' with the list of commands to be run.

### Tests written?
No. Tested with existing state file.