### PR TITLE
Correct an inaccurate warning when top_file_merging_strategy == merge_all

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2586,7 +2586,7 @@ class BaseHighState(object):
                     tops[saltenv].append({})
                     log.debug('No contents loaded for env: {0}'.format(saltenv))
 
-            if found > 1 and merging_strategy.startswith('merge'):
+            if found > 1 and merging_strategy == 'merge':
                 log.warning(
                     'top_file_merging_strategy is set to \'%s\' and '
                     'multiple top files were found. Merging order is not '


### PR DESCRIPTION
The merge_all strategy uses all configured SLS files, so there is no
danger from "merging" like there is in the default strategy. Therefore,
this log entry is spurious when multiple top files exist and the merging
strategy is set to "merge_all".