### PR TITLE
Don't lose the set reference for ec2 securitygroup ids

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1179,7 +1179,7 @@ def securitygroupid(vm_):
                 log.debug('AWS SecurityGroup ID of {0} is {1}'.format(
                     sg['groupName'], sg['groupId'])
                 )
-                securitygroupid_set = securitygroupid_set.add(sg['groupId'])
+                securitygroupid_set.add(sg['groupId'])
     return list(securitygroupid_set)
 
 


### PR DESCRIPTION
Fixes #38521

Refs #38183

When using `some_set = some_set.add('thing')`, the resulting set.add call returns None, which is not what we want to reference here.

Consider:
```
>>> my_set = set()
>>> my_set = my_set.add('thing')
>>> print(my_set)
None
>>>
>>> my_set = set()
>>> my_set.add('thing')
>>> print(my_set)
set(['thing'])
```