### PR TITLE
Add VC Redist 2008 SP1 MFC to installer

### DIFF
--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -9,6 +9,7 @@
 Set "CurrDir=%cd%"
 Set "BinDir=%cd%\buildenv\bin"
 Set "InsDir=%cd%\installer"
+Set "PreDir=%cd%\prereqs"
 Set "PyDir=C:\Python27"
 
 :: Get the version from git if not passed
@@ -35,6 +36,21 @@ If Exist "%BinDir%\" rd /S /Q "%BinDir%"
 :: Copy the Python27 directory to bin
 @echo xcopy /E /Q "%PyDir%" "%BinDir%\"
 xcopy /E /Q "%PyDir%" "%BinDir%\"
+@echo.
+
+@echo Copying VCRedist 2008 MFC to Prerequisites
+@echo ----------------------------------------------------------------------
+:: Make sure the "prereq" directory exists
+If NOT Exist "%PreDir%" mkdir "%PreDir%"
+
+:: Check for 64 bit by finding the Program Files (x86) directory
+Set Url64="http://repo.saltstack.com/windows/dependencies/64/vcredist_x64_2008_mfc.exe"
+Set Url32="http://repo.saltstack.com/windows/dependencies/32/vcredist_x86_2008_mfc.exe"
+If Exist "C:\Program Files (x86)" (
+    bitsadmin /transfer "VCRedist 2008 MFC AMD64" "%Url64%" "%PreDir%\vcredist.exe"
+) Else (
+    bitsadmin /transfer "VCRedist 2008 MFC x86" "%Url32%" "%PreDir%\vcredist.exe"
+)
 @echo.
 
 :: Remove the fixed path in .exe files

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -174,6 +174,44 @@ ShowInstDetails show
 ShowUnInstDetails show
 
 
+; Check and install Visual C++ 2008 SP1 MFC Security Update redist packages
+; See http://blogs.msdn.com/b/astebner/archive/2009/01/29/9384143.aspx for more info
+Section -Prerequisites
+
+    !define VC_REDIST_X64_GUID "{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
+    !define VC_REDIST_X86_GUID "{9BE518E6-ECC6-35A9-88E4-87755C07200F}"
+
+    Var /GLOBAL VcRedistGuid
+    Var /GLOBAL NeedVcRedist
+    ${If} ${CPUARCH} == "AMD64"
+        StrCpy $VcRedistGuid ${VC_REDIST_X64_GUID}
+    ${Else}
+        StrCpy $VcRedistGuid ${VC_REDIST_X86_GUID}
+    ${EndIf}
+
+    Push $VcRedistGuid
+    Call MsiQueryProductState
+    ${If} $NeedVcRedist == "True"
+        MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 \
+            "VC Redist 2008 SP1 MFC is currently not installed. Would you like to install?" \
+            /SD IDYES IDNO endVcRedist
+
+        ClearErrors
+        ; The Correct version of VCRedist is copied over by "build_pkg.bat"
+        SetOutPath "$INSTDIR\"
+        File "..\prereqs\vcredist.exe"
+        ExecWait "$INSTDIR\vcredist.exe /qb!"
+        IfErrors 0 endVcRedist
+            MessageBox MB_OK \
+                "VC Redist 2008 SP1 MFC failed to install. Try installing the package manually." \
+                /SD IDOK
+
+        endVcRedist:
+    ${EndIf}
+
+SectionEnd
+
+
 Section "MainSection" SEC01
 
     SetOutPath "$INSTDIR\"
@@ -235,6 +273,7 @@ Function .onInit
         Delete "$INSTDIR\uninst.exe"
         Delete "$INSTDIR\nssm.exe"
         Delete "$INSTDIR\salt*"
+        Delete "$INSTDIR\vcredist.exe"
         RMDir /r "$INSTDIR\bin"
 
         ; Remove registry entries
@@ -300,6 +339,8 @@ Section -Post
     Push "C:\salt"
     Call AddToPath
 
+    Delete "$INSTDIR\vcredist.exe"
+
 SectionEnd
 
 
@@ -331,6 +372,7 @@ Section Uninstall
     Delete "$INSTDIR\uninst.exe"
     Delete "$INSTDIR\nssm.exe"
     Delete "$INSTDIR\salt*"
+    Delete "$INSTDIR\vcredist.exe"
 
     ; Remove salt directory, you must check to make sure you're not removing
     ; the Program Files directory
@@ -366,6 +408,18 @@ FunctionEnd
 ###############################################################################
 # Helper Functions
 ###############################################################################
+Function MsiQueryProductState
+
+  !define INSTALLSTATE_DEFAULT "5"
+
+  Pop $R0
+  StrCpy $NeedVcRedist "False"
+  System::Call "msi::MsiQueryProductStateA(t '$R0') i.r0"
+  StrCmp $0 ${INSTALLSTATE_DEFAULT} +2 0
+  StrCpy $NeedVcRedist "True"
+
+FunctionEnd
+
 
 Function Trim
 

--- a/pkg/windows/installer/Salt-Setup.nsi
+++ b/pkg/windows/installer/Salt-Setup.nsi
@@ -306,6 +306,45 @@ ShowInstDetails show
 ShowUnInstDetails show
 
 
