### PR TITLE
Adds new import required for `extract_hash`

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -27,6 +27,7 @@ import hashlib  # do not remove, used in imported file.py functions
 import errno  # do not remove, used in imported file.py functions
 import shutil  # do not remove, used in imported file.py functions
 import re  # do not remove, used in imported file.py functions
+import string  # do not remove, used in imported file.py functions
 import sys  # do not remove, used in imported file.py functions
 import fileinput  # do not remove, used in imported file.py functions
 import fnmatch  # do not remove, used in imported file.py functions


### PR DESCRIPTION
### What does this PR do?

Adds an import required by `extract_hash`. The import was add to modules/file.py in #37368, but was not added to modules/win_file.py.

### What issues does this PR fix or reference?

Fixes #38443
