### PR TITLE
Added Lambda environment variables support to boto_lambda modules/states

### DIFF
--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -80,11 +80,12 @@ def __virtual__():
     return 'boto_lambda' if 'boto_lambda.function_exists' in __salt__ else False
 
 
-def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S3Bucket=None,
-            S3Key=None, S3ObjectVersion=None,
-            Description='', Timeout=3, MemorySize=128,
-            Permissions=None, RoleRetries=5,
-            region=None, key=None, keyid=None, profile=None, VpcConfig=None):
+def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None,
+                     S3Bucket=None, S3Key=None, S3ObjectVersion=None,
+                     Description='', Timeout=3, MemorySize=128,
+                     Permissions=None, RoleRetries=5, region=None, key=None,
+                     keyid=None, profile=None, VpcConfig=None,
+                     Environment=None):
     '''
     Ensure function exists.
 
@@ -157,6 +158,17 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
         During that time function creation may fail; this state will
         atuomatically retry this number of times. The default is 5.
 
+    Environment
+        The parent object that contains your environment's configuration
+        settings.  This is a dictionary of the form:
+        {
+            'Variables': {
+                'VariableName': 'VariableValue'
+            }
+        }
+
+        .. versionadded:: Nitrogen
+
     region
         Region to connect to.
 
@@ -185,67 +197,72 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None, S
             keyset = set(permission.keys())
             if not keyset.issuperset(required_keys):
                 raise SaltInvocationError('{0} are required for each permission '
-                           'specification'.format(', '.join(required_keys)))
+                                          'specification'.format(', '.join(required_keys)))
             keyset = keyset - required_keys
             keyset = keyset - optional_keys
             if bool(keyset):
-                raise SaltInvocationError('Invalid permission value {0}'.format(', '.join(keyset)))
+                raise SaltInvocationError(
+                    'Invalid permission value {0}'.format(', '.join(keyset)))
 
-    r = __salt__['boto_lambda.function_exists'](FunctionName=FunctionName, region=region,
-                                                key=key, keyid=keyid, profile=profile)
+    r = __salt__['boto_lambda.function_exists'](
+        FunctionName=FunctionName, region=region,
+        key=key, keyid=keyid, profile=profile)
 
     if 'error' in r:
         ret['result'] = False
-        ret['comment'] = 'Failed to create function: {0}.'.format(r['error']['message'])
+        ret['comment'] = ('Failed to create function: '
+                          '{0}.'.format(r['error']['message']))
         return ret
 
     if not r.get('exists'):
         if __opts__['test']:
-            ret['comment'] = 'Function {0} is set to be created.'.format(FunctionName)
+            ret['comment'] = 'Function {0} is set to be created.'.format(
+                FunctionName)
             ret['result'] = None
             return ret
-        r = __salt__['boto_lambda.create_function'](FunctionName=FunctionName, Runtime=Runtime,
-                                                    Role=Role, Handler=Handler,
-                                                    ZipFile=ZipFile, S3Bucket=S3Bucket,
-                                                    S3Key=S3Key,
-                                                    S3ObjectVersion=S3ObjectVersion,
-                                                    Description=Description,
-                                                    Timeout=Timeout, MemorySize=MemorySize,
-                                                    VpcConfig=VpcConfig,
-                                                    WaitForRole=True,
-                                                    RoleRetries=RoleRetries,
-                                                    region=region, key=key,
-                                                    keyid=keyid, profile=profile)
+        r = __salt__['boto_lambda.create_function'](
+            FunctionName=FunctionName, Runtime=Runtime, Role=Role,
+            Handler=Handler, ZipFile=ZipFile, S3Bucket=S3Bucket, S3Key=S3Key,
+            S3ObjectVersion=S3ObjectVersion, Description=Description,
+            Timeout=Timeout, MemorySize=MemorySize, VpcConfig=VpcConfig,
+            Environment=Environment, WaitForRole=True, RoleRetries=RoleRetries,
+            region=region, key=key, keyid=keyid, profile=profile)
         if not r.get('created'):
             ret['result'] = False
-            ret['comment'] = 'Failed to create function: {0}.'.format(r['error']['message'])
+            ret['comment'] = ('Failed to create function: '
+                              '{0}.'.format(r['error']['message']))
             return ret
 
         if Permissions:
             for sid, permission in six.iteritems(Permissions):
-                r = __salt__['boto_lambda.add_permission'](FunctionName=FunctionName,
-                                                       StatementId=sid,
-                                                       region=region, key=key,
-                                                       keyid=keyid, profile=profile,
-                                                       **permission)
+                r = __salt__['boto_lambda.add_permission'](
+                    FunctionName=FunctionName, StatementId=sid,
+                    region=region, key=key, keyid=keyid, profile=profile,
+                    **permission)
                 if not r.get('updated'):
                     ret['result'] = False
-                    ret['comment'] = 'Failed to create function: {0}.'.format(r['error']['message'])
+                    ret['comment'] = ('Failed to create function: '
+                                      '{0}.'.format(r['error']['message']))
 
-        _describe = __salt__['boto_lambda.describe_function'](FunctionName,
-                           region=region, key=key, keyid=keyid, profile=profile)
-        _describe['function']['Permissions'] = __salt__['boto_lambda.get_permissions'](FunctionName,
-                           region=region, key=key, keyid=keyid, profile=profile)['permissions']
+        _describe = __salt__['boto_lambda.describe_function'](
+            FunctionName, region=region, key=key, keyid=keyid, profile=profile)
+        _describe['function']['Permissions'] = (
+            __salt__['boto_lambda.get_permissions'](
+                FunctionName, region=region, key=key, keyid=keyid,
+                profile=profile)['permissions'])
         ret['changes']['old'] = {'function': None}
         ret['changes']['new'] = _describe
         ret['comment'] = 'Function {0} created.'.format(FunctionName)
         return ret
 
-    ret['comment'] = os.linesep.join([ret['comment'], 'Function {0} is present.'.format(FunctionName)])
+    ret['comment'] = os.linesep.join(
+        [ret['comment'], 'Function {0} is present.'.format(FunctionName)])
     ret['changes'] = {}
     # function exists, ensure config matches
-    _ret = _function_config_present(FunctionName, Role, Handler, Description, Timeout,
-                                    MemorySize, VpcConfig, region, key, keyid, profile, RoleRetries)
+    _ret = _function_config_present(FunctionName, Role, Handler, Description,
+                                    Timeout, MemorySize, VpcConfig,
+                                    Environment, region, key, keyid,
+                                    profile, RoleRetries)
     if not _ret.get('result'):
         ret['result'] = False
         ret['comment'] = _ret['comment']
@@ -285,10 +302,12 @@ def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
 
 
 def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
-                           MemorySize, VpcConfig, region, key, keyid, profile, RoleRetries):
+                             MemorySize, VpcConfig, Environment, region,
+                             key, keyid, profile, RoleRetries):
     ret = {'result': True, 'comment': '', 'changes': {}}
-    func = __salt__['boto_lambda.describe_function'](FunctionName,
-           region=region, key=key, keyid=keyid, profile=profile)['function']
+    func = __salt__['boto_lambda.describe_function'](
+        FunctionName, region=region,
+        key=key, keyid=keyid, profile=profile)['function']
     role_arn = _get_role_arn(Role, region, key, keyid, profile)
     need_update = False
     options = {'Role': 'role_arn',
@@ -309,33 +328,44 @@ def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
     if oldval != VpcConfig:
         need_update = True
         ret['changes'].setdefault('new', {})['VpcConfig'] = VpcConfig
-        ret['changes'].setdefault('old', {})['VpcConfig'] = func.get('VpcConfig')
+        ret['changes'].setdefault(
+            'old', {})['VpcConfig'] = func.get('VpcConfig')
+
+    if Environment is not None:
+        if func.get('Environment') != Environment:
+            need_update = True
+            ret['changes'].setdefault('new', {})['Environment'] = Environment
+            ret['changes'].setdefault('old', {})['Environment'] = func.get(
+                'Environment')
+
     if need_update:
-        ret['comment'] = os.linesep.join([ret['comment'], 'Function config to be modified'])
+        ret['comment'] = os.linesep.join(
+            [ret['comment'], 'Function config to be modified'])
         if __opts__['test']:
             msg = 'Function {0} set to be modified.'.format(FunctionName)
             ret['comment'] = msg
             ret['result'] = None
             return ret
-        _r = __salt__['boto_lambda.update_function_config'](FunctionName=FunctionName,
-                                        Role=Role, Handler=Handler, Description=Description,
-                                        Timeout=Timeout, MemorySize=MemorySize,
-                                        VpcConfig=VpcConfig,
-                                        region=region, key=key,
-                                        keyid=keyid, profile=profile,
-                                        WaitForRole=True, RoleRetries=RoleRetries)
+        _r = __salt__['boto_lambda.update_function_config'](
+            FunctionName=FunctionName, Role=Role, Handler=Handler,
+            Description=Description, Timeout=Timeout, MemorySize=MemorySize,
+            VpcConfig=VpcConfig, Environment=Environment, region=region,
+            key=key, keyid=keyid, profile=profile, WaitForRole=True,
+            RoleRetries=RoleRetries)
         if not _r.get('updated'):
             ret['result'] = False
-            ret['comment'] = 'Failed to update function: {0}.'.format(_r['error']['message'])
+            ret['comment'] = ('Failed to update function: '
+                              '{0}.'.format(_r['error']['message']))
             ret['changes'] = {}
     return ret
 
 
-def _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key, S3ObjectVersion,
-                         region, key, keyid, profile):
+def _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key,
+                           S3ObjectVersion, region, key, keyid, profile):
     ret = {'result': True, 'comment': '', 'changes': {}}
-    func = __salt__['boto_lambda.describe_function'](FunctionName,
-           region=region, key=key, keyid=keyid, profile=profile)['function']
+    func = __salt__['boto_lambda.describe_function'](
+        FunctionName, region=region,
+        key=key, keyid=keyid, profile=profile)['function']
     update = False
     if ZipFile:
         size = os.path.getsize(ZipFile)
@@ -363,18 +393,21 @@ def _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key, S3ObjectVersi
             'CodeSha256': func['CodeSha256'],
             'CodeSize': func['CodeSize'],
         }
-        func = __salt__['boto_lambda.update_function_code'](FunctionName, ZipFile, S3Bucket,
+        func = __salt__['boto_lambda.update_function_code'](
+            FunctionName, ZipFile, S3Bucket,
             S3Key, S3ObjectVersion,
             region=region, key=key, keyid=keyid, profile=profile)
         if not func.get('updated'):
             ret['result'] = False
-            ret['comment'] = 'Failed to update function: {0}.'.format(func['error']['message'])
+            ret['comment'] = ('Failed to update function: '
+                              '{0}.'.format(func['error']['message']))
             ret['changes'] = {}
             return ret
         func = func['function']
         if func['CodeSha256'] != ret['changes']['old']['CodeSha256'] or \
                 func['CodeSize'] != ret['changes']['old']['CodeSize']:
-            ret['comment'] = os.linesep.join([ret['comment'], 'Function code to be modified'])
+            ret['comment'] = os.linesep.join(
+                [ret['comment'], 'Function code to be modified'])
             ret['changes']['new'] = {
                 'CodeSha256': func['CodeSha256'],
                 'CodeSize': func['CodeSize'],
@@ -387,14 +420,16 @@ def _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key, S3ObjectVersi
 def _function_permissions_present(FunctionName, Permissions,
                                   region, key, keyid, profile):
     ret = {'result': True, 'comment': '', 'changes': {}}
-    curr_permissions = __salt__['boto_lambda.get_permissions'](FunctionName,
-           region=region, key=key, keyid=keyid, profile=profile).get('permissions')
+    curr_permissions = __salt__['boto_lambda.get_permissions'](
+        FunctionName, region=region,
+        key=key, keyid=keyid, profile=profile).get('permissions')
     if curr_permissions is None:
         curr_permissions = {}
     need_update = False
     diffs = salt.utils.compare_dicts(curr_permissions, Permissions or {})
     if bool(diffs):
-        ret['comment'] = os.linesep.join([ret['comment'], 'Function permissions to be modified'])
+        ret['comment'] = os.linesep.join(
+            [ret['comment'], 'Function permissions to be modified'])
         if __opts__['test']:
             msg = 'Function {0} set to be modified.'.format(FunctionName)
             ret['comment'] = msg
@@ -403,30 +438,29 @@ def _function_permissions_present(FunctionName, Permissions,
         for sid, diff in six.iteritems(diffs):
             if diff.get('old', '') != '':
                 # There's a permssion that needs to be removed
-                _r = __salt__['boto_lambda.remove_permission'](FunctionName=FunctionName,
-                                        StatementId=sid,
-                                        region=region, key=key,
-                                        keyid=keyid, profile=profile)
-                ret['changes'].setdefault('new', {}).setdefault('Permissions',
-                                 {})[sid] = {}
-                ret['changes'].setdefault('old', {}).setdefault('Permissions',
-                                 {})[sid] = diff['old']
+                _r = __salt__['boto_lambda.remove_permission'](
+                    FunctionName=FunctionName, StatementId=sid,
+                    region=region, key=key, keyid=keyid, profile=profile)
+                ret['changes'].setdefault(
+                    'new', {}).setdefault('Permissions', {})[sid] = {}
+                ret['changes'].setdefault(
+                    'old', {}).setdefault('Permissions', {})[sid] = diff['old']
             if diff.get('new', '') != '':
                 # New permission information needs to be added
-                _r = __salt__['boto_lambda.add_permission'](FunctionName=FunctionName,
-                                        StatementId=sid,
-                                        region=region, key=key,
-                                        keyid=keyid, profile=profile,
-                                        **diff['new'])
-                ret['changes'].setdefault('new', {}).setdefault('Permissions',
-                                 {})[sid] = diff['new']
-                oldperms = ret['changes'].setdefault('old', {}).setdefault('Permissions',
-                                 {})
+                _r = __salt__['boto_lambda.add_permission'](
+                    FunctionName=FunctionName, StatementId=sid,
+                    region=region, key=key, keyid=keyid, profile=profile,
+                    **diff['new'])
+                ret['changes'].setdefault(
+                    'new', {}).setdefault('Permissions', {})[sid] = diff['new']
+                oldperms = ret['changes'].setdefault(
+                    'old', {}).setdefault('Permissions', {})
                 if sid not in oldperms:
                     oldperms[sid] = {}
             if not _r.get('updated'):
                 ret['result'] = False
-                ret['comment'] = 'Failed to update function: {0}.'.format(_r['error']['message'])
+                ret['comment'] = ('Failed to update function: '
+                                  '{0}.'.format(_r['error']['message']))
                 ret['changes'] = {}
     return ret
 
@@ -461,11 +495,12 @@ def function_absent(name, FunctionName, region=None, key=None, keyid=None, profi
            'changes': {}
            }
 
-    r = __salt__['boto_lambda.function_exists'](FunctionName, region=region,
-                                    key=key, keyid=keyid, profile=profile)
+    r = __salt__['boto_lambda.function_exists'](
+        FunctionName, region=region, key=key, keyid=keyid, profile=profile)
     if 'error' in r:
         ret['result'] = False
-        ret['comment'] = 'Failed to delete function: {0}.'.format(r['error']['message'])
+        ret['comment'] = 'Failed to delete function: {0}.'.format(r['error'][
+            'message'])
         return ret
 
     if r and not r['exists']:
@@ -473,15 +508,17 @@ def function_absent(name, FunctionName, region=None, key=None, keyid=None, profi
         return ret
 
     if __opts__['test']:
-        ret['comment'] = 'Function {0} is set to be removed.'.format(FunctionName)
+        ret['comment'] = 'Function {0} is set to be removed.'.format(
+            FunctionName)
         ret['result'] = None
         return ret
     r = __salt__['boto_lambda.delete_function'](FunctionName,
-                                    region=region, key=key,
-                                    keyid=keyid, profile=profile)
+                                                region=region, key=key,
+                                                keyid=keyid, profile=profile)
     if not r['deleted']:
         ret['result'] = False
-        ret['comment'] = 'Failed to delete function: {0}.'.format(r['error']['message'])
+        ret['comment'] = ('Failed to delete function: '
+                          '{0}.'.format(r['error']['message']))
         return ret
     ret['changes']['old'] = {'function': FunctionName}
     ret['changes']['new'] = {'function': None}
@@ -490,7 +527,7 @@ def function_absent(name, FunctionName, region=None, key=None, keyid=None, profi
 
 
 def alias_present(name, FunctionName, Name, FunctionVersion, Description='',
-            region=None, key=None, keyid=None, profile=None):
+                  region=None, key=None, keyid=None, profile=None):
     '''
     Ensure alias exists.
 
