### PR TITLE
Modify daemons test to use multiprocessing

### DIFF
--- a/tests/unit/daemons_test.py
+++ b/tests/unit/daemons_test.py
@@ -89,7 +89,6 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
                 obj.config = {'user': 'dummy', 'hash_type': alg}
                 for attr in ['start_log_info', 'prepare', 'shutdown']:
                     setattr(obj, attr, MagicMock())
-                setattr(obj, 'minion', MagicMock(restart=False))
 
                 return obj
 

--- a/tests/unit/daemons_test.py
+++ b/tests/unit/daemons_test.py
@@ -85,7 +85,7 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
                 Create master instance
                 :return:
                 '''
-                obj = daemons.Minion()
+                obj = daemons.Master()
                 obj.config = {'user': 'dummy', 'hash_type': alg}
                 for attr in ['start_log_info', 'prepare', 'shutdown']:
                     setattr(obj, attr, MagicMock())

--- a/tests/unit/daemons_test.py
+++ b/tests/unit/daemons_test.py
@@ -15,6 +15,7 @@ ensure_in_syspath('../')
 
 # Import Salt libs
 import integration
+import multiprocessing
 from salt.cli import daemons
 
 
@@ -65,39 +66,52 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
     Unit test for the daemons starter classes.
     '''
 
+    def _multiproc_exec_test(self, exec_test):
+        m_parent, m_child = multiprocessing.Pipe()
+        p_ = multiprocessing.Process(target=exec_test, args=(m_child,))
+        p_.start()
+        self.assertTrue(m_parent.recv())
+        p_.join()
+
     def test_master_daemon_hash_type_verified(self):
         '''
         Verify if Master is verifying hash_type config option.
 
         :return:
         '''
-        def _create_master():
-            '''
-            Create master instance
-            :return:
-            '''
-            master = daemons.Master()
-            master.config = {'user': 'dummy', 'hash_type': alg}
-            for attr in ['master', 'start_log_info', 'prepare']:
-                setattr(master, attr, MagicMock())
+        def exec_test(child_pipe):
+            def _create_master():
+                '''
+                Create master instance
+                :return:
+                '''
+                obj = daemons.Minion()
+                obj.config = {'user': 'dummy', 'hash_type': alg}
+                for attr in ['start_log_info', 'prepare', 'shutdown']:
+                    setattr(obj, attr, MagicMock())
+                setattr(obj, 'minion', MagicMock(restart=False))
 
-            return master
+                return obj
 
-        _logger = LoggerMock()
-        with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
-            with patch('salt.cli.daemons.log', _logger):
-                for alg in ['md5', 'sha1']:
-                    _create_master().start()
-                    self.assertEqual(_logger.last_type, 'warning')
-                    self.assertTrue(_logger.last_message)
-                    self.assertTrue(_logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1)
+            _logger = LoggerMock()
+            ret = True
+            with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
+                with patch('salt.cli.daemons.log', _logger):
+                    for alg in ['md5', 'sha1']:
+                        _create_master().start()
+                        ret = ret and _logger.last_type == 'warning' \
+                                and _logger.last_message \
+                                and _logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1
 
-                _logger.reset()
+                    _logger.reset()
 
-                for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
-                    _create_master().start()
-                    self.assertEqual(_logger.last_type, None)
-                    self.assertFalse(_logger.last_message)
+                    for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
+                        _create_master().start()
+                        ret = ret and _logger.last_type is None \
+                                and not _logger.last_message
+                    child_pipe.send(ret)
+                    child_pipe.close()
+        self._multiproc_exec_test(exec_test)
 
     def test_minion_daemon_hash_type_verified(self):
         '''
@@ -105,35 +119,40 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
 
         :return:
         '''
+        def exec_test(child_pipe):
+            def _create_minion():
+                '''
+                Create minion instance
+                :return:
+                '''
+                obj = daemons.Minion()
+                obj.config = {'user': 'dummy', 'hash_type': alg}
+                for attr in ['start_log_info', 'prepare', 'shutdown']:
+                    setattr(obj, attr, MagicMock())
+                setattr(obj, 'minion', MagicMock(restart=False))
 
-        def _create_minion():
-            '''
-            Create minion instance
-            :return:
-            '''
-            obj = daemons.Minion()
-            obj.config = {'user': 'dummy', 'hash_type': alg}
-            for attr in ['start_log_info', 'prepare', 'shutdown']:
-                setattr(obj, attr, MagicMock())
-            setattr(obj, 'minion', MagicMock(restart=False))
+                return obj
 
-            return obj
+            ret = True
+            _logger = LoggerMock()
+            with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
+                with patch('salt.cli.daemons.log', _logger):
+                    for alg in ['md5', 'sha1']:
+                        _create_minion().start()
+                        ret = ret and _logger.last_type == 'warning' \
+                                and _logger.last_message \
+                                and _logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1
+                    _logger.reset()
 
-        _logger = LoggerMock()
-        with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
-            with patch('salt.cli.daemons.log', _logger):
-                for alg in ['md5', 'sha1']:
-                    _create_minion().start()
-                    self.assertEqual(_logger.last_type, 'warning')
-                    self.assertTrue(_logger.last_message)
-                    self.assertTrue(_logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1)
+                    for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
+                        _create_minion().start()
+                        ret = ret and _logger.last_type is None \
+                                and not _logger.last_message
 
