### PR TITLE
Add root_dir to salt-api file paths

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3314,6 +3314,10 @@ def api_config(path):
         'pidfile': opts.get('api_pidfile', DEFAULT_API_OPTS['api_pidfile']),
     })
     opts.update(api_opts)
+    prepend_root_dir(opts, [
+        'api_pidfile',
+        'api_logfile',
+    ])
     return opts
 
 


### PR DESCRIPTION
### What does this PR do?

Follow-up to regression in #37272 that caused salt-api file paths to not get prepended with the `root_dir` path.