### PR TITLE
Merge carlpett/salt-vault

### DIFF
--- a/salt/modules/vault.py
+++ b/salt/modules/vault.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+'''
+:maintainer:    SaltStack
+:maturity:      new
+:platform:      all
+
+Functions to interact with Hashicorp Vault.
+
+:configuration: The salt-master must be configured to allow peer-runner
+    configuration, as well as configuration for the module.
+
+    Add this segment to the master configuration file, or
+    /etc/salt/master.d/vault.conf:
+
+    .. code-block:: yaml
+
+        vault:
+            url: https://vault.service.domain:8200
+            auth:
+                method: token
+                token: 11111111-2222-3333-4444-555555555555
+            policies:
+                - saltstack/minions
+                - saltstack/minion/{minion}
+                .. more policies
+
+    url
+        Url to your Vault installation. Required.
+
+    auth
+        Currently only token auth is supported. The token must be able to create
+        tokens with the policies that should be assigned to minions. Required.
+
+    policies
+        Policies that are assigned to minions when requesting a token. These can
+        either be static, eg saltstack/minions, or templated, eg
+        ``saltstack/minion/{minion}``. ``{minion}`` is shorthand for grains[id].
+        Grains are also available, for example like this:
+        ``my-policies/{grains[os]}``
+
+        Optional. If policies is not configured, saltstack/minions and
+        saltstack/{minion} are used as defaults.
+
+
+    Add this segment to the master configuration file, or
+    /etc/salt/master.d/peer_run.conf:
+
+    .. code-block:: yaml
+
+        peer_run:
+            .*:
+                - vault.generate_token
+'''
+from __future__ import absolute_import
+import logging
+
+import salt.crypt
+import salt.exceptions
+
+
+log = logging.getLogger(__name__)
+
+
+def read_secret(path, key=None):
+    '''
+    Return the value of key at path in vault, or entire secret
+
+    Jinja Example:
+
+    .. code-block:: jinja
+
+            my-secret: {{ salt['vault'].read_secret('secret/my/secret', 'some-key') }}
+
+    .. code-block:: jinja
+
+            {% set supersecret = salt['vault'].read_secret('secret/my/secret') %}
+            secrets:
+                first: {{ supersecret.first }}
+                second: {{ supersecret.second }}
+    '''
+    log.debug('Reading Vault secret for {0} at {1}'.format(__grains__['id'], path))
+    try:
+        url = 'v1/{0}'.format(path)
+        response = __utils__['vault.make_request']('GET', url)
+        if response.status_code != 200:
+            response.raise_for_status()
+        data = response.json()['data']
+
+        if key is not None:
+            return data[key]
+        return data
+    except Exception as e:
+        log.error('Failed to read secret! {0}: {1}'.format(type(e).__name__, e))
+        raise salt.exceptions.CommandExecutionError(e)
+
+
+def write_secret(path, **kwargs):
+    '''
+    Set secret at the path in vault. The vault policy used must allow this.
+
+    CLI Example:
+
+    .. code-block:: bash
+            salt '*' vault.write_secret "secret/my/secret" user="foo" password="bar"
+    '''
+    log.debug(
+        'Writing vault secrets for {0} at {1}'.
+        format(__grains__['id'], path)
+        )
+    data = dict([(x, y) for x, y in kwargs.items() if not x.startswith('__')])
+    try:
+        url = 'v1/{0}'.format(path)
+        response = __utils__['vault.make_request']('POST', url, json=data)
+        if response.status_code != 204:
+            response.raise_for_status()
+        return True
+    except Exception as e:
+        log.error('Failed to write secret! {0}: {1}'.format(type(e).__name__, e))
+        raise salt.exceptions.CommandExecutionError(e)
+
+
+def delete_secret(path):
+    '''
+    Delete secret at the path in vault. The vault policy used must allow this.
+
+    CLI Example:
+
+    .. code-block:: bash
+            salt '*' vault.delete_secret "secret/my/secret"
+    '''
+    log.debug('Deleting vault secrets for {0} in {1}'
+              .format(__grains__['id'], path))
+    try:
+        url = 'v1/{0}'.format(path)
+        response = __utils__['vault.make_request']('DELETE', url)
+        if response.status_code != 204:
+            response.raise_for_status()
+        return True
+    except Exception as e:
+        log.error('Failed to delete secret! {0}: {1}'.format(type(e).__name__, e))
+        raise salt.exceptions.CommandExecutionError(e)
+
+
+def list_secrets(path):
+    '''
+    List secret keys at the path in vault. The vault policy used must allow this.
+    The path should end with a trailing slash.
+
+    CLI Example:
+
+    .. code-block:: bash
+            salt '*' vault.list_secrets "secret/my/"
+    '''
+    log.debug('Listing vault secret keys for {0} in {1}'
+              .format(__grains__['id'], path))
+    try:
+        url = 'v1/{0}'.format(path)
+        response = __utils__['vault.make_request']('LIST', url)
+        if response.status_code != 200:
+            response.raise_for_status()
+        return response.json()['data']
+    except Exception as e:
+        log.error('Failed to list secrets! {0}: {1}'.format(type(e).__name__, e))
+        raise salt.exceptions.CommandExecutionError(e)

