### PR TITLE
Add support for 'nilrt-xfce' systems in grains

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1106,6 +1106,7 @@ _OS_NAME_MAP = {
     'scientific': 'ScientificLinux',
     'synology': 'Synology',
     'nilrt': 'NILinuxRT',
+    'nilrt-xfce': 'NILinuxRT-XFCE',
     'manjaro': 'Manjaro',
     'antergos': 'Antergos',
     'sles': 'SUSE',
@@ -1171,6 +1172,7 @@ _OS_FAMILY_MAP = {
     'Devuan': 'Debian',
     'antiX': 'Debian',
     'NILinuxRT': 'NILinuxRT',
+    'NILinuxRT-XFCE': 'NILinuxRT',
     'Void': 'Void',
 }
 


### PR DESCRIPTION
### What does this PR do?

In addition to the currently supported systems that have 'nilrt'
mapped to 'os': 'NILinuxRT' and 'os_family': 'NILinuxRT', add
support for a 'nilrt-xfce' system which will map to 'os': 'NILinuxRT-XFCE'
and 'os_family': 'NILinuxRT'.

### Tests written?

No