### PR TITLE
Add new functionality to elasticsearch returner for state outputs

### DIFF
--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -116,6 +116,7 @@ STATE_FUNCTIONS = {
     'state.sls':       'state_apply',
 }
 
+
 def __virtual__():
     return __virtualname__
 
@@ -205,7 +206,6 @@ def returner(ret):
     '''
     Process the return from Salt
     '''
-    log.debug('Ret: {0}'.format(ret)) # JPH
 
     job_fun = ret['fun']
     job_fun_escaped = job_fun.replace('.', '_')
@@ -286,7 +286,7 @@ def returner(ret):
         # Need to count state successes and failures
         if options['states_count']:
             for state_data in ret['return'].values():
-                if state_data['result'] == False:
+                if state_data['result'] is False:
                     counts['failed'] += 1
                 else:
                     counts['suceeded'] += 1

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -31,7 +31,49 @@ In order to have the returner apply to all minions:
 
     ext_job_cache: elasticsearch
 
-Minion configuration example:
+Minion configuration:
+    debug_returner_payload': False
+        Output the payload being posted to the log file in debug mode
+
+    doc_type: 'default'
+        Document type to use for normal return messages
+
+    functions_blacklist
+        Optional list of functions that should not be returned to elasticsearch
+
+    index_date: False
+        Use a dated index (e.g. <index>-2016.11.29)
+
+    master_event_index: 'salt-master-event-cache'
+        Index to use when returning master events
+
+    master_event_doc_type: 'efault'
+        Document type to use got master events
+
+    master_job_cache_index: 'salt-master-job-cache'
+        Index to use for master job cache
+
+    master_job_cache_doc_type: 'default'
+        Document type to use for master job cache
+
+    number_of_shards: 1
+        Number of shards to use for the indexes
+
+    number_of_replicas: 0
+        Number of replicas to use for the indexes
+
+    NOTE: The following options are valid for 'state.apply', 'state.sls' and 'state.highstate' functions only.
+
+    states_count: False
+        Count the number of states which succeeded or failed and return it in top-level item called 'counts'.
+        States reporting None (i.e. changes would be made but it ran in test mode) are counted as successes.
+    states_order_output: False
+        Prefix the state UID (e.g. file_|-yum_configured_|-/etc/yum.conf_|-managed) with a zero-padded version
+        of the '__run_num__' value to allow for easier sorting. Also store the state function (i.e. file.managed)
+        into a new key '_func'. Change the index to be '<index>-ordered' (e.g. salt-state_apply-ordered).
+    states_single_index: False
+        Store results for state.apply, state.sls and state.highstate in the salt-state_apply index
+        (or -ordered/-<date>) indexes if enabled
 
 .. code-block:: yaml
 
@@ -43,9 +85,13 @@ Minion configuration example:
         index_date: True
         number_of_shards: 5
         number_of_replicas: 1
+        debug_returner_payload: True
+        states_count: True
+        states_order_output: True
+        states_single_index: True
         functions_blacklist:
