### PR TITLE
update gitfs.rst for clarity

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -73,6 +73,10 @@ packages. Additionally, keep in mind that :ref:`SSH authentication in pygit2
 <pygit2-authentication-ssh>` requires libssh2_ (*not* libssh) development
 libraries to be present before libgit2_ is built. On some Debian-based distros
 ``pkg-config`` is also required to link libgit2_ with libssh2.
+.. note::
+    If you are receiving the error "Unsupported URL Protocol" in the Salt Master
+    log when making a connection using SSH, review the libssh2 details listed 
+    above.
 
 Additionally, version 0.21.0 of pygit2 introduced a dependency on python-cffi_,
 which in turn depends on newer releases of libffi_. Upgrading libffi_ is not


### PR DESCRIPTION
Add note for "Unsupported URL Protocol" error when using pygit2 without libssh2.

### What does this PR do?
Documentation update
### What issues does this PR fix or reference?
N/A

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
