### PR TITLE
[WIP] First run at adding "slots"

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1749,6 +1749,7 @@ class State(object):
                 if self.mocked:
                     ret = mock_ret(cdata)
                 else:
+                    self.format_slots(cdata)
                     ret = self.states[cdata['full']](*cdata['args'],
                                                      **cdata['kwargs'])
                 self.states.inject_globals = {}
@@ -1848,6 +1849,20 @@ class State(object):
                                                 low['retry']['until'],
                                                 low['retry']['splay'])])
         return ret
+
+    def format_slots(self, cdata):
+        '''
+        Format slots reads in the arguments to the call and executes slots
+        '''
+        for ind in range(len(cdata['args'])):
+            arg = cdata['args'][ind]
+            if arg.startswih('__slot__:'):
+                # If is a slot! Call it!
+                fmt = arg.split(':')
+                if len(fmt) < 3:
+                    continue
+                if fmt[1] == 'salt':
+                    cdata['args'][ind] = self.functions[fmt[2]](*fmt[3])
 
     def verify_retry_data(self, retry_data):
         '''


### PR DESCRIPTION
I would like to have a review of this idea, it is to allow for
runtime evaluation of salt data.

This allows for us to make a state like this:

```
/tmp/foo:
  file.managed:
    - contents: __slot__:salt:mod.func:arg1,args2,arg3,kwarg1=foo
```

The second argument here, `salt` says to call an execution module, we could add call out systems to do other things like variable lookup etc. This is mainly for discussion about how would we do this in a good clean way