### PR TITLE
Correct `cp.get_file_str` docstring and add integration tests

### DIFF
--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -369,7 +369,8 @@ def get_url(path, dest='', saltenv='base', env=None):
 
 def get_file_str(path, saltenv='base', env=None):
     '''
-    Return the contents of a file from a URL
+    Download a file from a URL to the Minion cache directory and return the
+    contents of that file
 
     Returns ``False`` if Salt was unable to cache a file from a URL.
 
@@ -398,8 +399,9 @@ def get_file_str(path, saltenv='base', env=None):
 
 def cache_file(path, saltenv='base', env=None):
     '''
-    Used to cache a single file on the salt-minion
-    Returns the location of the new cached file on the minion
+    Used to cache a single file on the Minion
+
+    Returns the location of the new cached file on the Minion.
 
     CLI Example:
 
@@ -469,9 +471,9 @@ def cache_file(path, saltenv='base', env=None):
 
 def cache_files(paths, saltenv='base', env=None):
     '''
-    Used to gather many files from the master, the gathered files will be
+    Used to gather many files from the Master, the gathered files will be
     saved in the minion cachedir reflective to the paths retrieved from the
-    master.
+    Master
 
     CLI Example:
 

--- a/tests/integration/modules/cp.py
+++ b/tests/integration/modules/cp.py
@@ -144,6 +144,8 @@ class CPModuleTest(integration.ModuleCase):
         self.assertIn('empty', os.listdir(os.path.join(tgt, 'grail')))
         self.assertIn('scene', os.listdir(os.path.join(tgt, 'grail', '36')))
 
+    # cp.get_url tests
+
     def test_get_url(self):
         '''
         cp.get_url with salt:// source given
@@ -281,6 +283,62 @@ class CPModuleTest(integration.ModuleCase):
             ])
         self.assertIn('KNIGHT:  They\'re nervous, sire.', ret)
         self.assertNotIn('bacon', ret)
+
+    # cp.get_file_str tests
+
+    def test_get_file_str_salt(self):
+        '''
+        cp.get_file_str with salt:// source given
+        '''
+        src = 'salt://grail/scene33'
+        ret = self.run_function(
+            'cp.get_file_str',
+            [
+                src,
+            ])
+        self.assertIn('KNIGHT:  They\'re nervous, sire.', ret)
+
+    def test_get_file_str_nonexistent_source(self):
+        '''
+        cp.get_file_str with nonexistent salt:// source given
+        '''
+        src = 'salt://grail/nonexistent_scene'
+        ret = self.run_function(
+            'cp.get_file_str',
+            [
+                src,
+            ])
+        self.assertEqual(ret, False)
+
+    def test_get_file_str_https(self):
+        '''
+        cp.get_file_str with https:// source given
+        '''
+        src = 'https://repo.saltstack.com/index.html'
+        ret = self.run_function(
+            'cp.get_file_str',
+            [
+                src,
+            ])
+        self.assertIn('Bootstrap', ret)
+        self.assertIn('Debian', ret)
+        self.assertIn('Windows', ret)
+        self.assertNotIn('AYBABTU', ret)
+
+    def test_get_file_str_local(self):
+        '''
+        cp.get_file_str with file:// source given
+        '''
+        src = os.path.join('file://', integration.FILES, 'file/base/file.big')
+        ret = self.run_function(
+            'cp.get_file_str',
+            [
+                src,
+            ])
+        self.assertIn('KNIGHT:  They\'re nervous, sire.', ret)
+        self.assertNotIn('bacon', ret)
+
+    # caching tests
 
     def test_cache_file(self):
         '''


### PR DESCRIPTION
### What does this PR do?
It just clarifies behavior of the `cp.get_file_str` execution module function in its docstring.

### Tests written?
Yes, added missing integration tests for this function.

