### PR TITLE
2016.11

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1954,7 +1954,10 @@ def sftp_file(dest_path, contents=None, kwargs=None, local_file=None):
         if contents is not None:
             try:
                 tmpfd, file_to_upload = tempfile.mkstemp()
-                os.write(tmpfd, contents)
+                if isinstance(contents, str):
+                    os.write(tmpfd, contents.encode(__salt_system_encoding__))
+                else:
+                    os.write(tmpfd, contents)
             finally:
                 try:
                     os.close(tmpfd)

--- a/tests/unit/utils/cloud_test.py
+++ b/tests/unit/utils/cloud_test.py
@@ -122,7 +122,7 @@ class CloudUtilsTestCase(TestCase):
         with self.assertRaises(Exception) as context:
             cloud.sftp_file("/tmp/test", "ТЕСТ test content")
         # we successful pass the place with os.write(tmpfd, ...
-        self.assertEqual("'hostname'", str(context.exception))
+        self.assertNotEqual("a bytes-like object is required, not 'str'", str(context.exception))
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/utils/cloud_test.py
+++ b/tests/unit/utils/cloud_test.py
@@ -118,6 +118,12 @@ class CloudUtilsTestCase(TestCase):
             'fake_username')
         self.assertEqual(pw_in_keyring, 'fake_password_c8231')
 
+    def test_sftp_file_with_content_under_python3(self):
+        with self.assertRaises(Exception) as context:
+            cloud.sftp_file("/tmp/test", "ТЕСТ test content")
+        # we successful pass the place with os.write(tmpfd, ...
+        self.assertEqual("'hostname'", str(context.exception))
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(CloudUtilsTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

Fix os.write within sftp_file function of salt.util.cloud.py

### What issues does this PR fix or reference?

#38048

### Tests written?

Yes

Tested under python 2.7.12 and 3.5.2

Before the fix.

```
===================================================================================================================  Overall Tests Report  ==========
*** unit.utils.cloud_test Tests  ********************************************************************************************************************
 --------  Skipped Tests  ---------------------------------------------------------------------------------------------------------------------------
   -> unit.utils.cloud_test.CloudUtilsTestCase.test__save_password_in_keyring       ->  The python keyring library is not installed
   -> unit.utils.cloud_test.CloudUtilsTestCase.test_retrieve_password_from_keyring  ->  The python keyring library is not installed
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 --------  Failed Tests  ----------------------------------------------------------------------------------------------------------------------------
   -> unit.utils.cloud_test.CloudUtilsTestCase.test_sftp_file_with_content_under_python3  ...........................................................
       Traceback (most recent call last):
         File "/Users/aaksenov/workspace/distrib/salt-distrib/tests/unit/utils/cloud_test.py", line 125, in test_sftp_file_with_content_under_python3
           self.assertEqual("'hostname'", str(context.exception))
       AssertionError: "'hostname'" != "a bytes-like object is required, not 'str'"
       - 'hostname'
       + a bytes-like object is required, not 'str'
   ..................................................................................................................................................
 ----------------------------------------------------------------------------------------------------------------------------------------------------
=====================================================================================================================================================
FAILED (total=5, skipped=2, passed=2, failures=1, errors=0)
===================================================================================================================  Overall Tests Report  ==========
```

After the fix.

```
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Starting unit.utils.cloud_test Tests
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ss...
----------------------------------------------------------------------
Ran 5 tests in 0.004s

OK (skipped=2)

===================================================================================================================  Overall Tests Report  ==========
*** unit.utils.cloud_test Tests  ********************************************************************************************************************
 --------  Skipped Tests  ---------------------------------------------------------------------------------------------------------------------------
   -> unit.utils.cloud_test.CloudUtilsTestCase.test__save_password_in_keyring       ->  The python keyring library is not installed
   -> unit.utils.cloud_test.CloudUtilsTestCase.test_retrieve_password_from_keyring  ->  The python keyring library is not installed
 ----------------------------------------------------------------------------------------------------------------------------------------------------
=====================================================================================================================================================
OK (total=5, skipped=2, passed=3, failures=0, errors=0)
===================================================================================================================  Overall Tests Report  ==========
```
