### PR TITLE
Add a salt-minion service control file

### DIFF
--- a/pkg/suse/salt-minion.service
+++ b/pkg/suse/salt-minion.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=The Salt Minion
+After=network.target
+
+[Service]
+Type=notify
+NotifyAccess=all
+LimitNOFILE=8192
+ExecStart=/usr/bin/salt-minion
+KillMode=process
+Restart=on-failure
+RestartSec=15
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### What does this PR do?

Adds `salt-minion.service` file for packaging on SUSE OS series.

@cachedout For some reasons we kept these patches only to us, but maybe it is a time to have it upstream. The following file for `systemd` on Salt Minion allows properly update Salt with Salt without losing the running ongoing tasks.