### PR TITLE
refine the os detection in archive test

### DIFF
--- a/tests/integration/states/archive.py
+++ b/tests/integration/states/archive.py
@@ -36,10 +36,13 @@ ARCHIVE_TAR_SOURCE = 'http://localhost:{0}/custom.tar.gz'.format(PORT)
 UNTAR_FILE = os.path.join(ARCHIVE_DIR, 'custom/README')
 ARCHIVE_TAR_HASH = 'md5=7643861ac07c30fe7d2310e9f25ca514'
 STATE_DIR = os.path.join(integration.FILES, 'file', 'base')
-if '7' in platform.dist()[1]:
+
+REDHAT7 = False
+QUERY_OS = platform.dist()
+OS_VERSION = QUERY_OS[1]
+OS_FAMILY = QUERY_OS[0]
+if '7' in OS_VERSION and 'centos' in OS_FAMILY:
     REDHAT7 = True
-else:
-    REDHAT7 = False
 
 
 @skipIf(not REDHAT7, 'Only run on redhat7 for now due to hanging issues on other OS')


### PR DESCRIPTION
### What does this PR do?
Current on debian8 the following tests are failling:

```
integration.states.archive.ArchiveTest.test_archive_extracted_skip_verify
integration.states.archive.ArchiveTest.test_archive_extracted_with_root_user_and_group
integration.states.archive.ArchiveTest.test_archive_extracted_with_source_hash
integration.states.archive.ArchiveTest.test_archive_extracted_with_strip_components_in_options
integration.states.archive.ArchiveTest.test_archive_extracted_with_strip_in_options
integration.states.archive.ArchiveTest.test_archive_extracted_without_archive_format
```

The problem is these tests should not even be running on debian8. It should only be running on redhat7. I believe why this test started failing all of a sudden is because 8.7 was just released: https://www.debian.org/News/2017/20170114 and the previous os detection on checked for 7. This improves the os detection for this test.

### Tests written?

Yes
