### PR TITLE
Add one more option to "allow_failure" for doc test

### DIFF
--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -52,6 +52,7 @@ class SysModuleTest(integration.ModuleCase):
             'vsphere.get_service_instance_via_proxy',
             'vsphere.gets_service_instance_via_proxy',
             'vsphere.supports_proxies',
+            'vsphere.test_vcenter_connection',
             'vsphere.wraps',
             'yumpkg.expand_repo_def',
             'yumpkg5.expand_repo_def',


### PR DESCRIPTION
Looks like I missed this one in previous fixes.
