### PR TITLE
Turn None into an empty string (for minion matching)

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -634,6 +634,8 @@ class CkMinions(object):
         make sure everyone has checked back in.
         '''
         try:
+            if expr is None:
+                expr = ''
             check_func = getattr(self, '_check_{0}_minions'.format(expr_form), None)
             if expr_form in ('grain',
                              'grain_pcre',


### PR DESCRIPTION
### What does this PR do?
`check_minions()` does string checking on the `expr`. If `expr` is None, then the string checking will fail, so we switch it to an empty string instead.

### What issues does this PR fix or reference?
#38216

### Previous Behavior
```
[ERROR   ] Failed matching available minions with glob pattern: None
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/minions.py", line 650, in check_minions
    minions = check_func(expr, greedy)
  File "/usr/lib/python2.7/site-packages/salt/utils/minions.py", line 202, in _check_glob_minions
    return fnmatch.filter(self._pki_minions(), expr)
  File "/usr/lib/python2.7/fnmatch.py", line 53, in filter
    res = translate(pat)
  File "/usr/lib/python2.7/fnmatch.py", line 91, in translate
    i, n = 0, len(pat)
TypeError: object of type 'NoneType' has no len()
```
### New Behavior
(not that)

### Tests written?
No