### PR TITLE
Add top file merging docs to the master config file documentation

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -245,7 +245,7 @@ each of Salt's module types such as ``runners``, ``output``, ``wheel``,
 
     extension_modules: /root/salt_extmods
 
-.. conf_minion:: module_dirs
+.. conf_master:: module_dirs
 
 ``module_dirs``
 ---------------
@@ -1140,6 +1140,99 @@ root of the base environment.
 .. code-block:: yaml
 
     state_top: top.sls
+
+.. conf_master:: state_top_saltenv
+
+``state_top_saltenv``
+---------------------
+
+This option has no default value. Set it to an environment name to ensure that
+*only* the top file from that environment is considered during a
+:ref:`highstate <running-highstate>`.
+
+.. note::
+    Using this value does not change the merging strategy. For instance, if
+    :conf_master:`top_file_merging_strategy` is set to ``merge``, and
+    :conf_master:`state_top_saltenv` is set to ``foo``, then any sections for
+    environments other than ``foo`` in the top file for the ``foo`` environment
+    will be ignored. With :conf_master:`state_top_saltenv` set to ``base``, all
+    states from all environments in the ``base`` top file will be applied,
+    while all other top files are ignored. The only way to set
+    :conf_master:`state_top_saltenv` to something other than ``base`` and not
+    have the other environments in the targeted top file ignored, would be to
+    set :conf_master:`top_file_merging_strategy` to ``merge_all``.
+
+.. code-block:: yaml
+
+    state_top_saltenv: dev
+
+.. conf_master:: top_file_merging_strategy
+
+``top_file_merging_strategy``
+-----------------------------
+
+.. versionchanged:: 2016.11.0
+    A ``merge_all`` strategy has been added.
+
+Default: ``merge``
+
+When no specific fileserver environment (a.k.a. ``saltenv``) has been specified
+for a :ref:`highstate <running-highstate>`, all environments' top files are
+inspected. This config option determines how the SLS targets in those top files
+are handled.
+
+When set to ``merge``, the ``base`` environment's top file is evaluated first,
+followed by the other environments' top files. The first target expression
+(e.g. ``'*'``) for a given environment is kept, and when the same target
+expression is used in a different top file evaluated later, it is ignored.
+Because ``base`` is evaluated first, it is authoritative. For example, if there
+is a target for ``'*'`` for the ``foo`` environment in both the ``base`` and
+``foo`` environment's top files, the one in the ``foo`` environment would be
+ignored. The environments will be evaluated in no specific order (aside from
+``base`` coming first). For greater control over the order in which the
+environments are evaluated, use :conf_master:`env_order`. Note that, aside from
+the ``base`` environment's top file, any sections in top files that do not
+match that top file's environment will be ignored. So, for example, a section
+for the ``qa`` environment would be ignored if it appears in the ``dev``
+environment's top file. To keep use cases like this from being ignored, use the
+``merge_all`` strategy.
+
+When set to ``same``, then for each environment, only that environment's top
+file is processed, with the others being ignored. For example, only the ``dev``
+environment's top file will be processed for the ``dev`` environment, and any
+SLS targets defined for ``dev`` in the ``base`` environment's (or any other
+environment's) top file will be ignored. If an environment does not have a top
+file, then the top file from the :conf_master:`default_top` config parameter
+will be used as a fallback.
+
+When set to ``merge_all``, then all states in all environments in all top files
+will be applied. The order in which individual SLS files will be executed will
+depend on the order in which the top files were evaluated, and the environments
+will be evaluated in no specific order. For greater control over the order in
+which the environments are evaluated, use :conf_master:`env_order`.
+
+.. code-block:: yaml
+
+    top_file_merging_strategy: same
+
+.. conf_master:: env_order
+
+``env_order``
+-------------
+
+Default: ``[]``
+
+When :conf_master:`top_file_merging_strategy` is set to ``merge``, and no
+environment is specified for a :ref:`highstate <running-highstate>`, this
+config option allows for the order in which top files are evaluated to be
+explicitly defined.
+
+.. code-block:: yaml
+
+    env_order:
+      - base
+      - dev
+      - qa
 
 .. conf_master:: master_tops
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1184,6 +1184,136 @@ below.
       service: systemd
 
 
