### PR TITLE
Fix for #38704 archive extracted and dockerio states

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -869,7 +869,6 @@ def extracted(name,
     else:
         source_sum = {}
 
-    concurrent = bool(__opts__.get('sudo_user'))
     if not source_is_local and not os.path.isfile(cached_source):
         if __opts__['test']:
             ret['result'] = None
@@ -879,15 +878,14 @@ def extracted(name,
 
         log.debug('%s is not in cache, downloading it', source_match)
 
-        file_result = __salt__['state.single']('file.managed',
-                                               cached_source,
-                                               source=source_match,
-                                               source_hash=source_hash,
-                                               source_hash_name=source_hash_name,
-                                               makedirs=True,
-                                               skip_verify=skip_verify,
-                                               saltenv=__env__,
-                                               concurrent=concurrent)
+        file_result = __states__['file.managed'](cached_source,
+                                                 source=source_match,
+                                                 source_hash=source_hash,
+                                                 source_hash_name=source_hash_name,
+                                                 makedirs=True,
+                                                 skip_verify=skip_verify,
+                                                 env=__env__)
+
         log.debug('file.managed: {0}'.format(file_result))
 
         # Prevent a traceback if errors prevented the above state from getting

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -505,11 +505,9 @@ def loaded(name, tag='latest', source=None, source_hash='', force=False):
         return _ret_status(name=name, comment=comment)
 
     tmp_filename = salt.utils.files.mkstemp()
-    __salt__['state.single']('file.managed',
-                             name=tmp_filename,
-                             source=source,
-                             source_hash=source_hash,
-                             concurrent=bool(__opts__.get('sudo_user')))
+    __states__['file.managed'](name=tmp_filename,
+                               source=source,
+                               source_hash=source_hash)
     changes = {}
 
     if image_infos['status']:


### PR DESCRIPTION
Do not run file managed as state.single as this conflicts (and fails)
when additional state runs are already scheduled.

### What does this PR do?

Just use __states__['file.managed'] instead of running in a state.single

### What issues does this PR fix or reference?

#38704

### Previous Behavior

Buggy if state run was scheduled in parallel

### New Behavior

Archive extracted also works with state runs scheduled in parallel

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