@@ -529,12 +566,14 @@ def alias_present(name, FunctionName, Name, FunctionVersion, Description='',
            'changes': {}
            }
 
-    r = __salt__['boto_lambda.alias_exists'](FunctionName=FunctionName, Name=Name, region=region,
-                                    key=key, keyid=keyid, profile=profile)
+    r = __salt__['boto_lambda.alias_exists'](
+        FunctionName=FunctionName, Name=Name, region=region,
+        key=key, keyid=keyid, profile=profile)
 
     if 'error' in r:
         ret['result'] = False
-        ret['comment'] = 'Failed to create alias: {0}.'.format(r['error']['message'])
+        ret['comment'] = ('Failed to create alias: '
+                          '{0}.'.format(r['error']['message']))
         return ret
 
     if not r.get('exists'):
@@ -543,24 +582,27 @@ def alias_present(name, FunctionName, Name, FunctionVersion, Description='',
             ret['result'] = None
             return ret
         r = __salt__['boto_lambda.create_alias'](FunctionName, Name,
-                FunctionVersion, Description,
-                region, key, keyid, profile)
+                                                 FunctionVersion, Description,
+                                                 region, key, keyid, profile)
         if not r.get('created'):
             ret['result'] = False
-            ret['comment'] = 'Failed to create alias: {0}.'.format(r['error']['message'])
+            ret['comment'] = ('Failed to create alias: '
+                              '{0}.'.format(r['error']['message']))
             return ret
