### PR TITLE
Use signing passphrase as public passphrase when generating self-sign…

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -1417,6 +1417,9 @@ def create_certificate(
     # If neither public_key or csr are included, this cert is self-signed
     if 'public_key' not in kwargs and 'csr' not in kwargs:
         kwargs['public_key'] = kwargs['signing_private_key']
+        if 'signing_private_key_passphrase' in kwargs:
+            kwargs['public_key_passphrase'] = kwargs[
+                'signing_private_key_passphrase']
 
     csrexts = {}
     if 'csr' in kwargs:


### PR DESCRIPTION
…ed certificates

### What does this PR do?

Uses the signing key passphrase as the public key passphrase when the signing key is used as the public key.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/38081#issuecomment-275195391