### PR TITLE
bugfix adding subnetwork option to gce

### DIFF
--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -445,6 +445,15 @@ def __get_network(conn, vm_):
         default='default', search_global=False)
     return conn.ex_get_network(network)
 
+def __get_subnetwork(vm_):
+    '''
+    Get configured subnetwork.
+    '''
+    ex_subnetwork = config.get_cloud_config_value(
+        'subnetwork', vm_, __opts__,
+        default='default', search_global=False)
+
+    return ex_subnetwork
 
 def __get_ssh_interface(vm_):
     '''
@@ -2226,6 +2235,7 @@ def request_instance(vm_):
         'image': __get_image(conn, vm_),
         'location': __get_location(conn, vm_),
         'ex_network': __get_network(conn, vm_),
+        'ex_subnetwork': __get_subnetwork(vm_),
         'ex_tags': __get_tags(vm_),
         'ex_metadata': __get_metadata(vm_),
     }

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -445,6 +445,7 @@ def __get_network(conn, vm_):
         default='default', search_global=False)
     return conn.ex_get_network(network)
 
+
 def __get_subnetwork(vm_):
     '''
     Get configured subnetwork.
@@ -454,6 +455,7 @@ def __get_subnetwork(vm_):
         default='default', search_global=False)
 
     return ex_subnetwork
+
 
 def __get_ssh_interface(vm_):
     '''


### PR DESCRIPTION
### What does this PR do?
This PR adds the ability to set subnetwork in profile for Google Compute Engine instances.

### What issues does this PR fix or reference?
#31071

### Previous Behavior
Previously when deploying to custom networks salt-cloud would fail with the error described in #31071

### New Behavior
Now it is possible to specify a subnetwork in the profile, to deploy to a custom network and a specific subnet in that network.


### Tests written?
no

