### PR TITLE
Sort the return list from the fileserver.envs runner

### DIFF
--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -37,7 +37,7 @@ def envs(backend=None, sources=False, outputter=None):
         salt-run fileserver.envs git
     '''
     fileserver = salt.fileserver.Fileserver(__opts__)
-    output = fileserver.envs(back=backend, sources=sources)
+    output = sorted(fileserver.envs(back=backend, sources=sources))
 
     if outputter:
         salt.utils.warn_until(


### PR DESCRIPTION
This makes it easier to find envs in the list when there are many of them (e.g. when gitfs is used)