### PR TITLE
Compile Salt offline (without internet connection)

### DIFF
--- a/pkg/windows/build.bat
+++ b/pkg/windows/build.bat
@@ -1,5 +1,7 @@
 @echo off
-@echo Salt Windows Build Script
+@echo Salt Windows Build Script, which calls the other *.ps1 scripts.
+@echo    You may set SALTREPO_LOCAL_CACHE 
+@echo           and  SALTREPO_LOCAL_CACHE_PIP to permanent cache directories
 @echo ---------------------------------------------------------------------
 @echo.
 
@@ -68,6 +70,9 @@ if not %errorLevel%==0 (
 @echo %0 :: Install Current Version of salt...
 @echo ---------------------------------------------------------------------
 "%PyDir%\python.exe" "%SrcDir%\setup.py" --quiet install --force
+if not %errorLevel%==0 (
+    goto eof
+)
 @echo.
 
 :: Build the Salt Package

--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -22,10 +22,9 @@
 
 # Load parameters
 param(
-    [switch]$Silent
+	[switch]$Silent
 )
 
-# Clear-Host
 Write-Output "================================================================="
 Write-Output ""
 Write-Output "               Development Environment Installation"
@@ -46,6 +45,11 @@ $script_path = dir "$($myInvocation.MyCommand.Definition)"
 $script_path = $script_path.DirectoryName
 
 #==============================================================================
+# Get the name of actual script
+#==============================================================================
+$script_name = $MyInvocation.MyCommand.Name
+
+#==============================================================================
 # Import Modules
 #==============================================================================
 Import-Module $script_path\Modules\download-module.psm1
@@ -57,29 +61,28 @@ Import-Module $script_path\Modules\start-process-and-test-exitcode.psm1
 # Check for Elevated Privileges
 #==============================================================================
 If (!(Get-IsAdministrator)) {
-    If (Get-IsUacEnabled) {
-        # We are not running "as Administrator" - so relaunch as administrator
-        # Create a new process object that starts PowerShell
-        $newProcess = new-object System.Diagnostics.ProcessStartInfo "PowerShell";
+	If (Get-IsUacEnabled) {
+		# We are not running "as Administrator" - so relaunch as administrator
+		# Create a new process object that starts PowerShell
+		$newProcess = new-object System.Diagnostics.ProcessStartInfo "PowerShell";
 
-        # Specify the current script path and name as a parameter
-        $newProcess.Arguments = $myInvocation.MyCommand.Definition
+		# Specify the current script path and name as a parameter
+		$newProcess.Arguments = $myInvocation.MyCommand.Definition
 
-        # Specify the current working directory
-        $newProcess.WorkingDirectory = "$script_path"
+		# Specify the current working directory
+		$newProcess.WorkingDirectory = "$script_path"
 
-        # Indicate that the process should be elevated
-        $newProcess.Verb = "runas";
+		# Indicate that the process should be elevated
+		$newProcess.Verb = "runas";
 
-        # Start the new process
-        [System.Diagnostics.Process]::Start($newProcess);
+		# Start the new process
+		[System.Diagnostics.Process]::Start($newProcess);
 
-        # Exit from the current, unelevated, process
-        Exit
-
-    } Else {
-        Throw "You must be administrator to run this script"
-    }
+		# Exit from the current, unelevated, process
+		Exit
+	} Else {
+		Throw "You must be administrator to run this script"
+	}
 }
 
 #------------------------------------------------------------------------------
@@ -87,33 +90,35 @@ If (!(Get-IsAdministrator)) {
 #------------------------------------------------------------------------------
 $ini = Get-Settings
 
+
 #------------------------------------------------------------------------------
-# Create Directories
+# You can set SALTREPO_LOCAL_CACHE and SALTREPO_LOCAL_CACHE_PIP to  permanent cache directories (DownloadDir).
+# The script empties DownloadDir unless SALTREPO_LOCAL_CACHE environment variable set
 #------------------------------------------------------------------------------
-$p = New-Item $ini['Settings']['DownloadDir'] -ItemType Directory -Force
+if ( ! [bool]$Env:SALTREPO_LOCAL_CACHE ) {
+	$p = New-Item $ini['Settings']['DownloadDir'] -ItemType Directory -Force
+	$p = New-Item "$($ini['Settings']['DownloadDir'])\64" -ItemType Directory -Force
+	$p = New-Item "$($ini['Settings']['DownloadDir'])\32" -ItemType Directory -Force
+	# Write-Output "created  DownloadDir\64  ## $($ini['Settings']['DownloadDir'])\64 ##"
+}
 $p = New-Item $ini['Settings']['SaltDir'] -ItemType Directory -Force
 
 #------------------------------------------------------------------------------
 # Determine Architecture (32 or 64 bit) and assign variables
 #------------------------------------------------------------------------------
 If ([System.IntPtr]::Size -ne 4) {
+	Write-Output "Detected 64bit Architecture..."
 
-    Write-Output "Detected 64bit Architecture..."
-
-    $bitDLLs     = "64bitDLLs"
-    $bitPaths    = "64bitPaths"
-    $bitPrograms = "64bitPrograms"
-    $bitFolder   = "64"
-  
- } Else {
-
-    Write-Output "Detected 32bit Architecture"
-
-    $bitDLLs     = "32bitDLLs"
-    $bitPaths    = "32bitPaths"
-    $bitPrograms = "32bitPrograms"
-    $bitFolder   = "32"
-
+	$bitDLLs     = "64bitDLLs"
+	$bitPaths    = "64bitPaths"
+	$bitPrograms = "64bitPrograms"
+	$bitFolder   = "64"
+} Else {
+	Write-Output "Detected 32bit Architecture"
+	$bitDLLs     = "32bitDLLs"
+	$bitPaths    = "32bitPaths"
+	$bitPrograms = "32bitPrograms"
+	$bitFolder   = "32"
 }
 
 #------------------------------------------------------------------------------
@@ -121,25 +126,21 @@ If ([System.IntPtr]::Size -ne 4) {
 #------------------------------------------------------------------------------
 Write-Output " - Checking for NSIS installation . . ."
 If (Test-Path "$($ini[$bitPaths]['NSISDir'])\NSIS.exe") {
-
-    # Found NSIS, do nothing
-    Write-Output " - NSIS Found . . ."
-
+	# Found NSIS, do nothing
+	Write-Output " - NSIS Found . . ."
 } Else {
+	# NSIS not found, install
+	Write-Output " - NSIS Not Found . . ."
+	Write-Output " - Downloading $($ini['Prerequisites']['NSIS']) . . ."
+	$file = "$($ini['Prerequisites']['NSIS'])"
+	$url  = "$($ini['Settings']['SaltRepo'])/$file"
+	$file = "$($ini['Settings']['DownloadDir'])\$file"
+	DownloadFileWithProgress $url $file
 
-    # NSIS not found, install
-    Write-Output " - NSIS Not Found . . ."
-    Write-Output " - Downloading $($ini['Prerequisites']['NSIS']) . . ."
-    $file = "$($ini['Prerequisites']['NSIS'])"
-    $url  = "$($ini['Settings']['SaltRepo'])/$file"
-    $file = "$($ini['Settings']['DownloadDir'])\$file"
-    DownloadFileWithProgress $url $file
-
-    # Install NSIS
-    Write-Output " - Installing $($ini['Prerequisites']['NSIS']) . . ."
-    $file = "$($ini['Settings']['DownloadDir'])\$($ini['Prerequisites']['NSIS'])"
-    $p    = Start-Process $file -ArgumentList '/S' -Wait -NoNewWindow -PassThru
-
+	# Install NSIS
+	Write-Output " - Installing $($ini['Prerequisites']['NSIS']) . . ."
+	$file = "$($ini['Settings']['DownloadDir'])\$($ini['Prerequisites']['NSIS'])"
+	$p    = Start-Process $file -ArgumentList '/S' -Wait -NoNewWindow -PassThru
 }
 
 #------------------------------------------------------------------------------
@@ -147,25 +148,21 @@ If (Test-Path "$($ini[$bitPaths]['NSISDir'])\NSIS.exe") {
 #------------------------------------------------------------------------------
 Write-Output " - Checking for VC Compiler for Python 2.7 installation . . ."
 If (Test-Path "$($ini[$bitPaths]['VCforPythonDir'])\vcvarsall.bat") {
-
-    # Found Microsoft Visual C++ for Python2.7, do nothing
-    Write-Output " - Microsoft Visual C++ for Python 2.7 Found . . ."
-
+	# Found Microsoft Visual C++ for Python2.7, do nothing
+	Write-Output " - Microsoft Visual C++ for Python 2.7 Found . . ."
 } Else {
+	# Microsoft Visual C++ for Python2.7 not found, install
+	Write-Output " - Microsoft Visual C++ for Python2.7 Not Found . . ."
+	Write-Output " - Downloading $($ini['Prerequisites']['VCforPython']) . . ."
+	$file = "$($ini['Prerequisites']['VCforPython'])"
+	$url  = "$($ini['Settings']['SaltRepo'])/$file"
+	$file = "$($ini['Settings']['DownloadDir'])\$file"
+	DownloadFileWithProgress $url $file
 
-    # Microsoft Visual C++ for Python2.7 not found, install
-    Write-Output " - Microsoft Visual C++ for Python2.7 Not Found . . ."
-    Write-Output " - Downloading $($ini['Prerequisites']['VCforPython']) . . ."
-    $file = "$($ini['Prerequisites']['VCforPython'])"
-    $url  = "$($ini['Settings']['SaltRepo'])/$file"
-    $file = "$($ini['Settings']['DownloadDir'])\$file"
-    DownloadFileWithProgress $url $file
-
-    # Install Microsoft Visual C++ for Python2.7
-    Write-Output " - Installing $($ini['Prerequisites']['VCforPython']) . . ."
-    $file = "$($ini['Settings']['DownloadDir'])\$($ini['Prerequisites']['VCforPython'])"
-    $p    = Start-Process msiexec.exe -ArgumentList "/i $file /qb ALLUSERS=1" -Wait -NoNewWindow -PassThru
-
+	# Install Microsoft Visual C++ for Python2.7
+	Write-Output " - Installing $($ini['Prerequisites']['VCforPython']) . . ."
+	$file = "$($ini['Settings']['DownloadDir'])\$($ini['Prerequisites']['VCforPython'])"
+	$p    = Start-Process msiexec.exe -ArgumentList "/i $file /qb ALLUSERS=1" -Wait -NoNewWindow -PassThru
 }
 
 #------------------------------------------------------------------------------
@@ -173,22 +170,17 @@ If (Test-Path "$($ini[$bitPaths]['VCforPythonDir'])\vcvarsall.bat") {
 #------------------------------------------------------------------------------
 Write-Output " - Checking for Python 2.7 installation . . ."
 If (Test-Path "$($ini['Settings']['PythonDir'])\python.exe") {
-
-    # Found Python2.7, do nothing
-    Write-Output " - Python 2.7 Found . . ."
-
+	# Found Python2.7, do nothing
+	Write-Output " - Python 2.7 Found . . ."
 } Else {
+	Write-Output " - Downloading $($ini[$bitPrograms]['Python']) . . ."
+	$file = "$($ini[$bitPrograms]['Python'])"
+	$url  = "$($ini['Settings']['SaltRepo'])/$bitFolder/$file"
+	$file = "$($ini['Settings']['DownloadDir'])\$bitFolder\$file"
+	DownloadFileWithProgress $url $file
 
-    Write-Output " - Downloading $($ini[$bitPrograms]['Python']) . . ."
-    $file = "$($ini[$bitPrograms]['Python'])"
-    $url  = "$($ini['Settings']['SaltRepo'])/$bitFolder/$file"
-    $file = "$($ini['Settings']['DownloadDir'])\$file"
-    DownloadFileWithProgress $url $file
-    
-    Write-Output " - Installing $($ini[$bitPrograms]['Python']) . . ."
-    $file = "$($ini['Settings']['DownloadDir'])\$($ini[$bitPrograms]['Python'])"
-    $p    = Start-Process msiexec -ArgumentList "/i $file /qb ADDLOCAL=DefaultFeature,Extensions,pip_feature,PrependPath TARGETDIR=$($ini['Settings']['PythonDir'])" -Wait -NoNewWindow -PassThru
-
+	Write-Output " - $script_name :: Installing $($ini[$bitPrograms]['Python']) . . ."
+	$p    = Start-Process msiexec -ArgumentList "/i $file /qb ADDLOCAL=DefaultFeature,Extensions,pip_feature,PrependPath TARGETDIR=$($ini['Settings']['PythonDir'])" -Wait -NoNewWindow -PassThru
 }
 
 #------------------------------------------------------------------------------
@@ -197,96 +189,126 @@ If (Test-Path "$($ini['Settings']['PythonDir'])\python.exe") {
 Write-Output " - Updating Environment Variables . . ."
 $Path = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
 If (!($Path.ToLower().Contains("$($ini['Settings']['ScriptsDir'])".ToLower()))) {
-    $newPath  = "$($ini['Settings']['ScriptsDir']);$Path"
-    Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
-    $env:Path = $newPath
+	$newPath  = "$($ini['Settings']['ScriptsDir']);$Path"
+	Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+	$env:Path = $newPath
 }
 
 #==============================================================================
 # Update PIP and SetupTools
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
-Write-Output " - Updating PIP and SetupTools . . ."
+Write-Output " - $script_name :: Updating PIP and SetupTools . . ."
 Write-Output " ----------------------------------------------------------------"
-Start_Process_and_test_exitcode "$($ini['Settings']['PythonDir'])\python.exe" "-m pip --no-cache-dir install -r $($script_path)\req_pip.txt" "python pip"
+if ( ! [bool]$Env:SALTREPO_LOCAL_CACHE_PIP) {
+	Start_Process_and_test_exitcode "$($ini['Settings']['PythonDir'])\python.exe" "-m pip --no-cache-dir install -r $($script_path)\req_pip.txt" "python pip"
+} else {
+	if ( (Get-ChildItem $Env:SALTREPO_LOCAL_CACHE_PIP | Measure-Object).Count -eq 0 ) {
+		# folder empty
+		Write-Output "    pip download into empty local cache $Env:SALTREPO_LOCAL_CACHE_PIP"
+		Start_Process_and_test_exitcode "$($ini['Settings']['PythonDir'])\python.exe"  "-m pip download --dest $Env:SALTREPO_LOCAL_CACHE_PIP -r $($script_path)\req_pip.txt" "pip download"
+	}
+	Write-Output "    reading from local pip cache $Env:SALTREPO_LOCAL_CACHE_PIP"
+	Write-Output "    If a (new) ressource is missing, please delete all files in this cache, go online and repeat"
+  Start_Process_and_test_exitcode "$($ini['Settings']['PythonDir'])\python.exe" "-m pip install --no-index --find-links=$Env:SALTREPO_LOCAL_CACHE_PIP -r $($script_path)\req_pip.txt" "pip install"
+}
 
 #==============================================================================
 # Install pypi resources using pip
+#    caching depends on environmant variable SALTREPO_LOCAL_CACHE_PIP
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
-Write-Output " - Installing pypi resources using pip . . ."
+Write-Output " - $script_name :: Installing pypi resources using pip . . ."
 Write-Output " ----------------------------------------------------------------"
-Start_Process_and_test_exitcode "$($ini['Settings']['ScriptsDir'])\pip.exe"  "--no-cache-dir install -r $($script_path)\req.txt" "pip install"
+if ( ! [bool]$Env:SALTREPO_LOCAL_CACHE_PIP) {
+	Start_Process_and_test_exitcode "$($ini['Settings']['ScriptsDir'])\pip.exe"  "--no-cache-dir install -r $($script_path)\req.txt" "pip install"
+} else {
+	if ( (Get-ChildItem $Env:SALTREPO_LOCAL_CACHE_PIP | Measure-Object).Count -eq 0 ) {
+		# folder empty
+		Write-Output "    pip download into empty local cache $Env:SALTREPO_LOCAL_CACHE_PIP"
+		Start_Process_and_test_exitcode "$($ini['Settings']['PythonDir'])\python.exe"  "-m pip download --dest $Env:SALTREPO_LOCAL_CACHE_PIP -r $($script_path)\req.txt" "pip download"
+	}
+	Write-Output "    reading from local pip cache $Env:SALTREPO_LOCAL_CACHE_PIP"
+	Write-Output "    If a (new) ressource is missing, please delete all files in this cache, go online and repeat"
+  Start_Process_and_test_exitcode "$($ini['Settings']['PythonDir'])\python.exe" "-m pip install --no-index --find-links=$Env:SALTREPO_LOCAL_CACHE_PIP -r $($script_path)\req.txt" "pip install"
+}
 
 #==============================================================================
 # Install PyYAML with CLoader
 # This has to be a compiled binary to get the CLoader
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
-Write-Output " - Installing PyYAML . . ."
+Write-Output " - $script_name :: Installing PyYAML . . ."
 Write-Output " ----------------------------------------------------------------"
 # Download
 $file = "$($ini[$bitPrograms]['PyYAML'])"
 $url  = "$($ini['Settings']['SaltRepo'])/$bitFolder/$file"
-$file = "$($ini['Settings']['DownloadDir'])\$file"
+$file = "$($ini['Settings']['DownloadDir'])\$bitFolder\$file"
 DownloadFileWithProgress $url $file
 
 # Install
-$file = "$($ini['Settings']['DownloadDir'])\$($ini[$bitPrograms]['PyYAML'])"
-Start_Process_and_test_exitcode "$($ini['Settings']['ScriptsDir'])\easy_install.exe" "-Z $file " "easy_install PyYAML"
-
+if ( ! [bool]$Env:SALTREPO_LOCAL_CACHE_PIP) {
+	Start_Process_and_test_exitcode "$($ini['Settings']['ScriptsDir'])\easy_install.exe" "-Z $file " "easy_install PyYAML"
+} else {
+	Start_Process_and_test_exitcode "$($ini['Settings']['PythonDir'])\python.exe" "-m easy_install -Z $file " "easy_install PyYAML"
+}
 #==============================================================================
 # Install PyCrypto from wheel file
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
-Write-Output " - Installing PyCrypto . . ."
+Write-Output " - $script_name :: Installing PyCrypto . . ."
 Write-Output " ----------------------------------------------------------------"
 # Download
 $file = "$($ini[$bitPrograms]['PyCrypto'])"
 $url  = "$($ini['Settings']['SaltRepo'])/$bitFolder/$file"
-$file = "$($ini['Settings']['DownloadDir'])\$file"
+$file = "$($ini['Settings']['DownloadDir'])\$bitFolder\$file"
 DownloadFileWithProgress $url $file
 
 # Install
-$file = "$($ini['Settings']['DownloadDir'])\$($ini[$bitPrograms]['PyCrypto'])"
-Start_Process_and_test_exitcode  "$($ini['Settings']['ScriptsDir'])\pip.exe" "install --no-index --find-links=$($ini['Settings']['DownloadDir']) $file " "pip install PyCrypto"
-
+if ( ! [bool]$Env:SALTREPO_LOCAL_CACHE_PIP) {
+	Start_Process_and_test_exitcode  "$($ini['Settings']['ScriptsDir'])\pip.exe" "install --no-index --find-links=$($ini['Settings']['DownloadDir']) $file " "pip install PyCrypto"
+} else {
+	Start_Process_and_test_exitcode  "$($ini['Settings']['PythonDir'])\python.exe" "-m pip install --no-index --find-links=$($ini['Settings']['DownloadDir']) $file " "pip install PyCrypto"
+}
 #==============================================================================
 # Copy DLLs to Python Directory
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
-Write-Output "   - Copying DLLs . . ."
+Write-Output "   - $script_name :: Copying DLLs . . ."
 Write-Output " ----------------------------------------------------------------"
 # Architecture Specific DLL's
 ForEach($key in $ini[$bitDLLs].Keys) {
-    If ($arrInstalled -notcontains $key) {
-        Write-Output "   - $key . . ."
-        $file = "$($ini[$bitDLLs][$key])"
-        $url  = "$($ini['Settings']['SaltRepo'])/$bitFolder/$file"
-        $file = "$($ini['Settings']['PythonDir'])\$file"
-        DownloadFileWithProgress $url $file
-    }
+	If ($arrInstalled -notcontains $key) {
+		Write-Output "   - $key . . ."
+		$file = "$($ini[$bitDLLs][$key])"
+		$url  = "$($ini['Settings']['SaltRepo'])/$bitFolder/$file"
+		$file = "$($ini['Settings']['DownloadDir'])\$bitFolder\$file"
+		DownloadFileWithProgress $url $file
+		Copy-Item $file  -destination $($ini['Settings']['PythonDir'])
+	}
 }
 
 #------------------------------------------------------------------------------
 # Script complete
 #------------------------------------------------------------------------------
 Write-Output "================================================================="
-Write-Output "Salt Stack Dev Environment Script Complete"
+Write-Output " $script_name :: Salt Stack Dev Environment Script Complete"
 Write-Output "================================================================="
 Write-Output ""
 
 If (-Not $Silent) {
-    Write-Output "Press any key to continue ..."
-    $p = $HOST.UI.RawUI.Flushinputbuffer()
-    $p = $HOST.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+	Write-Output "Press any key to continue ..."
+	$p = $HOST.UI.RawUI.Flushinputbuffer()
+	$p = $HOST.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
 }
 
 #------------------------------------------------------------------------------
 # Remove the temporary download directory
 #------------------------------------------------------------------------------
 Write-Output " ----------------------------------------------------------------"
-Write-Output " - Cleaning up downloaded files"
+Write-Output " - $script_name :: Cleaning up downloaded files unless you use SALTREPO_LOCAL_CACHE"
 Write-Output " ----------------------------------------------------------------"
 Write-Output ""
-Remove-Item $($ini['Settings']['DownloadDir']) -Force -Recurse
+if ( ! [bool]$Env:SALTREPO_LOCAL_CACHE ) {
+	Remove-Item $($ini['Settings']['DownloadDir']) -Force -Recurse
+}

--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -16,37 +16,37 @@ Set "PyDir36=C:\Program Files\Python36"
 
 :: Get the version from git if not passed
 if [%1]==[] (
-    for /f "delims=" %%a in ('git describe') do @set "Version=%%a"
+	for /f "delims=" %%a in ('git describe') do @set "Version=%%a"
 ) else (
-    set "Version=%~1"
+	set "Version=%~1"
 )
 
 If Exist "%PyDir36%\python.exe" (
-    Set "PyDir=%PyDir36%"
-    Set "PyVerMajor=3"
-    Set "PyVerMinor=6"
+	Set "PyDir=%PyDir36%"
+	Set "PyVerMajor=3"
+	Set "PyVerMinor=6"
 ) Else (
-    If Exist "%PyDir35%\python.exe" (
-        Set "PyDir=%PyDir35%"
-        Set "PyVerMajor=3"
-        Set "PyVerMinor=5"
-    ) Else (
-        If Exist "%PyDir27%\python.exe" (
-            Set "PyDir=%PyDir27%"
-            Set "PyVerMajor=2"
-            Set "PyVerMinor=7"
-        ) Else (
-            @echo Could not find Python on the system
-            exit /b 1
-        )
-    )
+	If Exist "%PyDir35%\python.exe" (
+		Set "PyDir=%PyDir35%"
+		Set "PyVerMajor=3"
+		Set "PyVerMinor=5"
+	) Else (
+		If Exist "%PyDir27%\python.exe" (
+			Set "PyDir=%PyDir27%"
+			Set "PyVerMajor=2"
+			Set "PyVerMinor=7"
+		) Else (
+			@echo Could not find Python on the system
+			exit /b 1
+		)
+	)
 )
 
 :: Find the NSIS Installer
 If Exist "C:\Program Files\NSIS\" (
-    Set NSIS="C:\Program Files\NSIS\"
+	Set NSIS="C:\Program Files\NSIS\"
 ) Else (
-    Set NSIS="C:\Program Files (x86)\NSIS\"
+	Set NSIS="C:\Program Files (x86)\NSIS\"
 )
 Set "PATH=%NSIS%;%PATH%"
 @echo.
@@ -70,9 +70,9 @@ If NOT Exist "%PreDir%" mkdir "%PreDir%"
 Set Url64="http://repo.saltstack.com/windows/dependencies/64/vcredist_x64_2008_mfc.exe"
 Set Url32="http://repo.saltstack.com/windows/dependencies/32/vcredist_x86_2008_mfc.exe"
 If Exist "C:\Program Files (x86)" (
-    bitsadmin /transfer "VCRedist 2008 MFC AMD64" "%Url64%" "%PreDir%\vcredist.exe"
+	powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url64%" -file "%PreDir%\vcredist.exe"
 ) Else (
-    bitsadmin /transfer "VCRedist 2008 MFC x86" "%Url32%" "%PreDir%\vcredist.exe"
+	powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url32%" -file "%PreDir%\vcredist.exe"
 )
 @echo.
 

--- a/pkg/windows/download_url_file.ps1
+++ b/pkg/windows/download_url_file.ps1
@@ -1,0 +1,39 @@
+#
+# Download url to file. Optionally, store in cache
+#
+#
+Param(
+	[Parameter(Mandatory=$true)][string]$url,
+	[Parameter(Mandatory=$true)][string]$file
+)
+
+
+$VerbosePreference = 'Continue'
+
+
+Import-Module ./Modules/download-module.psm1
+
+if ( [bool]$Env:SALTREPO_LOCAL_CACHE) {
+	Write-Verbose "found SALTREPO_LOCAL_CACHE environment variable $Env:SALTREPO_LOCAL_CACHE"
+} else {
+	Write-Verbose "no SALTREPO_LOCAL_CACHE environment variable "
+}
+
+$saltrepo_url = "http://repo.saltstack.com/windows/dependencies/"
+
+if ( [bool]$Env:SALTREPO_LOCAL_CACHE -And $url.StartsWith($saltrepo_url) ) {
+	Write-Verbose "found SALTREPO_LOCAL_CACHE environment variable and url is saltrepo"
+	$url_relative__slash     = $url                 -replace [regex]::Escape($saltrepo_url), ""
+	$url_relative__backslash = $url_relative__slash -replace [regex]::Escape("/"), "\\"
+	$localCacheFile          = Join-Path $Env:SALTREPO_LOCAL_CACHE $url_relative__backslash
+	if (-Not (Test-Path $localCacheFile)) {
+		Write-Verbose "downloading to cache   $localCacheFile"
+		DownloadFileWithProgress $url $localCacheFile
+	}
+	Write-Verbose "copying from cache $file"
+	Copy-Item $localCacheFile  -destination $file
+} else {
+	Write-Verbose "no SALTREPO_LOCAL_CACHE environment variable, or URL not saltrepo, downloading directly"
+	DownloadFileWithProgress $url $file
+}
+

--- a/pkg/windows/modules/download-module.psm1
+++ b/pkg/windows/modules/download-module.psm1
@@ -1,58 +1,76 @@
 Function DownloadFileWithProgress {
 
-    # Code for this function borrowed from http://poshcode.org/2461
-    # Thanks Crazy Dave
+	# Code for this function borrowed from http://poshcode.org/2461
+	# Thanks Crazy Dave
 
-    # This function downloads the passed file and shows a progress bar
-    # It receives two parameters:
-    #    $url - the file source
-    #    $localfile - the file destination on the local machine
+	# This function downloads the passed file and shows a progress bar
+	# It receives two parameters:
+	#    $url - the file source
+	#    $localfile - the file destination on the local machine
 
-    param(
-        [Parameter(Mandatory=$true)]
-        [String] $url,
-        [Parameter(Mandatory=$false)]
-        [String] $localFile = (Join-Path $pwd.Path $url.SubString($url.LastIndexOf('/'))) 
-    )
+	# Originally, DownLoadDir is deleted for each install, therefore
+	# this function did not expect that the file exists.
+	# You may want to set an environment variable SALTREPO_LOCAL_CACHE, a cache which lives as long as you decide.
+	# Therefore this function must test if the file exists.
 
-    begin {
-        $client = New-Object System.Net.WebClient
-        $Global:downloadComplete = $false
-        $eventDataComplete = Register-ObjectEvent $client DownloadFileCompleted `
-            -SourceIdentifier WebClient.DownloadFileComplete `
-            -Action {$Global:downloadComplete = $true}
-        $eventDataProgress = Register-ObjectEvent $client DownloadProgressChanged `
-            -SourceIdentifier WebClient.DownloadProgressChanged `
-            -Action { $Global:DPCEventArgs = $EventArgs }
-    }
-    process {
-        Write-Progress -Activity 'Downloading file' -Status $url
-        $client.DownloadFileAsync($url, $localFile)
 
-        while (!($Global:downloadComplete)) {
-            $pc = $Global:DPCEventArgs.ProgressPercentage
-            if ($pc -ne $null) {
-                Write-Progress -Activity 'Downloading file' -Status $url -PercentComplete $pc
-            }
-        }
-        Write-Progress -Activity 'Downloading file' -Status $url -Complete
-    }
+	param(
+		[Parameter(Mandatory=$true)]
+		[String] $url,
+		[Parameter(Mandatory=$false)]
+		[String] $localFile = (Join-Path $pwd.Path $url.SubString($url.LastIndexOf('/')))
+	)
 
-    end {
-        Unregister-Event -SourceIdentifier WebClient.DownloadProgressChanged
-        Unregister-Event -SourceIdentifier WebClient.DownloadFileComplete
-        $client.Dispose()
-        $Global:downloadComplete = $null
-        $Global:DPCEventArgs = $null
-        Remove-Variable client
-        Remove-Variable eventDataComplete
-        Remove-Variable eventDataProgress
-        [GC]::Collect()
-        # 2016-07-06  mkr  Errorchecking added. nice-to-have: integration into the above code.
-        If (!((Test-Path "$localfile") -and ((Get-Item "$localfile").length -gt 0kb))) {
-            Write-Error "Exiting because download missing or zero-length:    $localfile"
-            exit 2
-        }
+	begin {
+		$Global:NEED_PROCESS_AND_END = $true
+		Write-Verbose " **** DownloadFileWithProgress looking for **** $localFile ********"
+		if ( [bool]$Env:SALTREPO_LOCAL_CACHE -and (Test-Path $localFile) ) {
+			Write-Verbose " **** found **** $localFile ********"
+			$Global:NEED_PROCESS_AND_END = $false
+		} else {
+			Write-Verbose " ++++++ BEGIN DOWNLOADING ++++++ $localFile +++++++"
+			$client = New-Object System.Net.WebClient
+			$Global:downloadComplete = $false
+			$eventDataComplete = Register-ObjectEvent $client DownloadFileCompleted `
+			-SourceIdentifier WebClient.DownloadFileComplete `
+			-Action {$Global:downloadComplete = $true}
+			$eventDataProgress = Register-ObjectEvent $client DownloadProgressChanged `
+			-SourceIdentifier WebClient.DownloadProgressChanged `
+			-Action { $Global:DPCEventArgs = $EventArgs }
+		}
+}
+	process {
+		if ( $Global:NEED_PROCESS_AND_END ) {
+			Write-Verbose " ++++++ actually DOWNLOADING ++++++ $localFile +++++++"
+			Write-Progress -Activity 'Downloading file' -Status $url
+			$client.DownloadFileAsync($url, $localFile)
 
-    }
+			while (!($Global:downloadComplete)) {
+				$pc = $Global:DPCEventArgs.ProgressPercentage
+				if ($pc -ne $null) {
+					Write-Progress -Activity 'Downloading file' -Status $url -PercentComplete $pc
+				}
+			}
+			Write-Progress -Activity 'Downloading file' -Status $url -Complete
+		}
+	}
+
+	end {
+		if ( $Global:NEED_PROCESS_AND_END ) {
+			Unregister-Event -SourceIdentifier WebClient.DownloadProgressChanged
+			Unregister-Event -SourceIdentifier WebClient.DownloadFileComplete
+			$client.Dispose()
+			$Global:downloadComplete = $null
+			$Global:DPCEventArgs     = $null
+			Remove-Variable client
+			Remove-Variable eventDataComplete
+			Remove-Variable eventDataProgress
+			[GC]::Collect()
+			# Errorchecking
+			If (!((Test-Path "$localfile") -and ((Get-Item "$localfile").length -gt 0kb))) {
+				Write-Error "download-module.psm1 exits in error, download is missing or has zero-length:	$localfile"
+				exit 2
+			}
+		}
+	}
 }

--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -1,87 +1,94 @@
 Function Get-Settings {
 
-    [CmdletBinding()]
-    Param()
+	[CmdletBinding()]
+	Param()
 
-    Begin
-        {Write-Verbose "$($MyInvocation.MyCommand.Name):: Function started"} 
+	Begin
+		{Write-Verbose "$($MyInvocation.MyCommand.Name):: Function started"}
 
-    Process
-    {
-        Write-Verbose "$($MyInvocation.MyCommand.Name):: Loading Settings"
+	Process
+	{
+		Write-Verbose "$($MyInvocation.MyCommand.Name):: Loading Settings"
 
-        $ini = @{}
+		$ini = @{}
 
-        # Location where the files are kept
-        $Settings = @{
-            "SaltRepo"    = "https://repo.saltstack.com/windows/dependencies"
-            "SaltDir"     = "C:\salt"
-            "PythonDir"   = "C:\Python27"
-            "ScriptsDir"  = "C:\Python27\Scripts"
-            "DownloadDir" = "$env:Temp\DevSalt"
-            }
-        $ini.Add("Settings", $Settings)
+		# Location where the files are kept
+		$Settings = @{
+			"SaltRepo"    = "https://repo.saltstack.com/windows/dependencies"
+			"SaltDir"     = "C:\salt"
+			"PythonDir"   = "C:\Python27"
+			"ScriptsDir"  = "C:\Python27\Scripts"
+			"DownloadDir" = "$env:Temp\DevSalt"
+			}
+		# The script deletes the DownLoadDir (above) for each install.
+		# You may want to set an environment variable SALTREPO_LOCAL_CACHE, a cache which lives as long as you decide.
+		if ( [bool]$Env:SALTREPO_LOCAL_CACHE ) {
+		  $Settings.Set_Item("DownloadDir", "$Env:SALTREPO_LOCAL_CACHE")
+		}
 
-        # Prerequisite software
-        $Prerequisites = @{
-            "NSIS"        = "nsis-3.0b1-setup.exe"
-            "VCforPython" = "VCForPython27.msi"
-        }
-        $ini.Add("Prerequisites", $Prerequisites)
+		$ini.Add("Settings", $Settings)
+		Write-Verbose "DownloadDir === $($ini['Settings']['DownloadDir']) ==="
 
-        # Location of programs on 64 bit Windows
-        $64bitPaths = @{
-            "NSISDir"        = "C:\Program Files (x86)\NSIS"
-            "VCforPythonDir" = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0"
-        }
-        $ini.Add("64bitPaths", $64bitPaths)
+		# Prerequisite software
+		$Prerequisites = @{
+			"NSIS"        = "nsis-3.0b1-setup.exe"
+			"VCforPython" = "VCForPython27.msi"
+		}
+		$ini.Add("Prerequisites", $Prerequisites)
 
-        # Location of programs on 32 bit Windows
-        $32bitPaths = @{
-            "NSISDir"        = "C:\Program Files\NSIS"
-            "VCforPythonDir" = "C:\Program Files\Common Files\Microsoft\Visual C++ for Python\9.0"
-        }
-        $ini.Add("32bitPaths", $32bitPaths)
+		# Location of programs on 64 bit Windows
+		$64bitPaths = @{
+			"NSISDir"        = "C:\Program Files (x86)\NSIS"
+			"VCforPythonDir" = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0"
+		}
+		$ini.Add("64bitPaths", $64bitPaths)
 
-        # Filenames for 64 bit Windows
-        $64bitPrograms = @{
-            "PyCrypto" = "pycrypto-2.6.1-cp27-none-win_amd64.whl"
-            "Python"   = "python-2.7.12.amd64.msi"
-            "PyYAML"   = "PyYAML-3.11.win-amd64-py2.7.exe"
-        }
-        $ini.Add("64bitPrograms", $64bitPrograms)
+		# Location of programs on 32 bit Windows
+		$32bitPaths = @{
+			"NSISDir"        = "C:\Program Files\NSIS"
+			"VCforPythonDir" = "C:\Program Files\Common Files\Microsoft\Visual C++ for Python\9.0"
+		}
+		$ini.Add("32bitPaths", $32bitPaths)
 
-        # Filenames for 32 bit Windows
-        $32bitPrograms = @{
-            "PyCrypto" = "pycrypto-2.6.1-cp27-none-win32.whl"
-            "Python"   = "python-2.7.12.msi"
-            "PyYAML"   = "PyYAML-3.11.win32-py2.7.exe"
-        }
-        $ini.Add("32bitPrograms", $32bitPrograms)
+		# Filenames for 64 bit Windows
+		$64bitPrograms = @{
+			"PyCrypto" = "pycrypto-2.6.1-cp27-none-win_amd64.whl"
+			"Python"   = "python-2.7.12.amd64.msi"
+			"PyYAML"   = "PyYAML-3.11.win-amd64-py2.7.exe"
+		}
+		$ini.Add("64bitPrograms", $64bitPrograms)
 
-        # DLL's for 64 bit Windows
-        $64bitDLLs = @{
-            "Libeay"     = "libeay32.dll"
-            "SSLeay"     = "ssleay32.dll"
-            "OpenSSLLic" = "OpenSSL_License.txt"
-            "libsodium"  = "libsodium.dll"
-            "msvcr"      = "msvcr120.dll"
-        }
-        $ini.Add("64bitDLLs", $64bitDLLs)
+		# Filenames for 32 bit Windows
+		$32bitPrograms = @{
+			"PyCrypto" = "pycrypto-2.6.1-cp27-none-win32.whl"
+			"Python"   = "python-2.7.12.msi"
+			"PyYAML"   = "PyYAML-3.11.win32-py2.7.exe"
+		}
+		$ini.Add("32bitPrograms", $32bitPrograms)
 
-        # DLL's for 32 bit Windows
-        $32bitDLLs = @{
-            "Libeay"     = "libeay32.dll"
-            "SSLeay"     = "ssleay32.dll"
-            "OpenSSLLic" = "OpenSSL_License.txt"
-            "libsodium"  = "libsodium.dll"
-            "msvcr"      = "msvcr120.dll"
-        }
-        $ini.Add("32bitDLLs", $32bitDLLs)
+		# DLL's for 64 bit Windows
+		$64bitDLLs = @{
+			"Libeay"     = "libeay32.dll"
+			"SSLeay"     = "ssleay32.dll"
+			"OpenSSLLic" = "OpenSSL_License.txt"
+			"libsodium"  = "libsodium.dll"
+			"msvcr"      = "msvcr120.dll"
+		}
+		$ini.Add("64bitDLLs", $64bitDLLs)
 
-        Write-Verbose "$($MyInvocation.MyCommand.Name):: Finished Loading Settings"
-        Return $ini
-    }
-    End
-        {Write-Verbose "$($MyInvocation.MyCommand.Name):: Function ended"}
+		# DLL's for 32 bit Windows
+		$32bitDLLs = @{
+			"Libeay"     = "libeay32.dll"
+			"SSLeay"     = "ssleay32.dll"
+			"OpenSSLLic" = "OpenSSL_License.txt"
+			"libsodium"  = "libsodium.dll"
+			"msvcr"      = "msvcr120.dll"
+		}
+		$ini.Add("32bitDLLs", $32bitDLLs)
+
+		Write-Verbose "$($MyInvocation.MyCommand.Name):: Finished Loading Settings"
+		Return $ini
+	}
+	End
+		{Write-Verbose "$($MyInvocation.MyCommand.Name):: Function ended"}
 }

--- a/pkg/windows/modules/start-process-and-test-exitcode.psm1
+++ b/pkg/windows/modules/start-process-and-test-exitcode.psm1
@@ -1,22 +1,22 @@
 Function Start_Process_and_test_exitcode {
 
-    # This function is a wrapper for Start-Process that checks the exitcode
-    # It receives 3 parameters:
-    #    $fun   - the process that shall be started
-    #    $args  - the the arguments of $fun
-    #    $descr - the short description shown in the case of an error
+	# This function is a wrapper for Start-Process that checks the exitcode
+	# It receives 3 parameters:
+	#    $fun   - the process that shall be started
+	#    $args  - the the arguments of $fun
+	#    $descr - the short description shown in the case of an error
 
-    param(
-        [Parameter(Mandatory=$true)] [String] $fun,
-        [Parameter(Mandatory=$true)] [String] $args,
-        [Parameter(Mandatory=$true)] [String] $descr
-    )
+	param(
+		[Parameter(Mandatory=$true)] [String] $fun,
+		[Parameter(Mandatory=$true)] [String] $args,
+		[Parameter(Mandatory=$true)] [String] $descr
+	)
 
-    begin {
-        $p = Start-Process "$fun" -ArgumentList "$args" -Wait -NoNewWindow -PassThru
-        If ( $($p.ExitCode) -ne 0) {
-            Write-Error "$descr returned exitcode $($p.ExitCode). "
-            exit $($p.ExitCode)
-        }
-    }
+	begin {
+		$p = Start-Process "$fun" -ArgumentList "$args" -Wait -NoNewWindow -PassThru
+		If ( $($p.ExitCode) -ne 0) {
+			Write-Error "$descr returned exitcode $($p.ExitCode). "
+			exit $($p.ExitCode)
+		}
+	}
 }

--- a/pkg/windows/modules/uac-module.psm1
+++ b/pkg/windows/modules/uac-module.psm1
@@ -1,12 +1,12 @@
 ﻿function Get-IsAdministrator
 {
-    $Identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
-    $Principal = New-Object System.Security.Principal.WindowsPrincipal($Identity)
-    $Principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+	$Identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+	$Principal = New-Object System.Security.Principal.WindowsPrincipal($Identity)
+	$Principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
 
 function Get-IsUacEnabled
 {
-    (Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System).EnableLua -ne 0
+	(Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System).EnableLua -ne 0
 }

--- a/pkg/windows/modules/zip-module.psm1
+++ b/pkg/windows/modules/zip-module.psm1
@@ -1,22 +1,22 @@
 Function Expand-ZipFile($zipfile, $destination) {
 
-    # This function unzips a zip file
-    # Code obtained from:
-    # http://www.howtogeek.com/tips/how-to-extract-zip-files-using-powershell/
+	# This function unzips a zip file
+	# Code obtained from:
+	# http://www.howtogeek.com/tips/how-to-extract-zip-files-using-powershell/
 
-    # Create a new directory if it doesn't exist
-    If (!(Test-Path -Path $destination)) {
-        $p = New-Item -ItemType directory -Path $destination
-    }
+	# Create a new directory if it doesn't exist
+	If (!(Test-Path -Path $destination)) {
+		$p = New-Item -ItemType directory -Path $destination
+	}
 
-    # Define Objects
-    $objShell = New-Object -Com Shell.Application
+	# Define Objects
+	$objShell = New-Object -Com Shell.Application
 
-    # Open the zip file
-    $objZip = $objShell.NameSpace($zipfile)
+	# Open the zip file
+	$objZip = $objShell.NameSpace($zipfile)
 
-    # Unzip each item in the zip file
-    ForEach($item in $objZip.Items()) {
-        $objShell.Namespace($destination).CopyHere($item, 0x14)
-    }
+	# Unzip each item in the zip file
+	ForEach($item in $objZip.Items()) {
+		$objShell.Namespace($destination).CopyHere($item, 0x14)
+	}
 }


### PR DESCRIPTION
### What does this PR do?

The goal is to compile Salt offline (without internet connection).
To this goal, two local caches are created, that keep the required software.
The internet connection is currently needed for required software.
This pull request only optionally uses the caches.
(The user must set two environment variables to activate the cache.
Without the environment variables, current behavior is unchanged.)
This pull request optionally replaces bitsadmin with DownloadFileWithProgress.
Reason is, that bitsadmin does not work for admin user (in our company),
instead DownloadFileWithProgress is used (through an added shim).
This pull request adds more tests on errorlevel and aborts the build script, if necessary.
This pull request changes PowerShell indentation levels from whitespace to tab, 
in the believe that tabs are more flexible and agreeable.

### What issues does this PR fix?

One must be admin user to compile.
My company proxy refuses internet connections for admin users.
Therefore, I cannot compile Salt within my company network.
As last resort I log into a public 50KB/sec network. 
Therefore, I need to cache downloads.
As an additional benefit, compile time goes down from 3:30 to 2:10.

### Previous Behavior

Every required software is downloaded for each compile.
This behavior is unchanged, if the user leaves `SALTREPO_LOCAL_CACHE` and `SALTREPO_LOCAL_CACHE_PIP` unset.

### New Behavior

If the user sets `SALTREPO_LOCAL_CACHE` and `SALTREPO_LOCAL_CACHE_PIP` to directories and the directories exist, 
these directories are used as caches.
Currently they will contain 130 MB in 50 files.
This is nearly perfect, only one download (PyYAML 3.11) remains:
although PyYAML 3.11 is installed, the wheel is downloaded from repo.saltstack.
After it is downloaded, it is not used, or deleted and installed again.
From reading the log, I believe that one must look into salt/setup.py to resolve that.
```
build.bat :: Install Current Version of salt...
Requirement already satisfied (use --upgrade to upgrade): wheel in c:\python27\lib\site-packages
Requirement already satisfied (use --upgrade to upgrade): pycrypto==2.6.1 from https://repo.saltstack.com/windows/dependencies/64/pycrypto-2.6.1-cp27-none-win_amd64.whl in c:\python27\lib\site-packages
You are using pip version 8.1.2, however version 9.0.1 is available.
You should consider upgrading via the 'python -m pip install --upgrade pip' command.
Downloading https://repo.saltstack.com/windows/dependencies/64/PyYAML-3.11.win-amd64-py2.7.exe
Processing PyYAML-3.11.win-amd64-py2.7.exe
creating 'c:\users\deadmi~1\appdata\local\temp\easy_install-hj1oo6\PyYAML-3.11-py2.7-win-amd64.egg' and adding 'c:\users\deadmi~1\appdata\local\temp\easy_install-hj1oo6\PyYAML-3.11-py2.7-win-amd64.egg.tmp' to it
removing 'c:\python27\lib\site-packages\PyYAML-3.11-py2.7-win-amd64.egg' (and everything under it)
creating c:\python27\lib\site-packages\PyYAML-3.11-py2.7-win-amd64.egg
Extracting PyYAML-3.11-py2.7-win-amd64.egg to c:\python27\lib\site-packages
PyYAML 3.11 is already the active version in easy-install.pth
Installed c:\python27\lib\site-packages\pyyaml-3.11-py2.7-win-amd64.egg
Processing dependencies for PyYAML==3.11
Finished processing dependencies for PyYAML==3.11
```


### Tests written?

Yes, tested with and without the environment variables.
