### PR TITLE
Revert addition of pillar_roots_override_ext_pillar

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2459,24 +2459,6 @@ Default: ``[]``
 
 There are additional details at :ref:`salt-pillars`
 
-.. conf_master:: pillar_roots_override_ext_pillar
-
-``pillar_roots_override_ext_pillar``
-------------------------------------
-
-.. versionadded:: 2016.11.0
-
-Default: ``False``
-
-This option allows for external pillar sources to be evaluated before
-:conf_master:`pillar_roots`, which means that values obtained from
-:conf_master:`pillar_roots` take precedence over those found from
-:conf_master:`ext_pillar` sources.
-
-.. code-block:: yaml
-
-    pillar_roots_override_ext_pillar: False
-
 .. conf_master:: ext_pillar_first
 
 ``ext_pillar_first``
@@ -2488,8 +2470,7 @@ Default: ``False``
 
 This option allows for external pillar sources to be evaluated before
 :conf_master:`pillar_roots`. This allows for targeting file system pillar from
-ext_pillar. Note that ext_pillar_first option is deprecated by
-pillar_roots_override_ext_pillar option and will be removed in future releases.
+ext_pillar.
 
 .. code-block:: yaml
 

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -780,27 +780,16 @@ class Pillar(object):
         '''
         top, top_errors = self.get_top()
         if ext:
-            if self.opts.get('pillar_roots_override_ext_pillar', False) or self.opts.get('ext_pillar_first', False):
-                salt.utils.warn_until('Nitrogen',
-                     'The \'ext_pillar_first\' option has been deprecated and '
-                     'replaced by \'pillar_roots_override_ext_pillar\'.'
-                )
+            if self.opts.get('ext_pillar_first', False):
                 self.opts['pillar'], errors = self.ext_pillar({}, pillar_dirs)
                 self.rend = salt.loader.render(self.opts, self.functions)
                 matches = self.top_matches(top)
                 pillar, errors = self.render_pillar(matches, errors=errors)
-                if self.opts.get('pillar_roots_override_ext_pillar', False):
-                    pillar = merge(self.opts['pillar'],
-                                   pillar,
-                                   self.merge_strategy,
-                                   self.opts.get('renderer', 'yaml'),
-                                   self.opts.get('pillar_merge_lists', False))
-                else:
-                    pillar = merge(pillar,
-                                   self.opts['pillar'],
-                                   self.merge_strategy,
-                                   self.opts.get('renderer', 'yaml'),
-                                   self.opts.get('pillar_merge_lists', False))
+                pillar = merge(self.opts['pillar'],
+                               pillar,
+                               self.merge_strategy,
+                               self.opts.get('renderer', 'yaml'),
+                               self.opts.get('pillar_merge_lists', False))
             else:
                 matches = self.top_matches(top)
                 pillar, errors = self.render_pillar(matches)


### PR DESCRIPTION
This turned out to be an unnecessary addition, as the root cause was ``ext_pillar_first`` not behaving as documented.

It was initially added back in February in PR #31316, on recommendation from our development team. However, when I encountered the same issue several weeks ago I discussed it with @cachedout and @thatch45 and we came to the consensus that making the merge order respect the documented behavior was the correct fix. The relevant discussion for this can be found in the comments for #36807.

Since @kraney's initial fix in #31316 and the fix I made in #36807 are identical, the extra config option and planned deprecation of ``ext_pillar_first`` are now redundant. Therefore, this pull request removes ``pillar_roots_override_ext_pillar``.