### PR TITLE
bugfix for boto_rds.present with IAM profile

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -144,7 +144,7 @@ def __init__(opts):
         __utils__['boto3.assign_funcs'](__name__, 'rds')
 
 
-def exists(name, tags=None, region=None, key=None, keyid=None, profile=None):
+def exists(name, region=None, key=None, keyid=None, profile=None):
     '''
     Check to see if an RDS exists.
 


### PR DESCRIPTION
### What does this PR do?
Fix a bug where boto_rds.present does not work when using profile parameter, only works with key: and keyid parameters.   Without the profile parameter, it's not possible to run salt using IAM roles, only baked-in AWS credentials.

### Previous Behavior

The current behavior is:
```
File "/venv/lib/python2.7/site-packages/salt/state.py", line 1744, in call
  **cdata['kwargs'])
File "/venv/lib/python2.7/site-packages/salt/loader.py", line 1702, in wrapper
  return f(*args, **kwargs)
File "/venv/lib/python2.7/site-packages/salt/states/boto_rds.py", line 312, in present
  r = __salt__['boto_rds.exists'](name, region, key, keyid, profile)
File "/venv/lib/python2.7/site-packages/salt/modules/boto_rds.py", line 155, in exists
  conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
File "/venv/lib/python2.7/site-packages/salt/utils/boto3.py", line 206, in get_connection
  keyid, profile)
File "/venv/lib/python2.7/site-packages/salt/utils/boto3.py", line 132, in _get_profile
  hash_string = region + keyid + key
TypeError: cannot concatenate 'str' and 'NoneType' objects
```
### New Behavior

boto_rds.present state works as expected.



