### PR TITLE
Fix for "cpu_model" core grain on some SPARC systems

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -370,7 +370,7 @@ def _sunos_cpudata():
     grains['cpuarch'] = __salt__['cmd.run']('isainfo -k')
     psrinfo = '/usr/sbin/psrinfo 2>/dev/null'
     grains['num_cpus'] = len(__salt__['cmd.run'](psrinfo, python_shell=True).splitlines())
-    kstat_info = 'kstat -p cpu_info:0:*:brand'
+    kstat_info = 'kstat -p cpu_info:*:*:brand'
     for line in __salt__['cmd.run'](kstat_info).splitlines():
         match = re.match(r'(\w+:\d+:\w+\d+:\w+)\s+(.+)', line)
         if match:


### PR DESCRIPTION
On T-Series SPARC systems, logical domains (LDOMs) can be configured such that the CPU IDs do not start with 0.  This fix allows the "cpu_model" grain to be set regardless of CPU ID indexing.

### What does this PR do?
Fixes a condition where the "cpu_model" core grain does not get set

### What issues does this PR fix or reference?
A condition where the "cpu_model" core grain does not get set

### Previous Behavior
On systems in which the CPUs are not 0-indexed, the "cpu_model" core grain does not get set

### New Behavior
On all systems the "cpu_model" core grain gets set

### Tests written?
No

