### PR TITLE
Allow NSG to be assigned to a new NIC for Azure ARM

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -866,8 +866,16 @@ def create_interface(call=None, kwargs=None):  # pylint: disable=unused-argument
             )
         ]
 
+    network_security_group = None
+    if kwargs.get('security_group') is not None:
+        network_security_group = netconn.network_security_groups.get(
+            resource_group_name=kwargs['resource_group'],
+            network_security_group_name=kwargs['security_group'],
+        )
+        
     iface_params = NetworkInterface(
         location=kwargs['location'],
+        network_security_group=network_security_group,
         ip_configurations=ip_configurations,
     )
 

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -872,7 +872,7 @@ def create_interface(call=None, kwargs=None):  # pylint: disable=unused-argument
             resource_group_name=kwargs['resource_group'],
             network_security_group_name=kwargs['security_group'],
         )
-        
+
     iface_params = NetworkInterface(
         location=kwargs['location'],
         network_security_group=network_security_group,


### PR DESCRIPTION
### What does this PR do?
Extends the Azure ARM support to allow an existing network security group to be assigned to a new network interface.
### What issues does this PR fix or reference?
None.
### Previous Behavior
Remove this section if not relevant
Cannot specify network security group when creating new network interface.
### New Behavior
Remove this section if not relevant
Add support for attaching network security group to a new network interface
### Tests written?
No automated test. Has been manually tested on Azure.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.