### PR TITLE
A couple of Python 3 compatibility fixes

### DIFF
--- a/salt/utils/schema.py
+++ b/salt/utils/schema.py
@@ -1537,7 +1537,7 @@ class DefinitionsSchema(Schema):
     '''
     .. versionadded:: 2016.11.0
 
-    JSON schema classs that supports ComplexSchemaItem objects by adding
+    JSON schema class that supports ComplexSchemaItem objects by adding
     a definitions section to the JSON schema, containing the item definitions.
 
     All references to ComplexSchemaItems are built using schema inline
@@ -1551,6 +1551,11 @@ class DefinitionsSchema(Schema):
         complex_items = []
         # Augment the serializations with the definitions of all complex items
         aux_items = cls._items.values()
+
+        # Convert dict_view object to a list on Python 3
+        if six.PY3:
+            aux_items = list(aux_items)
+
         while aux_items:
             item = aux_items.pop(0)
             # Add complex attributes

--- a/tests/unit/grains/core_test.py
+++ b/tests/unit/grains/core_test.py
@@ -417,6 +417,11 @@ PATCHLEVEL = 3
         osarch_mock = MagicMock(return_value="amd64")
         os_release_mock = MagicMock(return_value=os_release_map.get('os_release_file'))
 
+        if six.PY2:
+            built_in = '__builtin__'
+        else:
+            built_in = 'builtins'
+
         orig_import = __import__
 
         def _import_mock(name, *args):
@@ -433,7 +438,7 @@ PATCHLEVEL = 3
                 # Skip the init grain compilation (not pertinent)
                 with patch.object(os.path, 'exists', path_isfile_mock):
                     # Ensure that lsb_release fails to import
-                    with patch('__builtin__.__import__',
+                    with patch('{0}.__import__'.format(built_in),
                                side_effect=_import_mock):
                         # Skip all the /etc/*-release stuff (not pertinent)
                         with patch.object(os.path, 'isfile', path_isfile_mock):

--- a/tests/unit/modules/vsphere_test.py
+++ b/tests/unit/modules/vsphere_test.py
@@ -858,7 +858,7 @@ class TestVcenterConnectionTestCase(TestCase):
                     MagicMock(side_effect=exc)):
             with self.assertRaises(Exception) as excinfo:
                 res = vsphere.test_vcenter_connection()
-        self.assertEqual('NonVMwareSaltError', excinfo.exception.message)
+        self.assertEqual('NonVMwareSaltError', str(excinfo.exception))
 
     def test_output_true(self):
         with patch('salt.utils.vmware.is_connection_to_a_vcenter',

--- a/tests/unit/states/module_test.py
+++ b/tests/unit/states/module_test.py
@@ -66,8 +66,10 @@ class ModuleStateTest(TestCase):
         Tests the return of module.run state when arguments are missing
         '''
         ret = module.run(CMD)
-        comment = 'The following arguments are missing: world hello'
-        self.assertEqual(ret['comment'], comment)
+        comment = 'The following arguments are missing:'
+        self.assertIn(comment, ret['comment'])
+        self.assertIn('world', ret['comment'])
+        self.assertIn('hello', ret['comment'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- [utils/schema.py] Convert dict_view object to a list on Py3
- Update __builtin__ mock for PY3: module was moved to "builtins"
- [module_test.py] Don't rely on list ordering: assert items are in comment
- [vsphere_test.py] Exception.message has been removed in Python 3 Access the message from the Exception('exception message',) object.