### PR TITLE
Fix `rabbitmq.plugin_is_enabled`

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -913,7 +913,7 @@ def plugin_is_enabled(name, runas=None):
     cmd = [_get_rabbitmq_plugin(), 'list', '-m', '-e']
     ret = __salt__['cmd.run_all'](cmd, python_shell=False, runas=runas)
     _check_response(ret)
-    return bool(name in ret['stdout'])
+    return bool(name in ret['stdout'].split())
 
 
 def enable_plugin(name, runas=None):


### PR DESCRIPTION
### What does this PR do?
Corrects the behaviour of salt.modules.rabbitmq.plugin_is_enabled, which incorrectly returned True.

### Previous Behavior
If the plugin is a substring of another enabled plugin, then plugin_is_enabled wrongly returned True.

### Tests written?
No

### Description
If you have "rabbitmq_management_agent" enabled, the old code thinks that "rabbitmq_management" is enabled, because the check is whether the plugin list string contains the given plugin.

Simply splitting the plugin list on whitespace should fix this.