### PR TITLE
salt-ssh: Fix custom option definitions

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -10,6 +10,7 @@ import os
 import json
 import time
 import logging
+import shlex
 import subprocess
 
 # Import salt libs
@@ -128,7 +129,7 @@ class Shell(object):
 
         ret = []
         for option in options:
-            ret.append('-o {0} '.format(option))
+            ret.append('-o {0} '.format(shlex.quote(option)))
         return ''.join(ret)
 
     def _passwd_opts(self):
@@ -168,11 +169,11 @@ class Shell(object):
 
         ret = []
         for option in options:
-            ret.append('-o {0} '.format(option))
+            ret.append('-o {0} '.format(shlex.quote(option)))
         return ''.join(ret)
 
     def _ssh_opts(self):
-        return ' '.join(['-o {0}'.format(opt)
+        return ' '.join(['-o {0}'.format(shlex.quote(opt))
                         for opt in self.ssh_options])
 
     def _copy_id_str_old(self):


### PR DESCRIPTION
### What does this PR do?

Previously were not quoting correctly, resulting in only one value
getting passed to the `-o` argument when two may have been used, ie:

    --ssh-option='ProxyJump foo'

would become

    -o ProxyJump foo

SSH would only see the ProxyJump as part of the option, not the whole
`ProxyJump foo`.

### What issues does this PR fix or reference?

None.

### Previous Behavior
Having to double-quote (`'"optionname value"'`) when specifying an `--ssh-option`.

### New Behavior
SSH Options in `--ssh-option` are specified the same way one would do so in `ssh -o`, without the extra quotes. This is done by quoting each `option` using `shlex.quote()`.

### Tests written?

No