### PR TITLE
Fixed prepending of root_dir override to the other paths

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1760,13 +1760,18 @@ def prepend_root_dir(opts, path_options):
     'root_dir' option.
     '''
     root_dir = os.path.abspath(opts['root_dir'])
-    root_opt = opts['root_dir'].rstrip(os.sep)
+    def_root_dir = salt.syspaths.ROOT_DIR
+    if def_root_dir.endswith(os.sep):
+        def_root_dir = def_root_dir.rstrip(os.sep)
     for path_option in path_options:
         if path_option in opts:
             path = opts[path_option]
-            if path == root_opt or path.startswith(root_opt + os.sep):
-                path = path[len(root_opt):]
-            opts[path_option] = salt.utils.path_join(root_dir, path)
+            if not os.path.isabs(path):
+                opts[path_option] = salt.utils.path_join(root_dir, path)
+            elif path.startswith(def_root_dir) and (root_dir != def_root_dir):
+                # Strip out the default root_dir and add the updated root_dir
+                path = path[len(def_root_dir):]
+                opts[path_option] = salt.utils.path_join(root_dir, path)
 
 
 def insert_system_path(opts, paths):


### PR DESCRIPTION
### What does this PR do?

 Fixed prepending of root_dir override to the other paths

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/38663

### Previous Behavior
`root_dir` in config was added to default `root dir`, if default overrides existed in `_syspaths.py`

### New Behavior
Just the `root_dir` in the config is used if defined, otherwise the default `root_dir`

### Tests written?

No (existing tests work with new code)

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
