### PR TITLE
fix for push_dir in different OS

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1269,9 +1269,12 @@ class AESFuncs(object):
             return {}
         load.pop('tok')
 
+        # Join path
+        sep_path = os.sep.join(os.path.join(load['path']))
+
         # Path normalization should have been done by the sending
         # minion but we can't guarantee it. Re-do it here.
-        normpath = os.path.normpath(os.path.join(*load['path']))
+        normpath = os.path.normpath(sep_path)
 
         # Ensure that this safety check is done after the path
         # have been normalized.

--- a/salt/master.py
+++ b/salt/master.py
@@ -1270,7 +1270,7 @@ class AESFuncs(object):
         load.pop('tok')
 
         # Join path
-        sep_path = os.sep.join(os.path.join(load['path']))
+        sep_path = os.sep.join(load['path'])
 
         # Path normalization should have been done by the sending
         # minion but we can't guarantee it. Re-do it here.

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -687,7 +687,7 @@ def push(path, keep_symlinks=False, upload_path=None, remove_source=False):
     load_path_split_drive = os.path.splitdrive(load_path_normal)[1]
 
     # Finally, split the remaining path into a list for delivery to the master
-    load_path_list = os.path.split(load_path_split_drive)
+    load_path_list = load_path_split_drive.split(os.sep)
 
     load = {'cmd': '_file_recv',
             'id': __opts__['id'],


### PR DESCRIPTION
### What does this PR do?
fixes push directory under windows minion and linux master

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/38159

### Previous Behavior
linux master created one directory for each file uploaded 

### New Behavior
new directories are created normally

### Tests written?

No

