### PR TITLE
[Bugfix] Fix state x509.crl_managed

### DIFF
--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -646,18 +646,18 @@ def crl_managed(name,
     new_comp.pop('Next Update')
 
     file_args, kwargs = _get_file_args(name, **kwargs)
-    new_crl = False
+    new_crl_created = False
     if (current_comp == new_comp and
             current_days_remaining > days_remaining and
             __salt__['x509.verify_crl'](name, signing_cert)):
         file_args['contents'] = __salt__[
             'x509.get_pem_entry'](name, pem_type='X509 CRL')
     else:
-        new_crl = True
+        new_crl_created = True
         file_args['contents'] = new_crl
 
     ret = __states__['file.managed'](**file_args)
-    if new_crl:
+    if new_crl_created:
         ret['changes'] = {'Old': current, 'New': __salt__[
             'x509.read_crl'](crl=new_crl)}
     return ret


### PR DESCRIPTION
### What does this PR do?
This PR changes previously used boolean variable names to new ones which do not yet exist.

### What issues does this PR fix or reference?
Commit https://github.com/saltstack/salt/commit/a4d6598f1e3d6faa96c7e11ba2e2c367f9e68099 overwrites new_crl with boolean values but new_crl is still needed
### Previous Behavior
   Function: x509.crl_managed
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1745, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1702, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/x509.py", line 663, in crl_managed
                  'x509.read_crl'](crl=new_crl)}
                File "/usr/lib/python2.7/dist-packages/salt/modules/x509.py", line 647, in read_crl
                  text = _text_or_file(crl)
                File "/usr/lib/python2.7/dist-packages/salt/modules/x509.py", line 317, in _text_or_file
                  if os.path.isfile(input_):
                File "/usr/lib/python2.7/genericpath.py", line 37, in isfile
                  st = os.stat(path)
              TypeError: coercing to Unicode: need string or buffer, bool found


### New Behavior
   Function: x509.crl_managed
      Result: True
     Comment: File [...] updated
     Started: 15:28:51.428353
    Duration: 48.241 ms
     Changes:   
 [...]

### Tests written?
No