### PR TITLE
When we generate the pillar we should send in the master opts

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -896,9 +896,9 @@ class Single(object):
             opts_pkg['id'] = self.id
 
             retcode = 0
-
+            popts = self.context['master_opts'].update(opts_pkg)
             pillar = salt.pillar.Pillar(
-                    opts_pkg,
+                    popts,
                     opts_pkg['grains'],
                     opts_pkg['id'],
                     opts_pkg.get('environment', 'base')

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -896,7 +896,8 @@ class Single(object):
             opts_pkg['id'] = self.id
 
             retcode = 0
-            popts = copy.deepcopy(self.context['master_opts'])
+            popts = {}
+            popts.update(opts_pkg['__master_opts__'])
             popts.update(opts_pkg)
             pillar = salt.pillar.Pillar(
                     popts,

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -896,7 +896,7 @@ class Single(object):
             opts_pkg['id'] = self.id
 
             retcode = 0
-            popts = copy.copy(self.context['master_opts'])
+            popts = copy.deepcopy(self.context['master_opts'])
             popts.update(opts_pkg)
             pillar = salt.pillar.Pillar(
                     popts,

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -896,7 +896,8 @@ class Single(object):
             opts_pkg['id'] = self.id
 
             retcode = 0
-            popts = self.context['master_opts'].update(opts_pkg)
+            popts = copy.copy(self.context['master_opts'])
+            popts.update(opts_pkg)
             pillar = salt.pillar.Pillar(
                     popts,
                     opts_pkg['grains'],


### PR DESCRIPTION
This better reflects how salt normally works per #38830
@cachedout do you see any issues with this? The minion opts are still prioritized so this is not really a behavior change apart from allowing the master opts to be sent to pillar generation