### PR TITLE
Fix missing ipv6 options centos network

### DIFF
--- a/salt/templates/rh_ip/network.jinja
+++ b/salt/templates/rh_ip/network.jinja
@@ -5,4 +5,7 @@
 {%endif%}{% if nisdomain %}NISDOMAIN={{nisdomain}}
 {%endif%}{% if networkdelay %}NETWORKDELAY={{networkdelay}}
 {%endif%}{% if devtimeout %}DEVTIMEOUT={{devtimeout}}
-{%endif%}{% if nozeroconf %}NOZEROCONF={{nozeroconf}}{%endif%}
+{%endif%}{% if nozeroconf %}NOZEROCONF={{nozeroconf}}
+{%endif%}{% if enable_ipv6 %}IPV6INIT="yes"
+{%endif%}{% if ipv6gateway %}IPV6_DEFAULTGW="{{ipv6gateway}}"
+{%endif%}


### PR DESCRIPTION
### What does this PR do?
Adds IPv6 functionality to /etc/sysconfg/network file

### What issues does this PR fix or reference?
This fix allows people to use IPv6 globally with the /etc/sysconfig/network file


### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