-        _describe = __salt__['boto_lambda.describe_alias'](FunctionName, Name, region=region, key=key,
-                                                  keyid=keyid, profile=profile)
+        _describe = __salt__['boto_lambda.describe_alias'](
+            FunctionName, Name, region=region, key=key,
+            keyid=keyid, profile=profile)
         ret['changes']['old'] = {'alias': None}
         ret['changes']['new'] = _describe
         ret['comment'] = 'Alias {0} created.'.format(Name)
         return ret
 
-    ret['comment'] = os.linesep.join([ret['comment'], 'Alias {0} is present.'.format(Name)])
+    ret['comment'] = os.linesep.join(
+        [ret['comment'], 'Alias {0} is present.'.format(Name)])
     ret['changes'] = {}
-    _describe = __salt__['boto_lambda.describe_alias'](FunctionName, Name,
-                                                  region=region, key=key, keyid=keyid,
-                                                  profile=profile)['alias']
+    _describe = __salt__['boto_lambda.describe_alias'](
+        FunctionName, Name, region=region, key=key, keyid=keyid,
+        profile=profile)['alias']
 
     need_update = False
     options = {'FunctionVersion': 'FunctionVersion',
@@ -572,19 +614,21 @@ def alias_present(name, FunctionName, Name, FunctionVersion, Description='',
             ret['changes'].setdefault('new', {})[var] = locals()[var]
             ret['changes'].setdefault('old', {})[var] = _describe[val]
     if need_update:
-        ret['comment'] = os.linesep.join([ret['comment'], 'Alias config to be modified'])
+        ret['comment'] = os.linesep.join(
+            [ret['comment'], 'Alias config to be modified'])
         if __opts__['test']:
             msg = 'Alias {0} set to be modified.'.format(Name)
             ret['comment'] = msg
             ret['result'] = None
             return ret
-        _r = __salt__['boto_lambda.update_alias'](FunctionName=FunctionName, Name=Name,
-                                        FunctionVersion=FunctionVersion, Description=Description,
-                                        region=region, key=key,
-                                        keyid=keyid, profile=profile)
+        _r = __salt__['boto_lambda.update_alias'](
+            FunctionName=FunctionName, Name=Name,
+            FunctionVersion=FunctionVersion, Description=Description,
+            region=region, key=key, keyid=keyid, profile=profile)
         if not _r.get('updated'):
             ret['result'] = False
-            ret['comment'] = 'Failed to update alias: {0}.'.format(_r['error']['message'])
+            ret['comment'] = ('Failed to update alias: '
+                              '{0}.'.format(_r['error']['message']))
             ret['changes'] = {}
     return ret
 
@@ -622,11 +666,13 @@ def alias_absent(name, FunctionName, Name, region=None, key=None, keyid=None, pr
            'changes': {}
            }
 
-    r = __salt__['boto_lambda.alias_exists'](FunctionName, Name, region=region,
-                                    key=key, keyid=keyid, profile=profile)
+    r = __salt__['boto_lambda.alias_exists'](
+        FunctionName, Name, region=region, key=key, keyid=keyid,
+        profile=profile)
     if 'error' in r:
         ret['result'] = False
-        ret['comment'] = 'Failed to delete alias: {0}.'.format(r['error']['message'])
+        ret['comment'] = ('Failed to delete alias: '
+                          '{0}.'.format(r['error']['message']))
         return ret
 
     if r and not r['exists']:
@@ -637,12 +683,13 @@ def alias_absent(name, FunctionName, Name, region=None, key=None, keyid=None, pr
         ret['comment'] = 'Alias {0} is set to be removed.'.format(Name)
         ret['result'] = None
         return ret
-    r = __salt__['boto_lambda.delete_alias'](FunctionName, Name,
-                                    region=region, key=key,
-                                    keyid=keyid, profile=profile)
+    r = __salt__['boto_lambda.delete_alias'](
+        FunctionName, Name, region=region, key=key, keyid=keyid,
+        profile=profile)
     if not r['deleted']:
         ret['result'] = False
-        ret['comment'] = 'Failed to delete alias: {0}.'.format(r['error']['message'])
+        ret['comment'] = ('Failed to delete alias: '
+                          '{0}.'.format(r['error']['message']))
         return ret
     ret['changes']['old'] = {'alias': Name}
     ret['changes']['new'] = {'alias': None}
@@ -664,9 +711,10 @@ def _get_function_arn(name, region=None, key=None, keyid=None, profile=None):
     return 'arn:aws:lambda:{0}:{1}:function:{2}'.format(region, account_id, name)
 
 
-def event_source_mapping_present(name, EventSourceArn, FunctionName, StartingPosition,
-            Enabled=True, BatchSize=100,
-            region=None, key=None, keyid=None, profile=None):
+def event_source_mapping_present(name, EventSourceArn, FunctionName,
+                                 StartingPosition, Enabled=True, BatchSize=100,
+                                 region=None, key=None, keyid=None,
+                                 profile=None):
     '''
     Ensure event source mapping exists.
 
@@ -722,44 +770,49 @@ def event_source_mapping_present(name, EventSourceArn, FunctionName, StartingPos
            'changes': {}
            }
 
-    r = __salt__['boto_lambda.event_source_mapping_exists'](EventSourceArn=EventSourceArn,
-                                    FunctionName=FunctionName,
-                                    region=region, key=key, keyid=keyid, profile=profile)
+    r = __salt__['boto_lambda.event_source_mapping_exists'](
+        EventSourceArn=EventSourceArn, FunctionName=FunctionName,
+        region=region, key=key, keyid=keyid, profile=profile)
 
     if 'error' in r:
         ret['result'] = False
-        ret['comment'] = 'Failed to create event source mapping: {0}.'.format(r['error']['message'])
+        ret['comment'] = ('Failed to create event source mapping: '
+                          '{0}.'.format(r['error']['message']))
         return ret
 
     if not r.get('exists'):
         if __opts__['test']:
-            ret['comment'] = 'Event source mapping {0} is set to be created.'.format(FunctionName)
+            ret['comment'] = ('Event source mapping {0} is set '
+                              'to be created.'.format(FunctionName))
             ret['result'] = None
             return ret
-        r = __salt__['boto_lambda.create_event_source_mapping'](EventSourceArn=EventSourceArn,
-                    FunctionName=FunctionName, StartingPosition=StartingPosition,
-                    Enabled=Enabled, BatchSize=BatchSize,
-                    region=region, key=key, keyid=keyid, profile=profile)
+        r = __salt__['boto_lambda.create_event_source_mapping'](
+            EventSourceArn=EventSourceArn, FunctionName=FunctionName,
+            StartingPosition=StartingPosition, Enabled=Enabled,
+            BatchSize=BatchSize, region=region, key=key, keyid=keyid,
+            profile=profile)
         if not r.get('created'):
             ret['result'] = False
-            ret['comment'] = 'Failed to create event source mapping: {0}.'.format(r['error']['message'])
+            ret['comment'] = ('Failed to create event source mapping: '
+                              '{0}.'.format(r['error']['message']))
             return ret
         _describe = __salt__['boto_lambda.describe_event_source_mapping'](
-                                 EventSourceArn=EventSourceArn,
-                                 FunctionName=FunctionName,
-                                 region=region, key=key, keyid=keyid, profile=profile)
+            EventSourceArn=EventSourceArn, FunctionName=FunctionName,
+            region=region, key=key, keyid=keyid, profile=profile)
         ret['name'] = _describe['event_source_mapping']['UUID']
         ret['changes']['old'] = {'event_source_mapping': None}
         ret['changes']['new'] = _describe
-        ret['comment'] = 'Event source mapping {0} created.'.format(ret['name'])
+        ret['comment'] = ('Event source mapping {0} '
+                          'created.'.format(ret['name']))
         return ret
 
-    ret['comment'] = os.linesep.join([ret['comment'], 'Event source mapping is present.'])
+    ret['comment'] = os.linesep.join(
+        [ret['comment'], 'Event source mapping is present.'])
     ret['changes'] = {}
     _describe = __salt__['boto_lambda.describe_event_source_mapping'](
-                                 EventSourceArn=EventSourceArn,
-                                 FunctionName=FunctionName,
-                                 region=region, key=key, keyid=keyid, profile=profile)['event_source_mapping']
+        EventSourceArn=EventSourceArn, FunctionName=FunctionName,
+        region=region, key=key, keyid=keyid,
+        profile=profile)['event_source_mapping']
 
     need_update = False
     options = {'BatchSize': 'BatchSize'}
@@ -770,35 +823,38 @@ def event_source_mapping_present(name, EventSourceArn, FunctionName, StartingPos
             ret['changes'].setdefault('new', {})[var] = locals()[var]
             ret['changes'].setdefault('old', {})[var] = _describe[val]
     # verify FunctionName against FunctionArn
-    function_arn = _get_function_arn(FunctionName,
-                    region=region, key=key, keyid=keyid, profile=profile)
+    function_arn = _get_function_arn(FunctionName, region=region,
+                                     key=key, keyid=keyid, profile=profile)
     if _describe['FunctionArn'] != function_arn:
         need_update = True
         ret['changes'].setdefault('new', {})['FunctionArn'] = function_arn
-        ret['changes'].setdefault('old', {})['FunctionArn'] = _describe['FunctionArn']
-    # TODO check for 'Enabled', since it doesn't directly map to a specific state
+        ret['changes'].setdefault('old', {})['FunctionArn'] = _describe[
+            'FunctionArn']
+    # TODO check for 'Enabled', since it doesn't directly map to a specific
+    # state
     if need_update:
-        ret['comment'] = os.linesep.join([ret['comment'], 'Event source mapping to be modified'])
+        ret['comment'] = os.linesep.join(
+            [ret['comment'], 'Event source mapping to be modified'])
         if __opts__['test']:
-            msg = 'Event source mapping {0} set to be modified.'.format(_describe['UUID'])
+            msg = ('Event source mapping {0} set to be '
+                   'modified.'.format(_describe['UUID']))
             ret['comment'] = msg
             ret['result'] = None
             return ret
-        _r = __salt__['boto_lambda.update_event_source_mapping'](UUID=_describe['UUID'],
-                                        FunctionName=FunctionName,
-                                        Enabled=Enabled,
-                                        BatchSize=BatchSize,
-                                        region=region, key=key,
-                                        keyid=keyid, profile=profile)
+        _r = __salt__['boto_lambda.update_event_source_mapping'](
+            UUID=_describe['UUID'], FunctionName=FunctionName,
+            Enabled=Enabled, BatchSize=BatchSize,
+            region=region, key=key, keyid=keyid, profile=profile)
         if not _r.get('updated'):
             ret['result'] = False
-            ret['comment'] = 'Failed to update mapping: {0}.'.format(_r['error']['message'])
+            ret['comment'] = ('Failed to update mapping: '
+                              '{0}.'.format(_r['error']['message']))
             ret['changes'] = {}
     return ret
 
 
 def event_source_mapping_absent(name, EventSourceArn, FunctionName,
-                           region=None, key=None, keyid=None, profile=None):
+                                region=None, key=None, keyid=None, profile=None):
     '''
     Ensure event source mapping with passed properties is absent.
 
@@ -831,12 +887,13 @@ def event_source_mapping_absent(name, EventSourceArn, FunctionName,
            'changes': {}
            }
 
-    desc = __salt__['boto_lambda.describe_event_source_mapping'](EventSourceArn=EventSourceArn,
-                                    FunctionName=FunctionName,
-                                    region=region, key=key, keyid=keyid, profile=profile)
+    desc = __salt__['boto_lambda.describe_event_source_mapping'](
+        EventSourceArn=EventSourceArn, FunctionName=FunctionName,
+        region=region, key=key, keyid=keyid, profile=profile)
     if 'error' in desc:
         ret['result'] = False
-        ret['comment'] = 'Failed to delete event source mapping: {0}.'.format(desc['error']['message'])
+        ret['comment'] = ('Failed to delete event source mapping: '
+                          '{0}.'.format(desc['error']['message']))
         return ret
 
     if not desc.get('event_source_mapping'):
@@ -848,13 +905,13 @@ def event_source_mapping_absent(name, EventSourceArn, FunctionName,
         ret['comment'] = 'Event source mapping is set to be removed.'
         ret['result'] = None
         return ret
-    r = __salt__['boto_lambda.delete_event_source_mapping'](EventSourceArn=EventSourceArn,
-                                        FunctionName=FunctionName,
-                                        region=region, key=key,
-                                        keyid=keyid, profile=profile)
+    r = __salt__['boto_lambda.delete_event_source_mapping'](
+        EventSourceArn=EventSourceArn, FunctionName=FunctionName,
+        region=region, key=key, keyid=keyid, profile=profile)
     if not r['deleted']:
         ret['result'] = False
-        ret['comment'] = 'Failed to delete event source mapping: {0}.'.format(r['error']['message'])
+        ret['comment'] = 'Failed to delete event source mapping: {0}.'.format(r['error'][
+            'message'])
         return ret
     ret['changes']['old'] = desc
     ret['changes']['new'] = {'event_source_mapping': None}

--- a/tests/unit/modules/boto_lambda_test.py
+++ b/tests/unit/modules/boto_lambda_test.py
@@ -119,9 +119,10 @@ def _has_required_boto():
 
 
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
-@skipIf(_has_required_boto() is False, 'The boto3 module must be greater than'
-                                       ' or equal to version {0}'
-        .format(required_boto3_version))
+@skipIf(_has_required_boto() is False,
+        ('The boto3 module must be greater than or equal to version {0}, '
+         'and botocore must be greater than or equal to {1}'.format(
+             required_boto3_version, required_botocore_version)))
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class BotoLambdaTestCaseBase(TestCase):
     conn = None
@@ -148,7 +149,8 @@ class BotoLambdaTestCaseBase(TestCase):
 class TempZipFile(object):
 
     def __enter__(self):
-        with NamedTemporaryFile(suffix='.zip', prefix='salt_test_', delete=False) as tmp:
+        with NamedTemporaryFile(
+                suffix='.zip', prefix='salt_test_', delete=False) as tmp:
             to_write = '###\n'
             if six.PY3:
                 to_write = salt.utils.to_bytes(to_write)
@@ -208,12 +210,13 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             with TempZipFile() as zipfile:
                 self.conn.create_function.return_value = function_ret
-                lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
-                                                                     Runtime='python2.7',
-                                                                     Role='myrole',
-                                                                     Handler='file.method',
-                                                                     ZipFile=zipfile,
-                                                                     **conn_parameters)
+                lambda_creation_result = boto_lambda.create_function(
+                    FunctionName='testfunction',
+                    Runtime='python2.7',
+                    Role='myrole',
+                    Handler='file.method',
+                    ZipFile=zipfile,
+                    **conn_parameters)
 
         self.assertTrue(lambda_creation_result['created'])
 
@@ -223,13 +226,14 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             self.conn.create_function.return_value = function_ret
-            lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
-                                                                 Runtime='python2.7',
-                                                                 Role='myrole',
-                                                                 Handler='file.method',
-                                                                 S3Bucket='bucket',
-                                                                 S3Key='key',
-                                                                 **conn_parameters)
+            lambda_creation_result = boto_lambda.create_function(
+                FunctionName='testfunction',
+                Runtime='python2.7',
+                Role='myrole',
+                Handler='file.method',
+                S3Bucket='bucket',
+                S3Key='key',
+                **conn_parameters)
 
         self.assertTrue(lambda_creation_result['created'])
 
@@ -240,11 +244,12 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             with self.assertRaisesRegexp(SaltInvocationError,
                                          'Either ZipFile must be specified, or S3Bucket and S3Key must be provided.'):
-                lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
-                                                                     Runtime='python2.7',
-                                                                     Role='myrole',
-                                                                     Handler='file.method',
-                                                                     **conn_parameters)
+                lambda_creation_result = boto_lambda.create_function(
+                    FunctionName='testfunction',
+                    Runtime='python2.7',
+                    Role='myrole',
+                    Handler='file.method',
+                    **conn_parameters)
 
     def test_that_when_creating_a_function_with_zipfile_and_s3_raises_a_salt_invocation_error(self):
         '''
@@ -254,14 +259,15 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
             with self.assertRaisesRegexp(SaltInvocationError,
                                          'Either ZipFile must be specified, or S3Bucket and S3Key must be provided.'):
                 with TempZipFile() as zipfile:
-                    lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
-                                                                         Runtime='python2.7',
-                                                                         Role='myrole',
-                                                                         Handler='file.method',
-                                                                         ZipFile=zipfile,
-                                                                         S3Bucket='bucket',
-                                                                         S3Key='key',
-                                                                         **conn_parameters)
+                    lambda_creation_result = boto_lambda.create_function(
+                        FunctionName='testfunction',
+                        Runtime='python2.7',
+                        Role='myrole',
+                        Handler='file.method',
+                        ZipFile=zipfile,
+                        S3Bucket='bucket',
+                        S3Key='key',
+                        **conn_parameters)
 
     def test_that_when_creating_a_function_fails_the_create_function_method_returns_error(self):
         '''
@@ -271,12 +277,13 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
             self.conn.create_function.side_effect = ClientError(
                 error_content, 'create_function')
             with TempZipFile() as zipfile:
-                lambda_creation_result = boto_lambda.create_function(FunctionName='testfunction',
-                                                                     Runtime='python2.7',
-                                                                     Role='myrole',
-                                                                     Handler='file.method',
-                                                                     ZipFile=zipfile,
-                                                                     **conn_parameters)
+                lambda_creation_result = boto_lambda.create_function(
+                    FunctionName='testfunction',
+                    Runtime='python2.7',
+                    Role='myrole',
+                    Handler='file.method',
+                    ZipFile=zipfile,
+                    **conn_parameters)
         self.assertEqual(lambda_creation_result.get('error', {}).get(
             'message'), error_message.format('create_function'))
 
@@ -367,7 +374,8 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
             with TempZipFile() as zipfile:
                 self.conn.update_function_code.return_value = function_ret
                 result = boto_lambda.update_function_code(
-                    FunctionName=function_ret['FunctionName'], ZipFile=zipfile, **conn_parameters)
+                    FunctionName=function_ret['FunctionName'],
+                    ZipFile=zipfile, **conn_parameters)
 
         self.assertTrue(result['updated'])
 
