### PR TITLE
Fix #38388

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -572,6 +572,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
 
     def process_log_level(self):
         if not getattr(self.options, self._loglevel_config_setting_name_, None):
+            # Log level is not set via CLI, checking loaded configuration
             if self.config.get(self._loglevel_config_setting_name_, None):
                 # Is the regular log level setting set?
                 setattr(self.options,
@@ -579,7 +580,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
                         self.config.get(self._loglevel_config_setting_name_)
                        )
             else:
-                # Nothing is set on the configuration? Let's use the cli tool
+                # Nothing is set on the configuration? Let's use the CLI tool
                 # defined default
                 setattr(self.options,
                         self._loglevel_config_setting_name_,
@@ -595,6 +596,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
 
     def process_log_file(self):
         if not getattr(self.options, self._logfile_config_setting_name_, None):
+            # Log file is not set via CLI, checking loaded configuration
             if self.config.get(self._logfile_config_setting_name_, None):
                 # Is the regular log file setting set?
                 setattr(self.options,
@@ -602,7 +604,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
                         self.config.get(self._logfile_config_setting_name_)
                        )
             else:
-                # Nothing is set on the configuration? Let's use the cli tool
+                # Nothing is set on the configuration? Let's use the CLI tool
                 # defined default
                 setattr(self.options,
                         self._logfile_config_setting_name_,
@@ -614,6 +616,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
 
     def process_log_level_logfile(self):
         if not getattr(self.options, self._logfile_loglevel_config_setting_name_, None):
+            # Log file level is not set via CLI, checking loaded configuration
             if self.config.get(self._logfile_loglevel_config_setting_name_, None):
                 # Is the regular log file level setting set?
                 setattr(self.options,
@@ -621,19 +624,25 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
                         self.config.get(self._logfile_loglevel_config_setting_name_)
                        )
             else:
-                # Nothing is set on the configuration? Let's use the cli tool
+                # Nothing is set on the configuration? Let's use the CLI tool
                 # defined default
                 setattr(self.options,
                         self._logfile_loglevel_config_setting_name_,
-                        self._default_logging_level_
+                        # From the console log level config setting
+                        self.config.get(
+                            self._loglevel_config_setting_name_,
+                            self._default_logging_level_
+                        )
                        )
                 if self._logfile_loglevel_config_setting_name_ in self.config:
-                    # Remove it from config so it inherits from log_level
+                    # Remove it from config so it inherits from log_level_logfile
                     self.config.pop(self._logfile_loglevel_config_setting_name_)
 
     def setup_logfile_logger(self):
         loglevel = getattr(self.options,
+                           # From the options setting
                            self._logfile_loglevel_config_setting_name_,
+                           # From the default setting
                            self._default_logging_level_
                           )
 

--- a/tests/unit/utils/parsers_test.py
+++ b/tests/unit/utils/parsers_test.py
@@ -167,9 +167,6 @@ class LogSettingsParserTests(TestCase):
         '''
         Tests that log level match the configured value
         '''
-        # Set defaults
-        default_log_level = self.default_config[self.loglevel_config_setting_name]
-
         args = self.args
 
         # Set log level in config
@@ -193,7 +190,7 @@ class LogSettingsParserTests(TestCase):
                          log_level)
         self.assertEqual(self.log_setup.temp_log_level, 'error')
         # Check log file logger log level
-        self.assertEqual(self.log_setup.log_level_logfile, default_log_level)
+        self.assertEqual(self.log_setup.log_level_logfile, log_level)
 
     def test_get_log_level_default(self):
         '''
@@ -342,7 +339,7 @@ class LogSettingsParserTests(TestCase):
         Tests that file log level match command-line specified value
         '''
         # Set defaults
-        log_level = self.default_config[self.loglevel_config_setting_name]
+        default_log_level = self.default_config[self.loglevel_config_setting_name]
 
         # Set log file level in CLI
         log_level_logfile = 'error'
@@ -359,10 +356,10 @@ class LogSettingsParserTests(TestCase):
 
         if not self.skip_console_logging_config:
             # Check console loggger
-            self.assertEqual(self.log_setup.log_level, log_level)
+            self.assertEqual(self.log_setup.log_level, default_log_level)
             # Check extended logger
             self.assertEqual(self.log_setup.config[self.loglevel_config_setting_name],
-                             log_level)
+                             default_log_level)
             self.assertEqual(self.log_setup.config[self.logfile_loglevel_config_setting_name],
                              log_level_logfile)
         # Check temp logger
@@ -464,7 +461,6 @@ class LogSettingsParserTests(TestCase):
         parser = self.parser()
         with patch(self.config_func, MagicMock(return_value=opts)):
             parser.parse_args(args)
-
         with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
             parser.setup_logfile_logger()
 
@@ -701,31 +697,27 @@ class SaltKeyOptionParserTestCase(LogSettingsParserTests):
         '''
         Tests that log level set in config is ignored
         '''
-        # Set defaults
-        default_log_level = self.default_config[self.loglevel_config_setting_name]
-
-        log_level = None
+        log_level = 'info'
         args = self.args
 
         # Set log level in config
-        opts = {self.loglevel_config_setting_name: 'info'}
+        opts = {self.loglevel_config_setting_name: log_level}
 
         parser = self.parser()
         with patch(self.config_func, MagicMock(return_value=opts)):
             parser.parse_args(args)
-
         with patch('salt.utils.parsers.is_writeable', MagicMock(return_value=True)):
             parser.setup_logfile_logger()
 
         # Check config name absence in options
         self.assertNotIn(self.loglevel_config_setting_name, parser.options.__dict__)
         # Check console loggger has not been set
-        self.assertEqual(self.log_setup.log_level, log_level)
+        self.assertEqual(self.log_setup.log_level, None)
         self.assertNotIn(self.loglevel_config_setting_name, self.log_setup.config)
         # Check temp logger
         self.assertEqual(self.log_setup.temp_log_level, 'error')
         # Check log file logger log level
-        self.assertEqual(self.log_setup.log_level_logfile, default_log_level)
+        self.assertEqual(self.log_setup.log_level_logfile, log_level)
 
     def test_get_log_level_default(self):
         '''


### PR DESCRIPTION
### What does this PR do?
If `log_level_logfile`  is not set explicitly in the configuration or via CLI it should inherit the level set by `log_level` configuration option. 

### What issues does this PR fix or reference?
#38388

### Previous Behavior
Salt services always had default (`warning`) log level set for logging to a file when `log_level` was set, but the `log_level_logfile` was not.

### New Behavior
Salt services write out log file with log level set in `log_level` configuration option if it was not set in `log_level_logfile` config option or overridden via `--log-level-logfile` CLI option.

Specifying `--log-level` CLI option only affects console logging and has no influence on log file loglevel.

### Tests written?
Test cases have been corrected and now are checking for the expected behavior.