### PR TITLE
Various doc updates to fix warnings in doc build

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1,3 +1,6 @@
+.. _glossary:
+
+========
 Glossary
 ========
 

--- a/doc/ref/clouds/all/salt.cloud.clouds.virtualbox.rst
+++ b/doc/ref/clouds/all/salt.cloud.clouds.virtualbox.rst
@@ -1,6 +1,6 @@
-========================
+============================
 salt.cloud.clouds.virtualbox
-========================
+============================
 
 .. automodule:: salt.cloud.clouds.virtualbox
     :members:

--- a/doc/ref/configuration/examples.rst
+++ b/doc/ref/configuration/examples.rst
@@ -1,3 +1,5 @@
+.. _configuration-file-examples:
+
 ===========================
 Configuration file examples
 ===========================

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -735,7 +735,7 @@ Pass in an alternative location for the salt-ssh roster file.
 .. conf_master:: ssh_log_file
 
 ``ssh_log_file``
--------------------
+----------------
 
 .. versionadded:: 2016.3.5
 

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -1,4 +1,4 @@
-.. _all-salt_modules:
+.. _all-salt.modules:
 
 =================
 execution modules

--- a/doc/ref/modules/all/salt.modules.cytest.rst
+++ b/doc/ref/modules/all/salt.modules.cytest.rst
@@ -3,4 +3,3 @@ salt.modules.cytest module
 
 .. automodule:: salt.modules.cytest
     :members:
-

--- a/doc/ref/returners/index.rst
+++ b/doc/ref/returners/index.rst
@@ -47,7 +47,7 @@ Writing a Returner
 
 A returner is a Python module containing at minimum a ``returner`` function.
 Other optional functions can be included to add support for
-:ref:`master_job_cache`, :ref:`external_job_cache`, and `Event Returners`_.
+:conf_master:`master_job_cache`, :ref:`external-job-cache`, and `Event Returners`_.
 
 ``returner``
     The ``returner`` function must accept a single argument. The argument
@@ -85,8 +85,8 @@ serializes the data as JSON and sets it in redis.
 Master Job Cache Support
 ------------------------
 
-:ref:`master_job_cache`, :ref:`external_job_cache`, and `Event Returners`_.
-Salt's :ref:`master_job_cache` allows returners to be used as a pluggable
+:conf_master:`master_job_cache`, :ref:`external-job-cache`, and `Event Returners`_.
+Salt's :conf_master:`master_job_cache` allows returners to be used as a pluggable
 replacement for the :ref:`default_job_cache`. In order to do so, a returner
 must implement the following functions:
 
@@ -176,7 +176,7 @@ must implement the following functions:
 External Job Cache Support
 --------------------------
 
-Salt's :ref:`external_job_cache` extends the :ref:`master_job_cache`. External
+Salt's :ref:`external-job-cache` extends the :conf_master:`master_job_cache`. External
 Job Cache support requires the following functions in addition to what is
 required for Master Job Cache support:
 
@@ -328,7 +328,7 @@ Testing the Returner
 
 The ``returner``, ``prep_jid``, ``save_load``, ``get_load``, and
 ``event_return`` functions can be tested by configuring the
-:ref:`master_job_cache` and `Event Returners`_ in the master config
+:conf_master:`master_job_cache` and `Event Returners`_ in the master config
 file and submitting a job to ``test.ping`` each minion from the master.
 
 Once you have successfully exercised the Master Job Cache functions, test the

--- a/doc/topics/cloud/misc.rst
+++ b/doc/topics/cloud/misc.rst
@@ -94,7 +94,7 @@ profile or map:
 Setting Up a Salt Syndic with Salt Cloud
 ========================================
 
-In addition to `setting up new Salt Masters`_, :ref:`syndic`s can also be
+In addition to `setting up new Salt Masters`_, :ref:`syndics <syndic>` can also be
 provisioned using Salt Cloud. In order to set up a Salt Syndic via Salt Cloud,
 a Salt Master needs to be installed on the new machine and a master configuration
 file needs to be set up using the ``make_master`` setting. This setting can be

--- a/doc/topics/development/contributing.rst
+++ b/doc/topics/development/contributing.rst
@@ -418,3 +418,4 @@ and bug resolution. See the :ref:`Labels and Milestones
 .. _'Git resources`: https://help.github.com/articles/good-resources-for-learning-git-and-github/
 .. _`Closing issues via commit message`: https://help.github.com/articles/closing-issues-via-commit-messages
 .. _`git format-patch`: https://www.kernel.org/pub/software/scm/git/docs/git-format-patch.html
+.. _salt-users: https://groups.google.com/forum/#!forum/salt-users

