### PR TITLE
Infoblox: Convert IP values to unicode, convert IP value to list for host records

### DIFF
--- a/salt/states/infoblox.py
+++ b/salt/states/infoblox.py
@@ -69,6 +69,7 @@ def present(name,
               - sslVerify: False
     '''
     record_type = record_type.lower()
+    value_utf8 = unicode(value, "utf-8")
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     records = __salt__['infoblox.get_record'](name,
                                               record_type,
@@ -83,13 +84,13 @@ def present(name,
         for record in records:
             update_record = False
             if record_type == 'cname':
-                if record['Canonical Name'] != value:
+                if record['Canonical Name'] != value_utf8:
                     update_record = True
             elif record_type == 'a':
-                if record['IP Address'] != value:
+                if record['IP Address'] != value_utf8:
                     update_record = True
             elif record_type == 'host':
-                if record['IP Addresses'] != value:
+                if record['IP Addresses'] != [value_utf8]:
                     update_record = True
             if update_record:
                 if __opts__['test']:

--- a/salt/states/infoblox.py
+++ b/salt/states/infoblox.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 
 # Import Python libs
 import logging
+from salt.ext import six
 
 log = logging.getLogger(__name__)
 
@@ -69,7 +70,7 @@ def present(name,
               - sslVerify: False
     '''
     record_type = record_type.lower()
-    value_utf8 = unicode(value, "utf-8")
+    value_utf8 = six.text_type(value, "utf-8")
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     records = __salt__['infoblox.get_record'](name,
                                               record_type,


### PR DESCRIPTION
### What does this PR do?
- **Infoblox state module:** Converts the `value` variable provided to the state to Unicode
- **Infoblox state module:** Further converts the `value` variable provided to the state into a list in the `present()` function.

### What issues does this PR fix or reference?
Issue #38465 
When the Infoblox state module receives a response, the returned json data is in Unicode format. The current design of the state module compares the provided IP Address varaible, `value`, as a string instead of comparing apples-to-apples in Unicode format. 

Additionally, the Infoblox API returns IP addresses for `host` record types in a list format, which the current state module does not support. This PR provides support to compare `value` as a list in the event that the `record_type` is defined as `host`.

### Tests written?

No