### PR TITLE
Add the __sls__ field to the highstate output (the running dict)

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1791,6 +1791,7 @@ class State(object):
             low['__prereq__'] = False
             return ret
 
+        ret['__sls__'] = low.get('__sls__')
         ret['__run_num__'] = self.__run_num
         self.__run_num += 1
         format_log(ret)

--- a/tests/integration/files/file/base/gndn.sls
+++ b/tests/integration/files/file/base/gndn.sls
@@ -1,0 +1,3 @@
+# Goes nowhere, does nothing.
+gndn:
+  test.succeed_with_changes

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -110,12 +110,10 @@ class StateModuleTest(integration.ModuleCase,
         sls2 = self.run_function('state.sls', mods='gndn')
 
         for state, ret in sls1.items():
-            key_type = type(ret['__sls__'])
-            self.assertTrue(key_type is str or key_type is type(None))
+            self.assertTrue(isinstance(ret['__sls__'], type(None)))
 
         for state, ret in sls2.items():
-            key_type = type(ret['__sls__'])
-            self.assertTrue(key_type is str or key_type is type(None))
+            self.assertTrue(isinstance(ret['__sls__'], str))
 
     def _remove_request_cache_file(self):
         '''

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -99,6 +99,24 @@ class StateModuleTest(integration.ModuleCase,
             for field in running_dict_fields:
                 self.assertIn(field, ret)
 
+    def test_running_dictionary_key_sls(self):
+        '''
+        Ensure the __sls__ key is either null or a string
+        '''
+        sls1 = self.run_function('state.single',
+                fun='test.succeed_with_changes',
+                name='gndn')
+
+        sls2 = self.run_function('state.sls', mods='gndn')
+
+        for state, ret in sls1.items():
+            key_type = type(ret['__sls__'])
+            self.assertTrue(key_type is str or key_type is type(None))
+
+        for state, ret in sls2.items():
+            key_type = type(ret['__sls__'])
+            self.assertTrue(key_type is str or key_type is type(None))
+
     def _remove_request_cache_file(self):
         '''
         remove minion state request file

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -74,6 +74,31 @@ class StateModuleTest(integration.ModuleCase,
         sls = self.run_function('state.show_sls', mods='recurse_ok_two')
         self.assertIn('/etc/nagios/nrpe.cfg', sls)
 
+    def test_running_dictionary_consistency(self):
+        '''
+        Test the structure of the running dictionary so we don't change it
+        without deprecating/documenting the change
+        '''
+        running_dict_fields = [
+            '__id__',
+            '__run_num__',
+            '__sls__',
+            'changes',
+            'comment',
+            'duration',
+            'name',
+            'result',
+            'start_time',
+        ]
+
+        sls = self.run_function('state.single',
+                fun='test.succeed_with_changes',
+                name='gndn')
+
+        for state, ret in sls.items():
+            for field in running_dict_fields:
+                self.assertIn(field, ret)
+
     def _remove_request_cache_file(self):
         '''
         remove minion state request file


### PR DESCRIPTION
Request for comments:

There's a bunch of cool info in the running dictionary that is useful for summarizing a state run. I'd like to be able to show 'N states from M files' as well but I need the `__sls__` attribute from the low data to do that.