### PR TITLE
remove (?x) modifiers in file.comment regex

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4107,7 +4107,9 @@ def comment(name, regex, char='#', backup='.bak'):
     if not check_res:
         return _error(ret, check_msg)
 
-    unanchor_regex = regex.lstrip('^').rstrip('$')
+    # remove (?i)-like flags, ^ and $
+    unanchor_regex = re.sub(r'^(\(\?[iLmsux]\))?\^?(.*?)\$?$', r'\2', regex)
+
     comment_regex = char + unanchor_regex
 
     # Check if the line is already commented

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -267,6 +267,7 @@ import difflib
 import itertools
 import logging
 import os
+import re
 import shutil
 import sys
 import traceback


### PR DESCRIPTION
### What does this PR do?
At the start of the regex there can be modifiers which also have to be removed before searching for a comment, see #39188.

### What issues does this PR fix or reference?
39188 

### Previous Behavior
only removes ^ and $, and then the comment check trips if you have a (?i) for case-insensitivity in there.

### New Behavior
also remove (?x) with x all possible flags for a regex, see [here](https://docs.python.org/2/library/re.html)

### Tests written?
No