### PR TITLE
Don't overwrite the minion_ids var that was passed

### DIFF
--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -109,6 +109,8 @@ class MasterPillarUtil(object):
             log.debug('Skipping cached mine data minion_data_cache'
                       'and enfore_mine_cache are both disabled.')
             return mine_data
+        if not minion_ids:
+            minion_ids = self.cache.list('minions')
         for minion_id in minion_ids:
             if not salt.utils.verify.valid_id(self.opts, minion_id):
                 continue
@@ -126,6 +128,8 @@ class MasterPillarUtil(object):
             log.debug('Skipping cached data because minion_data_cache is not '
                       'enabled.')
             return grains, pillars
+        if not minion_ids:
+            minion_ids = self.cache.list('minions')
         for minion_id in minion_ids:
             if not salt.utils.verify.valid_id(self.opts, minion_id):
                 continue

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -109,7 +109,6 @@ class MasterPillarUtil(object):
             log.debug('Skipping cached mine data minion_data_cache'
                       'and enfore_mine_cache are both disabled.')
             return mine_data
-        minion_ids = self.cache.list('minions')
         for minion_id in minion_ids:
             if not salt.utils.verify.valid_id(self.opts, minion_id):
                 continue
@@ -127,7 +126,6 @@ class MasterPillarUtil(object):
             log.debug('Skipping cached data because minion_data_cache is not '
                       'enabled.')
             return grains, pillars
-        minion_ids = self.cache.list('minions')
         for minion_id in minion_ids:
             if not salt.utils.verify.valid_id(self.opts, minion_id):
                 continue


### PR DESCRIPTION
The minion_ids var that was passed into the function was being
overwritten by a list of ALL the minion ids found in the minion cache

Please don't merge until reviewed by @DmitryKuzmenko 

Fixes: #38003

ZD1187

### What does this PR do?
Stops overwriting the minion_ids variable that was passed in

### What issues does this PR fix or reference?
Fixes #38003 
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
