### PR TITLE
Add publisher_acl and publisher_acl_blacklist to defaults

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1091,6 +1091,8 @@ DEFAULT_MINION_OPTS = {
     'render_dirs': [],
     'outputter_dirs': [],
     'utils_dirs': [],
+    'publisher_acl': {},
+    'publisher_acl_blacklist': {},
     'providers': {},
     'clean_dynamic_modules': True,
     'open_mode': False,

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -753,7 +753,7 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
             if self.config['user'] != current_user:
                 # Yep, not the same user!
                 # Is the current user in ACL?
-                acl = self.config.get('publisher_acl')
+                acl = self.config['publisher_acl']
                 if salt.utils.check_whitelist_blacklist(current_user, whitelist=six.iterkeys(acl)):
                     # Yep, the user is in ACL!
                     # Let's write the logfile to its home directory instead.


### PR DESCRIPTION
### What does this PR do?
Fixes a problem with the minion stack tracing.

### What issues does this PR fix or reference?
None

### Previous Behavior
Minion would stacktrace because it couldn't find `publisher_acl` in the config

### New Behavior
Minion starts normally

### Tests written?
No