### PR TITLE
salt.utils.gitfs: remove dulwich support, make refspecs configurable

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -623,10 +623,11 @@
 
 # Git File Server Backend Configuration
 #
-# Optional parameter used to specify the provider to be used for gitfs. Must
-# be one of the following: pygit2, gitpython, or dulwich. If unset, then each
-# will be tried in that same order, and the first one with a compatible
-# version installed will be the provider that is used.
+# Optional parameter used to specify the provider to be used for gitfs. Must be
+# either pygit2 or gitpython. If unset, then both will be tried (in that
+# order), and the first one with a compatible version installed will be the
+# provider that is used.
+#
 #gitfs_provider: pygit2
 
 # Along with gitfs_password, is used to authenticate to HTTPS remotes.
@@ -678,6 +679,11 @@
 # within the repository. The path is defined relative to the root of the
 # repository and defaults to the repository root.
 #gitfs_root: somefolder/otherfolder
+#
+# The refspecs fetched by gitfs remotes
+#gitfs_refspecs:
+#  - '+refs/heads/*:refs/remotes/origin/*'
+#  - '+refs/tags/*:refs/tags/*'
 #
 #
 #####         Pillar settings        #####
@@ -827,6 +833,11 @@
 # This parameter is optional, required only when the SSH key being used
 # to authenticate is protected by a passphrase.
 #git_pillar_passphrase: ''
+
+# The refspecs fetched by git_pillar remotes
+#git_pillar_refspecs:
+#  - '+refs/heads/*:refs/remotes/origin/*'
+#  - '+refs/tags/*:refs/tags/*'
 
 # A master can cache pillars locally to bypass the expense of having to render them
 # for each minion on every request. This feature should only be enabled in cases
@@ -1073,6 +1084,11 @@
 #winrepo_remotes:
 #  - 'https://github.com/saltstack/salt-winrepo.git'
 
