### PR TITLE
Fix get_hostname to handle longer computer names

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -448,10 +448,9 @@ def get_hostname():
 
         salt 'minion-id' system.get_hostname
     '''
-    cmd = 'wmic computersystem get name'
+    cmd = 'hostname'
     ret = __salt__['cmd.run'](cmd=cmd)
-    _, hostname = ret.split("\n")
-    return hostname
+    return ret
 
 
 def set_hostname(hostname):

--- a/tests/unit/modules/win_system_test.py
+++ b/tests/unit/modules/win_system_test.py
@@ -291,11 +291,11 @@ class WinSystemTestCase(TestCase):
         '''
             Test setting a new hostname
         '''
-        cmd_run_mock = MagicMock(return_value="Name\nMINION")
+        cmd_run_mock = MagicMock(return_value="MINION")
         with patch.dict(win_system.__salt__, {'cmd.run': cmd_run_mock}):
             ret = win_system.get_hostname()
             self.assertEqual(ret, "MINION")
-        cmd_run_mock.assert_called_once_with(cmd="wmic computersystem get name")
+        cmd_run_mock.assert_called_once_with(cmd="hostname")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?
Fixes ``set_hostname`` to handle long computer names (>15 chars)

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/38442

Caused by:
https://github.com/saltstack/salt/pull/35722

The ``wmic`` command doesn't return consistent data across machines.

### Previous Behavior
The returned host name chops off anything after 15 chars

### New Behavior
The entire hostname is returned.

### Tests written?
Yes