### PR TITLE
GPG renderer support for cStringIO.InputType

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -214,6 +214,7 @@ import os
 import re
 import logging
 from subprocess import Popen, PIPE
+import cStringIO
 
 # Import salt libs
 import salt.utils
@@ -222,7 +223,6 @@ from salt.exceptions import SaltRenderError
 
 # Import 3rd-party libs
 import salt.ext.six as six
-import cStringIO, StringIO
 
 log = logging.getLogger(__name__)
 

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -222,7 +222,7 @@ from salt.exceptions import SaltRenderError
 
 # Import 3rd-party libs
 import salt.ext.six as six
-
+import cStringIO, StringIO
 
 log = logging.getLogger(__name__)
 
@@ -279,6 +279,8 @@ def _decrypt_object(obj, translate_newlines=False):
     (string or unicode), and it contains a valid GPG header, decrypt it,
     otherwise keep going until a string is found.
     '''
+    if isinstance(obj, cStringIO.InputType):
+        return _decrypt_object(obj.getvalue(), translate_newlines)
     if isinstance(obj, six.string_types):
         if GPG_HEADER.search(obj):
             return _decrypt_ciphertext(obj,


### PR DESCRIPTION
### What does this PR do?
It fixes the case where the GPG renderer is fed data from template.py of type cStringIO.InputType. This can't be handled normally and results in the GPG renderer doing nothing with the handed data.

### What issues does this PR fix or reference?
None

### Previous Behavior
[DEBUG   ] compile template: /path/to/encrypted/file.asc
[DEBUG   ] LazyLoaded gpg.render
[DEBUG   ] LazyLoaded config.get
[DEBUG   ] Reading GPG keys from: /etc/salt/gpgkeys
[PROFILE ] Time (in seconds) to render '/path/to/encrypted/file.asc' using 'gpg' renderer: 0.000746965408325
[DEBUG   ] Rendered data from file: /path/to/encrypted/file.asc:
#!gpg
-----BEGIN PGP MESSAGE-----
Version: GnuPG v2.0.22 (GNU/Linux)
<cut encrypted GPG content>

### New Behavior
GPG renderer decrypts the data nicely.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
