### PR TITLE
Don't force salt.cache to use cachedir from opts

### DIFF
--- a/salt/cache/__init__.py
+++ b/salt/cache/__init__.py
@@ -47,8 +47,12 @@ class Cache(object):
     Key name is a string identifier of a data container (like a file inside a
     directory) which will hold the data.
     '''
-    def __init__(self, opts):
+    def __init__(self, opts, cachedir=None):
         self.opts = opts
+        if cachedir is None:
+            self.cachedir = opts['cachedir']
+        else:
+            self.cachedir = cachedir
         self.driver = opts['cache']
         self.serial = Serial(opts)
         self._modules = None
@@ -119,7 +123,7 @@ class Cache(object):
             in the cache backend (auth, permissions, etc).
         '''
         fun = '{0}.{1}'.format(self.driver, 'store')
-        return self.modules[fun](bank, key, data)
+        return self.modules[fun](bank, key, data, self.cachedir)
 
     def fetch(self, bank, key):
         '''
@@ -143,7 +147,7 @@ class Cache(object):
             in the cache backend (auth, permissions, etc).
         '''
         fun = '{0}.{1}'.format(self.driver, 'fetch')
-        return self.modules[fun](bank, key)
+        return self.modules[fun](bank, key, self.cachedir)
 
     def updated(self, bank, key):
         '''
@@ -167,7 +171,7 @@ class Cache(object):
             in the cache backend (auth, permissions, etc).
         '''
         fun = '{0}.{1}'.format(self.driver, 'updated')
-        return self.modules[fun](bank, key)
+        return self.modules[fun](bank, key, self.cachedir)
 
     def flush(self, bank, key=None):
         '''
@@ -188,7 +192,7 @@ class Cache(object):
             in the cache backend (auth, permissions, etc).
         '''
         fun = '{0}.{1}'.format(self.driver, 'flush')
-        return self.modules[fun](bank, key=key)
+        return self.modules[fun](bank, key=key, cachedir=self.cachedir)
 
     def list(self, bank):
         '''
@@ -206,8 +210,8 @@ class Cache(object):
             Raises an exception if cache driver detected an error accessing data
             in the cache backend (auth, permissions, etc).
         '''
-        fun = '{0}.{1}'.format(self.driver, 'getlist')
-        return self.modules[fun](bank)
+        fun = '{0}.{1}'.format(self.driver, 'list')
+        return self.modules[fun](bank, self.cachedir)
 
     def contains(self, bank, key=None):
         '''
@@ -232,4 +236,4 @@ class Cache(object):
             in the cache backend (auth, permissions, etc).
         '''
         fun = '{0}.{1}'.format(self.driver, 'contains')
-        return self.modules[fun](bank, key)
+        return self.modules[fun](bank, key, self.cachedir)

--- a/salt/cache/__init__.py
+++ b/salt/cache/__init__.py
@@ -11,6 +11,7 @@ import time
 
 # Import Salt lobs
 import salt.loader
+import salt.syspaths
 from salt.payload import Serial
 
 
@@ -50,7 +51,7 @@ class Cache(object):
     def __init__(self, opts, cachedir=None):
         self.opts = opts
         if cachedir is None:
-            self.cachedir = opts['cachedir']
+            self.cachedir = opts.get('cachedir', salt.syspaths.CACHE_DIR)
         else:
             self.cachedir = cachedir
         self.driver = opts['cache']

--- a/salt/cache/__init__.py
+++ b/salt/cache/__init__.py
@@ -123,7 +123,10 @@ class Cache(object):
             in the cache backend (auth, permissions, etc).
         '''
         fun = '{0}.{1}'.format(self.driver, 'store')
-        return self.modules[fun](bank, key, data, self.cachedir)
+        try:
+            return self.modules[fun](bank, key, data, self.cachedir)
+        except TypeError:
+            return self.modules[fun](bank, key, data)
 
     def fetch(self, bank, key):
         '''
@@ -147,7 +150,10 @@ class Cache(object):
             in the cache backend (auth, permissions, etc).
         '''
         fun = '{0}.{1}'.format(self.driver, 'fetch')
-        return self.modules[fun](bank, key, self.cachedir)
+        try:
+            return self.modules[fun](bank, key, self.cachedir)
+        except TypeError:
+            return self.modules[fun](bank, key)
 
     def updated(self, bank, key):
         '''
