### PR TITLE
Update integration.states.handle_error.HandleErrorTest.test_handle_error

### DIFF
--- a/tests/integration/states/handle_error.py
+++ b/tests/integration/states/handle_error.py
@@ -27,7 +27,7 @@ class HandleErrorTest(integration.ModuleCase):
         # State salttest.hello found in sls issue-... is unavailable
         ret = self.run_function('state.sls', ['issue-9983-handleerror'])
         self.assertTrue(
-            'An exception occurred in this state: Traceback'
+            'Reason: \'salttest.hello\' is not available.'
             in ret[[a for a in ret][0]]['comment'])
 
 


### PR DESCRIPTION
It appears that we are now catching and formatting this error
differently, so the test has been updated to look for the updated
string.