### PR TITLE
Fix timezone handling for rpm installtime

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -575,7 +575,7 @@ def info(*packages, **attr):
             # Convert Unix ticks into ISO time format
             if key in ['build_date', 'install_date']:
                 try:
-                    pkg_data[key] = datetime.datetime.fromtimestamp(int(value)).isoformat() + "Z"
+                    pkg_data[key] = datetime.datetime.utcfromtimestamp(int(value)).isoformat() + "Z"
                 except ValueError:
                     log.warning('Could not convert "{0}" into Unix time'.format(value))
                 continue


### PR DESCRIPTION

### What does this PR do?

fix install_date and build_date reported for RPMs

### Previous Behavior

Previously datetime.fromtimestamp was used. If used without additional
parameters, this method returns date in the local timezone.

Our code took the result of fromtimestamp, appended 'Z' and returned
this string. This is wrong as 'Z' means UTC (the client code parses this
value as UTC, but it's in fact local time).

Fixed by using utcfromtimestamp.
