### PR TITLE
salt-ssh: pass additional ssh options

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -295,6 +295,9 @@ class SSH(object):
             'remote_port_forwards': self.opts.get(
                 'ssh_remote_port_forwards'
             ),
+            'ssh_options': self.opts.get(
+                'ssh_option'
+            )
         }
         if self.opts.get('rand_thin_dir'):
             self.defaults['thin_dir'] = os.path.join(
@@ -690,6 +693,7 @@ class Single(object):
             identities_only=False,
             sudo_user=None,
             remote_port_forwards=None,
+            ssh_options=None,
             **kwargs):
         # Get mine setting and mine_functions if defined in kwargs (from roster)
         self.mine = mine
@@ -746,7 +750,8 @@ class Single(object):
                 'mods': self.mods,
                 'identities_only': identities_only,
                 'sudo_user': sudo_user,
-                'remote_port_forwards': remote_port_forwards}
+                'remote_port_forwards': remote_port_forwards,
+                'ssh_options': ssh_options}
         # Pre apply changeable defaults
         self.minion_opts = {
                     'grains_cache': True,

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -64,7 +64,8 @@ class Shell(object):
             mods=None,
             identities_only=False,
             sudo_user=None,
-            remote_port_forwards=None):
+            remote_port_forwards=None,
+            ssh_options=None):
         self.opts = opts
         self.host = host
         self.user = user
@@ -77,6 +78,7 @@ class Shell(object):
         self.mods = mods
         self.identities_only = identities_only
         self.remote_port_forwards = remote_port_forwards
+        self.ssh_options=ssh_options
 
     def get_error(self, errstr):
         '''
@@ -168,6 +170,10 @@ class Shell(object):
             ret.append('-o {0} '.format(option))
         return ''.join(ret)
 
+    def _ssh_opts(self):
+        return ' '.join(['-o {0}'.format(opt)
+                        for opt in self.ssh_options])
+
     def _copy_id_str_old(self):
         '''
         Return the string to execute ssh-copy-id
@@ -175,11 +181,12 @@ class Shell(object):
         if self.passwd:
             # Using single quotes prevents shell expansion and
             # passwords containing '$'
-            return "{0} {1} '{2} -p {3} {4}@{5}'".format(
+            return "{0} {1} '{2} -p {3} {4} {5}@{6}'".format(
                     'ssh-copy-id',
                     '-i {0}.pub'.format(self.priv),
                     self._passwd_opts(),
                     self.port,
+                    self._ssh_opts(),
                     self.user,
                     self.host)
         return None
@@ -192,11 +199,12 @@ class Shell(object):
         if self.passwd:
             # Using single quotes prevents shell expansion and
             # passwords containing '$'
-            return "{0} {1} {2} -p {3} {4}@{5}".format(
+            return "{0} {1} {2} -p {3} {4} {5}@{6}".format(
                     'ssh-copy-id',
                     '-i {0}.pub'.format(self.priv),
                     self._passwd_opts(),
                     self.port,
+                    self._ssh_opts(),
                     self.user,
                     self.host)
         return None
@@ -228,6 +236,9 @@ class Shell(object):
         if ssh != 'scp' and self.remote_port_forwards:
             command.append(' '.join(['-R {0}'.format(item)
                                      for item in self.remote_port_forwards.split(',')]))
+        if self.ssh_options:
+            command.append(self._ssh_opts())
+
         command.append(cmd)
 
         return ' '.join(command)

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2829,11 +2829,11 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
             help='Pass a JID to be used instead of generating one.'
         )
 
-        ports_group = optparse.OptionGroup(
-            self, 'Port Forwarding Options',
-            'Parameters for setting up SSH port forwarding.'
+        ssh_group = optparse.OptionGroup(
+            self, 'SSH Options',
+            'Parameters for the SSH client.'
         )
-        ports_group.add_option(
+        ssh_group.add_option(
             '--remote-port-forwards',
             dest='ssh_remote_port_forwards',
             help='Setup remote port forwarding using the same syntax as with '
@@ -2841,7 +2841,15 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
                  'forwarding definitions will be translated into multiple '
                  '-R parameters.'
         )
-        self.add_option_group(ports_group)
+        ssh_group.add_option(
+            '--ssh-option',
+            dest='ssh_option',
+            action='append',
+            help='Equivalent to the -o ssh command option. Passes options to '
+                 'the SSH client in the format used in the client configuration file. '
+                 'Can be used multiple times.'
+        )
+        self.add_option_group(ssh_group)
 
         auth_group = optparse.OptionGroup(
             self, 'Authentication Options',


### PR DESCRIPTION
### What does this PR do?

Adds a new salt-ssh command line option `--ssh-option` equivalent to the ssh `-o` option. Allows passing arbitrary options to the ssh client in the format used in the configuration file.

### New Behavior
Additional parameters can be passed to the ssh client. 
E.g. salt-ssh via a http proxy with connect support:
```
salt-ssh --ssh-option "ProxyCommand='/usr/bin/nc -X connect -x 192.0.2.0:8080'" foo test.ping
```

### Tests written?

No

