### PR TITLE
Update primary bonding option in rh_ip.py

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -334,6 +334,9 @@ def _parse_settings_bond_1(opts, iface, bond_def):
         _log_default_iface(iface, 'use_carrier', bond_def['use_carrier'])
         bond.update({'use_carrier': bond_def['use_carrier']})
 
+    if 'primary' in opts:
+        bond.update({'primary': opts['primary']})
+        
     return bond
 
 
@@ -373,9 +376,6 @@ def _parse_settings_bond_2(opts, iface, bond_def):
     else:
         _log_default_iface(iface, 'arp_interval', bond_def['arp_interval'])
         bond.update({'arp_interval': bond_def['arp_interval']})
-
-    if 'primary' in opts:
-        bond.update({'primary': opts['primary']})
 
     if 'hashing-algorithm' in opts:
         valid = ['layer2', 'layer2+3', 'layer3+4']
@@ -507,6 +507,9 @@ def _parse_settings_bond_5(opts, iface, bond_def):
         _log_default_iface(iface, 'use_carrier', bond_def['use_carrier'])
         bond.update({'use_carrier': bond_def['use_carrier']})
 
+    if 'primary' in opts:
+        bond.update({'primary': opts['primary']})
+        
     return bond
 
 
@@ -543,6 +546,9 @@ def _parse_settings_bond_6(opts, iface, bond_def):
         _log_default_iface(iface, 'use_carrier', bond_def['use_carrier'])
         bond.update({'use_carrier': bond_def['use_carrier']})
 
+    if 'primary' in opts:
+        bond.update({'primary': opts['primary']})
+        
     return bond
 
 

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -336,7 +336,7 @@ def _parse_settings_bond_1(opts, iface, bond_def):
 
     if 'primary' in opts:
         bond.update({'primary': opts['primary']})
-        
+
     return bond
 
 
@@ -509,7 +509,7 @@ def _parse_settings_bond_5(opts, iface, bond_def):
 
     if 'primary' in opts:
         bond.update({'primary': opts['primary']})
-        
+
     return bond
 
 
@@ -548,7 +548,7 @@ def _parse_settings_bond_6(opts, iface, bond_def):
 
     if 'primary' in opts:
         bond.update({'primary': opts['primary']})
-        
+
     return bond
 
 


### PR DESCRIPTION
Add support for the "primary" bonding option in active-backup, balancd-tlb and balance-alb type bonds for Debian.  This is used to specify a preferred slave for the link.
### What does this PR do?
Remove support for the balance-xor bond type, since it is not supported by the kernel.

Reference: https://www.kernel.org/doc/Documentation/networking/bonding.txt
	
"The primary option is only valid for active-backup(1), balance-tlb (5) and balance-alb (6) mode."

### What issues does this PR fix or reference?
Issue #39065  

### Tests written?
No
