### PR TITLE
Vsphere decorators gh

### DIFF
--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -197,6 +197,10 @@ def __virtual__():
     return __virtualname__
 
 
+def get_proxy_type():
+    return __pillar__['proxy']['proxytype']
+
+
 def esxcli_cmd(cmd_str, host=None, username=None, password=None, protocol=None, port=None, esxi_hosts=None):
     '''
     Run an ESXCLI command directly on the host or list of hosts.

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -265,7 +265,7 @@ def gets_service_instance_via_proxy(fn):
 
     @wraps(fn)
     def _gets_service_instance_via_proxy(*args, **kwargs):
-        if not 'service_instance' in arg_names and not kwargs_name:
+        if 'service_instance' not in arg_names and not kwargs_name:
             raise CommandExecutionError(
                 'Function {0} must have either a \'service_instance\', or a '
                 '\'**kwargs\' type parameter'.format(fn_name))

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -4,6 +4,8 @@ Manage VMware vCenter servers and ESXi hosts.
 
 .. versionadded:: 2015.8.4
 
+:codeauthor: :email:`Alexandru Bleotu <alexandru.bleotu@morganstaley.com>`
+
 Dependencies
 ============
 

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -201,6 +201,25 @@ def get_proxy_type():
     return __pillar__['proxy']['proxytype']
 
 
+def _get_proxy_connection_details():
+    '''
+    Returns the connection details of the following proxies: esxi
+    '''
+    proxytype = get_proxy_type()
+    elif proxytype == 'esxi':
+        details = __salt__['esxi.get_details']()
+    else:
+        raise CommandExecutionError('\'{0}\' proxy is not supported'
+                                    ''.format(proxytype))
+    return \
+            details.get('vcenter') if 'vcenter' in details \
+            else details.get('host'), \
+            details.get('username'), \
+            details.get('password'), details.get('protocol'), \
+            details.get('port'), details.get('mechanism'), \
+            details.get('principal'), details.get('domain')
+
+
 def esxcli_cmd(cmd_str, host=None, username=None, password=None, protocol=None, port=None, esxi_hosts=None):
     '''
     Run an ESXCLI command directly on the host or list of hosts.

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -174,7 +174,7 @@ import salt.utils
 import salt.utils.vmware
 import salt.utils.http
 from salt.utils import dictupdate
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, VMwareSaltError
 from salt.utils import clean_kwargs
 
 # Import Third Party Libs
