### PR TITLE
authorized_key entry is not updated when options contain whitespace

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -159,8 +159,8 @@ def _replace_auth_key(
                     lines.append(line)
                     continue
                 key_ind = 1
-                if comps[0][:4:] not in ['ssh-', 'ecds']:
-                    key_ind = 2
+                while comps[key_ind - 1][:4:] not in ['ssh-', 'ecds'] and key_ind < len(comps):
+                    key_ind += 1
                 if comps[key_ind] == key:
                     lines.append(auth_line)
                 else:


### PR DESCRIPTION
The `ssh.set_auth_key` module does not update an authorized key when the key is already present in the `authorized_keys` file and the existing key options contain a whitespace.

This is because the `_replace_auth_key` helper method simply splits the line by whitespace using `.split()` and assumes the key type to be present as the second item. This does not work when the key options contain whitespaces.

Fixes: #18983