### PR TITLE
Fix bad set operations when setting up securitygroups in AWS.

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1159,11 +1159,12 @@ def securitygroupid(vm_):
     securitygroupid_list = config.get_cloud_config_value(
         'securitygroupid', vm_, __opts__, search_global=False
     )
+    # If the list is None, then the set will remain empty
+    # If the list is already a set then calling 'set' on it is a no-op
+    # If the list is a string, then calling 'set' generates a one-element set
+    # If the list is anything else, stacktrace
     if securitygroupid_list:
-        if isinstance(securitygroupid_list, list):
-            securitygroupid_set.union(securitygroupid_list)
-        else:
-            securitygroupid_set.add(securitygroupid_list)
+        securitygroupid_set = securitygroupid_set.union(set(securitygroupid_list))
 
     securitygroupname_list = config.get_cloud_config_value(
         'securitygroupname', vm_, __opts__, search_global=False
@@ -1178,7 +1179,7 @@ def securitygroupid(vm_):
                 log.debug('AWS SecurityGroup ID of {0} is {1}'.format(
                     sg['groupName'], sg['groupId'])
                 )
-                securitygroupid_set.add(sg['groupId'])
+                securitygroupid_set = securitygroupid_set.add(sg['groupId'])
     return list(securitygroupid_set)
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes the problem with security groups for AWS not being properly set.

### What issues does this PR fix or reference?

Fixes #37981 

### Previous Behavior

salt-cloud would always set security groups to the default, even if groups were listed in the profile.  Note: `this_set.add(set_items)` does not modify `this_set`, it returns a new set with `set_items` added.

### New Behavior

Security groups are properly set.
