### PR TITLE
Reset socket default timeout to None (fixes daemons_tests failures)

### DIFF
--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -40,6 +40,10 @@ class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             msg = 'error resolving {0}, possible network issue?'
             self.skipTest(msg.format(self.__domain))
 
+    def tearDown(self):
+        # Reset the dns timeout after the test is over
+        socket.setdefaulttimeout(None)
+
     def test_latest(self):
         '''
         git.latest

--- a/tests/integration/states/svn.py
+++ b/tests/integration/states/svn.py
@@ -47,6 +47,8 @@ class SvnTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
 
     def tearDown(self):
         shutil.rmtree(self.target, ignore_errors=True)
+        # Reset the dns timeout after the test is over
+        socket.setdefaulttimeout(None)
 
     def test_latest(self):
         '''

--- a/tests/unit/daemons_test.py
+++ b/tests/unit/daemons_test.py
@@ -5,7 +5,6 @@
 
 # Import python libs
 from __future__ import absolute_import
-import sys
 
 # Import Salt Testing libs
 from salttesting import TestCase, skipIf
@@ -18,10 +17,6 @@ ensure_in_syspath('../')
 import integration
 import multiprocessing
 from salt.cli import daemons
-
-PY26 = False
-if sys.version_info[1] < 7:
-    PY26 = True
 
 
 class LoggerMock(object):
@@ -77,7 +72,6 @@ class LoggerMock(object):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@skipIf(PY26, 'These tests don\'t run on Python 2.6. Skipping.')
 class DaemonsStarterTestCase(TestCase, integration.SaltClientTestCaseMixIn):
     '''
     Unit test for the daemons starter classes.


### PR DESCRIPTION
Also removed skipIf logic when on Python 2.6. This fix resolves the
same test failures on 2.6 as well as Ubuntu 12 (which is apparently
running Pyhton 2.7 on our test images from Linode these days).