### PR TITLE
default to utf8 encoding if not specified

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -87,7 +87,7 @@ def creds(provider):
                 proxies={'http': ''}, timeout=AWS_METADATA_TIMEOUT,
             )
             result.raise_for_status()
-            role = result.text.encode(result.encoding)
+            role = result.text.encode(result.encoding or 'utf-8')
         except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
             return provider['id'], provider['key'], ''
 
@@ -460,7 +460,7 @@ def query(params=None, setname=None, requesturl=None, location=None,
             )
             LOG.trace(
                 'AWS Response Text: {0}'.format(
-                    result.text.encode(result.encoding)
+                    result.text.encode(result.encoding or 'utf-8')
                 )
             )
             result.raise_for_status()
@@ -501,7 +501,7 @@ def query(params=None, setname=None, requesturl=None, location=None,
             return {'error': data}, requesturl
         return {'error': data}
 
-    response = result.text.encode(result.encoding)
+    response = result.text.encode(result.encoding or 'utf-8')
 
     root = ET.fromstring(response)
     items = root[1]


### PR DESCRIPTION
### What does this PR do?
On errors, for some reason AWS does not always have an encoding on the
message.  Default to 'utf-8'.

### What issues does this PR fix or reference?
#38856

### Tests written?

No
