### PR TITLE
Merge list values from config files

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1902,7 +1902,7 @@ def include_config(include, orig_path, verbose, exit_on_config_errors=False):
             if include:
                 opts.update(include_config(include, fn_, verbose))
 
-            salt.utils.dictupdate.update(configuration, opts)
+            salt.utils.dictupdate.update(configuration, opts, True, True)
 
     return configuration
 


### PR DESCRIPTION
### What does this PR do?
Extends merging of config files to merge lists such as file_roots and pillar_roots.

### What issues does this PR fix or reference?
Discussed and resolved in  #18582.

### Previous Behavior
Defining a config key twice with a list overrides the first definition.

### New Behavior
Config list values are merged and options can be managed among multiple files.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