@@ -377,10 +385,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             self.conn.update_function_code.return_value = function_ret
-            result = boto_lambda.update_function_code(FunctionName='testfunction',
-                                                      S3Bucket='bucket',
-                                                      S3Key='key',
-                                                      **conn_parameters)
+            result = boto_lambda.update_function_code(
+                FunctionName='testfunction',
+                S3Bucket='bucket',
+                S3Key='key',
+                **conn_parameters)
 
         self.assertTrue(result['updated'])
 
@@ -389,10 +398,13 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         tests Creating a function without code
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
-            with self.assertRaisesRegexp(SaltInvocationError,
-                                         'Either ZipFile must be specified, or S3Bucket and S3Key must be provided.'):
-                result = boto_lambda.update_function_code(FunctionName='testfunction',
-                                                          **conn_parameters)
+            with self.assertRaisesRegexp(
+                SaltInvocationError,
+                ('Either ZipFile must be specified, or S3Bucket '
+                 'and S3Key must be provided.')):
+                result = boto_lambda.update_function_code(
+                    FunctionName='testfunction',
+                    **conn_parameters)
 
     def test_that_when_updating_function_code_fails_the_update_function_method_returns_error(self):
         '''
@@ -401,10 +413,11 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             self.conn.update_function_code.side_effect = ClientError(
                 error_content, 'update_function_code')
-            result = boto_lambda.update_function_code(FunctionName='testfunction',
-                                                      S3Bucket='bucket',
-                                                      S3Key='key',
-                                                      **conn_parameters)
+            result = boto_lambda.update_function_code(
+                FunctionName='testfunction',
+                S3Bucket='bucket',
+                S3Key='key',
+                **conn_parameters)
         self.assertEqual(result.get('error', {}).get('message'),
                          error_message.format('update_function_code'))
 
@@ -415,8 +428,9 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             self.conn.list_versions_by_function.return_value = {
                 'Versions': [function_ret]}
-            result = boto_lambda.list_function_versions(FunctionName='testfunction',
-                                                        **conn_parameters)
+            result = boto_lambda.list_function_versions(
+                FunctionName='testfunction',
+                **conn_parameters)
 
         self.assertTrue(result['Versions'])
 
@@ -426,8 +440,9 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         '''
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             self.conn.list_versions_by_function.return_value = {'Versions': []}
-            result = boto_lambda.list_function_versions(FunctionName='testfunction',
-                                                        **conn_parameters)
+            result = boto_lambda.list_function_versions(
+                FunctionName='testfunction',
+                **conn_parameters)
         self.assertFalse(result['Versions'])
 
     def test_that_when_listing_function_versions_fails_the_list_function_versions_method_returns_error(self):
