### PR TITLE
make openvswitch state work with python3 

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -263,3 +263,7 @@ The ``git`` state had the following changes:
 The ``glusterfs`` state had the following function removed:
 
   - ``created``: Please use ``volume_present`` instead.
+
+The ``openvswitch_port`` state had the following change:
+
+  - The ``type`` option was removed from the ``present`` function. Please use ``tunnel_type`` instead.

--- a/salt/states/openvswitch_port.py
+++ b/salt/states/openvswitch_port.py
@@ -49,48 +49,51 @@ def present(name, bridge, type=None, id=None, remote=None, dst_port=None, intern
                                    }
                             }
 
-    comments['comment_vlan_invalid_id'] = 'VLANs id must be between 0 and 4095.'
-    comments['comment_vlan_invalid_name'] = 'Could not find network interface {0}.'.format(name)
-    comments['comment_vlan_port_exists'] = 'Port {0} with access to VLAN {1} already exists on bridge {2}.'.format(name, id, bridge)
-    comments['comment_vlan_created'] = 'Created port {0} with access to VLAN {1} on bridge {2}.'.format(name, id, bridge)
-    comments['comment_vlan_notcreated'] = 'Unable to create port {0} with access to VLAN {1} on ' \
-                              'bridge {2}.'.format(name, id, bridge)
-    comments['changes_vlan_created'] = {name: {'old': 'No port named {0} with access to VLAN {1} present on '
-                                          'bridge {2} present.'.format(name, id, bridge),
-                                   'new': 'Created port {1} with access to VLAN {2} on '
-                                          'bridge {0}.'.format(bridge, name, id),
-                                   }
-                            }
+    if type:
+        comments['comment_invalid_ip'] = 'Remote is not valid ip address.'
+        if type == "vlan":
+            comments['comment_vlan_invalid_id'] = 'VLANs id must be between 0 and 4095.'
+            comments['comment_vlan_invalid_name'] = 'Could not find network interface {0}.'.format(name)
+            comments['comment_vlan_port_exists'] = 'Port {0} with access to VLAN {1} already exists on bridge {2}.'.format(name, id, bridge)
+            comments['comment_vlan_created'] = 'Created port {0} with access to VLAN {1} on bridge {2}.'.format(name, id, bridge)
+            comments['comment_vlan_notcreated'] = 'Unable to create port {0} with access to VLAN {1} on ' \
+                                      'bridge {2}.'.format(name, id, bridge)
+            comments['changes_vlan_created'] = {name: {'old': 'No port named {0} with access to VLAN {1} present on '
+                                                  'bridge {2} present.'.format(name, id, bridge),
+                                           'new': 'Created port {1} with access to VLAN {2} on '
+                                                  'bridge {0}.'.format(bridge, name, id),
+                                           }
+                                    }
 
