### PR TITLE
Pass win_* options as kwargs when calling file.manage_file

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2225,10 +2225,10 @@ def managed(name,
                 follow_symlinks,
                 skip_verify,
                 keep_mode,
-                win_owner,
-                win_perms,
-                win_deny_perms,
-                win_inheritance,
+                win_owner=win_owner,
+                win_perms=win_perms,
+                win_deny_perms=win_deny_perms,
+                win_inheritance=win_inheritance,
                 **kwargs)
         except Exception as exc:
             ret['changes'] = {}

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -580,6 +580,7 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                 os.remove(managed_files[typ])
 
     @destructiveTest
+    @skipIf(salt.utils.is_windows(), 'Windows does not support "mode" kwarg. Skipping.')
     def test_managed_check_cmd(self):
         '''
         Test file.managed passing a basic check_cmd kwarg. See Issue #38111.

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -579,6 +579,27 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             for typ in managed_files:
                 os.remove(managed_files[typ])
 
+    @destructiveTest
+    def test_managed_check_cmd(self):
+        '''
+        Test file.managed passing a basic check_cmd kwarg. See Issue #38111.
+        '''
+        ret = self.run_state(
+            'file.managed',
+            name='/tmp/sudoers',
+            user='root',
+            group='root',
+            mode=440,
+            check_cmd='visudo -c -s -f'
+        )
+        self.assertSaltTrueReturn(ret)
+        self.assertInSaltComment('Empty file', ret)
+        self.assertEqual(ret['file_|-/tmp/sudoers_|-/tmp/sudoers_|-managed']['changes'],
+                         {'new': 'file /tmp/sudoers created', 'mode': '0440'})
+
+        # Clean Up File
+        os.remove('/tmp/sudoers')
+
     def test_directory(self):
         '''
         file.directory


### PR DESCRIPTION
### What does this PR do?
Fixes issue where when using file.managed with the `check_cmd` option on develop, the state would fail with a number of arguments failure. 

### What issues does this PR fix or reference?
Fixes #38111

### Previous Behavior
```
# salt-call --local state.sls test
local:
----------
          ID: /tmp/sudoers
    Function: file.managed
      Result: False
     Comment: Unable to check_cmd file: manage_file() takes at most 18 arguments (22 given)
     Started: 17:29:44.922137
    Duration: 9.15 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   9.150 ms
```

### New Behavior
```
# salt-call --local state.sls test
local:
----------
          ID: /tmp/sudoers
    Function: file.managed
      Result: True
     Comment: Empty file
     Started: 17:54:11.345151
    Duration: 301.116 ms
     Changes:
              ----------
              mode:
                  0440
              new:
                  file /tmp/sudoers created

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time: 301.116 ms
```

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
