### PR TITLE
Add boto3_elasticache exec and state modules

### DIFF
--- a/salt/modules/boto3_elasticache.py
+++ b/salt/modules/boto3_elasticache.py
@@ -273,6 +273,8 @@ def describe_cache_clusters(name=None, conn=None, region=None, key=None,
     '''
     Return details about all (or just one) Elasticache cache clusters.
 
+    Example:
+
     .. code-block:: bash
 
         salt myminion boto3_elasticache.describe_cache_clusters
@@ -287,6 +289,8 @@ def cache_cluster_exists(name, conn=None, region=None, key=None, keyid=None, pro
     '''
     Check to see if a cache cluster exists.
 
+    Example:
+
     .. code-block:: bash
 
         salt myminion boto3_elasticache.cache_cluster_exists myelasticache
@@ -298,6 +302,8 @@ def create_cache_cluster(name, wait=600, security_groups=None,
                          region=None, key=None, keyid=None, profile=None, **args):
     '''
     Create a cache cluster.
+
+    Example:
 
     .. code-block:: bash
 
@@ -336,6 +342,8 @@ def modify_cache_cluster(name, wait=600, security_groups=None, region=None,
             intentionally before a state call, and removed again before the next.  In
             practice this is not particularly useful and should probably be avoided.
 
+    Example:
+
     .. code-block:: bash
 
         salt myminion boto3_elasticache.create_cache_cluster name=myCacheCluster \
@@ -359,6 +367,8 @@ def delete_cache_cluster(name, wait=600, region=None, key=None, keyid=None, prof
     '''
     Delete a cache cluster.
 
+    Example:
+
     .. code-block:: bash
 
         salt myminion boto3_elasticache.delete myelasticache
@@ -373,6 +383,8 @@ def describe_replication_groups(name=None, conn=None, region=None, key=None, key
     '''
     Return details about all (or just one) Elasticache replication groups.
 
+    Example:
+
     .. code-block:: bash
 
         salt myminion boto3_elasticache.describe_replication_groups
@@ -386,6 +398,8 @@ def describe_replication_groups(name=None, conn=None, region=None, key=None, key
 def replication_group_exists(name, region=None, key=None, keyid=None, profile=None):
     '''
     Check to see if a replication group exists.
+
+    Example:
 
     .. code-block:: bash
 
@@ -402,6 +416,8 @@ def create_replication_group(name, wait=600, security_groups=None, region=None, 
     Params are extensive and variable - see
     http://boto3.readthedocs.io/en/latest/reference/services/elasticache.html?#ElastiCache.Client.create_replication_group
     for in-depth usage documentation.
+
+    Example:
 
     .. code-block:: bash
 
@@ -428,6 +444,8 @@ def modify_replication_group(name, wait=600, security_groups=None, region=None, 
     '''
     Modify a replication group.
 
+    Example:
+
     .. code-block:: bash
 
         salt myminion boto3_elasticache.modify_replication_group \
@@ -452,6 +470,8 @@ def delete_replication_group(name, wait=600, region=None, key=None, keyid=None, 
     '''
     Delete an ElastiCache replication group, optionally taking a snapshot first.
 
+    Example:
+
     .. code-block:: bash
 
         salt myminion boto3_elasticache.delete_replication_group my-replication-group
@@ -464,6 +484,8 @@ def delete_replication_group(name, wait=600, region=None, key=None, keyid=None, 
 def describe_cache_subnet_groups(name=None, conn=None, region=None, key=None, keyid=None, profile=None):
     '''
     Return details about all (or just one) Elasticache replication groups.
+
+    Example:
 
     .. code-block:: bash
 
@@ -478,6 +500,8 @@ def cache_subnet_group_exists(name, region=None, key=None, keyid=None, profile=N
     '''
     Check to see if an ElastiCache subnet group exists.
 
+    Example:
+
     .. code-block:: bash
 
         salt myminion boto3_elasticache.cache_subnet_group_exists my-subnet-group
@@ -488,6 +512,8 @@ def cache_subnet_group_exists(name, region=None, key=None, keyid=None, profile=N
 def list_cache_subnet_groups(region=None, key=None, keyid=None, profile=None):
     '''
     Return a list of all cache subnet group names
+
+    Example:
 
     .. code-block:: bash
 
@@ -500,6 +526,8 @@ def list_cache_subnet_groups(region=None, key=None, keyid=None, profile=None):
 def create_cache_subnet_group(name, subnets=None, region=None, key=None, keyid=None, profile=None, **args):
     '''
     Create an ElastiCache subnet group
+
+    Example:
 
     .. code-block:: bash
 
@@ -538,6 +566,8 @@ def modify_cache_subnet_group(name, subnets=None, region=None, key=None, keyid=N
     '''
     Modify an ElastiCache subnet group
 
+    Example:
+
     .. code-block:: bash
 
         salt myminion boto3_elasticache.modify_cache_subnet_group \
@@ -574,6 +604,8 @@ def delete_cache_subnet_group(name, region=None, key=None, keyid=None, profile=N
     '''
     Delete an ElastiCache subnet group.
 
+    Example:
+
     .. code-block:: bash
 
         salt myminion boto3_elasticache.delete_subnet_group my-subnet-group region=us-east-1
@@ -586,6 +618,8 @@ def delete_cache_subnet_group(name, region=None, key=None, keyid=None, profile=N
 def describe_cache_security_groups(name=None, conn=None, region=None, key=None, keyid=None, profile=None):
     '''
     Return details about all (or just one) Elasticache cache clusters.
+
+    Example:
 
     .. code-block:: bash
 
@@ -602,6 +636,8 @@ def cache_security_group_exists(name, region=None, key=None, keyid=None, profile
     '''
     Check to see if an ElastiCache security group exists.
 
+    Example:
+
     .. code-block:: bash
 
         salt myminion boto3_elasticache.cache_security_group_exists mysecuritygroup
@@ -612,6 +648,8 @@ def cache_security_group_exists(name, region=None, key=None, keyid=None, profile
 def create_cache_security_group(name, region=None, key=None, keyid=None, profile=None, **args):
     '''
     Create a cache security group.
+
+    Example:
 
     .. code-block:: bash
 
@@ -626,6 +664,8 @@ def delete_cache_security_group(name, region=None, key=None, keyid=None, profile
     '''
     Delete a cache security group.
 
+    Example:
+
     .. code-block:: bash
 
         salt myminion boto3_elasticache.delete_cache_security_group myelasticachesg
@@ -638,6 +678,8 @@ def delete_cache_security_group(name, region=None, key=None, keyid=None, profile
 def authorize_cache_security_group_ingress(name, region=None, key=None, keyid=None, profile=None, **args):
     '''
     Authorize network ingress from an ec2 security group to a cache security group.
+
+    Example:
 
     .. code-block:: bash
 
@@ -667,6 +709,8 @@ def revoke_cache_security_group_ingress(name, region=None, key=None, keyid=None,
     '''
     Revoke network ingress from an ec2 security group to a cache security
     group.
+
+    Example:
 
     .. code-block:: bash
 
@@ -803,6 +847,8 @@ def describe_cache_parameter_groups(name=None, conn=None, region=None, key=None,
     '''
     Return details about all (or just one) Elasticache cache clusters.
 
+    Example:
+
     .. code-block:: bash
 
         salt myminion boto3_elasticache.describe_cache_parameter_groups
@@ -816,6 +862,8 @@ def describe_cache_parameter_groups(name=None, conn=None, region=None, key=None,
 def create_cache_parameter_group(name, region=None, key=None, keyid=None, profile=None, **args):
     '''
     Create a cache parameter group.
+
+    Example:
 
     .. code-block:: bash
 
@@ -832,6 +880,8 @@ def create_cache_parameter_group(name, region=None, key=None, keyid=None, profil
 def delete_cache_parameter_group(name, region=None, key=None, keyid=None, profile=None, **args):
     '''
     Delete a cache parameter group.
+
+    Example:
 
     .. code-block:: bash
 

--- a/salt/modules/boto3_elasticache.py
+++ b/salt/modules/boto3_elasticache.py
@@ -1,0 +1,767 @@
+# -*- coding: utf-8 -*-
+'''
+Connection module for Amazon Elasticache
+
+.. versionadded:: 2014.7.0
+
+:configuration: This module accepts explicit elasticache credentials but can
+    also utilize IAM roles assigned to the instance through Instance Profiles.
+    Dynamic credentials are then automatically obtained from AWS API and no
+    further configuration is necessary. More Information available at:
+
+    .. code-block:: text
+
+        http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file:
+
+    .. code-block:: yaml
+
+        elasticache.keyid: GKTADJGHEIQSXMKKRBJ08H
+        elasticache.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration:
+
+    .. code-block:: yaml
+
+        elasticache.region: us-east-1
+
+    If a region is not specified, the default is us-east-1.
+
+    It's also possible to specify key, keyid and region via a profile, either
+    as a passed in dict, or as a string to pull from pillars or minion config:
+
+    .. code-block:: yaml
+
+        myprofile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+:depends: boto3
+'''
+
+# keep lint from choking on _get_conn and _cache_id
+#pylint: disable=E0602
+
+# Import Python libs
+from __future__ import absolute_import
+import logging
+import socket
+from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
+import time
+import random
+
+# Import Salt libs
+import salt.utils.boto3
+import salt.utils.compat
+from salt.exceptions import SaltInvocationError, CommandExecutionError
+from salt.ext.six.moves import range  # pylint: disable=import-error
+
+# from salt.utils import exactly_one
+# TODO: Uncomment this and s/_exactly_one/exactly_one/
+# See note in utils.boto
+PROVISIONING = 'provisioning'
+PENDING_ACCEPTANCE = 'pending-acceptance'
+ACTIVE = 'active'
+
+log = logging.getLogger(__name__)
+
+# Import third party libs
+import salt.ext.six as six
+try:
+    #pylint: disable=unused-import
+    import botocore
+    import boto3
+    #pylint: enable=unused-import
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist and if boto libraries are greater than
+    a given version.
+    '''
+    if not HAS_BOTO3:
+        return (False, 'The boto3_elasticache module could not be loaded: boto3 libraries not found')
+### Version reqs (if any) currently undetermined
+#    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
+#        return (False, 'The boto3_elasticache module could not be loaded: boto3 library version 1.2.6 is required')
+    return True
+
+
+def __init__(opts):
+    salt.utils.compat.pack_dunder(__name__)
+    if HAS_BOTO3:
+        __utils__['boto3.assign_funcs'](__name__, 'elasticache',
+                  get_conn_funcname='_get_conn',
+                  cache_id_funcname='_cache_id',
+                  exactly_one_funcname=None)
+
+
+def _collect_results(func, item, args, marker='Marker'):
+    ret = []
+    Marker = args[marker] if marker in args else ''
+    while Marker is not None:
+        r = func(**args)
+        ret += r.get(item)
+        Marker = r.get(marker)
+        args.update({marker: Marker})
+    return ret
+
+
+def describe_cache_clusters(name=None, ShowCacheNodeInfo=False, conn=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Return details about all (or just one) Elasticache cache clusters.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.describe_cache_clusters
+        salt myminion boto3_elasticache.describe_cache_clusters myelasticache
+    '''
+    if conn == None:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        args = {'CacheClusterId': name} if name else {'Marker': ''}
+        args.update({'ShowCacheNodeInfo': ShowCacheNodeInfo}) if ShowCacheNodeInfo else None
+        return _collect_results(conn.describe_cache_clusters, 'CacheClusters', args)
+    except botocore.exceptions.ClientError as e:
+        log.debug(e)
+        return None
+
+
+def cache_cluster_exists(name, conn=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Check to see if a cache cluster exists.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.cache_cluster_exists myelasticache
+    '''
+    return bool(describe_cache_clusters(name=name, conn=conn, region=region, key=key, keyid=keyid, profile=profile))
+
+
+def create_cache_cluster(name, wait=True, security_groups=None,
+                         region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Create a cache cluster.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.create_cache_cluster name=myCacheCluster \
+                                                             Engine=redis \
+                                                             CacheNodeType=cache.t2.micro \
+                                                             NumCacheNodes=1 \
+                                                             SecurityGroupIds='[sg-11223344]' \
+                                                             CacheSubnetGroupName=myCacheSubnetGroup
+    '''
+    if wait is True:
+        wait = (10, 6, 10)
+    try:
+        o, i, s = wait; o = int(o); i=int(i); s = int(s)
+    except:
+        log.warning("Invalid value for 'wait' param - must be a bool or tuple of three integers.")
+        wait = False
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'CacheClusterId' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'CacheClusterId: {1}'".format(name, args['CacheClusterId']))
+        name = args['CacheClusterId']
+    else:
+        args['CacheClusterId'] = name
+    if security_groups:
+        if not isinstance(security_groups, list):
+            security_groups = [security_groups]
+        sgs = __salt__['boto_secgroup.convert_to_group_ids'](groups=security_groups, region=region,
+                                                             key=key, keyid=keyid, profile=profile)
+        if 'SecurityGroupIds' not in args:
+            args['SecurityGroupIds'] = []
+        args['SecurityGroupIds'] += sgs
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.create_cache_cluster(**args)
+        if not wait:
+            log.info('Cache cluster {0} created.'.format(name))
+            return True
+        for outer in range(o):
+            for inner in range(i):
+                r = describe_cache_clusters(name=name, conn=conn)
+                if r and r[0].get('CacheClusterStatus') == 'available':
+                    log.info('Cache cluster {0} created and available.'.format(name))
+                    return True
+                time.sleep(s)
+            log.info('Waiting up to {0} seconds for cache cluster {1} to become '
+                     'available.'.format(o * i * s, name))
+        log.error('Cache cluster {0} not available after {1} seconds!'.format(name, o * i * s))
+        return False
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to create cache cluster {0}: {1}'.format(name, e))
+        return False
+
+
+def modify_cache_cluster(name, wait=True, security_groups=None, region=None,
+                         key=None, keyid=None, profile=None, **args):
+    '''
+    Update a cache cluster in place.
+
+    Notes:  {ApplyImmediately: False} is pretty danged silly in the context of salt.
+            You can pass it, but for fairly obvious reasons the results over multiple
+            runs will be undefined and probably contrary to your desired state.
+            Reducing the number of nodes requires an EXPLICIT CacheNodeIdsToRemove be
+            passed, which until a reasonable heuristic for programmatically deciding
+            which nodes to remove has been established, MUST be decided and populated
+            intentionally before a state call, and removed again before the next.  In
+            practice this is not particularly useful and should generally be avoided.
+
+    CacheClusterId
+        Cannot be changed.  Required param as it tells AWS what we'll be modifying.
+
+    NumCacheNodes
+        The number of cache nodes that the cache cluster should have. If the value for
+        NumCacheNodes is greater than the sum of the number of current cache nodes and
+        the number of cache nodes pending creation (which may be zero), more nodes are
+        added. If the value is less than the number of existing cache nodes, nodes are
+        removed. If the value is equal to the number of current cache nodes, any
+        pending add or remove requests are canceled.  If you are removing cache nodes,
+        you MUST use the CacheNodeIdsToRemove parameter to provide the IDs of the
+        specific cache nodes to remove.  For clusters running Redis, this value MUST be 1.
+        For clusters running Memcached, this value must be between 1 and 20.
+
+    CacheNodeIdsToRemove
+        A list of cache node IDs to be removed. A node ID is a numeric identifier (0001,
+        0002, etc.). This parameter is only valid when NumCacheNodes is less than the
+        existing number of cache nodes. The number of cache node IDs supplied in this
+        parameter must match the difference between the existing number of cache nodes in
+        the cluster or pending cache nodes, whichever is greater, and the value of
+        NumCacheNodes in the request.  For example: If you have 3 active cache nodes,
+        7 pending cache nodes, and the number of cache nodes in this ModifyCacheCluser
+        call is 5, you must list 2 (7 - 5) cache node IDs to remove.
+
+    AZMode
+        Specifies whether the new nodes in this Memcached cache cluster are all created
+        in a single Availability Zone or created across multiple Availability Zones.
+        Valid values:  single-az | cross-az
+        Notes:  This option is ONLY supported for Memcached cache clusters.
+                You cannot specify single-az if the Memcached cache cluster already has
+                cache nodes in different Availability Zones. If cross-az is specified,
+                existing Memcached nodes remain in their current Availability Zone.
+                Only newly created nodes are located in different Availability Zones.
+                For instructions on how to move existing Memcached nodes to different
+                Availability Zones, see the AWS docs.
+
+    NewAvailabilityZones
+        The list of Availability Zones where the new Memcached cache nodes are created.
+        This parameter is only valid when NumCacheNodes in the request is greater than
+        the sum of the number of active cache nodes and the number of cache nodes pending
+        creation (which may be zero). The number of Availability Zones supplied in this
+        list must match the cache nodes being added in this request.
+        Note:  This option is ONLY supported on Memcached clusters.
+
+    CacheSecurityGroupNames
+        A list of cache security group names to authorize on this cache cluster.  This
+        change is asynchronously applied as soon as possible.  You can use this parameter
+        only with clusters that are created outside of a VPC.
+        Constraints:  Must contain no more than 255 alphanumeric characters.
+                      Must not be "Default".
+
+    SecurityGroupIds
+        Specifies the VPC Security Groups associated with the cache cluster.  This
+        parameter can ONLY be used with clusters that are created in a VPC.
+
+    PreferredMaintenanceWindow
+        Desired maintenance window, as described for create_cache_cluster() above.
+
+    NotificationTopicArn
+        The Amazon Resource Name (ARN) of the Amazon SNS topic to which notifications
+        are sent.
+        Note:  The Amazon SNS topic owner must be same as the cache cluster owner.
+
+    CacheParameterGroupName
+        The name of the cache parameter group to apply to this cache cluster.  This
+        change is asynchronously applied as soon as possible when {ApplyImmediately:
+        True} is set for this request.
+
+    NotificationTopicStatus
+        The status of the Amazon SNS notification topic. Notifications are sent only
+        if the status is active.
+        Valid values:  active | inactive
+
+    ApplyImmediately
+        If True, this parameter causes the modifications in this request and any
+        pending modifications to be applied, asynchronously and as soon as possible,
+        regardless of the PreferredMaintenanceWindow setting for the cache cluster.
+        If False, changes to the cache cluster are applied on the next maintenance
+        reboot, or the next failure reboot, whichever occurs first.
+        Note:  If you perform a ModifyCacheCluster before a pending modification is
+               applied, the pending modification is replaced by the newer modification.
+        Default:  False
+
+    EngineVersion
+        The upgraded version of the cache engine to be run on the cache nodes.
+        Note:  You can upgrade to a newer engine version but you cannot downgrade to
+        an earlier engine version. If you want to use an earlier engine version, you
+        must delete the existing cache cluster and create it anew with the earlier
+        engine version.
+
+    AutoMinorVersionUpgrade
+        Per AWS, this parameter is currently disabled.
+
+    SnapshotRetentionLimit
+        The number of days for which ElastiCache retains automatic cache cluster
+        snapshots before deleting them.
+        Note: If the value of SnapshotRetentionLimit is set to zero (0), backups
+              are turned off.
+
+    SnapshotWindow
+        The daily time range (in UTC) during which ElastiCache begins taking a
+        daily snapshot of your cache cluster, as described above for
+        create_cache_cluster().
+
+    CacheNodeType
+        A valid cache node type (as described for create_cache_cluster() above)
+        that you want to scale this cache cluster to.
+    '''
+    if wait is True:
+        wait = (10, 6, 10)
+    try:
+        o, i, s = wait; o = int(o); i=int(i); s = int(s)
+    except:
+        log.warning("Invalid value for 'wait' param - must be a bool or tuple of three integers.")
+        wait = False
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'CacheClusterId' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'CacheClusterId: {1}'".format(name, args['CacheClusterId']))
+        name = args['CacheClusterId']
+    else:
+        args['CacheClusterId'] = name
+    if security_groups:
+        if not isinstance(security_groups, list):
+            security_groups = [security_groups]
+        sgs = __salt__['boto_secgroup.convert_to_group_ids'](groups=security_groups, region=region,
+                                                             key=key, keyid=keyid, profile=profile)
+        if 'SecurityGroupIds' not in args:
+            args['SecurityGroupIds'] = []
+        args['SecurityGroupIds'] += sgs
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.modify_cache_cluster(**args)
+        if not wait:
+            log.info('Cache cluster {0} being modified.'.format(name))
+            return True
+        for outer in range(o):
+            for inner in range(i):
+                r = describe_cache_clusters(name=name, conn=conn)
+                if r and r[0].get('CacheClusterStatus') == 'available':
+                    log.info('Cache cluster {0} modified and available.'.format(name))
+                    return True
+                time.sleep(s)
+            log.info('Waiting up to {0} seconds for cache cluster {1} to become '
+                     'available.'.format(o * i * s, name))
+        log.error('Cache cluster {0} not available after {1} seconds!'.format(name, o * i * s))
+        return False
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to modify cache cluster {0}: {1}'.format(name, e))
+        return False
+
+
+def delete_cache_cluster(name, wait=True, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Delete a cache cluster.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.delete myelasticache
+    '''
+    if wait is True:
+        wait = (10, 6, 10)
+    try:
+        o, i, s = wait; o = int(o); i=int(i); s = int(s)
+    except:
+        log.warning("Invalid value for 'wait' param - must be a bool or tuple of three integers.")
+        wait = False
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'CacheClusterId' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'CacheClusterId: {1}'".format(name, args['CacheClusterId']))
+        name = args['CacheClusterId']
+    else:
+        args['CacheClusterId'] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.delete_cache_cluster(**args)
+        if not wait:
+            log.info('Cache cluster {0} deleting.'.format(name))
+            return True
+        for outer in range(o):
+            for inner in range(i):
+                r = describe_cache_clusters(name=name, conn=conn)
+                if not r or r[0].get('CacheClusterStatus') == 'deleted':
+                    log.info('Cache cluster {0} deleted.'.format(name))
+                    return True
+                time.sleep(s)
+            log.info('Waiting up to {0} seconds for cache cluster {1} to be '
+                     'deleted.'.format(o * i * s, name))
+        log.error('Cache cluster {0} not deleted after {1} seconds!'.format(name, o * i * s))
+        return False
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to delete cache cluster {0}: {1}'.format(name, e))
+        return False
+
+
+def describe_replication_groups(name=None, conn=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Return details about all (or just one) Elasticache replication groups.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.describe_replication_groups
+        salt myminion boto3_elasticache.describe_replication_groups myelasticache
+    '''
+    if conn == None:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        args = {'ReplicationGroupId': name} if name else {'Marker': ''}
+        return _collect_results(conn.describe_replication_groups, 'ReplicationGroups', args)
+    except botocore.exceptions.ClientError as e:
+        log.debug(e)
+        return False
+
+
+def replication_group_exists(name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Check to see if a replication group exists.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.replication_group_exists myelasticache
+    '''
+    return bool(describe_replication_groups(name=name, region=region, key=key, keyid=keyid, profile=profile))
+
+
+def create_replication_group(name, wait=True, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Create replication group.
+    Params are extensive and variable - see
+    http://boto3.readthedocs.io/en/latest/reference/services/elasticache.html?#ElastiCache.Client.create_replication_group
+    for in-depth usage documentation.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.create_replication_group name=myelasticache ReplicationGroupDescription=description
+    '''
+    if wait is True:
+        wait = (10, 6, 10)
+    try:
+        o, i, s = wait; o = int(o); i=int(i); s = int(s)
+    except:
+        log.warning("Invalid value for 'wait' param - must be a bool or tuple of three integers.")
+        wait = False
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'ReplicationGroupId' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'ReplicationGroupId: {1}'".format(name, args['ReplicationGroupId']))
+        name = args['ReplicationGroupId']
+    else:
+        args['ReplicationGroupId'] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.create_replication_group(**args)
+        if not wait:
+            log.info('Replication group {0} created.'.format(name))
+            return True
+        for outer in range(o):
+            for inner in range(i):
+                r = describe_replication_groups(name, conn)
+                if r and r[0].get('Status') == 'available':
+                    log.info('Replication group {0} created and available.'.format(name))
+                    return True
+                time.sleep(s)
+            log.info('Waiting up to {0} seconds for replication group {1} to become '
+                     'available.'.format(o * i * s, name))
+        log.error('Replication group {0} not available after {1} seconds!'.format(name, o * i * s))
+        return False
+    except botocore.exceptions.ClientError as e:
+        msg = 'Failed to create replication group {0}: {1}'.format(name, e)
+        log.error(msg)
+        return False
+
+
+def delete_replication_group(name, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Delete an ElastiCache replication group, optionally taking a snapshot first.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.delete_replication_group my-replication-group
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'ReplicationGroupId' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'ReplicationGroupId: {1}'".format(name, args['ReplicationGroupId']))
+        name = args['ReplicationGroupId']
+    else:
+        args['ReplicationGroupId'] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.delete_replication_group(**args)
+        log.info('Replication group {0} deleted.'.format(name))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to delete Replication group {0}: {1}'.format(name, e))
+        return False
+
+
+def describe_cache_subnet_groups(name=None, conn=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Return details about all (or just one) Elasticache replication groups.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.describe_cache_subnet_groups region=us-east-1
+    '''
+    if conn == None:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        args = {'CacheSubnetGroupName': name} if name else {'Marker': ''}
+        return _collect_results(conn.describe_cache_subnet_groups, 'CacheSubnetGroups', args)
+    except botocore.exceptions.ClientError as e:
+        log.debug(e)
+        return None
+
+
+def cache_subnet_group_exists(name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Check to see if an ElastiCache subnet group exists.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.cache_subnet_group_exists my-subnet-group
+    '''
+    return bool(describe_cache_subnet_groups(name=name, region=region, key=key, keyid=keyid, profile=profile))
+
+
+def list_cache_subnet_groups(region=None, key=None, keyid=None, profile=None):
+    '''
+    Return a list of all cache subnet group names
+
+    CLI example::
+
+        salt myminion boto3_elasticache.list_cache_subnet_groups region=us-east-1
+    '''
+    return [g['CacheSubnetGroupName'] for g in
+            describe_cache_subnet_groups(None, region, key, keyid, profile)]
+
+
+def create_cache_subnet_group(name, subnets=None, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Create an ElastiCache subnet group
+
+    CLI example to create an ElastiCache subnet group::
+
+        salt myminion boto3_elasticache.create_cache_subnet_group my-subnet-group \ XXX
+            "group description" subnet_ids='[subnet-12345678, subnet-87654321]' \
+            region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'CacheSubnetGroupName' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'CacheSubnetGroupName: {1}'".format(name, args['CacheSubnetGroupName']))
+        name = args['CacheSubnetGroupName']
+    else:
+        args['CacheSubnetGroupName'] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    if subnets:
+        if 'SubnetIds' not in args:
+            args['SubnetIds'] = []
+        if not isinstance(subnets, list):
+            subnets = [subnets]
+        for subnet in subnets:
+            sn = __salt__['boto_vpc.describe_subnets'](subnet_names=security_groups,
+                                                       region=region, key=key, keyid=keyid,
+                                                       profile=profile).get('subnets')
+            if len(sn) == 1:
+                args['SubnetIds'] += [sn[0]['id']]
+            elif len(sn) > 1:
+                raise CommandExecutionError('Subnet Name {0} returned more than one '
+                                          'ID.'.format(subnet))
+            elif subnet.startswith('subnet-'):
+                # Moderately safe assumption... :)  Will be caught later if incorrect.
+                args['SubnetIds'] += [subnet]
+            else:
+                raise SaltInvocationError('Could not resolve Subnet Name {0} to an '
+                                          'ID.'.format(subnet))
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.create_cache_subnet_group(**args)
+        log.info('Cache subnet group {0} created.'.format(name))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to create cache subnet group {0}: {1}'.format(name, e))
+        return False
+
+
+def delete_cache_subnet_group(name, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Delete an ElastiCache subnet group.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.delete_subnet_group my-subnet-group region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'CacheSubnetGroupName' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'CacheSubnetGroupName: {1}'".format(name, args['CacheSubnetGroupName']))
+        name = args['CacheSubnetGroupName']
+    else:
+        args['CacheSubnetGroupName'] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.delete_cache_subnet_group(**args)
+        log.info('Cache subnet group {0} deleted.'.format(name))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to delete cache subnet group {0}: {1}'.format(name, e))
+        return False
+
+
+def describe_cache_security_groups(name=None, conn=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Return details about all (or just one) Elasticache cache clusters.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.describe_cache_security_groups
+        salt myminion boto3_elasticache.describe_cache_security_groups mycachesecgrp
+    '''
+    if conn == None:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        args = {'CacheSecurityGroupName': name} if name else {'Marker': ''}
+        return _collect_results(conn.describe_cache_security_groups, 'CacheSecurityGroups', args)
+    except botocore.exceptions.ClientError as e:
+        log.debug(e)
+        return None
+
+
+def cache_security_group_exists(name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Check to see if an ElastiCache security group exists.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.cache_security_group_exists mysecuritygroup
+    '''
+    return bool(describe_cache_security_groups(name=name, region=region, key=key, keyid=keyid, profile=profile))
+
+
+def create_cache_security_group(name, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Create a cache security group.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.create_cache_security_group mycachesecgrp Description='My Cache Security Group'
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'CacheSecurityGroupName' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'CacheSecurityGroupName: {1}'".format(name, args['CacheSecurityGroupName']))
+        name = args['CacheSecurityGroupName']
+    else:
+        args['CacheSecurityGroupName'] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.create_cache_security_group(**args)
+        log.info('Created cache security group {0}.'.format(name))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to create cache security group {0}: {1}'.format(name, e))
+        return False
+
+
+def delete_cache_security_group(name, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Delete a cache security group.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.delete_cache_security_group myelasticachesg
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'CacheSecurityGroupName' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'CacheSecurityGroupName: {1}'".format(name, args['CacheSecurityGroupName']))
+        name = args['CacheSecurityGroupName']
+    else:
+        args['CacheSubnetGroupName'] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.delete_cache_security_group(**args)
+        log.info('Cache security group {0} deleted.'.format(name))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to delete cache security group {0}: {1}'.format(name, e))
+        return False
+
+
+def authorize_cache_security_group_ingress(name, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Authorize network ingress from an ec2 security group to a cache security group.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.authorize_cache_security_group_ingress \
+                                        mycachesecgrp \
+                                        EC2SecurityGroupName=someEC2sg \
+                                        EC2SecurityGroupOwnerId=SOMEOWNERID
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'CacheSecurityGroupName' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'CacheSecurityGroupName: {1}'".format(name, args['CacheSecurityGroupName']))
+        name = args['CacheSecurityGroupName']
+    else:
+        args['CacheSubnetGroupName'] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.authorize_cache_security_group_ingress(**args)
+        log.info('Authorized {0} to cache security group {1}.'.format(args['EC2SecurityGroupName'], name))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to update security group {0}: {1}'.format(name, e))
+        return False
+
+
+def revoke_cache_security_group_ingress(name, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Revoke network ingress from an ec2 security group to a cache security
+    group.
+
+    CLI example::
+
+        salt myminion boto3_elasticache.revoke_cache_security_group_ingress \
+                                        mycachesecgrp \
+                                        EC2SecurityGroupName=someEC2sg \
+                                        EC2SecurityGroupOwnerId=SOMEOWNERID
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'CacheSecurityGroupName' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'CacheSecurityGroupName: {1}'".format(name, args['CacheSecurityGroupName']))
+        name = args['CacheSecurityGroupName']
+    else:
+        args['CacheSubnetGroupName'] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.revoke_cache_security_group_ingress(**args)
+        log.info('Revoked {0} from cache security group {1}.'.format(args['EC2SecurityGroupName'], name))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to update security group {0}: {1}'.format(name, e))
+        return False

--- a/salt/modules/boto3_elasticache.py
+++ b/salt/modules/boto3_elasticache.py
@@ -153,6 +153,7 @@ def _delete_resource(name, name_param, desc, res_type, wait=0, status_param=None
             log.info('{0} {1} deletion requested.'.format(desc.title(), name))
             return True
         log.info('Waiting up to {0} seconds for {1} {2} to be deleted.'.format(wait, desc, name))
+        orig_wait = wait
         while wait > 0:
             r = s(name=name, conn=conn)
             if not r or not len(r) or r[0].get(status_param) == status_gone:
@@ -163,7 +164,7 @@ def _delete_resource(name, name_param, desc, res_type, wait=0, status_param=None
                                                                                   name))
             time.sleep(sleep)
             wait -= sleep
-        log.error('{0} {1} not deleted after {2} seconds!'.format(desc.title(), name, wait))
+        log.error('{0} {1} not deleted after {2} seconds!'.format(desc.title(), name, orig_wait))
 
         return False
     except botocore.exceptions.ClientError as e:
@@ -202,6 +203,7 @@ def _create_resource(name, name_param=None, desc=None, res_type=None, wait=0, st
             return True
         log.info('Waiting up to {0} seconds for {1} {2} to be become available.'.format(wait, desc,
                                                                                         name))
+        orig_wait = wait
         while wait > 0:
             r = s(name=name, conn=conn)
             if r and r[0].get(status_param) == status_good:
@@ -212,7 +214,7 @@ def _create_resource(name, name_param=None, desc=None, res_type=None, wait=0, st
                                                                                     name))
             time.sleep(sleep)
             wait -= sleep
-        log.error('{0} {1} not available after {2} seconds!'.format(desc.title(), name, wait))
+        log.error('{0} {1} not available after {2} seconds!'.format(desc.title(), name, orig_wait))
         return False
     except botocore.exceptions.ClientError as e:
         msg = 'Failed to create {0} {1}: {2}'.format(desc, name, e)
@@ -251,6 +253,7 @@ def _modify_resource(name, name_param=None, desc=None, res_type=None, wait=0, st
             return True
         log.info('Waiting up to {0} seconds for {1} {2} to be become available.'.format(wait, desc,
                                                                                         name))
+        orig_wait = wait
         while wait > 0:
             r = s(name=name, conn=conn)
             if r and r[0].get(status_param) == status_good:
@@ -261,7 +264,7 @@ def _modify_resource(name, name_param=None, desc=None, res_type=None, wait=0, st
                                                                                     name))
             time.sleep(sleep)
             wait -= sleep
-        log.error('{0} {1} not available after {2} seconds!'.format(desc.title(), name, wait))
+        log.error('{0} {1} not available after {2} seconds!'.format(desc.title(), name, orig_wait))
         return False
     except botocore.exceptions.ClientError as e:
         msg = 'Failed to modify {0} {1}: {2}'.format(desc, name, e)

--- a/salt/modules/boto3_elasticache.py
+++ b/salt/modules/boto3_elasticache.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
-Connection module for Amazon Elasticache
+Execution module for Amazon Elasticache using boto3
+===================================================
 
-.. versionadded:: 2014.7.0
+.. versionadded:: Nitrogen
 
 :configuration: This module accepts explicit elasticache credentials but can
     also utilize IAM roles assigned to the instance through Instance Profiles.

--- a/salt/modules/boto3_elasticache.py
+++ b/salt/modules/boto3_elasticache.py
@@ -747,6 +747,13 @@ def list_tags_for_resource(name, region=None, key=None, keyid=None, profile=None
     about the account number, AWS partition, and other magic details to generate.
 
     If you happen to have those handy, feel free to utilize this however...
+
+    Example:
+
+    .. code-block:: bash
+
+        salt myminion boto3_elasticache.list_tags_for_resource \
+                name'=arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot'
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     if 'ResourceName' in args:
@@ -776,6 +783,14 @@ def add_tags_to_resource(name, region=None, key=None, keyid=None, profile=None, 
     about the account number, AWS partition, and other magic details to generate.
 
     If you happen to have those at hand though, feel free to utilize this function...
+
+    Example:
+
+    .. code-block:: bash
+
+        salt myminion boto3_elasticache.add_tags_to_resource \
+                name'=arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot' \
+                Tags="[{'Key': 'TeamOwner', 'Value': 'infrastructure'}]"
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     if 'ResourceName' in args:
@@ -804,6 +819,14 @@ def remove_tags_from_resource(name, region=None, key=None, keyid=None, profile=N
     about the account number, AWS partition, and other magic details to generate.
 
     If you happen to have those at hand though, feel free to utilize this function...
+
+    Example:
+
+    .. code-block:: bash
+
+        salt myminion boto3_elasticache.remove_tags_from_resource \
+                name'=arn:aws:elasticache:us-west-2:0123456789:snapshot:mySnapshot' \
+                TagKeys="['TeamOwner']"
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     if 'ResourceName' in args:
@@ -825,6 +848,13 @@ def remove_tags_from_resource(name, region=None, key=None, keyid=None, profile=N
 def copy_snapshot(name, region=None, key=None, keyid=None, profile=None, **args):
     '''
     Make a copy of an existing snapshot.
+
+    Example:
+
+    .. code-block:: bash
+
+        salt myminion boto3_elasticache.copy_snapshot name=mySnapshot \
+                                                      TargetSnapshotName=copyOfMySnapshot
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     if 'SourceSnapshotName' in args:

--- a/salt/modules/boto3_elasticache.py
+++ b/salt/modules/boto3_elasticache.py
@@ -51,25 +51,15 @@ import logging
 import socket
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 import time
-import random
 
 # Import Salt libs
 import salt.utils.boto3
 import salt.utils.compat
 from salt.exceptions import SaltInvocationError, CommandExecutionError
-from salt.ext.six.moves import range  # pylint: disable=import-error
-
-# from salt.utils import exactly_one
-# TODO: Uncomment this and s/_exactly_one/exactly_one/
-# See note in utils.boto
-PROVISIONING = 'provisioning'
-PENDING_ACCEPTANCE = 'pending-acceptance'
-ACTIVE = 'active'
 
 log = logging.getLogger(__name__)
 
 # Import third party libs
-import salt.ext.six as six
 try:
     #pylint: disable=unused-import
     import botocore
@@ -88,9 +78,6 @@ def __virtual__():
     '''
     if not HAS_BOTO3:
         return (False, 'The boto3_elasticache module could not be loaded: boto3 libraries not found')
-### Version reqs (if any) currently undetermined
-#    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
-#        return (False, 'The boto3_elasticache module could not be loaded: boto3 library version 1.2.6 is required')
     return True
 
 
@@ -114,43 +101,158 @@ def _collect_results(func, item, args, marker='Marker'):
     return ret
 
 
-def describe_cache_clusters(name=None, ShowCacheNodeInfo=False, conn=None, region=None, key=None, keyid=None, profile=None):
+def _describe_resource(name=None, name_param=None, res_type=None, info_node=None, conn=None,
+                            region=None, key=None, keyid=None, profile=None, **args):
+    if conn == None:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        func = 'describe_'+res_type+'s'
+        f = getattr(conn, func)
+    except (AttributeError, KeyError) as e:
+        raise SaltInvocationError("No function '{0}()' found: {1}".format(func, e.message))
+    # Undocumented, but you can't pass 'Marker' if searching for a specific resource...
+    args.update({name_param: name} if name else {'Marker': ''})
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        return _collect_results(f, info_node, args)
+    except botocore.exceptions.ClientError as e:
+        log.debug(e)
+        return None
+
+
+def _delete_resource(name, name_param, desc, res_type, wait=0, status_param=None,
+                     status_gone='deleted', region=None, key=None, keyid=None, profile=None,
+                     **args):
+    '''
+    Delete a generic Elasticache resource.
+    '''
+    try:
+        wait = int(wait)
+    except:
+        raise SaltInvocationError("Bad value ('{0}') passed for 'wait' param - must be an "
+                                  "int or boolean.".format(wait))
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if name_param in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'{1}: {2}'".format(name, name_param, args[name_param]))
+        name = args[name_param]
+    else:
+        args[name_param] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        func = 'delete_'+res_type
+        f = getattr(conn, func)
+        if wait:
+            func = 'describe_'+res_type+'s'
+            s = globals()[func]
+    except (AttributeError, KeyError) as e:
+        raise SaltInvocationError("No function '{0}()' found: {1}".format(func, e.message))
+    try:
+
+        f(**args)
+        if not wait:
+            log.info('{0} {1} deletion requested.'.format(desc.title(), name))
+            return True
+        log.info('Waiting up to {0} seconds for {1} {2} to be deleted.'.format(wait, desc, name))
+        while wait > 0:
+            r = s(name=name, conn=conn)
+            if not r or not len(r) or r[0].get(status_param) == status_gone:
+                log.info('{0} {1} deleted.'.format(desc.title(), name))
+                return True
+            sleep = wait if wait % 60 == wait else 60
+            log.info('Sleeping {0} seconds for {1} {2} to be deleted.'.format(sleep, desc,
+                                                                                  name))
+            time.sleep(sleep)
+            wait -= sleep
+        log.error('{0} {1} not deleted after {2} seconds!'.format(desc.title(), name, wait))
+
+        return False
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to delete {0} {1}: {2}'.format(desc, name, e))
+        return False
+
+
+def _create_resource(name, name_param=None, desc=None, res_type=None, wait=0, status_param=None,
+                     status_good='available', region=None, key=None, keyid=None, profile=None,
+                     **args):
+    try:
+        wait = int(wait)
+    except:
+        raise SaltInvocationError("Bad value ('{0}') passed for 'wait' param - must be an "
+                                  "int or boolean.".format(wait))
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if name_param in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'{1}: {2}'".format(name, name_param, args[name_param]))
+        name = args[name_param]
+    else:
+        args[name_param] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        func = 'create_'+res_type
+        f = getattr(conn, func)
+        if wait:
+            func = 'describe_'+res_type+'s'
+            s = globals()[func]
+    except (AttributeError, KeyError) as e:
+        raise SaltInvocationError("No function '{0}()' found: {1}".format(func, e.message))
+    try:
+        f(**args)
+        if not wait:
+            log.info('{0} {1} created.'.format(desc.title(), name))
+            return True
+        log.info('Waiting up to {0} seconds for {1} {2} to be become available.'.format(wait, desc,
+                                                                                        name))
+        while wait > 0:
+            r = s(name=name, conn=conn)
+            if r and r[0].get(status_param) == status_good:
+                log.info('{0} {1} created and available.'.format(desc.title(), name))
+                return True
+            sleep = wait if wait % 60 == wait else 60
+            log.info('Sleeping {0} seconds for {1} {2} to become available.'.format(sleep, desc,
+                                                                                    name))
+            time.sleep(sleep)
+            wait -= sleep
+        log.error('{0} {1} not available after {2} seconds!'.format(desc.title(), name, wait))
+        return False
+    except botocore.exceptions.ClientError as e:
+        msg = 'Failed to create {0} {1}: {2}'.format(desc, name, e)
+        log.error(msg)
+        return False
+
+
+def describe_cache_clusters(name=None, conn=None, region=None, key=None,
+                            keyid=None, profile=None, **args):
     '''
     Return details about all (or just one) Elasticache cache clusters.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.describe_cache_clusters
         salt myminion boto3_elasticache.describe_cache_clusters myelasticache
     '''
-    if conn == None:
-        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    try:
-        args = {'CacheClusterId': name} if name else {'Marker': ''}
-        args.update({'ShowCacheNodeInfo': ShowCacheNodeInfo}) if ShowCacheNodeInfo else None
-        return _collect_results(conn.describe_cache_clusters, 'CacheClusters', args)
-    except botocore.exceptions.ClientError as e:
-        log.debug(e)
-        return None
+    return  _describe_resource(name=name, name_param='CacheClusterId', res_type='cache_cluster',
+                               info_node='CacheClusters', conn=conn, region=region, key=key,
+                               keyid=keyid, profile=profile, **args)
 
 
 def cache_cluster_exists(name, conn=None, region=None, key=None, keyid=None, profile=None):
     '''
     Check to see if a cache cluster exists.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.cache_cluster_exists myelasticache
     '''
     return bool(describe_cache_clusters(name=name, conn=conn, region=region, key=key, keyid=keyid, profile=profile))
 
 
-def create_cache_cluster(name, wait=True, security_groups=None,
+def create_cache_cluster(name, wait=600, security_groups=None,
                          region=None, key=None, keyid=None, profile=None, **args):
     '''
     Create a cache cluster.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.create_cache_cluster name=myCacheCluster \
                                                              Engine=redis \
@@ -159,20 +261,6 @@ def create_cache_cluster(name, wait=True, security_groups=None,
                                                              SecurityGroupIds='[sg-11223344]' \
                                                              CacheSubnetGroupName=myCacheSubnetGroup
     '''
-    if wait is True:
-        wait = (10, 6, 10)
-    try:
-        o, i, s = wait; o = int(o); i=int(i); s = int(s)
-    except:
-        log.warning("Invalid value for 'wait' param - must be a bool or tuple of three integers.")
-        wait = False
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    if 'CacheClusterId' in args:
-        log.info("'name: {0}' param being overridden by explicitly provided "
-                 "'CacheClusterId: {1}'".format(name, args['CacheClusterId']))
-        name = args['CacheClusterId']
-    else:
-        args['CacheClusterId'] = name
     if security_groups:
         if not isinstance(security_groups, list):
             security_groups = [security_groups]
@@ -182,28 +270,12 @@ def create_cache_cluster(name, wait=True, security_groups=None,
             args['SecurityGroupIds'] = []
         args['SecurityGroupIds'] += sgs
     args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
-    try:
-        conn.create_cache_cluster(**args)
-        if not wait:
-            log.info('Cache cluster {0} created.'.format(name))
-            return True
-        for outer in range(o):
-            for inner in range(i):
-                r = describe_cache_clusters(name=name, conn=conn)
-                if r and r[0].get('CacheClusterStatus') == 'available':
-                    log.info('Cache cluster {0} created and available.'.format(name))
-                    return True
-                time.sleep(s)
-            log.info('Waiting up to {0} seconds for cache cluster {1} to become '
-                     'available.'.format(o * i * s, name))
-        log.error('Cache cluster {0} not available after {1} seconds!'.format(name, o * i * s))
-        return False
-    except botocore.exceptions.ClientError as e:
-        log.error('Failed to create cache cluster {0}: {1}'.format(name, e))
-        return False
+    return _create_resource(name, name_param='CacheClusterId', desc='cache cluster',
+                            res_type='cache_cluster', wait=wait, status_param='CacheClusterStatus',
+                            region=region, key=key, keyid=keyid, profile=profile, **args)
 
 
-def modify_cache_cluster(name, wait=True, security_groups=None, region=None,
+def modify_cache_cluster(name, wait=600, security_groups=None, region=None,
                          key=None, keyid=None, profile=None, **args):
     '''
     Update a cache cluster in place.
@@ -215,123 +287,18 @@ def modify_cache_cluster(name, wait=True, security_groups=None, region=None,
             passed, which until a reasonable heuristic for programmatically deciding
             which nodes to remove has been established, MUST be decided and populated
             intentionally before a state call, and removed again before the next.  In
-            practice this is not particularly useful and should generally be avoided.
+            practice this is not particularly useful and should probably be avoided.
 
-    CacheClusterId
-        Cannot be changed.  Required param as it tells AWS what we'll be modifying.
+    .. code-block:: bash
 
-    NumCacheNodes
-        The number of cache nodes that the cache cluster should have. If the value for
-        NumCacheNodes is greater than the sum of the number of current cache nodes and
-        the number of cache nodes pending creation (which may be zero), more nodes are
-        added. If the value is less than the number of existing cache nodes, nodes are
-        removed. If the value is equal to the number of current cache nodes, any
-        pending add or remove requests are canceled.  If you are removing cache nodes,
-        you MUST use the CacheNodeIdsToRemove parameter to provide the IDs of the
-        specific cache nodes to remove.  For clusters running Redis, this value MUST be 1.
-        For clusters running Memcached, this value must be between 1 and 20.
-
-    CacheNodeIdsToRemove
-        A list of cache node IDs to be removed. A node ID is a numeric identifier (0001,
-        0002, etc.). This parameter is only valid when NumCacheNodes is less than the
-        existing number of cache nodes. The number of cache node IDs supplied in this
-        parameter must match the difference between the existing number of cache nodes in
-        the cluster or pending cache nodes, whichever is greater, and the value of
-        NumCacheNodes in the request.  For example: If you have 3 active cache nodes,
-        7 pending cache nodes, and the number of cache nodes in this ModifyCacheCluser
-        call is 5, you must list 2 (7 - 5) cache node IDs to remove.
-
-    AZMode
-        Specifies whether the new nodes in this Memcached cache cluster are all created
-        in a single Availability Zone or created across multiple Availability Zones.
-        Valid values:  single-az | cross-az
-        Notes:  This option is ONLY supported for Memcached cache clusters.
-                You cannot specify single-az if the Memcached cache cluster already has
-                cache nodes in different Availability Zones. If cross-az is specified,
-                existing Memcached nodes remain in their current Availability Zone.
-                Only newly created nodes are located in different Availability Zones.
-                For instructions on how to move existing Memcached nodes to different
-                Availability Zones, see the AWS docs.
-
-    NewAvailabilityZones
-        The list of Availability Zones where the new Memcached cache nodes are created.
-        This parameter is only valid when NumCacheNodes in the request is greater than
-        the sum of the number of active cache nodes and the number of cache nodes pending
-        creation (which may be zero). The number of Availability Zones supplied in this
-        list must match the cache nodes being added in this request.
-        Note:  This option is ONLY supported on Memcached clusters.
-
-    CacheSecurityGroupNames
-        A list of cache security group names to authorize on this cache cluster.  This
-        change is asynchronously applied as soon as possible.  You can use this parameter
-        only with clusters that are created outside of a VPC.
-        Constraints:  Must contain no more than 255 alphanumeric characters.
-                      Must not be "Default".
-
-    SecurityGroupIds
-        Specifies the VPC Security Groups associated with the cache cluster.  This
-        parameter can ONLY be used with clusters that are created in a VPC.
-
-    PreferredMaintenanceWindow
-        Desired maintenance window, as described for create_cache_cluster() above.
-
-    NotificationTopicArn
-        The Amazon Resource Name (ARN) of the Amazon SNS topic to which notifications
-        are sent.
-        Note:  The Amazon SNS topic owner must be same as the cache cluster owner.
-
-    CacheParameterGroupName
-        The name of the cache parameter group to apply to this cache cluster.  This
-        change is asynchronously applied as soon as possible when {ApplyImmediately:
-        True} is set for this request.
-
-    NotificationTopicStatus
-        The status of the Amazon SNS notification topic. Notifications are sent only
-        if the status is active.
-        Valid values:  active | inactive
-
-    ApplyImmediately
-        If True, this parameter causes the modifications in this request and any
-        pending modifications to be applied, asynchronously and as soon as possible,
-        regardless of the PreferredMaintenanceWindow setting for the cache cluster.
-        If False, changes to the cache cluster are applied on the next maintenance
-        reboot, or the next failure reboot, whichever occurs first.
-        Note:  If you perform a ModifyCacheCluster before a pending modification is
-               applied, the pending modification is replaced by the newer modification.
-        Default:  False
-
-    EngineVersion
-        The upgraded version of the cache engine to be run on the cache nodes.
-        Note:  You can upgrade to a newer engine version but you cannot downgrade to
-        an earlier engine version. If you want to use an earlier engine version, you
-        must delete the existing cache cluster and create it anew with the earlier
-        engine version.
-
-    AutoMinorVersionUpgrade
-        Per AWS, this parameter is currently disabled.
-
-    SnapshotRetentionLimit
-        The number of days for which ElastiCache retains automatic cache cluster
-        snapshots before deleting them.
-        Note: If the value of SnapshotRetentionLimit is set to zero (0), backups
-              are turned off.
-
-    SnapshotWindow
-        The daily time range (in UTC) during which ElastiCache begins taking a
-        daily snapshot of your cache cluster, as described above for
-        create_cache_cluster().
-
-    CacheNodeType
-        A valid cache node type (as described for create_cache_cluster() above)
-        that you want to scale this cache cluster to.
+        salt myminion boto3_elasticache.create_cache_cluster name=myCacheCluster \
+                                                             NotificationTopicStatus=inactive
     '''
-    if wait is True:
-        wait = (10, 6, 10)
     try:
-        o, i, s = wait; o = int(o); i=int(i); s = int(s)
+        wait = int(wait)
     except:
-        log.warning("Invalid value for 'wait' param - must be a bool or tuple of three integers.")
-        wait = False
+        raise SaltInvocationError("Bad value ('{0}') passed for 'wait' param - must be an "
+                                  "int or boolean.".format(wait))
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     if 'CacheClusterId' in args:
         log.info("'name: {0}' param being overridden by explicitly provided "
@@ -351,194 +318,125 @@ def modify_cache_cluster(name, wait=True, security_groups=None, region=None,
     try:
         conn.modify_cache_cluster(**args)
         if not wait:
-            log.info('Cache cluster {0} being modified.'.format(name))
+            log.info('Cache cluster {0} modification requested.'.format(name))
             return True
-        for outer in range(o):
-            for inner in range(i):
-                r = describe_cache_clusters(name=name, conn=conn)
-                if r and r[0].get('CacheClusterStatus') == 'available':
-                    log.info('Cache cluster {0} modified and available.'.format(name))
-                    return True
-                time.sleep(s)
-            log.info('Waiting up to {0} seconds for cache cluster {1} to become '
-                     'available.'.format(o * i * s, name))
-        log.error('Cache cluster {0} not available after {1} seconds!'.format(name, o * i * s))
+        log.info('Waiting up to {0} seconds for cache cluster {1} to become '
+                 'available.'.format(wait, name))
+        while wait > 0:
+            r = describe_cache_clusters(name=name, conn=conn)
+            if r and r[0].get('CacheClusterStatus') == 'available':
+                log.info('Cache cluster {0} modified and available.'.format(name))
+                return True
+            sleep = wait if wait % 60 == wait else 60
+            log.info('Sleeping {0} seconds for cache cluster {1} to become '
+                     'available.'.format(sleep, name))
+            time.sleep(sleep)
+            wait -= sleep
+        log.error('Cache cluster {0} not available after {1} seconds!'.format(name, sleep))
         return False
     except botocore.exceptions.ClientError as e:
-        log.error('Failed to modify cache cluster {0}: {1}'.format(name, e))
+        msg = 'Failed to modify cache cluster {0}: {1}'.format(name, e)
+        log.error(msg)
         return False
 
 
-def delete_cache_cluster(name, wait=True, region=None, key=None, keyid=None, profile=None, **args):
+def delete_cache_cluster(name, wait=600, region=None, key=None, keyid=None, profile=None, **args):
     '''
     Delete a cache cluster.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.delete myelasticache
     '''
-    if wait is True:
-        wait = (10, 6, 10)
-    try:
-        o, i, s = wait; o = int(o); i=int(i); s = int(s)
-    except:
-        log.warning("Invalid value for 'wait' param - must be a bool or tuple of three integers.")
-        wait = False
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    if 'CacheClusterId' in args:
-        log.info("'name: {0}' param being overridden by explicitly provided "
-                 "'CacheClusterId: {1}'".format(name, args['CacheClusterId']))
-        name = args['CacheClusterId']
-    else:
-        args['CacheClusterId'] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
-    try:
-        conn.delete_cache_cluster(**args)
-        if not wait:
-            log.info('Cache cluster {0} deleting.'.format(name))
-            return True
-        for outer in range(o):
-            for inner in range(i):
-                r = describe_cache_clusters(name=name, conn=conn)
-                if not r or r[0].get('CacheClusterStatus') == 'deleted':
-                    log.info('Cache cluster {0} deleted.'.format(name))
-                    return True
-                time.sleep(s)
-            log.info('Waiting up to {0} seconds for cache cluster {1} to be '
-                     'deleted.'.format(o * i * s, name))
-        log.error('Cache cluster {0} not deleted after {1} seconds!'.format(name, o * i * s))
-        return False
-    except botocore.exceptions.ClientError as e:
-        log.error('Failed to delete cache cluster {0}: {1}'.format(name, e))
-        return False
+    return _delete_resource(name, name_param='CacheClusterId', desc='cache cluster',
+                            res_type='cache_cluster', wait=wait,
+                            status_param='CacheClusterStatus',
+                            region=region, key=key, keyid=keyid, profile=profile, **args)
 
 
 def describe_replication_groups(name=None, conn=None, region=None, key=None, keyid=None, profile=None):
     '''
     Return details about all (or just one) Elasticache replication groups.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.describe_replication_groups
         salt myminion boto3_elasticache.describe_replication_groups myelasticache
     '''
-    if conn == None:
-        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    try:
-        args = {'ReplicationGroupId': name} if name else {'Marker': ''}
-        return _collect_results(conn.describe_replication_groups, 'ReplicationGroups', args)
-    except botocore.exceptions.ClientError as e:
-        log.debug(e)
-        return False
+    return  _describe_resource(name=name, name_param='ReplicationGroupId',
+                               res_type='replication_group', info_node='ReplicationGroups',
+                               conn=conn, region=region, key=key, keyid=keyid, profile=profile)
 
 
 def replication_group_exists(name, region=None, key=None, keyid=None, profile=None):
     '''
     Check to see if a replication group exists.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.replication_group_exists myelasticache
     '''
-    return bool(describe_replication_groups(name=name, region=region, key=key, keyid=keyid, profile=profile))
+    return bool(describe_replication_groups(name=name, region=region, key=key, keyid=keyid,
+                profile=profile))
 
 
-def create_replication_group(name, wait=True, region=None, key=None, keyid=None, profile=None, **args):
+def create_replication_group(name, wait=600, security_groups=None, region=None, key=None, keyid=None,
+                             profile=None, **args):
     '''
     Create replication group.
     Params are extensive and variable - see
     http://boto3.readthedocs.io/en/latest/reference/services/elasticache.html?#ElastiCache.Client.create_replication_group
     for in-depth usage documentation.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.create_replication_group name=myelasticache ReplicationGroupDescription=description
     '''
-    if wait is True:
-        wait = (10, 6, 10)
-    try:
-        o, i, s = wait; o = int(o); i=int(i); s = int(s)
-    except:
-        log.warning("Invalid value for 'wait' param - must be a bool or tuple of three integers.")
-        wait = False
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    if 'ReplicationGroupId' in args:
-        log.info("'name: {0}' param being overridden by explicitly provided "
-                 "'ReplicationGroupId: {1}'".format(name, args['ReplicationGroupId']))
-        name = args['ReplicationGroupId']
-    else:
-        args['ReplicationGroupId'] = name
+    if security_groups:
+        if not isinstance(security_groups, list):
+            security_groups = [security_groups]
+        sgs = __salt__['boto_secgroup.convert_to_group_ids'](groups=security_groups, region=region,
+                                                             key=key, keyid=keyid, profile=profile)
+        if 'SecurityGroupIds' not in args:
+            args['SecurityGroupIds'] = []
+        args['SecurityGroupIds'] += sgs
     args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
-    try:
-        conn.create_replication_group(**args)
-        if not wait:
-            log.info('Replication group {0} created.'.format(name))
-            return True
-        for outer in range(o):
-            for inner in range(i):
-                r = describe_replication_groups(name, conn)
-                if r and r[0].get('Status') == 'available':
-                    log.info('Replication group {0} created and available.'.format(name))
-                    return True
-                time.sleep(s)
-            log.info('Waiting up to {0} seconds for replication group {1} to become '
-                     'available.'.format(o * i * s, name))
-        log.error('Replication group {0} not available after {1} seconds!'.format(name, o * i * s))
-        return False
-    except botocore.exceptions.ClientError as e:
-        msg = 'Failed to create replication group {0}: {1}'.format(name, e)
-        log.error(msg)
-        return False
+    return _create_resource(name, name_param='ReplicationGroupId', desc='replication group',
+                            res_type='replication_group', wait=wait, status_param='Status',
+                            region=region, key=key, keyid=keyid, profile=profile, **args)
 
 
-def delete_replication_group(name, region=None, key=None, keyid=None, profile=None, **args):
+def delete_replication_group(name, wait=600, region=None, key=None, keyid=None, profile=None, **args):
     '''
     Delete an ElastiCache replication group, optionally taking a snapshot first.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.delete_replication_group my-replication-group
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    if 'ReplicationGroupId' in args:
-        log.info("'name: {0}' param being overridden by explicitly provided "
-                 "'ReplicationGroupId: {1}'".format(name, args['ReplicationGroupId']))
-        name = args['ReplicationGroupId']
-    else:
-        args['ReplicationGroupId'] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
-    try:
-        conn.delete_replication_group(**args)
-        log.info('Replication group {0} deleted.'.format(name))
-        return True
-    except botocore.exceptions.ClientError as e:
-        log.error('Failed to delete Replication group {0}: {1}'.format(name, e))
-        return False
+    return _delete_resource(name, name_param='ReplicationGroupId', desc='replication group',
+                            res_type='replication_group', wait=wait, status_param='Status',
+                            region=region, key=key, keyid=keyid, profile=profile, **args)
 
 
 def describe_cache_subnet_groups(name=None, conn=None, region=None, key=None, keyid=None, profile=None):
     '''
     Return details about all (or just one) Elasticache replication groups.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.describe_cache_subnet_groups region=us-east-1
     '''
-    if conn == None:
-        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    try:
-        args = {'CacheSubnetGroupName': name} if name else {'Marker': ''}
-        return _collect_results(conn.describe_cache_subnet_groups, 'CacheSubnetGroups', args)
-    except botocore.exceptions.ClientError as e:
-        log.debug(e)
-        return None
+    return  _describe_resource(name=name, name_param='CacheSubnetGroupName',
+                               res_type='cache_subnet_group', info_node='CacheSubnetGroups',
+                               conn=conn, region=region, key=key, keyid=keyid, profile=profile)
 
 
 def cache_subnet_group_exists(name, region=None, key=None, keyid=None, profile=None):
     '''
     Check to see if an ElastiCache subnet group exists.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.cache_subnet_group_exists my-subnet-group
     '''
@@ -549,7 +447,7 @@ def list_cache_subnet_groups(region=None, key=None, keyid=None, profile=None):
     '''
     Return a list of all cache subnet group names
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.list_cache_subnet_groups region=us-east-1
     '''
@@ -561,27 +459,20 @@ def create_cache_subnet_group(name, subnets=None, region=None, key=None, keyid=N
     '''
     Create an ElastiCache subnet group
 
-    CLI example to create an ElastiCache subnet group::
+    .. code-block:: bash
 
-        salt myminion boto3_elasticache.create_cache_subnet_group my-subnet-group \ XXX
-            "group description" subnet_ids='[subnet-12345678, subnet-87654321]' \
-            region=us-east-1
+        salt myminion boto3_elasticache.create_cache_subnet_group \
+                                              name=my-subnet-group \
+                                              CacheSubnetGroupDescription="description" \
+                                              subnets='[myVPCSubnet1,myVPCSubnet2]'
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    if 'CacheSubnetGroupName' in args:
-        log.info("'name: {0}' param being overridden by explicitly provided "
-                 "'CacheSubnetGroupName: {1}'".format(name, args['CacheSubnetGroupName']))
-        name = args['CacheSubnetGroupName']
-    else:
-        args['CacheSubnetGroupName'] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
     if subnets:
         if 'SubnetIds' not in args:
             args['SubnetIds'] = []
         if not isinstance(subnets, list):
             subnets = [subnets]
         for subnet in subnets:
-            sn = __salt__['boto_vpc.describe_subnets'](subnet_names=security_groups,
+            sn = __salt__['boto_vpc.describe_subnets'](subnet_names=subnet,
                                                        region=region, key=key, keyid=keyid,
                                                        profile=profile).get('subnets')
             if len(sn) == 1:
@@ -596,64 +487,44 @@ def create_cache_subnet_group(name, subnets=None, region=None, key=None, keyid=N
                 raise SaltInvocationError('Could not resolve Subnet Name {0} to an '
                                           'ID.'.format(subnet))
     args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
-    try:
-        conn.create_cache_subnet_group(**args)
-        log.info('Cache subnet group {0} created.'.format(name))
-        return True
-    except botocore.exceptions.ClientError as e:
-        log.error('Failed to create cache subnet group {0}: {1}'.format(name, e))
-        return False
+    return _create_resource(name, name_param='CacheSubnetGroupName', desc='cache subnet group',
+                            res_type='cache_subnet_group',
+                            region=region, key=key, keyid=keyid, profile=profile, **args)
 
 
 def delete_cache_subnet_group(name, region=None, key=None, keyid=None, profile=None, **args):
     '''
     Delete an ElastiCache subnet group.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.delete_subnet_group my-subnet-group region=us-east-1
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    if 'CacheSubnetGroupName' in args:
-        log.info("'name: {0}' param being overridden by explicitly provided "
-                 "'CacheSubnetGroupName: {1}'".format(name, args['CacheSubnetGroupName']))
-        name = args['CacheSubnetGroupName']
-    else:
-        args['CacheSubnetGroupName'] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
-    try:
-        conn.delete_cache_subnet_group(**args)
-        log.info('Cache subnet group {0} deleted.'.format(name))
-        return True
-    except botocore.exceptions.ClientError as e:
-        log.error('Failed to delete cache subnet group {0}: {1}'.format(name, e))
-        return False
+    return _delete_resource(name, name_param='CacheSubnetGroupName',
+                            desc='cache subnet group', res_type='cache_subnet_group',
+                            region=region, key=key, keyid=keyid, profile=profile, **args)
 
 
 def describe_cache_security_groups(name=None, conn=None, region=None, key=None, keyid=None, profile=None):
     '''
     Return details about all (or just one) Elasticache cache clusters.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.describe_cache_security_groups
         salt myminion boto3_elasticache.describe_cache_security_groups mycachesecgrp
     '''
-    if conn == None:
-        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    try:
-        args = {'CacheSecurityGroupName': name} if name else {'Marker': ''}
-        return _collect_results(conn.describe_cache_security_groups, 'CacheSecurityGroups', args)
-    except botocore.exceptions.ClientError as e:
-        log.debug(e)
-        return None
+    return  _describe_resource(name=name, name_param='CacheSecurityGroupName',
+                               res_type='cache_security_group',
+                               info_node='CacheSecurityGroups', conn=conn, region=region, key=key,
+                               keyid=keyid, profile=profile)
 
 
 def cache_security_group_exists(name, region=None, key=None, keyid=None, profile=None):
     '''
     Check to see if an ElastiCache security group exists.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.cache_security_group_exists mysecuritygroup
     '''
@@ -664,57 +535,33 @@ def create_cache_security_group(name, region=None, key=None, keyid=None, profile
     '''
     Create a cache security group.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.create_cache_security_group mycachesecgrp Description='My Cache Security Group'
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    if 'CacheSecurityGroupName' in args:
-        log.info("'name: {0}' param being overridden by explicitly provided "
-                 "'CacheSecurityGroupName: {1}'".format(name, args['CacheSecurityGroupName']))
-        name = args['CacheSecurityGroupName']
-    else:
-        args['CacheSecurityGroupName'] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
-    try:
-        conn.create_cache_security_group(**args)
-        log.info('Created cache security group {0}.'.format(name))
-        return True
-    except botocore.exceptions.ClientError as e:
-        log.error('Failed to create cache security group {0}: {1}'.format(name, e))
-        return False
+    return _create_resource(name, name_param='CacheSecurityGroupName', desc='cache security group',
+                            res_type='cache_security_group',
+                            region=region, key=key, keyid=keyid, profile=profile, **args)
 
 
 def delete_cache_security_group(name, region=None, key=None, keyid=None, profile=None, **args):
     '''
     Delete a cache security group.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.delete_cache_security_group myelasticachesg
     '''
-    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    if 'CacheSecurityGroupName' in args:
-        log.info("'name: {0}' param being overridden by explicitly provided "
-                 "'CacheSecurityGroupName: {1}'".format(name, args['CacheSecurityGroupName']))
-        name = args['CacheSecurityGroupName']
-    else:
-        args['CacheSubnetGroupName'] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
-    try:
-        conn.delete_cache_security_group(**args)
-        log.info('Cache security group {0} deleted.'.format(name))
-        return True
-    except botocore.exceptions.ClientError as e:
-        log.error('Failed to delete cache security group {0}: {1}'.format(name, e))
-        return False
+    return _delete_resource(name, name_param='CacheSecurityGroupName',
+                            desc='cache security group', res_type='cache_security_group',
+                            region=region, key=key, keyid=keyid, profile=profile, **args)
 
 
 def authorize_cache_security_group_ingress(name, region=None, key=None, keyid=None, profile=None, **args):
     '''
     Authorize network ingress from an ec2 security group to a cache security group.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.authorize_cache_security_group_ingress \
                                         mycachesecgrp \
@@ -743,7 +590,7 @@ def revoke_cache_security_group_ingress(name, region=None, key=None, keyid=None,
     Revoke network ingress from an ec2 security group to a cache security
     group.
 
-    CLI example::
+    .. code-block:: bash
 
         salt myminion boto3_elasticache.revoke_cache_security_group_ingress \
                                         mycachesecgrp \
@@ -765,3 +612,153 @@ def revoke_cache_security_group_ingress(name, region=None, key=None, keyid=None,
     except botocore.exceptions.ClientError as e:
         log.error('Failed to update security group {0}: {1}'.format(name, e))
         return False
+
+
+def list_tags_for_resource(name, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    List tags on an Elasticache resource.
+
+    Note that this function is essentially useless as it requires a full AWS ARN for the
+    resource being operated on, but there is no provided API or programmatic way to find
+    the ARN for a given object from its name or ID alone.  It requires specific knowledge
+    about the account number, AWS partition, and other magic details to generate.
+
+    If you happen to have those handy, feel free to utilize this however...
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'ResourceName' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'ResourceName: {1}'".format(name, args['ResourceName']))
+        name = args['ResourceName']
+    else:
+        args['ResourceName'] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        r = conn.list_tags_for_resource(**args)
+        if r and 'Taglist' in r:
+            return r['TagList']
+        return []
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to list tags for resource {0}: {1}'.format(name, e))
+        return []
+
+
+def add_tags_to_resource(name, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Add tags to an Elasticache resource.
+
+    Note that this function is essentially useless as it requires a full AWS ARN for the
+    resource being operated on, but there is no provided API or programmatic way to find
+    the ARN for a given object from its name or ID alone.  It requires specific knowledge
+    about the account number, AWS partition, and other magic details to generate.
+
+    If you happen to have those at hand though, feel free to utilize this function...
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'ResourceName' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'ResourceName: {1}'".format(name, args['ResourceName']))
+        name = args['ResourceName']
+    else:
+        args['ResourceName'] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.add_tags_to_resource(**args)
+        log.info('Added tags {0} to {1}.'.format(args['Tags'], name))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to add tags to {0}: {1}'.format(name, e))
+        return False
+
+
+def remove_tags_from_resource(name, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Remove tags from an Elasticache resource.
+
+    Note that this function is essentially useless as it requires a full AWS ARN for the
+    resource being operated on, but there is no provided API or programmatic way to find
+    the ARN for a given object from its name or ID alone.  It requires specific knowledge
+    about the account number, AWS partition, and other magic details to generate.
+
+    If you happen to have those at hand though, feel free to utilize this function...
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'ResourceName' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'ResourceName: {1}'".format(name, args['ResourceName']))
+        name = args['ResourceName']
+    else:
+        args['ResourceName'] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.remove_tags_from_resource(**args)
+        log.info('Added tags {0} to {1}.'.format(args['Tags'], name))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to add tags to {0}: {1}'.format(name, e))
+        return False
+
+
+def copy_snapshot(name, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Make a copy of an existing snapshot.
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if 'SourceSnapshotName' in args:
+        log.info("'name: {0}' param being overridden by explicitly provided "
+                 "'SourceSnapshotName: {1}'".format(name, args['SourceSnapshotName']))
+        name = args['SourceSnapshotName']
+    else:
+        args['SourceSnapshotName'] = name
+    args = dict([(k, v) for k, v in args.items() if not k.startswith('_')])
+    try:
+        conn.copy_snapshot(**args)
+        log.info('Snapshot {0} copied to {1}.'.format(name, args['TargetSnapshotName']))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to copy snapshot {0}: {1}'.format(name, e))
+        return False
+
+
+def describe_cache_parameter_groups(name=None, conn=None, region=None, key=None, keyid=None,
+                                    profile=None):
+    '''
+    Return details about all (or just one) Elasticache cache clusters.
+
+    .. code-block:: bash
+
+        salt myminion boto3_elasticache.describe_cache_parameter_groups
+        salt myminion boto3_elasticache.describe_cache_parameter_groups myParameterGroup
+    '''
+    return  _describe_resource(name=name, name_param='CacheParameterGroupName',
+                               res_type='cache_parameter_group', info_node='CacheParameterGroups',
+                               conn=conn, region=region, key=key, keyid=keyid, profile=profile)
+
+
+def create_cache_parameter_group(name, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Create a cache parameter group.
+
+    .. code-block:: bash
+
+        salt myminion boto3_elasticache.create_cache_parameter_group \
+                name=myParamGroup \
+                CacheParameterGroupFamily=redis2.8 \
+                Description="My Parameter Group"
+    '''
+    return _create_resource(name, name_param='CacheParameterGroupName',
+                            desc='cache parameter group', res_type='cache_parameter_group',
+                            region=region, key=key, keyid=keyid, profile=profile, **args)
+
+
+def delete_cache_parameter_group(name, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Delete a cache parameter group.
+
+    .. code-block:: bash
+
+        salt myminion boto3_elasticache.delete_cache_parameter_group myParamGroup
+    '''
+    return _delete_resource(name, name_param='CacheParameterGroupName',
+                            desc='cache parameter group', res_type='cache_parameter_group',
+                            region=region, key=key, keyid=keyid, profile=profile, **args)

--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -48,7 +48,6 @@ from __future__ import absolute_import
 
 # Import Python libs
 import logging
-import re
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 import salt.ext.six as six
 from salt.exceptions import SaltInvocationError, CommandExecutionError
@@ -311,7 +310,7 @@ def get_group_id(name, vpc_id=None, vpc_name=None, region=None, key=None,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     if name.startswith('sg-'):
-        log.debug('group {0} is a group id. get_group_id not called.'.format(group))
+        log.debug('group {0} is a group id. get_group_id not called.'.format(name))
         return name
     group = _get_group(conn=conn, name=name, vpc_id=vpc_id, vpc_name=vpc_name,
                        region=region, key=key, keyid=keyid, profile=profile)

--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -51,7 +51,7 @@ import logging
 import re
 from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
 import salt.ext.six as six
-from salt.exceptions import SaltInvocationError
+from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -110,16 +110,11 @@ def exists(name=None, region=None, key=None, keyid=None, profile=None,
         return False
 
 
-def _check_vpc(vpc_id=None, vpc_name=None, region=None, key=None, keyid=None,
-               profile=None):
+def _vpc_name_to_id(vpc_id=None, vpc_name=None, region=None, key=None, keyid=None,
+                    profile=None):
     data = __salt__['boto_vpc.get_id'](name=vpc_name, region=region,
                                        key=key, keyid=keyid, profile=profile)
-    try:
-        return data.get('id')
-    except TypeError:
-        return None
-    except KeyError:
-        return None
+    return data.get('id')
 
 
 def _split_rules(rules):
@@ -159,7 +154,7 @@ def _get_group(conn=None, name=None, vpc_id=None, vpc_name=None, group_id=None,
                                   'are mutually exclusive.')
     if vpc_name:
         try:
-            vpc_id = _check_vpc(vpc_id=vpc_id, vpc_name=vpc_name, region=region,
+            vpc_id = _vpc_name_to_id(vpc_id=vpc_id, vpc_name=vpc_name, region=region,
                                 key=key, keyid=keyid, profile=profile)
         except boto.exception.BotoServerError as e:
             log.debug(e)
@@ -179,7 +174,7 @@ def _get_group(conn=None, name=None, vpc_id=None, vpc_name=None, group_id=None,
                     return group
             # If there are more security groups, and no vpc_id, we can't know which one to choose.
             if len(filtered_groups) > 1:
-                raise Exception('Security group belongs to more VPCs, specify the VPC ID!')
+                raise CommandExecutionError('Security group belongs to more VPCs, specify the VPC ID!')
             elif len(filtered_groups) == 1:
                 return filtered_groups[0]
             return None
@@ -315,13 +310,12 @@ def get_group_id(name, vpc_id=None, vpc_name=None, region=None, key=None,
         salt myminion boto_secgroup.get_group_id mysecgroup
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-
+    if name.startswith('sg-'):
+        log.debug('group {0} is a group id. get_group_id not called.'.format(group))
+        return name
     group = _get_group(conn=conn, name=name, vpc_id=vpc_id, vpc_name=vpc_name,
                        region=region, key=key, keyid=keyid, profile=profile)
-    if group:
-        return group.id
-    else:
-        return False
+    return getattr(group, 'id', None)
 
 
 def convert_to_group_ids(groups, vpc_id=None, vpc_name=None, region=None, key=None,
@@ -337,21 +331,15 @@ def convert_to_group_ids(groups, vpc_id=None, vpc_name=None, region=None, key=No
     log.debug('security group contents {0} pre-conversion'.format(groups))
     group_ids = []
     for group in groups:
-        if re.match('sg-.*', group):
-            log.debug('group {0} is a group id. get_group_id not called.'.format(group))
-            group_ids.append(group)
+        group_id = get_group_id(name=group, vpc_id=vpc_id,
+                                vpc_name=vpc_name, region=region,
+                                key=key, keyid=keyid, profile=profile)
+        if not group_id:
+            # Security groups are a big deal - need to fail if any can't be resolved...
+            raise CommandExecutionError('Could not resolve Security Group name '
+                                        '{0} to a Group ID'.format(group))
         else:
-            log.debug('calling boto_secgroup.get_group_id for'
-                      ' group name {0}'.format(group))
-            group_id = get_group_id(name=group, vpc_id=vpc_id,
-                                    vpc_name=vpc_name, region=region,
-                                    key=key, keyid=keyid, profile=profile)
-            if not group_id:
-                log.warning('group name {0} did not resolve to a group ID'.format(group))
-            else:
-                log.debug('group name {0} has group id {1}'.format(group, group_id))
-                group_ids.append(str(group_id))
-
+            group_ids.append(str(group_id))
     log.debug('security group contents {0} post-conversion'.format(group_ids))
     return group_ids
 
@@ -401,7 +389,7 @@ def create(name, description, vpc_id=None, vpc_name=None, region=None, key=None,
 
     if not vpc_id and vpc_name:
         try:
-            vpc_id = _check_vpc(vpc_id=vpc_id, vpc_name=vpc_name, region=region,
+            vpc_id = _vpc_name_to_id(vpc_id=vpc_id, vpc_name=vpc_name, region=region,
                                 key=key, keyid=keyid, profile=profile)
         except boto.exception.BotoServerError as e:
             log.debug(e)

--- a/salt/states/boto3_elasticache.py
+++ b/salt/states/boto3_elasticache.py
@@ -1014,35 +1014,6 @@ def cache_subnet_group_present(name, subnets=None, region=None, key=None, keyid=
     return ret
 
 
-def subnet_group_absent(name, tags=None, region=None, key=None, keyid=None, profile=None):
-    ret = {'name': name,
-           'result': True,
-           'comment': '',
-           'changes': {}
-           }
-
-    exists = __salt__['boto_elasticache.subnet_group_exists'](name=name, tags=tags, region=region, key=key,
-                                                              keyid=keyid, profile=profile)
-    if not exists:
-        ret['result'] = True
-        ret['comment'] = '{0} ElastiCache subnet group does not exist.'.format(name)
-        return ret
-
-    if __opts__['test']:
-        ret['comment'] = 'ElastiCache subnet group {0} would be removed.'.format(name)
-        ret['result'] = None
-        return ret
-    deleted = __salt__['boto_elasticache.delete_subnet_group'](name, region, key, keyid, profile)
-    if not deleted:
-        ret['result'] = False
-        ret['comment'] = 'Failed to delete {0} ElastiCache subnet group.'.format(name)
-        return ret
-    ret['changes']['old'] = name
-    ret['changes']['new'] = None
-    ret['comment'] = 'ElastiCache subnet group {0} deleted.'.format(name)
-    return ret
-
-
 def cache_subnet_group_absent(name, region=None, key=None, keyid=None, profile=None, **args):
     '''
     Ensure a given cache subnet group is deleted.

--- a/salt/states/boto3_elasticache.py
+++ b/salt/states/boto3_elasticache.py
@@ -424,7 +424,7 @@ def cache_cluster_present(name, wait=600, security_groups=None, region=None, key
                                'describe_cache_clusters'](name, region=region, key=key,
                                                           keyid=keyid, profile=profile)
                 if ret['comment']:  # 'create' just ran...
-                    ret['comment'] += ' ... and then immediately modified.'.format(name)
+                    ret['comment'] += ' ... and then immediately modified.'
                 else:
                     ret['comment'] = 'Cache cluster {0} was modified.'.format(name)
                     ret['changes']['old'] = current
@@ -551,8 +551,8 @@ def _diff_replication_group(current, desired):
     return need_update
 
 
-def replication_group_present(name, wait=600, region=None, key=None, keyid=None, profile=None,
-                              **args):
+def replication_group_present(name, wait=600, security_groups=None, region=None, key=None,
+                              keyid=None, profile=None, **args):
     '''
     Ensure a replication group exists and is in the given state.
 
@@ -565,6 +565,11 @@ def replication_group_present(name, wait=600, region=None, key=None, keyid=None,
         of course.  Note that waiting for the cluster to become available is generally the
         better course, as failure to do so will often lead to subsequent failures when managing
         dependent resources.
+
+    security_groups
+        One or more VPC security groups (names and/or IDs) associated with the cache cluster.
+        Note:  This is additive with any sec groups provided via the SecurityGroupIds parameter
+               below.  Use this parameter ONLY when you are creating a cluster in a VPC.
 
     ReplicationGroupId
         The replication group identifier. This parameter is stored as a lowercase string.
@@ -800,7 +805,7 @@ def replication_group_present(name, wait=600, region=None, key=None, keyid=None,
                 ret['result'] = None
                 return ret
             modified = __salt__['boto3_elasticache.'
-                                'modify_replication group'](name, wait=wait,
+                                'modify_replication_group'](name, wait=wait,
                                                             security_groups=security_groups,
                                                             region=region, key=key, keyid=keyid,
                                                             profile=profile, **need_update)
@@ -809,7 +814,7 @@ def replication_group_present(name, wait=600, region=None, key=None, keyid=None,
                                'describe_replication_groups'](name, region=region, key=key,
                                                               keyid=keyid, profile=profile)
                 if ret['comment']:  # 'create' just ran...
-                    ret['comment'] += ' ... and then immediately modified.'.format(name)
+                    ret['comment'] += ' ... and then immediately modified.'
                 else:
                     ret['comment'] = 'Replication group {0} was modified.'.format(name)
                     ret['changes']['old'] = current
@@ -919,7 +924,8 @@ def _diff_cache_subnet_group(current, desired):
     return need_update
 
 
-def cache_subnet_group_present(name, subnets=None, region=None, key=None, keyid=None, profile=None):
+def cache_subnet_group_present(name, subnets=None, region=None, key=None, keyid=None, profile=None,
+                               **args):
     '''
     Ensure cache subnet group exists.
 

--- a/salt/states/boto3_elasticache.py
+++ b/salt/states/boto3_elasticache.py
@@ -1,0 +1,547 @@
+# -*- coding: utf-8 -*-
+'''
+Manage Elasticache
+==================
+
+.. versionadded:: 2014.7.0
+
+Create, destroy and update Elasticache clusters. Be aware that this interacts
+with Amazon's services, and so may incur charges.
+
+This module uses boto3 behind the scenes - as a result it inherits any limitations
+it boto3's implementation of the AWS API.  It is also designed to as directly as
+possible leverage boto3's parameter naming and semantics.  This allows one to use
+http://boto3.readthedocs.io/en/latest/reference/services/elasticache.html as an
+excellent source for details too involved to reiterate here.
+
+Note:  This module is designed to be transparent to new AWS / boto options - since
+all params are passed through directly, any new args to existing functions which
+become available after this documentation is written should work immediately.
+
+Brand new API calls, of course, would still require new functions to be added :)
+
+XXX Note: This module currently only supports creation and deletion of
+elasticache resources and will not modify clusters when their configuration
+changes in your state files.
+
+This module accepts explicit elasticache credentials but can also utilize
+IAM roles assigned to the instance through Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More information available `here
+<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_.
+
+If IAM roles are not used you need to specify them either in a pillar file or
+in the minion's config file:
+
+.. code-block:: yaml
+
+    elasticache.keyid: GKTADJGHEIQSXMKKRBJ08H
+    elasticache.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+It's also possible to specify ``key``, ``keyid`` and ``region`` via a profile, either
+passed in as a dict, or as a string to pull from pillars or minion config:
+
+.. code-block:: yaml
+
+    myprofile:
+      keyid: GKTADJGHEIQSXMKKRBJ08H
+      key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+        region: us-east-1
+
+.. code-block:: yaml
+
+    Ensure myelasticache exists:
+      boto_elasticache.present:
+        - name: myelasticache
+        - engine: redis
+        - cache_node_type: cache.t1.micro
+        - num_cache_nodes: 1
+        - notification_topic_arn: arn:aws:sns:us-east-1:879879:my-sns-topic
+        - region: us-east-1
+        - keyid: GKTADJGHEIQSXMKKRBJ08H
+        - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    # Using a profile from pillars
+    Ensure myelasticache exists:
+      boto_elasticache.present:
+        - name: myelasticache
+        - engine: redis
+        - cache_node_type: cache.t1.micro
+        - num_cache_nodes: 1
+        - notification_topic_arn: arn:aws:sns:us-east-1:879879:my-sns-topic
+        - region: us-east-1
+        - profile: myprofile
+
+    # Passing in a profile
+    Ensure myelasticache exists:
+      boto_elasticache.present:
+        - name: myelasticache
+        - engine: redis
+        - cache_node_type: cache.t1.micro
+        - num_cache_nodes: 1
+        - notification_topic_arn: arn:aws:sns:us-east-1:879879:my-sns-topic
+        - region: us-east-1
+        - profile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if boto is available.
+    '''
+    if 'boto3_elasticache.cache_cluster_exists' in __salt__:
+        return 'boto3_elasticache'
+    else:
+        return False
+
+
+def cache_cluster_present(name, wait=True, security_groups=None, region=None, key=None, keyid=None, profile=None, **args):
+    '''
+    Ensure the cache cluster exists.
+
+    name
+        Name of the cache cluster (cache cluster id).
+
+    wait
+        Boolean, or tuple of 3 integers (the default, 'True', evaluates to '(10, 6, 10)'
+        on the backend.  Wait (up to (X * Y * Z) seconds) for confirmation from AWS that the
+        cluster is in the 'available' state.
+
+    security_groups
+        One or more VPC security groups (names and/or IDs) associated with the cache cluster.
+        Note:  This is additive with any sec groups provided via the SecurityGroupIds parameter
+               below.  Use this parameter ONLY when you are creating a cluster in a VPC.
+
+    CacheClusterId
+        The node group (shard) identifier. This parameter is stored as a lowercase string.
+        Constraints:
+        - A name must contain from 1 to 20 alphanumeric characters or hyphens.
+        - The first character must be a letter.
+        - A name cannot end with a hyphen or contain two consecutive hyphens.
+        Note:  In the general case this parameter is not needed, as 'name' is used if it's
+               not provided.
+
+    ReplicationGroupId
+        The ID of the replication group to which this cache cluster should belong. If this
+        parameter is specified, the cache cluster is added to the specified replication
+        group as a read replica; otherwise, the cache cluster is a standalone primary that
+        is not part of any replication group.  If the specified replication group is
+        Multi-AZ enabled and the Availability Zone is not specified, the cache cluster is
+        created in Availability Zones that provide the best spread of read replicas across
+        Availability Zones.
+        Notes:  This parameter is ONLY valid if the Engine parameter is redis.
+                Due to current limitations on Redis (cluster mode disabled), this parameter
+        is not supported on Redis (cluster mode enabled) replication groups.
+
+    AZMode
+        Specifies whether the nodes in this Memcached cluster are created in a single
+        Availability Zone or created across multiple Availability Zones in the cluster's
+        region.  If the AZMode and PreferredAvailabilityZones are not specified,
+        ElastiCache assumes single-az mode.
+        Note:  This parameter is ONLY supported for Memcached cache clusters.
+
+    PreferredAvailabilityZone
+        The EC2 Availability Zone in which the cache cluster is created.  All nodes
+        belonging to this Memcached cache cluster are placed in the preferred Availability
+        Zone. If you want to create your nodes across multiple Availability Zones, use
+        PreferredAvailabilityZones.
+        Default:  System chosen Availability Zone.
+
+    PreferredAvailabilityZones
+        A list of the Availability Zones in which cache nodes are created. The order of
+        the zones in the list is not important.  The number of Availability Zones listed
+        must equal the value of NumCacheNodes.  If you want all the nodes in the same
+        Availability Zone, use PreferredAvailabilityZone instead, or repeat the
+        Availability Zone multiple times in the list.
+        Note:  This option is ONLY supported on Memcached.
+        Note:  If you are creating your cache cluster in an Amazon VPC (recommended) you
+               can only locate nodes in Availability Zones that are associated with the
+               subnets in the selected subnet group.
+        Default:  System chosen Availability Zones.
+
+    NumCacheNodes
+        The initial (integer) number of cache nodes that the cache cluster has.
+        Notes:  For clusters running Redis, this value must be 1.
+                For clusters running Memcached, this value must be between 1 and 20.
+
+    CacheNodeType
+        The compute and memory capacity of the nodes in the node group (shard).
+        Valid node types (and pricing for them) are exhaustively described at
+        https://aws.amazon.com/elasticache/pricing/
+        Notes:  All T2 instances must be created in a VPC
+                Redis backup/restore is not supported for Redis (cluster mode disabled)
+                T1 and T2 instances. Backup/restore is supported on Redis (cluster mode
+                enabled) T2 instances.
+                Redis Append-only files (AOF) functionality is not supported for T1 or
+                T2 instances.
+
+    Engine
+        The name of the cache engine to be used for this cache cluster.  Valid values for
+        this parameter are:  memcached | redis
+
+    EngineVersion
+        The version number of the cache engine to be used for this cache cluster. To view
+        the supported cache engine versions, use the DescribeCacheEngineVersions operation.
+        Note:  You can upgrade to a newer engine version but you cannot downgrade to an
+               earlier engine version. If you want to use an earlier engine version, you
+               must delete the existing cache cluster or replication group and create it
+               anew with the earlier engine version.
+
+    CacheParameterGroupName
+        The name of the parameter group to associate with this cache cluster. If this
+        argument is omitted, the default parameter group for the specified engine is used.
+        You cannot use any parameter group which has cluster-enabled='yes' when creating
+        a cluster.
+
+    CacheSubnetGroupName
+        The name of the Cache Subnet Group to be used for the cache cluster.  Use this
+        parameter ONLY when you are creating a cache cluster within a VPC.
+
+        Note:  If you're going to launch your cluster in an Amazon VPC, you need to create
+        a subnet group before you start creating a cluster.
+
+    CacheSecurityGroupNames
+        A list of Cache Security Group names to associate with this cache cluster.  Use
+        this parameter ONLY when you are creating a cache cluster outside of a VPC.
+
+    SecurityGroupIds
+        One or more VPC security groups associated with the cache cluster.  Use this
+        parameter ONLY when you are creating a cache cluster within a VPC.
+
+    Tags
+        A list of tags to be added to this resource.
+
+    SnapshotArns
+        A single-element string list containing an Amazon Resource Name (ARN) that
+        uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot
+        file is used to populate the node group (shard). The Amazon S3 object name in
+        the ARN cannot contain any commas.
+        Note: This parameter is ONLY valid if the Engine parameter is redis.
+
+    SnapshotName
+        The name of a Redis snapshot from which to restore data into the new node group
+        (shard). The snapshot status changes to restoring while the new node group (shard)
+        is being created.
+        Note:  This parameter is ONLY valid if the Engine parameter is redis.
+
+    PreferredMaintenanceWindow
+        Specifies the weekly time range during which maintenance on the cache cluster is
+        permitted.  It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
+        (24H Clock UTC).  The minimum maintenance window is a 60 minute period.
+        Valid values for ddd are:  sun, mon, tue, wed, thu, fri, sat
+        Example:  sun:23:00-mon:01:30
+
+    Port
+        The port number on which each of the cache nodes accepts connections.
+        Default:  6379
+
+    NotificationTopicArn
+        The Amazon Resource Name (ARN) of the Amazon Simple Notification Service (SNS)
+        topic to which notifications are sent.
+        Note: The Amazon SNS topic owner must be the same as the cache cluster owner.
+
+    AutoMinorVersionUpgrade
+        This (boolean) parameter is currently disabled.
+
+    SnapshotRetentionLimit
+        The number of days for which ElastiCache retains automatic snapshots before
+        deleting them.
+        Note: This parameter is ONLY valid if the Engine parameter is redis.
+        Default:  0 (i.e., automatic backups are disabled for this cache cluster).
+
+    SnapshotWindow
+        The daily time range (in UTC) during which ElastiCache begins taking a daily
+        snapshot of your node group (shard).  If you do not specify this parameter,
+        ElastiCache automatically chooses an appropriate time range.
+        Note:  This parameter is ONLY valid if the Engine parameter is redis.
+        Example:  05:00-09:00
+
+    AuthToken
+        The password used to access a password protected server.
+        Password constraints:
+            Must be only printable ASCII characters.
+            Must be at least 16 characters and no more than 128 characters in length.
+            Cannot contain any of the following characters: '/', '"', or "@".
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+    current = __salt__['boto3_elasticache.describe_cache_clusters'](
+            name=name, region=region, key=key, keyid=keyid, profile=profile)
+    if current is None:
+        if __opts__['test']:
+            msg = 'Cache cluster {0} is set to be created.'.format(name)
+            ret['comment'] = msg
+            ret['result'] = None
+            return ret
+        created = __salt__['boto3_elasticache.create_cache_cluster'](
+            name=name, wait=wait, security_groups=security_groups,
+            region=region, key=key, keyid=keyid, profile=profile, **args)
+        if created:
+            ret['changes']['old'] = None
+            config = __salt__['boto_elasticache.get_config'](name, region, key,
+                                                             keyid, profile)
+            ret['changes']['new'] = config
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to create {0} cache cluster.'.format(name)
+            return ret
+    # TODO: support modification of existing elasticache clusters
+    else:
+        ret['comment'] = 'Cache cluster {0} is present.'.format(name)
+    return ret
+
+
+def subnet_group_present(name, subnet_ids=None, subnet_names=None,
+                         description=None, tags=None, region=None,
+                         key=None, keyid=None, profile=None):
+    '''
+    Ensure ElastiCache subnet group exists.
+
+    .. versionadded:: 2015.8.0
+
+    name
+        The name for the ElastiCache subnet group. This value is stored as a lowercase string.
+
+    subnet_ids
+        A list of VPC subnet IDs for the cache subnet group.  Exclusive with subnet_names.
+
+    subnet_names
+        A list of VPC subnet names for the cache subnet group.  Exclusive with subnet_ids.
+
+    description
+        Subnet group description.
+
+    tags
+        A list of tags.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    exists = __salt__['boto_elasticache.subnet_group_exists'](name=name, tags=tags, region=region, key=key,
+                                                              keyid=keyid, profile=profile)
+    if not exists:
+        if __opts__['test']:
+            ret['comment'] = 'Subnet group {0} is set to be created.'.format(name)
+            ret['result'] = None
+            return ret
+        created = __salt__['boto_elasticache.create_subnet_group'](name=name, subnet_ids=subnet_ids,
+                                                                   subnet_names=subnet_names,
+                                                                   description=description, tags=tags,
+                                                                   region=region, key=key, keyid=keyid,
+                                                                   profile=profile)
+        if not created:
+            ret['result'] = False
+            ret['comment'] = 'Failed to create {0} subnet group.'.format(name)
+            return ret
+        ret['changes']['old'] = None
+        ret['changes']['new'] = name
+        ret['comment'] = 'Subnet group {0} created.'.format(name)
+        return ret
+    ret['comment'] = 'Subnet group present.'
+    return ret
+
+
+def cache_cluster_absent(*args, **kwargs):
+    return absent(*args, **kwargs)
+
+
+def absent(name, wait=True, region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure the named elasticache cluster is deleted.
+
+    name
+        Name of the cache cluster.
+
+    wait
+        Boolean. Wait for confirmation from boto that the cluster is in the
+        deleting state.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    is_present = __salt__['boto_elasticache.exists'](name, region, key, keyid, profile)
+
+    if is_present:
+        if __opts__['test']:
+            ret['comment'] = 'Cache cluster {0} is set to be removed.'.format(name)
+            ret['result'] = None
+            return ret
+        deleted = __salt__['boto_elasticache.delete'](name, wait, region, key,
+                                                      keyid, profile)
+        if deleted:
+            ret['changes']['old'] = name
+            ret['changes']['new'] = None
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to delete {0} cache cluster.'.format(name)
+    else:
+        ret['comment'] = '{0} does not exist in {1}.'.format(name, region)
+    return ret
+
+
+def replication_group_present(*args, **kwargs):
+    return creategroup(*args, **kwargs)
+
+
+def creategroup(name, primary_cluster_id, replication_group_description, wait=None,
+                region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure the a replication group is create.
+
+    name
+        Name of replication group
+
+    wait
+        Waits for the group to be available
+
+    primary_cluster_id
+        Name of the master cache node
+
+    replication_group_description
+        Description for the group
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    is_present = __salt__['boto_elasticache.group_exists'](name, region, key, keyid,
+                                                                 profile)
+    if not is_present:
+        if __opts__['test']:
+            ret['comment'] = 'Replication {0} is set to be created.'.format(
+                name)
+            ret['result'] = None
+        created = __salt__['boto_elasticache.create_replication_group'](name, primary_cluster_id,
+                                                                        replication_group_description,
+                                                                        wait, region, key, keyid, profile)
+        if created:
+            config = __salt__['boto_elasticache.describe_replication_group'](name, region, key, keyid, profile)
+            ret['changes']['old'] = None
+            ret['changes']['new'] = config
+            ret['result'] = True
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to create {0} replication group.'.format(name)
+    else:
+        ret['comment'] = '{0} replication group exists .'.format(name)
+        ret['result'] = True
+    return ret
+
+
+def subnet_group_absent(name, tags=None, region=None, key=None, keyid=None, profile=None):
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    exists = __salt__['boto_elasticache.subnet_group_exists'](name=name, tags=tags, region=region, key=key,
+                                                              keyid=keyid, profile=profile)
+    if not exists:
+        ret['result'] = True
+        ret['comment'] = '{0} ElastiCache subnet group does not exist.'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'ElastiCache subnet group {0} is set to be removed.'.format(name)
+        ret['result'] = None
+        return ret
+    deleted = __salt__['boto_elasticache.delete_subnet_group'](name, region, key, keyid, profile)
+    if not deleted:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete {0} ElastiCache subnet group.'.format(name)
+        return ret
+    ret['changes']['old'] = name
+    ret['changes']['new'] = None
+    ret['comment'] = 'ElastiCache subnet group {0} deleted.'.format(name)
+    return ret
+
+
+def replication_group_absent(name, tags=None, region=None, key=None, keyid=None, profile=None):
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    exists = __salt__['boto_elasticache.group_exists'](name=name, region=region, key=key,
+                                                       keyid=keyid, profile=profile)
+    if not exists:
+        ret['result'] = True
+        ret['comment'] = '{0} ElastiCache replication group does not exist.'.format(name)
+        log.info(ret['comment'])
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'ElastiCache replication group {0} is set to be removed.'.format(name)
+        ret['result'] = True
+        return ret
+    deleted = __salt__['boto_elasticache.delete_replication_group'](name, region, key, keyid, profile)
+    if not deleted:
+        ret['result'] = False
+        log.error(ret['comment'])
+        ret['comment'] = 'Failed to delete {0} ElastiCache replication group.'.format(name)
+        return ret
+    ret['changes']['old'] = name
+    ret['changes']['new'] = None
+    ret['comment'] = 'ElastiCache replication group {0} deleted.'.format(name)
+    log.info(ret['comment'])
+    return ret

--- a/salt/states/boto3_elasticache.py
+++ b/salt/states/boto3_elasticache.py
@@ -796,8 +796,8 @@ def replication_group_present(name, wait=600, security_groups=None, region=None,
     if check_update:
         # Refresh this in case we're updating from 'only_on_modify' above...
         updated = __salt__['boto3_elasticache.'
-                           'describe_replication_group'](name, region=region, key=key,
-                                                      keyid=keyid, profile=profile)[0]
+                           'describe_replication_groups'](name, region=region, key=key,
+                                                          keyid=keyid, profile=profile)[0]
         need_update = _diff_replication_group(updated, args)
         if need_update:
             if __opts__['test']:
@@ -817,8 +817,8 @@ def replication_group_present(name, wait=600, security_groups=None, region=None,
                     ret['comment'] += ' ... and then immediately modified.'
                 else:
                     ret['comment'] = 'Replication group {0} was modified.'.format(name)
-                    ret['changes']['old'] = current
-                ret['changes']['new'] = new['ReplicationGroups'][0]
+                    ret['changes']['old'] = current[0] if len(current) else None
+                ret['changes']['new'] = new[0]
             else:
                 ret['result'] = False
                 ret['comment'] = 'Failed to modify replication group {0}.'.format(name)

--- a/salt/states/boto3_elasticache.py
+++ b/salt/states/boto3_elasticache.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
-Manage Elasticache
-==================
+Manage Elasticache with boto3
+=============================
 
-.. versionadded:: Philistinium
+.. versionadded:: Nitrogen
 
 Create, destroy and update Elasticache clusters. Be aware that this interacts
 with Amazon's services, and so may incur charges.


### PR DESCRIPTION
Adds new boto3-based modules for AWS Elasticache support.
Note that these exist in parallel to the original boto2-based versions, since they are not intended to be directly backwards compatible - the new modules use a different approach to passing through the AWS API params.
These new modules also support in-place modification of managed resources (the boto2 versions only provide for initial creation and subsequent deletion); and, most importantly they allow setting a large number of params (e.g. "SnapshotRetentionLimit", "SnapshotWindow", etc.) not exposed by boto2, and thus unsupported by the old modules.
The new modules essentially pass ALL unhandled params directly through to the underlying boto3 / AWS API layers, meaning that any new options provided at those layers will be immediately available in the salt functions (even if not yet added to the docstrings) and they thus should be largely forward-compatible.  Obviously, any entirely new functions added to boto3 would still need to be encapsulated...  As a bonus, things have been generic'ed to a high degree, so that adding new create/modify/delete functions should be trivial in most cases.

Lastly, a small amount of cleanup and re-org in the boto_secgroup exec module.

If someone will lemme know what the current 'versionadded' string should be I'll update it to suit :)