### PR TITLE
Enable __proxy__ availability in states, highstate, and utils. Enable __utils__ for proxies.

### DIFF
--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -115,8 +115,8 @@ class Engine(SignalHandlingMultiprocessingProcess):
                 self.runners = salt.loader.runner(self.opts)
             else:
                 self.runners = []
-            self.utils = salt.loader.utils(self.opts)
-            self.funcs = salt.loader.minion_mods(self.opts, utils=self.utils)
+            self.utils = salt.loader.utils(self.opts, proxy=self.proxy)
+            self.funcs = salt.loader.minion_mods(self.opts, utils=self.utils, proxy=self.proxy)
 
         self.engine = salt.loader.engines(self.opts,
                                           self.funcs,

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -286,7 +286,7 @@ def engines(opts, functions, runners, proxy=None):
     )
 
 
-def proxy(opts, functions=None, returners=None, whitelist=None):
+def proxy(opts, functions=None, returners=None, whitelist=None, utils=None):
     '''
     Returns the proxy module for this salt-proxy-minion
     '''
@@ -294,7 +294,7 @@ def proxy(opts, functions=None, returners=None, whitelist=None):
         _module_dirs(opts, 'proxy', 'proxy'),
         opts,
         tag='proxy',
-        pack={'__salt__': functions, '__ret__': returners},
+        pack={'__salt__': functions, '__ret__': returners, '__utils__': utils},
     )
 
     ret.pack['__proxy__'] = ret
@@ -302,7 +302,7 @@ def proxy(opts, functions=None, returners=None, whitelist=None):
     return ret
 
 
-def returners(opts, functions, whitelist=None, context=None):
+def returners(opts, functions, whitelist=None, context=None, proxy=None):
     '''
     Returns the returner modules
     '''
@@ -311,11 +311,11 @@ def returners(opts, functions, whitelist=None, context=None):
         opts,
         tag='returner',
         whitelist=whitelist,
-        pack={'__salt__': functions, '__context__': context},
+        pack={'__salt__': functions, '__context__': context, '__proxy__': proxy or {}},
     )
 
 
-def utils(opts, whitelist=None, context=None):
+def utils(opts, whitelist=None, context=None, proxy=proxy):
     '''
     Returns the utility modules
     '''
@@ -324,7 +324,7 @@ def utils(opts, whitelist=None, context=None):
         opts,
         tag='utils',
         whitelist=whitelist,
-        pack={'__context__': context},
+        pack={'__context__': context, '__proxy__': proxy or {}},
     )
 
 
@@ -455,7 +455,7 @@ def thorium(opts, functions, runners):
     return ret
 
 
-def states(opts, functions, utils, serializers, whitelist=None):
+def states(opts, functions, utils, serializers, whitelist=None, proxy=None):
     '''
     Returns the state modules
 
@@ -475,7 +475,7 @@ def states(opts, functions, utils, serializers, whitelist=None):
         _module_dirs(opts, 'states', 'states'),
         opts,
         tag='states',
-        pack={'__salt__': functions},
+        pack={'__salt__': functions, '__proxy__': proxy or {}},
         whitelist=whitelist,
     )
     ret.pack['__states__'] = ret
@@ -484,7 +484,7 @@ def states(opts, functions, utils, serializers, whitelist=None):
     return ret
 
 
-def beacons(opts, functions, context=None):
+def beacons(opts, functions, context=None, proxy=None):
     '''
     Load the beacon modules
 
@@ -496,7 +496,7 @@ def beacons(opts, functions, context=None):
         _module_dirs(opts, 'beacons', 'beacons'),
         opts,
         tag='beacons',
-        pack={'__context__': context, '__salt__': functions},
+        pack={'__context__': context, '__salt__': functions, '__proxy__': proxy or {}},
     )
 
 
@@ -918,7 +918,7 @@ def netapi(opts):
     )
 
 
-def executors(opts, functions=None, context=None):
+def executors(opts, functions=None, context=None, proxy=None):
     '''
     Returns the executor modules
     '''
@@ -926,7 +926,7 @@ def executors(opts, functions=None, context=None):
         _module_dirs(opts, 'executors', 'executor'),
         opts,
         tag='executor',
-        pack={'__salt__': functions, '__context__': context or {}},
+        pack={'__salt__': functions, '__context__': context or {}, '__proxy__': proxy or {}},
     )
 
 

--- a/salt/modules/rest_sample_utils.py
+++ b/salt/modules/rest_sample_utils.py
@@ -19,3 +19,10 @@ def fix_outage():
 
     '''
     return __proxy__['rest_sample.fix_outage']()
+
+
+def get_test_string():
+    '''
+    Helper function to test cross-calling to the __proxy__ dunder.
+    '''
+    return __proxy__['rest_sample.test_from_state']()

--- a/salt/proxy/rest_sample.py
+++ b/salt/proxy/rest_sample.py
@@ -200,3 +200,12 @@ def shutdown(opts):
     For this proxy shutdown is a no-op
     '''
     log.debug('rest_sample proxy shutdown() called...')
+
+
+def test_from_state():
+    '''
+    Test function so we have something to call from a state
+    :return:
+    '''
+    log.debug('test_from_state called')
+    return 'testvalue'

--- a/salt/state.py
+++ b/salt/state.py
@@ -656,7 +656,7 @@ class State(object):
         self._pillar_enc = pillar_enc
         self.opts['pillar'] = self._gather_pillar()
         self.state_con = context or {}
-        self.load_modules(proxy=proxy)
+        self.load_modules()
         self.active = set()
         self.mod_init = set()
         self.pre = {}
@@ -856,7 +856,8 @@ class State(object):
         if self.states_loader == 'thorium':
             self.states = salt.loader.thorium(self.opts, self.functions, {})  # TODO: Add runners
         else:
-            self.states = salt.loader.states(self.opts, self.functions, self.utils, self.serializers)
+            self.states = salt.loader.states(self.opts, self.functions, self.utils,
+                                             self.serializers, proxy=self.proxy)
 
     def load_modules(self, data=None, proxy=None):
         '''
@@ -866,7 +867,7 @@ class State(object):
         self.utils = salt.loader.utils(self.opts)
         self.functions = salt.loader.minion_mods(self.opts, self.state_con,
                                                  utils=self.utils,
-                                                 proxy=proxy)
+                                                 proxy=self.proxy)
         if isinstance(data, dict):
             if data.get('provider', False):
                 if isinstance(data['provider'], str):
@@ -906,7 +907,7 @@ class State(object):
                 log.error('Error encountered during module reload. Modules were not reloaded.')
             except TypeError:
                 log.error('Error encountered during module reload. Modules were not reloaded.')
-        self.load_modules(proxy=self.proxy)
+        self.load_modules()
         if not self.opts.get('local', False) and self.opts.get('multiprocessing', True):
             self.functions['saltutil.refresh_modules']()
 
@@ -3353,6 +3354,7 @@ class HighState(BaseHighState):
                            mocked=mocked,
                            loader=loader)
         self.matcher = salt.minion.Matcher(self.opts)
+        self.proxy = proxy
 
         # tracks all pydsl state declarations globally across sls files
         self._pydsl_all_decls = {}


### PR DESCRIPTION
### What does this PR do?

Makes the `__proxy__` variable available when calling state.highstate or state.sls/apply.  Makes the `__utils__` variable available to proxies.

### What issues does this PR fix or reference?

Counterpart to PR #38829, fixes #38753 #38265 for 2016.3
