### PR TITLE
enabled ec2 cloud tests

### DIFF
--- a/tests/integration/cloud/providers/ec2.py
+++ b/tests/integration/cloud/providers/ec2.py
@@ -14,7 +14,6 @@ import integration
 from salt.config import cloud_providers_config
 
 # Import Salt Testing Libs
-from salttesting import skipIf
 from salttesting.helpers import ensure_in_syspath, expensiveTest
 
 ensure_in_syspath('../../../')
@@ -37,7 +36,6 @@ INSTANCE_NAME = __random_name()
 PROVIDER_NAME = 'ec2'
 
 
-@skipIf(True, 'Skipping until we can figure out why the testrunner bails.')
 class EC2Test(integration.ShellCase):
     '''
     Integration tests for the EC2 cloud provider in Salt-Cloud


### PR DESCRIPTION
### What does this PR do?
This test was disabled here: 95d4fb80 but i tested it and the runner does not seem to hang and the amazon tests passes, so re-enabling the tests to get them running on the cloud tests again.

