### PR TITLE
DOCS: add C++ compiler installation on RHEL required for bundled 0mq

### DIFF
--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -90,14 +90,14 @@ the lines below, depending on the relevant Python version:
 
 To be able to run integration tests which utilizes ZeroMQ transport, you also
 need to install additional requirements for it. Make sure you have installed
-the C compiler and development libraries and header files needed for your
+the C/C++ compiler and development libraries and header files needed for your
 Python version.
 
 This is an example for RedHat-based operating systems:
 
 .. code-block:: bash
 
-    yum install gcc python-devel
+    yum install gcc gcc-c++ python-devel
     pip install -r requirements/zeromq.txt
 
 On Debian, Ubuntu or their derivatives run the following commands:

--- a/doc/topics/tutorials/writing_tests.rst
+++ b/doc/topics/tutorials/writing_tests.rst
@@ -44,14 +44,14 @@ depending on your relevant version of Python:
 
 To be able to run integration tests which utilizes ZeroMQ transport, you also
 need to install additional requirements for it. Make sure you have installed
-the C compiler and development libraries and header files needed for your
+the C/C++ compiler and development libraries and header files needed for your
 Python version.
 
 This is an example for RedHat-based operating systems:
 
 .. code-block:: bash
 
-    yum install gcc python-devel
+    yum install gcc gcc-c++ python-devel
     pip install -r requirements/zeromq.txt
 
 On Debian, Ubuntu or their derivatives run the following commands:


### PR DESCRIPTION
### What does this PR do?
Recent version of ZeroMQ bundled with `pyzmq` package from PyPi requires compilation tools from GCC C++ package.
If those binaries are missing, you will encounter following error:
```console
pip install -r requirements/zeromq.txt
...
    gcc: error trying to exec 'cc1plus': execvp: No such file or directory
    error: command 'gcc' failed with exit status 1
```

This PR adds necessary package to the installation guide for getting Salt tests running on RedHat-based distros.
Debian derivatives already have the required binaries installed by dependencies coming with `build-essential` package.
