### PR TITLE
Security Groups for New EC2 Cloud Instances

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1192,7 +1192,7 @@ def securitygroupid(vm_):
     )
     if securitygroupid_list:
         if isinstance(securitygroupid_list, list):
-            securitygroupid_set = securitygroupid_set.union(securitygroupid_list)
+            securitygroupid_set.update(securitygroupid_list)
         else:
             securitygroupid_set.add(securitygroupid_list)
 


### PR DESCRIPTION
### What does this PR do?
It fixes a bug whereby a new instance would never get the state defined security groups applied to the new instance. Instead returning with just the default security group for whichever VPC it was launched into.

### What issues does this PR fix or reference?
None were opened, it was part of an investigation prior to upgrading our infrastructure to 2016.11. 

### Tests written?
No