+# The refspecs fetched by winrepo remotes
+#winrepo_refspecs:
+#  - '+refs/heads/*:refs/remotes/origin/*'
+#  - '+refs/tags/*:refs/tags/*'
+#
 
 #####      Returner settings          ######
 ############################################

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1726,13 +1726,13 @@ Walkthrough <gitfs-per-remote-config>`.
 Optional parameter used to specify the provider to be used for gitfs. More
 information can be found in the :ref:`GitFS Walkthrough <gitfs-dependencies>`.
 
-Must be one of the following: ``pygit2``, ``gitpython``, or ``dulwich``. If
-unset, then each will be tried in that same order, and the first one with a
-compatible version installed will be the provider that is used.
+Must be either ``pygit2`` or ``gitpython``. If unset, then each will be tried
+in that same order, and the first one with a compatible version installed will
+be the provider that is used.
 
 .. code-block:: yaml
 
-    gitfs_provider: dulwich
+    gitfs_provider: gitpython
 
 .. conf_master:: gitfs_ssl_verify
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2024,6 +2024,28 @@ authenticate is protected by a passphrase.
 
     gitfs_passphrase: mypassphrase
 
+.. conf_master:: gitfs_refspecs
+
+``gitfs_refspecs``
+~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: Nitrogen
+
+Default: ``['+refs/heads/*:refs/remotes/origin/*', '+refs/tags/*:refs/tags/*']``
+
+When fetching from remote repositories, by default Salt will fetch branches and
+tags. This parameter can be used to override the default and specify
+alternate refspecs to be fetched. More information on how this feature works
+can be found in the :ref:`GitFS Walkthrough <gitfs-custom-refspecs>`.
+
+.. code-block:: yaml
+
+    gitfs_refspecs:
+      - '+refs/heads/*:refs/remotes/origin/*'
+      - '+refs/tags/*:refs/tags/*'
+      - '+refs/pull/*/head:refs/remotes/origin/pr/*'
+      - '+refs/pull/*/merge:refs/remotes/origin/merge/*'
+
 hg: Mercurial Remote File Server Backend
 ----------------------------------------
 
@@ -2959,7 +2981,7 @@ Git External Pillar Authentication Options
 ******************************************
 
 These parameters only currently apply to the ``pygit2``
-:conf_master:`git_pillar_provider`.  Authentication works the same as it does
+:conf_master:`git_pillar_provider`. Authentication works the same as it does
 in gitfs, as outlined in the :ref:`GitFS Walkthrough <gitfs-authentication>`,
 though the global configuration options are named differently to reflect that
 they are for git_pillar instead of gitfs.
@@ -3060,6 +3082,29 @@ authenticate is protected by a passphrase.
 .. code-block:: yaml
 
     git_pillar_passphrase: mypassphrase
+
+.. conf_master:: git_pillar_refspecs
+
+``git_pillar_refspecs``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: Nitrogen
+
+Default: ``['+refs/heads/*:refs/remotes/origin/*', '+refs/tags/*:refs/tags/*']``
+
+When fetching from remote repositories, by default Salt will fetch branches and
+tags. This parameter can be used to override the default and specify
+alternate refspecs to be fetched. This parameter works similarly to its
+:ref:`GitFS counterpart <git_pillar-custom-refspecs>`, in that it can be
+configured both globally and for individual remotes.
+
+.. code-block:: yaml
+
+    git_pillar_refspecs:
+      - '+refs/heads/*:refs/remotes/origin/*'
+      - '+refs/tags/*:refs/tags/*'
+      - '+refs/pull/*/head:refs/remotes/origin/pr/*'
+      - '+refs/pull/*/merge:refs/remotes/origin/merge/*'
 
 .. _pillar-merging-opts:
 
@@ -4028,3 +4073,26 @@ authenticate is protected by a passphrase.
 .. code-block:: yaml
 
     winrepo_passphrase: mypassphrase
+
+.. conf_master:: winrepo_refspecs
+
+``winrepo_refspecs``
+~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: Nitrogen
+
+Default: ``['+refs/heads/*:refs/remotes/origin/*', '+refs/tags/*:refs/tags/*']``
+
+When fetching from remote repositories, by default Salt will fetch branches and
+tags. This parameter can be used to override the default and specify
+alternate refspecs to be fetched. This parameter works similarly to its
+:ref:`GitFS counterpart <winrepo-custom-refspecs>`, in that it can be
+configured both globally and for individual remotes.
+
+.. code-block:: yaml
+
+    winrepo_refspecs:
+      - '+refs/heads/*:refs/remotes/origin/*'
+      - '+refs/tags/*:refs/tags/*'
+      - '+refs/pull/*/head:refs/remotes/origin/pr/*'
+      - '+refs/pull/*/merge:refs/remotes/origin/merge/*'

--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -195,7 +195,6 @@ dpkg
 DRS
 dryrun
 dst
-dulwich
 dumpe
 dvh
 eauth

--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -99,6 +99,7 @@ numbers like ``1.2.34-5.el7``. An example of the usage for this would be:
 
 - The :mod:`system <salt.modules.system>` module changed the returned format
   from "HH:MM AM/PM" to "HH:MM:SS AM/PM" for `get_system_time`.
+
 Master Configuration Additions
 ==============================
 
@@ -142,6 +143,7 @@ General Deprecations
 --------------------
 
 - Removed support for aliasing ``cmd.run`` to ``cmd.shell``.
+- Removed support for Dulwich from :ref:`GitFS <tutorial-gitfs>`.
 - Beacon configurations should be lists instead of dictionaries.
 - The ``PidfileMixin`` has been removed. Please use ``DaemonMixIn`` instead.
 - The ``use_pending`` argument was removed from the ``salt.utils.event.get_event``

--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -135,6 +135,14 @@ release cycle (two major releases after this one), those who are using the
 :ref:`netapi module <all-netapi-modules>`) are encouraged to update their code
 to use ``tgt_type``.
 
+Custom Refspecs in GitFS / git_pillar / winrepo
+===============================================
+
+It is now possible to specify the refspecs to use when fetching from remote
+repositores for GitFS, git_pillar, and winrepo. More information on how this
+feature works can be found :ref:`here <gitfs-custom-refspecs>` in the GitFS
+Walkthrough. The git_pillar and winrepo versions of this feature work the same
+as their GitFS counterpart.
 
 Deprecations
 ============

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -26,21 +26,17 @@ Branches and tags become Salt fileserver environments.
 Installing Dependencies
 =======================
 
-Beginning with version 2014.7.0, both pygit2_ and Dulwich_ are supported as
-alternatives to GitPython_. The desired provider can be configured using the
-:conf_master:`gitfs_provider` parameter in the master config file.
-
-If :conf_master:`gitfs_provider` is not configured, then Salt will prefer
-pygit2_ if a suitable version is available, followed by GitPython_ and
-Dulwich_.
+Both pygit2_ and GitPython_ are supported Python interfaces to git. If
+compatible versions of both are installed, pygit2_ will preferred. In these
+cases, GitPython_ can be forced using the :conf_master:`gitfs_provider`
+parameter in the master config file.
 
 .. note::
     It is recommended to always run the most recent version of any the below
-    dependencies. Certain features of gitfs may not be available without
+    dependencies. Certain features of GitFS may not be available without
     the most recent version of the chosen library.
 
 .. _pygit2: https://github.com/libgit2/pygit2
-.. _Dulwich: https://www.samba.org/~jelmer/dulwich/
 .. _GitPython: https://github.com/gitpython-developers/GitPython
 
 pygit2
@@ -157,49 +153,6 @@ install GitPython`` (or ``easy_install GitPython``) as root.
             - name: 'GitPython < 2.0.9'
 
 
-Dulwich
--------
-
-Dulwich 0.9.4 or newer is required to use Dulwich as backend for gitfs.
-
-Dulwich is available in EPEL, and can be easily installed on the master using
-yum:
-
-.. code-block:: bash
-
-    # yum install python-dulwich
-
-For APT-based distros such as Ubuntu and Debian:
-
-.. code-block:: bash
-
-    # apt-get install python-dulwich
-
-.. important::
-
-    If switching to Dulwich from GitPython/pygit2, or switching from
-    GitPython/pygit2 to Dulwich, it is necessary to clear the gitfs cache to
-    avoid unpredictable behavior. This is probably a good idea whenever
-    switching to a new :conf_master:`gitfs_provider`, but it is less important
-    when switching between GitPython and pygit2.
-
-    Beginning in version 2015.5.0, the gitfs cache can be easily cleared using
-    the :mod:`fileserver.clear_cache <salt.runners.fileserver.clear_cache>`
-    runner.
-
-    .. code-block:: bash
-
-        salt-run fileserver.clear_cache backend=git
-
-    If the Master is running an earlier version, then the cache can be cleared
-    by removing the ``gitfs`` and ``file_lists/gitfs`` directories (both paths
-    relative to the master cache directory, usually
-    ``/var/cache/salt/master``).
-
-    .. code-block:: bash
-
-        rm -rf /var/cache/salt/master{,/file_lists}/gitfs
-
 Simple Configuration
 ====================
 
@@ -233,14 +186,6 @@ master:
 
    Information on how to authenticate to SSH remotes can be found :ref:`here
    <gitfs-authentication>`.
-
-   .. note::
-
-       Dulwich does not recognize ``ssh://`` URLs, ``git+ssh://`` must be used
-       instead. Salt version 2015.5.0 and later will automatically add the
-       ``git+`` to the beginning of these URLs before fetching, but earlier
-       Salt versions will fail to fetch unless the URL is specified using
-       ``git+ssh://``.
 
 3. Restart the master to load the new configuration.
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -57,6 +57,7 @@ _DFLT_LOG_FMT_CONSOLE = '[%(levelname)-8s] %(message)s'
 _DFLT_LOG_FMT_LOGFILE = (
     '%(asctime)s,%(msecs)03d [%(name)-17s][%(levelname)-8s][%(process)d] %(message)s'
 )
+_DFLT_REFSPECS = ['+refs/heads/*:refs/remotes/origin/*', '+refs/tags/*:refs/tags/*']
 
 if salt.utils.is_windows():
     # Since an 'ipc_mode' of 'ipc' will never work on Windows due to lack of
@@ -580,6 +581,7 @@ VALID_OPTS = {
     'git_pillar_privkey': str,
     'git_pillar_pubkey': str,
     'git_pillar_passphrase': str,
+    'git_pillar_refspecs': list,
     'gitfs_remotes': list,
     'gitfs_mountpoint': str,
     'gitfs_root': str,
@@ -595,6 +597,7 @@ VALID_OPTS = {
     'gitfs_ssl_verify': bool,
     'gitfs_global_lock': bool,
     'gitfs_saltenv': list,
+    'gitfs_refspecs': list,
     'hgfs_remotes': list,
     'hgfs_mountpoint': str,
     'hgfs_root': str,
@@ -781,6 +784,7 @@ VALID_OPTS = {
     'winrepo_privkey': str,
     'winrepo_pubkey': str,
     'winrepo_passphrase': str,
+    'winrepo_refspecs': list,
 
     # Set a hard limit for the amount of memory modules can consume on a minion.
     'modules_max_memory': int,
@@ -1081,6 +1085,7 @@ DEFAULT_MINION_OPTS = {
     'git_pillar_privkey': '',
     'git_pillar_pubkey': '',
     'git_pillar_passphrase': '',
+    'git_pillar_refspecs': _DFLT_REFSPECS,
     'gitfs_remotes': [],
     'gitfs_mountpoint': '',
     'gitfs_root': '',
@@ -1096,6 +1101,7 @@ DEFAULT_MINION_OPTS = {
     'gitfs_global_lock': True,
     'gitfs_ssl_verify': True,
     'gitfs_saltenv': [],
+    'gitfs_refspecs': _DFLT_REFSPECS,
     'hash_type': 'sha256',
     'disable_modules': [],
     'disable_returners': [],
@@ -1181,6 +1187,7 @@ DEFAULT_MINION_OPTS = {
     'winrepo_privkey': '',
     'winrepo_pubkey': '',
     'winrepo_passphrase': '',
+    'winrepo_refspecs': _DFLT_REFSPECS,
     'pidfile': os.path.join(salt.syspaths.PIDFILE_DIR, 'salt-minion.pid'),
     'range_server': 'range:80',
     'reactor_refresh_interval': 60,
@@ -1297,6 +1304,7 @@ DEFAULT_MASTER_OPTS = {
     'git_pillar_privkey': '',
     'git_pillar_pubkey': '',
     'git_pillar_passphrase': '',
+    'git_pillar_refspecs': _DFLT_REFSPECS,
     'gitfs_remotes': [],
     'gitfs_mountpoint': '',
     'gitfs_root': '',
@@ -1312,6 +1320,7 @@ DEFAULT_MASTER_OPTS = {
     'gitfs_global_lock': True,
     'gitfs_ssl_verify': True,
     'gitfs_saltenv': [],
+    'gitfs_refspecs': _DFLT_REFSPECS,
     'hgfs_remotes': [],
     'hgfs_mountpoint': '',
     'hgfs_root': '',
@@ -1454,6 +1463,7 @@ DEFAULT_MASTER_OPTS = {
     'winrepo_privkey': '',
     'winrepo_pubkey': '',
     'winrepo_passphrase': '',
+    'winrepo_refspecs': _DFLT_REFSPECS,
     'syndic_wait': 5,
     'jinja_lstrip_blocks': False,
     'jinja_trim_blocks': False,

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -196,6 +196,13 @@ class GitLockError(SaltException):
         self.strerror = strerror
 
 
+class GitRemoteError(SaltException):
+    '''
+    Used by GitFS to denote a problem with the existence of the "origin" remote
+    or part of its configuration
+    '''
+
+
 class SaltInvocationError(SaltException, TypeError):
     '''
     Used when the wrong number of arguments are sent to modules or invalid

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -51,7 +51,7 @@ from __future__ import absolute_import
 import logging
 
 PER_REMOTE_OVERRIDES = ('base', 'mountpoint', 'root', 'ssl_verify',
-                        'env_whitelist', 'env_blacklist')
+                        'env_whitelist', 'env_blacklist', 'refspecs')
 PER_REMOTE_ONLY = ('name', 'saltenv')
 
 # Auth support (auth params can be global or per-remote, too)

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -13,37 +13,35 @@ Master config file.
     fileserver_backend:
       - git
 
-As of Salt 2014.7.0, the Git fileserver backend supports GitPython_, pygit2_,
-and dulwich_ to provide the Python interface to git. If more than one of these
-are present, the order of preference for which one will be chosen is the same
-as the order in which they were listed: pygit2, GitPython, dulwich (keep in
-mind, this order is subject to change).
+The Git fileserver backend supports both pygit2_ and GitPython_, to provide the
+Python interface to git. If both are present, the order of preference for which
+one will be chosen is the same as the order in which they were listed: pygit2,
+then GitPython.
 
 An optional master config parameter (:conf_master:`gitfs_provider`) can be used
-to specify which provider should be used.
+to specify which provider should be used, in the event that compatible versions
+of both pygit2_ and GitPython_ are installed.
 
-More detailed information on how to use gitfs can be found in the :ref:`Gitfs
+More detailed information on how to use GitFS can be found in the :ref:`GitFS
 Walkthrough <tutorial-gitfs>`.
 
 .. note:: Minimum requirements
 
