### PR TITLE
Fix usage of salt.utils.http.query in slack_notify.call_hook

### DIFF
--- a/salt/modules/slack_notify.py
+++ b/salt/modules/slack_notify.py
@@ -311,7 +311,7 @@ def call_hook(message,
             'payload': json.dumps(payload, ensure_ascii=False)
         }
     )
-    result = salt.utils.http.query(url, 'POST', data=data)
+    result = salt.utils.http.query(url, method='POST', data=data, status=True)
 
     if result['status'] <= 201:
         return True


### PR DESCRIPTION
### What does this PR do?
Fixes slack_notify.call_hook producing tracebacks

### What issues does this PR fix or reference?
Fixes #38518

### Previous Behavior
slack_notify.call_hook called salt.utils.http.query without setting status=True, but expected status to be set in the result, which it wasn't. This resulted in an error and traceback.
Also specifies method as a positional argument, although it is actually a keyword argument.

### New Behavior
Sets status=True and specifies method correctly.

### Tests written?
No
