### PR TITLE
Revert "fix augeas module so shlex doesn't strip quotes"

### DIFF
--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -199,7 +199,7 @@ def execute(context=None, lens=None, commands=(), load_path=None):
             method = METHOD_MAP[cmd]
             nargs = arg_map[method]
 
-            parts = salt.utils.shlex_split(arg, posix=False)
+            parts = salt.utils.shlex_split(arg)
 
             if len(parts) not in nargs:
                 err = '{0} takes {1} args: {2}'.format(method, nargs, parts)


### PR DESCRIPTION
Reverts saltstack/salt#34643--this causes quotes to remain where they should have been eliminated.  Recommend if quotes need to be left alone, to escape them.