-    comments['comment_gre_invalid_id'] = 'Id of GRE tunnel must be an unsigned 32-bit integer.'
-    comments['comment_gre_interface_exists'] = 'GRE tunnel interface {0} with rempte ip {1} and key {2} ' \
-                                   'already exists on bridge {3}.'.format(name, remote, id, bridge)
-    comments['comment_gre_created'] = 'Created GRE tunnel interface {0} with remote ip {1}  and key {2} ' \
-                          'on bridge {3}.'.format(name, remote, id, bridge)
-    comments['comment_gre_notcreated'] = 'Unable to create GRE tunnel interface {0} with remote ip {1} and key {2} ' \
-                             'on bridge {3}.'.format(name, remote, id, bridge)
-    comments['changes_gre_created'] = {name: {'old': 'No GRE tunnel interface {0} with remote ip {1} and key {2} '
-                                         'on bridge {3} present.'.format(name, remote, id, bridge),
-                                   'new': 'Created GRE tunnel interface {0} with remote ip {1} and key {2} '
-                                          'on bridge {3}.'.format(name, remote, id, bridge),
-                                   }
-                            }
-
-    comments['comment_dstport'] = ' (dst_port' + str(dst_port) + ')' if 0 < dst_port <= 65535 else ''
-    comments['comment_vxlan_invalid_id'] = 'Id of VXLAN tunnel must be an unsigned 64-bit integer.'
-    comments['comment_vxlan_interface_exists'] = 'VXLAN tunnel interface {0} with rempte ip {1} and key {2} ' \
-                                   'already exists on bridge {3}{4}.'.format(name, remote, id, bridge, comments['comment_dstport'])
-    comments['comment_vxlan_created'] = 'Created VXLAN tunnel interface {0} with remote ip {1}  and key {2} ' \
-                          'on bridge {3}{4}.'.format(name, remote, id, bridge, comments['comment_dstport'])
-    comments['comment_vxlan_notcreated'] = 'Unable to create VXLAN tunnel interface {0} with remote ip {1} and key {2} ' \
-                             'on bridge {3}{4}.'.format(name, remote, id, bridge, comments['comment_dstport'])
-    comments['changes_vxlan_created'] = {name: {'old': 'No VXLAN tunnel interface {0} with remote ip {1} and key {2} '
-                                         'on bridge {3}{4} present.'.format(name, remote, id, bridge, comments['comment_dstport']),
-                                   'new': 'Created VXLAN tunnel interface {0} with remote ip {1} and key {2} '
-                                          'on bridge {3}{4}.'.format(name, remote, id, bridge, comments['comment_dstport']),
-                                   }
-                            }
-    comments['comment_invalid_ip'] = 'Remote is not valid ip address.'
+        elif type == "gre":
+            comments['comment_gre_invalid_id'] = 'Id of GRE tunnel must be an unsigned 32-bit integer.'
+            comments['comment_gre_interface_exists'] = 'GRE tunnel interface {0} with rempte ip {1} and key {2} ' \
+                                           'already exists on bridge {3}.'.format(name, remote, id, bridge)
+            comments['comment_gre_created'] = 'Created GRE tunnel interface {0} with remote ip {1}  and key {2} ' \
+                                  'on bridge {3}.'.format(name, remote, id, bridge)
+            comments['comment_gre_notcreated'] = 'Unable to create GRE tunnel interface {0} with remote ip {1} and key {2} ' \
+                                     'on bridge {3}.'.format(name, remote, id, bridge)
+            comments['changes_gre_created'] = {name: {'old': 'No GRE tunnel interface {0} with remote ip {1} and key {2} '
+                                                 'on bridge {3} present.'.format(name, remote, id, bridge),
+                                           'new': 'Created GRE tunnel interface {0} with remote ip {1} and key {2} '
+                                                  'on bridge {3}.'.format(name, remote, id, bridge),
+                                           }
+                                    }
+        elif type == "vxlan":
+            comments['comment_dstport'] = ' (dst_port' + str(dst_port) + ')' if 0 < dst_port <= 65535 else ''
+            comments['comment_vxlan_invalid_id'] = 'Id of VXLAN tunnel must be an unsigned 64-bit integer.'
+            comments['comment_vxlan_interface_exists'] = 'VXLAN tunnel interface {0} with rempte ip {1} and key {2} ' \
+                                           'already exists on bridge {3}{4}.'.format(name, remote, id, bridge, comments['comment_dstport'])
+            comments['comment_vxlan_created'] = 'Created VXLAN tunnel interface {0} with remote ip {1}  and key {2} ' \
+                                  'on bridge {3}{4}.'.format(name, remote, id, bridge, comments['comment_dstport'])
+            comments['comment_vxlan_notcreated'] = 'Unable to create VXLAN tunnel interface {0} with remote ip {1} and key {2} ' \
+                                     'on bridge {3}{4}.'.format(name, remote, id, bridge, comments['comment_dstport'])
+            comments['changes_vxlan_created'] = {name: {'old': 'No VXLAN tunnel interface {0} with remote ip {1} and key {2} '
+                                                 'on bridge {3}{4} present.'.format(name, remote, id, bridge, comments['comment_dstport']),
+                                           'new': 'Created VXLAN tunnel interface {0} with remote ip {1} and key {2} '
+                                                  'on bridge {3}{4}.'.format(name, remote, id, bridge, comments['comment_dstport']),
+                                           }
+                                    }
 
     # Check VLANs attributes
     def _check_vlan():

