### PR TITLE
Do not use name resolving for --notrim check

### DIFF
--- a/pkg/rpm/salt-minion
+++ b/pkg/rpm/salt-minion
@@ -246,7 +246,7 @@ main() {
     fi
 
     # Check to see if --notrim is a valid netstat option
-    if netstat --notrim 2>&1 >/dev/null | grep -q 'unrecognized'; then
+    if netstat --notrim -n 2>&1 >/dev/null | grep -q 'unrecognized'; then
         NS_NOTRIM=''
     fi
 


### PR DESCRIPTION
### What does this PR do?

When starting salt-minion a check is performed to see if netstat supports --notrim option, this is done without the -n flag causing a delay on servers with many connections.

### What issues does this PR fix or reference?

#39052

### Previous Behavior

Minion restart can take up to minutes on servers with many connections

### New Behavior

Minion restart are faster

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
