### PR TITLE
adding python-jenkins as dependecy in docs

### DIFF
--- a/salt/modules/jenkins.py
+++ b/salt/modules/jenkins.py
@@ -2,6 +2,8 @@
 '''
 Module for controlling Jenkins
 
+:depends: python-jenkins
+
 .. versionadded:: 2016.3.0
 
 :configuration: This module can be used by either passing an api key and version


### PR DESCRIPTION
I came through this [SOF question](http://stackoverflow.com/questions/41586859/issue-in-creating-jenkins-job-in-saltstack). I think [python-jenkins](https://python-jenkins.readthedocs.io/en/latest/index.html) is not a library that would be installed by default so it needs to be added to the documentation