--- a/salt/runners/vault.py
+++ b/salt/runners/vault.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+'''
+:maintainer:    SaltStack
+:maturity:      new
+:platform:      all
+
+Runner functions supporting the Vault modules. Configuration instructions are
+documented in the execution module docs.
+'''
+
+from __future__ import absolute_import
+import base64
+import logging
+import requests
+
+import salt.crypt
+import salt.exceptions
+
+
+log = logging.getLogger(__name__)
+
+
+def generate_token(minion_id, signature, impersonated_by_master=False):
+    '''
+    Generate a Vault token for minion minion_id
+
+    minion_id
+        The id of the minion that requests a token
+
+    signature
+        Cryptographic signature which validates that the request is indeed sent
+        by the minion (or the master, see impersonated_by_master).
+
+    impersonated_by_master
+        If the master needs to create a token on behalf of the minion, this is
+        True. This happens when the master generates minion pillars.
+    '''
+    log.debug('Token generation request for {0} (impersonated by master: {1})'.
+              format(minion_id, impersonated_by_master))
+    _validate_signature(minion_id, signature, impersonated_by_master)
+
+    try:
+        config = __opts__['vault']
+
+        url = '{0}/v1/auth/token/create'.format(config['url'])
+        headers = {'X-Vault-Token': config['auth']['token']}
+        audit_data = {
+            'saltstack-jid': globals().get('__jid__', '<no jid set>'),
+            'saltstack-minion': minion_id,
+            'saltstack-user': globals().get('__user__', '<no user set>')
+        }
+        payload = {
+                    'policies': _get_policies(minion_id, config),
+                    'num_uses': 1,
+                    'metadata': audit_data
+                  }
+
+        log.trace('Sending token creation request to Vault')
+        response = requests.post(url, headers=headers, json=payload)
+
+        if response.status_code != 200:
+            return {'error': response.reason}
+
+        authData = response.json()['auth']
+        return {'token': authData['client_token'], 'url': config['url']}
+    except Exception as e:
+        return {'error': str(e)}
+
+
+def show_policies(minion_id):
+    '''
+    Show the Vault policies that are applied to tokens for the given minion
+
+    minion_id
+        The minions id
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run vault.show_policies myminion
+    '''
+    config = __opts__['vault']
+    return _get_policies(minion_id, config)
+
+
+def _validate_signature(minion_id, signature, impersonated_by_master):
+    '''
+    Validate that either minion with id minion_id, or the master, signed the
+    request
+    '''
+    pki_dir = __opts__['pki_dir']
+    if impersonated_by_master:
+        public_key = '{0}/master.pub'.format(pki_dir)
+    else:
+        public_key = '{0}/minions/{1}'.format(pki_dir, minion_id)
+
+    log.trace('Validating signature for {0}'.format(minion_id))
+    signature = base64.b64decode(signature)
+    if not salt.crypt.verify_signature(public_key, minion_id, signature):
+        raise salt.exceptions.AuthenticationError(
+            'Could not validate token request from {0}'.format(minion_id)
+            )
+    log.trace('Signature ok')
+
+
+def _get_policies(minion_id, config):
+    '''
+    Get the policies that should be applied to a token for minion_id
+    '''
+    _, grains, _ = salt.utils.minions.get_minion_data(minion_id, __opts__)
+    policy_patterns = config.get(
+                                 'policies',
+                                 ['saltstack/minion/{minion}', 'saltstack/minions']
+                                )
+    mappings = {'minion': minion_id, 'grains': grains}
+
+    policies = []
+    for pattern in policy_patterns:
+        policies.append(pattern.format(**mappings))
+
+    log.debug('{0} policies: {1}'.format(minion_id, policies))
+    return policies

