### PR TITLE
Restore "Salt Community" doc section

### DIFF
--- a/doc/topics/index.rst
+++ b/doc/topics/index.rst
@@ -89,3 +89,98 @@ the Salt project so that we can all benefit together as Salt grows.
 Please feel free to sprinkle Salt around your systems and let the
 deliciousness come forth.
 
+Salt Community
+==============
+
+Join the Salt!
+
+There are many ways to participate in and communicate with the Salt community.
+
+Salt has an active IRC channel and a mailing list.
+
+Mailing List
+============
+
+Join the `salt-users mailing list`_. It is the best place to ask questions
+about Salt and see whats going on with Salt development! The Salt mailing list
+is hosted by Google Groups. It is open to new members.
+
+.. _`salt-users mailing list`: https://groups.google.com/forum/#!forum/salt-users
+
+
+IRC
+===
+
+The ``#salt`` IRC channel is hosted on the popular `Freenode`_ network. You
+can use the `Freenode webchat client`_ right from your browser.
+
+`Logs of the IRC channel activity`_ are being collected courtesy of Moritz Lenz.
+
+.. _Freenode:: http://freenode.net/irc_servers.shtml
+.. _Freenode webchat client:: http://webchat.freenode.net/?channels=salt&uio=Mj10cnVlJjk9dHJ1ZSYxMD10cnVl83
+.. _Logs of the IRC channel activity:: http://irclog.perlgeek.de/salt/
+
+If you wish to discuss the development of Salt itself join us in
+``#salt-devel``.
+
+
+Follow on Github
+================
+
+The Salt code is developed via Github. Follow Salt for constant updates on what
+is happening in Salt development:
+
+|saltrepo|
+
+
+Blogs
+=====
+
+SaltStack Inc. keeps a `blog`_ with recent news and advancements:
+
+http://www.saltstack.com/blog/
+
+.. _`blog`: http://www.saltstack.com/blog/
+
+
+Example Salt States
+===================
+
+The official ``salt-states`` repository is:
+https://github.com/saltstack/salt-states
+
+A few examples of salt states from the community:
+
+* https://github.com/blast-hardcheese/blast-salt-states
+* https://github.com/kevingranade/kevingranade-salt-state
+* https://github.com/uggedal/states
+* https://github.com/mattmcclean/salt-openstack/tree/master/salt
+* https://github.com/rentalita/ubuntu-setup/
+* https://github.com/brutasse/states
+* https://github.com/bclermont/states
+* https://github.com/pcrews/salt-data
+
+Follow on ohloh
+===============
+
+https://www.ohloh.net/p/salt
+
+Other community links
+=====================
+
+- `Salt Stack Inc. <http://www.saltstack.com>`_
+- `Subreddit <http://www.reddit.com/r/saltstack>`_
+- `Google+ <https://plus.google.com/114449193225626631691/posts>`_
+- `YouTube <http://www.youtube.com/user/SaltStack>`_
+- `Facebook <https://www.facebook.com/SaltStack>`_
+- `Twitter <https://twitter.com/SaltStackInc>`_
+- `Wikipedia page <http://en.wikipedia.org/wiki/Salt_(software)>`_
+
+Hack the Source
+===============
+
+If you want to get involved with the development of source code or the
+documentation efforts, please review the :ref:`contributing documentation
+<contributing>`!
+
+.. _`Apache 2.0 license`: http://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
This was moved to the `topics/index.rst` page in PR #10792, but seems to have been accidentally removed in PR #30770.
