### PR TITLE
Add CLI Example for rest_sample_utils.get_test_string function

### DIFF
--- a/salt/modules/rest_sample_utils.py
+++ b/salt/modules/rest_sample_utils.py
@@ -24,5 +24,12 @@ def fix_outage():
 def get_test_string():
     '''
     Helper function to test cross-calling to the __proxy__ dunder.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'rest-sample-proxy' rest_sample.get_test_string
+
     '''
     return __proxy__['rest_sample.test_from_state']()


### PR DESCRIPTION
Fixes test_valid_doc test that is failing on 2016.11
