### PR TITLE
Key fingerprints

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -338,11 +338,11 @@ class MultiKeyCLI(KeyCLI):
     def print_all(self):
         self._call_all('print_all')
 
-    def finger(self, match):
-        self._call_all('finger', match)
+    def finger(self, match, hash_type):
+        self._call_all('finger', match, hash_type)
 
     def finger_all(self):
-        self._call_all('finger_all')
+        self._call_all('finger_all', hash_type)
 
     def prep_signature(self):
         self._call_all('prep_signature')
@@ -895,10 +895,13 @@ class Key(object):
             salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return self.list_keys()
 
-    def finger(self, match):
+    def finger(self, match, hash_type=None):
         '''
         Return the fingerprint for a specified key
         '''
+        if hash_type is None:
+            hash_type = __opts__['hash_type']
+
         matches = self.name_match(match, True)
         ret = {}
         for status, keys in six.iteritems(matches):
@@ -908,13 +911,16 @@ class Key(object):
                     path = os.path.join(self.opts['pki_dir'], key)
                 else:
                     path = os.path.join(self.opts['pki_dir'], status, key)
-                ret[status][key] = salt.utils.pem_finger(path, sum_type=self.opts['hash_type'])
+                ret[status][key] = salt.utils.pem_finger(path, sum_type=hash_type)
         return ret
 
-    def finger_all(self):
+    def finger_all(self, hash_type=None):
         '''
         Return fingerprints for all keys
         '''
+        if hash_type is None:
+            hash_type = __opts__['hash_type']
+
         ret = {}
         for status, keys in six.iteritems(self.all_keys()):
             ret[status] = {}
@@ -923,7 +929,7 @@ class Key(object):
                     path = os.path.join(self.opts['pki_dir'], key)
                 else:
                     path = os.path.join(self.opts['pki_dir'], status, key)
-                ret[status][key] = salt.utils.pem_finger(path, sum_type=self.opts['hash_type'])
+                ret[status][key] = salt.utils.pem_finger(path, sum_type=hash_type)
         return ret
 
 

--- a/salt/key.py
+++ b/salt/key.py
@@ -341,7 +341,7 @@ class MultiKeyCLI(KeyCLI):
     def finger(self, match, hash_type):
         self._call_all('finger', match, hash_type)
 
-    def finger_all(self):
+    def finger_all(self, hash_type):
         self._call_all('finger_all', hash_type)
 
     def prep_signature(self):

--- a/salt/modules/key.py
+++ b/salt/modules/key.py
@@ -11,9 +11,12 @@ import os
 import salt.utils
 
 
-def finger():
+def finger(hash_type=None):
     '''
     Return the minion's public key fingerprint
+
+    hash_type
+        The hash algorithm used to calculate the fingerprint
 
     CLI Example:
 
@@ -21,14 +24,20 @@ def finger():
 
         salt '*' key.finger
     '''
-    # MD5 here is temporary. Change to SHA256 when retired.
-    return salt.utils.pem_finger(os.path.join(__opts__['pki_dir'], 'minion.pub'),
-                                 sum_type=__opts__.get('hash_type', 'md5'))
+    if hash_type is None:
+        hash_type = __opts__['hash_type']
+
+    return salt.utils.pem_finger(
+        os.path.join(__opts__['pki_dir'], 'minion.pub'),
+        sum_type=hash_type)
 
 
-def finger_master():
+def finger_master(hash_type=None):
     '''
     Return the fingerprint of the master's public key on the minion.
+
+    hash_type
+        The hash algorithm used to calculate the fingerprint
 
     CLI Example:
 
@@ -36,6 +45,9 @@ def finger_master():
 
         salt '*' key.finger_master
     '''
-    # MD5 here is temporary. Change to SHA256 when retired.
-    return salt.utils.pem_finger(os.path.join(__opts__['pki_dir'], 'minion_master.pub'),
-                                 sum_type=__opts__.get('hash_type', 'md5'))
+    if hash_type is None:
+        hash_type = __opts__['hash_type']
+
+    return salt.utils.pem_finger(
+        os.path.join(__opts__['pki_dir'], 'minion_master.pub'),
+        sum_type=hash_type)

--- a/salt/wheel/key.py
+++ b/salt/wheel/key.py
@@ -274,12 +274,15 @@ def key_str(match):
     return skey.key_str(match)
 
 
-def finger(match):
+def finger(match, hash_type=None):
     '''
     Return the matching key fingerprints. Returns a dictionary.
 
     match
         The key for with to retrieve the fingerprint.
+
+    hash_type
+        The hash algorithm used to calculate the fingerprint
 
     .. code-block:: python
 
@@ -287,8 +290,11 @@ def finger(match):
         {'minions': {'minion1': '5d:f6:79:43:5e:d4:42:3f:57:b8:45:a8:7e:a4:6e:ca'}}
 
     '''
+    if hash_type is None:
+        hash_type = __opts__['hash_type']
+
     skey = get_key(__opts__)
-    return skey.finger(match)
+    return skey.finger(match, hash_type)
 
 
 def finger_master(hash_type=None):
@@ -308,7 +314,7 @@ def finger_master(hash_type=None):
         hash_type = __opts__['hash_type']
 
     fingerprint = salt.utils.pem_finger(
-        os.path.join(__opts__['pki_dir'], keyname), hash_type)
+        os.path.join(__opts__['pki_dir'], keyname), sum_type=hash_type)
     return {'local': {keyname: fingerprint}}
 
 

--- a/salt/wheel/key.py
+++ b/salt/wheel/key.py
@@ -291,6 +291,27 @@ def finger(match):
     return skey.finger(match)
 
 
+def finger_master(hash_type=None):
+    '''
+    Return the fingerprint of the master's public key
+
+    hash_type
+        The hash algorithm used to calculate the fingerprint
+
+    .. code-block:: python
+
+        >>> wheel.cmd('key.finger_master')
+        {'local': {'master.pub': '5d:f6:79:43:5e:d4:42:3f:57:b8:45:a8:7e:a4:6e:ca'}}
+    '''
+    keyname = 'master.pub'
+    if hash_type is None:
+        hash_type = __opts__['hash_type']
+
+    fingerprint = salt.utils.pem_finger(
+        os.path.join(__opts__['pki_dir'], keyname), hash_type)
+    return {'local': {keyname: fingerprint}}
+
+
 def gen(id_=None, keysize=2048):
     '''
     Generate a key pair. No keys are stored on the master. A key pair is


### PR DESCRIPTION
### What does this PR do?
1) Adds a wheel function to return the master public key fingerprint
2) Adds a hash_type argument to these fingerprint functions:
 - wheel.key.finger
 - wheel.key.finger_master (new)
 - modules.key.finger
 - modules.key.finger_master

### What issues does this PR fix or reference?
None

### Previous Behavior
1) There was no way to call a wheel module to return the master fingerprint.
2) The purpose of a key fingerprint is to allow comparison to verify the identity of a remote system. The behavior of the functions mentioned above produces a fingerprint according to the algorithm set by the hash_type configuration option. The problem with this approach is that, if the master and minion have different hash_type settings, it is impossible to compare the key fingerprints and, thus, verify the identity of the system.

### New Behavior
1) A new wheel.key.finger_master function has been added to return the master key fingerprint.
2) All the functions mentioned above still default to the algorithm specified by the hash_type configuration option. They now also accept an optional hash_type argument to override the default. This allows fingerprints to be calculated with a specific algorithm, regardless of the setting.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
