### PR TITLE
consul_pillar support for limiting pillar exposure via minion targeting

### DIFF
--- a/doc/topics/releases/2016.11.0.rst
+++ b/doc/topics/releases/2016.11.0.rst
@@ -268,6 +268,32 @@ Pillar Changes
   location on the Master so that they are available in execution modules called
   from Pillar SLS files.
 
+Network Automation: NAPALM
+==========================
+
+Beginning with 2016.11.0, network automation is inclued by default in the core
+of Salt. It is based on a the `NAPALM <https://github.com/napalm-automation/napalm>`_
+library and provides facilities to manage the configuration and retrieve data
+from network devices running widely used operating systems such: JunOS, IOS-XR,
+eOS, IOS, NX-OS etc.
+- see `the complete list of supported devices <http://napalm.readthedocs.io/en/latest/support/index.html#supported-devices>`_.
+
+The connection is established via the :mod:`NAPALM proxy <salt.proxy.napalm>`.
+
+In the current release, the following modules were included:
+
+- :mod:`NAPALM grains <salt.grains.napalm>` - Select network devices based on their characteristics
+- :mod:`NET execution module <salt.modules.napalm_network>` - Networking basic features
+- :mod:`NTP execution module <salt.modules.napalm_ntp>`
+- :mod:`BGP execution module <salt.modules.napalm_bgp>`
+- :mod:`Routes execution module <salt.modules.napalm_route>`
+- :mod:`SNMP execution module <salt.modules.napalm_snmp>`
+- :mod:`Users execution module <salt.modules.napalm_users>`
+- :mod:`Probes execution module <salt.modules.napalm_probes>`
+- :mod:`NTP peers management state <salt.states.netntp>`
+- :mod:`SNMP configuration management state <salt.states.netsnmp>`
+- :mod:`Users management state <salt.states.netusers>`
+
 Junos Module Changes
 ===================
 

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -115,7 +115,7 @@ def __virtual__():
     '''
     Only load this module if the psql and initdb bin exist
     '''
-    utils = ['psql']
+    utils = ['psql', 'initdb']
     if not HAS_CSV:
         return False
     for util in utils:

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -136,9 +136,11 @@ def _find_pg_binary(util):
     if not pg_bin_dir:  # Fallback to incorrectly-documented setting
         pg_bin_dir = __salt__['config.option']('postgres.bins_dir')
         if pg_bin_dir:
-            log.warning(
-                'Using postgres.bins_dir is not supported. '
-                'Replace this with postgres.pg_bin')
+            salt.utils.warn_until(
+                'Oxygen',
+                'Using \'postgres.bins_dir\' is not officially supported and '
+                'only exists as a workaround. Please replace this in your '
+                'configuration with \'postgres.pg_bin\'.')
 
     util_bin = salt.utils.which(util)
     if not util_bin:

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -26,6 +26,9 @@ Module to provide Postgres compatibility to salt.
     of the postgres bin's path to the relevant minion for this module::
 
         postgres.pg_bin: '/usr/pgsql-9.5/bin/'
+
+:note: Older versions of Salt had a bug where postgres.bins_dir was used
+    instead of postgres.pg_bin. You should upgrade this as soon as possible.
 '''
 
 # This pylint error is popping up where there are no colons?
@@ -112,7 +115,7 @@ def __virtual__():
     '''
     Only load this module if the psql and initdb bin exist
     '''
-    utils = ['psql', 'initdb']
+    utils = ['psql']
     if not HAS_CSV:
         return False
     for util in utils:
@@ -128,7 +131,15 @@ def _find_pg_binary(util):
 
     Helper function to locate various psql related binaries
     '''
-    pg_bin_dir = __salt__['config.option']('postgres.bins_dir')
+    pg_bin_dir = __salt__['config.option']('postgres.pg_bin')
+
+    if not pg_bin_dir:  # Fallback to incorrectly-documented setting
+        pg_bin_dir = __salt__['config.option']('postgres.bins_dir')
+        if pg_bin_dir:
+            log.warning(
+                'Using postgres.bins_dir is not supported. '
+                'Replace this with postgres.pg_bin')
+
     util_bin = salt.utils.which(util)
     if not util_bin:
         if pg_bin_dir:

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -502,6 +502,7 @@ def extracted(name,
     overwrite
         If archive was already extracted, then setting this to True will
         extract it all over again.
+        **WARNING: This operation will flush clean all the previous content, if exists!**
 
     **Examples**
 

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -909,7 +909,13 @@ def extracted(name,
     if extraction_needed:
         destination = os.path.join(name, contents['top_level_dirs'][0])
         if os.path.exists(destination):
-            shutil.rmtree(destination)
+            try:
+                shutil.rmtree(destination)
+            except OSError as err:
+                ret['comment'] = 'Error removing destination directory ' \
+                                 '"{0}": {1}'.format(destination, err)
+                ret['result'] = False
+                return ret
 
     try:
         if_missing_path_exists = os.path.exists(if_missing)

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import stat
 import tarfile
 from contextlib import closing
@@ -140,6 +141,7 @@ def extracted(name,
               enforce_toplevel=True,
               enforce_ownership_on=None,
               archive_format=None,
+              overwrite=False,
               **kwargs):
     '''
     .. versionadded:: 2014.1.0
@@ -496,6 +498,10 @@ def extracted(name,
     .. _tarfile: https://docs.python.org/2/library/tarfile.html
     .. _zipfile: https://docs.python.org/2/library/zipfile.html
     .. _xz-utils: http://tukaani.org/xz/
+
+    overwrite
+        If archive was already extracted, then setting this to True will
+        extract it all over again.
 
     **Examples**
 
@@ -897,7 +903,14 @@ def extracted(name,
     # already need to catch an OSError to cover edge cases where the minion is
     # running as a non-privileged user and is trying to check for the existence
     # of a path to which it does not have permission.
-    extraction_needed = False
+
+    extraction_needed = overwrite
+
+    if extraction_needed:
+        destination = os.path.join(name, contents['top_level_dirs'][0])
+        if os.path.exists(destination):
+            shutil.rmtree(destination)
+
     try:
         if_missing_path_exists = os.path.exists(if_missing)
     except TypeError:

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -545,10 +545,9 @@ def extracted(name,
         ret['comment'] = '{0} is not an absolute path'.format(name)
         return ret
     else:
-        if name is None:
-            # Only way this happens is if some doofus specifies "- name: None"
-            # in their SLS file. Prevent tracebacks by failing gracefully.
-            ret['comment'] = 'None is not a valid directory path'
+        if not name:
+            # Empty name, like None, '' etc.
+            ret['comment'] = 'Name of the directory path needs to be specified'
             return ret
         # os.path.isfile() returns False when there is a trailing slash, hence
         # our need for first stripping the slash and then adding it back later.

--- a/salt/utils/sanitizers.py
+++ b/salt/utils/sanitizers.py
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Import Python libs
+from __future__ import absolute_import
 import re
 import os.path
+
+# Import Salt libs
 from salt.ext.six import text_type as text
-
-
 from salt.exceptions import CommandExecutionError
 
 


### PR DESCRIPTION
### What does this PR do?
Adds the possibility to limit pillar exposure on the master via minion targeting. Should maintain full backwards compatibility.

### Previous Behavior
All minions always received all of the data available in consul.

### New Behavior
Optional minion targeting to limit the exposure of consul data.

### Tests written?
No