### PR TITLE
Fix exception when `event.fire_master` used without connection

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2001,8 +2001,9 @@ class Minion(MinionBase):
         elif tag.startswith('_minion_mine'):
             self._mine_send(tag, data)
         elif tag.startswith('fire_master'):
-            log.debug('Forwarding master event tag={tag}'.format(tag=data['tag']))
-            self._fire_master(data['data'], data['tag'], data['events'], data['pretag'])
+            if self.connected:
+                log.debug('Forwarding master event tag={tag}'.format(tag=data['tag']))
+                self._fire_master(data['data'], data['tag'], data['events'], data['pretag'])
         elif tag.startswith('__schedule_return'):
             # reporting current connection with master
             if data['schedule'].startswith(master_event(type='alive', master='')):


### PR DESCRIPTION
### What does this PR do?

When `event.fire_master` is invoked (via beacon, module, etc) and
there is no connection to the master (eg `'master_type': 'disable'`,
`beacons_before_connect`, etc), an exception is invoked. Prevent
the exception from occurring.

### Tests written?

No