### PR TITLE
Fix decoding of broken string from remote sources

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2977,7 +2977,9 @@ def to_str(s, encoding=None):
         return s
     if six.PY3:
         if isinstance(s, (bytes, bytearray)):
-            return s.decode(encoding or __salt_system_encoding__)
+            # https://docs.python.org/3/howto/unicode.html#the-unicode-type
+            # replace error with U+FFFD, REPLACEMENT CHARACTER
+            return s.decode(encoding or __salt_system_encoding__, "replace")
         raise TypeError('expected str, bytes, or bytearray')
     else:
         if isinstance(s, bytearray):

--- a/tests/unit/utils/utils_test.py
+++ b/tests/unit/utils/utils_test.py
@@ -768,6 +768,10 @@ class UtilsTestCase(TestCase):
             ut = bytes((0xe4, 0xb8, 0xad, 0xe5, 0x9b, 0xbd, 0xe8, 0xaa, 0x9e, 0x20, 0x28, 0xe7, 0xb9, 0x81, 0xe4, 0xbd, 0x93, 0x29))
             self.assertEqual(utils.to_str(ut, 'utf-8'), un)
             self.assertEqual(utils.to_str(bytearray(ut), 'utf-8'), un)
+            # Test situation when a minion returns incorrect utf-8 string because of... million reasons
+            ut2 = b'\x9c'
+            self.assertEqual(utils.to_str(ut2, 'utf-8'), u'\ufffd')
+            self.assertEqual(utils.to_str(bytearray(ut2), 'utf-8'), u'\ufffd')
         else:
             self.assertEqual(utils.to_str('plugh'), 'plugh')
             self.assertEqual(utils.to_str(u'áéíóúý', 'utf-8'), 'áéíóúý')


### PR DESCRIPTION
### What does this PR do?

Allow process broken UTF-8 sequences. It replace illegal characters with  U+FFFD, 'REPLACEMENT CHARACTER'

### What issues does this PR fix or reference?

#38070 

### Tests written?

Yes

Tested under python 3.5.2

Before the fix.

```
./tests/runtests.py -n unit.utils.utils_test
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Transplanting configuration files to '/private/tmp/salt-tests-tmpdir/config'
 * Current Directory: /Users/aaksenov/workspace/salt2
 * Test suite is running under PID 29392
 * Logging tests on /private/tmp/salt-runtests.log
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Starting unit.utils.utils_test Tests
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
............ss..............................E.........
======================================================================
ERROR: test_to_str (unit.utils.utils_test.UtilsTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aaksenov/workspace/salt2/tests/unit/utils/utils_test.py", line 773, in test_to_str
    self.assertEqual(utils.to_str(ut2, 'utf-8'), "")
  File "/Users/aaksenov/workspace/salt2/salt/utils/__init__.py", line 2976, in to_str
    return s.decode(encoding or __salt_system_encoding__)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9c in position 0: invalid start byte

----------------------------------------------------------------------
Ran 54 tests in 0.045s

FAILED (errors=1, skipped=2)

========================================  Overall Tests Report  =========================================
*** unit.utils.utils_test Tests  ************************************************************************
 --------  Skipped Tests  -------------------------------------------------------------------------------
   -> unit.utils.utils_test.UtilsTestCase.test_date_cast    ->  'timelib' is not installed
   -> unit.utils.utils_test.UtilsTestCase.test_date_format  ->  'timelib' is not installed
 --------------------------------------------------------------------------------------------------------
 --------  Tests with Errors  ---------------------------------------------------------------------------
   -> unit.utils.utils_test.UtilsTestCase.test_to_str  ..................................................
       Traceback (most recent call last):
         File "/Users/aaksenov/workspace/salt2/tests/unit/utils/utils_test.py", line 773, in test_to_str
           self.assertEqual(utils.to_str(ut2, 'utf-8'), "")
         File "/Users/aaksenov/workspace/salt2/salt/utils/__init__.py", line 2976, in to_str
           return s.decode(encoding or __salt_system_encoding__)
       UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9c in position 0: invalid start byte
   ......................................................................................................
 --------------------------------------------------------------------------------------------------------
=========================================================================================================
FAILED (total=54, skipped=2, passed=51, failures=0, errors=1)
========================================  Overall Tests Report  =========================================
```

After the fix

```
./tests/runtests.py -n unit.utils.utils_test
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Transplanting configuration files to '/private/tmp/salt-tests-tmpdir/config'
 * Current Directory: /Users/aaksenov/workspace/saaalt/salt
 * Test suite is running under PID 22089
 * Logging tests on /private/tmp/salt-runtests.log
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Starting unit.utils.utils_test Tests
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
............ss........................................
----------------------------------------------------------------------
Ran 54 tests in 0.046s

OK (skipped=2)

=================================  Overall Tests Report  ==================================
*** unit.utils.utils_test Tests  **********************************************************
 --------  Skipped Tests  -----------------------------------------------------------------
   -> unit.utils.utils_test.UtilsTestCase.test_date_cast    ->  'timelib' is not installed
   -> unit.utils.utils_test.UtilsTestCase.test_date_format  ->  'timelib' is not installed
 ------------------------------------------------------------------------------------------
===========================================================================================
OK (total=54, skipped=2, passed=52, failures=0, errors=0)
=================================  Overall Tests Report  ==================================
```

Fixes #38070
Suggest to replace incorrect UTF symbols with the special replacement character.
This would simplily interation with broken things in the real world.
https://docs.python.org/3/howto/unicode.html#the-unicode-type