### PR TITLE
Add link in toc for cloudstack page

### DIFF
--- a/doc/topics/cloud/index.rst
+++ b/doc/topics/cloud/index.rst
@@ -106,6 +106,7 @@ Cloud Provider Specifics
         Getting Started With Aliyun <aliyun>
         Getting Started With Azure <azure>
         Getting Started With Azure Arm <azurearm>
+        Getting Started With CloudStack <cloudstack>
         Getting Started With DigitalOcean <digitalocean>
         Getting Started With Dimension Data <dimensiondata>
         Getting Started With EC2 <aws>


### PR DESCRIPTION
### What does this PR do?

Add link in toc for Cloudstack page (sorry I forgot that change in my other PR #39201)

### What issues does this PR fix or reference?

#39201

### Previous Behavior
Missing toc link

### Tests written?

No

