### PR TITLE
Do not assume every object is a server

### DIFF
--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -326,10 +326,11 @@ def list_passwords(kwargs=None, call=None):
 
     ret = {}
     for item in response['list']:
-        server = item['server']['name']
-        if server not in ret:
-            ret[server] = []
-        ret[server].append(item)
+        if 'server' in item:
+            server = item['server']['name']
+            if server not in ret:
+                ret[server] = []
+            ret[server].append(item)
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?
This pullrequest fixes a bug in the Gogrid driver for Salt Cloud. The list_passwords function assumed that each object returned from the Gogrid API is a server. However if you have cloud storage these objects are also added to that list and the provision goes into an endless loop.

### Previous Behavior
Salt would not be able to properly roll out a server on Gogrid if the account has cloud storage.

### New Behavior
Salt now properly filters out non-server passwords.

### Tests written?
No
