### PR TITLE
Update arch installation docs with correct package name

### DIFF
--- a/doc/topics/installation/arch.rst
+++ b/doc/topics/installation/arch.rst
@@ -16,18 +16,7 @@ Install Salt stable releases from the Arch Linux Official repositories as follow
 
 .. code-block:: bash
 
-    pacman -S salt-zmq
-
-To install Salt stable releases using the :ref:`RAET protocol<raet>`,
-use the following:
-
-.. code-block:: bash
-
-    pacman -S salt-raet
-
-.. note:: transports
-
-    Unlike other linux distributions, please be aware that Arch Linux's package manager pacman defaults to RAET as the Salt transport. If you want to use ZeroMQ instead, make sure to enter the associated number for the salt-zmq repository when prompted.
+    pacman -S salt
 
 Tracking develop
 ----------------


### PR DESCRIPTION
When 2016.11.0 was released, the naming of the salt package was
changed. The salt-zmq version is now named just "salt" and the
salt-raet pacakge is no longer being updated.

I spoke with @gtmanfred about this change offline already.

Refs https://github.com/saltstack/salt-bootstrap/pull/1007 and https://github.com/saltstack/salt-bootstrap/issues/1005
