### PR TITLE
backport Add config option to pin pillarenv to effective saltenv to 2016.11

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1665,6 +1665,23 @@ the environment setting, but for pillar instead of states.
 
     pillarenv: None
 
+.. conf_minion:: pillarenv_from_saltenv
+
+``pillarenv_from_saltenv``
+--------------------------
+
+Default: ``False``
+
+When set to ``True``, the :conf_minion:`pillarenv` value will assume the value
+of the effective saltenv when running states. This essentially makes ``salt '*'
+state.sls mysls saltenv=dev`` equivalent to ``salt '*' state.sls mysls
+saltenv=dev pillarenv=dev``. If :conf_minion:`pillarenv` is set, either in the
+minion config file or via the CLI, it will override this option.
+
+.. code-block:: yaml
+
+    pillarenv_from_saltenv: True
+
 .. conf_minion:: pillar_raise_on_missing
 
 ``pillar_raise_on_missing``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -223,6 +223,9 @@ VALID_OPTS = {
     # Force the minion into a single pillar root when it fetches pillar data from the master
     'pillarenv': str,
 
+    # Make the pillarenv always match the effective saltenv
+    'pillarenv_from_saltenv': bool,
+
     # Allows a user to provide an alternate name for top.sls
     'state_top': str,
 
@@ -970,6 +973,7 @@ DEFAULT_MINION_OPTS = {
     'autoload_dynamic_modules': True,
     'environment': None,
     'pillarenv': None,
+    'pillarenv_from_saltenv': False,
     'pillar_opts': False,
     # ``pillar_cache``, ``pillar_cache_ttl`` and ``pillar_cache_backend``
     # are not used on the minion but are unavoidably in the code path

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -30,7 +30,8 @@ def get(key,
         default=KeyError,
         merge=False,
         delimiter=DEFAULT_TARGET_DELIM,
-        saltenv=None):
+        saltenv=None,
+        pillarenv=None):
     '''
     .. versionadded:: 0.14
 
@@ -66,6 +67,12 @@ def get(key,
         .. versionadded:: 2014.7.0
 
     saltenv
+        Included only for compatibility with
+        :conf_minion:`pillarenv_from_saltenv`, and is otherwise ignored.
+
+        .. versionadded:: Nitrogen
+
+    pillarenv
         If specified, this function will query the master to generate fresh
         pillar data on the fly, specifically from the requested pillar
         environment. Note that this can produce different pillar data than
@@ -92,7 +99,9 @@ def get(key,
         if default is KeyError:
             default = ''
     opt_merge_lists = __opts__.get('pillar_merge_lists', False)
-    pillar_dict = __pillar__ if saltenv is None else items(saltenv=saltenv)
+    pillar_dict = __pillar__ \
+        if all(x is None for x in (saltenv, pillarenv)) \
+        else items(saltenv=saltenv, pillarenv=pillarenv)
 
     if merge:
         if default is None:

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -511,7 +511,7 @@ def apply_(mods=None,
             multiple state runs can safely be run at the same time. Do *not*
             use this flag for performance optimization.
 
-    saltenv : None
+    saltenv
         Specify a salt fileserver environment to be used when applying states
 
         .. versionchanged:: 0.17.0
@@ -525,8 +525,11 @@ def apply_(mods=None,
             saltenv was not explicitly set.
 
     pillarenv
-        Specify a Pillar environment to be used when applying states. By
-        default, all Pillar environments will be merged together and used.
+        Specify a Pillar environment to be used when applying states. This
+        can also be set in the minion config file using the
+        :conf_minion:`pillarenv` option. When neither the
+        :conf_minion:`pillarenv` minion config option nor this CLI argument is
+        used, all Pillar environments will be merged together.
 
     localconfig
         Optionally, instead of using the minion config, load minion opts from
@@ -711,6 +714,26 @@ def highstate(test=None,
 
         .. versionadded:: 2016.3.0
 
+    saltenv
+        Specify a salt fileserver environment to be used when applying states
+
+        .. versionchanged:: 0.17.0
+            Argument name changed from ``env`` to ``saltenv``.
+
+        .. versionchanged:: 2014.7.0
+            If no saltenv is specified, the minion config will be checked for a
+            ``saltenv`` parameter and if found, it will be used. If none is
+            found, ``base`` will be used. In prior releases, the minion config
+            was not checked and ``base`` would always be assumed when the
+            saltenv was not explicitly set.
+
+    pillarenv
+        Specify a Pillar environment to be used when applying states. This
+        can also be set in the minion config file using the
+        :conf_minion:`pillarenv` option. When neither the
+        :conf_minion:`pillarenv` minion config option nor this CLI argument is
+        used, all Pillar environments will be merged together.
+
     queue : False
         Instead of failing immediately when another state run is in progress,
         queue the new state run to begin running once the other has finished.
@@ -774,6 +797,9 @@ def highstate(test=None,
     if 'saltenv' in kwargs:
         opts['environment'] = kwargs['saltenv']
 
+    if 'pillarenv' in kwargs:
+        opts['pillarenv'] = kwargs['pillarenv']
+
     pillar = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
     if pillar_enc is None \
@@ -783,9 +809,6 @@ def highstate(test=None,
             'Pillar data must be formatted as a dictionary, unless pillar_enc '
             'is specified.'
         )
-
-    if 'pillarenv' in kwargs:
-        opts['pillarenv'] = kwargs['pillarenv']
 
     try:
         st_ = salt.state.HighState(opts,
@@ -881,7 +904,7 @@ def sls(mods,
             multiple state runs can safely be run at the same time. Do *not*
             use this flag for performance optimization.
 
-    saltenv : None
+    saltenv
         Specify a salt fileserver environment to be used when applying states
 
         .. versionchanged:: 0.17.0
@@ -895,9 +918,11 @@ def sls(mods,
             saltenv was not explicitly set.
 
     pillarenv
-
-        Specify a Pillar environment to be used when applying states. By
-        default, all Pillar environments will be merged together and used.
+        Specify a Pillar environment to be used when applying states. This
+        can also be set in the minion config file using the
+        :conf_minion:`pillarenv` option. When neither the
+        :conf_minion:`pillarenv` minion config option nor this CLI argument is
+        used, all Pillar environments will be merged together.
 
     localconfig
 
@@ -1076,11 +1101,31 @@ def top(topfn,
         test=None,
         queue=False,
         saltenv=None,
+        pillarenv=None,
         **kwargs):
     '''
     Execute a specific top file instead of the default. This is useful to apply
     configurations from a different environment (for example, dev or prod), without
     modifying the default top file.
+
+    queue : False
+        Instead of failing immediately when another state run is in progress,
+        queue the new state run to begin running once the other has finished.
+
+        This option starts a new thread for each queued state run, so use this
+        option sparingly.
+
+    saltenv
+        Specify a salt fileserver environment to be used when applying states
+
+    pillarenv
+        Specify a Pillar environment to be used when applying states. This
+        can also be set in the minion config file using the
+        :conf_minion:`pillarenv` option. When neither the
+        :conf_minion:`pillarenv` minion config option nor this CLI argument is
+        used, all Pillar environments will be merged together.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -1101,6 +1146,12 @@ def top(topfn,
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
     opts['test'] = _get_test_value(test, **kwargs)
+
+    if saltenv is not None:
+        opts['environment'] = saltenv
+
+    if pillarenv is not None:
+        opts['pillarenv'] = pillarenv
 
     pillar = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
@@ -1199,6 +1250,7 @@ def sls_id(
         id_,
         mods,
         saltenv='base',
+        pillarenv=None,
         test=None,
         queue=False,
         **kwargs):
@@ -1208,6 +1260,16 @@ def sls_id(
     The state ID comes *before* the module ID(s) on the command line.
 
     .. versionadded:: 2014.7.0
+
+    saltenv : base
+        Specify a salt fileserver environment to be used when applying states
+
+    pillarenv
+        Specify a Pillar environment to be used when applying states. This
+        can also be set in the minion config file using the
+        :conf_minion:`pillarenv` option. When neither the
+        :conf_minion:`pillarenv` minion config option nor this CLI argument is
+        used, all Pillar environments will be merged together.
 
     CLI Example:
 
@@ -1221,8 +1283,9 @@ def sls_id(
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
     opts['test'] = _get_test_value(test, **kwargs)
-    if 'pillarenv' in kwargs:
-        opts['pillarenv'] = kwargs['pillarenv']
+    opts['environment'] = saltenv
+    if pillarenv is not None:
+        opts['pillarenv'] = pillarenv
     try:
         st_ = salt.state.HighState(opts, proxy=__proxy__)
     except NameError:
@@ -1258,12 +1321,23 @@ def sls_id(
 
 def show_low_sls(mods,
                  saltenv='base',
+                 pillarenv=None,
                  test=None,
                  queue=False,
                  **kwargs):
     '''
     Display the low data from a specific sls. The default environment is
     ``base``, use ``saltenv`` to specify a different environment.
+
+    saltenv
+        Specify a salt fileserver environment to be used when applying states
+
+    pillarenv
+        Specify a Pillar environment to be used when applying states. This
+        can also be set in the minion config file using the
+        :conf_minion:`pillarenv` option. When neither the
+        :conf_minion:`pillarenv` minion config option nor this CLI argument is
+        used, all Pillar environments will be merged together.
 
     CLI Example:
 
@@ -1286,8 +1360,9 @@ def show_low_sls(mods,
     orig_test = __opts__.get('test', None)
     opts = _get_opts(kwargs.get('localconfig'))
     opts['test'] = _get_test_value(test, **kwargs)
-    if 'pillarenv' in kwargs:
-        opts['pillarenv'] = kwargs['pillarenv']
+    opts['environment'] = saltenv
+    if pillarenv is not None:
+        opts['pillarenv'] = pillarenv
     st_ = salt.state.HighState(opts)
     if isinstance(mods, six.string_types):
         mods = mods.split(',')
@@ -1317,6 +1392,16 @@ def show_sls(mods, saltenv='base', test=None, queue=False, **kwargs):
     ``show_top`` instead.
 
     Custom Pillar data can be passed with the ``pillar`` kwarg.
+
+    saltenv
+        Specify a salt fileserver environment to be used when applying states
+
+    pillarenv
+        Specify a Pillar environment to be used when applying states. This
+        can also be set in the minion config file using the
+        :conf_minion:`pillarenv` option. When neither the
+        :conf_minion:`pillarenv` minion config option nor this CLI argument is
+        used, all Pillar environments will be merged together.
 
     CLI Example:
 

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -77,8 +77,12 @@ class AsyncRemotePillar(object):
         self.grains = grains
         self.minion_id = minion_id
         self.channel = salt.transport.client.AsyncReqChannel.factory(opts)
-        if pillarenv is not None or 'pillarenv' not in self.opts:
+        if pillarenv is not None:
             self.opts['pillarenv'] = pillarenv
+        elif self.opts.get('pillarenv_from_saltenv', False):
+            self.opts['pillarenv'] = saltenv
+        elif 'pillarenv' not in self.opts:
+            self.opts['pillarenv'] = None
         self.pillar_override = {}
         if pillar is not None:
             if isinstance(pillar, dict):
@@ -130,8 +134,12 @@ class RemotePillar(object):
         self.grains = grains
         self.minion_id = minion_id
         self.channel = salt.transport.Channel.factory(opts)
-        if pillarenv is not None or 'pillarenv' not in self.opts:
+        if pillarenv is not None:
             self.opts['pillarenv'] = pillarenv
+        elif self.opts.get('pillarenv_from_saltenv', False):
+            self.opts['pillarenv'] = saltenv
+        elif 'pillarenv' not in self.opts:
+            self.opts['pillarenv'] = None
         self.pillar_override = {}
         if pillar is not None:
             if isinstance(pillar, dict):


### PR DESCRIPTION
This is a backport of #38404 to 2016.11