### PR TITLE
Suppress errors when checking if an alternative exists

### DIFF
--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -112,12 +112,11 @@ def show_current(name):
 
         salt '*' alternatives.show_current editor
     '''
-    alt_link_path = '/etc/alternatives/{0}'.format(name)
     try:
-        return os.readlink(alt_link_path)
+        return _read_link(name)
     except OSError:
         log.error(
-            'alternatives: path {0} does not exist'.format(alt_link_path)
+            'alternative: {0} does not exist'.format(name)
         )
     return False
 
@@ -154,7 +153,10 @@ def check_installed(name, path):
 
         salt '*' alternatives.check_installed name path
     '''
-    return show_current(name) == path
+    try:
+        return _read_link(name) == path
+    except OSError:
+        return False
 
 
 def install(name, link, path, priority):
@@ -224,3 +226,13 @@ def set_(name, path):
     if out['retcode'] > 0:
         return out['stderr']
     return out['stdout']
+
+
+def _read_link(name):
+    '''
+    Read the link from /etc/alternatives
+
+    Throws an OSError if the link does not exist
+    '''
+    alt_link_path = '/etc/alternatives/{0}'.format(name)
+    return os.readlink(alt_link_path)

--- a/tests/unit/modules/alternatives_test.py
+++ b/tests/unit/modules/alternatives_test.py
@@ -78,8 +78,7 @@ class AlternativesTestCase(TestCase):
             os_readlink_mock.side_effect = OSError('Hell was not found!!!')
             self.assertFalse(alternatives.show_current('hell'))
             os_readlink_mock.assert_called_with('/etc/alternatives/hell')
-            self.assertIn('ERROR:alternatives: path /etc/alternatives/hell '
-                          'does not exist',
+            self.assertIn('ERROR:alternative: hell does not exist',
                           handler.messages)
 
     @patch('os.readlink')


### PR DESCRIPTION
### What does this PR do?
Update the `alternatives` execution module to suppress some logging

### What issues does this PR fix or reference?
N/A

### Previous Behavior
When running the `alternatives` state module, it would check to see if the alternative previously existed. If it did not, an error would be logged.

### New Behavior
Checking if an alternative exists does not produce an error.

### Tests written?
No. No functional behavior was changed

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
