### PR TITLE
Remove "event_publisher_pub_hwm" and "salt_event_pub_hwm" from config/__init__.py

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -479,11 +479,6 @@ VALID_OPTS = {
     # http://api.zeromq.org/3-2:zmq-setsockopt
     'pub_hwm': int,
 
-    # ZMQ HWM for SaltEvent pub socket
-    'salt_event_pub_hwm': int,
-    # ZMQ HWM for EventPublisher pub socket
-    'event_publisher_pub_hwm': int,
-
     # IPC buffer size
     # Refs https://github.com/saltstack/salt/issues/34215
     'ipc_write_buffer': int,
@@ -1088,10 +1083,6 @@ DEFAULT_MINION_OPTS = {
     'sudo_user': '',
     'http_request_timeout': 1 * 60 * 60.0,  # 1 hour
     'http_max_body': 100 * 1024 * 1024 * 1024,  # 100GB
-    # ZMQ HWM for SaltEvent pub socket - different for minion vs. master
-    'salt_event_pub_hwm': 2000,
-    # ZMQ HWM for EventPublisher pub socket - different for minion vs. master
-    'event_publisher_pub_hwm': 1000,
     'event_match_type': 'startswith',
 }
 
@@ -1099,10 +1090,6 @@ DEFAULT_MASTER_OPTS = {
     'interface': '0.0.0.0',
     'publish_port': 4505,
     'pub_hwm': 1000,
-    # ZMQ HWM for SaltEvent pub socket - different for minion vs. master
-    'salt_event_pub_hwm': 2000,
-    # ZMQ HWM for EventPublisher pub socket - different for minion vs. master
-    'event_publisher_pub_hwm': 1000,
     'auth_mode': 1,
     'user': 'root',
     'worker_threads': 5,


### PR DESCRIPTION
These options were used back when the event system was based on ZMQ. As of
PR #29294, these options are no longer needed and are obsolete. PR #29294 changed
the event system transport from ZMQ to TCP/tornado.

There are no other mentions of these configuration options in the salt code base
except in the man pages. Once the man pages are regenerated, those references will
be removed.

Fixes #38674
