### PR TITLE
Fix #38595 - Unexpected error log from redis retuner in master's log

### DIFF
--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -227,7 +227,8 @@ def clean_old_jobs():
         load_key = ret_key.replace('ret:', 'load:', 1)
         if load_key not in living_jids:
             to_remove.append(ret_key)
-    serv.delete(*to_remove)
+    if len(to_remove) != 0:
+        serv.delete(*to_remove)
 
 
 def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument


### PR DESCRIPTION
### What does this PR do?
Fixing #38595 , the performance of the BUG is stated in the corresponding issue.

### What issues does this PR fix or reference?
Fixing #38595 

### Previous Behavior
Master's daemon thread will write error log every 10 minutes when actually everything works fine from redis returner.

### New Behavior
No unnecessary error log will be appended to master's log file.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
