### PR TITLE
Backport #37375 to 2016.11

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3234,7 +3234,7 @@ def _write_regpol_data(data_to_write, policy_file_path, gpt_ini, gpt_extension):
     helper function to actually write the data to a Registry.pol file
 
     also updates/edits the gpt.ini file to include the ADM policy extensions
-    to let the computer know user and/or machine registyr policy files need
+    to let the computer know user and/or machine registry policy files need
     to be processed
 
     data_to_write: data to write into the user/machine registry.pol file

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -4172,7 +4172,7 @@ def set_computer_policy(name,
     '''
     pol = {}
     pol[name] = setting
-    ret = set(computer_policy=pol,
+    ret = set_(computer_policy=pol,
               user_policy=None,
               cumulative_rights_assignments=cumulative_rights_assignments,
               adml_language=adml_language)
@@ -4201,7 +4201,7 @@ def set_user_policy(name,
     '''
     pol = {}
     pol[name] = setting
-    ret = set(user_policy=pol,
+    ret = set_(user_policy=pol,
               computer_policy=None,
               cumulative_rights_assignments=True,
               adml_language=adml_language)

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -1636,15 +1636,22 @@ class _policy_info(object):
             'User': {
                 'policy_path': os.path.join(os.getenv('WINDIR'), 'System32', 'GroupPolicy', 'User', 'Registry.pol'),
                 'hive': 'HKEY_USERS',
-                'lgpo_section': 'User Configuration'
+                'lgpo_section': 'User Configuration',
+                'gpt_extension_location': 'gPCUserExtensionNames'
             },
             'Machine': {
                 'policy_path': os.path.join(os.getenv('WINDIR'), 'System32', 'GroupPolicy', 'Machine', 'Registry.pol'),
                 'hive': 'HKEY_LOCAL_MACHINE',
                 'lgpo_section': 'Computer Configuration',
+                'gpt_extension_location': 'gPCMachineExtensionNames'
             },
         }
         self.reg_pol_header = u'\u5250\u6765\x01\x00'
+        self.gpt_ini_info = {
+            'path': os.path.join(os.getenv('WINDIR'), 'System32',
+                                 'GroupPolicy', 'gpt.ini'),
+            'admxExtension': '[{35378EAC-683F-11D2-A89A-00C04FBBCFA2}{D02B1F72-3407-48AE-BA88-E8213C6761F1}]'
+        }
 
     @classmethod
     def _notEmpty(cls, val, **kwargs):
@@ -3222,9 +3229,18 @@ def _regexSearchKeyValueCombo(policy_data, policy_regpath, policy_regkey):
     return None
 
 
-def _write_regpol_data(data_to_write, policy_file_path):
+def _write_regpol_data(data_to_write, policy_file_path, gpt_ini, gpt_extension):
     '''
     helper function to actually write the data to a Registry.pol file
+
+    also updates/edits the gpt.ini file to include the ADM policy extensions
+    to let the computer know user and/or machine registyr policy files need
+    to be processed
+
+    data_to_write: data to write into the user/machine registry.pol file
+    policy_file_path: path to the registry.pol file
+    gpt_ini: gpt_ini_info dict from the _policy_info class
+    gpt_extension: gpt extension list name from _policy_info class for this registry class gpt_extension_location
     '''
     try:
         if data_to_write:
@@ -3233,6 +3249,71 @@ def _write_regpol_data(data_to_write, policy_file_path):
                 if not data_to_write.startswith(reg_pol_header):
                     pol_file.write(reg_pol_header.encode('utf-16-le'))
                 pol_file.write(data_to_write.encode('utf-16-le'))
+            try:
+                gpt_ini_data = ''
+                if os.path.exists(gpt_ini['path']):
+                    with open(gpt_ini['path'], 'rb') as gpt_file:
+                        gpt_ini_data = gpt_file.read()
+                if not _regexSearchRegPolData(r'\[General\]\r\n', gpt_ini_data):
+                    gpt_ini_data = '[General]\r\n' + gpt_ini_data
+                if _regexSearchRegPolData(r'{0}='.format(re.escape(gpt_extension)), gpt_ini_data):
+                    # ensure the line contains the ADM guid
+                    gpt_ext_loc = re.search(r'^{0}=.*\r\n'.format(re.escape(gpt_extension)),
+                                            gpt_ini_data,
+                                            re.IGNORECASE | re.MULTILINE)
+                    gpt_ext_str = gpt_ini_data[gpt_ext_loc.start():gpt_ext_loc.end()]
+                    if not _regexSearchRegPolData(r'{0}'.format(re.escape(gpt_ini['admxExtension'])),
+                                                  gpt_ext_str):
+                        gpt_ext_str = gpt_ext_str.split('=')
+                        gpt_ext_str[1] = gpt_ini['admxExtension'] + gpt_ext_str[1]
+                        gpt_ext_str = '='.join(gpt_ext_str)
+                        gpt_ini_data = gpt_ini_data[0:gpt_ext_loc.start()] + gpt_ext_str + gpt_ini_data[gpt_ext_loc.end():]
+                else:
+                    general_location = re.search(r'^\[General\]\r\n',
+                                                 gpt_ini_data,
+                                                 re.IGNORECASE | re.MULTILINE)
+                    gpt_ini_data = "{0}{1}={2}\r\n{3}".format(
+                            gpt_ini_data[general_location.start():general_location.end()],
+                            gpt_extension, gpt_ini['admxExtension'],
+                            gpt_ini_data[general_location.end():])
+                # https://technet.microsoft.com/en-us/library/cc978247.aspx
+                if _regexSearchRegPolData(r'Version=', gpt_ini_data):
+                    version_loc = re.search(r'^Version=.*\r\n',
+                                            gpt_ini_data,
+                                            re.IGNORECASE | re.MULTILINE)
+                    version_str = gpt_ini_data[version_loc.start():version_loc.end()]
+                    version_str = version_str.split('=')
+                    version_nums = struct.unpack('>2H', struct.pack('>I', int(version_str[1])))
+                    if gpt_extension.lower() == 'gPCMachineExtensionNames'.lower():
+                        version_nums = (version_nums[0], version_nums[1] + 1)
+                    elif gpt_extension.lower() == 'gPCUserExtensionNames'.lower():
+                        version_nums = (version_nums[0] + 1, version_nums[1])
+                    version_num = int("{0}{1}".format(str(version_nums[0]).zfill(4),
+                                                      str(version_nums[1]).zfill(4)), 16)
+                    gpt_ini_data = "{0}{1}={2}\r\n{3}".format(
+                            gpt_ini_data[0:version_loc.start()],
+                            'Version', version_num,
+                            gpt_ini_data[version_loc.end():])
+                else:
+                    general_location = re.search(r'^\[General\]\r\n',
+                                                 gpt_ini_data,
+                                                 re.IGNORECASE | re.MULTILINE)
+                    if gpt_extension.lower() == 'gPCMachineExtensionNames'.lower():
+                        version_nums = (0, 1)
+                    elif gpt_extension.lower() == 'gPCUserExtensionNames'.lower():
+                        version_nums = (1, 0)
+                    gpt_ini_data = "{0}{1}={2}\r\n{3}".format(
+                            gpt_ini_data[general_location.start():general_location.end()],
+                            'Version',
+                            int("{0}{1}".format(str(version_nums[0]).zfill(4), str(version_nums[1]).zfill(4)), 16),
+                            gpt_ini_data[general_location.end():])
+                if gpt_ini_data:
+                    with open(gpt_ini['path'], 'wb') as gpt_file:
+                        gpt_file.write(gpt_ini_data)
+            except Exception as e:
+                msg = 'An error occurred attempting to write to {0}, the exception was {1}'.format(
+                        gpt_ini['path'], e)
+                raise CommandExecutionError(msg)
     except Exception as e:
         msg = 'An error occurred attempting to write to {0}, the exception was {1}'.format(policy_file_path, e)
         raise CommandExecutionError(msg)
@@ -3615,7 +3696,10 @@ def _writeAdminTemplateRegPolFile(admtemplate_data,
                                                         enabled_value_string,
                                                         existing_data,
                                                         append_only=True)
-        _write_regpol_data(existing_data, policy_data.admx_registry_classes[registry_class]['policy_path'])
+        _write_regpol_data(existing_data,
+                           policy_data.admx_registry_classes[registry_class]['policy_path'],
+                           policy_data.gpt_ini_info,
+                           policy_data.admx_registry_classes[registry_class]['gpt_extension_location'])
     except Exception as e:
         log.error('Unhandled exception {0} occurred while attempting to write Adm Template Policy File'.format(e))
         return False

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -1637,21 +1637,20 @@ class _policy_info(object):
                 'policy_path': os.path.join(os.getenv('WINDIR'), 'System32', 'GroupPolicy', 'User', 'Registry.pol'),
                 'hive': 'HKEY_USERS',
                 'lgpo_section': 'User Configuration',
-                'gpt_extension_location': 'gPCUserExtensionNames'
+                'gpt_extension_location': 'gPCUserExtensionNames',
+                'gpt_extension_guid': '[{35378EAC-683F-11D2-A89A-00C04FBBCFA2}{D02B1F73-3407-48AE-BA88-E8213C6761F1}]'
             },
             'Machine': {
                 'policy_path': os.path.join(os.getenv('WINDIR'), 'System32', 'GroupPolicy', 'Machine', 'Registry.pol'),
                 'hive': 'HKEY_LOCAL_MACHINE',
                 'lgpo_section': 'Computer Configuration',
-                'gpt_extension_location': 'gPCMachineExtensionNames'
+                'gpt_extension_location': 'gPCMachineExtensionNames',
+                'gpt_extension_guid': '[{35378EAC-683F-11D2-A89A-00C04FBBCFA2}{D02B1F72-3407-48AE-BA88-E8213C6761F1}]'
             },
         }
         self.reg_pol_header = u'\u5250\u6765\x01\x00'