-                _logger.reset()
+                child_pipe.send(ret)
+                child_pipe.close()
 
-                for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
-                    _create_minion().start()
-                    self.assertEqual(_logger.last_type, None)
-                    self.assertFalse(_logger.last_message)
+        self._multiproc_exec_test(exec_test)
 
     def test_proxy_minion_daemon_hash_type_verified(self):
         '''
@@ -141,34 +160,39 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
 
         :return:
         '''
+        def exec_test(child_pipe):
+            def _create_proxy_minion():
+                '''
+                Create proxy minion instance
+                :return:
+                '''
+                obj = daemons.ProxyMinion()
+                obj.config = {'user': 'dummy', 'hash_type': alg}
+                for attr in ['minion', 'start_log_info', 'prepare', 'shutdown']:
+                    setattr(obj, attr, MagicMock())
 
-        def _create_proxy_minion():
-            '''
-            Create proxy minion instance
-            :return:
-            '''
-            obj = daemons.ProxyMinion()
-            obj.config = {'user': 'dummy', 'hash_type': alg}
-            for attr in ['minion', 'start_log_info', 'prepare', 'shutdown']:
-                setattr(obj, attr, MagicMock())
+                return obj
 
-            return obj
+            ret = True
+            _logger = LoggerMock()
+            with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
+                with patch('salt.cli.daemons.log', _logger):
+                    for alg in ['md5', 'sha1']:
+                        _create_proxy_minion().start()
+                        ret = ret and _logger.last_type == 'warning' \
+                                and _logger.last_message \
+                                and _logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1
 
-        _logger = LoggerMock()
-        with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
-            with patch('salt.cli.daemons.log', _logger):
-                for alg in ['md5', 'sha1']:
-                    _create_proxy_minion().start()
-                    self.assertEqual(_logger.last_type, 'warning')
-                    self.assertTrue(_logger.last_message)
-                    self.assertTrue(_logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1)
+                    _logger.reset()
 
-                _logger.reset()
+                    for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
+                        _create_proxy_minion().start()
+                        ret = ret and _logger.last_type is None \
+                                and not _logger.last_message
+            child_pipe.send(ret)
+            child_pipe.close()
 
-                for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
-                    _create_proxy_minion().start()
-                    self.assertEqual(_logger.last_type, None)
-                    self.assertFalse(_logger.last_message)
+        self._multiproc_exec_test(exec_test)
 
     def test_syndic_daemon_hash_type_verified(self):
         '''
@@ -176,34 +200,38 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
 
         :return:
         '''
+        def exec_test(child_pipe):
+            def _create_syndic():
+                '''
+                Create syndic instance
+                :return:
+                '''
+                obj = daemons.Syndic()
+                obj.config = {'user': 'dummy', 'hash_type': alg}
+                for attr in ['syndic', 'start_log_info', 'prepare', 'shutdown']:
+                    setattr(obj, attr, MagicMock())
 
-        def _create_syndic():
-            '''
-            Create syndic instance
-            :return:
-            '''
-            obj = daemons.Syndic()
-            obj.config = {'user': 'dummy', 'hash_type': alg}
-            for attr in ['syndic', 'start_log_info', 'prepare', 'shutdown']:
-                setattr(obj, attr, MagicMock())
+                return obj
 
-            return obj
+            ret = True
+            _logger = LoggerMock()
+            with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
+                with patch('salt.cli.daemons.log', _logger):
+                    for alg in ['md5', 'sha1']:
+                        _create_syndic().start()
+                        ret = ret and _logger.last_type == 'warning' \
+                                and _logger.last_message \
+                                and _logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1
 
-        _logger = LoggerMock()
-        with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
-            with patch('salt.cli.daemons.log', _logger):
-                for alg in ['md5', 'sha1']:
-                    _create_syndic().start()
-                    self.assertEqual(_logger.last_type, 'warning')
-                    self.assertTrue(_logger.last_message)
-                    self.assertTrue(_logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1)
+                    _logger.reset()
 
-                _logger.reset()
+                    for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
+                        _create_syndic().start()
+                        ret = ret and _logger.last_type is None \
+                                and _logger.last_message
 
-                for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
-                    _create_syndic().start()
-                    self.assertEqual(_logger.last_type, None)
-                    self.assertFalse(_logger.last_message)
+            child_pipe.send(ret)
+            child_pipe.close()
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/daemons_test.py
+++ b/tests/unit/daemons_test.py
@@ -87,7 +87,7 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
                 '''
                 obj = daemons.Master()
                 obj.config = {'user': 'dummy', 'hash_type': alg}
-                for attr in ['start_log_info', 'prepare', 'shutdown']:
+                for attr in ['start_log_info', 'prepare', 'shutdown', 'master']:
                     setattr(obj, attr, MagicMock())
 
                 return obj


### PR DESCRIPTION
Without this approach, instantiating a master/minion from this test would affect the parser tests down the line.