### PR TITLE
Remove unneeded 'AND' portion of 'if' compound statement for log_config

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -424,10 +424,10 @@ def _compare(actual, create_kwargs, defaults_from_image):
                 continue
         elif item == 'log_config':
             # https://github.com/saltstack/salt/issues/30577#issuecomment-238322721
-            if not data.get('Config', None) and actual_data.get('Config', None):
+            if not data.get('Config'):
                 data['Config'] = {}
                 actual_data['Config'] = {}
-            if not data.get('Type', None) and actual_data.get('Type', None):
+            if not data.get('Type'):
                 data['Type'] = None
                 actual_data['Type'] = None
             if data != actual_data:


### PR DESCRIPTION
### What does this PR do?

Remove unneeded 'AND' portion of 'if' compound statement for log_config

### What issues does this PR fix or reference?

Looks likes the returned data structure for actual_data changed between
docker 1.11.x and 1.12.x. No need to check if actual_data Config|Type contains any info if
their respective counterparts in data are empty. Still relates to https://github.com/saltstack/salt/issues/30577#issuecomment-238322721

### Tests written?

No

