### PR TITLE
Fix the new jinja_test failures

### DIFF
--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -946,13 +946,13 @@ class TestCustomExtensions(TestCase):
         '''Test the `min` Jinja filter.'''
         rendered = render_jinja_tmpl("{{ [1, 2, 3] | min }}",
                                      dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
-        self.assertEqual(rendered, u'1.0')
+        self.assertEqual(rendered, u'1')
 
     def test_max(self):
         '''Test the `max` Jinja filter.'''
         rendered = render_jinja_tmpl("{{ [1, 2, 3] | max }}",
                                      dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
-        self.assertEqual(rendered, u'3.0')
+        self.assertEqual(rendered, u'3')
 
     def test_avg(self):
         '''Test the `avg` Jinja filter.'''


### PR DESCRIPTION
Refs #37808

The max fuction returns an int, not a float, as does the min function.
This updates the assertions to compare against ints.
