### PR TITLE
Updated the bins_dir to default to pg_bin

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -115,7 +115,7 @@ def __virtual__():
     '''
     Only load this module if the psql and initdb bin exist
     '''
-    utils = ['psql']
+    utils = ['psql', 'initdb']
     if not HAS_CSV:
         return False
     for util in utils:

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -136,9 +136,11 @@ def _find_pg_binary(util):
     if not pg_bin_dir:  # Fallback to incorrectly-documented setting
         pg_bin_dir = __salt__['config.option']('postgres.bins_dir')
         if pg_bin_dir:
-            log.warning(
-                'Using postgres.bins_dir is not supported. '
-                'Replace this with postgres.pg_bin')
+            salt.utils.warn_until(
+                'Oxygen',
+                'Using \'postgres.bins_dir\' is not officially supported and '
+                'only exists as a workaround. Please replace this in your '
+                'configuration with \'postgres.pg_bin\'.')
 
     util_bin = salt.utils.which(util)
     if not util_bin:

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -26,6 +26,9 @@ Module to provide Postgres compatibility to salt.
     of the postgres bin's path to the relevant minion for this module::
 
         postgres.pg_bin: '/usr/pgsql-9.5/bin/'
+
+:note: Older versions of Salt had a bug where postgres.bins_dir was used
+    instead of postgres.pg_bin. You should upgrade this as soon as possible.
 '''
 
 # This pylint error is popping up where there are no colons?
@@ -112,7 +115,7 @@ def __virtual__():
     '''
     Only load this module if the psql and initdb bin exist
     '''
-    utils = ['psql', 'initdb']
+    utils = ['psql']
     if not HAS_CSV:
         return False
     for util in utils:
@@ -128,7 +131,15 @@ def _find_pg_binary(util):
 
     Helper function to locate various psql related binaries
     '''
-    pg_bin_dir = __salt__['config.option']('postgres.bins_dir')
+    pg_bin_dir = __salt__['config.option']('postgres.pg_bin')
+
+    if not pg_bin_dir:  # Fallback to incorrectly-documented setting
+        pg_bin_dir = __salt__['config.option']('postgres.bins_dir')
+        if pg_bin_dir:
+            log.warning(
+                'Using postgres.bins_dir is not supported. '
+                'Replace this with postgres.pg_bin')
+
     util_bin = salt.utils.which(util)
     if not util_bin:
         if pg_bin_dir:


### PR DESCRIPTION
### What does this PR do?

Updates the configuration to match the documentation. Originally the docs said `postgres.pg_bin` was the config to update, however the code looks at `postgres.bins_dir`. This PR supports both behaviours so we can transition users who need an immediate fix away from the original workaround.

I've also updated the documentation so we can be clear that the behavior is unsupported but is necessary in certain situations.

### What issues does this PR fix or reference?

#37935 

### Previous Behavior
The system only looked in `postgres.bins_dir` in the configuration. The docs said to update `postgres.pg_bin`

### New Behavior
The system defaults to look at `postgres.pg_bin` first, then falls back to `postgres.bins_dir` to prevent workarounds failing.

### Tests written?

No