### PR TITLE
Remove initdb dependency in postgres module

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -113,7 +113,7 @@ def __virtual__():
     Only load this module if the psql bin exist.
     initdb bin might also be used, but its presence will be detected on runtime.
     '''
-    utils = ['psql', 'initdb']
+    utils = ['psql']
     if not HAS_CSV:
         return False
     for util in utils:


### PR DESCRIPTION
The initdb dep was removed in PR #37993 to fix #37935, but was subsequently (likely accidentally) added back to the module in PR #38023.

ping @gtmanfred and @jrporcaro 