### PR TITLE
Fix `salt-minion` initscript for RHEL5 (SysV) to pick up proper python version

### DIFF
--- a/pkg/rpm/salt-minion
+++ b/pkg/rpm/salt-minion
@@ -25,12 +25,11 @@
 # processname: /usr/bin/salt-minion
 
 # Allow these to be overridden for tests
-: ${SALTMINION_BINDIR:=/usr/bin}
-: ${SALTMINION_SYSCONFDIR:=/etc}
-: ${SALTMINION_PYTHON:=python}    # Python must be 2.6 or newer
+: "${SALTMINION_BINDIR:=/usr/bin}"
+: "${SALTMINION_SYSCONFDIR:=/etc}"
 
 # Default values (can be overridden in settings file)
-: ${USER:=$(id -nu)}
+: "${USER:=$(id -nu)}"
 SALTMINION="${SALTMINION_BINDIR}/salt-minion"
 SALTCALL="${SALTMINION_BINDIR}/salt-call"
 # SALTMINION_CONFIGS are newline-separated entries of: MINION_USER CONFIG_DIR
@@ -42,7 +41,6 @@ SALTMINION_TIMEOUT=30
 SALTMINION_TICK=1
 
 SERVICE="salt-minion"
-PROCESS="salt-minion"
 
 # Read in settings file
 if [ -f "${SALTMINION_SYSCONFDIR}/default/salt" ]; then
@@ -82,7 +80,7 @@ _is_running() {
 _get_salt_config_value() {
     _su_cmd \
         "$MINION_USER" \
-        "\"$SALTMINION_PYTHON\" \
+        "\
             \"$SALTCALL\" \
             -c \"$CONFIG_DIR\" \
             --no-color \
@@ -127,7 +125,7 @@ start() {
 
     _su_cmd \
         "$MINION_USER" \
-        "\"$SALTMINION_PYTHON\" \
+        "\
             \"$SALTMINION\" \
             -c \"$CONFIG_DIR\" \
             -d $SALTMINION_ARGS \

--- a/pkg/rpm/salt-minion
+++ b/pkg/rpm/salt-minion
@@ -33,9 +33,9 @@
 SALTMINION="${SALTMINION_BINDIR}/salt-minion"
 SALTCALL="${SALTMINION_BINDIR}/salt-call"
 # SALTMINION_CONFIGS are newline-separated entries of: MINION_USER CONFIG_DIR
-: ${SALTMINION_CONFIGS:="
+: "${SALTMINION_CONFIGS:="
 $USER ${SALTMINION_SYSCONFDIR}/salt
-"}
+"}"
 SALTMINION_ARGS=""
 SALTMINION_TIMEOUT=30
 SALTMINION_TICK=1
@@ -68,7 +68,8 @@ _su_cmd() {
 
 _get_pid() {
     netstat $NS_NOTRIM -ap --protocol=unix 2>$ERROR_TO_DEVNULL \
-        | sed -r  -e "\|\s${SOCK_DIR}/minion_event_${MINION_ID_HASH}_pub\.ipc$|"'!d; s|/.*||; s/.*\s//;'
+        | sed -r -e "\|\s${SOCK_DIR}/minion_event_${MINION_ID_HASH}_pub\.ipc$|"'!d; s|/.*||; s/.*\s//;' \
+        | uniq
 }
 
 
@@ -218,7 +219,8 @@ status() {
     local pid="$(_get_pid)"
 
     if [ -n "$pid" ]; then
-        echo "$SERVICE:$MINION_USER:$MINION_ID is running: $pid"
+        # Unquote $pid here to display multiple PIDs in one line
+        echo "$SERVICE:$MINION_USER:$MINION_ID is running:" $pid
     else
         retval=3
         echo "$SERVICE:$MINION_USER:$MINION_ID is stopped."


### PR DESCRIPTION
### What does this PR do?
It fixes the init script used during "git" bootstrap (and could be probably used in package building process) on OS with System V style init, such as CentOS/RHEL 5.

### What issues does this PR fix or reference?
Long story short, the script tries to spin up Salt Minion with default Python binary installed:
`/usr/bin/python`, instead of using shebang provided path. On RHEL 5 this is:
```
# python -V
Python 2.4.3
```

But...
```
# head -n 1 /usr/bin/salt-minion 
#!/usr/bin/python2.6
```


### Previous Behavior
Attempting to start fresh installed `salt-minion` results into this error:
```
# /etc/init.d/salt-minion start
ERROR: Unable to look-up config values for /etc/salt
```

### New Behavior
```
# /etc/init.d/salt-minion start
Starting salt-minion:root:c5-sysv daemon: OK
# /etc/init.d/salt-minion status
salt-minion:root:c5-sysv is running: 1259
```

### Tests written?
No
