### PR TITLE
Use UTC for timing in case timezone changes

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1640,8 +1640,9 @@ class State(object):
         Call a state directly with the low data structure, verify data
         before processing.
         '''
-        start_time = datetime.datetime.now()
-        log.info('Running state [{0}] at time {1}'.format(low['name'], start_time.time().isoformat()))
+        utc_start_time = datetime.datetime.utcnow()
+        local_start_time = utc_start_time - (datetime.datetime.utcnow() - datetime.datetime.now())
+        log.info('Running state [{0}] at time {1}'.format(low['name'], local_start_time.time().isoformat()))
         errors = self.verify_data(low)
         if errors:
             ret = {
@@ -1775,14 +1776,17 @@ class State(object):
         self.__run_num += 1
         format_log(ret)
         self.check_refresh(low, ret)
-        finish_time = datetime.datetime.now()
-        ret['start_time'] = start_time.time().isoformat()
-        delta = (finish_time - start_time)
+        utc_finish_time = datetime.datetime.utcnow()
+        timezone_delta = datetime.datetime.utcnow() - datetime.datetime.now()
+        local_finish_time = utc_finish_time - timezone_delta
+        local_start_time = utc_start_time - timezone_delta
+        ret['start_time'] = local_start_time.time().isoformat()
+        delta = (utc_finish_time - utc_start_time)
         # duration in milliseconds.microseconds
         duration = (delta.seconds * 1000000 + delta.microseconds)/1000.0
         ret['duration'] = duration
         ret['__id__'] = low['__id__']
-        log.info('Completed state [{0}] at time {1} duration_in_ms={2}'.format(low['name'], finish_time.time().isoformat(), duration))
+        log.info('Completed state [{0}] at time {1} duration_in_ms={2}'.format(low['name'], local_finish_time.time().isoformat(), duration))
         return ret
 
     def call_chunks(self, chunks):


### PR DESCRIPTION
### What does this PR do?
Use utc for time durations of state runs.
Convert utc to localtime for log messages about starting and finishing states.

On states where the timezone is changed, the start time will be in the old timezone and the end time will be in the new timezone.

### What issues does this PR fix or reference?
Fixes #37684

### Tests written?

No
