### PR TITLE
add ability to override pillar data during state.sls_id run.

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1330,8 +1330,19 @@ def sls_id(
     opts['environment'] = saltenv
     if pillarenv is not None:
         opts['pillarenv'] = pillarenv
+
+    pillar = kwargs.get('pillar')
+    pillar_enc = kwargs.get('pillar_enc')
+    if pillar_enc is None \
+            and pillar is not None \
+            and not isinstance(pillar, dict):
+        raise SaltInvocationError(
+            'Pillar data must be formatted as a dictionary, unless pillar_enc '
+            'is specified.'
+        )
+
     try:
-        st_ = salt.state.HighState(opts, proxy=__proxy__)
+        st_ = salt.state.HighState(opts, pillar, pillar_enc=pillar_enc, proxy=__proxy__)
     except NameError:
         st_ = salt.state.HighState(opts)
     if isinstance(mods, six.string_types):

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1342,7 +1342,7 @@ def sls_id(
         )
 
     try:
-        st_ = salt.state.HighState(opts, pillar, pillar_enc=pillar_enc, proxy=__proxy__)
+        st_ = salt.state.HighState(opts, pillar=pillar, pillar_enc=pillar_enc, proxy=__proxy__)
     except NameError:
         st_ = salt.state.HighState(opts)
     if isinstance(mods, six.string_types):


### PR DESCRIPTION
### What does this PR do?
add ability to override pillar data during state.sls_id run.
### What issues does this PR fix or reference?
n/a
### Previous Behavior

pillar data override would have no effect in the following: 
```salt '*' state.sls_id apache http pillar="{'test': 'override'}"```
### New Behavior

pillar data override would take effect in the following: 
```salt '*' state.sls_id apache http pillar="{'test': 'override'}"```
### Tests written?

No

