### PR TITLE
have _in_range_inclusive function attempt to convert a string to an i…

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2481,7 +2481,10 @@ class _policy_info(object):
             if val.lower() == 'not defined':
                 return True
             else:
-                return False
+                try:
+                    val = int(val)
+                except ValueError:
+                    return False
         if 'min' in kwargs:
             minimum = kwargs['min']
         if 'max' in kwargs:


### PR DESCRIPTION
### What does this PR do?
When using lgpo.set, the CachedLogonsCount policy cannot be set due to the value verification function _in_range_inclusive.  CachedLogonsCount is stored in the registry as a string (REG_SZ) and must be specified as a string when setting the policy via lgpo.set.  The _in_range_inclusive verification function only performs a numerical range check, thus this PR attempts to convert the tested value to an integer to verify it is in range.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
CachedLogonsCount could not be set due to data verification errors

### New Behavior
CachedLogonsCount policy can be set

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

…nt for the test (allow string based numbers to be verified to be in range).  Specifically, this allows the CachedLogonsCount policy to be set (stored in the registry as a REG_SZ and specified as a string number when passed to the module)