### PR TITLE
Enable __proxy__ availability in states, highstate, and utils. Enable __utils__ for proxies. 

### DIFF
--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -116,7 +116,8 @@ class Engine(SignalHandlingMultiprocessingProcess):
                 self.runners = salt.loader.runner(self.opts, utils=self.utils)
             else:
                 self.runners = []
-            self.funcs = salt.loader.minion_mods(self.opts, utils=self.utils)
+            self.utils = salt.loader.utils(self.opts, proxy=self.proxy)
+            self.funcs = salt.loader.minion_mods(self.opts, utils=self.utils, proxy=self.proxy)
 
         self.engine = salt.loader.engines(self.opts,
                                           self.funcs,

--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -111,12 +111,11 @@ class Engine(SignalHandlingMultiprocessingProcess):
         '''
         if salt.utils.is_windows():
             # Calculate function references since they can't be pickled.
-            self.utils = salt.loader.utils(self.opts)
+            self.utils = salt.loader.utils(self.opts, proxy=self.proxy)
             if self.opts['__role'] == 'master':
                 self.runners = salt.loader.runner(self.opts, utils=self.utils)
             else:
                 self.runners = []
-            self.utils = salt.loader.utils(self.opts, proxy=self.proxy)
             self.funcs = salt.loader.minion_mods(self.opts, utils=self.utils, proxy=self.proxy)
 
         self.engine = salt.loader.engines(self.opts,

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -287,7 +287,7 @@ def engines(opts, functions, runners, proxy=None):
     )
 
 
-def proxy(opts, functions=None, returners=None, whitelist=None):
+def proxy(opts, functions=None, returners=None, whitelist=None, utils=None):
     '''
     Returns the proxy module for this salt-proxy-minion
     '''
@@ -295,7 +295,7 @@ def proxy(opts, functions=None, returners=None, whitelist=None):
         _module_dirs(opts, 'proxy'),
         opts,
         tag='proxy',
-        pack={'__salt__': functions, '__ret__': returners},
+        pack={'__salt__': functions, '__ret__': returners, '__utils__': utils},
     )
 
     ret.pack['__proxy__'] = ret
@@ -303,7 +303,7 @@ def proxy(opts, functions=None, returners=None, whitelist=None):
     return ret
 
 
-def returners(opts, functions, whitelist=None, context=None):
+def returners(opts, functions, whitelist=None, context=None, proxy=None):
     '''
     Returns the returner modules
     '''
@@ -312,11 +312,11 @@ def returners(opts, functions, whitelist=None, context=None):
         opts,
         tag='returner',
         whitelist=whitelist,
-        pack={'__salt__': functions, '__context__': context},
+        pack={'__salt__': functions, '__context__': context, '__proxy__': proxy or {}},
     )
 
 
-def utils(opts, whitelist=None, context=None):
+def utils(opts, whitelist=None, context=None, proxy=proxy):
     '''
     Returns the utility modules
     '''
@@ -325,7 +325,7 @@ def utils(opts, whitelist=None, context=None):
         opts,
         tag='utils',
         whitelist=whitelist,
-        pack={'__context__': context},
+        pack={'__context__': context, '__proxy__': proxy or {}},
     )
 
 
@@ -454,7 +454,7 @@ def thorium(opts, functions, runners):
     return ret
 
 
-def states(opts, functions, utils, serializers, whitelist=None):
+def states(opts, functions, utils, serializers, whitelist=None, proxy=None):
     '''
     Returns the state modules
 
@@ -474,7 +474,7 @@ def states(opts, functions, utils, serializers, whitelist=None):
         _module_dirs(opts, 'states'),
         opts,
         tag='states',
-        pack={'__salt__': functions},
+        pack={'__salt__': functions, '__proxy__': proxy or {}},
         whitelist=whitelist,
     )
     ret.pack['__states__'] = ret
@@ -483,7 +483,7 @@ def states(opts, functions, utils, serializers, whitelist=None):
     return ret
 
 
