### PR TITLE
Clarify delimiter argument

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -89,7 +89,9 @@ def get(key, default='', delimiter=DEFAULT_TARGET_DELIM):
 
 
     :param delimiter:
-        Specify an alternate delimiter to use when traversing a nested dict
+        Specify an alternate delimiter to use when traversing a nested dict.
+        This is useful for when the desired key contains a colon. See CLI
+        example below for usage.
 
         .. versionadded:: 2014.7.0
 
@@ -98,6 +100,7 @@ def get(key, default='', delimiter=DEFAULT_TARGET_DELIM):
     .. code-block:: bash
 
         salt '*' grains.get pkg:apache
+        salt '*' grains.get abc::def|ghi delimiter='|'
     '''
     return salt.utils.traverse_dict_and_list(__grains__,
                                              key,

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -55,7 +55,9 @@ def get(key,
         .. versionadded:: 2014.7.0
 
     delimiter
-        Specify an alternate delimiter to use when traversing a nested dict
+        Specify an alternate delimiter to use when traversing a nested dict.
+        This is useful for when the desired key contains a colon. See CLI
+        example below for usage.
 
         .. versionadded:: 2014.7.0
 
@@ -80,6 +82,7 @@ def get(key,
     .. code-block:: bash
 
         salt '*' pillar.get pkg:apache
+        salt '*' pillar.get abc::def|ghi delimiter='|'
     '''
     if not __opts__.get('pillar_raise_on_missing'):
         if default is KeyError:


### PR DESCRIPTION
This makes the usage of the delimiter argument in pillar.get/grains.get
more clear.