### PR TITLE
Don't require text_out path to exist

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -529,7 +529,7 @@ def query(url,
         log.trace(('Cannot Trace Log Response Text: {0}. This may be due to '
                   'incompatibilities between requests and logging.').format(exc))
 
-    if text_out is not None and os.path.exists(text_out):
+    if text_out is not None:
         with salt.utils.fopen(text_out, 'w') as tof:
             tof.write(result_text)
 


### PR DESCRIPTION
### What issues does this PR fix or reference?
#38867 and #32026.

### Previous Behavior
Writing a (non-decoded) file would require the entire path to exist.

### New Behavior
Not that.

### Tests written?
No.