### PR TITLE
Add support for wildcard versions in pkg.installed states

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -56,6 +56,38 @@ Execution Module Changes
   <salt.modules.systemd>` module have changed. These changes are described
   above alongside the information on the new states which have been added to
   manage masking of systemd units.
+- The :py:func:`pkg.list_repo_pkgs <salt.modules.yumpkg.list_repo_pkgs>`
+  function for yum/dnf-based distros has had its default output format changed.
+  In prior releases, results would be organized by repository. Now, the default
+  for each package will be a simple list of versions. To get the old behavior,
+  pass ``byrepo=True`` to the function.
+- A ``pkg.list_repo_pkgs`` function has been added for both
+  :py:func:`Debian/Ubuntu <salt.modules.aptpkg.list_repo_pkgs>` and
+  :py:func:`Arch Linux <salt.modules.pacman.list_repo_pkgs>`-based distros.
+
+Wildcard Versions in :py:func:`pkg.installed <salt.states.pkg.installed>` States
+================================================================================
+
+The :py:func:`pkg.installed <salt.states.pkg.installed>` state now supports
+wildcards in package versions, for the following platforms:
+
+- Debian/Ubuntu
+- RHEL/CentOS
+- Arch Linux
+
+This support also extends to any derivatives of these distros, which use the
+:mod:`aptpkg <salt.modules.aptpkg>`, :mod:`yumpkg <salt.modules.yumpkg>`, or
+:mod:`pacman <salt.modules.pacman>` providers for the ``pkg`` virtual module.
+
+Using wildcards can be useful for packages where the release name is built into
+the version in some way, such as for RHEL/CentOS which typically has version
+numbers like ``1.2.34-5.el7``. An example of the usage for this would be:
+
+.. code-block:: yaml
+
+    mypkg:
+      pkg.installed:
+        - version: '1.2.34*'
 
 - The :mod:`system <salt.modules.system>` module changed the returned format
   from "HH:MM AM/PM" to "HH:MM:SS AM/PM" for `get_system_time`.

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -13,9 +13,11 @@ A module to wrap pacman calls, since Arch is the best
 # Import python libs
 from __future__ import absolute_import
 import copy
+import fnmatch
 import logging
 import re
 import os.path
+from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=no-name-in-module,import-error
 
 # Import salt libs
 import salt.utils
@@ -511,6 +513,9 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
+    refresh = salt.utils.is_true(refresh)
+    sysupgrade = salt.utils.is_true(sysupgrade)
+
     try:
         pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](
             name, pkgs, sources, **kwargs
@@ -539,18 +544,19 @@ def install(name=None,
         cmd.extend(['systemd-run', '--scope'])
     cmd.append('pacman')
 
+    errors = []
     if pkg_type == 'file':
         cmd.extend(['-U', '--noprogressbar', '--noconfirm'])
         cmd.extend(pkg_params)
     elif pkg_type == 'repository':
         cmd.append('-S')
-        if salt.utils.is_true(refresh):
+        if refresh:
             cmd.append('-y')
-        if salt.utils.is_true(sysupgrade):
+        if sysupgrade:
             cmd.append('-u')
         cmd.extend(['--noprogressbar', '--noconfirm', '--needed'])
         targets = []
-        problems = []
+        wildcards = []
         for param, version_num in six.iteritems(pkg_params):
             if version_num is None:
                 targets.append(param)
@@ -562,38 +568,79 @@ def install(name=None,
                     prefix += eq or ''
                     # If no prefix characters were supplied, use '='
                     prefix = prefix or '='
+                    if '*' in verstr:
+                        if prefix == '=':
+                            wildcards.append((param, verstr))
+                        else:
+                            errors.append(
+                                'Invalid wildcard for {0}{1}{2}'.format(
+                                    param, prefix, verstr
+                                )
+                            )
+                        continue
                     targets.append('{0}{1}{2}'.format(param, prefix, verstr))
                 else:
-                    msg = ('Invalid version string \'{0}\' for package '
-                           '\'{1}\''.format(version_num, name))
-                    problems.append(msg)
-        if problems:
-            for problem in problems:
-                log.error(problem)
-            return {}
+                    errors.append(
+                        'Invalid version string \'{0}\' for package '
+                        '\'{1}\''.format(version_num, name)
+                    )
 
+    if wildcards:
+        # Resolve wildcard matches
+        _available = list_repo_pkgs(*[x[0] for x in wildcards], refresh=refresh)
+        for pkgname, verstr in wildcards:
+            candidates = _available.get(pkgname, [])
+            match = salt.utils.fnmatch_multiple(candidates, verstr)
+            if match is not None:
+                targets.append('='.join((pkgname, match)))
+            else:
+                errors.append(
+                    'No version matching \'{0}\' found for package \'{1}\' '
+                    '(available: {2})'.format(
+                        verstr,
+                        pkgname,
+                        ', '.join(candidates) if candidates else 'none'
+                    )
+                )
+
+        if refresh:
+            try:
+                # Prevent a second refresh when we run the install command
+                cmd.remove('-y')
+            except ValueError:
+                # Shouldn't happen since we only add -y when refresh is True,
+                # but just in case that code above is inadvertently changed,
+                # don't let this result in a traceback.
+                pass
+
+    if not errors:
         cmd.extend(targets)
+        old = list_pkgs()
+        out = __salt__['cmd.run_all'](
+            cmd,
+            output_loglevel='trace',
+            python_shell=False
+        )
 
-    old = list_pkgs()
-    out = __salt__['cmd.run_all'](
-        cmd,
-        output_loglevel='trace',
-        python_shell=False
-    )
+        if out['retcode'] != 0 and out['stderr']:
+            errors = [out['stderr']]
+        else:
+            errors = []
 
-    if out['retcode'] != 0 and out['stderr']:
-        errors = [out['stderr']]
-    else:
-        errors = []
-
-    __context__.pop('pkg.list_pkgs', None)
-    new = list_pkgs()
-    ret = salt.utils.compare_dicts(old, new)
+        __context__.pop('pkg.list_pkgs', None)
+        new = list_pkgs()
+        ret = salt.utils.compare_dicts(old, new)
 
     if errors:
+        try:
+            changes = ret
+        except UnboundLocalError:
+            # We ran into errors before we attempted to install anything, so
+            # there are no changes.
+            changes = {}
         raise CommandExecutionError(
             'Problem encountered installing package(s)',
-            info={'errors': errors, 'changes': ret}
+            info={'errors': errors, 'changes': changes}
         )
 
     return ret
@@ -905,3 +952,126 @@ def owner(*paths):
     if len(ret) == 1:
         return next(six.itervalues(ret))
     return ret
+
+
+def list_repo_pkgs(*args, **kwargs):
+    '''
+    Returns all available packages. Optionally, package names (and name globs)
+    can be passed and the results will be filtered to packages matching those
+    names.
+
+    This function can be helpful in discovering the version or repo to specify
+    in a :mod:`pkg.installed <salt.states.pkg.installed>` state.
+
+    The return data will be a dictionary mapping package names to a list of
+    version numbers, ordered from newest to oldest. If ``byrepo`` is set to
+    ``True``, then the return dictionary will contain repository names at the
+    top level, and each repository will map packages to lists of version
+    numbers. For example:
+
+    .. code-block:: python
+
+        # With byrepo=False (default)
+        {
+            'bash': ['4.4.005-2'],
+            'nginx': ['1.10.2-2']
+        }
+        # With byrepo=True
+        {
+            'core': {
+                'bash': ['4.4.005-2']
+            },
+            'extra': {
+                'nginx': ['1.10.2-2']
+            }
+        }
+
+    fromrepo : None
+        Only include results from the specified repo(s). Multiple repos can be
+        specified, comma-separated.
+
+    byrepo : False
+        When ``True``, the return data for each package will be organized by
+        repository.
+
+    refresh : False
+        When ``True``, the package database will be refreshed (i.e. ``pacman
+        -Sy``) before checking for available versions.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' pkg.list_repo_pkgs
+        salt '*' pkg.list_repo_pkgs foo bar baz
+        salt '*' pkg.list_repo_pkgs 'samba4*' fromrepo=base,updates
+        salt '*' pkg.list_repo_pkgs 'python2-*' byrepo=True
+    '''
+    kwargs = salt.utils.clean_kwargs(**kwargs)
+    fromrepo = kwargs.pop('fromrepo', '') or ''
+    byrepo = kwargs.pop('byrepo', False)
+    refresh = kwargs.pop('refresh', False)
+    if kwargs:
+        salt.utils.invalid_kwargs(kwargs)
+
+    if fromrepo:
+        try:
+            repos = [x.strip() for x in fromrepo.split(',')]
+        except AttributeError:
+            repos = [x.strip() for x in str(fromrepo).split(',')]
+    else:
+        repos = []
+
+    if refresh:
+        refresh_db()
+
+    out = __salt__['cmd.run_all'](
+        ['pacman', '-Sl'],
+        output_loglevel='trace',
+        ignore_retcode=True,
+        python_shell=False
+    )
+
+    ret = {}
+    for line in salt.utils.itertools.split(out['stdout'], '\n'):
+        try:
+            repo, pkg_name, pkg_ver = line.strip().split()[:3]
+        except ValueError:
+            continue
+
+        if repos and repo not in repos:
+            continue
+
+        if args:
+            for arg in args:
+                if fnmatch.fnmatch(pkg_name, arg):
+                    skip_pkg = False
+                    break
+            else:
+                # Package doesn't match any of the passed args, skip it
+                continue
+
+        ret.setdefault(repo, {}).setdefault(pkg_name, []).append(pkg_ver)
+
+    if byrepo:
+        for reponame in ret:
+            # Sort versions newest to oldest
+            for pkgname in ret[reponame]:
+                sorted_versions = sorted(
+                    [_LooseVersion(x) for x in ret[reponame][pkgname]],
+                    reverse=True
+                )
+                ret[reponame][pkgname] = [x.vstring for x in sorted_versions]
+        return ret
+    else:
+        byrepo_ret = {}
+        for reponame in ret:
+            for pkgname in ret[reponame]:
+                byrepo_ret.setdefault(pkgname, []).extend(ret[reponame][pkgname])
+        for pkgname in byrepo_ret:
+            sorted_versions = sorted(
+                [_LooseVersion(x) for x in byrepo_ret[pkgname]],
+                reverse=True
+            )
+            byrepo_ret[pkgname] = [x.vstring for x in sorted_versions]
+        return byrepo_ret

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -76,6 +76,7 @@ state module
 # Import python libs
 from __future__ import absolute_import
 import errno
+import fnmatch
 import logging
 import os
 import re
@@ -192,18 +193,14 @@ def _fulfills_version_spec(versions, oper, desired_version,
             versions = versions['version']
     for ver in versions:
         if oper == '==':
-            # support wildcards in desired version
-            limit = desired_version.find('*')
-            if limit == -1:
-                limit = None
-            ver =  ver[:limit]
-            desired_version = desired_version[:limit]
+            if fnmatch.fnmatch(ver, desired_version):
+                return True
 
-        if salt.utils.compare_versions(ver1=ver,
-                                       oper=oper,
-                                       ver2=desired_version,
-                                       cmp_func=cmp_func,
-                                       ignore_epoch=ignore_epoch):
+        elif salt.utils.compare_versions(ver1=ver,
+                                         oper=oper,
+                                         ver2=desired_version,
+                                         cmp_func=cmp_func,
+                                         ignore_epoch=ignore_epoch):
             return True
     return False
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -753,19 +753,18 @@ def installed(
 
         .. code-block:: bash
 
-            # salt myminion pkg.list_repo_pkgs httpd
+            # salt myminion pkg.list_repo_pkgs bash
             myminion:
-                ----------
-                base:
-                    |_
-                      ----------
-                      httpd:
-                          2.2.15-29.el6.centos
-                updates:
-                    |_
-                      ----------
-                      httpd:
-                          2.2.15-30.el6.centos
+            ----------
+                bash:
+                    - 4.2.46-21.el7_3
+                    - 4.2.46-20.el7_2
+
+        This function was first added for :mod:`pkg.list_repo_pkgs
+        <salt.modules.yumpkg.list_repo_pkgs>` in 2014.1.0, and was expanded to
+        :py:func:`Debian/Ubuntu <salt.modules.aptpkg.list_repo_pkgs>` and
+        :py:func:`Arch Linux <salt.modules.pacman.list_repo_pkgs>`-based
+        distros in the Nitrogen release.
 
         The version strings returned by either of these functions can be used
         as version specifiers in pkg states.
@@ -784,6 +783,21 @@ def installed(
 
         If the version given is the string ``latest``, the latest available
         package version will be installed à la ``pkg.latest``.
+
+        **WILDCARD VERSIONS**
+
+        As of the Nitrogen release, this state now supports wildcards in
+        package versions for Debian/Ubuntu, RHEL/CentOS, Arch Linux, and their
+        derivatives. Using wildcards can be useful for packages where the
+        release name is built into the version in some way, such as for
+        RHEL/CentOS which typically has version numbers like ``1.2.34-5.el7``.
+        An example of the usage for this would be:
+
+        .. code-block:: yaml
+
+            mypkg:
+              pkg.installed:
+                - version: '1.2.34*'
 
     :param bool refresh:
         This parameter controls whether or not the package repo database is

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -191,6 +191,14 @@ def _fulfills_version_spec(versions, oper, desired_version,
         if isinstance(versions, dict) and 'version' in versions:
             versions = versions['version']
     for ver in versions:
+        if oper == '==':
+            # support wildcards in desired version
+            limit = desired_version.find('*')
+            if limit == -1:
+                limit = None
+            ver =  ver[:limit]
+            desired_version = desired_version[:limit]
+
         if salt.utils.compare_versions(ver1=ver,
                                        oper=oper,
                                        ver2=desired_version,

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -3222,3 +3222,25 @@ def filter_by(lookup_dict,
             salt.utils.dictupdate.update(ret, copy.deepcopy(merge))
 
     return ret
+
+
+def fnmatch_multiple(candidates, pattern):
+    '''
+    Convenience function which runs fnmatch.fnmatch() on each element of passed
+    iterable. The first matching candidate is returned, or None if there is no
+    matching candidate.
+    '''
+    # Make sure that candidates is iterable to avoid a TypeError when we try to
+    # iterate over its items.
+    try:
+        candidates_iter = iter(candidates)
+    except TypeError:
+        return None
+
+    for candidate in candidates_iter:
+        try:
+            if fnmatch.fnmatch(candidate, pattern):
+                return candidate
+        except TypeError:
+            pass
+    return None


### PR DESCRIPTION
This pull request adds support for aptpkg, yumpkg, and pacman to specify a
wildcard in a version number. While apt supports resolving wildcards
intrinsically, this functionality has been added via the use of the
pkg.list_repo_pkgs function for yumpkg and pacman. Code has also been added to
the pkg.installed state to resolve wildcard versions, to preserve idempotence.

An integration test is included, and documentation has been added to the
state's docstring as well as the Nitrogen release notes.

Resolves #34438
Refs: #34442