### PR TITLE
Check if data['return'] is dict type

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -394,7 +394,8 @@ class SyncClientMixin(object):
             with tornado.stack_context.StackContext(self.functions.context_dict.clone):
                 data['return'] = self.functions[fun](*args, **kwargs)
                 data['success'] = True
-                if 'data' in data['return']:
+                if isinstance(data['return'], dict) and 'data' in data['return']:
+                    # some functions can return boolean values
                     data['success'] = salt.utils.check_state_result(data['return']['data'])
         except (Exception, SystemExit) as ex:
             if isinstance(ex, salt.exceptions.NotImplemented):


### PR DESCRIPTION
### What does this PR do?

Together with the improvements from https://github.com/saltstack/salt/pull/38251 (https://github.com/saltstack/salt/pull/38340), there were introduced some changes assuming erroneously that all the functions return dict-type objects.
In reality there are quite a few functions returning boolean values (and potentially other types...).

Fixes #39100, #38638 and #39098