### PR TITLE
Require VCRedist on 2008R2 and below instead of 2008

### DIFF
--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -179,8 +179,8 @@ ShowUnInstDetails show
 ; See http://blogs.msdn.com/b/astebner/archive/2009/01/29/9384143.aspx for more info
 Section -Prerequisites
 
-    ; VCRedist only needed on Server 2008/Vista and below
-    ${If} ${AtMostWin2008}
+    ; VCRedist only needed on Windows Server 2008R2/Windows 7 and below
+    ${If} ${AtMostWin2008r2}
 
         !define VC_REDIST_X64_GUID "{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
         !define VC_REDIST_X86_GUID "{9BE518E6-ECC6-35A9-88E4-87755C07200F}"

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -180,7 +180,7 @@ ShowUnInstDetails show
 Section -Prerequisites
 
     ; VCRedist only needed on Windows Server 2008R2/Windows 7 and below
-    ${If} ${AtMostWin2008r2}
+    ${If} ${AtMostWin2008R2}
 
         !define VC_REDIST_X64_GUID "{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
         !define VC_REDIST_X86_GUID "{9BE518E6-ECC6-35A9-88E4-87755C07200F}"


### PR DESCRIPTION
### What does this PR do?
Changes the requirement for VCRedist from 2008 and below to 2008R2 and below.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/39253

### Previous Behavior
VCRedist was only checked and installed on Windows Server 2008 and below (Vista).

### New Behavior
VCRedist is checked and installed on Windows Server 2008R2 and below (Windows 7)

### Tests written?
NA