### PR TITLE
Proper function parameter default

### DIFF
--- a/salt/modules/cassandra_cql.py
+++ b/salt/modules/cassandra_cql.py
@@ -194,7 +194,7 @@ def _get_ssl_opts():
 
 
 def _connect(contact_points=None, port=None, cql_user=None, cql_pass=None,
-             protocol_version=4):
+             protocol_version=None):
     '''
     Connect to a Cassandra cluster.
 


### PR DESCRIPTION
Change `protocol_version` default to `None` because `protocol_version`
is determined below and has the same default.

### What does this PR do?
Changes `protocol_version
### What issues does this PR fix or reference?
ZD1159

### Previous Behavior
The config setting for `protocol_version` wasn't being used because the
function definition was masking it.

### New Behavior
Config option is used if set.

### Tests written?

No

