### PR TITLE
Added missing source_hash_name argument in get_managed function

### DIFF
--- a/salt/states/jboss7.py
+++ b/salt/states/jboss7.py
@@ -412,6 +412,7 @@ def __get_artifact(salt_source):
                     template=None,
                     source=salt_source['source'],
                     source_hash=None,
+                    source_hash_name=None,
                     user=None,
                     group=None,
                     mode=None,


### PR DESCRIPTION
Additional fix to PR  #33187
Customer was still seeing errors, this should now work.


### What does this PR do?
Updates the get_managed call to pass the correct number of arguments. `source_hash_name` was missing.

### What issues does this PR fix or reference?
The call was failing because the incorrect number of 
arguments was being passed. It was missing `source_hash_name`

### Previous Behavior

State output shows:
```
Comment: Unable to manage file: get_managed() takes at least 11 non-keyword arguments (4 given)
```

###Tests

Tested with 2015.8.13 and 2016.11.2
