### PR TITLE
New getters: config and optics

### DIFF
--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -732,6 +732,95 @@ def mac(address='', interface='', vlan=0):
     return proxy_output
 
 
+def config(source=None):
+    '''
+    .. versionadded:: 2016.11.2
+
+    Return the whole configuration of the network device.
+    By default, it will return all possible configuration
+    sources supported by the network device.
+    At most, there will be:
+
+    - running config
+    - startup config
+    - candidate config
+
+    To return only one of the configurations, you can use
+    the `source` argument.
+
+    source (optional)
+        Which configuration type you want to display, default is all of them.
+
+    :return:
+        The object returned is a dictionary with the following keys:
+
+            - running (string): Representation of the native running configuration.
+            - candidate (string): Representation of the native candidate configuration.
+                If the device doesnt differentiate between running and startup
+                configuration this will an empty string.
+            - startup (string): Representation of the native startup configuration.
+                If the device doesnt differentiate between running and startup
+                configuration this will an empty string.
+
+    CLI Example:
+
+        .. code-block:: bash
+
+            salt '*' net.config
+            salt '*' net.config source=candidate
+    '''
+
+    return __proxy__['napalm.call'](
+        'get_config',
+        **{
+            'retrieve': source
+        }
+    )
+
+
+def optics():
+    '''
+    .. versionadded:: 2016.11.2
+
+    Fetches the power usage on the various transceivers installed
+    on the network device (in dBm), and returns a view that conforms with the
+    OpenConfig model openconfig-platform-transceiver.yang.
+
+    :return:
+        Returns a dictionary where the keys are as listed below:
+            * intf_name (unicode)
+                * physical_channels
+                    * channels (list of dicts)
+                        * index (int)
+                        * state
+                            * input_power
+                                * instant (float)
+                                * avg (float)
+                                * min (float)
+                                * max (float)
+                            * output_power
+                                * instant (float)
+                                * avg (float)
+                                * min (float)
+                                * max (float)
+                            * laser_bias_current
+                                * instant (float)
+                                * avg (float)
+                                * min (float)
+                                * max (float)
+
+    CLI Example:
+
+        .. code-block:: bash
+
+            salt '*' net.optics
+    '''
+    return __proxy__['napalm.call'](
+        'get_optics',
+        **{
+        }
+    )
+
 # <---- Call NAPALM getters --------------------------------------------------------------------------------------------
 
 # ----- Configuration specific functions ------------------------------------------------------------------------------>


### PR DESCRIPTION
### What does this PR do?

Adds two features to the existing `net` module.
If this is not suitable to be introduced in 2016.11.2, please feel free to close the PR and I will re-submit into develop after https://github.com/saltstack/salt/pull/38339 is rebased, fixed, merged et all.