### PR TITLE
Ignore plist files without Label key

### DIFF
--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -85,7 +85,7 @@ def _available_services():
                     }
                 except AttributeError:
                     # As of MacOS 10.12 there might be plist files without Label key
-                    # in the searched directories. As these files do not represent 
+                    # in the searched directories. As these files do not represent
                     # services, thay are not added to the list.
                     pass
 

--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -77,11 +77,17 @@ def _available_services():
                     else:
                         plist = plistlib.readPlistFromBytes(salt.utils.to_bytes(plist_xml))
 
-                available_services[plist.Label.lower()] = {
-                    'filename': filename,
-                    'file_path': true_path,
-                    'plist': plist,
-                }
+                try:
+                    available_services[plist.Label.lower()] = {
+                        'filename': filename,
+                        'file_path': true_path,
+                        'plist': plist,
+                    }
+                except AttributeError:
+                    # As of MacOS 10.12 there might be plist files without Label key
+                    # in the searched directories. As these files do not represent 
+                    # services, thay are not added to the list.
+                    pass
 
     return available_services
 


### PR DESCRIPTION
### What does this PR do?

Some of the files in the directories listed in `launchctl._launchd_paths()` might not represent a service and have no Label key (for example `/System/Library/LaunchDaemons/com.apple.jetsamproperties.Mac.plist ` on MacOS 10.12). Previously this prevented the `service` module from working correctly as any state trying to access `launchctl._available_services()` would fail with an uncaught `AttributeError` exception when encountering such a file.
With this change any `AttributeError` exception that might occur when accessing `plist.Label` will be caught, preventing the state from failing due to non-service plist files.

### What issues does this PR fix or reference?

There seems to be no issue for that yet.

### Previous Behavior
Salt states that access `_available_services()`, like `service.running` on MacOS, will fail, if any plist file in `/Library/LaunchAgents`, `/Library/LaunchDaemons`, `/System/Library/LaunchAgents` or `System/Library/LaunchDaemons` does not contain a key named "Label".


### New Behavior
Should a plist file not contain a key named "Label", this file will be ignored and not added to the list of available services.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
