### PR TITLE
Avoid recursion in s3/svn ext_pillars

### DIFF
--- a/salt/pillar/s3.py
+++ b/salt/pillar/s3.py
@@ -172,7 +172,7 @@ def ext_pillar(minion_id,
 
     pil = Pillar(opts, __grains__, minion_id, environment)
 
-    compiled_pillar = pil.compile_pillar()
+    compiled_pillar = pil.compile_pillar(ext=False)
 
     return compiled_pillar
 

--- a/salt/pillar/svn_pillar.py
+++ b/salt/pillar/svn_pillar.py
@@ -193,4 +193,4 @@ def ext_pillar(minion_id,
     opts = deepcopy(__opts__)
     opts['pillar_roots'][branch] = [pillar_dir]
     pil = Pillar(opts, __grains__, minion_id, branch)
-    return pil.compile_pillar()
+    return pil.compile_pillar(ext=False)


### PR DESCRIPTION
This passes ``ext=False`` when compiling pillar data in these ext_pillar
sources.