+Top File Settings
+=================
+
+These parameters only have an effect if running a masterless minion.
+
+.. conf_minion:: state_top
+
+``state_top``
+-------------
+
+Default: ``top.sls``
+
+The state system uses a "top" file to tell the minions what environment to
+use and what modules to use. The state_top file is defined relative to the
+root of the base environment.
+
+.. code-block:: yaml
+
+    state_top: top.sls
+
+.. conf_minion:: state_top_saltenv
+
+``state_top_saltenv``
+---------------------
+
+This option has no default value. Set it to an environment name to ensure that
+*only* the top file from that environment is considered during a
+:ref:`highstate <running-highstate>`.
+
+.. note::
+    Using this value does not change the merging strategy. For instance, if
+    :conf_minion:`top_file_merging_strategy` is set to ``merge``, and
+    :conf_minion:`state_top_saltenv` is set to ``foo``, then any sections for
+    environments other than ``foo`` in the top file for the ``foo`` environment
+    will be ignored. With :conf_minion:`state_top_saltenv` set to ``base``, all
+    states from all environments in the ``base`` top file will be applied,
+    while all other top files are ignored. The only way to set
+    :conf_minion:`state_top_saltenv` to something other than ``base`` and not
+    have the other environments in the targeted top file ignored, would be to
+    set :conf_minion:`top_file_merging_strategy` to ``merge_all``.
+
+.. code-block:: yaml
+
+    state_top_saltenv: dev
+
+.. conf_minion:: top_file_merging_strategy
+
+``top_file_merging_strategy``
+-----------------------------
+
+.. versionchanged:: 2016.11.0
+    A ``merge_all`` strategy has been added.
+
+Default: ``merge``
+
+When no specific fileserver environment (a.k.a. ``saltenv``) has been specified
+for a :ref:`highstate <running-highstate>`, all environments' top files are
+inspected. This config option determines how the SLS targets in those top files
+are handled.
+
+When set to ``merge``, the ``base`` environment's top file is evaluated first,
+followed by the other environments' top files. The first target expression
+(e.g. ``'*'``) for a given environment is kept, and when the same target
+expression is used in a different top file evaluated later, it is ignored.
+Because ``base`` is evaluated first, it is authoritative. For example, if there
+is a target for ``'*'`` for the ``foo`` environment in both the ``base`` and
+``foo`` environment's top files, the one in the ``foo`` environment would be
+ignored. The environments will be evaluated in no specific order (aside from
+``base`` coming first). For greater control over the order in which the
+environments are evaluated, use :conf_minion:`env_order`. Note that, aside from
+the ``base`` environment's top file, any sections in top files that do not
+match that top file's environment will be ignored. So, for example, a section
+for the ``qa`` environment would be ignored if it appears in the ``dev``
+environment's top file. To keep use cases like this from being ignored, use the
+``merge_all`` strategy.
+
+When set to ``same``, then for each environment, only that environment's top
+file is processed, with the others being ignored. For example, only the ``dev``
+environment's top file will be processed for the ``dev`` environment, and any
+SLS targets defined for ``dev`` in the ``base`` environment's (or any other
+environment's) top file will be ignored. If an environment does not have a top
+file, then the top file from the :conf_minion:`default_top` config parameter
+will be used as a fallback.
+
+When set to ``merge_all``, then all states in all environments in all top files
+will be applied. The order in which individual SLS files will be executed will
+depend on the order in which the top files were evaluated, and the environments
+will be evaluated in no specific order. For greater control over the order in
+which the environments are evaluated, use :conf_minion:`env_order`.
+
+.. code-block:: yaml
+
+    top_file_merging_strategy: same
+
+.. conf_minion:: env_order
+
+``env_order``
+-------------
+
+Default: ``[]``
+
+When :conf_minion:`top_file_merging_strategy` is set to ``merge``, and no
+environment is specified for a :ref:`highstate <running-highstate>`, this
+config option allows for the order in which top files are evaluated to be
+explicitly defined.
+
+.. code-block:: yaml
+
+    env_order:
+      - base
+      - dev
+      - qa
+
+.. conf_minion:: default_top
+
+``default_top``
+---------------
+
+Default: ``base``
+
+When :conf_minion:`top_file_merging_strategy` is set to ``same``, and no
+environment is specified for a :ref:`highstate <running-highstate>` (i.e.
+:conf_minion:`environment` is not set for the minion), this config option
+specifies a fallback environment in which to look for a top file if an
+environment lacks one.
+
+.. code-block:: yaml
+
+    default_top: dev
+
 State Management Settings
 =========================
 
