### PR TITLE
Add NM_CONTROLLED to redhat configured interfaces

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -748,6 +748,18 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
     if 'clonenum_start' in opts:
         result['clonenum_start'] = opts['clonenum_start']
 
+    # If NetworkManager is available, we can control whether we use
+    # it or not
+    if 'nm_controlled' in opts:
+        if opts['nm_controlled'] in _CONFIG_TRUE:
+            result['nm_controlled'] = 'yes'
+        elif opts['nm_controlled'] in _CONFIG_FALSE:
+            result['nm_controlled'] = 'no'
+        else:
+            _raise_error_iface(iface, opts['nm_controlled'], valid)
+    else:
+        result['nm_controlled'] = 'no'
+
     return result
 
 

--- a/salt/templates/rh_ip/rh7_eth.jinja
+++ b/salt/templates/rh_ip/rh7_eth.jinja
@@ -41,6 +41,7 @@ DEVICE="{{name}}"
 {%endif%}{% if bonding %}BONDING_OPTS="{%for item in bonding %}{{item}}={{bonding[item]}} {%endfor%}"
 {%endif%}{% if ethtool %}ETHTOOL_OPTS="{%for item in ethtool %}{{item}} {{ethtool[item]}} {%endfor%}"
 {%endif%}{% if domain %}DOMAIN="{{ domain|join(' ') }}"
+{%endif%}{% if nm_controlled %}NM_CONTROLLED="{{nm_controlled}}"
 {% endif %}{% for server in dns -%}
 DNS{{loop.index}}="{{server}}"
 {% endfor -%}


### PR DESCRIPTION
Some network interfaces (like openvswitch ports) are not backed by
physical devices, and NetworkManager barfs:

Error: Connection activation failed: No suitable device found for this
connection.

Preventing NetworkManager control to such a device will pass the control
to the other configuration tools, which operate 'ip' commands directly,
which do not suffer from this limitation.

### What does this PR do?
Allows the user to set NM_CONTROLLED=(yes|no) in redhat ifcfg scripts.

### What issues does this PR fix or reference?

### Previous Behavior
When trying to manage a virtual interface (like an openvswitch internal port) NetworkManager would error with the message:
Error: Connection activation failed: No suitable device found for this connection.

### New Behavior
Now I can control NM_CONTROLLED in the ifcfg script, which will let me bypass NetworkManager, and configure the interface with the network shell script tools that call 'ip' directly.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
