### PR TITLE
fix gce image bug

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2853,6 +2853,8 @@ def is_profile_configured(opts, provider, profile_name, vm_=None):
         linode_cloning = True
         non_image_drivers.append('linode')
         non_size_drivers.append('linode')
+    elif driver == 'gce' and 'sourceImage' in str(vm_.get('ex_disks_gce_struct')):
+        non_image_drivers.append('gce')
 
     if driver not in non_image_drivers:
         required_keys.append('image')

--- a/tests/integration/cloud/providers/gce.py
+++ b/tests/integration/cloud/providers/gce.py
@@ -22,6 +22,8 @@ ensure_in_syspath('../../../')
 # Import Third-Party Libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
+TIMEOUT = 500
+
 
 def _random_name(size=6):
     '''
@@ -92,18 +94,18 @@ class GCETest(integration.ShellCase):
         '''
 
         # create the instance
-        instance = self.run_cloud('-p gce-test {0}'.format(self.INSTANCE_NAME), timeout=500)
+        instance = self.run_cloud('-p gce-test {0}'.format(self.INSTANCE_NAME), timeout=TIMEOUT)
         ret_str = '{0}:'.format(self.INSTANCE_NAME)
 
         # check if instance returned with salt installed
         try:
             self.assertIn(ret_str, instance)
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=500)
+            self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=TIMEOUT)
             raise
 
         # delete the instance
-        delete = self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=500)
+        delete = self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=TIMEOUT)
         # example response: ['gce-config:', '----------', '    gce:', '----------', 'cloud-test-dq4e6c:', 'True', '']
         delete_str = ''.join(delete)
 
@@ -120,18 +122,20 @@ class GCETest(integration.ShellCase):
         '''
 
         # create the instance
-        instance = self.run_cloud('-p gce-test-extra {0}'.format(self.INSTANCE_NAME))
+        instance = self.run_cloud('-p gce-test-extra \
+                                  {0}'.format(self.INSTANCE_NAME),
+                                  timeout=TIMEOUT)
         ret_str = '{0}:'.format(self.INSTANCE_NAME)
 
         # check if instance returned with salt installed
         try:
             self.assertIn(ret_str, instance)
         except AssertionError:
-            self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=500)
+            self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=TIMEOUT)
             raise
 
         # delete the instance
-        delete = self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=500)
+        delete = self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=TIMEOUT)
         # example response: ['gce-config:', '----------', '    gce:', '----------', 'cloud-test-dq4e6c:', 'True', '']
         delete_str = ''.join(delete)
 
@@ -152,7 +156,7 @@ class GCETest(integration.ShellCase):
 
         # if test instance is still present, delete it
         if ret_str in query:
-            self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=500)
+            self.run_cloud('-d {0} --assume-yes'.format(self.INSTANCE_NAME), timeout=TIMEOUT)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?
Fixes issue #38353 to ensure if using gce and setting ex_disks_gce_struct with sourceImage instead of setting image in the profile.

### What issues does this PR fix or reference?
#38353

### Previous Behavior

```
[ERROR   ] The required 'image' configuration setting is missing from the 'gce-test-extra' profile, which is configured under the 'gce-config' alias.
Error: There was a profile error: There was an error creating the GCE instance.
```

### New Behavior
The VM is created

### Tests written?

Yes