### PR TITLE
correct issue when running lgpo.get with return_not_configured=True

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3466,7 +3466,8 @@ def _checkAllAdmxPolicies(policy_class,
             log.debug('returning non configured policies')
             not_configured_policies = ALL_CLASS_POLICY_XPATH(admx_policy_definitions, registry_class=policy_class)
             for policy_item in admx_policies:
-                not_configured_policies.remove(policy_item)
+                if policy_item in not_configured_policies:
+                    not_configured_policies.remove(policy_item)
 
             for not_configured_policy in not_configured_policies:
                 policy_vals[not_configured_policy.attrib['name']] = 'Not Configured'
@@ -3476,6 +3477,11 @@ def _checkAllAdmxPolicies(policy_class,
                             not_configured_policy.attrib['name'],
                             return_full_policy_names,
                             adml_policy_resources)
+                log.debug('building hierarchy for non-configured item {0}'.format(not_configured_policy.attrib['name']))
+                hierarchy[not_configured_policy.attrib['name']] = _build_parent_list(not_configured_policy,
+                                                                                     admx_policy_definitions,
+                                                                                     return_full_policy_names,
+                                                                                     adml_policy_resources)
         for admx_policy in admx_policies:
             this_key = None
             this_valuename = None
@@ -3788,7 +3794,7 @@ def _checkAllAdmxPolicies(policy_class,
                 policy_vals[full_names[policy_item]] = policy_vals.pop(policy_item)
                 unpathed_dict[full_names[policy_item]] = policy_item
         # go back and remove any "unpathed" policies that need a full path
-        for path_needed in pathed_dict.keys():
+        for path_needed in unpathed_dict.keys():
             # remove the item with the same full name and re-add it w/a path'd version
             full_path_list = hierarchy[unpathed_dict[path_needed]]
             full_path_list.reverse()
@@ -4902,9 +4908,9 @@ def set_computer_policy(name,
     pol = {}
     pol[name] = setting
     ret = set_(computer_policy=pol,
-              user_policy=None,
-              cumulative_rights_assignments=cumulative_rights_assignments,
-              adml_language=adml_language)
+               user_policy=None,
+               cumulative_rights_assignments=cumulative_rights_assignments,
+               adml_language=adml_language)
     return ret
 
 
@@ -4939,9 +4945,9 @@ def set_user_policy(name,
     pol = {}
     pol[name] = setting
     ret = set_(user_policy=pol,
-              computer_policy=None,
-              cumulative_rights_assignments=True,
-              adml_language=adml_language)
+               computer_policy=None,
+               cumulative_rights_assignments=True,
+               adml_language=adml_language)
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?
corrects an issue when running lgpo.get with the return_not_configured parameter set to True

### What issues does this PR fix or reference?
#38691

### Previous Behavior
lgpo.get could throw a value or key error due to:
1) an incorrect variable name 
2) improperly attempting to remove an item from a list
3) not properly creating the hierarchy data for an un-configured policy

### New Behavior
lgpo.get with return_not_configured=True should function properly

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
