### PR TITLE
fixes saltstack/salt-bootstrap#1021

### DIFF
--- a/pkg/smartos/salt-api.xml
+++ b/pkg/smartos/salt-api.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+        Created by Manifold
+-->
+  <service_bundle type="manifest" name="salt-api">
+    <service name="network/salt-api" type="service" version="1">
+
+      <create_default_instance enabled="false"/>
+
+      <single_instance/>
+
+      <dependency name="config-file"
+                  grouping="require_all"
+                  restart_on="none"
+                  type="path">
+          <service_fmri value='file:///opt/local/etc/salt/minion'/>
+      </dependency>
+
+      <dependency name="network"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/milestone/network:default"/>
+      </dependency>
+
+      <dependency name="filesystem"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/system/filesystem/local"/>
+      </dependency>
+
+      <method_context/>
+
+      <exec_method type="method"
+                   name="start"
+                   exec="/opt/local/bin/salt-api -c %{config_dir}"
+                   timeout_seconds="60"/>
+
+      <exec_method type="method"
+                   name="stop"
+                   exec=":kill"
+                   timeout_seconds="60"/>
+
+      <property_group name="startd" type="framework">
+        <propval name="duration" type="astring" value="child"/>
+        <propval name="ignore_error" type="astring" value="core,signal"/>
+      </property_group>
+
+      <property_group name="application" type="application">
+        <propval name="config_file" type="astring" value="/opt/local/etc/salt/master"/>
+        <propval name="config_dir" type="astring" value="/opt/local/etc/salt"/>
+      </property_group>
+
+      <stability value="Unstable"/>
+
+      <template>
+        <common_name>
+          <loctext xml:lang="C">Salt API</loctext>
+        </common_name>
+
+        <documentation>
+          <doc_link name="SaltStack Documentation"
+                    uri="http://docs.saltstack.com"/>
+        </documentation>
+      </template>
+    </service>
+</service_bundle>
+


### PR DESCRIPTION
### What does this PR do?
We add a SMF Manifest for salt-api on SmartOS, it is use by salt-bootstrap. 

### What issues does this PR fix or reference?
saltstack/salt-bootstrap#1021

### Previous Behavior
```
 *  INFO: Running install_smartos_post()
/tmp/salt-api.xml:1: parser error : Start tag expected, '<' not found
404: Not Found
^
svccfg: couldn't parse document
```

### New Behavior
Untested due the way bootstrap manually importing the xml create the salt-api service.

### Tests written?
No
