### PR TITLE
pass pillar to compound matcher in match module

### DIFF
--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -37,7 +37,7 @@ def compound(tgt, minion_id=None):
 
         salt '*' match.compound 'L@cheese,foo and *'
     '''
-    opts = {'grains': __grains__}
+    opts = {'grains': __grains__, 'pillar': __pillar__}
     if minion_id is not None:
         if not isinstance(minion_id, string_types):
             minion_id = str(minion_id)


### PR DESCRIPTION
### What does this PR do?
The pillar match passes the `__pillar__` dictionary to the `Matcher`, so we should be doing the same so it can be use for `I@` in the compound matcher.

### What issues does this PR fix or references
#38798 

### Tests written?

No
