### PR TITLE
system: fix system.set_computer_desc

### DIFF
--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -512,6 +512,7 @@ def set_computer_desc(desc):
                 lines.append(new_line)
             # time to write our changes to the file
             mach_info.seek(0, 0)
+            mach_info.truncate()
             mach_info.write(''.join(lines))
             mach_info.write('\n')
             return True


### PR DESCRIPTION
### What does this PR do?
system: fix system.set_computer_desc

Sometimes after setting a new computer description
there are some trailings characters. So I clear the
/etc/machine-info before writing the new settings.

Signed-off-by: Heghedus Razvan <razvan.heghedus@ni.com>

