### PR TITLE
Add missing requirements for running unit tests: libcloud and boto3

### DIFF
--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -110,23 +110,8 @@ On Debian, Ubuntu or their derivatives run the following commands:
 This will install the latest ``pycrypto`` and ``pyzmq`` (with bundled
 ``libzmq``) Python modules required for running integration tests suite.
 
-.. note::
-
-    In Salt 0.17, testing libraries were migrated into their own repo. To install them:
-
-    .. code-block:: bash
-
-        pip install git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting
-
-
-    Failure to install SaltTesting will result in import errors similar to the following:
-
-    .. code-block:: bash
-
-        ImportError: No module named salttesting
-
-Once all requirements are installed, use ``tests/runtests.py`` to
-run all of the tests included in Salt's test suite:
+Once all requirements are installed, use ``runtests.py`` script to run all of
+the tests included in Salt's test suite:
 
 .. code-block:: bash
 

--- a/requirements/dev_python27.txt
+++ b/requirements/dev_python27.txt
@@ -1,6 +1,8 @@
 -r base.txt
 
 mock
+apache-libcloud>=0.14.0
 boto>=2.32.1
+boto3>=1.2.1
 moto>=0.3.6
 SaltTesting==2015.2.16

--- a/requirements/dev_python34.txt
+++ b/requirements/dev_python34.txt
@@ -1,6 +1,8 @@
 -r base.txt
 
 mock
+apache-libcloud>=0.14.0
 boto>=2.32.1
+boto3>=1.2.1
 moto>=0.3.6
 SaltTesting>=2015.2.16


### PR DESCRIPTION
### What does this PR do?
Running the full Salt unit tests suite requires additional dependencies which were missing in the  ` requirements` file: `apache-libcloud` and `boto3`. This PR enables them to be installed via `pip install -r requirements/dev_python${PY_VERSION}.txt`.