@@ -171,7 +177,10 @@ class Cache(object):
             in the cache backend (auth, permissions, etc).
         '''
         fun = '{0}.{1}'.format(self.driver, 'updated')
-        return self.modules[fun](bank, key, self.cachedir)
+        try:
+            return self.modules[fun](bank, key, self.cachedir)
+        except TypeError:
+            return self.modules[fun](bank, key)
 
     def flush(self, bank, key=None):
         '''
@@ -192,7 +201,10 @@ class Cache(object):
             in the cache backend (auth, permissions, etc).
         '''
         fun = '{0}.{1}'.format(self.driver, 'flush')
-        return self.modules[fun](bank, key=key, cachedir=self.cachedir)
+        try:
+            return self.modules[fun](bank, key=key, cachedir=self.cachedir)
+        except TypeError:
+            return self.modules[fun](bank, key=key)
 
     def list(self, bank):
         '''
@@ -211,7 +223,10 @@ class Cache(object):
             in the cache backend (auth, permissions, etc).
         '''
         fun = '{0}.{1}'.format(self.driver, 'list')
-        return self.modules[fun](bank, self.cachedir)
+        try:
+            return self.modules[fun](bank, self.cachedir)
+        except TypeError:
+            return self.modules[fun](bank)
 
     def contains(self, bank, key=None):
         '''
@@ -236,4 +251,7 @@ class Cache(object):
             in the cache backend (auth, permissions, etc).
         '''
         fun = '{0}.{1}'.format(self.driver, 'contains')
-        return self.modules[fun](bank, key, self.cachedir)
+        try:
+            return self.modules[fun](bank, key, self.cachedir)
+        except TypeError:
+            return self.modules[fun](bank, key)

--- a/salt/cache/consul.py
+++ b/salt/cache/consul.py
@@ -46,6 +46,9 @@ except ImportError:
 
 from salt.exceptions import SaltCacheError
 
+# Don't shadow built-ins
+__func_alias__ = {'list_': 'list'}
+
 log = logging.getLogger(__name__)
 api = None
 
@@ -129,7 +132,7 @@ def flush(bank, key=None):
         )
 
 
-def getlist(bank):
+def _list(bank):
     '''
     Return an iterable object containing all entries stored in the specified bank.
     '''
@@ -151,6 +154,9 @@ def getlist(bank):
             out.add(key[len(bank) + 1:].rstrip('/'))
         keys = list(out)
     return keys
+
+
+getlist = _list
 
 
 def contains(bank, key):

--- a/salt/cache/consul.py
+++ b/salt/cache/consul.py
@@ -132,7 +132,7 @@ def flush(bank, key=None):
         )
 
 
-def _list(bank):
+def list_(bank):
     '''
     Return an iterable object containing all entries stored in the specified bank.
     '''
@@ -156,7 +156,7 @@ def _list(bank):
     return keys
 
 
-getlist = _list
+getlist = list_
 
 
 def contains(bank, key):

--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -18,14 +18,17 @@ from salt.exceptions import SaltCacheError
 import salt.utils
 import salt.utils.atomicfile
 
+# Don't shadow built-ins
+__func_alias__ = {'list_': 'list'}
+
 log = logging.getLogger(__name__)
 
 
-def store(bank, key, data):
+def store(bank, key, data, cachedir):
     '''
     Store information in a file.
     '''
-    base = os.path.join(__opts__['cachedir'], os.path.normpath(bank))
+    base = os.path.join(cachedir, os.path.normpath(bank))
     if not os.path.isdir(base):
         try:
             os.makedirs(base)
@@ -51,11 +54,11 @@ def store(bank, key, data):
         )
 
 
-def fetch(bank, key):
+def fetch(bank, key, cachedir):
     '''
     Fetch information from a file.
     '''
-    key_file = os.path.join(__opts__['cachedir'], os.path.normpath(bank), '{0}.p'.format(key))
+    key_file = os.path.join(cachedir, os.path.normpath(bank), '{0}.p'.format(key))
     if not os.path.isfile(key_file):
         log.debug('Cache file "%s" does not exist', key_file)
         return None
@@ -70,11 +73,11 @@ def fetch(bank, key):
         )
 
 
-def updated(bank, key):
+def updated(bank, key, cachedir):
     '''
     Return the epoch of the mtime for this cache file
     '''
-    key_file = os.path.join(__opts__['cachedir'], os.path.normpath(bank), '{0}.p'.format(key))
+    key_file = os.path.join(cachedir, os.path.normpath(bank), '{0}.p'.format(key))
     if not os.path.isfile(key_file):
         log.warning('Cache file "%s" does not exist', key_file)
         return None
@@ -88,18 +91,21 @@ def updated(bank, key):
         )
 
 
-def flush(bank, key=None):
+def flush(bank, key=None, cachedir=None):
     '''
     Remove the key from the cache bank with all the key content.
     '''
+    if cachedir is None:
+        cachedir = __opts__['cachedir']
+
     try:
         if key is None:
-            target = os.path.join(__opts__['cachedir'], os.path.normpath(bank))
+            target = os.path.join(cachedir, os.path.normpath(bank))
             if not os.path.isdir(target):
                 return False
             shutil.rmtree(target)
         else:
-            target = os.path.join(__opts__['cachedir'], os.path.normpath(bank), '{0}.p'.format(key))
+            target = os.path.join(cachedir, os.path.normpath(bank), '{0}.p'.format(key))
             if not os.path.isfile(target):
                 return False
             os.remove(target)
@@ -112,11 +118,11 @@ def flush(bank, key=None):
     return True
 
 
-def getlist(bank):
+def _list(bank, cachedir):
     '''
     Return an iterable object containing all entries stored in the specified bank.
     '''
-    base = os.path.join(__opts__['cachedir'], os.path.normpath(bank))
+    base = os.path.join(cachedir, os.path.normpath(bank))
     if not os.path.isdir(base):
         return []
     try:
@@ -129,13 +135,16 @@ def getlist(bank):
         )
 
 
-def contains(bank, key):
+getlist = _list
+
+
+def contains(bank, key, cachedir):
     '''
     Checks if the specified bank contains the specified key.
     '''
     if key is None:
-        base = os.path.join(__opts__['cachedir'], os.path.normpath(bank))
+        base = os.path.join(cachedir, os.path.normpath(bank))
         return os.path.isdir(base)
     else:
-        keyfile = os.path.join(__opts__['cachedir'], os.path.normpath(bank), '{0}.p'.format(key))
+        keyfile = os.path.join(cachedir, os.path.normpath(bank), '{0}.p'.format(key))
         return os.path.isfile(keyfile)

--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -118,7 +118,7 @@ def flush(bank, key=None, cachedir=None):
     return True
 
 
-def _list(bank, cachedir):
+def list_(bank, cachedir):
     '''
     Return an iterable object containing all entries stored in the specified bank.
     '''
@@ -135,7 +135,7 @@ def _list(bank, cachedir):
         )
 
 
-getlist = _list
+getlist = list_
 
 
 def contains(bank, key, cachedir):

--- a/tests/unit/cache/localfs_test.py
+++ b/tests/unit/cache/localfs_test.py
@@ -217,7 +217,7 @@ class LocalFSTest(TestCase):
         Tests that the list function returns an empty list if the bank directory
         doesn't exist.
         '''
