### PR TITLE
Add 'travisci.parse_qs' to the allow_failures option

### DIFF
--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -47,7 +47,8 @@ class SysModuleTest(integration.ModuleCase):
                 'state.apply',
                 'pip.iteritems',
                 'cmd.win_runas',
-                'status.list2cmdline'
+                'status.list2cmdline',
+                'travisci.parse_qs',
         )
 
         for fun in docs:


### PR DESCRIPTION
Fixes the `integration.modules.sysmod.SysModuleTest.test_valid_docs` test failure tuple which thinks a CLI example is needed.