--- a/doc/topics/development/modular_systems.rst
+++ b/doc/topics/development/modular_systems.rst
@@ -25,7 +25,7 @@ modules is that the defined functions always return a JSON serializable
 object.
 
 For a list of all built in execution modules, click :ref:`here
-<all-salt_modules>`
+<all-salt.modules>`
 
 For information on writing execution modules, see :ref:`this page
 <writing-execution-modules>`.

--- a/doc/topics/execution/index.rst
+++ b/doc/topics/execution/index.rst
@@ -15,7 +15,7 @@ a wide variety of tasks. These modules provide functionality such as installing
 packages, restarting a service, running a remote command, transferring files,
 and so on.
 
-    :ref:`Full list of execution modules <all-salt_modules>`
+    :ref:`Full list of execution modules <all-salt.modules>`
         Contains: a list of core modules that ship with Salt.
 
     :ref:`Writing execution modules <writing-execution-modules>`

--- a/doc/topics/highavailability/index.rst
+++ b/doc/topics/highavailability/index.rst
@@ -6,7 +6,7 @@ High Availability Features in Salt
 
 Salt supports several features for high availability and fault tolerance.
 Brief documentation for these features is listed alongside their configuration
-parameters in :ref:`Configuration file examples <configuration/examples>`.
+parameters in :ref:`Configuration file examples <configuration-file-examples>`.
 
 Multimaster
 ===========

--- a/doc/topics/index.rst
+++ b/doc/topics/index.rst
@@ -6,6 +6,7 @@ Introduction to Salt
 
 The 30 second summary
 =====================
+
 Salt is:
 
 * a configuration management system, capable of maintaining remote nodes
@@ -88,6 +89,8 @@ open and proprietary projects. Please submit your expansions back to
 the Salt project so that we can all benefit together as Salt grows.
 Please feel free to sprinkle Salt around your systems and let the
 deliciousness come forth.
+
+.. _salt-community:
 
 Salt Community
 ==============
@@ -184,3 +187,4 @@ documentation efforts, please review the :ref:`contributing documentation
 <contributing>`!
 
 .. _`Apache 2.0 license`: http://www.apache.org/licenses/LICENSE-2.0.html
+

--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -1,4 +1,4 @@
-.. _jinja:
+.. _understanding-jinja:
 
 ===================
 Understanding Jinja

--- a/doc/topics/jobs/external_cache.rst
+++ b/doc/topics/jobs/external_cache.rst
@@ -1,4 +1,4 @@
-.. _external-master-cache:
+.. _external-job-cache:
 
 =========================================
 Storing Job Results in an External System

--- a/doc/topics/jobs/job_cache.rst
+++ b/doc/topics/jobs/job_cache.rst
@@ -67,6 +67,6 @@ Many deployments may wish to use an external database to maintain a long term
 register of executed jobs. Salt comes with two main mechanisms to do this, the
 master job cache and the external job cache.
 
-See :ref:`Storing Job Results in an External System <external-master-cache>`.
+See :ref:`Storing Job Results in an External System <external-job-cache>`.
 
 

--- a/doc/topics/mine/index.rst
+++ b/doc/topics/mine/index.rst
@@ -22,7 +22,7 @@ refreshed on a very limited basis and are largely static data. Mines are
 designed to replace slow peer publishing calls when Minions need data from
 other Minions. Rather than having a Minion reach out to all the other Minions
 for a piece of data, the Salt Mine, running on the Master, can collect it from
-all the Minions every :ref:`mine-interval`, resulting in
+all the Minions every :ref:`mine_interval`, resulting in
 almost fresh data at any given time, with much less overhead.
 
 Mine Functions

--- a/doc/topics/reactor/index.rst
+++ b/doc/topics/reactor/index.rst
@@ -395,7 +395,7 @@ sets up and listens to the minions event bus, instead of to the masters.
 The biggest difference is that you have to use the caller method on the
 Reactor, which is the equivalent of salt-call, to run your commands.
 
-:ref:`Reactor Engine setup<salt.engines.reactor>`
+:mod:`Reactor Engine setup <salt.engines.reactor>`
 
 .. code-block:: yaml
 

--- a/doc/topics/releases/2014.1.0.rst
+++ b/doc/topics/releases/2014.1.0.rst
@@ -9,7 +9,7 @@ Salt 2014.1.0 Release Notes - Codename Hydrogen
    Due to a change in master to minion communication, 2014.1.0 minions are not
    compatible with older-version masters.  Please upgrade masters first.
    More info on backwards-compatibility policy :ref:`here
-   <installation`, under the "Upgrading Salt" subheading.
+   <installation>`, under the "Upgrading Salt" subheading.
 
 .. note::
 
@@ -248,7 +248,7 @@ Proxy Minions
 -------------
 
 Initial basic support for Proxy Minions is in this release. Documentation can
-be found :ref:`here <proxy>`.
+be found :ref:`here <proxy-minion>`.
 
 Proxy minions are a developing feature in Salt that enables control of devices
 that cannot run a minion. Examples include network gear like switches and

--- a/doc/topics/releases/2015.8.11.rst
+++ b/doc/topics/releases/2015.8.11.rst
@@ -17,7 +17,7 @@ New Configuration Parameter: ``rotate_aes_key``
 - ``Rotate_aes_key`` causes Salt to generate a new AES key whenever a minion key
   is deleted.  This eliminates the chance that a deleted minion could continue
   to eavesdrop on communications with the master if it continues to run after its
-  key is deleted.  See the entry in the documentation for `rotate_aes_key`_.
+  key is deleted.  See the entry in the documentation for :conf_master:`rotate_aes_key`.
 
 Ubuntu 16.04 Packages
 =====================
