### PR TITLE
Add nick to args for create_multi

### DIFF
--- a/salt/modules/xmpp.py
+++ b/salt/modules/xmpp.py
@@ -182,7 +182,7 @@ def send_msg_multi(message,
         password = creds.get('xmpp.password')
 
     xmpp = SendMsgBot.create_multi(
-        jid, password, message, recipients=recipients, rooms=rooms)
+        jid, password, message, recipients=recipients, rooms=rooms, nick=nick)
 
     if rooms:
         xmpp.register_plugin('xep_0045')  # MUC plugin


### PR DESCRIPTION
### What does this PR do?
Adds the nick arg to the create_multi method call in send_msg_multi function

### Previous Behavior
The nick was always set to the default value "Saltstack Bot"

### New Behavior
The nick is set to the value passed as the nick argument to the xmpp.send_msg_multi function

### Tests written?
No tests added
