### PR TITLE
Mock config.option call return for iptables unit test

### DIFF
--- a/tests/unit/modules/iptables_test.py
+++ b/tests/unit/modules/iptables_test.py
@@ -288,7 +288,8 @@ class IptablesTestCase(TestCase):
         '''
         mock = MagicMock(return_value=True)
         with patch.dict(iptables.__salt__, {'cmd.run': mock,
-                                            'file.write': mock}):
+                                            'file.write': mock,
+                                            'config.option': MagicMock(return_value=[])}):
             self.assertTrue(iptables.save(filename='/xyz', family='ipv4'))
 
     # 'check' function tests: 1


### PR DESCRIPTION
Refs #31662

We have a new call to the `__salt__` dict that we need to mock with the changes from #31662.