### PR TITLE
Compile offline3

### DIFF
--- a/pkg/windows/build.bat
+++ b/pkg/windows/build.bat
@@ -1,7 +1,11 @@
 @echo off
-@echo Salt Windows Build Script
+@echo Salt Windows Build Script, which calls the other *.ps1 scripts.
 @echo ---------------------------------------------------------------------
 @echo.
+:: To activate caching, set environment variables
+::   SALTREPO_LOCAL_CACHE  for resources from saltstack.com/...
+::   SALT_REQ_LOCAL_CACHE  for pip resources specified in req.txt
+::   SALT_PIP_LOCAL_CACHE  for pip resources specified in req_pip.txt
 
 :: Make sure the script is run as Admin
 @echo Administrative permissions required. Detecting permissions...
@@ -40,7 +44,7 @@ for /f "delims=" %%a in ('git rev-parse --show-toplevel') do @set "SrcDir=%%a"
 :: Get the version from git if not passed
 if [%1]==[] (
     for /f "delims=" %%a in ('git describe') do @set "Version=%%a"
-	echo ... Version from git describe == %Version%
+    echo ... Version from git describe == %Version%
 ) else (
     set "Version=%~1"
 )
@@ -68,6 +72,9 @@ if not %errorLevel%==0 (
 @echo %0 :: Install Current Version of salt...
 @echo ---------------------------------------------------------------------
 "%PyDir%\python.exe" "%SrcDir%\setup.py" --quiet install --force
+if not %errorLevel%==0 (
+    goto eof
+)
 @echo.
 
 :: Build the Salt Package

--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -70,9 +70,9 @@ If NOT Exist "%PreDir%" mkdir "%PreDir%"
 Set Url64="http://repo.saltstack.com/windows/dependencies/64/vcredist_x64_2008_mfc.exe"
 Set Url32="http://repo.saltstack.com/windows/dependencies/32/vcredist_x86_2008_mfc.exe"
 If Defined ProgramFiles(x86) (
-    bitsadmin /transfer "VCRedist 2008 MFC AMD64" "%Url64%" "%PreDir%\vcredist.exe"
+    powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url64%" -file "%PreDir%\vcredist.exe"
 ) Else (
-    bitsadmin /transfer "VCRedist 2008 MFC x86" "%Url32%" "%PreDir%\vcredist.exe"
+    powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url "%Url32%" -file "%PreDir%\vcredist.exe"
 )
 @echo.
 

--- a/pkg/windows/download_url_file.ps1
+++ b/pkg/windows/download_url_file.ps1
@@ -1,0 +1,39 @@
+#
+# Download url to file. Optionally, store in cache
+#
+#
+Param(
+    [Parameter(Mandatory=$true)][string]$url,
+    [Parameter(Mandatory=$true)][string]$file
+)
+
+
+$VerbosePreference = 'Continue'
+
+
+Import-Module ./Modules/download-module.psm1
+
+if ( [bool]$Env:SALTREPO_LOCAL_CACHE) {
+    Write-Verbose "found SALTREPO_LOCAL_CACHE environment variable $Env:SALTREPO_LOCAL_CACHE"
+} else {
+    Write-Verbose "no SALTREPO_LOCAL_CACHE environment variable "
+}
+
+$saltrepo_url = "http://repo.saltstack.com/windows/dependencies/"
+
+if ( [bool]$Env:SALTREPO_LOCAL_CACHE -And $url.StartsWith($saltrepo_url) ) {
+    Write-Verbose "found SALTREPO_LOCAL_CACHE environment variable and url is saltrepo"
+    $url_relative__slash     = $url                 -replace [regex]::Escape($saltrepo_url), ""
+    $url_relative__backslash = $url_relative__slash -replace [regex]::Escape("/"), "\\"
+    $localCacheFile          = Join-Path $Env:SALTREPO_LOCAL_CACHE $url_relative__backslash
+    if (-Not (Test-Path $localCacheFile)) {
+        Write-Verbose "downloading to cache   $localCacheFile"
+        DownloadFileWithProgress $url $localCacheFile
+    }
+    Write-Verbose "copying from cache $file"
+    Copy-Item $localCacheFile  -destination $file
+} else {
+    Write-Verbose "no SALTREPO_LOCAL_CACHE environment variable, or URL not saltrepo, downloading directly"
+    DownloadFileWithProgress $url $file
+}
+

--- a/pkg/windows/modules/download-module.psm1
+++ b/pkg/windows/modules/download-module.psm1
@@ -8,51 +8,69 @@ Function DownloadFileWithProgress {
     #    $url - the file source
     #    $localfile - the file destination on the local machine
 
+    # Originally, DownLoadDir is deleted for each install, therefore
+    # this function did not expect that the file exists.
+    # You may want to set an environment variable SALTREPO_LOCAL_CACHE, a cache which lives as long as you decide.
+    # Therefore this function must test if the file exists.
+
+
     param(
         [Parameter(Mandatory=$true)]
         [String] $url,
         [Parameter(Mandatory=$false)]
-        [String] $localFile = (Join-Path $pwd.Path $url.SubString($url.LastIndexOf('/'))) 
+        [String] $localFile = (Join-Path $pwd.Path $url.SubString($url.LastIndexOf('/')))
     )
 
     begin {
-        $client = New-Object System.Net.WebClient
-        $Global:downloadComplete = $false
-        $eventDataComplete = Register-ObjectEvent $client DownloadFileCompleted `
+        $Global:NEED_PROCESS_AND_END = $true
+        Write-Verbose " **** DownloadFileWithProgress looking for **** $localFile ********"
+        if ( [bool]$Env:SALTREPO_LOCAL_CACHE -and (Test-Path $localFile) ) {
+            Write-Verbose " **** found **** $localFile ********"
+            $Global:NEED_PROCESS_AND_END = $false
+        } else {
+            Write-Verbose " ++++++ BEGIN DOWNLOADING ++++++ $localFile +++++++"
+            $client = New-Object System.Net.WebClient
+            $Global:downloadComplete = $false
+            $eventDataComplete = Register-ObjectEvent $client DownloadFileCompleted `
             -SourceIdentifier WebClient.DownloadFileComplete `
             -Action {$Global:downloadComplete = $true}
-        $eventDataProgress = Register-ObjectEvent $client DownloadProgressChanged `
+            $eventDataProgress = Register-ObjectEvent $client DownloadProgressChanged `
             -SourceIdentifier WebClient.DownloadProgressChanged `
             -Action { $Global:DPCEventArgs = $EventArgs }
-    }
-    process {
-        Write-Progress -Activity 'Downloading file' -Status $url
-        $client.DownloadFileAsync($url, $localFile)
-
-        while (!($Global:downloadComplete)) {
-            $pc = $Global:DPCEventArgs.ProgressPercentage
-            if ($pc -ne $null) {
-                Write-Progress -Activity 'Downloading file' -Status $url -PercentComplete $pc
-            }
         }
-        Write-Progress -Activity 'Downloading file' -Status $url -Complete
+}
+    process {
+        if ( $Global:NEED_PROCESS_AND_END ) {
+            Write-Verbose " ++++++ actually DOWNLOADING ++++++ $localFile +++++++"
+            Write-Progress -Activity 'Downloading file' -Status $url
+            $client.DownloadFileAsync($url, $localFile)
+
+            while (!($Global:downloadComplete)) {
+                $pc = $Global:DPCEventArgs.ProgressPercentage
+                if ($pc -ne $null) {
+                    Write-Progress -Activity 'Downloading file' -Status $url -PercentComplete $pc
+                }
+            }
+            Write-Progress -Activity 'Downloading file' -Status $url -Complete
+        }
     }
 
     end {
-        Unregister-Event -SourceIdentifier WebClient.DownloadProgressChanged
-        Unregister-Event -SourceIdentifier WebClient.DownloadFileComplete
-        $client.Dispose()
-        $Global:downloadComplete = $null
-        $Global:DPCEventArgs = $null
-        Remove-Variable client
-        Remove-Variable eventDataComplete
-        Remove-Variable eventDataProgress
-        [GC]::Collect()
-        # 2016-07-06  mkr  Errorchecking added. nice-to-have: integration into the above code.
-        If (!((Test-Path "$localfile") -and ((Get-Item "$localfile").length -gt 0kb))) {
-            Write-Error "Exiting because download missing or zero-length:    $localfile"
-            exit 2
+        if ( $Global:NEED_PROCESS_AND_END ) {
+            Unregister-Event -SourceIdentifier WebClient.DownloadProgressChanged
+            Unregister-Event -SourceIdentifier WebClient.DownloadFileComplete
+            $client.Dispose()
+            $Global:downloadComplete = $null
+            $Global:DPCEventArgs     = $null
+            Remove-Variable client
+            Remove-Variable eventDataComplete
+            Remove-Variable eventDataProgress
+            [GC]::Collect()
+            # Errorchecking
+            If (!((Test-Path "$localfile") -and ((Get-Item "$localfile").length -gt 0kb))) {
+                Write-Error "download-module.psm1 exits in error, download is missing or has zero-length: $localfile"
+                exit 2
+            }
         }
-
     }
 }

--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -4,7 +4,7 @@ Function Get-Settings {
     Param()
 
     Begin
-        {Write-Verbose "$($MyInvocation.MyCommand.Name):: Function started"} 
+        {Write-Verbose "$($MyInvocation.MyCommand.Name):: Function started"}
 
     Process
     {
@@ -20,7 +20,14 @@ Function Get-Settings {
             "ScriptsDir"  = "C:\Python27\Scripts"
             "DownloadDir" = "$env:Temp\DevSalt"
             }
+        # The script deletes the DownLoadDir (above) for each install.
+        # You may want to set an environment variable SALTREPO_LOCAL_CACHE, a cache which lives as long as you decide.
+        if ( [bool]$Env:SALTREPO_LOCAL_CACHE ) {
+          $Settings.Set_Item("DownloadDir", "$Env:SALTREPO_LOCAL_CACHE")
+        }
+
         $ini.Add("Settings", $Settings)
+        Write-Verbose "DownloadDir === $($ini['Settings']['DownloadDir']) ==="
 
         # Prerequisite software
         $Prerequisites = @{

--- a/setup.py
+++ b/setup.py
@@ -396,7 +396,7 @@ class InstallPyCryptoWindowsWheel(Command):
             call_subprocess(call_arguments)
 
 def uri_to_resource(resource_file):
-    ### Returns the URI for a resouce 
+    ### Returns the URI for a resource 
     # The basic case is that the resource is on saltstack.com
     # It could be the case that the resource is cached.
     salt_uri = 'https://repo.saltstack.com/windows/dependencies/'  + resource_file

--- a/setup.py
+++ b/setup.py
@@ -395,7 +395,28 @@ class InstallPyCryptoWindowsWheel(Command):
         with indent_log():
             call_subprocess(call_arguments)
 
+def uri_to_resource(resource_file):
+    ### Returns the URI for a resouce 
+    # The basic case is that the resource is on saltstack.com
+    # It could be the case that the resource is cached.
+    salt_uri = 'https://repo.saltstack.com/windows/dependencies/'  + resource_file
+    if os.getenv('SALTREPO_LOCAL_CACHE') == None:
+        # if environment variable not set, return the basic case
+        return salt_uri
+    if not os.path.isdir(os.getenv('SALTREPO_LOCAL_CACHE')):
+        # if environment variable is not a directory, return the basic case
+        return salt_uri
+    cached_resource = os.path.join(os.getenv('SALTREPO_LOCAL_CACHE'), resource_file)
+    cached_resource = cached_resource.replace('/', '\\')
+    if not os.path.isfile(cached_resource):
+        # if file does not exist, return the basic case    
+        return salt_uri
+    if os.path.getsize(cached_resource) == 0:
+        # if file has zero size, return the basic case        
+        return salt_uri            
+    return cached_resource
 
+            
 class InstallCompiledPyYaml(Command):
 
     description = 'Install PyYAML on Windows'
@@ -405,6 +426,7 @@ class InstallCompiledPyYaml(Command):
 
     def finalize_options(self):
         pass
+        
 
     def run(self):
         if getattr(self.distribution, 'salt_installing_pyyaml_windows', None) is None:
@@ -417,11 +439,11 @@ class InstallCompiledPyYaml(Command):
         call_arguments = ['easy_install', '-Z']
         if platform_bits == '64bit':
             call_arguments.append(
-                'https://repo.saltstack.com/windows/dependencies/64/PyYAML-3.11.win-amd64-py2.7.exe'
+                uri_to_resource('64/PyYAML-3.11.win-amd64-py2.7.exe')
             )
         else:
             call_arguments.append(
-                'https://repo.saltstack.com/windows/dependencies/32/PyYAML-3.11.win32-py2.7.exe'
+                uri_to_resource('32/PyYAML-3.11.win32-py2.7.exe')
             )
         with indent_log():
             call_subprocess(call_arguments)


### PR DESCRIPTION
### What does this PR do?

a) optionally caches required software for the Windows installer build.
(The user must set two environment variables to activate the cache.
Without the environment variables, current behavior is unchanged.)
b) optionally replaces bitsadmin with DownloadFileWithProgress.
Reason is, that admin user cannot use bitsadmin (in our company network),
instead DownloadFileWithProgress is used (through an added shim).
c) adds another test on errorlevel.
d) adds the name of build_env.ps1 to the logging.
e) enables easy_install in setup.py to use the cache
f) removes unecessary variables in build_env.ps1.
g) removes Clear-Host in build_env.ps1, so that errors in build.bat are visible

### What issues does this PR fix?

One must be admin user to build the installer.
My company proxy refuses internet connections for admin users.
Therefore, I cannot build within my company network.
As an additional benefit, build time goes down from 3:30 to 2:10.

### Previous (and New) Behavior

Every required software is downloaded for each build.
This behavior is unchanged, if the user leaves these environment variables unset:
```
SALTREPO_LOCAL_CACHE  for resources from saltstack.com/...
SALT_REQ_LOCAL_CACHE  for pip resources specified in req.txt
SALT_PIP_LOCAL_CACHE  for pip resources specified in req_pip.txt
```


### New Behavior

The above environment variables are used for directories (caches).
After the first build, the caches will contain 50 MB in 50 files, and used for offline build.
For caching new pip resources, one must delete the cache.


### Tests written?

Yes, the minion builds and passed a smoke test
 - without the environment variables.
 - with the environment variables, online.
 - with the environment variables, offline.
