### PR TITLE
setup.py: Remove global options from install command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -716,31 +716,6 @@ class Build(build):
 
 
 class Install(install):
-    user_options = install.user_options + [
-        ('salt-transport=', None, 'The transport to prepare salt for. Choices are \'zeromq\' '
-                                  '\'raet\' or \'both\'. Defaults to \'zeromq\'', 'zeromq'),
-        ('salt-root-dir=', None,
-         'Salt\'s pre-configured root directory'),
-        ('salt-config-dir=', None,
-         'Salt\'s pre-configured configuration directory'),
-        ('salt-cache-dir=', None,
-         'Salt\'s pre-configured cache directory'),
-        ('salt-sock-dir=', None,
-         'Salt\'s pre-configured socket directory'),
-        ('salt-srv-root-dir=', None,
-         'Salt\'s pre-configured service directory'),
-        ('salt-base-file-roots-dir=', None,
-         'Salt\'s pre-configured file roots directory'),
-        ('salt-base-pillar-roots-dir=', None,
-         'Salt\'s pre-configured pillar roots directory'),
-        ('salt-base-master-roots-dir=', None,
-         'Salt\'s pre-configured master roots directory'),
-        ('salt-logs-dir=', None,
-         'Salt\'s pre-configured logs directory'),
-        ('salt-pidfile-dir=', None,
-         'Salt\'s pre-configured pidfiles directory'),
-    ]
-
     def initialize_options(self):
         install.initialize_options(self)
 


### PR DESCRIPTION
### What does this PR do?
Remove user options from the Install class of setup.py. I'm not overly familiar with distutils so it's probably best if someone can double check that the change is okay.

### What issues does this PR fix or reference?
#39078

### Previous Behavior
https://github.com/saltstack/salt/commit/b03f95bf0f43d8945d7f5319327163e21a8febda removed the ability to pass global settings through the install command. It looks like the option definitions were left in, so when looking at the ouput of `setup.py install --help` they are still suggested as valid options.
<pre>Options for 'Install' command:
  --prefix                      installation prefix
  --exec-prefix                 (Unix only) prefix for platform-specific files
  --home                        (Unix only) home directory to install under
  --user                        install in user site-package
                                '/root/.local/lib/python2.7/site-packages'
  --install-base                base installation directory (instead of --
                                prefix or --home)
  --install-platbase            base installation directory for platform-
                                specific files (instead of --exec-prefix or --
                                home)
  --root                        install everything relative to this alternate
                                root directory
  --install-purelib             installation directory for pure Python module
                                distributions
  --install-platlib             installation directory for non-pure module
                                distributions
  --install-lib                 installation directory for all module
                                distributions (overrides --install-purelib and
                                --install-platlib)
  --install-headers             installation directory for C/C++ headers
  --install-scripts             installation directory for Python scripts
  --install-data                installation directory for data files
  --compile (-c)                compile .py to .pyc [default]
  --no-compile                  don't compile .py files
  --optimize (-O)               also compile with optimization: -O1 for
                                "python -O", -O2 for "python -OO", and -O0 to
                                disable [default: -O0]
  --force (-f)                  force installation (overwrite any existing
                                files)
  --skip-build                  skip rebuilding everything (for
                                testing/debugging)
  --record                      filename in which to record list of installed
                                files
  --salt-transport              The transport to prepare salt for. Choices are
                                'zeromq' 'raet' or 'both'. Defaults to
                                'zeromq'
  --salt-root-dir               Salt's pre-configured root directory
  --salt-config-dir             Salt's pre-configured configuration directory
  --salt-cache-dir              Salt's pre-configured cache directory
  --salt-sock-dir               Salt's pre-configured socket directory
  --salt-srv-root-dir           Salt's pre-configured service directory
  --salt-base-file-roots-dir    Salt's pre-configured file roots directory
  --salt-base-pillar-roots-dir  Salt's pre-configured pillar roots directory
  --salt-base-master-roots-dir  Salt's pre-configured master roots directory
  --salt-logs-dir               Salt's pre-configured logs directory
  --salt-pidfile-dir            Salt's pre-configured pidfiles directory</pre>

### New Behavior
<pre>Options for 'Install' command:
  --prefix            installation prefix
  --exec-prefix       (Unix only) prefix for platform-specific files
  --home              (Unix only) home directory to install under
  --user              install in user site-package
                      '/root/.local/lib/python2.7/site-packages'
  --install-base      base installation directory (instead of --prefix or --
                      home)
  --install-platbase  base installation directory for platform-specific files
                      (instead of --exec-prefix or --home)
  --root              install everything relative to this alternate root
                      directory
  --install-purelib   installation directory for pure Python module
                      distributions
  --install-platlib   installation directory for non-pure module distributions
  --install-lib       installation directory for all module distributions
                      (overrides --install-purelib and --install-platlib)
  --install-headers   installation directory for C/C++ headers
  --install-scripts   installation directory for Python scripts
  --install-data      installation directory for data files
  --compile (-c)      compile .py to .pyc [default]
  --no-compile        don't compile .py files
  --optimize (-O)     also compile with optimization: -O1 for "python -O", -O2
                      for "python -OO", and -O0 to disable [default: -O0]
  --force (-f)        force installation (overwrite any existing files)
  --skip-build        skip rebuilding everything (for testing/debugging)
  --record            filename in which to record list of installed files</pre>

### Tests written?

No