### PR TITLE
SaltTesting fixes for Windows

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -37,6 +37,8 @@ STATE_FUNCTION_RUNNING_RE = re.compile(
 INTEGRATION_TEST_DIR = os.path.dirname(
     os.path.normpath(os.path.abspath(__file__))
 )
+if os.name == 'nt':
+    INTEGRATION_TEST_DIR = INTEGRATION_TEST_DIR.replace('\\', '\\\\')
 CODE_DIR = os.path.dirname(os.path.dirname(INTEGRATION_TEST_DIR))
 
 # Import Salt Testing libs

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -352,9 +352,20 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             # Turn on expensive tests execution
             os.environ['EXPENSIVE_TESTS'] = 'True'
 
+        import salt.utils
+        if salt.utils.is_windows():
+            import salt.utils.win_functions
+            current_user = salt.utils.win_functions.get_current_user()
+            if current_user == 'SYSTEM':
+                is_admin = True
+            else:
+                is_admin = salt.utils.win_functions.is_admin(current_user)
+        else:
+            is_admin = os.geteuid() == 0
+
         if self.options.coverage and any((
                     self.options.name,
-                    os.geteuid() != 0,
+                    is_admin,
                     not self.options.run_destructive)) \
                 and self._check_enabled_suites(include_unit=True):
             self.error(


### PR DESCRIPTION
### What does this PR do?
Fixes problem with path to the testing folder in Windows. It was failing with the use of single `\`. Needs to use double `\\` for paths in Windows.
Fixes problem with `geteuid` missing from the os module in Windows.

### Tests written?
No