### PR TITLE
Create query_change state

### DIFF
--- a/salt/states/http.py
+++ b/salt/states/http.py
@@ -18,6 +18,120 @@ __monitor__ = [
         ]
 
 
+def query_change(name, match=None, match_type='string', status=None, wait_for=None, **kwargs):
+    '''
+    Perform an HTTP query and statefully return the result
+
+    .. versionadded:: Nitrogen
+
+    name
+        The name of the query.
+
+    match
+        Specifies a pattern to look for in the return text. By default, this will
+        perform a string comparison of looking for the value of match in the return
+        text.
+
+    match_type
+        Specifies the type of pattern matching to use. Default is ``string``, but
+        can also be set to ``pcre`` to use regular expression matching if a more
+        complex pattern matching is required.
+
+        .. note::
+
+            Despite the name of ``match_type`` for this argument, this setting
+            actually uses Python's ``re.search()`` function rather than Python's
+            ``re.match()`` function.
+
+    status
+        The status code for a URL for which to be checked. Can be used instead of
+        or in addition to the ``match`` setting.
+
+    Query_change mirrors the functionality of query, only instead of returning a failure
+    when status or match is not found, it will instead return changed. This is useful
+    to use an http query to call an action through onchanges.
+
+    If both ``match`` and ``status`` options are set, both settings will be checked.
+    However, note that if only one option is ``True`` and the other is ``False``,
+    then ``changed`` will be returned. If this case is reached, the comments in the
+    return data will contain troubleshooting information.
+
+    For more information about the ``http.query`` state, refer to the
+    :ref:`HTTP Tutorial <tutorial-http>`.
+
+    .. code-block:: yaml
+
+        query_example:
+          http.query:
+            - name: 'http://example.com/'
+            - status: '200'
+
+    '''
+    # Monitoring state, but changes may be made over HTTP
+    ret = {'name': name,
+           'result': None,
+           'comment': '',
+           'changes': {},
+           'data': {}}  # Data field for monitoring state
+
+    if match is None and status is None:
+        ret['result'] = False
+        ret['comment'] += (
+            ' Either match text (match) or a status code (status) is required.'
+        )
+        return ret
+
+    if 'decode' not in kwargs:
+        kwargs['decode'] = False
+    kwargs['text'] = True
+    kwargs['status'] = True
+    if __opts__['test']:
+        kwargs['test'] = True
+
+    if wait_for:
+        data = __salt__['http.wait_for_successful_query'](name, wait_for=wait_for, **kwargs)
+    else:
+        data = __salt__['http.query'](name, **kwargs)
+
+    if match is not None:
+        if match_type == 'string':
+            if match in data.get('text', ''):
+                ret['result'] = True
+                ret['comment'] += ' Match text "{0}" was found.'.format(match)
+            else:
+                ret['result'] = True
+                ret['comment'] += ' Match text "{0}" was not found.'.format(match)
+                ret['changes'] += ' Match text "{0}" was not found. Run changes.'.format(match)
+        elif match_type == 'pcre':
+            if re.search(match, data.get('text', '')):
+                ret['result'] = True
+                ret['comment'] += ' Match pattern "{0}" was found.'.format(match)
+            else:
+                ret['result'] = True
+                ret['comment'] += ' Match pattern "{0}" was not found.'.format(match)
+                ret['changes'] += ' Match pattern "{0}" was not found. Run changes.'.format(match)
+
+    if status is not None:
+        if data.get('status', '') == status:
+            ret['comment'] += 'Status {0} was found, as specified.'.format(status)
+            if ret['result'] is None:
+                ret['result'] = True
+        else:
+            ret['comment'] += 'Status {0} was not found, as specified.'.format(status)
+            ret['changes'] += 'Status {0} was not found, as specified. Run changes.'.format(status)
+            ret['result'] = True
+
+    if __opts__['test'] is True:
+        ret['result'] = None
+        ret['comment'] += ' (TEST MODE'
+        if 'test_url' in kwargs:
+            ret['comment'] += ', TEST URL WAS: {0}'.format(kwargs['test_url'])
+        ret['comment'] += ')'
+
+    ret['data'] = data
+    return ret
+
+
 def query(name, match=None, match_type='string', status=None, wait_for=None, **kwargs):
     '''
     Perform an HTTP query and statefully return the result


### PR DESCRIPTION
### What does this PR do?
Discussed in #38533

This duplicates the existing query functionality, but instead of failing when a match is not found, it instead notifies of a change. This is useful when needing to perform an action and being able to wrap that in an http.query_change state and onchanges call. The Alternative could use the http.query state and use onfail, but this results in requiring a state to fail in order to retain idempotency, which breaks testkitchen runs.


### Previous Behavior
```
check_if_cluster_exists:
  http.query:
    - url: http://localhost/api/clustername
    - status: 200

create_cluster:
  http.query:
    - url: http://localhost/api
    - post: '{"some": "json"}'
    - onfail:
      - check_if_cluster_exists
```

### New Behavior
```
check_if_cluster_exists:
  http.query_changes:
    - url: http://localhost/api/clustername
    - status: 200

create_cluster:
  http.query:
    - url: http://localhost/api
    - post: '{"some": "json"}'
    - onchanges:
      - check_if_cluster_exists
```

### Tests written?

No