### PR TITLE
Allow use of globs with cloud cache roster

### DIFF
--- a/salt/roster/cloud.py
+++ b/salt/roster/cloud.py
@@ -42,76 +42,56 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
     '''
     ret = {}
 
-    cache = os.path.join(syspaths.CACHE_DIR, 'cloud', 'index.p')
-
-    if not os.path.exists(cache):
-        return {}
-
-    with salt.utils.fopen(cache, 'r') as fh_:
-        cache_data = msgpack.load(fh_)
-
-    indexed_minion = cache_data.get(tgt, None)
-
-    if indexed_minion is None:
-        return {}
-
-    client = salt.cloud.CloudClient(
-            os.path.join(os.path.dirname(__opts__['conf_file']), 'cloud')
-            )
-    info = client.action('show_instance', names=[tgt])
-    if not info:
-        return {}
-
-    provider = indexed_minion.get('provider', None)
-    profile = indexed_minion.get('profile', None)
-    driver = indexed_minion.get('driver', None)
-    vm_ = {
-        'provider': provider,
-        'profile': profile,
-    }
-
-    full_info = info.get(provider, {}).get(driver, {}).get(tgt, {}).get(tgt, {})
-    public_ips = full_info.get('public_ips', [])
-    private_ips = full_info.get('private_ips', [])
-    ip_list = []
-    for item in (public_ips, private_ips):
-        if isinstance(item, list):
-            ip_list = ip_list + item
-        elif isinstance(item, string_types):
-            ip_list.append(item)
-
-    roster_order = __opts__.get('roster_order', (
-        'public', 'private', 'local'
-    ))
-    preferred_ip = extract_ipv4(roster_order, ip_list)
-
-    ret['tgt'] = __opts__.get('roster_defaults', {})
-    ret['tgt'].update({'host': preferred_ip})
-
     cloud_opts = salt.config.cloud_config('/etc/salt/cloud')
-    ssh_username = salt.utils.cloud.ssh_usernames({}, cloud_opts)
-    if isinstance(ssh_username, string_types):
-        ret['tgt']['user'] = ssh_username
-    elif isinstance(ssh_username, list):
-        ret['tgt']['user'] = ssh_username[0]
 
-    password = salt.config.get_cloud_config_value(
-        'password', vm_, cloud_opts, search_global=False, default=None
-    )
-    if password:
-        ret['tgt']['password'] = password
+    minions = __runners__['cache.cloud'](tgt)
+    for minion_id, full_info in minions.items():
+        profile, provider = full_info.get('profile', None), full_info.get('provider', None)
+        vm_ = {
+            'provider': provider,
+            'profile': profile,
+        }
+        public_ips = full_info.get('public_ips', [])
+        private_ips = full_info.get('private_ips', [])
+        ip_list = []
+        for item in (public_ips, private_ips):
+            if isinstance(item, list):
+                ip_list = ip_list + item
+            elif isinstance(item, string_types):
+                ip_list.append(item)
 
-    key_filename = salt.config.get_cloud_config_value(
-        'private_key', vm_, cloud_opts, search_global=False, default=None
-    )
-    if key_filename:
-        ret['tgt']['priv'] = key_filename
+        roster_order = __opts__.get('roster_order', (
+            'public', 'private', 'local'
+        ))
+        preferred_ip = extract_ipv4(roster_order, ip_list)
 
-    sudo = salt.config.get_cloud_config_value(
-        'sudo', vm_, cloud_opts, search_global=False, default=None
-    )
-    if sudo:
-        ret['tgt']['sudo'] = sudo
+        ret[minion_id] = __opts__.get('roster_defaults', {})
+        ret[minion_id].update({'host': preferred_ip})
+
+        ssh_username = salt.utils.cloud.ssh_usernames({}, cloud_opts)
+        if isinstance(ssh_username, string_types):
+            ret[minion_id]['user'] = ssh_username
+        elif isinstance(ssh_username, list):
+            if ssh_username[0] != 'root':
+                ret[minion_id]['user'] = ssh_username[0]
+
+        password = salt.config.get_cloud_config_value(
+            'ssh_password', vm_, cloud_opts, search_global=False, default=None
+        )
+        if password:
+            ret[minion_id]['password'] = password
+
+        key_filename = salt.config.get_cloud_config_value(
+            'private_key', vm_, cloud_opts, search_global=False, default=None
+        )
+        if key_filename:
+            ret[minion_id]['priv'] = key_filename
+
+        sudo = salt.config.get_cloud_config_value(
+            'sudo', vm_, cloud_opts, search_global=False, default=None
+        )
+        if sudo:
+            ret[minion_id]['sudo'] = sudo
 
     return ret
 

--- a/salt/roster/cloud.py
+++ b/salt/roster/cloud.py
@@ -20,10 +20,6 @@ usually located at /etc/salt/cloud. For example, add the following:
 
 # Import python libs
 from __future__ import absolute_import
-import os.path
-
-# Import 3rd-party libs
-import msgpack
 
 # Import Salt libs
 import salt.loader
@@ -31,7 +27,6 @@ import salt.utils
 import salt.utils.cloud
 import salt.utils.validate.net
 import salt.config
-from salt import syspaths
 from salt.ext.six import string_types
 
 
@@ -44,7 +39,7 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
 
     cloud_opts = salt.config.cloud_config('/etc/salt/cloud')
 
-    minions = __runners__['cache.cloud'](tgt)
+    minions = __runner__['cache.cloud'](tgt)
     for minion_id, full_info in minions.items():
         profile, provider = full_info.get('profile', None), full_info.get('provider', None)
         vm_ = {

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -411,5 +411,5 @@ def cloud(tgt, provider=None):
             for name, data in servers.items():
                 if fnmatch.fnmatch(name, tgt):
                     ret[name] = data
-		    ret['name']['provider'] = provider
+                    ret['name']['provider'] = provider
     return ret

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -411,4 +411,5 @@ def cloud(tgt, provider=None):
             for name, data in servers.items():
                 if fnmatch.fnmatch(name, tgt):
                     ret[name] = data
+		    ret['name']['provider'] = provider
     return ret

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -4,9 +4,12 @@ Return cached data from minions
 '''
 from __future__ import absolute_import
 # Import python libs
