### PR TITLE
template.py: Fix error thrown if default passed to compile_template i…

### DIFF
--- a/salt/template.py
+++ b/salt/template.py
@@ -11,6 +11,7 @@ import os
 import codecs
 import logging
 import cStringIO
+import StringIO
 
 # Import salt libs
 import salt.utils
@@ -83,7 +84,7 @@ def compile_template(template,
 
     input_data = string_io(input_data)
     for render, argline in render_pipe:
-        if isinstance(input_data, cStringIO.InputType):
+        if isinstance(input_data, (cStringIO.InputType, StringIO.StringIO)):
             input_data.seek(0)      # pylint: disable=no-member
         render_kwargs = dict(renderers=renderers, tmplpath=template)
         render_kwargs.update(kwargs)
@@ -107,7 +108,7 @@ def compile_template(template,
             # If ret is not a StringIO (which means it was rendered using
             # yaml, mako, or another engine which renders to a data
             # structure) we don't want to log this.
-            if isinstance(ret, cStringIO.InputType):
+            if isinstance(ret, (cStringIO.InputType, StringIO.StringIO)):
                 log.debug('Rendered data from file: {0}:\n{1}'.format(
                     template,
                     ret.read()))    # pylint: disable=no-member

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -406,7 +406,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     if newline:
         output += '\n'
 
-    return output
+    return output.encode(SLS_ENCODING)
 
 
 def render_mako_tmpl(tmplstr, context, tmplpath=None):

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -153,7 +153,7 @@ def wrap_tmpl_func(render_str):
             tmplstr = tmplsrc.read()
             tmplsrc.close()
         try:
-            output = render_str(tmplstr, context, tmplpath)
+            output = render_str(tmplstr, context, tmplpath).encode(SLS_ENCODING)
             if salt.utils.is_windows():
                 # Write out with Windows newlines
                 output = os.linesep.join(output.splitlines())
@@ -168,7 +168,7 @@ def wrap_tmpl_func(render_str):
             if to_str:  # then render as string
                 return dict(result=True, data=output)
             with tempfile.NamedTemporaryFile('wb', delete=False, prefix=salt.utils.files.TEMPFILE_PREFIX) as outf:
-                outf.write(SLS_ENCODER(output)[0])
+                outf.write(output)
                 # Note: If nothing is replaced or added by the rendering
                 #       function, then the contents of the output file will
                 #       be exactly the same as the input.
@@ -406,7 +406,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     if newline:
         output += '\n'
 
-    return output.encode(SLS_ENCODING)
+    return output
 
 
 def render_mako_tmpl(tmplstr, context, tmplpath=None):


### PR DESCRIPTION
### What does this PR do?
It reduces errors logged when using a renderer pipeline with more than one renderer where this renderer does not produce data of type cStringIO (and therefor does not have a .seek method).
It renders data as-is when the data has a shebang, but none of the renderers are recognized or all are blacklisted.
It causes the renderer to render the data as-is when the default renderer supplied is None.

### What issues does this PR fix or reference?
None

### Previous Behavior
Files rendered with a shebang where all mentioned renderers are blacklisted are rendered with the default renderer pipeline instead.
Error logged ([ERROR   ] error while compiling template '/path/to/file': 'str' object has no attribute 'seek') when using multiple renderers in a pipeline where the rendered data is not of type cStringIO.

### New Behavior
Files rendered with a shebang where all mentioned renderers are blacklisted are rendered as-is
No more "no attribute 'seek'"-errors.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
