### PR TITLE
Fixes for the behaviour of rabbitmq module functions.

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -181,6 +181,7 @@ def _output_to_dict(cmdoutput, values_mapper=None):
         ret[key] = values_mapper(values)
     return ret
 
+
 def _output_to_list(cmdoutput):
     '''
     Convert rabbitmqctl output to a list of strings (assuming whitespace-delimited output).
@@ -189,6 +190,7 @@ def _output_to_list(cmdoutput):
     '''
     return [item for line in cmdoutput.splitlines() if _safe_output(line) for item in line.split()]
 
+
 def _output_lines_to_list(cmdoutput):
     '''
     Convert rabbitmqctl output to a list of strings (assuming newline-delimited output).
@@ -196,6 +198,7 @@ def _output_lines_to_list(cmdoutput):
     cmdoutput: string output of rabbitmqctl commands
     '''
     return [line.strip() for line in cmdoutput.splitlines() if _safe_output(line)]
+
 
 def list_users(runas=None):
     '''


### PR DESCRIPTION
### What does this PR do?
All rabbitmq.list_* functions return lists/dicts as appropriate now. Fixes a bug in rabbitmq.plugin_is_enabled and adds rabbitmq.list_{available, enabled}_plugins.

### Previous Behavior
The rabbitmq.plugin_is_enabled function call was broken - if the plugin "saltstack" is enabled, it would claim that "salt" and "altstack" and all substrings were also enabled.
A few rabbitmq.list_* functions returned raw string output rather than parsing into a dictionary or a list (most list_* functions returned a dict/list).
Several functions weren't robust to warnings in the output.

### New Behavior
rabbitmq.plugin_is_enabled now behaves as expected. All list_* functions parse the output into a list or dictionary, as appropriate. Things hopefully more robust.

### Tests written?
Yes - tests were altered to check the new behaviour.