### PR TITLE
Fixes #38505: Return an available version also when the named package…

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -233,7 +233,7 @@ def latest_version(*names, **kwargs):
         ret[name] = ''
         installed = _cpv_to_version(_vartree().dep_bestmatch(name))
         avail = _cpv_to_version(_porttree().dep_bestmatch(name))
-        if avail and salt.utils.compare_versions(ver1=installed, oper='<', ver2=avail, cmp_func=version_cmp):
+        if avail and (not installed or salt.utils.compare_versions(ver1=installed, oper='<', ver2=avail, cmp_func=version_cmp)):
             ret[name] = avail
 
     # Return a string if only one package name passed


### PR DESCRIPTION
… is not installed.

### What issues does this PR fix or reference?
Fixes #38505 

### Previous Behavior
Don't return a version if the named package is not installed.

### New Behavior
Returns the latest available version to install if the names package is not installed or the latest available version for update if existing.