### PR TITLE
Backport #38887 to 2016.11: Call correct function for resetting a VM

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2076,7 +2076,7 @@ def reset(name, call=None):
                 return ret
             try:
                 log.info('Resetting VM {0}'.format(name))
-                task = vm["object"].Reset()
+                task = vm["object"].ResetVM_Task()
                 salt.utils.vmware.wait_for_task(task, name, 'reset')
             except Exception as exc:
                 log.error(


### PR DESCRIPTION
### What does this PR do?

Corrects the call to VMware to perform a reset of a VM (like pushing the reset button on a physical computer). The call needed to be updated from vm.Reset() to vm.ResetVM_Task.

### What issues does this PR fix or reference?

Closes #37413

### Previous Behavior

salt-cloud -a reset vm_name would not do anything.

### New Behavior

salt-cloud -a reset vm_name now hard-resets vm_name.