### PR TITLE
Various pillar deprecations for Nitrogen

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -87,6 +87,14 @@ General Deprecations
 
 - Beacon configurations should be lists instead of dictionaries.
 
+Pillar Deprecations
+-------------------
+
+- Support for the ``raw_data`` argument for the file_tree ext_pillar has been
+  removed. Please use ``keep_newline`` instead.
+- SQLite3 database connection configuration previously had keys under
+  pillar. This legacy compatibility has been removed.
+
 Proxy Minion Deprecations
 -------------------------
 

--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -253,21 +253,12 @@ def ext_pillar(minion_id,
                root_dir=None,
                follow_dir_links=False,
                debug=False,
-               raw_data=None,
                keep_newline=False):
     '''
     Compile pillar data for the specified minion ID
     '''
     # Not used
     del pillar
-
-    if raw_data is not None:
-        salt.utils.warn_until(
-            'Nitrogen',
-            'The \'raw_data\' argument for the file_tree ext_pillar has been '
-            'deprecated, please use \'keep_newline\' instead'
-        )
-        keep_newline = raw_data
 
     if not root_dir:
         log.error('file_tree: no root_dir specified')

--- a/salt/pillar/sqlite3.py
+++ b/salt/pillar/sqlite3.py
@@ -26,20 +26,6 @@ Note, timeout is in seconds.
     sqlite3.database: /var/lib/salt/pillar.db
     sqlite3.timeout: 5.0
 
-Legacy Compatibility
-====================
-
-SQLite3 database connection configuration previously had keys under
-pillar.
-
-.. code-block:: yaml
-
-    pillar.sqlite3.database: /var/lib/salt/pillar.db
-    pillar.sqlite3.timeout: 5.0
-
-This has been deprecated in 2016.3.0 and will be removed in Salt
-Nitrogen.
-
 
 Complete Example
 ================
@@ -94,23 +80,9 @@ class SQLite3ExtPillar(SqlBaseExtPillar):
         defaults = {'database': '/var/lib/salt/pillar.db',
                     'timeout': 5.0}
         _options = {}
+        _opts = {}
         if 'sqlite3' in __opts__ and 'database' in __opts__['sqlite3']:
-            # new configuration
             _opts = __opts__.get('sqlite3', {})
-        else:
-            # legacy configuration
-            salt.utils.warn_until(
-                'Nitrogen',
-                'Configurations under the pillar key are deprecated.'
-                'See the docs for the new style of configuration.'
-                'This functionality will be removed in Salt Nitro­gen.'
-            )
-            _opts = __opts__.get('pillar', {}).get('sqlite3', {})
-            if 'database' not in _opts:
-                _sqlite3_opts = __opts__.get('pillar', {}).get('master', {})\
-                    .get('pillar', {}).get('sqlite3')
-                if _sqlite3_opts is not None:
-                    _opts = _sqlite3_opts
         for attr in defaults:
             if attr not in _opts:
                 log.debug('Using default for SQLite3 pillar {0}'.format(attr))

--- a/salt/pillar/sqlite3.py
+++ b/salt/pillar/sqlite3.py
@@ -54,7 +54,6 @@ import logging
 import sqlite3
 
 # Import Salt libs
-import salt.utils
 from salt.pillar.sql_base import SqlBaseExtPillar
 
 # Set up logging


### PR DESCRIPTION
- Remove support for legacy sqlite3 pillar configuration
- Remove support for the "raw_data" kwarg in the file_tree external pillar