### PR TITLE
Update earlier release channels' docs with Carbon release notes

### DIFF
--- a/doc/ref/states/top.rst
+++ b/doc/ref/states/top.rst
@@ -438,7 +438,7 @@ environment, no states from the ``qa`` environment would be applied.
 Scenario 3 - No Environment Specified, :conf_minion:`top_file_merging_strategy` is "same"
 -----------------------------------------------------------------------------------------
 
-.. versionchanged:: Carbon
+.. versionchanged:: 2016.11.0
     In prior versions, "same" did not quite work as described below (see
     here__). This has now been corrected. It was decided that changing
     something like top file handling in a point release had the potential to

--- a/doc/topics/cloud/vsphere.rst
+++ b/doc/topics/cloud/vsphere.rst
@@ -4,11 +4,11 @@ Getting Started With vSphere
 
 .. note::
 
-    .. deprecated:: Carbon
+    .. deprecated:: 2016.11.0
 
         The :py:func:`vsphere <salt.cloud.clouds.vsphere>` cloud driver has been
         deprecated in favor of the :py:func:`vmware <salt.cloud.clouds.vmware>`
-        cloud driver and will be removed in Salt Carbon. Please refer to
+        cloud driver and will be removed in Salt 2016.11.0. Please refer to
         :doc:`Getting started with VMware </topics/cloud/vmware>` instead to get
         started with the configuration.
 

--- a/doc/topics/releases/version_numbers.rst
+++ b/doc/topics/releases/version_numbers.rst
@@ -27,8 +27,9 @@ Assigned codenames:
 - Helium: ``2014.7.0``
 - Lithium: ``2015.5.0``
 - Beryllium: ``2015.8.0``
-- Boron: ``TBD``
-- Carbon: ``TBD``
+- Boron: ``2016.3.0``
+- Carbon: ``2016.11.0``
+- Nitrogen: ``TBD``
 
 Example
 -------

--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -67,7 +67,7 @@ def show_link(name):
     '''
     Display master link for the alternative
 
-    .. versionadded:: 2015.8.13,2016.3.4,Carbon
+    .. versionadded:: 2015.8.13,2016.3.4,2016.11.0
 
     CLI Example:
 

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -379,7 +379,7 @@ def install(name=None,
             reinstall=False,
             **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -805,7 +805,7 @@ def autoremove(list_only=False, purge=False):
 
 def remove(name=None, pkgs=None, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -849,7 +849,7 @@ def remove(name=None, pkgs=None, **kwargs):
 
 def purge(name=None, pkgs=None, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -893,7 +893,7 @@ def purge(name=None, pkgs=None, **kwargs):
 
 def upgrade(refresh=True, dist_upgrade=False, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -465,7 +465,7 @@ def install(name=None,
             binhost=None,
             **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -700,7 +700,7 @@ def install(name=None,
 
 def update(pkg, slot=None, fromrepo=None, refresh=False, binhost=None):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -782,7 +782,7 @@ def update(pkg, slot=None, fromrepo=None, refresh=False, binhost=None):
 
 def upgrade(refresh=True, binhost=None, backtrack=3):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -870,7 +870,7 @@ def upgrade(refresh=True, binhost=None, backtrack=3):
 
 def remove(name=None, slot=None, fromrepo=None, pkgs=None, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -953,7 +953,7 @@ def remove(name=None, slot=None, fromrepo=None, pkgs=None, **kwargs):
 
 def purge(name=None, slot=None, fromrepo=None, pkgs=None, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -1369,7 +1369,7 @@ def diff(cwd,
          cached=False,
          paths=None):
     '''
-    .. versionadded:: 2015.8.12,2016.3.3,Carbon
+    .. versionadded:: 2015.8.12,2016.3.3,2016.11.0
 
     Interface to `git-diff(1)`_
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -262,7 +262,7 @@ def install(name=None,
             sources=None,
             **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -404,7 +404,7 @@ def install(name=None,
 
 def upgrade(refresh=False, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -496,7 +496,7 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
 
 def remove(name=None, pkgs=None, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -540,7 +540,7 @@ def remove(name=None, pkgs=None, **kwargs):
 
 def purge(name=None, pkgs=None, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -508,7 +508,7 @@ def missing(name):
 def unmask(name):
     '''
     .. versionadded:: 2015.5.0
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -547,7 +547,7 @@ def unmask(name):
 def mask(name, runtime=False):
     '''
     .. versionadded:: 2015.5.0
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -613,7 +613,7 @@ def masked(name):
 
 def start(name):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -642,7 +642,7 @@ def start(name):
 
 def stop(name):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -669,7 +669,7 @@ def stop(name):
 
 def restart(name):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -697,7 +697,7 @@ def restart(name):
 
 def reload_(name):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -725,7 +725,7 @@ def reload_(name):
 
 def force_reload(name):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -776,7 +776,7 @@ def status(name, sig=None):  # pylint: disable=unused-argument
 # established by Salt's service management states.
 def enable(name, **kwargs):  # pylint: disable=unused-argument
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -820,7 +820,7 @@ def enable(name, **kwargs):  # pylint: disable=unused-argument
 # established by Salt's service management states.
 def disable(name, **kwargs):  # pylint: disable=unused-argument
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1103,7 +1103,7 @@ def install(name=None,
             normalize=True,
             **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -1454,7 +1454,7 @@ def install(name=None,
 def upgrade(refresh=True, skip_verify=False, **kwargs):
     '''
     .. versionchanged:: 2014.7.0
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -1530,7 +1530,7 @@ def upgrade(refresh=True, skip_verify=False, **kwargs):
 
 def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -1594,7 +1594,7 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
 
 def purge(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -887,7 +887,7 @@ def install(name=None,
             ignore_repo_failure=False,
             **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -1054,7 +1054,7 @@ def upgrade(refresh=True,
             novendorchange=False,
             **kwargs):  # pylint: disable=unused-argument
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -1174,7 +1174,7 @@ def _uninstall(name=None, pkgs=None):
 
 def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -1218,7 +1218,7 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
 
 def purge(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd


### PR DESCRIPTION
This retroactively makes earlier releases' docs reflect the version number for Carbon.