### PR TITLE
Strip .p from cache file names

### DIFF
--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -126,13 +126,17 @@ def list_(bank, cachedir):
     if not os.path.isdir(base):
         return []
     try:
-        return os.listdir(base)
+        items = os.listdir(base)
     except OSError as exc:
         raise SaltCacheError(
             'There was an error accessing directory "{0}": {1}'.format(
                 base, exc
             )
         )
+    ret = []
+    for item in items:
+        ret.append(item.rstrip('.p'))
+    return ret
 
 
 getlist = list_

--- a/tests/unit/cache/localfs_test.py
+++ b/tests/unit/cache/localfs_test.py
@@ -241,7 +241,7 @@ class LocalFSTest(TestCase):
 
         # Now test the return of the list function
         with patch.dict(localfs.__opts__, {'cachedir': tmp_dir}):
-            self.assertEqual(localfs.list_(bank='bank', cachedir=tmp_dir), ['key.p'])
+            self.assertEqual(localfs.list_(bank='bank', cachedir=tmp_dir), ['key'])
 
     # 'contains' function tests: 1
 


### PR DESCRIPTION
### Previous Behavior
Running `cache.list()` using `localfs` would return a list of keys that ended with `.p` (because it was performing a directory lookup). This would not match an analogous entry from another cache provider.

### New Behavior
Strip `.p` from list items before returning them.

### Tests written?
No.

Ping @DmitryKuzmenko, please verify that I'm not breaking your minion data/mine caches.