### PR TITLE
Document the requirements for running ZeroMQ-based integration tests

### DIFF
--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -45,7 +45,7 @@ sent through the started daemons.
 Integration tests are particularly good at testing modules, states, and
 shell commands, among other segments of Salt's ecosystem. By utilizing
 the integration test daemons, integration tests are easy to write. They
-are also SaltStack's gerneally preferred method of adding new tests.
+are also SaltStack's generally preferred method of adding new tests.
 
 The discussion in the :ref:`Integration vs. Unit <integration-vs-unit>`
 section of the :ref:`testing tutorial <tutorial-salt-testing>` is
@@ -87,6 +87,28 @@ the lines below, depending on the relevant Python version:
 
     pip install -r requirements/dev_python26.txt
     pip install -r requirements/dev_python27.txt
+
+To be able to run integration tests which utilizes ZeroMQ transport, you also
+need to install additional requirements for it. Make sure you have installed
+the C compiler and development libraries and header files needed for your
+Python version.
+
+This is an example for RedHat-based operating systems:
+
+.. code-block:: bash
+
+    yum install gcc python-devel
+    pip install -r requirements/zeromq.txt
+
+On Debian, Ubuntu or their derivatives run the following commands:
+
+.. code-block:: bash
+
+    apt-get install build-essential python-dev
+    pip install -r requirements/zeromq.txt
+
+This will install the latest ``pycrypto`` and ``pyzmq`` (with bundled
+``libzmq``) Python modules required for running integration tests suite.
 
 .. note::
 

--- a/doc/topics/tutorials/writing_tests.rst
+++ b/doc/topics/tutorials/writing_tests.rst
@@ -42,6 +42,28 @@ depending on your relevant version of Python:
     pip install -r requirements/dev_python26.txt
     pip install -r requirements/dev_python27.txt
 
+To be able to run integration tests which utilizes ZeroMQ transport, you also
+need to install additional requirements for it. Make sure you have installed
+the C compiler and development libraries and header files needed for your
+Python version.
+
+This is an example for RedHat-based operating systems:
+
+.. code-block:: bash
+
+    yum install gcc python-devel
+    pip install -r requirements/zeromq.txt
+
+On Debian, Ubuntu or their derivatives run the following commands:
+
+.. code-block:: bash
+
+    apt-get install build-essential python-dev
+    pip install -r requirements/zeromq.txt
+
+This will install the latest ``pycrypto`` and ``pyzmq`` (with bundled
+``libzmq``) Python modules required for running integration tests suite.
+
 
 Test Directory Structure
 ========================


### PR DESCRIPTION
### What does this PR do?
Adds missing instructions about how to install requirements for running integration test suite with ZeroMQ transport.