### PR TITLE
Fix psutil regressions in 2016.11

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -76,7 +76,7 @@ def _gather_buffer_space():
 
     Result is in bytes.
     '''
-    if HAS_PSUTIL:
+    if HAS_PSUTIL and psutil.version_info >= (0, 6, 0):
         # Oh good, we have psutil. This will be quick.
         total_mem = psutil.virtual_memory().total
     else:

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -15,6 +15,7 @@ import codecs
 import logging
 from copy import deepcopy
 import types
+import platform
 
 # Import third party libs
 import yaml
@@ -40,14 +41,13 @@ import salt.utils.xdg
 import salt.exceptions
 from salt.utils.locales import sdecode
 import salt.defaults.exitcodes
+import salt.grains.core
 
 try:
     import psutil
     HAS_PSUTIL = True
 except ImportError:
     HAS_PSUTIL = False
-    import platform
-    import salt.grains.core
 
 log = logging.getLogger(__name__)
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -15,7 +15,6 @@ import codecs
 import logging
 from copy import deepcopy
 import types
-import platform
 
 # Import third party libs
 import yaml
@@ -41,7 +40,6 @@ import salt.utils.xdg
 import salt.exceptions
 from salt.utils.locales import sdecode
 import salt.defaults.exitcodes
-import salt.grains.core
 
 try:
     import psutil
@@ -80,6 +78,9 @@ def _gather_buffer_space():
         # Oh good, we have psutil. This will be quick.
         total_mem = psutil.virtual_memory().total
     else:
+        # Avoid loading core grains unless absolutely required
+        import platform
+        import salt.grains.core
         # We need to load up ``mem_total`` grain. Let's mimic required OS data.
         os_data = {'kernel': platform.system()}
         grains = salt.grains.core._memdata(os_data)

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -496,6 +496,9 @@ def total_physical_memory():
 
         salt '*' ps.total_physical_memory
     '''
+    if psutil.version_info < (0, 6, 0):
+        msg = 'virtual_memory is only available in psutil 0.6.0 or greater'
+        raise CommandExecutionError(msg)
     try:
         return psutil.virtual_memory().total
     except AttributeError:


### PR DESCRIPTION
### What does this PR do?

Fixes a regression issue when running 2016.11.1 on systems with an older version of python-psutil.

### What issues does this PR fix or reference?

None filed.

### Previous Behavior

Produced python stack traces.

### Tests written?

No