### PR TITLE
Update pillar tutorial lanuage regarding pillar_opts settings

### DIFF
--- a/doc/topics/tutorials/pillar.rst
+++ b/doc/topics/tutorials/pillar.rst
@@ -59,9 +59,16 @@ pillar data:
     Prior to version 0.16.2, this function is named ``pillar.data``. This
     function name is still supported for backwards compatibility.
 
-By default the contents of the master configuration file are loaded into
-pillar for all minions. This enables the master configuration file to
-be used for global configuration of minions.
+By default, the contents of the master configuration file are not loaded into
+pillar for all minions. This default is stored in the ``pillar_opts`` setting,
+which defaults to ``False``.
+
+The contents of the master configuration file can be made available to minion
+pillar files. This makes global configuration of services and systems very easy,
+but note that this may not be desired or appropriate if sensitive data is stored
+in the master's configuration file. To enable the master configuration file to be
+available to a minion's pillar files, set ``pillar_opts`` to ``True`` in the
+minion configuration file.
 
 Similar to the state tree, the pillar is comprised of sls files and has a top file.
 The default location for the pillar is in /srv/pillar.


### PR DESCRIPTION
The pillar_opts option defaults to ``False``. This change updates the language in the pillar tutorial to be in-line with the default setting.

Fixes #38629
