### PR TITLE
Fixes no IPv6 functionality in /etc/sysconfig/network

### DIFF
--- a/salt/templates/rh_ip/network.jinja
+++ b/salt/templates/rh_ip/network.jinja
@@ -5,4 +5,8 @@
 {%endif%}{% if nisdomain %}NISDOMAIN={{nisdomain}}
 {%endif%}{% if networkdelay %}NETWORKDELAY={{networkdelay}}
 {%endif%}{% if devtimeout %}DEVTIMEOUT={{devtimeout}}
-{%endif%}{% if nozeroconf %}NOZEROCONF={{nozeroconf}}{%endif%}
+{%endif%}{% if nozeroconf %}NOZEROCONF={{nozeroconf}}
+{%endif%}{% if enable_ipv6 %}IPV6INIT="yes"
+{%endif%}{% if ipv6gateway %}IPV6_DEFAULTGW="{{ipv6gateway}}"
+{%endif%}
+~

--- a/salt/templates/rh_ip/network.jinja
+++ b/salt/templates/rh_ip/network.jinja
@@ -9,4 +9,3 @@
 {%endif%}{% if enable_ipv6 %}IPV6INIT="yes"
 {%endif%}{% if ipv6gateway %}IPV6_DEFAULTGW="{{ipv6gateway}}"
 {%endif%}
-~


### PR DESCRIPTION
### What does this PR do?
Fixes missing IPv6 functionality in /etc/sysconfig/network

### What issues does this PR fix or reference?
Allows people to use IPv6 global setting for default gateway in CentOS's /etc/sysconfig/network file


### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