@@ -404,11 +404,13 @@ Changes:
 
 .. _`#20226`: https://github.com/saltstack/salt/pull/20226
 .. _`#22480`: https://github.com/saltstack/salt/pull/22480
+.. _`#23643`: https://github.com/saltstack/salt/issues/23643
 .. _`#25089`: https://github.com/saltstack/salt/pull/25089
 .. _`#28325`: https://github.com/saltstack/salt/pull/28325
 .. _`#28467`: https://github.com/saltstack/salt/pull/28467
 .. _`#32484`: https://github.com/saltstack/salt/pull/32484
 .. _`#32857`: https://github.com/saltstack/salt/pull/32857
+.. _`#33266`: https://github.com/saltstack/salt/issues/33266
 .. _`#33282`: https://github.com/saltstack/salt/pull/33282
 .. _`#33286`: https://github.com/saltstack/salt/pull/33286
 .. _`#33287`: https://github.com/saltstack/salt/pull/33287
@@ -491,6 +493,7 @@ Changes:
 .. _`#33555`: https://github.com/saltstack/salt/pull/33555
 .. _`#33558`: https://github.com/saltstack/salt/pull/33558
 .. _`#33581`: https://github.com/saltstack/salt/pull/33581
+.. _`#33582`: https://github.com/saltstack/salt/issues/33582
 .. _`#33599`: https://github.com/saltstack/salt/pull/33599
 .. _`#33611`: https://github.com/saltstack/salt/pull/33611
 .. _`#33615`: https://github.com/saltstack/salt/pull/33615
@@ -647,4 +650,3 @@ Changes:
 .. _`#34647`: https://github.com/saltstack/salt/pull/34647
 .. _`#34651`: https://github.com/saltstack/salt/pull/34651
 .. _`#34676`: https://github.com/saltstack/salt/pull/34676
-.. _ `rotate_aes_key`: https://docs.saltstack.com/en/2015.8/ref/configuration/master.html#rotate-aes-key

--- a/doc/topics/releases/2015.8.4.rst
+++ b/doc/topics/releases/2015.8.4.rst
@@ -48,8 +48,6 @@ Core Changes
     salt '*' state.highstate mock=True
     salt '*' state.apply edit.vim mock=True
 
-.. _`#28994`: https://github.com/saltstack/salt/pull/28994
-
 Changes for v2015.8.3..v2015.8.4
 --------------------------------
 
@@ -515,7 +513,7 @@ Changes:
 
 - **PR** `#29317`_: (*basepi*) [2015.8] Merge forward from 2015.5 to 2015.8
 
-- **PR** `#29240`_: (*clan*) handle acl_type [[d]efault:][user|group|mask|other]
+- **PR** `#29240`_: (*clan*) handle acl_type ``[[d]efault:][user|group|mask|other]``
 
 - **PR** `#29305`_: (*lorengordon*) Add 'file' as a source_hash proto
 
@@ -578,11 +576,13 @@ Changes:
 - **PR** `#29178`_: (*whytewolf*) Profile not being passed to keystone.endpoint_get in _auth. so if a p…
 
 .. _`#19332`: https://github.com/saltstack/salt/issues/19332
+.. _`#24237`: https://github.com/saltstack/salt/issues/24237
 .. _`#29116`: https://github.com/saltstack/salt/issues/29116
 .. _`#29187`: https://github.com/saltstack/salt/issues/29187
 .. _`#23825`: https://github.com/saltstack/salt/pull/23825
 .. _`#26511`: https://github.com/saltstack/salt/pull/26511
 .. _`#26853`: https://github.com/saltstack/salt/pull/26853
+.. _`#26845`: https://github.com/saltstack/salt/issues/26845
 .. _`#26962`: https://github.com/saltstack/salt/pull/26962
 .. _`#27104`: https://github.com/saltstack/salt/pull/27104
 .. _`#27606`: https://github.com/saltstack/salt/pull/27606

--- a/doc/topics/releases/2015.8.8.rst
+++ b/doc/topics/releases/2015.8.8.rst
@@ -599,13 +599,16 @@ Changes:
 
 - **PR** `#30625`_: (*jfindlay*) doc.topics.eauth: clarify client_acl vs eauth
 
+.. _`#27796`: https://github.com/saltstack/salt/issues/27796
 .. _`#29650`: https://github.com/saltstack/salt/pull/29650
 .. _`#29718`: https://github.com/saltstack/salt/pull/29718
 .. _`#30062`: https://github.com/saltstack/salt/pull/30062
 .. _`#30217`: https://github.com/saltstack/salt/pull/30217
 .. _`#30279`: https://github.com/saltstack/salt/pull/30279
+.. _`#30300`: https://github.com/saltstack/salt/issues/30300
 .. _`#30378`: https://github.com/saltstack/salt/pull/30378
 .. _`#30458`: https://github.com/saltstack/salt/pull/30458
+.. _`#30461`: https://github.com/saltstack/salt/issues/30461
 .. _`#30542`: https://github.com/saltstack/salt/pull/30542
 .. _`#30586`: https://github.com/saltstack/salt/pull/30586
 .. _`#30591`: https://github.com/saltstack/salt/pull/30591
