### PR TITLE
Use --all when calling pip.py

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -970,15 +970,40 @@ def freeze(bin_env=None,
     cwd
         Current working directory to run pip from
 
+    .. note::
+
+        If the version of pip available is older than 8.0.3, the list will not
+        include the packages pip, wheel, setuptools, or distribute even if they
+        are installed.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' pip.freeze /home/code/path/to/virtualenv/
+
+    .. versionchanged:: 2016.11.2
+
+        The packages pip, wheel, setuptools, and distribute are included if the
+        installed pip is new enough.
     '''
     pip_bin = _get_pip_bin(bin_env)
 
     cmd = [pip_bin, 'freeze']
+
+    # Include pip, setuptools, distribute, wheel
+    min_version = '8.0.3'
+    cur_version = version(bin_env)
+    if not salt.utils.compare_versions(ver1=cur_version, oper='>=',
+                                       ver2=min_version):
+        logger.warning(
+            ('The version of pip installed is {0}, which is older than {1}. '
+             'The packages pip, wheel, setuptools, and distribute will not be '
+             'included in the output of pip.freeze').format(cur_version,
+                                                            min_version))
+    else:
+        cmd.append('--all')
+
     cmd_kwargs = dict(runas=user, cwd=cwd, use_vt=use_vt, python_shell=False)
     if bin_env and os.path.isdir(bin_env):
         cmd_kwargs['env'] = {'VIRTUAL_ENV': bin_env}
@@ -998,30 +1023,31 @@ def list_(prefix=None,
     Filter list of installed apps from ``freeze`` and check to see if
     ``prefix`` exists in the list of packages installed.
 
+    .. note::
+
+        If the version of pip available is older than 8.0.3, the packages
+        wheel, setuptools, and distribute will not be reported by this function
+        even if they are installed. Unlike
+        :py:func:`pip.freeze <salt.modules.pip.freeze>`, this function always
+        reports the version of pip which is installed.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' pip.list salt
+
+    .. versionchanged:: 2016.11.2
+
+        The packages wheel, setuptools, and distribute are included if the
+        installed pip is new enough.
     '''
     packages = {}
 
-    pip_bin = _get_pip_bin(bin_env)
-
-    cmd = [pip_bin, 'freeze']
-
-    cmd_kwargs = dict(runas=user, cwd=cwd, python_shell=False)
-    if bin_env and os.path.isdir(bin_env):
-        cmd_kwargs['env'] = {'VIRTUAL_ENV': bin_env}
-
-    if not prefix or prefix in ('p', 'pi', 'pip'):
+    if prefix is None or 'pip'.startswith(prefix):
         packages['pip'] = version(bin_env)
 
-    result = __salt__['cmd.run_all'](cmd, **cmd_kwargs)
-    if result['retcode'] > 0:
-        raise CommandExecutionError(result['stderr'])
-
-    for line in result['stdout'].splitlines():
+    for line in freeze(bin_env=bin_env, user=user, cwd=cwd):
         if line.startswith('-f') or line.startswith('#'):
             # ignore -f line as it contains --find-links directory
             # ignore comment lines
@@ -1044,6 +1070,7 @@ def list_(prefix=None,
                 packages[name] = version_
         else:
             packages[name] = version_
+
     return packages
 
 

--- a/tests/unit/modules/pip_test.py
+++ b/tests/unit/modules/pip_test.py
@@ -900,23 +900,66 @@ class PipTestCase(TestCase):
             }
         )
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-            ret = pip.freeze()
-            mock.assert_called_once_with(
-                ['pip', 'freeze'],
-                cwd=None,
-                runas=None,
-                use_vt=False,
-                python_shell=False,
-            )
-            self.assertEqual(ret, eggs)
+            with patch('salt.modules.pip.version',
+                       MagicMock(return_value='6.1.1')):
+                ret = pip.freeze()
+                mock.assert_called_once_with(
+                    ['pip', 'freeze'],
+                    cwd=None,
+                    runas=None,
+                    use_vt=False,
+                    python_shell=False,
+                )
+                self.assertEqual(ret, eggs)
 
         # Non zero returncode raises exception?
         mock = MagicMock(return_value={'retcode': 1, 'stderr': 'CABOOOOMMM!'})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-            self.assertRaises(
-                CommandExecutionError,
-                pip.freeze,
-            )
+            with patch('salt.modules.pip.version',
+                       MagicMock(return_value='6.1.1')):
+                self.assertRaises(
+                    CommandExecutionError,
+                    pip.freeze,
+                )
+
+    def test_freeze_command_with_all(self):
+        eggs = [
+            'M2Crypto==0.21.1',
+            '-e git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8#egg=SaltTesting-dev',
+            'bbfreeze==1.1.0',
+            'bbfreeze-loader==1.1.0',
+            'pip==0.9.1',
+            'pycrypto==2.6',
+            'setuptools==20.10.1'
+        ]
+        mock = MagicMock(
+            return_value={
+                'retcode': 0,
+                'stdout': '\n'.join(eggs)
+            }
+        )
+        with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
+            with patch('salt.modules.pip.version',
+                       MagicMock(return_value='9.0.1')):
+                ret = pip.freeze()
+                mock.assert_called_once_with(
+                    ['pip', 'freeze', '--all'],
+                    cwd=None,
+                    runas=None,
+                    use_vt=False,
+                    python_shell=False,
+                )
+                self.assertEqual(ret, eggs)
+
+        # Non zero returncode raises exception?
+        mock = MagicMock(return_value={'retcode': 1, 'stderr': 'CABOOOOMMM!'})
+        with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
+            with patch('salt.modules.pip.version',
+                       MagicMock(return_value='9.0.1')):
+                self.assertRaises(
+                    CommandExecutionError,
+                    pip.freeze,
+                )
 
     def test_list_command(self):
         eggs = [
@@ -937,6 +980,7 @@ class PipTestCase(TestCase):
                     cwd=None,
                     runas=None,
                     python_shell=False,
+                    use_vt=False,
                 )
                 self.assertEqual(
                     ret, {
@@ -946,6 +990,54 @@ class PipTestCase(TestCase):
                         'bbfreeze': '1.1.0',
                         'pip': mock_version,
                         'pycrypto': '2.6'
+                    }
+                )
+
+        # Non zero returncode raises exception?
+        mock = MagicMock(return_value={'retcode': 1, 'stderr': 'CABOOOOMMM!'})
+        with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
+            with patch('salt.modules.pip.version',
+                       MagicMock(return_value='6.1.1')):
+                self.assertRaises(
+                    CommandExecutionError,
+                    pip.list_,
+                )
+
+    def test_list_command_with_all(self):
+        eggs = [
+            'M2Crypto==0.21.1',
+            '-e git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8#egg=SaltTesting-dev',
+            'bbfreeze==1.1.0',
+            'bbfreeze-loader==1.1.0',
+            'pip==9.0.1',
+            'pycrypto==2.6',
+            'setuptools==20.10.1'
+        ]
+        # N.B.: this is deliberately different from the "output" of pip freeze.
+        # This is to demonstrate that the version reported comes from freeze
+        # instead of from the pip.version function.
+        mock_version = '9.0.0'
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': '\n'.join(eggs)})
+        with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
+            with patch('salt.modules.pip.version',
+                       MagicMock(return_value=mock_version)):
+                ret = pip.list_()
+                mock.assert_called_with(
+                    ['pip', 'freeze', '--all'],
+                    cwd=None,
+                    runas=None,
+                    python_shell=False,
+                    use_vt=False,
+                )
+                self.assertEqual(
+                    ret, {
+                        'SaltTesting-dev': 'git+git@github.com:s0undt3ch/salt-testing.git@9ed81aa2f918d59d3706e56b18f0782d1ea43bf8',
+                        'M2Crypto': '0.21.1',
+                        'bbfreeze-loader': '1.1.0',
+                        'bbfreeze': '1.1.0',
+                        'pip': '9.0.1',
+                        'pycrypto': '2.6',
+                        'setuptools': '20.10.1'
                     }
                 )
 
