### PR TITLE
[Nitrogen Deprecation] Beacons config should be a list not a dict now

### DIFF
--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -13,6 +13,7 @@ import salt.loader
 import salt.utils
 import salt.utils.minion
 from salt.ext.six.moves import map
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -30,12 +31,14 @@ class Beacon(object):
     def process(self, config, grains):
         '''
         Process the configured beacons
+
         The config must be a list and looks like this in yaml
-        code_block:: yaml
+
+        .. code_block:: yaml
             beacons:
-                inotify:
-                    - /etc/fstab: {}
-                    - /var/cache/foo: {}
+              inotify:
+                - /etc/fstab: {}
+                - /var/cache/foo: {}
         '''
         ret = []
         b_config = copy.deepcopy(config)
@@ -51,11 +54,9 @@ class Beacon(object):
                 current_beacon_config = {}
                 list(map(current_beacon_config.update, config[mod]))
             elif isinstance(config[mod], dict):
-                salt.utils.warn_until(
-                    'Nitrogen',
+                raise CommandExecutionError(
                     'Beacon configuration should be a list instead of a dictionary.'
                 )
-                current_beacon_config = config[mod]
 
             if 'enabled' in current_beacon_config:
                 if not current_beacon_config['enabled']:


### PR DESCRIPTION
Change the deprecation warning to raising an error when a dict is used