### PR TITLE
Fix top_file_merging_strategy warning if env_order is set

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2590,7 +2590,7 @@ class BaseHighState(object):
                     tops[saltenv].append({})
                     log.debug('No contents loaded for env: {0}'.format(saltenv))
 
-            if found > 1 and merging_strategy == 'merge':
+            if found > 1 and merging_strategy == 'merge' and not self.opts.get('env_order', None):
                 log.warning(
                     'top_file_merging_strategy is set to \'%s\' and '
                     'multiple top files were found. Merging order is not '

--- a/salt/state.py
+++ b/salt/state.py
@@ -2509,8 +2509,7 @@ class BaseHighState(object):
         env_order = self.opts.get('env_order', [])
         client_envs = self.client.envs()
         if env_order and client_envs:
-            client_env_list = self.client.envs()
-            env_intersection = set(env_order).intersection(client_env_list)
+            env_intersection = set(env_order).intersection(client_envs)
             final_list = []
             for ord_env in env_order:
                 if ord_env in env_intersection and ord_env not in final_list:

--- a/salt/state.py
+++ b/salt/state.py
@@ -2507,21 +2507,17 @@ class BaseHighState(object):
             envs.extend([x for x in list(self.opts['file_roots'])
                          if x not in envs])
         env_order = self.opts.get('env_order', [])
+        # Remove duplicates while preserving the order
+        members = set()
+        env_order = [env for env in env_order if not (env in members or members.add(env))]
         client_envs = self.client.envs()
         if env_order and client_envs:
-            env_intersection = set(env_order).intersection(client_envs)
-            final_list = []
-            for ord_env in env_order:
-                if ord_env in env_intersection and ord_env not in final_list:
-                    final_list.append(ord_env)
-            return final_list
+            return [env for env in env_order if env in client_envs]
 
         elif env_order:
             return env_order
         else:
-            for cenv in client_envs:
-                if cenv not in envs:
-                    envs.append(cenv)
+            envs.extend([env for env in client_envs if env not in envs])
             return envs
 
     def get_tops(self):


### PR DESCRIPTION
### What does this PR do?

According to the documentation, the `env_order` config option allows one to explicitly define the order in which top files are evaluated, when `top_file_merging_strategy` is set to `merge`, and no environment is specified for a highstate.

Despite honoring the environment order specified in `env_order` in `BaseHighState._get_envs()`, salt still prints a warning recommending setting env_order. Thus silence the warning when `env_order` is set.

In addition, remove duplicate code and simplify `_get_envs()` by using list comprehensions.

### What issues does this PR fix or reference?

This PR fixes #29104

### Tests written?

No