@@ -664,6 +667,7 @@ Changes:
 .. _`#30813`: https://github.com/saltstack/salt/pull/30813
 .. _`#30815`: https://github.com/saltstack/salt/pull/30815
 .. _`#30818`: https://github.com/saltstack/salt/pull/30818
+.. _`#30820`: https://github.com/saltstack/salt/issues/30820
 .. _`#30822`: https://github.com/saltstack/salt/pull/30822
 .. _`#30823`: https://github.com/saltstack/salt/pull/30823
 .. _`#30826`: https://github.com/saltstack/salt/pull/30826
@@ -700,6 +704,7 @@ Changes:
 .. _`#30920`: https://github.com/saltstack/salt/pull/30920
 .. _`#30922`: https://github.com/saltstack/salt/pull/30922
 .. _`#30924`: https://github.com/saltstack/salt/pull/30924
+.. _`#30934`: https://github.com/saltstack/salt/issues/30934
 .. _`#30940`: https://github.com/saltstack/salt/pull/30940
 .. _`#30941`: https://github.com/saltstack/salt/pull/30941
 .. _`#30942`: https://github.com/saltstack/salt/pull/30942
@@ -713,10 +718,12 @@ Changes:
 .. _`#30978`: https://github.com/saltstack/salt/pull/30978
 .. _`#30987`: https://github.com/saltstack/salt/pull/30987
 .. _`#30998`: https://github.com/saltstack/salt/pull/30998
+.. _`#30999`: https://github.com/saltstack/salt/issues/30999
 .. _`#31002`: https://github.com/saltstack/salt/pull/31002
 .. _`#31004`: https://github.com/saltstack/salt/pull/31004
 .. _`#31007`: https://github.com/saltstack/salt/pull/31007
 .. _`#31012`: https://github.com/saltstack/salt/pull/31012
+.. _`#31014`: https://github.com/saltstack/salt/issues/31014
 .. _`#31015`: https://github.com/saltstack/salt/pull/31015
 .. _`#31024`: https://github.com/saltstack/salt/pull/31024
 .. _`#31026`: https://github.com/saltstack/salt/pull/31026
@@ -737,6 +744,7 @@ Changes:
 .. _`#31100`: https://github.com/saltstack/salt/pull/31100
 .. _`#31103`: https://github.com/saltstack/salt/pull/31103
 .. _`#31105`: https://github.com/saltstack/salt/pull/31105
+.. _`#31106`: https://github.com/saltstack/salt/issues/31106
 .. _`#31107`: https://github.com/saltstack/salt/pull/31107
 .. _`#31108`: https://github.com/saltstack/salt/pull/31108
 .. _`#31110`: https://github.com/saltstack/salt/pull/31110
@@ -769,6 +777,7 @@ Changes:
 .. _`#31191`: https://github.com/saltstack/salt/pull/31191
 .. _`#31196`: https://github.com/saltstack/salt/pull/31196
 .. _`#31201`: https://github.com/saltstack/salt/pull/31201
+.. _`#31223`: https://github.com/saltstack/salt/issues/31223
 .. _`#31225`: https://github.com/saltstack/salt/pull/31225
 .. _`#31226`: https://github.com/saltstack/salt/pull/31226
 .. _`#31233`: https://github.com/saltstack/salt/pull/31233
@@ -868,6 +877,7 @@ Changes:
 .. _`#31598`: https://github.com/saltstack/salt/pull/31598
 .. _`#31601`: https://github.com/saltstack/salt/pull/31601
 .. _`#31604`: https://github.com/saltstack/salt/pull/31604
+.. _`#31617`: https://github.com/saltstack/salt/issues/31617
 .. _`#31622`: https://github.com/saltstack/salt/pull/31622
 .. _`#31627`: https://github.com/saltstack/salt/pull/31627
 .. _`#31629`: https://github.com/saltstack/salt/pull/31629

--- a/doc/topics/releases/2015.8.9.rst
+++ b/doc/topics/releases/2015.8.9.rst
@@ -297,7 +297,7 @@ Changes:
 
 - **PR** `#32425`_: (*cachedout*) Fix salt-cloud parallel provisioning
 
-* 51fb2ac FreeBSD supports packages in format java/openjdk7 so the prior commit broke that functionality. Check freebsd/pkg`#1409`_ for more info.
+* 51fb2ac FreeBSD supports packages in format java/openjdk7 so the prior commit broke that functionality. Check freebsd/pkg #1409 for more info.
 
 * 709410a Improve git_pillar documentation/logging
 
@@ -325,7 +325,7 @@ Changes:
 
 - **PR** `#32321`_: (*abednarik*) Better message when minion fail to start
 
-- **PR** `#32345`_: (*nmadhok*) [2015.8] Check if profile key exists in vm_ dict
+- **PR** `#32345`_: (*nmadhok*) [2015.8] Check if profile key exists in ``vm_`` dict
 
 - **PR** `#32343`_: (*Ferbla*) Fixed win_wua example documentation
 
@@ -467,15 +467,21 @@ Changes:
 
 - **PR** `#31912`_: (*jfindlay*) log.mixins: remove extermporaneous .record
 