@@ -974,19 +1066,22 @@ class PipTestCase(TestCase):
             }
         )
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-            ret = pip.list_(prefix='bb')
-            mock.assert_called_with(
-                ['pip', 'freeze'],
-                cwd=None,
-                runas=None,
-                python_shell=False,
-            )
-            self.assertEqual(
-                ret, {
-                    'bbfreeze-loader': '1.1.0',
-                    'bbfreeze': '1.1.0',
-                }
-            )
+            with patch('salt.modules.pip.version',
+                       MagicMock(return_value='6.1.1')):
+                ret = pip.list_(prefix='bb')
+                mock.assert_called_with(
+                    ['pip', 'freeze'],
+                    cwd=None,
+                    runas=None,
+                    python_shell=False,
+                    use_vt=False,
+                )
+                self.assertEqual(
+                    ret, {
+                        'bbfreeze-loader': '1.1.0',
+                        'bbfreeze': '1.1.0',
+                    }
+                )
 
     def test_install_pre_argument_in_resulting_command(self):
         pkg = 'pep8'


### PR DESCRIPTION
### What does this PR do?

This adds the `--all` flag to calls to `pip freeze` when the version of pip is new enough. This causes the output to include pip, setuptools, distribute, and wheel. The `pip.list` function is now implemented in terms of `pip.freeze` in the interest of DRY.

### What issues does this PR fix or reference?

Fixes #38253.

### Previous Behavior
Installing pip, setuptools, distribute, or wheel would succeed with a warning that the installation did not fail, but the module is not listed in the output of pip freeze.

### New Behavior
Installing the mentioned modules succeeds confidently.

### Tests written?

I updated the existing unit tests to mock out the version of pip to an old version and added new tests that mock it out with a new version to cover both cases.
