### PR TITLE
Fix selinux.mode state config file handling

### DIFF
--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -89,6 +89,27 @@ def getenforce():
         return 'Disabled'
 
 
+def getconfig():
+    '''
+    Return the selinux mode from the config file
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' selinux.getconfig
+    '''
+    try:
+        config = '/etc/selinux/config'
+        with salt.utils.fopen(config, 'r') as _fp:
+            for line in _fp:
+                if line.strip().startswith('SELINUX='):
+                    return line.split('=')[1].capitalize().strip()
+    except (IOError, OSError, AttributeError):
+        return None
+    return None
+
+
 def setenforce(mode):
     '''
     Set the SELinux enforcing mode

--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -116,7 +116,7 @@ def mode(name):
         return ret
 
     oldmode, mode = mode, __salt__['selinux.setenforce'](tmode)
-    if mode == tmode:
+    if mode == tmode or (tmode == 'Disabled' and __salt__['selinux.getconfig']() == tmode):
         ret['result'] = True
         ret['comment'] = 'SELinux has been set to {0} mode'.format(tmode)
         ret['changes'] = {'old': oldmode,

--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -94,7 +94,14 @@ def mode(name):
     if tmode == 'unknown':
         ret['comment'] = '{0} is not an accepted mode'.format(name)
         return ret
+    # Either the current mode in memory or a non-matching config value
+    # will trigger setenforce
     mode = __salt__['selinux.getenforce']()
+    config = __salt__['selinux.getconfig']()
+    # Just making sure the oldmode reflects the thing that didn't match tmode
+    if mode == tmode and mode != config and tmode != config:
+        mode = config
+
     if mode == tmode:
         ret['result'] = True
         ret['comment'] = 'SELinux is already in {0} mode'.format(tmode)

--- a/tests/unit/states/selinux_test.py
+++ b/tests/unit/states/selinux_test.py
@@ -47,6 +47,7 @@ class SelinuxTestCase(TestCase):
         mock_pr = MagicMock(side_effect=['Permissive', 'Enforcing'])
         with patch.dict(selinux.__salt__,
                         {'selinux.getenforce': mock_en,
+                         'selinux.getconfig': mock_en,
                          'selinux.setenforce': mock_pr}):
             comt = ('SELinux is already in Enforcing mode')
             ret = {'name': 'Enforcing', 'comment': comt, 'result': True, 'changes': {}}


### PR DESCRIPTION
### What does this PR do?
This commit enhances idempotency of the state in regards to both the in-memory and configuration file enforcement of SELinux.

### What issues does this PR fix or reference?
The selinux.mode state only checked the current status of SELinux in-memory (getenforce) when determining if changes needed to be made. The /etc/selinux/config file could have a different value, and it would not be changed. 

### Previous Behavior
If the desired mode was 'Enforcing', the results of `getenforce` was 'Enforcing', and the `/etc/selinux/config` file contained 'Permissive'... then the state would assume that everything was fine and not change the configuration file to the desired mode.

### New Behavior
The selinux.mode state now checks the content of the `/etc/selinux/config` file in addition to the in-memory status before determining if the state needs to correct the mode values. 

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