-    To use GitPython_ for gitfs requires a minimum GitPython version of 0.3.0,
-    as well as the git CLI utility. Instructions for installing GitPython can
-    be found :ref:`here <gitfs-dependencies>`.
-
-    To use pygit2_ for gitfs requires a minimum pygit2_ version of 0.20.3.
+    To use pygit2_ for GitFS requires a minimum pygit2_ version of 0.20.3.
     pygit2_ 0.20.3 requires libgit2_ 0.20.0. pygit2_ and libgit2_ are developed
     alongside one another, so it is recommended to keep them both at the same
     major release to avoid unexpected behavior. For example, pygit2_ 0.21.x
     requires libgit2_ 0.21.x, pygit2_ 0.22.x will require libgit2_ 0.22.x, etc.
 
-    To find stale refs, pygit2 additionally requires the git CLI utility to be
-    installed.
+    To use GitPython_ for GitFS requires a minimum GitPython version of 0.3.0,
+    as well as the git CLI utility. Instructions for installing GitPython can
+    be found :ref:`here <gitfs-dependencies>`.
 
-.. _GitPython: https://github.com/gitpython-developers/GitPython
+    To clear stale refs the git CLI utility must also be installed.
+
 .. _pygit2: https://github.com/libgit2/pygit2
 .. _libgit2: https://libgit2.github.com/
