### PR TITLE
Fix default returner

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -771,8 +771,16 @@
 
 ######      Returner  settings        ######
 ############################################
-# Which returner(s) will be used for minion's result:
+# Default Minion returners. Can be a comma delimited string or a list:
+#
 #return: mysql
+#
+#return: mysql,slack,redis
+#
+#return:
+#  - mysql
+#  - hipchat
+#  - slack
 
 
 ######    Miscellaneous  settings     ######

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -867,6 +867,9 @@ VALID_OPTS = {
 
     # Extra modules for Salt Thin
     'thin_extra_mods': str,
+
+    # Default returners minion should use. List or comma-delimited string
+    'return': (str, list),
 }
 
 # default configurations
@@ -1090,6 +1093,8 @@ DEFAULT_MINION_OPTS = {
     # ZMQ HWM for EventPublisher pub socket - different for minion vs. master
     'event_publisher_pub_hwm': 1000,
     'event_match_type': 'startswith',
+    # Default Minion returner
+    'return': '',
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1093,8 +1093,6 @@ DEFAULT_MINION_OPTS = {
     # ZMQ HWM for EventPublisher pub socket - different for minion vs. master
     'event_publisher_pub_hwm': 1000,
     'event_match_type': 'startswith',
-    # Default Minion returner
-    'return': '',
 }
 
 DEFAULT_MASTER_OPTS = {
@@ -1548,6 +1546,11 @@ def _validate_opts(opts):
                            type(val).__name__,
                            format_multi_opt(VALID_OPTS[key]))
             )
+
+    # Convert list to comma-delimited string for 'return' config option
+    if isinstance(opts.get('return'), list):
+        opts['return'] = ','.join(opts['return'])
+
 
     # RAET on Windows uses 'win32file.CreateMailslot()' for IPC. Due to this,
     # sock_dirs must start with '\\.\mailslot\' and not contain any colons.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1551,7 +1551,6 @@ def _validate_opts(opts):
     if isinstance(opts.get('return'), list):
         opts['return'] = ','.join(opts['return'])
 
-
     # RAET on Windows uses 'win32file.CreateMailslot()' for IPC. Due to this,
     # sock_dirs must start with '\\.\mailslot\' and not contain any colons.
     # We don't expect the user to know this, so we will fix up their path for

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1451,17 +1451,12 @@ class Minion(MinionBase):
         )
 
         # Add default returners from minion config
+        # Should have been coverted to comma-delimited string already
         if isinstance(opts.get('return'), six.string_types):
             if data['ret']:
                 data['ret'] = ','.join((data['ret'], opts['return']))
             else:
                 data['ret'] = opts['return']
-        if isinstance(opts.get('return'), list):
-            if data['ret']:
-                for item in opts['return']:
-                    data['ret'] = ','.join((data['ret'], item))
-            else:
-                data['ret'] = ','.join(opts['return'])
 
         # TODO: make a list? Seems odd to split it this late :/
         if data['ret'] and isinstance(data['ret'], six.string_types):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1449,6 +1449,20 @@ class Minion(MinionBase):
             ret,
             timeout=minion_instance._return_retry_timer()
         )
+
+        # Add default returners from minion config
+        if isinstance(opts.get('return'), six.string_types):
+            if data['ret']:
+                data['ret'] = ','.join((data['ret'], opts['return']))
+            else:
+                data['ret'] = opts['return']
+        if isinstance(opts.get('return'), list):
+            if data['ret']:
+                for item in opts['return']:
+                    data['ret'] = ','.join((data['ret'], item))
+            else:
+                data['ret'] = ','.join(opts['return'])
+
         # TODO: make a list? Seems odd to split it this late :/
         if data['ret'] and isinstance(data['ret'], six.string_types):
             if 'ret_config' in data:


### PR DESCRIPTION
### What does this PR do?
Fixes the default minion returner.
### What issues does this PR fix or reference?
ZD 1070
### Previous Behavior
Any returners in the `return` config in the minion config file were ignored.

### New Behavior
Any returners listed in the `return` config option in the minion config file are actually used to send the minions's return data.

### Tests written?

No
