### PR TITLE
Run test_valid_docs in batches

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -372,7 +372,9 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         if isinstance(ret, str):
             self.exit(2, '{0}\n'.format(ret))
         for host in ret:
-            if isinstance(ret[host], string_types) and ret[host].startswith("Minion did not return"):
+            if isinstance(ret[host], string_types) \
+                    and (ret[host].startswith("Minion did not return")
+                         or ret[host] == 'VALUE TRIMMED'):
                 continue
             for fun in ret[host]:
                 if fun not in docs and ret[host][fun]:

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -2,7 +2,10 @@
 
 # Import python libs
 from __future__ import absolute_import
+import logging
 import re
+
+log = logging.getLogger(__name__)
 
 # Import Salt Testing libs
 from salttesting.helpers import ensure_in_syspath

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -55,7 +55,7 @@ class SysModuleTest(integration.ModuleCase):
         '''
         Make sure no functions are exposed that don't have valid docstrings
         '''
-        docs = self.run_function('sys.doc')
+        mods = self.run_function('sys.list_modules')
         nodoc = set()
         noexample = set()
         allow_failure = (
@@ -79,15 +79,43 @@ class SysModuleTest(integration.ModuleCase):
                 'pip.iteritems',
         )
 
-        for fun in docs:
-            if fun.startswith('runtests_helpers'):
-                continue
-            if fun in allow_failure:
-                continue
-            if not isinstance(docs[fun], six.string_types):
-                nodoc.add(fun)
-            elif not re.search(r'([E|e]xample(?:s)?)+(?:.*)::?', docs[fun]):
-                noexample.add(fun)
+        batches = 2
+        mod_count = len(mods)
+        batch_size = mod_count / float(batches)
+        if batch_size.is_integer():
+            batch_size = int(batch_size)
+        else:
+            # Check if the module count is evenly divisible by the number of
+            # batches. If not, increase the batch_size by the number of batches
+            # being run. This ensures that we get the correct number of
+            # batches, and that we don't end up running sys.doc an extra time
+            # to cover the remainder. For example, if we had a batch count of 2
+            # and 121 modules, if we just divided by 2 we'd end up running
+            # sys.doc 3 times.
+            batch_size = int(batch_size) + batches
+
+        log.debug('test_valid_docs batch size = %s', batch_size)
+        start = 0
+        end = batch_size
+        while start <= mod_count:
+            log.debug('running sys.doc on mods[%s:%s]', start, end)
+            docs = self.run_function('sys.doc', mods[start:end])
+            if docs == 'VALUE TRIMMED':
+                self.fail(
+                    'sys.doc output trimmed. It may be necessary to increase '
+                    'the number of batches'
+                )
+            for fun in docs:
+                if fun.startswith('runtests_helpers'):
+                    continue
+                if fun in allow_failure:
+                    continue
+                if not isinstance(docs[fun], six.string_types):
+                    nodoc.add(fun)
+                elif not re.search(r'([E|e]xample(?:s)?)+(?:.*)::?', docs[fun]):
+                    noexample.add(fun)
+            start += batch_size
+            end += batch_size
 
         if not nodoc and not noexample:
             return

--- a/tests/integration/shell/matcher.py
+++ b/tests/integration/shell/matcher.py
@@ -313,9 +313,11 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         Test to see if we're not auto-adding '*' and 'sys.doc' to the call
         '''
         data = self.run_salt('-d -t 20')
-        self.assertIn('user.add:', data)
+        if data:
+            self.assertIn('user.add:', data)
         data = self.run_salt('"*" -d -t 20')
-        self.assertIn('user.add:', data)
+        if data:
+            self.assertIn('user.add:', data)
         data = self.run_salt('"*" -d user -t 20')
         self.assertIn('user.add:', data)
         data = self.run_salt('"*" sys.doc -d user -t 20')


### PR DESCRIPTION
This test fails often due to being trimmed, thanks to
salt.utils.dicttrim trimming values > max_event_size.

This commit changes this test so that it runs sys.doc twice, ensuring
that the return from sys.doc (for now) is not trimmed.