### PR TITLE
Added preemptible flag to gce.py - see issue #31606

### DIFF
--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -2255,7 +2255,9 @@ def request_instance(vm_):
             'ex_service_accounts': config.get_cloud_config_value(
                 'ex_service_accounts', vm_, __opts__, default=None),
             'ex_can_ip_forward': config.get_cloud_config_value(
-                'ip_forwarding', vm_, __opts__, default=False
+                'ip_forwarding', vm_, __opts__, default=False),
+	    'ex_preemptible': config.get_cloud_config_value(
+		'preemptible', vm_, __opts__, default=False
             )
         })
         if kwargs.get('ex_disk_type') not in ('pd-standard', 'pd-ssd'):


### PR DESCRIPTION
### What does this PR do?
Adds preemptible support to the google compute engine salt-cloud driver.

### What issues does this PR fix or reference?
#31606 

### Previous Behavior
Instances could not be created as preemptible in gce with salt-cloud.

### New Behavior
Instances can be created as preemptible in gce with salt-cloud, by setting preemptible: True in the cloud profile definition.

### Tests written?

No

