### PR TITLE
Add False + msg tuple return if requests is missing for zenoss module

### DIFF
--- a/salt/modules/zenoss.py
+++ b/salt/modules/zenoss.py
@@ -4,6 +4,8 @@ Module for working with the Zenoss API
 
 .. versionadded:: 2016.3.0
 
+:depends: requests
+
 :configuration: This module requires a 'zenoss' entry in the master/minion config.
 
     For example:
@@ -36,13 +38,18 @@ urllib3_logger.setLevel(logging.WARNING)
 
 log = logging.getLogger(__name__)
 
+__virtualname__ = 'zenoss'
+
 
 def __virtual__():
     '''
     Only load if requests is installed
     '''
     if HAS_LIBS:
-        return 'zenoss'
+        return __virtualname__
+    else:
+        return False, 'The \'{0}\' module could not be loaded: ' \
+                      '\'requests\' is not installed.'.format(__virtualname__)
 
 ROUTERS = {'MessagingRouter': 'messaging',
            'EventsRouter': 'evconsole',


### PR DESCRIPTION
### What does this PR do?
Adds the `False` and reason message tuple to the `zenoss` execution module when `requests` is missing. 

### What issues does this PR fix or reference?
Fixes #38091

### Previous Behavior
```
[WARNING ] salt.loaded.int.module.zenoss.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'zenoss', please fix this.
```

### New Behavior
The warning no longer displays because the virtual function will no longer return `None`.


### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.