### PR TITLE
Add deprecation notices to nitrogen release notes

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -71,3 +71,30 @@ release cycle (two major releases after this one), those who are using the
 :ref:`LocalClient <local-client>` (either directly, or implictly via a
 :ref:`netapi module <all-netapi-modules>`) are encouraged to update their code
 to use ``tgt_type``.
+
+
+Deprecations
+============
+
+General Deprecations
+--------------------
+
+- Beacon configurations should be lists instead of dictionaries.
+
+Proxy Minion Deprecations
+-------------------------
+
+- The ``proxy_merge_grains_in_module`` default has been switched from
+  ``False`` to ``True``.
+
+Salt-API Deprecations
+---------------------
+
+- The ``SaltAPI.run()`` function has been removed. Please use the
+  ``SaltAPI.start()`` function instead.
+
+Salt-SSH Deprecations
+---------------------
+
+- The ``wipe_ssh`` option for ``salt-ssh`` has been removed. Please use the
+  ``ssh_wipe`` option instead.


### PR DESCRIPTION
There were several deprecation PRs I made the other day for the Nitrogen release and I forgot to add their removals to the release notes. This PR updates the release notes with those changes.

Refs #37960 #37973 #37974 and #37977