### PR TITLE
beacons.diskusage: regular expression handling

### DIFF
--- a/salt/beacons/diskusage.py
+++ b/salt/beacons/diskusage.py
@@ -43,7 +43,7 @@ def __validate__(config):
 
 
 def beacon(config):
-    '''
+    r'''
     Monitor the disk usage of the minion
 
     Specify thresholds for each disk and only emit a beacon if any of them are

--- a/salt/beacons/diskusage.py
+++ b/salt/beacons/diskusage.py
@@ -66,6 +66,22 @@ def beacon(config):
             - 'c:\': 90%
             - 'd:\': 50%
 
+    Regular expressions can be used as mount points.
+
+    .. code-block:: yaml
+
+        beacons:
+          diskusage:
+            - '^\/(?!home).*$': 90%
+            - '^[a-zA-Z]:\$': 50%
+
+    The first one will match all mounted disks beginning with "/", except /home
+    The second one will match disks from A:\ to Z:\ on a Windows system
+
+    Note that if a regular expression are evaluated after static mount points,
+    which means that if a regular expression matches an other defined mount point,
+    it will override the previously defined threshold.
+
     '''
     parts = psutil.disk_partitions(all=False)
     ret = []
@@ -76,7 +92,7 @@ def beacon(config):
             _current_usage = psutil.disk_usage(mount)
         except OSError:
             # Ensure a valid mount point
-            log.error('{0} is not a valid mount point, try regex.'.format(mount))
+            log.warning('{0} is not a valid mount point, try regex.'.format(mount))
             for part in parts:
                 if re.match(mount, part.mountpoint):
                     row = {}

--- a/salt/beacons/diskusage.py
+++ b/salt/beacons/diskusage.py
@@ -67,6 +67,7 @@ def beacon(config):
             - 'd:\': 50%
 
     '''
+    parts = psutil.disk_partitions(all=False)
     ret = []
     for mounts in config:
         mount = mounts.keys()[0]
@@ -75,7 +76,12 @@ def beacon(config):
             _current_usage = psutil.disk_usage(mount)
         except OSError:
             # Ensure a valid mount point
-            log.error('{0} is not a valid mount point, skipping.'.format(mount))
+            log.error('{0} is not a valid mount point, try regex.'.format(mount))
+            for part in parts:
+                if re.match(mount, part.mountpoint):
+                    row = {}
+                    row[part.mountpoint] = mounts[mount]
+                    config.append(row)
             continue
 
         current_usage = _current_usage.percent


### PR DESCRIPTION
### What does this PR do?
If the psutil.disk_usage(mount) fails, the beacon will now check
if there is a partition mount point matching the initial mount point
as regular expression.

### Previous Behavior
There was no generic way to include all disks in the config

### New Behavior
You can now put one or more regex in the config like this

```
beacons:
  diskusage:
    - "/.*": 63%
    - ".*:": 13%
```

### Tests written?
No