### PR TITLE
Allow an existing ioloop to be passed to salt-key

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -533,7 +533,7 @@ class Key(object):
     REJ = 'minions_rejected'
     DEN = 'minions_denied'
 
-    def __init__(self, opts):
+    def __init__(self, opts, io_loop=None):
         self.opts = opts
         kind = self.opts.get('__role', '')  # application kind
         if kind not in kinds.APPL_KINDS:
@@ -545,7 +545,9 @@ class Key(object):
                 opts['sock_dir'],
                 opts['transport'],
                 opts=opts,
-                listen=False)
+                listen=False,
+                io_loop=io_loop
+                )
 
     def _check_minions_directories(self):
         '''


### PR DESCRIPTION
Fixes #38209
