### PR TITLE
Fix status beacon config default values

### DIFF
--- a/salt/beacons/status.py
+++ b/salt/beacons/status.py
@@ -109,11 +109,11 @@ def beacon(config):
 
     if len(config) < 1:
         config = {
-            'loadavg': 'all',
-            'cpustats': 'all',
-            'meminfo': 'all',
-            'vmstats': 'all',
-            'time': 'all',
+            'loadavg': ['all'],
+            'cpustats': ['all'],
+            'meminfo': ['all'],
+            'vmstats': ['all'],
+            'time': ['all'],
         }
 
     ret = {}


### PR DESCRIPTION
### What does this PR do?
Config values are expected as lists but default values where set to strings.

### What issues does this PR fix or reference?
This addresses #37976

### Previous Behavior
If run without configuration the beacon will not run and log the following error:
```[CRITICAL] The beacon errored:
Traceback (most recent call last):
File "/usr/lib/python2.7/site-packages/salt/minion.py", line 2153, in handle_beacons
beacons = self.process_beacons(self.functions)
File "/usr/lib/python2.7/site-packages/salt/minion.py", line 409, in process_beacons
return self.beacons.process(b_conf, self.opts['grains']) # pylint: disable=no-member
File "/usr/lib/python2.7/site-packages/salt/beacons/init.py", line 100, in process
raw = self.beaconsfun_str
File "/usr/lib/python2.7/site-packages/salt/beacons/status.py", line 131, in beacon
ret[func][item] = data[int(item)]
ValueError: invalid literal for int() with base 10: 'a'
```

### New Behavior
It just works :)

### Tests written?

No