### PR TITLE
Prevent FreeBSD minion from stacktracing on start if hostname not configured

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1641,6 +1641,16 @@ def hostname():
     grains['localhost'] = socket.gethostname()
     if __FQDN__ is None:
         __FQDN__ = salt.utils.network.get_fqhostname()
+
+    # On some distros (notably FreeBSD) if there is no hostname set
+    # salt.utils.network.get_fqhostname() will return None.
+    # In this case we punt and log a message at error level, but force the
+    # hostname and domain to be localhost.localdomain
+    # Otherwise we would stacktrace below
+    if __FQDN__ is None:   # still!
+        log.error('Having trouble getting a hostname.  Does this machine have its hostname and domain set properly?')
+        __FQDN__ = 'localhost.localdomain'
+
     grains['fqdn'] = __FQDN__
     (grains['host'], grains['domain']) = grains['fqdn'].partition('.')[::2]
     return grains


### PR DESCRIPTION
### What does this PR do?

Currently if a FreeBSD minion doesn't have a hostname setup, the minion will stacktrace on start.

### What issues does this PR fix or reference?

Fixes #37323 

### Previous Behavior

Stacktrace with:

```
  File "/opt/salt/lib/python2.7/site-packages/salt/grains/core.py", line 1616, in hostname
    (grains['host'], grains['domain']) = grains['fqdn'].partition('.')[::2]
AttributeError: 'NoneType' object has no attribute 'partition'
```

### New Behavior

If salt.utils.network.get_fqhostname() returns None, then force the FQDN to `localhost.localdomain`.

### Tests written?

No
