### PR TITLE
How about using RxPy (Reactive Programming) in Salt?

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,7 @@ msgpack-python>0.3
 PyYAML
 MarkupSafe
 requests>=1.0.0
+rx
 tornado>=4.2.1
 # Required by Tornado to handle threads stuff.
 futures>=2.0


### PR DESCRIPTION
### What does this PR do?

I have resolved several asynchronous issues on Salt Stack, and I realize that how asynchronous programming is hard, tricky, and difficult to maintain. I'm pretty sure that commiters know about the various asynchronous and concurrent programming issues in Salt better than me.

There is a concept (or programming style, or programming principle for the asynchronous programming) for the asynchronous programming and the name of it is [Reactive Programming](http://reactivex.io). The concept helps to build concurrent programs (especially, the aspect of asynchronous programming) more straightforward, and to raise the abstract level of concurrent programming. Juggling future objects, handling callback functions increase the complexity of the program and I think those sometimes cause significant bugs. The Reactive Programming is extremely effective for the systems which have many I/O waitings. (check out the following [article](https://www.lightbend.com/blog/how-reactive-systems-help-paypal-squbs-scale-to-billions-of-transactions-daily), I think the following article is little bit bluffing, but I agree that bunch of I/O waitings could be managed more effectively by using Reactive Programming.)

I think Salt Stack is a perfectly fit to accept the concept. Salt is event-driven, and aims to get high concurrency by using Tornado, and has very complex concurrent/asynchronous programming logics. There is [a major library](https://github.com/ReactiveX/RxPY) that supports Reactive Programming in Python and also the library supports Tornado. In my opinion, the library RxPY is the best choice among what we can choose, but if there are other options, let's discuss about the libraries (or frameworks).

I know that accepting the Reactive Programming concept right now for the entire Salt code is very hard and risky. Thus, I want to suggest that how about trying to apply for the small parts first very experimentally, and after reviewing the experimental small piece of code, expanding the concept incrementally to entire Salt.

As a pilot case, I refactorized tornado version of Salt API using RxPy. There are improvements of code readability and more straightforward logics than handling future objects. I suggest that look carefully following changes. [`EventListener`](https://github.com/saltstack/salt/blob/develop/salt/netapi/rest_tornado/saltnado.py#L286) is changed into [`EventSubject`](https://github.com/kstreee/salt/blob/rxpy/salt/netapi/rest_tornado/saltnado.py#L282). The logic of `_disbatch_local` and `_disbatch_local_batch` is changed more declaratively, and I believe that the new way to handle asynchronous logics is much more straightforward than the former way that juggling futures. The existed logic was really hard to understand, but the refactorized logic is easier to understand for people who knows the concept and patterns of RxPy.

I can't 100% sure that the refactorized code work exactly same in comparing to the vanilla `rest_tornado`, but I did my best, and passed all test cases. But, there are several works to be done to use this commit in the main branch, for example, [`saltnado_websockets`](https://github.com/kstreee/salt/blob/rxpy/salt/netapi/rest_tornado/saltnado_websockets.py) should be changed to use RxPy because the object [`event_listener`](https://github.com/kstreee/salt/blob/rxpy/salt/netapi/rest_tornado/saltnado_websockets.py#L356) is deprecated. But before fixing and working further than now, I want to discuss this issue with Salt community people.

I strongly recommend reading several articles about the concept of Rx (Reactive Programming) after that, take some time to think about the Rx and asynchronous programming. In my opinion, it could be a next big thing in our industry. Moreover, the major frameworks, which really care about performances, have a plan to use the concept of Reactive Programming, ([Spring](https://spring.io/blog/2016/02/09/reactive-spring), [Akka Stream](http://doc.akka.io/docs/akka/2.4.3/scala/stream/index.html), ..). Following articles could help to understand the paradigm.
[The introduction to Reactive Programming you've been missing](https://gist.github.com/staltz/868e7e9bc2a7b8c1f754)
[ReactiveX Introduction](http://reactivex.io/intro.html)
[Your Mouse is a Database](http://queue.acm.org/detail.cfm?id=2169076)
[Reactive Programming in the Netflix API with RxJava](http://techblog.netflix.com/2013/02/rxjava-netflix-api.html)

Please don't hesitate to discuss this issue and ask questions about this issue and Rx. I'm also not a very expert of those, but I will do my best. If you guys agree with this opinion, I am very pleasure to make an issue to track folloiwng issues of applying the concept Reactive Programming to Salt. Thank you for your reading.


#### Python Version Issues
RxPy [officially supports Python 2.7, 3.5, IronPyhton](https://github.com/ReactiveX/RxPY#install), but it works well on Pyhton 2.6.
Only we have to concern is that scheduler. Some of scheduler in RxPy doesn't support Python 2.6, (there are several schedulers which are using timedelta.total_seconds(), which is only available from Pyhton 2.7). But, we already are using IOLoop of Torando, and [RxPy supports the IOLoop for the scheduler of RxPy](https://github.com/ReactiveX/RxPY#schedulers). Thus, we don't have problems with this, and I think, even we can contribute to RxPy to support Python 2.6 by changing the function which is using the function `total_seconds()`.

### What issues does this PR fix or reference?
Nothing.

### Tests written?
Yes