### PR TITLE
Various Python 3 compatibility fixes

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -493,7 +493,7 @@ class LocalClient(object):
                               'sys.list_functions',
                               tgt_type=tgt_type,
                               **kwargs)
-        minions = minion_ret.keys()
+        minions = list(minion_ret)
         random.shuffle(minions)
         f_tgt = []
         for minion in minions:

--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -490,7 +490,8 @@ class PrintOption(Option):
                     _FILE_TYPES.get(stat.S_IFMT(fstat[stat.ST_MODE]), '?')
                 )
             elif arg == 'mode':
-                result.append(int(oct(fstat[stat.ST_MODE])[-3:]))
+                # PY3 compatibility: Use radix value 8 on int type-cast explicitly
+                result.append(int(oct(fstat[stat.ST_MODE])[-3:], 8))
             elif arg == 'mtime':
                 result.append(fstat[stat.ST_MTIME])
             elif arg == 'user':

--- a/tests/unit/modules/timezone_test.py
+++ b/tests/unit/modules/timezone_test.py
@@ -19,6 +19,8 @@ ensure_in_syspath('../../')
 
 # Import Salt Libs
 from salt.modules import timezone
+import salt.ext.six as six
+import salt.utils
 
 # Globals
 timezone.__salt__ = {}
@@ -76,7 +78,10 @@ class TimezoneTestCase(TestCase):
 
     def create_tempfile_with_contents(self, contents):
         temp = NamedTemporaryFile(delete=False)
-        temp.write(contents)
+        if six.PY3:
+            temp.write(salt.utils.to_bytes(contents))
+        else:
+            temp.write(contents)
         temp.close()
         self.tempfiles.append(temp)
         return temp

--- a/tests/unit/utils/find_test.py
+++ b/tests/unit/utils/find_test.py
@@ -15,6 +15,7 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
+import salt.ext.six as six
 import salt.utils
 import salt.utils.find
 
@@ -122,11 +123,19 @@ class TestFind(TestCase):
 
         min_size, max_size = salt.utils.find._parse_size('+1m')
         self.assertEqual(min_size, 1048576)
-        self.assertEqual(max_size, sys.maxint)
+        # sys.maxint has been removed in Python3. Use maxsize instead.
+        if six.PY3:
+            self.assertEqual(max_size, sys.maxsize)
+        else:
+            self.assertEqual(max_size, sys.maxint)
 
         min_size, max_size = salt.utils.find._parse_size('+1M')
         self.assertEqual(min_size, 1048576)
-        self.assertEqual(max_size, sys.maxint)
+        # sys.maxint has been removed in Python3. Use maxsize instead.
+        if six.PY3:
+            self.assertEqual(max_size, sys.maxsize)
+        else:
+            self.assertEqual(max_size, sys.maxint)
 
     def test_option_requires(self):
         option = salt.utils.find.Option()


### PR DESCRIPTION
All of these fixes were found by going through some of the test failures on the Python 3 runs in Jenkins. Some of these fixes are in sensitive areas, particularly in the filebuffer.py, so some careful eyes would be good and appreciated. 

The tests I was specifically working with here are passing in both PY2 and PY3, but I am interested to see how the rest of the test suite feels about these changes. I'll keep an eye on it. :)

