### PR TITLE
Remove support for deprecation options/functions in win* files

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -97,7 +97,6 @@ Configuration Option Deprecations
 - The ``win_repo_mastercachefile`` configuration option has been removed.
   Please use the ``winrepo_cachefile`` option instead.
 
-
 Module Deprecations
 -------------------
 
@@ -129,3 +128,11 @@ Salt-SSH Deprecations
 
 - The ``wipe_ssh`` option for ``salt-ssh`` has been removed. Please use the
   ``ssh_wipe`` option instead.
+
+State Deprecations
+------------------
+
+- The ``chocolatey`` state had the following functions removed:
+
+  - ``install``: Please use ``installed`` instead.
+  - ``uninstall``: Please use ``uninstalled`` instead.

--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -87,6 +87,12 @@ General Deprecations
 
 - Beacon configurations should be lists instead of dictionaries.
 
+Module Deprecations
+-------------------
+
+- The ``win_repo_source_dir`` option has been removed from the ``win_repo``
+  module. Please use ``winrepo_source_dir`` instead.
+
 Pillar Deprecations
 -------------------
 

--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -87,6 +87,17 @@ General Deprecations
 
 - Beacon configurations should be lists instead of dictionaries.
 
+Configuration Option Deprecations
+---------------------------------
+
+- The ``win_gitrepos`` configuration option has been removed. Please use
+  the ``winrepo_remotes`` option instead.
+- The ``win_repo`` configuration option has been removed. Please use
+  ``winrepo_dir`` instead.
+- The ``win_repo_mastercachefile`` configuration option has been removed.
+  Please use the ``winrepo_cachefile`` option instead.
+
+
 Module Deprecations
 -------------------
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -541,16 +541,7 @@ def _get_repo_details(saltenv):
     if contextkey in __context__:
         (winrepo_source_dir, local_dest, winrepo_file) = __context__[contextkey]
     else:
-        if 'win_repo_source_dir' in __opts__:
-            salt.utils.warn_until(
-                'Nitrogen',
-                'The \'win_repo_source_dir\' config option is deprecated, '
-                'please use \'winrepo_source_dir\' instead.'
-            )
-            winrepo_source_dir = __opts__['win_repo_source_dir']
-        else:
-            winrepo_source_dir = __opts__['winrepo_source_dir']
-
+        winrepo_source_dir = __opts__['winrepo_source_dir']
         dirs = [__opts__['cachedir'], 'files', saltenv]
         url_parts = _urlparse(winrepo_source_dir)
         dirs.append(url_parts.netloc)

--- a/salt/modules/win_repo.py
+++ b/salt/modules/win_repo.py
@@ -55,16 +55,7 @@ def __virtual__():
 
 
 def _get_local_repo_dir(saltenv='base'):
-    if 'win_repo_source_dir' in __opts__:
-        salt.utils.warn_until(
-            'Nitrogen',
-            'The \'win_repo_source_dir\' config option is deprecated, please '
-            'use \'winrepo_source_dir\' instead.'
-        )
-        winrepo_source_dir = __opts__['win_repo_source_dir']
-    else:
-        winrepo_source_dir = __opts__['winrepo_source_dir']
-
+    winrepo_source_dir = __opts__['winrepo_source_dir']
     dirs = []
     dirs.append(salt.syspaths.CACHE_DIR)
     dirs.extend(['minion', 'files'])

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -55,7 +55,7 @@ def available(software=True,
               severities=None,
               ):
     '''
-    .. versionadded:: nitrogen
+    .. versionadded:: Nitrogen
 
     List updates that match the passed criteria.
 
@@ -179,7 +179,7 @@ def available(software=True,
 
 def list_update(name, download=False, install=False):
     '''
-    .. deprecated:: nitrogen
+    .. deprecated:: Nitrogen
        Use :func:`get` instead
     Returns details for all updates that match the search criteria
 
@@ -246,15 +246,15 @@ def list_update(name, download=False, install=False):
         salt '*' win_wua.list_update 'Microsoft Camera Codec Pack'
     '''
     salt.utils.warn_until(
-        'Oxygen',
+        'Fluorine',
         'This function is replaced by \'get\' as of Salt Nitrogen. This'
-        'warning will be removed in Salt Oxygen')
+        'warning will be removed in Salt Fluorine.')
     return get(name, download, install)
 
 
 def get(name, download=False, install=False):
     '''
-    .. versionadded:: nitrogen
+    .. versionadded:: Nitrogen
 
     Returns details for all updates that match the search criteria
 