+
+; Check and install Visual C++ 2008 SP1 MFC Security Update redist packages
+; See http://blogs.msdn.com/b/astebner/archive/2009/01/29/9384143.aspx for more info
+Section -Prerequisites
+
+    !define VC_REDIST_X64_GUID "{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
+    !define VC_REDIST_X86_GUID "{9BE518E6-ECC6-35A9-88E4-87755C07200F}"
+
+    Var /GLOBAL VcRedistGuid
+    Var /GLOBAL NeedVcRedist
+    ${If} ${CPUARCH} == "AMD64"
+        StrCpy $VcRedistGuid ${VC_REDIST_X64_GUID}
+    ${Else}
+        StrCpy $VcRedistGuid ${VC_REDIST_X86_GUID}
+    ${EndIf}
+
+    Push $VcRedistGuid
+    Call MsiQueryProductState
+    ${If} $NeedVcRedist == "True"
+        MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 \
+            "VC Redist 2008 SP1 MFC is currently not installed. Would you like to install?" \
+            /SD IDYES IDNO endVcRedist
+
+        ClearErrors
+        ; The Correct version of VCRedist is copied over by "build_pkg.bat"
+        SetOutPath "$INSTDIR\"
+        File "..\prereqs\vcredist.exe"
+        ExecWait "$INSTDIR\vcredist.exe /qb!"
+        IfErrors 0 endVcRedist
+            MessageBox MB_OK \
+                "VC Redist 2008 SP1 MFC failed to install. Try installing the package manually." \
+                /SD IDOK
+
+        endVcRedist:
+    ${EndIf}
+
+SectionEnd
+
+
 Section "MainSection" SEC01
 
     SetOutPath "$INSTDIR\"
@@ -367,6 +406,7 @@ Function .onInit
         Delete "$INSTDIR\uninst.exe"
         Delete "$INSTDIR\nssm.exe"
         Delete "$INSTDIR\salt*"
+        Delete "$INSTDIR\vcredist.ext"
         RMDir /r "$INSTDIR\bin"
 
         ; Remove registry entries
@@ -477,6 +517,8 @@ Section -Post
     Push "C:\salt"
     Call AddToPath
 
+    Delete "$INSTDIR\vcredist.ext"
+
 SectionEnd
 
 
@@ -516,6 +558,7 @@ Section Uninstall
     Delete "$INSTDIR\uninst.exe"
     Delete "$INSTDIR\nssm.exe"
     Delete "$INSTDIR\salt*"
+    Delete "$INSTDIR\vcredist.ext"
 
     ; Remove salt directory, you must check to make sure you're not removing
     ; the Program Files directory
@@ -556,6 +599,18 @@ FunctionEnd
 ###############################################################################
 # Helper Functions
 ###############################################################################
+Function MsiQueryProductState
+
+  !define INSTALLSTATE_DEFAULT "5"
+
+  Pop $R0
+  StrCpy $NeedVcRedist "False"
+  System::Call "msi::MsiQueryProductStateA(t '$R0') i.r0"
+  StrCmp $0 ${INSTALLSTATE_DEFAULT} +2 0
+  StrCpy $NeedVcRedist "True"
+
+FunctionEnd
+
 
 Function Trim
 

--- a/pkg/windows/installer/Salt-Setup.nsi
+++ b/pkg/windows/installer/Salt-Setup.nsi
@@ -406,7 +406,7 @@ Function .onInit
         Delete "$INSTDIR\uninst.exe"
         Delete "$INSTDIR\nssm.exe"
         Delete "$INSTDIR\salt*"
-        Delete "$INSTDIR\vcredist.ext"
+        Delete "$INSTDIR\vcredist.exe"
         RMDir /r "$INSTDIR\bin"
 
         ; Remove registry entries
@@ -517,7 +517,7 @@ Section -Post
     Push "C:\salt"
     Call AddToPath
 
-    Delete "$INSTDIR\vcredist.ext"
+    Delete "$INSTDIR\vcredist.exe"
 
 SectionEnd
 
@@ -558,7 +558,7 @@ Section Uninstall
     Delete "$INSTDIR\uninst.exe"
     Delete "$INSTDIR\nssm.exe"
     Delete "$INSTDIR\salt*"
-    Delete "$INSTDIR\vcredist.ext"
+    Delete "$INSTDIR\vcredist.exe"
 
     ; Remove salt directory, you must check to make sure you're not removing
     ; the Program Files directory


### PR DESCRIPTION
### What does this PR do?
Adds the Visual C++ 2008 SP1 MFC Redistributable (vcredist) binary to the Salt installer. Required for older versions of Windows (2008, poss 2008r2, etc). The vcredist is required by Python 2.7. Python itself will not install unless that prereq is present. Since we're bundling python, we need to make sure that's on the system. This bundles the vcredist binary in the Salt installer for closed networks.

The Salt installer checks for the presence of vcredist and prompts the user to install VCRedist. If the user clicks `No`, salt will continue to install but will fail to start. The user will need to install the VCRedist manually.

If the Silent option is passed (`/S`) it just installs it.

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1088
https://github.com/saltstack/salt/issues/37669#issuecomment-260673162

### Previous Behavior
Salt would fail to start if VCRedist is not found on the system.

### New Behavior
Salt installer prompts you to install VCRedist if it's not installed.

### Tests written?
NA
