### PR TITLE
Fix for #37897 aptpkg.refresh_db inaccurate results

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -343,7 +343,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def refresh_db(cache_valid_time=0, fail_on_error=False):
+def refresh_db(cache_valid_time=0, failhard=False):
     '''
     Updates the APT database to latest packages based upon repositories
 
@@ -361,12 +361,12 @@ def refresh_db(cache_valid_time=0, fail_on_error=False):
         Skip refreshing the package database if refresh has already occurred within
         <value> seconds
 
-    fail_on_error
+    failhard
 
         If False, return results of Err lines as ``False`` for the package database that
         encountered the error.
-        If True, raises CommandExecutionError with a list of the package databases that
-        encountered errors.
+        If True, raise an error with a list of the package databases that encountered
+        errors.
 
     CLI Example:
 
@@ -422,7 +422,7 @@ def refresh_db(cache_valid_time=0, fail_on_error=False):
             ret[ident] = False
             error_repos.append(ident)
 
-    if fail_on_error and error_repos:
+    if failhard and error_repos:
         raise CommandExecutionError('Error getting repos: {0}'.format(', '.join(error_repos)))
 
     return ret

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -179,8 +179,8 @@ def _get_virtual():
         if HAS_APT:
             try:
                 apt_cache = apt.cache.Cache()
-            except SystemError as se:
-                msg = 'Failed to get virtual package information ({0})'.format(se)
+            except SystemError as syserr:
+                msg = 'Failed to get virtual package information ({0})'.format(syserr)
                 log.error(msg)
                 raise CommandExecutionError(msg)
             pkgs = getattr(apt_cache._cache, 'packages', [])
@@ -343,7 +343,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def refresh_db(cache_valid_time=0):
+def refresh_db(cache_valid_time=0, fail_on_error=False):
     '''
     Updates the APT database to latest packages based upon repositories
 
@@ -361,6 +361,13 @@ def refresh_db(cache_valid_time=0):
         Skip refreshing the package database if refresh has already occurred within
         <value> seconds
 
+    fail_on_error
+
+        If False, return results of Err lines as ``False`` for the package database that
+        encountered the error.
+        If True, raises CommandExecutionError with a list of the package databases that
+        encountered errors.
+
     CLI Example:
 
     .. code-block:: bash
@@ -369,6 +376,8 @@ def refresh_db(cache_valid_time=0):
     '''
     APT_LISTS_PATH = "/var/lib/apt/lists"
     ret = {}
+    error_repos = list()
+
     if cache_valid_time:
         try:
             latest_update = os.stat(APT_LISTS_PATH).st_mtime
@@ -409,6 +418,13 @@ def refresh_db(cache_valid_time=0):
             ret[ident] = False
         elif 'Hit' in cols[0]:
             ret[ident] = None
+        elif 'Err' in cols[0]:
+            ret[ident] = False
+            error_repos.append(ident)
+
+    if fail_on_error and error_repos:
+        raise CommandExecutionError('Error getting repos: {0}'.format(', '.join(error_repos)))
+
     return ret
 
 


### PR DESCRIPTION
### Notes:

- Since the reported issue hasn't been commented on, tagged, etc yet, I'm not sure if this should be back-ported to 2016.3/2016.11, and if so, what steps need to be taken in order to do so.

### What does this PR do?

- Adds parsing of `Err` prefixed lines to `refresh_db` (produced when `apt-get -q update` encounters issues with inaccessible sources).
- Adds parameter to `refresh_db` to allow toggling between actions taken when encountering `Err` prefixed lines.
- Fixes minor pre-existing linting issue.

### What issues does this PR fix or reference?

- #37897

### Previous Behavior

- Existing code fails to parse `Err` lines, leading to incomplete/inaccurate results. 

### New Behavior

- Adds parsing of `Err` prefixed lines to `refresh_db` (produced when `apt-get -q update` encounters issues with inaccessible sources).
- Adds parameter to `refresh_db` to allow toggling between actions taken when encountering `Err` prefixed lines.
- Fixes minor pre-existing linting issue.

### Tests written?

No