+.. _`#14277`: https://github.com/saltstack/salt/issues/14277
+.. _`#23714`: https://github.com/saltstack/salt/issues/23714
+.. _`#24237`: https://github.com/saltstack/salt/issues/24237
 .. _`#26518`: https://github.com/saltstack/salt/pull/26518
 .. _`#26648`: https://github.com/saltstack/salt/pull/26648
 .. _`#26676`: https://github.com/saltstack/salt/pull/26676
+.. _`#28262`: https://github.com/saltstack/salt/issues/28262
 .. _`#28639`: https://github.com/saltstack/salt/pull/28639
+.. _`#28706`: https://github.com/saltstack/salt/issues/28706
 .. _`#29322`: https://github.com/saltstack/salt/pull/29322
 .. _`#30824`: https://github.com/saltstack/salt/pull/30824
 .. _`#31139`: https://github.com/saltstack/salt/pull/31139
 .. _`#31162`: https://github.com/saltstack/salt/pull/31162
 .. _`#31164`: https://github.com/saltstack/salt/pull/31164
+.. _`#31270`: https://github.com/saltstack/salt/issues/31270
 .. _`#31364`: https://github.com/saltstack/salt/pull/31364
 .. _`#31382`: https://github.com/saltstack/salt/pull/31382
 .. _`#31598`: https://github.com/saltstack/salt/pull/31598
@@ -778,6 +784,7 @@ Changes:
 .. _`#33224`: https://github.com/saltstack/salt/pull/33224
 .. _`#33236`: https://github.com/saltstack/salt/pull/33236
 .. _`#33237`: https://github.com/saltstack/salt/pull/33237
+.. _`#33238`: https://github.com/saltstack/salt/issues/33238
 .. _`#33239`: https://github.com/saltstack/salt/pull/33239
 .. _`#33244`: https://github.com/saltstack/salt/pull/33244
 .. _`#33245`: https://github.com/saltstack/salt/pull/33245
@@ -789,5 +796,6 @@ Changes:
 .. _`#33274`: https://github.com/saltstack/salt/pull/33274
 .. _`#33293`: https://github.com/saltstack/salt/pull/33293
 .. _`#33294`: https://github.com/saltstack/salt/pull/33294
+.. _`#33299`: https://github.com/saltstack/salt/issues/33299
 .. _`#33300`: https://github.com/saltstack/salt/pull/33300
 .. _`#33305`: https://github.com/saltstack/salt/pull/33305

--- a/doc/topics/releases/2016.3.0.rst
+++ b/doc/topics/releases/2016.3.0.rst
@@ -351,7 +351,7 @@ Documentation of the Dimension Data SaltStack integration is found on `developer
 Minion Blackout
 ---------------
 During a blackout, minions will not execute any remote execution commands,
-except for :ref:`saltutil.refresh_pillar
+except for :mod:`saltutil.refresh_pillar
 <salt.modules.saltutil.refresh_pillar>`. Blackouts are enabled using a special
 pillar key, ``minion_blackout`` set to ``True``.
 

--- a/doc/topics/releases/2016.3.1.rst
+++ b/doc/topics/releases/2016.3.1.rst
@@ -155,14 +155,18 @@ Changes:
 .. _`#33519`: https://github.com/saltstack/salt/pull/33519
 .. _`#33520`: https://github.com/saltstack/salt/pull/33520
 .. _`#33522`: https://github.com/saltstack/salt/pull/33522
+.. _`#33530`: https://github.com/saltstack/salt/issues/33530
 .. _`#33538`: https://github.com/saltstack/salt/pull/33538
 .. _`#33549`: https://github.com/saltstack/salt/pull/33549
 .. _`#33550`: https://github.com/saltstack/salt/pull/33550
 .. _`#33555`: https://github.com/saltstack/salt/pull/33555
 .. _`#33558`: https://github.com/saltstack/salt/pull/33558
 .. _`#33562`: https://github.com/saltstack/salt/pull/33562
+.. _`#33565`: https://github.com/saltstack/salt/issues/33565
 .. _`#33576`: https://github.com/saltstack/salt/pull/33576
+.. _`#33578`: https://github.com/saltstack/salt/issues/33578
 .. _`#33581`: https://github.com/saltstack/salt/pull/33581
+.. _`#33590`: https://github.com/saltstack/salt/issues/33590
 .. _`#33599`: https://github.com/saltstack/salt/pull/33599
 .. _`#33603`: https://github.com/saltstack/salt/pull/33603
 .. _`#33604`: https://github.com/saltstack/salt/pull/33604
@@ -170,6 +174,7 @@ Changes:
 .. _`#33613`: https://github.com/saltstack/salt/pull/33613
 .. _`#33615`: https://github.com/saltstack/salt/pull/33615
 .. _`#33631`: https://github.com/saltstack/salt/pull/33631
+.. _`#33632`: https://github.com/saltstack/salt/issues/33632
 .. _`#33637`: https://github.com/saltstack/salt/pull/33637
 .. _`#33638`: https://github.com/saltstack/salt/pull/33638
 .. _`#33641`: https://github.com/saltstack/salt/pull/33641
@@ -205,6 +210,7 @@ Changes:
 .. _`#33743`: https://github.com/saltstack/salt/pull/33743
 .. _`#33745`: https://github.com/saltstack/salt/pull/33745
 .. _`#33748`: https://github.com/saltstack/salt/pull/33748
