### PR TITLE
Remove debugging code

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2211,7 +2211,6 @@ class GitBase(object):
                             conf['ref'], []).append(key)
 
                 self.remotes.append(repo_obj)
-        repo_obj.mountpoint('frap')
 
         # Don't allow collisions in cachedir naming
         cachedir_map = {}


### PR DESCRIPTION
This was left in to debug per-saltenv config overlays. I thought I had
removed it weeks ago, but I guess I didn't, and it made it into
2016.11.0. This commit removes the debugging code.

Fixes #37980.