### PR TITLE
remove default print statements from ldap pillar

### DIFF
--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -226,7 +226,6 @@ def _result_to_dict(data, result, conf, source):
                             data[skey] = [sval]
                         else:
                             data[skey].append(sval)
-    print('Returning data {0}'.format(data))
     return data
 
 
@@ -298,7 +297,7 @@ def ext_pillar(minion_id,  # pylint: disable=W0613
     for source in opts['search_order']:
         config = opts[source]
         result = _do_search(config)
-        print('source {0} got result {1}'.format(source, result))
+        log.debug('source {0} got result {1}'.format(source, result))
         if result:
             data = _result_to_dict(data, result, config, source)
     return data


### PR DESCRIPTION
### What does this PR do?
Removes print statements which displayed on any salt command execution.

### Previous Behavior
Running any salt command resulted in console printing the entire output of the ldap search. 

### New Behavior
Standard use no longer clutters console. Info is still available in the master's log at debug level. 

### Tests written?
No