### PR TITLE
Make sysctl.persist fail when failing to set a value into the running kernel

### DIFF
--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -232,7 +232,12 @@ def persist(name, value, config=None):
                     if str(running[name]) != str(value):
                         assign(name, value)
                         return 'Updated'
-                return 'Already set'
+                    else:
+                        return 'Already set'
+                # It is missing from the running config. We can not set it.
+                else:
+                    raise CommandExecutionError('sysctl {0} does not exist'.format(name))
+
             nlines.append('{0} = {1}\n'.format(name, value))
             edited = True
             continue


### PR DESCRIPTION
### What does this PR do?
* Make sysctl.persist fail when unable to set a value into memory.

### What issues does this PR fix or reference?
 issue 38433
https://github.com/saltstack/salt/issues/38433
### Previous Behavior
Set an invalid twice and it will return success and say "Already set" if the value is non the config file but not in the running kernel.
```
root@saltmaster:/srv/salt/state# salt-call -lquiet  sysctl.persist foo bar
Error running 'sysctl.persist': sysctl foo does not exist

root@saltmaster:/srv/salt/state# salt-call -lquiet  sysctl.persist foo bar
local:
    Already set
```

### New Behavior
Reports that it was unable to set and fail the state:
```
root@saltmaster:/srv/salt/state# salt-call -lquiet  sysctl.persist foo2 bar2
Error running 'sysctl.persist': sysctl foo2 does not exist

 root@saltmaster:/srv/salt/state# salt-call -lquiet  sysctl.persist foo2 bar2
Error running 'sysctl.persist': sysctl foo2 does not exist
```

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
