### PR TITLE
documentation: added overview (table) of requisites to requisites doc

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -144,6 +144,47 @@ so either of the following versions for "Extract server package" works:
           - file: /usr/local/share/myapp.tar.xz
 
 
+Requisite overview
+~~~~~~~~~~~~~~~~~~
+
+
++------------+-------------------+---------------+-----------+--------------------+
+| requisite  | state is only     | state is only | Order:    | comment            |
+|            | executed if       | executed if   |           |                    |
+|            | target execution  | target        | 1. target |                    |
+|            |                   | has changes   | 2. state  |                    |
++============+===================+===============+===========+====================+
+| require    | ok                | no            | yes       | state will always  |
+|            |                   |               |           | exececute unless   |
+|            |                   |               |           | target fails       |
++------------+-------------------+---------------+-----------+--------------------+
+| watch      | ok                | no            | yes       | “If mod_watch is   |
+|            |                   |               |           | absent from the    |
+|            |                   |               |           | watching state     |
+|            |                   |               |           | module, the watch  |
+|            |                   |               |           | requisite behaves  |
+|            |                   |               |           | exactly like a     |
+|            |                   |               |           | require requisite.“|
++------------+-------------------+---------------+-----------+--------------------+
+| prereq     | ok                | yes           | switched  | like onchanges,    |
+|            |                   |               |           | except order       |
++------------+-------------------+---------------+-----------+--------------------+
+| onchanges  | ok                | yes           | yes       | execute state if   |
+|            |                   |               |           | target ok and has  |
+|            |                   |               |           | changes            |
++------------+-------------------+---------------+-----------+--------------------+
+| onfail     | fails             | no            | yes       | Only requisite     |
+|            |                   |               |           | where state exec.  |
+|            |                   |               |           | if target fails    |
++------------+-------------------+---------------+-----------+--------------------+
+
+In this table, the following short form of terms is used:
+
+* **state** (= dependent state): state containing requisite 
+* **target** (= state target) : state referenced by requisite
+
+
+
 Direct Requisite and Requisite_in types
 ---------------------------------------
 

--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -151,31 +151,32 @@ Requisite overview
 +------------+-------------------+---------------+-----------+--------------------+
 | requisite  | state is only     | state is only | Order:    | comment            |
 |            | executed if       | executed if   |           |                    |
-|            | target execution  | target        | 1. target |                    |
-|            |                   | has changes   | 2. state  |                    |
+|            | target execution  | target        |           |                    |
+|            | result is         |               |           |                    |
 +============+===================+===============+===========+====================+
-| require    | ok                | no            | yes       | state will always  |
-|            |                   |               |           | exececute unless   |
-|            |                   |               |           | target fails       |
+| require    | success           |               | default:  | state will always  |
+|            |                   |               | 1. target | exececute unless   |
+|            |                   |               | 2. state  | target fails       |
 +------------+-------------------+---------------+-----------+--------------------+
-| watch      | ok                | no            | yes       | “If mod_watch is   |
-|            |                   |               |           | absent from the    |
-|            |                   |               |           | watching state     |
+| watch      | success           |               | default:  | “If mod_watch is   |
+|            |                   |               | 1. target | absent from the    |
+|            |                   |               | 2. state  | watching state     |
 |            |                   |               |           | module, the watch  |
 |            |                   |               |           | requisite behaves  |
 |            |                   |               |           | exactly like a     |
 |            |                   |               |           | require requisite.“|
 +------------+-------------------+---------------+-----------+--------------------+
-| prereq     | ok                | yes           | switched  | like onchanges,    |
-|            |                   |               |           | except order       |
+| prereq     | success           | has changes   | switched: | like onchanges,    |
+|            |                   |               | 1. state  | except order       |
+|            |                   |               | 2. target |                    |
 +------------+-------------------+---------------+-----------+--------------------+
-| onchanges  | ok                | yes           | yes       | execute state if   |
-|            |                   |               |           | target ok and has  |
-|            |                   |               |           | changes            |
+| onchanges  | success           | has changes   | default:  | execute state if   |
+|            |                   |               | 1. target | target ok and has  |
+|            |                   |               | 2. state  | changes            |
 +------------+-------------------+---------------+-----------+--------------------+
