### PR TITLE
Fix regression in user/group mgmt for archive.extracted

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -600,7 +600,7 @@ def extracted(name,
 
         if user:
             uid = __salt__['file.user_to_uid'](user)
-            if not uid:
+            if uid == '':
                 ret['comment'] = 'User {0} does not exist'.format(user)
                 return ret
         else:
@@ -608,7 +608,7 @@ def extracted(name,
 
         if group:
             gid = __salt__['file.group_to_gid'](group)
-            if not gid:
+            if gid == '':
                 ret['comment'] = 'Group {0} does not exist'.format(group)
                 return ret
         else:

--- a/tests/integration/states/archive.py
+++ b/tests/integration/states/archive.py
@@ -119,6 +119,24 @@ class ArchiveTest(integration.ModuleCase,
 
         self._check_ext_remove(ARCHIVE_DIR, UNTAR_FILE)
 
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def test_archive_extracted_with_root_user_and_group(self):
+        '''
+        test archive.extracted without skip_verify
+        only external resources work to check to
+        ensure source_hash is verified correctly
+        '''
+        ret = self.run_state('archive.extracted', name=ARCHIVE_DIR,
+                             source=ARCHIVE_TAR_SOURCE, archive_format='tar',
+                             source_hash=ARCHIVE_TAR_HASH,
+                             user='root', group='root')
+        if 'Timeout' in ret:
+            self.skipTest('Timeout talking to local tornado server.')
+
+        self.assertSaltTrueReturn(ret)
+
+        self._check_ext_remove(ARCHIVE_DIR, UNTAR_FILE)
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
I was using a simple boolean check on uid/gid. This breaks setting the
user/group to root as its uid/gid is 0.

We should probably make user_to_uid/group_to_gid raise an exception when the
user does not exist, but this is something that should be done in develop for a
future release. For now, this PR just checks for an empty string instead of
doing a simple boolean check.

Resolves #37969.