### PR TITLE
Fix 'changes' for pip.installed from requirements

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -718,9 +718,19 @@ def installed(name,
         if requirements or editable:
             comments = []
             if requirements:
+                PIP_REQUIREMENTS_NOCHANGE = [
+                    'Requirement already satisfied',
+                    'Collecting',
+                    'Cloning',
+                    'Cleaning up...',
+                ]
                 for line in pip_install_call.get('stdout', '').split('\n'):
-                    if not line.startswith('Requirement already satisfied') \
-                            and line != 'Cleaning up...':
+                    if not any(
+                        [
+                            line.strip().startswith(x)
+                            for x in PIP_REQUIREMENTS_NOCHANGE
+                        ]
+                    ):
                         ret['changes']['requirements'] = True
                 if ret['changes'].get('requirements'):
                     comments.append('Successfully processed requirements file '


### PR DESCRIPTION
### What does this PR do?
Fixes changed output for pip.installed with requirements.txt
 
### What issues does this PR fix or reference?
Matching for unchanged packages from pip -r requirements.txt

### Previous Behavior
Installing packages using requirements.txt always report changes

### New Behavior
Installing packages using requirements.txt will not always report changes, if there were no changes


### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

- add more lines for matching no change from pip