### PR TITLE
Extend support for pillarenv_from_saltenv to master config

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -731,6 +731,11 @@
 # Recursively merge lists by aggregating them instead of replacing them.
 #pillar_merge_lists: False
 
+# Set this option to True to force the pillarenv to be the same as the effective
+# saltenv when running states. If pillarenv is specified this option will be
+# ignored.
+#pillarenv_from_saltenv: False
+
 # Set this option to 'True' to force a 'KeyError' to be raised whenever an
 # attempt to retrieve a named value from pillar fails. When this option is set
 # to 'False', the failed attempt returns an empty string. Default is 'False'.

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2530,6 +2530,27 @@ ext_pillar keys to override those from :conf_master:`pillar_roots`.
 
     ext_pillar_first: False
 
+.. conf_minion:: pillarenv_from_saltenv
+
+``pillarenv_from_saltenv``
+--------------------------
+
+Default: ``False``
+
+When set to ``True``, the :conf_master:`pillarenv` value will assume the value
+of the effective saltenv when running states. This essentially makes ``salt-run
+pillar.show_pillar saltenv=dev`` equivalent to ``salt-run pillar.show_pillar
+saltenv=dev pillarenv=dev``. If :conf_master:`pillarenv` is set on the CLI, it
+will override this option.
+
+.. code-block:: yaml
+
+    pillarenv_from_saltenv: True
+
+.. note::
+    For salt remote execution commands this option should be set in the Minion
+    configuration instead.
+
 .. conf_master:: pillar_raise_on_missing
 
 ``pillar_raise_on_missing``

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -270,6 +270,9 @@ class Pillar(object):
     def __init__(self, opts, grains, minion_id, saltenv, ext=None, functions=None,
                  pillar=None, pillarenv=None, rend=None):
         self.minion_id = minion_id
+        if pillarenv is None:
+            if opts.get('pillarenv_from_saltenv', False):
+                opts['pillarenv'] = saltenv
         # Store the file_roots path so we can restore later. Issue 5449
         self.actual_file_roots = opts['file_roots']
         # use the local file client

--- a/tests/unit/pillar_test.py
+++ b/tests/unit/pillar_test.py
@@ -25,6 +25,25 @@ import salt.pillar
 class PillarTestCase(TestCase):
 
     @patch('salt.pillar.compile_template')
+    def test_pillarenv_from_saltenv(self, compile_template):
+        opts = {
+            'renderer': 'json',
+            'renderer_blacklist': [],
+            'renderer_whitelist': [],
+            'state_top': '',
+            'pillar_roots': ['dev', 'base'],
+            'file_roots': ['dev', 'base'],
+            'extension_modules': '',
+            'pillarenv_from_saltenv': True
+        }
+        grains = {
+            'os': 'Ubuntu',
+        }
+        pillar = salt.pillar.Pillar(opts, grains, 'mocked-minion', 'dev')
+        self.assertEqual(pillar.opts['environment'], 'dev')
+        self.assertEqual(pillar.opts['pillarenv'], 'dev')
+
+    @patch('salt.pillar.compile_template')
     def test_malformed_pillar_sls(self, compile_template):
         opts = {
             'renderer': 'json',
@@ -135,7 +154,7 @@ class PillarTestCase(TestCase):
         self.assertEqual(pillar.compile_pillar()['ssh'], 'foo')
 
     def _setup_test_topfile_mocks(self, Matcher, get_file_client,
-            nodegroup_order, glob_order):
+                                  nodegroup_order, glob_order):
         # Write a simple topfile and two pillar state files
         self.top_file = tempfile.NamedTemporaryFile()
         s = '''


### PR DESCRIPTION
### What does this PR do?

`pillarenv_from_saltenv` is already an option for minion config, this change enables this feature on the master.

### What issues does this PR fix or reference?

While I don't think anyone has asked for this feature directly, on the master this feature has the side-effect of providing a work-around for modules that don't yet properly support `pillarenv`

#37695
#32435

### New Behavior

If set to `pillarenv_from_saltenv` is `true`, salt will derive the pillar environment set on the master:

    $ salt-run pillar.show_pillar saltenv=radman
    my_passphrase:
        XYZ
    
    $ salt-run pillar.show_pillar saltenv=radman2
    my_passphrase:
        ABC

### Tests written?

Yes
