### PR TITLE
Fixes icinga2 module return code

### DIFF
--- a/salt/modules/icinga2.py
+++ b/salt/modules/icinga2.py
@@ -8,6 +8,8 @@ Module to provide icinga2 compatibility to salt.
 # Import python libs
 from __future__ import absolute_import
 import logging
+import os
+import subprocess
 
 # Import Salt libs
 import salt.utils
@@ -28,6 +30,18 @@ def __virtual__():
     return (False, 'Icinga2 not installed.')
 
 
+def _execute(cmd, ret_code=False):
+    process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    if ret_code:
+        return process.wait()
+    output, error = process.communicate()
+    if output:
+        log.debug(output)
+        return output
+    log.debug(error)
+    return error
+
+
 def generate_ticket(domain):
     '''
     Generate and save an icinga2 ticket.
@@ -42,7 +56,7 @@ def generate_ticket(domain):
         salt '*' icinga2.generate_ticket domain.tld
 
     '''
-    result = __salt__['cmd.run']("icinga2 pki ticket --cn {0}".format(domain))
+    result = _execute(["icinga2", "pki", "ticket", "--cn", domain])
     return result
 
 
@@ -60,7 +74,7 @@ def generate_cert(domain):
         salt '*' icinga2.generate_cert domain.tld
 
     '''
-    result = __salt__['cmd.run']("icinga2 pki new-cert --cn {0} --key /etc/icinga2/pki/{0}.key --cert /etc/icinga2/pki/{0}.crt".format(domain))
+    result = _execute(["icinga2", "pki", "new-cert", "--cn", domain, "--key", "/etc/icinga2/pki/{0}.key".format(domain), "--cert", "/etc/icinga2/pki/{0}.crt".format(domain)], ret_code=True)
     return result
 
 
@@ -78,8 +92,8 @@ def save_cert(domain, master):
         salt '*' icinga2.save_cert domain.tld master.domain.tld
 
     '''
-    result = __salt__['cmd.run']("icinga2 pki save-cert --key /etc/icinga2/pki/{0}.key --cert /etc/icinga2/pki/{0}.cert --trustedcert /etc/icinga2/pki/trusted-master.crt \
-                                 --host {1}".format(domain, master))
+    result = _execute(["icinga2", "pki", "save-cert", "--key", "/etc/icinga2/pki/{0}.key".format(domain), "--cert", "/etc/icinga2/pki/{0}.cert".format(domain), "--trustedcert",
+                       "/etc/icinga2/pki/trusted-master.crt", "--host", master], ret_code=True)
     return result
 
 
@@ -98,8 +112,8 @@ def request_cert(domain, master, ticket, port):
         salt '*' icinga2.request_cert domain.tld master.domain.tld TICKET_ID
 
     '''
-    result = __salt__['cmd.run']("icinga2 pki request --host {0} --port {1} --ticket {2} --key /etc/icinga2/pki/{3}.key --cert \
-                       /etc/icinga2/pki/{3}.crt --trustedcert /etc/icinga2/pki/trusted-master.crt --ca /etc/icinga2/pki/ca.crt".format(master, port, ticket, domain))
+    result = _execute(["icinga2", "pki", "request", "--host", master, "--port", port, "--ticket", ticket, "--key", "/etc/icinga2/pki/{0}.key".format(domain), "--cert",
+                       "/etc/icinga2/pki/{0}.crt".format(domain), "--trustedcert", "/etc/icinga2/pki/trusted-master.crt", "--ca", "/etc/icinga2/pki/ca.crt"], ret_code=True)
     return result
 
 
@@ -118,5 +132,6 @@ def node_setup(domain, master, ticket):
         salt '*' icinga2.node_setup domain.tld master.domain.tld TICKET_ID
 
     '''
-    result = __salt__['cmd.run']("icinga2 node setup --ticket {0} --endpoint {1} --zone {2} --master_host {1} --trustedcert /etc/icinga2/pki/trusted-master.crt".format(ticket, master, domain))
+    result = _execute(["icinga2", "node", "setup", "--ticket", ticket, "--endpoint", master, "--zone", domain, "--master_host", master, "--trustedcert", "/etc/icinga2/pki/trusted-master.crt"],
+                       ret_code=True)
     return result

--- a/salt/modules/icinga2.py
+++ b/salt/modules/icinga2.py
@@ -8,7 +8,6 @@ Module to provide icinga2 compatibility to salt.
 # Import python libs
 from __future__ import absolute_import
 import logging
-import os
 import subprocess
 
 # Import Salt libs


### PR DESCRIPTION
### What does this PR do?
Replaces __salt__['cmd.run'] with local cmd execute function due to return codes.

### What issues does this PR fix or reference?
The module was failing even though the calls were a success.

### Previous Behavior
Certificates were generated correctly but salt was reporting the actions as failed.

### Tests written?
No


I am not sure if this is the best way of handling it.
Problem is that icinga2 command returns some text + a return code.
While using __salt__['cmd.run'] the calls were marked as failed and I did not understand why, even though the return code was 0.