@@ -348,7 +348,7 @@ def list_updates(software=True,
                  download=False,
                  install=False):
     '''
-    .. deprecated:: nitrogen
+    .. deprecated:: Nitrogen
        Use :func:`list` instead
 
     Returns a detailed list of available updates or a summary. If download or
@@ -462,9 +462,9 @@ def list_updates(software=True,
         salt '*' win_wua.list_updates categories=['Feature Packs','Windows 8.1'] summary=True
     '''
     salt.utils.warn_until(
-        'Oxygen',
+        'Fluorine',
         'This function is replaced by \'list\' as of Salt Nitrogen. This'
-        'warning will be removed in Salt Oxygen')
+        'warning will be removed in Salt Fluorine.')
     return list(software, drivers, summary, skip_installed, categories,
                 severities, download, install)
 
@@ -478,7 +478,7 @@ def list(software=True,
          download=False,
          install=False):
     '''
-    .. versionadded:: nitrogen
+    .. versionadded:: Nitrogen
 
     Returns a detailed list of available updates or a summary. If download or
     install is True the same list will be downloaded and/or installed.
@@ -616,7 +616,7 @@ def list(software=True,
 
 def download_update(name):
     '''
-    .. deprecated:: oxygen
+    .. deprecated:: Nitrogen
        Use :func:`download` instead
 
     Downloads a single update.
@@ -642,15 +642,15 @@ def download_update(name):
 
     '''
     salt.utils.warn_until(
-        'Oxygen',
+        'Fluorine',
         'This function is replaced by \'download\' as of Salt Nitrogen. This'
-        'warning will be removed in Salt Oxygen')
+        'warning will be removed in Salt Fluorine.')
     return download(name)
 
 
 def download_updates(names):
     '''
-    .. deprecated:: oxygen
+    .. deprecated:: Nitrogen
        Use :func:`download` instead
 
     Downloads updates that match the list of passed identifiers. It's easier to
@@ -673,15 +673,16 @@ def download_updates(names):
         salt '*' win_wua.download guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB2131233']
     '''
     salt.utils.warn_until(
-        'Oxygen',
+        'Fluorine',
         'This function is replaced by \'download\' as of Salt Nitrogen. This'
-        'warning will be removed in Salt Oxygen')
+        'warning will be removed in Salt Fluorine.')
     return download(names)
 
 
 def download(names):
     '''
-    .. versionadded:: nitrogen
+    .. versionadded:: Nitrogen
+
     Downloads updates that match the list of passed identifiers. It's easier to
     use this function by using list_updates and setting install=True.
 
@@ -720,7 +721,7 @@ def download(names):
 
 def install_update(name):
     '''
-    .. deprecated:: oxygen
+    .. deprecated:: Nitrogen
        Use :func:`install` instead
 
     Installs a single update
@@ -746,15 +747,15 @@ def install_update(name):
         salt '*' win_wua.install_update KB12312231
     '''
     salt.utils.warn_until(
-        'Oxygen',
+        'Fluorine',
         'This function is replaced by \'install\' as of Salt Nitrogen. This'
-        'warning will be removed in Salt Oxygen')
+        'warning will be removed in Salt Fluorine.')
     return install(name)
 
 
 def install_updates(names):
     '''
-    .. deprecated:: oxygen
+    .. deprecated:: Nitrogen
        Use :func:`install` instead
 
     Installs updates that match the list of identifiers. It may be easier to use
@@ -777,15 +778,15 @@ def install_updates(names):
         salt '*' win_wua.install_updates guid=['12345678-abcd-1234-abcd-1234567890ab', 'KB12323211']
     '''
     salt.utils.warn_until(
-        'Oxygen',
+        'Fluorine',
         'This function is replaced by \'install\' as of Salt Nitrogen. This'
-        'warning will be removed in Salt Oxygen')
+        'warning will be removed in Salt Fluorine.')
     return install(names)
 
 
 def install(names):
     '''
-    .. versionadded:: nitrogen
+    .. versionadded:: Nitrogen
 
     Installs updates that match the list of identifiers. It may be easier to use
     the list_updates function and set install=True.
@@ -825,7 +826,7 @@ def install(names):
 
 def uninstall(names):
     '''
-    .. versionadded:: nitrogen
+    .. versionadded:: Nitrogen
 
     Uninstall updates.
 

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -332,25 +332,8 @@ def clear_git_lock(role, remote=None, **kwargs):
                 obj.init_remotes(ext_pillar['git'], __GIT_PILLAR_OVERRIDES)
                 git_objects.append(obj)
     elif role == 'winrepo':
