### PR TITLE
fix unit.modules.file_test

### DIFF
--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -30,6 +30,7 @@ filemod.__opts__ = {
     'file_roots': {'base': 'tmp'},
     'pillar_roots': {'base': 'tmp'},
     'cachedir': 'tmp',
+    'grains': {},
 }
 filemod.__grains__ = {'kernel': 'Linux'}
 


### PR DESCRIPTION
### What does this PR do?

Currently the following test is failing as follows:

```
ERROR: test_apply_template_on_contents (unit.modules.file_test.FileModuleTestCase)
[CPU:18.1%|MEM:51.6%|Z:0] 
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/testing/tests/unit/modules/file_test.py", line 644, in test_apply_template_on_contents
    saltenv='base')
  File "/testing/salt/modules/file.py", line 3480, in apply_template_on_contents
    grains=__opts__['grains'],
KeyError: 'grains'
```

This started occuring after https://github.com/saltstack/salt/pull/35390 was added. I believe we just need to fix the test and not the code but was hoping the reviewer could confirm that you would always expect to see grains in `__opts__`

### Previous Behavior

```
ERROR: test_apply_template_on_contents (unit.modules.file_test.FileModuleTestCase)
[CPU:18.1%|MEM:51.6%|Z:0] 
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/testing/tests/unit/modules/file_test.py", line 644, in test_apply_template_on_contents
    saltenv='base')
  File "/testing/salt/modules/file.py", line 3480, in apply_template_on_contents
    grains=__opts__['grains'],
KeyError: 'grains'
```

### New Behavior

```
Ran 1 test in 0.003s

OK

==========================================================================  Overall Tests Report  ==========================================================================
***  No Problems Found While Running Tests  ********************************************************************************************************************************
============================================================================================================================================================================
OK (total=1, skipped=0, passed=1, failures=0, errors=0) 
```

### Tests written?

Yes
