### PR TITLE
Do not assume only one top level directory to be removed.

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -123,7 +123,7 @@ def _cleanup_destdir(name):
 
 def _remove_destination(names, root=None, ret=None, fail=False):
     '''
-    Remove the specified directory.
+    Remove the specified directory or file.
 
     :param names: List of destinations (directories or files)
     :param root: General root for all desinations

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -125,6 +125,7 @@ def _remove_destination(names, root=None, ret=None, fail=False):
 
     for name in names:
         name = root and os.path.join(root, name) or name
+        log.debug('Attempt to remove path: {}'.format(name))
         if os.path.exists(name):
             if os.path.isdir(name):
                 remove, obj_name = shutil.rmtree, 'directory'
@@ -133,15 +134,18 @@ def _remove_destination(names, root=None, ret=None, fail=False):
 
             try:
                 remove(name)
+                log.debug("Path '{}' has been removed".format(name))
             except OSError as err:
+                error_msg = 'Error removing destination {obj} "{name}": {error}'.format(
+                    obj=obj_name, name=name, error=err)
+                log.error(error_msg)
+
                 if ret:
-                    ret['comment'] = 'Error removing destination ' \
-                                     '{obj} "{name}": {error}'.format(
-                        obj=obj_name, name=name, error=err)
+                    ret['comment'] = error_msg
                     ret['result'] = False
+
                 if fail:
                     return False
-
     return True
 
 

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -941,29 +941,12 @@ def extracted(name,
 
     extraction_needed = overwrite
 
-    if extraction_needed and (contents.get('top_level_dirs', []) or contents.get('top_level_files', [])):
-        # Remove directories, if any
-        for top_level_dir in contents.get('top_level_dirs', []):
-            top_level_dir = os.path.join(name, top_level_dir)
-            if os.path.exists(top_level_dir):
-                try:
-                    shutil.rmtree(top_level_dir)
-                except OSError as err:
-                    ret['comment'] = 'Error removing destination directory ' \
-                                     '"{0}": {1}'.format(top_level_dir, err)
-                    ret['result'] = False
-                    return ret
-        # Remove top level files, if any
-        for top_level_file in contents.get('top_level_files'[]):
-            top_level_file = os.path.join(name, top_level_file)
-            if os.path.exists(top_level_file):
-                try:
-                    os.unlink(top_level_file)
-                except OSError as err:
-                    ret['comment'] = 'Error removing destination file ' \
-                                     '"{0}": {1}'.format(top_level_file, err)
-                    ret['result'] = False
-                    return ret
+    if (extraction_needed
+        and (contents.get('top_level_dirs', []) or contents.get('top_level_files', []))
+        and not _remove_destination(contents.get('top_level_dirs', []) +
+                                    contents.get('top_level_files', []),
+                                    root=name, ret=ret, fail=True)):
+            return ret
 
     try:
         if_missing_path_exists = os.path.exists(if_missing)

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -121,6 +121,40 @@ def _cleanup_destdir(name):
         pass
 
 
+def _remove_destination(names, root=None, ret=None, fail=False):
+    '''
+    Remove the specified directory.
+
+    :param names: List of destinations (directories or files)
+    :param root: General root for all desinations
+    :param ret: Passed return hash.
+    :param fail: Exit early on first fail, otherwise be quiet
+
+    :return:
+    '''
+
+    for name in names:
+        name = root and os.path.join(root, name) or name
+        if os.path.exists(name):
+            if os.path.isdir(name):
+                remove, obj_name = shutil.rmtree, 'directory'
+            else:
+                remove, obj_name = os.unlink, 'file'
+
+            try:
+                remove(name)
+            except OSError as err:
+                if ret:
+                    ret['comment'] = 'Error removing destination ' \
+                                     '{obj} "{name}": {error}'.format(
+                        obj=obj_name, name=name, error=err)
+                    ret['result'] = False
+                if fail:
+                    return False
+
+    return True
+
+
 def extracted(name,
               source,
               source_hash=None,

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -907,15 +907,27 @@ def extracted(name,
 
     extraction_needed = overwrite
 
-    if extraction_needed and contents['top_level_dirs']:
-        for top_level_dir in contents['top_level_dirs']:
-            destination = os.path.join(name, top_level_dir)
-            if os.path.exists(destination):
+    if extraction_needed and (contents.get('top_level_dirs', []) or contents.get('top_level_files', [])):
+        # Remove directories, if any
+        for top_level_dir in contents.get('top_level_dirs', []):
+            top_level_dir = os.path.join(name, top_level_dir)
+            if os.path.exists(top_level_dir):
                 try:
-                    shutil.rmtree(destination)
+                    shutil.rmtree(top_level_dir)
                 except OSError as err:
                     ret['comment'] = 'Error removing destination directory ' \
-                                     '"{0}": {1}'.format(destination, err)
+                                     '"{0}": {1}'.format(top_level_dir, err)
+                    ret['result'] = False
+                    return ret
+        # Remove top level files, if any
+        for top_level_file in contents.get('top_level_files'[]):
+            top_level_file = os.path.join(name, top_level_file)
+            if os.path.exists(top_level_file):
+                try:
+                    os.unlink(top_level_file)
+                except OSError as err:
+                    ret['comment'] = 'Error removing destination file ' \
+                                     '"{0}": {1}'.format(top_level_file, err)
                     ret['result'] = False
                     return ret
 

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -111,16 +111,6 @@ def _is_bsdtar():
                                            python_shell=False)
 
 
-def _cleanup_destdir(name):
-    '''
-    Attempt to remove the specified directory
-    '''
-    try:
-        os.rmdir(name)
-    except OSError:
-        pass
-
-
 def _remove_destination(names, root=None, ret=None, fail=False):
     '''
     Remove the specified directory or file.
