### PR TITLE
Dockerng dryrun for sls build

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5917,13 +5917,31 @@ def sls(name, mods=None, saltenv='base', **kwargs):
 
 
 def sls_build(name, base='opensuse/python', mods=None, saltenv='base',
-              **kwargs):
+              dryrun=False, **kwargs):
     '''
     Build a docker image using the specified sls modules and base image.
 
     For example, if your master defines the states ``web`` and ``rails``, you
     can build a docker image inside myminion that results of applying those
     states by doing:
+
+    base
+        the base image
+
+    mods
+        the state modules to execute during build
+
+    saltenv
+        the salt environment to use
+
+    dryrun: False
+        when set to True the container will not be commited at the end of
+        the build. The dryrun succeed also when the state contains errors.
+
+    **RETURN DATA**
+
+    A dictionary with the ID of the new container. In case of a dryrun,
+    the state result is returned and the container gets removed.
 
     CLI Example:
 
@@ -5957,9 +5975,12 @@ def sls_build(name, base='opensuse/python', mods=None, saltenv='base',
         # Now execute the state into the container
         ret = __salt__['dockerng.sls'](id_, mods, saltenv, **kwargs)
         # fail if the state was not successful
-        if not salt.utils.check_state_result(ret):
+        if not dryrun and not salt.utils.check_state_result(ret):
             raise CommandExecutionError(ret)
     finally:
         __salt__['dockerng.stop'](id_)
 
+    if dryrun:
+        __salt__['dockerng.rm'](id_)
+        return ret
     return __salt__['dockerng.commit'](id_, name)

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5807,7 +5807,9 @@ def call(name, function, *args, **kwargs):
         raise CommandExecutionError('Missing function parameter')
 
     # move salt into the container
-    thin_path = salt.utils.thin.gen_thin(__opts__['cachedir'])
+    thin_path = salt.utils.thin.gen_thin(__opts__['cachedir'],
+                                         extra_mods=__salt__['config.option']("thin_extra_mods", ''),
+                                         so_mods=__salt__['config.option']("thin_so_mods", ''))
     with io.open(thin_path, 'rb') as file:
         _client_wrapper('put_archive', name, thin_dest_path, file)
     try:


### PR DESCRIPTION
### What does this PR do?

- add option dryrun to dockerng.sls_build
- provide the possibility to define extra modules for the thin
- enhance docs

When using sls_build the container was always commited. With the new dryrun option 
the build can be tested or this function could be used for any readonly state to get info
about the container internals (packagelist, etc.).

To run some salt modules, additional python modules may be required. Instead of
installing them into the container they could be added to the thin environment.
The configuration can be done via minion config or pillar data.

### Tests written?

No