### PR TITLE
Stop request from being processed if bad ip

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -634,11 +634,12 @@ def salt_ip_verify_tool():
                 logger.debug("Request from IP: {0}".format(rem_ip))
                 if rem_ip not in auth_ip_list:
                     logger.error("Blocked IP: {0}".format(rem_ip))
-                    cherrypy.response.status = 403
-                    return {
-                        'status': cherrypy.response.status,
-                        'return': "Bad IP",
-                    }
+                    raise cherrypy.HTTPError(403, 'Bad IP')
+                    #cherrypy.response.status = 403
+                    #return {
+                    #    'status': cherrypy.response.status,
+                    #    'return': "Bad IP",
+                    #}
 
 
 def salt_auth_tool():

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -635,11 +635,6 @@ def salt_ip_verify_tool():
                 if rem_ip not in auth_ip_list:
                     logger.error("Blocked IP: {0}".format(rem_ip))
                     raise cherrypy.HTTPError(403, 'Bad IP')
-                    #cherrypy.response.status = 403
-                    #return {
-                    #    'status': cherrypy.response.status,
-                    #    'return': "Bad IP",
-                    #}
 
 
 def salt_auth_tool():


### PR DESCRIPTION
### What does this PR do?
This PR will fix an issue in the REST CherryPy.

