### PR TITLE
Add "try-restart" to fix autorestarting on SUSE systems

### DIFF
--- a/pkg/rpm/salt-api
+++ b/pkg/rpm/salt-api
@@ -139,7 +139,7 @@ case "$1" in
             RETVAL=$?
         fi
         ;;
-    condrestart)
+    condrestart|try-restart)
         [ -f $LOCKFILE ] && restart || :
         ;;
     reload)
@@ -147,7 +147,7 @@ case "$1" in
         RETVAL=1
         ;;
     *)
-        echo $"Usage: $0 {start|stop|status|restart|condrestart|reload}"
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload}"
         exit 1
         ;;
 esac

--- a/pkg/suse/salt-master
+++ b/pkg/suse/salt-master
@@ -122,7 +122,7 @@ case "$1" in
             RETVAL=$?
         fi
         ;;
-    condrestart)
+    condrestart|try-restart)
         [ -f $LOCKFILE ] && restart || :
         ;;
     reload)
@@ -130,7 +130,7 @@ case "$1" in
         RETVAL=1
         ;;
     *)
-        echo $"Usage: $0 {start|stop|status|restart|condrestart|reload}"
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload}"
         exit 1
         ;;
 esac

--- a/pkg/suse/salt-minion
+++ b/pkg/suse/salt-minion
@@ -129,7 +129,7 @@ case "$1" in
             RETVAL=$?
         fi
         ;;
-    condrestart)
+    condrestart|try-restart)
         [ -f $LOCKFILE ] && restart || :
         ;;
     reload)
@@ -137,7 +137,7 @@ case "$1" in
         RETVAL=1
         ;;
     *)
-        echo $"Usage: $0 {start|stop|status|restart|condrestart|reload}"
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload}"
         exit 1
         ;;
 esac

--- a/pkg/suse/salt-syndic
+++ b/pkg/suse/salt-syndic
@@ -123,7 +123,7 @@ case "$1" in
             RETVAL=$?
         fi
         ;;
-    condrestart)
+    condrestart|try-restart)
         [ -f $LOCKFILE ] && restart || :
         ;;
     reload)
@@ -131,7 +131,7 @@ case "$1" in
         RETVAL=$?
         ;;
     *)
-        echo $"Usage: $0 {start|stop|status|restart|condrestart|reload}"
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload}"
         exit 1
         ;;
 esac


### PR DESCRIPTION
### What does this PR do?
This PR adds some missing `try-restart` support in the salt SysV init scripts to fix autorestarting during salt package upgrade on SUSE systems.

### Previous Behavior
On SUSE systems with SysV, upgrading salt packages won't restart current running salt services because `try-restart` call is not supported by the current SUSE SysV init scripts.

### New Behavior
The salt services will be restarted after the salt package upgrading.

### Tests written?
No

/cc @mcalmer 