### PR TITLE
BUGFIX: return NoneType instead of set

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1278,7 +1278,7 @@ def securitygroupid(vm_):
                 log.debug('AWS SecurityGroup ID of {0} is {1}'.format(
                     sg['groupName'], sg['groupId'])
                 )
-                securitygroupid_set = securitygroupid_set.add(sg['groupId'])
+                securitygroupid_set.add(sg['groupId'])
     return list(securitygroupid_set)
 
 


### PR DESCRIPTION
### What does this PR do?
Fix a bug in salt-cloud when using security group names in the profiles definition

### What issues does this PR fix or reference?
The add() method works on the existing set, doesn't return a new one.

### Tests written?
No