### PR TITLE
archive.extracted: fix problems with overwrite arg

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -12,7 +12,6 @@ import logging
 import os
 import re
 import shlex
-import shutil
 import stat
 import tarfile
 from contextlib import closing
@@ -131,6 +130,8 @@ def extracted(name,
               options=None,
               list_options=None,
               force=False,
+              overwrite=False,
+              clean=False,
               user=None,
               group=None,
               if_missing=None,
@@ -141,7 +142,6 @@ def extracted(name,
               enforce_toplevel=True,
               enforce_ownership_on=None,
               archive_format=None,
-              overwrite=False,
               **kwargs):
     '''
     .. versionadded:: 2014.1.0
@@ -394,6 +394,24 @@ def extracted(name,
 
         .. versionadded:: 2016.11.0
 
+    overwrite : False
+        Set this to ``True`` to force the archive to be extracted. This is
+        useful for cases where the filenames/directories have not changed, but
+        the content of the files have.
+
+        .. versionadded:: 2016.11.1
+
+    clean : False
+        Set this to ``True`` to remove any top-level files and recursively
+        remove any top-level directory paths before extracting.
+
+        .. note::
+            Files will only be cleaned first if extracting the archive is
+            deemed necessary, either by paths missing on the minion, or if
+            ``overwrite`` is set to ``True``.
+
+        .. versionadded:: 2016.11.1
+
     user
         The user to own each extracted file. Not available on Windows.
 
@@ -498,11 +516,6 @@ def extracted(name,
     .. _tarfile: https://docs.python.org/2/library/tarfile.html
     .. _zipfile: https://docs.python.org/2/library/zipfile.html
     .. _xz-utils: http://tukaani.org/xz/
-
-    overwrite
-        If archive was already extracted, then setting this to True will
-        extract it all over again.
-        **WARNING: This operation will flush clean all the previous content, if exists!**
 
     **Examples**
 
@@ -904,19 +917,7 @@ def extracted(name,
     # already need to catch an OSError to cover edge cases where the minion is
     # running as a non-privileged user and is trying to check for the existence
     # of a path to which it does not have permission.
-
     extraction_needed = overwrite
-
-    if extraction_needed:
-        destination = os.path.join(name, contents['top_level_dirs'][0])
-        if os.path.exists(destination):
-            try:
-                shutil.rmtree(destination)
-            except OSError as err:
-                ret['comment'] = 'Error removing destination directory ' \
-                                 '"{0}": {1}'.format(destination, err)
-                ret['result'] = False
-                return ret
 
     try:
         if_missing_path_exists = os.path.exists(if_missing)
@@ -939,55 +940,77 @@ def extracted(name,
                     return ret
         else:
             incorrect_type = []
-            extraction_needed = False
             for path_list, func in ((contents['dirs'], stat.S_ISDIR),
                                     (contents['files'], stat.S_ISREG)):
                 for path in path_list:
                     full_path = os.path.join(name, path)
                     try:
-                        path_mode = os.stat(full_path).st_mode
+                        path_mode = os.stat(full_path.rstrip(os.sep)).st_mode
                         if not func(path_mode):
                             incorrect_type.append(path)
                     except OSError as exc:
                         if exc.errno == errno.ENOENT:
                             extraction_needed = True
-                        else:
+                        elif exc.errno != errno.ENOTDIR:
+                            # In cases where a directory path was occupied by a
+                            # file instead, all os.stat() calls to files within
+                            # that dir will raise an ENOTDIR OSError. So we
+                            # expect these and will only abort here if the
+                            # error code is something else.
                             ret['comment'] = exc.__str__()
                             return ret
 
             if incorrect_type:
-                if not force:
-                    msg = (
-                        'The below paths (relative to {0}) exist, but are the '
-                        'incorrect type (i.e. file instead of directory or '
-                        'vice-versa). To proceed with extraction, set '
-                        '\'force\' to True.\n'.format(name)
-                    )
-                    for path in incorrect_type:
-                        msg += '\n- {0}'.format(path)
-                    ret['comment'] = msg
-                else:
-                    errors = []
-                    for path in incorrect_type:
-                        full_path = os.path.join(name, path)
-                        try:
-                            salt.utils.rm_rf(full_path)
-                            ret['changes'].setdefault(
-                                'removed', []).append(full_path)
-                        except OSError as exc:
-                            if exc.errno != errno.ENOENT:
-                                errors.append(exc.__str__())
-                    if errors:
-                        msg = (
-                            'One or more paths existed by were the incorrect '
-                            'type (i.e. file instead of directory or '
-                            'vice-versa), but could not be removed. The '
-                            'following errors were observed:\n'
+                incorrect_paths = '\n\n' + '\n'.join(
+                    ['- {0}'.format(x) for x in incorrect_type]
+                )
+                ret['comment'] = (
+                    'The below paths (relative to {0}) exist, but are the '
+                    'incorrect type (i.e. file instead of directory or '
+                    'vice-versa).'.format(name)
+                )
+                if __opts__['test'] and clean and contents is not None:
+                    ret['result'] = None
+                    ret['comment'] += (
+                        ' Since the \'clean\' option is enabled, the '
+                        'destination paths would be cleared and the '
+                        'archive would be extracted.{0}'.format(
+                            incorrect_paths
                         )
-                        for error in errors:
-                            msg += '\n- {0}'.format(error)
-                        ret['comment'] = msg
+                    )
+                    return ret
+
+                # Skip notices of incorrect types if we're cleaning
+                if not (clean and contents is not None):
+                    if not force:
+                        ret['comment'] += (
+                            'To proceed with extraction, set \'force\' to '
+                            'True. Note that this will remove these paths '
+                            'before extracting.{0}'.format(incorrect_paths)
+                        )
                         return ret
+                    else:
+                        errors = []
+                        for path in incorrect_type:
+                            full_path = os.path.join(name, path)
+                            try:
+                                salt.utils.rm_rf(full_path.rstrip(os.sep))
+                                ret['changes'].setdefault(
+                                    'removed', []).append(full_path)
+                            except OSError as exc:
+                                if exc.errno != errno.ENOENT:
+                                    errors.append(exc.__str__())
+                        if errors:
+                            msg = (
+                                'One or more paths existed by were the incorrect '
+                                'type (i.e. file instead of directory or '
+                                'vice-versa), but could not be removed. The '
+                                'following errors were observed:\n'
+                            )
+                            for error in errors:
+                                msg += '\n- {0}'.format(error)
+                            ret['comment'] = msg
+                            return ret
 
     created_destdir = False
 
@@ -999,7 +1022,33 @@ def extracted(name,
                     source_match,
                     name
                 )
+            if clean and contents is not None:
+                ret['comment'] += ', after cleaning destination path(s)'
             return ret
+
+        if clean and contents is not None:
+            errors = []
+            log.debug('Cleaning archive paths from within %s', name)
+            for path in contents['top_level_dirs'] + contents['top_level_files']:
+                full_path = os.path.join(name, path)
+                try:
+                    log.debug('Removing %s', full_path)
+                    salt.utils.rm_rf(full_path.rstrip(os.sep))
+                    ret['changes'].setdefault(
+                        'removed', []).append(full_path)
+                except OSError as exc:
+                    if exc.errno != errno.ENOENT:
+                        errors.append(exc.__str__())
+
+            if errors:
+                msg = (
+                    'One or more paths could not be cleaned. The following '
+                    'errors were observed:\n'
+                )
+                for error in errors:
+                    msg += '\n- {0}'.format(error)
+                ret['comment'] = msg
+                return ret
 
         if not os.path.isdir(name):
             __salt__['file.makedirs'](name, user=user)


### PR DESCRIPTION
Pull request #37889 introduced several problems:

1. It forces a wipe of the extracted contents if you are setting
   ``overwrite`` to ``True``. This should be configurable, to allow for
   the use case where extraction should be forced but there are contents
   added to the extracted content which the user does not want purged
   before the archive is re-extracted.

2. It ignores the case where ``enforce_toplevel`` is set to ``False``
   and the archive doesn't have all contents in a single top-level
   directory, by only deleting the first listed top-level directory (and
   ignoring completely any top-level files).

3. It ignores the case where ``archive.list`` was unable to list the
   contents of the archive (in which case ``contents`` would be
   ``None``). This would result in a TypeError when this case was
   combined with setting ``overwrite`` to ``True``.

This commit fixes all of the above problems. Additionally, a new
argument called ``clean`` now controls whether destination paths are
wiped before extraction is performed.

Finally, an issue with how I implemented detection (and cleaning) of
paths with incorrect types has been fixed. Specifically, when a path
that should have been a directory is instead a file, the ``os.stat()``
will raise an ENOTDIR when the path passed to it contains a trailing
path separator, because the path exists but is not a directory.