### PR TITLE
added docs about LXC container templates

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1805,8 +1805,11 @@ def create(name,
     **Container Creation Arguments**
 
     template
-        The template to use. For example, ``ubuntu`` or ``fedora``. Conflicts
-        with the ``image`` argument.
+        The template to use. For example, ``ubuntu`` or ``fedora``.
+        For a full list of available templates, check out
+        the :mod:`lxc.templates <salt.modules.lxc.templates>` function.
+
+        Conflicts with the ``image`` argument.
 
         .. note::
 
@@ -1828,6 +1831,10 @@ def create(name,
         .. code-block:: bash
 
             options='{"dist": "centos", "release": "6", "arch": "amd64"}'
+
+        For available template options, refer to the lxc template scripts
+        which are ususally located under ``/usr/share/lxc/templates``,
+        or run ``lxc-create -t <template> -h``.
 
     image
         A tar archive to use as the rootfs for the container. Conflicts with

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -79,8 +79,11 @@ def present(name,
     **Container Creation Arguments**
 
     template
-        The template to use. E.g., 'ubuntu' or 'fedora'. Conflicts with the
-        ``image`` argument.
+        The template to use. For example, ``ubuntu`` or ``fedora``.
+        For a full list of available templates, check out
+        the :mod:`lxc.templates <salt.modules.lxc.templates>` function.
+
+        Conflicts with the ``image`` argument.
 
         .. note::
 
@@ -114,6 +117,10 @@ def present(name,
 
         Remember to double-indent the options, due to :ref:`how PyYAML works
         <nested-dict-indentation>`.
+
+        For available template options, refer to the lxc template scripts
+        which are ususally located under ``/usr/share/lxc/templates``,
+        or run ``lxc-create -t <template> -h``.
 
     image
         A tar archive to use as the rootfs for the container. Conflicts with


### PR DESCRIPTION
### What does this PR do?

In current docs it is not clear which templates are available and also
which options these have. Added references to the docs that help the
user find the list of templates as well as the options.

My local sphinx version is too old so I could not test the HTML output,
please verify syntax is correct.