### PR TITLE
Fix salt-minion reconnection problem when master breaks connection

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1988,9 +1988,9 @@ class Minion(MinionBase):
                                                              schedule=schedule)
                                 else:
                                     self.schedule.delete_job(name=master_event(type='failback'), persist=True)
-                    else:
-                        self.restart = True
-                        self.io_loop.stop()
+                else:
+                    self.restart = True
+                    self.io_loop.stop()
 
         elif tag.startswith(master_event(type='connected')):
             # handle this event only once. otherwise it will pollute the log


### PR DESCRIPTION
### What does this PR do?

Looks like the the problem with #38742 is that salt-minion doesn't get told to reconnect when the connection is broken. I see a disconnection event in the log and then nothing else happens, it just sits there without attempting to connect, no matter what `master_tries` is set to.
    
It looks like the indent level of this block is wrong, and restart is only triggered when `master_type` is 'failover' **and** `self.connected` is false (two individual nested if blocks), rather then when `master_type` *isn't* failover.

When dropping this block one indent level, the salt-minion does successfully reconnected, and it does hit DNS again, completely addressing #38742.

### What issues does this PR fix or reference?

#38742

### Previous Behavior

When taking down the salt-master, I'd see the salt-minion notice the connection broke, but just sit there and never attempt to reconnect.

That said, I don't know if this is the correct fix, but I might as well share what I've found.

### Tests written?

No
