### PR TITLE
Sends pass-through params to state module

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -253,6 +253,7 @@ def state(
             cmd_kw['topfn'] = ''.join(cmd_kw.pop('arg'))
         elif sls:
             cmd_kw['mods'] = cmd_kw.pop('arg')
+        cmd_kw.update(cmd_kw.pop('kwarg'))
         tmp_ret = __salt__[fun](**cmd_kw)
         cmd_ret = {__opts__['id']: {
             'ret': tmp_ret,


### PR DESCRIPTION
When using the state.orchestrate runner, salt.state gathers several
parameters into the `cmd_kw['kwarg']` key, which are then handled
by the `saltutil.cmd` function. This works fine.

When using the `state.orchestrate` module on a masterless minion,
`salt.state` calls the state module directly, rather than `saltutil.cmd`.
The state module does not know about the `kwarg` key, so was not
processing all parameters passed through orchestration.

This patch pulls the extra params from the `cmd_kw['kwarg']` key
and moves them directly into the `cmd_kw` dict, so the state module
gets them as normal parameters.

Fixes #38631
