### PR TITLE
Remove support for "enabled" in pkgrepo.managed state

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -276,4 +276,10 @@ The ``glusterfs`` state had the following function removed:
 
 The ``openvswitch_port`` state had the following change:
 
-  - The ``type`` option was removed from the ``present`` function. Please use ``tunnel_type`` instead.
+  - The ``type`` option was removed from the ``present`` function. Please use
+    ``tunnel_type`` instead.
+
+The ``pkgrepo`` state had the following change:
+
+  - The ``enabled`` option was removed from the ``managed`` function. Please
+    use ``disabled`` instead.

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -279,13 +279,6 @@ def managed(name, ppa=None, **kwargs):
                           'intended.')
         return ret
 
-    if 'enabled' in kwargs:
-        salt.utils.warn_until(
-            'Nitrogen',
-            'The `enabled` argument has been deprecated in favor of '
-            '`disabled`.'
-        )
-
     repo = name
     if __grains__['os'] in ('Ubuntu', 'Mint'):
         if ppa is not None:
@@ -299,23 +292,11 @@ def managed(name, ppa=None, **kwargs):
     elif __grains__['os_family'].lower() in ('redhat', 'suse'):
         if 'humanname' in kwargs:
             kwargs['name'] = kwargs.pop('humanname')
-        _val = lambda x: '1' if salt.utils.is_true(x) else '0'
-        if 'disabled' in kwargs:
-            if 'enabled' in kwargs:
-                ret['result'] = False
-                ret['comment'] = 'Only one of enabled/disabled is permitted'
-                return ret
-            _reverse = lambda x: '1' if x == '0' else '0'
-            kwargs['enabled'] = _reverse(_val(kwargs.pop('disabled')))
-        elif 'enabled' in kwargs:
-            kwargs['enabled'] = _val(kwargs['enabled'])
         if 'name' not in kwargs:
             # Fall back to the repo name if humanname not provided
             kwargs['name'] = repo
 
-    # Replace 'enabled' from kwargs with 'disabled'
-    enabled = kwargs.pop('enabled', True)
-    kwargs['disabled'] = not salt.utils.is_true(enabled)
+    kwargs['disabled'] = salt.utils.is_true(kwargs.pop('disabled', False))
 
     for kwarg in _STATE_INTERNAL_KEYWORDS:
         kwargs.pop(kwarg, None)


### PR DESCRIPTION
This was deprecated in favor if "disabled" in 2016.3. Please use "disabled" instead of "enabled".

Instead of using a more complicated system of getting the truth value of the disabled setting, reversing it to an "enabled" setting, and then popping the enabled setting (which defaults to `True`) and reversing it again, let's just set the default value of "disabled" to False if it is not provided.

Extra eyes on this would be good. I am not sure what the tests might do either in this case.

@terminalmage Would you mind taking a look at this so far? I also need to look at some code below that is referencing "enabled" that previously, afaict, would have been dead code since we were popping off "enabled" from kwargs. Now that the pop is gone, that code will no longer be dead and might have a change in behavior if people are still using enabled, even though warnings have been there for some time, rather than just ignoring the option.

Specifically, [this part](https://github.com/saltstack/salt/pull/38834/files#diff-e9e2acf29e86def27bc064e2317ae215R331) of the code below.