### PR TITLE
The lint fix broke some tests: use pylint disable instead

### DIFF
--- a/salt/modules/win_ip.py
+++ b/salt/modules/win_ip.py
@@ -76,7 +76,7 @@ def _interface_configs():
             current_ip_list.append(val)
 
         elif 'ip address' in lkey:
-            current_iface.setdefault('ip_addrs', []).append({key: val})
+            current_iface.setdefault('ip_addrs', []).append({key:val})  # pylint: disable=E8231
 
         elif 'subnet prefix' in lkey:
             subnet, _, netmask = val.split(' ', 2)


### PR DESCRIPTION
The change in #39202, which was a follow up to #38793, broke the following tests:
- unit.modules.win_ip_test.WinShadowTestCase.test_get_interface
- unit.modules.win_ip_test.WinShadowTestCase.test_get_all_interfaces