### PR TITLE
Bugfix ext pillar nodegroups

### DIFF
--- a/salt/cache/__init__.py
+++ b/salt/cache/__init__.py
@@ -22,7 +22,7 @@ class Cache(object):
 
     :param cache:
         The name of the cache driver to use. This is the name of the python
-        module of the `salt.cache` package. Defult is `localfs`.
+        module of the `salt.cache` package. Default is `localfs`.
 
     :param serial:
         The module of `salt.serializers` package that should be used by the cache

--- a/tests/unit/pillar/nodegroups_test.py
+++ b/tests/unit/pillar/nodegroups_test.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 # Import Salt Testing libs
 from salttesting import TestCase
 from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import patch, MagicMock
 
 ensure_in_syspath('../../')
 
@@ -15,13 +16,23 @@ from salt.pillar import nodegroups
 fake_minion_id = 'fake_id'
 fake_pillar = {}
 fake_nodegroups = {
-    'a': fake_minion_id,
-    'b': 'nodegroup_b',
+    'groupA': fake_minion_id,
+    'groupB': 'another_minion_id',
 }
-fake_opts = {'nodegroups': fake_nodegroups, 'id': fake_minion_id}
+fake_opts = {
+    'cache': 'localfs',
+    'nodegroups': fake_nodegroups,
+    'id': fake_minion_id
+}
 fake_pillar_name = 'fake_pillar_name'
 
 nodegroups.__opts__ = fake_opts
+
+
+def side_effect(group_sel, t):
+    if group_sel.find(fake_minion_id) != -1:
+        return [fake_minion_id, ]
+    return ['another_minion_id', ]
 
 
 class NodegroupsPillarTestCase(TestCase):
@@ -29,11 +40,13 @@ class NodegroupsPillarTestCase(TestCase):
     Tests for salt.pillar.nodegroups
     '''
 
+    @patch('salt.utils.minions.CkMinions.check_minions',
+           MagicMock(side_effect=side_effect))
     def _runner(self, expected_ret, pillar_name=None):
         pillar_name = pillar_name or fake_pillar_name
         actual_ret = nodegroups.ext_pillar(fake_minion_id, fake_pillar, pillar_name=pillar_name)
         self.assertDictEqual(actual_ret, expected_ret)
 
     def test_succeeds(self):
-        ret = {fake_pillar_name: ['a', ]}
+        ret = {fake_pillar_name: ['groupA', ]}
         self._runner(ret)


### PR DESCRIPTION
### What does this PR do?

It corrects the nodegroups matching for minions not running on the master.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/pull/33179#issuecomment-264497525

### Previous Behavior

```
nodegroups:
  master: 'salt* or master*'
  push: 'node* or push* or testing0*'

salt 'salt*' pillar.item nodegroups --> "[ master ]" (correct)
salt 'node*' pillar.item nodegroups --> "[ master ]" (incorrect)
```
### New Behavior

```
salt 'node*' pillar.item nodegroups --> "[ push ]" (correct)
```

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
