### PR TITLE
Change reload_modules to trigger only on state changes (#39015)

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -937,12 +937,12 @@ class State(object):
             self.opts['pillar'] = self._gather_pillar()
             _reload_modules = True
 
+        if not ret['changes']:
+            return
+
         if data.get('reload_modules', False) or _reload_modules:
             # User explicitly requests a reload
             self.module_refresh()
-            return
-
-        if not ret['changes']:
             return
 
         if data['state'] == 'file':

--- a/salt/state.py
+++ b/salt/state.py
@@ -937,7 +937,7 @@ class State(object):
             self.opts['pillar'] = self._gather_pillar()
             _reload_modules = True
 
-        if not ret['changes']:
+        if not ret['changes'] and not data.get('force_reload_modules', False):
             return
 
         if data.get('reload_modules', False) or _reload_modules:

--- a/salt/state.py
+++ b/salt/state.py
@@ -937,7 +937,9 @@ class State(object):
             self.opts['pillar'] = self._gather_pillar()
             _reload_modules = True
 
-        if not ret['changes'] and not data.get('force_reload_modules', False):
+        if not ret['changes']:
+            if data.get('force_reload_modules', False):
+                self.module_refresh()
             return
 
         if data.get('reload_modules', False) or _reload_modules:


### PR DESCRIPTION
### What does this PR do?
It changes state behaviour while used with
```
reload_modules: True
```

* Helps with performance
* reload_modules 99.9% of the time used by Salt users along with pip.installed, pkg.installed or cmd.run which remain compatible.
* Creates minor incompatibility if used with a logically-incomplete state that does not properly report changes.

It's somehow related to another performance bug #39011 and makes it affect my execution time a lot less :)

Please merge forward to 2016.11 if accepted.

### What issues does this PR fix or reference?

Fixes #39015, related to #39011

### Previous Behavior

reload all modules even if the state didn't report any changes

### New Behavior

reload the modules only in case the state reported some changes

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
