### PR TITLE
Add support for 'rootfs' lxc container option to salt-cloud proxmox driver

### DIFF
--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -678,7 +678,7 @@ def create_node(vm_, newid):
         newnode['hostname'] = vm_['name']
         newnode['ostemplate'] = vm_['image']
 
-        for prop in 'cpuunits', 'description', 'memory', 'onboot', 'net0', 'password', 'nameserver', 'swap', 'storage':
+        for prop in 'cpuunits', 'description', 'memory', 'onboot', 'net0', 'password', 'nameserver', 'swap', 'storage', 'rootfs':
             if prop in vm_:  # if the property is set, use it for the VM request
                 newnode[prop] = vm_[prop]
 


### PR DESCRIPTION
### What does this PR do?

Add support for 'rootfs' lxc container option to salt-cloud proxmox driver. This allows container disk size to be configured.

### Tests written?

No
