### PR TITLE
runners/pillar.py: Updated documentation to use pillarenv instead of …

### DIFF
--- a/salt/runners/pillar.py
+++ b/salt/runners/pillar.py
@@ -57,10 +57,12 @@ def show_pillar(minion='*', **kwargs):
         salt-run pillar.show_pillar
 
     shows global pillar for 'dev' pillar environment:
+    (note that not specifying pillarenv will merge all pillar environments
+    using the master config option pillar_source_merging_strategy.)
 
     .. code-block:: bash
 
-        salt-run pillar.show_pillar 'saltenv=dev'
+        salt-run pillar.show_pillar 'pillarenv=dev'
 
     API Example:
 
@@ -75,6 +77,7 @@ def show_pillar(minion='*', **kwargs):
     '''
 
     saltenv = 'base'
+    pillarenv = __opts__['pillarenv'] if 'pillarenv' in __opts__ else None
     id_, grains, _ = salt.utils.minions.get_minion_data(minion, __opts__)
     if grains is None:
         grains = {'fqdn': minion}
@@ -82,6 +85,8 @@ def show_pillar(minion='*', **kwargs):
     for key in kwargs:
         if key == 'saltenv':
             saltenv = kwargs[key]
+        elif key == 'pillarenv':
+            pillarenv = kwargs[key]
         else:
             grains[key] = kwargs[key]
 
@@ -89,7 +94,8 @@ def show_pillar(minion='*', **kwargs):
         __opts__,
         grains,
         id_,
-        saltenv)
+        saltenv,
+        pillarenv=pillarenv)
 
     compiled_pillar = pillar.compile_pillar()
     return compiled_pillar


### PR DESCRIPTION
…saltenv when wanting to show the pillar of a specific environment. Added parsing of pillarenv argument so it actually gets used.

### What does this PR do?
It allows an override of pillarenv given from the commandline in order to have show_pillar only show the pillar for that specific environment. The documentation currently states that saltenv is to be used, but that turns out not to be the case.

### What issues does this PR fix or reference?
None that I know of.

### Previous Behavior
Documentation states using saltenv=env can be used to only show pillar data for that environment, but it does not. Argument pillarenv is not passed through.

### New Behavior
Documentation updated to state that pillarenv is to be used instead. Passed pillarenv argument now overrides pillarenv in __opts__ (if present) and is passed through to the Pillar constructor.

### Tests written?
No