### PR TITLE
Deprecate expr_form argument in the LocalClient

### DIFF
--- a/doc/ref/peer.rst
+++ b/doc/ref/peer.rst
@@ -119,8 +119,11 @@ To execute the manage.up runner:
 
     # salt-call publish.runner manage.up
 
-To match minions using other matchers, use ``expr_form``:
+To match minions using other matchers, use ``tgt_type``:
 
 .. code-block:: bash
 
-    # salt-call publish.publish 'webserv* and not G@os:Ubuntu' test.ping expr_form='compound'
+    # salt-call publish.publish 'webserv* and not G@os:Ubuntu' test.ping tgt_type='compound'
+
+.. note::
+    In pre-Nitrogen releases, use ``expr_form`` instead of ``tgt_type``.

--- a/doc/topics/event/master_events.rst
+++ b/doc/topics/event/master_events.rst
@@ -133,8 +133,10 @@ Runner Events
     :var tgt: The target expression (e.g. ``*``). Included for ``state`` and
         ``function`` types only.
     :var args: The args passed to the orchestration job. **Note:** for
-        ``state`` and ``function`` types, also includes an ``expr_form`` which
-        shows what kind of match (``glob``, ``pcre``, etc.) was used.
+        ``state`` and ``function`` types, also includes a ``tgt_type`` value
+        which shows what kind of match (``glob``, ``pcre``, etc.) was used.
+        This value was named ``expr_form`` in the 2016.11 release cycle but has
+        been renamed to ``tgt_type`` in Nitrogen for consistency with other.
 
 .. _event-master_presence:
 

--- a/doc/topics/event/master_events.rst
+++ b/doc/topics/event/master_events.rst
@@ -136,7 +136,8 @@ Runner Events
         ``state`` and ``function`` types, also includes a ``tgt_type`` value
         which shows what kind of match (``glob``, ``pcre``, etc.) was used.
         This value was named ``expr_form`` in the 2016.11 release cycle but has
-        been renamed to ``tgt_type`` in Nitrogen for consistency with other.
+        been renamed to ``tgt_type`` in Nitrogen for consistency with other
+        events.
 
 .. _event-master_presence:
 

--- a/doc/topics/mine/index.rst
+++ b/doc/topics/mine/index.rst
@@ -174,7 +174,7 @@ to add them to the pool of load balanced servers.
 
     <...file contents snipped...>
 
-    {% for server, addrs in salt['mine.get']('roles:web', 'network.ip_addrs', expr_form='grain') | dictsort() %}
+    {% for server, addrs in salt['mine.get']('roles:web', 'network.ip_addrs', tgt_type='grain') | dictsort() %}
     server {{ server }} {{ addrs[0] }}:80 check
     {% endfor %}
 

--- a/doc/topics/reactor/index.rst
+++ b/doc/topics/reactor/index.rst
@@ -375,14 +375,14 @@ command:
 
     salt '*' cmd.run 'rm -rf /tmp/*'
 
-Use the ``expr_form`` argument to specify a matcher:
+Use the ``tgt_type`` argument to specify a matcher:
 
 .. code-block:: yaml
 
     clean_tmp:
       local.cmd.run:
         - tgt: 'os:Ubuntu'
