### PR TITLE
Update jsonschema tests to reflect change in jsonschema 2.6.0

### DIFF
--- a/tests/unit/config/schemas/ssh_test.py
+++ b/tests/unit/config/schemas/ssh_test.py
@@ -7,6 +7,7 @@
 '''
 # Import python libs
 from __future__ import absolute_import, print_function
+from distutils.version import LooseVersion as _LooseVersion
 
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
@@ -23,8 +24,10 @@ try:
     import jsonschema
     import jsonschema.exceptions
     HAS_JSONSCHEMA = True
+    JSONSCHEMA_VERSION = _LooseVersion(jsonschema.__version__)
 except ImportError:
     HAS_JSONSCHEMA = False
+    JSONSCHEMA_VERSION = _LooseVersion('0')
 
 
 class RoosterEntryConfigTest(TestCase):
@@ -296,7 +299,13 @@ class RosterItemTest(TestCase):
                 ssh_schemas.RosterItem.serialize(),
                 format_checker=jsonschema.FormatChecker()
             )
-        self.assertIn(
-            'Additional properties are not allowed (\'target-1:1\' was unexpected)',
-            excinfo.exception.message
-        )
+        if JSONSCHEMA_VERSION < _LooseVersion('2.6.0'):
+            self.assertIn(
+                'Additional properties are not allowed (\'target-1:1\' was unexpected)',
+                excinfo.exception.message
+            )
+        else:
+            self.assertIn(
+                '\'target-1:1\' does not match any of the regexes',
+                excinfo.exception.message
+            )

--- a/tests/unit/utils/schema_test.py
+++ b/tests/unit/utils/schema_test.py
@@ -6,7 +6,7 @@
 # Import python libs
 from __future__ import absolute_import
 
-from distutils.version import LooseVersion
+from distutils.version import LooseVersion as _LooseVersion
 
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
@@ -22,10 +22,10 @@ try:
     import jsonschema
     import jsonschema.exceptions
     HAS_JSONSCHEMA = True
-    JSONSCHEMA_VERSION = jsonschema.__version__
+    JSONSCHEMA_VERSION = _LooseVersion(jsonschema.__version__)
 except ImportError:
-    JSONSCHEMA_VERSION = ''
     HAS_JSONSCHEMA = False
+    JSONSCHEMA_VERSION = _LooseVersion('0')
 
 
 # pylint: disable=unused-import
@@ -749,8 +749,7 @@ class ConfigTestCase(TestCase):
             }
         )
 
-    @skipIf(HAS_JSONSCHEMA is False, 'The \'jsonschema\' library is missing')
-    @skipIf(HAS_JSONSCHEMA and LooseVersion(jsonschema.__version__) <= LooseVersion('2.5.0'), 'Requires jsonschema 2.5.0 or greater')
+    @skipIf(JSONSCHEMA_VERSION <= _LooseVersion('2.5.0'), 'Requires jsonschema 2.5.0 or greater')
     def test_ipv4_config_validation(self):
         class TestConf(schema.Schema):
             item = schema.IPv4Item(title='Item', description='Item description')
@@ -1702,7 +1701,14 @@ class ConfigTestCase(TestCase):
 
         with self.assertRaises(jsonschema.exceptions.ValidationError) as excinfo:
             jsonschema.validate({'item': {'color': 'green', 'sides': 4, 'surfaces': 4}}, TestConf.serialize())
-        self.assertIn('Additional properties are not allowed', excinfo.exception.message)
+        if JSONSCHEMA_VERSION < _LooseVersion('2.6.0'):
+            self.assertIn(
+                'Additional properties are not allowed',
+                excinfo.exception.message)
+        else:
+            self.assertIn(
+                '\'surfaces\' does not match any of the regexes',
+                excinfo.exception.message)
 
         class TestConf(schema.Schema):
             item = schema.DictItem(


### PR DESCRIPTION
Version 2.6.0 changed the wording of one of the exceptions tested,
causing tests to fail when jsonschema 2.6.0 is installed. This commit
updates the tests to change the assert for 2.6.0 and later.