### PR TITLE
archive.extracted: Prevent traceback when state.single cannot be run

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -888,6 +888,15 @@ def extracted(name,
                                                saltenv=__env__)
         log.debug('file.managed: {0}'.format(file_result))
 
+        # Prevent a traceback if errors prevented the above state from getting
+        # off the ground.
+        if isinstance(file_result, list):
+            try:
+                ret['comment'] = '\n'.join(file_result)
+            except TypeError:
+                ret['comment'] = '\n'.join([str(x) for x in file_result])
+            return ret
+
         # Get actual state result. The state.single return is a single-element
         # dictionary with the state's unique ID at the top level, and its value
         # being the state's return dictionary. next(iter(dict_name)) will give


### PR DESCRIPTION
The error that prompted this should be fixed by #38598, but this will
prevent other possible sources of this issue from triggering a similar
traceback.