-def beacons(opts, functions, context=None):
+def beacons(opts, functions, context=None, proxy=None):
     '''
     Load the beacon modules
 
@@ -495,8 +495,8 @@ def beacons(opts, functions, context=None):
         _module_dirs(opts, 'beacons'),
         opts,
         tag='beacons',
-        pack={'__context__': context, '__salt__': functions},
         virtual_funcs=['__validate__'],
+        pack={'__context__': context, '__salt__': functions, '__proxy__': proxy or {}},
     )
 
 
@@ -917,7 +917,7 @@ def netapi(opts):
     )
 
 
-def executors(opts, functions=None, context=None):
+def executors(opts, functions=None, context=None, proxy=None):
     '''
     Returns the executor modules
     '''
@@ -925,7 +925,7 @@ def executors(opts, functions=None, context=None):
         _module_dirs(opts, 'executors', 'executor'),
         opts,
         tag='executor',
-        pack={'__salt__': functions, '__context__': context or {}},
+        pack={'__salt__': functions, '__context__': context or {}, '__proxy__': proxy or {}},
     )
 
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1163,7 +1163,7 @@ class Minion(MinionBase):
 
         if grains is None:
             self.opts['grains'] = salt.loader.grains(self.opts, force_refresh, proxy=proxy)
-        self.utils = salt.loader.utils(self.opts)
+        self.utils = salt.loader.utils(self.opts, proxy=proxy)
 
         if self.opts.get('multimaster', False):
             s_opts = copy.deepcopy(self.opts)
@@ -1171,7 +1171,7 @@ class Minion(MinionBase):
                                                 loaded_base_name=self.loaded_base_name, notify=notify)
         else:
             functions = salt.loader.minion_mods(self.opts, utils=self.utils, notify=notify, proxy=proxy)
-        returners = salt.loader.returners(self.opts, functions)
+        returners = salt.loader.returners(self.opts, functions, proxy=proxy)
         errors = {}
         if '_errors' in functions:
             errors = functions['_errors']
@@ -1181,7 +1181,7 @@ class Minion(MinionBase):
         if modules_max_memory is True:
             resource.setrlimit(resource.RLIMIT_AS, old_mem_limit)
 
-        executors = salt.loader.executors(self.opts, functions)
+        executors = salt.loader.executors(self.opts, functions, proxy=proxy)
 
         return functions, returners, errors, executors
 
@@ -3057,6 +3057,9 @@ class ProxyMinion(Minion):
         # SPM or was manually placed in /srv/salt/_modules etc.
         self.functions['saltutil.sync_all'](saltenv='base')
 
+        # Pull in the utils
+        self.utils = salt.loader.utils(self.opts)
+
         # Then load the proxy module
         self.proxy = salt.loader.proxy(self.opts)
 
@@ -3066,6 +3069,10 @@ class ProxyMinion(Minion):
         self.proxy.pack['__salt__'] = self.functions
         self.proxy.pack['__ret__'] = self.returners
         self.proxy.pack['__pillar__'] = self.opts['pillar']
+
+        # Reload utils as well (chicken and egg, __utils__ needs __proxy__ and __proxy__ needs __utils__
+        self.utils = salt.loader.utils(self.opts, proxy=self.proxy)
+        self.proxy.pack['__utils__'] = self.utils
 
         # Start engines here instead of in the Minion superclass __init__
         # This is because we need to inject the __proxy__ variable but

--- a/salt/modules/rest_sample_utils.py
+++ b/salt/modules/rest_sample_utils.py
@@ -19,3 +19,10 @@ def fix_outage():
 
     '''
     return __proxy__['rest_sample.fix_outage']()
+
+
+def get_test_string():
+    '''
+    Helper function to test cross-calling to the __proxy__ dunder.
+    '''
+    return __proxy__['rest_sample.test_from_state']()

--- a/salt/proxy/rest_sample.py
+++ b/salt/proxy/rest_sample.py
@@ -200,3 +200,12 @@ def shutdown(opts):
     For this proxy shutdown is a no-op
     '''
     log.debug('rest_sample proxy shutdown() called...')
+
+
+def test_from_state():
+    '''
+    Test function so we have something to call from a state
+    :return:
+    '''
+    log.debug('test_from_state called')
+    return 'testvalue'

--- a/salt/state.py
+++ b/salt/state.py
@@ -661,7 +661,7 @@ class State(object):
         self._pillar_enc = pillar_enc
         self.opts['pillar'] = self._gather_pillar()
         self.state_con = context or {}
-        self.load_modules(proxy=proxy)
+        self.load_modules()
         self.active = set()
         self.mod_init = set()
         self.pre = {}
@@ -861,7 +861,8 @@ class State(object):
         if self.states_loader == 'thorium':
             self.states = salt.loader.thorium(self.opts, self.functions, {})  # TODO: Add runners
         else:
-            self.states = salt.loader.states(self.opts, self.functions, self.utils, self.serializers)
+            self.states = salt.loader.states(self.opts, self.functions, self.utils,
+                                             self.serializers, proxy=self.proxy)
 
     def load_modules(self, data=None, proxy=None):
         '''
@@ -871,7 +872,7 @@ class State(object):
         self.utils = salt.loader.utils(self.opts)
         self.functions = salt.loader.minion_mods(self.opts, self.state_con,
                                                  utils=self.utils,
-                                                 proxy=proxy)
+                                                 proxy=self.proxy)
         if isinstance(data, dict):
             if data.get('provider', False):
                 if isinstance(data['provider'], str):
@@ -911,7 +912,7 @@ class State(object):
                 log.error('Error encountered during module reload. Modules were not reloaded.')
             except TypeError:
                 log.error('Error encountered during module reload. Modules were not reloaded.')
-        self.load_modules(proxy=self.proxy)
+        self.load_modules()
         if not self.opts.get('local', False) and self.opts.get('multiprocessing', True):
             self.functions['saltutil.refresh_modules']()
 
@@ -3533,6 +3534,7 @@ class HighState(BaseHighState):
                            mocked=mocked,
                            loader=loader)
         self.matcher = salt.minion.Matcher(self.opts)
+        self.proxy = proxy
 
         # tracks all pydsl state declarations globally across sls files
         self._pydsl_all_decls = {}


### PR DESCRIPTION
### What does this PR do?

Makes the __proxy__ variable available when calling state.highstate or state.sls/apply. Makes the __utils__ variable available to proxies.

### What issues does this PR fix or reference?

Counterpart to PR #38829 and #38899, fixes #38753 #38265 for 2016.11