@@ -1087,7 +1077,7 @@ def extracted(name,
                                     python_shell=True)
                                 if results['retcode'] != 0:
                                     if created_destdir:
-                                        _cleanup_destdir(name)
+                                        _remove_destination([name])
                                     ret['result'] = False
                                     ret['changes'] = results
                                     return ret
@@ -1099,7 +1089,7 @@ def extracted(name,
                                 # Failed to open tar archive and it is not
                                 # XZ-compressed, gracefully fail the state
                                 if created_destdir:
-                                    _cleanup_destdir(name)
+                                    _remove_destination([name])
                                 ret['result'] = False
                                 ret['comment'] = (
                                     'Failed to read from tar archive using '
@@ -1113,7 +1103,7 @@ def extracted(name,
                                 return ret
                         else:
                             if created_destdir:
-                                _cleanup_destdir(name)
+                                _remove_destination([name])
                             ret['result'] = False
                             ret['comment'] = (
                                 'Failed to read from tar archive. If it is '

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -907,16 +907,17 @@ def extracted(name,
 
     extraction_needed = overwrite
 
-    if extraction_needed:
-        destination = os.path.join(name, contents['top_level_dirs'][0])
-        if os.path.exists(destination):
-            try:
-                shutil.rmtree(destination)
-            except OSError as err:
-                ret['comment'] = 'Error removing destination directory ' \
-                                 '"{0}": {1}'.format(destination, err)
-                ret['result'] = False
-                return ret
+    if extraction_needed and contents['top_level_dirs']:
+        for top_level_dir in contents['top_level_dirs']:
+            destination = os.path.join(name, top_level_dir)
+            if os.path.exists(destination):
+                try:
+                    shutil.rmtree(destination)
+                except OSError as err:
+                    ret['comment'] = 'Error removing destination directory ' \
+                                     '"{0}": {1}'.format(destination, err)
+                    ret['result'] = False
+                    return ret
 
     try:
         if_missing_path_exists = os.path.exists(if_missing)


### PR DESCRIPTION
### What issues does this PR fix or reference?

Bugfix: wrong assumption that archive can have only one top level directory. It also refactors the code a bit.

### Previous Behavior

Only first top level directory has been removed.

### New Behavior

All directories are removed.

### Tests written?

No