-.. _dulwich: https://www.samba.org/~jelmer/dulwich/
+.. _GitPython: https://github.com/gitpython-developers/GitPython
 '''
 
 # Import python libs

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -1126,7 +1126,7 @@ def proxy_reconnect(proxy_name, opts=None):
         The virtual name of the proxy module.
 
     opts: None
-        Opts dictionary.
+        Opts dictionary. Not intended for CLI usage.
 
     CLI Example:
 

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -156,9 +156,8 @@ Configuring git_pillar for Salt releases 2015.8.0 and later
     will also be logged.
 
 Beginning with Salt version 2015.8.0, pygit2_ is now supported in addition to
-GitPython_ (Dulwich_ will not be supported for the foreseeable future). The
-requirements for GitPython_ and pygit2_ are the same as for gitfs, as described
-:ref:`here <gitfs-dependencies>`.
+GitPython_. The requirements for GitPython_ and pygit2_ are the same as for
+GitFS, as described :ref:`here <gitfs-dependencies>`.
 
 .. important::
     git_pillar has its own set of global configuration parameters. While it may
@@ -295,7 +294,6 @@ instead of ``gitfs`` (e.g. :conf_master:`git_pillar_pubkey`,
 
 .. _GitPython: https://github.com/gitpython-developers/GitPython
 .. _pygit2: https://github.com/libgit2/pygit2
-.. _Dulwich: https://www.samba.org/~jelmer/dulwich/
 '''
 from __future__ import absolute_import
 

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -322,7 +322,7 @@ except ImportError:
     HAS_GITPYTHON = False
 # pylint: enable=import-error
 
-PER_REMOTE_OVERRIDES = ('env', 'root', 'ssl_verify')
+PER_REMOTE_OVERRIDES = ('env', 'root', 'ssl_verify', 'refspecs')
 
 # Set up logging
 log = logging.getLogger(__name__)

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -29,7 +29,7 @@ import salt.template
 log = logging.getLogger(__name__)
 
 # Global parameters which can be overridden on a per-remote basis
-PER_REMOTE_OVERRIDES = ('ssl_verify',)
+PER_REMOTE_OVERRIDES = ('ssl_verify', 'refspecs')
 
 
 def genrepo(opts=None, fire_event=True):

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -36,7 +36,7 @@ from salt.utils.event import tagify
 # Import third party libs
 import salt.ext.six as six
 
-VALID_PROVIDERS = ('gitpython', 'pygit2', 'dulwich')
+VALID_PROVIDERS = ('pygit2', 'gitpython')
 # Optional per-remote params that can only be used on a per-remote basis, and
 # thus do not have defaults in salt/config.py.
 PER_REMOTE_ONLY = ('name',)
