### PR TITLE
[Nitrogen Deprecation] Remove SaltAPI.run() function

### DIFF
--- a/salt/cli/api.py
+++ b/salt/cli/api.py
@@ -56,16 +56,6 @@ class SaltAPI(parsers.SaltAPIParser):
         self.daemonize_if_required()
         self.set_pidfile()
 
-    def run(self):
-        import salt.utils
-        salt.utils.warn_until(
-            'Nitrogen',
-            'Please stop calling \'SaltAPI.run()\' and instead call '
-            '\'SaltAPI.start()\'. \'SaltAPI.run()\' will be supported '
-            'until Salt {version}.'
-        )
-        self.start()
-
     def start(self):
         '''
         Start the actual master.

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -215,7 +215,7 @@ SCRIPT_TEMPLATES = {
         'import salt.cli\n',
         'def main():\n',
         '    sapi = salt.cli.SaltAPI()',
-        '    sapi.run()\n',
+        '    sapi.start()\n',
         'if __name__ == \'__main__\':',
         '    main()'
     ],


### PR DESCRIPTION
Also remove reference to SaltAPI.run() call and move to SaltAPI.start() call instead in `integration/__init__.py`