### PR TITLE
Remove use_pending and pending_tags from salt.utils.event.get_event function

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -87,6 +87,10 @@ General Deprecations
 
 - Beacon configurations should be lists instead of dictionaries.
 - The ``PidfileMixin`` has been removed. Please use ``DaemonMixIn`` instead.
+- The ``use_pending`` argument was removed from the ``salt.utils.event.get_event``
+  function.
+- The ``pending_tags`` argument was removed from the ``salt.utils.event.get_event``
+  function.
 
 Configuration Option Deprecations
 ---------------------------------

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -569,8 +569,6 @@ class SaltEvent(object):
                   wait=5,
                   tag='',
                   full=False,
-                  use_pending=None,
-                  pending_tags=None,
                   match_type=None,
                   no_block=False,
                   auto_reconnect=False):
@@ -620,18 +618,6 @@ class SaltEvent(object):
         '''
         assert self._run_io_loop_sync
 
-        if use_pending is not None:
-            salt.utils.warn_until(
-                'Nitrogen',
-                'The \'use_pending\' keyword argument is deprecated and is simply ignored. '
-                'Please stop using it since it\'s support will be removed in {version}.'
-            )
-        if pending_tags is not None:
-            salt.utils.warn_until(
-                'Nitrogen',
-                'The \'pending_tags\' keyword argument is deprecated and is simply ignored. '
-                'Please stop using it since it\'s support will be removed in {version}.'
-            )
         match_func = self._get_match_func(match_type)
 
         ret = self._check_pending(tag, match_func)


### PR DESCRIPTION
These were marked for removal in Nitrogen, and were ignored in the function itself. There were no other uses of these arguments with this function in the salt codebase.