### PR TITLE
Backport PR #37333: Fixed state.salt.runner() reporting success on exceptions

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -652,7 +652,10 @@ def runner(name, **kwargs):
                                       full_return=True,
                                       **kwargs)
 
-    ret['result'] = True
+    if 'success' in out and not out['success']:
+        ret['result'] = False
+    else:
+        ret['result'] = True
     ret['comment'] = "Runner function '{0}' executed.".format(name)
 
     ret['__orchestration__'] = True

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -638,7 +638,6 @@ def runner(name, **kwargs):
           salt.runner:
             - name: manage.up
     '''
-    ret = {'name': name, 'result': False, 'changes': {}, 'comment': ''}
     try:
         jid = __orchestration_jid__
     except NameError:
@@ -652,19 +651,25 @@ def runner(name, **kwargs):
                                       full_return=True,
                                       **kwargs)
 
+    runner_return = out.get('return')
     if 'success' in out and not out['success']:
-        ret['result'] = False
+        ret = {
+            'name': name,
+            'result': False,
+            'changes': {},
+            'comment': runner_return if runner_return else "Runner function '{0}' failed without comment.".format(name)
+        }
     else:
-        ret['result'] = True
-    ret['comment'] = "Runner function '{0}' executed.".format(name)
+        ret = {
+            'name': name,
+            'result': True,
+            'changes': runner_return if runner_return else {},
+            'comment': "Runner function '{0}' executed.".format(name)
+        }
 
     ret['__orchestration__'] = True
     if 'jid' in out:
         ret['__jid__'] = out['jid']
-
-    runner_return = out.get('return')
-    if runner_return:
-        ret['changes'] = runner_return
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?
Backport to 2016.11 for Pull Request #37333: Fix a bug where states.salt.runner() would always report success, even if the runner that was called raises an exception.

### Tests written?
No