-        if 'win_repo' in __opts__:
-            salt.utils.warn_until(
-                'Nitrogen',
-                'The \'win_repo\' config option is deprecated, please use '
-                '\'winrepo_dir\' instead.'
-            )
-            winrepo_dir = __opts__['win_repo']
-        else:
-            winrepo_dir = __opts__['winrepo_dir']
-
-        if 'win_gitrepos' in __opts__:
-            salt.utils.warn_until(
-                'Nitrogen',
-                'The \'win_gitrepos\' config option is deprecated, please use '
-                '\'winrepo_remotes\' instead.'
-            )
-            winrepo_remotes = __opts__['win_gitrepos']
-        else:
-            winrepo_remotes = __opts__['winrepo_remotes']
+        winrepo_dir = __opts__['winrepo_dir']
+        winrepo_remotes = __opts__['winrepo_remotes']
 
         git_objects = []
         for remotes, base_dir in (

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -52,25 +52,8 @@ def genrepo(opts=None, fire_event=True):
     if opts is None:
         opts = __opts__
 
-    if 'win_repo' in opts:
-        salt.utils.warn_until(
-            'Nitrogen',
-            'The \'win_repo\' config option is deprecated, please use '
-            '\'winrepo_dir\' instead.'
-        )
-        winrepo_dir = opts['win_repo']
-    else:
-        winrepo_dir = opts['winrepo_dir']
-
-    if 'win_repo_mastercachefile' in opts:
-        salt.utils.warn_until(
-            'Nitrogen',
-            'The \'win_repo_mastercachefile\' config option is deprecated, '
-            'please use \'winrepo_cachefile\' instead.'
-        )
-        winrepo_cachefile = opts['win_repo_mastercachefile']
-    else:
-        winrepo_cachefile = opts['winrepo_cachefile']
+    winrepo_dir = opts['winrepo_dir']
+    winrepo_cachefile = opts['winrepo_cachefile']
 
     ret = {}
     if not os.path.exists(winrepo_dir):
@@ -171,25 +154,8 @@ def update_git_repos(opts=None, clean=False, masterless=False):
     if opts is None:
         opts = __opts__
 
-    if 'win_repo' in opts:
-        salt.utils.warn_until(
-            'Nitrogen',
-            'The \'win_repo\' config option is deprecated, please use '
-            '\'winrepo_dir\' instead.'
-        )
-        winrepo_dir = opts['win_repo']
-    else:
-        winrepo_dir = opts['winrepo_dir']
-
-    if 'win_gitrepos' in opts:
-        salt.utils.warn_until(
-            'Nitrogen',
-            'The \'win_gitrepos\' config option is deprecated, please use '
-            '\'winrepo_remotes\' instead.'
-        )
-        winrepo_remotes = opts['win_gitrepos']
-    else:
-        winrepo_remotes = opts['winrepo_remotes']
+    winrepo_dir = opts['winrepo_dir']
+    winrepo_remotes = opts['winrepo_remotes']
 
     winrepo_cfg = [(winrepo_remotes, winrepo_dir),
                    (opts['winrepo_remotes_ng'], opts['winrepo_dir_ng'])]
@@ -198,21 +164,6 @@ def update_git_repos(opts=None, clean=False, masterless=False):
     for remotes, base_dir in winrepo_cfg:
         if not any((salt.utils.gitfs.HAS_GITPYTHON, salt.utils.gitfs.HAS_PYGIT2)):
             # Use legacy code
-            if not salt.utils.is_windows():
-                # Don't warn on Windows, because Windows can't do cool things like
-                # use pygit2. It has to fall back to git.latest.
-                salt.utils.warn_until(
-                    'Nitrogen',
-                    'winrepo git support now requires either GitPython or pygit2. '
-                    'Please install either GitPython >= {0} (or pygit2 >= {1} with '
-                    'libgit2 >= {2}), clear out {3}, and restart the salt-master '
-                    'service.'.format(
-                        salt.utils.gitfs.GITPYTHON_MINVER,
-                        salt.utils.gitfs.PYGIT2_MINVER,
-                        salt.utils.gitfs.LIBGIT2_MINVER,
-                        base_dir
-                    )
-                )
             winrepo_result = {}
             for remote_info in remotes:
                 if '/' in remote_info:

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -19,18 +19,6 @@ def __virtual__():
     return 'chocolatey' if 'chocolatey.install' in __salt__ else False
 
 
-def install(*args, **kwargs):
-    '''
-    Deprecated, please use 'installed'. This function will be removed in Salt
-    Nitrogen.
-    '''
-    salt.utils.warn_until('Nitrogen',
-                          'Please use chocolatey.installed. '
-                          'chocolatey.install will be removed in '
-                          'Salt Nitrogen.')
-    installed(*args, **kwargs)
-
-
 def installed(name, version=None, source=None, force=False, pre_versions=False,
               install_args=None, override_args=False, force_x86=False,
               package_args=None):
@@ -127,18 +115,6 @@ def installed(name, version=None, source=None, force=False, pre_versions=False,
         ret['comment'] = 'Failed to install the package {0}'.format(name)
 
     return ret
-
-
-def uninstall(*args, **kwargs):
-    '''
-    Deprecated, please use 'uninstalled'. This function will be removed in Salt
-    Nitrogen.
-    '''
-    salt.utils.warn_until('Nitrogen',
-                          'Please use chocolatey.uninstalled. '
-                          'chocolatey.uninstall will be removed in '
-                          'Salt Nitrogen.')
-    uninstalled(*args, **kwargs)
 
 
 def uninstalled(name, version=None, uninstall_args=None, override_args=False):

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -8,9 +8,6 @@ Manage Chocolatey package installs
 # Import Python libs
 from __future__ import absolute_import
 
-# Import salt libs
-import salt.utils
-
 
 def __virtual__():
     '''

--- a/salt/states/winrepo.py
+++ b/salt/states/winrepo.py
@@ -50,25 +50,8 @@ def genrepo(name, force=False, allow_empty=False):
         os.path.join(salt.syspaths.CONFIG_DIR, 'master')
     )
 
-    if 'win_repo' in master_config:
-        salt.utils.warn_until(
-            'Nitrogen',
-            'The \'win_repo\' config option is deprecated, please use '
-            '\'winrepo_dir\' instead.'
-        )
-        winrepo_dir = master_config['win_repo']
-    else:
-        winrepo_dir = master_config['winrepo_dir']
-
-    if 'win_repo_mastercachefile' in master_config:
-        salt.utils.warn_until(
-            'Nitrogen',
-            'The \'win_repo_mastercachefile\' config option is deprecated, '
-            'please use \'winrepo_cachefile\' instead.'
-        )
-        winrepo_cachefile = master_config['win_repo_mastercachefile']
-    else:
-        winrepo_cachefile = master_config['winrepo_cachefile']
+    winrepo_dir = master_config['winrepo_dir']
+    winrepo_cachefile = master_config['winrepo_cachefile']
 
     # We're actually looking for the full path to the cachefile here, so
     # prepend the winrepo_dir

--- a/tests/unit/modules/win_pki_test.py
+++ b/tests/unit/modules/win_pki_test.py
@@ -3,7 +3,7 @@
     :synopsis: Unit Tests for Windows PKI Module 'module.win_pki'
     :platform: Windows
     :maturity: develop
-    versionadded:: Nitrogen
+    .. versionadded:: Nitrogen
 '''
 
 # Import Python Libs

--- a/tests/unit/modules/win_snmp_test.py
+++ b/tests/unit/modules/win_snmp_test.py
@@ -3,7 +3,7 @@
     :synopsis: Unit Tests for Windows SNMP Module 'module.win_snmp'
     :platform: Windows
     :maturity: develop
-    versionadded:: Nitrogen
+    .. versionadded:: Nitrogen
 '''
 
 # Import Python Libs

--- a/tests/unit/states/win_pki_test.py
+++ b/tests/unit/states/win_pki_test.py
@@ -3,7 +3,7 @@
     :synopsis: Unit Tests for Windows PKI Module 'state.win_pki'
     :platform: Windows
     :maturity: develop
-    versionadded:: Nitrogen
+    .. versionadded:: Nitrogen
 '''
 
 # Import Python Libs

--- a/tests/unit/states/win_snmp_test.py
+++ b/tests/unit/states/win_snmp_test.py
@@ -3,7 +3,7 @@
     :synopsis: Unit Tests for Windows SNMP Module 'state.win_snmp'
     :platform: Windows
     :maturity: develop
-    versionadded:: Nitrogen
+    .. versionadded:: Nitrogen
 '''
 
 # Import Python Libs


### PR DESCRIPTION
- Give 2 feature release cycles for deprecations in win_wua execution module
- Remove deprecated "win_repo_source_dir" in favor of "winrepo_source_dir"
- Remove suport for the "win_repo", "win_repo_mastercachefile", and "win_gitrepos" options