### PR TITLE
Clarifies file.replace behavior on symlinks

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1857,7 +1857,8 @@ def replace(path,
     This is a pure Python implementation that wraps Python's :py:func:`~re.sub`.
 
     path
-        Filesystem path to the file to be edited
+        Filesystem path to the file to be edited. If a symlink is specified, it
+        will be resolved to its target.
 
     pattern
         A regular expression, to be matched using Python's

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3218,7 +3218,8 @@ def replace(name,
     .. versionadded:: 0.17.0
 
     name
-        Filesystem path to the file to be edited.
+        Filesystem path to the file to be edited. If a symlink is specified, it
+        will be resolved to its target.
 
     pattern
         A regular expression, to be matched using Python's


### PR DESCRIPTION
### What does this PR do?

Makes a small edit to the docstring to clarify `file.replace` behavior on symlinks.
