### PR TITLE
file.line fail with mode=delete

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1534,17 +1534,15 @@ def line(path, content, match=None, mode=None, location=None,
     before = _regex_to_static(body, before)
     match = _regex_to_static(body, match)
 
-    if mode == 'delete':
+    if os.stat(path).st_size == 0 and mode in ('delete', 'replace'):
+        log.warning('Cannot find text to {0}. File \'{1}\' is empty.'.format(mode, path))
+        body = ''
+    elif mode == 'delete':
         body = os.linesep.join([line for line in body.split(os.linesep) if line.find(match) < 0])
-
     elif mode == 'replace':
-        if os.stat(path).st_size == 0:
-            log.warning('Cannot find text to replace. File \'{0}\' is empty.'.format(path))
-            body = ''
-        else:
-            body = os.linesep.join([(_get_line_indent(file_line, content, indent)
-                                    if (file_line.find(match) > -1 and not file_line == content) else file_line)
-                                    for file_line in body.split(os.linesep)])
+        body = os.linesep.join([(_get_line_indent(file_line, content, indent)
+                                if (file_line.find(match) > -1 and not file_line == content) else file_line)
+                                for file_line in body.split(os.linesep)])
     elif mode == 'insert':
         if not location and not before and not after:
             raise CommandExecutionError('On insert must be defined either "location" or "before/after" conditions.')

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -669,6 +669,32 @@ class FileModuleTestCase(TestCase):
         empty_file.close()
         os.remove(empty_file.name)
 
+    def test_delete_line_in_empty_file(self):
+        '''
+        Tests that when calling file.line with ``mode=delete``,
+        the function doesn't stack trace if the file is empty.
+        Should return ``False``.
+
+        See Issue #38438.
+        '''
+        # Create an empty temporary named file
+        empty_file = tempfile.NamedTemporaryFile(delete=False,
+                                                 mode='w+')
+
+        # Assert that the file was created and is empty
+        self.assertEqual(os.stat(empty_file.name).st_size, 0)
+
+        # Now call the function on the empty file and assert
+        # the return is False instead of stack-tracing
+        self.assertFalse(filemod.line(empty_file.name,
+                                      content='foo',
+                                      match='bar',
+                                      mode='delete'))
+
+        # Close and remove the file
+        empty_file.close()
+        os.remove(empty_file.name)
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?
If the file is empty, it also fails, fix that.

### What issues does this PR fix or reference?
Fixes #38438

### Previous Behavior
This stacktraces on doing a split on the empty body

### New Behavior
Don't try to split the empty body

### Tests written?

Yes!