### PR TITLE
fix runit init support (grain init) in 2016.11

### DIFF
--- a/doc/ref/clouds/all/index.rst
+++ b/doc/ref/clouds/all/index.rst
@@ -11,6 +11,7 @@ Full list of Salt Cloud modules
     :template: autosummary.rst.tmpl
 
     aliyun
+    azurearm
     cloudstack
     digital_ocean
     dimensiondata

--- a/doc/ref/clouds/all/salt.cloud.clouds.azureare.rst
+++ b/doc/ref/clouds/all/salt.cloud.clouds.azureare.rst
@@ -1,0 +1,6 @@
+==========================
+salt.cloud.clouds.azurearm
+==========================
+
+.. automodule:: salt.cloud.clouds.azurearm
+    :members:

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1888,7 +1888,7 @@ def request_instance(vm_=None, call=None):
             params[termination_key] = str(set_del_root_vol_on_destroy).lower()
 
             # Use default volume type if not specified
-            if 'Ebs.VolumeType' not in ex_blockdevicemappings[dev_index]:
+            if ex_blockdevicemappings and 'Ebs.VolumeType' not in ex_blockdevicemappings[dev_index]:
                 type_key = '{0}BlockDeviceMapping.{1}.Ebs.VolumeType'.format(spot_prefix, dev_index)
                 params[type_key] = rd_type
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1256,7 +1256,7 @@ def os_data():
                     init_cmdline = fhr.read().replace('\x00', ' ').split()
                     init_bin = salt.utils.which(init_cmdline[0])
                     if init_bin is not None and init_bin.endswith('bin/init'):
-                        supported_inits = (six.b('upstart'), six.b('sysvinit'), six.b('systemd'), six.b('runit'))
+                        supported_inits = (six.b('upstart'), six.b('sysvinit'), six.b('systemd'))
                         edge_len = max(len(x) for x in supported_inits) - 1
                         try:
                             buf_size = __opts__['file_buffer_size']
@@ -1286,6 +1286,8 @@ def os_data():
                             )
                     elif salt.utils.which('supervisord') in init_cmdline:
                         grains['init'] = 'supervisord'
+                    elif init_cmdline == ['runit']:
+                        grains['init'] = 'runit'
                     else:
                         log.info(
                             'Could not determine init system from command line: ({0})'

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -954,6 +954,9 @@ def is_encrypted(name, clean=False, saltenv='base'):
     Returns ``True`` if the zip archive is password-protected, ``False`` if
     not. If the specified file is not a ZIP archive, an error will be raised.
 
+    name
+        The path / URL of the archive to check.
+
     clean : False
         Set this value to ``True`` to delete the path referred to by ``name``
         once the contents have been listed. This option should be used with
@@ -970,6 +973,7 @@ def is_encrypted(name, clean=False, saltenv='base'):
 
             salt '*' archive.is_encrypted /path/to/myfile.zip
             salt '*' archive.is_encrypted salt://foo.zip
+            salt '*' archive.is_encrypted salt://foo.zip saltenv=dev
             salt '*' archive.is_encrypted https://domain.tld/myfile.zip clean=True
             salt '*' archive.is_encrypted ftp://10.1.2.3/foo.zip
     '''

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -509,7 +509,7 @@ def file(name,
         Overrides the default backup mode for the user's crontab.
     '''
     # Initial set up
-    mode = salt.utils.normalize_mode('0600')
+    mode = '0600'
     owner, group, crontab_dir = _get_cron_info()
 
     cron_path = salt.utils.mkstemp()


### PR DESCRIPTION
### What does this PR do?

fix detection of runit as init system (PID 1) in grain 'init'.

### What issues does this PR fix or reference?

Support of runit as init system was introduced with VoidLinux distribution support. It has been merged into 2016.11.0 release (issue #30195 and PR #31262). 
But big rewrites of `salt/grains/core.py` made runit support broken.

Consequence: `sv` as service management is broken too.

### Previous Behavior

```
$ sudo salt-call grains.item init
local:
    ----------
    init:
        unknown
```
`sv` broken support:
```
$ sudo salt-call  service.show sshd
'service' virtual returned False: Your OS is on the disabled list
```

### New Behavior
```
$ sudo PYTHONPATH=$(pwd) ./scripts/salt-call --log-file=./log --local --refresh-grains-cache  grains.item init
local:
    ----------
    init:
        runit
```

`sv` support is fine now (too):

``` 
$ sudo PYTHONPATH=$(pwd) ./scripts/salt-call --log-file=./log --local --refresh-grains-cache service.show sshd
local:
    ----------
    autostart:
        False
    available:
        True
    command_path:
        /etc/sv/sshd/run
    disabled:
        False
    enabled:
        True
    running:
        False
    service_path:
        /etc/sv/sshd
```
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
