### PR TITLE
Salt-SSH client: Don't overwrite self.host w/IPv6 brackets

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -333,10 +333,11 @@ class Shell(object):
             self.exec_cmd('mkdir -p {0}'.format(os.path.dirname(remote)))
 
         # scp needs [<ipv6}
-        if ':' in self.host:
-            self.host = '[{0}]'.format(self.host)
+        host = self.host
+        if ':' in host:
+            host = '[{0}]'.format(host)
 
-        cmd = '{0} {1}:{2}'.format(local, self.host, remote)
+        cmd = '{0} {1}:{2}'.format(local, host, remote)
         cmd = self._cmd_str(cmd, ssh='scp')
 
         logmsg = 'Executing command: {0}'.format(cmd)


### PR DESCRIPTION
Addendum to #38831 : Keep the brackets out of self.host to prevent them from being added multiple times