### PR TITLE
Fix crashes when source attr is missing, as well as when description is missing

### DIFF
--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -348,7 +348,12 @@ def create(vm_):
 
             domain_xml = ElementTree.fromstring(xml)
             domain_xml.find('./name').text = name
-            domain_xml.find('./description').text = "Cloned from {0}".format(base)
+            if domain_xml.find('./description'):
+                description = domain_xml.find('./description')            
+            else:
+                description = ElementTree.SubElement(domain_elem, 'description')
+                domain_xml.insert(0, description)
+            description.text = "Cloned from {0}".format(base)
             domain_xml.remove(domain_xml.find('./uuid'))
 
             for iface_xml in domain_xml.findall('./devices/interface'):
@@ -368,7 +373,7 @@ def create(vm_):
                 if agent_xml.find("""./target[@type='virtio'][@name='org.qemu.guest_agent.0']""") is not None:
                     source_element = agent_xml.find("""./source[@mode='bind']""")
                     # see if there is a path element that needs rewriting
-                    if 'path' in source_element.attrib:
+                    if source_element and 'path' in source_element.attrib:
                         path = source_element.attrib['path']
                         new_path = path.replace('/domain-{0}/'.format(base), '/domain-{0}/'.format(name))
                         log.debug("Rewriting agent socket path to {0}".format(new_path))

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -348,11 +348,10 @@ def create(vm_):
 
             domain_xml = ElementTree.fromstring(xml)
             domain_xml.find('./name').text = name
-            if domain_xml.find('./description'):
-                description = domain_xml.find('./description')            
-            else:
-                description = ElementTree.SubElement(domain_elem, 'description')
-                domain_xml.insert(0, description)
+            if domain_xml.find('./description') == None:
+                description_elem = ElementTree.Element('description')
+                domain_xml.insert(0, description_elem)
+            description = domain_xml.find('./description')
             description.text = "Cloned from {0}".format(base)
             domain_xml.remove(domain_xml.find('./uuid'))
 

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -348,7 +348,7 @@ def create(vm_):
 
             domain_xml = ElementTree.fromstring(xml)
             domain_xml.find('./name').text = name
-            if domain_xml.find('./description') == None:
+            if domain_xml.find('./description') is None:
                 description_elem = ElementTree.Element('description')
                 domain_xml.insert(0, description_elem)
             description = domain_xml.find('./description')


### PR DESCRIPTION
### What does this PR do?
Fix crashes when source attr is missing, as well as when description is missing in libvirt cloud provider

### What issues does this PR fix or reference?
None

### Previous Behavior
salt-cloud would crash while deploying if either the description tag was missing in the xml on source  vm or if the source attr for qemu-agent was missing, which is optional on libvirt 1.4+
https://wiki.libvirt.org/page/Qemu_guest_agent

### New Behavior
salt-cloud does not crash when either of these conditions are true

### Tests written?
No - I don't think there are tests for this yet, if there are let me know :)

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
