### PR TITLE
add list_nodes_min to nova driver

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -1016,6 +1016,26 @@ def list_nodes_full(call=None, **kwargs):
     return ret
 
 
+def list_nodes_min(call=None, **kwargs):
+    '''
+    Return a list of the VMs that in this location
+    '''
+    if call == 'action':
+        raise SaltCloudSystemExit(
+            (
+                'The list_nodes_min function must be called with'
+                ' -f or --function.'
+            )
+        )
+
+    conn = get_conn()
+    server_list = conn.server_list_min()
+
+    if not server_list:
+        return {}
+    return server_list
+
+
 def list_nodes_select(call=None):
     '''
     Return a list of the VMs that are on the provider, with select fields

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -771,6 +771,22 @@ class SaltNova(object):
                 pass
         return ret
 
+    def server_list_min(self):
+        '''
+        List minimal information about servers
+        '''
+        nt_ks = self.compute_conn
+        ret = {}
+        for item in nt_ks.servers.list(detailed=False):
+            try:
+                ret[item.name] = {
+                    'id': item.id,
+                    'status': 'Running'
+                }
+            except TypeError:
+                pass
+        return ret
+
     def server_list_detailed(self):
         '''
         Detailed list of servers


### PR DESCRIPTION
### What does this PR do?

This allows for speeding up calls to just list servers when trying to build a new server.  Without this, there are multiple api calls made for each server made by novaclient to get all the information for list_nodes_full.