### PR TITLE
Allow the creation of an internal interface for an openvswitch port

### DIFF
--- a/salt/modules/openvswitch.py
+++ b/salt/modules/openvswitch.py
@@ -335,7 +335,7 @@ def interface_get_type(port):
     return _stdout_list_split(retcode, stdout)
 
 
-def port_create_vlan(br, port, id):
+def port_create_vlan(br, port, id, internal):
     '''
     Isolate VM traffic using VLANs.
 
@@ -343,6 +343,7 @@ def port_create_vlan(br, port, id):
         br: A string - bridge name.
         port: A string - port name.
         id: An integer in the valid range 0 to 4095 (inclusive), name of VLAN.
+        internal: A boolean to create an internal interface if one does not exist.
 
     Returns:
         True on success, else False.
@@ -359,14 +360,18 @@ def port_create_vlan(br, port, id):
         return False
     elif not bridge_exists(br):
         return False
-    elif port not in interfaces:
+    elif not internal and port not in interfaces:
         return False
     elif port in port_list(br):
         cmd = 'ovs-vsctl set port {0} tag={1}'.format(port, id)
+    if internal:
+        cmd += ' -- set interface {0} type=internal'.format(port)
         result = __salt__['cmd.run_all'](cmd)
         return _retcode_to_bool(result['retcode'])
     else:
         cmd = 'ovs-vsctl add-port {0} {1} tag={2}'.format(br, port, id)
+    if internal:
+        cmd += ' -- set interface {0} type=internal'.format(port)
         result = __salt__['cmd.run_all'](cmd)
         return _retcode_to_bool(result['retcode'])
 

--- a/salt/states/openvswitch_port.py
+++ b/salt/states/openvswitch_port.py
@@ -11,7 +11,7 @@ def __virtual__():
     return 'openvswitch.port_add' in __salt__
 
 
-def present(name, bridge, type=None, id=None, remote=None, dst_port=None):
+def present(name, bridge, type=None, id=None, remote=None, dst_port=None, internal=False):
     '''
     Ensures that the named port exists on bridge, eventually creates it.
 
@@ -22,6 +22,7 @@ def present(name, bridge, type=None, id=None, remote=None, dst_port=None):
         id: Optional tunnel's key.
         remote: Remote endpoint's IP address.
         dst_port: Port to use when creating tunnelport in the switch.
+        internal: Create an internal port if one does not exist
 
     '''
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
@@ -95,7 +96,7 @@ def present(name, bridge, type=None, id=None, remote=None, dst_port=None):
         if not 0 <= id <= 4095:
             ret['result'] = False
             ret['comment'] = comment_vlan_invalid_id
-        elif name not in interfaces:
+        elif not internal and name not in interfaces:
             ret['result'] = False
             ret['comment'] = comment_vlan_invalid_name
         elif tag and name in port_list:
@@ -180,7 +181,7 @@ def present(name, bridge, type=None, id=None, remote=None, dst_port=None):
         if type == 'vlan':
             _check_vlan()
             if not ret['comment']:
-                port_create_vlan = __salt__['openvswitch.port_create_vlan'](bridge, name, id)
+                port_create_vlan = __salt__['openvswitch.port_create_vlan'](bridge, name, id, internal)
                 if port_create_vlan:
                     ret['result'] = True
                     ret['comment'] = comment_vlan_created


### PR DESCRIPTION
Openvswitch can create a virtual nic instead of only allowing existing
interfaces to be added. Once this virtual nic is created, it can be
managed by network.manage.

This patch allows me to configure a gre-tunnel private virtual network
for all my VMs, and then insert my host machine into that network.

br0:
  openvswitch_bridge.present

port0:
  openvswitch_port.present:
    - bridge: br0
    - type: vlan
    - id: 100
    - internal: true
  network.managed:
    - enabled: true
    - type: eth
    - ipaddr: 192.168.55.1
    - netmask: 255.255.255.0

### What does this PR do?
Allows the port state to indicate that the port should be an internal port, if the port does not already exist. This would do nothing if 'port0' existed, like you might expect 'eth0' to already exist.

### What issues does this PR fix or reference?

### Previous Behavior
The port would fail to get created. Consider the sls above, but with out the '- internal: true' line. The sls returns:
practice-host:
----------
          ID: br0
    Function: openvswitch_bridge.present
      Result: True
     Comment: Bridge br0 created.
     Started: 17:01:38.463410
    Duration: 17.747 ms
     Changes:   
              ----------
              br0:
                  ----------
                  new:
                      Bridge br0 created
                  old:
                      Bridge br0 does not exist.
----------
          ID: port0
    Function: openvswitch_port.present
      Result: False
     Comment: Could not find network interface port0.
     Started: 17:01:38.481702
    Duration: 28.945 ms
     Changes:   
----------
          ID: port0
    Function: network.managed
      Result: True
     Comment: Interface port0 added.
     Started: 17:01:38.514256
    Duration: 385.346 ms
     Changes:   
              ----------
              interface:
                  Added network interface.
              status:
                  Interface port0 is up

Summary for practice-host
------------
Succeeded: 2 (changed=2)
Failed:    1
------------
Total states run:     3
Total run time: 432.038 ms


### New Behavior
With out the 'internal' option set, the behavior is the same. With internal set to true, we succeed:

[kai.meyer@practice-host ~]$ sudo salt 'practice-host' state.apply                                                                                                                                                                                                                              
practice-host:
----------
          ID: br0
    Function: openvswitch_bridge.present
      Result: True
     Comment: Bridge br0 created.
     Started: 17:03:54.682920
    Duration: 18.03 ms
     Changes:   
              ----------
              br0:
                  ----------
                  new:
                      Bridge br0 created
                  old:
                      Bridge br0 does not exist.
----------
          ID: port0
    Function: openvswitch_port.present
      Result: True
     Comment: Created port port0 with access to VLAN 100 on bridge br0.
     Started: 17:03:54.701471
    Duration: 59.815 ms
     Changes:   
              ----------
              port0:
                  ----------
                  new:
                      Created port port0 with access to VLAN 100 on bridge br0.
                  old:
                      No port named port0 with access to VLAN 100 present on bridge br0 present.
----------
          ID: port0
    Function: network.managed
      Result: True
     Comment: Interface port0 added.
     Started: 17:03:54.765262
    Duration: 2722.269 ms
     Changes:   
              ----------
              interface:
                  Added network interface.
              status:
                  Interface port0 is up

Summary for practice-host
------------
Succeeded: 3 (changed=3)
Failed:    0
------------
Total states run:     3
Total run time:   2.800 s
[kai.meyer@practice-host ~]$ ip a s port0
60: port0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN 
    link/ether 7a:25:c2:a3:dd:d5 brd ff:ff:ff:ff:ff:ff
    inet 192.168.55.1/24 brd 192.168.55.255 scope global port0
       valid_lft forever preferred_lft forever
    inet6 fe80::7825:c2ff:fea3:ddd5/64 scope link 
       valid_lft forever preferred_lft forever


### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
