### PR TITLE
[virt] setvcpus/setmem: fix return value parsing issue when calling vm_state(vm_)

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1028,7 +1028,7 @@ def setmem(vm_, memory, config=False):
         salt '*' virt.setmem <domain> <size>
         salt '*' virt.setmem my_domain 768
     '''
-    if vm_state(vm_) != 'shutdown':
+    if vm_state(vm_)[vm_] != 'shutdown':
         return False
 
     dom = _get_domain(vm_)
@@ -1062,7 +1062,7 @@ def setvcpus(vm_, vcpus, config=False):
         salt '*' virt.setvcpus <domain> <amount>
         salt '*' virt.setvcpus my_domain 4
     '''
-    if vm_state(vm_) != 'shutdown':
+    if vm_state(vm_)[vm_] != 'shutdown':
         return False
 
     dom = _get_domain(vm_)


### PR DESCRIPTION

### What does this PR do?
[virt] setvcpus/setmem: always return false because we are unable to get vm state
### What issues does this PR fix or reference?
#38446 
### Previous Behavior
vm_state(vm_) !=  'shutdown' is evaluated as {'centos7.0': 'shutdown'} != 'shutdown'

### New Behavior
vm_state(vm_) is modified to vm_state(vm_)[vm_]

### Tests written?

No

