### PR TITLE
Get hosts gh

### DIFF
--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -1127,8 +1127,7 @@ def get_hosts(service_instance, datacenter_name=None, host_names=None,
         if cluster_name:
             # Retrieval to test if cluster exists. Cluster existence only makes
             # sense if the cluster has been specified
-            cluster = get_cluster(service_instance, datacenter_name,
-                                  cluster_name)
+            cluster = get_cluster(start_point, cluster_name)
     else:
         # Assume the root folder is the starting point
         start_point = get_root_folder(service_instance)

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -1094,6 +1094,68 @@ def list_datastores(service_instance):
     return list_objects(service_instance, vim.Datastore)
 
 
+def get_hosts(service_instance, datacenter_name=None, host_names=None,
+              cluster_name=None, get_all_hosts=False):
+    '''
+    Returns a list of vim.HostSystem objects representing ESXi hosts
+    in a vcenter filtered by their names and/or datacenter, cluster membership.
+
+    service_instance
+        The Service Instance Object from which to obtain the hosts.
+
+    datacenter_name
+        The datacenter name. Default is None.
+
+    host_names
+        The host_names to be retrieved. Default is None.
+
+    cluster_name
+        The cluster name - used to restrict the hosts retrieved. Only used if
+        the datacenter is set.  This argument is optional.
+
+    get_all_hosts
+        Specifies whether to retrieve all hosts in the container.
+        Default value is False.
+    '''
+    properties = ['name']
+    if not host_names:
+        host_names=[]
+    if cluster_name:
+        properties.append('parent')
+    if datacenter_name:
+        start_point = get_datacenter(service_instance, datacenter_name)
+        if cluster_name:
+            # Retrieval to test if cluster exists. Cluster existence only makes
+            # sense if the cluster has been specified
+            cluster = get_cluster(service_instance, datacenter_name,
+                                  cluster_name)
+    else:
+        # Assume the root folder is the starting point
+        start_point = get_root_folder(service_instance)
+
+    # Search for the objects
+    hosts = get_mors_with_properties(service_instance,
+                                     vim.HostSystem,
+                                     container_ref=start_point,
+                                     property_list=properties)
+    filtered_hosts = []
+    for h in hosts:
+            # Complex conditions checking if a host should be added to the
+            # filtered list (either due to its name and/or cluster membership)
+            name_condition = get_all_hosts or (h['name'] in host_names)
+            # the datacenter_name needs to be set in order for the cluster
+            # condition membership to be checked, otherwise the condition is
+            # ignored
+            cluster_condition = (not datacenter_name or not cluster_name or \
+                    (isinstance(h['parent'], vim.ClusterComputeResource) and \
+                     h['parent'].name == cluster_name))
+
+            if name_condition  and cluster_condition:
+                filtered_hosts.append(h['object'])
+
+    return filtered_hosts
+
+
 def list_hosts(service_instance):
     '''
     Returns a list of hosts associated with a given service instance.

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -1119,7 +1119,7 @@ def get_hosts(service_instance, datacenter_name=None, host_names=None,
     '''
     properties = ['name']
     if not host_names:
-        host_names=[]
+        host_names = []
     if cluster_name:
         properties.append('parent')
     if datacenter_name:
@@ -1139,18 +1139,19 @@ def get_hosts(service_instance, datacenter_name=None, host_names=None,
                                      property_list=properties)
     filtered_hosts = []
     for h in hosts:
-            # Complex conditions checking if a host should be added to the
-            # filtered list (either due to its name and/or cluster membership)
-            name_condition = get_all_hosts or (h['name'] in host_names)
-            # the datacenter_name needs to be set in order for the cluster
-            # condition membership to be checked, otherwise the condition is
-            # ignored
-            cluster_condition = (not datacenter_name or not cluster_name or \
-                    (isinstance(h['parent'], vim.ClusterComputeResource) and \
-                     h['parent'].name == cluster_name))
+        # Complex conditions checking if a host should be added to the
+        # filtered list (either due to its name and/or cluster membership)
+        name_condition = get_all_hosts or (h['name'] in host_names)
+        # the datacenter_name needs to be set in order for the cluster
+        # condition membership to be checked, otherwise the condition is
+        # ignored
+        cluster_condition = \
+                (not datacenter_name or not cluster_name or
+                 (isinstance(h['parent'], vim.ClusterComputeResource) and 
+                  h['parent'].name == cluster_name))
 
-            if name_condition  and cluster_condition:
-                filtered_hosts.append(h['object'])
+        if name_condition and cluster_condition:
+            filtered_hosts.append(h['object'])
 
     return filtered_hosts
 

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -1147,7 +1147,7 @@ def get_hosts(service_instance, datacenter_name=None, host_names=None,
         # ignored
         cluster_condition = \
                 (not datacenter_name or not cluster_name or
-                 (isinstance(h['parent'], vim.ClusterComputeResource) and 
+                 (isinstance(h['parent'], vim.ClusterComputeResource) and
                   h['parent'].name == cluster_name))
 
         if name_condition and cluster_condition:

--- a/tests/unit/utils/vmware_test/host_test.py
+++ b/tests/unit/utils/vmware_test/host_test.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Alexandru Bleotu <alexandru.bleotu@morganstanley.com>`
+
+    Tests for host functions in salt.utils.vmware
+'''
+
+# Import python libraries
+from __future__ import absolute_import
+import logging
+
+# Import Salt testing libraries
+from salttesting import TestCase, skipIf
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
+
+# Import Salt libraries
+import salt.utils.vmware
+# Import Third Party Libs
+try:
+    from pyVmomi import vim
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+# Get Logging Started
+log = logging.getLogger(__name__)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
+@patch('salt.utils.vmware.get_mors_with_properties',
+       MagicMock(return_value=[]))
+@patch('salt.utils.vmware.get_datacenter',
+       MagicMock(return_value=None))
+@patch('salt.utils.vmware.get_cluster',
+       MagicMock(return_value=None))
+class GetHostsTestCase(TestCase):
+    '''Tests for salt.utils.vmware.get_hosts'''
+
+    def setUp(self):
+        self.mock_root_folder = MagicMock()
+        self.mock_si = MagicMock()
+        self.mock_host1, self.mock_host2, self.mock_host3 = MagicMock(), \
+                MagicMock(), MagicMock()
+        self.mock_prop_host1 = {'name': 'fake_hostname1',
+                            'object': self.mock_host1}
+        self.mock_prop_host2 = {'name': 'fake_hostname2',
+                            'object': self.mock_host2}
+        self.mock_prop_host3 = {'name': 'fake_hostname3',
+                            'object': self.mock_host3}
+        self.mock_prop_hosts = [self.mock_prop_host1, self.mock_prop_host2,
+                                self.mock_prop_host3]
+
+    def test_get_si_no_datacenter_no_cluster(self):
+        mock_get_mors = MagicMock()
+        mock_get_root_folder = MagicMock(return_value=self.mock_root_folder)
+        with patch('salt.utils.vmware.get_root_folder', mock_get_root_folder):
+            with patch('salt.utils.vmware.get_mors_with_properties',
+                       mock_get_mors):
+                salt.utils.vmware.get_hosts(self.mock_si)
+        mock_get_root_folder.assert_called_once_with(self.mock_si)
+        mock_get_mors.assert_called_once_with(
+            self.mock_si, vim.HostSystem, container_ref=self.mock_root_folder,
+            property_list=['name'])
+
+    def test_get_si_datacenter_name_no_cluster_name(self):
+        mock_dc = MagicMock()
+        mock_get_dc = MagicMock(return_value=mock_dc)
+        mock_get_mors = MagicMock()
+        with patch('salt.utils.vmware.get_datacenter', mock_get_dc):
+            with patch('salt.utils.vmware.get_mors_with_properties',
+                       mock_get_mors):
+                salt.utils.vmware.get_hosts(self.mock_si,
+                                            datacenter_name='fake_datacenter')
+        mock_get_dc.assert_called_once_with(self.mock_si, 'fake_datacenter')
+        mock_get_mors.assert_called_once_with(self.mock_si,
+                                              vim.HostSystem,
+                                              container_ref=mock_dc,
+                                              property_list=['name'])
+
+    def test_get_si_datacenter_name_and_cluster_name(self):
+        mock_dc = MagicMock()
+        mock_get_dc = MagicMock(return_value=mock_dc)
+        mock_get_cl = MagicMock()
+        mock_get_mors = MagicMock()
+        with patch('salt.utils.vmware.get_datacenter', mock_get_dc):
+            with patch('salt.utils.vmware.get_cluster', mock_get_cl):
+                with patch('salt.utils.vmware.get_mors_with_properties',
+                           mock_get_mors):
+                    salt.utils.vmware.get_hosts(
+                        self.mock_si, datacenter_name='fake_datacenter',
+                        cluster_name='fake_cluster')
+        mock_get_dc.assert_called_once_with(self.mock_si, 'fake_datacenter')
+        mock_get_cl.assert_called_once_with(self.mock_si, 'fake_datacenter',
+                                            'fake_cluster')
+        mock_get_mors.assert_called_once_with(self.mock_si,
+                                              vim.HostSystem,
+                                              container_ref=mock_dc,
+                                              property_list=['name', 'parent'])
+
+    def test_host_get_all_hosts(self):
+        with patch('salt.utils.vmware.get_root_folder',
+                   MagicMock(return_value=self.mock_root_folder)):
+            with patch('salt.utils.vmware.get_mors_with_properties',
+                       MagicMock(return_value=self.mock_prop_hosts)):
+                res = salt.utils.vmware.get_hosts(self.mock_si, get_all_hosts=True)
+        self.assertEqual(res,[self.mock_host1, self.mock_host2,
+                              self.mock_host3])
+
+    def test_filter_hostname(self):
+        with patch('salt.utils.vmware.get_mors_with_properties',
+                   MagicMock(return_value=self.mock_prop_hosts)):
+            res = salt.utils.vmware.get_hosts(self.mock_si,
+                                              host_names=['fake_hostname1',
+                                                          'fake_hostname2'])
+        self.assertEqual(res,[self.mock_host1, self.mock_host2])
+
+    def test_get_all_host_flag_not_set_and_no_host_names(self):
+        with patch('salt.utils.vmware.get_mors_with_properties',
+                   MagicMock(return_value=self.mock_prop_hosts)):
+            res = salt.utils.vmware.get_hosts(self.mock_si)
+        self.assertEqual(res,[])
+
+    def test_filter_cluster(self):
+        cluster1 = vim.ClusterComputeResource('fake_good_cluster')
+        cluster2 = vim.ClusterComputeResource('fake_bad_cluster')
+        # Mock cluster1.name and cluster2.name
+        cluster1._stub = MagicMock(InvokeAccessor=MagicMock(
+            return_value='fake_good_cluster'))
+        cluster2._stub = MagicMock(InvokeAccessor=MagicMock(
+            return_value='fake_bad_cluster'))
+        self.mock_prop_host1['parent'] = cluster2
+        self.mock_prop_host2['parent'] = cluster1
+        self.mock_prop_host3['parent'] = cluster1
+        with patch('salt.utils.vmware.get_mors_with_properties',
+                   MagicMock(return_value=self.mock_prop_hosts)):
+            res = salt.utils.vmware.get_hosts(self.mock_si,
+                                              datacenter_name='fake_datacenter',
+                                              cluster_name='fake_good_cluster',
+                                              get_all_hosts=True)
+        self.assertEqual(res,[self.mock_host2, self.mock_host3])
+
+    def test_no_hosts(self):
+        with patch('salt.utils.vmware.get_mors_with_properties',
+                   MagicMock(return_value=[])):
+            res = salt.utils.vmware.get_hosts(self.mock_si, get_all_hosts=True)
+        self.assertEqual(res,[])
+
+    def test_one_host_returned(self):
+        with patch('salt.utils.vmware.get_mors_with_properties',
+                   MagicMock(return_value=[self.mock_prop_host1])):
+            res = salt.utils.vmware.get_hosts(self.mock_si, get_all_hosts=True)
+        self.assertEqual(res,[self.mock_host1])
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(GetHostsTestCase, needs_daemon=False)
+

--- a/tests/unit/utils/vmware_test/host_test.py
+++ b/tests/unit/utils/vmware_test/host_test.py
@@ -91,8 +91,7 @@ class GetHostsTestCase(TestCase):
                         self.mock_si, datacenter_name='fake_datacenter',
                         cluster_name='fake_cluster')
         mock_get_dc.assert_called_once_with(self.mock_si, 'fake_datacenter')
-        mock_get_cl.assert_called_once_with(self.mock_si, 'fake_datacenter',
-                                            'fake_cluster')
+        mock_get_cl.assert_called_once_with(mock_dc, 'fake_cluster')
         mock_get_mors.assert_called_once_with(self.mock_si,
                                               vim.HostSystem,
                                               container_ref=mock_dc,

--- a/tests/unit/utils/vmware_test/host_test.py
+++ b/tests/unit/utils/vmware_test/host_test.py
@@ -104,8 +104,8 @@ class GetHostsTestCase(TestCase):
             with patch('salt.utils.vmware.get_mors_with_properties',
                        MagicMock(return_value=self.mock_prop_hosts)):
                 res = salt.utils.vmware.get_hosts(self.mock_si, get_all_hosts=True)
-        self.assertEqual(res,[self.mock_host1, self.mock_host2,
-                              self.mock_host3])
+        self.assertEqual(res, [self.mock_host1, self.mock_host2,
+                               self.mock_host3])
 
     def test_filter_hostname(self):
         with patch('salt.utils.vmware.get_mors_with_properties',
@@ -113,13 +113,13 @@ class GetHostsTestCase(TestCase):
             res = salt.utils.vmware.get_hosts(self.mock_si,
                                               host_names=['fake_hostname1',
                                                           'fake_hostname2'])
-        self.assertEqual(res,[self.mock_host1, self.mock_host2])
+        self.assertEqual(res, [self.mock_host1, self.mock_host2])
 
     def test_get_all_host_flag_not_set_and_no_host_names(self):
         with patch('salt.utils.vmware.get_mors_with_properties',
                    MagicMock(return_value=self.mock_prop_hosts)):
             res = salt.utils.vmware.get_hosts(self.mock_si)
-        self.assertEqual(res,[])
+        self.assertEqual(res, [])
 
     def test_filter_cluster(self):
         cluster1 = vim.ClusterComputeResource('fake_good_cluster')
@@ -138,22 +138,21 @@ class GetHostsTestCase(TestCase):
                                               datacenter_name='fake_datacenter',
                                               cluster_name='fake_good_cluster',
                                               get_all_hosts=True)
-        self.assertEqual(res,[self.mock_host2, self.mock_host3])
+        self.assertEqual(res, [self.mock_host2, self.mock_host3])
 
     def test_no_hosts(self):
         with patch('salt.utils.vmware.get_mors_with_properties',
                    MagicMock(return_value=[])):
             res = salt.utils.vmware.get_hosts(self.mock_si, get_all_hosts=True)
-        self.assertEqual(res,[])
+        self.assertEqual(res, [])
 
     def test_one_host_returned(self):
         with patch('salt.utils.vmware.get_mors_with_properties',
                    MagicMock(return_value=[self.mock_prop_host1])):
             res = salt.utils.vmware.get_hosts(self.mock_si, get_all_hosts=True)
-        self.assertEqual(res,[self.mock_host1])
+        self.assertEqual(res, [self.mock_host1])
 
 
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(GetHostsTestCase, needs_daemon=False)
-


### PR DESCRIPTION
### What does this PR do?
Added utils.vmware.get_hosts
- returns a list of vim.HostSystem objects representing ESXi hosts in a vCenter filtered by their names and/or datacenter, cluster membership.

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
