### PR TITLE
Respect follow_symlinks when run with test=True

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -486,7 +486,8 @@ def _check_directory(name,
                      clean,
                      require,
                      exclude_pat,
-                     max_depth=None):
+                     max_depth=None,
+                     follow_symlinks=False):
     '''
     Check what changes need to be made on a directory
     '''
@@ -519,7 +520,7 @@ def _check_directory(name,
                     fchange = {}
                     path = os.path.join(root, fname)
                     stats = __salt__['file.stats'](
-                        path, None, follow_symlinks=False
+                        path, None, follow_symlinks
                     )
                     if user is not None and user != stats.get('user'):
                         fchange['user'] = user
@@ -530,11 +531,11 @@ def _check_directory(name,
             if check_dirs:
                 for name_ in dirs:
                     path = os.path.join(root, name_)
-                    fchange = _check_dir_meta(path, user, group, mode)
+                    fchange = _check_dir_meta(path, user, group, mode, follow_symlinks)
                     if fchange:
                         changes[path] = fchange
     # Recurse skips root (we always do dirs, not root), so always check root:
-    fchange = _check_dir_meta(name, user, group, mode)
+    fchange = _check_dir_meta(name, user, group, mode, follow_symlinks)
     if fchange:
         changes[name] = fchange
     if clean:
@@ -699,11 +700,12 @@ def _check_directory_win(name,
 def _check_dir_meta(name,
                     user,
                     group,
-                    mode):
+                    mode,
+                    follow_symlinks=False):
     '''
     Check the changes in directory metadata
     '''
-    stats = __salt__['file.stats'](name, follow_symlinks=False)
+    stats = __salt__['file.stats'](name, None, follow_symlinks)
     changes = {}
     if not stats:
         changes['directory'] = 'new'
@@ -2503,7 +2505,7 @@ def directory(name,
     else:
         presult, pcomment, ret['pchanges'] = _check_directory(
             name, user, group, recurse or [], dir_mode, clean, require,
-            exclude_pat, max_depth)
+            exclude_pat, max_depth, follow_symlinks)
 
     if __opts__['test']:
         ret['result'] = presult

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -588,6 +588,28 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         self.assertSaltTrueReturn(ret)
         self.assertTrue(os.path.isdir(name))
 
+    def test_directory_symlink_dry_run(self):
+        '''
+        Ensure that symlinks are followed when file.directory is run with
+        test=True
+        '''
+        try:
+            tmp_dir = os.path.join(integration.TMP, 'pgdata')
+            sym_dir = os.path.join(integration.TMP, 'pg_data')
+            os.mkdir(tmp_dir, 0o700)
+            os.symlink(tmp_dir, sym_dir)
+
+            ret = self.run_state(
+                'file.directory', test=True, name=sym_dir, follow_symlinks=True,
+                mode=700
+            )
+            self.assertSaltTrueReturn(ret)
+        finally:
+            if os.path.isdir(tmp_dir):
+                shutil.rmtree(tmp_dir)
+            if os.path.islink(sym_dir):
+                os.unlink(sym_dir)
+
     @skipIf(IS_WINDOWS, 'Mode not available in Windows')
     def test_directory_max_depth(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Plumb the `follow_symlinks` parameter to test-only functions used by `file.directory`

### What issues does this PR fix or reference?

#18668

### Previous Behavior

Previously file.directory correctly sets the permissions of the target of a symlink, but it did not return the correct result during a dry run.

### New Behavior

File permission/ownership are properly resolved when `file.directory` is run with `test=True`

### Tests written?

Yes