+.. _`#33754`: https://github.com/saltstack/salt/issues/33754
 .. _`#33757`: https://github.com/saltstack/salt/pull/33757
 .. _`#33759`: https://github.com/saltstack/salt/pull/33759
 .. _`#33763`: https://github.com/saltstack/salt/pull/33763

--- a/doc/topics/releases/2016.3.4.rst
+++ b/doc/topics/releases/2016.3.4.rst
@@ -423,6 +423,7 @@ Changes:
 .. _`#36016`: https://github.com/saltstack/salt/pull/36016
 .. _`#36018`: https://github.com/saltstack/salt/pull/36018
 .. _`#36019`: https://github.com/saltstack/salt/pull/36019
+.. _`#36021`: https://github.com/saltstack/salt/issues/36021
 .. _`#36022`: https://github.com/saltstack/salt/pull/36022
 .. _`#36023`: https://github.com/saltstack/salt/pull/36023
 .. _`#36024`: https://github.com/saltstack/salt/pull/36024
@@ -434,6 +435,7 @@ Changes:
 .. _`#36039`: https://github.com/saltstack/salt/pull/36039
 .. _`#36040`: https://github.com/saltstack/salt/pull/36040
 .. _`#36047`: https://github.com/saltstack/salt/pull/36047
+.. _`#36055`: https://github.com/saltstack/salt/issues/36055
 .. _`#36061`: https://github.com/saltstack/salt/pull/36061
 .. _`#36062`: https://github.com/saltstack/salt/pull/36062
 .. _`#36068`: https://github.com/saltstack/salt/pull/36068
@@ -474,6 +476,7 @@ Changes:
 .. _`#36227`: https://github.com/saltstack/salt/pull/36227
 .. _`#36235`: https://github.com/saltstack/salt/pull/36235
 .. _`#36238`: https://github.com/saltstack/salt/pull/36238
+.. _`#36240`: https://github.com/saltstack/salt/issues/36240
 .. _`#36241`: https://github.com/saltstack/salt/pull/36241
 .. _`#36244`: https://github.com/saltstack/salt/pull/36244
 .. _`#36245`: https://github.com/saltstack/salt/pull/36245
@@ -731,6 +734,7 @@ Changes:
 .. _`#37179`: https://github.com/saltstack/salt/pull/37179
 .. _`#37183`: https://github.com/saltstack/salt/pull/37183
 .. _`#37186`: https://github.com/saltstack/salt/pull/37186
+.. _`#37187`: https://github.com/saltstack/salt/issues/37187
 .. _`#37188`: https://github.com/saltstack/salt/pull/37188
 .. _`#37206`: https://github.com/saltstack/salt/pull/37206
 .. _`#37207`: https://github.com/saltstack/salt/pull/37207

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -67,7 +67,8 @@ be used to install it:
 
 
 If pygit2_ is not packaged for the platform on which the Master is running, the
-pygit2_ website has installation instructions here__. Keep in mind however that
+pygit2_ website has installation instructions
+`here <pygit2-install-instructions>`_. Keep in mind however that
 following these instructions will install libgit2_ and pygit2_ without system
 packages. Additionally, keep in mind that :ref:`SSH authentication in pygit2
 <pygit2-authentication-ssh>` requires libssh2_ (*not* libssh) development
@@ -80,26 +81,26 @@ advisable as several other applications depend on it, so on older LTS linux
 releases pygit2_ 0.20.3 and libgit2_ 0.20.0 is the recommended combination.
 While these are not packaged in the official repositories for Debian and
 Ubuntu, SaltStack is actively working on adding packages for these to our
-repositories_. The progress of this effort can be tracked here__.
+repositories_. The progress of this effort can be tracked `here <salt-pack-70>`_.
 
 .. warning::
-    pygit2_ is actively developed and :ref:`frequently makes
-    non-backwards-compatible API changes <pygit2-version-policy>`, even in
+    pygit2_ is actively developed and `frequently makes
+    non-backwards-compatible API changes <pygit2-version-policy>`_, even in
     minor releases. It is not uncommon for pygit2_ upgrades to result in errors
     in Salt. Please take care when upgrading pygit2_, and pay close attention
     to the changelog_, keeping an eye out for API changes. Errors can be
-    reported on the :ref:`SaltStack issue tracker <saltstack-issue-tracker>`.
+    reported on the `SaltStack issue tracker <saltstack-issue-tracker>`_.
 
 .. _pygit2-version-policy: http://www.pygit2.org/install.html#version-numbers
 .. _changelog: https://github.com/libgit2/pygit2#changelog
 .. _saltstack-issue-tracker: https://github.com/saltstack/salt/issues
-.. __: http://www.pygit2.org/install.html
+.. _pygit2-install-instructions: http://www.pygit2.org/install.html
 .. _libgit2: https://libgit2.github.com/
 .. _libssh2: http://www.libssh2.org/
 .. _python-cffi: https://pypi.python.org/pypi/cffi
 .. _libffi: http://sourceware.org/libffi/
 .. _repositories: https://repo.saltstack.com
