### PR TITLE
Update disk fstype, inodeusage, percent and mount.active functions for AIX support

### DIFF
--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -75,7 +75,7 @@ def usage(args=None):
         return {}
     if __grains__['kernel'] == 'Linux':
         cmd = 'df -P'
-    elif __grains__['kernel'] == 'OpenBSD' or  __grains__['kernel'] == 'AIX':
+    elif __grains__['kernel'] == 'OpenBSD' or __grains__['kernel'] == 'AIX':
         cmd = 'df -kP'
     else:
         cmd = 'df'

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -141,7 +141,10 @@ def inodeusage(args=None):
         salt '*' disk.inodeusage
     '''
     flags = _clean_flags(args, 'disk.inodeusage')
-    cmd = 'df -iP'
+    if __grains__['kernel'] == 'AIX':
+        cmd = 'df -i'
+    else:
+        cmd = 'df -iP'
     if flags:
         cmd += ' -{0}'.format(flags)
     ret = {}
@@ -161,6 +164,14 @@ def inodeusage(args=None):
                     'used': comps[5],
                     'free': comps[6],
                     'use': comps[7],
+                    'filesystem': comps[0],
+                }
+            elif __grains__['kernel'] == 'AIX':
+                ret[comps[6]] = {
+                    'inodes': comps[4],
+                    'used': comps[5],
+                    'free': comps[2],
+                    'use': comps[5],
                     'filesystem': comps[0],
                 }
             else:
@@ -191,6 +202,8 @@ def percent(args=None):
         cmd = 'df -P'
     elif __grains__['kernel'] == 'OpenBSD':
         cmd = 'df -kP'
+    elif __grains__['kernel'] == 'AIX':
+        cmd = 'df -kP'
     else:
         cmd = 'df'
     ret = {}
@@ -201,9 +214,11 @@ def percent(args=None):
         if line.startswith('Filesystem'):
             continue
         comps = line.split()
-        while not comps[1].isdigit():
+        while len(comps) >= 2 and not comps[1].isdigit():
             comps[0] = '{0} {1}'.format(comps[0], comps[1])
             comps.pop(1)
+        if len(comps) < 2:
+            continue
         try:
             if __grains__['kernel'] == 'Darwin':
                 ret[comps[8]] = comps[4]
@@ -464,11 +479,18 @@ def fstype(device):
     if salt.utils.which('df'):
         # the fstype was not set on the block device, so inspect the filesystem
         # itself for its type
-        df_out = __salt__['cmd.run']('df -T {0}'.format(device)).splitlines()
-        if len(df_out) > 1:
-            fs_type = df_out[1]
-            if fs_type:
-                return fs_type
+        if __grains__['kernel'] == 'AIX' and os.stat('/usr/sysv/bin/df'):
+            df_out = __salt__['cmd.run']('/usr/sysv/bin/df -n {0}'.format(device)).split()
+            if len(df_out) > 2:
+                fs_type = df_out[2]
+                if fs_type:
+                    return fs_type
+        else:
+            df_out = __salt__['cmd.run']('df -T {0}'.format(device)).splitlines()
+            if len(df_out) > 1:
+                fs_type = df_out[1]
+                if fs_type:
+                    return fs_type
 
     return ''
 

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -75,9 +75,7 @@ def usage(args=None):
         return {}
     if __grains__['kernel'] == 'Linux':
         cmd = 'df -P'
-    elif __grains__['kernel'] == 'OpenBSD':
-        cmd = 'df -kP'
-    elif __grains__['kernel'] == 'AIX':
+    elif __grains__['kernel'] == 'OpenBSD' or  __grains__['kernel'] == 'AIX':
         cmd = 'df -kP'
     else:
         cmd = 'df'
@@ -200,9 +198,7 @@ def percent(args=None):
     '''
     if __grains__['kernel'] == 'Linux':
         cmd = 'df -P'
-    elif __grains__['kernel'] == 'OpenBSD':
-        cmd = 'df -kP'
-    elif __grains__['kernel'] == 'AIX':
+    elif __grains__['kernel'] == 'OpenBSD' or __grains__['kernel'] == 'AIX':
         cmd = 'df -kP'
     else:
         cmd = 'df'
@@ -479,7 +475,7 @@ def fstype(device):
     if salt.utils.which('df'):
         # the fstype was not set on the block device, so inspect the filesystem
         # itself for its type
-        if __grains__['kernel'] == 'AIX' and os.stat('/usr/sysv/bin/df'):
+        if __grains__['kernel'] == 'AIX' and os.path.isfile('/usr/sysv/bin/df'):
             df_out = __salt__['cmd.run']('/usr/sysv/bin/df -n {0}'.format(device)).split()
             if len(df_out) > 2:
                 fs_type = df_out[2]

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -110,6 +110,27 @@ def _active_mounts(ret):
     return ret
 
 
+def _active_mounts_aix(ret):
+    '''
+    List active mounts on AIX systems
+    '''
+    for line in __salt__['cmd.run_stdout']('mount -p').split('\n'):
+        comps = re.sub(r"\s+", " ", line).split()
+        if comps and comps[0] == 'node' or comps[0] == '--------':
+            continue
+        if len(comps) < 8:
+            ret[comps[1]] = {'device': comps[0],
+                             'fstype': comps[2],
+                             'opts': _resolve_user_group_names(comps[6].split(','))}
+        else:
+            ret[comps[2]] = {'node': comps[0],
+                             'device': comps[1],
+                             'fstype': comps[3],
+                             'opts': _resolve_user_group_names(comps[7].split(','))}
+
+    return ret
+
+
 def _active_mounts_freebsd(ret):
     '''
     List active mounts on FreeBSD systems
@@ -202,6 +223,8 @@ def active(extended=False):
     ret = {}
     if __grains__['os'] == 'FreeBSD':
         _active_mounts_freebsd(ret)
+    elif __grains__['kernel'] == 'AIX':
+        _active_mounts_aix(ret)
     elif __grains__['kernel'] == 'SunOS':
         _active_mounts_solaris(ret)
     elif __grains__['os'] == 'OpenBSD':


### PR DESCRIPTION
### What does this PR do?
Allows disk.fstype, disk.inodeusage, disk.percent and mount.active to function on AIX

### What issues does this PR fix or reference?
ZD-1196--URMC - University of Rochester Medical Center--Command Line "disk.percent" fails on AIX Minion.-2016.11.1

### Previous Behavior
the above functions returned errors or did not operate

### New Behavior
the functions now return relevant information requested

### Tests written?
No, unit tested by hand on AIX system

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
