### PR TITLE
Fix BUG: 'salt-run jobs.list_jobs' occured error when using etcd as j…

### DIFF
--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -198,10 +198,10 @@ def get_jids():
     ret = {}
     client, path = _get_conn(__opts__)
     items = client.get('/'.join((path, 'jobs')))
-    for item in items.children:
-        if item.dir is True:
-            jid = str(item.key).split('/')[-1]
-            load = client.get('/'.join((item.key, '.load.p'))).value
+    for item in items:
+        if item['dir'] is True:
+            jid = str(item['key']).split('/')[-1]
+            load = client.get('/'.join((item['key'], '.load.p')))
             ret[jid] = salt.utils.jid.format_jid_instance(jid, json.loads(load))
     return ret
 

--- a/salt/utils/etcd_util.py
+++ b/salt/utils/etcd_util.py
@@ -185,7 +185,10 @@ class EtcdClient(object):
         except ValueError:
             return None
 
-        return getattr(result, 'value', None)
+        if result.value is None and result._children :
+            return getattr(result, '_children', None)
+        else:
+            return getattr(result, 'value', None)
 
     def read(self, key, recursive=False, wait=False, timeout=None, waitIndex=None):
         try:


### PR DESCRIPTION
…ob_cache

Signed-off-by: yue9944882 <291271447@qq.com>

### What does this PR do?

Fixing bugs of interaction between salt and etcd when using etcd as returner, or rather, job_cache.

### What issues does this PR fix or reference?

When we use etcd as master_job_cache, error will happen:

```
# salt-run jobs.list_jobs
Exception occurred in runner jobs.list_jobs: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/client/mixins.py", line 395, in _low
    data['return'] = self.functions[fun](*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/runners/jobs.py", line 305, in list_jobs
    ret = mminion.returners['{0}.get_jids'.format(returner)]()
  File "/usr/lib/python2.7/site-packages/salt/returners/etcd_return.py", line 201, in get_jids
    for item in items.children:
AttributeError: 'NoneType' object has no attribute 'children'
```
This is because salt is trying out get the wrong attribute from the EtcdResult object in the following code ( salt/utils/etcd_utils.py:188):

```
 def get(self, key, recurse=False):
        try:
            result = self.read(key, recursive=recurse)
        except etcd.EtcdKeyNotFound:
            # etcd already logged that the key wasn't found, no need to do
            # anything here but return
            return None
        except etcd.EtcdConnectionFailed:
            log.error("etcd: failed to perform 'get' operation on key {0} due to connection error".format(key))
            return None
        except ValueError:
            return None

        return getattr(result, 'value', None)
```
Actually we should get the result data from '_children' attributes from EtcdResult instead of 'value'.
So the solution is that we can judge if 'value' is None at the same time the '_children' attribute is not None. When it is, just return the '_children' field of object. And because the object in the '_children' field is a dictionary. So we have to edit the code of reading data from '_children'.

### New Behavior
Remove this section if not relevant

After fixing the etcd returner runs fine.
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
