### PR TITLE
Stops git.latest checking for local changes in a bare repo

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -879,7 +879,11 @@ def latest(name,
 
             revs_match = _revs_equal(local_rev, remote_rev, remote_rev_type)
             try:
+                # If not a bare repo, check `git diff HEAD` to determine if
+                # there are local changes.
                 local_changes = bool(
+                    not bare
+                    and
                     __salt__['git.diff'](target,
                                          'HEAD',
                                          user=user,


### PR DESCRIPTION
### What does this PR do?

This prevents checking `git diff HEAD` on bare git repos.

### What issues does this PR fix or reference?

Using `git.latest` with bare git repos will result in cmd errors.

**Example sls:**

```yaml
git://local-git/dist.git:
  git.latest:
    - user: myuser
    - target: /opt/git/mirrors/dist.git
    - mirror: True  # implies bare
```

**Results in:**

```
[ERROR   ][20198] Command ['git', 'diff', 'HEAD'] failed with return code: 128
[ERROR   ][20198] stdout: fatal: This operation must be run in a work tree
```

### Tests written?

No - relies on the existing integration tests.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
