### PR TITLE
states saltmod wait_for_event data dictionary fix

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -594,6 +594,8 @@ def wait_for_event(
 
         if fnmatch.fnmatch(event['tag'], name):
             val = event['data'].get(event_id)
+            if val is None and 'data' in event['data']:
+                val = event['data']['data'].get(event_id)
 
             if val is not None:
                 try:


### PR DESCRIPTION
### What does this PR do?
possibly related to core issues discussed here: #38087 #26509

the setup affected is using the orchestrate runner to call salt.wait_for_event

the event is being sent by a reactor (effectively, chaining events)

```sls
send_ready_event:
  local.cmd.run:
    - tgt: 'salt-minion-running-on-salt-master'
    - arg:
      - "salt-call event.send 'core/instance/test-instance/ready' '{minion: test-instance}'"
```

this is the wait_for_event call:
_Notice the use of `event_id`. This would not be a problem if I didn't want to override [`event_id`'s default value of `id`](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.saltmod.html#salt.states.saltmod.function) and look elsewhere is the custom event data for the id to match._ The reason I need to somewhere besides `id` is that `id` is not always the `id` of the minion id that I need to match in the event tag. Since I am not always firing the event from the minion I want to match.
```sls
wait_for_ready:
  salt.wait_for_event:
    - name: 'core/instance/*/ready'
    - event_id: 'minion'
    - id_list:
      - test-instance
```

this is the dict for the event when a match is found while listening: 
```
{
    tag: core/instance/test-instance/ready,
    data: 
    {
        _stamp: 2016-12-18T05:05:28.047408,
        pretag: None,
        cmd: _minion_event,
        tag: core/instance/test-instance/ready,
        data: 
        {
            __pub_user: root,
            __pub_arg: 
            [
                core/instance/test-instance/ready,
                {minion: test-instance}
            ],
            minion: test-instance,
            __pub_fun: event.send,
            __pub_jid: 20161218000528008327,
            __pub_tgt: test-instance,
            __pub_tgt_type: glob,
            __pub_ret: 
        },
        id: test-instance
    }
}
```

these changes keep the previous functionality intact and uses the inner 'data' dictionary when available to get the proper event data.

the event parsing implemented here: https://github.com/saltstack/salt/blob/develop/salt/thorium/status.py would leave me to believe that this is expected behavior for reading event data.

now my wait_for_event blocking call works as expected when the event is fired (whether it is fired from the minion or master is no longer relevant) :)

### What issues does this PR fix or reference?
#38087 #26509

### Previous Behavior
didn't work for this case

### New Behavior
works now