### PR TITLE
boto_rds: backwards compatibility issues and various bug fixes

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -277,9 +277,9 @@ def create(name, allocated_storage, db_instance_class, engine,
             val = locals()[key]
             if val is not None:
                 mapped = boto3_param_map[key]
-                if key == 'tags':
-                    val = _tag_doc(val)
                 kwargs[mapped[0]] = mapped[1](val)
+
+        taglist = _tag_doc(tags)
 
         # Validation doesn't want parameters that are None
         # https://github.com/boto/boto3/issues/400
@@ -548,7 +548,7 @@ def describe(name, tags=None, region=None, key=None, keyid=None,
                     'CopyTagsToSnapshot', 'MonitoringInterval',
                     'MonitoringRoleArn', 'PromotionTier',
                     'DomainMemberships')
-            return {'rds': dict([(k, rds.get('DBInstances', [{}])[0].get(k)) for k in keys])}
+            return {'rds': dict([(k, rds.get(k)) for k in keys])}
         else:
             return {'rds': None}
     except ClientError as e:
@@ -567,31 +567,27 @@ def get_endpoint(name, tags=None, region=None, key=None, keyid=None,
         salt myminion boto_rds.get_endpoint myrds
 
     '''
-    endpoint = 'None'
+    endpoint = False
     res = __salt__['boto_rds.exists'](name, tags, region, key, keyid,
                                       profile)
-    if not res:
-        return {'exists': bool(res), 'message':
-                'RDS instance {0} does not exist.'.format(name)}
+    if res.get('exists'):
+        try:
+            conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+            if conn:
+                rds = conn.describe_db_instances(DBInstanceIdentifier=name)
 
-    try:
-        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-        if not conn:
-            return {'results': bool(conn)}
+                if rds and 'Endpoint' in rds['DBInstances'][0]:
+                    endpoint = rds['DBInstances'][0]['Endpoint']['Address']
+                    return endpoint
 
-        rds = conn.describe_db_instances(DBInstanceIdentifier=name)
+        except ClientError as e:
+            return {'error': salt.utils.boto3.get_error(e)}
 
-        if rds:
-            inst = rds['DBInstances'][0]['Endpoint']
-            endpoint = '{0}:{1}'.format(inst.get('Address'), inst.get('Port'))
-            return endpoint
-
-    except ClientError as e:
-        return {'error': salt.utils.boto3.get_error(e)}
+    return endpoint
 
 
 def delete(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
-           region=None, key=None, keyid=None, profile=None,
+           region=None, key=None, keyid=None, profile=None, tags=None,
            wait_for_deletion=True, timeout=180):
     '''
     Delete an RDS instance.
@@ -629,10 +625,10 @@ def delete(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
 
         start_time = time()
         while True:
-            if not __salt__['boto_rds.exists'](name=name, region=region,
+            res = __salt__['boto_rds.exists'](name=name, tags=tags, region=region,
                                                key=key, keyid=keyid,
-                                               profile=profile):
-
+                                               profile=profile)
+            if not res.get('exists'):
                 return {'deleted': bool(res), 'message':
                         'Deleted RDS instance {0} completely.'.format(name)}
 

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -377,7 +377,7 @@ def replica_present(name, source, db_instance_class=None,
            }
     replica_exists = __salt__['boto_rds.exists'](name, tags, region, key,
                                                  keyid, profile)
-    if not replica.get('exists'):
+    if not replica_exists.get('exists'):
         if __opts__['test']:
             ret['comment'] = 'RDS read replica {0} is set to be created '.format(name)
             ret['result'] = None

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -50,12 +50,7 @@ config:
         - keyid: GKTADJGHEIQSXMKKRBJ08H
         - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
         - tags:
-          -
-            - key1
-            - value1
-          -
-            - key2
-            - value2
+            key: value
 
 .. code-block:: yaml
 
@@ -261,7 +256,7 @@ def present(name,
         the state. Available states: available, modifying, backing-up
 
     tags
-        A list of tags.
+        A dict of tags.
 
     copy_tags_to_snapshot
         Specifies whether tags are copied from the DB instance to snapshots of
@@ -382,7 +377,7 @@ def replica_present(name, source, db_instance_class=None,
            }
     replica_exists = __salt__['boto_rds.exists'](name, tags, region, key,
                                                  keyid, profile)
-    if not replica_exists:
+    if not replica.get('exists'):
         if __opts__['test']:
             ret['comment'] = 'RDS read replica {0} is set to be created '.format(name)
             ret['result'] = None
@@ -442,7 +437,7 @@ def subnet_group_present(name, description, subnet_ids=None, subnet_names=None,
         Subnet group description.
 
     tags
-        A list of tags.
+        A dict of tags.
 
     region
         Region to connect to.
@@ -538,7 +533,7 @@ def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
         snapshot.
 
     tags
-        A list of tags.
+        A dict of tags.
 
     region
         Region to connect to.
@@ -570,7 +565,7 @@ def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
 
     exists = __salt__['boto_rds.exists'](name, tags, region, key, keyid,
                                          profile)
-    if not exists:
+    if not exists.get('exists'):
         ret['result'] = True
         ret['comment'] = '{0} RDS does not exist.'.format(name)
         return ret
@@ -581,7 +576,7 @@ def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
         return ret
     deleted = __salt__['boto_rds.delete'](name, skip_final_snapshot,
                                           final_db_snapshot_identifier,
-                                          region, key, keyid, profile,
+                                          region, key, keyid, profile, tags,
                                           wait_for_deletion, timeout)
     if not deleted:
         ret['result'] = False
@@ -652,7 +647,7 @@ def parameter_present(name, db_parameter_group_family, description, parameters=N
         parameters.
 
     tags
-        A list of tags.
+        A dict of tags.
 
     region
         Region to connect to.


### PR DESCRIPTION
I started out on version 2016.11.0 and went to 2016.11.1 for a few things, then debugged some other things a bit further, then merged with develop. Here are my findings:

### What does this PR do?
**module: boto_rds**
* updated `boto_rds.create`'s use of describe return value changes from `{'db_instance_status': string}` to `{'rds': 'DBInstanceStatus': string}` -- fixes Runtime Exception
* updated `boto_rds.get_endpoint`:
  - return the same values as in previous `boto2.rds2` implementation -- since: https://github.com/saltstack/salt/commit/fae87f1d5eca3ac5e1795deaf4c2108262273af5#diff-59e36191d3e2ecda4e684feddb25b2d0L452
  - Added sanity check for 'Endpoint' index to avoid exception when endpoint is not available (happens during initial "backing-up" stage after creation.)
  - Returns only string endpoint (Address) with no port value. Previous rds2 implementation only returned address.
  - Rolled back a change to describe here: https://github.com/saltstack/salt/pull/38268/commits/b5a2e11e6071f2a793136b8cf03689ae8ff86159
    
> Should either roll back to what it was, or if it should include the port (return a dict instead of string??)..I'd listen to reason :)
>     i've already updated states to split port off if colon is found.. so either implementation will work for me now.. not sure of scope of impact to any others..

* updated `boto_rds.delete` to accept tags param and pass it thru to `__salt__['boto_rds.exists']` when checking if rds has been completely deleted to be consistent with other uses of the exists calls in the module

**state: boto_rds**
* updated `boto_rds.present`'s sample code-block to reflect the new syntax with tags in a dict instead of list of lists. In the latest implementation in the module, `boto_rds._tag_doc` is used to build the tag list according to the boto3 api reference: http://boto3.readthedocs.io/en/latest/reference/services/rds.html?highlight=rds#RDS.Client.create_db_instance
* fix docblocks to reflect that the tags is expected to be a 'dict'
* fixed use of `boto_rds.exists` return data to expect `{'exists': bool}` instead of `bool`
* updated `boto_rds.absent` to pass in tags to `__salt__['boto_rds.delete']` to go along with the change in the method signature in the module


### What issues does this PR fix or reference?

Rebasing #38284 (totally deleted branch by accident, lol)

Cheers 👍 