-        self.gpt_ini_info = {
-            'path': os.path.join(os.getenv('WINDIR'), 'System32',
-                                 'GroupPolicy', 'gpt.ini'),
-            'admxExtension': '[{35378EAC-683F-11D2-A89A-00C04FBBCFA2}{D02B1F72-3407-48AE-BA88-E8213C6761F1}]'
-        }
+        self.gpt_ini_path = os.path.join(os.getenv('WINDIR'), 'System32',
+                                         'GroupPolicy', 'gpt.ini')
 
     @classmethod
     def _notEmpty(cls, val, **kwargs):
@@ -3229,7 +3228,11 @@ def _regexSearchKeyValueCombo(policy_data, policy_regpath, policy_regkey):
     return None
 
 
-def _write_regpol_data(data_to_write, policy_file_path, gpt_ini, gpt_extension):
+def _write_regpol_data(data_to_write,
+                       policy_file_path,
+                       gpt_ini_path,
+                       gpt_extension,
+                       gpt_extension_guid):
     '''
     helper function to actually write the data to a Registry.pol file
 
@@ -3239,8 +3242,9 @@ def _write_regpol_data(data_to_write, policy_file_path, gpt_ini, gpt_extension):
 
     data_to_write: data to write into the user/machine registry.pol file
     policy_file_path: path to the registry.pol file
-    gpt_ini: gpt_ini_info dict from the _policy_info class
+    gpt_ini_path: path to gpt.ini file
     gpt_extension: gpt extension list name from _policy_info class for this registry class gpt_extension_location
+    gpt_extension_guid: admx registry extension guid for the class
     '''
     try:
         if data_to_write:
@@ -3251,8 +3255,8 @@ def _write_regpol_data(data_to_write, policy_file_path, gpt_ini, gpt_extension):
                 pol_file.write(data_to_write.encode('utf-16-le'))
             try:
                 gpt_ini_data = ''
-                if os.path.exists(gpt_ini['path']):
-                    with open(gpt_ini['path'], 'rb') as gpt_file:
+                if os.path.exists(gpt_ini_path):
+                    with open(gpt_ini_path, 'rb') as gpt_file:
                         gpt_ini_data = gpt_file.read()
                 if not _regexSearchRegPolData(r'\[General\]\r\n', gpt_ini_data):
                     gpt_ini_data = '[General]\r\n' + gpt_ini_data
@@ -3262,10 +3266,10 @@ def _write_regpol_data(data_to_write, policy_file_path, gpt_ini, gpt_extension):
                                             gpt_ini_data,
                                             re.IGNORECASE | re.MULTILINE)
                     gpt_ext_str = gpt_ini_data[gpt_ext_loc.start():gpt_ext_loc.end()]
-                    if not _regexSearchRegPolData(r'{0}'.format(re.escape(gpt_ini['admxExtension'])),
+                    if not _regexSearchRegPolData(r'{0}'.format(re.escape(gpt_extension_guid)),
                                                   gpt_ext_str):
                         gpt_ext_str = gpt_ext_str.split('=')
-                        gpt_ext_str[1] = gpt_ini['admxExtension'] + gpt_ext_str[1]
+                        gpt_ext_str[1] = gpt_extension_guid + gpt_ext_str[1]
                         gpt_ext_str = '='.join(gpt_ext_str)
                         gpt_ini_data = gpt_ini_data[0:gpt_ext_loc.start()] + gpt_ext_str + gpt_ini_data[gpt_ext_loc.end():]
                 else:
@@ -3274,7 +3278,7 @@ def _write_regpol_data(data_to_write, policy_file_path, gpt_ini, gpt_extension):
                                                  re.IGNORECASE | re.MULTILINE)
                     gpt_ini_data = "{0}{1}={2}\r\n{3}".format(
                             gpt_ini_data[general_location.start():general_location.end()],
-                            gpt_extension, gpt_ini['admxExtension'],
+                            gpt_extension, gpt_extension_guid,
                             gpt_ini_data[general_location.end():])
                 # https://technet.microsoft.com/en-us/library/cc978247.aspx
                 if _regexSearchRegPolData(r'Version=', gpt_ini_data):
