### PR TITLE
Add device port option to proxy

### DIFF
--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -47,7 +47,8 @@ def init(opts):
     log.debug('Opening connection to junos')
     thisproxy['conn'] = jnpr.junos.Device(user=opts['proxy']['username'],
                                           host=opts['proxy']['host'],
-                                          password=opts['proxy']['passwd'])
+                                          password=opts['proxy']['passwd'],
+                                          port=opts['proxy']['port'])
     thisproxy['conn'].open()
     thisproxy['conn'].bind(cu=jnpr.junos.utils.config.Config)
     thisproxy['conn'].bind(sw=jnpr.junos.utils.sw.SW)


### PR DESCRIPTION
### What does this PR do?
Adds ability to run a proxy minion against a netconf port on a Junos device that is not the standard 830.  

### What issues does this PR fix or reference?
Many users do not expose port 830 for security, reasons, choosing only to run Netconf inside of the ssh subsystem on port 22.  This fix allows any abitrary port to be selected by the user.

### Previous Behavior
Proxy minion connection to a device with netconf blocked on port 830 would timeout and continue retrying infinitely until killed by user. 

### New Behavior
Proxy minion connection to a device with netconf blocked on port 830 will succeed. 

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
