### PR TITLE
salt utils aws encoding fix

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -87,7 +87,9 @@ def creds(provider):
                 proxies={'http': ''}, timeout=AWS_METADATA_TIMEOUT,
             )
             result.raise_for_status()
-            role = result.text.encode(result.encoding)
+            role = result.text.encode(
+                result.encoding if result.encoding else 'utf-8'
+            )
         except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
             return provider['id'], provider['key'], ''
 
@@ -460,7 +462,9 @@ def query(params=None, setname=None, requesturl=None, location=None,
             )
             LOG.trace(
                 'AWS Response Text: {0}'.format(
-                    result.text.encode(result.encoding)
+                    result.text.encode(
+                        result.encoding if result.encoding else 'utf-8'
+                    )
                 )
             )
             result.raise_for_status()
@@ -501,7 +505,9 @@ def query(params=None, setname=None, requesturl=None, location=None,
             return {'error': data}, requesturl
         return {'error': data}
 
-    response = result.text.encode(result.encoding)
+    response = result.text.encode(
+        result.encoding if result.encoding else 'utf-8'
+    )
 
     root = ET.fromstring(response)
     items = root[1]


### PR DESCRIPTION
### What does this PR do?
requests api says Response.encoding can sometimes be `None` http://docs.python-requests.org/en/master/api/#requests.Response.encoding and `result.text.encode()` doesn't accept `None` (expects a string.)

this change prevents unexpected type exceptions and defaults the encoding back to 'utf-8' (the default prior to #37912 )

### What issues does this PR fix or reference?
#37912