-          - "test.ping"
-
+          - test.ping
+          - saltutil.find_job
 '''
 
 # Import Python libs
@@ -64,9 +110,14 @@ __virtualname__ = 'elasticsearch'
 
 log = logging.getLogger(__name__)
 
+STATE_FUNCTIONS = {
+    'state.apply':     'state_apply',
+    'state.highstate': 'state_apply',
+    'state.sls':       'state_apply',
+}
 
 def __virtual__():
-    return 'elasticsearch.alias_exists' in __salt__
+    return __virtualname__
 
 
 def _get_options(ret=None):
@@ -85,6 +136,9 @@ def _get_options(ret=None):
         'master_job_cache_doc_type': 'default',
         'number_of_shards': 1,
         'number_of_replicas': 0,
+        'states_order_output': False,
+        'states_count': False,
+        'states_single_index': False,
     }
 
     attrs = {
@@ -98,6 +152,9 @@ def _get_options(ret=None):
         'master_job_cache_doc_type': 'master_job_cache_doc_type',
         'number_of_shards': 'number_of_shards',
         'number_of_replicas': 'number_of_replicas',
+        'states_count': 'states_count',
+        'states_order_output': 'states_order_output',
+        'states_single_index': 'states_single_index',
     }
 
     _options = salt.returners.get_returner_options(
@@ -127,16 +184,19 @@ def _ensure_index(index):
 
 
 def _convert_keys(data):
-    if not isinstance(data, dict):
+    if isinstance(data, dict):
+        new_data = {}
+        for k, sub_data in data.items():
+            if '.' in k:
+                new_data['_orig_key'] = k
+                k = k.replace('.', '_')
+            new_data[k] = _convert_keys(sub_data)
+    elif isinstance(data, list):
+        new_data = []
+        for item in data:
+            new_data.append(_convert_keys(item))
+    else:
         return data
-
-    new_data = {}
-    for k, sub_data in data.items():
-        if '.' in k:
-            new_data['_orig_key'] = k
-            k = k.replace('.', '_')
-
-        new_data[k] = _convert_keys(sub_data)
 
     return new_data
 
@@ -145,19 +205,15 @@ def returner(ret):
     '''
     Process the return from Salt
     '''
+    log.debug('Ret: {0}'.format(ret)) # JPH
+
     job_fun = ret['fun']
     job_fun_escaped = job_fun.replace('.', '_')
     job_id = ret['jid']
-    job_minion_id = ret['id']
-    job_success = True if ret['return'] else False
     job_retcode = ret.get('retcode', 1)
+    job_success = True if not job_retcode else False
 
     options = _get_options(ret)
-
-    index = 'salt-{0}'.format(job_fun_escaped)
-    if options['index_date']:
-        index = '{0}-{1}'.format(index,
-            datetime.date.today().strftime('%Y.%m.%d'))
 
     if job_fun in options['functions_blacklist']:
         log.info(
@@ -166,13 +222,79 @@ def returner(ret):
             'functions'.format(job_id, job_fun))
         return
 
-    if not job_success:
+    if ret.get('return', None) is None:
         log.info('Won\'t push new data to Elasticsearch, job with jid={0} was '
                  'not succesful'.format(job_id))
         return
 
+    # Build the index name
+    if options['states_single_index'] and job_fun in STATE_FUNCTIONS:
+        index = 'salt-{0}'.format(STATE_FUNCTIONS[job_fun])
+    else:
+        index = 'salt-{0}'.format(job_fun_escaped)
+
+    if options['index_date']:
+        index = '{0}-{1}'.format(index,
+            datetime.date.today().strftime('%Y.%m.%d'))
+
+    counts = {}
+
+    # Do some special processing for state returns
+    if job_fun in STATE_FUNCTIONS:
+        # Init the state counts
+        if options['states_count']:
+            counts = {
+                'suceeded': 0,
+                'failed':   0,
+            }
+
+        # Prepend each state execution key in ret['return'] with a zero-padded
+        # version of the '__run_num__' field allowing the states to be ordered
+        # more easily. Change the index to be
+        # index to be '<index>-ordered' so as not to clash with the unsorted
+        # index data format
+        if options['states_order_output'] and isinstance(ret['return'], dict):
+            index = '{0}-ordered'.format(index)
+            max_chars = len(str(len(ret['return'])))
+
+            for uid, data in ret['return'].iteritems():
+                # Skip keys we've already prefixed
+                if uid.startswith(tuple('0123456789')):
+                    continue
+
+                # Store the function being called as it's a useful key to search
+                decoded_uid = uid.split('_|-')
+                ret['return'][uid]['_func'] = '{0}.{1}'.format(
+                    decoded_uid[0],
+                    decoded_uid[-1]
+                )
+
+                # Prefix the key with the run order so it can be sorted
+                new_uid = '{0}_|-{1}'.format(
+                    str(data['__run_num__']).zfill(max_chars),
+                    uid,
+                )
+
+                ret['return'][new_uid] = ret['return'].pop(uid)
+
+        # Catch a state output that has failed and where the error message is
+        # not in a dict as expected. This prevents elasticsearch from
+        # complaining about a mapping error
+        elif not isinstance(ret['return'], dict):
+            ret['return'] = {'return': ret['return']}
+
+        # Need to count state successes and failures
+        if options['states_count']:
+            for state_data in ret['return'].values():
+                if state_data['result'] == False:
+                    counts['failed'] += 1
+                else:
+                    counts['suceeded'] += 1
+
+    # Ensure the index exists
     _ensure_index(index)
 
+    # Build the payload
     class UTC(tzinfo):
         def utcoffset(self, dt):
             return timedelta(0)
@@ -188,15 +310,17 @@ def returner(ret):
         '@timestamp': datetime.datetime.now(utc).isoformat(),
         'success': job_success,
         'retcode': job_retcode,
-        'minion': job_minion_id,
+        'minion': ret['id'],
         'fun': job_fun,
         'jid': job_id,
+        'counts': counts,
         'data': _convert_keys(ret['return'])
     }
 
     if options['debug_returner_payload']:
         log.debug('Payload: {0}'.format(data))
 
+    # Post the payload
     ret = __salt__['elasticsearch.document_create'](index=index,
                                                     doc_type=options['doc_type'],
                                                     body=json.dumps(data))


### PR DESCRIPTION
### What does this PR do?
Adds functionality to the elasticsearch returner to better support job/state data storage

### What issues does this PR fix or reference?
NA

### New Behavior
Adds "states_count", "states_order_output" and "states_single_index" options to provide ways of arranging state data in elasticsearch

### Tests written?
No tests exist for this returner

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
