### PR TITLE
rh networking: add missing values

### DIFF
--- a/salt/templates/rh_ip/network.jinja
+++ b/salt/templates/rh_ip/network.jinja
@@ -3,4 +3,6 @@
 {%endif%}{% if gateway %}GATEWAY={{gateway}}
 {%endif%}{% if gatewaydev %}GATEWAYDEV={{gatewaydev}}
 {%endif%}{% if nisdomain %}NISDOMAIN={{nisdomain}}
+{%endif%}{% if networkdelay %}NETWORKDELAY={{networkdelay}}
+{%endif%}{% if devtimeout %}DEVTIMEOUT={{devtimeout}}
 {%endif%}{% if nozeroconf %}NOZEROCONF={{nozeroconf}}{%endif%}


### PR DESCRIPTION
this patch enables configuration of NETWORKDELAY= and DEVTIMEOUT= in
/etc/sysconfig/network