### PR TITLE
Pillar file tree templating

### DIFF
--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -51,6 +51,21 @@ intended to be used to deploy a file using ``contents_pillar`` with a
     files would not affected by the ``keep_newline`` configuration.  However,
     this module does not actually distinguish between binary and text files.
 
+.. versionchanged:: develop
+    Templating/rendering has been added. You can now specify a default render
+    pipeline and a black- and whitelist of (dis)allowed renderers.
+
+    .. code-block:: yaml
+
+        ext_pillar:
+          - file_tree:
+            root_dir: /path/to/root/directory
+            render_default: jinja|yaml
+            renderer_blacklist:
+              - gpg
+            renderer_whitelist:
+              - jinja
+              - yaml
 
 Assigning Pillar Data to Individual Hosts
 -----------------------------------------
@@ -198,9 +213,9 @@ def _check_newline(prefix, file_name, keep_newline):
 def _construct_pillar(top_dir,
                       follow_dir_links,
                       keep_newline=False,
-                      template_default=None,
-                      template_blacklist=None,
-                      template_whitelist=None):
+                      render_default=None,
+                      renderer_blacklist=None,
+                      renderer_whitelist=None):
     '''
     Construct pillar from file tree.
     '''
@@ -254,9 +269,9 @@ def _construct_pillar(top_dir,
             else:
                 data = salt.template.compile_template_str(template=contents,
                                                           renderers=renderers,
-                                                          default=template_default,
-                                                          blacklist=template_blacklist,
-                                                          whitelist=template_whitelist)
+                                                          default=render_default,
+                                                          blacklist=renderer_blacklist,
+                                                          whitelist=renderer_whitelist)
                 if isinstance(data, cStringIO.InputType):
                     pillar_node[file_name] = data.getvalue()
                 else:
@@ -271,9 +286,9 @@ def ext_pillar(minion_id,
                follow_dir_links=False,
                debug=False,
                keep_newline=False,
-               template_default=None,
-               template_blacklist=None,
-               template_whitelist=None):
+               render_default=None,
+               renderer_blacklist=None,
+               renderer_whitelist=None):
     '''
     Compile pillar data for the specified minion ID
     '''
@@ -319,9 +334,9 @@ def ext_pillar(minion_id,
                             _construct_pillar(ngroup_dir,
                                               follow_dir_links,
                                               keep_newline,
-                                              template_default,
-                                              template_blacklist,
-                                              template_whitelist)
+                                              render_default,
+                                              renderer_blacklist,
+                                              renderer_whitelist)
                         )
         else:
             if debug is True:
@@ -345,9 +360,9 @@ def ext_pillar(minion_id,
     host_pillar = _construct_pillar(host_dir,
                                     follow_dir_links,
                                     keep_newline,
-                                    template_default,
-                                    template_blacklist,
-                                    template_whitelist)
+                                    render_default,
+                                    renderer_blacklist,
+                                    renderer_whitelist)
     return salt.utils.dictupdate.merge(ngroup_pillar,
                                        host_pillar,
                                        strategy='recurse')

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -214,6 +214,7 @@ import os
 import re
 import logging
 from subprocess import Popen, PIPE
+import cStringIO
 
 # Import salt libs
 import salt.utils
@@ -222,7 +223,6 @@ from salt.exceptions import SaltRenderError
 
 # Import 3rd-party libs
 import salt.ext.six as six
-import cStringIO, StringIO
 
 log = logging.getLogger(__name__)
 

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -222,7 +222,7 @@ from salt.exceptions import SaltRenderError
 
 # Import 3rd-party libs
 import salt.ext.six as six
-
+import cStringIO, StringIO
 
 log = logging.getLogger(__name__)
 
@@ -279,6 +279,8 @@ def _decrypt_object(obj, translate_newlines=False):
     (string or unicode), and it contains a valid GPG header, decrypt it,
     otherwise keep going until a string is found.
     '''
+    if isinstance(obj, cStringIO.InputType):
+        return _decrypt_object(obj.getvalue(), translate_newlines)
     if isinstance(obj, six.string_types):
         if GPG_HEADER.search(obj):
             return _decrypt_ciphertext(obj,


### PR DESCRIPTION
### What does this PR do?
This PR adds templating/renderers to the file_tree pillar. File contents will be passed through compile_template_str in salt/template.py. Default renderer pipeline, renderer black-/white-lists are configurable in the master config.

### What issues does this PR fix or reference?
None

### Previous Behavior
Content of files in file_tree were added to pillar as-is, with optional end-of-file-newline-removal, but nothing else.

### New Behavior
Content of files in file_tree are added to the pillar rendered by the renderer(s) specified in the shebang of the file in question (if they survive the blacklist-filter), or by the configured default renderer pipeline.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
