### PR TITLE
Adding more function to Snapper module

### DIFF
--- a/salt/modules/snapper.py
+++ b/salt/modules/snapper.py
@@ -400,6 +400,59 @@ def delete_snapshot(snapshots_ids=None, config="root"):
         raise CommandExecutionError(_dbus_exception_to_reason(exc, locals()))
 
 
+def modify_snapshot(snapshot_id=None,
+                    description=None,
+                    userdata=None,
+                    cleanup=None,
+                    config="root"):
+    '''
+    Modify attributes of an existing snapshot.
+
+    config
+        Configuration name. (Default: root)
+
+    snapshot_id
+        ID of the snapshot to be modified.
+
+    cleanup
+        Change the cleanup method of the snapshot. (str)
+
+    description
+        Change the description of the snapshot. (str)
+
+    userdata
+        Change the userdata dictionary of the snapshot. (dict)
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' snapper.modify_snapshot 54 description="my snapshot description"
+        salt '*' snapper.modify_snapshot 54 description="my snapshot description"
+        salt '*' snapper.modify_snapshot 54 userdata='{"foo": "bar"}'
+        salt '*' snapper.modify_snapshot snapshot_id=54 cleanup="number"
+    '''
+    if not snapshot_id:
+        raise CommandExecutionError('Error: No snapshot ID has been provided')
+
+    snapshot = get_snapshot(config=config, number=snapshot_id)
+    try:
+        # Updating only the explicitely provided attributes by the user 
+        updated_opts = {
+            'description': description if description != None else snapshot['description'],
+            'cleanup': cleanup if cleanup != None else snapshot['cleanup'],
+            'userdata': userdata if userdata != None else snapshot['userdata'],
+        }
+        snapper.SetSnapshot(config,
+                            snapshot_id,
+                            updated_opts['description'],
+                            updated_opts['cleanup'],
+                            updated_opts['userdata'])
+        return get_snapshot(config=config, number=snapshot_id)
+    except dbus.DBusException as exc:
+        raise CommandExecutionError(_dbus_exception_to_reason(exc, locals()))
+
+
 def _get_num_interval(config, num_pre, num_post):
     '''
     Returns numerical interval based on optionals num_pre, num_post values

--- a/salt/modules/snapper.py
+++ b/salt/modules/snapper.py
@@ -290,6 +290,60 @@ def get_config(name='root'):
         )
 
 
+def create_config(name=None,
+                  subvolume=None,
+                  fstype=None,
+                  template=None,
+                  extra_opts=None):
+    '''
+    Creates a new Snapper configuration
+
+    name
+        Name of the new Snapper configuration.
+    subvolume
+        Path to the related subvolume.
+    fstype
+        Filesystem type of the subvolume.
+    template
+        Configuration template to use. (Default: default)
+    extra_opts
+        Extra Snapper configuration opts dictionary. It will override the values provided
+        by the given template (if any).
+
+    CLI example:
+
+    .. code-block:: bash
+
+      salt '*' snapper.create_config name=myconfig subvolume=/foo/bar/ fstype=btrfs
+      salt '*' snapper.create_config name=myconfig subvolume=/foo/bar/ fstype=btrfs template="default"
+      salt '*' snapper.create_config name=myconfig subvolume=/foo/bar/ fstype=btrfs extra_opts='{"NUMBER_CLEANUP": False}'
+    '''
+    def raise_arg_error(argname):
+        raise CommandExecutionError(
+            'You must provide a "{0}" for the new configuration'.format(argname)
+        )
+
+    if not name:
+        raise_arg_error("name")
+    if not subvolume:
+        raise_arg_error("subvolume")
+    if not fstype:
+        raise_arg_error("fstype")
+    if not template:
+        template = ""
+
+    try:
+        snapper.CreateConfig(name, subvolume, fstype, template)
+        if extra_opts:
+            set_config(name, **extra_opts)
+        return get_config(name)
+    except dbus.DBusException as exc:
+        raise CommandExecutionError(
+            'Error encountered while creating the new configuration: {0}'
+            .format(_dbus_exception_to_reason(exc, locals()))
+        )
+
+
 def create_snapshot(config='root', snapshot_type='single', pre_number=None,
                     description=None, cleanup_algorithm='number', userdata=None,
                     **kwargs):

--- a/salt/modules/snapper.py
+++ b/salt/modules/snapper.py
@@ -493,9 +493,9 @@ def modify_snapshot(snapshot_id=None,
     try:
         # Updating only the explicitely provided attributes by the user
         updated_opts = {
-            'description': description if description != None else snapshot['description'],
-            'cleanup': cleanup if cleanup != None else snapshot['cleanup'],
-            'userdata': userdata if userdata != None else snapshot['userdata'],
+            'description': description if description is not None else snapshot['description'],
+            'cleanup': cleanup if cleanup is not None else snapshot['cleanup'],
+            'userdata': userdata if userdata is not None else snapshot['userdata'],
         }
         snapper.SetSnapshot(config,
                             snapshot_id,

--- a/salt/modules/snapper.py
+++ b/salt/modules/snapper.py
@@ -363,14 +363,14 @@ def create_snapshot(config='root', snapshot_type='single', pre_number=None,
     cleanup_algorithm
         Set the cleanup algorithm for the snapshot.
 
-        number
-            Deletes old snapshots when a certain number of snapshots
-            is reached.
-        timeline
-            Deletes old snapshots but keeps a number of hourly,
-            daily, weekly, monthly and yearly snapshots.
-        empty-pre-post
-            Deletes pre/post snapshot pairs with empty diffs.
+    number
+        Deletes old snapshots when a certain number of snapshots
+        is reached.
+    timeline
+        Deletes old snapshots but keeps a number of hourly,
+        daily, weekly, monthly and yearly snapshots.
+    empty-pre-post
+        Deletes pre/post snapshot pairs with empty diffs.
     userdata
         Set userdata for the snapshot (key-value pairs).
 
@@ -491,7 +491,7 @@ def modify_snapshot(snapshot_id=None,
 
     snapshot = get_snapshot(config=config, number=snapshot_id)
     try:
-        # Updating only the explicitely provided attributes by the user 
+        # Updating only the explicitely provided attributes by the user
         updated_opts = {
             'description': description if description != None else snapshot['description'],
             'cleanup': cleanup if cleanup != None else snapshot['cleanup'],

--- a/tests/unit/modules/snapper_test.py
+++ b/tests/unit/modules/snapper_test.py
@@ -229,6 +229,23 @@ class SnapperTestCase(TestCase):
         self.assertRaises(CommandExecutionError, snapper.delete_snapshot, snapshots_ids=1)
         self.assertRaises(CommandExecutionError, snapper.delete_snapshot, snapshots_ids=[1, 2])
 
+    @patch('salt.modules.snapper.snapper.SetSnapshot', MagicMock())
+    def test_modify_snapshot(self):
+        _ret = {
+            'userdata': {'userdata2': 'uservalue2'},
+            'description': 'UPDATED DESCRIPTION', 'timestamp': 1457006571,
+            'cleanup': 'number', 'user': 'root', 'type': 'pre', 'id': 42
+        }
+        _opts = {
+            'config': 'root',
+            'snapshot_id': 42,
+            'cleanup': 'number',
+            'description': 'UPDATED DESCRIPTION',
+            'userdata': {'userdata2': 'uservalue2'},
+        }
+        with patch('salt.modules.snapper.get_snapshot', MagicMock(side_effect=[DBUS_RET['ListSnapshots'][0], _ret])):
+            self.assertDictEqual(snapper.modify_snapshot(**_opts), _ret)
+
     @patch('salt.modules.snapper._get_last_snapshot', MagicMock(return_value={'id': 42}))
     def test__get_num_interval(self):
         self.assertEqual(snapper._get_num_interval(config=None, num_pre=None, num_post=None), (42, 0))  # pylint: disable=protected-access

--- a/tests/unit/modules/snapper_test.py
+++ b/tests/unit/modules/snapper_test.py
@@ -216,6 +216,19 @@ class SnapperTestCase(TestCase):
             }
             self.assertEqual(snapper.create_snapshot(**opts), 1234)
 
+    @patch('salt.modules.snapper.snapper.DeleteSnapshots', MagicMock())
+    @patch('salt.modules.snapper.snapper.ListSnapshots', MagicMock(return_value=DBUS_RET['ListSnapshots']))
+    def test_delete_snapshot_id_success(self):
+        self.assertEqual(snapper.delete_snapshot(snapshots_ids=43), {"root": {"ids": [43], "status": "deleted"}})
+        self.assertEqual(snapper.delete_snapshot(snapshots_ids=[42, 43]), {"root": {"ids": [42, 43], "status": "deleted"}})
+
+    @patch('salt.modules.snapper.snapper.DeleteSnapshots', MagicMock())
+    @patch('salt.modules.snapper.snapper.ListSnapshots', MagicMock(return_value=DBUS_RET['ListSnapshots']))
+    def test_delete_snapshot_id_fail(self):
+        self.assertRaises(CommandExecutionError, snapper.delete_snapshot)
+        self.assertRaises(CommandExecutionError, snapper.delete_snapshot, snapshots_ids=1)
+        self.assertRaises(CommandExecutionError, snapper.delete_snapshot, snapshots_ids=[1, 2])
+
     @patch('salt.modules.snapper._get_last_snapshot', MagicMock(return_value={'id': 42}))
     def test__get_num_interval(self):
         self.assertEqual(snapper._get_num_interval(config=None, num_pre=None, num_post=None), (42, 0))  # pylint: disable=protected-access


### PR DESCRIPTION
### What does this PR do?
This PR adds more functionality to the Snapper execution module:

- Creating Snapper configurations: `snapper.create_config`
- Deleting snapshots: `snapper.delete_snapshot`
- Modifying snapshot metadata: `snapper.modify_snapshot`

### Tests written?

Yes