### PR TITLE
SELINUXTYPE should not be changed

### DIFF
--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -134,7 +134,7 @@ def setenforce(mode):
             conf = _cf.read()
         try:
             with salt.utils.fopen(config, 'w') as _cf:
-                conf = re.sub(r"\nSELINUX.*\n", "\nSELINUX=" + modestring + "\n", conf)
+                conf = re.sub(r"\nSELINUX=.*\n", "\nSELINUX=" + modestring + "\n", conf)
                 _cf.write(conf)
         except (IOError, OSError) as exc:
             msg = 'Could not write SELinux config file: {0}'

--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -104,12 +104,16 @@ def mode(name):
         ret['comment'] = 'SELinux mode is set to be changed to {0}'.format(
                 tmode)
         ret['result'] = None
+        ret['changes'] = {'old': mode,
+                          'new': tmode}
         return ret
 
-    mode = __salt__['selinux.setenforce'](tmode)
+    oldmode, mode = mode, __salt__['selinux.setenforce'](tmode)
     if mode == tmode:
         ret['result'] = True
         ret['comment'] = 'SELinux has been set to {0} mode'.format(tmode)
+        ret['changes'] = {'old': oldmode,
+                          'new': mode}
         return ret
     ret['comment'] = 'Failed to set SELinux to {0} mode'.format(tmode)
     return ret

--- a/tests/unit/states/selinux_test.py
+++ b/tests/unit/states/selinux_test.py
@@ -37,13 +37,10 @@ class SelinuxTestCase(TestCase):
         Test to verifies the mode SELinux is running in,
         can be set to enforcing or permissive.
         '''
-        ret = {'name': '',
+        ret = {'name': 'unknown',
                'changes': {},
                'result': False,
-               'comment': ''}
-
-        comt = ('unknown is not an accepted mode')
-        ret.update({'name': 'unknown', 'comment': comt})
+               'comment': 'unknown is not an accepted mode'}
         self.assertDictEqual(selinux.mode('unknown'), ret)
 
         mock_en = MagicMock(return_value='Enforcing')
@@ -52,24 +49,24 @@ class SelinuxTestCase(TestCase):
                         {'selinux.getenforce': mock_en,
                          'selinux.setenforce': mock_pr}):
             comt = ('SELinux is already in Enforcing mode')
-            ret.update({'name': 'Enforcing', 'comment': comt, 'result': True})
+            ret = {'name': 'Enforcing', 'comment': comt, 'result': True, 'changes': {}}
             self.assertDictEqual(selinux.mode('Enforcing'), ret)
 
             with patch.dict(selinux.__opts__, {'test': True}):
                 comt = ('SELinux mode is set to be changed to Permissive')
-                ret.update({'name': 'Permissive', 'comment': comt,
-                            'result': None})
+                ret = {'name': 'Permissive', 'comment': comt,
+                       'result': None, 'changes': {'new': 'Permissive', 'old': 'Enforcing'}}
                 self.assertDictEqual(selinux.mode('Permissive'), ret)
 
             with patch.dict(selinux.__opts__, {'test': False}):
                 comt = ('SELinux has been set to Permissive mode')
-                ret.update({'name': 'Permissive', 'comment': comt,
-                            'result': True})
+                ret = {'name': 'Permissive', 'comment': comt,
+                       'result': True, 'changes': {'new': 'Permissive', 'old': 'Enforcing'}}
                 self.assertDictEqual(selinux.mode('Permissive'), ret)
 
                 comt = ('Failed to set SELinux to Permissive mode')
                 ret.update({'name': 'Permissive', 'comment': comt,
-                            'result': False})
+                            'result': False, 'changes': {}})
                 self.assertDictEqual(selinux.mode('Permissive'), ret)
 
     # 'boolean' function tests: 1


### PR DESCRIPTION
### What does this PR do?

Without the `=`, SELINUXTYPE is also being matched in the
/etc/sysconfig/selinux file is being removed.

Also add `changes` to the result in the selinux state

Fixes #38200