### PR TITLE
Allow changing baseurl with pkg.mod_repo(zypper)

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -794,6 +794,18 @@ def mod_repo(repo, **kwargs):
                 'Please check zypper logs.'.format(repo))
         added = True
 
+    repo_info = _get_repo_info(repo)
+    if (
+        not added and 'baseurl' in kwargs and
+        not (kwargs['baseurl'] == repo_info['baseurl'])
+    ):
+        # Note: zypper does not support changing the baseurl
+        # we need to remove the repository and add it again with the new baseurl
+        repo_info.update(kwargs)
+        repo_info.setdefault('cache', False)
+        del_repo(repo)
+        return mod_repo(repo, **repo_info)
+
     # Modify added or existing repo according to the options
     cmd_opt = []
     global_cmd_opt = []


### PR DESCRIPTION
### What does this PR do?

Allows changing the url of a existing repo using pkg.mod_repo (zypper)

### Previous Behavior
I comment was returned saying: 'Specified arguments did not result in modification of repo'

### New Behavior
Because zypper does not allow changing the url (yet?) the existing repo metadata is fetched, the repo is removed and then added back with the metadata obtained previously and the new url.

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