-        - expr_form: grain
+        - tgt_type: grain
         - arg:
           - rm -rf /tmp/*
 
@@ -390,9 +390,13 @@ Use the ``expr_form`` argument to specify a matcher:
     clean_tmp:
       local.cmd.run:
         - tgt: 'G@roles:hbase_master'
-        - expr_form: compound
+        - tgt_type: compound
         - arg:
           - rm -rf /tmp/*
+
+.. note::
+    The ``tgt_type`` argument was named ``expr_form`` in releases prior to
+    Nitrogen (2016.11.x and earlier).
 
 Any other parameters in the :py:meth:`LocalClient().cmd()
 <salt.client.LocalClient.cmd>` method can be specified as well.

--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -56,3 +56,18 @@ Execution Module Changes
   <salt.modules.systemd>` module have changed. These changes are described
   above alongside the information on the new states which have been added to
   manage masking of systemd units.
+
+Python API Changes
+==================
+
+The :ref:`LocalClient <local-client>`'s ``expr_form`` argument has been
+deprecated and renamed to ``tgt_type``. This change was made due to numerous
+reports of confusion among community members, since the targeting method is
+published to minions as ``tgt_type``, and appears as ``tgt_type`` in the job
+cache as well.
+
+While ``expr_form`` will continue to be supported until the **Fluorine**
+release cycle (two major releases after this one), those who are using the
+:ref:`LocalClient <local-client>` (either directly, or implictly via a
+:ref:`netapi module <all-netapi-modules>`) are encouraged to update their code
+to use ``tgt_type``.

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -50,7 +50,7 @@ class Batch(object):
         if selected_target_option is not None:
             args.append(selected_target_option)
         else:
-            args.append(self.opts.get('expr_form', 'glob'))
+            args.append(self.opts.get('tgt_type', 'glob'))
 
         self.pub_kwargs['yield_pub_data'] = True
         ping_gen = self.local.cmd_iter(*args, **self.pub_kwargs)

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -79,9 +79,9 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         kwargs['delimiter'] = self.options.delimiter
 
         if self.selected_target_option:
-            kwargs['expr_form'] = self.selected_target_option
+            kwargs['tgt_type'] = self.selected_target_option
         else:
-            kwargs['expr_form'] = 'glob'
+            kwargs['tgt_type'] = 'glob'
 
         if getattr(self.options, 'return'):
             kwargs['ret'] = getattr(self.options, 'return')

--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -77,7 +77,7 @@ class APIClient(object):
             'fun' : 'modulefunctionstring',
             'kwarg': functionkeywordargdictionary,
             'tgt' : 'targetpatternstring',
-            'expr_form' : 'targetpatterntype',
+            'tgt_type' : 'targetpatterntype',
             'ret' : 'returner namestring',
             'timeout': 'functiontimeout',
             'arg' : 'functionpositionalarg sequence',
@@ -106,7 +106,7 @@ class APIClient(object):
         kwarg: A dictionary of keyword function parameters to be passed to the eventual
                salt function specified by fun:
         tgt: Pattern string specifying the targeted minions when the implied client is local
-        expr_form: Optional target pattern type string when client is local minion.
+        tgt_type: Optional target pattern type string when client is local minion.
             Defaults to 'glob' if missing
         ret: Optional name string of returner when local minion client.
         arg: Optional positional argument string when local minion client
@@ -181,7 +181,7 @@ class APIClient(object):
         {
             'module' : 'modulestring',
             'tgt' : 'targetpatternstring',
-            'expr_form' : 'targetpatterntype',
+            'tgt_type' : 'targetpatterntype',
             'token': 'salttokenstring',
             'username': 'usernamestring',
             'password': 'passwordstring',
@@ -194,7 +194,7 @@ class APIClient(object):
             the specified client.
         tgt: Optional pattern string specifying the targeted minions when client
           is 'minion'
-        expr_form: Optional target pattern type string when client is 'minion'.
+        tgt_type: Optional target pattern type string when client is 'minion'.
             Example: 'glob' defaults to 'glob' if missing
         token: the salt token. Either token: is required or the set of username:,
             password: , and eauth:

--- a/salt/client/raet/__init__.py
+++ b/salt/client/raet/__init__.py
@@ -36,7 +36,7 @@ class LocalClient(salt.client.LocalClient):
             tgt,
             fun,
             arg=(),
-            expr_form='glob',
+            tgt_type='glob',
             ret='',
             jid='',
             timeout=5,
@@ -44,11 +44,20 @@ class LocalClient(salt.client.LocalClient):
         '''
         Publish the command!
         '''
+        if 'expr_form' in kwargs:
+            salt.utils.warn_until(
+                'Fluorine',
+                'The target type should be passed using the \'tgt_type\' '
+                'argument instead of \'expr_form\'. Support for using '
+                '\'expr_form\' will be removed in Salt Fluorine.'
+            )
+            tgt_type = kwargs.pop('expr_form')
+
         payload_kwargs = self._prep_pub(
                 tgt,
                 fun,
                 arg=arg,
-                expr_form=expr_form,
+                tgt_type=tgt_type,
                 ret=ret,
                 jid=jid,
                 timeout=timeout,

--- a/salt/client/ssh/client.py
+++ b/salt/client/ssh/client.py
@@ -41,19 +41,28 @@ class SSHClient(object):
             fun,
             arg=(),
             timeout=None,
-            expr_form='glob',
+            tgt_type='glob',
             kwarg=None,
             **kwargs):
         '''
         Prepare the arguments
         '''
+        if 'expr_form' in kwargs:
+            salt.utils.warn_until(
+                'Fluorine',
+                'The target type should be passed using the \'tgt_type\' '
+                'argument instead of \'expr_form\'. Support for using '
+                '\'expr_form\' will be removed in Salt Fluorine.'
+            )
+            tgt_type = kwargs.pop('expr_form')
+
         opts = copy.deepcopy(self.opts)
         opts.update(kwargs)
         if timeout:
             opts['timeout'] = timeout
         arg = salt.utils.args.condition_input(arg, kwarg)
         opts['argv'] = [fun] + arg
-        opts['selected_target_option'] = expr_form
+        opts['selected_target_option'] = tgt_type
         opts['tgt'] = tgt
         opts['arg'] = arg
         return salt.client.ssh.SSH(opts)
@@ -64,7 +73,7 @@ class SSHClient(object):
             fun,
             arg=(),
             timeout=None,
-            expr_form='glob',
+            tgt_type='glob',
             ret='',
             kwarg=None,
             **kwargs):
@@ -74,24 +83,32 @@ class SSHClient(object):
 
         .. versionadded:: 2015.5.0
         '''
+        if 'expr_form' in kwargs:
+            salt.utils.warn_until(
+                'Fluorine',
+                'The target type should be passed using the \'tgt_type\' '
+                'argument instead of \'expr_form\'. Support for using '
+                '\'expr_form\' will be removed in Salt Fluorine.'
+            )
+            tgt_type = kwargs.pop('expr_form')
+
         ssh = self._prep_ssh(
                 tgt,
                 fun,
                 arg,
                 timeout,
-                expr_form,
+                tgt_type,
                 kwarg,
                 **kwargs)
         for ret in ssh.run_iter(jid=kwargs.get('jid', None)):
             yield ret
 
-    def cmd(
-            self,
+    def cmd(self,
             tgt,
             fun,
             arg=(),
             timeout=None,
-            expr_form='glob',
+            tgt_type='glob',
             kwarg=None,
             **kwargs):
         '''
@@ -100,12 +117,21 @@ class SSHClient(object):
 
         .. versionadded:: 2015.5.0
         '''
+        if 'expr_form' in kwargs:
+            salt.utils.warn_until(
+                'Fluorine',
+                'The target type should be passed using the \'tgt_type\' '
+                'argument instead of \'expr_form\'. Support for using '
+                '\'expr_form\' will be removed in Salt Fluorine.'
+            )
+            tgt_type = kwargs.pop('expr_form')
+
         ssh = self._prep_ssh(
                 tgt,
                 fun,
                 arg,
                 timeout,
-                expr_form,
+                tgt_type,
                 kwarg,
                 **kwargs)
         final = {}
@@ -127,7 +153,7 @@ class SSHClient(object):
                 'tgt': 'silver',
                 'fun': 'test.ping',
                 'arg': (),
-                'expr_form'='glob',
+                'tgt_type'='glob',
                 'kwarg'={}
                 })
             {'silver': {'fun_args': [], 'jid': '20141202152721523072', 'return': True, 'retcode': 0, 'success': True, 'fun': 'test.ping', 'id': 'silver'}}
@@ -135,7 +161,7 @@ class SSHClient(object):
 
         kwargs = copy.deepcopy(low)
 
-        for ignore in ['tgt', 'fun', 'arg', 'timeout', 'expr_form', 'kwarg']:
+        for ignore in ['tgt', 'fun', 'arg', 'timeout', 'tgt_type', 'kwarg']:
             if ignore in kwargs:
                 del kwargs[ignore]
 
@@ -143,7 +169,7 @@ class SSHClient(object):
                         low['fun'],
                         low.get('arg', []),
                         low.get('timeout'),
-                        low.get('expr_form'),
+                        low.get('tgt_type'),
                         low.get('kwarg'),
                         **kwargs)
 
@@ -159,7 +185,7 @@ class SSHClient(object):
                 'tgt': 'silver',
                 'fun': 'test.ping',
                 'arg': (),
-                'expr_form'='glob',
+                'tgt_type'='glob',
                 'kwarg'={}
                 })
             {'silver': {'fun_args': [], 'jid': '20141202152721523072', 'return': True, 'retcode': 0, 'success': True, 'fun': 'test.ping', 'id': 'silver'}}

--- a/salt/client/ssh/wrapper/mine.py
+++ b/salt/client/ssh/wrapper/mine.py
@@ -14,9 +14,9 @@ import copy
 import salt.client.ssh
 
 
-def get(tgt, fun, expr_form='glob', roster='flat'):
+def get(tgt, fun, tgt_type='glob', roster='flat'):
     '''
-    Get data from the mine based on the target, function and expr_form
+    Get data from the mine based on the target, function and tgt_type
 
     This will actually run the function on all targeted minions (like
     publish.publish), as salt-ssh clients can't update the mine themselves.
@@ -42,7 +42,7 @@ def get(tgt, fun, expr_form='glob', roster='flat'):
     if roster:
         opts['roster'] = roster
     opts['argv'] = [fun]
-    opts['selected_target_option'] = expr_form
+    opts['selected_target_option'] = tgt_type
     opts['tgt'] = tgt
     opts['arg'] = []
 

--- a/salt/client/ssh/wrapper/publish.py
+++ b/salt/client/ssh/wrapper/publish.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 def _publish(tgt,
              fun,
              arg=None,
-             expr_form='glob',
+             tgt_type='glob',
              returner='',
              timeout=None,
              form='clean',
@@ -80,7 +80,7 @@ def _publish(tgt,
     if timeout:
         opts['timeout'] = timeout
     opts['argv'] = [fun] + arg
-    opts['selected_target_option'] = expr_form
+    opts['selected_target_option'] = tgt_type
     opts['tgt'] = tgt
     opts['arg'] = arg
 
@@ -107,10 +107,11 @@ def _publish(tgt,
 def publish(tgt,
             fun,
             arg=None,
-            expr_form='glob',
+            tgt_type='glob',
             returner='',
             timeout=5,
-            roster=None):
+            roster=None,
+            expr_form=None):
     '''
     Publish a command "from the minion out to other minions". In reality, the
     minion does not execute this function, it is executed by the master. Thus,
@@ -124,11 +125,15 @@ def publish(tgt,
 
     Returners are not currently supported
 
-    The expr_form argument is used to pass a target other than a glob into
+    The tgt_type argument is used to pass a target other than a glob into
     the execution, the available options are:
 
     - glob
     - pcre
+
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
 
     The arguments sent to the minion publish function are separated with
     commas. This means that for a minion executing a command with multiple
@@ -165,10 +170,21 @@ def publish(tgt,
 
 
     '''
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
+
     return _publish(tgt,
                     fun,
                     arg=arg,
-                    expr_form=expr_form,
+                    tgt_type=tgt_type,
                     returner=returner,
                     timeout=timeout,
                     form='clean',
@@ -178,10 +194,11 @@ def publish(tgt,
 def full_data(tgt,
               fun,
               arg=None,
-              expr_form='glob',
+              tgt_type='glob',
               returner='',
               timeout=5,
-              roster=None):
+              roster=None,
+              expr_form=None):
     '''
     Return the full data about the publication, this is invoked in the same
     way as the publish function
@@ -203,10 +220,21 @@ def full_data(tgt,
             salt-ssh '*' publish.full_data test.kwarg arg='cheese=spam'
 
     '''
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
+
     return _publish(tgt,
                     fun,
                     arg=arg,
-                    expr_form=expr_form,
+                    tgt_type=tgt_type,
                     returner=returner,
                     timeout=timeout,
                     form='full',

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -2276,7 +2276,7 @@ class Map(Cloud):
                     client = salt.client.get_local_client()
                     out.update(client.cmd(
                         ','.join(group), self.opts['start_action'],
-                        timeout=self.opts['timeout'] * 60, expr_form='list'
+                        timeout=self.opts['timeout'] * 60, tgt_type='list'
                     ))
                 for obj in output_multip:
                     next(six.itervalues(obj))['ret'] = out[next(six.iterkeys(obj))]

--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -156,8 +156,8 @@ def _salt(fun, *args, **kw):
         runner = _runner()
         rkwargs = kwargs.copy()
         rkwargs['timeout'] = timeout
-        rkwargs.setdefault('expr_form', 'list')
-        kwargs.setdefault('expr_form', 'list')
+        rkwargs.setdefault('tgt_type', 'list')
+        kwargs.setdefault('tgt_type', 'list')
         ping_retries = 0
         # the target(s) have environ one minute to respond
         # we call 60 ping request, this prevent us

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -588,7 +588,7 @@ class RemoteFuncs(object):
         ret = {}
         if not salt.utils.verify.valid_id(self.opts, load['id']):
             return ret
-        match_type = load.get('expr_form', 'glob')
+        match_type = load.get('tgt_type', 'glob')
         if match_type.lower() == 'pillar':
             match_type = 'pillar_exact'
         if match_type.lower() == 'compound':
@@ -895,7 +895,7 @@ class RemoteFuncs(object):
         pub_load = {
             'fun': load['fun'],
             'arg': load['arg'],
-            'expr_form': load.get('tgt_type', 'glob'),
+            'tgt_type': load.get('tgt_type', 'glob'),
             'tgt': load['tgt'],
             'ret': load['ret'],
             'id': load['id'],
@@ -904,17 +904,16 @@ class RemoteFuncs(object):
             if load['tgt_type'].startswith('node'):
                 if load['tgt'] in self.opts['nodegroups']:
                     pub_load['tgt'] = self.opts['nodegroups'][load['tgt']]
-                    pub_load['expr_form_type'] = 'compound'
-                    pub_load['expr_form'] = load['tgt_type']
+                    pub_load['tgt_type'] = 'compound'
                 else:
                     return {}
             else:
-                pub_load['expr_form'] = load['tgt_type']
+                pub_load['tgt_type'] = load['tgt_type']
         ret = {}
         ret['jid'] = self.local.cmd_async(**pub_load)
         ret['minions'] = self.ckminions.check_minions(
                 load['tgt'],
-                pub_load['expr_form'])
+                pub_load['tgt_type'])
         auth_cache = os.path.join(
                 self.opts['cachedir'],
                 'publish_auth')
@@ -949,7 +948,7 @@ class RemoteFuncs(object):
         pub_load = {
             'fun': load['fun'],
             'arg': load['arg'],
-            'expr_form': load.get('tgt_type', 'glob'),
+            'tgt_type': load.get('tgt_type', 'glob'),
             'tgt': load['tgt'],
             'ret': load['ret'],
             'id': load['id'],
@@ -974,11 +973,11 @@ class RemoteFuncs(object):
             if load['tgt_type'].startswith('node'):
                 if load['tgt'] in self.opts['nodegroups']:
                     pub_load['tgt'] = self.opts['nodegroups'][load['tgt']]
-                    pub_load['expr_form_type'] = 'compound'
+                    pub_load['tgt_type'] = 'compound'
                 else:
                     return {}
             else:
-                pub_load['expr_form'] = load['tgt_type']
+                pub_load['tgt_type'] = load['tgt_type']
         pub_load['raw'] = True
         ret = {}
         for minion in self.local.cmd_iter(**pub_load):

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -306,7 +306,10 @@ def glob(tgt, minion_id=None):
         return False
 
 
-def filter_by(lookup, expr_form='compound', minion_id=None):
+def filter_by(lookup,
+              tgt_type='compound',
+              minion_id=None,
+              expr_form=None):
     '''
     Return the first match in a dictionary of target patterns
 
@@ -331,12 +334,23 @@ def filter_by(lookup, expr_form='compound', minion_id=None):
         # Make the filtered data available to Pillar:
         roles: {{ roles | yaml() }}
     '''
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
+
     expr_funcs = dict(inspect.getmembers(sys.modules[__name__],
         predicate=inspect.isfunction))
 
     for key in lookup:
         params = (key, minion_id) if minion_id else (key, )
-        if expr_funcs[expr_form](*params):
+        if expr_funcs[tgt_type](*params):
             return lookup[key]
 
     return None

--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -42,7 +42,7 @@ def _publish(
         tgt,
         fun,
         arg=None,
-        expr_form='glob',
+        tgt_type='glob',
         returner='',
         timeout=5,
         form='clean',
@@ -111,7 +111,7 @@ def _publish(
             'fun': fun,
             'arg': arg,
             'tgt': tgt,
-            'tgt_type': expr_form,
+            'tgt_type': tgt_type,
             'ret': returner,
             'tok': tok,
             'tmo': timeout,
@@ -174,7 +174,14 @@ def _publish(
             return ret
 
 
-def publish(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5, via_master=None):
+def publish(tgt,
+            fun,
+            arg=None,
+            tgt_type='glob',
+            returner='',
+            timeout=5,
+            via_master=None,
+            expr_form=None):
     '''
     Publish a command from the minion out to other minions.
 
@@ -184,7 +191,7 @@ def publish(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5, via_ma
     minion cannot command another minion to command another minion as
     that would create an infinite command loop.
 
-    The expr_form argument is used to pass a target other than a glob into
+    The ``tgt_type`` argument is used to pass a target other than a glob into
     the execution, the available options are:
 
     - glob
@@ -196,6 +203,10 @@ def publish(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5, via_ma
     - ipcidr
     - range
     - compound
+
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
 
     Note that for pillar matches must be exact, both in the pillar matcher
     and the compound matcher. No globbing is supported.
@@ -237,10 +248,21 @@ def publish(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5, via_ma
     master the publication should be sent to. Only one master may be specified. If
     unset, the publication will be sent only to the first master in minion configuration.
     '''
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
+
     return _publish(tgt,
                     fun,
                     arg=arg,
-                    expr_form=expr_form,
+                    tgt_type=tgt_type,
                     returner=returner,
                     timeout=timeout,
                     form='clean',
@@ -248,7 +270,13 @@ def publish(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5, via_ma
                     via_master=via_master)
 
 
-def full_data(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
+def full_data(tgt,
+              fun,
+              arg=None,
+              tgt_type='glob',
+              returner='',
+              timeout=5,
+              expr_form=None):
     '''
     Return the full data about the publication, this is invoked in the same
     way as the publish function
@@ -270,10 +298,21 @@ def full_data(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
             salt '*' publish.full_data test.kwarg arg='cheese=spam'
 
     '''
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
+
     return _publish(tgt,
                     fun,
                     arg=arg,
-                    expr_form=expr_form,
+                    tgt_type=tgt_type,
                     returner=returner,
                     timeout=timeout,
                     form='full',

--- a/salt/modules/raet_publish.py
+++ b/salt/modules/raet_publish.py
@@ -41,7 +41,7 @@ def _publish(
         tgt,
         fun,
         arg=None,
-        expr_form='glob',
+        tgt_type='glob',
         returner='',
         timeout=5,
         form='clean'):
@@ -74,7 +74,7 @@ def _publish(
             'fun': fun,
             'arg': arg,
             'tgt': tgt,
-            'tgt_type': expr_form,
+            'tgt_type': tgt_type,
             'ret': returner,
             'tmo': timeout,
             'form': form,
@@ -102,7 +102,13 @@ def _publish(
         return ret
 
 
-def publish(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
+def publish(tgt,
+            fun,
+            arg=None,
+            tgt_type='glob',
+            returner='',
+            timeout=5,
+            expr_form=None):
     '''
     Publish a command from the minion out to other minions.
 
@@ -112,7 +118,7 @@ def publish(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
     minion cannot command another minion to command another minion as
     that would create an infinite command loop.
 
-    The expr_form argument is used to pass a target other than a glob into
+    The ``tgt_type`` argument is used to pass a target other than a glob into
     the execution, the available options are:
 
     - glob
@@ -124,6 +130,10 @@ def publish(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
     - ipcidr
     - range
     - compound
+
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
 
     The arguments sent to the minion publish function are separated with
     commas. This means that for a minion executing a command with multiple
@@ -153,16 +163,33 @@ def publish(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
 
 
     '''
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
+
     return _publish(tgt,
                     fun,
                     arg=arg,
-                    expr_form=expr_form,
+                    tgt_type=tgt_type,
                     returner=returner,
                     timeout=timeout,
                     form='clean')
 
 
-def full_data(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
+def full_data(tgt,
+              fun,
+              arg=None,
+              tgt_type='glob',
+              returner='',
+              timeout=5,
+              expr_form=None):
     '''
     Return the full data about the publication, this is invoked in the same
     way as the publish function
@@ -184,10 +211,21 @@ def full_data(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
             salt '*' publish.full_data test.kwarg arg='cheese=spam'
 
     '''
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
+
     return _publish(tgt,
                     fun,
                     arg=arg,
-                    expr_form=expr_form,
+                    tgt_type=tgt_type,
                     returner=returner,
                     timeout=timeout,
                     form='full')

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -939,7 +939,7 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):  # pylint: disable=W
         # let the upper level deal with this one
         ping_ret = yield self._disbatch_local({'tgt': chunk['tgt'],
                                                'fun': 'test.ping',
-                                               'expr_form': f_call['kwargs']['expr_form']})
+                                               'tgt_type': f_call['kwargs']['tgt_type']})
 
         chunk_ret = {}
 
@@ -950,8 +950,8 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):  # pylint: disable=W
         maxflight = get_batch_size(f_call['kwargs']['batch'], len(minions))
         inflight_futures = []
 
-        # override the expr_form
-        f_call['kwargs']['expr_form'] = 'list'
+        # override the tgt_type
+        f_call['kwargs']['tgt_type'] = 'list'
         # do this batch
         while len(minions) > 0 or len(inflight_futures) > 0:
             # if you have more to go, lets disbatch jobs
@@ -959,7 +959,7 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):  # pylint: disable=W
                 minion_id = minions.pop(0)
                 batch_chunk = dict(chunk)
                 batch_chunk['tgt'] = [minion_id]
-                batch_chunk['expr_form'] = 'list'
+                batch_chunk['tgt_type'] = 'list'
                 future = self._disbatch_local(batch_chunk)
                 inflight_futures.append(future)
 
@@ -1006,7 +1006,7 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):  # pylint: disable=W
 
         job_not_running = self.job_not_running(pub_data['jid'],
                                                chunk['tgt'],
-                                               f_call['kwargs']['expr_form'],
+                                               f_call['kwargs']['tgt_type'],
                                                minions_remaining=minions_remaining
                                                )
 
@@ -1072,7 +1072,7 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):  # pylint: disable=W
         ping_pub_data = self.saltclients['local'](tgt,
                                                   'saltutil.find_job',
                                                   [jid],
-                                                  expr_form=tgt_type)
+                                                  tgt_type=tgt_type)
         ping_tag = tagify([ping_pub_data['jid'], 'ret'], 'job')
 
         minion_running = False
@@ -1089,7 +1089,7 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):  # pylint: disable=W
                     ping_pub_data = self.saltclients['local'](tgt,
                                                               'saltutil.find_job',
                                                               [jid],
-                                                              expr_form=tgt_type)
+                                                              tgt_type=tgt_type)
                     ping_tag = tagify([ping_pub_data['jid'], 'ret'], 'job')
                     minion_running = False
                     continue

--- a/salt/roster/cache.py
+++ b/salt/roster/cache.py
@@ -35,7 +35,7 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
         'public', 'private', 'local'
     ))
 
-    cached_data = __runner__['cache.grains'](tgt=tgt, expr_form=tgt_type)
+    cached_data = __runner__['cache.grains'](tgt=tgt, tgt_type=tgt_type)
     ret = {}
     for server, grains in cached_data.items():
         ret[server] = __opts__.get('roster_defaults', {}).copy()

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -21,8 +21,12 @@ from salt.runners.winrepo import PER_REMOTE_OVERRIDES as __WINREPO_OVERRIDES
 log = logging.getLogger(__name__)
 
 
-def grains(tgt=None, expr_form='glob', **kwargs):
+def grains(tgt=None, tgt_type='glob', **kwargs):
     '''
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
+
     Return cached grains of the targeted minions
 
     CLI Example:
@@ -31,7 +35,16 @@ def grains(tgt=None, expr_form='glob', **kwargs):
 
         salt-run cache.grains
     '''
-    pillar_util = salt.utils.master.MasterPillarUtil(tgt, expr_form,
+    if 'expr_form' in kwargs:
+        salt.utils.warn_until(
+            'Fluorine',
+            'The target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = kwargs.pop('expr_form')
+
+    pillar_util = salt.utils.master.MasterPillarUtil(tgt, tgt_type,
                                                      use_cached_grains=True,
                                                      grains_fallback=False,
                                                      opts=__opts__)
@@ -39,8 +52,12 @@ def grains(tgt=None, expr_form='glob', **kwargs):
     return cached_grains
 
 
-def pillar(tgt=None, expr_form='glob', **kwargs):
+def pillar(tgt=None, tgt_type='glob', **kwargs):
     '''
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
+
     Return cached pillars of the targeted minions
 
     CLI Example:
@@ -49,7 +66,16 @@ def pillar(tgt=None, expr_form='glob', **kwargs):
 
         salt-run cache.pillar
     '''
-    pillar_util = salt.utils.master.MasterPillarUtil(tgt, expr_form,
+    if 'expr_form' in kwargs:
+        salt.utils.warn_until(
+            'Fluorine',
+            'The target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = kwargs.pop('expr_form')
+
+    pillar_util = salt.utils.master.MasterPillarUtil(tgt, tgt_type,
                                                      use_cached_grains=True,
                                                      grains_fallback=False,
                                                      use_cached_pillar=True,
@@ -59,8 +85,12 @@ def pillar(tgt=None, expr_form='glob', **kwargs):
     return cached_pillar
 
 
-def mine(tgt=None, expr_form='glob', **kwargs):
+def mine(tgt=None, tgt_type='glob', **kwargs):
     '''
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
+
     Return cached mine data of the targeted minions
 
     CLI Example:
@@ -69,7 +99,16 @@ def mine(tgt=None, expr_form='glob', **kwargs):
 
         salt-run cache.mine
     '''
-    pillar_util = salt.utils.master.MasterPillarUtil(tgt, expr_form,
+    if 'expr_form' in kwargs:
+        salt.utils.warn_until(
+            'Fluorine',
+            'The target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = kwargs.pop('expr_form')
+
+    pillar_util = salt.utils.master.MasterPillarUtil(tgt, tgt_type,
                                                      use_cached_grains=False,
                                                      grains_fallback=False,
                                                      use_cached_pillar=False,
@@ -80,7 +119,7 @@ def mine(tgt=None, expr_form='glob', **kwargs):
 
 
 def _clear_cache(tgt=None,
-                 expr_form='glob',
+                 tgt_type='glob',
                  clear_pillar_flag=False,
                  clear_grains_flag=False,
                  clear_mine_flag=False,
@@ -90,7 +129,7 @@ def _clear_cache(tgt=None,
     '''
     if tgt is None:
         return False
-    pillar_util = salt.utils.master.MasterPillarUtil(tgt, expr_form,
+    pillar_util = salt.utils.master.MasterPillarUtil(tgt, tgt_type,
                                                      use_cached_grains=True,
                                                      grains_fallback=False,
                                                      use_cached_pillar=True,
@@ -102,8 +141,12 @@ def _clear_cache(tgt=None,
                                                 clear_mine_func=clear_mine_func_flag)
 
 
-def clear_pillar(tgt=None, expr_form='glob'):
+def clear_pillar(tgt=None, tgt_type='glob', expr_form=None):
     '''
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
+
     Clear the cached pillar data of the targeted minions
 
     CLI Example:
@@ -112,11 +155,26 @@ def clear_pillar(tgt=None, expr_form='glob'):
 
         salt-run cache.clear_pillar
     '''
-    return _clear_cache(tgt, expr_form, clear_pillar_flag=True)
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
+
+    return _clear_cache(tgt, tgt_type, clear_pillar_flag=True)
 
 
-def clear_grains(tgt=None, expr_form='glob'):
+def clear_grains(tgt=None, tgt_type='glob', expr_form=None):
     '''
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
+
     Clear the cached grains data of the targeted minions
 
     CLI Example:
@@ -125,11 +183,26 @@ def clear_grains(tgt=None, expr_form='glob'):
 
         salt-run cache.clear_grains
     '''
-    return _clear_cache(tgt, expr_form, clear_grains_flag=True)
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
+
+    return _clear_cache(tgt, tgt_type, clear_grains_flag=True)
 
 
-def clear_mine(tgt=None, expr_form='glob'):
+def clear_mine(tgt=None, tgt_type='glob', expr_form=None):
     '''
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
+
     Clear the cached mine data of the targeted minions
 
     CLI Example:
@@ -138,11 +211,29 @@ def clear_mine(tgt=None, expr_form='glob'):
 
         salt-run cache.clear_mine
     '''
-    return _clear_cache(tgt, expr_form, clear_mine_flag=True)
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
+
+    return _clear_cache(tgt, tgt_type, clear_mine_flag=True)
 
 
-def clear_mine_func(tgt=None, expr_form='glob', clear_mine_func_flag=None):
+def clear_mine_func(tgt=None,
+                    tgt_type='glob',
+                    clear_mine_func_flag=None,
+                    expr_form=None):
     '''
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
+
     Clear the cached mine function data of the targeted minions
 
     CLI Example:
@@ -151,11 +242,15 @@ def clear_mine_func(tgt=None, expr_form='glob', clear_mine_func_flag=None):
 
         salt-run cache.clear_mine_func tgt='*' clear_mine_func_flag='network.interfaces'
     '''
-    return _clear_cache(tgt, expr_form, clear_mine_func_flag=clear_mine_func_flag)
+    return _clear_cache(tgt, tgt_type, clear_mine_func_flag=clear_mine_func_flag)
 
 
-def clear_all(tgt=None, expr_form='glob'):
+def clear_all(tgt=None, tgt_type='glob', expr_form=None):
     '''
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
+
     Clear the cached pillar, grains, and mine data of the targeted minions
 
     CLI Example:
@@ -164,8 +259,19 @@ def clear_all(tgt=None, expr_form='glob'):
 
         salt-run cache.clear_all
     '''
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
+
     return _clear_cache(tgt,
-                        expr_form,
+                        tgt_type,
                         clear_pillar_flag=True,
                         clear_grains_flag=True,
                         clear_mine_flag=True)

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -315,7 +315,7 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
             saved_kwargs = kw
             kw = client.cmd(
                 host, 'lxc.cloud_init_interface', args + [kw],
-                expr_form='list', timeout=600).get(host, {})
+                tgt_type='list', timeout=600).get(host, {})
             kw.update(saved_kwargs)
         name = kw.pop('name', name)
         # be sure not to seed an already seeded host

--- a/salt/runners/smartos_vmadm.py
+++ b/salt/runners/smartos_vmadm.py
@@ -45,7 +45,7 @@ def _action(action='get', search=None, one=True, force=False):
             vmadm_args['search'] = search
         for cn in client.cmd_iter('G@virtual:physical and G@os:smartos',
                                     'vmadm.list', kwarg=vmadm_args,
-                                    expr_form='compound'):
+                                    tgt_type='compound'):
             if not cn:
                 continue
             node = next(cn.iterkeys())
@@ -150,7 +150,7 @@ def nodes(verbose=False):
     ## get list of nodes
     try:
         for cn in client.cmd_iter('G@virtual:physical and G@os:smartos',
-                                    'grains.items', expr_form='compound'):
+                                    'grains.items', tgt_type='compound'):
             if not cn:
                 continue
             node = next(cn.iterkeys())
@@ -209,7 +209,7 @@ def list_vms(search=None, verbose=False):
             vmadm_args['search'] = search
         for cn in client.cmd_iter('G@virtual:physical and G@os:smartos',
                                     'vmadm.list', kwarg=vmadm_args,
-                                    expr_form='compound'):
+                                    tgt_type='compound'):
             if not cn:
                 continue
             node = next(cn.iterkeys())

--- a/salt/runners/ssh.py
+++ b/salt/runners/ssh.py
@@ -12,22 +12,35 @@ from __future__ import absolute_import
 import salt.client.ssh.client
 
 
-def cmd(
-        tgt,
+def cmd(tgt,
         fun,
         arg=(),
         timeout=None,
-        expr_form='glob',
-        kwarg=None):
+        tgt_type='glob',
+        kwarg=None,
+        expr_form=None):
     '''
+    .. versionadded:: 2015.5.0
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
+
     Execute a single command via the salt-ssh subsystem and return all
     routines at once
-
-    .. versionadded:: 2015.5.0
 
     A wrapper around the :py:meth:`SSHClient.cmd
     <salt.client.ssh.client.SSHClient.cmd>` method.
     '''
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
 
     client = salt.client.ssh.client.SSHClient(mopts=__opts__)
     return client.cmd(
@@ -35,5 +48,5 @@ def cmd(
             fun,
             arg,
             timeout,
-            expr_form,
+            tgt_type,
             kwarg)

--- a/salt/runners/survey.py
+++ b/salt/runners/survey.py
@@ -153,15 +153,15 @@ def _get_pool_results(*args, **kwargs):
     sort = kwargs.pop('survey_sort', 'down')
     direction = sort != 'up'
 
-    expr_form = kwargs.pop('expr_form', 'compound')
-    if expr_form not in ['compound', 'pcre']:
-        expr_form = 'compound'
+    tgt_type = kwargs.pop('tgt_type', 'compound')
+    if tgt_type not in ['compound', 'pcre']:
+        tgt_type = 'compound'
 
     kwargs_passthru = dict((k, kwargs[k]) for k in kwargs.iterkeys() if not k.startswith('_'))
 
     client = salt.client.get_local_client(__opts__['conf_file'])
     try:
-        minions = client.cmd(tgt, cmd, args[2:], timeout=__opts__['timeout'], expr_form=expr_form, kwarg=kwargs_passthru)
+        minions = client.cmd(tgt, cmd, args[2:], timeout=__opts__['timeout'], tgt_type=tgt_type, kwarg=kwargs_passthru)
     except SaltClientError as client_error:
         print(client_error)
         return ret

--- a/salt/runners/virt.py
+++ b/salt/runners/virt.py
@@ -68,7 +68,7 @@ def query(host=None, quiet=False):
     client = salt.client.get_local_client(__opts__['conf_file'])
     try:
         for info in client.cmd_iter('virtual:physical',
-                                    'virt.full_info', expr_form='grain'):
+                                    'virt.full_info', tgt_type='grain'):
             if not info:
                 continue
             if not isinstance(info, dict):
@@ -105,7 +105,7 @@ def list(host=None, quiet=False, hyper=None):  # pylint: disable=redefined-built
     ret = {}
     client = salt.client.get_local_client(__opts__['conf_file'])
     for info in client.cmd_iter('virtual:physical',
-                                'virt.vm_info', expr_form='grain'):
+                                'virt.vm_info', tgt_type='grain'):
         if not info:
             continue
         if not isinstance(info, dict):

--- a/salt/states/modjk_worker.py
+++ b/salt/states/modjk_worker.py
@@ -18,6 +18,7 @@ Mandatory Settings:
 - The modjk load balancer must be configured as stated in the :strong:`modjk`
   execution module :mod:`documentation <salt.modules.modjk>`
 '''
+from __future__ import absolute_import
 import salt.utils
 
 

--- a/salt/states/modjk_worker.py
+++ b/salt/states/modjk_worker.py
@@ -18,6 +18,7 @@ Mandatory Settings:
 - The modjk load balancer must be configured as stated in the :strong:`modjk`
   execution module :mod:`documentation <salt.modules.modjk>`
 '''
+import salt.utils
 
 
 def __virtual__():
@@ -32,7 +33,7 @@ def _send_command(cmd,
                   lbn,
                   target,
                   profile='default',
-                  expr_form='glob'):
+                  tgt_type='glob'):
     '''
     Send a command to the modjk loadbalancer
     The minion need to be able to publish the commands to the load balancer
@@ -52,7 +53,7 @@ def _send_command(cmd,
     # Send the command to target
     func = 'modjk.{0}'.format(cmd)
     args = [worker, lbn, profile]
-    response = __salt__['publish.publish'](target, func, args, expr_form)
+    response = __salt__['publish.publish'](target, func, args, tgt_type)
 
     # Get errors and list of affeced minions
     errors = []
@@ -83,7 +84,7 @@ def _worker_status(target,
                    worker,
                    activation,
                    profile='default',
-                   expr_form='glob'):
+                   tgt_type='glob'):
     '''
     Check if the worker is in `activation` state in the targeted load balancers
 
@@ -102,7 +103,7 @@ def _worker_status(target,
 
     args = [worker, profile]
     status = __salt__['publish.publish'](
-        target, 'modjk.worker_status', args, expr_form
+        target, 'modjk.worker_status', args, tgt_type
     )
 
     # Did we got any respone from someone ?
@@ -120,7 +121,7 @@ def _worker_status(target,
     return ret
 
 
-def _talk2modjk(name, lbn, target, action, profile='default', expr_form='glob'):
+def _talk2modjk(name, lbn, target, action, profile='default', tgt_type='glob'):
     '''
     Wrapper function for the stop/disable/activate functions
     '''
@@ -138,7 +139,7 @@ def _talk2modjk(name, lbn, target, action, profile='default', expr_form='glob'):
 
     # Check what needs to be done
     status = _worker_status(
-        target, name, action_map[action], profile, expr_form
+        target, name, action_map[action], profile, tgt_type
     )
     if not status['result']:
         ret['result'] = False
@@ -164,14 +165,18 @@ def _talk2modjk(name, lbn, target, action, profile='default', expr_form='glob'):
         return ret
 
     # Send the action command to target
-    response = _send_command(action, name, lbn, target, profile, expr_form)
+    response = _send_command(action, name, lbn, target, profile, tgt_type)
     ret['comment'] = response['msg']
     ret['result'] = response['code']
     return ret
 
 
-def stop(name, lbn, target, profile='default', expr_form='glob'):
+def stop(name, lbn, target, profile='default', tgt_type='glob', expr_form=None):
     '''
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
+
     Stop the named worker from the lbn load balancers at the targeted minions
     The worker won't get any traffic from the lbn
 
@@ -184,14 +189,28 @@ def stop(name, lbn, target, profile='default', expr_form='glob'):
             - name: {{ grains['id'] }}
             - lbn: application
             - target: 'roles:balancer'
-            - expr_form: grain
+            - tgt_type: grain
     '''
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
 
-    return _talk2modjk(name, lbn, target, 'worker_stop', profile, expr_form)
+    return _talk2modjk(name, lbn, target, 'worker_stop', profile, tgt_type)
 
 
-def activate(name, lbn, target, profile='default', expr_form='glob'):
+def activate(name, lbn, target, profile='default', tgt_type='glob', expr_form=None):
     '''
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
+
     Activate the named worker from the lbn load balancers at the targeted
     minions
 
@@ -204,18 +223,31 @@ def activate(name, lbn, target, profile='default', expr_form='glob'):
             - name: {{ grains['id'] }}
             - lbn: application
             - target: 'roles:balancer'
-            - expr_form: grain
+            - tgt_type: grain
     '''
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
 
-    return _talk2modjk(name, lbn, target, 'worker_activate', profile, expr_form)
+    return _talk2modjk(name, lbn, target, 'worker_activate', profile, tgt_type)
 
 
-def disable(name, lbn, target, profile='default', expr_form='glob'):
+def disable(name, lbn, target, profile='default', tgt_type='glob', expr_form=None):
     '''
+    .. versionchanged:: Nitrogen
+        The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
+        releases must use ``expr_form``.
+
     Disable the named worker from the lbn load balancers at the targeted
-    minions.
-    The worker will get traffic only for current sessions and won't get new
-    ones.
+    minions. The worker will get traffic only for current sessions and won't
+    get new ones.
 
     Example:
 
@@ -226,7 +258,17 @@ def disable(name, lbn, target, profile='default', expr_form='glob'):
             - name: {{ grains['id'] }}
             - lbn: application
             - target: 'roles:balancer'
-            - expr_form: grain
+            - tgt_type: grain
     '''
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
+        tgt_type = expr_form
 
-    return _talk2modjk(name, lbn, target, 'worker_disable', profile, expr_form)
+    return _talk2modjk(name, lbn, target, 'worker_disable', profile, tgt_type)

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -60,11 +60,10 @@ def _fire_args(tag_data):
         )
 
 
-def state(
-        name,
+def state(name,
         tgt,
         ssh=False,
-        tgt_type=None,
+        tgt_type='glob',
         expr_form=None,
         ret='',
         highstate=None,
@@ -95,8 +94,12 @@ def state(
         Masterless support: When running on a masterless minion, the ``tgt``
         is ignored and will always be the local minion.
 
-    tgt_type | expr_form
-        The target type to resolve, defaults to glob
+    tgt_type
+        The target type to resolve, defaults to ``glob``
+
+    expr_form
+        .. deprecated:: Nitrogen
+            Use tgt_type instead
 
     ret
         Optionally set a single or a list of returners to use
@@ -195,18 +198,18 @@ def state(
         state_ret['comment'] = 'Passed invalid value for \'allow_fail\', must be an int'
         return state_ret
 
-    if expr_form and tgt_type:
-        state_ret.setdefault('warnings', []).append(
-            'Please only use \'tgt_type\' or \'expr_form\' not both. '
-            'Preferring \'tgt_type\' over \'expr_form\''
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
         )
-        expr_form = None
-    elif expr_form and not tgt_type:
         tgt_type = expr_form
-    elif not tgt_type and not expr_form:
-        tgt_type = 'glob'
 
-    cmd_kw['expr_form'] = tgt_type
+    cmd_kw['tgt_type'] = tgt_type
     cmd_kw['ssh'] = ssh
     cmd_kw['expect_minions'] = expect_minions
     if highstate:
@@ -351,7 +354,7 @@ def function(
         name,
         tgt,
         ssh=False,
-        tgt_type=None,
+        tgt_type='glob',
         expr_form=None,
         ret='',
         expect_minions=False,
@@ -370,8 +373,12 @@ def function(
     tgt
         The target specification, aka '*' for all minions
 
-    tgt_type | expr_form
-        The target type, defaults to glob
+    tgt_type
+        The target type, defaults to ``glob``
+
+    expr_form
+        .. deprecated:: Nitrogen
+            Use tgt_type instead
 
     arg
         The list of arguments to pass into the function
@@ -409,21 +416,21 @@ def function(
 
     cmd_kw = {'arg': arg or [], 'kwarg': kwarg, 'ret': ret, 'timeout': timeout}
 
-    if expr_form and tgt_type:
-        func_ret['warnings'] = [
-            'Please only use \'tgt_type\' or \'expr_form\' not both. '
-            'Preferring \'tgt_type\' over \'expr_form\''
-        ]
-        expr_form = None
-    elif expr_form and not tgt_type:
+    # remember to remove the expr_form argument from this function when
+    # performing the cleanup on this deprecation.
+    if expr_form is not None:
+        salt.utils.warn_until(
+            'Fluorine',
+            'the target type should be passed using the \'tgt_type\' '
+            'argument instead of \'expr_form\'. Support for using '
+            '\'expr_form\' will be removed in Salt Fluorine.'
+        )
         tgt_type = expr_form
-    elif not tgt_type and not expr_form:
-        tgt_type = 'glob'
 
     if batch is not None:
         cmd_kw['batch'] = str(batch)
 
-    cmd_kw['expr_form'] = tgt_type
+    cmd_kw['tgt_type'] = tgt_type
     cmd_kw['ssh'] = ssh
     cmd_kw['expect_minions'] = expect_minions
     cmd_kw['_cmd_meta'] = True

--- a/salt/thorium/local.py
+++ b/salt/thorium/local.py
@@ -9,8 +9,7 @@ from __future__ import absolute_import
 import salt.client
 
 
-def cmd(
-        name,
+def cmd(name,
         tgt,
         func,
         arg=(),
@@ -49,14 +48,12 @@ def cmd(
            'comment': '',
            'result': True}
     local = salt.client.get_local_client(mopts=__opts__)
-    jid = local.cmd_async(
-                          tgt,
+    jid = local.cmd_async(tgt,
                           func,
                           arg,
-                          expr_form=tgt_type,
+                          tgt_type=tgt_type,
                           ret=ret,
                           kwarg=kwarg,
-                          **kwargs
-                          )
+                          **kwargs)
     ret['changes']['jid'] = jid
     return ret

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -830,8 +830,7 @@ class ZeroMQPubServerChannel(salt.transport.server.PubServerChannel):
         if self.opts['zmq_filtering'] and load['tgt_type'] in match_targets:
             # Fetch a list of minions that match
             match_ids = self.ckminions.check_minions(load['tgt'],
-                                                     expr_form=load['tgt_type']
-                                                     )
+                                                     tgt_type=load['tgt_type'])
 
             log.debug("Publish Side Match: {0}".format(match_ids))
             # Send list of miions thru so zmq can target them

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -61,18 +61,30 @@ class MasterPillarUtil(object):
 
         # my_runner.py
         tgt = 'web*'
-        pillar_util = salt.utils.master.MasterPillarUtil(tgt, expr_form='glob', opts=__opts__)
+        pillar_util = salt.utils.master.MasterPillarUtil(tgt, tgt_type='glob', opts=__opts__)
         pillar_data = pillar_util.get_minion_pillar()
     '''
     def __init__(self,
                  tgt='',
-                 expr_form='glob',
+                 tgt_type='glob',
                  saltenv=None,
                  use_cached_grains=True,
                  use_cached_pillar=True,
                  grains_fallback=True,
                  pillar_fallback=True,
-                 opts=None):
+                 opts=None,
+                 expr_form=None):
+
+        # remember to remove the expr_form argument from this function when
+        # performing the cleanup on this deprecation.
+        if expr_form is not None:
+            salt.utils.warn_until(
+                'Fluorine',
+                'the target type should be passed using the \'tgt_type\' '
+                'argument instead of \'expr_form\'. Support for using '
+                '\'expr_form\' will be removed in Salt Fluorine.'
+            )
+            tgt_type = expr_form
 
         log.debug('New instance of {0} created.'.format(
             self.__class__.__name__))
@@ -85,7 +97,7 @@ class MasterPillarUtil(object):
             self.opts = opts
         self.serial = salt.payload.Serial(self.opts)
         self.tgt = tgt
-        self.expr_form = expr_form
+        self.tgt_type = tgt_type
         self.saltenv = saltenv
         self.use_cached_grains = use_cached_grains
         self.use_cached_pillar = use_cached_pillar
@@ -93,10 +105,10 @@ class MasterPillarUtil(object):
         self.pillar_fallback = pillar_fallback
         self.cache = salt.cache.Cache(opts)
         log.debug(
-            'Init settings: tgt: \'{0}\', expr_form: \'{1}\', saltenv: \'{2}\', '
+            'Init settings: tgt: \'{0}\', tgt_type: \'{1}\', saltenv: \'{2}\', '
             'use_cached_grains: {3}, use_cached_pillar: {4}, '
             'grains_fallback: {5}, pillar_fallback: {6}'.format(
-                tgt, expr_form, saltenv, use_cached_grains, use_cached_pillar,
+                tgt, tgt_type, saltenv, use_cached_grains, use_cached_pillar,
                 grains_fallback, pillar_fallback
             )
         )
@@ -146,7 +158,7 @@ class MasterPillarUtil(object):
                        ','.join(minion_ids),
                         'grains.items',
                         timeout=self.opts['timeout'],
-                        expr_form='list')
+                        tgt_type='list')
         return ret
 
     def _get_live_minion_pillar(self, minion_id=None, minion_grains=None):
@@ -221,14 +233,14 @@ class MasterPillarUtil(object):
         return ret
 
     def _tgt_to_list(self):
-        # Return a list of minion ids that match the target and expr_form
+        # Return a list of minion ids that match the target and tgt_type
         minion_ids = []
         ckminions = salt.utils.minions.CkMinions(self.opts)
-        minion_ids = ckminions.check_minions(self.tgt, self.expr_form)
+        minion_ids = ckminions.check_minions(self.tgt, self.tgt_type)
         if len(minion_ids) == 0:
-            log.debug('No minions matched for tgt="{0}" and expr_form="{1}"'.format(self.tgt, self.expr_form))
+            log.debug('No minions matched for tgt="{0}" and tgt_type="{1}"'.format(self.tgt, self.tgt_type))
             return {}
-        log.debug('Matching minions for tgt="{0}" and expr_form="{1}": {2}'.format(self.tgt, self.expr_form, minion_ids))
+        log.debug('Matching minions for tgt="{0}" and tgt_type="{1}": {2}'.format(self.tgt, self.tgt_type, minion_ids))
         return minion_ids
 
     def get_minion_pillar(self):
@@ -660,7 +672,7 @@ def ping_all_connected_minions(opts):
     else:
         tgt = '*'
         form = 'glob'
-    client.cmd(tgt, 'test.ping', expr_form=form)
+    client.cmd(tgt, 'test.ping', tgt_type=form)
 
 # test code for the ConCache class
 if __name__ == '__main__':

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -624,7 +624,7 @@ class CkMinions(object):
 
     def check_minions(self,
                       expr,
-                      expr_form='glob',
+                      tgt_type='glob',
                       delimiter=DEFAULT_TARGET_DELIM,
                       greedy=True):
         '''
@@ -634,8 +634,8 @@ class CkMinions(object):
         make sure everyone has checked back in.
         '''
         try:
-            check_func = getattr(self, '_check_{0}_minions'.format(expr_form), None)
-            if expr_form in ('grain',
+            check_func = getattr(self, '_check_{0}_minions'.format(tgt_type), None)
+            if tgt_type in ('grain',
                              'grain_pcre',
                              'pillar',
                              'pillar_pcre',
@@ -648,7 +648,7 @@ class CkMinions(object):
         except Exception:
             log.exception(
                     'Failed matching available minions with {0} pattern: {1}'
-                    .format(expr_form, expr))
+                    .format(tgt_type, expr))
             minions = []
         return minions
 
@@ -672,14 +672,25 @@ class CkMinions(object):
 
         return set(self.check_minions(v_expr, v_matcher))
 
-    def validate_tgt(self, valid, expr, expr_form, minions=None):
+    def validate_tgt(self, valid, expr, tgt_type, minions=None, expr_form=None):
         '''
         Return a Bool. This function returns if the expression sent in is
         within the scope of the valid expression
         '''
+        # remember to remove the expr_form argument from this function when
+        # performing the cleanup on this deprecation.
+        if expr_form is not None:
+            salt.utils.warn_until(
+                'Fluorine',
+                'the target type should be passed using the \'tgt_type\' '
+                'argument instead of \'expr_form\'. Support for using '
+                '\'expr_form\' will be removed in Salt Fluorine.'
+            )
+            tgt_type = expr_form
+
         v_minions = self._expand_matching(valid)
         if minions is None:
-            minions = set(self.check_minions(expr, expr_form))
+            minions = set(self.check_minions(expr, tgt_type))
         else:
             minions = set(minions)
         d_bool = not bool(minions.difference(v_minions))

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1404,7 +1404,7 @@ class TestDaemon(object):
 
     def __client_job_running(self, targets, jid):
         running = self.client.cmd(
-            list(targets), 'saltutil.running', expr_form='list'
+            list(targets), 'saltutil.running', tgt_type='list'
         )
         return [
             k for (k, v) in six.iteritems(running) if v and v[0]['jid'] == jid
@@ -1443,7 +1443,7 @@ class TestDaemon(object):
 
             try:
                 responses = self.client.cmd(
-                    list(expected_connections), 'test.ping', expr_form='list',
+                    list(expected_connections), 'test.ping', tgt_type='list',
                 )
             # we'll get this exception if the master process hasn't finished starting yet
             except SaltClientError:
@@ -1503,7 +1503,7 @@ class TestDaemon(object):
         syncing = set(targets)
         jid_info = self.client.run_job(
             list(targets), 'saltutil.sync_{0}'.format(modules_kind),
-            expr_form='list',
+            tgt_type='list',
             timeout=999999999999999,
         )
 

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -58,20 +58,20 @@ class LocalClientTestCase(TestCase,
             self.client.cmd_subset('*', 'first.func', sub=1, cli=True)
             try:
                 cmd_cli_mock.assert_called_with(['minion2'], 'first.func', (), progress=False,
-                                                kwarg=None, expr_form='list',
+                                                kwarg=None, tgt_type='list',
                                                 ret='')
             except AssertionError:
                 cmd_cli_mock.assert_called_with(['minion1'], 'first.func', (), progress=False,
-                                                kwarg=None, expr_form='list',
+                                                kwarg=None, tgt_type='list',
                                                 ret='')
             self.client.cmd_subset('*', 'first.func', sub=10, cli=True)
             try:
                 cmd_cli_mock.assert_called_with(['minion2', 'minion1'], 'first.func', (), progress=False,
-                                                kwarg=None, expr_form='list',
+                                                kwarg=None, tgt_type='list',
                                                 ret='')
             except AssertionError:
                 cmd_cli_mock.assert_called_with(['minion1', 'minion2'], 'first.func', (), progress=False,
-                                                kwarg=None, expr_form='list',
+                                                kwarg=None, tgt_type='list',
                                                 ret='')
 
     @skipIf(NOT_ZMQ, 'This test only works with ZeroMQ')
@@ -88,7 +88,7 @@ class LocalClientTestCase(TestCase,
                 # Do we raise an exception if the nodegroup can't be matched?
                 self.assertRaises(SaltInvocationError,
                                   self.client.pub,
-                                  'non_existent_group', 'test.ping', expr_form='nodegroup')
+                                  'non_existent_group', 'test.ping', tgt_type='nodegroup')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The published commands and the events all use tgt_type, expr_form is
only used in the LocalClient, which has been confusing to many users.
This puts expr_form on a deprecation path, allowing it to continue to be
supported while tgt_type becomes the new official argument name.