### PR TITLE
Skip daemon unit tests when running on Python 2.6

### DIFF
--- a/tests/unit/daemons_test.py
+++ b/tests/unit/daemons_test.py
@@ -5,6 +5,7 @@
 
 # Import python libs
 from __future__ import absolute_import
+import sys
 
 # Import Salt Testing libs
 from salttesting import TestCase, skipIf
@@ -17,6 +18,10 @@ ensure_in_syspath('../')
 import integration
 import multiprocessing
 from salt.cli import daemons
+
+PY26 = False
+if sys.version_info[1] < 7:
+    PY26 = True
 
 
 class LoggerMock(object):
@@ -61,6 +66,7 @@ class LoggerMock(object):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(PY26, 'These tests don\'t run on Python 2.6. Skipping.')
 class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
     '''
     Unit test for the daemons starter classes.


### PR DESCRIPTION
When switching the daemon unit tests to using multiprocessing pipes, this exposed a deep bug in Python 2.6. Let's skip these on 2.6.