### PR TITLE
Always use ps -efHww

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -877,10 +877,8 @@ def _ps(osdata):
             '/proc/[0-9]*/status | sed -e \"s=/proc/\\([0-9]*\\)/.*=\\1=\")  '
             '| awk \'{ $7=\"\"; print }\''
         )
-    elif osdata['os_family'] == 'Debian':
-        grains['ps'] = 'ps -efHww'
     else:
-        grains['ps'] = 'ps -efH'
+        grains['ps'] = 'ps -efHww'
     return grains
 
 


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
status.pid fails on gentoo under some cases (similar to https://github.com/saltstack/salt/issues/5646 )

### New Behavior
Processes with long names and a service "sig" that requires seeing the full name should work reliably

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

The "ww" isn't only needed in Debian, but likely all linux distros

According to "ps" docs, there are several invocation cases where the
output width is undefined, unless env COLUMNS or 'ww' is specified