### PR TITLE
Fix eauth error with openLDAP/389 directory server groups

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1718,13 +1718,6 @@ class ClearFuncs(object):
                                    message=msg))
 
         name = self.loadauth.load_name(clear_load)
-        if not ((name in self.opts['external_auth'][clear_load['eauth']]) |
-                ('*' in self.opts['external_auth'][clear_load['eauth']])):
-            msg = ('Authentication failure of type "eauth" occurred for '
-                   'user {0}.').format(clear_load.get('username', 'UNKNOWN'))
-            log.warning(msg)
-            return dict(error=dict(name='EauthAuthenticationError',
-                                   message=msg))
         if self.loadauth.time_auth(clear_load) is False:
             msg = ('Authentication failure of type "eauth" occurred for '
                    'user {0}.').format(clear_load.get('username', 'UNKNOWN'))


### PR DESCRIPTION
Fixes #36148

### What does this PR do?
Enable external (ldap) authorization based on users and groups.

### What issues does this PR fix or reference?
#36148 

### Previous Behavior
It seems that the current tests for external user/group permissions fail to check groups, if permissions are set for groups only and no users are mentioned in the config file, users of that group won't be able to run commands.

### New Behavior
There is already a test that checks for groups and users in master.py, after removing the test that checks user permissions it is possible to use groups.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
