### PR TITLE
use sleep from path for docker.sls_build

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5883,7 +5883,7 @@ def sls_build(name, base='opensuse/python', mods=None, saltenv='base',
     # start a new container
     ret = __salt__['dockerng.create'](image=base,
                                       name=name,
-                                      cmd='/usr/bin/sleep infinity',
+                                      cmd='sleep infinity',
                                       interactive=True, tty=True)
     id_ = ret['Id']
     try:

--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -671,7 +671,7 @@ class DockerngTestCase(TestCase):
                 mods='foo',
             )
         docker_create_mock.assert_called_once_with(
-            cmd='/usr/bin/sleep infinity',
+            cmd='sleep infinity',
             image='opensuse/python', interactive=True, name='foo', tty=True)
         docker_start_mock.assert_called_once_with('ID')
         docker_sls_mock.assert_called_once_with('ID', 'foo', 'base')


### PR DESCRIPTION
### What does this PR do?

sleep sometimes is found in /bin/sleep, like in ubuntu.  We should just
depend on the PATH variable being correct, and finding sleep, instead of
explicitly saying /usr/bin/sleep

### What issues does this PR fix or reference?

Closes #37940 