### PR TITLE
Fixing white space issue with cmd, and making internal default to False

### DIFF
--- a/salt/modules/openvswitch.py
+++ b/salt/modules/openvswitch.py
@@ -335,7 +335,7 @@ def interface_get_type(port):
     return _stdout_list_split(retcode, stdout)
 
 
-def port_create_vlan(br, port, id, internal):
+def port_create_vlan(br, port, id, internal=False):
     '''
     Isolate VM traffic using VLANs.
 
@@ -364,14 +364,14 @@ def port_create_vlan(br, port, id, internal):
         return False
     elif port in port_list(br):
         cmd = 'ovs-vsctl set port {0} tag={1}'.format(port, id)
-    if internal:
-        cmd += ' -- set interface {0} type=internal'.format(port)
+        if internal:
+            cmd += ' -- set interface {0} type=internal'.format(port)
         result = __salt__['cmd.run_all'](cmd)
         return _retcode_to_bool(result['retcode'])
     else:
         cmd = 'ovs-vsctl add-port {0} {1} tag={2}'.format(br, port, id)
-    if internal:
-        cmd += ' -- set interface {0} type=internal'.format(port)
+        if internal:
+            cmd += ' -- set interface {0} type=internal'.format(port)
         result = __salt__['cmd.run_all'](cmd)
         return _retcode_to_bool(result['retcode'])
 


### PR DESCRIPTION
### What does this PR do?
Fixes a whitespace typo, and makes the internal parameter optional ( default to False).
### What issues does this PR fix or reference?
#38363 
### Previous Behavior
New internal parameter was required, and typo caused openvswitch module to fail.

### New Behavior
New internal parameter is optional, and typo is fixed.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
