### PR TITLE
Issue 38239

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2994,6 +2994,13 @@ class BaseHighState(object):
                                     _filter_matches(match, data, _opts)
                             if isinstance(item, six.string_types):
                                 matches[saltenv].append(item)
+                            elif isinstance(item, dict):
+                                env_key, inc_sls = item.popitem()
+                                if env_key not in self.avail:
+                                    continue
+                                if env_key not in matches:
+                                    matches[env_key] = []
+                                matches[env_key].append(inc_sls)
                 _filter_matches(match, data, self.opts['nodegroups'])
         ext_matches = self._ext_nodes()
         for saltenv in ext_matches:


### PR DESCRIPTION
### What does this PR do?
This PR allows state to be included in top.sls like:
```
base:
  '*':
    - <other env>: test
```
This is to mirror how these includes work in normal state files.
I'm not positive this change won't cause other issues so would like some extra eyes on it.
### What issues does this PR fix or reference?
#38239 
### Previous Behavior
When states from other environments are specified in top.sls they are silently ignored and not run.

### New Behavior
Included stats are now included correctly.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
