### PR TITLE
Add salt-minion.sleep

### DIFF
--- a/pkg/salt-minion.sleep
+++ b/pkg/salt-minion.sleep
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+
+markerfile=/var/run/stopped-salt-minion-on-suspend
+
+if [ "$1" = pre ] ; then
+	if systemctl is-active salt-minion ; then
+		systemctl stop salt-minion
+		echo 1 > $markerfile
+	fi
+fi
+if [ "$1" = post ] && [ -e $markerfile ] ; then
+	rm -f $markerfile
+	systemctl start salt-minion
+fi


### PR DESCRIPTION
### What does this PR do?
Add a file for use with systemd-based systems
to be installed in
/usr/lib/systemd/system-sleep/salt-minion.sleep

### What issues does this PR fix or reference?
It helps to avoid stale minion-master connections after machine suspend as described in
https://bugzilla.opensuse.org/show_bug.cgi?id=1018791

### Previous Behavior
after suspend+resume of a managed machine,
salt $NODEID test.ping returned
`Minion did not return. [No response]`

### New Behavior
`test.ping` returns `True`  when the machine resumed and
`Minion did not return. [Not connected]` while the machine is suspended.

### Tests written?
No

note: still missing the part that installs this file into the right target directory. help or pointers appreciated.