### PR TITLE
[Bugfix] fix argument order for usermod call

### DIFF
--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -305,7 +305,7 @@ def set_password(name, password, use_usermod=False):
         return uinfo['passwd'] == password
     else:
         # Use usermod -p (less secure, but more feature-complete)
-        cmd = 'usermod -p {0} {1}'.format(name, password)
+        cmd = 'usermod -p {0} {1}'.format(password, name)
         __salt__['cmd.run'](cmd, python_shell=False, output_loglevel='quiet')
         uinfo = info(name)
         return uinfo['passwd'] == password


### PR DESCRIPTION
The argument order for the usermod -p call was reversed.

### What does this PR do?

Fix the order for the arguments to usermod -p call

### What issues does this PR fix or reference?

#3655

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
