### PR TITLE
Remove `Users` from c:\salt [DO NOT MERGE FORWARD]

### DIFF
--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -215,7 +215,6 @@ def set_path_permissions(path):
     '''
     # TODO: Need to make this more generic, maybe a win_dacl utility
     admins = win32security.ConvertStringSidToSid('S-1-5-32-544')
-    user = win32security.ConvertStringSidToSid('S-1-5-32-545')
     system = win32security.ConvertStringSidToSid('S-1-5-18')
     owner = win32security.ConvertStringSidToSid('S-1-3-4')
 
@@ -225,14 +224,10 @@ def set_path_permissions(path):
     inheritance = win32security.CONTAINER_INHERIT_ACE |\
         win32security.OBJECT_INHERIT_ACE
     full_access = ntsecuritycon.GENERIC_ALL
-    user_access = ntsecuritycon.GENERIC_READ | \
-        ntsecuritycon.GENERIC_EXECUTE
 
     dacl.AddAccessAllowedAceEx(revision, inheritance, full_access, admins)
     dacl.AddAccessAllowedAceEx(revision, inheritance, full_access, system)
     dacl.AddAccessAllowedAceEx(revision, inheritance, full_access, owner)
-    if 'pki' not in path:
-        dacl.AddAccessAllowedAceEx(revision, inheritance, user_access, user)
 
     try:
         win32security.SetNamedSecurityInfo(


### PR DESCRIPTION
DO NOT MERGE FORWARD
Develop branch changes handled by https://github.com/saltstack/salt/pull/38820

### What does this PR do?
Removes access to C:\Salt for Users Group.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/38756
https://github.com/saltstack/zh/issues/1103

### Previous Behavior
Users had Read & Execute permissions to C:\Salt.

### New Behavior
Users Group is not given perms to C:\Salt

### Tests written?
No