### PR TITLE
Show a lot less data when requesting a VM

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2567,7 +2567,11 @@ def create(vm_):
             'event',
             'requesting instance',
             'salt/cloud/{0}/requesting'.format(vm_['name']),
-            args={'kwargs': vm_},
+            args={
+                'name': vm_['name'],
+                'profile': vm_['profile'],
+                'provider': vm_['driver'],
+            },
             sock_dir=__opts__['sock_dir'],
             transport=__opts__['transport']
         )


### PR DESCRIPTION
### What does this PR do?
When requesting a VM, a _lot_ of data is spewed into the event bus. We want almost none of it there.

### Tests written?
No