### PR TITLE
fix runit init support (grain init) in 2016.11

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1256,7 +1256,7 @@ def os_data():
                     init_cmdline = fhr.read().replace('\x00', ' ').split()
                     init_bin = salt.utils.which(init_cmdline[0])
                     if init_bin is not None and init_bin.endswith('bin/init'):
-                        supported_inits = (six.b('upstart'), six.b('sysvinit'), six.b('systemd'), six.b('runit'))
+                        supported_inits = (six.b('upstart'), six.b('sysvinit'), six.b('systemd'))
                         edge_len = max(len(x) for x in supported_inits) - 1
                         try:
                             buf_size = __opts__['file_buffer_size']
@@ -1286,6 +1286,8 @@ def os_data():
                             )
                     elif salt.utils.which('supervisord') in init_cmdline:
                         grains['init'] = 'supervisord'
+                    elif init_cmdline == ['runit']:
+                        grains['init'] = 'runit'
                     else:
                         log.info(
                             'Could not determine init system from command line: ({0})'


### PR DESCRIPTION
### What does this PR do?

fix detection of runit as init system (PID 1) in grain 'init'.

### What issues does this PR fix or reference?

Support of runit as init system was introduced with VoidLinux distribution support. It has been merged into 2016.11.0 release (issue #30195 and PR #31262). 
But big rewrites of `salt/grains/core.py` made runit support broken.

Consequence: `sv` as service management is broken too.

### Previous Behavior

```
$ sudo salt-call grains.item init
local:
    ----------
    init:
        unknown
```
`sv` broken support:
```
$ sudo salt-call  service.show sshd
'service' virtual returned False: Your OS is on the disabled list
```

### New Behavior
```
$ sudo PYTHONPATH=$(pwd) ./scripts/salt-call --log-file=./log --local --refresh-grains-cache  grains.item init
local:
    ----------
    init:
        runit
```

`sv` support is fine now (too):

``` 
$ sudo PYTHONPATH=$(pwd) ./scripts/salt-call --log-file=./log --local --refresh-grains-cache service.show sshd
local:
    ----------
    autostart:
        False
    available:
        True
    command_path:
        /etc/sv/sshd/run
    disabled:
        False
    enabled:
        True
    running:
        False
    service_path:
        /etc/sv/sshd
```
### Tests written?

No