### PR TITLE
Move boto_vpc.describe_route_table deprecation version to Oxygen

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -2453,7 +2453,7 @@ def describe_route_table(route_table_id=None, route_table_name=None,
 
     '''
 
-    salt.utils.warn_until('Nitrogen',
+    salt.utils.warn_until('Oxygen',
          'The \'describe_route_table\' method has been deprecated and '
          'replaced by \'describe_route_tables\'.'
     )


### PR DESCRIPTION
Deprecations need 2 feature releases before we can remove them. This deprecation notice appeared first in 2016.11, so we need to allow a little more time to adapt to the change.
