### PR TITLE
Loader optimzation

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1416,8 +1416,12 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             # It default's of course to the found callable attribute name
             # if no alias is defined.
             funcname = getattr(mod, '__func_alias__', {}).get(attr, attr)
+            try:
+                full_funcname = '.'.join((module_name, funcname))
+            except TypeError:
+                full_funcname = '{0}.{1}'.format(module_name, funcname)
             # Save many references for lookups
-            self._dict['{0}.{1}'.format(module_name, funcname)] = func
+            self._dict[full_funcname] = func
             setattr(mod_dict, funcname, func)
             mod_dict[funcname] = func
             self._apply_outputter(func, mod)


### PR DESCRIPTION
Use a str.join instead of str.format to make the full function name. Based on the below benchmarking using ``timeit``, we should get a considerable improvement, especially with hundreds of functions being loaded in a single loader invocation.

```python
>>> import timeit
>>> try1 = '''\
  2 full_funcname = '{0}.{1}'.format(module_name, funcname)
  3 '''
>>> try2 = '''\
  2 full_funcname = '.'.join((module_name, funcname))
  3 '''
>>> try3 = '''\
  2 try:
  3     full_funcname = '.'.join((module_name, funcname))
  4 except TypeError:
  5     full_funcname = '{0}.{1}'.format(module_name, funcname)
  6 '''
>>> prep = '''\
  2 module_name = 'foo'
  3 funcname = 'bar'
  4 '''
>>> t1 = timeit.Timer(try1, prep)
>>> t2 = timeit.Timer(try2, prep)
>>> t3 = timeit.Timer(try3, prep)
>>> t1.repeat()
[0.28724193572998047, 0.25792503356933594, 0.2585139274597168]
>>> t2.repeat()
[0.14360880851745605, 0.12038207054138184, 0.12308502197265625]
>>> t3.repeat()
[0.16092491149902344, 0.13240313529968262, 0.1337299346923828]
>>>
```