### PR TITLE
provide kwargs of sls_build to dockerng.create

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5881,11 +5881,19 @@ def sls_build(name, base='opensuse/python', mods=None, saltenv='base',
     .. versionadded:: 2016.11.0
     '''
 
+    create_kwargs = salt.utils.clean_kwargs(**copy.deepcopy(kwargs))
+    create_kwargs.pop('image')
+    create_kwargs.pop('name')
+    create_kwargs.pop('cmd')
+    create_kwargs.pop('interactive')
+    create_kwargs.pop('tty')
+
     # start a new container
     ret = __salt__['dockerng.create'](image=base,
                                       name=name,
                                       cmd='sleep infinity',
-                                      interactive=True, tty=True)
+                                      interactive=True, tty=True,
+                                      **create_kwargs)
     id_ = ret['Id']
     try:
         __salt__['dockerng.start'](id_)

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5882,11 +5882,11 @@ def sls_build(name, base='opensuse/python', mods=None, saltenv='base',
     '''
 
     create_kwargs = salt.utils.clean_kwargs(**copy.deepcopy(kwargs))
-    create_kwargs.pop('image', '')
-    create_kwargs.pop('name', '')
-    create_kwargs.pop('cmd', '')
-    create_kwargs.pop('interactive', True)
-    create_kwargs.pop('tty', True)
+    for key in ('image', 'name', 'cmd', 'interactive', 'tty'):
+        try:
+            del create_kwargs[key]
+        except KeyError:
+            pass
 
     # start a new container
     ret = __salt__['dockerng.create'](image=base,

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5882,11 +5882,11 @@ def sls_build(name, base='opensuse/python', mods=None, saltenv='base',
     '''
 
     create_kwargs = salt.utils.clean_kwargs(**copy.deepcopy(kwargs))
-    create_kwargs.pop('image')
-    create_kwargs.pop('name')
-    create_kwargs.pop('cmd')
-    create_kwargs.pop('interactive')
-    create_kwargs.pop('tty')
+    create_kwargs.pop('image', '')
+    create_kwargs.pop('name', '')
+    create_kwargs.pop('cmd', '')
+    create_kwargs.pop('interactive', True)
+    create_kwargs.pop('tty', True)
 
     # start a new container
     ret = __salt__['dockerng.create'](image=base,


### PR DESCRIPTION
### What does this PR do?

dockerng.sls_build support kwargs but do not use them in the dockerng.create call which happens internally. dockerng.create has a lot of interesting options which should be usable for sls_build as well.

This PR create a copy of kwargs, remove the keys which are directly provided to the function call and provide the rest to the create function call.

### Tests written?

No
