### PR TITLE
Change saltutil.pillar_refresh -> saltutil.refresh_pillar in pillar tutorial

### DIFF
--- a/doc/topics/tutorials/pillar.rst
+++ b/doc/topics/tutorials/pillar.rst
@@ -101,7 +101,7 @@ to them asking that they fetch their pillars from the master:
 
 .. code-block:: bash
     
-    salt '*' saltutil.pillar_refresh
+    salt '*' saltutil.refresh_pillar
 
 Now that the minions have the new pillar, it can be retreived:
 


### PR DESCRIPTION
### What does this PR do?

The pillar tutorial specifies that `saltutil.pillar_refresh` should be run to refresh the pillar data, but `pillar_refresh()` does not exist in `modules/saltutil.py`.

This PR updates the tutorial doc to use the relevant call.

Looks like #28202 fixed this in 2015 onward.

### What issues does this PR fix or reference?

No issue opened; small doc fix

### Tests written?

No
