### PR TITLE
Add clarification for jenkins execution module

### DIFF
--- a/salt/modules/jenkins.py
+++ b/salt/modules/jenkins.py
@@ -4,6 +4,11 @@ Module for controlling Jenkins
 
 .. versionadded:: 2016.3.0
 
+:depends: python-jenkins_ Python module (not to be confused with jenkins_)
+
+.. _python-jenkins: https://pypi.python.org/pypi/python-jenkins
+.. _jenkins: https://pypi.python.org/pypi/jenkins
+
 :configuration: This module can be used by either passing an api key and version
     directly or by specifying both in a configuration profile in the salt
     master/minion config.
@@ -45,9 +50,15 @@ def __virtual__():
     :return: The virtual name of the module.
     '''
     if HAS_JENKINS:
-        return __virtualname__
+        if hasattr(jenkins, 'Jenkins'):
+            return __virtualname__
+        else:
+            return (False,
+                    'The wrong Python module appears to be installed. Please '
+                    'make sure that \'python-jenkins\' is installed, not '
+                    '\'jenkins\'.')
     return (False, 'The jenkins execution module cannot be loaded: '
-            'python jenkins library is not installed.')
+                   'python-jenkins is not installed.')
 
 
 def _connect():


### PR DESCRIPTION
There are two modules on PyPI which import as "jenkins". Installing the
wrong one will result in a traceback when the execution module tries to
use the Python bindings. This commit adds information about the
dependency to the docstring for the module. It also checks to make sure
that ``jenkins.Jenkins`` is present in the ``__virtual__()`` func, and if not it
will fail to load the execution module with a meaningful error message
in the log.