### PR TITLE
Fix SIGCHLD handling

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -703,8 +703,7 @@ def default_signals(*signals):
     old_signals = {}
     for signum in signals:
         try:
-            signal.signal(signum, signal.SIG_DFL)
-            old_signals[signum] = signal.getsignal(signum)
+            old_signals[signum] = signal.signal(signum, signal.SIG_DFL)
         except ValueError as exc:
             # This happens when a netapi module attempts to run a function
             # using wheel_async, because the process trying to register signals

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -722,3 +722,19 @@ def default_signals(*signals):
         signal.signal(signum, old_signals[signum])
 
     del old_signals
+
+
+@contextlib.contextmanager
+def handle_signal(signum, handler):
+    old_signal = 0
+    try:
+        old_signal = signal.signal(signum, handler)
+    except ValueError as exc:
+        log.trace(
+            'Failed to register signal for signum %d: %s',
+            signum, exc
+        )
+
+    yield
+
+    signal.signal(signum, old_signal)


### PR DESCRIPTION
### What does this PR do?
When child exit, Popen.communicate returns because of HUP on stdout and stderr. In case if 1) stderr (e.g.) is used by daemonized process, 2) child exit (in case of postinstall, which is starting some daemon), Popen.communicate hang, and child turned to zombie. To cower this case, SIGCHLD is handled properly.

### What issues does this PR fix or reference?
Installation of some packages like MySQL, test case

    docker run -i -t yottatsa/test1662173 python /root/test.py

### Previous Behavior
Salt hangs.

### New Behavior
Salt continue working.

### Tests written?

No