### PR TITLE
Ensure Identity files are mode 0600

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -177,6 +177,8 @@ def _git_run(command, cwd=None, user=None, password=None, identity=None,
                 if not id_file:
                     log.error('identity {0} does not exist.'.format(_id_file))
                     continue
+                else:
+                    __salt__['file.set_mode'](id_file,'0600')
             else:
                 if not __salt__['file.file_exists'](id_file):
                     missing_keys.append(id_file)

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -178,7 +178,7 @@ def _git_run(command, cwd=None, user=None, password=None, identity=None,
                     log.error('identity {0} does not exist.'.format(_id_file))
                     continue
                 else:
-                    __salt__['file.set_mode'](id_file,'0600')
+                    __salt__['file.set_mode'](id_file, '0600')
             else:
                 if not __salt__['file.file_exists'](id_file):
                     missing_keys.append(id_file)


### PR DESCRIPTION
### What does this PR do?
SSH will sometimes refuse to use identity files that are group/world readable. 
This hopefully fixes that issue.

We set permissions on git identity files cached on minions.

No idea if this works as I am science-dog.jpg

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/38144

### Tests written?
No

