### PR TITLE
Parse ansible dynamic inventory output correctly

### DIFF
--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -46,18 +46,14 @@ There is also the option of specifying a dynamic inventory, and generating it on
 
     #!/bin/bash
     echo '{
-      "servers": {
-        "hosts": [
-          "salt.gtmanfred.com"
-        ]
-      },
-      "desktop": {
-        "hosts": [
-          "home"
-        ]
-      },
+      "servers": [
+        "salt.gtmanfred.com"
+      ],
+      "desktop": [
+        "home"
+      ],
       "computers": {
-        "hosts":{},
+        "hosts": [],
         "children": [
           "desktop",
           "servers"
@@ -257,6 +253,8 @@ class Script(Target):
         for key, value in six.iteritems(self.inventory):
             if key == '_meta':
                 continue
+            if type(value) is list:
+                self._parse_groups(key, value)
             if 'hosts' in value:
                 self._parse_groups(key, value['hosts'])
             if 'children' in value:
@@ -277,7 +275,8 @@ class Script(Target):
                 if server not in host:
                     host[server] = dict()
                 for tmpkey, tmpval in six.iteritems(tmp):
-                    host[server][CONVERSION[tmpkey]] = tmpval
+                    if tmpkey in CONVERSION:
+                        host[server][CONVERSION[tmpkey]] = tmpval
                 if 'sudo' in host[server]:
                     host[server]['passwd'], host[server]['sudo'] = host[server]['sudo'], True
 


### PR DESCRIPTION
### What does this PR do?
Allows salt-ssh to handle the full dynamic inventory format. See: http://docs.ansible.com/ansible/dev_guide/developing_inventory.html#script-conventions
Ignores Ansible dynamic inventory "_meta" fields that are not convertible to Salt equivalents.

### What issues does this PR fix or reference?
n/a

### Previous Behavior
Crashes if the one of the returned JSON's fields is an array. Crashes if one of the meta fields is not in the 'CONVERSION' dictionary.

### New Behavior
Handles if the returned JSON's field is an array. Ignore non-convertible _meta fields.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
