### PR TITLE
consul_pillar support for limiting pillar exposure via minion targeting

### DIFF
--- a/salt/pillar/consul_pillar.py
+++ b/salt/pillar/consul_pillar.py
@@ -164,7 +164,7 @@ def ext_pillar(minion_id,
     match = target_re.search(temp)
     if match:
     	opts['target'] = match.group(1)
-    	temp = temp.strip(match.group(0))
+    	temp = temp.replace(match.group(0), '')
         checker = salt.utils.minions.CkMinions(__opts__)
         minions = checker.check_minions(opts['target'], 'compound')
         if minion_id not in minions:
@@ -174,7 +174,7 @@ def ext_pillar(minion_id,
     match = root_re.search(temp)
     if match:
     	opts['root'] = match.group(1)
-    	temp = temp.strip(match.group(0))
+    	temp = temp.replace(match.group(0), '')
     else:
     	opts['root'] = ""
 
@@ -182,7 +182,7 @@ def ext_pillar(minion_id,
     match = profile_re.search(temp)
     if match:
     	opts['profile'] = match.group(1)
-    	temp = temp.strip(match.group(0))
+    	temp = temp.replace(match.group(0), '')
     else:
     	opts['profile'] = None
 		

--- a/salt/pillar/consul_pillar.py
+++ b/salt/pillar/consul_pillar.py
@@ -109,6 +109,16 @@ If using the ``role`` or ``environment`` grain in the consul key path, be sure t
     role: my-minion-role
     environment: dev
 
+It's possible to lock down where the pillar values are shared through minion
+targeting. Note that double quotes ``"`` are required around the target value
+and cannot be used inside the matching statement. See the section on Compound
+Matchers for more examples.
+
+.. code-block:: yaml
+
+    ext_pillar:
+      - consul: my_consul_config root=salt target="L@salt.example.com and G@osarch:x86_64"
+
 '''
 from __future__ import absolute_import
 
@@ -116,6 +126,7 @@ from __future__ import absolute_import
 import logging
 import re
 import yaml
+import salt.utils.minions
 
 from salt.exceptions import CommandExecutionError
 from salt.utils.dictupdate import update as dict_merge
@@ -147,30 +158,49 @@ def ext_pillar(minion_id,
     '''
     Check consul for all data
     '''
-    comps = conf.split()
+    opts = {}
+    temp = conf
+    target_re = re.compile('target="(.*?)"')
+    match = target_re.search(temp)
+    if match:
+    	opts['target'] = match.group(1)
+    	temp = temp.strip(match.group(0))
+        checker = salt.utils.minions.CkMinions(__opts__)
+        minions = checker.check_minions(opts['target'], 'compound')
+        if minion_id not in minions:
+		return {}
 
-    profile = None
-    if comps[0]:
-        profile = comps[0]
-    client = get_conn(__opts__, profile)
+    root_re = re.compile('root=(\S*)')
+    match = root_re.search(temp)
+    if match:
+    	opts['root'] = match.group(1)
+    	temp = temp.strip(match.group(0))
+    else:
+    	opts['root'] = ""
 
-    path = ''
-    if len(comps) > 1 and comps[1].startswith('root='):
-        path = comps[1].replace('root=', '')
+    profile_re = re.compile('(?:profile=)?(\S+)')
+    match = profile_re.search(temp)
+    if match:
+    	opts['profile'] = match.group(1)
+    	temp = temp.strip(match.group(0))
+    else:
+    	opts['profile'] = None
+		
+    client = get_conn(__opts__, opts['profile'])
 
     role = __salt__['grains.get']('role')
     environment = __salt__['grains.get']('environment')
     # put the minion's ID in the path if necessary
-    path %= {
+    opts['root'] %= {
         'minion_id': minion_id,
         'role': role,
         'environment': environment
     }
 
     try:
-        pillar = fetch_tree(client, path)
+        pillar = fetch_tree(client, opts['root'])
     except KeyError:
-        log.error('No such key in consul profile %s: %s', profile, path)
+        log.error('No such key in consul profile %s: %s', opts['profile'], opts['root'])
         pillar = {}
 
     return pillar

--- a/salt/pillar/consul_pillar.py
+++ b/salt/pillar/consul_pillar.py
@@ -170,7 +170,7 @@ def ext_pillar(minion_id,
         if minion_id not in minions:
             return {}
 
-    root_re = re.compile('root=(\S*)')
+    root_re = re.compile('root=(\S*)')  # pylint: disable=W1401
     match = root_re.search(temp)
     if match:
         opts['root'] = match.group(1)
@@ -178,7 +178,7 @@ def ext_pillar(minion_id,
     else:
         opts['root'] = ""
 
-    profile_re = re.compile('(?:profile=)?(\S+)')
+    profile_re = re.compile('(?:profile=)?(\S+)')  # pylint: disable=W1401
     match = profile_re.search(temp)
     if match:
         opts['profile'] = match.group(1)

--- a/salt/pillar/consul_pillar.py
+++ b/salt/pillar/consul_pillar.py
@@ -163,29 +163,29 @@ def ext_pillar(minion_id,
     target_re = re.compile('target="(.*?)"')
     match = target_re.search(temp)
     if match:
-    	opts['target'] = match.group(1)
-    	temp = temp.replace(match.group(0), '')
+        opts['target'] = match.group(1)
+        temp = temp.replace(match.group(0), '')
         checker = salt.utils.minions.CkMinions(__opts__)
         minions = checker.check_minions(opts['target'], 'compound')
         if minion_id not in minions:
-		return {}
+            return {}
 
     root_re = re.compile('root=(\S*)')
     match = root_re.search(temp)
     if match:
-    	opts['root'] = match.group(1)
-    	temp = temp.replace(match.group(0), '')
+        opts['root'] = match.group(1)
+        temp = temp.replace(match.group(0), '')
     else:
-    	opts['root'] = ""
+        opts['root'] = ""
 
     profile_re = re.compile('(?:profile=)?(\S+)')
     match = profile_re.search(temp)
     if match:
-    	opts['profile'] = match.group(1)
-    	temp = temp.replace(match.group(0), '')
+        opts['profile'] = match.group(1)
+        temp = temp.replace(match.group(0), '')
     else:
-    	opts['profile'] = None
-		
+        opts['profile'] = None
+
     client = get_conn(__opts__, opts['profile'])
 
     role = __salt__['grains.get']('role')


### PR DESCRIPTION
### What does this PR do?
Adds the possibility to limit pillar exposure on the master via minion targeting. Should maintain full backwards compatibility.

### Previous Behavior
All minions always received all of the data available in consul.

### New Behavior
Optional minion targeting to limit the exposure of consul data.

### Tests written?
No

New attempt at pull request after aborting #37985