### PR TITLE
Fix the comparison of existing and new CSR (x509)

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -614,6 +614,8 @@ def read_csr(csr):
         # Get size returns in bytes. The world thinks of key sizes in bits.
         'Subject': _parse_subject(csr.get_subject()),
         'Subject Hash': _dec2hex(csr.get_subject().as_hash()),
+        'Public Key Hash': hashlib.sha1(csr.get_pubkey().get_modulus())\
+        .hexdigest()
     }
 
     ret['X509v3 Extensions'] = _get_csr_extensions(csr)


### PR DESCRIPTION
### Fixes the comparison of existing and new CSR

### Fixes #38511

### Previous Behavior
Two CSR's with different keys and same attributes appeared the same

### New Behavior
The public key hash is now compared, so the CSR's will not appear as the same

### Tests written?

No

