### PR TITLE
Apply glob pattern to file_roots and pillar_roots (master & minion).

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1561,25 +1561,24 @@ PROVIDER_CONFIG_DEFAULTS = {
 # <---- Salt Cloud Configuration Defaults ------------------------------------
 
 
-def _validate_file_roots(opts):
+def _validate_file_roots(file_roots):
     '''
     If the file_roots option has a key that is None then we will error out,
     just replace it with an empty list
     '''
-    if not isinstance(opts['file_roots'], dict):
+    if not isinstance(file_roots, dict):
         log.warning('The file_roots parameter is not properly formatted,'
                     ' using defaults')
         return {'base': _expand_glob_path([salt.syspaths.BASE_FILE_ROOTS_DIR])}
-    for saltenv, dirs in six.iteritems(opts['file_roots']):
+    for saltenv, dirs in six.iteritems(file_roots):
         normalized_saltenv = six.text_type(saltenv)
         if normalized_saltenv != saltenv:
-            opts['file_roots'][normalized_saltenv] = \
-                opts['file_roots'].pop(saltenv)
+            file_roots[normalized_saltenv] = file_roots.pop(saltenv)
         if not isinstance(dirs, (list, tuple)):
-            opts['file_roots'][normalized_saltenv] = []
-        opts['file_roots'][normalized_saltenv] = \
-            _expand_glob_path(opts['file_roots'][normalized_saltenv])
-    return opts['file_roots']
+            file_roots[normalized_saltenv] = []
+        file_roots[normalized_saltenv] = \
+                _expand_glob_path(file_roots[normalized_saltenv])
+    return file_roots
 
 
 def _expand_glob_path(file_roots):
@@ -3153,6 +3152,8 @@ def apply_minion_config(overrides=None,
     # Enabling open mode requires that the value be set to True, and
     # nothing else!
     opts['open_mode'] = opts['open_mode'] is True
+    opts['file_roots'] = _validate_file_roots(opts['file_roots'])
+    opts['pillar_roots'] = _validate_file_roots(opts['pillar_roots'])
     # Make sure ext_mods gets set if it is an untrue value
     # (here to catch older bad configs)
     opts['extension_modules'] = (
@@ -3309,7 +3310,8 @@ def apply_master_config(overrides=None, defaults=None):
     # nothing else!
     opts['open_mode'] = opts['open_mode'] is True
     opts['auto_accept'] = opts['auto_accept'] is True
-    opts['file_roots'] = _validate_file_roots(opts)
+    opts['file_roots'] = _validate_file_roots(opts['file_roots'])
+    opts['pillar_roots'] = _validate_file_roots(opts['pillar_roots'])
 
     if opts['file_ignore_regex']:
         # If file_ignore_regex was given, make sure it's wrapped in a list.

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -353,6 +353,118 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
             if os.path.isdir(tempdir):
                 shutil.rmtree(tempdir)
 
+    def test_master_file_roots_glob(self):
+        # Config file and stub file_roots.
+        fpath = tempfile.mktemp()
+        tempdir = tempfile.mkdtemp(dir=integration.SYS_TMP_DIR)
+        try:
+            # Create some kown files.
+            for f in 'abc':
+                fpath = os.path.join(tempdir, f)
+                salt.utils.fopen(fpath, 'w').write(f)
+
+            salt.utils.fopen(fpath, 'w').write(
+                'file_roots:\n'
+                '  base:\n'
+                '    - {0}'.format(os.path.join(tempdir, '*'))
+            )
+            config = sconfig.master_config(fpath)
+            base = config['file_roots']['base']
+            self.assertEqual(set(base), set([
+                os.path.join(tempdir, 'a'),
+                os.path.join(tempdir, 'b'),
+                os.path.join(tempdir, 'c')
+            ]))
+        finally:
+            if os.path.isfile(fpath):
+                os.unlink(fpath)
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)
+
+    def test_master_pillar_roots_glob(self):
+        # Config file and stub pillar_roots.
+        fpath = tempfile.mktemp()
+        tempdir = tempfile.mkdtemp(dir=integration.SYS_TMP_DIR)
+        try:
+            # Create some kown files.
+            for f in 'abc':
+                fpath = os.path.join(tempdir, f)
+                salt.utils.fopen(fpath, 'w').write(f)
+
+            salt.utils.fopen(fpath, 'w').write(
+                'pillar_roots:\n'
+                '  base:\n'
+                '    - {0}'.format(os.path.join(tempdir, '*'))
+            )
+            config = sconfig.master_config(fpath)
+            base = config['pillar_roots']['base']
+            self.assertEqual(set(base), set([
+                os.path.join(tempdir, 'a'),
+                os.path.join(tempdir, 'b'),
+                os.path.join(tempdir, 'c')
+            ]))
+        finally:
+            if os.path.isfile(fpath):
+                os.unlink(fpath)
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)
+
+    def test_minion_file_roots_glob(self):
+        # Config file and stub file_roots.
+        fpath = tempfile.mktemp()
+        tempdir = tempfile.mkdtemp(dir=integration.SYS_TMP_DIR)
+        try:
+            # Create some kown files.
+            for f in 'abc':
+                fpath = os.path.join(tempdir, f)
+                salt.utils.fopen(fpath, 'w').write(f)
+
+            salt.utils.fopen(fpath, 'w').write(
+                'file_roots:\n'
+                '  base:\n'
+                '    - {0}'.format(os.path.join(tempdir, '*'))
+            )
+            config = sconfig.minion_config(fpath)
+            base = config['file_roots']['base']
+            self.assertEqual(set(base), set([
+                os.path.join(tempdir, 'a'),
+                os.path.join(tempdir, 'b'),
+                os.path.join(tempdir, 'c')
+            ]))
+        finally:
+            if os.path.isfile(fpath):
+                os.unlink(fpath)
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)
+
+    def test_minion_pillar_roots_glob(self):
+        # Config file and stub pillar_roots.
+        fpath = tempfile.mktemp()
+        tempdir = tempfile.mkdtemp(dir=integration.SYS_TMP_DIR)
+        try:
+            # Create some kown files.
+            for f in 'abc':
+                fpath = os.path.join(tempdir, f)
+                salt.utils.fopen(fpath, 'w').write(f)
+
+            salt.utils.fopen(fpath, 'w').write(
+                'pillar_roots:\n'
+                '  base:\n'
+                '    - {0}'.format(os.path.join(tempdir, '*'))
+            )
+            config = sconfig.minion_config(fpath)
+            base = config['pillar_roots']['base']
+            self.assertEqual(set(base), set([
+                os.path.join(tempdir, 'a'),
+                os.path.join(tempdir, 'b'),
+                os.path.join(tempdir, 'c')
+            ]))
+        finally:
+            if os.path.isfile(fpath):
+                os.unlink(fpath)
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)
+
     def test_syndic_config(self):
         syndic_conf_path = self.get_config_file_path('syndic')
         minion_conf_path = self.get_config_file_path('minion')


### PR DESCRIPTION
### What does this PR do?
Implements glob expansion on `pillar_roots` as described in issue #38736 
Also applies glob expansion to `file_roots` and `pillar_roots` in `salt-minion` (for `salt-call --local`).

### What issues does this PR fix or reference?
#38736

### Previous Behavior
Paths with globs (i.e, `/some/path/*`) in `file_roots` are expanded on the `salt-master`.
Paths in the `pillar_roots` option are not, neither paths in `salt-minion`.

### New Behavior
Glob expansion is applied to both `file_roots` and `pillar_roots` on both `salt-master` and `salt-minion`.

### Tests written?
Yes