### PR TITLE
Touch deploy.sh before use

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -786,6 +786,8 @@ def bootstrap(version='develop',
         try:
             client_opts['argv'] = ['file.makedirs', tmp_dir, 'mode=0700']
             salt.client.ssh.SSH(client_opts).run()
+            client_opts['argv'] = ['file.touch', deploy_command]
+            salt.client.ssh.SSH(client_opts).run()
             client_opts['argv'] = [
                 'http.query',
                 script,


### PR DESCRIPTION
http.query output will only write to an existing file, so touch it before using it. 

### What does this PR do?
Adds a file.touch before the http.query attempts to write to the file. 

### What issues does this PR fix or reference?
Adding hosts into /etc/salt/roster, then running 
```
salt-run manage.bootstrap hosts='*' script_args='-A <salt master ip>'
```
fails after the http.query with .../deploy.sh no such file. Touching the file before the http.query allows the contents to be updated, and the runner proceeds as expected.

### Previous Behavior
/tmp/uuid directory structure created. Then error is thrown about missing deploy.sh file.

### New Behavior
/tmp/uuid directory structure created, deploy.sh touched, the deploy.sh is then updated from the http.query and the runner continues. 

### Tests written?
No