### PR TITLE
redirect output when daemonizing and close std* first

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -495,9 +495,14 @@ def daemonize(redirect_out=True):
     # multiprocessing process attempts to access stdout or err.
     if redirect_out:
         with fopen('/dev/null', 'r+') as dev_null:
+            # Redirect python stdin/out/err
+            # and the os stdin/out/err which can be different
             os.dup2(dev_null.fileno(), sys.stdin.fileno())
             os.dup2(dev_null.fileno(), sys.stdout.fileno())
             os.dup2(dev_null.fileno(), sys.stderr.fileno())
+            os.dup2(dev_null.fileno(), 0)
+            os.dup2(dev_null.fileno(), 1)
+            os.dup2(dev_null.fileno(), 2)
 
 
 def daemonize_if(opts):


### PR DESCRIPTION
### What does this PR do?
This PR redirects input/output to `/dev/null` when daemonizing. It also closes stdin, stdout, and stderr before redirecting them.

### What issues does this PR fix or reference?
This addresses #37934

### Previous Behavior
Salt did not redirect or close the standard inputs/outputs when daemonizing

### Tests written?
No

I'm not sure this is the correct way to go about this. The current behaviour was implemented in [28847a8e](https://github.com/saltstack/salt/commit/28847a8e60d437e80ba64abf2881331aec1e3074) and both the redirect functionality, and daemonizing without it where implemented at the same time, so it was clearly a conscious choice by @thatch45 not to do any redirection.

It appears that `daemonize` is never called anywhere except `deamonize_if` so it's possible that the redirect functionality has never been used.

Also I'm closing the 3 file descriptors before reopening them, because otherwise I was still seeing the behaviour described in #37934, though I'm not sure why that was the case.

I'd welcome any guidance if there are better ideas or preferred approaches.