### PR TITLE
Strip user:pass from cached URLs

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -807,6 +807,9 @@ class Client(object):
         else:
             netloc = url_data.netloc
 
+        # Strip user:pass from URLs
+        netloc = netloc.split('@')[-1]
+
         if cachedir is None:
             cachedir = self.opts['cachedir']
         elif not os.path.isabs(cachedir):


### PR DESCRIPTION
### What issues does this PR fix or reference?
Fixes #38187 

### Previous Behavior
URLs with user:pass in them were cached with said credentials in the filename.

### New Behavior
If credentials exist in the URL, they are now stripped from the filename.

### Tests written?
No.