### PR TITLE
Apply Defined Tags to New RDS Instance

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -277,9 +277,9 @@ def create(name, allocated_storage, db_instance_class, engine,
             val = locals()[key]
             if val is not None:
                 mapped = boto3_param_map[key]
+                if key == 'tags':
+                    val = _tag_doc(val)
                 kwargs[mapped[0]] = mapped[1](val)
-
-        taglist = _tag_doc(tags)
 
         # Validation doesn't want parameters that are None
         # https://github.com/boto/boto3/issues/400


### PR DESCRIPTION
### What does this PR do?
The tags were not being applied to a newly launched RDS instance.

### What issues does this PR fix or reference?
None were opened. This was part of an evaluation before upgrading our infrastructure to 2016.11. It seems like it got broken in [this](https://github.com/saltstack/salt/commit/d8eb7494db9e00e6868971a57a4b26f11695c932) cleanup of `boto3` arguments and was simply overlooked.

### Previous Behavior
In 2016.3, the tags were applied correctly.

### Tests written?
No
