### PR TITLE
Remove rtag when windows minion refreshes early in state

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -75,6 +75,7 @@ state module
 
 # Import python libs
 from __future__ import absolute_import
+import errno
 import logging
 import os
 import re
@@ -1277,6 +1278,15 @@ def installed(
 
     if salt.utils.is_windows():
         was_refreshed = was_refreshed or refresh
+        if was_refreshed:
+            try:
+                os.remove(rtag)
+            except OSError as exc:
+                if exc.errno != errno.ENOENT:
+                    log.error(
+                        'Failed to remove refresh tag %s: %s',
+                        rtag, exc.__str__()
+                    )
         kwargs.pop('refresh')
         refresh = False
 
@@ -1498,7 +1508,14 @@ def installed(
                                        if not hold_ret[x]['result']]
 
     if os.path.isfile(rtag) and was_refreshed:
-        os.remove(rtag)
+        try:
+            os.remove(rtag)
+        except OSError as exc:
+            if exc.errno != errno.ENOENT:
+                log.error(
+                    'Failed to remove refresh tag %s: %s',
+                    rtag, exc.__str__()
+                )
 
     if to_unpurge:
         changes['purge_desired'] = __salt__['lowpkg.unpurge'](*to_unpurge)


### PR DESCRIPTION
Failure to remove the rtag if a pkg.refresh_db was performed in the
process of running _find_install_targets() caused it to still be present
in subsequent pkg state runs, resulting in the refresh being repeated.

This commit fixes that by removing the rtag after that early refresh on
Windows minions. It also adds a try/except to guard against a traceback
which could occur if the rtag were removed outside of salt, during the
state run.

Refs: #38090