### PR TITLE
`mine.update` only on certain functions

### DIFF
--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -80,7 +80,7 @@ def _mine_get(load, opts):
     return ret
 
 
-def update(clear=False):
+def update(clear=False, mine_functions=None):
     '''
     Execute the configured functions and send the data back up to the master.
     The functions to be executed are merged from the master config, pillar and
@@ -102,9 +102,17 @@ def update(clear=False):
 
         salt '*' mine.update
     '''
-    m_data = __salt__['config.merge']('mine_functions', {})
-    # If we don't have any mine functions configured, then we should just bail out
-    if not m_data:
+    m_data = {}
+    if not mine_functions:
+        m_data = __salt__['config.merge']('mine_functions', {})
+        # If we don't have any mine functions configured, then we should just bail out
+        if not m_data:
+            return
+    elif mine_functions and isinstance(mine_functions, list):
+        m_data = dict((fun, {}) for fun in mine_functions)
+    elif mine_functions and isinstance(mine_functions, dict):
+        m_data = mine_functions
+    else:
         return
 
     data = {}

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -93,6 +93,34 @@ def update(clear=False, mine_functions=None):
             - eth0
           disk.usage: []
 
+    This function accepts the following arguments:
+
+    clear: False
+        Boolean flag specifying whether updating will clear the existing
+        mines, or will update. Default: `False` (update).
+
+    mine_functions
+        Update the mine data on certain functions only.
+        This feature can be used when updating the mine for functions
+        that require refresh at different intervals than the rest of
+        the functions specified under `mine_functions` in the
+        minion/master config or pillar.
+        A potential use would be together with the `scheduler`, for example:
+
+        .. code-block:: yaml
+
+            schedule:
+              lldp_mine_update:
+                function: mine.update
+                kwargs:
+                    mine_functions:
+                      net.lldp: []
+                hours: 12
+
+        In the example above, the mine for `net.lldp` would be refreshed
+        every 12 hours, while  `network.ip_addrs` would continue to be updated
+        as specified in `mine_interval`.
+
     The function cache will be populated with information from executing these
     functions
 


### PR DESCRIPTION
### What does this PR do?

Without changing the existing behaviour, I'm proposing these changes in order to allow mine updates at different intervals for certain function(s).
As `mine.update` is scheduled for the minions to update their mines, by default it is going to update all the mines at the same interval.
But there are some particular cases when some mines don't need to be refreshed very often.

### Previous Behavior

The user is able to schedule mines using `mine_interval`, e.g.:

```yaml
mine_functions:
  net.lldp: []
  net.interfaces: []
  net.arp: []

mine_interval: 5
```

And all `net.lldp`, `net.interfaces` and `net.arp` would be refreshed every 5 minutes.

### New Behavior

Mine update per fun, if wanted:

```yaml
schedule:
  lldp_mine_update:
    function: mine.update
    kwargs:
        mine_functions:
          net.lldp: []
    hours: 12
```

and

```yaml
mine_functions:
  net.interfaces: []
  net.arp: []

mine_interval: 5
```

Which will refresh `net.interfaces` and `net.arp` every 5 minutes, whilst `net.lldp` is refreshed every 12 hours.

The schedule above does not look very sexy, but I found this "hack" as a potential solution.
So I'm waiting for feedback. Thanks!

### Tests written?

Not yet, but shall write some + doc.