--- a/salt/states/vault.py
+++ b/salt/states/vault.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+'''
+:maintainer:    SaltStack
+:maturity:      new
+:platform:      all
+
+.. versionadded:: 2017.x.0
+
+States for managing Hashicorp Vault. Currently handles policies. Configuration
+instructions are documented in the execution module docs.
+'''
+from __future__ import absolute_import
+import logging
+import difflib
+
+log = logging.getLogger(__name__)
+
+
+def policy_present(name, rules):
+    '''
+    Ensure a Vault policy with the given name and rules is present.
+
+    name
+        The name of the policy
+
+    rules
+        Rules formatted as in-line HCL
+
+
+    .. code-block:: yaml
+    demo-policy:
+      vault.policy_present:
+        - name: foo/bar
+        - rules: |
+            path "secret/top-secret/*" {
+              policy = "deny"
+            }
+            path "secret/not-very-secret/*" {
+              policy = "write"
+            }
+
+    '''
+    url = "v1/sys/policy/{0}".format(name)
+    response = __utils__['vault.make_request']('GET', url)
+    try:
+        if response.status_code == 200:
+            return _handle_existing_policy(name, rules, response.json()['rules'])
+        elif response.status_code == 404:
+            return _create_new_policy(name, rules)
+        else:
+            response.raise_for_status()
+    except Exception as e:
+        return {
+            'name': name,
+            'changes': None,
+            'result': False,
+            'comment': 'Failed to get policy: {0}'.format(e)
+        }
+
+
+def _create_new_policy(name, rules):
+    if __opts__['test']:
+        return {
+            'name': name,
+            'changes': {name: {'old': '', 'new': rules}},
+            'result': None,
+            'comment': 'Policy would be created'
+        }
+
+    payload = {'rules': rules}
+    url = "v1/sys/policy/{0}".format(name)
+    response = __utils__['vault.make_request']('PUT', url, json=payload)
+    if response.status_code != 204:
+        return {
+            'name': name,
+            'changes': None,
+            'result': False,
+            'comment': 'Failed to create policy: {0}'.format(response.reason)
+        }
+
+    return {
+        'name': name,
+        'result': True,
+        'changes': {name: {'old': None, 'new': rules}},
+        'comment': 'Policy was created'
+    }
+
+
+def _handle_existing_policy(name, new_rules, existing_rules):
+    ret = {'name': name}
+    if new_rules == existing_rules:
+        ret['result'] = True
+        ret['changes'] = None
+        ret['comment'] = 'Policy exists, and has the correct content'
+        return ret
+
+    change = ''.join(difflib.unified_diff(existing_rules.splitlines(True), new_rules.splitlines(True)))
+    if __opts__['test']:
+        ret['result'] = None
+        ret['changes'] = {name: {'change': change}}
+        ret['comment'] = 'Policy would be changed'
+        return ret
+
+    payload = {'rules': new_rules}
+
+    url = "v1/sys/policy/{0}".format(name)
+    response = __utils__['vault.make_request']('PUT', url, json=payload)
+    if response.status_code != 204:
+        return {
+            'name': name,
+            'changes': None,
+            'result': False,
+            'comment': 'Failed to change policy: {0}'.format(response.reason)
+        }
+
+    ret['result'] = True
+    ret['changes'] = {name: {'change': change}}
+    ret['comment'] = 'Policy was updated'
+
+    return ret

