### PR TITLE
Fix smtp ret require gnupg

### DIFF
--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -217,7 +217,8 @@ def returner(ret):
                                    input_data=template,
                                    **ret)
 
-    if HAS_GNUPG and gpgowner:
+    if gpgowner:
+        assert HAS_GNUPG, "gnupg is required in order to user gpgowner in smtp returner"
         gpg = gnupg.GPG(gnupghome=os.path.expanduser('~{0}/.gnupg'.format(gpgowner)),
                         options=['--trust-model always'])
         encrypted_data = gpg.encrypt(content, to_addrs)

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -231,8 +231,6 @@ def returner(ret):
                     encrypted_data.status, encrypted_data.stderr)
         else:
             log.error("gnupg python module is required in order to user gpgowner in smtp returner ; ignoring gpgowner configuration for now")
-            
-
     if isinstance(content, six.moves.StringIO):
         content = content.read()
 

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -132,9 +132,7 @@ __virtualname__ = 'smtp'
 
 
 def __virtual__():
-    if HAS_GNUPG:
-        return __virtualname__
-    return False, 'Could not import smtp returner; gnupg is not installed.'
+    return __virtualname__
 
 
 def _get_options(ret=None):


### PR DESCRIPTION
### What does this PR do?
This PR makes smtp returner be independant from gnupg installation

### What issues does this PR fix or reference?
Can't find an issue for that. I encountered the problem myself.

### Previous Behavior
Smtp returner could not be used if gnupg python module is not installed

### New Behavior
Smtp returner could be used without gnupg. If gpgowner is set and gnupg is not installed, an error is shown.

### Tests written?
No