@@ -437,8 +452,9 @@ class BotoLambdaFunctionTestCase(BotoLambdaTestCaseBase, BotoLambdaTestCaseMixin
         with patch.dict(boto_lambda.__salt__, {'boto_iam.get_account_id': MagicMock(return_value='1234')}):
             self.conn.list_versions_by_function.side_effect = ClientError(
                 error_content, 'list_versions_by_function')
-            result = boto_lambda.list_function_versions(FunctionName='testfunction',
-                                                        **conn_parameters)
+            result = boto_lambda.list_function_versions(
+                FunctionName='testfunction',
+                **conn_parameters)
         self.assertEqual(result.get('error', {}).get('message'),
                          error_message.format('list_versions_by_function'))
 
@@ -695,8 +711,10 @@ class BotoLambdaEventSourceMappingTestCase(BotoLambdaTestCaseBase, BotoLambdaTes
         '''
         tests Deleting a mapping without identifier
         '''
-        with self.assertRaisesRegexp(SaltInvocationError,
-                                     'Either UUID must be specified, or EventSourceArn and FunctionName must be provided.'):
+        with self.assertRaisesRegexp(
+            SaltInvocationError,
+            ('Either UUID must be specified, or EventSourceArn '
+             'and FunctionName must be provided.')):
             result = boto_lambda.delete_event_source_mapping(**conn_parameters)
 
     def test_that_when_deleting_an_event_source_mapping_fails_the_delete_event_source_mapping_method_returns_false(self):


### PR DESCRIPTION
### What does this PR do?
exposed Lambda Variables to boto_lambda modules/states

### What issues does this PR fix or reference?
NA

### New Behavior
User can now set Lambda Variables as part of boto_lambda function states

### Tests written?
Tested Manually vs. AWS, unit tests for modules were updated to return Environments.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
