### PR TITLE
Add strict flag to ini.options_present

### DIFF
--- a/tests/unit/states/ini_manage_test.py
+++ b/tests/unit/states/ini_manage_test.py
@@ -56,6 +56,23 @@ class IniManageTestCase(TestCase):
                 ret.update({'comment': comt, 'result': True, 'changes': changes})
                 self.assertDictEqual(ini_manage.options_present(name), ret)
 
+        original = {'mysection': {'first': 'who is on',
+                                  'second': 'what is on',
+                                  'third': "I don't know"}}
+        desired = {'mysection': {'first': 'who is on',
+                                 'second': 'what is on'}}
+        changes = {'mysection': {'first': 'who is on',
+                                 'second': 'what is on',
+                                 'third': {'after': None, 'before': "I don't know"}}}
+        with patch.dict(ini_manage.__salt__, {'ini.get_section': MagicMock(return_value=original['mysection'])}):
+            with patch.dict(ini_manage.__salt__, {'ini.remove_option': MagicMock(return_value='third')}):
+                with patch.dict(ini_manage.__salt__, {'ini.get_option': MagicMock(return_value="I don't know")}):
+                    with patch.dict(ini_manage.__salt__, {'ini.set_option': MagicMock(return_value=desired)}):
+                        with patch.dict(ini_manage.__opts__, {'test': False}):
+                            comt = ('Changes take effect')
+                            ret.update({'comment': comt, 'result': True, 'changes': changes})
+                            self.assertDictEqual(ini_manage.options_present(name, desired, strict=True), ret)
+
     # 'options_absent' function tests: 1
 
     def test_options_absent(self):


### PR DESCRIPTION
### What does this PR do?

Adds "Strict" option to ini.options_present, to remove options not present in the sls.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/29287

### Previous Behavior

The flag is optional, previous behavior is unaffected.

### New Behavior

Described in the issue.

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
