### PR TITLE
Fix Problem with win_service module

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -92,9 +92,11 @@ def __virtual__():
     Only works on Windows systems with PyWin32 installed
     '''
     if not salt.utils.is_windows():
-        return (False, 'Module win_service: module only works on Windows.')
+        return False, 'Module win_service: module only works on Windows.'
+
     if not HAS_WIN32_MODS:
-        return (False, 'Module win_service: failed to load win32 modules')
+        return False, 'Module win_service: failed to load win32 modules'
+
     return __virtualname__
 
 
@@ -654,13 +656,15 @@ def modify(name,
     '''
     # https://msdn.microsoft.com/en-us/library/windows/desktop/ms681987(v=vs.85).aspx
     # https://msdn.microsoft.com/en-us/library/windows/desktop/ms681988(v-vs.85).aspx
-
     handle_scm = win32service.OpenSCManager(
         None, None, win32service.SC_MANAGER_CONNECT)
 
     try:
         handle_svc = win32service.OpenService(
-            handle_scm, name, win32service.SERVICE_ALL_ACCESS)
+            handle_scm,
+            name,
+            win32service.SERVICE_CHANGE_CONFIG |
+            win32service.SERVICE_QUERY_CONFIG)
     except pywintypes.error as exc:
         raise CommandExecutionError(
             'Failed To Open {0}: {1}'.format(name, exc[2]))


### PR DESCRIPTION
### What does this PR do?
Some services were unable to be edited because the user was missing some permissions. Specifies the exact permissions needed to edit a service.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/38445

### Previous Behavior
The handle to the service was opened with the `SERVICE_ALL_ACCESS` flag. If the user didn't have "All Access" to the service, it would fail.

### New Behavior
Specify the `SERVICE_CHANGE_CONFIG` and `SERVICE_QUERY_CONFIG` permissions as they are all that's needed to edit the service.

### Tests written?
No