-        self.assertEqual(localfs.list(bank='', cachedir=''), [])
+        self.assertEqual(localfs.list_(bank='', cachedir=''), [])
 
     @patch('os.path.isdir', MagicMock(return_value=True))
     @patch('os.listdir', MagicMock(side_effect=OSError))
@@ -226,7 +226,7 @@ class LocalFSTest(TestCase):
         Tests that a SaltCacheError is raised when there is a problem accessing the
         cache bank directory.
         '''
-        self.assertRaises(SaltCacheError, localfs.list, bank='', cachedir='')
+        self.assertRaises(SaltCacheError, localfs.list_, bank='', cachedir='')
 
     @destructiveTest
     def test_list_success(self):

--- a/tests/unit/cache/localfs_test.py
+++ b/tests/unit/cache/localfs_test.py
@@ -43,7 +43,7 @@ class LocalFSTest(TestCase):
         '''
         with patch.dict(localfs.__opts__, {'cachedir': tmp_dir}):
             with patch.dict(localfs.__context__, {'serial': serializer}):
-                localfs.store(bank='bank', key='key', data='payload data')
+                localfs.store(bank='bank', key='key', data='payload data', cachedir=tmp_dir)
 
     # 'store' function tests: 4
 
@@ -54,7 +54,7 @@ class LocalFSTest(TestCase):
         Tests that a SaltCacheError is raised when the base directory doesn't exist and
         cannot be created.
         '''
-        self.assertRaises(SaltCacheError, localfs.store, bank='', key='', data='')
+        self.assertRaises(SaltCacheError, localfs.store, bank='', key='', data='', cachedir='')
 
     @patch('os.path.isdir', MagicMock(return_value=True))
     @patch('tempfile.mkstemp', MagicMock(return_value=(12345, 'foo')))
@@ -66,7 +66,7 @@ class LocalFSTest(TestCase):
         This test mocks the call to mkstemp, but forces an OSError to be raised when the
         close() function is called on a file descriptor that doesn't exist.
         '''
