### PR TITLE
Ungate the status.py module and raise unsupported errors in functions not executable on Windows.

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -38,13 +38,6 @@ __func_alias__ = {
 }
 
 
-def __virtual__():
-    if salt.utils.is_windows():
-        return False, 'Windows platform is not supported by this module'
-
-    return __virtualname__
-
-
 def _number(text):
     '''
     Convert a string to a number.
@@ -71,6 +64,8 @@ def procs():
         salt '*' status.procs
     '''
     # Get the user, pid and cmd
+    if salt.utils.is_windows():
+        raise CommandExecutionError('This platform is not supported')
     ret = {}
     uind = 0
     pind = 0
@@ -119,6 +114,8 @@ def custom():
 
         salt '*' status.custom
     '''
+    if salt.utils.is_windows():
+        raise CommandExecutionError('This platform is not supported')
     ret = {}
     conf = __salt__['config.dot_vals']('status')
     for key, val in six.iteritems(conf):
@@ -587,6 +584,10 @@ def diskusage(*args):
         salt '*' status.diskusage ext?    # usage for ext[234] filesystems
         salt '*' status.diskusage / ext?  # usage for / and all ext filesystems
     '''
+
+    if salt.utils.is_windows():
+        raise CommandExecutionError('This platform is not supported')
+
     selected = set()
     fstypes = set()
     if not args:
@@ -925,6 +926,8 @@ def w():  # pylint: disable=C0103
 
         salt '*' status.w
     '''
+    if salt.utils.is_windows():
+        raise CommandExecutionError('This platform is not supported')
     user_list = []
     users = __salt__['cmd.run']('w -h').splitlines()
     for row in users:


### PR DESCRIPTION
### What does this PR do?

Removes the windows gate for the entire status.py module and instead raises errors for unsupported functions.

### What issues does this PR fix or reference?

Not filed--master failover was not working on Windows because status.ping_master was not getting loaded.