--- a/salt/utils/vault.py
+++ b/salt/utils/vault.py
@@ -1,140 +1,158 @@
 # -*- coding: utf-8 -*-
 '''
-Vault Connection Functions
-
 :maintainer:    SaltStack
-:maturity:      New
+:maturity:      new
 :platform:      all
 
-.. versionadded:: 2016.11.0
-
-This module allows access to Hashicorp Vault using an ``sdb://`` URI.
-
-Like all sdb modules, the vault module requires a configuration profile to
-be configured in either the minion or master configuration file. This profile
-requires very little. In the example:
-
-.. code-block:: yaml
-
-    myvault:
-      driver: vault
-      vault.host: 127.0.0.1
-      vault.port: 8200
-      vault.scheme: http  # Optional; default is https
-      vault.token: 012356789abcdef  # Required, unless set in environment
-
-The ``driver`` refers to the ``vault`` module, ``vault.host`` refers to the host
-that is hosting vault and ``vault.port`` refers to the port on that host. A
-vault token is also required. It may be set statically, as above, or as an
-environment variable:
-
-.. code-block:: bash
-
-    $ export VAULT_TOKEN=0123456789abcdef
-
-Once configured you can access data using a URL such as:
-
-.. code-block:: yaml
-
-    password: sdb://myvault/secret/passwords?mypassword
-
-In this URL, ``myvault`` refers to the configuration profile,
-``secret/passwords`` is the path where the data resides, and ``mypassword`` is
-the key of the data to return.
-
-The above URI is analogous to running the following vault command:
-
-.. code-block:: bash
-
-    $ vault read -field=mypassword secret/passwords
+Utilities supporting modules for Hashicorp Vault. Configuration instructions are
+documented in the execution module docs.
 '''
 
-# import python libs
 from __future__ import absolute_import
-import os
+import base64
 import logging
-import json
-import salt.utils.http
-from salt.exceptions import CommandExecutionError
+import os
+import requests
+
+import salt.crypt
+import salt.exceptions
 
 log = logging.getLogger(__name__)
+logging.getLogger("requests").setLevel(logging.WARNING)
 
 
-def _get_token(profile):
-    '''
-    Get a token and raise an error if it can't be found
-    '''
-    token = os.environ.get('VAULT_TOKEN', profile.get('vault.token'))
-    if token is None:
-        raise CommandExecutionError('A token was not configured')
-    return token
+# Load the __salt__ dunder if not already loaded (when called from utils-module)
+__salt__ = None
+def __virtual__():  # pylint: disable=expected-2-blank-lines-found-0
+    try:
+        global __salt__  # pylint: disable=global-statement
+        if not __salt__:
+            __salt__ = salt.loader.minion_mods(__opts__)
+            return True
+    except Exception as e:
+        log.error("Could not load __salt__: {0}".format(e))
+        return False
 
 
-def write_(path, key, value, profile=None):
+def _get_token_and_url_from_master():
     '''
-    Set a key/value pair in the vault service
+    Get a token with correct policies for the minion, and the url to the Vault
+    service
     '''
