### PR TITLE
mode needs to be an integer

### DIFF
--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -107,6 +107,7 @@ def setenforce(mode):
             mode = '0'
             modestring = 'Permissive'
         elif mode.lower() == 'disabled':
+            mode = '0'
             modestring = 'Disabled'
         else:
             return 'Invalid mode {0}'.format(mode)


### PR DESCRIPTION
### What does this PR do?

It can't be 'Disabled'.  That cannot be written to /sys/fs/selinux/enforce