### PR TITLE
Fix proposal for #38604

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -223,6 +223,9 @@ class Batch(object):
                     active.remove(minion)
                     if bwait:
                         wait.append(datetime.now() + timedelta(seconds=bwait))
+                # Munge retcode into return data
+                if 'retcode' in data and isinstance(data['ret'], dict) and 'retcode' not in data['ret']:
+                    data['ret']['retcode'] = data['retcode']
                 if self.opts.get('raw'):
                     ret[minion] = data
                     yield data

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -227,8 +227,8 @@ class Batch(object):
                     ret[minion] = data
                     yield data
                 else:
-                    ret[minion] = data
-                    yield {minion: data}
+                    ret[minion] = data['ret']
+                    yield {minion: data['ret']}
                 if not self.quiet:
                     ret[minion] = data['ret']
                     data[minion] = data.pop('ret')


### PR DESCRIPTION
This changes it so that the batch return is returned to ``salt.states.saltmod.state()``. I'm not entirely certain how this will impact ``_run_batch()`` in salt/cli/salt.py, however. I tried dropping in logging and launching pudb from the block of code that checks the retcode (see [here](https://github.com/saltstack/salt/blob/7b850d472de51fce40211f2016d4e82f8a15319a/salt/cli/salt.py#L244)), and the flow does not appear to hit that block of code. I can dig further, but I'd also like to get @cachedout's input on this fix. I don't want to fix something just to break something else inadvertently.