@@ -1768,6 +1768,24 @@ def get_vsan_eligible_disks(host, username, password, protocol=None, port=None, 
             ret.update({host_name: {'Eligible': disks}})
 
     return ret
+
+
+@supports_proxies('esxi')
+@gets_service_instance_via_proxy
+def test_vcenter_connection(service_instance=None):
+    '''
+    Checks if a connection is to a vCenter
+
+    .. code-block:: bash
+
+        salt '*' vsphere.test_vcenter_connection
+    '''
+    try:
+        if salt.utils.vmware.is_connection_to_a_vcenter(service_instance):
+            return True
+    except VMwareSaltError:
+        return False
+    return False
 
 
 def system_info(host, username, password, protocol=None, port=None):

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -321,8 +321,7 @@ def gets_service_instance_via_proxy(fn):
             if local_service_instance:
                 salt.utils.vmware.disconnect(local_service_instance)
             # raise original exception and traceback
-            exc_info = sys.exc_info()
-            raise exc_info[0], exc_info[1], exc_info[2]
+            six.reraise(*sys.exc_info())
     return _gets_service_instance_via_proxy
 
 

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -164,6 +164,9 @@ connection credentials are used instead of vCenter credentials, the ``host_names
 from __future__ import absolute_import
 import datetime
 import logging
+import sys
+import inspect
+from functools import wraps
 
 # Import Salt Libs
 import salt.ext.six as six
@@ -172,6 +175,7 @@ import salt.utils.vmware
 import salt.utils.http
 from salt.utils import dictupdate
 from salt.exceptions import CommandExecutionError
+from salt.utils import clean_kwargs
 
 # Import Third Party Libs
 try:
@@ -237,6 +241,89 @@ def supports_proxies(*proxy_types):
             return fn(*args, **clean_kwargs(**kwargs))
         return __supports_proxies
     return _supports_proxies
+
+
+def gets_service_instance_via_proxy(fn):
+    '''
+    Decorator that connects to a target system (vCenter or ESXi host) using the
+    proxy details and passes the connection (vim.ServiceInstance) to
+    the decorated function.
+
+    Notes:
+        1. The decorated function must have a ``serviec_instance`` parameter
+        or a ``**kwarg`` type argument (name of argument is not important);
+        2. If the ``service_instance`` parameter is already defined, the value
+        is passed through to the decorated function;
+        3. If the ``service_instance`` parameter in not defined, the
+        connection is created using the proxy details and the service instance
+        is returned.
+    '''
+    fn_name = fn.__name__
+    arg_names, args_name, kwargs_name, default_values = \
+            inspect.getargspec(fn)
+    default_values = default_values if default_values is not None else []
+
+    @wraps(fn)
+    def _gets_service_instance_via_proxy(*args, **kwargs):
+        if not 'service_instance' in arg_names and not kwargs_name:
+            raise CommandExecutionError(
+                'Function {0} must have either a \'service_instance\', or a '
+                '\'**kwargs\' type parameter'.format(fn_name))
+        connection_details = _get_proxy_connection_details()
+        # Figure out how to pass in the connection value
+        local_service_instance = None
+        if 'service_instance' in arg_names:
+            idx = arg_names.index('service_instance')
+            if idx >= len(arg_names) - len(default_values):
+                # 'service_instance' has a default value:
+                #     we check if we need to instantiate it or
+                #     pass it through
+                #
+                # NOTE: if 'service_instance' doesn't have a default value
+                # it must be explicitly set in the function call so we pass it
+                # through
+
+                # There are two cases:
+                #   1. service_instance was passed in as a positional parameter
+                #   2. service_instance was passed in as a named paramter
+                if len(args) > idx:
+                    # case 1: The call was made with enough positional
+                    # parameters to include 'service_instance'
+                    if not args[idx]:
+                        local_service_instance = \
+                                salt.utils.vmware.get_service_instance(
+                                    *connection_details)
+                        args[idx] = local_service_instance
+                else:
+                    # case 2: Not enough positional parameters so
+                    # 'service_instance' must be a named parameter
+                    if not kwargs.get('service_instance'):
+                        local_service_instance = \
+                                salt.utils.vmware.get_service_instance(
+                                    *connection_details)
+                        kwargs['service_instance'] = local_service_instance
+        else:
+            # 'service_instance' is not a paremter in the function definition
+            # but it will be caught by the **kwargs parameter
+            if not kwargs.get('service_instance'):
+                local_service_instance = \
+                        salt.utils.vmware.get_service_instance(
+                            *connection_details)
+                kwargs['service_instance'] = local_service_instance
+        try:
+            ret = fn(*args, **clean_kwargs(**kwargs))
+            # Disconnect if connected in the decorator
+            if local_service_instance:
+                salt.utils.vmware.disconnect(local_service_instance)
+            return ret
+        except Exception as e:
+            # Disconnect if connected in the decorator
+            if local_service_instance:
+                salt.utils.vmware.disconnect(local_service_instance)
+            # raise original exception and traceback
+            exc_info = sys.exc_info()
+            raise exc_info[0], exc_info[1], exc_info[2]
+    return _gets_service_instance_via_proxy
 
 
 def esxcli_cmd(cmd_str, host=None, username=None, password=None, protocol=None, port=None, esxi_hosts=None):

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -210,7 +210,7 @@ def _get_proxy_connection_details():
     Returns the connection details of the following proxies: esxi
     '''
     proxytype = get_proxy_type()
-    elif proxytype == 'esxi':
+    if proxytype == 'esxi':
         details = __salt__['esxi.get_details']()
     else:
         raise CommandExecutionError('\'{0}\' proxy is not supported'

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -220,6 +220,25 @@ def _get_proxy_connection_details():
             details.get('principal'), details.get('domain')
 
 
+def supports_proxies(*proxy_types):
+    '''
+    Decorator to specify which proxy types are supported by a function
+
+    proxy_types:
+        Arbitrary list of strings with the supported types of proxies
+    '''
+    def _supports_proxies(fn):
+        def __supports_proxies(*args, **kwargs):
+            proxy_type = get_proxy_type()
+            if proxy_type not in proxy_types:
+                raise CommandExecutionError(
+                    '\'{0}\' proxy is not supported by function {1}'
+                    ''.format(proxy_type, fn.__name__))
+            return fn(*args, **clean_kwargs(**kwargs))
+        return __supports_proxies
+    return _supports_proxies
+
+
 def esxcli_cmd(cmd_str, host=None, username=None, password=None, protocol=None, port=None, esxi_hosts=None):
     '''
     Run an ESXCLI command directly on the host or list of hosts.

--- a/tests/unit/modules/vsphere_test.py
+++ b/tests/unit/modules/vsphere_test.py
@@ -31,6 +31,8 @@ USER = 'root'
 PASSWORD = 'SuperSecret!'
 ERROR = 'Some Testing Error Message'
 
+# Inject empty dunders do they can be patched
+vsphere.__pillar__ = {}
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @patch('salt.modules.vsphere.__virtual__', MagicMock(return_value='vsphere'))
@@ -551,3 +553,15 @@ class VsphereTestCase(TestCase):
         config = 'logdir'
         self.assertEqual({config: {'success': True}},
                          vsphere._set_syslog_config_helper(HOST, USER, PASSWORD, config, 'foo'))
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.modules.vsphere.__virtual__', MagicMock(return_value='vsphere'))
+class GetProxyTypeTestCase(TestCase):
+    '''Tests for salt.modules.vsphere.get_proxy_type'''
+
+    def test_output(self):
+        with patch.dict(vsphere.__pillar__,
+                        {'proxy': {'proxytype': 'fake_proxy_type'}}):
+            ret = vsphere.get_proxy_type()
+        self.assertEqual('fake_proxy_type', ret)

--- a/tests/unit/modules/vsphere_test.py
+++ b/tests/unit/modules/vsphere_test.py
@@ -36,6 +36,7 @@ mock_si = MagicMock()
 vsphere.__pillar__ = {}
 vsphere.__salt__ = {}
 
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @patch('salt.modules.vsphere.__virtual__', MagicMock(return_value='vsphere'))
 class VsphereTestCase(TestCase):
@@ -682,6 +683,7 @@ class GetsServiceInstanceViaProxyTestCase(TestCase):
 
     def test___get_proxy_connection_details_call(self):
         mock__get_proxy_connection_details = MagicMock()
+
         @vsphere.gets_service_instance_via_proxy
         def mock_function(service_instance=None):
             return service_instance
@@ -694,6 +696,7 @@ class GetsServiceInstanceViaProxyTestCase(TestCase):
     def test_service_instance_named_parameter_no_value(self):
         mock_get_service_instance = MagicMock(return_value=self.mock_si)
         mock_disconnect = MagicMock()
+
         @vsphere.gets_service_instance_via_proxy
         def mock_function(service_instance=None):
             return service_instance
@@ -713,6 +716,7 @@ class GetsServiceInstanceViaProxyTestCase(TestCase):
     def test_service_instance_kwargs_parameter_no_value(self):
         mock_get_service_instance = MagicMock(return_value=self.mock_si)
         mock_disconnect = MagicMock()
+
         @vsphere.gets_service_instance_via_proxy
         def mock_function(**kwargs):
             return kwargs['service_instance']
@@ -732,6 +736,7 @@ class GetsServiceInstanceViaProxyTestCase(TestCase):
     def test_service_instance_positional_parameter_no_default_value(self):
         mock_get_service_instance = MagicMock()
         mock_disconnect = MagicMock()
+
         @vsphere.gets_service_instance_via_proxy
         def mock_function(service_instance):
             return service_instance
@@ -750,6 +755,7 @@ class GetsServiceInstanceViaProxyTestCase(TestCase):
     def test_service_instance_positional_parameter_with_default_value(self):
         mock_get_service_instance = MagicMock()
         mock_disconnect = MagicMock()
+
         @vsphere.gets_service_instance_via_proxy
         def mock_function(service_instance=None):
             return service_instance
@@ -768,6 +774,7 @@ class GetsServiceInstanceViaProxyTestCase(TestCase):
     def test_service_instance_named_parameter_with_default_value(self):
         mock_get_service_instance = MagicMock()
         mock_disconnect = MagicMock()
+
         @vsphere.gets_service_instance_via_proxy
         def mock_function(service_instance=None):
             return service_instance
@@ -786,6 +793,7 @@ class GetsServiceInstanceViaProxyTestCase(TestCase):
     def test_service_instance_kwargs_parameter_passthrough(self):
         mock_get_service_instance = MagicMock()
         mock_disconnect = MagicMock()
+
         @vsphere.gets_service_instance_via_proxy
         def mock_function(**kwargs):
             return kwargs['service_instance']
@@ -805,7 +813,7 @@ class GetsServiceInstanceViaProxyTestCase(TestCase):
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @patch('salt.modules.vsphere.__virtual__', MagicMock(return_value='vsphere'))
 # Decorator mocks
-@patch('salt.modules.vsphere.get_proxy_type',MagicMock(return_value='esxi'))
+@patch('salt.modules.vsphere.get_proxy_type', MagicMock(return_value='esxi'))
 @patch('salt.modules.vsphere._get_proxy_connection_details', MagicMock())
 @patch('salt.utils.vmware.get_service_instance',
        MagicMock(return_value=mock_si))

--- a/tests/unit/modules/vsphere_test.py
+++ b/tests/unit/modules/vsphere_test.py
@@ -570,6 +570,35 @@ class GetProxyTypeTestCase(TestCase):
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @patch('salt.modules.vsphere.__virtual__', MagicMock(return_value='vsphere'))
+class SupportsProxiesTestCase(TestCase):
+    '''Tests for salt.modules.vsphere.supports_proxies decorator'''
+
+    def test_supported_proxy(self):
+        @vsphere.supports_proxies('supported')
+        def mock_function():
+            return 'fake_function'
+
+        with patch('salt.modules.vsphere.get_proxy_type',
+                   MagicMock(return_value='supported')):
+            ret = mock_function()
+        self.assertEqual('fake_function', ret)
+
+    def test_unsupported_proxy(self):
+        @vsphere.supports_proxies('supported')
+        def mock_function():
+            return 'fake_function'
+
+        with patch('salt.modules.vsphere.get_proxy_type',
+                   MagicMock(return_value='unsupported')):
+            with self.assertRaises(CommandExecutionError) as excinfo:
+                mock_function()
+        self.assertEqual('\'unsupported\' proxy is not supported by '
+                         'function mock_function',
+                         excinfo.exception.strerror)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.modules.vsphere.__virtual__', MagicMock(return_value='vsphere'))
 class _GetProxyConnectionDetailsTestCase(TestCase):
     '''Tests for salt.modules.vsphere._get_proxy_connection_details'''
 

--- a/tests/unit/modules/vsphere_test.py
+++ b/tests/unit/modules/vsphere_test.py
@@ -650,3 +650,152 @@ class _GetProxyConnectionDetailsTestCase(TestCase):
                 ret = vsphere._get_proxy_connection_details()
         self.assertEqual('\'unsupported\' proxy is not supported',
                          excinfo.exception.strerror)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.modules.vsphere.__virtual__', MagicMock(return_value='vsphere'))
+@patch('salt.modules.vsphere._get_proxy_connection_details', MagicMock())
+@patch('salt.utils.vmware.get_service_instance', MagicMock())
+@patch('salt.utils.vmware.disconnect', MagicMock())
+class GetsServiceInstanceViaProxyTestCase(TestCase):
+    '''
+    Tests for salt.modules.vsphere.gets_service_instance_via_proxy
+    decorator
+    '''
+
+    def setUp(self):
+        self.mock_si = MagicMock()
+        self.mock_details1 = MagicMock()
+        self.mock_details2 = MagicMock()
+
+    def test_no_service_instance_or_kwargs_parameters(self):
+        @vsphere.gets_service_instance_via_proxy
+        def mock_function():
+            return 'fake_function'
+
+        with self.assertRaises(CommandExecutionError) as excinfo:
+            mock_function()
+        self.assertEqual('Function mock_function must have either a '
+                         '\'service_instance\', or a \'**kwargs\' type '
+                         'parameter', excinfo.exception.strerror)
+
+    def test___get_proxy_connection_details_call(self):
+        mock__get_proxy_connection_details = MagicMock()
+        @vsphere.gets_service_instance_via_proxy
+        def mock_function(service_instance=None):
+            return service_instance
+
+        with patch('salt.modules.vsphere._get_proxy_connection_details',
+                   mock__get_proxy_connection_details):
+            mock_function()
+        mock__get_proxy_connection_details.assert_called_once_with()
+
+    def test_service_instance_named_parameter_no_value(self):
+        mock_get_service_instance = MagicMock(return_value=self.mock_si)
+        mock_disconnect = MagicMock()
+        @vsphere.gets_service_instance_via_proxy
+        def mock_function(service_instance=None):
+            return service_instance
+
+        with patch('salt.modules.vsphere._get_proxy_connection_details',
+                   MagicMock(return_value=(self.mock_details1,
+                                           self.mock_details2))):
+            with patch('salt.utils.vmware.get_service_instance',
+                       mock_get_service_instance):
+                with patch('salt.utils.vmware.disconnect', mock_disconnect):
+                    ret = mock_function()
+        mock_get_service_instance.assert_called_once_with(self.mock_details1,
+                                                          self.mock_details2)
+        mock_disconnect.assert_called_once_with(self.mock_si)
+        self.assertEqual(ret, self.mock_si)
+
+    def test_service_instance_kwargs_parameter_no_value(self):
+        mock_get_service_instance = MagicMock(return_value=self.mock_si)
+        mock_disconnect = MagicMock()
+        @vsphere.gets_service_instance_via_proxy
+        def mock_function(**kwargs):
+            return kwargs['service_instance']
+
+        with patch('salt.modules.vsphere._get_proxy_connection_details',
+                   MagicMock(return_value=(self.mock_details1,
+                                           self.mock_details2))):
+            with patch('salt.utils.vmware.get_service_instance',
+                       mock_get_service_instance):
+                with patch('salt.utils.vmware.disconnect', mock_disconnect):
+                    ret = mock_function()
+        mock_get_service_instance.assert_called_once_with(self.mock_details1,
+                                                          self.mock_details2)
+        mock_disconnect.assert_called_once_with(self.mock_si)
+        self.assertEqual(ret, self.mock_si)
+
+    def test_service_instance_positional_parameter_no_default_value(self):
+        mock_get_service_instance = MagicMock()
+        mock_disconnect = MagicMock()
+        @vsphere.gets_service_instance_via_proxy
+        def mock_function(service_instance):
+            return service_instance
+
+        with patch('salt.modules.vsphere._get_proxy_connection_details',
+                   MagicMock(return_value=(self.mock_details1,
+                                           self.mock_details2))):
+            with patch('salt.utils.vmware.get_service_instance',
+                       mock_get_service_instance):
+                with patch('salt.utils.vmware.disconnect', mock_disconnect):
+                    ret = mock_function(self.mock_si)
+        self.assertEqual(mock_get_service_instance.call_count, 0)
+        self.assertEqual(mock_disconnect.call_count, 0)
+        self.assertEqual(ret, self.mock_si)
+
+    def test_service_instance_positional_parameter_with_default_value(self):
+        mock_get_service_instance = MagicMock()
+        mock_disconnect = MagicMock()
+        @vsphere.gets_service_instance_via_proxy
+        def mock_function(service_instance=None):
+            return service_instance
+
+        with patch('salt.modules.vsphere._get_proxy_connection_details',
+                   MagicMock(return_value=(self.mock_details1,
+                                           self.mock_details2))):
+            with patch('salt.utils.vmware.get_service_instance',
+                       mock_get_service_instance):
+                with patch('salt.utils.vmware.disconnect', mock_disconnect):
+                    ret = mock_function(self.mock_si)
+        self.assertEqual(mock_get_service_instance.call_count, 0)
+        self.assertEqual(mock_disconnect.call_count, 0)
+        self.assertEqual(ret, self.mock_si)
+
+    def test_service_instance_named_parameter_with_default_value(self):
+        mock_get_service_instance = MagicMock()
+        mock_disconnect = MagicMock()
+        @vsphere.gets_service_instance_via_proxy
+        def mock_function(service_instance=None):
+            return service_instance
+
+        with patch('salt.modules.vsphere._get_proxy_connection_details',
+                   MagicMock(return_value=(self.mock_details1,
+                                           self.mock_details2))):
+            with patch('salt.utils.vmware.get_service_instance',
+                       mock_get_service_instance):
+                with patch('salt.utils.vmware.disconnect', mock_disconnect):
+                    ret = mock_function(service_instance=self.mock_si)
+        self.assertEqual(mock_get_service_instance.call_count, 0)
+        self.assertEqual(mock_disconnect.call_count, 0)
+        self.assertEqual(ret, self.mock_si)
+
+    def test_service_instance_kwargs_parameter_passthrough(self):
+        mock_get_service_instance = MagicMock()
+        mock_disconnect = MagicMock()
+        @vsphere.gets_service_instance_via_proxy
+        def mock_function(**kwargs):
+            return kwargs['service_instance']
+
+        with patch('salt.modules.vsphere._get_proxy_connection_details',
+                   MagicMock(return_value=(self.mock_details1,
+                                           self.mock_details2))):
+            with patch('salt.utils.vmware.get_service_instance',
+                       mock_get_service_instance):
+                with patch('salt.utils.vmware.disconnect', mock_disconnect):
+                    ret = mock_function(service_instance=self.mock_si)
+        self.assertEqual(mock_get_service_instance.call_count, 0)
+        self.assertEqual(mock_disconnect.call_count, 0)
+        self.assertEqual(ret, self.mock_si)

--- a/tests/unit/modules/vsphere_test.py
+++ b/tests/unit/modules/vsphere_test.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Nicole Thomas <nicole@saltstack.com>`
+    :codeauthor: :email:`Alexandru Bleotu <alexandru.bleotu@morganstanley.com>`
+
+    Tests for functions in salt.modules.vsphere
 '''
 
 # Import Python Libs

--- a/tests/unit/modules/vsphere_test.py
+++ b/tests/unit/modules/vsphere_test.py
@@ -807,7 +807,6 @@ class GetsServiceInstanceViaProxyTestCase(TestCase):
 # Decorator mocks
 @patch('salt.modules.vsphere.get_proxy_type',MagicMock(return_value='esxi'))
 @patch('salt.modules.vsphere._get_proxy_connection_details', MagicMock())
-@patch('salt.modules.vsphere._get_proxy_target', MagicMock())
 @patch('salt.utils.vmware.get_service_instance',
        MagicMock(return_value=mock_si))
 @patch('salt.utils.vmware.disconnect', MagicMock())


### PR DESCRIPTION
### What does this PR do?

Adds decorators for connections and specifying which proxy types are supported. Effectively, connection parameters will no longer be specified as parameters of the execution function, rather they will be inherited from the proxy. 

This provides significant benefits:
- less function parameters to specify making the functions more usable
- there is a guarantee that functions invoked via a proxy can only affect the environment the proxy manages (connects to) and not a random environment specified on the command line
- disconnects can be invoked even when the commands run in separate processes
- boiler plate code is separated in a decorator, rather than explicitly copied in each function
- code becomes easier to test

Example of decorated, new-style function:
`vsphere.test_vcenter_connection`

All existing functions will co-exist with new-style functions

### Previous Behavior
All existing execution functions receive connection arguments, which need to be specified on the command line when invoked via the cli

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
