### PR TITLE
mine.update runner

### DIFF
--- a/salt/runners/mine.py
+++ b/salt/runners/mine.py
@@ -27,3 +27,42 @@ def get(tgt, fun, tgt_type='glob'):
     '''
     ret = salt.utils.minions.mine_get(tgt, fun, tgt_type, __opts__)
     return ret
+
+
+def update(tgt,
+           tgt_type='glob',
+           clear=False,
+           mine_functions=None):
+    '''
+    Update the mine data on a certain group of minions.
+
+    tgt
+        Which minions to target for the execution.
+
+    tgt_type: ``glob``
+        The type of ``tgt``.
+
+    clear: ``False``
+        Boolean flag specifying whether updating will clear the existing
+        mines, or will update. Default: ``False`` (update).
+
+    mine_functions
+        Update the mine data on certain functions only.
+        This feature can be used when updating the mine for functions
+        that require refresh at different intervals than the rest of
+        the functions specified under ``mine_functions`` in the
+        minion/master config or pillar.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run mine.update '*'
+        salt-run mine.update 'juniper-edges' tgt_type='nodegroup'
+    '''
+    ret = __salt__['salt.execute'](tgt,
+                                   'mine.update',
+                                   tgt_type=tgt_type,
+                                   clear=clear,
+                                   mine_functions=mine_functions)
+    return ret


### PR DESCRIPTION
### What does this PR do?

Yet another weird runner from me, but I find it pretty handy in some circumstances. So I'm sharing it hoping that it will help other users as well.

It's using the `salt.execute` function from https://github.com/saltstack/salt/pull/39007 and the selective mine update from https://github.com/saltstack/salt/pull/38874.