### PR TITLE
Try to resolve guest IP if VMware Tools is not installed

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -456,6 +456,14 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
     so salt will be installed using the bootstrap script. If ``template: True`` or
     ``power_on: False`` is set, this field is ignored and salt will not be installed.
 
+``wait_for_ip_timeout``
+    When ``deploy: True``, this timeout determines the maximum time to wait for
+    VMware tools to be installed on the virtual machine. If this timeout is
+    reached, an attempt to determine the client's IP will be made by resolving
+    the VM's name.  By lowering this value a salt bootstrap can be fully
+    automated for systems that are not built with VMware tools.  Default is
+    ``wait_for_ip_timeout: 1200``.
+
 ``customization``
     Specify whether the new virtual machine should be customized or not. If
     ``customization: False`` is set, the new virtual machine will not be customized.

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -126,6 +126,7 @@ import subprocess
 # Import salt libs
 import salt.utils
 import salt.utils.cloud
+import salt.utils.network
 import salt.utils.xmlutil
 import salt.utils.vmware
 from salt.exceptions import SaltCloudSystemExit
@@ -907,7 +908,16 @@ def _wait_for_ip(vm_ref, max_wait):
     max_wait_ip = max_wait
     vmware_tools_status = _wait_for_vmware_tools(vm_ref, max_wait_vmware_tools)
     if not vmware_tools_status:
-        return False
+        # VMware will only report the IP if VMware tools are installed. Try to
+        # determine the IP using DNS
+        vm_name = vm_ref.summary.config.name
+        resolved_ips = salt.utils.network.host_to_ips(vm_name)
+        log.debug("Timeout waiting for VMware tools. The name {0} resolved "
+                  "to {1}".format(vm_name, str(resolved_ips)))
+        if len(resolved_ips) > 0:
+            return resolved_ips[0]
+        else:
+            return False
     time_counter = 0
     starttime = time.time()
     while time_counter < max_wait_ip:

--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -53,7 +53,7 @@ passed in as a dict, or as a string to pull from pillars or minion config:
                   to_port: 8090
                   cidr_ip:
                     - 10.0.0.0/8
-                    - 192.168.0.0/16                    
+                    - 192.168.0.0/16
                 - ip_protocol: icmp
                   from_port: -1
                   to_port: -1

--- a/tests/unit/modules/vsphere_test.py
+++ b/tests/unit/modules/vsphere_test.py
@@ -813,7 +813,7 @@ class GetsServiceInstanceViaProxyTestCase(TestCase):
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @patch('salt.modules.vsphere.__virtual__', MagicMock(return_value='vsphere'))
 # Decorator mocks
-@patch('salt.modules.vsphere.get_proxy_type',MagicMock(return_value='esxi'))
+@patch('salt.modules.vsphere.get_proxy_type', MagicMock(return_value='esxi'))
 # Function mocks
 @patch('salt.modules.vsphere._get_proxy_connection_details', MagicMock())
 @patch('salt.utils.vmware.get_service_instance', MagicMock())
@@ -877,7 +877,7 @@ class DisconnectTestCase(TestCase):
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @patch('salt.modules.vsphere.__virtual__', MagicMock(return_value='vsphere'))
 # Decorator mocks
-@patch('salt.modules.vsphere.get_proxy_type',MagicMock(return_value='esxi'))
+@patch('salt.modules.vsphere.get_proxy_type', MagicMock(return_value='esxi'))
 @patch('salt.modules.vsphere._get_proxy_connection_details', MagicMock())
 @patch('salt.utils.vmware.get_service_instance',
        MagicMock(return_value=mock_si))


### PR DESCRIPTION
### What does this PR do?

In some cases installation of VMware Tools is not possible (e.g. *BSD) or not supported within an organization. Enable `salt-cloud` to bootstrap a minion by using DNS to resolve it's IP.

### Previous Behavior

Without vmware tools `salt-cloud -p` waits until `wait_for_ip_timeout` and exits with an error.

### New Behavior

New host is bootstraped after `wait_for_ip_timeout` and new minion is associated after a successful build.

This assumes that the VM _name_ corresponds to a _nameserver entry_. An assumption to be sure, but an assumption that will hold true in many corporate environments.

### Tests written?

No, tested manually on ESX server