--- a/salt/states/openvswitch_port.py
+++ b/salt/states/openvswitch_port.py
@@ -37,57 +37,60 @@ def present(name, bridge, type=None, id=None, remote=None, dst_port=None, intern
         port_list = __salt__['openvswitch.port_list'](bridge)
 
     # Comment and change messages
-    comment_bridge_notexists = 'Bridge {0} does not exist.'.format(bridge)
-    comment_port_exists = 'Port {0} already exists.'.format(name)
-    comment_port_created = 'Port {0} created on bridge {1}.'.format(name, bridge)
-    comment_port_notcreated = 'Unable to create port {0} on bridge {1}.'.format(name, bridge)
-    changes_port_created = {name: {'old': 'No port named {0} present.'.format(name),
+    
+    comments = {}
+
+    comments['comment_bridge_notexists'] = 'Bridge {0} does not exist.'.format(bridge)
+    comments['comment_port_exists'] = 'Port {0} already exists.'.format(name)
+    comments['comment_port_created'] = 'Port {0} created on bridge {1}.'.format(name, bridge)
+    comments['comment_port_notcreated'] = 'Unable to create port {0} on bridge {1}.'.format(name, bridge)
+    comments['changes_port_created'] = {name: {'old': 'No port named {0} present.'.format(name),
                                    'new': 'Created port {1} on bridge {0}.'.format(bridge, name),
                                    }
                             }
 
-    comment_vlan_invalid_id = 'VLANs id must be between 0 and 4095.'
-    comment_vlan_invalid_name = 'Could not find network interface {0}.'.format(name)
-    comment_vlan_port_exists = 'Port {0} with access to VLAN {1} already exists on bridge {2}.'.format(name, id, bridge)
-    comment_vlan_created = 'Created port {0} with access to VLAN {1} on bridge {2}.'.format(name, id, bridge)
-    comment_vlan_notcreated = 'Unable to create port {0} with access to VLAN {1} on ' \
+    comments['comment_vlan_invalid_id'] = 'VLANs id must be between 0 and 4095.'
+    comments['comment_vlan_invalid_name'] = 'Could not find network interface {0}.'.format(name)
+    comments['comment_vlan_port_exists'] = 'Port {0} with access to VLAN {1} already exists on bridge {2}.'.format(name, id, bridge)
+    comments['comment_vlan_created'] = 'Created port {0} with access to VLAN {1} on bridge {2}.'.format(name, id, bridge)
+    comments['comment_vlan_notcreated'] = 'Unable to create port {0} with access to VLAN {1} on ' \
                               'bridge {2}.'.format(name, id, bridge)
-    changes_vlan_created = {name: {'old': 'No port named {0} with access to VLAN {1} present on '
+    comments['changes_vlan_created'] = {name: {'old': 'No port named {0} with access to VLAN {1} present on '
                                           'bridge {2} present.'.format(name, id, bridge),
                                    'new': 'Created port {1} with access to VLAN {2} on '
                                           'bridge {0}.'.format(bridge, name, id),
                                    }
                             }
 
-    comment_gre_invalid_id = 'Id of GRE tunnel must be an unsigned 32-bit integer.'
-    comment_gre_interface_exists = 'GRE tunnel interface {0} with rempte ip {1} and key {2} ' \
+    comments['comment_gre_invalid_id'] = 'Id of GRE tunnel must be an unsigned 32-bit integer.'
+    comments['comment_gre_interface_exists'] = 'GRE tunnel interface {0} with rempte ip {1} and key {2} ' \
                                    'already exists on bridge {3}.'.format(name, remote, id, bridge)
-    comment_gre_created = 'Created GRE tunnel interface {0} with remote ip {1}  and key {2} ' \
+    comments['comment_gre_created'] = 'Created GRE tunnel interface {0} with remote ip {1}  and key {2} ' \
                           'on bridge {3}.'.format(name, remote, id, bridge)
-    comment_gre_notcreated = 'Unable to create GRE tunnel interface {0} with remote ip {1} and key {2} ' \
+    comments['comment_gre_notcreated'] = 'Unable to create GRE tunnel interface {0} with remote ip {1} and key {2} ' \
                              'on bridge {3}.'.format(name, remote, id, bridge)
-    changes_gre_created = {name: {'old': 'No GRE tunnel interface {0} with remote ip {1} and key {2} '
+    comments['changes_gre_created'] = {name: {'old': 'No GRE tunnel interface {0} with remote ip {1} and key {2} '
                                          'on bridge {3} present.'.format(name, remote, id, bridge),
                                    'new': 'Created GRE tunnel interface {0} with remote ip {1} and key {2} '
                                           'on bridge {3}.'.format(name, remote, id, bridge),
                                    }
                             }
 
-    comment_dstport = ' (dst_port' + str(dst_port) + ')' if 0 < dst_port <= 65535 else ''
-    comment_vxlan_invalid_id = 'Id of VXLAN tunnel must be an unsigned 64-bit integer.'
-    comment_vxlan_interface_exists = 'VXLAN tunnel interface {0} with rempte ip {1} and key {2} ' \
-                                   'already exists on bridge {3}{4}.'.format(name, remote, id, bridge, comment_dstport)
-    comment_vxlan_created = 'Created VXLAN tunnel interface {0} with remote ip {1}  and key {2} ' \
-                          'on bridge {3}{4}.'.format(name, remote, id, bridge, comment_dstport)
-    comment_vxlan_notcreated = 'Unable to create VXLAN tunnel interface {0} with remote ip {1} and key {2} ' \
-                             'on bridge {3}{4}.'.format(name, remote, id, bridge, comment_dstport)
-    changes_vxlan_created = {name: {'old': 'No VXLAN tunnel interface {0} with remote ip {1} and key {2} '
-                                         'on bridge {3}{4} present.'.format(name, remote, id, bridge, comment_dstport),
+    comments['comment_dstport'] = ' (dst_port' + str(dst_port) + ')' if 0 < dst_port <= 65535 else ''
+    comments['comment_vxlan_invalid_id'] = 'Id of VXLAN tunnel must be an unsigned 64-bit integer.'
+    comments['comment_vxlan_interface_exists'] = 'VXLAN tunnel interface {0} with rempte ip {1} and key {2} ' \
+                                   'already exists on bridge {3}{4}.'.format(name, remote, id, bridge, comments['comment_dstport'])
+    comments['comment_vxlan_created'] = 'Created VXLAN tunnel interface {0} with remote ip {1}  and key {2} ' \
+                          'on bridge {3}{4}.'.format(name, remote, id, bridge, comments['comment_dstport'])
+    comments['comment_vxlan_notcreated'] = 'Unable to create VXLAN tunnel interface {0} with remote ip {1} and key {2} ' \
+                             'on bridge {3}{4}.'.format(name, remote, id, bridge, comments['comment_dstport'])
+    comments['changes_vxlan_created'] = {name: {'old': 'No VXLAN tunnel interface {0} with remote ip {1} and key {2} '
+                                         'on bridge {3}{4} present.'.format(name, remote, id, bridge, comments['comment_dstport']),
                                    'new': 'Created VXLAN tunnel interface {0} with remote ip {1} and key {2} '
-                                          'on bridge {3}{4}.'.format(name, remote, id, bridge, comment_dstport),
+                                          'on bridge {3}{4}.'.format(name, remote, id, bridge, comments['comment_dstport']),
                                    }
                             }
-    comment_invalid_ip = 'Remote is not valid ip address.'
+    comments['comment_invalid_ip'] = 'Remote is not valid ip address.'
 
     # Check VLANs attributes
     def _check_vlan():
@@ -95,15 +98,15 @@ def present(name, bridge, type=None, id=None, remote=None, dst_port=None, intern
         interfaces = __salt__['network.interfaces']()
         if not 0 <= id <= 4095:
             ret['result'] = False
-            ret['comment'] = comment_vlan_invalid_id
+            ret['comment'] = comments['comment_vlan_invalid_id']
         elif not internal and name not in interfaces:
             ret['result'] = False
-            ret['comment'] = comment_vlan_invalid_name
+            ret['comment'] = comments['comment_vlan_invalid_name']
         elif tag and name in port_list:
             try:
                 if int(tag[0]) == id:
                     ret['result'] = True
-                    ret['comment'] = comment_vlan_port_exists
+                    ret['comment'] = comments['comment_vlan_port_exists']
             except (ValueError, KeyError):
                 pass
 
@@ -113,16 +116,16 @@ def present(name, bridge, type=None, id=None, remote=None, dst_port=None, intern
         interface_type = __salt__['openvswitch.interface_get_type'](name)
         if not 0 <= id <= 2**32:
             ret['result'] = False
-            ret['comment'] = comment_gre_invalid_id
+            ret['comment'] = comments['comment_gre_invalid_id']
         elif not __salt__['dig.check_ip'](remote):
             ret['result'] = False
-            ret['comment'] = comment_invalid_ip
+            ret['comment'] = comments['comment_invalid_ip']
         elif interface_options and interface_type and name in port_list:
             interface_attroptions = '{key=\"' + str(id) + '\", remote_ip=\"' + str(remote) + '\"}'
             try:
                 if interface_type[0] == 'gre' and interface_options[0] == interface_attroptions:
                     ret['result'] = True
-                    ret['comment'] = comment_gre_interface_exists
+                    ret['comment'] = comments['comment_gre_interface_exists']
             except KeyError:
                 pass
 
@@ -132,17 +135,17 @@ def present(name, bridge, type=None, id=None, remote=None, dst_port=None, intern
         interface_type = __salt__['openvswitch.interface_get_type'](name)
         if not 0 <= id <= 2**64:
             ret['result'] = False
-            ret['comment'] = comment_vxlan_invalid_id
+            ret['comment'] = comments['comment_vxlan_invalid_id']
         elif not __salt__['dig.check_ip'](remote):
             ret['result'] = False
-            ret['comment'] = comment_invalid_ip
+            ret['comment'] = comments['comment_invalid_ip']
         elif interface_options and interface_type and name in port_list:
             opt_port = 'dst_port=\"' + str(dst_port) + '\", ' if 0 < dst_port <= 65535 else ''
             interface_attroptions = '{{{0}key=\"'.format(opt_port) + str(id) + '\", remote_ip=\"' + str(remote) + '\"}'
             try:
                 if interface_type[0] == 'vxlan' and interface_options[0] == interface_attroptions:
                     ret['result'] = True
-                    ret['comment'] = comment_vxlan_interface_exists
+                    ret['comment'] = comments['comment_vxlan_interface_exists']
             except KeyError:
                 pass
 
@@ -153,27 +156,27 @@ def present(name, bridge, type=None, id=None, remote=None, dst_port=None, intern
                 _check_vlan()
                 if not ret['comment']:
                     ret['result'] = None
-                    ret['comment'] = comment_vlan_created
+                    ret['comment'] = comments['comment_vlan_created']
             elif type == 'vxlan':
                 _check_vxlan()
                 if not ret['comment']:
                     ret['result'] = None
-                    ret['comment'] = comment_vxlan_created
+                    ret['comment'] = comments['comment_vxlan_created']
             elif type == 'gre':
                 _check_gre()
                 if not ret['comment']:
                     ret['result'] = None
-                    ret['comment'] = comment_gre_created
+                    ret['comment'] = comments['comment_gre_created']
             else:
                 if name in port_list:
                     ret['result'] = True
-                    ret['comment'] = comment_port_exists
+                    ret['comment'] = comments['comment_port_exists']
                 else:
                     ret['result'] = None
-                    ret['comment'] = comment_port_created
+                    ret['comment'] = comments['comment_port_created']
         else:
             ret['result'] = None
-            ret['comment'] = comment_bridge_notexists
+            ret['comment'] = comments['comment_bridge_notexists']
 
         return ret
 
@@ -184,49 +187,49 @@ def present(name, bridge, type=None, id=None, remote=None, dst_port=None, intern
                 port_create_vlan = __salt__['openvswitch.port_create_vlan'](bridge, name, id, internal)
                 if port_create_vlan:
                     ret['result'] = True
-                    ret['comment'] = comment_vlan_created
-                    ret['changes'] = changes_vlan_created
+                    ret['comment'] = comments['comment_vlan_created']
+                    ret['changes'] = comments['changes_vlan_created']
                 else:
                     ret['result'] = False
-                    ret['comment'] = comment_vlan_notcreated
+                    ret['comment'] = comments['comment_vlan_notcreated']
         elif type == 'vxlan':
             _check_vxlan()
             if not ret['comment']:
                 port_create_vxlan = __salt__['openvswitch.port_create_vxlan'](bridge, name, id, remote, dst_port)
                 if port_create_vxlan:
                     ret['result'] = True
-                    ret['comment'] = comment_vxlan_created
-                    ret['changes'] = changes_vxlan_created
+                    ret['comment'] = comments['comment_vxlan_created']
+                    ret['changes'] = comments['changes_vxlan_created']
                 else:
                     ret['result'] = False
-                    ret['comment'] = comment_vxlan_notcreated
+                    ret['comment'] = comments['comment_vxlan_notcreated']
         elif type == 'gre':
             _check_gre()
             if not ret['comment']:
                 port_create_gre = __salt__['openvswitch.port_create_gre'](bridge, name, id, remote)
                 if port_create_gre:
                     ret['result'] = True
-                    ret['comment'] = comment_gre_created
-                    ret['changes'] = changes_gre_created
+                    ret['comment'] = comments['comment_gre_created']
+                    ret['changes'] = comments['changes_gre_created']
                 else:
                     ret['result'] = False
-                    ret['comment'] = comment_gre_notcreated
+                    ret['comment'] = comments['comment_gre_notcreated']
         else:
             if name in port_list:
                 ret['result'] = True
-                ret['comment'] = comment_port_exists
+                ret['comment'] = comments['comment_port_exists']
             else:
                 port_add = __salt__['openvswitch.port_add'](bridge, name)
                 if port_add:
                     ret['result'] = True
-                    ret['comment'] = comment_port_created
-                    ret['changes'] = changes_port_created
+                    ret['comment'] = comments['comment_port_created']
+                    ret['changes'] = comments['changes_port_created']
                 else:
                     ret['result'] = False
-                    ret['comment'] = comment_port_notcreated
+                    ret['comment'] = comments['comment_port_notcreated']
     else:
         ret['result'] = False
-        ret['comment'] = comment_bridge_notexists
+        ret['comment'] = comments['comment_bridge_notexists']
 
     return ret
 
@@ -253,11 +256,11 @@ def absent(name, bridge=None):
         port_list = [name]
 
     # Comment and change messages
-    comment_bridge_notexists = 'Bridge {0} does not exist.'.format(bridge)
-    comment_port_notexists = 'Port {0} does not exist on bridge {1}.'.format(name, bridge)
-    comment_port_deleted = 'Port {0} deleted.'.format(name)
-    comment_port_notdeleted = 'Unable to delete port {0}.'.format(name)
-    changes_port_deleted = {name: {'old': 'Port named {0} may exist.'.format(name),
+    comments['comment_bridge_notexists'] = 'Bridge {0} does not exist.'.format(bridge)
+    comments['comment_port_notexists'] = 'Port {0} does not exist on bridge {1}.'.format(name, bridge)
+    comments['comment_port_deleted'] = 'Port {0} deleted.'.format(name)
+    comments['comment_port_notdeleted'] = 'Unable to delete port {0}.'.format(name)
+    comments['changes_port_deleted'] = {name: {'old': 'Port named {0} may exist.'.format(name),
                                    'new': 'Deleted port {0}.'.format(name),
                                    }
                             }
@@ -266,21 +269,21 @@ def absent(name, bridge=None):
     if __opts__['test']:
         if bridge and not bridge_exists:
             ret['result'] = None
-            ret['comment'] = comment_bridge_notexists
+            ret['comment'] = comments['comment_bridge_notexists']
         elif name not in port_list:
             ret['result'] = True
-            ret['comment'] = comment_port_notexists
+            ret['comment'] = comments['comment_port_notexists']
         else:
             ret['result'] = None
-            ret['comment'] = comment_port_deleted
+            ret['comment'] = comments['comment_port_deleted']
         return ret
 
     if bridge and not bridge_exists:
         ret['result'] = False
-        ret['comment'] = comment_bridge_notexists
+        ret['comment'] = comments['comment_bridge_notexists']
     elif name not in port_list:
         ret['result'] = True
-        ret['comment'] = comment_port_notexists
+        ret['comment'] = comments['comment_port_notexists']
     else:
         if bridge:
             port_remove = __salt__['openvswitch.port_remove'](br=bridge, port=name)
@@ -289,10 +292,10 @@ def absent(name, bridge=None):
 
         if port_remove:
             ret['result'] = True
-            ret['comment'] = comment_port_deleted
-            ret['changes'] = changes_port_deleted
+            ret['comment'] = comments['comment_port_deleted']
+            ret['changes'] = comments['changes_port_deleted']
         else:
             ret['result'] = False
-            ret['comment'] = comment_port_notdeleted
+            ret['comment'] = comments['comment_port_notdeleted']
 
     return ret

--- a/salt/states/openvswitch_port.py
+++ b/salt/states/openvswitch_port.py
@@ -259,6 +259,7 @@ def absent(name, bridge=None):
         port_list = [name]
 
     # Comment and change messages
+    comments = {}
     comments['comment_bridge_notexists'] = 'Bridge {0} does not exist.'.format(bridge)
     comments['comment_port_notexists'] = 'Port {0} does not exist on bridge {1}.'.format(name, bridge)
     comments['comment_port_deleted'] = 'Port {0} deleted.'.format(name)

--- a/salt/states/openvswitch_port.py
+++ b/salt/states/openvswitch_port.py
@@ -248,7 +248,7 @@ def absent(name, bridge=None):
 
     '''
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
-
+    bridge_exists = False
     if bridge:
         bridge_exists = __salt__['openvswitch.bridge_exists'](bridge)
         if bridge_exists:

--- a/salt/states/openvswitch_port.py
+++ b/salt/states/openvswitch_port.py
@@ -32,7 +32,7 @@ def present(name, bridge, tunnel_type=None, id=None, remote=None, dst_port=None,
         raise TypeError('The optional type argument must be one of these values: {0}.'.format(str(tunnel_types)))
 
     bridge_exists = __salt__['openvswitch.bridge_exists'](bridge)
-
+    port_list = []
     if bridge_exists:
         port_list = __salt__['openvswitch.port_list'](bridge)
 

--- a/salt/states/openvswitch_port.py
+++ b/salt/states/openvswitch_port.py
@@ -37,7 +37,7 @@ def present(name, bridge, type=None, id=None, remote=None, dst_port=None, intern
         port_list = __salt__['openvswitch.port_list'](bridge)
 
     # Comment and change messages
-    
+
     comments = {}
 
     comments['comment_bridge_notexists'] = 'Bridge {0} does not exist.'.format(bridge)

--- a/tests/unit/states/openvswitch_port_test.py
+++ b/tests/unit/states/openvswitch_port_test.py
@@ -64,6 +64,23 @@ class OpenvswitchPortTestCase(TestCase):
                 }
             })
             self.assertDictEqual(openvswitch_port.present(name, bridge), ret)
+        with patch.dict(openvswitch_port.__salt__, {'openvswitch.bridge_exists': mock,
+                                                    'openvswitch.port_list': mock_n,
+                                                    'openvswitch.port_add': mock,
+                                                    'openvswitch.interface_get_options': mock_n,
+                                                    'openvswitch.interface_get_type': MagicMock(return_value=''),
+                                                    'openvswitch.port_create_gre': mock,
+                                                    }):
+            comt = 'Port salt created on bridge br-salt.'
+            self.maxDiff = None
+            ret.update({'result': True, 'comment': 'Created GRE tunnel interface salt with remote ip 10.0.0.1  and key 1 on bridge br-salt.', 'changes': 
+                { 'salt': 
+                    {'new': 'Created GRE tunnel interface salt with remote ip 10.0.0.1 and key 1 on bridge br-salt.',
+                      'old': 'No GRE tunnel interface salt with remote ip 10.0.0.1 and key 1 on bridge br-salt present.',
+                    },
+                }
+            })
+            self.assertDictEqual(openvswitch_port.present(name, bridge, type="gre", id=1, remote="10.0.0.1"), ret)
 
 
 if __name__ == '__main__':

--- a/tests/unit/states/openvswitch_port_test.py
+++ b/tests/unit/states/openvswitch_port_test.py
@@ -71,6 +71,7 @@ class OpenvswitchPortTestCase(TestCase):
                                                     'openvswitch.interface_get_options': mock_n,
                                                     'openvswitch.interface_get_type': MagicMock(return_value=''),
                                                     'openvswitch.port_create_gre': mock,
+                                                    'dig.check_ip': mock,
                                                     }):
             comt = 'Port salt created on bridge br-salt.'
             self.maxDiff = None

--- a/tests/unit/states/openvswitch_port_test.py
+++ b/tests/unit/states/openvswitch_port_test.py
@@ -26,6 +26,7 @@ class OpenvswitchPortTestCase(TestCase):
     '''
     Test cases for salt.states.openvswitch_port
     '''
+
     # 'present' function tests: 1
 
     def test_present(self):
@@ -56,13 +57,13 @@ class OpenvswitchPortTestCase(TestCase):
                                                     'openvswitch.port_add': mock
                                                     }):
             comt = 'Port salt created on bridge br-salt.'
-            ret.update({'comment': comt, 'result': True, 'changes': 
-                { 'salt': 
-                    {'new': 'Created port salt on bridge br-salt.',
+            ret.update({'comment': comt, 'result': True, 'changes':
+                {'salt':
+                     {'new': 'Created port salt on bridge br-salt.',
                       'old': 'No port named salt present.',
-                    },
-                }
-            })
+                      },
+                 }
+                        })
             self.assertDictEqual(openvswitch_port.present(name, bridge), ret)
         with patch.dict(openvswitch_port.__salt__, {'openvswitch.bridge_exists': mock,
                                                     'openvswitch.port_list': mock_n,
@@ -73,16 +74,20 @@ class OpenvswitchPortTestCase(TestCase):
                                                     }):
             comt = 'Port salt created on bridge br-salt.'
             self.maxDiff = None
-            ret.update({'result': True, 'comment': 'Created GRE tunnel interface salt with remote ip 10.0.0.1  and key 1 on bridge br-salt.', 'changes': 
-                { 'salt': 
-                    {'new': 'Created GRE tunnel interface salt with remote ip 10.0.0.1 and key 1 on bridge br-salt.',
-                      'old': 'No GRE tunnel interface salt with remote ip 10.0.0.1 and key 1 on bridge br-salt present.',
-                    },
-                }
-            })
+            ret.update({'result': True,
+                        'comment': 'Created GRE tunnel interface salt with remote ip 10.0.0.1  and key 1 on bridge br-salt.',
+                        'changes':
+                            {'salt':
+                                {
+                                    'new': 'Created GRE tunnel interface salt with remote ip 10.0.0.1 and key 1 on bridge br-salt.',
+                                    'old': 'No GRE tunnel interface salt with remote ip 10.0.0.1 and key 1 on bridge br-salt present.',
+                                },
+                            }
+                        })
             self.assertDictEqual(openvswitch_port.present(name, bridge, type="gre", id=1, remote="10.0.0.1"), ret)
 
 
 if __name__ == '__main__':
     from integration import run_tests
+
     run_tests(OpenvswitchPortTestCase, needs_daemon=False)

--- a/tests/unit/states/openvswitch_port_test.py
+++ b/tests/unit/states/openvswitch_port_test.py
@@ -85,7 +85,7 @@ class OpenvswitchPortTestCase(TestCase):
                                 },
                             }
                         })
-            self.assertDictEqual(openvswitch_port.present(name, bridge, type="gre", id=1, remote="10.0.0.1"), ret)
+            self.assertDictEqual(openvswitch_port.present(name, bridge, tunnel_type="gre", id=1, remote="10.0.0.1"), ret)
 
 
 if __name__ == '__main__':

--- a/tests/unit/states/openvswitch_port_test.py
+++ b/tests/unit/states/openvswitch_port_test.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import skipIf, TestCase
+from salttesting.mock import (
+    MagicMock,
+    NO_MOCK,
+    NO_MOCK_REASON,
+    patch)
+
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.states import openvswitch_port
+
+openvswitch_port.__salt__ = {}
+openvswitch_port.__opts__ = {'test': False}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class OpenvswitchPortTestCase(TestCase):
+    '''
+    Test cases for salt.states.openvswitch_port
+    '''
+    # 'present' function tests: 1
+
+    def test_present(self):
+        '''
+        Test to verify that the named port exists on bridge, eventually creates it.
+        '''
+        name = 'salt'
+        bridge = 'br-salt'
+
+        ret = {'name': name,
+               'result': None,
+               'comment': '',
+               'changes': {}}
+
+        mock = MagicMock(return_value=True)
+        mock_l = MagicMock(return_value=['salt'])
+        mock_n = MagicMock(return_value=[])
+
+        with patch.dict(openvswitch_port.__salt__, {'openvswitch.bridge_exists': mock,
+                                                    'openvswitch.port_list': mock_l
+                                                    }):
+            comt = 'Port salt already exists.'
+            ret.update({'comment': comt, 'result': True})
+            self.assertDictEqual(openvswitch_port.present(name, bridge), ret)
+
+        with patch.dict(openvswitch_port.__salt__, {'openvswitch.bridge_exists': mock,
+                                                    'openvswitch.port_list': mock_n,
+                                                    'openvswitch.port_add': mock
+                                                    }):
+            comt = 'Port salt created on bridge br-salt.'
+            ret.update({'comment': comt, 'result': True, 'changes': 
+                { 'salt': 
+                    {'new': 'Created port salt on bridge br-salt.',
+                      'old': 'No port named salt present.',
+                    },
+                }
+            })
+            self.assertDictEqual(openvswitch_port.present(name, bridge), ret)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(OpenvswitchPortTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

openvswitch state was failing when running under python3, because it was comparing an optional argument with a number, and this argument was None when not provided.

This PR encloses the comparison in a condition.

### What issues does this PR fix or reference?

#38869 

### Previous Behavior

Openvswitch state fails when creating a GRE tunnel with python3

### New Behavior

Openvswitch state works when creating a GRE tunnel with python3
### Tests written?

Yes (but very basic test cases, i'm not very comfortable with pyunit)

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
