### PR TITLE
INFRA-1963 - add boto3_route53 exec and state modules

### DIFF
--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -1,0 +1,866 @@
+# -*- coding: utf-8 -*-
+'''
+Execution module for Amazon Route53 written against Boto 3
+
+.. versionadded:: Nitrogen
+
+:configuration: This module accepts explicit route53 credentials but can also
+    utilize IAM roles assigned to the instance through Instance Profiles.
+    Dynamic credentials are then automatically obtained from AWS API and no
+    further configuration is necessary. More Information available at:
+
+    .. code-block:: yaml
+
+        http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file:
+
+    .. code-block:: yaml
+
+        route53.keyid: GKTADJGHEIQSXMKKRBJ08H
+        route53.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration:
+
+    .. code-block:: yaml
+
+        route53.region: us-east-1
+
+    It's also possible to specify key, keyid and region via a profile, either
+    as a passed in dict, or as a string to pull from pillars or minion config:
+
+    .. code-block:: yaml
+
+        myprofile:
+          keyid: GKTADJGHEIQSXMKKRBJ08H
+          key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+          region: us-east-1
+
+    Note that Route53 essentially ignores all (valid) settings for 'region',
+    since there is only one Endpoint (in us-east-1 if you care) and any (valid)
+    region setting will just send you there.  It is entirely safe to set it to
+    None as well.
+
+:depends: boto3
+'''
+
+# keep lint from choking on _get_conn and _cache_id
+#pylint: disable=E0602
+
+# Import Python libs
+from __future__ import absolute_import
+import logging
+import time
+
+# Import Salt libs
+import salt.utils.boto3
+import salt.utils.compat
+from salt.exceptions import SaltInvocationError, CommandExecutionError
+
+log = logging.getLogger(__name__)
+
+# Import third party libs
+try:
+    #pylint: disable=unused-import
+    import boto3
+    #pylint: enable=unused-import
+    from botocore.exceptions import ClientError
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist and if boto libraries are greater than
+    a given version.
+    '''
+    if not HAS_BOTO3:
+        return (False, 'The boto3_route53 module could not be loaded: boto3 libraries not found')
+    return True
+
+
+def __init__(opts):
+    salt.utils.compat.pack_dunder(__name__)
+    if HAS_BOTO3:
+        __utils__['boto3.assign_funcs'](__name__, 'route53')
+
+
+def _collect_results(func, item, args, marker='Marker', nextmarker='NextMarker'):
+    ret = []
+    Marker = args.get(marker, '')
+    tries = 10
+    while Marker is not None:
+        try:
+            r = func(**args)
+        except ClientError as e:
+            if tries and e.response.get('Error', {}).get('Code') == 'Throttling':
+                # Rate limited - retry
+                log.debug('Throttled by AWS API.')
+                time.sleep(3)
+                tries -= 1
+                continue
+            log.error('Could not collect results from {0}(): {1}'.format(func, str(e)))
+            return []
+        i = r.get(item, []) if item else r
+        i.pop('ResponseMetadata', None) if isinstance(i, dict) else None
+        ret += i if isinstance(i, list) else [i]
+        Marker = r.get(nextmarker)
+        args.update({marker: Marker})
+    return ret
+
+
+def _wait_for_sync(change, conn, tries=10, sleep=20):
+    for retry in range(1, tries+1):
+        log.info('Getting route53 status (attempt {0})'.format(retry))
+        try:
+            status = conn.get_change(Id=change)['ChangeInfo']['Status']
+        except ClientError as e:
+            if e.response.get('Error', {}).get('Code') == 'Throttling':
+                log.debug('Throttled by AWS API.')
+            else:
+                raise e
+        if status == 'INSYNC':
+            return True
+        time.sleep(sleep)
+    log.error('Timed out waiting for Route53 INSYNC status.')
+    return False
+
+
+def find_hosted_zone(Id=None, Name=None, PrivateZone=None,
+                     region=None, key=None, keyid=None, profile=None):
+    '''
+    Find a hosted zone with the given characteristics.
+
+    Id
+        The unique Zone Identifier for the Hosted Zone.  Exclusive with Name.
+
+    Name
+        The domain name associated with the Hosted Zone.  Exclusive with Id.
+        Note this has the potential to match more then one hosted zone (e.g. a public and a private
+        if both exist) which will raise an error unless PrivateZone has also been passed in order
+        split the different.
+
+    PrivateZone
+        Boolean - Set to True if searching for a private hosted zone.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        Dict, or pillar key pointing to a dict, containing AWS region/key/keyid.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto3_route53.find_hosted_zone Name=salt.org. \
+                profile='{"region": "us-east-1", "keyid": "A12345678AB", "key": "xblahblahblah"}'
+    '''
+    if not _exactly_one((Id, Name)):
+        raise SaltInvocationError('Exactly one of either Id or Name is required.')
+    if PrivateZone is not None and not isinstance(PrivateZone, bool):
+        raise SaltInvocationError('If set, PrivateZone must be a bool (e.g. True / False).')
+    if Id:
+        ret = get_hosted_zone(Id, region=region, key=key, keyid=keyid, profile=profile)
+    else:
+        ret = get_hosted_zones_by_domain(Name, region=region, key=key, keyid=keyid, profile=profile)
+    if PrivateZone is not None:
+        ret = [m for m in ret if m['HostedZone']['Config']['PrivateZone'] is PrivateZone]
+    if len(ret) > 1:
+        log.error('Request matched more than one Hosted Zone ({0}).  Refine your criteria and try '
+                  'again.'.format([z['HostedZone']['Id'] for z in ret]))
+        ret = []
+    return ret
+
+
+def get_hosted_zone(Id, region=None, key=None, keyid=None, profile=None):
+    '''
+    Return detailed info about the given zone.
+
+    Id
+        The unique Zone Identifier for the Hosted Zone.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        Dict, or pillar key pointing to a dict, containing AWS region/key/keyid.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto3_route53.get_hosted_zone Z1234567690 \
+                profile='{"region": "us-east-1", "keyid": "A12345678AB", "key": "xblahblahblah"}'
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    args = {'Id': Id}
+    return _collect_results(conn.get_hosted_zone, None, args)
+
+
+def get_hosted_zones_by_domain(Name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Find any zones with the given domain name and return detailed info about them.
+    Note that this can return multiple Route53 zones, since a domain name can be used in
+    both public and private zones.
+
+    Name
+        The domain name associated with the Hosted Zone(s).
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        Dict, or pillar key pointing to a dict, containing AWS region/key/keyid.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto3_route53.get_hosted_zones_by_domain salt.org. \
+                profile='{"region": "us-east-1", "keyid": "A12345678AB", "key": "xblahblahblah"}'
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    zones = [z for z in _collect_results(conn.list_hosted_zones, 'HostedZones', {})
+            if z['Name'] == Name ]
+    ret = []
+    for z in zones:
+        ret += get_hosted_zone(Id=z['Id'], region=region, key=key, keyid=keyid, profile=profile)
+    return ret
+
+
+def list_hosted_zones(DelegationSetId=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Return detailed info about all zones in the bound account.
+
+    DelegationSetId
+        If you're using reusable delegation sets and you want to list all of the hosted zones that
+        are associated with a reusable delegation set, specify the ID of that delegation set.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        Dict, or pillar key pointing to a dict, containing AWS region/key/keyid.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto3_route53.describe_hosted_zones \
+                profile='{"region": "us-east-1", "keyid": "A12345678AB", "key": "xblahblahblah"}'
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    args = {'DelegationSetId': DelegationSetId} if DelegationSetId else {}
+    return _collect_results(conn.list_hosted_zones, 'HostedZones', args)
+
+
+def create_hosted_zone(Name, VPCId=None, VPCName=None, VPCRegion=None, CallerReference=None,
+                       Comment='', PrivateZone=False, DelegationSetId=None,
+                       region=None, key=None, keyid=None, profile=None):
+    '''
+    Create a new Route53 Hosted Zone. Returns a Python data structure with information about the
+    newly created Hosted Zone.
+
+    Name
+        The name of the domain. This should be a fully-specified domain, and should terminate with
+        a period. This is the name you have registered with your DNS registrar. It is also the name
+        you will delegate from your registrar to the Amazon Route 53 delegation servers returned in
+        response to this request.
+
+    VPCId
+        When creating a private hosted zone, either the VPC ID or VPC Name to associate with is
+        required.  Exclusive with VPCName.  Ignored if passed for a non-private zone.
+
+    VPCName
+        When creating a private hosted zone, either the VPC ID or VPC Name to associate with is
+        required.  Exclusive with VPCId.  Ignored if passed for a non-private zone.
+
+    VPCRegion
+        When creating a private hosted zone, the region of the associated VPC is required.  If not
+        provided, an effort will be made to determine it from VPCId or VPCName, if possible.  If
+        this fails, you'll need to provide an explicit value for this option.  Ignored if passed for
+        a non-private zone.
+
+    CallerReference
+        A unique string that identifies the request and that allows create_hosted_zone() calls to be
+        retried without the risk of executing the operation twice.  This is a required parameter
+        when creating new Hosted Zones.  Maximum length of 128.
+
+    Comment
+        Any comments you want to include about the hosted zone.
+
+    PrivateZone
+        Boolean - Set to True if creating a private hosted zone.
+
+    DelegationSetId
+        If you want to associate a reusable delegation set with this hosted zone, the ID that Amazon
+        Route 53 assigned to the reusable delegation set when you created it.  Note that XXX TODO
+        create_delegation_set() is not yet implemented, so you'd need to manually create any
+        delegation sets before utilizing this.
+
+    region
+        Region endpoint to connect to.
+
+    key
+        AWS key to bind with.
+
+    keyid
+        AWS keyid to bind with.
+
+    profile
+        Dict, or pillar key pointing to a dict, containing AWS region/key/keyid.
+
+    CLI Example::
+
+        salt myminion boto3_route53.create_hosted_zone example.org.
+    '''
+    if not Name.endswith('.'):
+        raise SaltInvocationError('Domain must be fully-qualified, complete with trailing period.')
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    deets = find_hosted_zone(Name=Name, PrivateZone=PrivateZone,
+                             region=region, key=key, keyid=keyid, profile=profile)
+    if deets:
+        log.info('Route 53 hosted zone {0} already exists.  You may want to pass e.g. '
+                 "'PrivateZone=True' or similar...".format(Name))
+        return None
+    args = {
+            'Name': Name,
+            'CallerReference': CallerReference,
+            'HostedZoneConfig': {
+              'Comment': Comment,
+              'PrivateZone': PrivateZone
+            }
+          }
+    args.update({'DelegationSetId': DelegationSetId}) if DelegationSetId else None
+    if PrivateZone:
+        if not _exactly_one((VPCName, VPCId)):
+            raise SaltInvocationError('Either VPCName or VPCId is required when creating a '
+                                      'private zone.')
+        vpcs = __salt__['boto_vpc.describe_vpcs'](
+                vpc_id=VPCId, name=VPCName, region=region, key=key,
+                keyid=keyid, profile=profile).get('vpcs', [])
+        if VPCRegion and vpcs:
+            vpcs = [v for v in vpcs if v['region'] == VPCRegion]
+        if not vpcs:
+            log.error('Private zone requested but no VPC matching given criteria found.')
+            return None
+        if len(vpcs) > 1:
+            log.error('Private zone requested but multiple VPCs matching given criteria found: '
+                      '{0}.'.format([v['id'] for v in vpcs]))
+            return None
+        vpc = vpcs[0]
+        if VPCName:
+            VPCId = vpc['id']
+        if not VPCRegion:
+            VPCRegion = vpc['region']
+        args.update({'VPC': {'VPCId': VPCId, 'VPCRegion': VPCRegion}})
+    else:
+        if any((VPCId, VPCName, VPCRegion)):
+            log.info('Options VPCId, VPCName, and VPCRegion are ignored when creating '
+                     'non-private zones.')
+    tries = 10
+    while tries:
+        try:
+            r = conn.create_hosted_zone(**args)
+            r.pop('ResponseMetadata', None)
+            if _wait_for_sync(r['ChangeInfo']['Id'], conn):
+                return [r]
+            return []
+        except ClientError as e:
+            if tries and e.response.get('Error', {}).get('Code') == 'Throttling':
+                log.debug('Throttled by AWS API.')
+                time.sleep(3)
+                retries -= 1
+                continue
+            log.error('Failed to create hosted zone {0}: {1}'.format(Name, str(e)))
+            return []
+    return []
+
+
+def update_hosted_zone_comment(Id=None, Name=None, Comment=None, PrivateZone=None,
+                               region=None, key=None, keyid=None, profile=None):
+    '''
+    Update the comment on an existing Route 53 hosted zone.
+
+    Id
+        The unique Zone Identifier for the Hosted Zone.
+
+    Name
+        The domain name associated with the Hosted Zone(s).
+
+    Comment
+        Any comments you want to include about the hosted zone.
+
+    PrivateZone
+        Boolean - Set to True if changing a private hosted zone.
+
+    CLI Example::
+
+        salt myminion boto3_route53.update_hosted_zone_comment Name=example.org. \
+                Comment="This is an example comment for an example zone"
+    '''
+    if not _exactly_one((Id, Name)):
+        raise SaltInvocationError('Exactly one of either Id or Name is required.')
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if Name:
+        args = {'Name': Name, 'PrivateZone': PrivateZone, 'region': region,
+                'key': key, 'keyid': keyid, 'profile': profile}
+        zone = find_hosted_zone(**args)
+        if not zone:
+            log.error("Couldn't resolve domain name {0} to a hosted zone ID.".format(Name))
+            return []
+        Id = zone[0]['HostedZone']['Id']
+    tries = 10
+    while tries:
+        try:
+            r = conn.update_hosted_zone_comment(Id=Id, Comment=Comment)
+            r.pop('ResponseMetadata', None)
+            return [r]
+        except ClientError as e:
+            if tries and e.response.get('Error', {}).get('Code') == 'Throttling':
+                log.debug('Throttled by AWS API.')
+                time.sleep(3)
+                retries -= 1
+                continue
+            log.error('Failed to update comment on hosted zone {0}: {1}'.format(
+                      Name or Id, str(e)))
+    return []
+
+
+def associate_vpc_with_hosted_zone(HostedZoneId=None, Name=None, VPCId=None,
+                                   VPCName=None, VPCRegion=None, Comment=None,
+                                   region=None, key=None, keyid=None, profile=None):
+    '''
+    Associates an Amazon VPC with a private hosted zone.
+
+    To perform the association, the VPC and the private hosted zone must already exist. You can't
+    convert a public hosted zone into a private hosted zone.  If you want to associate a VPC from
+    one AWS account with a zone from a another, the AWS account owning the hosted zone must first
+    submit a CreateVPCAssociationAuthorization (using create_vpc_association_authorization() or by
+    other means, such as the AWS console).  With that done, the account owning the VPC can then call
+    associate_vpc_with_hosted_zone() to create the association.
+
+    Note that if both sides happen to be within the same account, associate_vpc_with_hosted_zone()
+    is enough on its own, and there is no need for the CreateVPCAssociationAuthorization step.
+
+    Also note that looking up hosted zones by name (e.g. using the Name parameter) only works
+    within a single account - if you're associating a VPC to a zone in a different account, as
+    outlined above, you unfortunately MUST use the HostedZoneId parameter exclusively.
+
+    HostedZoneId
+        The unique Zone Identifier for the Hosted Zone.
+
+    Name
+        The domain name associated with the Hosted Zone(s).
+
+    VPCId
+        When working with a private hosted zone, either the VPC ID or VPC Name to associate with is
+        required.  Exclusive with VPCName.
+
+    VPCName
+        When working with a private hosted zone, either the VPC ID or VPC Name to associate with is
+        required.  Exclusive with VPCId.
+
+    VPCRegion
+        When working with a private hosted zone, the region of the associated VPC is required.  If
+        not provided, an effort will be made to determine it from VPCId or VPCName, if possible.  If
+        this fails, you'll need to provide an explicit value for VPCRegion.
+
+    Comment
+        Any comments you want to include about the change being made.
+
+    CLI Example::
+
+        salt myminion boto3_route53.associate_vpc_with_hosted_zone \
+                    Name=example.org. VPCName=myVPC \
+                    VPCRegion=us-east-1 Comment="Whoo-hoo!  I added another VPC."
+
+    '''
+    if not _exactly_one((HostedZoneId, Name)):
+        raise SaltInvocationError('Exactly one of either HostedZoneId or Name is required.')
+    if not _exactly_one((VPCId, VPCName)):
+        raise SaltInvocationError('Exactly one of either VPCId or VPCName is required.')
+    if Name:
+        # {'PrivateZone': True} because you can only associate VPCs with private hosted zones.
+        args = {'Name': Name, 'PrivateZone': True, 'region': region,
+                'key': key, 'keyid': keyid, 'profile': profile}
+        zone = find_hosted_zone(**args)
+        if not zone:
+            log.error("Couldn't resolve domain name {0} to a private hosted zone"
+                      'ID.'.format(Name))
+            return False
+        HostedZoneId = zone[0]['HostedZone']['Id']
+    vpcs = __salt__['boto_vpc.describe_vpcs'](vpc_id=VPCId, name=VPCName, region=region, key=key,
+                                              keyid=keyid, profile=profile).get('vpcs', [])
+    if VPCRegion and vpcs:
+        vpcs = [v for v in vpcs if v['region'] == VPCRegion]
+    if not vpcs:
+        log.error('No VPC matching the given criteria found.')
+        return False
+    if len(vpcs) > 1:
+        log.error('Multiple VPCs matching the given criteria found: {0}.'
+                  ''.format(', '.join([v['id'] for v in vpcs])))
+        return False
+    vpc = vpcs[0]
+    if VPCName:
+        VPCId = vpc['id']
+    if not VPCRegion:
+        VPCRegion = vpc['region']
+    args = {'HostedZoneId': HostedZoneId, 'VPC': {'VPCId': VPCId, 'VPCRegion': VPCRegion}}
+    args.update({'Comment': Comment}) if Comment is not None else None
+
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    tries = 10
+    while tries:
+        try:
+            r = conn.associate_vpc_with_hosted_zone(**args)
+            return _wait_for_sync(r['ChangeInfo']['Id'], conn)
+        except ClientError as e:
+            if tries and e.response.get('Error', {}).get('Code') == 'Throttling':
+                log.debug('Throttled by AWS API.')
+                time.sleep(3)
+                retries -= 1
+                continue
+            log.error('Failed to associate VPC {0} with hosted zone {1}: {2}'.format(
+                      VPCName or VPCId, Name or HostedZoneId, str(e)))
+    return False
+
+
+def diassociate_vpc_from_hosted_zone(HostedZoneId=None, Name=None, VPCId=None,
+                                     VPCName=None, VPCRegion=None, Comment=None,
+                                     region=None, key=None, keyid=None, profile=None):
+    '''
+    Disassociates an Amazon VPC from a private hosted zone.
+
+    You can't disassociate the last VPC from a private hosted zone.  You also can't convert a
+    private hosted zone into a public hosted zone.
+
+    Note that looking up hosted zones by name (e.g. using the Name parameter) only works XXX FACTCHECK
+    within a single AWS account - if you're disassociating a VPC in one account from a hosted zone
+    in a different account you unfortunately MUST use the HostedZoneId parameter exclusively. XXX FIXME DOCU
+
+    HostedZoneId
+        The unique Zone Identifier for the Hosted Zone.
+
+    Name
+        The domain name associated with the Hosted Zone(s).
+
+    VPCId
+        When working with a private hosted zone, either the VPC ID or VPC Name to associate with is
+        required.  Exclusive with VPCName.
+
+    VPCName
+        When working with a private hosted zone, either the VPC ID or VPC Name to associate with is
+        required.  Exclusive with VPCId.
+
+    VPCRegion
+        When working with a private hosted zone, the region of the associated VPC is required.  If
+        not provided, an effort will be made to determine it from VPCId or VPCName, if possible.  If
+        this fails, you'll need to provide an explicit value for VPCRegion.
+
+    Comment
+        Any comments you want to include about the change being made.
+
+    CLI Example::
+
+        salt myminion boto3_route53.disassociate_vpc_from_hosted_zone \
+                    Name=example.org. VPCName=myVPC \
+                    VPCRegion=us-east-1 Comment="Whoops!  Don't wanna talk to this-here zone no more."
+
+    '''
+    if not _exactly_one((HostedZoneId, Name)):
+        raise SaltInvocationError('Exactly one of either HostedZoneId or Name is required.')
+    if not _exactly_one((VPCId, VPCName)):
+        raise SaltInvocationError('Exactly one of either VPCId or VPCName is required.')
+    if Name:
+        # {'PrivateZone': True} because you can only associate VPCs with private hosted zones.
+        args = {'Name': Name, 'PrivateZone': True, 'region': region,
+                'key': key, 'keyid': keyid, 'profile': profile}
+        zone = find_hosted_zone(**args)
+        if not zone:
+            log.error("Couldn't resolve domain name {0} to a private hosted zone"
+                      'ID.'.format(Name))
+            return False
+        HostedZoneId = zone[0]['HostedZone']['Id']
+    vpcs = __salt__['boto_vpc.describe_vpcs'](vpc_id=VPCId, name=VPCName, region=region, key=key,
+                                              keyid=keyid, profile=profile).get('vpcs', [])
+    if VPCRegion and vpcs:
+        vpcs = [v for v in vpcs if v['region'] == VPCRegion]
+    if not vpcs:
+        log.error('No VPC matching the given criteria found.')
+        return False
+    if len(vpcs) > 1:
+        log.error('Multiple VPCs matching the given criteria found: {0}.'
+                  ''.format(', '.join([v['id'] for v in vpcs])))
+        return False
+    vpc = vpcs[0]
+    if VPCName:
+        VPCId = vpc['id']
+    if not VPCRegion:
+        VPCRegion = vpc['region']
+    args = ({'HostedZoneId': HostedZoneId, 'VPC': {'VPCId': VPCId, 'VPCRegion': VPCRegion}})
+    args.update({'Comment': Comment}) if Comment is not None else None
+
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    tries = 10
+    while tries:
+        try:
+            r = conn.disassociate_vpc_from_hosted_zone(**args)
+            return _wait_for_sync(r['ChangeInfo']['Id'], conn)
+        except ClientError as e:
+            if tries and e.response.get('Error', {}).get('Code') == 'Throttling':
+                log.debug('Throttled by AWS API.')
+                time.sleep(3)
+                retries -= 1
+                continue
+            log.error('Failed to associate VPC {0} with hosted zone {1}: {2}'.format(
+                      VPCName or VPCId, Name or HostedZoneId, str(e)))
+    return False
+
+
+def create_vpc_association_authorization(*args, **kwargs):
+    '''
+    unimplemented
+    '''
+    pass
+
+
+def delete_vpc_association_authorization(*args, **kwargs):
+    '''
+    unimplemented
+    '''
+    pass
+
+
+def list_vpc_association_authorizations(*args, **kwargs):
+    '''
+    unimplemented
+    '''
+    pass
+
+
+def delete_hosted_zone(Id, region=None, key=None, keyid=None, profile=None):
+    '''
+    Delete a Route53 hosted zone.
+
+    CLI Example::
+
+        salt myminion boto3_route53.delete_hosted_zone Z1234567890
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        r = conn.delete_hosted_zone(Id=Id)
+        return _wait_for_sync(r['ChangeInfo']['Id'], conn)
+    except ClientError as e:
+        log.error('Failed to delete hosted zone {0}: {1}'.format(Id, str(e)))
+    return False
+
+
+def delete_hosted_zone_by_domain(Name, PrivateZone=None, region=None, key=None, keyid=None,
+                                 profile=None):
+    '''
+    Delete a Route53 hosted zone by domain name, and PrivateZone status if provided.
+
+    CLI Example::
+
+        salt myminion boto3_route53.delete_hosted_zone_by_domain example.org.
+    '''
+    args = {'Name': Name, 'PrivateZone': PrivateZone,
+            'region': region, 'key': key, 'keyid': keyid, 'profile': profile}
+    # Be extra pedantic in the service of safety - if public/private is not provided and the domain
+    # name resolves to both, fail and require them to declare it explicitly.
+    zone = find_hosted_zone(**args)
+    if not zone:
+        log.error("Couldn't resolve domain name {0} to a hosted zone ID.".format(Name))
+        return False
+    Id = zone[0]['HostedZone']['Id']
+    return delete_hosted_zone(Id=Id, region=region, key=key, keyid=keyid, profile=profile)
+
+
+def get_resource_records(HostedZoneId=None, Name=None, StartRecordName=None,
+                         StartRecordType=None, PrivateZone=None,
+                         region=None, key=None, keyid=None, profile=None):
+    '''
+    Get all resource records from a given zone matching the provided StartRecordName (if given) or all
+    records in the zone (if not), optionally filtered by a specific StartRecordType.  This will return
+    any and all RRs matching, regardless of their special AWS flavors (weighted, geolocation, alias,
+    etc.) so your code should be prepared for potentially large numbers of records back from this
+    function - for example, if you've created a complex geolocation mapping with lots of entries all
+    over the world providing the same server name to many different regional clients.
+
+    If you want EXACTLY ONE record to operate on, you'll need to implement any logic required to
+    pick the specific RR you care about from those returned.
+
+    Note that if you pass in Name without providing a value for PrivateZone (either True or
+    False), CommandExecutionError can be raised in the case of both public and private zones
+    matching the domain. XXX FIXME DOCU
+
+    CLI example::
+
+        salt myminion boto3_route53.get_records test.example.org example.org A
+    '''
+    if not _exactly_one((HostedZoneId, Name)):
+        raise SaltInvocationError('Exactly one of either HostedZoneId or Name must '
+                                  'be provided.')
+    if Name:
+        args = {'Name': Name, 'region': region, 'key': key, 'keyid': keyid,
+                'profile': profile}
+        args.update({'PrivateZone': PrivateZone}) if PrivateZone is not None else None
+        zone = find_hosted_zone(**args)
+        if not zone:
+            log.error("Couldn't resolve domain name {0} to a hosted zone ID.".format(Name))
+            return []
+        HostedZoneId = zone[0]['HostedZone']['Id']
+
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    ret = []
+    next_rr_name = StartRecordName
+    next_rr_type = StartRecordType
+    next_rr_id = None
+    done = False
+    while True:
+        if done:
+            return ret
+        args = {'HostedZoneId': HostedZoneId}
+        args.update({'StartRecordName': next_rr_name}) if next_rr_name else None
+        # Grrr, can't specify type unless name is set...  We'll do this via filtering later instead
+        args.update({'StartRecordType': next_rr_type}) if next_rr_name and next_rr_type else None
+        args.update({'StartRecordIdentifier': next_rr_id}) if next_rr_id else None
+        try:
+            r = conn.list_resource_record_sets(**args)
+            rrs = r['ResourceRecordSets']
+            next_rr_name = r.get('NextRecordName')
+            next_rr_type = r.get('NextRecordType')
+            next_rr_id = r.get('NextRecordIdentifier')
+            for rr in rrs:
+                if StartRecordName and rr['Name'] != StartRecordName:
+                    done = True
+                    break
+                if StartRecordType and rr['Type'] != StartRecordType:
+                    if StartRecordName:
+                        done = True
+                        break
+                    else:
+                        # We're filtering by type alone, and there might be more later, so...
+                        continue
+                ret += [rr]
+            if not next_rr_name:
+                done = True
+        except ClientError as e:
+            # Try forever on a simple thing like this...
+            if e.response.get('Error', {}).get('Code') == 'Throttling':
+                log.debug('Throttled by AWS API.')
+                time.sleep(3)
+                continue
+            raise e
+
+
+def change_resource_record_sets(HostedZoneId=None, Name=None,
+                                PrivateZone=None, ChangeBatch=None,
+                                region=None, key=None, keyid=None, profile=None):
+    '''
+    Ugh!!!  Not gonna try to reproduce this mess in here - just pass what we get to AWS and let it
+    decide if it's valid or not... :)
+
+    See the `AWS Route53 API docs`__ as well as the `Boto3 documentation`__ for all the ugly details...
+
+    .. __: https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html
+    .. __: http://boto3.readthedocs.io/en/latest/reference/services/route53.html#Route53.Client.change_resource_record_sets
+
+    .. code-block:: json
+    ChangeBatch={
+        'Comment': 'string',
+        'Changes': [
+            {
+                'Action': 'CREATE'|'DELETE'|'UPSERT',
+                'ResourceRecordSet': {
+                    'Name': 'string',
+                    'Type': 'SOA'|'A'|'TXT'|'NS'|'CNAME'|'MX'|'NAPTR'|'PTR'|'SRV'|'SPF'|'AAAA',
+                    'SetIdentifier': 'string',
+                    'Weight': 123,
+                    'Region': 'us-east-1'|'us-east-2'|'us-west-1'|'us-west-2'|'ca-central-1'|'eu-west-1'|'eu-west-2'|'eu-central-1'|'ap-southeast-1'|'ap-southeast-2'|'ap-northeast-1'|'ap-northeast-2'|'sa-east-1'|'cn-north-1'|'ap-south-1',
+                    'GeoLocation': {
+                        'ContinentCode': 'string',
+                        'CountryCode': 'string',
+                        'SubdivisionCode': 'string'
+                    },
+                    'Failover': 'PRIMARY'|'SECONDARY',
+                    'TTL': 123,
+                    'ResourceRecords': [
+                        {
+                            'Value': 'string'
+                        },
+                    ],
+                    'AliasTarget': {
+                        'HostedZoneId': 'string',
+                        'DNSName': 'string',
+                        'EvaluateTargetHealth': True|False
+                    },
+                    'HealthCheckId': 'string',
+                    'TrafficPolicyInstanceId': 'string'
+                }
+            },
+        ]
+    }
+
+    '''
+    if HostedZoneId and Name:
+        raise SaltInvocationError('Only one of either HostZoneId or Name may '
+                                  'be provided. Got "%s" and "%s"' % (HostedZoneId, Name))
+    if not _exactly_one((HostedZoneId, Name)):
+        raise SaltInvocationError('Exactly one of either HostZoneId or Name must '
+                                  'be provided.')
+    if Name:
+        args = {'Name': Name, 'region': region, 'key': key, 'keyid': keyid,
+                'profile': profile}
+        args.update({'PrivateZone': PrivateZone}) if PrivateZone is not None else None
+        zone = find_hosted_zone(**args)
+        if not zone:
+            log.error("Couldn't resolve domain name {0} to a hosted zone ID.".format(Name))
+            return []
+        Id = zone[0]['HostedZone']['Id']
+
+    args = {'HostedZoneId': Id, 'ChangeBatch': ChangeBatch}
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    tries = 20  # A bit more headroom
+    while tries:
+        try:
+            r = conn.change_resource_record_sets(**args)
+            return _wait_for_sync(r['ChangeInfo']['Id'], conn, 30)  # And a little extra time here
+        except ClientError as e:
+            if tries and e.response.get('Error', {}).get('Code') == 'Throttling':
+                log.debug('Throttled by AWS API.')
+                time.sleep(3)
+                retries -= 1
+                continue
+            log.error('Failed to apply requested changes to the hosted zone {0}: {1}'.format(
+                    Name or Id, str(e)))
+    return False

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -47,6 +47,7 @@ Execution module for Amazon Route53 written against Boto 3
 
 # keep lint from choking on _get_conn and _cache_id
 #pylint: disable=E0602
+#pylint: disable=E0611
 
 # Import Python libs
 from __future__ import absolute_import
@@ -56,7 +57,7 @@ import time
 # Import Salt libs
 import salt.utils.boto3
 import salt.utils.compat
-from salt.exceptions import SaltInvocationError, CommandExecutionError
+from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
 
@@ -243,7 +244,7 @@ def get_hosted_zones_by_domain(Name, region=None, key=None, keyid=None, profile=
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     zones = [z for z in _collect_results(conn.list_hosted_zones, 'HostedZones', {})
-            if z['Name'] == Name ]
+            if z['Name'] == Name]
     ret = []
     for z in zones:
         ret += get_hosted_zone(Id=z['Id'], region=region, key=key, keyid=keyid, profile=profile)
@@ -832,12 +833,8 @@ def change_resource_record_sets(HostedZoneId=None, Name=None,
     }
 
     '''
-    if HostedZoneId and Name:
-        raise SaltInvocationError('Only one of either HostZoneId or Name may '
-                                  'be provided. Got "%s" and "%s"' % (HostedZoneId, Name))
     if not _exactly_one((HostedZoneId, Name)):
-        raise SaltInvocationError('Exactly one of either HostZoneId or Name must '
-                                  'be provided.')
+        raise SaltInvocationError('Exactly one of either HostZoneId or Name must be provided.')
     if Name:
         args = {'Name': Name, 'region': region, 'key': key, 'keyid': keyid,
                 'profile': profile}

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -57,7 +57,7 @@ import time
 import salt.utils.boto3
 import salt.utils.compat
 from salt.exceptions import SaltInvocationError
-log = logging.getLogger(__name__)
+log = logging.getLogger(__name__)  # pylint: disable=W1699
 
 # Import third party libs
 try:

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -841,9 +841,9 @@ def change_resource_record_sets(HostedZoneId=None, Name=None,
         if not zone:
             log.error("Couldn't resolve domain name {0} to a hosted zone ID.".format(Name))
             return []
-        Id = zone[0]['HostedZone']['Id']
+        HostedZoneId = zone[0]['HostedZone']['Id']
 
-    args = {'HostedZoneId': Id, 'ChangeBatch': ChangeBatch}
+    args = {'HostedZoneId': HostedZoneId, 'ChangeBatch': ChangeBatch}
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     tries = 20  # A bit more headroom
     while tries:
@@ -857,5 +857,5 @@ def change_resource_record_sets(HostedZoneId=None, Name=None,
                 retries -= 1
                 continue
             log.error('Failed to apply requested changes to the hosted zone {0}: {1}'.format(
-                    Name or Id, str(e)))
+                    Name or HostedZoneId, str(e)))
     return False

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -46,8 +46,7 @@ Execution module for Amazon Route53 written against Boto 3
 '''
 
 # keep lint from choking on _get_conn and _cache_id
-#pylint: disable=E0602
-#pylint: disable=E0611
+#pylint: disable=E0602,W0106
 
 # Import Python libs
 from __future__ import absolute_import
@@ -58,7 +57,6 @@ import time
 import salt.utils.boto3
 import salt.utils.compat
 from salt.exceptions import SaltInvocationError
-
 log = logging.getLogger(__name__)
 
 # Import third party libs

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -645,25 +645,25 @@ def diassociate_vpc_from_hosted_zone(HostedZoneId=None, Name=None, VPCId=None,
     return False
 
 
-def create_vpc_association_authorization(*args, **kwargs):
-    '''
-    unimplemented
-    '''
-    pass
+#def create_vpc_association_authorization(*args, **kwargs):
+#    '''
+#    unimplemented
+#    '''
+#    pass
 
 
-def delete_vpc_association_authorization(*args, **kwargs):
-    '''
-    unimplemented
-    '''
-    pass
+#def delete_vpc_association_authorization(*args, **kwargs):
+#    '''
+#    unimplemented
+#    '''
+#    pass
 
 
-def list_vpc_association_authorizations(*args, **kwargs):
-    '''
-    unimplemented
-    '''
-    pass
+#def list_vpc_association_authorizations(*args, **kwargs):
+#    '''
+#    unimplemented
+#    '''
+#    pass
 
 
 def delete_hosted_zone(Id, region=None, key=None, keyid=None, profile=None):
@@ -786,13 +786,17 @@ def change_resource_record_sets(HostedZoneId=None, Name=None,
                                 PrivateZone=None, ChangeBatch=None,
                                 region=None, key=None, keyid=None, profile=None):
     '''
-    Ugh!!!  Not gonna try to reproduce this mess in here - just pass what we get to AWS and let it
-    decide if it's valid or not... :)
+    Ugh!!!  Not gonna try to reproduce and validatethis mess in here - just pass what we get to AWS
+    and let it decide if it's valid or not...
 
-    See the `AWS Route53 API docs`__ as well as the `Boto3 documentation`__ for all the ugly details...
+    See the `AWS Route53 API docs`__ as well as the `Boto3 documentation`__ for all the details...
 
     .. __: https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html
     .. __: http://boto3.readthedocs.io/en/latest/reference/services/route53.html#Route53.Client.change_resource_record_sets
+
+    The syntax for a ChangeBatch parameter is as follows, but note that the permutations of allowed
+    parameters and combinations thereof are quite varied, so perusal of the above linked docs is
+    highly recommended for any non-trival configurations.
 
     .. code-block:: json
     ChangeBatch={
@@ -830,6 +834,24 @@ def change_resource_record_sets(HostedZoneId=None, Name=None,
         ]
     }
 
+    CLI Example:
+
+    .. code-block:: bash
+
+        foo='{
+               "Name": "my-cname.example.org.",
+               "TTL": 600,
+               "Type": "CNAME",
+               "ResourceRecords": [
+                 {
+                   "Value": "my-host.example.org"
+                 }
+               ]
+             }'
+        foo=`echo $foo`  # Remove newlines
+        salt myminion boto3_route53.change_resource_record_sets DomainName=example.org. \
+                keyid=A1234567890ABCDEF123 key=xblahblahblah \
+                ChangeBatch="{'Changes': [{'Action': 'UPSERT', 'ResourceRecordSet': $foo}]}"
     '''
     if not _exactly_one((HostedZoneId, Name)):
         raise SaltInvocationError('Exactly one of either HostZoneId or Name must be provided.')

--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -141,7 +141,7 @@ def describe_hosted_zones(zone_id=None, domain_name=None, region=None,
     .. code-block:: bash
 
         salt myminion boto_route53.describe_hosted_zones domain_name=foo.bar.com. \
-                profile='{"region": "us-east-1", "keyd": "A12345678AB", "key": "xblahblahblah"}'
+                profile='{"region": "us-east-1", "keyid": "A12345678AB", "key": "xblahblahblah"}'
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     if zone_id and domain_name:

--- a/salt/states/boto3_route53.py
+++ b/salt/states/boto3_route53.py
@@ -1,0 +1,826 @@
+# -*- coding: utf-8 -*-
+'''
+Manage Route53 records with Boto 3
+
+.. versionadded:: Nitrogen
+
+Create and delete Route53 records. Be aware that this interacts with Amazon's
+services, and so may incur charges.
+
+This module uses ``boto3``, which can be installed via package, or pip.
+
+This module accepts explicit route53 credentials but can also utilize
+IAM roles assigned to the instance through Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More information available `here
+<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_.
+
+If IAM roles are not used you need to specify them either in a pillar file or
+in the minion's config file:
+
+.. code-block:: yaml
+
+    route53.keyid: GKTADJGHEIQSXMKKRBJ08H
+    route53.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+It's also possible to specify ``key``, ``keyid`` and ``region`` via a profile, either
+passed in as a dict, or as a string to pull from pillars or minion config:
+
+.. code-block:: yaml
+
+    myprofile:
+      keyid: GKTADJGHEIQSXMKKRBJ08H
+      key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+      region: us-east-1
+
+.. code-block:: yaml
+
+    An exciting new AWS Route 53 Hosted Zone:
+      boto_route53.hosted_zone_present:
+        - Name: example.com.
+        - PrivateZone: true
+        - VPCs:
+          - VPCName: MyLittleVPC
+            VPCRegion: us-east-1
+          - VPCId: vpc-12345678
+        - region: us-east-1
+        - keyid: GKTADJGHEIQSXMKKRBJ08H
+        - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    mycnamerecord:
+      boto_route53.rr_present:
+        - Name: test.example.com.
+        - ResourceRecords:
+          - my-elb.us-east-1.elb.amazonaws.com.
+        - DomainName: example.com.
+        - TTL: 60
+        - Type: CNAME
+        - region: us-east-1
+        - keyid: GKTADJGHEIQSXMKKRBJ08H
+        - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import json
+import uuid
+
+# Import Salt Libs
+import salt.utils.dictupdate as dictupdate
+from salt.utils import SaltInvocationError, exactly_one
+import logging
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if boto is available.
+    '''
+    return 'boto3_route53' if 'boto3_route53.find_hosted_zone' in __salt__ else False
+
+
+def _to_aws_encoding(instring):
+    '''
+    A partial implememtation of the `AWS domain encoding`__ rules. The punycode section is
+    ignored for now, so you'll have to input any unicode characters already punycoded.
+
+    .. __: http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html
+
+    The only breakage is that we don't permit ASCII 92 ('backslash') in domain names, even though
+    AWS seems to allow it, becuase it's used to introduce octal escapes, and I can't think of a
+    good way to allow it while still parsing those escapes.  Imagine a domain name containing the
+    literal string '\134' - pathological to be sure, but allowed by AWS's rules.  If someone
+    dislikes this restriction, feel free to update this function to correctly handle such madness.
+
+    Oh, and the idea of allowing '.' (period) within a domain component (e.g. not as a separator,
+    but as part of a field) is as stupid it sounds, and is also not supported by these functions.
+    Again, if you can figure out a sensible way to make it work, more power too you.  If you
+    REALLY need this, just embed '\056' directly in your strings.  I can't promise it won't break
+    your DNS out in the real world though.
+    '''
+    outlist = []
+    printable_ascii_which_must_be_octalized = ['!', '"', '#', '$', '%', '&', "'", '(', ')', '*',
+                                               '+', ',', '/', ':', ';', '<', '=', '>', '?', '@',
+                                               '[', ']', '^', '`', '{', '|', '}', '~']
+    acceptable_points_which_must_be_octalized = [ord(c) for c in
+                                                 printable_ascii_which_must_be_octalized ]
+    acceptable_points_which_must_be_octalized += range(0, 33)     # 0-32 inclusive
+    acceptable_points_which_must_be_octalized += range(127, 256)  # 127-255 inclusive
+    # ^^^ This, BTW, is incompatible with punycode as far as I can tell, since unicode only aligns
+    # with ASCII for the first 127 code-points...  Oh well.
+    for char in instring:
+        point = ord(char)
+        octal = '\{:03o}'.format(point)
+        if point in range(65, 91):      # ASCII A-Z is 65-90 inclusive
+            point += 32                 # Convert to lowercase
+            outlist += [chr(point)]     # This is safe, since ASCII and unicode agree in this range
+        elif point in range(97, 123):   # a-z is 97-122 inclusive
+            outlist += [char]
+        elif point in range(48, 58):    # 0-9 is 48-57 inclusive
+            outlist += [char]
+        elif point in (45, 46, 95):     # ASCII hyphen, period and underscore, respectively
+            outlist += [char]
+        elif point == 92:               # Backslash is used for octal escapes
+            outlist += [char]
+        elif point in acceptable_points_which_must_be_octalized:
+            outlist += [octal]
+        else:
+            raise SaltInvocationError("Invalid Route53 domain character seen (octal {0}) in string "
+                                      "{1}.  Do you need to punycode it?".format(octal, instring))
+    ret = ''.join(outlist)
+    log.debug('Name after massaging is: {}'.format(ret))
+    return ret
+
+
+def _from_aws_encoding(string):  # XXX TODO
+    pass
+
+
+def hosted_zone_present(name, Name=None, PrivateZone=False,
+                        CallerReference=None, Comment=None, VPCs=None,
+                        region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure a hosted zone exists with the given attributes.
+
+    name
+        The name of the state definition.  This will be used as the 'CallerReference' param when
+        creating the hosted zone to help ensure idempotency.
+
+    Name
+        The name of the domain. This should be a fully-specified domain, and should terminate with a
+        period. This is the name you have registered with your DNS registrar. It is also the name
+        you will delegate from your registrar to the Amazon Route 53 delegation servers returned in
+        response to this request.  If not provided, the value of name will be used.
+
+    PrivateZone
+        Set True if creating a private hosted zone.  If true, then 'VPCs' is also required.
+
+    Comment
+        Any comments you want to include about the hosted zone.
+
+    CallerReference
+        A unique string that identifies the request and that allows create_hosted_zone() calls to be
+        retried without the risk of executing the operation twice.  This helps ensure idempotency
+        across state calls, but can cause issues if a zone is deleted and then an attempt is made
+        to recreate it with the same CallerReference.  If not provided, a unique UUID will be
+        generated at each state run, which can potentially lead to duplicate zones being created if
+        the state is run again while the previous zone creation is still in PENDING status (which
+        can occasionally take several minutes to clear).  Maximum length of 128.
+
+    VPCs
+        A list of dicts, each dict composed of a VPCRegion, and either a VPCId or a VPCName.
+        Note that this param is ONLY used if PrivateZone == True
+
+        VPCId
+            When creating a private hosted zone, either the VPC ID or VPC Name to associate with is
+            required.  Exclusive with VPCName.
+
+        VPCName
+            When creating a private hosted zone, either the VPC ID or VPC Name to associate with is
+            required.  Exclusive with VPCId.
+
+        VPCRegion
+            When creating a private hosted zone, the region of the associated VPC is required.  If
+            not provided, an effort will be made to determine it from VPCId or VPCName, if
+            possible.  This will fail if a given VPCName exists in multiple regions visible to the
+            bound account, in which case you'll need to provide an explicit value for VPCRegion.
+    '''
+    Name = Name if Name else name
+    Name = _to_aws_encoding(Name)
+
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {'old': {}, 'new': {}}}
+
+    if not PrivateZone and VPCs:
+        raise SaltInvocationError("Parameter 'VPCs' is invalid when creating a public zone.")
+    if PrivateZone and not VPCs:
+        raise SaltInvocationError("Parameter 'VPCs' is required when creating a private zone.")
+    if VPCs:
+        if not isinstance(VPCs, list):
+            raise SaltInvocationError("Parameter 'VPCs' must be a list of dicts.")
+        for v in VPCs:
+            if not isinstance(v, dict) or not exactly_one((v.get('VPCId'), v.get('VPCName'))):
+                raise SaltInvocationError("Parameter 'VPCs' must be a list of dicts, each composed "
+                                      "of either a 'VPCId' or a 'VPCName', and optionally a "
+                                      "'VPCRegion', to help distinguish between multitple matches.")
+    # Massage VPCs into something AWS will accept...
+    fixed_vpcs = []
+    if PrivateZone:
+        for v in VPCs:
+            VPCId = v.get('VPCId')
+            VPCName = v.get('VPCName')
+            VPCRegion = v.get('VPCRegion')
+            VPCs = __salt__['boto_vpc.describe_vpcs'](vpc_id=VPCId, name=VPCName, region=region,
+                    key=key, keyid=keyid, profile=profile).get( 'vpcs', [])
+            if VPCRegion and VPCs:
+                VPCs = [v for v in VPCs if v['region'] == VPCRegion]
+            if not VPCs:
+                ret['comment'] = ('A VPC matching given criteria (vpc: {0} / vpc_region: {1}) not '
+                                  'found.'.format(VPCName or VPCId, VPCRegion))
+                log.error(ret['comment'])
+                ret['result'] = False
+                return ret
+            if len(VPCs) > 1:
+                ret['comment'] = ('Multiple VPCs matching given criteria (vpc: {0} / vpc_region: '
+                                  '{1}) found: {2}.'.format(VPCName or VPCId, VPCRegion,
+                                  ', '.join([v['id'] for v in VPCs])))
+                log.error(ret['comment'])
+                ret['result'] = False
+                return ret
+            vpc = VPCs[0]
+            if VPCName:
+                VPCId = vpc['id']
+            if not VPCRegion:
+                VPCRegion = vpc['region']
+            fixed_vpcs += [{'VPCId': VPCId, 'VPCRegion': VPCRegion}]
+
+    create = False
+    update_comment = False
+    add_vpcs = []
+    del_vpcs = []
+    args = {'Name': Name, 'PrivateZone': PrivateZone,
+            'region': region, 'key': key, 'keyid': keyid, 'profile': profile}
+    zone = __salt__['boto3_route53.find_hosted_zone'](**args)
+    if not zone:
+        create = True
+        # Grrrr - can only pass one VPC when initially creating a private zone...
+        # The rest have to be added (one-by-one) later in a separate step.
+        if len(fixed_vpcs) > 1:
+            add_vpcs = fixed_vpcs[1:]
+            fixed_vpcs = fixed_vpcs[:1]
+        CallerReference = CallerReference if CallerReference else str(uuid.uuid4())
+    else:
+        # Currently the only modifiable traits about a zone are associated VPCs and the comment.
+        zone = zone[0]
+        if PrivateZone:
+            for z in zone.get('VPCs'):
+                if z not in fixed_vpcs:
+                    del_vpcs += [z]
+            for z in fixed_vpcs:
+                if z not in zone.get('VPCs'):
+                    add_vpcs += [z]
+        if zone['HostedZone']['Config'].get('Comment') != Comment:
+            update_comment = True
+
+    if not (create or add_vpcs or del_vpcs or update_comment):
+        ret['comment'] = 'Hostd Zone {0} already in desired state'.format(Name)
+        return ret
+
+    if create:
+        if __opts__['test']:
+            ret['comment'] = 'Route 53 {} hosted zone {} would be created.'.format('private' if
+                    PrivateZone else 'public', Name)
+            ret['result'] = None
+            return ret
+        newzone = __salt__['boto3_route53.create_hosted_zone'](Name=Name,
+                CallerReference=CallerReference, Comment=Comment, PrivateZone=PrivateZone,
+                VPCId=fixed_vpcs[0]['VPCId'], VPCRegion=fixed_vpcs[0]['VPCRegion'],
+                region=region, key=key, keyid=keyid, profile=profile)
+        if newzone:
+            newzone = newzone[0]
+            ret['comment'] = 'Route 53 {} hosted zone {} successfully created'.format('private' if
+                    PrivateZone else 'public', Name)
+            log.info(ret['comment'])
+            ret['changes']['new'] = newzone
+        else:
+            ret['comment'] = 'Creation of Route 53 {} hosted zone {} failed'.format('private' if
+                    PrivateZone else 'public', Name)
+            log.error(ret['comment'])
+            ret['result'] = False
+            return ret
+
+    if update_comment:
+        if __opts__['test']:
+            ret['comment'] = 'Route 53 {} hosted zone {} comment would be updated.'.format('private'
+                    if PrivateZone else 'public', Name)
+            ret['result'] = None
+            return ret
+        r = __salt__['boto3_route53.update_hosted_zone_comment'](Name=Name,
+                Comment=Comment, PrivateZone=PrivateZone, region=region, key=key, keyid=keyid,
+                profile=profile)
+        if r:
+            r = r[0]
+            msg = 'Route 53 {} hosted zone {} comment successfully updated'.format('private' if
+                    PrivateZone else 'public', Name)
+            log.info(msg)
+            ret['comment'] = '  '.join(ret['comment'], msg)
+            ret['changes']['old'] = zone
+            ret['changes']['new'] = dictupdate.update(ret['changes']['new'], r)
+        else:
+            ret['comment'] = 'Update of Route 53 {} hosted zone {} comment failed'.format('private'
+                    if PrivateZone else 'public', Name)
+            log.error(ret['comment'])
+            ret['result'] = False
+            return ret
+
+    if add_vpcs or del_vpcs:
+        if __opts__['test']:
+            ret['comment'] = 'Route 53 {} hosted zone {} associated VPCs would be updated.'.format(
+                    'private' if PrivateZone else 'public', Name)
+            ret['result'] = None
+            return ret
+        all_added = True
+        all_deled = True
+        for vpc in add_vpcs:  # Add any new first to avoid the "can't delete last VPC" errors.
+            r = __salt__['boto3_route53.associate_vpc_with_hosted_zone'](Name=Name,
+                    VPCId=vpc['VPCId'], VPCRegion=vpc['VPCRegion'], region=region, key=key,
+                    keyid=keyid, profile=profile)
+            if not r:
+                all_added = False
+        for vpc in del_vpcs:
+            r = __salt__['boto3_route53.disassociate_vpc_from_hosted_zone'](Name=Name,
+                    VPCId=vpc['VPCId'], VPCRegion=vpc['VPCRegion'], region=region, key=key,
+                    keyid=keyid, profile=profile)
+            if not r:
+                all_deled = False
+
+        ret['changes']['old'] = zone
+        ret['changes']['new'] = __salt__['boto3_route53.find_hosted_zone'](**args)
+        if all_added and all_deled:
+            msg = 'Route 53 {} hosted zone {} associated VPCs successfully updated'.format('private'
+                    if PrivateZone else 'public', Name)
+            log.info(msg)
+            ret['comment'] = '  '.join(ret['comment'], msg)
+        else:
+            ret['comment'] = 'Update of Route 53 {} hosted zone {} associated VPCs failed'.format(
+                    'private' if PrivateZone else 'public', Name)
+            log.error(ret['comment'])
+            ret['result'] = False
+            return ret
+
+    return ret
+
+
+def hosted_zone_absent(name, Name=None, PrivateZone=False,
+                       region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure the Route53 Hostes Zone described is absent
+
+    name
+        The name of the state definition.
+
+    Name
+        The name of the domain. This should be a fully-specified domain, and should terminate with a
+        period.  If not provided, the value of name will be used.
+
+    PrivateZone
+        Set True if deleting a private hosted zone.
+
+    '''
+    Name = Name if Name else name
+
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    args = {'Name': Name, 'PrivateZone': PrivateZone, 'region': region, 'key': key,
+            'keyid': keyid, 'profile': profile}
+    zone = __salt__['boto3_route53.find_hosted_zone'](**args)
+    if not zone:
+        ret['comment'] = 'Route 53 {} hosted zone {} already absent'.format('private' if
+                PrivateZone else 'public', Name)
+        log.info(ret['comment'])
+        return ret
+    if __opts__['test']:
+        ret['comment'] = 'Route 53 {} hosted zone {} would be deleted'.format('private' if
+                PrivateZone else 'public', Name)
+        ret['result'] = None
+        return ret
+    zone = zone[0]
+    Id = zone['HostedZone']['Id']
+    if __salt__['boto3_route53.delete_hosted_zone'](Id=Id, region=region, key=key,
+            keyid=keyid, profile=profile):
+        ret['comment'] = 'Route 53 {} hosted zone {} deleted'.format('private' if PrivateZone else
+                'public', Name)
+        log.info(ret['comment'])
+        ret['changes']['old'] = zone
+        ret['changes']['new'] = None
+    else:
+        ret['comment'] = 'Failed to delete Route 53 {} hosted zone {}'.format('private' if
+                PrivateZone else 'public', Name)
+        log.info(ret['comment'])
+        ret['result'] = False
+        return ret
+
+    return ret
+
+
+def rr_present(name, HostedZoneId=None, DomainName=None, PrivateZone=False, Name=None, Type=None,
+               SetIdentifier=None, Weight=None, Region=None, GeoLocation=None, Failover=None,
+               TTL=None, ResourceRecords=None, AliasTarget=None, HealthCheckId=None,
+               TrafficPolicyInstanceId=None,
+               region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure the Route53 record is present.
+
+    name
+        The name of the state definition.  This will be used for Name if the latter is
+        not provided.
+
+    HostedZoneId
+        The ID of a zone to create the record in.  Exclusive with DomainName.
+
+    DomainName
+        The domain name of a zone to create the record in.  Exclusive with HostedZoneId.
+
+    PrivateZone
+        Set to True if the resource record should be in a private zone, False if public.
+
+    Name
+        Name of the Route 53 resource record being managed.
+
+    Type
+        The record type (A, NS, MX, TXT, etc.)
+
+    SetIdentifier
+        Valid for Weighted, Latency, Geolocation, and Failover resource record sets only.
+        An identifier that differentiates among multiple resource record sets that have the same
+        combination of DNS name and type.  The value of SetIdentifier must be unique for each
+        resource record set that has the same combination of DNS name and type. Omit SetIdentifier
+        for any other types of record sets.
+
+    Weight
+        Valid for Weighted resource record sets only.  Among resource record sets that have the
+        same combination of DNS name and type, a value that determines the proportion of DNS
+        queries that Amazon Route 53 responds to using the current resource record set. Amazon Route
+        53 calculates the sum of the weights for the resource record sets that have the same
+        combination of DNS name and type. Amazon Route 53 then responds to queries based on the
+        ratio of a resource's weight to the total.
+
+        Note the following:
+          - You must specify a value for the Weight element for every weighted resource record set.
+          - You can only specify one ResourceRecord per weighted resource record set.
+          - You can't create latency, failover, or geolocation resource record sets that have the
+            same values for the Name and Type elements as weighted resource record sets.
+          - You can create a maximum of 100 weighted resource record sets that have the same values
+            for the Name and Type elements.
+          - For weighted (but not weighted alias) resource record sets, if you set Weight to 0 for a
+            resource record set, Amazon Route 53 never responds to queries with the applicable value
+            for that resource record set.  However, if you set Weight to 0 for all resource record
+            sets that have the same combination of DNS name and type, traffic is routed to all
+            resources with equal probability.  The effect of setting Weight to 0 is different when
+            you associate health checks with weighted resource record sets. For more information,
+            see `Options for Configuring Amazon Route 53 Active-Active and Active-Passive Failover`__
+            in the Amazon Route 53 Developer Guide.
+            .. __: http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-configuring-options.html
+
+    Region
+        Valid for Latency-based resource record sets only.  The Amazon EC2 Region where the resource
+        that is specified in this resource record set resides. The resource typically is an AWS
+        resource, such as an EC2 instance or an ELB load balancer, and is referred to by an IP
+        address or a DNS domain name, depending on the record type.
+
+    GeoLocation
+        Geo location resource record sets only.  A dict that lets you control how Route 53 responds
+        to DNS queries based on the geographic origin of the query.  For example, if you want all
+        queries from Africa to be routed to a web server with an IP address of 192.0.2.111, create a
+        resource record set with a Type of A and a ContinentCode of AF.
+
+            ContinentCode
+                The two-letter code for the continent.
+                Valid values: AF | AN | AS | EU | OC | NA | SA
+                Constraint: Specifying ContinentCode with either CountryCode or SubdivisionCode
+                            returns an InvalidInput error.
+            CountryCode
+                The two-letter code for the country.
+            SubdivisionCode
+                The code for the subdivision, for example, a state in the United States or a
+                province in Canada.
+
+        Notes
+          - Creating geolocation and geolocation alias resource record sets in private hosted zones
+            is not supported.
+          - If you create separate resource record sets for overlapping geographic regions (for
+            example, one resource record set for a continent and one for a country on the same
+            continent), priority goes to the smallest geographic region. This allows you to route
+            most queries for a continent to one resource and to route queries for a country on that
+            continent to a different resource.
+          - You can't create two geolocation resource record sets that specify the same geographic
+            location.
+          - The value * in the CountryCode element matches all geographic locations that aren't
+            specified in other geolocation resource record sets that have the same values for the
+            Name and Type elements.
+          - Geolocation works by mapping IP addresses to locations.  However, some IP addresses
+            aren't mapped to geographic locations, so even if you create geolocation resource
+            record sets that cover all seven continents, Amazon Route 53 will receive some DNS
+            queries from locations that it can't identify.  We recommend that you create a resource
+            record set for which the value of CountryCode is *, which handles both queries that
+            come from locations for which you haven't created geolocation resource record sets and
+            queries from IP addresses that aren't mapped to a location.  If you don't create a *
+            resource record set, Amazon Route 53 returns a "no answer" response for queries from
+            those locations.
+          - You can't create non-geolocation resource record sets that have the same values for the
+            Name and Type elements as geolocation resource record sets.
+
+    TTL
+        The resource record cache time to live (TTL), in seconds.
+        Note the following:
+          - If you're creating an alias resource record set, omit TTL. Amazon Route 53 uses the
+            value of TTL for the alias target.
+          - If you're associating this resource record set with a health check (if you're adding
+            a HealthCheckId element), we recommend that you specify a TTL of 60 seconds or less so
+            clients respond quickly to changes in health status.
+          - All of the resource record sets in a group of weighted, latency, geolocation, or
+            failover resource record sets must have the same value for TTL.
+          - If a group of weighted resource record sets includes one or more weighted alias
+            resource record sets for which the alias target is an ELB load balancer, we recommend
+            that you specify a TTL of 60 seconds for all of the non-alias weighted resource record
+            sets that have the same name and type. Values other than 60 seconds (the TTL for load
+            balancers) will change the effect of the values that you specify for Weight.
+
+    ResourceRecords
+        A list, containing one or more values for the resource record.  No single value can exceed
+        4,000 characters.  For details on how to format values for different record types, see
+        `Supported DNS Resource Record Types`__ in the Amazon Route 53 Developer Guide.
+        .. __: http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html
+
+        Note:  You can specify more than one value for all record types except CNAME and SOA.
+
+        It is also possible to pass "magic" strings as resource record values.  This functionality
+        can easily be extended, but for the moment supports the following:
+
+            'magic:ec2_instance_tag:some_tag_name:some_string:some_instance_attr'
+
+        This tells salt to lookup an EC2 instance with a tag 'some_tag_name' which has the value
+        'some_string' and substitute the 'some_instance_attr' attribute of that instance as the
+        resource record value being evaluated.
+
+        This should work generally for any EC2 instance tags, as long as the instance attribute
+        being fetched is available to getattr(instance, 'attribute') as seen in the code below.
+        Anything else will most likely require this function to be extended to handle it.
+
+        The canonical use-case for this (at least at our site) is to query the Name tag (which
+        we always populate with the host's FQDN) to lookup the public or private IPs bound to the
+        instance, so we can then automgically create Route 53 records for them.
+
+    AliasTarget
+        The rules governing how to define an AliasTarget for the various supported use-cases are
+        obtuse beyond reason and attempting to paraphrase them (or even worse, cut-and-paste them
+        in their entirety) would be silly and counterproductive.  If you need this feature, then
+        Read The Fine Materials at the `Boto 3 Route 53 page`__ and/or the `AWS Route 53 docs`__
+        and suss them for yourself - I sure won't claim to understand them partcularly well.
+        .. __: http://boto3.readthedocs.io/en/latest/reference/services/route53.html#Route53.Client.change_resource_record_sets
+        .. __: http://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html
+
+    region
+        The region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        Dict, or pillar key pointing to a dict, containing AWS region/key/keyid.
+    '''
+    Name = Name if Name else name
+    if Type is None:
+        raise SaltInvocationError("'Type' is a required parameter when adding or updating"
+                                  "resource records.")
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    args = {'Id': HostedZoneId, 'Name': DomainName, 'PrivateZone': PrivateZone,
+            'region': region, 'key': key, 'keyid': keyid, 'profile': profile}
+    zone = __salt__['boto3_route53.find_hosted_zone'](**args)
+    if not zone:
+        ret['comment'] = 'Route 53 {} hosted zone {} not found'.format('private' if PrivateZone
+                else 'public', DomainName)
+        log.info(ret['comment'])
+        return ret
+    zone = zone[0]
+    HostedZoneId = zone['HostedZone']['Id']
+
+    # Convert any magic RR values to something AWS will understand, and otherwise clean them up.
+    fixed_rrs = []
+    for rr in ResourceRecords:
+      if rr.startswith('magic:'):
+        fields = rr.split(':')
+        if fields[1] == 'ec2_instance_tag':
+            if len(fields) != 5:
+                log.warning("Invalid magic RR value seen: '{}'.  Passing as-is.".format(rr))
+                fixed_rrs += [rr]
+                continue
+            tag_name = fields[2]
+            tag_value = fields[3]
+            instance_attr = fields[4]
+            good_states = ('pending', 'rebooting', 'running', 'stopping', 'stopped')
+            r = __salt__['boto_ec2.find_instances'](tags={tag_name: tag_value}, return_objs=True,
+                                                    in_states=good_states, region=region, key=key,
+                                                    keyid=keyid, profile=profile)
+            if len(r) < 1:
+                ret['comment'] = 'No EC2 instance with tag {} == {} found'.format(tag_name,
+                        tag_value)
+                log.error(ret['comment'])
+                ret['result'] = False
+                return ret
+            if len(r) > 1:
+                ret['comment'] = 'Multiple EC2 instances with tag {} == {} found'.format(tag_name,
+                        tag_value)
+                log.error(ret['comment'])
+                ret['result'] = False
+                return ret
+            instance = r[0]
+            res = getattr(instance, instance_attr, None)
+            if res:
+                log.debug('Found {} {} for instance {}'.format(instance_attr, res, instance.id))
+                fixed_rrs += [res]
+            else:
+                ret['comment'] = 'Attribute {} not found on instance {}'.format(instance_attr,
+                        instance.id)
+                log.error(ret['comment'])
+                ret['result'] = False
+                return ret
+        else:
+            ret['comment'] = ('Unknown RR magic value seen: {}.  Please extend the boto3_route53 '
+                              'state module to add support for your preferred incantation.'.format(
+                              fields[1]))
+            log.error(ret['comment'])
+            ret['result'] = False
+            return ret
+    ResourceRecords = [{'Value': _to_aws_encoding(rr)} for rr in sorted(fixed_rrs)]
+
+    recordsets = __salt__['boto3_route53.get_resource_records'](HostedZoneId=HostedZoneId,
+            StartRecordName=Name, StartRecordType=Type, region=region, key=key, keyid=keyid,
+            profile=profile)
+
+    if SetIdentifier and recordsets:
+        log.debug('Filter recordsets {} by SetIdentifier {}.'.format(recordsets, SetIdentifier))
+        recordsets = [r for r in recordsets if r.get('SetIdentifier') == SetIdentifier]
+        log.debug('Resulted in recordsets {}.'.format(recordsets))
+
+    create = False
+    update = False
+    if not recordsets:
+        create = True
+        if __opts__['test']:
+            ret['comment'] = 'Route 53 resource record {} with type {} would be added.'.format(
+                    Name, Type)
+            ret['result'] = None
+            return ret
+    elif len(recordsets) > 1:
+        ret['comment'] = 'Given criteria matched more than one ResourceRecordSet.'
+        log.error(ret['comment'])
+        ret['result'] = False
+        return ret
+    rrset = recordsets[0]
+
+    updatable = ['SetIdentifier', 'Weight', 'Region', 'GeoLocation', 'Failover', 'TTL',
+                 'AliasTarget', 'HealthCheckId', 'TrafficPolicyInstanceId']
+    for u in updatable:
+        if locals().get(u) != rrset.get(u):
+            update = True
+            break
+    if ResourceRecords != sorted(rrset.get('ResourceRecords'), key=lambda x: x['Value']):
+        update = True
+
+    if not create or update:
+        ret['comment'] = ('Route 53 resource record {} with type {} is already in the desired state.'
+                         ''.format(Name, Type))
+        log.info(ret['comment'])
+        return ret
+    else:
+        if __opts__['test']:
+            ret['comment'] = 'Route 53 resource record {} with type {} would be updated.'.format(
+                    Name, Type)
+            ret['result'] = None
+            return ret
+        ResourceRecordSet = {
+            'Name': Name,
+            'Type': Type,
+            'ResourceRecords': ResourceRecords
+        }
+        for u in updatable:
+            ResourceRecordSet.update({u: locals().get(u)}) if locals().get(u) else None
+
+        ChangeBatch = {
+            'Changes': [
+                {
+                    'Action': 'UPSERT',
+                    'ResourceRecordSet': ResourceRecordSet,
+                }
+            ]
+        }
+
+        if __salt__['boto3_route53.change_resource_record_sets'](HostedZoneId=HostedZoneId,
+                ChangeBatch=ChangeBatch, region=region, key=key, keyid=keyid, profile=profile):
+            ret['comment'] = 'Route 53 resource record {} with type {} {}.'.format(Name,
+                    Type, 'created' if create else 'updated')
+            log.info(ret['comment'])
+            if created:
+                ret['changes']['old'] = None
+            else:
+                ret['changes']['old'] = rrset
+            ret['changes']['new'] = ResourceRecordSet
+        else:
+            ret['comment'] = 'Failed to {} Route 53 resource record {} with type {}.'.format(
+                    'create' if create else 'update', Name, Type)
+            log.error(ret['comment'])
+            ret['result'] = False
+
+    return ret
+
+
+def rr_absent(name, HostedZoneId=None, DomainName=None, PrivateZone=False,
+              Name=None, Type=None, SetIdentifier=None,
+              region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure the Route53 record is deleted.
+
+    name
+        The name of the state definition.  This will be used for Name if the latter is
+        not provided.
+
+    HostedZoneId
+        The ID of the zone to delete the record from.  Exclusive with DomainName.
+
+    DomainName
+        The domain name of the zone to delete the record from.  Exclusive with HostedZoneId.
+
+    PrivateZone
+        Set to True if the RR to be removed is in a private zone, False if public.
+
+    Name
+        Name of the resource record.
+
+    Type
+        The record type (A, NS, MX, TXT, etc.)
+
+    SetIdentifier
+        Valid for Weighted, Latency, Geolocation, and Failover resource record sets only.
+        An identifier that differentiates among multiple resource record sets that have the same
+        combination of DNS name and type.  The value of SetIdentifier must be unique for each
+        resource record set that has the same combination of DNS name and type. Omit SetIdentifier
+        for any other types of record sets.
+
+    region
+        The region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        Dict, or pillar key pointing to a dict, containing AWS region/key/keyid.
+    '''
+    Name = Name if Name else name
+    if Type is None:
+        raise SaltInvocationError("'Type' is a required parameter when deleting resource records.")
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    args = {'Id': HostedZoneId, 'Name': DomainName, 'PrivateZone': PrivateZone,
+            'region': region, 'key': key, 'keyid': keyid, 'profile': profile}
+    zone = __salt__['boto3_route53.find_hosted_zone'](**args)
+    if not zone:
+        ret['comment'] = 'Route 53 {} hosted zone {} not found'.format('private' if PrivateZone
+                else 'public', DomainName)
+        log.info(ret['comment'])
+        return ret
+    zone = zone[0]
+    HostedZoneId = zone['HostedZone']['Id']
+
+    recordsets = __salt__['boto3_route53.get_resource_records'](HostedZoneId=HostedZoneId,
+            StartRecordName=Name, StartRecordType=Type, region=region, key=key, keyid=keyid,
+            profile=profile)
+    if SetIdentifier and recordsets:
+        log.debug('Filter recordsets {} by SetIdentifier {}.'.format(recordsets, SetIdentifier))
+        recordsets = [r for r in recordsets if r.get('SetIdentifier') == SetIdentifier]
+        log.debug('Resulted in recordsets {}.'.format(recordsets))
+    if not recordsets:
+        ret['comment'] = 'Route 53 resource record {} with type {} already absent.'.format(
+                Name, Type)
+        return ret
+    elif len(recordsets) > 1:
+        ret['comment'] = 'Given criteria matched more than one ResourceRecordSet.'
+        log.error(ret['comment'])
+        ret['result'] = False
+        return ret
+    ResourceRecordSet = recordsets[0]
+    if __opts__['test']:
+        ret['comment'] = 'Route 53 resource record {} with type {} would be deleted.'.format(
+                Name, Type)
+        ret['result'] = None
+        return ret
+
+    ChangeBatch = {
+        'Changes': [
+            {
+                'Action': 'DELETE',
+                'ResourceRecordSet': ResourceRecordSet,
+            }
+        ]
+    }
+
+    if __salt__['boto3_route53.change_resource_record_sets'](HostedZoneId=HostedZoneId,
+            ChangeBatch=ChangeBatch, region=region, key=key, keyid=keyid, profile=profile):
+        ret['comment'] = 'Route 53 resource record {} with type {} deleted.'.format(Name, Type)
+        log.info(ret['comment'])
+        ret['changes']['old'] = ResourceRecordSet
+        ret['changes']['new'] = None
+    else:
+        ret['comment'] = 'Failed to delete Route 53 resource record {} with type {}.'.format(Name,
+                Type)
+        log.error(ret['comment'])
+        ret['result'] = False
+
+    return ret

--- a/salt/states/boto3_route53.py
+++ b/salt/states/boto3_route53.py
@@ -72,7 +72,8 @@ import uuid
 import salt.utils.dictupdate as dictupdate
 from salt.utils import SaltInvocationError, exactly_one
 import logging
-log = logging.getLogger(__name__)  #pylint: disable=W1699
+log = logging.getLogger(__name__)  # pylint: disable=W1699
+
 
 def __virtual__():
     '''

--- a/salt/states/boto3_route53.py
+++ b/salt/states/boto3_route53.py
@@ -188,7 +188,7 @@ def hosted_zone_present(name, Name=None, PrivateZone=False,
     Name = Name if Name else name
     Name = _to_aws_encoding(Name)
 
-    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     if not PrivateZone and VPCs:
         raise SaltInvocationError("Parameter 'VPCs' is invalid when creating a public zone.")


### PR DESCRIPTION
Adds new exec and state modules for AWS Route53 based on the newer Boto 3 API.  This allows a number of improvements and additional features by leveraging options which were not available in  Boto version 2.

Please don't merge quite yet - I'm still testing some of the code-paths which don't generally get exercised in our environment, and mostly just wanna get some eyeballs on the code and linting from upstream :)  Will prolly be ready to merge in a day or two.
