### PR TITLE
Clear functions context in schedule tasks for ZeroMQ.

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -629,10 +629,13 @@ class Schedule(object):
         '''
         Execute this method in a multiprocess or thread
         '''
-        if salt.utils.is_windows():
+        if salt.utils.is_windows() or self.opts.get('transport') == 'zeromq':
             # Since function references can't be pickled and pickling
             # is required when spawning new processes on Windows, regenerate
             # the functions and returners.
+            # This also needed for ZeroMQ transport to reset all functions
+            # context data that could keep paretns connections. ZeroMQ will
+            # hang on polling parents connections from the child process.
             self.functions = salt.loader.minion_mods(self.opts)
             self.returners = salt.loader.returners(self.opts, self.functions)
         ret = {'id': self.opts.get('id', 'master'),


### PR DESCRIPTION
### What does this PR do?
Fixes hanging of the schedule execution process utilizing 100% CPU if transport is ZeroMQ.
This happen if main minion process (beacons, for instance) executes at least one function using `fileclient.RemoteClient` and then schedule runs any function from the same module that also uses the `fileclient.RemoteClient`.

### What issues does this PR fix or reference?
#37059
Also actual for 2016.11, carbon and develop.

### Previous Behavior
Function modules could keep cached parents' connections in context that could be reused in scheduled tasks that produces schedule task hang forever utilizing CPU. This affects the only ZeroMQ transport: poller hangs forever if the polling list contains at least one ZeroMQ socket created in another process.

### New Behavior
Recreate schedule `functions` and `returners` to clear the contexts for ZeroMQ transport.

### Tests written?
No