### PR TITLE
Avoid errors when sudo_user is set (2016.3 branch)

### DIFF
--- a/salt/modules/vbox_guest.py
+++ b/salt/modules/vbox_guest.py
@@ -101,19 +101,22 @@ def _additions_install_opensuse(**kwargs):
         r'^(\d|\.|-)*', '', __grains__.get('kernelrelease', ''))
     kernel_devel = 'kernel-{0}-devel'.format(kernel_type)
     ret = __salt__['state.single']('pkg.installed', 'devel packages',
-                                   pkgs=['make', 'gcc', kernel_devel])
+                                   pkgs=['make', 'gcc', kernel_devel],
+                                   concurrent=bool(__opts__.get('sudo_user')))
     return ret
 
 
 def _additions_install_ubuntu(**kwargs):
     ret = __salt__['state.single']('pkg.installed', 'devel packages',
-                                   pkgs=['dkms', ])
+                                   pkgs=['dkms', ],
+                                   concurrent=bool(__opts__.get('sudo_user')))
     return ret
 
 
 def _additions_install_fedora(**kwargs):
     ret = __salt__['state.single']('pkg.installed', 'devel packages',
-                                   pkgs=['dkms', 'gcc'])
+                                   pkgs=['dkms', 'gcc'],
+                                   concurrent=bool(__opts__.get('sudo_user')))
     return ret
 
 

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -343,6 +343,7 @@ def extracted(name,
             __env__,
             '{0}.{1}'.format(re.sub('[:/\\\\]', '_', if_missing), archive_format))
 
+    concurrent = bool(__opts__.get('sudo_user'))
     if not source_is_local and not os.path.isfile(filename):
         if __opts__['test']:
             ret['result'] = None
@@ -363,7 +364,8 @@ def extracted(name,
                                                makedirs=True,
                                                skip_verify=skip_verify,
                                                saltenv=__env__,
-                                               source_hash_name=source_hash_name)
+                                               source_hash_name=source_hash_name,
+                                               concurrent=concurrent)
         log.debug('file.managed: {0}'.format(file_result))
         # get value of first key
         try:
@@ -527,7 +529,8 @@ def extracted(name,
                                                   if_missing,
                                                   user=user,
                                                   group=group,
-                                                  recurse=recurse)
+                                                  recurse=recurse,
+                                                  concurrent=concurrent)
             log.debug('file.directory: %s', dir_result)
         elif os.path.isfile(if_missing):
             log.debug('if_missing (%s) is a file, not enforcing user/group '

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -507,7 +507,8 @@ def loaded(name, tag='latest', source=None, source_hash='', force=False):
     __salt__['state.single']('file.managed',
                              name=tmp_filename,
                              source=source,
-                             source_hash=source_hash)
+                             source_hash=source_hash,
+                             concurrent=bool(__opts__.get('sudo_user')))
     changes = {}
 
     if image_infos['status']:


### PR DESCRIPTION
This is #38598 for the 2016.3 branch. It contains a separate implementation of the fix for salt/states/archive.py, as the code diverged significantly between 2016.3 and 2016.11. It also contains similar fixes for other code that invokes states, to prevent the same issue from affecting those states/modules.