### PR TITLE
Disable custom roster for Salt API

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -404,6 +404,17 @@
 # Pass in an alternative location for the salt-ssh roster file
 #roster_file: /etc/salt/roster
 
+# Define a locations for roster files so they can be chosen when using Salt API.
+# An administrator can place roster files into these locations. Then when
+# calling Salt API, parameter 'roster_file' should contain a relative path to
+# these locations. That is, "roster_file=/foo/roster" will be resolved as
+# "/etc/salt/roster.d/foo/roster" etc. This feature prevents passing insecure
+# custom rosters through the Salt API.
+#
+#rosters:
+# - /etc/salt/roster.d
+# - /opt/salt/some/more/rosters
+
 # The log file of the salt-ssh command:
 #ssh_log_file: /var/log/salt/ssh
 

--- a/salt/client/ssh/client.py
+++ b/salt/client/ssh/client.py
@@ -22,7 +22,8 @@ class SSHClient(object):
     '''
     def __init__(self,
                  c_path=os.path.join(syspaths.CONFIG_DIR, 'master'),
-                 mopts=None):
+                 mopts=None,
+                 disable_custom_roster=False):
         if mopts:
             self.opts = mopts
         else:
@@ -34,6 +35,9 @@ class SSHClient(object):
                     )
                 )
             self.opts = salt.config.client_config(c_path)
+
+        # Salt API should never offer a custom roster!
+        self.opts['__disable_custom_roster'] = disable_custom_roster
 
     def _prep_ssh(
             self,

--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -129,7 +129,8 @@ class NetapiClient(object):
 
         :return: Returns the result from the salt-ssh command
         '''
-        ssh_client = salt.client.ssh.client.SSHClient(mopts=self.opts)
+        ssh_client = salt.client.ssh.client.SSHClient(mopts=self.opts,
+                                                      disable_custom_roster=True)
         return ssh_client.cmd_sync(kwargs)
 
     def runner(self, fun, timeout=None, **kwargs):

--- a/salt/roster/__init__.py
+++ b/salt/roster/__init__.py
@@ -19,6 +19,12 @@ log = logging.getLogger(__name__)
 
 
 def get_roster_file(options):
+    '''
+    Find respective roster file.
+
+    :param options:
+    :return:
+    '''
     template = None
     if options.get('__disable_custom_roster') and options.get('roster_file'):
         roster = options.get('roster_file').strip('/')

--- a/salt/roster/__init__.py
+++ b/salt/roster/__init__.py
@@ -26,6 +26,10 @@ def get_roster_file(options):
     :return:
     '''
     template = None
+    # The __disable_custom_roster is always True if Salt SSH Client comes
+    # from Salt API. In that case no way to define own 'roster_file', instead
+    # this file needs to be chosen from already validated rosters
+    # (see /etc/salt/master config).
     if options.get('__disable_custom_roster') and options.get('roster_file'):
         roster = options.get('roster_file').strip('/')
         for roster_location in options.get('rosters'):

--- a/salt/roster/__init__.py
+++ b/salt/roster/__init__.py
@@ -54,7 +54,7 @@ def get_roster_file(options):
         raise IOError('No roster file found')
 
     if not os.access(template, os.R_OK):
-        raise IOError('Access denied to roster "{}"'.format(template))
+        raise IOError('Access denied to roster "{0}"'.format(template))
 
     return template
 


### PR DESCRIPTION
### What does this PR do?

Fixes a vulnerability. :boom: 

### Previous Behavior

It is possible to add a Shell expression into a roster file so it will be interpreted. Like this:
```
foo:
  host: $(touch /tmp/p0wned)
  user: bogus
  passwd: bogus
```

From the point of view command-line Salt SSH, this does not do any bad: the file `/tmp/p0wned` will be created, but from the user that is executing Salt SSH. However, if this is done through the Salt API, then this file will be created from the user, which is running Salt API. That is, if a regular API user is authenticated to execute Salt SSH via API, and API is running as user `root`, then the local user can gain full access to the system.

### New Behavior

Solution is not to allow custom rosters to the Salt API on Salt SSH client, but only choose from those that are located. New behavior is to define rosters in the `/etc/salt/master` (or `/etc/salt/master.d/...`):
```
rosters:
  - /opt/group-1/verified-rosters
  - /opt/group-2/verified-rosters
```

So the parameter `roster_file` in the REST request will be prefixed with one of those locations above. In this way any administrator will be able to keep an eye on rosters.

### Important

**Salt SSH Cli is unchanged and custom rosters are still possible to add.**
This limitation is only when Salt SSH is called through the Salt API.

### Tests written?

No

@thatch45 @cachedout 