### PR TITLE
Support docker-py 2.0 in dockerng

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -767,7 +767,11 @@ def _get_client(timeout=None):
             # it's not defined by user.
             client_kwargs['version'] = 'auto'
 
-        __context__['docker.client'] = docker.Client(**client_kwargs)
+        try:
+            __context__['docker.client'] = docker.Client(**client_kwargs)
+        except AttributeError:
+            # docker-py 2.0 renamed this client attribute
+            __context__['docker.client'] = docker.APIClient(**client_kwargs)
 
     # Set a new timeout if one was passed
     if timeout is not None and __context__['docker.client'].timeout != timeout:


### PR DESCRIPTION
docker-py 2.0 has renamed ``docker.Client()`` to ``docker.APIClient()``