### PR TITLE
Update some saltenv refs to environment in salt.modules.state docs

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -434,8 +434,8 @@ def apply_(mods=None,
             Argument name changed from ``env`` to ``saltenv``
 
         .. versionchanged:: 2014.7.0
-            If no saltenv is specified, the minion config will be checked for a
-            ``saltenv`` parameter and if found, it will be used. If none is
+            If no saltenv is specified, the minion config will be checked for an
+            ``environment`` parameter and if found, it will be used. If none is
             found, ``base`` will be used. In prior releases, the minion config
             was not checked and ``base`` would always be assumed when the
             saltenv was not explicitly set.
@@ -799,8 +799,8 @@ def sls(mods,
             Argument name changed from ``env`` to ``saltenv``.
 
         .. versionchanged:: 2014.7.0
-            If no saltenv is specified, the minion config will be checked for a
-            ``saltenv`` parameter and if found, it will be used. If none is
+            If no saltenv is specified, the minion config will be checked for an
+            ``environment`` parameter and if found, it will be used. If none is
             found, ``base`` will be used. In prior releases, the minion config
             was not checked and ``base`` would always be assumed when the
             saltenv was not explicitly set.


### PR DESCRIPTION
If saltenv is not specified in some of these functions, the the "environment" option is used instead.

Fixes #38622

