### PR TITLE
Fix two wheel issues in netapi

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1805,9 +1805,9 @@ class ClearFuncs(object):
                     'user': token['name']}
             try:
                 self.event.fire_event(data, tagify([jid, 'new'], 'wheel'))
-                ret = self.wheel_.call_func(fun, **clear_load)
-                data['return'] = ret
-                data['success'] = True
+                ret = self.wheel_.call_func(fun, full_return=True, **clear_load)
+                data['return'] = ret['return']
+                data['success'] = ret['success']
                 self.event.fire_event(data, tagify([jid, 'ret'], 'wheel'))
                 return {'tag': tag,
                         'data': data}

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -668,8 +668,17 @@ class SignalHandlingMultiprocessingProcess(MultiprocessingProcess):
 def default_signals(*signals):
     old_signals = {}
     for signum in signals:
-        old_signals[signum] = signal.getsignal(signum)
-        signal.signal(signum, signal.SIG_DFL)
+        try:
+            signal.signal(signum, signal.SIG_DFL)
+            old_signals[signum] = signal.getsignal(signum)
+        except ValueError as exc:
+            # This happens when a netapi module attempts to run a function
+            # using wheel_async, because the process trying to register signals
+            # will not be the main PID.
+            log.trace(
+                'Failed to register signal for signum %d: %s',
+                signum, exc
+            )
 
     # Do whatever is needed with the reset signals
     yield


### PR DESCRIPTION
The ClearFuncs was assuming a ``success`` of True 100% of the time for
wheel functions. This causes wheel funcs executed via salt-api (and
probably elsewhere) to incorrectly report the ``success`` field when the
wheel function triggers a traceback (such as when required positional
arguments are not passed).

Also, fixes a traceback when a netapi module tries to use ``wheel_async``.

Resolves #38540
Resolves #38537