### PR TITLE
Set default Salt Master address for a Syndic (like for a Minion)

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -798,7 +798,7 @@
 
 # If this master will be running a salt syndic daemon, syndic_master tells
 # this master where to receive commands from.
-#syndic_master: masterofmaster
+#syndic_master: masterofmasters
 
 # This is the 'ret_port' of the MasterOfMaster:
 #syndic_master_port: 4506

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -41,7 +41,7 @@ The local interface to bind to.
 Default: ``False``
 
 Whether the master should listen for IPv6 connections. If this is set to True,
-the interface option must be adjusted too (for example: "interface: '::'")
+the interface option must be adjusted too (for example: ``interface: '::'``)
 
 .. code-block:: yaml
 
@@ -1558,7 +1558,6 @@ directories above the one specified will be ignored and the relative path will
     gitfs_root: somefolder/otherfolder
 
 .. versionchanged:: 2014.7.0
-
    Ability to specify gitfs roots on a per-remote basis was added. See
    :ref:`here <gitfs-per-remote-config>` for more info.
 
@@ -2888,7 +2887,11 @@ value must be set to True
 ``syndic_master``
 -----------------
 
-Default: ``''``
+.. versionchanged:: 2016.3.5,2016.11.1
+
+    Set default higher level master address.
+
+Default: ``masterofmasters``
 
 If this master will be running the ``salt-syndic`` to connect to a higher level
 master, specify the higher level master with this configuration value.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1190,7 +1190,7 @@ DEFAULT_MASTER_OPTS = {
     'ping_on_rotate': False,
     'peer': {},
     'preserve_minion_cache': False,
-    'syndic_master': '',
+    'syndic_master': 'salt',
     'syndic_failover': 'random',
     'syndic_log_file': os.path.join(salt.syspaths.LOGS_DIR, 'syndic'),
     'syndic_pidfile': os.path.join(salt.syspaths.PIDFILE_DIR, 'salt-syndic.pid'),

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1190,7 +1190,7 @@ DEFAULT_MASTER_OPTS = {
     'ping_on_rotate': False,
     'peer': {},
     'preserve_minion_cache': False,
-    'syndic_master': 'salt',
+    'syndic_master': 'masterofmasters',
     'syndic_failover': 'random',
     'syndic_log_file': os.path.join(salt.syspaths.LOGS_DIR, 'syndic'),
     'syndic_pidfile': os.path.join(salt.syspaths.PIDFILE_DIR, 'salt-syndic.pid'),


### PR DESCRIPTION
### What does this PR do?
A Salt Minion is always coming up from the cold start with default Master address set as `salt`. That's how you can add hosts to your Salt infrastructure with minimum configuration (except of setting resolver properly of course).

But currently that's not the case with Salt Syndic, because `syndic_master` default value is undefined.

### What issues does this PR fix or reference?
Setting default "Master of Masters" address for Syndic allows to install and use it right out-of-the-box in easy way, just with making proper changes to a local DNS.

### Previous Behavior
Salt Syndic fails to start:
```
[ERROR   ][564] Master address: 'unknown address' could not be resolved.
Invalid or unresolveable address. Set 'syndic_master' value in minion config.
```

### New Behavior
Salt Syndic works right after the installation.

### Tests written?
No