@@ -3308,11 +3312,11 @@ def _write_regpol_data(data_to_write, policy_file_path, gpt_ini, gpt_extension):
                             int("{0}{1}".format(str(version_nums[0]).zfill(4), str(version_nums[1]).zfill(4)), 16),
                             gpt_ini_data[general_location.end():])
                 if gpt_ini_data:
-                    with open(gpt_ini['path'], 'wb') as gpt_file:
+                    with open(gpt_ini_path, 'wb') as gpt_file:
                         gpt_file.write(gpt_ini_data)
             except Exception as e:
                 msg = 'An error occurred attempting to write to {0}, the exception was {1}'.format(
-                        gpt_ini['path'], e)
+                        gpt_ini_path, e)
                 raise CommandExecutionError(msg)
     except Exception as e:
         msg = 'An error occurred attempting to write to {0}, the exception was {1}'.format(policy_file_path, e)
@@ -3698,8 +3702,9 @@ def _writeAdminTemplateRegPolFile(admtemplate_data,
                                                         append_only=True)
         _write_regpol_data(existing_data,
                            policy_data.admx_registry_classes[registry_class]['policy_path'],
-                           policy_data.gpt_ini_info,
-                           policy_data.admx_registry_classes[registry_class]['gpt_extension_location'])
+                           policy_data.gpt_ini_path,
+                           policy_data.admx_registry_classes[registry_class]['gpt_extension_location'],
+                           policy_data.admx_registry_classes[registry_class]['gpt_extension_guid'])
     except Exception as e:
         log.error('Unhandled exception {0} occurred while attempting to write Adm Template Policy File'.format(e))
         return False

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -1868,6 +1868,11 @@ class _policy_info(object):
         '''
         minimum = 0
         maximum = 1
+        if isinstance(val, string_types):
+            if val.lower() == 'not defined':
+                return True
+            else:
+                return False
         if 'min' in kwargs:
             minimum = kwargs['min']
         if 'max' in kwargs:


### PR DESCRIPTION
### What does this PR do?
Backports #37375 

Adds updating of the gpt.ini file when ADM policies are modified.

Also corrects a number of bugs found in the module:
policies with the in_range_inclusive verification function would fail due to incorrect argument ordering in a call to isinstance
set_computer_policy and set_user_policy functions incorrectly called the "set" function instead of "set"

### What issues does this PR fix or reference?
No bug filed on these issues

### Previous Behavior
gpt.ini was not modified. If ADM policies were configured only via the lgpo module, the ADM policies may not apply (depending on if ADM policies had been modified previously via the gpedit gui)

set_computer_policy and set_user_policy functions would throw an error that "set does not take keyword arguments"

policies that used the _in_range_inclusive verification function would throw an error indicating the incorrect call of isinstance

### New Behavior
Gpt.ini is updated to include the proper group policy extension data for ADM templates as well as updating the policy version number in the gpt.ini

set_computer_policy and set_user_policy functions work correctly

policies with the _in_range_inclusive verification function can be set properly

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
