### PR TITLE
add option for syndics to forward all events to all masters

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -637,6 +637,7 @@ VALID_OPTS = {
     # specify 'random' (default) or 'ordered'. If set to 'random' masters will be iterated in random
     # order if 'ordered' the configured order will be used.
     'syndic_failover': str,
+    'syndic_forward_all_events': bool,
     'runner_dirs': list,
     'client_acl': dict,
     'client_acl_verify': bool,
@@ -1290,6 +1291,7 @@ DEFAULT_MASTER_OPTS = {
     'preserve_minion_cache': False,
     'syndic_master': '',
     'syndic_failover': 'random',
+    'syndic_forward_all_events': False,
     'syndic_log_file': os.path.join(salt.syspaths.LOGS_DIR, 'syndic'),
     'syndic_pidfile': os.path.join(salt.syspaths.PIDFILE_DIR, 'salt-syndic.pid'),
     'runner_dirs': [],

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2573,7 +2573,7 @@ class SyndicManager(MinionBase):
         '''
         Wrapper to call the '_return_pub_multi' a syndic, best effort to get the one you asked for
         '''
-        success = True
+        success = False
         func = '_return_pub_multi'
         for master, syndic_future in self.iter_master_options(master_id):
             if not syndic_future.done() or syndic_future.exception():
@@ -2603,7 +2603,6 @@ class SyndicManager(MinionBase):
             if self.opts['syndic_forward_all_events']:
                 continue
             break
-        # Loop done and didn't exit: wasn't sent, try again later
         return success
 
     def iter_master_options(self, master_id=None):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2559,7 +2559,7 @@ class SyndicManager(MinionBase):
             try:
                 getattr(syndic_future.result(), func)(*args, **kwargs)
                 success = True
-                if self.opts['syndic_forward_events'] == 'all':
+                if self.opts['syndic_forward_all_events']:
                     continue
                 return
             except SaltClientError:
@@ -2600,7 +2600,7 @@ class SyndicManager(MinionBase):
             future = getattr(syndic_future.result(), func)(values)
             self.pub_futures[master] = (future, values)
             success = True
-            if self.opts['syndic_forward_events'] == 'all':
+            if self.opts['syndic_forward_all_events']:
                 continue
             break
         # Loop done and didn't exit: wasn't sent, try again later

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2548,6 +2548,7 @@ class SyndicManager(MinionBase):
         '''
         Wrapper to call a given func on a syndic, best effort to get the one you asked for
         '''
+        success = False
         if kwargs is None:
             kwargs = {}
         for master, syndic_future in self.iter_master_options(master_id):
@@ -2557,17 +2558,22 @@ class SyndicManager(MinionBase):
 
             try:
                 getattr(syndic_future.result(), func)(*args, **kwargs)
+                success = True
+                if self.opts['syndic_forward_events'] == 'all':
+                    continue
                 return
             except SaltClientError:
                 log.error('Unable to call {0} on {1}, trying another...'.format(func, master))
                 self._mark_master_dead(master)
                 continue
-        log.critical('Unable to call {0} on any masters!'.format(func))
+        if not success:
+            log.critical('Unable to call {0} on any masters!'.format(func))
 
     def _return_pub_syndic(self, values, master_id=None):
         '''
         Wrapper to call the '_return_pub_multi' a syndic, best effort to get the one you asked for
         '''
+        success = True
         func = '_return_pub_multi'
         for master, syndic_future in self.iter_master_options(master_id):
             if not syndic_future.done() or syndic_future.exception():
@@ -2593,9 +2599,12 @@ class SyndicManager(MinionBase):
                     continue
             future = getattr(syndic_future.result(), func)(values)
             self.pub_futures[master] = (future, values)
-            return True
+            success = True
+            if self.opts['syndic_forward_events'] == 'all':
+                continue
+            break
         # Loop done and didn't exit: wasn't sent, try again later
-        return False
+        return success
 
     def iter_master_options(self, master_id=None):
         '''


### PR DESCRIPTION
What does this PR do?

Adds a configuration option to forward events to all masters connected to the syndics.

Previous Behaviors

Events were forwarded to random/sorted master

New Behaviour

User can choose to forward events to all masters.

Tests written?

No