### PR TITLE
fixes #31393 don't convert the iface to lower case

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -955,7 +955,6 @@ def build_interface(iface, iface_type, enabled, **settings):
     else:
         rh_major = __grains__['osrelease'][:1]
 
-    iface = iface.lower()
     iface_type = iface_type.lower()
 
     if iface_type not in _IFACE_TYPES:


### PR DESCRIPTION
### What does this PR do?

This fixes an issue where ppc64  and ppc64le machines have interfaces that have uppercase letters in the device names

### What issues does this PR fix or reference?

This fixes #31393 