-.. __: https://github.com/saltstack/salt-pack/issues/70
+.. _salt-pack-70: https://github.com/saltstack/salt-pack/issues/70
 
 GitPython
 ---------
@@ -931,7 +932,7 @@ the minion is running.
 
 .. _`post-receive hook`: http://www.git-scm.com/book/en/Customizing-Git-Git-Hooks#Server-Side-Hooks
 
-.. _git-as-ext_pillar
+.. _git-as-ext_pillar:
 
 Using Git as an External Pillar Source
 ======================================

--- a/doc/topics/tutorials/http.rst
+++ b/doc/topics/tutorials/http.rst
@@ -377,7 +377,8 @@ using the ``ca_bundle`` variable.
     )
 
 Updating CA Bundles
-'''''''''''''''''''
+```````````````````
+
 The ``update_ca_bundle()`` function can be used to update the bundle file at a
 specified location. If the target location is not specified, then it will
 attempt to auto-detect the location of the bundle file. If the URL to download

--- a/doc/topics/tutorials/modules.rst
+++ b/doc/topics/tutorials/modules.rst
@@ -82,7 +82,7 @@ Run an arbitrary shell command:
 
     salt '*' cmd.run 'uname -a'
 
-.. seealso:: :ref:`the full list of modules <all-salt_modules>`
+.. seealso:: :ref:`the full list of modules <all-salt.modules>`
 
 arguments
 ---------

--- a/doc/topics/tutorials/starting_states.rst
+++ b/doc/topics/tutorials/starting_states.rst
@@ -348,7 +348,7 @@ gives you a `"Pythonic"`_ interface to building state data.
     They can also be used in :mod:`file.managed <salt.states.file.managed>`
     states, making file management much more dynamic and flexible. Some
     examples for using templates in managed files can be found in the
-    documentation for the :ref:`file state <salt.states.file>`, as well as the
+    documentation for the :mod:`file state <salt.states.file>`, as well as the
     :ref:`MooseFS example<jinja-example-moosefs>` below.
 
 

--- a/doc/topics/tutorials/walkthrough.rst
+++ b/doc/topics/tutorials/walkthrough.rst
@@ -294,7 +294,7 @@ This will display a very large list of available functions and documentation on
 them.
 
 .. note::
-    Module documentation is also available :ref:`on the web <all-salt_modules>`.
+    Module documentation is also available :ref:`on the web <all-salt.modules>`.
 
 These functions cover everything from shelling out to package management to
 manipulating database servers. They comprise a powerful system management API
@@ -304,7 +304,7 @@ of Salt.
 .. note::
 
     Salt comes with many plugin systems. The functions that are available via
-    the ``salt`` command are called :ref:`Execution Modules <all-salt_modules>`.
+    the ``salt`` command are called :ref:`Execution Modules <all-salt.modules>`.
 
 
 Helpful Functions to Know

--- a/doc/topics/tutorials/walkthrough_macosx.rst
+++ b/doc/topics/tutorials/walkthrough_macosx.rst
@@ -7,13 +7,10 @@ The macOS (Maverick) Developer Step By Step Guide To Salt Installation
 This document provides a step-by-step guide to installing a Salt cluster
 consisting of  one master, and one minion running on a local VM hosted on macOS.
 
-
 .. note::
     This guide is aimed at developers who wish to run Salt in a virtual machine.
     The official (Linux) walkthrough can be found
     `here <http://docs.saltstack.com/topics/tutorials/walkthrough.html>`_.
-
-
 
 The 5 Cent Salt Intro
 ---------------------
@@ -63,18 +60,19 @@ Here's a brief overview of a Salt cluster:
     that.
 
 
-
 Before Digging In, The Architecture Of The Salt Cluster
 -------------------------------------------------------
 
 Salt Master
 +++++++++++
+
 The "Salt master" server is going to be the Mac OS machine, directly. Commands
 will be run from a terminal app, so Salt will need to be installed on the Mac.
 This is going to be more convenient for toying around with configuration files.
 
 Salt Minion
 +++++++++++
+
 We'll only have one "Salt minion" server. It is going to be running on a
 Virtual Machine running on the Mac, using VirtualBox. It will run an Ubuntu
 distribution.
@@ -193,6 +191,7 @@ There should be no errors when running the above command.
 
 
 Now that the master is set, let's configure a minion on a VM.
+
 
 Step 2 - Configuring The Minion VM
 ==================================
@@ -324,6 +323,7 @@ following:
 
 It's now time to connect the VM to the salt master
 
+
 Step 3 - Connecting Master and Minion
 =====================================
 
@@ -369,7 +369,6 @@ Then copy the .pub file into the list of accepted minions:
 
     sudo cp minion1.pub /etc/salt/pki/master/minions/minion1
 
-
 Modify Vagrantfile to Use Salt Provisioner
 ------------------------------------------
 
@@ -414,6 +413,7 @@ following:
 
 You should see your minion answering the ping. It's now time to do some
 configuration.
+
 
 Step 4 - Configure Services to Install On the Minion
 ====================================================

--- a/doc/topics/tutorials/writing_tests.rst
+++ b/doc/topics/tutorials/writing_tests.rst
@@ -8,7 +8,7 @@ Salt's Test Suite: An Introduction
 
     This tutorial makes a couple of assumptions. The first assumption is that
     you have a basic knowledge of Salt. To get up to speed, check out the
