### PR TITLE
update vmware getting started doc

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -618,8 +618,8 @@ Example of a complete profile:
           SCSI controller 0:
             type: lsilogic_sas
         ide:
-          IDE 0
-          IDE 1
+          IDE 0: {}
+          IDE 1: {}
         disk:
           Hard disk 0:
             controller: 'SCSI controller 0'


### PR DESCRIPTION
### What does this PR do?
The IDE entry needs to be a dictionary entry.  Without this, it is seen
as a string.  This is probably done this way so that in the future,
configurations can be added to the IDE device.

### What issues does this PR fix or reference?
ZD 1176

### Tests written?

No