### PR TITLE
Increasing timeouts for running integrations tests

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -801,7 +801,7 @@ class TestDaemon(object):
             )
             sys.stdout.flush()
             process.start()
-            process.wait_until_running(timeout=15)
+            process.wait_until_running(timeout=60)
             sys.stdout.write(
                 '\r{0}\r'.format(
                     ' ' * getattr(self.parser.options, 'output_columns', PNUM)
@@ -1863,14 +1863,14 @@ class ShellCase(AdaptedConfigurationTestCaseMixIn, ShellTestCase, ScriptPathMixi
         except OSError:
             os.chdir(INTEGRATION_TEST_DIR)
 
-    def run_salt(self, arg_str, with_retcode=False, catch_stderr=False, timeout=30):  # pylint: disable=W0221
+    def run_salt(self, arg_str, with_retcode=False, catch_stderr=False, timeout=60):  # pylint: disable=W0221
         '''
         Execute salt
         '''
         arg_str = '-c {0} {1}'.format(self.get_config_dir(), arg_str)
         return self.run_script('salt', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr, timeout=timeout)
 
-    def run_ssh(self, arg_str, with_retcode=False, catch_stderr=False, timeout=25):  # pylint: disable=W0221
+    def run_ssh(self, arg_str, with_retcode=False, catch_stderr=False, timeout=60):  # pylint: disable=W0221
         '''
         Execute salt-ssh
         '''
@@ -1885,7 +1885,7 @@ class ShellCase(AdaptedConfigurationTestCaseMixIn, ShellTestCase, ScriptPathMixi
                                                   arg_str,
                                                   timeout=timeout,
                                                   async_flag=' --async' if async else '')
-        return self.run_script('salt-run', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr, timeout=30)
+        return self.run_script('salt-run', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr, timeout=60)
 
     def run_run_plus(self, fun, *arg, **kwargs):
         '''
@@ -1932,7 +1932,7 @@ class ShellCase(AdaptedConfigurationTestCaseMixIn, ShellTestCase, ScriptPathMixi
             arg_str,
             catch_stderr=catch_stderr,
             with_retcode=with_retcode,
-            timeout=30
+            timeout=60
         )
 
     def run_cp(self, arg_str, with_retcode=False, catch_stderr=False):
@@ -1940,16 +1940,16 @@ class ShellCase(AdaptedConfigurationTestCaseMixIn, ShellTestCase, ScriptPathMixi
         Execute salt-cp
         '''
         arg_str = '--config-dir {0} {1}'.format(self.get_config_dir(), arg_str)
-        return self.run_script('salt-cp', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr, timeout=30)
+        return self.run_script('salt-cp', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr, timeout=60)
 
     def run_call(self, arg_str, with_retcode=False, catch_stderr=False):
         '''
         Execute salt-call.
         '''
         arg_str = '--config-dir {0} {1}'.format(self.get_config_dir(), arg_str)
-        return self.run_script('salt-call', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr, timeout=30)
+        return self.run_script('salt-call', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr, timeout=60)
 
-    def run_cloud(self, arg_str, catch_stderr=False, timeout=15):
+    def run_cloud(self, arg_str, catch_stderr=False, timeout=30):
         '''
         Execute salt-cloud
         '''

--- a/tests/integration/runners/state.py
+++ b/tests/integration/runners/state.py
@@ -109,7 +109,7 @@ class OrchEventTest(integration.ShellCase):
     Tests for orchestration events
     '''
     def setUp(self):
-        self.timeout = 15
+        self.timeout = 60
         self.master_d_dir = os.path.join(self.get_config_dir(), 'master.d')
         try:
             os.makedirs(self.master_d_dir)

--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -272,7 +272,7 @@ class CallTest(integration.ShellCase, testprogram.TestProgramCase, integration.S
                 '--config-dir {0} --local cmd.run "echo foo"'.format(
                     config_dir
                 ),
-                timeout=15
+                timeout=60
             )
             try:
                 self.assertIn('local:', ret)
@@ -295,7 +295,7 @@ class CallTest(integration.ShellCase, testprogram.TestProgramCase, integration.S
                 '--config-dir {0} cmd.run "echo foo"'.format(
                     config_dir
                 ),
-                timeout=15
+                timeout=60
             )
             self.assertIn('local:', ret)
         finally:
@@ -325,7 +325,7 @@ class CallTest(integration.ShellCase, testprogram.TestProgramCase, integration.S
             '--config-dir {0} cmd.run "echo foo"'.format(
                 config_dir
             ),
-            timeout=15,
+            timeout=60,
             catch_stderr=True,
             with_retcode=True
         )

--- a/tests/integration/shell/key.py
+++ b/tests/integration/shell/key.py
@@ -265,7 +265,7 @@ class KeyTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
             '--config-dir {0} -L'.format(
                 config_dir
             ),
-            timeout=15
+            timeout=60
         )
         try:
             self.assertIn('minion', '\n'.join(ret))

--- a/tests/integration/shell/matcher.py
+++ b/tests/integration/shell/matcher.py
@@ -353,7 +353,7 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
             '--config-dir {0} minion test.ping'.format(
                 config_dir
             ),
-            timeout=15,
+            timeout=60,
             catch_stderr=True,
             with_retcode=True
         )

--- a/tests/integration/shell/runner.py
+++ b/tests/integration/shell/runner.py
@@ -109,7 +109,7 @@ class RunTest(integration.ShellCase, testprogram.TestProgramCase, integration.Sh
             '--config-dir {0} -d'.format(
                 config_dir
             ),
-            timeout=15,
+            timeout=60,
             catch_stderr=True,
             with_retcode=True
         )


### PR DESCRIPTION
### What does this PR do?
This PR increases the `timeout` value for running integrations tests to prevent from killing processes if the running integration test takes more more than 15 or 30 seconds. In some cases, when the test system has certain load, some tests exceed the current `timeout` value and then fail even if they're actually passing.

This causes random failures for certain tests that are actually passing.

This PR set the common timeouts values to 60 seconds. Are you OK with this changes?