### PR TITLE
Salt-SSH deal with raw IPv6 addresses

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -67,7 +67,8 @@ class Shell(object):
             remote_port_forwards=None,
             ssh_options=None):
         self.opts = opts
-        self.host = host
+        # ssh <ipv6>, but scp [<ipv6]:/path
+        self.host = host.strip('[]')
         self.user = user
         self.port = port
         self.passwd = str(passwd) if passwd else passwd
@@ -330,6 +331,10 @@ class Shell(object):
         '''
         if makedirs:
             self.exec_cmd('mkdir -p {0}'.format(os.path.dirname(remote)))
+
+        # scp needs [<ipv6}
+        if ':' in self.host:
+            self.host = '[{0}]'.format(self.host)
 
         cmd = '{0} {1}:{2}'.format(local, self.host, remote)
         cmd = self._cmd_str(cmd, ssh='scp')


### PR DESCRIPTION
### What does this PR do?
Salt-SSH can't deal with being fed raw IPv6 addresses because they need to be `[<ipv6>]` for `scp`, but `<ipv6>` for `ssh`.
See issues.

Fix lightly tested in my env.

By forceably stripping the '[]' off and reinserting both inputs become supported.
And since ':' and '[' and ']' aren't valid DNS chars otherwise, no other impact is expected.

### What issues does this PR fix or reference?
#30561
#22984
