### PR TITLE
[2016.11.2/napalm] Better error message when NotImplementedError raised

### DIFF
--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -297,14 +297,20 @@ def call(method, **params):
         # either not connected
         # either unable to execute the command
         err_tb = traceback.format_exc()  # let's get the full traceback and display for debugging reasons.
-        comment = 'Cannot execute "{method}" on {device}{port} as {user}. Reason: {error}!'.format(
-            device=NETWORK_DEVICE.get('HOSTNAME', '[unspecified hostname]'),
-            port=(':{port}'.format(port=NETWORK_DEVICE.get('OPTIONAL_ARGS', {}).get('port'))
-                  if NETWORK_DEVICE.get('OPTIONAL_ARGS', {}).get('port') else ''),
-            user=NETWORK_DEVICE.get('USERNAME', ''),
-            method=method,
-            error=error
-        )
+        if isinstance(error, NotImplementedError):
+            comment = '{method} is not implemented for the NAPALM {driver} driver!'.format(
+                method=method,
+                driver=NETWORK_DEVICE.get('DRIVER_NAME')
+            )
+        else:
+            comment = 'Cannot execute "{method}" on {device}{port} as {user}. Reason: {error}!'.format(
+                device=NETWORK_DEVICE.get('HOSTNAME', '[unspecified hostname]'),
+                port=(':{port}'.format(port=NETWORK_DEVICE.get('OPTIONAL_ARGS', {}).get('port'))
+                      if NETWORK_DEVICE.get('OPTIONAL_ARGS', {}).get('port') else ''),
+                user=NETWORK_DEVICE.get('USERNAME', ''),
+                method=method,
+                error=error
+            )
         log.error(comment)
         log.error(err_tb)
         return {


### PR DESCRIPTION
### What does this PR do?

Yup, yet another PR... apologies.
This one only brings some makeup as users complained that the error message is not clear enough when a certain feature is not implemented in the underlying library.