### PR TITLE
Allow pillar environment to be specified for salt-run

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -233,6 +233,9 @@ def state(name,
     if pillar:
         cmd_kw['kwarg']['pillar'] = pillar
 
+    if __opts__.get('pillarenv'):
+        cmd_kw['kwarg']['pillarenv'] = __opts__['pillarenv']
+
     cmd_kw['kwarg']['saltenv'] = __env__
     cmd_kw['kwarg']['queue'] = queue
 

--- a/tests/unit/statemod_test.py
+++ b/tests/unit/statemod_test.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Eric Radman <ericshane@eradman.com`
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import tempfile
+import os.path
+
+# Import Salt Testing libs
+from salttesting import TestCase, skipIf
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON
+
+ensure_in_syspath('../')
+
+# Import Salt libs
+import integration
+from salt.states import saltmod
+
+
+# Globals
+saltmod.__opts__ = dict()
+saltmod.__env__ = dict()
+saltmod.__salt__ = dict()
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class StatemodTests(TestCase):
+    def setUp(self):
+        self.tmp_cachedir = tempfile.mkdtemp(dir=integration.TMP)
+
+    @patch('salt.states.saltmod.__salt__', MagicMock())
+    def test_statemod_state(self):
+        ''' Smoke test for for salt.states.statemod.state().  Ensures that we
+            don't take an exception if optional parameters are not specified in
+            __opts__ or __env__.
+        '''
+        argv = []
+        saltmod.__opts__ = {
+            'id': 'webserver2',
+            'argv': argv,
+            '__role': 'master',
+            'cachedir': self.tmp_cachedir,
+            'extension_modules': os.path.join(self.tmp_cachedir, 'extmods'),
+        }
+        args = ('webserver_setup', 'webserver2')
+        kwargs = {
+            'tgt_type': 'glob',
+            'fail_minions': None,
+            'pillar': None,
+            'top': None,
+            'batch': None,
+            'orchestration_jid': None,
+            'sls': 'vroom',
+            'queue': False,
+            'concurrent': False,
+            'highstate': None,
+            'expr_form': None,
+            'ret': '',
+            'ssh': False,
+            'timeout': None, 'test': False,
+            'allow_fail': 0,
+            'saltenv': None,
+            'expect_minions': False
+        }
+        ret = saltmod.state(*args, **kwargs)
+        expected = {
+            'comment': 'States ran successfully.',
+            'changes': {},
+            'name': 'webserver_setup',
+            'result': True
+        }
+        self.assertEqual(ret, expected)
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(StatemodTests, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

Allows a pillarenv to be used with `state.orchestrate`. Example

    salt-run state.orchestrate deploy saltenv=base pillarenv=dev

### What issues does this PR fix or reference?

#32435

### Previous Behavior

`salt-run state.orchestrate` would always try to merge all available `pillar_roots`.

### New Behavior

`pillarenv` is respected, and if `pillarenv_from_saltenv: True` is set in the master config, the pillarenv will be set to match `saltenv`.

### Tests written?

Yes, although it is only a smoke test intended to gain confidence that this change does not cause a regression