### PR TITLE
Add states to manage systemd masking

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -4,6 +4,38 @@
 Salt Release Notes - Codename Nitrogen
 ======================================
 
+States Added for Management of systemd Unit Masking
+===================================================
+
+The :py:func:`service.masked <salt.states.service.masked>` and
+:py:func:`service.umasked <salt.states.service.unmasked>` states have been
+added to allow Salt to manage masking of systemd units.
+
+Additionally, the following functions in the :mod:`systemd
+<salt.modules.systemd>` execution module have changed to accomodate the fact
+that indefinite and runtime masks can co-exist for the same unit:
+
+- :py:func:`service.masked <salt.modules.systemd.masked>` - The return from
+  this function has changed from previous releases. Before, ``False`` would be
+  returned if the unit was not masked, and the output of ``systemctl is-enabled
+  <unit name>`` would be returned if the unit was masked. However, since
+  indefinite and runtime masks can exist for the same unit at the same time,
+  this function has been altered to accept a ``runtime`` argument. If ``True``,
+  the minion will be checked for a runtime mask assigned to the named unit. If
+  ``False``, then the minion will be checked for an indefinite mask. If one is
+  found, ``True`` will be returned. If not, then ``False`` will be returned.
+- :py:func:`service.masked <salt.modules.systemd.masked>` - This function used
+  to just run ``systemctl is-enabled <unit name>`` and based on the return
+  from this function the corresponding mask type would be removed. However, if
+  both runtime and indefinite masks are set for the same unit, then ``systemctl
+  is-enabled <unit name>`` would show just the indefinite mask. The indefinite
+  mask would be removed, but the runtime mask would remain. The function has
+  been modified to accept a ``runtime`` argument, and will attempt to remove a
+  runtime mask if that argument is set to ``True``. If set to ``False``, it
+  will attempt to remove an indefinite mask.
+
+These new ``runtime`` arguments default to ``False``.
+
 Grains Changes
 ==============
 
@@ -15,7 +47,12 @@ Grains Changes
 Execution Module Changes
 ========================
 
-- The ``refresh`` kwarg for the ``list_upgrades`` function in the ``solarisips``
-  package module default value has been changed from ``True`` to ``False``. This
-  makes the function more consistent with all of the other package execution
-  modules. All other ``pkg.list_upgrades`` functions already default to ``True``.
+- In the :mod:`solarisips <salt.modules.solarisips>` ``pkg`` module, the
+  default value for the ``refresh`` argument to the ``list_upgrades`` function
+  has been changed from ``False`` to ``True``. This makes the function more
+  consistent with all of the other ``pkg`` modules (The other
+  ``pkg.list_upgrades`` functions all defaulted to ``True``).
+- The functions which handle masking in the :mod:`systemd
+  <salt.modules.systemd>` module have changed. These changes are described
+  above alongside the information on the new states which have been added to
+  manage masking of systemd units.

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -555,6 +555,158 @@ def disabled(name, **kwargs):
     return ret
 
 
+def masked(name, runtime=False):
+    '''
+    .. versionadded:: Nitrogen
+
+    .. note::
+        This state is only available on minions which use systemd_.
+
+    Ensures that the named service is masked (i.e. prevented from being
+    started).
+
+    name
+        Name of the service to mask
+
+    runtime : False
+        By default, this state will manage an indefinite mask for the named
+        service. Set this argument to ``True`` to runtime mask the service.
+
+    .. note::
+        It is possible for a service to have both indefinite and runtime masks
+        set for it. Therefore, this state will manage a runtime or indefinite
+        mask independently of each other. This means that if the service is
+        already indefinitely masked, running this state with ``runtime`` set to
+        ``True`` will _not_ remove the indefinite mask before setting a runtime
+        mask. In these cases, if it is desirable to ensure that the service is
+        runtime masked and not indefinitely masked, pair this state with a
+        :py:func:`service.unmasked <salt.states.service.unmasked>` state, like
+        so:
+
+        .. code-block:: yaml
+
+            mask_runtime_foo:
+              service.masked:
+                - name: foo
+                - runtime: True
+
+            unmask_indefinite_foo:
+              service.unmasked:
+                - name: foo
+                - runtime: False
+
+    .. _systemd: https://freedesktop.org/wiki/Software/systemd/
+
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    if 'service.masked' not in __salt__:
+        ret['comment'] = 'Service masking not available on this minion'
+        ret['result'] = False
+        return ret
+
+    mask_type = 'runtime masked' if runtime else 'masked'
+    expected_changes = {mask_type: {'old': False, 'new': True}}
+
+    try:
+        if __salt__['service.masked'](name, runtime):
+            ret['comment'] = 'Service {0} is already {1}'.format(
+                name,
+                mask_type,
+            )
+            return ret
+
+        if __opts__['test']:
+            ret['result'] = None
+            ret['changes'] = expected_changes
+            ret['comment'] = 'Service {0} would be {1}'.format(name, mask_type)
+            return ret
+
+        __salt__['service.mask'](name, runtime)
+
+        if __salt__['service.masked'](name, runtime):
+            ret['changes'] = expected_changes
+            ret['comment'] = 'Service {0} was {1}'.format(name, mask_type)
+        else:
+            ret['comment'] = 'Failed to mask service {0}'.format(name)
+        return ret
+
+    except CommandExecutionError as exc:
+        ret['result'] = False
+        ret['comment'] = exc.strerror
+        return ret
+
+
+def unmasked(name, runtime=False):
+    '''
+    .. versionadded:: Nitrogen
+
+    .. note::
+        This state is only available on minions which use systemd_.
+
+    Ensures that the named service is unmasked
+
+    name
+        Name of the service to unmask
+
+    runtime : False
+        By default, this state will manage an indefinite mask for the named
+        service. Set this argument to ``True`` to ensure that the service is
+        runtime masked.
+
+    .. note::
+        It is possible for a service to have both indefinite and runtime masks
+        set for it. Therefore, this state will manage a runtime or indefinite
+        mask independently of each other. This means that if the service is
+        indefinitely masked, running this state with ``runtime`` set to
+        ``True`` will _not_ remove the indefinite mask.
+
+    .. _systemd: https://freedesktop.org/wiki/Software/systemd/
+
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    if 'service.masked' not in __salt__:
+        ret['comment'] = 'Service masking not available on this minion'
+        ret['result'] = False
+        return ret
+
+    mask_type = 'runtime masked' if runtime else 'masked'
+    action = 'runtime unmasked' if runtime else 'unmasked'
+    expected_changes = {mask_type: {'old': True, 'new': False}}
+
+    try:
+        if not __salt__['service.masked'](name, runtime):
+            ret['comment'] = 'Service {0} was already {1}'.format(name, action)
+            return ret
+
+        if __opts__['test']:
+            ret['result'] = None
+            ret['changes'] = expected_changes
+            ret['comment'] = 'Service {0} would be {1}'.format(name, action)
+            return ret
+
+        __salt__['service.unmask'](name, runtime)
+
+        if not __salt__['service.masked'](name, runtime):
+            ret['changes'] = expected_changes
+            ret['comment'] = 'Service {0} was {1}'.format(name, action)
+        else:
+            ret['comment'] = 'Failed to unmask service {0}'.format(name)
+        return ret
+
+    except CommandExecutionError as exc:
+        ret['result'] = False
+        ret['comment'] = exc.strerror
+        return ret
+
+
 def mod_watch(name,
               sfun=None,
               sig=None,


### PR DESCRIPTION
This also changes how the systemd module handles masking, to accommodate
the fact that both indefinite and runtime masks can be set
simultaneously for the same service.

Resolves #37698.