### PR TITLE
cloud: add security groups for node creation for cloudstack

### DIFF
--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -158,6 +158,14 @@ def get_location(conn, vm_):
             return location
 
 
+def get_security_groups(conn, vm_):
+    '''
+    Return a list of security groups to use, defaulting to ['default']
+    '''
+    return config.get_cloud_config_value('securitygroup', vm_, __opts__,
+                                         default=['default'])
+
+
 def get_password(vm_):
     '''
     Return the password to use
@@ -271,6 +279,7 @@ def create(vm_):
         'image': get_image(conn, vm_),
         'size': get_size(conn, vm_),
         'location': get_location(conn, vm_),
+        'ex_security_groups': get_security_groups(conn, vm_)
     }
 
     if get_keypair(vm_) is not False:


### PR DESCRIPTION
Signed-off-by: Marc-Aurèle Brothier <m@brothier.org>

### What does this PR do?
Add the possibility to create nodes with other security groups than the default one. One or more security groups can be listed by their name.

### Previous Behavior
Nodes were only created with the `default` security group.

### New Behavior
You can specify a list of security group names to assign to the node on creation. A sample configuration is like that:
```yaml
my_provider:
  driver: cloudstack
  host: api.exoscale.ch
  path: /compute
  apikey: ....
  secretkey: ...
  private_key: /etc/salt/pki/id_rsa.cloud
  keypair: cloud
  securitygroup:
    - salt-minion
    - default
```

This new configuration option allow user to fully implement their firewalling though security groups.

### Tests written?

No, but successfully tested on a cloudstack provider (exoscale.ch)
