### PR TITLE
Pass full_return to saltutil.runner

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -1155,6 +1155,7 @@ def runner(name, **kwargs):
     '''
     jid = kwargs.pop('__orchestration_jid__', None)
     saltenv = kwargs.pop('__env__', 'base')
+    full_return = kwargs.pop('full_return', False)
     kwargs = salt.utils.clean_kwargs(**kwargs)
 
     if 'master_job_cache' not in __opts__:
@@ -1178,7 +1179,10 @@ def runner(name, **kwargs):
             prefix='run'
         )
 
-    return rclient.cmd(name, kwarg=kwargs, print_event=False, full_return=True)
+    return rclient.cmd(name,
+                       kwarg=kwargs,
+                       print_event=False,
+                       full_return=full_return)
 
 
 def wheel(name, *args, **kwargs):

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -649,6 +649,7 @@ def runner(name, **kwargs):
     out = __salt__['saltutil.runner'](name,
                                       __orchestration_jid__=jid,
                                       __env__=__env__,
+                                      full_return=True,
                                       **kwargs)
 
     ret['result'] = True


### PR DESCRIPTION
This preserves the traditional return data structure for normal usage
while allowing for the full return in orchestration.

Resolves #38000.