### PR TITLE
Add functions from network.py to win_network.py

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1517,5 +1517,5 @@ def iphexval(ip):
     a = ip.split('.')
     hexval = ""
     for val in a:
-        hexval = hexval.join(hex(int(val))[2:])
+        hexval = ''.join([hexval, hex(int(val))[2:].zfill(2)])
     return hexval.upper()

--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -15,8 +15,8 @@ import salt.utils.network
 import salt.utils.validate.net
 from salt.modules.network import (wol, get_hostname, interface, interface_ip,
                                   subnets6, ip_in_subnet, convert_cidr,
-                                  calc_net, get_fqdn, is_private, is_loopback,
-                                  reverse_ip, ifacestartswith, iphexval)
+                                  calc_net, get_fqdn, ifacestartswith,
+                                  iphexval)
 from salt.utils import namespaced_function as _namespaced_function
 
 try:
@@ -26,7 +26,7 @@ except ImportError:
     HAS_DEPENDENCIES = False
 
 # Import 3rd party libraries
-import salt.ext.six as six  # pylint: disable=import-error,no-name-in-module
+import salt.ext.six as six  # pylint: disable=W0611
 try:
     import wmi  # pylint: disable=W0611
 except ImportError:
@@ -47,14 +47,14 @@ def __virtual__():
         return False, "Module win_network: Missing dependencies"
 
     global wol, get_hostname, interface, interface_ip, subnets6, ip_in_subnet
-    global convert_cidr, calc_net, get_fqdn, is_private, is_loopback
-    global reverse_ip, ifacestartswith, iphexval
+    global convert_cidr, calc_net, get_fqdn, reverse_ip, ifacestartswith
+    global iphexval
     wol = _namespaced_function(wol, globals())
     get_hostname = _namespaced_function(get_hostname, globals())
     interface = _namespaced_function(interface, globals())
     interface_ip = _namespaced_function(interface_ip, globals())
     subnets6 = _namespaced_function(subnets6, globals())
-    ip_in_subnet= _namespaced_function(ip_in_subnet, globals())
+    ip_in_subnet = _namespaced_function(ip_in_subnet, globals())
     convert_cidr = _namespaced_function(convert_cidr, globals())
     calc_net = _namespaced_function(calc_net, globals())
     get_fqdn = _namespaced_function(get_fqdn, globals())

--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -4,13 +4,20 @@ Module for gathering and managing network information
 '''
 from __future__ import absolute_import
 
-# Import salt libs
-import salt.utils
+# Import python libs
 import hashlib
 import datetime
 import socket
+
+# Import salt libs
+import salt.utils
 import salt.utils.network
 import salt.utils.validate.net
+from salt.modules.network import (wol, get_hostname, interface, interface_ip,
+                                  subnets6, ip_in_subnet, convert_cidr,
+                                  calc_net, get_fqdn, is_private, is_loopback,
+                                  reverse_ip, ifacestartswith, iphexval)
+from salt.utils import namespaced_function as _namespaced_function
 
 try:
     import salt.utils.winapi
@@ -19,6 +26,7 @@ except ImportError:
     HAS_DEPENDENCIES = False
 
 # Import 3rd party libraries
+import salt.ext.six as six  # pylint: disable=import-error,no-name-in-module
 try:
     import wmi  # pylint: disable=W0611
 except ImportError:
@@ -32,9 +40,28 @@ def __virtual__():
     '''
     Only works on Windows systems
     '''
-    if salt.utils.is_windows() and HAS_DEPENDENCIES is True:
-        return __virtualname__
-    return (False, "Module win_network: module only works on Windows systems")
+    if not salt.utils.is_windows():
+        return False, "Module win_network: Only available on Windows"
+
+    if not HAS_DEPENDENCIES:
+        return False, "Module win_network: Missing dependencies"
+
+    global wol, get_hostname, interface, interface_ip, subnets6, ip_in_subnet
+    global convert_cidr, calc_net, get_fqdn, is_private, is_loopback
+    global reverse_ip, ifacestartswith, iphexval
+    wol = _namespaced_function(wol, globals())
+    get_hostname = _namespaced_function(get_hostname, globals())
+    interface = _namespaced_function(interface, globals())
+    interface_ip = _namespaced_function(interface_ip, globals())
+    subnets6 = _namespaced_function(subnets6, globals())
+    ip_in_subnet= _namespaced_function(ip_in_subnet, globals())
+    convert_cidr = _namespaced_function(convert_cidr, globals())
+    calc_net = _namespaced_function(calc_net, globals())
+    get_fqdn = _namespaced_function(get_fqdn, globals())
+    ifacestartswith = _namespaced_function(ifacestartswith, globals())
+    iphexval = _namespaced_function(iphexval, globals())
+
+    return __virtualname__
 
 
 def ping(host, timeout=False, return_boolean=False):

--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -47,8 +47,8 @@ def __virtual__():
         return False, "Module win_network: Missing dependencies"
 
     global wol, get_hostname, interface, interface_ip, subnets6, ip_in_subnet
-    global convert_cidr, calc_net, get_fqdn, reverse_ip, ifacestartswith
-    global iphexval
+    global convert_cidr, calc_net, get_fqdn, ifacestartswith, iphexval
+
     wol = _namespaced_function(wol, globals())
     get_hostname = _namespaced_function(get_hostname, globals())
     interface = _namespaced_function(interface, globals())


### PR DESCRIPTION
### What does this PR do?
Adds functions from `network.py` that should work on Windows to `win_network.py`. Similar to what we do with the `file.py` and `win_file.py` modules.

Specifically:
- network.wol
- network.get_hostname
- network.interface
- network.interface_ip
- network.subnets6
- network.ip_in_subnet
- network.convert_cidr
- network.calc_net
- network.get_fqdn
- network.ifacestartswith
- network.iphexval

Fixes `network.iphexval`. Was returning the hex for only the last octet. Now returns a zero padded hex value for the passed IP address.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/36735
https://github.com/saltstack/salt/issues/36708

### Previous Behavior
Some functions from `network.py` that work on Windows weren't available. Specifically, `network.get_hostname` and `network.wol`.

### New Behavior
The above functions are now available.

### Tests written?
No