### PR TITLE
Avoid KeyError: 'multiprocessing' in the master logs

### DIFF
--- a/salt/utils/minion.py
+++ b/salt/utils/minion.py
@@ -81,7 +81,7 @@ def _read_proc_file(path, opts):
         except IOError:
             pass
         return None
-    if opts['multiprocessing']:
+    if opts.get('multiprocessing'):
         if data.get('pid') == pid:
             return None
     else:


### PR DESCRIPTION
Fix for #39059
