### PR TITLE
Avoid errors when sudo_user is set

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -869,6 +869,7 @@ def extracted(name,
     else:
         source_sum = {}
 
+    concurrent = bool(__opts__.get('sudo_user'))
     if not source_is_local and not os.path.isfile(cached_source):
         if __opts__['test']:
             ret['result'] = None
@@ -885,7 +886,8 @@ def extracted(name,
                                                source_hash_name=source_hash_name,
                                                makedirs=True,
                                                skip_verify=skip_verify,
-                                               saltenv=__env__)
+                                               saltenv=__env__,
+                                               concurrent=concurrent)
         log.debug('file.managed: {0}'.format(file_result))
 
         # Get actual state result. The state.single return is a single-element
@@ -1324,7 +1326,8 @@ def extracted(name,
                                                       user=user,
                                                       group=group,
                                                       recurse=recurse,
-                                                      test=__opts__['test'])
+                                                      test=__opts__['test'],
+                                                      concurrent=concurrent)
                 try:
                     dir_result = dir_result[next(iter(dir_result))]
                 except AttributeError:


### PR DESCRIPTION
When sudo_user is used, the job is forked into a new pid when sudo is
executed. If a state then tries itself to execute states (such as when a
state invokes state.single), the fact that the forked PID was different
from the PID from which the job was started will cause Salt to refuse to
run the state.

This avoids this by conditionally setting concurrent to True when
invoking states from within states.