### PR TITLE
Provide an example for overriding nested parameters in a map file

### DIFF
--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -82,6 +82,36 @@ A map file can include grains and minion configuration options:
             cheese: more tasty
             omelet: with peppers
 
+Any top level data element from your profile may be overridden in the map file:
+
+.. code-block:: yaml
+
+    fedora_small:
+      - web1:
+        size: t2.micro
+      - web2:
+        size: t2.nano
+
+Nested elements cannot be specified individually. Instead, the complete
+definition for any top level data element must be repeated. In this example a
+separate subnet is assigned to each ec2 instance:
+
+.. code-block:: yaml
+
+    fedora_small_aws:
+      - web1:
+        network_interfaces:
+          - DeviceIndex: 0
+            SubnetId: subnet-3bf94a72
+            SecurityGroupId:
+              - sg-9f644fe5
+      - web2:
+        network_interfaces:
+          - DeviceIndex: 0
+            SubnetId: subnet-c3ad9fa4
+            SecurityGroupId:
+              - sg-9f644fe5
+
 A map file may also be used with the various query options:
 
 .. code-block:: bash


### PR DESCRIPTION
### What does this PR do?

Adjust the docs/topics/cloud/map.html to be very clear about how to override nested data elements in a cloud map file.

At first reading it appears that that any data element can be specified individually in a map, but this is not the case. Under the hood, the map file is merged with the profile configuration using dict.update().

Employ the term 'top level data element' from #23416

### What issues does this PR fix or reference?

#23535

