### PR TITLE
Log module

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -345,6 +345,24 @@ in the current Jinja context.
 
     Context is: {{ show_full_context() }}
 
+Logs
+----
+
+.. versionadded:: Nitrogen
+
+Yes, in Salt, one is able to debug a complex Jinja template using the logs.
+For example, making the call:
+
+.. code-block:: yaml
+
+    {%- set logged = salt.log.error('testing jinja logging') -%}
+
+Will insert the following message in the minion logs:
+
+.. code-block:: text
+
+    2017-02-01 01:24:40,728 [salt.module.logmod][ERROR   ][3779] testing jinja logging
+
 Custom Execution Modules
 ========================
 

--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -355,7 +355,7 @@ For example, making the call:
 
 .. code-block:: yaml
 
-    {%- set logged = salt.log.error('testing jinja logging') -%}
+    {%- do salt.log.error('testing jinja logging') -%}
 
 Will insert the following message in the minion logs:
 

--- a/salt/modules/logmod.py
+++ b/salt/modules/logmod.py
@@ -19,8 +19,6 @@ CLI Example:
 .. code-block:: bash
 
     salt '*' log.error 'Please dont do that, this module is not for CLI use!'
-
-However, please note that it will not log the message when executed from the CLI.
 '''
 from __future__ import absolute_import
 
@@ -36,55 +34,37 @@ def __virtual__():
     return __virtualname__
 
 
-def debug(message, **kwargs):
+def debug(message):
     '''Log message at level DEBUG.'''
-    if not kwargs:
-        # log only when not executed from the CLI
-        log.debug(message)
-        return True
-    return False
+    log.debug(message)
+    return True
 
 
-def info(message, **kwargs):
+def info(message):
     '''Log message at level INFO.'''
-    if not kwargs:
-        # log only when not executed from the CLI
-        log.info(message)
-        return True
-    return False
+    log.info(message)
+    return True
 
 
-def warning(message, **kwargs):
+def warning(message):
     '''Log message at level WARNING.'''
-    if not kwargs:
-        # log only when not executed from the CLI
-        log.warning(message)
-        return True
-    return False
+    log.warning(message)
+    return True
 
 
-def error(message, **kwargs):
+def error(message):
     '''Log message at level ERROR.'''
-    if not kwargs:
-        # log only when not executed from the CLI
-        log.error(message)
-        return True
-    return False
+    log.error(message)
+    return True
 
 
-def critical(message, **kwargs):
+def critical(message):
     '''Log message at level CRITICAL.'''
-    if not kwargs:
-        # log only when not executed from the CLI
-        log.critical(message)
-        return True
-    return False
+    log.critical(message)
+    return True
 
 
-def exception(message, **kwargs):
+def exception(message):
     '''Log message at level EXCEPTION.'''
-    if not kwargs:
-        # log only when not executed from the CLI
-        log.exception(message)
-        return True
-    return False
+    log.exception(message)
+    return True

--- a/salt/modules/logmod.py
+++ b/salt/modules/logmod.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+'''
+On-demand logging
+=================
+
+.. versionadded:: Nitrogen
+
+The sole purpose of this module is logging messages in the (proxy) minion.
+It comes very handy when debugging complex Jinja templates, for example:
+
+.. code-block:: jinja
+
+    {%- for var in range(10) %}
+      {%- do salt.log.info(var) -%}
+    {%- endfor %}
+
+CLI Example:
+
+.. code-block:: bash
+
+    salt '*' log.error 'Please dont do that, this module is not for CLI use!'
+
+However, please note that it will not log the message when executed from the CLI.
+'''
+from __future__ import absolute_import
+
+# Import python libs
+import logging
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'log'
+__proxyenabled__ = ['*']
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def debug(message, **kwargs):
+    '''Log message at level DEBUG.'''
+    if not kwargs:
+        # log only when not executed from the CLI
+        log.debug(message)
+        return True
+    return False
+
+
+def info(message, **kwargs):
+    '''Log message at level INFO.'''
+    if not kwargs:
+        # log only when not executed from the CLI
+        log.info(message)
+        return True
+    return False
+
+
+def warning(message, **kwargs):
+    '''Log message at level WARNING.'''
+    if not kwargs:
+        # log only when not executed from the CLI
+        log.warning(message)
+        return True
+    return False
+
+
+def error(message, **kwargs):
+    '''Log message at level ERROR.'''
+    if not kwargs:
+        # log only when not executed from the CLI
+        log.error(message)
+        return True
+    return False
+
+
+def critical(message, **kwargs):
+    '''Log message at level CRITICAL.'''
+    if not kwargs:
+        # log only when not executed from the CLI
+        log.critical(message)
+        return True
+    return False
+
+
+def exception(message, **kwargs):
+    '''Log message at level EXCEPTION.'''
+    if not kwargs:
+        # log only when not executed from the CLI
+        log.exception(message)
+        return True
+    return False


### PR DESCRIPTION
### What does this PR do?

I am proposing this module... that is just logging :) Yeah, I find it funny too!

I don't know how you guys feel, but I find Jinja the most painful thing to debug.
Although the `show_full_context` function (https://docs.saltstack.com/en/latest/topics/jinja/index.html#debugging) is very handy, sometimes I feel like I would need to log elements and see what's going on inside a for loop, etc. 

So with this module, one would be able to:

```jinja
{%- do salt.log.error('testing jinja logging') -%}
```

inside their template and:

```
2017-02-01 01:24:40,728 [salt.loader.localhost.int.module.logmod][ERROR   ][3779] testing jinja logging
```

appears in the minion log.

If you find this sane, please let me know and I will add some tests (kidding), better doc + some notes under the Jinja debugging section - https://docs.saltstack.com/en/latest/topics/jinja/index.html#debugging

Cheers,
Mircea