### PR TITLE
Perform a "starts-with" search to match ADML text names

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -109,7 +109,7 @@ try:
     VALUE_LIST_XPATH = etree.XPath('.//*[local-name() = "valueList"]')
     ENUM_ITEM_DISPLAY_NAME_XPATH = etree.XPath('.//*[local-name() = "item" and @*[local-name() = "displayName" = $display_name]]')
     ADMX_SEARCH_XPATH = etree.XPath('//*[local-name() = "policy" and @*[local-name() = "name"] = $policy_name and (@*[local-name() = "class"] = "Both" or @*[local-name() = "class"] = $registry_class)]')
-    ADML_SEARCH_XPATH = etree.XPath('//*[text() = $policy_name and @*[local-name() = "id"]]')
+    ADML_SEARCH_XPATH = etree.XPath('//*[starts-with(text(), $policy_name) and @*[local-name() = "id"]]')
     ADMX_DISPLAYNAME_SEARCH_XPATH = etree.XPath('//*[local-name() = "policy" and @*[local-name() = "displayName"] = $display_name and (@*[local-name() = "class"] = "Both" or @*[local-name() = "class"] = $registry_class) ]')
     PRESENTATION_ANCESTOR_XPATH = etree.XPath('ancestor::*[local-name() = "presentation"]')
     TEXT_ELEMENT_XPATH = etree.XPath('.//*[local-name() = "text"]')
@@ -4555,6 +4555,9 @@ def _lookup_admin_template(policy_name,
             suggested_policies = ''
             if len(adml_search_results) > 1:
                 multiple_adml_entries = True
+                for adml_search_result in adml_search_results:
+                    if not adml_search_result.attrib['text'].strip() == policy_name:
+                        adml_search_results.remove(adml_search_result)
             for adml_search_result in adml_search_results:
                 dmsg = 'found an ADML entry matching the string! {0} -- {1}'
                 log.debug(dmsg.format(adml_search_result.tag,


### PR DESCRIPTION
### What does this PR do?
Modifies win_lgpo to search ADML files for a long/full text name using starts-with instead of an exact match search.  Some text policy names contain trailing whitespace, which isn't viewable in gpedit.msc and is stripped when using lgpo.get

### What issues does this PR fix or reference?
#38782 

### Previous Behavior
Some Administrative template policies could not be configured

### New Behavior
Administrative template policies which have a trailing space can now be set

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
