### PR TITLE
remove empty strings from list but not ones with one empty space char

### DIFF
--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -687,7 +687,7 @@ def push(path, keep_symlinks=False, upload_path=None, remove_source=False):
     load_path_split_drive = os.path.splitdrive(load_path_normal)[1]
 
     # Finally, split the remaining path into a list for delivery to the master
-    load_path_list = load_path_split_drive.split(os.sep)
+    load_path_list = filter(None, load_path_split_drive.split(os.sep))
 
     load = {'cmd': '_file_recv',
             'id': __opts__['id'],

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -687,7 +687,7 @@ def push(path, keep_symlinks=False, upload_path=None, remove_source=False):
     load_path_split_drive = os.path.splitdrive(load_path_normal)[1]
 
     # Finally, split the remaining path into a list for delivery to the master
-    load_path_list = filter(None, load_path_split_drive.split(os.sep))
+    load_path_list = [_f for _f in load_path_split_drive.split(os.sep) if _f]
 
     load = {'cmd': '_file_recv',
             'id': __opts__['id'],


### PR DESCRIPTION
### What does this PR do?
fixes initial pr #38188 to remove empty list members in windows

### What issues does this PR fix or reference?
#38188

### Previous Behavior
Windows adds an empty list member in the uploaded file

### New Behavior
list member is removed.

### Tests written?
No

@cachedout , @rallytime 
really sorry I missed this in the previous commit.

