### PR TITLE
Properly quote .app files containing spaces

### DIFF
--- a/salt/modules/mac_package.py
+++ b/salt/modules/mac_package.py
@@ -99,8 +99,6 @@ def install_app(app, target='/Applications/'):
 
         salt '*' macpackage.install_app /tmp/tmp.app /Applications/
     '''
-    app = _quote(app)
-    target = _quote(target)
 
     if not target[-4:] == '.app':
         if app[-1:] == '/':
@@ -113,7 +111,7 @@ def install_app(app, target='/Applications/'):
     if not app[-1] == '/':
         app += '/'
 
-    cmd = 'rsync -a --delete {0} {1}'.format(app, target)
+    cmd = 'rsync -a --delete "{0}" "{1}"'.format(app, target)
     return __salt__['cmd.run'](cmd)
 
 

--- a/tests/unit/modules/mac_package_test.py
+++ b/tests/unit/modules/mac_package_test.py
@@ -57,8 +57,8 @@ class MacPackageTestCase(TestCase):
         mock = MagicMock()
         with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
             macpackage.install_app('/path/to/file.app')
-            mock.assert_called_once_with('rsync -a --delete /path/to/file.app/ '
-                                         '/Applications/file.app')
+            mock.assert_called_once_with('rsync -a --delete "/path/to/file.app/" '
+                                         '"/Applications/file.app"')
 
     def test_install_app_specify_target(self):
         '''
@@ -67,8 +67,8 @@ class MacPackageTestCase(TestCase):
         mock = MagicMock()
         with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
             macpackage.install_app('/path/to/file.app', '/Applications/new.app')
-            mock.assert_called_once_with('rsync -a --delete /path/to/file.app/ '
-                                         '/Applications/new.app')
+            mock.assert_called_once_with('rsync -a --delete "/path/to/file.app/" '
+                                         '"/Applications/new.app"')
 
     def test_install_app_with_slash(self):
         '''
@@ -77,8 +77,8 @@ class MacPackageTestCase(TestCase):
         mock = MagicMock()
         with patch.dict(macpackage.__salt__, {'cmd.run': mock}):
             macpackage.install_app('/path/to/file.app/')
-            mock.assert_called_once_with('rsync -a --delete /path/to/file.app/ '
-                                         '/Applications/file.app')
+            mock.assert_called_once_with('rsync -a --delete "/path/to/file.app/" '
+                                         '"/Applications/file.app"')
 
     def test_uninstall(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Quote the rsync command parameters so that the install_app function returns when installing a .app application containing spaces.

### What issues does this PR fix or reference?
Installing .app on macOS containing spaces, e.g. 'Google Chrome.app'

### Previous Behavior
Install_app would return an error if given a .app containing a space.

### New Behavior
Install_app returns and the .app is installed.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

