### PR TITLE
Fix issue #38517, added time.sleep(1) at line 227 in slack.py

### DIFF
--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -224,6 +224,6 @@ def start(token,
                     else:
                         # Fire event to event bus
                         fire('{0}/{1}'.format(tag, _m['type']), _m)
-            time.sleep(1)
+            time.sleep(1)
     else:
         raise UserWarning("Could not connect to slack")

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -224,5 +224,6 @@ def start(token,
                     else:
                         # Fire event to event bus
                         fire('{0}/{1}'.format(tag, _m['type']), _m)
+            time.sleep(1)
     else:
         raise UserWarning("Could not connect to slack")


### PR DESCRIPTION
There is a bug in the Slack engine which creates a high CPU load.
There needs to be a time.sleep(1) statement in the while True loop.

### What does this PR do?
It adds one line of code, "time.sleep(1)", to prevent high CPU usage.

### What issues does this PR fix or reference?
Issue #38517 

### Previous Behavior
100% CPU load (or core load in a multicore system) when using Slack.py Engine.

### New Behavior
CPU load is normal, small delay in functionality when using "!" commands in Slack.

### Tests written?
No
