### PR TITLE
cron - implement all features for special period

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -446,6 +446,7 @@ def _get_cron_date_time(**kwargs):
 
     return ret
 
+
 def _set_job(user,
             cmd,
             special=None,


### PR DESCRIPTION
### What does this PR do?

As reported in #38425, previously when the 'special' keyword was used in
states, or 'cron.set_special' module used. This commit merges code for set_job
and set_special behind the scenes, thus implementing all features that were
previously available with setting a job with minute, hour, etc. when 'special'
is used.

The api remains unchanged.


### What issues does this PR fix or reference?
ref #38425

### Previous Behavior
Use of 'special' keyword disabled use of identifier lines and other useful features that were available when not using 'special'.

### New Behavior
Features implemented for when using 'special' keyboard as well.

### Tests written?
Please let me know if/what tests should be written.