@@ -60,11 +60,6 @@ _RECOMMEND_GITPYTHON = (
 _RECOMMEND_PYGIT2 = (
     'pygit2 is installed, you may wish to set {0}_provider to '
     '\'pygit2\' to use pygit2 for for {0} support.'
-)
-
-_RECOMMEND_DULWICH = (
-    'Dulwich is installed, you may wish to set {0}_provider to '
-    '\'dulwich\' to use Dulwich for {0} support.'
 )
 
 _INVALID_REPO = (
@@ -98,24 +93,12 @@ except Exception as err:  # cffi VerificationError also may happen
     if not isinstance(err, ImportError):
         log.error('Import pygit2 failed: %s', err)
 
-try:
-    import dulwich.errors
-    import dulwich.repo
-    import dulwich.client
-    import dulwich.config
-    import dulwich.objects
-    HAS_DULWICH = True
-except ImportError:
-    HAS_DULWICH = False
 # pylint: enable=import-error
 
 # Minimum versions for backend providers
 GITPYTHON_MINVER = '0.3'
 PYGIT2_MINVER = '0.20.3'
 LIBGIT2_MINVER = '0.20.0'
-# dulwich.__version__ is a versioninfotuple so we can compare tuples
-# instead of using distutils.version.LooseVersion
-DULWICH_MINVER = (0, 9, 4)
 
 
 def enforce_types(key, val):
@@ -1793,398 +1776,6 @@ class Pygit2(GitProvider):
             fp_.write(blob.data)
 
 
-class Dulwich(GitProvider):  # pylint: disable=abstract-method
-    '''
-    Interface to dulwich
-    '''
-    def __init__(self, opts, remote, per_remote_defaults, per_remote_only,
-                 override_params, cache_root, role='gitfs'):
-        self.get_env_refs = lambda refs: [
-            x for x in refs if re.match('refs/(remotes|tags)', x)
-            and not x.endswith('^{}')
-        ]
-        self.provider = 'dulwich'
-        GitProvider.__init__(self, opts, remote, per_remote_defaults,
-                             per_remote_only, override_params, cache_root, role)
-
-    def dir_list(self, tgt_env):
-        '''
-        Get a list of directories for the target environment using dulwich
-        '''
-        def _traverse(tree, blobs, prefix):
-            '''
-            Traverse through a dulwich Tree object recursively, accumulating
-            all the empty directories within it in the "blobs" list
-            '''
-            for item in six.iteritems(tree):
-                try:
-                    obj = self.repo.get_object(item.sha)
-                except KeyError:
-                    # Entry is a submodule, skip it
-                    continue
-                if not isinstance(obj, dulwich.objects.Tree):
-                    continue
-                blobs.append(salt.utils.path_join(prefix, item.path))
-                if len(self.repo.get_object(item.sha)):
-                    _traverse(obj, blobs, salt.utils.path_join(prefix, item.path))
-
-        ret = set()
-        tree = self.get_tree(tgt_env)
-        tree = self.walk_tree(tree, self.root(tgt_env))
-        if not isinstance(tree, dulwich.objects.Tree):
-            return ret
-        blobs = []
-        if len(tree):
-            _traverse(tree, blobs, self.root(tgt_env))
-        if self.root(tgt_env):
-            relpath = lambda path: os.path.relpath(path, self.root(tgt_env))
-        else:
-            relpath = lambda path: path
-        add_mountpoint = lambda path: salt.utils.path_join(self.mountpoint(tgt_env), path)
-        for blob in blobs:
-            ret.add(add_mountpoint(relpath(blob)))
-        if self.mountpoint(tgt_env):
-            ret.add(self.mountpoint(tgt_env))
-        return ret
-
-    def envs(self):
-        '''
-        Check the refs and return a list of the ones which can be used as salt
-        environments.
-        '''
-        ref_paths = self.get_env_refs(self.repo.get_refs())
-        return self._get_envs_from_ref_paths(ref_paths)
-
-    def _fetch(self):
-        '''
-        Fetch the repo. If the local copy was updated, return True. If the
-        local copy was already up-to-date, return False.
-        '''
-        # origin is just a url here, there is no origin object
-        origin = self.url
-        client, path = \
-            dulwich.client.get_transport_and_path_from_url(
-                origin, thin_packs=True
-            )
-        refs_pre = self.repo.get_refs()
-        try:
-            refs_post = client.fetch(path, self.repo)
-        except dulwich.errors.NotGitRepository:
-            log.error(
-                'Dulwich does not recognize %s as a valid remote '
-                'remote URL. Perhaps it is missing \'.git\' at the '
-                'end.', self.id, exc_info_on_loglevel=logging.DEBUG
-            )
-            return False
-        except KeyError:
-            log.error(
-                'Local repository cachedir \'%s\' (corresponding '
-                'remote: \'%s\') has been corrupted. Salt will now '
-                'attempt to remove the local checkout to allow it to '
-                'be re-initialized in the next fileserver cache '
-                'update.', self.cachedir, self.id
-            )
-            try:
-                salt.utils.rm_rf(self.cachedir)
-            except OSError as exc:
-                log.error(
-                    'Unable to remove {0}: {1}'.format(self.cachedir, exc)
-                )
-            return False
-        else:
-            # Dulwich does not write fetched references to the gitdir, that is
-            # done manually below (see the "Update local refs" comment). Since
-            # A) gitfs doesn't check out any local branches, B) both Pygit2 and
-            # GitPython set remote refs when fetching instead of head refs, and
-            # C) Dulwich is not supported for git_pillar or winrepo, there is
-            # no harm in simply renaming the head refs from the fetch results
-            # to remote refs. This allows the same logic (see the
-            # "_get_envs_from_ref_paths()" function) to be used for all three
-            # GitProvider subclasses to derive available envs.
-            for ref in [x for x in refs_post if x.startswith('refs/heads/')]:
-                val = refs_post.pop(ref)
-                key = ref.replace('refs/heads/', 'refs/remotes/origin/', 1)
-                refs_post[key] = val
-
-        if refs_post is None:
-            # Empty repository
-            log.warning(
-                '{0} remote \'{1}\' is an empty repository and will '
-                'be skipped.'.format(self.role, self.id)
-            )
-            return False
-        if refs_pre != refs_post:
-            # Update local refs
-            for ref in self.get_env_refs(refs_post):
-                self.repo[ref] = refs_post[ref]
-            # Prune stale refs
-            for ref in refs_pre:
-                if ref not in refs_post:
-                    del self.repo[ref]
-            return True
-        return False
-
-    def file_list(self, tgt_env):
-        '''
-        Get file list for the target environment using dulwich
-        '''
-        def _traverse(tree, blobs, prefix):
-            '''
-            Traverse through a dulwich Tree object recursively, accumulating
-            all the file paths and symlinks info in the "blobs" dict
-            '''
-            for item in six.iteritems(tree):
-                try:
-                    obj = self.repo.get_object(item.sha)
-                except KeyError:
-                    # Entry is a submodule, skip it
-                    continue
-                if isinstance(obj, dulwich.objects.Blob):
-                    repo_path = salt.utils.path_join(prefix, item.path)
-                    blobs.setdefault('files', []).append(repo_path)
-                    mode, oid = tree[item.path]
-                    if stat.S_ISLNK(mode):
-                        link_tgt = self.repo.get_object(oid).as_raw_string()
-                        blobs.setdefault('symlinks', {})[repo_path] = link_tgt
-                elif isinstance(obj, dulwich.objects.Tree):
-                    _traverse(obj, blobs, salt.utils.path_join(prefix, item.path))
-
-        files = set()
-        symlinks = {}
-        tree = self.get_tree(tgt_env)
-        tree = self.walk_tree(tree, self.root(tgt_env))
-        if not isinstance(tree, dulwich.objects.Tree):
-            return files, symlinks
-        blobs = {}
-        if len(tree):
-            _traverse(tree, blobs, self.root(tgt_env))
-        if self.root(tgt_env):
-            relpath = lambda path: os.path.relpath(path, self.root(tgt_env))
-        else:
-            relpath = lambda path: path
-        add_mountpoint = lambda path: salt.utils.path_join(self.mountpoint(tgt_env), path)
-        for repo_path in blobs.get('files', []):
-            files.add(add_mountpoint(relpath(repo_path)))
-        for repo_path, link_tgt in six.iteritems(blobs.get('symlinks', {})):
-            symlinks[add_mountpoint(relpath(repo_path))] = link_tgt
-        return files, symlinks
-
-    def find_file(self, path, tgt_env):
-        '''
-        Find the specified file in the specified environment
-        '''
-        tree = self.get_tree(tgt_env)
-        if not tree:
-            # Branch/tag/SHA not found
-            return None, None, None
-        blob = None
-        mode = None
-        depth = 0
-        while True:
-            depth += 1
-            if depth > SYMLINK_RECURSE_DEPTH:
-                blob = None
-                break
-            prefix_dirs, _, filename = path.rpartition(os.path.sep)
-            tree = self.walk_tree(tree, prefix_dirs)
-            if not isinstance(tree, dulwich.objects.Tree):
-                # Branch/tag/SHA not found in repo
-                break
-            try:
-                mode, oid = tree[filename]
-                if stat.S_ISLNK(mode):
-                    # Path is a symlink. The blob data corresponding to
-                    # this path's object ID will be the target of the
-                    # symlink. Follow the symlink and set path to the
-                    # location indicated in the blob data.
-                    link_tgt = self.repo.get_object(oid).as_raw_string()
-                    path = salt.utils.path_join(os.path.dirname(path), link_tgt)
-                else:
-                    blob = self.repo.get_object(oid)
-                    if isinstance(blob, dulwich.objects.Tree):
-                        # Path is a directory, not a file.
-                        blob = None
-                    break
-            except KeyError:
-                blob = None
-                break
-        if isinstance(blob, dulwich.objects.Blob):
-            return blob, blob.sha().hexdigest(), mode
-        return None, None, None
-
-    def get_conf(self):
-        '''
-        Returns a dulwich.config.ConfigFile object for the specified repo
-        '''
-        return dulwich.config.ConfigFile().from_path(
-            salt.utils.path_join(self.repo.controldir(), 'config')
-        )
-
-    def get_remote_url(self, repo):
-        '''
-        Returns the remote url for the specified repo
-        '''
-        return self.get_conf().get(('remote', 'origin'), 'url')
-
-    def get_tree(self, tgt_env):
-        '''
-        Return a dulwich.objects.Tree object if the branch/tag/SHA is found,
-        otherwise None
-        '''
-        tgt_ref = self.ref(tgt_env)
-        refs = self.repo.get_refs()
-        # Sorting ensures we check heads (branches) before tags
-        for ref in sorted(self.get_env_refs(refs)):
-            # ref will be something like 'refs/remotes/origin/master'
-            try:
-                rtype, rspec = re.split('^refs/(remotes/origin|tags)/',
-                                        ref,
-                                        1)[-2:]
-            except ValueError:
-                # No match was fount for the split regex, we don't care about
-                # this ref. We shouldn't see any of these as the refs are being
-                # filtered through self.get_env_refs(), but just in case, this
-                # will avoid a traceback.
-                continue
-            if rspec == tgt_ref and self.env_is_exposed(tgt_env):
-                if rtype == 'remotes/origin':
-                    commit = self.repo.get_object(refs[ref])
-                elif rtype == 'tags':
-                    tag = self.repo.get_object(refs[ref])
-                    if isinstance(tag, dulwich.objects.Tag):
-                        # Tag.get_object() returns a 2-tuple, the 2nd element
-                        # of which is the commit SHA to which the tag refers
-                        commit = self.repo.get_object(tag.object[1])
-                    elif isinstance(tag, dulwich.objects.Commit):
-                        commit = tag
-                    else:
-                        log.error(
-                            'Unhandled object type \'{0}\' in '
-                            'Dulwich get_tree. This is a bug, please '
-                            'report it.'.format(tag.type_name)
-                        )
-                return self.repo.get_object(commit.tree)
-
-        # Branch or tag not matched, check if 'tgt_env' is a commit. This is more
-        # difficult with Dulwich because of its inability to deal with shortened
-        # SHA-1 hashes.
-        if not self.env_is_exposed(tgt_env):
-            return None
-        elif not salt.utils.is_hex(tgt_ref):
-            # Not hexidecimal, likely just a non-matching environment
-            return None
-
-        try:
-            if len(tgt_ref) == 40:
-                sha_obj = self.repo.get_object(tgt_ref)
-                if isinstance(sha_obj, dulwich.objects.Commit):
-                    sha_commit = sha_obj
-            else:
-                matches = set([
-                    x for x in (
-                        self.repo.get_object(y)
-                        for y in self.repo.object_store
-                        if y.startswith(tgt_ref)
-                    )
-                    if isinstance(x, dulwich.objects.Commit)
-                ])
-                if len(matches) > 1:
-                    log.warning('Ambiguous commit ID \'{0}\''.format(tgt_ref))
-                    return None
-                try:
-                    sha_commit = matches.pop()
-                except IndexError:
-                    pass
-        except TypeError as exc:
-            log.warning('Invalid environment {0}: {1}'.format(tgt_env, exc))
-        except KeyError:
-            # No matching SHA
-            return None
-
-        try:
-            return self.repo.get_object(sha_commit.tree)
-        except NameError:
-            # No matching sha_commit object was created. Unable to find SHA.
-            pass
-        return None
-
-    def init_remote(self):
-        '''
-        Initialize/attach to a remote using dulwich. Return a boolean which
-        will let the calling function know whether or not a new repo was
-        initialized by this function.
-        '''
-        if self.url.startswith('ssh://'):
-            # Dulwich will throw an error if 'ssh://' is used, so make the URL
-            # use git+ssh:// as dulwich expects
-            self.url = 'git+' + self.url
-        new = False
-        if not os.listdir(self.cachedir):
-            # Repo cachedir is empty, initialize a new repo there
-            self.repo = dulwich.repo.Repo.init(self.cachedir)
-            new = True
-        else:
-            # Repo cachedir exists, try to attach
-            try:
-                self.repo = dulwich.repo.Repo(self.cachedir)
-            except dulwich.repo.NotGitRepository:
-                log.error(_INVALID_REPO.format(self.cachedir, self.url, self.role))
-                return new
-
-        self.gitdir = salt.utils.path_join(self.repo.path, '.git')
-
-        # Read in config file and look for the remote
-        try:
-            conf = self.get_conf()
-            conf.get(('remote', 'origin'), 'url')
-        except KeyError:
-            try:
-                conf.set('http', 'sslVerify', self.ssl_verify)
-                # Add remote manually, there is no function/object to do this
-                conf.set(
-                    'remote "origin"',
-                    'fetch',
-                    '+refs/heads/*:refs/remotes/origin/*'
-                )
-                conf.set('remote "origin"', 'url', self.url)
-                conf.set('remote "origin"', 'pushurl', self.url)
-                conf.write_to_path()
-            except os.error:
-                pass
-            else:
-                new = True
-        except os.error:
-            pass
-        return new
-
-    def walk_tree(self, tree, path):
-        '''
-        Dulwich does not provide a means of directly accessing subdirectories.
-        This function will walk down to the directory specified by 'path', and
-        return a Tree object at that path. If path is an empty string, the
-        original tree will be returned, and if there are any issues encountered
-        walking the tree, None will be returned.
-        '''
-        if not path:
-            return tree
-        # Walk down the tree to get to the file
-        for parent in path.split(os.path.sep):
-            try:
-                tree = self.repo.get_object(tree[parent][1])
-            except (KeyError, TypeError):
-                # Directory not found, or tree passed into function is not a Tree
-                # object. Either way, desired path does not exist.
-                return None
-        return tree
-
-    def write_file(self, blob, dest):
-        '''
-        Using the blob object, write the file to the destination path
-        '''
-        with salt.utils.fopen(dest, 'w+') as fp_:
-            fp_.write(blob.as_raw_string())
-
-
 class GitBase(object):
     '''
     Base class for gitfs/git_pillar
@@ -2508,8 +2099,6 @@ class GitBase(object):
                     self.provider = 'pygit2'
                 elif self.verify_gitpython(quiet=True):
                     self.provider = 'gitpython'
-                elif self.verify_dulwich(quiet=True):
-                    self.provider = 'dulwich'
             else:
                 # Ensure non-lowercase providers work
                 try:
@@ -2530,8 +2119,6 @@ class GitBase(object):
                     self.provider = 'pygit2'
                 elif desired_provider == 'gitpython' and self.verify_gitpython():
                     self.provider = 'gitpython'
-                elif desired_provider == 'dulwich' and self.verify_dulwich():
-                    self.provider = 'dulwich'
         if not hasattr(self, 'provider'):
             log.critical(
                 'No suitable {0} provider module is installed.'
@@ -2542,8 +2129,6 @@ class GitBase(object):
             self.provider_class = Pygit2
         elif self.provider == 'gitpython':
             self.provider_class = GitPython
-        elif self.provider == 'dulwich':
-            self.provider_class = Dulwich
 
     def verify_gitpython(self, quiet=False):
         '''
@@ -2552,8 +2137,6 @@ class GitBase(object):
         def _recommend():
             if HAS_PYGIT2 and 'pygit2' in self.valid_providers:
                 log.error(_RECOMMEND_PYGIT2.format(self.role))
-            if HAS_DULWICH and 'dulwich' in self.valid_providers:
-                log.error(_RECOMMEND_DULWICH.format(self.role))
 
         if not HAS_GITPYTHON:
             if not quiet:
@@ -2605,8 +2188,6 @@ class GitBase(object):
         def _recommend():
             if HAS_GITPYTHON and 'gitpython' in self.valid_providers:
                 log.error(_RECOMMEND_GITPYTHON.format(self.role))
-            if HAS_DULWICH and 'dulwich' in self.valid_providers:
-                log.error(_RECOMMEND_DULWICH.format(self.role))
 
         if not HAS_PYGIT2:
             if not quiet:
@@ -2661,50 +2242,6 @@ class GitBase(object):
 
         self.opts['verified_{0}_provider'.format(self.role)] = 'pygit2'
         log.debug('pygit2 {0}_provider enabled'.format(self.role))
-        return True
-
-    def verify_dulwich(self, quiet=False):
-        '''
-        Check if dulwich is available.
-        '''
-        def _recommend():
-            if HAS_GITPYTHON and 'gitpython' in self.valid_providers:
-                log.error(_RECOMMEND_GITPYTHON.format(self.role))
-            if HAS_PYGIT2 and 'pygit2' in self.valid_providers:
-                log.error(_RECOMMEND_PYGIT2.format(self.role))
-
-        if not HAS_DULWICH:
-            if not quiet:
-                log.error(
-                    '%s is configured but could not be loaded. Is Dulwich '
-                    'installed?', self.role
-                )
-                _recommend()
-            return False
-        elif 'dulwich' not in self.valid_providers:
-            return False
-
-        errors = []
-
-        if dulwich.__version__ < DULWICH_MINVER:
-            errors.append(
-                '{0} is configured, but the installed version of Dulwich is '
-                'earlier than {1}. Version {2} detected.'.format(
-                    self.role,
-                    DULWICH_MINVER,
-                    dulwich.__version__
-                )
-            )
-
-        if errors:
-            for error in errors:
-                log.error(error)
-            if not quiet:
-                _recommend()
-            return False
-
-        self.opts['verified_{0}_provider'.format(self.role)] = 'dulwich'
-        log.debug('dulwich {0}_provider enabled'.format(self.role))
         return True
 
     def write_remote_map(self):
@@ -3075,11 +2612,7 @@ class GitPillar(GitBase):
     '''
     def __init__(self, opts):
         self.role = 'git_pillar'
-        # Dulwich has no function to check out a branch/tag, so this will be
-        # limited to GitPython and Pygit2 for the foreseeable future.
-        GitBase.__init__(self,
-                         opts,
-                         valid_providers=('gitpython', 'pygit2'))
+        GitBase.__init__(self, opts)
 
     def checkout(self):
         '''
@@ -3116,12 +2649,7 @@ class WinRepo(GitBase):
     '''
     def __init__(self, opts, winrepo_dir):
         self.role = 'winrepo'
-        # Dulwich has no function to check out a branch/tag, so this will be
-        # limited to GitPython and Pygit2 for the foreseeable future.
-        GitBase.__init__(self,
-                         opts,
-                         valid_providers=('gitpython', 'pygit2'),
-                         cache_root=winrepo_dir)
+        GitBase.__init__(self, opts, cache_root=winrepo_dir)
 
     def checkout(self):
         '''

--- a/tests/integration/fileserver/gitfs_test.py
+++ b/tests/integration/fileserver/gitfs_test.py
@@ -36,6 +36,8 @@ gitfs.__opts__ = {'cachedir': '/tmp/gitfs_test_cache',
                   'gitfs_privkey': '',
                   'gitfs_pubkey': '',
                   'gitfs_passphrase': '',
+                  'gitfs_refspecs': ['+refs/heads/*:refs/remotes/origin/*',
+                                     '+refs/tags/*:refs/tags/*'],
                   'gitfs_ssl_verify': True
 }
 

--- a/tests/unit/fileserver/gitfs_test.py
+++ b/tests/unit/fileserver/gitfs_test.py
@@ -52,6 +52,8 @@ class GitfsConfigTestCase(TestCase):
             'gitfs_global_lock': True,
             'gitfs_ssl_verify': True,
             'gitfs_saltenv': [],
+            'gitfs_refspecs': ['+refs/heads/*:refs/remotes/origin/*',
+                               '+refs/tags/*:refs/tags/*'],
         }
 
     def tearDown(self):

--- a/tests/unit/utils/gitfs_test.py
+++ b/tests/unit/utils/gitfs_test.py
@@ -39,20 +39,18 @@ class TestGitFSProvider(TestCase):
                               MagicMock(return_value=True)):
                 with patch.object(role_class, 'verify_pygit2',
                                   MagicMock(return_value=False)):
