### PR TITLE
Fixes #37648 and related bugs

### DIFF
--- a/salt/modules/pyenv.py
+++ b/salt/modules/pyenv.py
@@ -176,9 +176,9 @@ def install_python(python, runas=None):
 
     ret = {}
     ret = _pyenv_exec('install', python, env=env, runas=runas, ret=ret)
-    if ret['retcode'] == 0:
+    if ret != False:
         rehash(runas=runas)
-        return ret['stderr']
+        return ret['stdout']
     else:
         # Cleanup the failed installation so it doesn't list as installed
         uninstall_python(python, runas=runas)

--- a/salt/modules/pyenv.py
+++ b/salt/modules/pyenv.py
@@ -176,7 +176,7 @@ def install_python(python, runas=None):
 
     ret = {}
     ret = _pyenv_exec('install', python, env=env, runas=runas, ret=ret)
-    if ret != False:
+    if ret is not False:
         rehash(runas=runas)
         return ret['stdout']
     else:

--- a/salt/states/pyenv.py
+++ b/salt/states/pyenv.py
@@ -85,7 +85,7 @@ def _check_and_install_python(ret, python, default=False, user=None):
     '''
     ret = _python_installed(ret, python, user=user)
     if not ret['result']:
-        if __salt__['pyenv.install_python'](python, runas=user):
+        if __salt__['pyenv.install_python'](python, runas=user) != False:
             ret['result'] = True
             ret['changes'][python] = 'Installed'
             ret['comment'] = 'Successfully installed python'
@@ -216,4 +216,4 @@ def install_pyenv(name, user=None):
         ret['comment'] = 'pyenv is set to be installed'
         return ret
 
-    return _check_and_install_python(ret, user)
+    return _check_and_install_python(ret, name, False, user)

--- a/salt/states/pyenv.py
+++ b/salt/states/pyenv.py
@@ -85,7 +85,7 @@ def _check_and_install_python(ret, python, default=False, user=None):
     '''
     ret = _python_installed(ret, python, user=user)
     if not ret['result']:
-        if __salt__['pyenv.install_python'](python, runas=user) != False:
+        if __salt__['pyenv.install_python'](python, runas=user) is not False:
             ret['result'] = True
             ret['changes'][python] = 'Installed'
             ret['comment'] = 'Successfully installed python'


### PR DESCRIPTION
### What does this PR do?
Fixes multiple bugs on `pyenv` installation procedure.
* pyenv.install_pyenv state using the wrong signature when calling _check_and_install_python()
* Incorrect assumptions on returned type in comparisons

### What issues does this PR fix or reference?
#37648

### Previous Behavior
A fun-to-debug traceback for signature mismatch (see issue)
Boring and clear to debug tracebacks for comparison mismatch

### New Behavior
Correctly attempt installation

### Tests written?
Preexisting

