### PR TITLE
State Gem: fix incorrect warning about missing rvm/rbenv

### DIFF
--- a/salt/states/gem.py
+++ b/salt/states/gem.py
@@ -74,7 +74,7 @@ def installed(name,          # pylint: disable=C0103
         Format: http://hostname[:port]
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
-    if ruby is not None and (__salt__['rvm.is_installed'](runas=user) or __salt__['rbenv.is_installed'](runas=user)):
+    if ruby is not None and not(__salt__['rvm.is_installed'](runas=user) or __salt__['rbenv.is_installed'](runas=user)):
         log.warning(
             'Use of argument ruby found, but neither rvm or rbenv is installed'
         )


### PR DESCRIPTION
### What does this PR do?
Fixes logging of warning `Use of argument ruby found, but neither rvm or rbenv is installed`, although one of them is installed.

### What issues does this PR fix or reference?
n/a

### Previous Behavior
`[WARNING ] Use of argument ruby found, but neither rvm or rbenv is installed` is logged if rvm or rbenv are installed.

### New Behavior
`[WARNING ] Use of argument ruby found, but neither rvm or rbenv is installed` is **not** logged anymore if rvm or rbenv are installed.

### Tests written?

No. Let me know if tests are necessary for this.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
