### PR TITLE
Allow minion/CLI saltenv/pillarenv to override master when compiling pillar

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -372,11 +372,14 @@ class Pillar(object):
             opts['grains'] = {}
         else:
             opts['grains'] = grains
-        if not opts.get('environment'):
-            opts['environment'] = saltenv
+        # Allow minion/CLI saltenv/pillarenv to take precedence over master
+        opts['environment'] = saltenv \
+            if saltenv is not None \
+            else opts.get('environment')
+        opts['pillarenv'] = pillarenv \
+            if pillarenv is not None \
+            else opts.get('pillarenv')
         opts['id'] = self.minion_id
-        if not opts.get('pillarenv'):
-            opts['pillarenv'] = pillarenv
         if opts['state_top'].startswith('salt://'):
             opts['state_top'] = opts['state_top']
         elif opts['state_top'].startswith('/'):


### PR DESCRIPTION
Because we check in the master opts first, if the ``environment`` or
``pillarenv`` values are set in the master config file, they will take
precedence over the values specified in the minion config (or gathered
via the CLI). This commit fixes that ordering such that the values
passed to ``__gen_opts()`` take precedence over the values from the master
config.