### PR TITLE
[Nitrogen Deprecation] Remove warning/support for wipe_ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -701,13 +701,6 @@ class Single(object):
         if kwargs.get('wipe'):
             self.wipe = 'False'
         else:
-            if self.opts.get('wipe_ssh'):
-                salt.utils.warn_until(
-                    'Nitrogen',
-                    'Support for \'wipe_ssh\' has been deprecated in Saltfile and will be removed '
-                    'in Salt Nitrogen. Please use \'ssh_wipe\' instead.'
-                )
-                self.wipe = 'True'
             self.wipe = 'True' if self.opts.get('ssh_wipe') else 'False'
         if kwargs.get('thin_dir'):
             self.thin_dir = kwargs['thin_dir']


### PR DESCRIPTION
This should be ``ssh_wipe`` instead.

See PR #30634 for more information.