### PR TITLE
Backport #38779 to 2016.11

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2055,7 +2055,7 @@ def _processPolicyDefinitions(policy_def_path='c:\\Windows\\PolicyDefinitions', 
                 parser = lxml.etree.XMLParser(remove_comments=True)
                 try:
                     xmltree = lxml.etree.parse(admfile, parser=parser)
-                except:
+                except lxml.etree.XMLSyntaxError:
                     msg = ('A syntax error was found while processing admx file {0},'
                            ' all policies from this file will be unavailable via this module')
                     log.error(msg.format(admfile))

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2074,7 +2074,7 @@ def _processPolicyDefinitions(policy_def_path='c:\\Windows\\PolicyDefinitions',
                 except lxml.etree.XMLSyntaxError:
                     try:
                         xmltree = _remove_unicode_encoding(admfile)
-                    except as Exception:
+                    except Exception:
                         msg = ('A error was found while processing admx file {0},'
                                ' all policies from this file will be unavailable via this module')
                         log.error(msg.format(admfile))
@@ -2133,7 +2133,7 @@ def _processPolicyDefinitions(policy_def_path='c:\\Windows\\PolicyDefinitions',
                     # see issue #38100
                     try:
                         xmltree = _remove_unicode_encoding(adml_file)
-                    except as Exception:
+                    except Exception:
                         msg = ('An error was found while processing adml file {0}, all policy'
                                ' languange data from this file will be unavailable via this module')
                         log.error(msg.format(adml_file))

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -48,6 +48,7 @@ from salt.exceptions import SaltInvocationError
 import salt.utils.dictupdate as dictupdate
 from salt.ext.six import string_types
 from salt.ext.six.moves import range
+from salt.ext.six import StringIO
 
 log = logging.getLogger(__name__)
 __virtualname__ = 'lgpo'
@@ -86,7 +87,6 @@ try:
     import struct
     from lxml import etree
     from salt.modules.reg import Registry as Registry
-    import StringIO
     HAS_WINDOWS_MODULES = True
     TRUE_VALUE_XPATH = etree.XPath('.//*[local-name() = "trueValue"]')
     FALSE_VALUE_XPATH = etree.XPath('.//*[local-name() = "falseValue"]')
@@ -2074,7 +2074,7 @@ def _processPolicyDefinitions(policy_def_path='c:\\Windows\\PolicyDefinitions',
                 except lxml.etree.XMLSyntaxError:
                     try:
                         xmltree = _remove_unicode_encoding(admfile)
-                    except:
+                    except as Exception:
                         msg = ('A error was found while processing admx file {0},'
                                ' all policies from this file will be unavailable via this module')
                         log.error(msg.format(admfile))
@@ -2133,7 +2133,7 @@ def _processPolicyDefinitions(policy_def_path='c:\\Windows\\PolicyDefinitions',
                     # see issue #38100
                     try:
                         xmltree = _remove_unicode_encoding(adml_file)
-                    except:
+                    except as Exception:
                         msg = ('An error was found while processing adml file {0}, all policy'
                                ' languange data from this file will be unavailable via this module')
                         log.error(msg.format(adml_file))

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2053,7 +2053,13 @@ def _processPolicyDefinitions(policy_def_path='c:\\Windows\\PolicyDefinitions', 
             for t_admfile in files:
                 admfile = os.path.join(root, t_admfile)
                 parser = lxml.etree.XMLParser(remove_comments=True)
-                xmltree = lxml.etree.parse(admfile, parser=parser)
+                try:
+                    xmltree = lxml.etree.parse(admfile, parser=parser)
+                except:
+                    msg = ('A syntax error was found while processing admx file {0},'
+                           ' all policies from this file will be unavailable via this module')
+                    log.error(msg.format(admfile))
+                    continue
                 namespaces = xmltree.getroot().nsmap
                 namespace_string = ''
                 if None in namespaces:
@@ -2102,7 +2108,13 @@ def _processPolicyDefinitions(policy_def_path='c:\\Windows\\PolicyDefinitions', 
                         raise SaltInvocationError(msg.format(display_language,
                                                              display_language_fallback,
                                                              t_admfile))
-                xmltree = lxml.etree.parse(adml_file)
+                try:
+                    xmltree = lxml.etree.parse(adml_file)
+                except lxml.etree.XMLSyntaxError:
+                    msg = ('A syntax error was found while processing adml file {0}, all policy'
+                           ' languange data from this file will be unavailable via this module')
+                    log.error(msg.format(adml_file))
+                    continue
                 if None in namespaces:
                     namespaces['None'] = namespaces[None]
                     namespaces.pop(None)


### PR DESCRIPTION
### What does this PR do?
Backports #38779 
Addresses an underlying issue with lxml on windows in which xml files with "encoding='unicode'" in the xml header cannot be processed (throws an xml syntax error). If an xml file with the "encoding='unicode'" is encountered, the module will attempt to remove this from the xml header and parse the file, if the parse succeeds (using utf-16 encoding) the module continues. If the parse fails, the module will log an error message that the file could not be processed and the entries from that admx/l file will not be available through the module.

### What issues does this PR fix or reference?
#38100 

### Previous Behavior
When an admx file with "encoding='unicode'" in the xml header was parsed, an exception would be thrown and the module would exit

### New Behavior
If an xml file with the "encoding='unicode'" is encountered, the module will attempt to remove this from the xml header and parse the file, if the parse succeeds the module continues. If the parse fails, the module will log an error message that the file could not be processed and the entries from that admx/l file will not be available through the module.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
