### PR TITLE
Add NameError to exception in avahi_announce beacon

### DIFF
--- a/salt/beacons/avahi_announce.py
+++ b/salt/beacons/avahi_announce.py
@@ -32,7 +32,7 @@ try:
     GROUP = dbus.Interface(BUS.get_object(avahi.DBUS_NAME, SERVER.EntryGroupNew()),
                            avahi.DBUS_INTERFACE_ENTRY_GROUP)
     HAS_DBUS = True
-except ImportError:
+except (ImportError, NameError):
     HAS_DBUS = False
 except DBusException:
     HAS_DBUS = False


### PR DESCRIPTION
Fixes #38684

If you have dbus installed, but not avahi, you will get a NameError in the `dbus.Interface` call. We need to catch this situation and not stack trace when the beacon gets loaded.
