### PR TITLE
Fixes #38097: Make the Gentoo version of pkg.latest_version return a …

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -233,7 +233,7 @@ def latest_version(*names, **kwargs):
         ret[name] = ''
         installed = _cpv_to_version(_vartree().dep_bestmatch(name))
         avail = _cpv_to_version(_porttree().dep_bestmatch(name))
-        if avail:
+        if avail and salt.utils.compare_versions(ver1=installed,oper='<',ver2=avail,cmp_func=version_cmp):
             ret[name] = avail
 
     # Return a string if only one package name passed

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -233,7 +233,7 @@ def latest_version(*names, **kwargs):
         ret[name] = ''
         installed = _cpv_to_version(_vartree().dep_bestmatch(name))
         avail = _cpv_to_version(_porttree().dep_bestmatch(name))
-        if avail and salt.utils.compare_versions(ver1=installed,oper='<',ver2=avail,cmp_func=version_cmp):
+        if avail and salt.utils.compare_versions(ver1=installed, oper='<', ver2=avail, cmp_func=version_cmp):
             ret[name] = avail
 
     # Return a string if only one package name passed


### PR DESCRIPTION
### What does this PR do?
Make the Gentoo version of `pkg.latest_version` return a version only if it is not installed or if there is an update availabe. Following the docs, this should be the default behavior.
### What issues does this PR fix or reference?
Fixes #38097
### Previous Behavior
`pkg.latest_version` also returned the currently installed version which results in `pkg.update` always re-installing up-to-date packages.