-    result = _query(
-        'POST',
-        path,
-        profile=profile,
-        data=json.dumps({key: value}),
+    minion_id = __grains__['id']
+    pki_dir = __opts__['pki_dir']
+
+    # When rendering pillars, the module executes on the master, but the token
+    # should be issued for the minion, so that the correct policies are applied
+    if __opts__.get('__role', 'minion') == 'minion':
+        private_key = '{0}/minion.pem'.format(pki_dir)
+        log.debug(
+                  'Running on minion, signing token request with key {0}'.
+                  format(private_key)
+                 )
+        signature = base64.b64encode(salt.crypt.sign_message(
+                                                             private_key,
+                                                             minion_id
+                                                            ))
+        result = __salt__['publish.runner'](
+                                            'vault.generate_token',
+                                            arg=[minion_id, signature]
+                                           )
+    else:
+        private_key = '{0}/master.pem'.format(pki_dir)
+        log.debug(
+                  'Running on master, signing token request for {0} with key {1}'.
+                  format(minion_id, private_key)
+                 )
+        signature = base64.b64encode(salt.crypt.sign_message(
+                                                             private_key,
+                                                             minion_id
+                                                            ))
+        result = __salt__['saltutil.runner'](
+                                             'vault.generate_token',
+                                             minion_id=minion_id,
+                                             signature=signature,
+                                             impersonated_by_master=True
+                                            )
+
+    if not result:
+        log.error('Failed to get token from master! No result returned - '
+                  'is the peer publish configuration correct?')
+        raise salt.exceptions.CommandExecutionError(result)
+    if not isinstance(result, dict):
+        log.error('Failed to get token from master! '
+                  'Response is not a dict: {0}'.format(result))
+        raise salt.exceptions.CommandExecutionError(result)
+    if 'error' in result:
+        log.error('Failed to get token from master! '
+                  'An error was returned: {0}'.format(result['error']))
+        raise salt.exceptions.CommandExecutionError(result)
+    return {
+            'url': result['url'],
+            'token': result['token']
+           }
+
+
+def _get_vault_connection():
+    '''
+    Get the connection details for calling Vault, from local configuration if
+    it exists, or from the master otherwise
+    '''
+    if 'vault' in __opts__ and not __opts__.get('__role', 'minion') == 'master':
+        log.debug('Using Vault connection details from local config')
+        try:
+            return {
+                'url': __opts__['vault']['url'],
+                'token': __opts__['vault']['auth']['token']
+            }
+        except KeyError as err:
+            errmsg = 'Minion has "vault" config section, but could not find key "{0}" within'.format(err.message)
+            raise salt.exceptions.CommandExecutionError(errmsg)
+    else:
+        log.debug('Contacting master for Vault connection details')
+        return _get_token_and_url_from_master()
+
+
+def make_request(method, resource, profile=None, **args):
+    '''
+    Make a request to Vault
+    '''
+    if profile is not None and profile.keys().remove('driver') is not None:
+        # Deprecated code path
+        return make_request_with_profile(method, resource, profile, **args)
+
+    connection = _get_vault_connection()
+    token, vault_url = connection['token'], connection['url']
+
+    url = "{0}/{1}".format(vault_url, resource)
+    headers = {'X-Vault-Token': token, 'Content-Type': 'application/json'}
+    response = requests.request(method, url, headers=headers, **args)
+
+    return response
+
+
+def make_request_with_profile(method, resource, profile, **args):
+    '''
+    DEPRECATED! Make a request to Vault, with a profile including connection
+    details.
+    '''
+    salt.utils.warn_until(
+        'Oxygen',
+        'Specifying Vault connection data within a \'profile\' has been '
+        'deprecated. Please see the documentation for details on the new '
+        'configuration schema.'
     )
-
-    return read_(path, key, profile)
-
-
-def read_(path, key=None, profile=None):
-    '''
-    Get a value from the vault service
-    '''
-    result = _query(
-        'GET',
-        path,
-        profile=profile,
-        decode=True,
-        decode_type='json',
-    )
-
-    data = result['dict'].get('data', {})
-    if key is None:
-        return data
-
-    value = data.get(key)
-    if value is None:
-        log.error('The key was not found')
-    return value
-
-
-def _query(method, path, profile=None, **kwargs):
-    '''
-    Perform a query to Vault
-    '''
-    token = _get_token(profile)
-    headers = {'X-Vault-Token': token}
-
     url = '{0}://{1}:{2}/v1/{3}'.format(
         profile.get('vault.scheme', 'https'),
         profile.get('vault.host'),
         profile.get('vault.port'),
-        path,
+        resource,
     )
+    token = os.environ.get('VAULT_TOKEN', profile.get('vault.token'))
+    if token is None:
+        raise salt.exceptions.CommandExecutionError('A token was not configured')
 
-    result = salt.utils.http.query(
-        url,
-        method,
-        header_dict=headers,
-        status=True,
-        **kwargs
-    )
+    headers = {'X-Vault-Token': token, 'Content-Type': 'application/json'}
+    response = requests.request(method, url, headers=headers, **args)
 
-    if not str(result['status']).startswith('2'):
-        # This includes 200 and 204, both of which are a success
-        error = result.get(
-            'error',
-            'There was an error: status {0} returned'.format(result['status'])
-        )
-        log.error(error)
-        raise CommandExecutionError(error)
-
-    return result
+    return response


### PR DESCRIPTION
### What does this PR do?
This merges the repo [carlpett/salt-vault](https://github.com/carlpett/salt-vault) which contains a separate implementation of Vault integration that was developed concurrently by @techhat with the existing implementation. 

The approaches taken in the two implementations are slightly different, but old configuration should still be compatible with the merged code (albeit with deprecation warnings).

Note that this PR has an implicit dependency on #39174 for the sdb module to work, so it cannot be merged before that PR.

Since this is my first larger PR to salt: have I missed something? The linting _mostly_ passes, for instance, do I need to suppress all the things I consider false positives, or are they mainly advisory? 
Have I formatted the documentation correctly? 

### What issues does this PR fix or reference?
#27020

### New Behavior
Vault policies are enforced when reading secrets. Supports state management of policies, and an execution module for CRUD operations.

### Tests written?
No