### PR TITLE
Fix modules.linux_lvm.pvcreate on existing LVM PVs

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -229,7 +229,7 @@ def pvcreate(devices, override=True, **kwargs):
         elif not override:
             raise CommandExecutionError('Device "{0}" is already an LVM physical volume.'.format(device))
 
-    if not cmd[1:]:
+    if not cmd[2:]:
         # All specified devices are already LVM volumes
         return True
 

--- a/tests/unit/modules/linux_lvm_test.py
+++ b/tests/unit/modules/linux_lvm_test.py
@@ -163,6 +163,20 @@ class LinuxLVMTestCase(TestCase):
                 with patch.dict(linux_lvm.__salt__, {'cmd.run_all': mock}):
                     self.assertEqual(linux_lvm.pvcreate('A', metadatasize=1000), True)
 
+    def test_pvcreate_existing_pvs(self):
+        '''
+        Test a scenario when all the submitted devices are already LVM PVs.
+        '''
+        pvdisplay = MagicMock(return_value=True)
+        with patch('salt.modules.linux_lvm.pvdisplay', pvdisplay):
+            with patch.object(os.path, 'exists', return_value=True):
+                ret = {'stdout': 'saltines', 'stderr': 'cheese', 'retcode': 0, 'pid': '1337'}
+                cmd_mock = MagicMock(return_value=ret)
+                with patch.dict(linux_lvm.__salt__, {'cmd.run_all': cmd_mock}):
+                    self.assertEqual(linux_lvm.pvcreate('A', metadatasize=1000),
+                                     True)
+                    cmd_mock.assert_not_called()
+
     def test_pvremove(self):
         '''
         Tests for remove a physical device being used as an LVM physical volume

--- a/tests/unit/modules/linux_lvm_test.py
+++ b/tests/unit/modules/linux_lvm_test.py
@@ -152,7 +152,10 @@ class LinuxLVMTestCase(TestCase):
 
         self.assertRaises(CommandExecutionError, linux_lvm.pvcreate, 'A')
 
-        pvdisplay = MagicMock(return_value=True)
+        # pvdisplay() would be called by pvcreate() twice: firstly to check
+        # whether a device is already initialized for use by LVM and then to
+        # ensure that the pvcreate executable did its job correctly.
+        pvdisplay = MagicMock(side_effect=[False, True])
         with patch('salt.modules.linux_lvm.pvdisplay', pvdisplay):
             with patch.object(os.path, 'exists', return_value=True):
                 ret = {'stdout': 'saltines', 'stderr': 'cheese', 'retcode': 0, 'pid': '1337'}


### PR DESCRIPTION
### What does this PR do?

Stops modules.linux_lvm.pvcreate from calling the pvcreate executable with no (device) arguments if all the submitted devices are already LVM PVs.

### What issues does this PR fix or reference?

Fixes #39070 

### Tests written?

Yes