### PR TITLE
Fix DSC LCM Config int checks

### DIFF
--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -456,6 +456,7 @@ def set_lcm_config(config_mode=None,
 
         salt '*' dsc.set_lcm_config ApplyOnly
     '''
+    temp_dir = os.getenv('TEMP', '{0}\\temp'.format(os.getenv('WINDIR')))
     cmd = 'Configuration SaltConfig {'
     cmd += '    Node localhost {'
     cmd += '        LocalConfigurationManager {'
@@ -468,7 +469,7 @@ def set_lcm_config(config_mode=None,
             return error
         cmd += '            ConfigurationMode = "{0}";'.format(config_mode)
     if config_mode_freq:
-        if isinstance(config_mode_freq, int):
+        if not isinstance(config_mode_freq, int):
             SaltInvocationError('config_mode_freq must be an integer')
             return 'config_mode_freq must be an integer. Passed {0}'.\
                 format(config_mode_freq)
@@ -479,7 +480,7 @@ def set_lcm_config(config_mode=None,
                                 'or Pull')
         cmd += '            RefreshMode = "{0}";'.format(refresh_mode)
     if refresh_freq:
-        if isinstance(refresh_freq, int):
+        if not isinstance(refresh_freq, int):
             SaltInvocationError('refresh_freq must be an integer')
         cmd += '            RefreshFrequencyMins = {0};'.format(refresh_freq)
     if reboot_if_needed is not None:
@@ -521,19 +522,21 @@ def set_lcm_config(config_mode=None,
                                 'All')
         cmd += '            DebugMode = "{0}";'.format(debug_mode)
     if status_retention_days:
-        if isinstance(status_retention_days, int):
+        if not isinstance(status_retention_days, int):
             SaltInvocationError('status_retention_days must be an integer')
         cmd += '            StatusRetentionTimeInDays = {0};'.format(status_retention_days)
     cmd += '        }}};'
-    cmd += r'SaltConfig -OutputPath "C:\DSC\SaltConfig"'
+    cmd += r'SaltConfig -OutputPath "{0}\SaltConfig"'.format(temp_dir)
 
     # Execute Config to create the .mof
     _pshell(cmd)
 
     # Apply the config
-    cmd = r'Set-DscLocalConfigurationManager -Path "C:\DSC\SaltConfig"'
-    ret = _pshell(cmd)
-    if not ret:
+    cmd = r'Set-DscLocalConfigurationManager -Path "{0}\SaltConfig"' \
+          r''.format(temp_dir)
+    ret = __salt__['cmd.run_all'](cmd, shell='powershell', python_shell=True)
+    __salt__['file.remove']('{0}\SaltConfig'.format(temp_dir))
+    if not ret['retcode']:
         log.info('LCM config applied successfully')
         return True
     else:

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -535,7 +535,7 @@ def set_lcm_config(config_mode=None,
     cmd = r'Set-DscLocalConfigurationManager -Path "{0}\SaltConfig"' \
           r''.format(temp_dir)
     ret = __salt__['cmd.run_all'](cmd, shell='powershell', python_shell=True)
-    __salt__['file.remove']('{0}\SaltConfig'.format(temp_dir))
+    __salt__['file.remove'](r'{0}\SaltConfig'.format(temp_dir))
     if not ret['retcode']:
         log.info('LCM config applied successfully')
         return True


### PR DESCRIPTION
### What does this PR do?
Fixes bad logic when verifying parameter input for integers.
Also, briefly stores the MOF file in the user's temp directory or Windows Temp if not found.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/34882

### Previous Behavior
There were a few parameters that expected int values. If you passed an int value, it would tell you an int value was not passed.
The MOF file was hardcoded to be stored in C:\DSC\SaltConfig.
Was using the _pshell function to apply the config which converts the output to JSON. A successful run doesn't return anything so it was returning an Invalid JSON error on success.

### New Behavior
Int parameters are properly detected.
MOF stored in Temp Directory and removed after run.
Applies the config using `cmd.run_all` instead of using the `_pshell` function and checks the retcode.

### Tests written?
No