### PR TITLE
Salt CLI target preview

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -203,8 +203,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         Return a list of minions from a given target
         '''
         minion_list = self.local_client.gather_minions(self.config['tgt'], self.selected_target_option or 'glob')
-        self._output_ret( minion_list, self.config.get('output', 'nested'))
-
+        self._output_ret(minion_list, self.config.get('output', 'nested'))
 
     def _run_batch(self):
         import salt.cli.batch

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -60,7 +60,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             return
 
         if self.options.preview_target:
-            print(self._preview_target())
+            self._preview_target()
             return
 
         if self.options.timeout <= 0:
@@ -202,7 +202,8 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         '''
         Return a list of minions from a given target
         '''
-        return self.local_client.gather_minions(self.config['tgt'], self.selected_target_option or 'glob')
+        minion_list = self.local_client.gather_minions(self.config['tgt'], self.selected_target_option or 'glob')
+        self._output_ret( minion_list, self.config.get('output', 'nested'))
 
 
     def _run_batch(self):

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -59,6 +59,10 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             self._run_batch()
             return
 
+        if self.options.preview_target:
+            print(self._preview_target())
+            return
+
         if self.options.timeout <= 0:
             self.options.timeout = self.local_client.opts['timeout']
 
@@ -193,6 +197,13 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         except (SaltInvocationError, EauthAuthenticationError, SaltClientError) as exc:
             ret = str(exc)
             self._output_ret(ret, '')
+
+    def _preview_target(self):
+        '''
+        Return a list of minions from a given target
+        '''
+        return self.local_client.gather_minions(self.config['tgt'], self.selected_target_option or 'glob')
+
 
     def _run_batch(self):
         import salt.cli.batch

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -345,6 +345,9 @@ class LocalClient(object):
 
         return self._check_pub_data(pub_data)
 
+    def gather_minions(self, tgt, expr_form):
+        return salt.utils.minions.CkMinions(self.opts).check_minions(tgt, tgt_type=expr_form)
+
     @tornado.gen.coroutine
     def run_job_async(
             self,

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1983,9 +1983,16 @@ class SaltCMDOptionParser(six.with_metaclass(OptionParserMeta,
             default=False,
             help=('Dump the master configuration values')
         )
+        self.add_option(
+            '--preview-target',
+            dest='preview_target',
+            action='store_true',
+            default=False,
+            help=('Show the minions expected to match a target. Does not issue any command.')
+        )
 
     def _mixin_after_parsed(self):
-        if len(self.args) <= 1 and not self.options.doc:
+        if len(self.args) <= 1 and not self.options.doc and not self.options.preview_target:
             try:
                 self.print_help()
             except Exception:  # pylint: disable=broad-except
@@ -2001,6 +2008,10 @@ class SaltCMDOptionParser(six.with_metaclass(OptionParserMeta,
             cfg = config.master_config(self.get_config_file_path())
             sys.stdout.write(yaml.dump(cfg, default_flow_style=False))
             sys.exit(salt.defaults.exitcodes.EX_OK)
+
+        if self.options.preview_target:
+            # Insert dummy arg which won't be used
+            self.args.append('not_a_valid_command')
 
         if self.options.doc:
             # Include the target


### PR DESCRIPTION
Make it easy to see what minions will match a given target without
ever having to launch a command.

```
mp@silver ...salt/salt/cli % sudo salt --preview-target -C 'G@os:Arch'                                                                                                                                                                      (git)-[preview_target] 
['correct_usage', 'silver2', '20-1', '20-0', '20-3', '20-2', '20-4', 'zjenkins-ubuntu16-e98c5c', 'mp_test_1', 'zjenkins-ubuntu164096-4633f6', 'zjenkins-fedora24-8521be', 'silver']
```