### PR TITLE
Fixed nested orchestrate not respecting failures

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -396,6 +396,8 @@ class SyncClientMixin(object):
             with tornado.stack_context.StackContext(self.functions.context_dict.clone):
                 data['return'] = self.functions[fun](*args, **kwargs)
                 data['success'] = True
+                if 'data' in data['return']:
+                    data['success'] = salt.utils.check_state_result(data['return']['data'])
         except (Exception, SystemExit) as ex:
             if isinstance(ex, salt.exceptions.NotImplemented):
                 data['return'] = str(ex)

--- a/tests/integration/files/file/base/nested-orch/inner.sls
+++ b/tests/integration/files/file/base/nested-orch/inner.sls
@@ -1,0 +1,6 @@
+cmd.run:
+  salt.function:
+    - tgt: minion
+    - arg:
+      - /bin/false
+    - failhard: True

--- a/tests/integration/files/file/base/nested-orch/outer.sls
+++ b/tests/integration/files/file/base/nested-orch/outer.sls
@@ -1,0 +1,10 @@
+state.orchestrate:
+  salt.runner:
+    - mods: nested-orch.inner
+    - failhard: True
+
+cmd.run:
+  salt.function:
+    - tgt: minion
+    - arg:
+      - touch /tmp/ewu-2016-12-13

--- a/tests/integration/runners/state.py
+++ b/tests/integration/runners/state.py
@@ -68,6 +68,20 @@ class StateRunnerTest(integration.ShellCase):
         for item in good_out:
             self.assertIn(item, ret_output)
 
+    def test_orchestrate_nested(self):
+        '''
+        test salt-run state.orchestrate and failhard with nested orchestration
+        '''
+        if os.path.exists('/tmp/ewu-2016-12-13'):
+            os.remove('/tmp/ewu-2016-12-13')
+
+        _, code = self.run_run(
+                'state.orchestrate nested-orch.outer',
+                with_retcode=True)
+
+        self.assertFalse(os.path.exists('/tmp/ewu-2016-12-13'))
+        self.assertNotEqual(code, 0)
+
     def test_state_event(self):
         '''
         test to ensure state.event


### PR DESCRIPTION
### What does this PR do?
Changes nested orchestration with salt.runner to respect failurers in inner orchestration.

### Previous Behavior
Result of inner orchestration was always success and thus failhard was not respected.

### New Behavior
If the inner orchestration fails, the outer orchestration will respect failhard and exit with correct code.

### Tests written?
Yes: integration.runners.state.StateRunnerTest.test_orchestrate_nested
