### PR TITLE
fix api logfile

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3321,6 +3321,7 @@ def api_config(path):
     api_opts = DEFAULT_API_OPTS
     api_opts.update({
         'pidfile': opts.get('api_pidfile', DEFAULT_API_OPTS['api_pidfile']),
+        'log_file': opts.get('api_logfile', DEFAULT_API_OPTS['api_logfile']),
     })
     opts.update(api_opts)
     prepend_root_dir(opts, [


### PR DESCRIPTION
### What does this PR do?
Adds log_file option back in for salt-api custom logfile location. Was removed here: https://github.com/saltstack/salt/pull/37272

This will need to be merged forward to 2016.11 before we tag next 2016.11 release

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/38479

### Previous Behavior
If you set `api_logfile: /tmp/blah.log` in your config it would not log to that location but the default location

### New Behavior
Logs to custom locatio now

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
