### PR TITLE
Update the 'ports' option in bridge settings.

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1134,7 +1134,7 @@ def _parse_bridge_opts(opts, iface):
 
     if 'ports' in opts:
         if isinstance(opts['ports'], list):
-            opts['ports'] = ','.join(opts['ports'])
+            opts['ports'] = ' '.join(opts['ports'])
         config.update({'ports': opts['ports']})
 
     for opt in ['ageing', 'fd', 'gcint', 'hello', 'maxage']:


### PR DESCRIPTION
### What does this PR do?
Fix the delimiter in ports option of bridge on debian/ubuntu.
### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant
Original change is from
https://github.com/saltstack/salt/issues/12178

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

It seems space is right delimiter. On trusty I got the following error trying to bringing up the bridge:

$ ifup br0
interface em1,em2 does not exist!