### PR TITLE
Fix NetBSD sockstat parsing

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1057,14 +1057,14 @@ def _netbsd_remotes_on(port, which_end):
     Parses output of shell 'sockstat' (NetBSD)
     to get connections
 
-    $ sudo sockstat -4
+    $ sudo sockstat -4 -n
     USER    COMMAND     PID     FD  PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
     root    python2.7   1456    29  tcp4   *.4505           *.*
     root    python2.7   1445    17  tcp4   *.4506           *.*
     root    python2.7   1294    14  tcp4   127.0.0.1.11813  127.0.0.1.4505
     root    python2.7   1294    41  tcp4   127.0.0.1.61115  127.0.0.1.4506
 
-    $ sudo sockstat -4 -c -p 4506
+    $ sudo sockstat -4 -c -n -p 4506
     USER    COMMAND     PID     FD  PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
     root    python2.7   1294    41  tcp4   127.0.0.1.61115  127.0.0.1.4506
     '''
@@ -1073,7 +1073,7 @@ def _netbsd_remotes_on(port, which_end):
     remotes = set()
 
     try:
-        cmd = salt.utils.shlex_split('sockstat -4 -c -p {0}'.format(port))
+        cmd = salt.utils.shlex_split('sockstat -4 -c -n -p {0}'.format(port))
         data = subprocess.check_output(cmd)  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError as ex:
         log.error('Failed "sockstat" with returncode = {0}'.format(ex.returncode))

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1059,14 +1059,14 @@ def _netbsd_remotes_on(port, which_end):
 
     $ sudo sockstat -4 -n
     USER    COMMAND     PID     FD  PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
-    root    python2.7   1456    29  tcp4   *.4505           *.*
-    root    python2.7   1445    17  tcp4   *.4506           *.*
-    root    python2.7   1294    14  tcp4   127.0.0.1.11813  127.0.0.1.4505
-    root    python2.7   1294    41  tcp4   127.0.0.1.61115  127.0.0.1.4506
+    root    python2.7   1456    29  tcp    *.4505           *.*
+    root    python2.7   1445    17  tcp    *.4506           *.*
+    root    python2.7   1294    14  tcp    127.0.0.1.11813  127.0.0.1.4505
+    root    python2.7   1294    41  tcp    127.0.0.1.61115  127.0.0.1.4506
 
     $ sudo sockstat -4 -c -n -p 4506
     USER    COMMAND     PID     FD  PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
-    root    python2.7   1294    41  tcp4   127.0.0.1.61115  127.0.0.1.4506
+    root    python2.7   1294    41  tcp    127.0.0.1.61115  127.0.0.1.4506
     '''
 
     port = int(port)
@@ -1085,7 +1085,7 @@ def _netbsd_remotes_on(port, which_end):
         chunks = line.split()
         if not chunks:
             continue
-        # ['root', 'python2.7', '1456', '37', 'tcp4',
+        # ['root', 'python2.7', '1456', '37', 'tcp',
         #  '127.0.0.1.4505-', '127.0.0.1.55703']
         # print chunks
         if 'COMMAND' in chunks[1]:


### PR DESCRIPTION
### What does this PR do?
NetBSD `sockstat` parsing in network utils is missing the switch to return numeric output only. This adds the extra switch so that IP addresses are returned instead of DNS names, which fixes presence events with a NetBSD master.
<pre># uname -a
NetBSD salt-master 7.0 NetBSD 7.0 (XEN3_DOMU.201509250726Z) amd64
# sockstat -4 -c
USER     COMMAND    PID   FD PROTO  LOCAL ADDRESS         FOREIGN ADDRESS
root     python2.7  14115 28 tcp    localhost.4505        localhost.64584
root     python2.7  20895 31 tcp    localhost.64584       localhost.4505
# sockstat -4 -c -n
USER     COMMAND    PID   FD PROTO  LOCAL ADDRESS         FOREIGN ADDRESS
root     python2.7  14115 28 tcp    127.0.0.1.4505        127.0.0.1.64584
root     python2.7  20895 31 tcp    127.0.0.1.64584       127.0.0.1.4505</pre>

### What issues does this PR fix or reference?
Presence events are broken when using a NetBSD master.

### Previous Behavior
With a NetBSD master:
- Change events are not fired
- Present events are empty

### New Behavior
With a NetBSD master, presence events work as normal.

### Tests written?

No