### PR TITLE
Successfully exit of salt-api child processes when SIGTERM is received

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -424,7 +424,9 @@ import itertools
 import functools
 import logging
 import json
+import os
 import StringIO
+import signal
 import tarfile
 import time
 from multiprocessing import Process, Pipe
@@ -2182,6 +2184,12 @@ class WebsocketEndpoint(object):
                     listen=True)
             stream = event.iter_events(full=True, auto_reconnect=True)
             SaltInfo = event_processor.SaltInfo(handler)
+
+            def signal_handler(signal, frame):
+                os._exit(0)
+
+            signal.signal(signal.SIGTERM, signal_handler)
+
             while True:
                 data = next(stream)
                 if data:


### PR DESCRIPTION
### What does this PR do?
So far, `rest_cherrypy` `salt-api` handles connection creating child processes, but these new processes are not handling the SIGTERM signal, so when `systemctl stop salt-api` is called the `salt-api` service is going to be KILLED due `TimeoutStopSec=3` option of the `salt-api` systemd service.

This causes that salt-api apears as FAILED for systemd even if we perform a manually stop because it was KILLED. The FAILED systemd services have different behavior when `systemd try-restart` is called so we may have troubles i.e. when updating salt-api package.

This PR enables SIGTERM handling for the `salt-api` child processes to perform a successfully exit after SIGTERM and prevent unexpected behaviors due failed unit.

### Previous Behavior
```
suma3pg:~ # systemctl stop salt-api
suma3pg:~ # systemctl status salt-api
salt-api.service - The Salt API
   Loaded: loaded (/usr/lib/systemd/system/salt-api.service; enabled)
   Active: failed (Result: signal) since mié 2016-12-14 11:57:04 UTC; 2s ago
  Process: 971 ExecStart=/usr/bin/salt-api (code=killed, signal=KILL)
 Main PID: 971 (code=killed, signal=KILL)
```

### New Behavior
```
suma3pg:~ # systemctl stop salt-api
suma3pg:~ # systemctl status salt-api
salt-api.service - The Salt API
   Loaded: loaded (/usr/lib/systemd/system/salt-api.service; enabled)
   Active: inactive (dead) since mié 2016-12-14 11:58:25 UTC; 6s ago
  Process: 9489 ExecStart=/usr/bin/salt-api (code=exited, status=0/SUCCESS)
 Main PID: 9489 (code=exited, status=0/SUCCESS)

```

### Tests written?

No