### PR TITLE
Fixes #39214. FTP authentication and clean disconnect.

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -531,10 +531,12 @@ class Client(object):
                 )
         if url_data.scheme == 'ftp':
             try:
-                ftp = ftplib.FTP(url_data.hostname)
-                ftp.login()
+                ftp = ftplib.FTP()
+                ftp.connect(url_data.hostname, url_data.port)
+                ftp.login(url_data.username, url_data.password)
                 with salt.utils.fopen(dest, 'wb') as fp_:
                     ftp.retrbinary('RETR {0}'.format(url_data.path), fp_.write)
+                ftp.quit()
                 return dest
             except Exception as exc:
                 raise MinionError('Could not retrieve {0} from FTP server. Exception: {1}'.format(url, exc))


### PR DESCRIPTION
### What does this PR do?

* Adds support for FTP authentication when the credentials are provided in the FTP URL
* Adds support for custom FTP port
* Performs a clean FTP disconnect (`QUIT`) after the transfer is done

If the credentials are not provided, it falls back to the `ftplib`'s defaults, which are to use `username = 'anonymous'` and `password = 'anonymous@'`.
If the port is not provided, it falls back to the `ftplib` default port `21`.

### What issues does this PR fix or reference?

Fixes #39214

### Previous Behavior
* `file.managed` `ftp://`protocol only worked with anonymous FTP servers
* No option to provide a custom port

### New Behavior
* `file.managed` `ftp://`protocol works with FTP servers that require authentication
* Custom port can be provided

### Tests written?

No