### PR TITLE
Let IOLoop run other tasks between connection attempts

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -536,6 +536,10 @@ class MinionBase(object):
                 opts['master_uri_list'].append(resolve_dns(opts)['master_uri'])
 
             while True:
+                if attempts != 0:
+                    # Give up a little time between connection attempts
+                    # to allow the IOLoop to run any other scheduled tasks.
+                    yield tornado.gen.sleep(1)
                 attempts += 1
                 if tries > 0:
                     log.debug('Connecting to master. Attempt {0} '
@@ -597,6 +601,10 @@ class MinionBase(object):
             if opts['random_master']:
                 log.warning('random_master is True but there is only one master specified. Ignoring.')
             while True:
+                if attempts != 0:
+                    # Give up a little time between connection attempts
+                    # to allow the IOLoop to run any other scheduled tasks.
+                    yield tornado.gen.sleep(1)
                 attempts += 1
                 if tries > 0:
                     log.debug('Connecting to master. Attempt {0} '


### PR DESCRIPTION
### What does this PR do?

Between connection attempts, sleep for a small duration to allow
the IOLoop to run any other scheduled tasks in the case when the
system is configured for multiple or infinite connection attempts. An
example of when this is useful is when the connection failure is due
to DNS lookup, and in such a case the IOLoop will never get a chance
to run any other scheduled tasks. If we hope to run other tasks (such
as when `beacons_before_connect` or `scheduler_before_connect` is
`True`), this will give the IOLoop the opportunity to do so.

### Tests written?

No