### PR TITLE
Fix several minor linting issues with aptpkg in develop

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1574,7 +1574,7 @@ def _consolidate_repo_sources(sources):
     for file_ in delete_files:
         try:
             os.remove(file_)
-        except Exception:
+        except OSError:
             pass
     return sources
 
@@ -2242,11 +2242,7 @@ def mod_repo(repo, saltenv='base', **kwargs):
         kwargs['architectures'] = kwargs['architectures'].split(',')
 
     if 'disabled' in kwargs:
-        kw_disabled = kwargs['disabled']
-        if kw_disabled is True or str(kw_disabled).lower() == 'true':
-            kwargs['disabled'] = True
-        else:
-            kwargs['disabled'] = False
+        kwargs['disabled'] = salt.utils.is_true(kwargs['disabled'])
 
     kw_type = kwargs.get('type')
     kw_dist = kwargs.get('dist')
@@ -2256,11 +2252,10 @@ def mod_repo(repo, saltenv='base', **kwargs):
         # and the resulting source line.  The idea here is to ensure
         # we are not retuning bogus data because the source line
         # has already been modified on a previous run.
-        if ((source.type == repo_type and source.uri == repo_uri
-             and source.dist == repo_dist) or
-            (source.dist == kw_dist and source.type == kw_type
-             and source.type == kw_type)):
+        repo_matches = source.type == repo_type and source.uri == repo_uri and source.dist == repo_dist
+        kw_matches = source.dist == kw_dist and source.type == kw_type
 
+        if repo_matches or kw_matches:
             for comp in full_comp_list:
                 if comp in getattr(source, 'comps', []):
                     mod_source = source

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2250,7 +2250,7 @@ def mod_repo(repo, saltenv='base', **kwargs):
     for source in repos:
         # This series of checks will identify the starting source line
         # and the resulting source line.  The idea here is to ensure
-        # we are not retuning bogus data because the source line
+        # we are not returning bogus data because the source line
         # has already been modified on a previous run.
         repo_matches = source.type == repo_type and source.uri == repo_uri and source.dist == repo_dist
         kw_matches = source.dist == kw_dist and source.type == kw_type


### PR DESCRIPTION
### What does this PR do?

Fixed the low-hanging fruit among the many remaining linting issues with aptpkg in develop:
- Replace broad `Exception` with `OSError` in try/except block surrounding `os.remove(file_)`.
- Simplified the checking/assignment of boolean to `kwargs['disabled']`.
- Simplified checking of whether the settings derived from the `repo` argument or the settings provided via `kwargs` match the repo source settings.

### What issues does this PR fix or reference?

- None

### Tests written?

No
