### PR TITLE
Removed overloading of list()

### DIFF
--- a/salt/cache/__init__.py
+++ b/salt/cache/__init__.py
@@ -206,7 +206,7 @@ class Cache(object):
             Raises an exception if cache driver detected an error accessing data
             in the cache backend (auth, permissions, etc).
         '''
-        fun = '{0}.{1}'.format(self.driver, 'list')
+        fun = '{0}.{1}'.format(self.driver, 'getlist')
         return self.modules[fun](bank)
 
     def contains(self, bank, key=None):

--- a/salt/cache/consul.py
+++ b/salt/cache/consul.py
@@ -129,7 +129,7 @@ def flush(bank, key=None):
         )
 
 
-def list(bank):
+def getlist(bank):
     '''
     Return an iterable object containing all entries stored in the specified bank.
     '''

--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -112,7 +112,7 @@ def flush(bank, key=None):
     return True
 
 
-def list(bank):
+def getlist(bank):
     '''
     Return an iterable object containing all entries stored in the specified bank.
     '''


### PR DESCRIPTION
### What does this PR do?
Fix the consul backend for minion cache

### What issues does this PR fix or reference?
#38677

### Previous Behavior
When using the consul cache backend, you could run into:
```SaltCacheError: There was an error getting the key "set([u'host1', u'host2', u'host3', u'host4'])": unsupported operand type(s) for +: 'set' and 'str'``` because the function getting the data was called list and also attempted to return a casted list (which turned out to be the function itself)

### New Behavior
It works(tm)

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
