### PR TITLE
Backport #38690 to 2016.11

### DIFF
--- a/salt/states/win_lgpo.py
+++ b/salt/states/win_lgpo.py
@@ -203,12 +203,12 @@ def set_(name,
     else:
         user_policy = {}
         computer_policy = {}
-        if policy_class == 'both':
+        if policy_class.lower() == 'both':
             user_policy[name] = setting
             computer_policy[name] = setting
-        elif policy_class == 'user':
+        elif policy_class.lower() == 'user':
             user_policy[name] = setting
-        elif policy_class == 'machine' or policy_class == 'computer':
+        elif policy_class.lower() == 'machine' or policy_class.lower() == 'computer':
             computer_policy[name] = setting
     pol_data = {}
     pol_data['user'] = {'output_section': 'User Configuration',


### PR DESCRIPTION
### What does this PR do?
Backports #38690

### What issues does this PR fix or reference?
#38689 

### Previous Behavior
Following the documentation of the state and using a policy_class of "Machine", "User", or "Both" would not set the policy.

### New Behavior
policy_class can be passed in any case

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
