### PR TITLE
Add support for a multi-func job using same func more than once

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -946,6 +946,14 @@ VALID_OPTS = {
     # Note: to set enum arguments values like `cert_reqs` and `ssl_version` use constant names
     # without ssl module prefix: `CERT_REQUIRED` or `PROTOCOL_SSLv23`.
     'ssl': (dict, None),
+
+    # Controls how a multi-function job returns its data. If this is False,
+    # it will return its data using a dictionary with the function name as
+    # the key. This is compatible with legacy systems. If this is True, it
+    # will return its data using an array in the same order as the input
+    # array of functions to execute. This allows for calling the same
+    # function multiple times in the same multi-function job.
+    'multifunc_ordered': bool,
 }
 
 # default configurations
@@ -1191,6 +1199,7 @@ DEFAULT_MINION_OPTS = {
     'proxy_port': 0,
     'minion_jid_queue_hwm': 100,
     'ssl': None,
+    'multifunc_ordered': False,
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1573,13 +1573,24 @@ class Minion(MinionBase):
         minion side execution.
         '''
         salt.utils.appendproctitle('{0}._thread_multi_return {1}'.format(cls.__name__, data['jid']))
-        ret = {
-            'return': {},
-            'retcode': {},
-            'success': {}
-        }
-        for ind in range(0, len(data['fun'])):
-            ret['success'][data['fun'][ind]] = False
+        multifunc_ordered = opts.get('multifunc_ordered', False)
+        num_funcs = len(data['fun'])
+        if multifunc_ordered:
+            ret = {
+                'return': [None] * num_funcs,
+                'retcode': [None] * num_funcs,
+                'success': [False] * num_funcs
+            }
+        else:
+            ret = {
+                'return': {},
+                'retcode': {},
+                'success': {}
+            }
+
+        for ind in range(0, num_funcs):
+            if not multifunc_ordered:
+                ret['success'][data['fun'][ind]] = False
             try:
                 if minion_instance.connected and minion_instance.opts['pillar'].get('minion_blackout', False):
                     # this minion is blacked out. Only allow saltutil.refresh_pillar
@@ -1594,12 +1605,20 @@ class Minion(MinionBase):
                     data['arg'][ind],
                     data)
                 minion_instance.functions.pack['__context__']['retcode'] = 0
-                ret['return'][data['fun'][ind]] = func(*args, **kwargs)
-                ret['retcode'][data['fun'][ind]] = minion_instance.functions.pack['__context__'].get(
-                    'retcode',
-                    0
-                )
-                ret['success'][data['fun'][ind]] = True
+                if multifunc_ordered:
+                    ret['return'][ind] = func(*args, **kwargs)
+                    ret['retcode'][ind] = minion_instance.functions.pack['__context__'].get(
+                        'retcode',
+                        0
+                    )
+                    ret['success'][ind] = True
+                else:
+                    ret['return'][data['fun'][ind]] = func(*args, **kwargs)
+                    ret['retcode'][data['fun'][ind]] = minion_instance.functions.pack['__context__'].get(
+                        'retcode',
+                        0
+                    )
+                    ret['success'][data['fun'][ind]] = True
             except Exception as exc:
                 trb = traceback.format_exc()
                 log.warning(
@@ -1607,7 +1626,10 @@ class Minion(MinionBase):
                         exc
                     )
                 )
-                ret['return'][data['fun'][ind]] = trb
+                if multifunc_ordered:
+                    ret['return'][ind] = trb
+                else:
+                    ret['return'][data['fun'][ind]] = trb
             ret['jid'] = data['jid']
             ret['fun'] = data['fun']
             ret['fun_args'] = data['arg']


### PR DESCRIPTION
### What does this PR do?

One of the big limitations using current multi-function jobs is that
the same function may not be invoked more than once. This is due to the
function name being the key in the return data, hence separate runs of
the same function cannot have their results differentiated.

Add a minion side configuration option called 'multifunc_ordered'. The
description is:

Controls how a multi-function job returns its data. If this is False,
it will return its data using a dictionary with the function name as
the key. This is compatible with legacy systems. If this is True, it
will return its data using an array in the same order as the input
array of functions to execute. This allows for calling the same
function multiple times in the same multi-function job.

This will default to False to support legacy systems in the case their
runners have logic to hangle existing multi-function jobs.

### Tests written?

No

Signed-off-by: Sergey Kizunov <sergey.kizunov@ni.com>