### PR TITLE
minionswarm.py: allow random machine id

### DIFF
--- a/tests/minionswarm.py
+++ b/tests/minionswarm.py
@@ -18,6 +18,7 @@ import random
 import tempfile
 import shutil
 import sys
+import hashlib
 
 # Import salt libs
 import salt
@@ -89,6 +90,12 @@ def parse():
         default=False,
         action='store_true',
         help='Each Minion claims a different version grain')
+    parser.add_option(
+        '--rand-machine-id',
+        dest='rand_machine_id',
+        default=False,
+        action='store_true',
+        help='Each Minion claims a different machine id grain')
     parser.add_option(
         '-k',
         '--keep-modules',
@@ -318,6 +325,8 @@ class MinionSwarm(Swarm):
             data['grains']['os'] = random.choice(OSES)
         if self.opts['rand_ver']:
             data['grains']['saltversion'] = random.choice(VERS)
+        if self.opts['rand_machine_id']:
+            data['grains']['machine_id'] = hashlib.md5(minion_id).hexdigest()
 
         with open(path, 'w+') as fp_:
             yaml.dump(data, fp_)


### PR DESCRIPTION
### What does this PR do?

It adds a `--rand-machine-id` option to `minionswarm.py` that sets a pseudorandom machine id to minions.

This helped us testing SUSE Manager, which de-duplicates minions based on this value.

### What issues does this PR fix or reference?
None, it is a small new feature.

### Previous Behavior
The `machine_id` grain was taken from the minion swarm host.

### New Behavior
The `machine_id` grain is taken from the minion swarm host (by default) or specified by the user (with the newly added `--rand-machine-id` option.

### Tests written?
No, changes are in test code itself.

