### PR TITLE
Fix YAML deserialization of unicode

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -349,7 +349,6 @@ class SerializerExtension(Extension, object):
         super(SerializerExtension, self).__init__(environment)
         self.environment.filters.update({
             'yaml': self.format_yaml,
-            'yaml_safe': self.format_yaml_safe,
             'json': self.format_json,
             'python': self.format_python,
             'load_yaml': self.load_yaml,
@@ -389,13 +388,6 @@ class SerializerExtension(Extension, object):
                              Dumper=OrderedDictDumper).strip()
         if yaml_txt.endswith('\n...'):
             yaml_txt = yaml_txt[:len(yaml_txt)-4]
-        return Markup(yaml_txt)
-
-    def format_yaml_safe(self, value, flow_style=True):
-        yaml_txt = yaml.safe_dump(value, default_flow_style=flow_style,
-                                  Dumper=OrderedDictDumper).strip()
-        if yaml_txt.endswith('\n...\n'):
-            yaml_txt = yaml_txt[:len(yaml_txt-5)]
         return Markup(yaml_txt)
 
     def format_python(self, value):

--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -45,6 +45,9 @@ class SaltYamlSafeLoader(yaml.SafeLoader, object):
             self.add_constructor(
                 u'tag:yaml.org,2002:omap',
                 type(self).construct_yaml_map)
+            self.add_constructor(
+                u'tag:yaml.org,2002:python/unicode',
+                type(self).construct_unicode)
         self.dictclass = dictclass
 
     def construct_yaml_map(self, node):
@@ -52,6 +55,9 @@ class SaltYamlSafeLoader(yaml.SafeLoader, object):
         yield data
         value = self.construct_mapping(node)
         data.update(value)
+
+    def construct_unicode(self, node):
+        return node.value
 
     def construct_mapping(self, node, deep=False):
         '''

--- a/tests/unit/renderers/yaml_test.py
+++ b/tests/unit/renderers/yaml_test.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt libs
+from salt.renderers import yaml
+
+yaml.__salt__ = {}
+yaml.__opts__ = {}
+
+
+class YAMLRendererTestCase(TestCase):
+    def test_yaml_render_string(self):
+        data = "string"
+        result = yaml.render(data)
+
+        self.assertEqual(result, data)
+
+    def test_yaml_render_unicode(self):
+        data = "!!python/unicode python unicode string"
+        result = yaml.render(data)
+
+        self.assertEqual(result, u"python unicode string")

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -471,7 +471,14 @@ class TestCustomExtensions(TestCase):
             "foo": True,
             "bar": 42,
             "baz": [1, 2, 3],
-            "qux": 2.0
+            "qux": 2.0,
+            "spam": OrderedDict([
+                ('foo', OrderedDict([
+                    ('bar', 'baz'),
+                    ('qux', 42)
+                ])
+                )
+            ])
         }
         env = Environment(extensions=[SerializerExtension])
         rendered = env.from_string('{{ dataset|yaml }}').render(dataset=dataset)

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -490,6 +490,12 @@ class TestCustomExtensions(TestCase):
         rendered = env.from_string('{{ dataset|yaml }}').render(dataset=dataset)
         self.assertEqual(dataset, rendered)
 
+    def test_serialize_yaml_unicode(self):
+        dataset = u"str value"
+        env = Environment(extensions=[SerializerExtension])
+        rendered = env.from_string('{{ dataset|yaml }}').render(dataset=dataset)
+        self.assertEqual("!!python/unicode str value", rendered)
+
     def test_serialize_python(self):
         dataset = {
             "foo": True,


### PR DESCRIPTION
### What does this PR do?

This PR proposes a YAML deserializer for unicode values.

It also revert the patch from #30481 as it didn't fix the original problem in #30454 and it's actually broken code since the very beginning (see commit f7712d417f15d4b20144003cc379158ec0394f83 for more info)

### What issues does this PR fix or reference?

Fixes #30454

### Previous Behavior

When using the ``yaml`` filter, Python's unicode values would be serialized as ``!!python/unicode ...`` which was not understood by the YAML parser.

### New Behavior

The YAML parser is now able to properly deserialize these YAML tagged values.

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