-        self.assertRaises(OSError, localfs.store, bank='', key='', data='')
+        self.assertRaises(OSError, localfs.store, bank='', key='', data='', cachedir='')
 
     @patch('os.path.isdir', MagicMock(return_value=True))
     @patch('tempfile.mkstemp', MagicMock(return_value=('one', 'two')))
@@ -77,7 +77,7 @@ class LocalFSTest(TestCase):
         Tests that a SaltCacheError is raised when there is a problem writing to the
         cache file.
         '''
-        self.assertRaises(SaltCacheError, localfs.store, bank='', key='', data='')
+        self.assertRaises(SaltCacheError, localfs.store, bank='', key='', data='', cachedir='')
 
     @destructiveTest
     def test_store_success(self):
@@ -103,7 +103,7 @@ class LocalFSTest(TestCase):
         Tests that the fetch function returns None when the cache key file doesn't
         exist.
         '''
-        self.assertIsNone(localfs.fetch(bank='', key=''))
+        self.assertIsNone(localfs.fetch(bank='', key='', cachedir=''))
 
     @patch('os.path.isfile', MagicMock(return_value=True))
     @patch('salt.utils.fopen', MagicMock(side_effect=IOError))
@@ -112,7 +112,7 @@ class LocalFSTest(TestCase):
         Tests that a SaltCacheError is raised when there is a problem reading the cache
         file.
         '''
-        self.assertRaises(SaltCacheError, localfs.fetch, bank='', key='')
+        self.assertRaises(SaltCacheError, localfs.fetch, bank='', key='', cachedir='')
 
     @destructiveTest
     def test_fetch_success(self):
@@ -131,7 +131,7 @@ class LocalFSTest(TestCase):
         # Now fetch the data from the new cache key file
         with patch.dict(localfs.__opts__, {'cachedir': tmp_dir}):
             with patch.dict(localfs.__context__, {'serial': serializer}):
-                self.assertIn('payload data', localfs.fetch(bank='bank', key='key'))
+                self.assertIn('payload data', localfs.fetch(bank='bank', key='key', cachedir=tmp_dir))
 
     # 'updated' function tests: 3
 
@@ -141,7 +141,7 @@ class LocalFSTest(TestCase):
         Tests that the updated function returns None when the cache key file doesn't
         exist.
         '''
-        self.assertIsNone(localfs.updated(bank='', key=''))
+        self.assertIsNone(localfs.updated(bank='', key='', cachedir=''))
 
     @patch('os.path.isfile', MagicMock(return_value=True))
     @patch('os.path.getmtime', MagicMock(side_effect=IOError))
@@ -150,7 +150,7 @@ class LocalFSTest(TestCase):
         Tests that a SaltCacheError is raised when there is a problem reading the mtime
         of the cache file.
         '''
-        self.assertRaises(SaltCacheError, localfs.updated, bank='', key='')
+        self.assertRaises(SaltCacheError, localfs.updated, bank='', key='', cachedir='')
 
     @destructiveTest
     def test_updated_success(self):
@@ -164,7 +164,7 @@ class LocalFSTest(TestCase):
         self._create_tmp_cache_file(tmp_dir, salt.payload.Serial(self))
 
         with patch('os.path.join', MagicMock(return_value=tmp_dir + '/bank/key.p')):
-            self.assertIsInstance(localfs.updated(bank='bank', key='key'), int)
+            self.assertIsInstance(localfs.updated(bank='bank', key='key', cachedir=tmp_dir), int)
 
     # 'flush' function tests: 4
 
@@ -174,7 +174,7 @@ class LocalFSTest(TestCase):
         Tests that the flush function returns False when no key is passed in and the
         target directory doesn't exist.
         '''
-        self.assertFalse(localfs.flush(bank='', key=None))
+        self.assertFalse(localfs.flush(bank='', key=None, cachedir=''))
 
     @patch('os.path.isfile', MagicMock(return_value=False))
     def test_flush_key_provided_and_no_key_file_false(self):
