### PR TITLE
Fix server trust in test run of svn.latest

### DIFF
--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -102,6 +102,10 @@ def latest(name,
                     ('{0} doesn\'t exist and is set to be checked out.').format(target))
         svn_cmd = 'svn.diff'
         opts += ('-r', 'HEAD')
+
+        if trust:
+            opts += ('--trust-server-cert',)
+
         out = __salt__[svn_cmd](cwd, target, user, username, password, *opts)
         return _neutral_test(
                 ret,


### PR DESCRIPTION
### What does this PR do?
Adds missing `--trust-server-cert` option while running svn.latest in test=True mode

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/33747

### Previous Behavior
`state.highstate test=True` containing `svn.latest` state failed regardless of `trust: True` option for already checkouted SVN repository if server certificate is not trusted by default (self-signed).

### New Behavior
`state.highstate` with `svn.latest` state now succeeds in `test=True` mode.

### Tests written?

No