### PR TITLE
Proposition regarding cherrypy token for salt-api

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1679,9 +1679,13 @@ class Login(LowDataAdapter):
                     'Could not authenticate using provided credentials')
 
         cherrypy.response.headers['X-Auth-Token'] = cherrypy.session.id
+        cherrypy.session.delete()
+        cherrypy.session.id = token['token']
+        cherrypy.session.acquire_lock()
         cherrypy.session['token'] = token['token']
         cherrypy.session['timeout'] = (token['expire'] - token['start']) / 60
         cherrypy.session['user'] = token['name']
+
         if 'groups' in token:
             cherrypy.session['groups'] = token['groups']
 
@@ -1709,7 +1713,7 @@ class Login(LowDataAdapter):
             perms = None
 
         return {'return': [{
-            'token': cherrypy.session.id,
+            'token': token['token'],
             'expire': token['expire'],
             'start': token['start'],
             'user': token['name'],


### PR DESCRIPTION
### What does this PR do?

Upon login once we have received the salt token change the id of the session so that the X-Auth-Token become a valid salt token.

### What issues does this PR fix or reference?

#38139

### Previous Behavior

Token was a generated session_id with no correlation to salt_master.

### New Behavior


Token is now a valid salt token as well, potentially allowing to be used in different calls from the callee to other custom endpoint.


### Tests written?

No
