### PR TITLE
Add mysql file handling to mysql module and state

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -716,7 +716,7 @@ def file_query(database, file_name, **connection_args):
             query_result = query(database, query_string, **connection_args)
             query_string = ""
 
-            if query_result == False:
+            if query_result is False:
                 # Fail out on error
                 return False
 

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -40,6 +40,7 @@ import logging
 import re
 import sys
 import shlex
+import os
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -677,6 +677,25 @@ def query(database, query, **connection_args):
 
 
 def file_query(database, file_name, **connection_args):
+    '''
+    Run an arbitrary SQL query from the specified file and return the
+    the number of affected rows.
+
+    .. versionadded:: Nitrogen
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mysql.file_query mydb file_name=/tmp/sqlfile.sql
+
+    Return data:
+
+    .. code-block:: python
+
+        {'query time': {'human': '39.0ms', 'raw': '0.03899'}, 'rows affected': 1L}
+
+    '''
     if os.path.exists(file_name):
         with salt.utils.fopen(file_name, 'r') as ifile:
             contents = ifile.read()
@@ -687,13 +706,13 @@ def file_query(database, file_name, **connection_args):
     query_string = ""
     ret = {'rows returned': 0, 'columns': 0, 'results': 0, 'rows affected': 0, 'query time': {'raw': 0}}
     for line in contents.splitlines():
-        if re.match(r'--', line): #ignore sql comments
+        if re.match(r'--', line):  # ignore sql comments
             continue
-        if not re.search(r'[^-;]+;', line): # keep appending lines that don't end in ;
+        if not re.search(r'[^-;]+;', line):  # keep appending lines that don't end in ;
             query_string = query_string + line
         else:
-            query_string = query_string + line # append lines that end with ; and run query
-            query_result=query(database, query_string, **connection_args)
+            query_string = query_string + line  # append lines that end with ; and run query
+            query_result = query(database, query_string, **connection_args)
             query_string = ""
 
             if query_result == False:

--- a/salt/states/mysql_query.py
+++ b/salt/states/mysql_query.py
@@ -152,7 +152,7 @@ def run_file(name,
     # The database is present, execute the query
     query_result = __salt__['mysql.file_query'](database, query_file, **connection_args)
 
-    if query_result == False:
+    if query_result is False:
         ret['result'] = False
         return ret
 

--- a/salt/states/mysql_query.py
+++ b/salt/states/mysql_query.py
@@ -49,6 +49,151 @@ def _get_mysql_error():
     ].__context__.pop('mysql.error', None)
 
 
