### PR TITLE
"test" is not necessarily in opts, for thorium

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1818,7 +1818,7 @@ class State(object):
         Check if the low data chunk should send a failhard signal
         '''
         tag = _gen_tag(low)
-        if self.opts['test']:
+        if self.opts.get('test', False):
             return False
         if (low.get('failhard', False) or self.opts['failhard']
                 and tag in running):


### PR DESCRIPTION
### What does this PR do?
Don't assume that `test` is in `opts`. It always will be for states, but not for thorium.

### Tests written?
No.