### PR TITLE
Fixing issue 39161, salt-ssh : match:grain for pillars inconsistencies

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -899,6 +899,15 @@ class Single(object):
             opts_pkg['id'] = self.id
 
             retcode = 0
+
+            # Restore master grains
+            for grain in conf_grains:
+                opts_pkg['grains'][grain] = conf_grains[grain]
+            # Enable roster grains support
+            if 'grains' in self.target:
+                for grain in self.target['grains']:
+                    opts_pkg['grains'][grain] = self.target['grains'][grain]
+
             popts = {}
             popts.update(opts_pkg['__master_opts__'])
             popts.update(opts_pkg)


### PR DESCRIPTION
### What does this PR do?
It copies the restoring of master and roster grains into the if refresh code path, that the code as written will always use.

### What issues does this PR fix or reference?
It fixes issue #39161.

### Previous Behavior
A grain match in the pillar top.sls wouldn't work if the grain came from the roster.

### New Behavior
A grain match in the pillar top.sls will work if the grain came from the roster.

### Tests written?
No