### PR TITLE
Remove support for aliasing cmd.run to cmd.shell

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -99,6 +99,7 @@ Deprecations
 General Deprecations
 --------------------
 
+- Removed support for aliasing ``cmd.run`` to ``cmd.shell``.
 - Beacon configurations should be lists instead of dictionaries.
 - The ``PidfileMixin`` has been removed. Please use ``DaemonMixIn`` instead.
 - The ``use_pending`` argument was removed from the ``salt.utils.event.get_event``

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -42,18 +42,6 @@ TEMPLATE_DIRNAME = os.path.join(saltpath[0], 'templates')
 SLS_ENCODING = 'utf-8'  # this one has no BOM.
 SLS_ENCODER = codecs.getencoder(SLS_ENCODING)
 
-ALIAS_WARN = (
-        'Starting in 2015.5, cmd.run uses python_shell=False by default, '
-        'which doesn\'t support shellisms (pipes, env variables, etc). '
-        'cmd.run is currently aliased to cmd.shell to prevent breakage. '
-        'Please switch to cmd.shell or set python_shell=True to avoid '
-        'breakage in the future, when this aliasing is removed.'
-)
-ALIASES = {
-        'cmd.run': 'cmd.shell',
-        'cmd': {'run': 'shell'},
-}
-
 
 class AliasedLoader(object):
     '''
@@ -71,18 +59,10 @@ class AliasedLoader(object):
         self.wrapped = wrapped
 
     def __getitem__(self, name):
-        if name in ALIASES:
-            salt.utils.warn_until('Nitrogen', ALIAS_WARN)
-            return self.wrapped[ALIASES[name]]
-        else:
-            return self.wrapped[name]
+        return self.wrapped[name]
 
     def __getattr__(self, name):
-        if name in ALIASES:
-            salt.utils.warn_until('Nitrogen', ALIAS_WARN)
-            return AliasedModule(getattr(self.wrapped, name), ALIASES[name])
-        else:
-            return getattr(self.wrapped, name)
+        return getattr(self.wrapped, name)
 
 
 class AliasedModule(object):
@@ -98,11 +78,7 @@ class AliasedModule(object):
         self.wrapped = wrapped
 
     def __getattr__(self, name):
-        if name in self.aliases:
-            salt.utils.warn_until('Nitrogen', ALIAS_WARN)
-            return getattr(self.wrapped, self.aliases[name])
-        else:
-            return getattr(self.wrapped, name)
+        return getattr(self.wrapped, name)
 
 
 def wrap_tmpl_func(render_str):

--- a/tests/integration/shell/enabled.py
+++ b/tests/integration/shell/enabled.py
@@ -44,9 +44,13 @@ class EnabledTest(integration.ModuleCase):
         ret = self.run_function('cmd.run', [self.cmd], python_shell=False)
         self.assertEqual(ret, disabled_ret)
 
-    def test_template_default_enabled(self):
+    def test_template_shell(self):
         '''
-        ensure that python_shell defaults to True for templates
+        Test cmd.shell works correctly when using a template.
+
+        Note: This test used to test that python_shell defaulted to True for templates
+        in releases before Nitrogen. The cmd.run --> cmd.shell aliasing was removed in
+        Nitrogen. Templates should now be using cmd.shell.
         '''
         state_name = 'template_shell_enabled'
         state_filename = state_name + '.sls'
@@ -58,7 +62,7 @@ class EnabledTest(integration.ModuleCase):
         try:
             with salt.utils.fopen(state_file, 'w') as fp_:
                 fp_.write(textwrap.dedent('''\
-                {{% set shell_enabled = salt['cmd.run']("{0}").strip() %}}
+                {{% set shell_enabled = salt['cmd.shell']("{0}").strip() %}}
 
                 shell_enabled:
                   test.configurable_test_state:
@@ -70,9 +74,10 @@ class EnabledTest(integration.ModuleCase):
         finally:
             os.remove(state_file)
 
-    def test_template_disabled(self):
+    def test_template_default_disabled(self):
         '''
-        test shell disabled output for templates
+        test shell disabled output for templates (python_shell=False is the default
+        beginning with the Nitrogen release).
         '''
         state_name = 'template_shell_disabled'
         state_filename = state_name + '.sls'
@@ -86,7 +91,7 @@ class EnabledTest(integration.ModuleCase):
         try:
             with salt.utils.fopen(state_file, 'w') as fp_:
                 fp_.write(textwrap.dedent('''\
-                {{% set shell_disabled = salt['cmd.run']("{0}", python_shell=False) %}}
+                {{% set shell_disabled = salt['cmd.run']("{0}") %}}
 
                 shell_enabled:
                   test.configurable_test_state:


### PR DESCRIPTION
It's time to remove the aliasing for cmd.run to cmd.shell. This deprecation path has been here for a while.