+def run_file(name,
+        database,
+        query_file=None,
+        output=None,
+        grain=None,
+        key=None,
+        overwrite=True,
+        **connection_args):
+    '''
+    Execute an arbitrary query on the specified database
+
+    name
+        Used only as an ID
+
+    database
+        The name of the database to execute the query_file on
+
+    query_file
+        The file of mysql commands to run
+
+    output
+        grain: output in a grain
+        other: the file to store results
+        None:  output to the result comment (default)
+
+    grain:
+        grain to store the output (need output=grain)
+
+    key:
+        the specified grain will be treated as a dictionary, the result
+        of this state will be stored under the specified key.
+
+    overwrite:
+        The file or grain will be overwritten if it already exists (default)
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': 'Database {0} is already present'.format(name)}
+    # check if database exists
+    if not __salt__['mysql.db_exists'](database, **connection_args):
+        err = _get_mysql_error()
+        if err is not None:
+            ret['comment'] = err
+            ret['result'] = False
+            return ret
+
+        ret['result'] = None
+        ret['comment'] = ('Database {0} is not present'
+                ).format(database)
+        return ret
+
+    # Check if execution needed
+    if output == 'grain':
+        if grain is not None and key is None:
+            if not overwrite and grain in __salt__['grains.ls']():
+                ret['comment'] = 'No execution needed. Grain ' + grain\
+                               + ' already set'
+                return ret
+            elif __opts__['test']:
+                ret['result'] = None
+                ret['comment'] = 'Query would execute, storing result in '\
+                               + 'grain: ' + grain
+                return ret
+        elif grain is not None:
+            if grain in __salt__['grains.ls']():
+                grain_value = __salt__['grains.get'](grain)
+            else:
+                grain_value = {}
+            if not overwrite and key in grain_value:
+                ret['comment'] = 'No execution needed. Grain ' + grain\
+                               + ':' + key + ' already set'
+                return ret
+            elif __opts__['test']:
+                ret['result'] = None
+                ret['comment'] = 'Query would execute, storing result in '\
+                               + 'grain: ' + grain + ':' + key
+                return ret
+        else:
+            ret['result'] = False
+            ret['comment'] = "Error: output type 'grain' needs the grain "\
+                           + "parameter\n"
+            return ret
+    elif output is not None:
+        if not overwrite and os.path.isfile(output):
+            ret['comment'] = 'No execution needed. File ' + output\
+                           + ' already set'
+            return ret
+        elif __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Query would execute, storing result in '\
+                           + 'file: ' + output
+            return ret
+    elif __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Query would execute, not storing result'
+        return ret
+
+    # The database is present, execute the query
+    query_result = __salt__['mysql.file_query'](database, query_file, **connection_args)
+
+    if query_result == False:
+        ret['result'] = False
+        return ret
+
+    mapped_results = []
+    if 'results' in query_result:
+        for res in query_result['results']:
+            mapped_line = {}
+            for idx, col in enumerate(query_result['columns']):
+                mapped_line[col] = res[idx]
+            mapped_results.append(mapped_line)
+        query_result['results'] = mapped_results
+
+    ret['comment'] = str(query_result)
+
+    if output == 'grain':
+        if grain is not None and key is None:
+            __salt__['grains.setval'](grain, query_result)
+            ret['changes']['query'] = "Executed. Output into grain: "\
+                                        + grain
+        elif grain is not None:
+            if grain in __salt__['grains.ls']():
+                grain_value = __salt__['grains.get'](grain)
+            else:
+                grain_value = {}
+            grain_value[key] = query_result
+            __salt__['grains.setval'](grain, grain_value)
+            ret['changes']['query'] = "Executed. Output into grain: "\
+                                    + grain + ":" + key
+    elif output is not None:
+        ret['changes']['query'] = "Executed. Output into " + output
+        with salt.utils.fopen(output, 'w') as output_file:
+            if 'results' in query_result:
+                for res in query_result['results']:
+                    for col, val in six.iteritems(res):
+                        output_file.write(col + ':' + val + '\n')
+            else:
+                output_file.write(str(query_result))
+    else:
+        ret['changes']['query'] = "Executed"
+
+    return ret
+
+
 def run(name,
         database,
         query,

--- a/salt/states/mysql_query.py
+++ b/salt/states/mysql_query.py
@@ -83,6 +83,8 @@ def run_file(name,
 
     overwrite:
         The file or grain will be overwritten if it already exists (default)
+
+    .. versionadded:: Nitrogen
     '''
     ret = {'name': name,
            'changes': {},


### PR DESCRIPTION
This is an attempt to work around the issues described in https://groups.google.com/forum/#!topic/salt-users/Zc4D7NN5RKQ

In short, many salt states rely on the mysql.create_db state, but then install the mysql client in order to populate the database. This overcomplicates the state handling as the mysql client package name must now be tracked for every state doing this behavior and is unusable in an environment not directly connected to the internet. 

### What does this PR do?
This pull request attempts to solve this issue by extending the mysql module with a file_query function where it attempts to read a sql file and run a query for each statement up until the trailing ; and ignores -- comments. In order to detect errors from the mysql module, it also modifies the standard query behavior to return False on error instead of an empty dict. This will cause all mysql processing to stop on any error, which I would think is the expected behavior. 

It also adds a run_file state allowing for use such as:
```
import_schema:
  mysql_query.run_file:
    - database: some_db
    - query_file: /tmp/schema.sql
```

With resulting output:
```
local:
----------
          ID: import_schema
    Function: mysql_query.run_file
      Result: True
     Comment: {'rows affected': 1L, 'query time': {'raw': 21.2241, 'human': '21.22s'}}
     Started: 17:36:00.136384
    Duration: 23852.153 ms
     Changes:
              ----------
              query:
                  Executed
```


### Tests written?
No