### PR TITLE
Change daemontools __virtualname__ from service to daemontools

### DIFF
--- a/salt/modules/daemontools.py
+++ b/salt/modules/daemontools.py
@@ -31,7 +31,7 @@ __func_alias__ = {
 
 log = logging.getLogger(__name__)
 
-__virtualname__ = 'service'
+__virtualname__ = 'daemontools'
 
 VALID_SERVICE_DIRS = [
     '/service',


### PR DESCRIPTION
Fixes #37498

When `__virtualname__` is set to `service` in the daemontools execution
module, it overrides the default system-wide service provider. We need
to keep the default service provider, since daemontools is a third-party
service.
