### PR TITLE
Adjust description for param cwd

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -757,8 +757,8 @@ def run(cmd,
 
     :param str cmd: The command to run. ex: ``ls -lart /home``
 
-    :param str cwd: The current working directory to execute the command in,
-      defaults to ``/root`` (``C:\`` in windows)
+    :param str cwd: The current working directory to execute the command in.
+      Defaults to the home directory of the user specified by ``runas``.
 
     :param str stdin: A string of standard input can be specified for the
       command to be run using the ``stdin`` parameter. This can be useful in cases
@@ -968,8 +968,8 @@ def shell(cmd,
 
     :param str cmd: The command to run. ex: 'ls -lart /home'
 
-    :param str cwd: The current working directory to execute the command in,
-      defaults to /root
+    :param str cwd: The current working directory to execute the command in.
+      Defaults to the home directory of the user specified by ``runas``.
 
     :param str stdin: A string of standard input can be specified for the
       command to be run using the ``stdin`` parameter. This can be useful in cases
@@ -1155,8 +1155,8 @@ def run_stdout(cmd,
 
     :param str cmd: The command to run. ex: 'ls -lart /home'
 
-    :param str cwd: The current working directory to execute the command in,
-      defaults to /root
+    :param str cwd: The current working directory to execute the command in.
+      Defaults to the home directory of the user specified by ``runas``.
 
     :param str stdin: A string of standard input can be specified for the
       command to be run using the ``stdin`` parameter. This can be useful in cases
@@ -1336,8 +1336,8 @@ def run_stderr(cmd,
 
     :param str cmd: The command to run. ex: 'ls -lart /home'
 
-    :param str cwd: The current working directory to execute the command in,
-      defaults to /root
+    :param str cwd: The current working directory to execute the command in.
+      Defaults to the home directory of the user specified by ``runas``.
 
     :param str stdin: A string of standard input can be specified for the
       command to be run using the ``stdin`` parameter. This can be useful in cases
@@ -1519,8 +1519,8 @@ def run_all(cmd,
 
     :param str cmd: The command to run. ex: 'ls -lart /home'
 
-    :param str cwd: The current working directory to execute the command in,
-      defaults to /root
+    :param str cwd: The current working directory to execute the command in.
+      Defaults to the home directory of the user specified by ``runas``.
 
     :param str stdin: A string of standard input can be specified for the
       command to be run using the ``stdin`` parameter. This can be useful in cases
@@ -1710,8 +1710,8 @@ def retcode(cmd,
 
     :param str cmd: The command to run. ex: 'ls -lart /home'
 
-    :param str cwd: The current working directory to execute the command in,
-      defaults to /root
+    :param str cwd: The current working directory to execute the command in.
+      Defaults to the home directory of the user specified by ``runas``.
 
     :param str stdin: A string of standard input can be specified for the
       command to be run using the ``stdin`` parameter. This can be useful in cases
@@ -1945,8 +1945,8 @@ def script(source,
       string containing spaces in YAML, you will need to doubly-quote it:
       "arg1 'arg two' arg3"
 
-    :param str cwd: The current working directory to execute the command in,
-      defaults to /root
+    :param str cwd: The current working directory to execute the command in.
+      Defaults to the home directory of the user specified by ``runas``.
 
     :param str stdin: A string of standard input can be specified for the
       command to be run using the ``stdin`` parameter. This can be useful in cases
@@ -2173,8 +2173,8 @@ def script_retcode(source,
       string containing spaces in YAML, you will need to doubly-quote it:  "arg1
       'arg two' arg3"
 
-    :param str cwd: The current working directory to execute the command in,
-      defaults to /root
+    :param str cwd: The current working directory to execute the command in.
+      Defaults to the home directory of the user specified by ``runas``.
 
     :param str stdin: A string of standard input can be specified for the
       command to be run using the ``stdin`` parameter. This can be useful in cases
@@ -2454,7 +2454,7 @@ def run_chroot(root,
         The command to run. ex: 'ls -lart /home'
 
     cwd
-        The current working directory to execute the command in, defaults to
+        The current working directory to execute the command in. defaults to
         /root
 
     stdin
@@ -2673,7 +2673,7 @@ def shell_info(shell, list_modules=False):
     .. versionadded:: 2016.11.0
 
     Provides information about a shell or script languages which often use
-    ``#!``. The values returned are dependant on the shell or scripting
+    ``#!``. The values returned are dependent on the shell or scripting
     languages all return the ``installed``, ``path``, ``version``,
     ``version_raw``
 
@@ -2907,7 +2907,8 @@ def powershell(cmd,
 
     :param str cmd: The powershell command to run.
 
-    :param str cwd: The current working directory to execute the command in
+    :param str cwd: The current working directory to execute the command in.
+      Defaults to the home directory of the user specified by ``runas``.
 
     :param str stdin: A string of standard input can be specified for the
       command to be run using the ``stdin`` parameter. This can be useful in cases
@@ -3093,8 +3094,8 @@ def run_bg(cmd,
 
     :param str cmd: The command to run. ex: 'ls -lart /home'
 
-    :param str cwd: The current working directory to execute the command in,
-      defaults to `/root` (`C:\` in windows)
+    :param str cwd: The current working directory to execute the command in.
+      Defaults to the home directory of the user specified by ``runas``.
 
     :param str output_loglevel: Control the loglevel at which the output from
       the command is logged. Note that the command being run will still be logged


### PR DESCRIPTION
### What does this PR do?

Provides a more pedantic explanation for the `cwd` parameter

On most Linux systems root's home directory is `/root`, but this is not true on other platforms. On MacOS 10.12 for example, it is `/var/root` or `/var/private/root`.

Also, the salt master may not be running as root, so perhaps it is best to avoid making any promises about the current working directory if `runas` is not specified.
