### PR TITLE
minionswarm.py: allow temporary data reuse

### DIFF
--- a/tests/minionswarm.py
+++ b/tests/minionswarm.py
@@ -171,16 +171,17 @@ class Swarm(object):
         Create the shared pki directory
         '''
         path = os.path.join(self.swarm_root, 'pki')
-        os.makedirs(path)
+        if not os.path.exists(path):
+            os.makedirs(path)
 
-        print('Creating shared pki keys for the swarm on: {0}'.format(path))
-        subprocess.call(
-            'salt-key -c {0} --gen-keys minion --gen-keys-dir {0} '
-            '--log-file {1} --user {2}'.format(
-                path, os.path.join(path, 'keys.log'), self.opts['user'],
-            ), shell=True
-        )
-        print('Keys generated')
+            print('Creating shared pki keys for the swarm on: {0}'.format(path))
+            subprocess.call(
+              'salt-key -c {0} --gen-keys minion --gen-keys-dir {0} '
+              '--log-file {1} --user {2}'.format(
+                  path, os.path.join(path, 'keys.log'), self.opts['user'],
+              ), shell=True
+            )
+            print('Keys generated')
         return path
 
     def start(self):
@@ -282,7 +283,8 @@ class MinionSwarm(Swarm):
                 )
 
         dpath = os.path.join(self.swarm_root, minion_id)
-        os.makedirs(dpath)
+        if not os.path.exists(dpath):
+            os.makedirs(dpath)
 
         data.update({
             'id': minion_id,
@@ -295,11 +297,12 @@ class MinionSwarm(Swarm):
 
         if self.opts['transport'] == 'zeromq':
             minion_pkidir = os.path.join(dpath, 'pki')
-            os.makedirs(minion_pkidir)
-            minion_pem = os.path.join(self.pki, 'minion.pem')
-            minion_pub = os.path.join(self.pki, 'minion.pub')
-            shutil.copy(minion_pem, minion_pkidir)
-            shutil.copy(minion_pub, minion_pkidir)
+            if not os.path.exists(minion_pkidir):
+                os.makedirs(minion_pkidir)
+                minion_pem = os.path.join(self.pki, 'minion.pem')
+                minion_pub = os.path.join(self.pki, 'minion.pub')
+                shutil.copy(minion_pem, minion_pkidir)
+                shutil.copy(minion_pub, minion_pkidir)
             data['pki_dir'] = minion_pkidir
         elif self.opts['transport'] == 'raet':
             data['transport'] = 'raet'

--- a/tests/minionswarm.py
+++ b/tests/minionswarm.py
@@ -104,6 +104,11 @@ def parse():
         help=('Run the minions with debug output of the swarm going to '
               'the terminal'))
     parser.add_option(
+        '--temp-dir',
+        dest='temp_dir',
+        default=None,
+        help='Place temporary files/directories here')
+    parser.add_option(
         '--no-clean',
         action='store_true',
         default=False,
@@ -142,15 +147,18 @@ class Swarm(object):
         self.opts = opts
         self.raet_port = 4550
 
-        # If given a root_dir, keep the tmp files there as well
-        if opts['root_dir']:
-            tmpdir = os.path.join(opts['root_dir'], 'tmp')
+        # If given a temp_dir, use it for temporary files
+        if opts['temp_dir']:
+            self.swarm_root = opts['temp_dir']
         else:
-            tmpdir = opts['root_dir']
-
-        self.swarm_root = tempfile.mkdtemp(
-            prefix='mswarm-root', suffix='.d',
-            dir=tmpdir)
+            # If given a root_dir, keep the tmp files there as well
+            if opts['root_dir']:
+                tmpdir = os.path.join(opts['root_dir'], 'tmp')
+            else:
+                tmpdir = opts['root_dir']
+            self.swarm_root = tempfile.mkdtemp(
+                prefix='mswarm-root', suffix='.d',
+                dir=tmpdir)
 
         if self.opts['transport'] == 'zeromq':
             self.pki = self._pki_dir()


### PR DESCRIPTION
### What does this PR do?

It adds a `--temp-dir` option to `minionswarm.py` so that users can control where temporary data is generated. In addition to that, it allows to re-use this directory between invocations.

This helped us testing SUSE Manager, in that the Swarm could be "stopped" and "restarted" later without losing associations to minions.

### What issues does this PR fix or reference?

None, it is a small new feature.

### Previous Behavior
Temporary data location was generated at random.

### New Behavior
Temporary data location can be either generated randomly (by default) or specified by the user (with the newly added `--temp-dir` option.

### Tests written?
No, changes are in test code itself.

