### PR TITLE
add runas as a global state variable

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -152,7 +152,7 @@ Requisite overview
 | name       | state is only     | state is only | order      | comment            |
 |  of        | executed if       | executed if   |            |  or                |
 |            | target execution  | target has    | 1.target   |                    |
-|            |                   |               | 2.state    |                    |  
+|            |                   |               | 2.state    |                    |
 | requisite  | result is         | changes       | (default)  | description        |
 +============+===================+===============+============+====================+
 | require    | success           |               | default    | state will always  |
@@ -173,7 +173,7 @@ Requisite overview
 |            |                   |               |            | target execution   |
 |            |                   |               |            | result is success  |
 |            |                   |               |            | and target has     |
-|            |                   |               |            | changes            |  
+|            |                   |               |            | changes            |
 +------------+-------------------+---------------+------------+--------------------+
 | onfail     | failed            |               | default    | Only requisite     |
 |            |                   |               |            | where state exec.  |
@@ -183,7 +183,7 @@ Requisite overview
 
 In this table, the following short form of terms is used:
 
-* **state** (= dependent state): state containing requisite 
+* **state** (= dependent state): state containing requisite
 * **target** (= state target) : state referenced by requisite
 
 
@@ -513,6 +513,24 @@ multiple network interfaces.
 The ``use`` statement does not inherit the requisites arguments of the
 targeted state. This means also a chain of ``use`` requisites would not
 inherit inherited options.
+
+runas
+~~~~~
+
+.. versionadded:: Nitrogen
+
+The ``runas`` global option is used to set the user which will be used to run the command in the ``cmd.run`` module.
+
+.. code-block:: yaml
+
+    django:
+      pip.installed:
+        - name: django >= 1.6, <= 1.7
+        - runas: daniel
+        - require:
+          - pkg: python-pip
+
+In the above state, the pip command run by ``cmd.run`` will be run by the daniel user.
 
 .. _requisites-require-in:
 .. _requisites-watch-in:
@@ -905,7 +923,7 @@ The ``started`` return value is the ``started`` from the first run.
 
 The ``duration`` return value is the total duration of all attempts plus the retry intervals.
 
-The ``comment`` return value will include the result and comment from all previous attempts. 
+The ``comment`` return value will include the result and comment from all previous attempts.
 
 For example:
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -289,6 +289,9 @@ def _run(cmd,
 
     log_callback = _check_cb(log_callback)
 
+    if runas is None and '__context__' in globals():
+        runas = __context__.get('runas')
+
     # Set the default working directory to the home directory of the user
     # salt-minion is running as. Defaults to home directory of user under which
     # the minion is running.

--- a/salt/state.py
+++ b/salt/state.py
@@ -91,6 +91,7 @@ STATE_RUNTIME_KEYWORDS = frozenset([
     'reload_modules',
     'reload_grains',
     'reload_pillar',
+    'runas',
     'fire_event',
     'saltenv',
     'use',
@@ -1647,6 +1648,8 @@ class State(object):
             return ret
         else:
             ret = {'result': False, 'name': low['name'], 'changes': {}}
+
+        self.state_con['runas'] = low.get('runas', None)
 
         if not low.get('__prereq__'):
             log.info(


### PR DESCRIPTION
### What does this PR do?
Adds runas to `__context__` for states to specify what the underlying `cmd` module should use.

A recommendation for where to put the documentation for this would be appreciated!

### What issues does this PR fix or reference?
#37835

### Tests written?

No
