### PR TITLE
Enable resetting a VM via salt-cloud & VMware driver

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -369,6 +369,9 @@
 # Pass in an alternative location for the salt-ssh roster file
 #roster_file: /etc/salt/roster
 
+# The log file of the salt-ssh command:
+#ssh_log_file: /var/log/salt/ssh
+
 # Pass in minion option overrides that will be inserted into the SHIM for
 # salt-ssh calls. The local minion config is not used for salt-ssh. Can be
 # overridden on a per-minion basis in the roster (`minion_opts`)

--- a/conf/master
+++ b/conf/master
@@ -803,8 +803,8 @@
 # PID file of the syndic daemon:
 #syndic_pidfile: /var/run/salt-syndic.pid
 
-# LOG file of the syndic daemon:
-#syndic_log_file: syndic.log
+# The log file of the salt-syndic daemon:
+#syndic_log_file: /var/log/salt/syndic
 
 # The behaviour of the multi-syndic when connection to a master of masters failed.
 # Can specify ``random`` (default) or ``ordered``. If set to ``random``, masters

--- a/conf/master
+++ b/conf/master
@@ -798,7 +798,7 @@
 
 # If this master will be running a salt syndic daemon, syndic_master tells
 # this master where to receive commands from.
-#syndic_master: masterofmaster
+#syndic_master: masterofmasters
 
 # This is the 'ret_port' of the MasterOfMaster:
 #syndic_master_port: 4506

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -193,7 +193,7 @@ project = 'Salt'
 copyright = '2016 SaltStack, Inc.'
 
 version = salt.version.__version__
-latest_release = '2016.3.4'  # latest release
+latest_release = '2016.11.0'  # latest release
 previous_release = '2015.8.12'  # latest release from previous branch
 previous_release_dir = '2015.8'  # path on web server for previous branch
 next_release = ''  # next release

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2842,15 +2842,16 @@ can be utilized:
 Syndic Server Settings
 ======================
 
-A Salt syndic is a Salt master used to pass commands from a higher Salt master to
-minions below the syndic. Using the syndic is simple. If this is a master that
-will have syndic servers(s) below it, set the "order_masters" setting to True.
+A Salt syndic is a Salt master used to pass commands from a higher Salt master
+to minions below the syndic. Using the syndic is simple. If this is a master
+that will have syndic servers(s) below it, set the ``order_masters`` setting to
+``True``.
 
 If this is a master that will be running a syndic daemon for passthrough the
-"syndic_master" setting needs to be set to the location of the master server.
+``syndic_master`` setting needs to be set to the location of the master server.
 
-Do not not forget that, in other words, it means that it shares with the local minion
-its ID and PKI_DIR.
+Do not forget that, in other words, it means that it shares with the local minion
+its ID and PKI directory.
 
 .. conf_master:: order_masters
 
@@ -2874,7 +2875,7 @@ value must be set to True
 
 Default: ``''``
 
-If this master will be running a salt-syndic to connect to a higher level
+If this master will be running the ``salt-syndic`` to connect to a higher level
 master, specify the higher level master with this configuration value.
 
 .. code-block:: yaml
@@ -2882,7 +2883,7 @@ master, specify the higher level master with this configuration value.
     syndic_master: masterofmasters
 
 You can optionally connect a syndic to multiple higher level masters by
-setting the 'syndic_master' value to a list:
+setting the ``syndic_master`` value to a list:
 
 .. code-block:: yaml
 
@@ -2890,7 +2891,7 @@ setting the 'syndic_master' value to a list:
       - masterofmasters1
       - masterofmasters2
 
-Each higher level master must be set up in a multimaster configuration.
+Each higher level master must be set up in a multi-master configuration.
 
 .. conf_master:: syndic_master_port
 
@@ -2899,7 +2900,7 @@ Each higher level master must be set up in a multimaster configuration.
 
 Default: ``4506``
 
-If this master will be running a salt-syndic to connect to a higher level
+If this master will be running the ``salt-syndic`` to connect to a higher level
 master, specify the higher level master port with this configuration value.
 
 .. code-block:: yaml
@@ -2911,28 +2912,28 @@ master, specify the higher level master port with this configuration value.
 ``syndic_pidfile``
 ------------------
 
-Default: ``salt-syndic.pid``
+Default: ``/var/run/salt-syndic.pid``
 
-If this master will be running a salt-syndic to connect to a higher level
+If this master will be running the ``salt-syndic`` to connect to a higher level
 master, specify the pidfile of the syndic daemon.
 
 .. code-block:: yaml
 
-    syndic_pidfile: syndic.pid
+    syndic_pidfile: /var/run/syndic.pid
 
 .. conf_master:: syndic_log_file
 
 ``syndic_log_file``
 -------------------
 
-Default: ``syndic.log``
+Default: ``/var/log/salt/syndic``
 
-If this master will be running a salt-syndic to connect to a higher level
-master, specify the log_file of the syndic daemon.
+If this master will be running the ``salt-syndic`` to connect to a higher level
+master, specify the log file of the syndic daemon.
 
 .. code-block:: yaml
 
-    syndic_log_file: salt-syndic.log
+    syndic_log_file: /var/log/salt-syndic.log
 
 .. master_conf:: syndic_failover
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -41,7 +41,7 @@ The local interface to bind to.
 Default: ``False``
 
 Whether the master should listen for IPv6 connections. If this is set to True,
-the interface option must be adjusted too (for example: "interface: '::'")
+the interface option must be adjusted too (for example: ``interface: '::'``)
 
 .. code-block:: yaml
 
@@ -1558,7 +1558,6 @@ directories above the one specified will be ignored and the relative path will
     gitfs_root: somefolder/otherfolder
 
 .. versionchanged:: 2014.7.0
-
    Ability to specify gitfs roots on a per-remote basis was added. See
    :ref:`here <gitfs-per-remote-config>` for more info.
 
@@ -2888,7 +2887,11 @@ value must be set to True
 ``syndic_master``
 -----------------
 
-Default: ``''``
+.. versionchanged:: 2016.3.5,2016.11.1
+
+    Set default higher level master address.
+
+Default: ``masterofmasters``
 
 If this master will be running the ``salt-syndic`` to connect to a higher level
 master, specify the higher level master with this configuration value.

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2297,8 +2297,19 @@ There are additional details at :ref:`salt-pillars`
 Default: ``False``
 
 This option allows for external pillar sources to be evaluated before
-:conf_master:`pillar_roots`. This allows for targeting file system pillar from
-ext_pillar.
+:conf_master:`pillar_roots`. External pillar data is evaluated separately from
+:conf_master:`pillar_roots` pillar data, and then both sets of pillar data are
+merged into a single pillar dictionary, so the value of this config option will
+have an impact on which key "wins" when there is one of the same name in both
+the external pillar data and :conf_master:`pillar_roots` pillar data. By
+setting this option to ``True``, ext_pillar keys will be overridden by
+:conf_master:`pillar_roots`, while leaving it as ``False`` will allow
+ext_pillar keys to override those from :conf_master:`pillar_roots`.
+
+.. note::
+    For a while, this config option did not work as specified above, because of
+    a bug in Pillar compilation. This bug has been resolved in version 2016.3.4
+    and later.
 
 .. code-block:: yaml
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -706,6 +706,21 @@ Pass in an alternative location for the salt-ssh roster file.
 
     roster_file: /root/roster
 
+.. conf_master:: ssh_log_file
+
+``ssh_log_file``
+-------------------
+
+.. versionadded:: 2016.3.5
+
+Default: ``/var/log/salt/ssh``
+
+Specify the log file of the ``salt-ssh`` command.
+
+.. code-block:: yaml
+
+    ssh_log_file: /var/log/salt/ssh
+
 .. conf_master:: ssh_minion_opts
 
 ``ssh_minion_opts``

--- a/doc/ref/peer.rst
+++ b/doc/ref/peer.rst
@@ -124,3 +124,7 @@ To match minions using other matchers, use ``expr_form``:
 .. code-block:: bash
 
     # salt-call publish.publish 'webserv* and not G@os:Ubuntu' test.ping expr_form='compound'
+
+.. note::
+    The expr_form argument will be renamed to ``tgt_type`` in the Nitrogen
+    release of Salt.

--- a/doc/ref/states/top.rst
+++ b/doc/ref/states/top.rst
@@ -438,7 +438,7 @@ environment, no states from the ``qa`` environment would be applied.
 Scenario 3 - No Environment Specified, :conf_minion:`top_file_merging_strategy` is "same"
 -----------------------------------------------------------------------------------------
 
-.. versionchanged:: Carbon
+.. versionchanged:: 2016.11.0
     In prior versions, "same" did not quite work as described below (see
     here__). This has now been corrected. It was decided that changing
     something like top file handling in a point release had the potential to

--- a/doc/topics/cloud/vsphere.rst
+++ b/doc/topics/cloud/vsphere.rst
@@ -4,11 +4,11 @@ Getting Started With vSphere
 
 .. note::
 
-    .. deprecated:: Carbon
+    .. deprecated:: 2016.11.0
 
         The :py:func:`vsphere <salt.cloud.clouds.vsphere>` cloud driver has been
         deprecated in favor of the :py:func:`vmware <salt.cloud.clouds.vmware>`
-        cloud driver and will be removed in Salt Carbon. Please refer to
+        cloud driver and will be removed in Salt 2016.11.0. Please refer to
         :doc:`Getting started with VMware </topics/cloud/vmware>` instead to get
         started with the configuration.
 

--- a/doc/topics/mine/index.rst
+++ b/doc/topics/mine/index.rst
@@ -179,3 +179,7 @@ to add them to the pool of load balanced servers.
     {% endfor %}
 
     <...file contents snipped...>
+
+.. note::
+    The expr_form argument will be renamed to ``tgt_type`` in the Nitrogen
+    release of Salt.

