### PR TITLE
Clarify where sdb profiles need to be configured

### DIFF
--- a/doc/topics/sdb/index.rst
+++ b/doc/topics/sdb/index.rst
@@ -14,12 +14,14 @@ SDB was added to Salt in version 2014.7.0.
 
 SDB Configuration
 =================
-In order to use the SDB interface, a configuration profile must be set up in
-either the master or minion configuration file. The configuration stanza
-includes the name/ID that the profile will be referred to as, a ``driver``
-setting, and any other arguments that are necessary for the SDB module that will
-be used. For instance, a profile called ``mykeyring``, which uses the
-``system`` service in the ``keyring`` module would look like:
+In order to use the SDB interface, a configuration profile must be set up.
+To be available for master commands, such as runners, it needs to be
+configured in the master configuration. For modules executed on a minion, it
+can be set either in the minion configuration file, or as a pillar. The
+configuration stanza includes the name/ID that the profile will be referred to
+as, a ``driver`` setting, and any other arguments that are necessary for the SDB
+module that will be used. For instance, a profile called ``mykeyring``, which
+uses the ``system`` service in the ``keyring`` module would look like:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
### What does this PR do?
I understood the existing wording of the docs such that if I configured a profile in the master configuration, it would be available when running modules on a minion. After trying to get it to work for a while, I checked the code, and it seems like this is not actually how it works.

I rephrased such that at least to me it is clearer what is required, as well as mentioning the pillar alternative merged in #36934. 

If this is clearer to others as well, the wording should be updated in all (?) the sdb modules as well, as it seems to have been copied into their documentation.