### PR TITLE
Use unambigous long names with double dashes

### DIFF
--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -328,6 +328,7 @@ def list_windowsfeatures():
 
     return result['stdout']
 
+
 def install(name,
             version=None,
             source=None,

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -106,7 +106,7 @@ def chocolatey_version():
         return __context__['chocolatey._version']
 
     cmd = [_find_chocolatey(__context__, __salt__)]
-    cmd.append('-v')
+    cmd.append('--version')
     out = __salt__['cmd.run'](cmd, python_shell=False)
     __context__['chocolatey._version'] = out
 
@@ -248,11 +248,11 @@ def list_(narrow=None,
     if narrow:
         cmd.append(narrow)
     if salt.utils.is_true(all_versions):
-        cmd.append('-allversions')
+        cmd.append('--allversions')
     if salt.utils.is_true(pre_versions):
-        cmd.append('-prerelease')
+        cmd.append('--prerelease')
     if source:
-        cmd.extend(['-source', source])
+        cmd.extend(['--source', source])
     if local_only:
         cmd.extend(['-localonly'])
         cmd.extend(['-limitoutput'])
@@ -292,7 +292,7 @@ def list_webpi():
         salt '*' chocolatey.list_webpi
     '''
     choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'list', '-source', 'webpi']
+    cmd = [choc_path, 'list', '--source', 'webpi']
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if result['retcode'] != 0:
@@ -318,7 +318,7 @@ def list_windowsfeatures():
         salt '*' chocolatey.list_windowsfeatures
     '''
     choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'list', '-source', 'windowsfeatures']
+    cmd = [choc_path, 'list', '--source', 'windowsfeatures']
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if result['retcode'] != 0:
@@ -327,7 +327,6 @@ def list_windowsfeatures():
         raise CommandExecutionError(err)
 
     return result['stdout']
-
 
 def install(name,
             version=None,
@@ -398,23 +397,25 @@ def install(name,
     '''
     choc_path = _find_chocolatey(__context__, __salt__)
     # chocolatey helpfully only supports a single package argument
+    # CORRECTION: it also supports multiple package names separated by spaces
+    # but any additional arguments apply to ALL packages specified
     cmd = [choc_path, 'install', name]
     if version:
-        cmd.extend(['-version', version])
+        cmd.extend(['--version', version])
     if source:
-        cmd.extend(['-source', source])
+        cmd.extend(['--source', source])
     if salt.utils.is_true(force):
-        cmd.append('-force')
+        cmd.append('--force')
     if salt.utils.is_true(pre_versions):
-        cmd.append('-prerelease')
+        cmd.append('--prerelease')
     if install_args:
-        cmd.extend(['-installarguments', install_args])
+        cmd.extend(['--installarguments', install_args])
     if override_args:
-        cmd.append('-overridearguments')
+        cmd.append('--overridearguments')
     if force_x86:
-        cmd.append('-forcex86')
+        cmd.append('--forcex86')
     if package_args:
-        cmd.extend(['-packageparameters', package_args])
+        cmd.extend(['--packageparameters', package_args])
     cmd.extend(_yes(__context__))
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
@@ -530,9 +531,9 @@ def install_missing(name, version=None, source=None):
     # chocolatey helpfully only supports a single package argument
     cmd = [choc_path, 'installmissing', name]
     if version:
-        cmd.extend(['-version', version])
+        cmd.extend(['--version', version])
     if source:
-        cmd.extend(['-source', source])
+        cmd.extend(['--source', source])
     # Shouldn't need this as this code should never run on v0.9.9 and newer
     cmd.extend(_yes(__context__))
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
@@ -658,11 +659,11 @@ def uninstall(name, version=None, uninstall_args=None, override_args=False):
     # chocolatey helpfully only supports a single package argument
     cmd = [choc_path, 'uninstall', name]
     if version:
-        cmd.extend(['-version', version])
+        cmd.extend(['--version', version])
     if uninstall_args:
-        cmd.extend(['-uninstallarguments', uninstall_args])
+        cmd.extend(['--uninstallarguments', uninstall_args])
     if override_args:
-        cmd.extend(['-overridearguments'])
+        cmd.extend(['--overridearguments'])
     cmd.extend(_yes(__context__))
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
@@ -741,19 +742,19 @@ def upgrade(name,
     if version:
         cmd.extend(['-version', version])
     if source:
-        cmd.extend(['-source', source])
+        cmd.extend(['--source', source])
     if salt.utils.is_true(force):
-        cmd.append('-force')
+        cmd.append('--force')
     if salt.utils.is_true(pre_versions):
-        cmd.append('-prerelease')
+        cmd.append('--prerelease')
     if install_args:
-        cmd.extend(['-installarguments', install_args])
+        cmd.extend(['--installarguments', install_args])
     if override_args:
-        cmd.append('-overridearguments')
+        cmd.append('--overridearguments')
     if force_x86:
-        cmd.append('-forcex86')
+        cmd.append('--forcex86')
     if package_args:
-        cmd.extend(['-packageparameters', package_args])
+        cmd.extend(['--packageparameters', package_args])
     cmd.extend(_yes(__context__))
 
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
@@ -796,9 +797,9 @@ def update(name, source=None, pre_versions=False):
 
     cmd = [choc_path, 'update', name]
     if source:
-        cmd.extend(['-source', source])
+        cmd.extend(['--source', source])
     if salt.utils.is_true(pre_versions):
-        cmd.append('-prerelease')
+        cmd.append('--prerelease')
     cmd.extend(_yes(__context__))
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
@@ -844,11 +845,11 @@ def version(name, check_remote=False, source=None, pre_versions=False):
 
     cmd = [choc_path, 'list', name]
     if not salt.utils.is_true(check_remote):
-        cmd.append('-localonly')
+        cmd.append('--localonly')
     if salt.utils.is_true(pre_versions):
-        cmd.append('-prerelease')
+        cmd.append('--prerelease')
     if source:
-        cmd.extend(['-source', source])
+        cmd.extend(['--source', source])
 
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
@@ -861,7 +862,7 @@ def version(name, check_remote=False, source=None, pre_versions=False):
 
     res = result['stdout'].split('\n')
 
-    ver_re = re.compile(r'(\S+)\s+(.+)')
+    ver_re = re.compile(r'(\S+)\|(.+)')
     for line in res:
         if 'packages found' not in line and 'packages installed' not in line:
             for name, ver in ver_re.findall(line):
@@ -896,11 +897,11 @@ def add_source(name, source_location, username=None, password=None):
 
     '''
     choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'sources', 'add', '-name', name, "-source", source_location]
+    cmd = [choc_path, 'sources', 'add', '-name', name, "--source", source_location]
     if username:
-        cmd.extend(['-u', username])
+        cmd.extend(['--user', username])
     if password:
-        cmd.extend(['-p', password])
+        cmd.extend(['--password', password])
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if result['retcode'] != 0:
@@ -923,7 +924,7 @@ def _change_source_state(name, state):
 
     '''
     choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'source', state, "-name", name]
+    cmd = [choc_path, 'source', state, "--name", name]
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if result['retcode'] != 0:

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -106,7 +106,7 @@ def chocolatey_version():
         return __context__['chocolatey._version']
 
     cmd = [_find_chocolatey(__context__, __salt__)]
-    cmd.append('--version')
+    cmd.append('-v')
     out = __salt__['cmd.run'](cmd, python_shell=False)
     __context__['chocolatey._version'] = out
 
@@ -254,8 +254,8 @@ def list_(narrow=None,
     if source:
         cmd.extend(['--source', source])
     if local_only:
-        cmd.extend(['-localonly'])
-        cmd.extend(['-limitoutput'])
+        cmd.extend(['--localonly'])
+        cmd.extend(['--limitoutput'])
 
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
@@ -897,7 +897,7 @@ def add_source(name, source_location, username=None, password=None):
 
     '''
     choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'sources', 'add', '-name', name, "--source", source_location]
+    cmd = [choc_path, 'sources', 'add', '--name', name, '--source', source_location]
     if username:
         cmd.extend(['--user', username])
     if password:
@@ -924,7 +924,7 @@ def _change_source_state(name, state):
 
     '''
     choc_path = _find_chocolatey(__context__, __salt__)
-    cmd = [choc_path, 'source', state, "--name", name]
+    cmd = [choc_path, 'source', state, '--name', name]
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if result['retcode'] != 0:


### PR DESCRIPTION
### What does this PR do?
Resolves some warnings being thrown about unknown/unbundled parameters. Chocolatey convention is to use a single dash and single character OR double dash and words, previously these were being mixed this takes care of those cases.

### What issues does this PR fix or reference?
I decided not to file an issue since it was an easy fix. :)

### Previous Behavior
Warnings like below:
```
Parsing -Version resulted in error (converted to warning):
 Cannot bundle unregistered option '-e'.
```

### New Behavior
Hopefully no more warnings

### Tests written?
No tests as this isn't a functional change beyond extending the name|version matching from an already accepted PR.