### PR TITLE
Add config option to pin pillarenv to effective saltenv

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1599,6 +1599,23 @@ the environment setting, but for pillar instead of states.
 
     pillarenv: None
 
+.. conf_minion:: pillarenv_from_saltenv
+
+``pillarenv_from_saltenv``
+--------------------------
+
+Default: ``False``
+
+When set to ``True``, the :conf_minion:`pillarenv` value will assume the value
+of the effective saltenv when running states. This essentially makes ``salt '*'
+state.sls mysls saltenv=dev`` equivalent to ``salt '*' state.sls mysls
+saltenv=dev pillarenv=dev``. If :conf_minion:`pillarenv` is set, either in the
+minion config file or via the CLI, it will override this option.
+
+.. code-block:: yaml
+
+    pillarenv_from_saltenv: True
+
 .. conf_minion:: pillar_raise_on_missing
 
 ``pillar_raise_on_missing``

--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -60,8 +60,22 @@ Execution Module Changes
 Master Configuration Additions
 ==============================
 
-- ``syndic_forward_all_events``: Option on multi-syndic or single when connected
-  to multiple masters to be able to send events to all connected masters.
+- :conf_master:`syndic_forward_all_events` - Option on multi-syndic or single
+  when connected to multiple masters to be able to send events to all connected
+  masters.
+
+Minion Configuration Additions
+==============================
+
+- :conf_minion:`pillarenv_from_saltenv` - When set to ``True`` (default is
+  ``False``), the :conf_minion:`pillarenv` option will take the same value as
+  the effective saltenv when running states. This would allow a user to run
+  ``salt '*' state.apply mysls saltenv=dev``, and the SLS for both the state
+  and pillar data would be sourced from the ``dev`` environment, essentially
+  the equivalent of running ``salt '*' state.apply mysls saltenv=dev
+  pillarenv=dev``. Note that if :conf_minion:`pillarenv` is set in the minion
+  config file, or if ``pillarenv`` is provided on the CLI, it will override
+  this option.
 
 Python API Changes
 ==================

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -224,6 +224,9 @@ VALID_OPTS = {
     # Force the minion into a single pillar root when it fetches pillar data from the master
     'pillarenv': str,
 
+    # Make the pillarenv always match the effective saltenv
+    'pillarenv_from_saltenv': bool,
+
     # Allows a user to provide an alternate name for top.sls
     'state_top': str,
 
@@ -1001,6 +1004,7 @@ DEFAULT_MINION_OPTS = {
     'autoload_dynamic_modules': True,
     'environment': None,
     'pillarenv': None,
+    'pillarenv_from_saltenv': False,
     'pillar_opts': False,
     # ``pillar_cache``, ``pillar_cache_ttl`` and ``pillar_cache_backend``
     # are not used on the minion but are unavoidably in the code path

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -26,7 +26,8 @@ def get(key,
         default=KeyError,
         merge=False,
         delimiter=DEFAULT_TARGET_DELIM,
-        saltenv=None):
+        saltenv=None,
+        pillarenv=None):
     '''
     .. versionadded:: 0.14
 
@@ -60,6 +61,12 @@ def get(key,
         .. versionadded:: 2014.7.0
 
     saltenv
+        Included only for compatibility with
+        :conf_minion:`pillarenv_from_saltenv`, and is otherwise ignored.
+
+        .. versionadded:: Nitrogen
+
+    pillarenv
         If specified, this function will query the master to generate fresh
         pillar data on the fly, specifically from the requested pillar
         environment. Note that this can produce different pillar data than
@@ -85,7 +92,9 @@ def get(key,
         if default is KeyError:
             default = ''
     opt_merge_lists = __opts__.get('pillar_merge_lists', False)
-    pillar_dict = __pillar__ if saltenv is None else items(saltenv=saltenv)
+    pillar_dict = __pillar__ \
+        if all(x is None for x in (saltenv, pillarenv)) \
+        else items(saltenv=saltenv, pillarenv=pillarenv)
 
     if merge:
         ret = salt.utils.traverse_dict_and_list(pillar_dict, key, {}, delimiter)

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 import collections
 
 # Import third party libs
+import copy
 import os
 import yaml
 import salt.ext.six as six
@@ -119,11 +120,13 @@ def items(*args, **kwargs):
         .. versionadded:: 2015.5.0
 
     saltenv
+        Included only for compatibility with
+        :conf_minion:`pillarenv_from_saltenv`, and is otherwise ignored.
+
+        .. versionadded:: Nitrogen
+
+    pillarenv
         Pass a specific pillar environment from which to compile pillar data.
-        If unspecified, the minion's :conf_minion:`environment` option is used,
-        and if that also is not specified then all configured pillar
-        environments will be merged into a single pillar dictionary and
-        returned.
 
         .. versionadded:: Nitrogen
 
@@ -137,11 +140,20 @@ def items(*args, **kwargs):
     if args:
         return item(*args)
 
+    pillarenv = kwargs.get('pillarenv')
+    if pillarenv is None:
+        if __opts__.get('pillarenv_from_saltenv', False):
+            pillarenv = kwargs.get('saltenv') or __opts__['environment']
+        else:
+            pillarenv = __opts__.get('pillarenv')
+
+    opts = copy.copy(__opts__)
+    opts['pillarenv'] = pillarenv
     pillar = salt.pillar.get_pillar(
-        __opts__,
+        opts,
         __grains__,
-        __opts__['id'],
-        kwargs.get('saltenv') or __opts__['environment'],
+        opts['id'],
+        saltenv=pillarenv,
         pillar=kwargs.get('pillar'))
 
     return pillar.compile_pillar()

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -78,8 +78,12 @@ class AsyncRemotePillar(object):
         self.grains = grains
         self.minion_id = minion_id
         self.channel = salt.transport.client.AsyncReqChannel.factory(opts)
-        if pillarenv is not None or 'pillarenv' not in self.opts:
+        if pillarenv is not None:
             self.opts['pillarenv'] = pillarenv
+        elif self.opts.get('pillarenv_from_saltenv', False):
+            self.opts['pillarenv'] = saltenv
+        elif 'pillarenv' not in self.opts:
+            self.opts['pillarenv'] = None
         self.pillar_override = {}
         if pillar is not None:
             if isinstance(pillar, dict):
@@ -131,8 +135,12 @@ class RemotePillar(object):
         self.grains = grains
         self.minion_id = minion_id
         self.channel = salt.transport.Channel.factory(opts)
-        if pillarenv is not None or 'pillarenv' not in self.opts:
+        if pillarenv is not None:
             self.opts['pillarenv'] = pillarenv
+        elif self.opts.get('pillarenv_from_saltenv', False):
+            self.opts['pillarenv'] = saltenv
+        elif 'pillarenv' not in self.opts:
+            self.opts['pillarenv'] = None
         self.pillar_override = {}
         if pillar is not None:
             if isinstance(pillar, dict):


### PR DESCRIPTION
When ``pillarenv_from_saltenv`` is set to ``True``, then the pillarenv will be
pinned to the effective saltenv (if passed).