### PR TITLE
Add nick to args for create_multi

### DIFF
--- a/salt/modules/xmpp.py
+++ b/salt/modules/xmpp.py
@@ -182,7 +182,7 @@ def send_msg_multi(message,
         password = creds.get('xmpp.password')
 
     xmpp = SendMsgBot.create_multi(
-        jid, password, message, recipients=recipients, rooms=rooms)
+        jid, password, message, recipients=recipients, rooms=rooms, nick=nick)
 
     if rooms:
         xmpp.register_plugin('xep_0045')  # MUC plugin


### PR DESCRIPTION
Fixes the send_msg_multi function behavior to include the nick value in the args passed to create_multi method.

Prior to this fix, nick would use the default value "Saltstack Bot" regardless of the value used in the salt call to xmpp.send_msg_multi

No tests added