@@ -1285,111 +1415,6 @@ environments is to isolate via the top file.
 .. code-block:: yaml
 
     environment: dev
-
-.. conf_minion:: state_top_saltenv
-
-``state_top_saltenv``
----------------------
-
-This option has no default value. Set it to an environment name to ensure that
-*only* the top file from that environment is considered during a
-:ref:`highstate <running-highstate>`.
-
-.. note::
-    Using this value does not change the merging strategy. For instance, if
-    :conf_minion:`top_file_merging_strategy` is set to ``merge``, and
-    :conf_minion:`state_top_saltenv` is set to ``foo``, then any sections for
-    environments other than ``foo`` in the top file for the ``foo`` environment
-    will be ignored. With :conf_minion:`state_top_saltenv` set to ``base``, all
-    states from all environments in the ``base`` top file will be applied,
-    while all other top files are ignored. The only way to set
-    :conf_minion:`state_top_saltenv` to something other than ``base`` and not
-    have the other environments in the targeted top file ignored, would be to
-    set :conf_minion:`top_file_merging_strategy` to ``merge_all``.
-
-.. code-block:: yaml
-
-    state_top_saltenv: dev
-
-.. conf_minion:: top_file_merging_strategy
-
-``top_file_merging_strategy``
------------------------------
-
-.. versionchanged:: 2016.11.0
-    A ``merge_all`` strategy has been added.
-
-Default: ``merge``
-
-When no specific fileserver environment (a.k.a. ``saltenv``) has been specified
-for a :ref:`highstate <running-highstate>`, all environments' top files are
-inspected. This config option determines how the SLS targets in those top files
-are handled.
-
-When set to ``merge``, the ``base`` environment's top file is evaluated first,
-followed by the other environments' top files. The first target expression
-(e.g. ``'*'``) for a given environment is kept, and when the same target
-expression is used in a different top file evaluated later, it is ignored.
-Because ``base`` is evaluated first, it is authoritative. For example, if there
-is a target for ``'*'`` for the ``foo`` environment in both the ``base`` and
-``foo`` environment's top files, the one in the ``foo`` environment would be
-ignored. The environments will be evaluated in no specific order (aside from
-``base`` coming first). For greater control over the order in which the
-environments are evaluated, use :conf_minion:`env_order`.
-
-When set to ``same``, then for each environment, only that environment's top
-file is processed, with the others being ignored. For example, only the ``dev``
-environment's top file will be processed for the ``dev`` environment, and any
-SLS targets defined for ``dev`` in the ``base`` environment's (or any other
-environment's) top file will be ignored. If an environment does not have a top
-file, then the top file from the :conf_minion:`default_top` config parameter
-will be used as a fallback.
-
-When set to ``merge_all``, then all states in all environments in all top files
-will be applied. The order in which individual SLS files will be executed will
-depend on the order in which the top files were evaluated, and the environments
-will be evaluated in no specific order. For greater control over the order in
-which the environments are evaluated, use :conf_minion:`env_order`.
-
-.. code-block:: yaml
-
-    top_file_merging_strategy: same
-
-.. conf_minion:: env_order
-
-``env_order``
--------------
-
-Default: ``[]``
-
-When :conf_minion:`top_file_merging_strategy` is set to ``merge``, and no
-environment is specified for a :ref:`highstate <running-highstate>`, this
-config option allows for the order in which top files are evaluated to be
-explicitly defined.
-
-.. code-block:: yaml
-
-    env_order:
-      - base
-      - dev
-      - qa
-
-.. conf_minion:: default_top
-
-``default_top``
----------------
-
-Default: ``base``
-
-When :conf_minion:`top_file_merging_strategy` is set to ``same``, and no
-environment is specified for a :ref:`highstate <running-highstate>` (i.e.
-:conf_minion:`environment` is not set for the minion), this config option
-specifies a fallback environment in which to look for a top file if an
-environment lacks one.
-
-.. code-block:: yaml
-
-    default_top: dev
 
 .. conf_minion:: snapper_states
 


### PR DESCRIPTION
Also put the top file stuff in its own section of the minion config
file, along with a message explaining that these options are only used
in masterless salt.