### PR TITLE
add docs for hash_type change to sha256

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1434,15 +1434,15 @@ on a large number of minions.
 ``hash_type``
 -------------
 
-Default: ``md5``
+Default: ``sha256``
 
 The hash_type is the hash to use when discovering the hash of a file on
-the master server. The default is md5, but sha1, sha224, sha256, sha384, and
+the master server. The default is sha256, but md5, sha1, sha224, sha384, and
 sha512 are also supported.
 
 .. code-block:: yaml
 
-    hash_type: md5
+    hash_type: sha256
 
 .. conf_master:: file_buffer_size
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1546,15 +1546,15 @@ is impacted.
 ``hash_type``
 -------------
 
-Default: ``md5``
+Default: ``sha256``
 
 The hash_type is the hash to use when discovering the hash of a file on the
-local fileserver. The default is md5, but sha1, sha224, sha256, sha384, and
+local fileserver. The default is sha256, but md5, sha1, sha224, sha384, and
 sha512 are also supported.
 
 .. code-block:: yaml
 
-    hash_type: md5
+    hash_type: sha256
 
 
 Pillar Settings

--- a/doc/topics/releases/2016.11.0.rst
+++ b/doc/topics/releases/2016.11.0.rst
@@ -375,6 +375,8 @@ Functionality Changes
   specifies the number of times a minion should attempt to contact a master to
   attempt a connection.  This allows better handling of occasional master
   downtime in a multi-master topology.
+- The default hash_type is now sha256 instead of md5. You will need to make sure both
+  your master and minion share the same hash_type.
 - Nodegroups consisting of a simple list of minion IDs can now also be declared
   as a yaml list. The below two examples are equivalent:
 


### PR DESCRIPTION
### What does this PR do?
Documentation that explains the default hash_type has changed to sha256 in release notes and master/minion configurations.

### What issues does this PR fix or reference?
#37941
