### PR TITLE
Revert "call sdecode for the filename in file.managed()"

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1746,7 +1746,7 @@ def managed(name,
             )
         kwargs.pop('env')
 
-    name = os.path.expanduser(sdecode(name))
+    name = os.path.expanduser(name)
 
     ret = {'changes': {},
            'pchanges': {},


### PR DESCRIPTION
This reverts commit 619e4b5b1e7f65dc9e63ac8eed879f1667b95f74. It was not the correct fix for #38282, the correct fix has been submitted in https://github.com/saltstack/salt/pull/38415. Once merged forward, the fix will make it here into the develop branch.