-    :ref:`Salt Walkthrough </topics/tutorials/walkthrough>`.
+    :ref:`Salt Walkthrough <tutorial-salt-walk-through>`.
 
     The second assumption is that your Salt development environment is already
     configured and that you have a basic understanding of contributing to the

--- a/doc/topics/yaml/index.rst
+++ b/doc/topics/yaml/index.rst
@@ -78,7 +78,7 @@ And in Python:
     }
 
 Rule Three: Dashes
--------------------
+------------------
 
 To represent lists of items, a single dash followed by a space is used. Multiple
 items are a part of the same list as a function of their having the same level of indentation.
@@ -115,5 +115,4 @@ One excellent choice for experimenting with YAML parsing is: http://yaml-online-
 Templating
 ----------
 Jinja statements and expressions are allowed by default in SLS files. See
-:ref:`Understanding Jinja <jinja>`.
-
+:ref:`Understanding Jinja <understanding-jinja>`.

--- a/salt/modules/solaris_user.py
+++ b/salt/modules/solaris_user.py
@@ -3,10 +3,12 @@
 Manage users with the useradd command
 
 .. important::
+
     If you feel that Salt should be using this module to manage users on a
     minion, and it is using a different module (or gives an error similar to
     *'user.info' is not available*), see :ref:`here
     <module-provider-override>`.
+
 '''
 
 # Import python libs

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -2,7 +2,7 @@
 '''
 Jinja loading utils to enable a more powerful backend for jinja templates
 
-For Jinja usage information see :ref:`Understanding Jinja <jinja>`.
+For Jinja usage information see :ref:`Understanding Jinja <understanding-jinja>`.
 '''
 
 # Import python libs

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -5,7 +5,7 @@ Return data to a postgresql server
 .. note::
     :mod:`returners.postgres_local_cache <salt.returners.postgres_local_cache>`
     is recommended instead of this module when using PostgreSQL as a
-    :ref:`master job cache <external-master-cache>`. These two modules
+    :ref:`master job cache <external-job-cache>`. These two modules
     provide different functionality so you should compare each to see which
     module best suits your particular needs.
 

--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -6,7 +6,7 @@ cope with scale.
 .. note::
     :mod:`returners.postgres <salt.returners.postgres>` is also available if
     you are not using PostgreSQL as a :ref:`master job cache
-    <external-master-cache>`.  These two modules provide different
+    <external-job-cache>`.  These two modules provide different
     functionality so you should compare each to see which module best suits
     your particular needs.
 

--- a/salt/runners/salt.py
+++ b/salt/runners/salt.py
@@ -7,14 +7,14 @@ execution modules available
 on the salt master.
 
 .. _salt_salt_runner:
+
 Salt's execution modules are normally available
 on the salt minion. Use this runner to call
 execution modules on the salt master.
 Salt :ref:`execution modules <writing-execution-modules>`
 are the functions called by the ``salt`` command.
 
-Execution modules can be
-called with ``salt-run``:
+Execution modules can be called with ``salt-run``:
 
 .. code-block:: bash
 
@@ -43,7 +43,7 @@ log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 def cmd(fun, *args, **kwargs):
     '''
     Execute ``fun`` with the given ``args`` and ``kwargs``.
-    Parameter ``fun`` should be the string :ref:`name <all-salt_modules>`
+    Parameter ``fun`` should be the string :ref:`name <all-salt.modules>`
     of the execution module to call.
 
     Note that execution modules will be *loaded every time*

--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
 Manage Apigateway Rest APIs
-=================
+===========================
 
 .. versionadded:: 2016.11.0
 
@@ -31,18 +31,18 @@ config:
 .. code-block:: yaml
 
     myprofile:
-        keyid: GKTADJGHEIQSXMKKRBJ08H
-        key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
-            region: us-east-1
+      keyid: GKTADJGHEIQSXMKKRBJ08H
+      key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+      region: us-east-1
 
 .. code-block:: yaml
 
     Ensure Apigateway API exists:
-        boto_apigateway.present:
-            - name: myfunction
-            - region: us-east-1
-            - keyid: GKTADJGHEIQSXMKKRBJ08H
-            - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+      boto_apigateway.present:
+        - name: myfunction
+        - region: us-east-1
+        - keyid: GKTADJGHEIQSXMKKRBJ08H
+        - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
 
 '''
 

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -579,7 +579,7 @@ def wait_script(name,
             **no**, **on**, **off**, **true**, and **false** are all loaded as
             boolean ``True`` and ``False`` values, and must be enclosed in
             quotes to be used as strings. More info on this (and other) PyYAML
-            idiosyncrasies can be found :ref:`here <yaml-idiosyncrasies.>`.
+            idiosyncrasies can be found :ref:`here <yaml-idiosyncrasies>`.
 
         Variables as values are not evaluated. So $PATH in the following
         example is a literal '$PATH':


### PR DESCRIPTION
There are a ton of doc warnings that occur when building the docs. @whiteinge used to clean these up more regularly, but we haven't been doing them lately. This fixes a handful of them.