### PR TITLE
Grammar fixes in docstrings

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -205,7 +205,7 @@ def pvcreate(devices, override=True, **kwargs):
     Set a physical device to be used as an LVM physical volume
 
     override
-        Skip devices, if they are already an LVM physical volumes
+        Skip devices, if they are already LVM physical volumes
 
     CLI Examples:
 
@@ -258,7 +258,7 @@ def pvremove(devices, override=True):
     Remove a physical device being used as an LVM physical volume
 
     override
-        Skip devices, if they are already not used as an LVM physical volumes
+        Skip devices, if they are already not used as LVM physical volumes
 
     CLI Examples:
 


### PR DESCRIPTION
Remove unneeded 'an' articles from docstrings in salt/modules/linux_lvm.py 