### PR TITLE
Get datacenters gh

### DIFF
--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -949,11 +949,8 @@ def get_datacenter(service_instance, datacenter_name):
     datacenter_name
         The datacenter name
     '''
-    items = [i['object'] for i in
-             get_mors_with_properties(service_instance,
-                                      vim.Datacenter,
-                                      property_list=['name'])
-            if i['name'] == datacenter_name]
+    items = get_datacenters(service_instance,
+                            datacenter_names=[datacenter_name])
     if not items:
         raise salt.exceptions.VMwareObjectRetrievalError(
             'Datacenter \'{0}\' was not found'.format(datacenter_name))

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -915,6 +915,30 @@ def list_datacenters(service_instance):
     return list_objects(service_instance, vim.Datacenter)
 
 
+def get_datacenters(service_instance, datacenter_names=None,
+                    get_all_datacenters=False):
+    '''
+    Returns all datacenters in a vCenter.
+
+    service_instance
+        The Service Instance Object from which to obtain cluster.
+
+    datacenter_names
+        List of datacenter names to filter by. Default value is None.
+
+    get_all_datacenters
+        Flag specifying whether to retrieve all datacenters.
+        Default value is None.
+    '''
+    items = [i['object'] for i in
+             get_mors_with_properties(service_instance,
+                                      vim.Datacenter,
+                                      property_list=['name'])
+             if get_all_datacenters or
+             (datacenter_names and i['name'] in datacenter_names)]
+    return items
+
+
 def get_datacenter(service_instance, datacenter_name):
     '''
     Returns a vim.Datacenter managed object.

--- a/tests/unit/utils/vmware_test/datacenter_test.py
+++ b/tests/unit/utils/vmware_test/datacenter_test.py
@@ -90,6 +90,40 @@ class GetDatacentersTestCase(TestCase):
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
+@patch('salt.utils.vmware.get_datacenters',
+       MagicMock(return_value=[MagicMock()]))
+class GetDatacenterTestCase(TestCase):
+    '''Tests for salt.utils.vmware.get_datacenter'''
+
+    def setUp(self):
+        self.mock_si = MagicMock()
+        self.mock_dc = MagicMock()
+
+    def test_get_datacenters_call(self):
+        mock_get_datacenters = MagicMock(return_value=[MagicMock()])
+        with patch('salt.utils.vmware.get_datacenters',
+                   mock_get_datacenters):
+            vmware.get_datacenter(self.mock_si, 'fake_dc1')
+        mock_get_datacenters.assert_called_once_with(
+            self.mock_si, datacenter_names=['fake_dc1'])
+
+    def test_no_datacenters_returned(self):
+        with patch('salt.utils.vmware.get_datacenters',
+                   MagicMock(return_value=[])):
+            with self.assertRaises(VMwareObjectRetrievalError) as excinfo:
+                vmware.get_datacenter(self.mock_si, 'fake_dc1')
+        self.assertEqual('Datacenter \'fake_dc1\' was not found',
+                         excinfo.exception.strerror)
+
+    def test_get_datacenter_return(self):
+        with patch('salt.utils.vmware.get_datacenters',
+                   MagicMock(return_value=[self.mock_dc])):
+            res = vmware.get_datacenter(self.mock_si, 'fake_dc1')
+        self.assertEqual(res, self.mock_dc)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
 @patch('salt.utils.vmware.get_root_folder', MagicMock())
 class CreateDatacenterTestCase(TestCase):
     '''Tests for salt.utils.vmware.create_datacenter'''

--- a/tests/unit/utils/vmware_test/datacenter_test.py
+++ b/tests/unit/utils/vmware_test/datacenter_test.py
@@ -32,12 +32,11 @@ log = logging.getLogger(__name__)
 @skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
 @patch('salt.utils.vmware.get_mors_with_properties',
        MagicMock(return_value=[{'name': 'fake_dc', 'object': MagicMock()}]))
-class GetDatacenterTestCase(TestCase):
-    '''Tests for salt.utils.vmware.get_datacenter'''
+class GetDatacentersTestCase(TestCase):
+    '''Tests for salt.utils.vmware.get_datacenters'''
 
     def setUp(self):
         self.mock_si = MagicMock()
-        self.mock_properties = [MagicMock()]
         self.mock_dc1 = MagicMock()
         self.mock_dc2 = MagicMock()
         self.mock_entries = [{'name': 'fake_dc1',
@@ -50,31 +49,43 @@ class GetDatacenterTestCase(TestCase):
             return_value=[{'name': 'fake_dc', 'object': MagicMock()}])
         with patch('salt.utils.vmware.get_mors_with_properties',
                    mock_get_mors_with_properties):
-            vmware.get_datacenter(self.mock_si, 'fake_dc')
+            vmware.get_datacenters(self.mock_si, datacenter_names=['fake_dc1'])
         mock_get_mors_with_properties.assert_called_once_with(
             self.mock_si, vim.Datacenter, property_list=['name'])
 
     def test_get_mors_with_properties_returns_empty_array(self):
         with patch('salt.utils.vmware.get_mors_with_properties',
                    MagicMock(return_value=[])):
-            with self.assertRaises(VMwareObjectRetrievalError) as excinfo:
-                vmware.get_datacenter(self.mock_si, 'fake_dc')
-        self.assertEqual(excinfo.exception.strerror,
-                         'Datacenter \'fake_dc\' was not found')
+            res = vmware.get_datacenters(self.mock_si,
+                                         datacenter_names=['fake_dc1'])
+        self.assertEqual(res, [])
+
+    def test_no_parameters(self):
+        with patch('salt.utils.vmware.get_mors_with_properties',
+                   MagicMock(return_value=self.mock_entries)):
+            res = vmware.get_datacenters(self.mock_si)
+        self.assertEqual(res, [])
 
     def test_datastore_not_found(self):
         with patch('salt.utils.vmware.get_mors_with_properties',
                    MagicMock(return_value=self.mock_entries)):
-            with self.assertRaises(VMwareObjectRetrievalError) as excinfo:
-                vmware.get_datacenter(self.mock_si, 'fake_dc')
-        self.assertEqual(excinfo.exception.strerror,
-                         'Datacenter \'fake_dc\' was not found')
+            res = vmware.get_datacenters(self.mock_si,
+                                         datacenter_names=['fake_dc'])
+        self.assertEqual(res, [])
 
     def test_datastore_found(self):
         with patch('salt.utils.vmware.get_mors_with_properties',
                    MagicMock(return_value=self.mock_entries)):
-            res = vmware.get_datacenter(self.mock_si, 'fake_dc2')
-        self.assertEqual(res, self.mock_dc2)
+            res = vmware.get_datacenters(
+                self.mock_si, datacenter_names=['fake_dc2'])
+        self.assertEqual(res, [self.mock_dc2])
+
+    def test_get_all_datastores(self):
+        with patch('salt.utils.vmware.get_mors_with_properties',
+                   MagicMock(return_value=self.mock_entries)):
+            res = vmware.get_datacenters(
+                self.mock_si, get_all_datacenters=True)
+        self.assertEqual(res, [self.mock_dc1, self.mock_dc2])
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)


### PR DESCRIPTION
### What does this PR do?
Added utils.vmware.get_datacenters which returns all datacenters in a vCenter
Updated utils.vmware.get_datacenter to use utils.vmware.get_datacenters

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
