### PR TITLE
Reactor: fix traceback when salt:// path is nonexistant

### DIFF
--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -419,6 +419,9 @@ def cache_file(path, saltenv='base', env=None):
         salt '*' cp.cache_file salt://foo/bar.conf saltenv=config
         salt '*' cp.cache_file salt://foo/bar.conf?saltenv=config
 
+    If the path being cached is a ``salt://`` URI, and the path does not exist,
+    then ``False`` will be returned.
+
     .. note::
         It may be necessary to quote the URL when using the querystring method,
         depending on the shell being used to run the command.

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -58,7 +58,7 @@ class Reactor(salt.utils.process.SignalHandlingMultiprocessingProcess, salt.stat
         react = {}
 
         if glob_ref.startswith('salt://'):
-            glob_ref = self.minion.functions['cp.cache_file'](glob_ref)
+            glob_ref = self.minion.functions['cp.cache_file'](glob_ref) or ''
         globbed_ref = glob.glob(glob_ref)
         if not globbed_ref:
             log.error('Can not render SLS {0} for tag {1}. File missing or not found.'.format(glob_ref, tag))


### PR DESCRIPTION
The get_file() function is what is run when a minion requests a file
using cp.cache_file. The expected return data from cp.cache_file is a
string, not a bool. This is likely the root cause of #36121.