### PR TITLE
[2016.3] Fix when targeting via pillar with Salt syndic

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1054,6 +1054,10 @@ class LocalClient(object):
                 if raw['data']['return'] == {}:
                     continue
 
+                if 'return' in raw['data']['return'] and \
+                    raw['data']['return']['return'] == {}:
+                    continue
+
                 # if we didn't originally target the minion, lets add it to the list
                 if raw['data']['id'] not in minions:
                     minions.add(raw['data']['id'])


### PR DESCRIPTION
### What does this PR do?
Fixing a weird edge case when using salt syndics and targetting via pillar.  Without this fix the master of masters ends up in an infinite loop since the data returned from the minions is differently structured than if a sync was not in use.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
When using a Salt syndic setup and targeting minions by Pillar values from the master of masters, the process would end up in an infinite loop since the data returned from the minions was different than what the previous logic was expected.

### New Behavior
Adds an additional case looking for empty return data to allow the processes to properly exit once the minions have returned.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
