### PR TITLE
Revert "Fixed prepending of root_dir override to the other paths"

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1747,18 +1747,13 @@ def prepend_root_dir(opts, path_options):
     'root_dir' option.
     '''
     root_dir = os.path.abspath(opts['root_dir'])
-    def_root_dir = salt.syspaths.ROOT_DIR
-    if def_root_dir.endswith(os.sep):
-        def_root_dir = def_root_dir.rstrip(os.sep)
+    root_opt = opts['root_dir'].rstrip(os.sep)
     for path_option in path_options:
         if path_option in opts:
             path = opts[path_option]
-            if not os.path.isabs(path):
-                opts[path_option] = salt.utils.path_join(root_dir, path)
-            elif path.startswith(def_root_dir) and (root_dir != def_root_dir):
-                # Strip out the default root_dir and add the updated root_dir
-                path = path[len(def_root_dir):]
-                opts[path_option] = salt.utils.path_join(root_dir, path)
+            if path == root_opt or path.startswith(root_opt + os.sep):
+                path = path[len(root_opt):]
+            opts[path_option] = salt.utils.path_join(root_dir, path)
 
 
 def insert_system_path(opts, paths):


### PR DESCRIPTION
Reverts saltstack/salt#38707

We have to revert this because it's broken quite a number of tests and is blocking the release. We need to come back to this and see what's wrong.