### PR TITLE
network.ifacestartswith throws exception on Solaris-like platforms

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1489,7 +1489,10 @@ def ifacestartswith(cidr):
         if 'inet' in ifval:
             for inet in ifval['inet']:
                 if inet['address'][0:size] == pattern:
-                    intfnames.append(inet['label'])
+                    if 'label' in inet:
+                        intfnames.append(inet['label'])
+                    else:
+                        intfnames.append(ifname)
     return intfnames
 
 


### PR DESCRIPTION
### What does this PR do?
Make it so on Solaris-like platforms network.ifacestartswith does not throw exceptions.
There is no 'label' when data is collected using ifconfig. So other platforms lacking 'ip' are probably also effected by this bug.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
```bash
 salt cronos network.ifacestartswith 172.16.30
```
```yaml
cronos:
    The minion function caused an exception: Traceback (most recent call last):
      File "/opt/local/lib/python2.7/site-packages/salt/minion.py", line 1412, in _thread_return
        return_data = executor.execute()
      File "/opt/local/lib/python2.7/site-packages/salt/executors/direct_call.py", line 28, in execute
        return self.func(*self.args, **self.kwargs)
      File "/opt/local/lib/python2.7/site-packages/salt/modules/network.py", line 1492, in ifacestartswith
        intfnames.append(inet['label'])
    KeyError: 'label'
```

### New Behavior
```bash
 salt cronos network.ifacestartswith 172.16.30
```
```yaml
cronos:
    - net0
```

### Tests written?
No

PS: happy new year everyone, hopefully this year will be filled with awesome saltstack commits and PR's also!