--- a/doc/topics/reactor/index.rst
+++ b/doc/topics/reactor/index.rst
@@ -376,6 +376,13 @@ Use the ``expr_form`` argument to specify a matcher:
         - arg:
           - rm -rf /tmp/*
 
+.. note::
+    An easy mistake to make here is to use ``tgt_type`` instead of
+    ``expr_form``, since the job cache and events all refer to the targeting
+    method as ``tgt_type``. As of the Nitrogen release of Salt, ``expr_form``
+    will be deprecated in favor of using ``tgt_type``, to help with this
+    confusion.
+
 Any other parameters in the :py:meth:`LocalClient().cmd()
 <salt.client.LocalClient.cmd>` method can be specified as well.
 

--- a/doc/topics/releases/version_numbers.rst
+++ b/doc/topics/releases/version_numbers.rst
@@ -27,8 +27,9 @@ Assigned codenames:
 - Helium: ``2014.7.0``
 - Lithium: ``2015.5.0``
 - Beryllium: ``2015.8.0``
-- Boron: ``TBD``
-- Carbon: ``TBD``
+- Boron: ``2016.3.0``
+- Carbon: ``2016.11.0``
+- Nitrogen: ``TBD``
 
 Example
 -------

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -223,14 +223,15 @@ class CloudClient(object):
         profile = opts.get('profile', None)
         # filter other profiles if one is specified
         if profile:
-            for _profile in [a for a in opts.get('profiles', {})]:
+            tmp_profiles = opts.get('profiles', {}).copy()
+            for _profile in [a for a in tmp_profiles]:
                 if not _profile == profile:
-                    opts['profiles'].pop(_profile)
+                    tmp_profiles.pop(_profile)
             # if profile is specified and we have enough info about providers
             # also filter them to speedup methods like
             # __filter_non_working_providers
             providers = [a.get('provider', '').split(':')[0]
-                         for a in six.itervalues(opts['profiles'])
+                         for a in six.itervalues(tmp_profiles)
                          if a.get('provider', '')]
             if providers:
                 _providers = opts.get('providers', {})

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -206,7 +206,7 @@ class CloudClient(object):
         the kwargs
         '''
         # Let's start with the default salt cloud configuration
-        opts = salt.config.CLOUD_CONFIG_DEFAULTS.copy()
+        opts = salt.config.DEFAULT_CLOUD_OPTS.copy()
         # Update it with the loaded configuration
         opts.update(self.opts.copy())
         # Reset some of the settings to sane values

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -1016,6 +1016,26 @@ def list_nodes_full(call=None, **kwargs):
     return ret
 
 
+def list_nodes_min(call=None, **kwargs):
+    '''
+    Return a list of the VMs that in this location
+    '''
+    if call == 'action':
+        raise SaltCloudSystemExit(
+            (
+                'The list_nodes_min function must be called with'
+                ' -f or --function.'
+            )
+        )
+
+    conn = get_conn()
+    server_list = conn.server_list_min()
+
+    if not server_list:
+        return {}
+    return server_list
+
+
 def list_nodes_select(call=None):
     '''
     Return a list of the VMs that are on the provider, with select fields

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -62,6 +62,7 @@ to find the IP of the new VM.
 
 # Import Python Libs
 from __future__ import absolute_import
+import distutils
 import logging
 import os
 import pprint

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1993,7 +1993,7 @@ def reset(name, call=None):
                 return ret
             try:
                 log.info('Resetting VM {0}'.format(name))
-                task = vm["object"].Reset()
+                task = vm["object"].ResetVM_Task()
                 salt.utils.vmware.wait_for_task(task, name, 'reset')
             except Exception as exc:
                 log.error(

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1912,7 +1912,7 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
                  providers_config_path=None, providers_config=None,
                  profiles_config_path=None, profiles_config=None):
     '''
-    Read in the salt cloud config and return the dict
+    Read in the Salt Cloud config and return the dict
     '''
     if path:
         config_dir = os.path.dirname(path)
@@ -1927,14 +1927,15 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
     )
 
     if defaults is None:
-        defaults = DEFAULT_CLOUD_OPTS
+        defaults = DEFAULT_CLOUD_OPTS.copy()
+
+    # Set defaults early to override Salt Master's default config values later
+    defaults.update(overrides)
+    overrides = defaults
 
     # Load cloud configuration from any default or provided includes
-    default_include = overrides.get(
-        'default_include', defaults['default_include']
-    )
     overrides.update(
-        salt.config.include_config(default_include, path, verbose=False)
+        salt.config.include_config(overrides['default_include'], path, verbose=False)
     )
     include = overrides.get('include', [])
     overrides.update(

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3285,24 +3285,16 @@ def client_config(path, env_var='SALT_CLIENT_CONFIG', defaults=None):
 
 def api_config(path):
     '''
-    Read in the salt master config file and add additional configs that
+    Read in the Salt Master config file and add additional configs that
     need to be stubbed out for salt-api
     '''
     # Let's grab a copy of salt's master opts
     opts = client_config(path, defaults=DEFAULT_MASTER_OPTS)
     # Let's override them with salt-api's required defaults
-    api_opts = {
-        'log_file': opts.get(
-            'api_logfile', os.path.join(
-                opts['root_dir'], DEFAULT_API_OPTS['api_logfile'].lstrip('/')
-            )
-        ),
-        'pidfile': opts.get(
-            'api_pidfile', os.path.join(
-                opts['root_dir'], DEFAULT_API_OPTS['api_pidfile'].lstrip('/')
-            )
-        ),
-    }
+    api_opts = DEFAULT_API_OPTS
+    api_opts.update({
+        'pidfile': opts.get('api_pidfile', DEFAULT_API_OPTS['api_pidfile']),
+    })
     opts.update(api_opts)
     return opts
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -771,6 +771,7 @@ VALID_OPTS = {
     # The length that the syndic event queue must hit before events are popped off and forwarded
     'syndic_jid_forward_cache_hwm': int,
 
+    # Salt SSH configuration
     'ssh_passwd': str,
     'ssh_port': str,
     'ssh_sudo': bool,
@@ -780,6 +781,7 @@ VALID_OPTS = {
     'ssh_scan_ports': str,
     'ssh_scan_timeout': float,
     'ssh_identities_only': bool,
+    'ssh_log_file': str,
 
     # Enable ioflo verbose logging. Warning! Very verbose!
     'ioflo_verbose': int,
@@ -1311,6 +1313,7 @@ DEFAULT_MASTER_OPTS = {
     'ssh_scan_ports': '22',
     'ssh_scan_timeout': 0.01,
     'ssh_identities_only': False,
+    'ssh_log_file': os.path.join(salt.syspaths.LOGS_DIR, 'ssh'),
     'master_floscript': os.path.join(FLO_DIR, 'master.flo'),
     'worker_floscript': os.path.join(FLO_DIR, 'worker.flo'),
     'maintenance_floscript': os.path.join(FLO_DIR, 'maint.flo'),

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -144,19 +144,20 @@ VALID_OPTS = {
     # Must also set master_sign_pubkey for this to work
     'verify_master_pubkey_sign': bool,
 
-    # If verify_master_pubkey_sign is enabled, the signature is only verified, if the public-key of the master changes.
-    # If the signature should always be verified, this can be set to True.
+    # If verify_master_pubkey_sign is enabled, the signature is only verified, if the public-key of
+    # the master changes. If the signature should always be verified, this can be set to True.
     'always_verify_signature': bool,
 
-    # The name of the file in the masters pki-directory that holds the pre-calculated signature of the masters public-key.
+    # The name of the file in the masters pki-directory that holds the pre-calculated signature of
+    # the masters public-key
     'master_pubkey_signature': str,
 
     # Instead of computing the signature for each auth-reply, use a pre-calculated signature.
     # The master_pubkey_signature must also be set for this.
     'master_use_pubkey_signature': bool,
 
-    # The key fingerprint of the higher-level master for the syndic to verify it is talking to the intended
-    # master
+    # The key fingerprint of the higher-level master for the syndic to verify it is talking to the
+    # intended master
     'syndic_finger': str,
 
     # The user under which the daemon should run
@@ -432,8 +433,8 @@ VALID_OPTS = {
     # have an event_return(event) function!
     'event_return': str,
 
-    # The number of events to queue up in memory before pushing them down the pipe to an event returner
-    # specified by 'event_return'
+    # The number of events to queue up in memory before pushing them down the pipe to an event
+    # returner specified by 'event_return'
     'event_return_queue': int,
 
     # Only forward events to an event returner if it matches one of the tags in this list
@@ -451,8 +452,8 @@ VALID_OPTS = {
     # Used with the SECO range master tops system
     'range_server': str,
 
-    # The tcp keepalive interval to set on TCP ports. This setting can be used to tune salt connectivity
-    # issues in messy network environments with misbehaving firewalls
+    # The tcp keepalive interval to set on TCP ports. This setting can be used to tune Salt
+    # connectivity issues in messy network environments with misbehaving firewalls
     'tcp_keepalive': bool,
 
     # Sets zeromq TCP keepalive idle. May be used to tune issues with minion disconnects
@@ -675,7 +676,8 @@ VALID_OPTS = {
     # index
     'search_index_interval': int,
 
-    # A compound target definition. See: http://docs.saltstack.com/en/latest/topics/targeting/nodegroups.html
+    # A compound target definition.
+    # See: http://docs.saltstack.com/en/latest/topics/targeting/nodegroups.html
     'nodegroups': dict,
 
     # List-only nodegroups for salt-ssh. Each group must be formed as either a
@@ -784,7 +786,8 @@ VALID_OPTS = {
 
     'ioflo_period': float,
 
-    # Set ioflo to realtime. Useful only for testing/debugging to simulate many ioflo periods very quickly.
+    # Set ioflo to realtime. Useful only for testing/debugging to simulate many ioflo periods very
+    # quickly
     'ioflo_realtime': bool,
 
     # Location for ioflo logs
@@ -842,14 +845,14 @@ VALID_OPTS = {
     # If set, all minion exec module actions will be rerouted through sudo as this user
     'sudo_user': str,
 
-    # HTTP request timeout in seconds. Applied for tornado http fetch functions like cp.get_url should be greater than
-    # overall download time.
+    # HTTP request timeout in seconds. Applied for tornado http fetch functions like cp.get_url
+    # should be greater than overall download time
     'http_request_timeout': float,
 
     # HTTP request max file content size.
     'http_max_body': int,
 
-    # Delay in seconds before executing bootstrap (salt cloud)
+    # Delay in seconds before executing bootstrap (Salt Cloud)
     'bootstrap_delay': int,
 
     # If a proxymodule has a function called 'grains', then call it during
@@ -857,7 +860,7 @@ VALID_OPTS = {
     # dictionary.  Otherwise it is assumed that the module calls the grains
     # function in a custom way and returns the data elsewhere
     #
-    # Default to False for 2016.3 and Carbon.  Switch to True for Nitrogen
+    # Default to False for 2016.3 and Carbon. Switch to True for Nitrogen
     'proxy_merge_grains_in_module': bool,
 
     # Extra modules for Salt Thin
@@ -1360,7 +1363,7 @@ DEFAULT_PROXY_MINION_OPTS = {
 }
 
 # ----- Salt Cloud Configuration Defaults ----------------------------------->
-CLOUD_CONFIG_DEFAULTS = {
+DEFAULT_CLOUD_OPTS = {
     'verify_env': True,
     'default_include': 'cloud.conf.d/*.conf',
     # Global defaults
@@ -1400,7 +1403,7 @@ DEFAULT_SPM_OPTS = {
     'formula_path': '/srv/spm/salt',
     'pillar_path': '/srv/spm/pillar',
     'reactor_path': '/srv/spm/reactor',
-    'spm_logfile': '/var/log/salt/spm',
+    'spm_logfile': os.path.join(salt.syspaths.LOGS_DIR, 'spm'),
     'default_include': 'spm.d/*.conf',
     # spm_repos_config also includes a .d/ directory
     'spm_repos_config': '/etc/salt/spm.repos',
@@ -1924,7 +1927,7 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
     )
 
     if defaults is None:
-        defaults = CLOUD_CONFIG_DEFAULTS
+        defaults = DEFAULT_CLOUD_OPTS
 
     # Load cloud configuration from any default or provided includes
     default_include = overrides.get(
@@ -2134,7 +2137,7 @@ def apply_cloud_config(overrides, defaults=None):
     Return a cloud config
     '''
     if defaults is None:
-        defaults = CLOUD_CONFIG_DEFAULTS
+        defaults = DEFAULT_CLOUD_OPTS
 
     config = defaults.copy()
     if overrides:

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1190,7 +1190,7 @@ DEFAULT_MASTER_OPTS = {
     'ping_on_rotate': False,
     'peer': {},
     'preserve_minion_cache': False,
-    'syndic_master': '',
+    'syndic_master': 'salt',
     'syndic_failover': 'random',
     'syndic_log_file': os.path.join(salt.syspaths.LOGS_DIR, 'syndic'),
     'syndic_pidfile': os.path.join(salt.syspaths.PIDFILE_DIR, 'salt-syndic.pid'),

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -327,7 +327,7 @@ VALID_OPTS = {
     'log_level': str,
 
     # The log level to log to a given file
-    'log_level_logfile': bool,
+    'log_level_logfile': str,
 
     # The format to construct dates in log files
     'log_datefmt': str,

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1190,7 +1190,7 @@ DEFAULT_MASTER_OPTS = {
     'ping_on_rotate': False,
     'peer': {},
     'preserve_minion_cache': False,
-    'syndic_master': 'salt',
+    'syndic_master': 'masterofmasters',
     'syndic_failover': 'random',
     'syndic_log_file': os.path.join(salt.syspaths.LOGS_DIR, 'syndic'),
     'syndic_pidfile': os.path.join(salt.syspaths.PIDFILE_DIR, 'salt-syndic.pid'),

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1781,7 +1781,7 @@ def minion_config(path,
         minion_opts = salt.config.minion_config('/etc/salt/minion')
     '''
     if defaults is None:
-        defaults = DEFAULT_MINION_OPTS
+        defaults = DEFAULT_MINION_OPTS.copy()
 
     if path is not None and path.endswith('proxy'):
         defaults.update(DEFAULT_PROXY_MINION_OPTS)
@@ -3314,7 +3314,7 @@ def spm_config(path):
     .. versionadded:: 2015.8.0
     '''
     # Let's grab a copy of salt's master default opts
-    defaults = DEFAULT_MASTER_OPTS
+    defaults = DEFAULT_MASTER_OPTS.copy()
     # Let's override them with spm's required defaults
     defaults.update(DEFAULT_SPM_OPTS)
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -13,6 +13,7 @@ import re
 import time
 import stat
 import tempfile
+import msgpack
 
 # Import salt libs
 import salt.crypt
@@ -146,7 +147,12 @@ def clean_expired_tokens(opts):
         for token in filenames:
             token_path = os.path.join(dirpath, token)
             with salt.utils.fopen(token_path) as token_file:
-                token_data = serializer.loads(token_file.read())
+                try:
+                    token_data = serializer.loads(token_file.read())
+                except msgpack.UnpackValueError:
+                    # Bad token file or empty. Remove.
+                    os.remove(token_path)
+                    return
                 if 'expire' not in token_data or token_data.get('expire', 0) < time.time():
                     try:
                         os.remove(token_path)

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1270,7 +1270,9 @@ def os_data():
                     key
                 )
                 grains[lsb_param] = value
-        except ImportError:
+        # Catch a NameError to workaround possible breakage in lsb_release
+        # See https://github.com/saltstack/salt/issues/37867
+        except (ImportError, NameError):
             # if the python library isn't available, default to regex
             if os.path.isfile('/etc/lsb-release'):
                 # Matches any possible format:

--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -67,7 +67,7 @@ def show_link(name):
     '''
     Display master link for the alternative
 
-    .. versionadded:: 2015.8.13,2016.3.4,Carbon
+    .. versionadded:: 2015.8.13,2016.3.4,2016.11.0
 
     CLI Example:
 

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -379,7 +379,7 @@ def install(name=None,
             reinstall=False,
             **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -805,7 +805,7 @@ def autoremove(list_only=False, purge=False):
 
 def remove(name=None, pkgs=None, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -849,7 +849,7 @@ def remove(name=None, pkgs=None, **kwargs):
 
 def purge(name=None, pkgs=None, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -893,7 +893,7 @@ def purge(name=None, pkgs=None, **kwargs):
 
 def upgrade(refresh=True, dist_upgrade=False, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -465,7 +465,7 @@ def install(name=None,
             binhost=None,
             **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -700,7 +700,7 @@ def install(name=None,
 
 def update(pkg, slot=None, fromrepo=None, refresh=False, binhost=None):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -782,7 +782,7 @@ def update(pkg, slot=None, fromrepo=None, refresh=False, binhost=None):
 
 def upgrade(refresh=True, binhost=None, backtrack=3):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -870,7 +870,7 @@ def upgrade(refresh=True, binhost=None, backtrack=3):
 
 def remove(name=None, slot=None, fromrepo=None, pkgs=None, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -953,7 +953,7 @@ def remove(name=None, slot=None, fromrepo=None, pkgs=None, **kwargs):
 
 def purge(name=None, slot=None, fromrepo=None, pkgs=None, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -1369,7 +1369,7 @@ def diff(cwd,
          cached=False,
          paths=None):
     '''
-    .. versionadded:: 2015.8.12,2016.3.3,Carbon
+    .. versionadded:: 2015.8.12,2016.3.3,2016.11.0
 
     Interface to `git-diff(1)`_
 

--- a/salt/modules/nacl.py
+++ b/salt/modules/nacl.py
@@ -93,6 +93,7 @@ multiline encrypted secrets from pillar in a state, use the following format to 
 creating extra whitespace at the beginning of each line in the cert file:
 
 .. code-block:: yaml
+
     secret.txt:
         file.managed:
             - template: jinja

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -262,7 +262,7 @@ def install(name=None,
             sources=None,
             **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -404,7 +404,7 @@ def install(name=None,
 
 def upgrade(refresh=False, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -496,7 +496,7 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
 
 def remove(name=None, pkgs=None, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -540,7 +540,7 @@ def remove(name=None, pkgs=None, **kwargs):
 
 def purge(name=None, pkgs=None, **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -508,7 +508,7 @@ def missing(name):
 def unmask(name):
     '''
     .. versionadded:: 2015.5.0
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -547,7 +547,7 @@ def unmask(name):
 def mask(name, runtime=False):
     '''
     .. versionadded:: 2015.5.0
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -613,7 +613,7 @@ def masked(name):
 
 def start(name):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -642,7 +642,7 @@ def start(name):
 
 def stop(name):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -669,7 +669,7 @@ def stop(name):
 
 def restart(name):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -697,7 +697,7 @@ def restart(name):
 
 def reload_(name):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -725,7 +725,7 @@ def reload_(name):
 
 def force_reload(name):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -776,7 +776,7 @@ def status(name, sig=None):  # pylint: disable=unused-argument
 # established by Salt's service management states.
 def enable(name, **kwargs):  # pylint: disable=unused-argument
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where
@@ -820,7 +820,7 @@ def enable(name, **kwargs):  # pylint: disable=unused-argument
 # established by Salt's service management states.
 def disable(name, **kwargs):  # pylint: disable=unused-argument
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands run by this function from the ``salt-minion`` daemon's
         control group. This is done to avoid a race condition in cases where

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -412,28 +412,6 @@ def latest_version(*names, **kwargs):
     if len(names) == 0:
         return ''
 
-    # Initialize the return dict with empty strings, and populate namearch_map.
-    # namearch_map will provide a means of distinguishing between multiple
-    # matches for the same package name, for example a target of 'glibc' on an
-    # x86_64 arch would return both x86_64 and i686 versions.
-    #
-    # Note that the logic in the for loop below would place the osarch into the
-    # map for noarch packages, but those cases are accounted for when iterating
-    # through the 'yum list' results later on. If the match for that package is
-    # a noarch, then the package is assumed to be noarch, and the namearch_map
-    # is ignored.
-    ret = {}
-    namearch_map = {}
-    for name in names:
-        ret[name] = ''
-        try:
-            arch = name.rsplit('.', 1)[-1]
-            if arch not in salt.utils.pkg.rpm.ARCHES:
-                arch = __grains__['osarch']
-        except ValueError:
-            arch = __grains__['osarch']
-        namearch_map[name] = arch
-
     repo_arg = _get_repo_options(**kwargs)
     exclude_arg = _get_excludes_option(**kwargs)
 
@@ -489,9 +467,33 @@ def latest_version(*names, **kwargs):
             # Package is not installed
             return True
 
+    ret = {}
     for name in names:
+        # Derive desired pkg arch (for arch-specific packages) based on the
+        # package name(s) passed to the function. On a 64-bit OS, "pkgame"
+        # would be assumed to match the osarch, while "pkgname.i686" would
+        # have an arch of "i686". This desired arch is then compared against
+        # the updates derived from _yum_pkginfo() above, so that we can
+        # distinguish an update for a 32-bit version of a package from its
+        # 64-bit counterpart.
+        try:
+            arch = name.rsplit('.', 1)[-1]
+            if arch not in salt.utils.pkg.rpm.ARCHES:
+                arch = __grains__['osarch']
+        except ValueError:
+            arch = __grains__['osarch']
+
+        # This loop will iterate over the updates derived by _yum_pkginfo()
+        # above, which have been sorted descendingly by version number,
+        # ensuring that the latest available version for the named package is
+        # examined first. The call to _check_cur() will ensure that a package
+        # seen by yum as "available" will only be detected as an upgrade if it
+        # has a version higher than all currently-installed versions of the
+        # package.
         for pkg in (x for x in updates if x.name == name):
-            if pkg.arch == 'noarch' or pkg.arch == namearch_map[name] \
+            # This if/or statement makes sure that we account for noarch
+            # packages as well as arch-specific packages.
+            if pkg.arch == 'noarch' or pkg.arch == arch \
                     or salt.utils.pkg.rpm.check_32(pkg.arch):
                 if _check_cur(pkg):
                     ret[name] = pkg.version

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1103,7 +1103,7 @@ def install(name=None,
             normalize=True,
             **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -1454,7 +1454,7 @@ def install(name=None,
 def upgrade(refresh=True, skip_verify=False, **kwargs):
     '''
     .. versionchanged:: 2014.7.0
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -1530,7 +1530,7 @@ def upgrade(refresh=True, skip_verify=False, **kwargs):
 
 def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -1594,7 +1594,7 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
 
 def purge(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -887,7 +887,7 @@ def install(name=None,
             ignore_repo_failure=False,
             **kwargs):
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -1054,7 +1054,7 @@ def upgrade(refresh=True,
             novendorchange=False,
             **kwargs):  # pylint: disable=unused-argument
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -1174,7 +1174,7 @@ def _uninstall(name=None, pkgs=None):
 
 def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd
@@ -1218,7 +1218,7 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
 
 def purge(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
     '''
-    .. versionchanged:: 2015.8.12,2016.3.3,Carbon
+    .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
         isolate commands which modify installed packages from the
         ``salt-minion`` daemon's control group. This is done to keep systemd

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3340,9 +3340,16 @@ def comment(name, regex, char='#', backup='.bak'):
         return _error(ret, check_msg)
 
     unanchor_regex = regex.lstrip('^').rstrip('$')
+    comment_regex = char + unanchor_regex
+
+    # Check if the line is already commented
+    if __salt__['file.search'](name, comment_regex, multiline=True):
+        commented = True
+    else:
+        commented = False
 
     # Make sure the pattern appears in the file before continuing
-    if not __salt__['file.search'](name, regex, multiline=True):
+    if commented or not __salt__['file.search'](name, regex, multiline=True):
         if __salt__['file.search'](name, unanchor_regex, multiline=True):
             ret['comment'] = 'Pattern already commented'
             ret['result'] = True

--- a/salt/templates/rh_ip/network.jinja
+++ b/salt/templates/rh_ip/network.jinja
@@ -5,4 +5,8 @@
 {%endif%}{% if nisdomain %}NISDOMAIN={{nisdomain}}
 {%endif%}{% if networkdelay %}NETWORKDELAY={{networkdelay}}
 {%endif%}{% if devtimeout %}DEVTIMEOUT={{devtimeout}}
-{%endif%}{% if nozeroconf %}NOZEROCONF={{nozeroconf}}{%endif%}
+{%endif%}{% if nozeroconf %}NOZEROCONF={{nozeroconf}}
+{%endif%}{% if enable_ipv6 %}IPV6INIT="yes"
+{%endif%}{% if ipv6gateway %}IPV6_DEFAULTGW="{{ipv6gateway}}"
+{%endif%}
+~

--- a/salt/templates/rh_ip/network.jinja
+++ b/salt/templates/rh_ip/network.jinja
@@ -5,4 +5,7 @@
 {%endif%}{% if nisdomain %}NISDOMAIN={{nisdomain}}
 {%endif%}{% if networkdelay %}NETWORKDELAY={{networkdelay}}
 {%endif%}{% if devtimeout %}DEVTIMEOUT={{devtimeout}}
-{%endif%}{% if nozeroconf %}NOZEROCONF={{nozeroconf}}{%endif%}
+{%endif%}{% if nozeroconf %}NOZEROCONF={{nozeroconf}}
+{%endif%}{% if enable_ipv6 %}IPV6INIT="yes"
+{%endif%}{% if ipv6gateway %}IPV6_DEFAULTGW="{{ipv6gateway}}"
+{%endif%}

--- a/salt/templates/rh_ip/network.jinja
+++ b/salt/templates/rh_ip/network.jinja
@@ -9,4 +9,3 @@
 {%endif%}{% if enable_ipv6 %}IPV6INIT="yes"
 {%endif%}{% if ipv6gateway %}IPV6_DEFAULTGW="{{ipv6gateway}}"
 {%endif%}
-~

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -87,7 +87,7 @@ def creds(provider):
                 proxies={'http': ''}, timeout=AWS_METADATA_TIMEOUT,
             )
             result.raise_for_status()
-            role = result.text.encode('utf-8')
+            role = result.text.encode(result.encoding)
         except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
             return provider['id'], provider['key'], ''
 
@@ -460,7 +460,7 @@ def query(params=None, setname=None, requesturl=None, location=None,
             )
             LOG.trace(
                 'AWS Response Text: {0}'.format(
-                    result.text.encode('utf-8')
+                    result.text.encode(result.encoding)
                 )
             )
             result.raise_for_status()
@@ -501,7 +501,7 @@ def query(params=None, setname=None, requesturl=None, location=None,
             return {'error': data}, requesturl
         return {'error': data}
 
-    response = result.text.encode('utf-8')
+    response = result.text.encode(result.encoding)
 
     root = ET.fromstring(response)
     items = root[1]

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -87,7 +87,7 @@ def creds(provider):
                 proxies={'http': ''}, timeout=AWS_METADATA_TIMEOUT,
             )
             result.raise_for_status()
-            role = result.text
+            role = result.text.encode('utf-8')
         except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
             return provider['id'], provider['key'], ''
 
@@ -460,7 +460,7 @@ def query(params=None, setname=None, requesturl=None, location=None,
             )
             LOG.trace(
                 'AWS Response Text: {0}'.format(
-                    result.text
+                    result.text.encode('utf-8')
                 )
             )
             result.raise_for_status()
@@ -501,7 +501,7 @@ def query(params=None, setname=None, requesturl=None, location=None,
             return {'error': data}, requesturl
         return {'error': data}
 
-    response = result.text
+    response = result.text.encode('utf-8')
 
     root = ET.fromstring(response)
     items = root[1]

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -771,6 +771,22 @@ class SaltNova(object):
                 pass
         return ret
 
+    def server_list_min(self):
+        '''
+        List minimal information about servers
+        '''
+        nt_ks = self.compute_conn
+        ret = {}
+        for item in nt_ks.servers.list(detailed=False):
+            try:
+                ret[item.name] = {
+                    'id': item.id,
+                    'status': 'Running'
+                }
+            except TypeError:
+                pass
+        return ret
+
     def server_list_detailed(self):
         '''
         Detailed list of servers

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2600,14 +2600,15 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
                                              SaltfileMixIn,
                                              HardCrashMixin)):
 
-    usage = '%prog [options]'
+    usage = '%prog [options] \'<target>\' <function> [arguments]'
 
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
 
     # LogLevelMixIn attributes
+    _logfile_config_setting_name_ = 'ssh_log_file'
     _default_logging_level_ = config.DEFAULT_MASTER_OPTS['log_level']
-    _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'ssh')
+    _default_logging_logfile_ = config.DEFAULT_MASTER_OPTS[_logfile_config_setting_name_]
 
     def _mixin_setup(self):
         self.add_option(

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1659,8 +1659,8 @@ class SyndicOptionParser(six.with_metaclass(OptionParserMeta,
                                             SaltfileMixIn)):
 
     description = (
-        'A seamless master of Salt Masters. Scale Salt to thousands of hosts or\n'
-        'across many different networks.'
+        'The Salt Syndic daemon, a special Minion that passes through commands from a\n'
+        'higher Master. Scale Salt to thousands of hosts or across many different networks.'
     )
 
     # ConfigDirMixIn config filename attribute

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1588,7 +1588,7 @@ class MasterOptionParser(six.with_metaclass(OptionParserMeta,
                                             DaemonMixIn,
                                             SaltfileMixIn)):
 
-    description = 'The Salt Master, used to control the Salt Minions.'
+    description = 'The Salt Master, used to control the Salt Minions'
 
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
@@ -1604,7 +1604,7 @@ class MinionOptionParser(six.with_metaclass(OptionParserMeta,
                                             MasterOptionParser)):  # pylint: disable=no-init
 
     description = (
-        'The Salt Minion, receives commands from a remote Salt Master.'
+        'The Salt Minion, receives commands from a remote Salt Master'
     )
 
     # ConfigDirMixIn config filename attribute

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -180,8 +180,9 @@ class OptionParser(optparse.OptionParser, object):
         # Let's get some proper sys.stderr logging as soon as possible!!!
         # This logging handler will be removed once the proper console or
         # logfile logging is setup.
+        temp_log_level = getattr(self.options, 'log_level', None)
         log.setup_temp_logger(
-            getattr(self.options, 'log_level', 'error')
+            'error' if temp_log_level is None else temp_log_level
         )
 
         # Gather and run the process_<option> functions in the proper order
@@ -1599,10 +1600,11 @@ class MasterOptionParser(six.with_metaclass(OptionParserMeta,
         return config.master_config(self.get_config_file_path())
 
 
-class MinionOptionParser(six.with_metaclass(OptionParserMeta, MasterOptionParser)):  # pylint: disable=no-init
+class MinionOptionParser(six.with_metaclass(OptionParserMeta,
+                                            MasterOptionParser)):  # pylint: disable=no-init
 
     description = (
-        'The Salt minion, receives commands from a remote Salt master.'
+        'The Salt Minion, receives commands from a remote Salt Master.'
     )
 
     # ConfigDirMixIn config filename attribute

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -720,7 +720,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
             log_format=log_file_fmt,
             date_format=log_file_datefmt
         )
-        for name, level in six.iteritems(self.config['log_granular_levels']):
+        for name, level in six.iteritems(self.config.get('log_granular_levels', {})):
             log.set_logger_level(name, level)
 
     def __setup_extended_logging(self, *args):  # pylint: disable=unused-argument
@@ -764,7 +764,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
         log.setup_console_logger(
             self.config['log_level'], log_format=logfmt, date_format=datefmt
         )
-        for name, level in six.iteritems(self.config['log_granular_levels']):
+        for name, level in six.iteritems(self.config.get('log_granular_levels', {})):
             log.set_logger_level(name, level)
 
 
@@ -1238,7 +1238,7 @@ class OutputOptionsMixIn(six.with_metaclass(MixInMeta, object)):
 
     def _mixin_after_parsed(self):
         group_options_selected = [
-                option for option in self.output_options_group.option_list if (
+            option for option in self.output_options_group.option_list if (
                 getattr(self.options, option.dest) and
                 (option.dest.endswith('_out') or option.dest == 'output'))
         ]
@@ -1507,8 +1507,8 @@ class CloudProvidersListsMixIn(six.with_metaclass(MixInMeta, object)):
 
     def _mixin_after_parsed(self):
         list_options_selected = [
-                option for option in self.providers_listings_group.option_list if
-                getattr(self.options, option.dest) is not None
+            option for option in self.providers_listings_group.option_list if
+            getattr(self.options, option.dest) is not None
         ]
         if len(list_options_selected) > 1:
             self.error(

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -167,8 +167,8 @@ class OptionParser(optparse.OptionParser, object):
             new_inargs = sys.stdin.readlines()
             new_inargs = [arg.rstrip('\r\n') for arg in new_inargs]
             new_options, new_args = optparse.OptionParser.parse_args(
-                    self,
-                    new_inargs)
+                self,
+                new_inargs)
             options.__dict__.update(new_options.__dict__)
             args.extend(new_args)
 
@@ -2925,7 +2925,7 @@ class SaltAPIParser(six.with_metaclass(OptionParserMeta,
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
     # LogLevelMixIn attributes
-    _default_logging_logfile_ = config.DEFAULT_API_OPTS['logfile']
+    _default_logging_logfile_ = config.DEFAULT_API_OPTS['api_logfile']
 
     def setup_config(self):
         return salt.config.api_config(self.get_config_file_path())  # pylint: disable=no-member

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -631,22 +631,17 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
                     self.config.pop(self._logfile_loglevel_config_setting_name_)
 
     def setup_logfile_logger(self):
-        loglevel = self.config.get(
-            self._logfile_loglevel_config_setting_name_,
-            self.config.get(
-                # From the config setting
-                self._loglevel_config_setting_name_,
-                # From the console setting
-                self.config['log_level']
-            )
-        )
+        loglevel = getattr(self.options,
+                           self._logfile_loglevel_config_setting_name_,
+                           self._default_logging_level_
+                          )
 
-        logfile = self.config.get(
-            # From the config setting
-            self._logfile_config_setting_name_,
-            # From the default setting
-            self._default_logging_logfile_
-        )
+        logfile = getattr(self.options,
+                          # From the options setting
+                          self._logfile_config_setting_name_,
+                          # From the default setting
+                          self._default_logging_logfile_
+                         )
 
         if self.config.get('log_fmt_logfile', None) is None:
             # Remove it from config so it inherits from log_fmt_console

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -569,12 +569,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
 
     def process_log_level(self):
         if not self.options.log_level:
-            cli_log_level = 'cli_{0}_log_level'.format(
-                self.get_prog_name().replace('-', '_')
-            )
-            if self.config.get(cli_log_level, None) is not None:
-                self.options.log_level = self.config.get(cli_log_level)
-            elif self.config.get(self._loglevel_config_setting_name_, None):
+            if self.config.get(self._loglevel_config_setting_name_, None):
                 self.options.log_level = self.config.get(
                     self._loglevel_config_setting_name_
                 )
@@ -590,14 +585,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
 
     def process_log_file(self):
         if not self.options.log_file:
-            cli_setting_name = 'cli_{0}_log_file'.format(
-                self.get_prog_name().replace('-', '_')
-            )
-            if self.config.get(cli_setting_name, None) is not None:
-                # There's a configuration setting defining this log file path,
-                # i.e., `key_log_file` if the cli tool is `salt-key`
-                self.options.log_file = self.config.get(cli_setting_name)
-            elif self.config.get(self._logfile_config_setting_name_, None):
+            if self.config.get(self._logfile_config_setting_name_, None):
                 # Is the regular log file setting set?
                 self.options.log_file = self.config.get(
                     self._logfile_config_setting_name_
@@ -609,15 +597,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
 
     def process_log_file_level(self):
         if not self.options.log_file_level:
-            cli_setting_name = 'cli_{0}_log_file_level'.format(
-                self.get_prog_name().replace('-', '_')
-            )
-            if self.config.get(cli_setting_name, None) is not None:
-                # There's a configuration setting defining this log file
-                # logging level, i.e., `key_log_file_level` if the cli tool is
-                # `salt-key`
-                self.options.log_file_level = self.config.get(cli_setting_name)
-            elif self.config.get(
+            if self.config.get(
                     self._logfile_loglevel_config_setting_name_, None):
                 # Is the regular log file level setting set?
                 self.options.log_file_level = self.config.get(
@@ -644,67 +624,32 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
             )
         )
 
-        cli_log_path = 'cli_{0}_log_file'.format(
-            self.get_prog_name().replace('-', '_')
-        )
-        if cli_log_path in self.config and not self.config.get(cli_log_path):
-            # Remove it from config so it inherits from log_level_logfile
-            self.config.pop(cli_log_path)
-
         if self._logfile_config_setting_name_ in self.config and not \
                 self.config.get(self._logfile_config_setting_name_):
             # Remove it from config so it inherits from log_file
             self.config.pop(self._logfile_config_setting_name_)
 
         logfile = self.config.get(
-            # First from the config cli setting
-            cli_log_path,
-            self.config.get(
-                # From the config setting
-                self._logfile_config_setting_name_,
-                # From the default setting
-                self._default_logging_logfile_
-            )
+            # From the config setting
+            self._logfile_config_setting_name_,
+            # From the default setting
+            self._default_logging_logfile_
         )
-
-        cli_log_file_fmt = 'cli_{0}_log_file_fmt'.format(
-            self.get_prog_name().replace('-', '_')
-        )
-        if cli_log_file_fmt in self.config and not \
-                self.config.get(cli_log_file_fmt):
-            # Remove it from config so it inherits from log_fmt_logfile
-            self.config.pop(cli_log_file_fmt)
 
         if self.config.get('log_fmt_logfile', None) is None:
             # Remove it from config so it inherits from log_fmt_console
             self.config.pop('log_fmt_logfile', None)
 
         log_file_fmt = self.config.get(
-            cli_log_file_fmt,
+            'log_fmt_logfile',
             self.config.get(
-                'cli_{0}_log_fmt'.format(
-                    self.get_prog_name().replace('-', '_')
-                ),
+                'log_fmt_console',
                 self.config.get(
-                    'log_fmt_logfile',
-                    self.config.get(
-                        'log_fmt_console',
-                        self.config.get(
-                            'log_fmt',
-                            config._DFLT_LOG_FMT_CONSOLE
-                        )
-                    )
+                    'log_fmt',
+                    config._DFLT_LOG_FMT_CONSOLE
                 )
             )
         )
-
-        cli_log_file_datefmt = 'cli_{0}_log_file_datefmt'.format(
-            self.get_prog_name().replace('-', '_')
-        )
-        if cli_log_file_datefmt in self.config and not \
-                self.config.get(cli_log_file_datefmt):
-            # Remove it from config so it inherits from log_datefmt_logfile
-            self.config.pop(cli_log_file_datefmt)
 
         if self.config.get('log_datefmt_logfile', None) is None:
             # Remove it from config so it inherits from log_datefmt_console
@@ -715,20 +660,12 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
             self.config.pop('log_datefmt_console', None)
 
         log_file_datefmt = self.config.get(
-            cli_log_file_datefmt,
+            'log_datefmt_logfile',
             self.config.get(
-                'cli_{0}_log_datefmt'.format(
-                    self.get_prog_name().replace('-', '_')
-                ),
+                'log_datefmt_console',
                 self.config.get(
-                    'log_datefmt_logfile',
-                    self.config.get(
-                        'log_datefmt_console',
-                        self.config.get(
-                            'log_datefmt',
-                            '%Y-%m-%d %H:%M:%S'
-                        )
-                    )
+                    'log_datefmt',
+                    '%Y-%m-%d %H:%M:%S'
                 )
             )
         )
@@ -798,43 +735,23 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
             return
 
         # Since we're not going to be a daemon, setup the console logger
-        cli_log_fmt = 'cli_{0}_log_fmt'.format(
-            self.get_prog_name().replace('-', '_')
-        )
-        if cli_log_fmt in self.config and not self.config.get(cli_log_fmt):
-            # Remove it from config so it inherits from log_fmt_console
-            self.config.pop(cli_log_fmt)
-
         logfmt = self.config.get(
-            cli_log_fmt, self.config.get(
-                'log_fmt_console',
-                self.config.get(
-                    'log_fmt',
-                    config._DFLT_LOG_FMT_CONSOLE
-                )
+            'log_fmt_console',
+            self.config.get(
+                'log_fmt',
+                config._DFLT_LOG_FMT_CONSOLE
             )
         )
-
-        cli_log_datefmt = 'cli_{0}_log_datefmt'.format(
-            self.get_prog_name().replace('-', '_')
-        )
-        if cli_log_datefmt in self.config and not \
-                self.config.get(cli_log_datefmt):
-            # Remove it from config so it inherits from log_datefmt_console
-            self.config.pop(cli_log_datefmt)
 
         if self.config.get('log_datefmt_console', None) is None:
             # Remove it from config so it inherits from log_datefmt
             self.config.pop('log_datefmt_console', None)
 
         datefmt = self.config.get(
-            cli_log_datefmt,
+            'log_datefmt_console',
             self.config.get(
-                'log_datefmt_console',
-                self.config.get(
-                    'log_datefmt',
-                    '%Y-%m-%d %H:%M:%S'
-                )
+                'log_datefmt',
+                '%Y-%m-%d %H:%M:%S'
             )
         )
         log.setup_console_logger(

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1659,15 +1659,16 @@ class SyndicOptionParser(six.with_metaclass(OptionParserMeta,
                                             SaltfileMixIn)):
 
     description = (
-        'A seamless master of masters. Scale Salt to thousands of hosts or '
+        'A seamless master of Salt Masters. Scale Salt to thousands of hosts or\n'
         'across many different networks.'
     )
 
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
     # LogLevelMixIn attributes
+    _logfile_config_setting_name_ = 'syndic_log_file'
     _default_logging_level_ = config.DEFAULT_MASTER_OPTS['log_level']
-    _default_logging_logfile_ = config.DEFAULT_MASTER_OPTS['syndic_log_file']
+    _default_logging_logfile_ = config.DEFAULT_MASTER_OPTS[_logfile_config_setting_name_]
     _setup_mp_logging_listener_ = True
 
     def setup_config(self):
@@ -1689,6 +1690,11 @@ class SaltCMDOptionParser(six.with_metaclass(OptionParserMeta,
                                              ArgsStdinMixIn)):
 
     default_timeout = 5
+
+    description = (
+        'Salt allows for commands to be executed across a swath of remote systems in\n'
+        'parallel, so they can be both controlled and queried with ease.'
+    )
 
     usage = '%prog [options] \'<target>\' <function> [arguments]'
 
@@ -1972,14 +1978,13 @@ class SaltCPOptionParser(six.with_metaclass(OptionParserMeta,
                                             HardCrashMixin,
                                             SaltfileMixIn)):
     description = (
-        'salt-cp is NOT intended to broadcast large files, it is intended to '
-        'handle text files.\nsalt-cp can be used to distribute configuration '
-        'files.'
+        'salt-cp is NOT intended to broadcast large files, it is intended to handle text\n'
+        'files. salt-cp can be used to distribute configuration files.'
     )
 
-    default_timeout = 5
-
     usage = '%prog [options] \'<target>\' SOURCE DEST'
+
+    default_timeout = 5
 
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
@@ -2026,7 +2031,7 @@ class SaltKeyOptionParser(six.with_metaclass(OptionParserMeta,
     # LogLevelMixIn attributes
     _skip_console_logging_config_ = True
     _logfile_config_setting_name_ = 'key_logfile'
-    _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'key')
+    _default_logging_logfile_ = config.DEFAULT_MASTER_OPTS[_logfile_config_setting_name_]
 
     def _mixin_setup(self):
         actions_group = optparse.OptionGroup(self, 'Actions')
@@ -2259,7 +2264,7 @@ class SaltKeyOptionParser(six.with_metaclass(OptionParserMeta,
         if self.options.gen_keys:
             # Since we're generating the keys, some defaults can be assumed
             # or tweaked
-            keys_config['key_logfile'] = os.devnull
+            keys_config[self._logfile_config_setting_name_] = os.devnull
             keys_config['pki_dir'] = self.options.gen_keys_dir
 
         return keys_config
@@ -2314,8 +2319,9 @@ class SaltCallOptionParser(six.with_metaclass(OptionParserMeta,
                                               ArgsStdinMixIn,
                                               ProfilingPMixIn)):
 
-    description = ('Salt call is used to execute module functions locally '
-                   'on a minion')
+    description = (
+        'salt-call is used to execute module functions locally on a Salt Minion'
+    )
 
     usage = '%prog [options] <function> [arguments]'
 
@@ -2525,7 +2531,12 @@ class SaltRunOptionParser(six.with_metaclass(OptionParserMeta,
 
     default_timeout = 1
 
-    usage = '%prog [options]'
+    description = (
+        'salt-run is the frontend command for executing Salt Runners.\n'
+        'Salt Runners are modules used to execute convenience functions on the Salt Master'
+    )
+
+    usage = '%prog [options] <function> [arguments]'
 
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
@@ -2833,6 +2844,13 @@ class SaltCloudParser(six.with_metaclass(OptionParserMeta,
                                          HardCrashMixin,
                                          SaltfileMixIn)):
 
+    description = (
+        'Salt Cloud is the system used to provision virtual machines on various public\n'
+        'clouds via a cleanly controlled profile and mapping system'
+        )
+
+    usage = '%prog [options] <-m MAP | -p PROFILE> <NAME> [NAME2 ...]'
+
     # ConfigDirMixIn attributes
     _config_filename_ = 'cloud'
 
@@ -2879,16 +2897,17 @@ class SPMParser(six.with_metaclass(OptionParserMeta,
                                    MergeConfigMixIn,
                                    SaltfileMixIn)):
     '''
-    The cli parser object used to fire up the salt spm system.
+    The CLI parser object used to fire up the Salt SPM system.
     '''
     description = 'SPM is used to manage 3rd party formulas and other Salt components'
 
-    usage = '%prog [options] <function> [arguments]'
+    usage = '%prog [options] <function> <argument>'
 
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'spm'
     # LogLevelMixIn attributes
-    _default_logging_logfile_ = config.DEFAULT_SPM_OPTS['spm_logfile']
+    _logfile_config_setting_name_ = 'spm_logfile'
+    _default_logging_logfile_ = config.DEFAULT_SPM_OPTS[_logfile_config_setting_name_]
 
     def _mixin_setup(self):
         self.add_option(
@@ -2928,12 +2947,17 @@ class SaltAPIParser(six.with_metaclass(OptionParserMeta,
                                        DaemonMixIn,
                                        MergeConfigMixIn)):
     '''
-    The Salt API cli parser object used to fire up the salt api system.
+    The CLI parser object used to fire up the Salt API system.
     '''
+    description = (
+        'The Salt API system manages network API connectors for the Salt Master'
+    )
+
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
     # LogLevelMixIn attributes
-    _default_logging_logfile_ = config.DEFAULT_API_OPTS['api_logfile']
+    _logfile_config_setting_name_ = 'api_logfile'
+    _default_logging_logfile_ = config.DEFAULT_API_OPTS[_logfile_config_setting_name_]
 
     def setup_config(self):
         return salt.config.api_config(self.get_config_file_path())  # pylint: disable=no-member

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -540,6 +540,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
         if not getattr(self, '_skip_console_logging_config_', False):
             group.add_option(
                 '-l', '--log-level',
+                dest=self._loglevel_config_setting_name_,
                 choices=list(log.LOG_LEVELS),
                 help='Console logging log level. One of {0}. '
                      'Default: \'{1}\'.'.format(
@@ -550,6 +551,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
 
         group.add_option(
             '--log-file',
+            dest=self._logfile_config_setting_name_,
             default=None,
             help='Log file path. Default: \'{0}\'.'.format(
                 self._default_logging_logfile_

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -299,7 +299,7 @@ class MergeConfigMixIn(six.with_metaclass(MixInMeta, object)):
                 if value is not None:
                     # There's an actual value, add it to the config
                     self.config[option.dest] = value
-            elif value is not None and getattr(option, "explicit", False):
+            elif value is not None and getattr(option, 'explicit', False):
                 # Only set the value in the config file IF it was explicitly
                 # specified by the user, this makes it possible to tweak settings
                 # on the configuration files bypassing the shell option flags'
@@ -544,7 +544,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
                 help='Console logging log level. One of {0}. '
                      'Default: \'{1}\'.'.format(
                          ', '.join([repr(l) for l in log.SORTED_LEVEL_NAMES]),
-                         getattr(self, '_default_logging_level_', 'warning')
+                         self._default_logging_level_
                      )
             )
 
@@ -563,18 +563,27 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
             help='Logfile logging log level. One of {0}. '
                  'Default: \'{1}\'.'.format(
                      ', '.join([repr(l) for l in log.SORTED_LEVEL_NAMES]),
-                     getattr(self, '_default_logging_level_', 'warning')
+                     self._default_logging_level_
                  )
         )
 
     def process_log_level(self):
-        if not self.options.log_level:
-            if self.config.get(self._loglevel_config_setting_name_, None):
-                self.options.log_level = self.config.get(
-                    self._loglevel_config_setting_name_
-                )
+        if not getattr(self.options, self._loglevel_config_setting_name_, None):
+            if getattr(self.config, self._loglevel_config_setting_name_, None):
+                # Is the regular log level setting set?
+                setattr(self.options,
+                        self._loglevel_config_setting_name_,
+                        getattr(self.config,
+                                self._loglevel_config_setting_name_
+                               )
+                       )
             else:
-                self.options.log_level = self._default_logging_level_
+                # Nothing is set on the configuration? Let's use the cli tool
+                # defined default
+                setattr(self.options,
+                        self._loglevel_config_setting_name_,
+                        self._default_logging_level_
+                       )
 
         # Setup extended logging right before the last step
         self._mixin_after_parsed_funcs.append(self.__setup_extended_logging)
@@ -584,29 +593,40 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
         self._mixin_after_parsed_funcs.append(self.__setup_console_logger)
 
     def process_log_file(self):
-        if not self.options.log_file:
-            if self.config.get(self._logfile_config_setting_name_, None):
+        if not getattr(self.options, self._logfile_config_setting_name_, None):
+            if getattr(self.config, self._logfile_config_setting_name_, None):
                 # Is the regular log file setting set?
-                self.options.log_file = self.config.get(
-                    self._logfile_config_setting_name_
-                )
+                setattr(self.options,
+                        self._logfile_config_setting_name_,
+                        getattr(self.config,
+                                self._logfile_config_setting_name_
+                               )
+                       )
             else:
                 # Nothing is set on the configuration? Let's use the cli tool
                 # defined default
-                self.options.log_file = self._default_logging_logfile_
+                setattr(self.options,
+                        self._logfile_config_setting_name_,
+                        self._default_logging_logfile_
+                       )
 
     def process_log_file_level(self):
-        if not self.options.log_file_level:
-            if self.config.get(
-                    self._logfile_loglevel_config_setting_name_, None):
-                # Is the regular log file level setting set?
-                self.options.log_file_level = self.config.get(
-                    self._logfile_loglevel_config_setting_name_
-                )
+        if not getattr(self.options, self._logfile_loglevel_config_setting_name_, None):
+            if getattr(self.config, self._logfile_loglevel_config_setting_name_, None):
+                # Is the regular log file setting set?
+                setattr(self.options,
+                        self._logfile_loglevel_config_setting_name_,
+                        getattr(self.config,
+                                self._default_logging_level_
+                               )
+                       )
             else:
                 # Nothing is set on the configuration? Let's use the cli tool
                 # defined default
-                self.options.log_level = self._default_logging_level_
+                setattr(self.options,
+                        self._logfile_config_setting_name_,
+                        self._default_logging_logfile_
+                       )
 
     def setup_logfile_logger(self):
         if self._logfile_loglevel_config_setting_name_ in self.config and not \
@@ -1566,8 +1586,8 @@ class CloudCredentialsMixIn(six.with_metaclass(MixInMeta, object)):
     def process_set_password(self):
         if self.options.set_password:
             raise RuntimeError(
-                    'This functionality is not supported; '
-                    'please see the keyring module at http://docs.saltstack.com/en/latest/topics/sdb/'
+                'This functionality is not supported; '
+                'please see the keyring module at http://docs.saltstack.com/en/latest/topics/sdb/'
             )
 
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -324,7 +324,7 @@ class MergeConfigMixIn(six.with_metaclass(MixInMeta, object)):
                     if value is not None:
                         # There's an actual value, add it to the config
                         self.config[option.dest] = value
-                elif value is not None and getattr(option, "explicit", False):
+                elif value is not None and getattr(option, 'explicit', False):
                     # Only set the value in the config file IF it was explicitly
                     # specified by the user, this makes it possible to tweak
                     # settings on the configuration files bypassing the shell
@@ -569,13 +569,11 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
 
     def process_log_level(self):
         if not getattr(self.options, self._loglevel_config_setting_name_, None):
-            if getattr(self.config, self._loglevel_config_setting_name_, None):
+            if self.config.get(self._loglevel_config_setting_name_, None):
                 # Is the regular log level setting set?
                 setattr(self.options,
                         self._loglevel_config_setting_name_,
-                        getattr(self.config,
-                                self._loglevel_config_setting_name_
-                               )
+                        self.config.get(self._loglevel_config_setting_name_)
                        )
             else:
                 # Nothing is set on the configuration? Let's use the cli tool
@@ -594,13 +592,11 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
 
     def process_log_file(self):
         if not getattr(self.options, self._logfile_config_setting_name_, None):
-            if getattr(self.config, self._logfile_config_setting_name_, None):
+            if self.config.get(self._logfile_config_setting_name_, None):
                 # Is the regular log file setting set?
                 setattr(self.options,
                         self._logfile_config_setting_name_,
-                        getattr(self.config,
-                                self._logfile_config_setting_name_
-                               )
+                        self.config.get(self._logfile_config_setting_name_)
                        )
             else:
                 # Nothing is set on the configuration? Let's use the cli tool
@@ -609,31 +605,30 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
                         self._logfile_config_setting_name_,
                         self._default_logging_logfile_
                        )
+                if self._logfile_config_setting_name_ in self.config:
+                    # Remove it from config so it inherits from log_file
+                    self.config.pop(self._logfile_config_setting_name_)
 
-    def process_log_file_level(self):
+    def process_log_level_logfile(self):
         if not getattr(self.options, self._logfile_loglevel_config_setting_name_, None):
-            if getattr(self.config, self._logfile_loglevel_config_setting_name_, None):
-                # Is the regular log file setting set?
+            if self.config.get(self._logfile_loglevel_config_setting_name_, None):
+                # Is the regular log file level setting set?
                 setattr(self.options,
                         self._logfile_loglevel_config_setting_name_,
-                        getattr(self.config,
-                                self._default_logging_level_
-                               )
+                        self.config.get(self._logfile_loglevel_config_setting_name_)
                        )
             else:
                 # Nothing is set on the configuration? Let's use the cli tool
                 # defined default
                 setattr(self.options,
-                        self._logfile_config_setting_name_,
-                        self._default_logging_logfile_
+                        self._logfile_loglevel_config_setting_name_,
+                        self._default_logging_level_
                        )
+                if self._logfile_loglevel_config_setting_name_ in self.config:
+                    # Remove it from config so it inherits from log_level
+                    self.config.pop(self._logfile_loglevel_config_setting_name_)
 
     def setup_logfile_logger(self):
-        if self._logfile_loglevel_config_setting_name_ in self.config and not \
-                self.config.get(self._logfile_loglevel_config_setting_name_):
-            # Remove it from config so it inherits from log_level
-            self.config.pop(self._logfile_loglevel_config_setting_name_)
-
         loglevel = self.config.get(
             self._logfile_loglevel_config_setting_name_,
             self.config.get(
@@ -643,11 +638,6 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
                 self.config['log_level']
             )
         )
-
-        if self._logfile_config_setting_name_ in self.config and not \
-                self.config.get(self._logfile_config_setting_name_):
-            # Remove it from config so it inherits from log_file
-            self.config.pop(self._logfile_config_setting_name_)
 
         logfile = self.config.get(
             # From the config setting

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -127,7 +127,7 @@ class CustomOption(optparse.Option, object):
 class OptionParser(optparse.OptionParser, object):
     VERSION = version.__saltstack_version__.formatted_version
 
-    usage = '%prog'
+    usage = '%prog [options]'
 
     epilog = ('You can find additional help about %prog issuing "man %prog" '
               'or on http://docs.saltstack.com')
@@ -1588,7 +1588,7 @@ class MasterOptionParser(six.with_metaclass(OptionParserMeta,
                                             DaemonMixIn,
                                             SaltfileMixIn)):
 
-    description = 'The Salt master, used to control the Salt minions.'
+    description = 'The Salt Master, used to control the Salt Minions.'
 
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
@@ -1629,8 +1629,8 @@ class ProxyMinionOptionParser(six.with_metaclass(OptionParserMeta,
                                                  SaltfileMixIn)):  # pylint: disable=no-init
 
     description = (
-        'The Salt proxy minion, connects to and controls devices not able to run a minion.  '
-        'Receives commands from a remote Salt master.'
+        'The Salt Proxy Minion, connects to and controls devices not able to run a minion.\n'
+        'Receives commands from a remote Salt Master.'
     )
 
     # ConfigDirMixIn config filename attribute
@@ -1698,6 +1698,7 @@ class SaltCMDOptionParser(six.with_metaclass(OptionParserMeta,
     # LogLevelMixIn attributes
     _default_logging_level_ = config.DEFAULT_MASTER_OPTS['log_level']
     _default_logging_logfile_ = config.DEFAULT_MASTER_OPTS['log_file']
+
     try:
         os.getcwd()
     except OSError:
@@ -1945,7 +1946,7 @@ class SaltCMDOptionParser(six.with_metaclass(OptionParserMeta,
                     # interface
                     for i in range(len(self.config['arg'])):
                         self.config['arg'][i] = salt.utils.args.parse_input(
-                                self.config['arg'][i])
+                            self.config['arg'][i])
                 else:
                     self.config['fun'] = self.args[1]
                     self.config['arg'] = self.args[2:]
@@ -2017,9 +2018,7 @@ class SaltKeyOptionParser(six.with_metaclass(OptionParserMeta,
                                              HardCrashMixin,
                                              SaltfileMixIn)):
 
-    description = 'Salt key is used to manage Salt authentication keys'
-
-    usage = '%prog [options]'
+    description = 'salt-key is used to manage Salt authentication keys'
 
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
@@ -2859,7 +2858,7 @@ class SaltCloudParser(six.with_metaclass(OptionParserMeta,
         if 'DUMP_SALT_CLOUD_CONFIG' in os.environ:
             import pprint
 
-            print('Salt cloud configuration dump(INCLUDES SENSIBLE DATA):')
+            print('Salt Cloud configuration dump (INCLUDES SENSIBLE DATA):')
             pprint.pprint(self.config)
             self.exit(salt.defaults.exitcodes.EX_OK)
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1668,7 +1668,7 @@ class MasterOptionParser(six.with_metaclass(OptionParserMeta,
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
     # LogLevelMixIn attributes
-    _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'master')
+    _default_logging_logfile_ = config.DEFAULT_MASTER_OPTS['log_file']
     _setup_mp_logging_listener_ = True
 
     def setup_config(self):
@@ -1684,7 +1684,7 @@ class MinionOptionParser(six.with_metaclass(OptionParserMeta, MasterOptionParser
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'minion'
     # LogLevelMixIn attributes
-    _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'minion')
+    _default_logging_logfile_ = config.DEFAULT_MINION_OPTS['log_file']
     _setup_mp_logging_listener_ = True
 
     def setup_config(self):
@@ -1710,7 +1710,7 @@ class ProxyMinionOptionParser(six.with_metaclass(OptionParserMeta,
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'proxy'
     # LogLevelMixIn attributes
-    _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'proxy')
+    _default_logging_logfile_ = config.DEFAULT_PROXY_MINION_OPTS['log_file']
 
     def setup_config(self):
         try:
@@ -1719,7 +1719,8 @@ class ProxyMinionOptionParser(six.with_metaclass(OptionParserMeta,
             minion_id = None
 
         return config.minion_config(self.get_config_file_path(),
-                                   cache_minion_id=False, minion_id=minion_id)
+                                    cache_minion_id=False,
+                                    minion_id=minion_id)
 
 
 class SyndicOptionParser(six.with_metaclass(OptionParserMeta,
@@ -1739,7 +1740,8 @@ class SyndicOptionParser(six.with_metaclass(OptionParserMeta,
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
     # LogLevelMixIn attributes
-    _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'master')
+    _default_logging_level_ = config.DEFAULT_MASTER_OPTS['log_level']
+    _default_logging_logfile_ = config.DEFAULT_MASTER_OPTS['syndic_log_file']
     _setup_mp_logging_listener_ = True
 
     def setup_config(self):
@@ -1768,9 +1770,8 @@ class SaltCMDOptionParser(six.with_metaclass(OptionParserMeta,
     _config_filename_ = 'master'
 
     # LogLevelMixIn attributes
-    _default_logging_level_ = 'warning'
-    _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'master')
-    _loglevel_config_setting_name_ = 'cli_salt_log_file'
+    _default_logging_level_ = config.DEFAULT_MASTER_OPTS['log_level']
+    _default_logging_logfile_ = config.DEFAULT_MASTER_OPTS['log_file']
     try:
         os.getcwd()
     except OSError:
@@ -2057,9 +2058,8 @@ class SaltCPOptionParser(six.with_metaclass(OptionParserMeta,
     _config_filename_ = 'master'
 
     # LogLevelMixIn attributes
-    _default_logging_level_ = 'warning'
-    _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'master')
-    _loglevel_config_setting_name_ = 'cli_salt_cp_log_file'
+    _default_logging_level_ = config.DEFAULT_MASTER_OPTS['log_level']
+    _default_logging_logfile_ = config.DEFAULT_MASTER_OPTS['log_file']
 
     def _mixin_after_parsed(self):
         # salt-cp needs arguments
@@ -2398,8 +2398,8 @@ class SaltCallOptionParser(six.with_metaclass(OptionParserMeta,
     _config_filename_ = 'minion'
 
     # LogLevelMixIn attributes
-    _default_logging_level_ = 'info'
-    _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'minion')
+    _default_logging_level_ = config.DEFAULT_MINION_OPTS['log_level']
+    _default_logging_logfile_ = config.DEFAULT_MINION_OPTS['log_file']
 
     def _mixin_setup(self):
         self.add_option(
@@ -2606,9 +2606,8 @@ class SaltRunOptionParser(six.with_metaclass(OptionParserMeta,
     _config_filename_ = 'master'
 
     # LogLevelMixIn attributes
-    _default_logging_level_ = 'warning'
-    _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'master')
-    _loglevel_config_setting_name_ = 'cli_salt_run_log_file'
+    _default_logging_level_ = config.DEFAULT_MASTER_OPTS['log_level']
+    _default_logging_logfile_ = config.DEFAULT_MASTER_OPTS['log_file']
 
     def _mixin_setup(self):
         self.add_option(
@@ -2671,9 +2670,8 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
     _config_filename_ = 'master'
 
     # LogLevelMixIn attributes
-    _default_logging_level_ = 'warning'
+    _default_logging_level_ = config.DEFAULT_MASTER_OPTS['log_level']
     _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'ssh')
-    _loglevel_config_setting_name_ = 'cli_salt_run_log_file'
 
     def _mixin_setup(self):
         self.add_option(
@@ -2914,10 +2912,8 @@ class SaltCloudParser(six.with_metaclass(OptionParserMeta,
     _config_filename_ = 'cloud'
 
     # LogLevelMixIn attributes
-    _default_logging_level_ = 'info'
-    _logfile_config_setting_name_ = 'log_file'
-    _loglevel_config_setting_name_ = 'log_level_logfile'
-    _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'cloud')
+    _default_logging_level_ = config.DEFAULT_CLOUD_OPTS['log_level']
+    _default_logging_logfile_ = config.DEFAULT_CLOUD_OPTS['log_file']
 
     def print_versions_report(self, file=sys.stdout):  # pylint: disable=redefined-builtin
         print('\n'.join(version.versions_report(include_salt_cloud=True)),
@@ -2967,7 +2963,7 @@ class SPMParser(six.with_metaclass(OptionParserMeta,
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'spm'
     # LogLevelMixIn attributes
-    _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'spm')
+    _default_logging_logfile_ = config.DEFAULT_SPM_OPTS['spm_logfile']
 
     def _mixin_setup(self):
         self.add_option(
@@ -3012,7 +3008,7 @@ class SaltAPIParser(six.with_metaclass(OptionParserMeta,
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
     # LogLevelMixIn attributes
-    _default_logging_logfile_ = os.path.join(syspaths.LOGS_DIR, 'api')
+    _default_logging_logfile_ = config.DEFAULT_API_OPTS['logfile']
 
     def setup_config(self):
         return salt.config.api_config(self.get_config_file_path())  # pylint: disable=no-member

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -629,10 +629,13 @@ class Schedule(object):
         '''
         Execute this method in a multiprocess or thread
         '''
-        if salt.utils.is_windows():
+        if salt.utils.is_windows() or self.opts.get('transport') == 'zeromq':
             # Since function references can't be pickled and pickling
             # is required when spawning new processes on Windows, regenerate
             # the functions and returners.
+            # This also needed for ZeroMQ transport to reset all functions
+            # context data that could keep paretns connections. ZeroMQ will
+            # hang on polling parents connections from the child process.
             self.functions = salt.loader.minion_mods(self.opts)
             self.returners = salt.loader.returners(self.opts, self.functions)
         ret = {'id': self.opts.get('id', 'master'),

--- a/tests/integration/modules/gem.py
+++ b/tests/integration/modules/gem.py
@@ -127,7 +127,7 @@ class GemModuleTest(integration.ModuleCase):
 
         self.run_function('gem.update', [OLD_GEM])
         gem_list = self.run_function('gem.list', [OLD_GEM])
-        self.assertEqual({'thor': ['0.19.1', '0.17.0']}, gem_list)
+        self.assertEqual({'thor': ['0.19.4', '0.17.0']}, gem_list)
 
         self.run_function('gem.uninstall', [OLD_GEM])
         self.assertFalse(self.run_function('gem.list', [OLD_GEM]))

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -1233,6 +1233,11 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             # write a line to file
             with salt.utils.fopen(name, 'w+') as fp_:
                 fp_.write('comment_me')
+
+            # Look for changes with test=True: return should be "None" at the first run
+            ret = self.run_state('file.comment', test=True, name=name, regex='^comment')
+            self.assertSaltNoneReturn(ret)
+
             # comment once
             ret = self.run_state('file.comment', name=name, regex='^comment')
             # result is positive
@@ -1248,6 +1253,11 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             # line is still commented
             with salt.utils.fopen(name, 'r') as fp_:
                 self.assertTrue(fp_.read().startswith('#comment'))
+
+            # Test previously commented file returns "True" now and not "None" with test=True
+            ret = self.run_state('file.comment', test=True, name=name, regex='^comment')
+            self.assertSaltTrueReturn(ret)
+
         finally:
             os.remove(name)
 

--- a/tests/unit/daemons_test.py
+++ b/tests/unit/daemons_test.py
@@ -232,6 +232,8 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
             child_pipe.send(ret)
             child_pipe.close()
 
+        self._multiproc_exec_test(exec_test)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(DaemonsStarterTestCase, needs_daemon=False)

--- a/tests/unit/daemons_test.py
+++ b/tests/unit/daemons_test.py
@@ -15,6 +15,7 @@ ensure_in_syspath('../')
 
 # Import Salt libs
 import integration
+import multiprocessing
 from salt.cli import daemons
 
 
@@ -65,39 +66,51 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
     Unit test for the daemons starter classes.
     '''
 
+    def _multiproc_exec_test(self, exec_test):
+        m_parent, m_child = multiprocessing.Pipe()
+        p_ = multiprocessing.Process(target=exec_test, args=(m_child,))
+        p_.start()
+        self.assertTrue(m_parent.recv())
+        p_.join()
+
     def test_master_daemon_hash_type_verified(self):
         '''
         Verify if Master is verifying hash_type config option.
 
         :return:
         '''
-        def _create_master():
-            '''
-            Create master instance
-            :return:
-            '''
-            master = daemons.Master()
-            master.config = {'user': 'dummy', 'hash_type': alg}
-            for attr in ['master', 'start_log_info', 'prepare']:
-                setattr(master, attr, MagicMock())
+        def exec_test(child_pipe):
+            def _create_master():
+                '''
+                Create master instance
+                :return:
+                '''
+                obj = daemons.Master()
+                obj.config = {'user': 'dummy', 'hash_type': alg}
+                for attr in ['start_log_info', 'prepare', 'shutdown', 'master']:
+                    setattr(obj, attr, MagicMock())
 
-            return master
+                return obj
 
-        _logger = LoggerMock()
-        with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
-            with patch('salt.cli.daemons.log', _logger):
-                for alg in ['md5', 'sha1']:
-                    _create_master().start()
-                    self.assertEqual(_logger.last_type, 'warning')
-                    self.assertTrue(_logger.last_message)
-                    self.assertTrue(_logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1)
+            _logger = LoggerMock()
+            ret = True
+            with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
+                with patch('salt.cli.daemons.log', _logger):
+                    for alg in ['md5', 'sha1']:
+                        _create_master().start()
+                        ret = ret and _logger.last_type == 'warning' \
+                                and _logger.last_message \
+                                and _logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1
 
-                _logger.reset()
+                    _logger.reset()
 
-                for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
-                    _create_master().start()
-                    self.assertEqual(_logger.last_type, None)
-                    self.assertFalse(_logger.last_message)
+                    for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
+                        _create_master().start()
+                        ret = ret and _logger.last_type is None \
+                                and not _logger.last_message
+                    child_pipe.send(ret)
+                    child_pipe.close()
+        self._multiproc_exec_test(exec_test)
 
     def test_minion_daemon_hash_type_verified(self):
         '''
@@ -105,35 +118,40 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
 
         :return:
         '''
+        def exec_test(child_pipe):
+            def _create_minion():
+                '''
+                Create minion instance
+                :return:
+                '''
+                obj = daemons.Minion()
+                obj.config = {'user': 'dummy', 'hash_type': alg}
+                for attr in ['start_log_info', 'prepare', 'shutdown']:
+                    setattr(obj, attr, MagicMock())
+                setattr(obj, 'minion', MagicMock(restart=False))
 
-        def _create_minion():
-            '''
-            Create minion instance
-            :return:
-            '''
-            obj = daemons.Minion()
-            obj.config = {'user': 'dummy', 'hash_type': alg}
-            for attr in ['start_log_info', 'prepare', 'shutdown']:
-                setattr(obj, attr, MagicMock())
-            setattr(obj, 'minion', MagicMock(restart=False))
+                return obj
 
-            return obj
+            ret = True
+            _logger = LoggerMock()
+            with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
+                with patch('salt.cli.daemons.log', _logger):
+                    for alg in ['md5', 'sha1']:
+                        _create_minion().start()
+                        ret = ret and _logger.last_type == 'warning' \
+                                and _logger.last_message \
+                                and _logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1
+                    _logger.reset()
 
-        _logger = LoggerMock()
-        with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
-            with patch('salt.cli.daemons.log', _logger):
-                for alg in ['md5', 'sha1']:
-                    _create_minion().start()
-                    self.assertEqual(_logger.last_type, 'warning')
-                    self.assertTrue(_logger.last_message)
-                    self.assertTrue(_logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1)
+                    for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
+                        _create_minion().start()
+                        ret = ret and _logger.last_type is None \
+                                and not _logger.last_message
 
-                _logger.reset()
+                child_pipe.send(ret)
+                child_pipe.close()
 
-                for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
-                    _create_minion().start()
-                    self.assertEqual(_logger.last_type, None)
-                    self.assertFalse(_logger.last_message)
+        self._multiproc_exec_test(exec_test)
 
     def test_proxy_minion_daemon_hash_type_verified(self):
         '''
@@ -141,34 +159,39 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
 
         :return:
         '''
+        def exec_test(child_pipe):
+            def _create_proxy_minion():
+                '''
+                Create proxy minion instance
+                :return:
+                '''
+                obj = daemons.ProxyMinion()
+                obj.config = {'user': 'dummy', 'hash_type': alg}
+                for attr in ['minion', 'start_log_info', 'prepare', 'shutdown']:
+                    setattr(obj, attr, MagicMock())
 
-        def _create_proxy_minion():
-            '''
-            Create proxy minion instance
-            :return:
-            '''
-            obj = daemons.ProxyMinion()
-            obj.config = {'user': 'dummy', 'hash_type': alg}
-            for attr in ['minion', 'start_log_info', 'prepare', 'shutdown']:
-                setattr(obj, attr, MagicMock())
+                return obj
 
-            return obj
+            ret = True
+            _logger = LoggerMock()
+            with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
+                with patch('salt.cli.daemons.log', _logger):
+                    for alg in ['md5', 'sha1']:
+                        _create_proxy_minion().start()
+                        ret = ret and _logger.last_type == 'warning' \
+                                and _logger.last_message \
+                                and _logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1
 
-        _logger = LoggerMock()
-        with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
-            with patch('salt.cli.daemons.log', _logger):
-                for alg in ['md5', 'sha1']:
-                    _create_proxy_minion().start()
-                    self.assertEqual(_logger.last_type, 'warning')
-                    self.assertTrue(_logger.last_message)
-                    self.assertTrue(_logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1)
+                    _logger.reset()
 
-                _logger.reset()
+                    for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
+                        _create_proxy_minion().start()
+                        ret = ret and _logger.last_type is None \
+                                and not _logger.last_message
+            child_pipe.send(ret)
+            child_pipe.close()
 
-                for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
-                    _create_proxy_minion().start()
-                    self.assertEqual(_logger.last_type, None)
-                    self.assertFalse(_logger.last_message)
+        self._multiproc_exec_test(exec_test)
 
     def test_syndic_daemon_hash_type_verified(self):
         '''
@@ -176,34 +199,38 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
 
         :return:
         '''
+        def exec_test(child_pipe):
+            def _create_syndic():
+                '''
+                Create syndic instance
+                :return:
+                '''
+                obj = daemons.Syndic()
+                obj.config = {'user': 'dummy', 'hash_type': alg}
+                for attr in ['syndic', 'start_log_info', 'prepare', 'shutdown']:
+                    setattr(obj, attr, MagicMock())
 
-        def _create_syndic():
-            '''
-            Create syndic instance
-            :return:
-            '''
-            obj = daemons.Syndic()
-            obj.config = {'user': 'dummy', 'hash_type': alg}
-            for attr in ['syndic', 'start_log_info', 'prepare', 'shutdown']:
-                setattr(obj, attr, MagicMock())
+                return obj
 
-            return obj
+            ret = True
+            _logger = LoggerMock()
+            with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
+                with patch('salt.cli.daemons.log', _logger):
+                    for alg in ['md5', 'sha1']:
+                        _create_syndic().start()
+                        ret = ret and _logger.last_type == 'warning' \
+                                and _logger.last_message \
+                                and _logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1
 
-        _logger = LoggerMock()
-        with patch('salt.cli.daemons.check_user', MagicMock(return_value=True)):
-            with patch('salt.cli.daemons.log', _logger):
-                for alg in ['md5', 'sha1']:
-                    _create_syndic().start()
-                    self.assertEqual(_logger.last_type, 'warning')
-                    self.assertTrue(_logger.last_message)
-                    self.assertTrue(_logger.last_message.find('Do not use {alg}'.format(alg=alg)) > -1)
+                    _logger.reset()
 
-                _logger.reset()
+                    for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
+                        _create_syndic().start()
+                        ret = ret and _logger.last_type is None \
+                                and _logger.last_message
 
-                for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
-                    _create_syndic().start()
-                    self.assertEqual(_logger.last_type, None)
-                    self.assertFalse(_logger.last_message)
+            child_pipe.send(ret)
+            child_pipe.close()
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/daemons_test.py
+++ b/tests/unit/daemons_test.py
@@ -227,7 +227,7 @@ class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
                     for alg in ['sha224', 'sha256', 'sha384', 'sha512']:
                         _create_syndic().start()
                         ret = ret and _logger.last_type is None \
-                                and _logger.last_message
+                                and not _logger.last_message
 
             child_pipe.send(ret)
             child_pipe.close()

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -989,7 +989,6 @@ class FileTestCase(TestCase):
 
         mock_t = MagicMock(return_value=True)
         mock_f = MagicMock(return_value=False)
-        mock = MagicMock(side_effect=[False, True, False, False])
         with patch.object(os.path, 'isabs', mock_f):
             comt = ('Specified file {0} is not an absolute path'.format(name))
             ret.update({'comment': comt, 'name': name})
@@ -997,8 +996,7 @@ class FileTestCase(TestCase):
 
         with patch.object(os.path, 'isabs', mock_t):
             with patch.dict(filestate.__salt__,
-                            {'file.contains_regex_multiline': mock,
-                             'file.search': mock}):
+                            {'file.search': MagicMock(side_effect=[True, True, True, False, False])}):
                 comt = ('Pattern already commented')
                 ret.update({'comment': comt, 'result': True})
                 self.assertDictEqual(filestate.comment(name, regex), ret)
@@ -1008,8 +1006,7 @@ class FileTestCase(TestCase):
                 self.assertDictEqual(filestate.comment(name, regex), ret)
 
             with patch.dict(filestate.__salt__,
-                            {'file.contains_regex_multiline': mock_t,
-                             'file.search': mock_t,
+                            {'file.search': MagicMock(side_effect=[False, True, False, True, True]),
                              'file.comment': mock_t,
                              'file.comment_line': mock_t}):
                 with patch.dict(filestate.__opts__, {'test': True}):

--- a/tests/unit/utils/parsers_test.py
+++ b/tests/unit/utils/parsers_test.py
@@ -1,0 +1,948 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Denys Havrysh <denys.gavrysh@gmail.com>`
+'''
+
+# Import python libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import skipIf, TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt Libs
+import salt.utils.parsers
+import salt.log.setup as log
+import salt.config
+import salt.syspaths
+
+ensure_in_syspath('../../')
+
+
+class ErrorMock(object):  # pylint: disable=too-few-public-methods
+    '''
+    Error handling
+    '''
+    def __init__(self):
+        '''
+        init
+        '''
+        self.msg = None
+
+    def error(self, msg):
+        '''
+        Capture error message
+        '''
+        self.msg = msg
+
+
+class LogSetupMock(object):
+    '''
+    Logger setup
+    '''
+    def __init__(self):
+        '''
+        init
+        '''
+        self.log_level = None
+        self.log_file = None
+        self.log_level_logfile = None
+        self.config = {}
+        self.temp_log_level = None
+
+    def setup_console_logger(self, log_level='error', **kwargs):  # pylint: disable=unused-argument
+        '''
+        Set console loglevel
+        '''
+        self.log_level = log_level
+
+    def setup_extended_logging(self, opts):
+        '''
+        Set opts
+        '''
+        self.config = opts
+
+    def setup_logfile_logger(self, logfile, loglevel, **kwargs):  # pylint: disable=unused-argument
+        '''
+        Set logfile and loglevel
+        '''
+        self.log_file = logfile
+        self.log_level_logfile = loglevel
+
+    @staticmethod
+    def get_multiprocessing_logging_queue():  # pylint: disable=invalid-name
+        '''
+        Mock
+        '''
+        return None
+
+    def setup_multiprocessing_logging_listener(self, opts, *args):  # pylint: disable=invalid-name,unused-argument
+        '''
+        Set opts
+        '''
+        self.config = opts
+
+    def setup_temp_logger(self, log_level='error'):
+        '''
+        Set temp loglevel
+        '''
+        self.temp_log_level = log_level
+
+
+class ObjectView(object):  # pylint: disable=too-few-public-methods
+    '''
+    Dict object view
+    '''
+    def __init__(self, d):
+        self.__dict__ = d
+
+
+class LogSettingsParserTests(TestCase):
+    '''
+    Unit Tests for Log Level Mixin with Salt parsers
+    '''
+    args = []
+
+    skip_console_logging_config = False
+
+    log_setup = None
+
+    # Set config option names
+    loglevel_config_setting_name = 'log_level'
+    logfile_config_setting_name = 'log_file'
+    logfile_loglevel_config_setting_name = 'log_level_logfile'  # pylint: disable=invalid-name
+
+    def setup_log(self):
+        '''
+        Mock logger functions
+        '''
+        self.log_setup = LogSetupMock()
+        log.setup_console_logger = self.log_setup.setup_console_logger
+        log.setup_extended_logging = self.log_setup.setup_extended_logging
+        log.setup_logfile_logger = self.log_setup.setup_logfile_logger
+        log.get_multiprocessing_logging_queue = \
+                self.log_setup.get_multiprocessing_logging_queue
+        log.setup_multiprocessing_logging_listener = \
+                self.log_setup.setup_multiprocessing_logging_listener
+        log.setup_temp_logger = self.log_setup.setup_temp_logger
+
+    # log level configuration tests
+
+    def test_get_log_level_cli(self):
+        '''
+        Tests that log level match command-line specified value
+        '''
+        # Set defaults
+        default_log_level = self.default_config[self.loglevel_config_setting_name]
+
+        # Set log level in CLI
+        log_level = 'critical'
+        args = ['--log-level', log_level] + self.args
+
+        parser = self.parser()
+        with patch(self.config_func, MagicMock(return_value=self.default_config)):
+            parser.parse_args(args)
+        with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
+            parser.setup_logfile_logger()
+
+        console_log_level = getattr(parser.options, self.loglevel_config_setting_name)
+
+        # Check console log level setting
+        self.assertEqual(console_log_level, log_level)
+        # Check console loggger log level
+        self.assertEqual(self.log_setup.log_level, log_level)
+        self.assertEqual(self.log_setup.config[self.loglevel_config_setting_name],
+                         log_level)
+        self.assertEqual(self.log_setup.temp_log_level, log_level)
+        # Check log file logger log level
+        self.assertEqual(self.log_setup.log_level_logfile, default_log_level)
+
+    def test_get_log_level_config(self):
+        '''
+        Tests that log level match the configured value
+        '''
+        # Set defaults
+        default_log_level = self.default_config[self.loglevel_config_setting_name]
+
+        args = self.args
+
+        # Set log level in config
+        log_level = 'info'
+        opts = self.default_config.copy()
+        opts.update({self.loglevel_config_setting_name: log_level})
+
+        parser = self.parser()
+        with patch(self.config_func, MagicMock(return_value=opts)):
+            parser.parse_args(args)
+        with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
+            parser.setup_logfile_logger()
+
+        console_log_level = getattr(parser.options, self.loglevel_config_setting_name)
+
+        # Check console log level setting
+        self.assertEqual(console_log_level, log_level)
+        # Check console loggger log level
+        self.assertEqual(self.log_setup.log_level, log_level)
+        self.assertEqual(self.log_setup.config[self.loglevel_config_setting_name],
+                         log_level)
+        self.assertEqual(self.log_setup.temp_log_level, 'error')
+        # Check log file logger log level
+        self.assertEqual(self.log_setup.log_level_logfile, default_log_level)
+
+    def test_get_log_level_default(self):
+        '''
+        Tests that log level match the default value
+        '''
+        # Set defaults
+        log_level = default_log_level = self.default_config[self.loglevel_config_setting_name]
+
+        args = self.args
+
+        parser = self.parser()
+        with patch(self.config_func, MagicMock(return_value=self.default_config)):
+            parser.parse_args(args)
+        with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
+            parser.setup_logfile_logger()
+
+        console_log_level = getattr(parser.options, self.loglevel_config_setting_name)
+
+        # Check log level setting
+        self.assertEqual(console_log_level, log_level)
+        # Check console loggger log level
+        self.assertEqual(self.log_setup.log_level, log_level)
+        # Check extended logger
+        self.assertEqual(self.log_setup.config[self.loglevel_config_setting_name],
+                         log_level)
+        self.assertEqual(self.log_setup.temp_log_level, 'error')
+        # Check log file logger
+        self.assertEqual(self.log_setup.log_level_logfile, default_log_level)
+        # Check help message
+        self.assertIn('Default: \'{0}\'.'.format(default_log_level),
+                      parser.get_option('--log-level').help)
+
+    # log file configuration tests
+
+    def test_get_log_file_cli(self):
+        '''
+        Tests that log file match command-line specified value
+        '''
+        # Set defaults
+        log_level = self.default_config[self.loglevel_config_setting_name]
+
+        # Set log file in CLI
+        log_file = '{0}_cli.log'.format(self.log_file)
+        args = ['--log-file', log_file] + self.args
+
+        parser = self.parser()
+        with patch(self.config_func, MagicMock(return_value=self.default_config)):
+            parser.parse_args(args)
+        with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
+            parser.setup_logfile_logger()
+
+        log_file_option = getattr(parser.options, self.logfile_config_setting_name)
+
+        if not self.skip_console_logging_config:
+            # Check console loggger
+            self.assertEqual(self.log_setup.log_level, log_level)
+            # Check extended logger
+            self.assertEqual(self.log_setup.config[self.loglevel_config_setting_name],
+                             log_level)
+            self.assertEqual(self.log_setup.config[self.logfile_config_setting_name],
+                             log_file)
+        # Check temp logger
+        self.assertEqual(self.log_setup.temp_log_level, 'error')
+        # Check log file setting
+        self.assertEqual(log_file_option, log_file)
+        # Check log file logger
+        self.assertEqual(self.log_setup.log_file, log_file)
+
+    def test_get_log_file_config(self):
+        '''
+        Tests that log file match the configured value
+        '''
+        # Set defaults
+        log_level = self.default_config[self.loglevel_config_setting_name]
+
+        args = self.args
+
+        # Set log file in config
+        log_file = '{0}_config.log'.format(self.log_file)
+        opts = self.default_config.copy()
+        opts.update({self.logfile_config_setting_name: log_file})
+
+        parser = self.parser()
+        with patch(self.config_func, MagicMock(return_value=opts)):
+            parser.parse_args(args)
+        with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
+            parser.setup_logfile_logger()
+
+        log_file_option = getattr(parser.options, self.logfile_config_setting_name)
+
+        if not self.skip_console_logging_config:
+            # Check console loggger
+            self.assertEqual(self.log_setup.log_level, log_level)
+            # Check extended logger
+            self.assertEqual(self.log_setup.config[self.loglevel_config_setting_name],
+                             log_level)
+            self.assertEqual(self.log_setup.config[self.logfile_config_setting_name],
+                             log_file)
+        # Check temp logger
+        self.assertEqual(self.log_setup.temp_log_level, 'error')
+        # Check log file setting
+        self.assertEqual(log_file_option, log_file)
+        # Check log file logger
+        self.assertEqual(self.log_setup.log_file, log_file)
+
+    def test_get_log_file_default(self):
+        '''
+        Tests that log file match the default value
+        '''
+        # Set defaults
+        log_level = self.default_config[self.loglevel_config_setting_name]
+        log_file = default_log_file = self.default_config[self.logfile_config_setting_name]
+
+        args = self.args
+
+        parser = self.parser()
+        with patch(self.config_func, MagicMock(return_value=self.default_config)):
+            parser.parse_args(args)
+        with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
+            parser.setup_logfile_logger()
+
+        log_file_option = getattr(parser.options, self.logfile_config_setting_name)
+
+        if not self.skip_console_logging_config:
+            # Check console loggger
+            self.assertEqual(self.log_setup.log_level, log_level)
+            # Check extended logger
+            self.assertEqual(self.log_setup.config[self.loglevel_config_setting_name],
+                             log_level)
+            self.assertEqual(self.log_setup.config[self.logfile_config_setting_name],
+                             log_file)
+        # Check temp logger
+        self.assertEqual(self.log_setup.temp_log_level, 'error')
+        # Check log file setting
+        self.assertEqual(log_file_option, log_file)
+        # Check log file logger
+        self.assertEqual(self.log_setup.log_file, log_file)
+       # Check help message
+        self.assertIn('Default: \'{0}\'.'.format(default_log_file),
+                      parser.get_option('--log-file').help)
+
+    # log file log level configuration tests
+
+    def test_get_log_file_level_cli(self):
+        '''
+        Tests that file log level match command-line specified value
+        '''
+        # Set defaults
+        log_level = self.default_config[self.loglevel_config_setting_name]
+
+        # Set log file level in CLI
+        log_level_logfile = 'error'
+        args = ['--log-file-level', log_level_logfile] + self.args
+
+        parser = self.parser()
+        with patch(self.config_func, MagicMock(return_value=self.default_config)):
+            parser.parse_args(args)
+        with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
+            parser.setup_logfile_logger()
+
+        log_level_logfile_option = getattr(parser.options,
+                                           self.logfile_loglevel_config_setting_name)
+
+        if not self.skip_console_logging_config:
+            # Check console loggger
+            self.assertEqual(self.log_setup.log_level, log_level)
+            # Check extended logger
+            self.assertEqual(self.log_setup.config[self.loglevel_config_setting_name],
+                             log_level)
+            self.assertEqual(self.log_setup.config[self.logfile_loglevel_config_setting_name],
+                             log_level_logfile)
+        # Check temp logger
+        self.assertEqual(self.log_setup.temp_log_level, 'error')
+        # Check log file level setting
+        self.assertEqual(log_level_logfile_option, log_level_logfile)
+        # Check log file logger
+        self.assertEqual(self.log_setup.log_level_logfile, log_level_logfile)
+
+    def test_get_log_file_level_config(self):
+        '''
+        Tests that log file level match the configured value
+        '''
+        # Set defaults
+        log_level = self.default_config[self.loglevel_config_setting_name]
+
+        args = self.args
+
+        # Set log file level in config
+        log_level_logfile = 'info'
+        opts = self.default_config.copy()
+        opts.update({self.logfile_loglevel_config_setting_name: log_level_logfile})
+
+        parser = self.parser()
+        with patch(self.config_func, MagicMock(return_value=opts)):
+            parser.parse_args(args)
+        with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
+            parser.setup_logfile_logger()
+
+        log_level_logfile_option = getattr(parser.options,
+                                           self.logfile_loglevel_config_setting_name)
+
+        if not self.skip_console_logging_config:
+            # Check console loggger
+            self.assertEqual(self.log_setup.log_level, log_level)
+            # Check extended logger
+            self.assertEqual(self.log_setup.config[self.loglevel_config_setting_name],
+                             log_level)
+            self.assertEqual(self.log_setup.config[self.logfile_loglevel_config_setting_name],
+                             log_level_logfile)
+        # Check temp logger
+        self.assertEqual(self.log_setup.temp_log_level, 'error')
+        # Check log file level setting
+        self.assertEqual(log_level_logfile_option, log_level_logfile)
+        # Check log file logger
+        self.assertEqual(self.log_setup.log_level_logfile, log_level_logfile)
+
+    def test_get_log_file_level_default(self):
+        '''
+        Tests that log file level match the default value
+        '''
+        # Set defaults
+        default_log_level = self.default_config[self.loglevel_config_setting_name]
+
+        log_level = default_log_level
+        log_level_logfile = default_log_level
+
+        args = self.args
+
+        parser = self.parser()
+        with patch(self.config_func, MagicMock(return_value=self.default_config)):
+            parser.parse_args(args)
+        with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
+            parser.setup_logfile_logger()
+
+        log_level_logfile_option = getattr(parser.options,
+                                           self.logfile_loglevel_config_setting_name)
+
+        if not self.skip_console_logging_config:
+            # Check console loggger
+            self.assertEqual(self.log_setup.log_level, log_level)
+            # Check extended logger
+            self.assertEqual(self.log_setup.config[self.loglevel_config_setting_name],
+                             log_level)
+            self.assertEqual(self.log_setup.config[self.logfile_loglevel_config_setting_name],
+                             log_level_logfile)
+        # Check temp logger
+        self.assertEqual(self.log_setup.temp_log_level, 'error')
+        # Check log file level setting
+        self.assertEqual(log_level_logfile_option, log_level_logfile)
+        # Check log file logger
+        self.assertEqual(self.log_setup.log_level_logfile, log_level_logfile)
+        # Check help message
+        self.assertIn('Default: \'{0}\'.'.format(default_log_level),
+                      parser.get_option('--log-file-level').help)
+
+    def test_get_console_log_level_with_file_log_level(self):  # pylint: disable=invalid-name
+        '''
+        Tests that both console log level and log file level setting are working together
+        '''
+        log_level = 'critical'
+        log_level_logfile = 'debug'
+
+        args = ['--log-file-level', log_level_logfile] + self.args
+
+        opts = self.default_config.copy()
+        opts.update({self.loglevel_config_setting_name: log_level})
+
+        parser = self.parser()
+        with patch(self.config_func, MagicMock(return_value=opts)):
+            parser.parse_args(args)
+
+        with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
+            parser.setup_logfile_logger()
+
+        log_level_logfile_option = getattr(parser.options,
+                                           self.logfile_loglevel_config_setting_name)
+
+        if not self.skip_console_logging_config:
+            # Check console loggger
+            self.assertEqual(self.log_setup.log_level, log_level)
+            # Check extended logger
+            self.assertEqual(self.log_setup.config[self.loglevel_config_setting_name],
+                             log_level)
+            self.assertEqual(self.log_setup.config[self.logfile_loglevel_config_setting_name],
+                             log_level_logfile)
+        # Check temp logger
+        self.assertEqual(self.log_setup.temp_log_level, 'error')
+        # Check log file level setting
+        self.assertEqual(log_level_logfile_option, log_level_logfile)
+        # Check log file logger
+        self.assertEqual(self.log_setup.log_level_logfile, log_level_logfile)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class MasterOptionParserTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing Salt Master options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_MASTER_OPTS
+
+        # Log file
+        self.log_file = '/tmp/salt_master_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.master_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.MasterOptionParser
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class MinionOptionParserTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing Salt Minion options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_MINION_OPTS
+
+        # Log file
+        self.log_file = '/tmp/salt_minion_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.minion_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.MinionOptionParser
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class ProxyMinionOptionParserTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing Salt Proxy Minion options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_MINION_OPTS.copy()
+        self.default_config.update(salt.config.DEFAULT_PROXY_MINION_OPTS)
+
+        # Log file
+        self.log_file = '/tmp/salt_proxy_minion_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.minion_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.ProxyMinionOptionParser
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SyndicOptionParserTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing Salt Syndic options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        # Set config option names
+        self.logfile_config_setting_name = 'syndic_log_file'
+
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_MASTER_OPTS
+
+        # Log file
+        self.log_file = '/tmp/salt_syndic_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.syndic_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.SyndicOptionParser
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SaltCMDOptionParserTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing Salt CLI options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        # Set mandatory CLI options
+        self.args = ['foo', 'bar.baz']
+
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_MASTER_OPTS
+
+        # Log file
+        self.log_file = '/tmp/salt_cmd_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.client_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.SaltCMDOptionParser
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SaltCPOptionParserTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing salt-cp options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        # Set mandatory CLI options
+        self.args = ['foo', 'bar', 'baz']
+
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_MASTER_OPTS
+
+        # Log file
+        self.log_file = '/tmp/salt_cp_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.master_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.SaltCPOptionParser
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SaltKeyOptionParserTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing salt-key options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        self.skip_console_logging_config = True
+
+        # Set config option names
+        self.logfile_config_setting_name = 'key_logfile'
+
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_MASTER_OPTS
+
+        # Log file
+        self.log_file = '/tmp/salt_key_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.master_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.SaltKeyOptionParser
+
+    # log level configuration tests
+
+    def test_get_log_level_cli(self):
+        '''
+        Tests that console log level option is not recognized
+        '''
+        # No console log level will be actually set
+        log_level = default_log_level = None
+
+        option = '--log-level'
+        args = self.args + [option, 'error']
+
+        parser = self.parser()
+        mock_err = ErrorMock()
+
+        with patch('optparse.OptionParser.error', mock_err.error):
+            parser.parse_args(args)
+
+        # Check error msg
+        self.assertEqual(mock_err.msg, 'no such option: {0}'.format(option))
+        # Check console loggger has not been set
+        self.assertEqual(self.log_setup.log_level, log_level)
+        self.assertNotIn(self.loglevel_config_setting_name, self.log_setup.config)
+        # Check temp logger
+        self.assertEqual(self.log_setup.temp_log_level, 'error')
+        # Check log file logger log level
+        self.assertEqual(self.log_setup.log_level_logfile, default_log_level)
+
+    def test_get_log_level_config(self):
+        '''
+        Tests that log level set in config is ignored
+        '''
+        # Set defaults
+        default_log_level = self.default_config[self.loglevel_config_setting_name]
+
+        log_level = None
+        args = self.args
+
+        # Set log level in config
+        opts = {self.loglevel_config_setting_name: 'info'}
+
+        parser = self.parser()
+        with patch(self.config_func, MagicMock(return_value=opts)):
+            parser.parse_args(args)
+
+        with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
+            parser.setup_logfile_logger()
+
+        # Check config name absence in options
+        self.assertNotIn(self.loglevel_config_setting_name, parser.options.__dict__)
+        # Check console loggger has not been set
+        self.assertEqual(self.log_setup.log_level, log_level)
+        self.assertNotIn(self.loglevel_config_setting_name, self.log_setup.config)
+        # Check temp logger
+        self.assertEqual(self.log_setup.temp_log_level, 'error')
+        # Check log file logger log level
+        self.assertEqual(self.log_setup.log_level_logfile, default_log_level)
+
+    def test_get_log_level_default(self):
+        '''
+        Tests that log level default value is ignored
+        '''
+        # Set defaults
+        default_log_level = self.default_config[self.loglevel_config_setting_name]
+
+        log_level = None
+        args = self.args
+
+        parser = self.parser()
+        parser.parse_args(args)
+
+        with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
+            parser.setup_logfile_logger()
+
+        # Check config name absence in options
+        self.assertNotIn(self.loglevel_config_setting_name, parser.options.__dict__)
+        # Check console loggger has not been set
+        self.assertEqual(self.log_setup.log_level, log_level)
+        self.assertNotIn(self.loglevel_config_setting_name, self.log_setup.config)
+        # Check temp logger
+        self.assertEqual(self.log_setup.temp_log_level, 'error')
+        # Check log file logger log level
+        self.assertEqual(self.log_setup.log_level_logfile, default_log_level)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SaltCallOptionParserTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing Salt Minion options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        # Set mandatory CLI options
+        self.args = ['foo.bar']
+
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_MINION_OPTS
+
+        # Log file
+        self.log_file = '/tmp/salt_call_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.minion_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.SaltCallOptionParser
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SaltRunOptionParserTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing Salt Master options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        # Set mandatory CLI options
+        self.args = ['foo.bar']
+
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_MASTER_OPTS
+
+        # Log file
+        self.log_file = '/tmp/salt_run_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.master_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.SaltRunOptionParser
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SaltSSHOptionParserTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing Salt Master options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        # Set mandatory CLI options
+        self.args = ['foo', 'bar.baz']
+
+        # Set config option names
+        self.logfile_config_setting_name = 'ssh_log_file'
+
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_MASTER_OPTS
+
+        # Log file
+        self.log_file = '/tmp/salt_ssh_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.master_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.SaltSSHOptionParser
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SaltCloudParserTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing Salt Cloud options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        # Set mandatory CLI options
+        self.args = ['-p', 'foo', 'bar']
+
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_CLOUD_OPTS
+
+        # Log file
+        self.log_file = '/tmp/salt_cloud_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.cloud_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.SaltCloudParser
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SPMParserTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing Salt Cloud options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        # Set mandatory CLI options
+        self.args = ['foo', 'bar']
+
+        # Set config option names
+        self.logfile_config_setting_name = 'spm_logfile'
+
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_MASTER_OPTS.copy()
+        self.default_config.update(salt.config.DEFAULT_SPM_OPTS)
+
+        # Log file
+        self.log_file = '/tmp/spm_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.spm_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.SPMParser
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class SaltAPIParserTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing Salt Cloud options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        # Set mandatory CLI options
+        self.args = []
+
+        # Set config option names
+        self.logfile_config_setting_name = 'api_logfile'
+
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_MASTER_OPTS.copy()
+        self.default_config.update(salt.config.DEFAULT_API_OPTS)
+
+        # Log file
+        self.log_file = '/tmp/salt_api_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.api_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.SaltAPIParser
+
+
+# Hide the class from unittest framework when it searches for TestCase classes in the module
+del LogSettingsParserTests
+
+if __name__ == '__main__':
+    from integration import run_tests  # pylint: disable=import-error,wrong-import-position
+    run_tests(MasterOptionParserTestCase,
+              MinionOptionParserTestCase,
+              ProxyMinionOptionParserTestCase,
+              SyndicOptionParserTestCase,
+              SaltCMDOptionParserTestCase,
+              SaltCPOptionParserTestCase,
+              SaltKeyOptionParserTestCase,
+              SaltCallOptionParserTestCase,
+              SaltRunOptionParserTestCase,
+              SaltSSHOptionParserTestCase,
+              SaltCloudParserTestCase,
+              SPMParserTestCase,
+              SaltAPIParserTestCase,
+              needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

Corrects the call to VMware to perform a reset of a VM (like pushing the reset button on a physical computer).  The call needed to be updated from `vm.Reset()` to `vm.ResetVM_Task`.

### What issues does this PR fix or reference?

Closes #37413

### Previous Behavior

`salt-cloud -a reset vm_name` would not do anything.

### New Behavior

`salt-cloud -a reset vm_name` now hard-resets `vm_name`.
