### PR TITLE
Added ipv4 arg to connect_container_to_network

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -4621,7 +4621,7 @@ def inspect_network(network_id):
 
 @_api_version(1.21)
 @_client_version('1.5.0')
-def connect_container_to_network(container, network_id):
+def connect_container_to_network(container, network_id, ipv4_address=None):
     '''
     Connect container to network.
 
@@ -4631,6 +4631,9 @@ def connect_container_to_network(container, network_id):
     network_id
         ID of network
 
+    ipv4_address
+        The IPv4 address to connect to the container
+
     CLI Example:
 
     .. code-block:: bash
@@ -4639,7 +4642,8 @@ def connect_container_to_network(container, network_id):
     '''
     response = _client_wrapper('connect_container_to_network',
                                container,
-                               network_id)
+                               network_id,
+                               ipv4_address)
     _clear_context()
     # Only non-error return case is a True return, so just return the response
     return response


### PR DESCRIPTION
### What does this PR do?
Added support for connect_container_to_network of dockerng to pass an IPv4 address along. This was already implemented by the docker-py API but not yet supported in SaltStack.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/39126

### New Behavior
Connecting a container to a network with the supplied IPv4 address.

### Tests written?
No