### PR TITLE
Remove enable/disable funcs from apache_* states

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -132,6 +132,21 @@ Salt-SSH Deprecations
 State Deprecations
 ------------------
 
+The ``apache_conf`` state had the following functions removed:
+
+  - ``disable``: Please use ``disabled`` instead.
+  - ``enable``: Please use ``enabled`` instead.
+
+The ``apache_module`` state had the following functions removed:
+
+  - ``disable``: Please use ``disabled`` instead.
+  - ``enable``: Please use ``enabled`` instead.
+
+The ``apache_site`` state had the following functions removed:
+
+  - ``disable``: Please use ``disabled`` instead.
+  - ``enable``: Please use ``enabled`` instead.
+
 - The ``chocolatey`` state had the following functions removed:
 
   - ``install``: Please use ``installed`` instead.

--- a/salt/states/apache_conf.py
+++ b/salt/states/apache_conf.py
@@ -64,25 +64,6 @@ def enabled(name):
     return ret
 
 
-def enable(name):
-    '''
-    Ensure an Apache conf is enabled.
-
-    .. warning::
-
-        This function is deprecated and will be removed in Salt Nitrogen.
-
-    name
-        Name of the Apache conf
-    '''
-    salt.utils.warn_until(
-        'Nitrogen',
-        'apache_module.enable function has been renamed'
-        ' apache_module.enabled and will be removed in Salt Nitrogen'
-    )
-    return enabled(name)
-
-
 def disabled(name):
     '''
     Ensure an Apache conf is disabled.
@@ -115,22 +96,3 @@ def disabled(name):
     else:
         ret['comment'] = '{0} already disabled.'.format(name)
     return ret
-
-
-def disable(name):
-    '''
-    Ensure an Apache conf is disabled.
-
-    .. warning::
-
-        This function is deprecated and will be removed in Salt Nitrogen.
-
-    name
-        Name of the Apache conf
-    '''
-    salt.utils.warn_until(
-        'Nitrogen',
-        'apache_module.disable function has been renamed'
-        ' apache_module.disabled and will be removed in Salt Nitrogen'
-    )
-    return disabled(name)

--- a/salt/states/apache_module.py
+++ b/salt/states/apache_module.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 # Import salt libs
 from salt.ext.six import string_types
 
+
 def __virtual__():
     '''
     Only load if a2enmod is available.

--- a/salt/states/apache_module.py
+++ b/salt/states/apache_module.py
@@ -68,25 +68,6 @@ def enabled(name):
     return ret
 
 
-def enable(name):
-    '''
-    Ensure an Apache module is enabled. This function is deprecated and will be
-    removed in Salt Nitrogen. Please use the ``enabled`` state function instead.
-
-    .. deprecated:: 2016.3.0
-
-    name
-        Name of the Apache module
-    '''
-    salt.utils.warn_until(
-        'Nitrogen',
-        'This functionality has been deprecated; use "apache_module.enabled" '
-        'instead.'
-    )
-
-    return enabled(name)
-
-
 def disabled(name):
     '''
     Ensure an Apache module is disabled.
@@ -121,21 +102,3 @@ def disabled(name):
     else:
         ret['comment'] = '{0} already disabled.'.format(name)
     return ret
-
-
-def disable(name):
-    '''
-    Ensure an Apache module is disabled.
-
-    .. deprecated:: 2016.3.0
-
-    name
-        Name of the Apache module
-    '''
-    salt.utils.warn_until(
-        'Nitrogen',
-        'This functionality has been deprecated; use "apache_module.disabled" '
-        'instead.'
-    )
-
-    return disabled(name)

--- a/salt/states/apache_module.py
+++ b/salt/states/apache_module.py
@@ -19,11 +19,9 @@ Enable and disable apache modules.
 
 # Import Python libs
 from __future__ import absolute_import
-from salt.ext.six import string_types
 
 # Import salt libs
-import salt.utils
-
+from salt.ext.six import string_types
 
 def __virtual__():
     '''

--- a/salt/states/apache_site.py
+++ b/salt/states/apache_site.py
@@ -17,11 +17,9 @@ Enable and disable apache sites.
         - name: default
 '''
 from __future__ import absolute_import
-from salt.ext.six import string_types
 
 # Import salt libs
-import salt.utils
-
+from salt.ext.six import string_types
 
 def __virtual__():
     '''

--- a/salt/states/apache_site.py
+++ b/salt/states/apache_site.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 # Import salt libs
 from salt.ext.six import string_types
 
+
 def __virtual__():
     '''
     Only load if a2ensite is available.

--- a/salt/states/apache_site.py
+++ b/salt/states/apache_site.py
@@ -64,25 +64,6 @@ def enabled(name):
     return ret
 
 
-def enable(name):
-    '''
-    Ensure an Apache site is enabled.
-
-    .. warning::
-
-        This function is deprecated and will be removed in Salt Nitrogen.
-
-    name
-        Name of the Apache site
-    '''
-    salt.utils.warn_until(
-        'Nitrogen',
-        'apache_module.enable function has been renamed'
-        ' apache_module.enabled and will be removed in Salt Nitrogen'
-    )
-    return enabled(name)
-
-
 def disabled(name):
     '''
     Ensure an Apache site is disabled.
@@ -115,22 +96,3 @@ def disabled(name):
     else:
         ret['comment'] = '{0} already disabled.'.format(name)
     return ret
-
-
-def disable(name):
-    '''
-    Ensure an Apache site is disabled.
-
-    .. warning::
-
-        This function is deprecated and will be removed in Salt Nitrogen.
-
-    name
-        Name of the Apache site
-    '''
-    salt.utils.warn_until(
-        'Nitrogen',
-        'apache_module.disable function has been renamed'
-        ' apache_module.disabled and will be removed in Salt Nitrogen'
-    )
-    return disabled(name)


### PR DESCRIPTION
The apache_*.enable and apache_*.disable state functions are deprecated in favor of apache_*.enabled and apache_*.disabled.