### PR TITLE
Import napalm_base instead of napalm

### DIFF
--- a/salt/modules/napalm_probes.py
+++ b/salt/modules/napalm_probes.py
@@ -33,7 +33,7 @@ try:
     # will try to import NAPALM
     # https://github.com/napalm-automation/napalm
     # pylint: disable=W0611
-    from napalm import get_network_driver
+    from napalm_base import get_network_driver
     # pylint: enable=W0611
     HAS_NAPALM = True
 except ImportError:


### PR DESCRIPTION
### What does this PR do?

Not much change, but for the record: this is needed as the user might not have the complete napalm package installed. No matter what driver they use, the base library is needed so that's what we should to check if installed.