### PR TITLE
DOCS: correct examples of running test suite

### DIFF
--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -139,13 +139,13 @@ Running Test Subsections
 Instead of running the entire test suite all at once, which can take a long time,
 there are several ways to run only specific groups of tests or individual tests:
 
-* Run unit tests only: ``./tests/runtests.py --unit-tests``
-* Run unit and integration tests for states: ``./tests/runtests.py --state``
-* Run integration tests for an individual module: ``./tests/runtests.py -n integration.modules.virt``
-* Run unit tests for an individual module: ``./tests/runtests.py -n unit.modules.virt_test``
+* Run :ref:`unit tests only<running-unit-tests-no-daemons>`: ``python tests/runtests.py --unit-tests``
+* Run unit and integration tests for states: ``python tests/runtests.py --state``
+* Run integration tests for an individual module: ``python tests/runtests.py -n integration.modules.virt``
+* Run unit tests for an individual module: ``python tests/runtests.py -n unit.modules.virt_test``
 * Run an individual test by using the class and test name (this example is for the
   ``test_default_kvm_profile`` test in the ``integration.module.virt``):
-  ``./tests/runtests.py -n integration.module.virt.VirtTest.test_default_kvm_profile``
+  ``python tests/runtests.py -n integration.module.virt.VirtTest.test_default_kvm_profile``
 
 For more specific examples of how to run various test subsections or individual
 tests, please see the :ref:`Test Selection Options <test-selection-options>`
@@ -163,14 +163,14 @@ Since the unit tests do not require a master or minion to execute, it is often u
 run unit tests individually, or as a whole group, without having to start up the integration testing
 daemons. Starting up the master, minion, and syndic daemons takes a lot of time before the tests can
 even start running and is unnecessary to run unit tests. To run unit tests without invoking the
-integration test daemons, simple remove the ``/tests`` portion of the ``runtests.py`` command:
+integration test daemons, simply run the ``runtests.py`` script with ``--unit`` argument:
 
 .. code-block:: bash
 
-    ./runtests.py --unit
+    python tests/runtests.py --unit
 
-All of the other options to run individual tests, entire classes of tests, or entire test modules still
-apply.
+All of the other options to run individual tests, entire classes of tests, or
+entire test modules still apply.
 
 
 Running Destructive Integration Tests
@@ -191,13 +191,14 @@ successfully. Therefore, running destructive tests should be done with caution.
 
 .. note::
 
-    Running destructive tests will change the underlying system. Use caution when running destructive tests.
+    Running destructive tests will change the underlying system.
+    Use caution when running destructive tests.
 
 To run tests marked as destructive, set the ``--run-destructive`` flag:
 
 .. code-block:: bash
 
-    ./tests/runtests.py --run-destructive
+    python tests/runtests.py --run-destructive
 
 
 Running Cloud Provider Tests
@@ -259,13 +260,13 @@ Here's a simple usage example:
 
 .. code-block:: bash
 
-    tests/runtests.py --docked=ubuntu-12.04 -v
+    python tests/runtests.py --docked=ubuntu-12.04 -v
 
 The full `docker`_ container repository can also be provided:
 
 .. code-block:: bash
 
-    tests/runtests.py --docked=salttest/ubuntu-12.04 -v
+    python tests/runtests.py --docked=salttest/ubuntu-12.04 -v
 
 
 The SaltStack team is creating some containers which will have the necessary


### PR DESCRIPTION
### What does this PR do?
It prepends test suite script invocation with `python` interpreter, because the `tests/runtests.py` doesn't have executable bit set in the Git repo. And I think this is the right way to do it :smile: 