### PR TITLE
Avoid normalization call for normalized mode value

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -509,7 +509,7 @@ def file(name,
         Overrides the default backup mode for the user's crontab.
     '''
     # Initial set up
-    mode = salt.utils.normalize_mode('0600')
+    mode = '0600'
     owner, group, crontab_dir = _get_cron_info()
 
     cron_path = salt.utils.mkstemp()


### PR DESCRIPTION
### What does this PR do?
The `normalize_mode` method allows to convert '644' and '000000644' strings into '0644'.

Any call to already normalized mode isn't useful for already normalized strings.


