### PR TITLE
ldap external_auth groups fix for auth.ldap.groupclass option

### DIFF
--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -372,6 +372,9 @@ def groups(username, **kwargs):
                                            ldap.SCOPE_SUBTREE,
                                            search_string,
                                            [_config('accountattributename'), 'cn'])
+            for _, entry in search_results:
+                if username in entry[_config('accountattributename')]:
+                    group_list.append(entry['cn'][0])
             for user, entry in search_results:
                 if username == user.split(',')[0].split('=')[-1]:
                     for group in entry[_config('groupattribute')]:


### PR DESCRIPTION
### What does this PR do?
allows for `auth.ldap.groupclass: posixGroup` or `auth.ldap.groupclass: person` style of group class for ldap servers that do not have 'memberOf' overlay enabled

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/38259

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.