@@ -182,7 +182,7 @@ class LocalFSTest(TestCase):
         Tests that the flush function returns False when a key file is provided but
         the target key file doesn't exist in the cache bank.
         '''
-        self.assertFalse(localfs.flush(bank='', key='key'))
+        self.assertFalse(localfs.flush(bank='', key='key', cachedir=''))
 
     @patch('os.path.isfile', MagicMock(return_value=True))
     def test_flush_success(self):
@@ -198,7 +198,7 @@ class LocalFSTest(TestCase):
 
         # Now test the return of the flush function
         with patch.dict(localfs.__opts__, {'cachedir': tmp_dir}):
-            self.assertTrue(localfs.flush(bank='bank', key='key'))
+            self.assertTrue(localfs.flush(bank='bank', key='key', cachedir=tmp_dir))
 
     @patch('os.path.isfile', MagicMock(return_value=True))
     @patch('os.remove', MagicMock(side_effect=OSError))
@@ -207,7 +207,7 @@ class LocalFSTest(TestCase):
         Tests that a SaltCacheError is raised when there is a problem removing the
         key file from the cache bank
         '''
-        self.assertRaises(SaltCacheError, localfs.flush, bank='', key='key')
+        self.assertRaises(SaltCacheError, localfs.flush, bank='', key='key', cachedir='/var/cache/salt')
 
     # 'list' function tests: 3
 
@@ -217,7 +217,7 @@ class LocalFSTest(TestCase):
         Tests that the list function returns an empty list if the bank directory
         doesn't exist.
         '''
-        self.assertEqual(localfs.list(bank=''), [])
+        self.assertEqual(localfs.list(bank='', cachedir=''), [])
 
     @patch('os.path.isdir', MagicMock(return_value=True))
     @patch('os.listdir', MagicMock(side_effect=OSError))
@@ -226,7 +226,7 @@ class LocalFSTest(TestCase):
         Tests that a SaltCacheError is raised when there is a problem accessing the
         cache bank directory.
         '''
-        self.assertRaises(SaltCacheError, localfs.list, bank='')
+        self.assertRaises(SaltCacheError, localfs.list, bank='', cachedir='')
 
     @destructiveTest
     def test_list_success(self):
@@ -241,7 +241,7 @@ class LocalFSTest(TestCase):
 
         # Now test the return of the list function
         with patch.dict(localfs.__opts__, {'cachedir': tmp_dir}):
-            self.assertEqual(localfs.list(bank='bank'), ['key.p'])
+            self.assertEqual(localfs.list(bank='bank', cachedir=tmp_dir), ['key.p'])
 
     # 'contains' function tests: 1
 
@@ -259,11 +259,11 @@ class LocalFSTest(TestCase):
 
         # Now test the return of the contains function when key=None
         with patch.dict(localfs.__opts__, {'cachedir': tmp_dir}):
-            self.assertTrue(localfs.contains(bank='bank', key=None))
+            self.assertTrue(localfs.contains(bank='bank', key=None, cachedir=tmp_dir))
 
         # Now test the return of the contains function when key='key'
         with patch.dict(localfs.__opts__, {'cachedir': tmp_dir}):
-            self.assertTrue(localfs.contains(bank='bank', key='key'))
+            self.assertTrue(localfs.contains(bank='bank', key='key', cachedir=tmp_dir))
 
 
 if __name__ == '__main__':

--- a/tests/unit/cache/localfs_test.py
+++ b/tests/unit/cache/localfs_test.py
@@ -241,7 +241,7 @@ class LocalFSTest(TestCase):
 
         # Now test the return of the list function
         with patch.dict(localfs.__opts__, {'cachedir': tmp_dir}):
-            self.assertEqual(localfs.list(bank='bank', cachedir=tmp_dir), ['key.p'])
+            self.assertEqual(localfs.list_(bank='bank', cachedir=tmp_dir), ['key.p'])
 
     # 'contains' function tests: 1
 


### PR DESCRIPTION
### What does this PR do?
Allows the salt.cache loader to have a custom `cachedir` specified without having to modify `opts`.

### Previous Behavior
The `cachedir` used in `localfs` (previously called `msgpack`) initially used `salt.syspaths.CACHE_DIR` (normally set to `/var/cache/salt/`) in order to be used generically. It was changed to use the `cachedir` setting from `opts`, which is normally `/var/cache/salt/{master,minion}/`, which breaks the intended functionality.

### New Behavior
The default is still `cachedir` from `opts`, but a custom `cachedir` may be passed in to override that setting, without having to modify `opts` (which would break far more functionality).

### Tests written?
Self tested. No automated tests.