### PR TITLE
fix boto ec2 module create_image doc

### DIFF
--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -495,8 +495,8 @@ def create_image(ami_name, instance_id=None, instance_name=None, tags=None, regi
 
     .. code-block:: bash
 
-        salt myminion boto_ec2.create_instance ami_name instance_name=myinstance
-        salt myminion boto_ec2.create_instance another_ami_name tags='{"mytag": "value"}' description='this is my ami'
+        salt myminion boto_ec2.create_image ami_name instance_name=myinstance
+        salt myminion boto_ec2.create_image another_ami_name tags='{"mytag": "value"}' description='this is my ami'
 
     '''
 


### PR DESCRIPTION
### What does this PR do?
The example in create_image uses the wrong function name in the dogs. This pr fixes the function name.

the original pr that added this doc: https://github.com/saltstack/salt/pull/27221

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/39135