### PR TITLE
Raise an error for a disk size that is too small

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -644,9 +644,17 @@ def _manage_devices(devices, vm=None, container_ref=None):
                                      ' Using existing disk size.')
                             size_kb = device.capacityInKB
 
+                        log.debug('device capacity is {0}'.format(device.capacityInKB))
+                        log.debug('specified capacity is {0}'.format(size_kb))
                         if device.capacityInKB < size_kb:
                             # expand the disk
                             disk_spec = _edit_existing_hard_disk_helper(device, size_kb)
+                        elif device.capacityInKB < size_kb:
+                            raise SaltCloudSystemExit(
+                                'The specified disk size is smaller than the '
+                                'size of the disk image. It must be equal to '
+                                'or greater than the disk image'
+                            )
 
                         if 'mode' in devices['disk'][device.deviceInfo.label]:
                             if devices['disk'][device.deviceInfo.label]['mode'] \

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -644,8 +644,6 @@ def _manage_devices(devices, vm=None, container_ref=None):
                                      ' Using existing disk size.')
                             size_kb = device.capacityInKB
 
-                        log.debug('device capacity is {0}'.format(device.capacityInKB))
-                        log.debug('specified capacity is {0}'.format(size_kb))
                         if device.capacityInKB < size_kb:
                             # expand the disk
                             disk_spec = _edit_existing_hard_disk_helper(device, size_kb)

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -647,7 +647,7 @@ def _manage_devices(devices, vm=None, container_ref=None):
                         if device.capacityInKB < size_kb:
                             # expand the disk
                             disk_spec = _edit_existing_hard_disk_helper(device, size_kb)
-                        elif device.capacityInKB < size_kb:
+                        elif device.capacityInKB > size_kb:
                             raise SaltCloudSystemExit(
                                 'The specified disk size is smaller than the '
                                 'size of the disk image. It must be equal to '


### PR DESCRIPTION
### What does this PR do?
When a disk size is specified that is smaller than the cloned image, VMWare will (correctly) refuse to create the new VM. This PR will raise an error if such a size is specified.

### What issues does this PR fix or reference?
Fixes #38370.

### Tests written?
No.