### PR TITLE
Add init delay

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -417,7 +417,7 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
     return ret
 
 
-def dead(name, enable=None, sig=None, **kwargs):
+def dead(name, enable=None, sig=None, init_delay=None, **kwargs):
     '''
     Ensure that the named service is dead by stopping the service if it is running
 
@@ -431,6 +431,10 @@ def dead(name, enable=None, sig=None, **kwargs):
 
     sig
         The string to search for when looking for the service process with ps
+
+    init_delay
+        Add a sleep command (in seconds) before the check to make sure service
+        is killed.
     '''
     ret = {'name': name,
            'changes': {},
@@ -489,6 +493,9 @@ def dead(name, enable=None, sig=None, **kwargs):
         elif enable is False:
             ret.update(_disable(name, True, result=False, **kwargs))
         return ret
+
+    if init_delay:
+        time.sleep(init_delay)
 
     # only force a change state if we have explicitly detected them
     after_toggle_status = __salt__['service.status'](name)

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -435,6 +435,7 @@ def dead(name, enable=None, sig=None, init_delay=None, **kwargs):
     init_delay
         Add a sleep command (in seconds) before the check to make sure service
         is killed.
+        .. versionadded:: Nitrogen
     '''
     ret = {'name': name,
            'changes': {},

--- a/tests/integration/states/service.py
+++ b/tests/integration/states/service.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Tests for the archive state
+Tests for the service state
 '''
 # Import python libs
 from __future__ import absolute_import

--- a/tests/integration/states/service.py
+++ b/tests/integration/states/service.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for the archive state
+'''
+# Import python libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+from salttesting import skipIf
+from salttesting.helpers import (
+    ensure_in_syspath,
+    destructiveTest
+)
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+import salt.utils
+
+INIT_DELAY = 5
+SERVICE_NAME = 'crond'
+
+@destructiveTest
+@skipIf(salt.utils.which('crond') is None, 'crond not installed')
+class ServiceTest(integration.ModuleCase,
+                  integration.SaltReturnAssertsMixIn):
+    '''
+    Validate the service state
+    '''
+    def check_service_status(self, exp_return):
+        '''
+        helper method to check status of service
+        '''
+        check_status = self.run_function('service.status', name=SERVICE_NAME)
+        if check_status is not exp_return:
+            self.assertFalse('status of service is not returning correctly')
+
+    def test_service_dead(self):
+        '''
+        test service.dead state module
+        '''
+        start_service = self.run_state('service.running', name=SERVICE_NAME)
+        self.assertSaltTrueReturn(start_service)
+        self.check_service_status(True)
+
+        ret = self.run_state('service.dead', name=SERVICE_NAME)
+        self.assertSaltTrueReturn(ret)
+        self.check_service_status(False)
+
+    def test_service_dead_init_delay(self):
+        '''
+        test service.dead state module with init_delay arg
+        '''
+        start_service = self.run_state('service.running', name=SERVICE_NAME)
+        self.assertSaltTrueReturn(start_service)
+        self.check_service_status(True)
+
+        ret = self.run_state('service.dead', name=SERVICE_NAME,
+                             init_delay=INIT_DELAY)
+        self.assertSaltTrueReturn(ret)
+        self.check_service_status(False)
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(ServiceTest)

--- a/tests/integration/states/service.py
+++ b/tests/integration/states/service.py
@@ -20,6 +20,7 @@ import salt.utils
 INIT_DELAY = 5
 SERVICE_NAME = 'crond'
 
+
 @destructiveTest
 @skipIf(salt.utils.which('crond') is None, 'crond not installed')
 class ServiceTest(integration.ModuleCase,


### PR DESCRIPTION
### What does this PR do?
add `init_delay` argument to `service.dead`. Sometimes a service is still shutting down before the check happens, so it returns false if it sees the service is still up. 

### Tests written?

Yes

### Previous Behavior
The state module would return False for the return value. It would still shut down the service and work correctly but the check to make sure the service was shutdown was run before it was shutdown entirely.

### New Behavior
Now one can add an `init_delay` option to sleep for a designated time before that check occurs. 
