### PR TITLE
Fix test name

### DIFF
--- a/tests/unit/modules/linux_lvm_test.py
+++ b/tests/unit/modules/linux_lvm_test.py
@@ -117,7 +117,7 @@ class LinuxLVMTestCase(TestCase):
                                         'Volume Group Size (kB)': 'L',
                                         'Volume Group Status': 'C'}})
 
-    def test__lvdisplay(self):
+    def test_lvdisplay(self):
         '''
         Return information about the logical volume(s)
         '''


### PR DESCRIPTION
Remove an unnecessary underscore character from the name of the
linux_lvm.lvdisplay test:

  test__lvdisplay -> test_lvdisplay