-                    with patch.object(role_class, 'verify_dulwich',
-                                      MagicMock(return_value=False)):
-                        args = [OPTS]
-                        if role_name == 'winrepo':
-                            args.append('/tmp/winrepo-dir')
-                        with patch.dict(OPTS, {key: provider}):
-                            # Try to create an instance with uppercase letters in
-                            # provider name. If it fails then a
-                            # FileserverConfigError will be raised, so no assert is
-                            # necessary.
-                            role_class(*args)
-                            # Now try to instantiate an instance with all lowercase
-                            # letters. Again, no need for an assert here.
-                            role_class(*args)
+                    args = [OPTS]
+                    if role_name == 'winrepo':
+                        args.append('/tmp/winrepo-dir')
+                    with patch.dict(OPTS, {key: provider}):
+                        # Try to create an instance with uppercase letters in
+                        # provider name. If it fails then a
+                        # FileserverConfigError will be raised, so no assert is
+                        # necessary.
+                        role_class(*args)
+                        # Now try to instantiate an instance with all lowercase
+                        # letters. Again, no need for an assert here.
+                        role_class(*args)
 
     def test_valid_provider(self):
         '''
@@ -77,36 +75,20 @@ class TestGitFSProvider(TestCase):
                     verify = 'verify_pygit2'
                     mock2 = _get_mock(verify, provider)
                     with patch.object(role_class, verify, mock2):
-                        verify = 'verify_dulwich'
-                        mock3 = _get_mock(verify, provider)
-                        with patch.object(role_class, verify, mock3):
-                            args = [OPTS]
-                            if role_name == 'winrepo':
-                                args.append('/tmp/winrepo-dir')
-                            with patch.dict(OPTS, {key: provider}):
-                                if role_name == 'gitfs' \
-                                        or (role_name != 'gitfs'
-                                            and provider != 'dulwich'):
-                                    # This is a valid provider, so this should
-                                    # pass without raising an exception.
-                                    role_class(*args)
-                                else:
-                                    # Dulwich is not supported for git_pillar nor
-                                    # winrepo, so trying to use it should raise an
-                                    # exception.
-                                    self.assertRaises(
-                                        FileserverConfigError,
-                                        role_class,
-                                        *args
-                                    )
+                        args = [OPTS]
+                        if role_name == 'winrepo':
+                            args.append('/tmp/winrepo-dir')
 
-                            with patch.dict(OPTS, {key: 'foo'}):
-                                # Set the provider name to a known invalid provider
-                                # and make sure it raises an exception.
-                                self.assertRaises(
-                                    FileserverConfigError,
-                                    role_class,
-                                    *args
+                        with patch.dict(OPTS, {key: provider}):
+                            role_class(*args)
+
+                        with patch.dict(OPTS, {key: 'foo'}):
+                            # Set the provider name to a known invalid provider
+                            # and make sure it raises an exception.
+                            self.assertRaises(
+                                FileserverConfigError,
+                                role_class,
+                                *args
                                 )
 
 


### PR DESCRIPTION
Dulwich still lacks important features, including (but not limited to) the
following:

- Lack of the necessary support for checking out a ref needed for
  git_pillar/winrepo support

- No support in its config objects for multivar git config items, making it
  impossible to detect when repos have multiple refspecs set for a given git
  remote

Given this information, and the fact that it trails as a distant third to
Pygit2 and GitPython, Salt will cease to support Dulwich as a git interface
moving forward.

This pull request also resolves #36913 by making refspecs a configurable
parameter for the salt.utils.gitfs.GitBase subclasses.