### PR TITLE
Call exec_test for the Syndic daemon in tests.unit.daemons_test.py

### DIFF
--- a/tests/unit/daemons_test.py
+++ b/tests/unit/daemons_test.py
@@ -232,6 +232,8 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
             child_pipe.send(ret)
             child_pipe.close()
 
+        self._multiproc_exec_test(exec_test)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(DaemonsStarterTestCase, needs_daemon=False)

--- a/tests/unit/daemons_test.py
+++ b/tests/unit/daemons_test.py
@@ -227,7 +227,7 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
                     for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
                         _create_syndic().start()
                         ret = ret and _logger.last_type is None \
-                                and _logger.last_message
+                                and not _logger.last_message
 
             child_pipe.send(ret)
             child_pipe.close()


### PR DESCRIPTION
I discovered during a conflict resolution for the last merge-forward that we are not actually running the `test_syndic_daemon_hash_type_verified` test because we forgot to call the `exec_test` func. 

This is already resolved in the 2016.11 merge forward PR, but we should make sure this is running here, too.

Refs #38034 and #38057

