### PR TITLE
dockerng.wait: do not fail_on_exit_status with ignore_already_stopped

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5098,7 +5098,7 @@ def wait(name, ignore_already_stopped=False, fail_on_exit_status=False):
               'exit_status': response}
     if already_stopped:
         result['comment'] = 'Container \'{0}\' already stopped'.format(name)
-    if fail_on_exit_status and result['result']:
+    elif fail_on_exit_status and result['result']:
         result['result'] = result['exit_status'] == 0
     return result
 


### PR DESCRIPTION
The following state should not fail in case the container is already stopped:

    wait-for-something-to-complete:
      module.run:
        - name: dockerng.wait
        - m_name: migrate-app
        - ignore_already_stopped: True
        - fail_on_exit_status: True

Currently this will result in:

              ID: wait-for-something-to-complete
        Function: module.run
            Name: dockerng.wait
          Result: False
         Comment: Module function dockerng.wait executed
         Started: 15:45:16.819739
        Duration: 8.804 ms
         Changes:
                  ----------
                  ret:
                      ----------
                      comment:
                          Container 'migrate-app' already stopped
                      exit_status:
                          1
                      result:
                          False
                      state:
                          ----------
                          new:
                              stopped
                          old:
                              stopped

### Tests written?

No, but hopefully an existing one can be adjusted/extended.

/cc @ticosax