### PR TITLE
pip_state: mention Python 2 pip module is required

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -110,9 +110,9 @@ def _check_pkg_version_format(pkg):
 
     if not HAS_PIP:
         ret['comment'] = (
-            'An importable pip module is required but could not be found on '
-            'your system. This usually means that the system\'s pip package '
-            'is not installed properly.'
+            'An importable Python 2 pip module is required but could not be '
+            'found on your system. This usually means that the system\'s pip '
+            'package is not installed properly.'
         )
 
         return ret


### PR DESCRIPTION
To use the pip state for Python 3, the pip module for Python 3 *and* Python 2 are required to be installed.  This adds "Python 2" in the error message when the Python 2 pip module can't be found.
