### PR TITLE
Vmware states helper functions gh

### DIFF
--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -342,6 +342,21 @@ def get_service_instance_via_proxy(service_instance=None):
     return salt.utils.vmware.get_service_instance(*connection_details)
 
 
+@supports_proxies('esxi')
+def disconnect(service_instance):
+    '''
+    Disconnects from a vCenter or ESXi host
+
+    Note:
+        Should be used by state functions, not invoked directly.
+
+    service_instance
+        Service instance (vim.ServiceInstance)
+    '''
+    salt.utils.vmware.disconnect(service_instance)
+    return True
+
+
 def esxcli_cmd(cmd_str, host=None, username=None, password=None, protocol=None, port=None, esxi_hosts=None):
     '''
     Run an ESXCLI command directly on the host or list of hosts.

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -330,6 +330,18 @@ def gets_service_instance_via_proxy(fn):
     return _gets_service_instance_via_proxy
 
 
+@supports_proxies('esxi')
+def get_service_instance_via_proxy(service_instance=None):
+    '''
+    Returns a service instance to the proxied endpoint (vCenter/ESXi host).
+
+    Note:
+        Should be used by state functions not invoked directly.
+    '''
+    connection_details = _get_proxy_connection_details()
+    return salt.utils.vmware.get_service_instance(*connection_details)
+
+
 def esxcli_cmd(cmd_str, host=None, username=None, password=None, protocol=None, port=None, esxi_hosts=None):
     '''
     Run an ESXCLI command directly on the host or list of hosts.

--- a/tests/unit/modules/vsphere_test.py
+++ b/tests/unit/modules/vsphere_test.py
@@ -813,6 +813,42 @@ class GetsServiceInstanceViaProxyTestCase(TestCase):
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @patch('salt.modules.vsphere.__virtual__', MagicMock(return_value='vsphere'))
 # Decorator mocks
+@patch('salt.modules.vsphere.get_proxy_type',MagicMock(return_value='esxi'))
+# Function mocks
+@patch('salt.modules.vsphere._get_proxy_connection_details', MagicMock())
+@patch('salt.utils.vmware.get_service_instance', MagicMock())
+class GetServiceInstanceViaProxyTestCase(TestCase):
+    '''Tests for salt.modules.vsphere.get_service_instance_via_proxy'''
+
+    def test_supported_proxes(self):
+        supported_proxies = ['esxi']
+        for proxy_type in supported_proxies:
+            with patch('salt.modules.vsphere.get_proxy_type',
+                       MagicMock(return_value=proxy_type)):
+                vsphere.get_service_instance_via_proxy()
+
+    def test_get_service_instance_call(self):
+        mock_connection_details = [MagicMock(), MagicMock(), MagicMock()]
+        mock_get_service_instance = MagicMock()
+        with patch('salt.modules.vsphere._get_proxy_connection_details',
+                    MagicMock(return_value=mock_connection_details)):
+            with patch('salt.utils.vmware.get_service_instance',
+                       mock_get_service_instance):
+                vsphere.get_service_instance_via_proxy()
+        mock_get_service_instance.assert_called_once_with(
+            *mock_connection_details)
+
+    def test_output(self):
+        mock_si = MagicMock()
+        with patch('salt.utils.vmware.get_service_instance',
+                    MagicMock(return_value=mock_si)):
+            res = vsphere.get_service_instance_via_proxy()
+        self.assertEqual(res, mock_si)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.modules.vsphere.__virtual__', MagicMock(return_value='vsphere'))
+# Decorator mocks
 @patch('salt.modules.vsphere.get_proxy_type', MagicMock(return_value='esxi'))
 @patch('salt.modules.vsphere._get_proxy_connection_details', MagicMock())
 @patch('salt.utils.vmware.get_service_instance',

--- a/tests/unit/modules/vsphere_test.py
+++ b/tests/unit/modules/vsphere_test.py
@@ -850,6 +850,34 @@ class GetServiceInstanceViaProxyTestCase(TestCase):
 @patch('salt.modules.vsphere.__virtual__', MagicMock(return_value='vsphere'))
 # Decorator mocks
 @patch('salt.modules.vsphere.get_proxy_type', MagicMock(return_value='esxi'))
+# Function mocks
+@patch('salt.modules.vsphere._get_proxy_connection_details', MagicMock())
+@patch('salt.utils.vmware.disconnect', MagicMock())
+class DisconnectTestCase(TestCase):
+    '''Tests for salt.modules.vsphere.disconnect'''
+
+    def test_supported_proxes(self):
+        supported_proxies = ['esxi']
+        for proxy_type in supported_proxies:
+            with patch('salt.modules.vsphere.get_proxy_type',
+                       MagicMock(return_value=proxy_type)):
+                vsphere.disconnect(mock_si)
+
+    def test_disconnect_call(self):
+        mock_disconnect = MagicMock()
+        with patch('salt.utils.vmware.disconnect', mock_disconnect):
+            vsphere.disconnect(mock_si)
+        mock_disconnect.assert_called_once_with(mock_si)
+
+    def test_output(self):
+        res = vsphere.disconnect(mock_si)
+        self.assertEqual(res, True)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.modules.vsphere.__virtual__', MagicMock(return_value='vsphere'))
+# Decorator mocks
+@patch('salt.modules.vsphere.get_proxy_type',MagicMock(return_value='esxi'))
 @patch('salt.modules.vsphere._get_proxy_connection_details', MagicMock())
 @patch('salt.utils.vmware.get_service_instance',
        MagicMock(return_value=mock_si))


### PR DESCRIPTION
### What does this PR do?
Added modules.vsphere.disconnect
- retrieves a service instance to the endpoint defined by the proxy
Added modules.vsphere.get_service_instance_via_proxy
- retrieves a service instance to the endpoint defined by the proxy
[NOTE] Should be used in state modules, not invoked directly

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
