### PR TITLE
Update primary bonding option in debian_ip.py

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -923,7 +923,7 @@ def _parse_settings_bond_1(opts, iface, bond_def):
 
     if 'primary' in opts:
         bond.update({'primary': opts['primary']})
-        
+
     if not (__grains__['os'] == "Ubuntu" and __grains__['osrelease_info'][0] >= 16):
         if 'use_carrier' in opts:
             if opts['use_carrier'] in _CONFIG_TRUE:
@@ -1109,7 +1109,7 @@ def _parse_settings_bond_5(opts, iface, bond_def):
 
     if 'primary' in opts:
         bond.update({'primary': opts['primary']})
-    
+
     return bond
 
 
@@ -1148,7 +1148,7 @@ def _parse_settings_bond_6(opts, iface, bond_def):
 
     if 'primary' in opts:
         bond.update({'primary': opts['primary']})
-        
+
     return bond
 
 

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -921,6 +921,9 @@ def _parse_settings_bond_1(opts, iface, bond_def):
             _log_default_iface(iface, binding, bond_def[binding])
             bond.update({binding: bond_def[binding]})
 
+    if 'primary' in opts:
+        bond.update({'primary': opts['primary']})
+        
     if not (__grains__['os'] == "Ubuntu" and __grains__['osrelease_info'][0] >= 16):
         if 'use_carrier' in opts:
             if opts['use_carrier'] in _CONFIG_TRUE:
@@ -973,9 +976,6 @@ def _parse_settings_bond_2(opts, iface, bond_def):
     else:
         _log_default_iface(iface, 'arp_interval', bond_def['arp_interval'])
         bond.update({'arp_interval': bond_def['arp_interval']})
-
-    if 'primary' in opts:
-        bond.update({'primary': opts['primary']})
 
     if 'hashing-algorithm' in opts:
         valid = ['layer2', 'layer2+3', 'layer3+4']
@@ -1107,6 +1107,9 @@ def _parse_settings_bond_5(opts, iface, bond_def):
         _log_default_iface(iface, 'use_carrier', bond_def['use_carrier'])
         bond.update({'use_carrier': bond_def['use_carrier']})
 
+    if 'primary' in opts:
+        bond.update({'primary': opts['primary']})
+    
     return bond
 
 
@@ -1143,6 +1146,9 @@ def _parse_settings_bond_6(opts, iface, bond_def):
         _log_default_iface(iface, 'use_carrier', bond_def['use_carrier'])
         bond.update({'use_carrier': bond_def['use_carrier']})
 
+    if 'primary' in opts:
+        bond.update({'primary': opts['primary']})
+        
     return bond
 
 


### PR DESCRIPTION
Add support for the "primary" bonding option in active-backup, balancd-tlb and balance-alb type bonds for Debian.  This is used to specify a preferred slave for the link.

Remove support for the balance-xor bond type, since it is not supported by the kernel.

Reference: https://www.kernel.org/doc/Documentation/networking/bonding.txt
	
"The primary option is only valid for active-backup(1), balance-tlb (5) and balance-alb (6) mode."

### What does this PR do?

### What issues does this PR fix or reference?
Issue #39065 

### Tests written?
No
