### PR TITLE
Don't abort pillar.get with merge=True if default is None

### DIFF
--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -10,6 +10,7 @@ import collections
 # Import third party libs
 import os
 import copy
+import logging
 import yaml
 import salt.ext.six as six
 
@@ -20,6 +21,8 @@ from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 __proxyenabled__ = ['*']
+
+log = logging.getLogger(__name__)
 
 
 def get(key,
@@ -91,15 +94,22 @@ def get(key,
     pillar_dict = __pillar__ if saltenv is None else items(saltenv=saltenv)
 
     if merge:
-        if not isinstance(default, dict):
-            raise SaltInvocationError(
-                'default must be a dictionary when merge=True'
-            )
-        ret = salt.utils.traverse_dict_and_list(pillar_dict, key, {}, delimiter)
-        if isinstance(ret, collections.Mapping) and \
-                isinstance(default, collections.Mapping):
-            default = copy.deepcopy(default)
-            return salt.utils.dictupdate.update(default, ret)
+        if default is None:
+            log.debug('pillar.get: default is None, skipping merge')
+        else:
+            if not isinstance(default, dict):
+                raise SaltInvocationError(
+                    'default must be a dictionary or None when merge=True'
+                )
+            ret = salt.utils.traverse_dict_and_list(
+                pillar_dict,
+                key,
+                {},
+                delimiter)
+            if isinstance(ret, collections.Mapping) and \
+                    isinstance(default, collections.Mapping):
+                default = copy.deepcopy(default)
+                return salt.utils.dictupdate.update(default, ret)
 
     ret = salt.utils.traverse_dict_and_list(pillar_dict,
                                             key,

--- a/tests/unit/modules/pillar_test.py
+++ b/tests/unit/modules/pillar_test.py
@@ -89,6 +89,21 @@ class PillarModuleTestCase(TestCase):
         self.assertEqual({'l2': {'l3': 42}}, res)
         self.assertEqual({'l2': {'l3': 43}}, default)
 
+    def test_pillar_get_default_merge_regression_39062(self):
+        '''
+        Confirm that we do not raise an exception if default is None and
+        merge=True.
+
+        See https://github.com/saltstack/salt/issues/39062 for more info.
+        '''
+        pillarmod.__opts__ = {}
+        pillarmod.__pillar__ = {'foo': 'bar'}
+
+        self.assertEqual(
+            pillarmod.get(key='foo', default=None, merge=True),
+            'bar',
+        )
+
 
 # gracinet: not sure this is really useful, but other test modules have this as well
 if __name__ == '__main__':


### PR DESCRIPTION
This prevents a SaltInvocationError from being raised if the default is
loaded from a import_yaml jinja macro and the file being loaded is empty
(which is an entirely valid use case). In these cases, the loaded default
would be None, which we don't want to cause an exception.