### PR TITLE
Fix http.query when result has no text

### DIFF
--- a/salt/states/http.py
+++ b/salt/states/http.py
@@ -93,7 +93,7 @@ def query(name, match=None, match_type='string', status=None, **kwargs):
                 ret['result'] = False
                 ret['comment'] += ' Match text "{0}" was not found.'.format(match)
         elif match_type == 'pcre':
-            if re.search(match, data['text']):
+            if re.search(match, data.get('text', '')):
                 ret['result'] = True
                 ret['comment'] += ' Match pattern "{0}" was found.'.format(match)
             else:


### PR DESCRIPTION
This PR handles a case where an `http.query` state results in an error, and doesn't have the `text` field populated in the results from the `http.query` module call, but when using `match_type: pcre` the code expects it there and throws an exception.

This mirrors the behavior of `match_type: string` (default) on line 89 of this file.