-| onfail     | fails             | no            | yes       | Only requisite     |
-|            |                   |               |           | where state exec.  |
-|            |                   |               |           | if target fails    |
+| onfail     | failed            |               | default   | Only requisite     |
+|            |                   |               | 1. target | where state exec.  |
+|            |                   |               | 2. state  | if target fails    |
 +------------+-------------------+---------------+-----------+--------------------+
 
 In this table, the following short form of terms is used:

--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -148,36 +148,38 @@ Requisite overview
 ~~~~~~~~~~~~~~~~~~
 
 
-+------------+-------------------+---------------+-----------+--------------------+
-| requisite  | state is only     | state is only | Order:    | comment            |
-|            | executed if       | executed if   |           |                    |
-|            | target execution  | target        |           |                    |
-|            | result is         |               |           |                    |
-+============+===================+===============+===========+====================+
-| require    | success           |               | default:  | state will always  |
-|            |                   |               | 1. target | exececute unless   |
-|            |                   |               | 2. state  | target fails       |
-+------------+-------------------+---------------+-----------+--------------------+
-| watch      | success           |               | default:  | “If mod_watch is   |
-|            |                   |               | 1. target | absent from the    |
-|            |                   |               | 2. state  | watching state     |
-|            |                   |               |           | module, the watch  |
-|            |                   |               |           | requisite behaves  |
-|            |                   |               |           | exactly like a     |
-|            |                   |               |           | require requisite.“|
-+------------+-------------------+---------------+-----------+--------------------+
-| prereq     | success           | has changes   | switched: | like onchanges,    |
-|            |                   |               | 1. state  | except order       |
-|            |                   |               | 2. target |                    |
-+------------+-------------------+---------------+-----------+--------------------+
-| onchanges  | success           | has changes   | default:  | execute state if   |
-|            |                   |               | 1. target | target ok and has  |
-|            |                   |               | 2. state  | changes            |
-+------------+-------------------+---------------+-----------+--------------------+
-| onfail     | failed            |               | default   | Only requisite     |
-|            |                   |               | 1. target | where state exec.  |
-|            |                   |               | 2. state  | if target fails    |
-+------------+-------------------+---------------+-----------+--------------------+
++------------+-------------------+---------------+------------+--------------------+
+| name       | state is only     | state is only | order      | comment            |
+|  of        | executed if       | executed if   |            |  or                |
+|            | target execution  | target has    | 1.target   |                    |
+|            |                   |               | 2.state    |                    |  
+| requisite  | result is         | changes       | (default)  | description        |
++============+===================+===============+============+====================+
+| require    | success           |               | default    | state will always  |
+|            |                   |               |            | execute unless     |
+|            |                   |               |            | target fails       |
++------------+-------------------+---------------+------------+--------------------+
+| watch      | success           |               | default    | like require,      |
+|            |                   |               |            | but adds additional|
+|            |                   |               |            | behaviour          |
+|            |                   |               |            | (mod_watch)        |
++------------+-------------------+---------------+------------+--------------------+
+| prereq     | success           | has changes   | switched   | like onchanges,    |
+|            |                   | (run          |            | except order       |
+|            |                   | individually  |            |                    |
+|            |                   | as dry-run)   |            |                    |
++------------+-------------------+---------------+------------+--------------------+
+| onchanges  | success           | has changes   | default    | execute state if   |
+|            |                   |               |            | target execution   |
+|            |                   |               |            | result is success  |
+|            |                   |               |            | and target has     |
+|            |                   |               |            | changes            |  
++------------+-------------------+---------------+------------+--------------------+
+| onfail     | failed            |               | default    | Only requisite     |
+|            |                   |               |            | where state exec.  |
+|            |                   |               |            | if target fails    |
++------------+-------------------+---------------+------------+--------------------+
+
 
 In this table, the following short form of terms is used:
 


### PR DESCRIPTION
This is an addition to the documentation page on requisites. It adds a table of requisites as a handy overview showing the differences in the behaviour of the requisites, e.g. execute only if target has changes, execute only if target is successful / fails, execution order etc. 

This PR does not handle an open issue.

Push to "develop" because it is more of a new feature than a fix. 

