### PR TITLE
Second attempt to fix prepending of root_dir to paths

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1747,12 +1747,26 @@ def prepend_root_dir(opts, path_options):
     'root_dir' option.
     '''
     root_dir = os.path.abspath(opts['root_dir'])
-    root_opt = opts['root_dir'].rstrip(os.sep)
+    root_opt = opts['root_dir']
+    if root_opt.endswith(os.sep):
+        root_opt = root_opt.rstrip(os.sep)
+    def_root_dir = salt.syspaths.ROOT_DIR
+    if def_root_dir.endswith(os.sep):
+        def_root_dir = def_root_dir.rstrip(os.sep)
     for path_option in path_options:
         if path_option in opts:
             path = opts[path_option]
-            if path == root_opt or path.startswith(root_opt + os.sep):
+            if path == def_root_dir or path.startswith(def_root_dir + os.sep):
+                # Remove the default root dir so we can add the override
+                path = path[len(def_root_dir):]
+            elif path == root_opt or path.startswith(root_opt + os.sep):
+                # Remove relative root dir so we can add the absolute root dir
                 path = path[len(root_opt):]
+            elif os.path.isabs(path_option):
+                # Absolute path (not default or overriden root_dir)
+                # No prepending required
+                continue
+            # Prepending the root dir
             opts[path_option] = salt.utils.path_join(root_dir, path)
 
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1747,12 +1747,8 @@ def prepend_root_dir(opts, path_options):
     'root_dir' option.
     '''
     root_dir = os.path.abspath(opts['root_dir'])
-    root_opt = opts['root_dir']
-    if root_opt.endswith(os.sep):
-        root_opt = root_opt.rstrip(os.sep)
-    def_root_dir = salt.syspaths.ROOT_DIR
-    if def_root_dir.endswith(os.sep):
-        def_root_dir = def_root_dir.rstrip(os.sep)
+    root_opt = opts['root_dir'].rstrip(os.sep)
+    def_root_dir = salt.syspaths.ROOT_DIR.rstrip(os.sep)
     for path_option in path_options:
         if path_option in opts:
             path = opts[path_option]

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1766,6 +1766,7 @@ def prepend_root_dir(opts, path_options):
             # Prepending the root dir
             opts[path_option] = salt.utils.path_join(root_dir, path)
 
+
 def insert_system_path(opts, paths):
     '''
     Inserts path into python path taking into consideration 'root_dir' option.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1752,7 +1752,8 @@ def prepend_root_dir(opts, path_options):
     for path_option in path_options:
         if path_option in opts:
             path = opts[path_option]
-            if path == def_root_dir or path.startswith(def_root_dir + os.sep):
+            # When running testsuite, salt.syspaths.ROOT_DIR is often empty
+            if def_root_dir != '' and (path == def_root_dir or path.startswith(def_root_dir + os.sep)):
                 # Remove the default root dir so we can add the override
                 path = path[len(def_root_dir):]
             elif path == root_opt or path.startswith(root_opt + os.sep):
@@ -1764,7 +1765,6 @@ def prepend_root_dir(opts, path_options):
                 continue
             # Prepending the root dir
             opts[path_option] = salt.utils.path_join(root_dir, path)
-
 
 def insert_system_path(opts, paths):
     '''


### PR DESCRIPTION
### What does this PR do?
Second attempt to fix prepending of root_dir to paths

Fixes: https://github.com/saltstack/salt/issues/38663

### Previous Behavior
Prepended the root_dir override to the default one

### New Behavior
Prepend the root_dir override only

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
