### PR TITLE
Remove virtual funcs for archive state/module

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -36,14 +36,6 @@ __func_alias__ = {
 log = logging.getLogger(__name__)
 
 
-def __virtual__():
-    commands = ('tar', 'gzip', 'gunzip', 'zip', 'unzip', 'rar', 'unrar')
-    # If none of the above commands are in $PATH this module is a no-go
-    if not any(salt.utils.which(cmd) for cmd in commands):
-        return (False, 'Unable to find commands tar,gzip,gunzip,zip,unzip,rar,unrar')
-    return True
-
-
 def list_(name,
           archive_format=None,
           options=None,
@@ -177,6 +169,10 @@ def list_(name,
             raise CommandExecutionError('{0} is not a ZIP file'.format(name))
 
     def _list_rar(name, cached):
+        if not salt.utils.which('rar'):
+            raise CommandExecutionError(
+                'rar command not available, is it installed?'
+            )
         output = __salt__['cmd.run'](
             ['rar', 'lt', path],
             python_shell=False,
@@ -185,7 +181,7 @@ def list_(name,
         ret = [x + '/' if y == 'Directory' else x for x, y in matches]
         if not ret:
             raise CommandExecutionError(
-                'Failed to decompress {0}'.format(name),
+                'Failed to list {0}, is it a rar file?'.format(name),
                 info={'error': output}
             )
         return ret

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -25,21 +25,9 @@ from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: dis
 # Import salt libs
 import salt.utils
 import salt.utils.files
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
 log = logging.getLogger(__name__)
-
-__virtualname__ = 'archive'
-
-
-def __virtual__():
-    '''
-    Only load if the archive module is available in __salt__
-    '''
-    if 'archive.unzip' in __salt__ and 'archive.unrar' in __salt__:
-        return __virtualname__
-    else:
-        return False
 
 
 def _path_is_abs(path):
@@ -572,7 +560,7 @@ def extracted(name,
         # Add back the slash so that file.makedirs properly creates the
         # destdir if it needs to be created. file.makedirs expects a trailing
         # slash in the directory path.
-        name += '/'
+        name += os.sep
     if not _path_is_abs(if_missing):
         ret['comment'] = 'Value for \'if_missing\' is not an absolute path'
         return ret
@@ -699,6 +687,13 @@ def extracted(name,
                     'Either remove \'use_cmd_unzip\', or set it to True.'
                 )
                 return ret
+            if use_cmd_unzip:
+                if 'archive.cmd_unzip' not in __salt__:
+                    ret['comment'] = (
+                        'archive.cmd_unzip function not available, unzip might '
+                        'not be installed on minion'
+                    )
+                    return ret
         if password:
             if use_cmd_unzip is None:
                 log.info(
@@ -718,6 +713,14 @@ def extracted(name,
         if password:
             ret['comment'] = \
                 'The \'password\' argument is only supported for zip archives'
+            return ret
+
+    if archive_format == 'rar':
+        if 'archive.unrar' not in __salt__:
+            ret['comment'] = (
+                'archive.unrar function not available, rar/unrar might '
+                'not be installed on minion'
+            )
             return ret
 
     supports_options = ('tar', 'zip')
@@ -1009,12 +1012,17 @@ def extracted(name,
         try:
             if archive_format == 'zip':
                 if use_cmd_unzip:
-                    files = __salt__['archive.cmd_unzip'](cached_source,
-                                                          name,
-                                                          options=options,
-                                                          trim_output=trim_output,
-                                                          password=password,
-                                                          **kwargs)
+                    try:
+                        files = __salt__['archive.cmd_unzip'](
+                            cached_source,
+                            name,
+                            options=options,
+                            trim_output=trim_output,
+                            password=password,
+                            **kwargs)
+                    except (CommandExecutionError, CommandNotFoundError) as exc:
+                        ret['comment'] = exc.strerror
+                        return ret
                 else:
                     files = __salt__['archive.unzip'](cached_source,
                                                       name,
@@ -1023,10 +1031,14 @@ def extracted(name,
                                                       password=password,
                                                       **kwargs)
             elif archive_format == 'rar':
-                files = __salt__['archive.unrar'](cached_source,
-                                                  name,
-                                                  trim_output=trim_output,
-                                                  **kwargs)
+                try:
+                    files = __salt__['archive.unrar'](cached_source,
+                                                      name,
+                                                      trim_output=trim_output,
+                                                      **kwargs)
+                except (CommandExecutionError, CommandNotFoundError) as exc:
+                    ret['comment'] = exc.strerror
+                    return ret
             else:
                 if options is None:
                     try:
@@ -1092,6 +1104,13 @@ def extracted(name,
                             )
                             return ret
                 else:
+                    if not salt.utils.which('tar'):
+                        ret['comment'] = (
+                            'tar command not available, it might not be '
+                            'installed on minion'
+                        )
+                        return ret
+
                     try:
                         tar_opts = shlex.split(options)
                     except AttributeError:


### PR DESCRIPTION
Since not all funcs require the CLI commands, the better way of handling
this is to check for presence of the needed funcs and gracefully exit a
state when the function is not present.

This also fixes the use of a *NIX-specific path separator.

Fixes #38062.