### PR TITLE
Throw error when setting invalid timezone

### DIFF
--- a/tests/unit/modules/timezone_test.py
+++ b/tests/unit/modules/timezone_test.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+# Import Python Libs
+from __future__ import absolute_import
+from tempfile import NamedTemporaryFile
+import os
+
+# Import Salt Testing Libs
+from salt.exceptions import CommandExecutionError, SaltInvocationError
+from salttesting import TestCase, skipIf
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import (
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.modules import timezone
+
+# Globals
+timezone.__salt__ = {}
+timezone.__opts__ = {}
+timezone.__grains__ = {}
+
+GET_ZONE_FILE = 'salt.modules.timezone._get_zone_file'
+GET_ETC_LOCALTIME_PATH = 'salt.modules.timezone._get_etc_localtime_path'
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch.dict(timezone.__grains__, {'os_family': 'Ubuntu'})
+class TimezoneTestCase(TestCase):
+
+    def setUp(self):
+        self.tempfiles = []
+
+    def tearDown(self):
+        for tempfile in self.tempfiles:
+            try:
+                os.remove(tempfile.name)
+            except OSError:
+                pass
+
+    def test_zone_compare_equal(self):
+        etc_localtime = self.create_tempfile_with_contents('a')
+        zone_path = self.create_tempfile_with_contents('a')
+
+        with patch(GET_ZONE_FILE, lambda p: zone_path.name):
+            with patch(GET_ETC_LOCALTIME_PATH, lambda: etc_localtime.name):
+
+                self.assertTrue(timezone.zone_compare('foo'))
+
+    def test_zone_compare_nonexistent(self):
+        etc_localtime = self.create_tempfile_with_contents('a')
+
+        with patch(GET_ZONE_FILE, lambda p: '/foopath/nonexistent'):
+            with patch(GET_ETC_LOCALTIME_PATH, lambda: etc_localtime.name):
+
+                self.assertRaises(SaltInvocationError, timezone.zone_compare, 'foo')
+
+    def test_zone_compare_unequal(self):
+        etc_localtime = self.create_tempfile_with_contents('a')
+        zone_path = self.create_tempfile_with_contents('b')
+
+        with patch(GET_ZONE_FILE, lambda p: zone_path.name):
+            with patch(GET_ETC_LOCALTIME_PATH, lambda: etc_localtime.name):
+
+                self.assertFalse(timezone.zone_compare('foo'))
+
+    def test_missing_localtime(self):
+        with patch(GET_ZONE_FILE, lambda p: '/nonexisting'):
+            with patch(GET_ETC_LOCALTIME_PATH, lambda: '/also-missing'):
+                self.assertRaises(CommandExecutionError, timezone.zone_compare, 'foo')
+
+    def create_tempfile_with_contents(self, contents):
+        temp = NamedTemporaryFile(delete=False)
+        temp.write(contents)
+        temp.close()
+        self.tempfiles.append(temp)
+        return temp
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(TimezoneTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?
Ensures that setting an invalid time zone doesn't silently succeed without doing anything.

This check should be vastly faster and simpler than the previous hash comparison, which would require reading both files fully plus computing their hashes to determine if they're different. I suspect that this pattern is sadly common in the rest of the codebase too, as I couldn't find any previous usage of `filecmp` apart from an integration test, but I didn't look for other places where this could make things faster. Comparing hashes do make sense when stuff is remote, but makes absolutely no sense when both files are local. Also removed a call to `timedatectl`, as I didn't see any reason to keep it there.

### What issues does this PR fix or reference?
#37685 

### Previous Behavior
Silently ignored invalid timezones:
```
$ sudo salt-call state.sls timezone
[ERROR   ] Command 'timedatectl set-timezone foobar' failed with return code: 1
[ERROR   ] output: Failed to set time zone: Invalid time zone 'foobar'
local:
----------
          ID: timezone
    Function: timezone.system
        Name: foobar
      Result: True
     Comment: Set timezone foobar
     Started: 14:56:43.656404
    Duration: 29.321 ms
     Changes:
              ----------
              timezone:
                  foobar

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:  29.321 ms
```

### New Behavior
```
vagrant@debian:~$ sudo salt-call state.sls timezone
[ERROR   ] Unable to compare desired timezone 'foobar' to system timezone: Can't find a local timezone "foobar"
local:
----------
          ID: timezone
    Function: timezone.system
        Name: foobar
      Result: False
     Comment: Unable to compare desired timezone 'foobar' to system timezone: Can't find a local timezone "foobar"
     Started: 06:21:33.183724
    Duration: 1.143 ms
     Changes:   

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   1.143 ms
```

### Tests written?
You betcha.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

Closes #37685.