### PR TITLE
Update deprecation notices to the correct version

### DIFF
--- a/salt/modules/htpasswd.py
+++ b/salt/modules/htpasswd.py
@@ -35,7 +35,7 @@ def useradd_all(pwfile, user, password, opts='', runas=None):
     Add a user to htpasswd file using the htpasswd command. If the htpasswd
     file does not exist, it will be created.
 
-    .. deprecated:: Nitrogen
+    .. deprecated:: 2016.3.0
 
     pwfile
         Path to htpasswd file

--- a/salt/modules/img.py
+++ b/salt/modules/img.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
 Virtual machine image management tools
+
+.. deprecated:: 2016.3.0
 '''
 
 # Import python libs

--- a/salt/modules/smartos_virt.py
+++ b/salt/modules/smartos_virt.py
@@ -244,7 +244,7 @@ def get_macs(domain):
 # Deprecated aliases
 def create(domain):
     '''
-    .. deprecated:: Nitrogen
+    .. deprecated:: 2016.3.0
        Use :py:func:`~salt.modules.virt.start` instead.
 
     Start a defined domain
@@ -261,7 +261,7 @@ def create(domain):
 
 def destroy(domain):
     '''
-    .. deprecated:: Nitrogen
+    .. deprecated:: 2016.3.0
        Use :py:func:`~salt.modules.virt.stop` instead.
 
     Power off a defined domain
@@ -278,7 +278,7 @@ def destroy(domain):
 
 def list_vms():
     '''
-    .. deprecated:: Nitrogen
+    .. deprecated:: 2016.3.0
        Use :py:func:`~salt.modules.virt.list_domains` instead.
 
     List all virtual machines.

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -382,7 +382,7 @@ def get_resource_path(venv,
     package_or_requirement
         Name of the package in which the resource resides
 
-        .. deprecated:: Nitrogen
+        .. deprecated:: 2016.3.0
             Use ``package`` instead.
 
     resource
@@ -393,7 +393,7 @@ def get_resource_path(venv,
     resource_name
         Name of the resource of which the path is to be returned
 
-        .. deprecated:: Nitrogen
+        .. deprecated:: 2016.3.0
 
 
     .. versionadded:: 2015.5.0
@@ -473,7 +473,7 @@ def get_resource_content(venv,
     package_or_requirement
         Name of the package in which the resource resides
 
-        .. deprecated:: Nitrogen
+        .. deprecated:: 2016.3.0
             Use ``package`` instead.
 
     resource
@@ -484,7 +484,7 @@ def get_resource_content(venv,
     resource_name
         Name of the resource of which the content is to be returned
 
-        .. deprecated:: Nitrogen
+        .. deprecated:: 2016.3.0
 
 
     .. versionadded:: 2015.5.0

--- a/salt/modules/xapi.py
+++ b/salt/modules/xapi.py
@@ -931,7 +931,7 @@ def vm_diskstats(vm_=None):
 # Deprecated aliases
 def create(domain):
     '''
-    .. deprecated:: Nitrogen
+    .. deprecated:: 2016.3.0
        Use :py:func:`~salt.modules.virt.start` instead.
 
     Start a defined domain
@@ -948,7 +948,7 @@ def create(domain):
 
 def destroy(domain):
     '''
-    .. deprecated:: Nitrogen
+    .. deprecated:: 2016.3.0
        Use :py:func:`~salt.modules.virt.stop` instead.
 
     Power off a defined domain
@@ -965,7 +965,7 @@ def destroy(domain):
 
 def list_vms():
     '''
-    .. deprecated:: Nitrogen
+    .. deprecated:: 2016.3.0
        Use :py:func:`~salt.modules.virt.list_domains` instead.
 
     List all virtual machines.

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -455,7 +455,7 @@ def info_available(*names, **kwargs):
 
 def info(*names, **kwargs):
     '''
-    .. deprecated:: Nitrogen
+    .. deprecated:: 2016.3.0
        Use :py:func:`~salt.modules.pkg.info_available` instead.
 
     Return the information of the named package available for the system.


### PR DESCRIPTION
The removal of these code pieces happens in Nitrogen, but they are marked for deprecation (with warnings) in 2016.3.0.

Refs #38420