### PR TITLE
Fix failing unit.states.boto_vpc_test.BotoVpcRouteTableTestCase.test_present_with_routes

### DIFF
--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -8,10 +8,12 @@ from __future__ import absolute_import
 from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
 import pkg_resources
 from pkg_resources import DistributionNotFound
+import random
+import string
 
 # Import Salt Testing libs
 from salttesting.unit import skipIf, TestCase
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 from salttesting.helpers import ensure_in_syspath
 
 ensure_in_syspath('../../')
@@ -22,6 +24,7 @@ import salt.loader
 from salt.modules import boto_vpc
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 from salt.modules.boto_vpc import _maybe_set_name_tag, _maybe_set_tags
+from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -118,6 +121,9 @@ def _has_required_moto():
         return True
 
 
+context = {}
+
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
 @skipIf(HAS_MOTO is False, 'The moto module must be installed.')
@@ -128,6 +134,19 @@ def _has_required_moto():
 class BotoVpcTestCaseBase(TestCase):
     def setUp(self):
         boto_vpc.__context__ = {}
+        context.clear()
+        # connections keep getting cached from prior tests, can't find the
+        # correct context object to clear it. So randomize the cache key, to prevent any
+        # cache hits
+        conn_parameters['key'] = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(50))
+
+        self.patcher = patch('boto3.session.Session')
+        self.addCleanup(self.patcher.stop)
+        mock_session = self.patcher.start()
+
+        session_instance = mock_session.return_value
+        self.conn3 = MagicMock()
+        session_instance.client.return_value = self.conn3
 
 
 class BotoVpcTestCaseMixin(object):
@@ -165,7 +184,7 @@ class BotoVpcTestCaseMixin(object):
         if not self.conn:
             self.conn = boto.vpc.connect_to_region(region)
 
-        igw = self.conn.create_internet_gateway(vpc_id)
+        igw = self.conn.create_internet_gateway()
         _maybe_set_name_tag(name, igw)
         _maybe_set_tags(tags, igw)
         return igw


### PR DESCRIPTION
I am not familiar with the boto stuff, I just applied changes made in 2016.3,
so I would appreciate extra scrutiny.