### PR TITLE
Improved jenkins job comparing

### DIFF
--- a/salt/states/jenkins.py
+++ b/salt/states/jenkins.py
@@ -14,9 +14,26 @@ import logging
 
 # Import Salt libs
 import salt.ext.six as six
+from salt.ext.six.moves import zip
 import salt.utils
 
+# Import XML parser
+import xml.etree.ElementTree as ET
 log = logging.getLogger(__name__)
+
+
+def _elements_equal(e1, e2):
+    if e1.tag != e2.tag:
+        return False
+    if e1.text != e2.text:
+        return False
+    if e1.tail != e2.tail:
+        return False
+    if e1.attrib != e2.attrib:
+        return False
+    if len(e1) != len(e2):
+        return False
+    return all(_elements_equal(c1, c2) for c1, c2 in zip(e1, e2))
 
 
 def present(name,
@@ -25,10 +42,8 @@ def present(name,
     '''
     Ensure the job is present in the Jenkins
     configured jobs
-
     name
         The unique name for the Jenkins job
-
     config
         The Salt URL for the file to use for
         configuring the job.
@@ -44,14 +59,15 @@ def present(name,
     if _job_exists:
         _current_job_config = __salt__['jenkins.get_job_config'](name)
         buf = six.moves.StringIO(_current_job_config)
-        _current_job_config = buf.readlines()
+        oldXML = ET.fromstring(buf.read())
 
         cached_source_path = __salt__['cp.cache_file'](config, __env__)
         with salt.utils.fopen(cached_source_path) as _fp:
-            new_config_xml = _fp.readlines()
-
-        if _current_job_config != new_config_xml:
-            diff = difflib.unified_diff(_current_job_config, new_config_xml, lineterm='')
+            newXML = ET.fromstring(_fp.read())
+        if not _elements_equal(oldXML, newXML):
+            diff = difflib.unified_diff(
+                ET.tostringlist(oldXML, encoding='utf8', method='xml'),
+                ET.tostringlist(newXML, encoding='utf8', method='xml'), lineterm='')
             __salt__['jenkins.update_job'](name, config, __env__)
             ret['changes'] = ''.join(diff)
             ret['comment'].append('Job {0} updated.'.format(name))


### PR DESCRIPTION
### What does this PR do?
Improve existing jenkins job comparing
Comparison implemented by comparing parsed XML objects instead of XML lines

### What issues does this PR fix or reference?
No issues afaik

### Previous Behavior
Jenkins job source code for existing jobs was compared line-by-line, so even extra whitespace is considered as change and job will be replaced.

### New Behavior
Comparison is done by parsed XML objects using ElementTree native library.

### Tests written?

No, but maybe tests exists from previous jenkins-state author.