### What issues does this PR fix or reference? & Previous Behavior
While reading the code of [app.py](https://github.com/saltstack/salt/blob/2016.11/salt/netapi/rest_cherrypy/app.py) I noticed that there is undocumented feature which should be used in defining the [authorized IPs](https://github.com/saltstack/salt/blob/2016.11/salt/netapi/rest_cherrypy/app.py#L630) to communicate with the REST API

Salt-Master installed in a docker container on my local machine and I have added the following to the `rest_cherrypy` key in config file:
```
rest_cherrypy:
  port: 8000
  debug: True
  ssl_crt: /etc/pki/tls/certs/localhost.crt
  ssl_key: /etc/pki/tls/certs/localhost.key
  authorized_ips:
    - 127.0.12.12 #this is a random ip not my actual ip
```
After that I tried to login normally then I got the following:
```
$ curl -sSki https://172.19.0.2:8000/login \
>       -c ~/cookies.txt \
>       -H 'Accept: application/x-yaml' \
>       -d username=saltyuser \
>       -d password=thePassword2 \
>       -d eauth=pam
HTTP/1.1 403 Forbidden
Content-Length: 199
Access-Control-Expose-Headers: GET, POST
Vary: Accept-Encoding
Server: CherryPy/3.2.2
Allow: GET, HEAD, POST
Access-Control-Allow-Credentials: true
Date: Sat, 31 Dec 2016 06:52:05 GMT
Access-Control-Allow-Origin: *
X-Auth-Token: 62c69b2d78862316f38a9f16ca821dcc538c7181
Content-Type: application/x-yaml
Set-Cookie: session_id=62c69b2d78862316f38a9f16ca821dcc538c7181; expires=Sat, 31 Dec 2016 16:52:05 GMT; Path=/

return:
- eauth: pam
  expire: 1483210326.786791
  perms:
  - .*
  - '@wheel'
  - '@runner'
  - '@jobs'
  start: 1483167126.786789
  token: 62c69b2d78862316f38a9f16ca821dcc538c7181
  user: saltyuser
```
Then by using the generated token I can list all keys:
```
$ curl -sSki https://172.19.0.2:8000 \
>     -H 'Accept: application/x-yaml' \
>     -H 'X-Auth-Token: 62c69b2d78862316f38a9f16ca821dcc538c7181'\
>     -d client=wheel \
>     -d tgt='*' \
>     -d fun=key.list_all
HTTP/1.1 403 Forbidden
Content-Length: 408
Access-Control-Expose-Headers: GET, POST
Cache-Control: private
Vary: Accept-Encoding
Server: CherryPy/3.2.2
Allow: GET, HEAD, POST
Access-Control-Allow-Credentials: true
Date: Sat, 31 Dec 2016 06:55:06 GMT
Access-Control-Allow-Origin: *
Content-Type: application/x-yaml
Set-Cookie: session_id=62c69b2d78862316f38a9f16ca821dcc538c7181; expires=Sat, 31 Dec 2016 16:55:06 GMT; Path=/

return:
- data:
    _stamp: '2016-12-31T06:55:07.175263'
    fun: wheel.key.list_all
    jid: '20161231065506286546'
    return:
      local:
      - master.pem
      - master.pub
      minions: []
      minions_denied: []
      minions_pre:
      - sony-v4io-me
      minions_rejected: []
    success: true
    tag: salt/wheel/20161231065506286546
    user: saltyuser
  tag: salt/wheel/20161231065506286546
```

However on `/var/log/salt/api` I am getting these results which are the reason behind the `403 response`
```
2016-12-31 06:52:05,319 [salt.loaded.int.netapi.rest_cherrypy.app][ERROR   ][5995] Blocked IP: 172.19.0.1
2016-12-31 06:55:06,150 [salt.loaded.int.netapi.rest_cherrypy.app][ERROR   ][5995] Blocked IP: 172.19.0.1
```
I think the problem because [this line](https://github.com/saltstack/salt/blob/2016.11/salt/netapi/rest_cherrypy/app.py#L638) as the request is served even after recognizing it as an unauthorized IP the `return` is not working as expected. Also to make sure I have added 172.19.0.1 to the `authorized IPs` then reproduced the steps again, the login step to get a token
```
$ curl -sSki https://172.19.0.2:8000/login \
      -c ~/cookies.txt \             
      -H 'Accept: application/x-yaml' \                         
      -d username=saltyuser \
      -d password=thePassword2 \
      -d eauth=pam     
HTTP/1.1 200 OK
Content-Length: 199
Access-Control-Expose-Headers: GET, POST
Vary: Accept-Encoding
Server: CherryPy/3.2.2
Allow: GET, HEAD, POST
Access-Control-Allow-Credentials: true
Date: Sat, 31 Dec 2016 07:03:19 GMT
Access-Control-Allow-Origin: *
X-Auth-Token: ad608e9191bf2d0d4d58fc47f472728ae087b037
Content-Type: application/x-yaml
Set-Cookie: session_id=ad608e9191bf2d0d4d58fc47f472728ae087b037; expires=Sat, 31 Dec 2016 17:03:19 GMT; Path=/

return:
- eauth: pam
  expire: 1483210999.789219
  perms:
  - .*
  - '@wheel'
  - '@runner'
  - '@jobs'
  start: 1483167799.789218
  token: ad608e9191bf2d0d4d58fc47f472728ae087b037
```
then making use of that generated token
```
$ curl -sSki https://172.19.0.2:8000 \      
    -H 'Accept: application/x-yaml' \
    -H 'X-Auth-Token: ad608e9191bf2d0d4d58fc47f472728ae087b037'\
    -d client=wheel \        
    -d tgt='*' \                
    -d fun=key.list_all
HTTP/1.1 200 OK
Content-Length: 408
Access-Control-Expose-Headers: GET, POST
Cache-Control: private
Vary: Accept-Encoding
Server: CherryPy/3.2.2
Allow: GET, HEAD, POST
Access-Control-Allow-Credentials: true
Date: Sat, 31 Dec 2016 07:03:44 GMT
Access-Control-Allow-Origin: *
Content-Type: application/x-yaml
Set-Cookie: session_id=ad608e9191bf2d0d4d58fc47f472728ae087b037; expires=Sat, 31 Dec 2016 17:03:44 GMT; Path=/

return:
- data:
    _stamp: '2016-12-31T07:03:44.438229'
    fun: wheel.key.list_all
    jid: '20161231070344065631'
    return:
      local:
      - master.pem
      - master.pub
      minions: []
      minions_denied: []
      minions_pre:
      - sony-v4io-me
      minions_rejected: []
    success: true
    tag: salt/wheel/20161231070344065631
    user: saltyuser
  tag: salt/wheel/20161231070344065631
```
As you can see in this case the response is `200` because the IP is authorized BUT in both cases (`403` and `200`) the request is served normally. As a quick fix I have added the following line which will prevent the request from being processed. It will return HTML content not a JSON. I tried the [following](http://stackoverflow.com/a/39515345/2336650) solution but i didn't work if there is a better solution let me know and I think its fine as we have `401` returning HTML too
```
raise cherrypy.HTTPError(403, 'Bad IP')
```

### New Behavior
```
$ curl -sSki https://172.19.0.2:8000/login \
      -c ~/cookies.txt \
      -H 'Accept: application/x-yaml' \
      -d username=saltyuser \
      -d password=thePassword2 \
      -d eauth=pam
HTTP/1.1 403 Forbidden
Content-Length: 976
Access-Control-Expose-Headers: GET, POST
Vary: Accept-Encoding
Server: CherryPy/3.2.2
Allow: GET, HEAD, POST
Access-Control-Allow-Credentials: true
Date: Sat, 31 Dec 2016 08:10:17 GMT
Access-Control-Allow-Origin: *
Content-Type: text/html;charset=utf-8
Set-Cookie: session_id=5abbc589fe0a99113e8e7e53a37e411b8c5aa1f9; expires=Sat, 31 Dec 2016 18:10:17 GMT; Path=/

<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html>
<head>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"></meta>
    <title>403 Forbidden</title>
    <style type="text/css">
    #powered_by {
        margin-top: 20px;
        border-top: 2px solid black;
        font-style: italic;
    }

    #traceback {
        color: red;
    }
    </style>
</head>
    <body>
        <h2>403 Forbidden</h2>
        <p>Bad IP</p>
        <pre id="traceback">Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/cherrypy/_cprequest.py", line 653, in respond
    self.hooks.run('before_handler')
  File "/usr/lib/python2.7/site-packages/cherrypy/_cprequest.py", line 112, in run
    raise exc
HTTPError: (403, 'Bad IP')
</pre>
    <div id="powered_by">
    <span>Powered by <a href="http://www.cherrypy.org">CherryPy 3.2.2</a></span>
    </div>
    </body>
</html>
```
### Versions Report
```
Salt Version:
           Salt: 2016.11.1
 
Dependency Versions:
           cffi: Not Installed
       cherrypy: 3.2.2
       dateutil: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.7.2
        libgit2: Not Installed
        libnacl: Not Installed
       M2Crypto: Not Installed
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.4.8
   mysql-python: Not Installed
      pycparser: Not Installed
       pycrypto: 2.6.1
         pygit2: Not Installed
         Python: 2.7.5 (default, Nov  6 2016, 00:28:07)
   python-gnupg: Not Installed
         PyYAML: 3.11
          PyZMQ: 15.3.0
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.1.4
 
System Versions:
           dist: centos 7.3.1611 Core
        machine: x86_64
        release: 4.4.14-200.fc22.x86_64
         system: Linux
        version: CentOS Linux 7.3.1611 Core
```

Note: the same issue exist on the [develop](https://github.com/saltstack/salt/blob/develop/salt/netapi/rest_cherrypy/app.py#L638) branch but i sent this PR to the current stable version as i think its a critical issue