### PR TITLE
Isbm zypper state unknown pkg crash

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1909,7 +1909,7 @@ def latest(
     for pkg in desired_pkgs:
         if not avail.get(pkg):
             # Package either a) is up-to-date, or b) does not exist
-            if not cur[pkg]:
+            if not cur.get(pkg):
                 # Package does not exist
                 msg = 'No information found for \'{0}\'.'.format(pkg)
                 log.error(msg)


### PR DESCRIPTION
### What issues does this PR fix or reference?

Prevent minion crash if passed unknown package name. E.g., in the `foo.sls`:
```
crash-your-minion:
  pkg.latest:
    -name: fun-begins
```

Then calling `state.apply` will render minion with the following error:
```
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/state.py", line 1744, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1702, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/states/pkg.py", line 1912, in latest
    if not cur[pkg]:
KeyError: 'fun-begins'
```
### Tests written?

No
