### PR TITLE
Add volumes quota support to GlusterFS Module

### DIFF
--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -550,7 +550,6 @@ def add_volume_bricks(name, bricks):
     return True
 
 
-
 def enable_quota_volume(name):
     '''
     Enable quota on a glusterfs volume.
@@ -645,7 +644,6 @@ def list_quota_volume(name):
         Name of the gluster volume
 
     '''
-    
     cmd = 'volume quota {0}'.format(name)
     cmd += ' list'
 
@@ -659,4 +657,3 @@ def list_quota_volume(name):
         ret[path] = _etree_to_dict(limit)
 
     return ret
-

--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -548,3 +548,115 @@ def add_volume_bricks(name, bricks):
             cmd += ' {0}'.format(brick)
         return _gluster(cmd)
     return True
+
+
+
+def enable_quota_volume(name):
+    '''
+    Enable quota on a glusterfs volume.
+
+    name
+        Name of the gluster volume
+    '''
+
+    cmd = 'volume quota {0} enable'.format(name)
+    if not _gluster(cmd):
+        return False
+    return True
+
+
+def disable_quota_volume(name):
+    '''
+    Disable quota on a glusterfs volume.
+
+    name
+        Name of the gluster volume
+    '''
+
+    cmd = 'volume quota {0} disable'.format(name)
+    if not _gluster(cmd):
+        return False
+    return True
+
+
+def set_quota_volume(name, path, size, enable_quota=False):
+    '''
+    Set quota to glusterfs volume.
+
+    name
+        Name of the gluster volume
+
+    path
+        Folder path for restriction in volume ("/")
+
+    size
+        Hard-limit size of the volume (MB/GB)
+
+    enable_quota
+        Enable quota before set up restriction
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' glusterfs.set_quota_volume <volume> <path> <size> enable_quota=True
+
+    '''
+    cmd = 'volume quota {0}'.format(name)
+    if path:
+        cmd += ' limit-usage {0}'.format(path)
+    if size:
+        cmd += ' {0}'.format(size)
+
+    if enable_quota:
+        if not enable_quota_volume(name):
+            pass
+    if not _gluster(cmd):
+        return False
+    return True
+
+
+def unset_quota_volume(name, path):
+    '''
+    Unset quota to glusterfs volume.
+    name
+        Name of the gluster volume
+    path
+        Folder path for restriction in volume
+    CLI Example:
+    .. code-block:: bash
+
+        salt '*' glusterfs.unset_quota_volume <volume> <path>
+
+    '''
+    cmd = 'volume quota {0}'.format(name)
+    if path:
+        cmd += ' remove {0}'.format(path)
+
+    if not _gluster(cmd):
+        return False
+    return True
+
+
+def list_quota_volume(name):
+    '''
+    List quotas of glusterfs volume.
+    name
+        Name of the gluster volume
+
+    '''
+    
+    cmd = 'volume quota {0}'.format(name)
+    cmd += ' list'
+
+    root = _gluster_xml(cmd)
+    if not _gluster_ok(root):
+        return None
+
+    ret = {}
+    for limit in _iter(root, 'limit'):
+        path = limit.find('path').text
+        ret[path] = _etree_to_dict(limit)
+
+    return ret
+


### PR DESCRIPTION
### What does this PR do?

This PR add the ability to **manage GlusterFS quotas on volume**.

- You can Enable/Disable quota for a volume.
- You can Set/Unset quota (MB/GB) for a specific path in a volume.
- You can list all quotas for a volume.

### What issues does this PR fix or reference?

This PR fix the incapacity to manage Gluster quotas using Saltstack module.

### Tests written?

No specific test needed ? 
(Thanks for indulgence, it's my first commit to Salt). 

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
