### PR TITLE
Switch proxy_merge_grains_in_module option default from False to True

### DIFF
--- a/conf/proxy
+++ b/conf/proxy
@@ -28,8 +28,8 @@
 # dictionary.  Otherwise it is assumed that the module calls the grains
 # function in a custom way and returns the data elsewhere
 #
-# Default to False for 2016.3 and 2016.11.  Switch to True for Nitrogen.
-# proxy_merge_grains_in_module: False
+# Default to False for 2016.3 and 2016.11. Switch to True for Nitrogen.
+# proxy_merge_grains_in_module: True
 
 # If multiple masters are specified in the 'master' setting, the default behavior
 # is to always try to connect to them in the order they are listed. If random_master is

--- a/doc/topics/proxyminion/index.rst
+++ b/doc/topics/proxyminion/index.rst
@@ -113,9 +113,7 @@ will be executed on proxy-minion startup and its contents will be merged with
 the rest of the proxy's grains.  Since older proxy-minions might have used other
 methods to call such a function and add its results to grains, this is config-gated
 by a new proxy configuration option called ``proxy_merge_grains_in_module``.  This
-defaults to ``False`` in this release.  It will default to True in the release after
-next.  The next release is 2016.11.0, the following is **Nitrogen**.
-
+defaults to ``True`` in the **Nitrogen** release.
 
 
 New in 2015.8.2
@@ -357,8 +355,7 @@ controlled device and make sure it is really available.
 the standard install directories for grains, grains can be computed and
 returned by this function.  This function will be called automatically
 if ``proxy_merge_grains_in_module`` is set to ``True`` in /etc/salt/proxy.
-This variable defaults to ``False`` in 2016.3 but will default to ``True`` in
-the release code-named *Nitrogen*.
+This variable defaults to ``True`` in the release code-named *Nitrogen*.
 
 Pre 2015.8 the proxymodule also must have an ``id()`` function.  2015.8 and following don't use
 this function because the proxy's id is required on the command line.
@@ -588,7 +585,7 @@ the proxy and grains directories.
 
 This function will only be called automatically if the configuration variable ``proxy_merge_grains_in_module``
 is set to True in the proxy configuration file (default ``/etc/salt/proxy``).  This
-variable will default to True in the release code-named *Nitrogen*.
+variable defaults to ``True`` in the release code-named *Nitrogen*.
 
 
 .. code: python::

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1469,7 +1469,7 @@ DEFAULT_PROXY_MINION_OPTS = {
     'conf_file': os.path.join(salt.syspaths.CONFIG_DIR, 'proxy'),
     'log_file': os.path.join(salt.syspaths.LOGS_DIR, 'proxy'),
     'add_proxymodule_to_opts': False,
-    'proxy_merge_grains_in_module': False,
+    'proxy_merge_grains_in_module': True,
     'append_minionid_config_dirs': ['cachedir', 'pidfile'],
     'default_include': 'proxy.d/*.conf',
 }

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -741,7 +741,7 @@ def grains(opts, force_refresh=False, proxy=None):
         else:
             grains_data.update(ret)
 
-    if opts.get('proxy_merge_grains_in_module', False) and proxy:
+    if opts.get('proxy_merge_grains_in_module', True) and proxy:
         try:
             proxytype = proxy.opts['proxy']['proxytype']
             if proxytype+'.grains' in proxy:

--- a/salt/proxy/nxos.py
+++ b/salt/proxy/nxos.py
@@ -53,16 +53,18 @@ the :doc:`salt.modules.nxos</ref/modules/all/salt.modules.nxos>` execution modul
     `multiprocessing: False`
 
 '''
+
+# Import Python libs
 from __future__ import absolute_import
+import logging
 import multiprocessing
 import re
 
-import salt.utils
+# Import Salt libs
 from salt.utils.pycrypto import gen_hash, secure_password
 from salt.utils.vt_helper import SSHConnection
 from salt.utils.vt import TerminalException
 
-import logging
 log = logging.getLogger(__file__)
 
 __proxyenabled__ = ['nxos']

--- a/salt/proxy/nxos.py
+++ b/salt/proxy/nxos.py
@@ -46,11 +46,6 @@ key_accept
 The functions from the proxy minion can be run from the salt commandline using
 the :doc:`salt.modules.nxos</ref/modules/all/salt.modules.nxos>` execution module.
 
-.. note::
-    The option `proxy_merge_grains_in_module: True` is required to have the NXOS
-    grains be available from the proxy minion, for the 2016.11.0 release.  For
-    Nitrogen, the setting will be True by default.
-
 .. note:
     If `multiprocessing: True` is set for the proxy minion config, each forked
     worker will open up a new connection to the Cisco NX OS Switch.  If you
@@ -80,14 +75,6 @@ def __virtual__():
     Only return if all the modules are available
     '''
     log.info('nxos proxy __virtual__() called...')
-
-    if __opts__.get('proxy_merge_grains_in_module', False) is False:
-        salt.utils.warn_until(
-            'Nitrogen',
-            'To use grains with the NXOS proxy minion, '
-            '`proxy_merge_grains_in_module: True` must be set in the '
-            'proxy minion config.'
-        )
 
     return __virtualname__
 


### PR DESCRIPTION
There are warnings in the docs about this option changing from ``False`` to ``True`` as the default in the ``Nitrogen`` release. This PR makes that switch.

I spoke with @cro about this offline and he says this looks good to him.