### PR TITLE
Add sane cache defaults for minion and cloud

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1175,6 +1175,7 @@ DEFAULT_MINION_OPTS = {
     'proxy_port': 0,
     'minion_jid_queue_hwm': 100,
     'ssl': None,
+    'cache': 'localfs',
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1489,6 +1489,7 @@ DEFAULT_CLOUD_OPTS = {
     'log_fmt_logfile': _DFLT_LOG_FMT_LOGFILE,
     'log_granular_levels': {},
     'bootstrap_delay': None,
+    'cache': 'localfs',
 }
 
 DEFAULT_API_OPTS = {


### PR DESCRIPTION
### Previous Behavior
You would need to manually set the `cache` value in opts in order to use `salt.cache` in either the minion or cloud.

### New Behavior
Sane `cache` value set.

### Tests written?
No.