### PR TITLE
Master config includes may contain errors and be safely skipped

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1628,7 +1628,7 @@ def _absolute_path(path, relative_to=None):
     return path
 
 
-def load_config(path, env_var, default_path=None):
+def load_config(path, env_var, default_path=None, exit_on_config_errors=True):
     '''
     Returns configuration dict from parsing either the file described by
     ``path`` or the environment variable described by ``env_var`` as YAML.
@@ -1676,17 +1676,20 @@ def load_config(path, env_var, default_path=None):
                     ifile.readline()  # skip first line
                     out.write(ifile.read())
 
+    opts = {}
+
     if salt.utils.validate.path.is_readable(path):
         try:
             opts = _read_conf_file(path)
             opts['conf_file'] = path
-            return opts
         except salt.exceptions.SaltConfigurationError as error:
             log.error(error)
-            sys.exit(salt.defaults.exitcodes.EX_GENERIC)
+            if exit_on_config_errors:
+                sys.exit(salt.defaults.exitcodes.EX_GENERIC)
+    else:
+        log.debug('Missing configuration file: {0}'.format(path))
 
-    log.debug('Missing configuration file: {0}'.format(path))
-    return {}
+    return opts
 
 
 def include_config(include, orig_path, verbose, exit_on_config_errors=False):
@@ -1731,6 +1734,9 @@ def include_config(include, orig_path, verbose, exit_on_config_errors=False):
                 log.error(error)
                 if exit_on_config_errors:
                     sys.exit(salt.defaults.exitcodes.EX_GENERIC)
+                else:
+                    # Initialize default config if we wish to skip config errors
+                    opts = {}
 
             include = opts.get('include', [])
             if include:
@@ -3085,8 +3091,10 @@ def master_config(path, env_var='SALT_MASTER_CONFIG', defaults=None, exit_on_con
                                     defaults['default_include'])
     include = overrides.get('include', [])
 
-    overrides.update(include_config(default_include, path, verbose=False), exit_on_config_errors=exit_on_config_errors)
-    overrides.update(include_config(include, path, verbose=True), exit_on_config_errors=exit_on_config_errors)
+    overrides.update(include_config(default_include, path, verbose=False),
+                     exit_on_config_errors=exit_on_config_errors)
+    overrides.update(include_config(include, path, verbose=True),
+                     exit_on_config_errors=exit_on_config_errors)
     opts = apply_master_config(overrides, defaults)
     _validate_opts(opts)
     # If 'nodegroups:' is uncommented in the master config file, and there are


### PR DESCRIPTION
### What does this PR do?
Looking at the code and thinking pragmatically, I assume it was previously designed in way that any errors found by parsing Master *included* configuration (from `/etc/salt/master.d/*.conf`) should be just ignored and the reading of malformed file will be skipped, while all other configuration files are going to be processed.

Even if such thing was not introduced decidedly, it would be really nice feature to have.

### Previous Behavior
The Salt Master daemon fails with cryptic stack trace if it encounters invalid included config:
```
[salt.utils.process][ERROR   ][18780] An un-handled exception from the multiprocessing process 'Maintenance-158' was caught:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/process.py", line 623, in _run
    return self._original_run()
  File "/usr/lib/python2.7/site-packages/salt/master.py", line 224, in run
    self._post_fork_init()
  File "/usr/lib/python2.7/site-packages/salt/master.py", line 200, in _post_fork_init
    self.search = salt.search.Search(self.opts)
  File "/usr/lib/python2.7/site-packages/salt/search/__init__.py", line 99, in __init__
    matcher=False)
  File "/usr/lib/python2.7/site-packages/salt/minion.py", line 687, in __init__
    self.opts['grains'] = salt.loader.grains(opts)
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 684, in grains
    default_include, opts['conf_file'], verbose=False
  File "/usr/lib/python2.7/site-packages/salt/config/__init__.py", line 1724, in include_config
    include = opts.get('include', [])
UnboundLocalError: local variable 'opts' referenced before assignment
```

### New Behavior
The Salt Master continues to operate when error found in the included configuration and reveals it in the log:
```
[DEBUG   ] Reading configuration from /etc/salt/master
[DEBUG   ] Including configuration from '/etc/salt/master.d/error_test.conf'
[DEBUG   ] Reading configuration from /etc/salt/master.d/error_test.conf
[ERROR   ] Error parsing configuration file: /etc/salt/master.d/error_test.conf - while scanning for the next token
found character '\t' that cannot start any token
  in "<string>", line 2, column 1:
...
[DEBUG   ] Configuration file path: /etc/salt/master
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
[INFO    ] Setting up the Salt Master
[DEBUG   ] Loaded master key: /etc/salt/pki/master/master.pem
[PROFILE ] Beginning pwd.getpwall() call in masterarpi acess_keys function
[PROFILE ] End pwd.getpwall() call in masterarpi acess_keys function
[INFO    ] Preparing the root key for local communication
[DEBUG   ] Removing stale keyfile: /var/cache/salt/master/.root_key
[DEBUG   ] Created pidfile: /var/run/salt-master.pid
[WARNING ] IMPORTANT: Do not use md5 hashing algorithm! Please set "hash_type" to sha256 in Salt Master config!
[INFO    ] The Salt Master is starting up
```

### Tests written?
Yes! Added 3 tests.