+import fnmatch
 import logging
 
 # Import salt libs
+import salt.config
+import salt.ext.six as six
 import salt.log
 import salt.utils
 import salt.utils.master
@@ -376,4 +379,36 @@ def clear_git_lock(role, remote=None, **kwargs):
                 ret.setdefault('errors', []).extend(errors)
     if not ret:
         return 'No locks were removed'
+    return ret
+
+
+def cloud(tgt, provider=None):
+    '''
+    Return cloud cache data for target.
+
+    .. note:: Only works with glob matching
+
+    tgt
+      Glob Target to match minion ids
+
+    provider
+      Cloud Provider
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cache.cloud 'salt*'
+        salt-run cache.cloud glance.example.org provider=openstack
+    '''
+    if not isinstance(tgt, six.string_types):
+        return {}
+    ret = {}
+    opts = salt.config.cloud_config('/etc/salt/cloud')
+    cloud_cache = __utils__['cloud.list_cache_nodes_full'](opts=opts, provider=provider)
+    for driver, providers in cloud_cache.items():
+        for provider, servers in providers.items():
+            for name, data in servers.items():
+                if fnmatch.fnmatch(name, tgt):
+                    ret[name] = data
     return ret

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2666,16 +2666,18 @@ def delete_minion_cachedir(minion_id, provider, opts, base=None):
             os.remove(path)
 
 
-def list_cache_nodes_full(opts, provider=None, base=None):
+def list_cache_nodes_full(opts=None, provider=None, base=None):
     '''
     Return a list of minion data from the cloud cache, rather from the cloud
     providers themselves. This is the cloud cache version of list_nodes_full().
     '''
+    if opts is None:
+        opts = __opts__
     if opts.get('update_cachedir', False) is False:
         return
 
     if base is None:
-        base = os.path.join(__opts__['cachedir'], 'active')
+        base = os.path.join(opts['cachedir'], 'active')
 
     minions = {}
     # First, get a list of all drivers in use
@@ -2690,10 +2692,10 @@ def list_cache_nodes_full(opts, provider=None, base=None):
             minions[driver][prov] = {}
             min_dir = os.path.join(prov_dir, prov)
             # Get a list of all nodes per provider
-            for minion_id in os.listdir(min_dir):
+            for fname in os.listdir(min_dir):
                 # Finally, get a list of full minion data
-                fname = '{0}.p'.format(minion_id)
                 fpath = os.path.join(min_dir, fname)
+                minion_id = fname[:-2]  # strip '.p' from end of msgpack filename
                 with salt.utils.fopen(fpath, 'r') as fh_:
                     minions[driver][prov][minion_id] = msgpack.load(fh_)
 
@@ -2706,7 +2708,7 @@ def cache_nodes_ip(opts, base=None):
     addresses. Returns a dict.
     '''
     if base is None:
-        base = __opts__['cachedir']
+        base = opts['cachedir']
 
     minions = list_cache_nodes_full(opts, base=base)
 


### PR DESCRIPTION
### What does this PR do?
Use the cache runner to do lookups in the cloud cache.  Then use that information in the cloud roster instead of looking up each msgpack file individually.

### Tests written?

No