### PR TITLE
Remove `Users` from c:\salt

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -567,9 +567,6 @@ def win_verify_env(dirs, permissive=False, pki_dir='', skip_extra=False):
                 # Owner
                 dacl.add_ace('S-1-3-4', 'grant', 'full_control',
                              'this_folder_subfolders_files')
-                # Users Group
-                dacl.add_ace('S-1-5-32-545', 'grant', 'read_execute',
-                             'this_folder_subfolders_files')
 
                 # Save the dacl to the object
                 dacl.save(path, True)


### PR DESCRIPTION
### What does this PR do?
Removes access to C:\Salt for Users Group.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/38756
https://github.com/saltstack/zh/issues/1103

### Previous Behavior
Users had Read & Execute permissions to C:\Salt.

### New Behavior
Users Group is not given perms to C:\Salt

### Tests written?
No