### PR TITLE
system: add {set/get}_computer_name

### DIFF
--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -517,3 +517,29 @@ def set_computer_desc(desc):
             return True
     except IOError:
         return False
+
+
+def set_computer_name(hostname):
+    '''
+    Modify hostname.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.set_conputer_name master.saltstack.com
+    '''
+    return __salt__['network.mod_hostname'](hostname)
+
+
+def get_computer_name():
+    '''
+    Get hostname.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' network.get_hostname
+    '''
+    return __salt__['network.get_hostname']()


### PR DESCRIPTION
### What does this PR do?

Add {set/get}_computer_name for setting/getting
computer hostname. I add this in system module to be
the same as on windows, creating a cross-platform
way to interact with computer's hostname.

Signed-off-by: Heghedus Razvan <razvan.heghedus@ni.com>


