### PR TITLE
use opts for metadata grains

### DIFF
--- a/salt/grains/metadata.py
+++ b/salt/grains/metadata.py
@@ -30,7 +30,7 @@ HOST = 'http://{0}/'.format(IP)
 
 
 def __virtual__():
-    if __salt__['config.get']('metadata_server_grains', False) is False:
+    if __opts__.get('metadata_server_grains', False) is False:
         return False
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(.1)


### PR DESCRIPTION
### What does this PR do?

I checked for them, but apparently we manually load the cmdmod stuff for
the core grains, so __salt__ is not loaded in metadata grain.  This just
means that this setting will have to be put in the minion config to
enable it.