### PR TITLE
Fix 64bit detection, vcredist only on <= 2008

### DIFF
--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -46,7 +46,7 @@ If NOT Exist "%PreDir%" mkdir "%PreDir%"
 :: Check for 64 bit by finding the Program Files (x86) directory
 Set Url64="http://repo.saltstack.com/windows/dependencies/64/vcredist_x64_2008_mfc.exe"
 Set Url32="http://repo.saltstack.com/windows/dependencies/32/vcredist_x86_2008_mfc.exe"
-If Exist "C:\Program Files (x86)" (
+If Defined ProgramFiles(x86) (
     bitsadmin /transfer "VCRedist 2008 MFC AMD64" "%Url64%" "%PreDir%\vcredist.exe"
 ) Else (
     bitsadmin /transfer "VCRedist 2008 MFC x86" "%Url32%" "%PreDir%\vcredist.exe"

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -20,6 +20,7 @@
 !include "StrFunc.nsh"
 !include "x64.nsh"
 !include "WinMessages.nsh"
+!include "WinVer.nsh"
 ${StrLoc}
 ${StrStrAdv}
 
@@ -178,35 +179,40 @@ ShowUnInstDetails show
 ; See http://blogs.msdn.com/b/astebner/archive/2009/01/29/9384143.aspx for more info
 Section -Prerequisites
 
-    !define VC_REDIST_X64_GUID "{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
-    !define VC_REDIST_X86_GUID "{9BE518E6-ECC6-35A9-88E4-87755C07200F}"
+    ; VCRedist only needed on Server 2008/Vista and below
+    ${If} ${AtMostWin2008}
 
-    Var /GLOBAL VcRedistGuid
-    Var /GLOBAL NeedVcRedist
-    ${If} ${CPUARCH} == "AMD64"
-        StrCpy $VcRedistGuid ${VC_REDIST_X64_GUID}
-    ${Else}
-        StrCpy $VcRedistGuid ${VC_REDIST_X86_GUID}
-    ${EndIf}
+        !define VC_REDIST_X64_GUID "{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
+        !define VC_REDIST_X86_GUID "{9BE518E6-ECC6-35A9-88E4-87755C07200F}"
 
-    Push $VcRedistGuid
-    Call MsiQueryProductState
-    ${If} $NeedVcRedist == "True"
-        MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 \
-            "VC Redist 2008 SP1 MFC is currently not installed. Would you like to install?" \
-            /SD IDYES IDNO endVcRedist
+        Var /GLOBAL VcRedistGuid
+        Var /GLOBAL NeedVcRedist
+        ${If} ${CPUARCH} == "AMD64"
+            StrCpy $VcRedistGuid ${VC_REDIST_X64_GUID}
+        ${Else}
+            StrCpy $VcRedistGuid ${VC_REDIST_X86_GUID}
+        ${EndIf}
 
-        ClearErrors
-        ; The Correct version of VCRedist is copied over by "build_pkg.bat"
-        SetOutPath "$INSTDIR\"
-        File "..\prereqs\vcredist.exe"
-        ExecWait "$INSTDIR\vcredist.exe /qb!"
-        IfErrors 0 endVcRedist
-            MessageBox MB_OK \
-                "VC Redist 2008 SP1 MFC failed to install. Try installing the package manually." \
-                /SD IDOK
+        Push $VcRedistGuid
+        Call MsiQueryProductState
+        ${If} $NeedVcRedist == "True"
+            MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 \
+                "VC Redist 2008 SP1 MFC is currently not installed. Would you like to install?" \
+                /SD IDYES IDNO endVcRedist
 
-        endVcRedist:
+            ClearErrors
+            ; The Correct version of VCRedist is copied over by "build_pkg.bat"
+            SetOutPath "$INSTDIR\"
+            File "..\prereqs\vcredist.exe"
+            ExecWait "$INSTDIR\vcredist.exe /qb!"
+            IfErrors 0 endVcRedist
+                MessageBox MB_OK \
+                    "VC Redist 2008 SP1 MFC failed to install. Try installing the package manually." \
+                    /SD IDOK
+
+            endVcRedist:
+        ${EndIf}
+
     ${EndIf}
 
 SectionEnd

--- a/pkg/windows/installer/Salt-Setup.nsi
+++ b/pkg/windows/installer/Salt-Setup.nsi
@@ -20,6 +20,7 @@
 !include "StrFunc.nsh"
 !include "x64.nsh"
 !include "WinMessages.nsh"
+!include "WinVer.nsh"
 ${StrLoc}
 ${StrStrAdv}
 
@@ -311,35 +312,40 @@ ShowUnInstDetails show
 ; See http://blogs.msdn.com/b/astebner/archive/2009/01/29/9384143.aspx for more info
 Section -Prerequisites
 
-    !define VC_REDIST_X64_GUID "{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
-    !define VC_REDIST_X86_GUID "{9BE518E6-ECC6-35A9-88E4-87755C07200F}"
+    ; VCRedist only needed on Server 2008/Vista and below
+    ${If} ${AtMostWin2008}
 
-    Var /GLOBAL VcRedistGuid
-    Var /GLOBAL NeedVcRedist
-    ${If} ${CPUARCH} == "AMD64"
-        StrCpy $VcRedistGuid ${VC_REDIST_X64_GUID}
-    ${Else}
-        StrCpy $VcRedistGuid ${VC_REDIST_X86_GUID}
-    ${EndIf}
+        !define VC_REDIST_X64_GUID "{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
+        !define VC_REDIST_X86_GUID "{9BE518E6-ECC6-35A9-88E4-87755C07200F}"
 
-    Push $VcRedistGuid
-    Call MsiQueryProductState
-    ${If} $NeedVcRedist == "True"
-        MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 \
-            "VC Redist 2008 SP1 MFC is currently not installed. Would you like to install?" \
-            /SD IDYES IDNO endVcRedist
+        Var /GLOBAL VcRedistGuid
+        Var /GLOBAL NeedVcRedist
+        ${If} ${CPUARCH} == "AMD64"
+            StrCpy $VcRedistGuid ${VC_REDIST_X64_GUID}
+        ${Else}
+            StrCpy $VcRedistGuid ${VC_REDIST_X86_GUID}
+        ${EndIf}
 
-        ClearErrors
-        ; The Correct version of VCRedist is copied over by "build_pkg.bat"
-        SetOutPath "$INSTDIR\"
-        File "..\prereqs\vcredist.exe"
-        ExecWait "$INSTDIR\vcredist.exe /qb!"
-        IfErrors 0 endVcRedist
-            MessageBox MB_OK \
-                "VC Redist 2008 SP1 MFC failed to install. Try installing the package manually." \
-                /SD IDOK
+        Push $VcRedistGuid
+        Call MsiQueryProductState
+        ${If} $NeedVcRedist == "True"
+            MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 \
+                "VC Redist 2008 SP1 MFC is currently not installed. Would you like to install?" \
+                /SD IDYES IDNO endVcRedist
 
-        endVcRedist:
+            ClearErrors
+            ; The Correct version of VCRedist is copied over by "build_pkg.bat"
+            SetOutPath "$INSTDIR\"
+            File "..\prereqs\vcredist.exe"
+            ExecWait "$INSTDIR\vcredist.exe /qb!"
+            IfErrors 0 endVcRedist
+                MessageBox MB_OK \
+                    "VC Redist 2008 SP1 MFC failed to install. Try installing the package manually." \
+                    /SD IDOK
+
+            endVcRedist:
+        ${EndIf}
+
     ${EndIf}
 
 SectionEnd


### PR DESCRIPTION
### What does this PR do?
Fixes 64bit/32bit detection in build_pgk.bat.
Only install VCRedist on 2008/Vista and older.

### Previous Behavior
On a windows 32 box, git installs itself in `C:\Program Files (x86)` which shouldn't be present on 32bit Windows systems. So the build script would detect 64bit on a 32bit box with git installed.
Additionally, VCRedist was installed on all versions of Windows whether it needed it or not. It is only needed on versions of Windows older than 2008/Vista.

### New Behavior
Detects the presence of the `ProgramFiles(x86)` environment variable instead of the existence of the `C:\Program Files (x86)` directory.
Only installs the VCRedist on Windows Server 2008/Vista.

### Tests written?
NA