### PR TITLE
Autodetect IPv6 connectivity from minion to master

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -81,9 +81,10 @@ The option can can also be set to a list of masters, enabling
 ``ipv6``
 --------
 
-Default: ``False``
+Default: ``None``
 
-Whether the master should be connected over IPv6.
+Whether the master should be connected over IPv6. By default salt minion
+will try to automatically detect IPv6 connectivity to master.
 
 .. code-block:: yaml
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -990,7 +990,7 @@ DEFAULT_MINION_OPTS = {
     'mine_interval': 60,
     'ipc_mode': _DFLT_IPC_MODE,
     'ipc_write_buffer': _DFLT_IPC_WBUFFER,
-    'ipv6': False,
+    'ipv6': None,
     'file_buffer_size': 262144,
     'tcp_pub_port': 4510,
     'tcp_pull_port': 4511,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -149,7 +149,7 @@ def resolve_dns(opts, fallback=True):
             if opts['master'] == '':
                 raise SaltSystemExit
             ret['master_ip'] = \
-                    salt.utils.dns_check(opts['master'], True, opts['ipv6'])
+                    salt.utils.dns_check(opts['master'], opts['master_port'], True, opts['ipv6'])
         except SaltClientError:
             if opts['retry_dns']:
                 while True:
@@ -163,7 +163,7 @@ def resolve_dns(opts, fallback=True):
                     time.sleep(opts['retry_dns'])
                     try:
                         ret['master_ip'] = salt.utils.dns_check(
-                            opts['master'], True, opts['ipv6']
+                            opts['master'], opts['master_port'], True, opts['ipv6']
                         )
                         break
                     except SaltClientError:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -132,7 +132,7 @@ log = logging.getLogger(__name__)
 # 6. Handle publications
 
 
-def resolve_dns(opts, fallback=True):
+def resolve_dns(opts, connect=True, fallback=True):
     '''
     Resolves the master_ip and master_uri options
     '''
@@ -149,7 +149,7 @@ def resolve_dns(opts, fallback=True):
             if opts['master'] == '':
                 raise SaltSystemExit
             ret['master_ip'] = \
-                    salt.utils.dns_check(opts['master'], opts['master_port'], True, opts['ipv6'])
+                    salt.utils.dns_check(opts['master'], opts['master_port'], connect, True, opts['ipv6'])
         except SaltClientError:
             if opts['retry_dns']:
                 while True:
@@ -163,7 +163,7 @@ def resolve_dns(opts, fallback=True):
                     time.sleep(opts['retry_dns'])
                     try:
                         ret['master_ip'] = salt.utils.dns_check(
-                            opts['master'], opts['master_port'], True, opts['ipv6']
+                            opts['master'], opts['master_port'], connect, True, opts['ipv6']
                         )
                         break
                     except SaltClientError:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -132,7 +132,7 @@ log = logging.getLogger(__name__)
 # 6. Handle publications
 
 
-def resolve_dns(opts, connect=True, fallback=True):
+def resolve_dns(opts, fallback=True, connect=True):
     '''
     Resolves the master_ip and master_uri options
     '''
@@ -149,7 +149,7 @@ def resolve_dns(opts, connect=True, fallback=True):
             if opts['master'] == '':
                 raise SaltSystemExit
             ret['master_ip'] = \
-                    salt.utils.dns_check(opts['master'], opts['master_port'], connect, True, opts['ipv6'])
+                    salt.utils.dns_check(opts['master'], opts['master_port'], True, opts['ipv6'], connect)
         except SaltClientError:
             if opts['retry_dns']:
                 while True:
@@ -163,7 +163,7 @@ def resolve_dns(opts, connect=True, fallback=True):
                     time.sleep(opts['retry_dns'])
                     try:
                         ret['master_ip'] = salt.utils.dns_check(
-                            opts['master'], opts['master_port'], connect, True, opts['ipv6']
+                            opts['master'], opts['master_port'], True, opts['ipv6'], connect
                         )
                         break
                     except SaltClientError:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -154,8 +154,8 @@ def resolve_dns(opts, fallback=True):
             if opts['retry_dns']:
                 while True:
                     import salt.log
-                    msg = ('Master hostname: \'{0}\' not found. Retrying in {1} '
-                           'seconds').format(opts['master'], opts['retry_dns'])
+                    msg = ('Master hostname: \'{0}\' not found or not responsive. '
+                           'Retrying in {1} seconds').format(opts['master'], opts['retry_dns'])
                     if salt.log.setup.is_console_configured():
                         log.error(msg)
                     else:

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -346,7 +346,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
                 zmq.RECONNECT_IVL_MAX, self.opts['recon_max']
             )
 
-        if self.opts['ipv6'] is True and hasattr(zmq, 'IPV4ONLY'):
+        if (self.opts['ipv6'] is True or ':' in self.opts['master_ip']) and hasattr(zmq, 'IPV4ONLY'):
             # IPv6 sockets work for both IPv6 and IPv4 addresses
             self._socket.setsockopt(zmq.IPV4ONLY, 0)
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -716,7 +716,7 @@ def ip_bracket(addr):
     return addr
 
 
-def dns_check(addr, port, safe=False, ipv6=None):
+def dns_check(addr, port, connect=True, safe=False, ipv6=None):
     '''
     Return the ip resolved by dns, but do not exit on failure, only raise an
     exception. Obeys system preference for IPv4/6 address resolution.
@@ -739,8 +739,13 @@ def dns_check(addr, port, safe=False, ipv6=None):
                     continue
                 if h[0] == socket.AF_INET6 and ipv6 is False:
                     continue
+                if h[0] == socket.AF_INET6 and connect is False and ipv6 is None:
+                    continue
 
                 candidate_addr = ip_bracket(h[4][0])
+
+                if not connect:
+                    resolved = candidate_addr
 
                 s = socket.socket(h[0], socket.SOCK_STREAM)
                 try:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -749,7 +749,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
 
                     addr = candidate_addr
                     break
-                except:
+                except Exception:
                     pass
             if not addr:
                 error = True

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -754,7 +754,7 @@ def dns_check(addr, port, connect=True, safe=False, ipv6=None):
 
                     resolved = candidate_addr
                     break
-                except Exception:
+                except socket.error:
                     pass
             if not resolved:
                 error = True

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -716,7 +716,7 @@ def ip_bracket(addr):
     return addr
 
 
-def dns_check(addr, port, connect=True, safe=False, ipv6=None):
+def dns_check(addr, port, safe=False, ipv6=None, connect=True):
     '''
     Return the ip resolved by dns, but do not exit on failure, only raise an
     exception. Obeys system preference for IPv4/6 address resolution.

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -733,7 +733,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
         if not hostnames:
             error = True
         else:
-            addr = False
+            resolved = False
             for h in hostnames:
                 if h[0] == socket.AF_INET and ipv6 is True:
                     continue
@@ -747,11 +747,11 @@ def dns_check(addr, port, safe=False, ipv6=None):
                     s.connect((candidate_addr.strip('[]'), port))
                     s.close()
 
-                    addr = candidate_addr
+                    resolved = candidate_addr
                     break
                 except Exception:
                     pass
-            if not addr:
+            if not resolved:
                 error = True
     except TypeError:
         err = ('Attempt to resolve address \'{0}\' failed. Invalid or unresolveable address').format(addr)
@@ -760,7 +760,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
         error = True
 
     if error:
-        err = ('DNS lookup of \'{0}\' failed.').format(addr)
+        err = ('DNS lookup or connection check of \'{0}\' failed.').format(addr)
         if safe:
             if salt.log.is_console_configured():
                 # If logging is not configured it also means that either
@@ -769,7 +769,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
                 log.error(err)
             raise SaltClientError()
         raise SaltSystemExit(code=42, msg=err)
-    return addr
+    return resolved
 
 
 def required_module_list(docstring=None):

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -716,12 +716,25 @@ def ip_bracket(addr):
     return addr
 
 
-def dns_check(addr, safe=False, ipv6=False):
+def dns_check(addr, safe=False, ipv6=None):
     '''
     Return the ip resolved by dns, but do not exit on failure, only raise an
     exception. Obeys system preference for IPv4/6 address resolution.
     '''
     error = False
+
+    # Detect IPv6 support if it is not forced by trying to connect
+    # to the give address over IPv6.
+    if ipv6 is None:
+        s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        try:
+            s.connect((addr, 0))
+            s.close()
+
+            ipv6 = True
+        except:
+            ipv6 = False
+
     try:
         # issue #21397: force glibc to re-read resolv.conf
         if HAS_RESINIT:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -742,7 +742,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
 
                 candidate_addr = ip_bracket(h[4][0])
 
-                s = socket.socket(h[0], socket.SOCK_DGRAM)
+                s = socket.socket(h[0], socket.SOCK_STREAM)
                 try:
                     s.connect((candidate_addr.strip('[]'), port))
                     s.close()

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -364,7 +364,7 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
         syndic_opts = sconfig.syndic_config(
             syndic_conf_path, minion_conf_path
         )
-        syndic_opts.update(salt.minion.resolve_dns(syndic_opts))
+        syndic_opts.update(salt.minion.resolve_dns(syndic_opts, connect=False))
         root_dir = syndic_opts['root_dir']
         # id & pki dir are shared & so configured on the minion side
         self.assertEqual(syndic_opts['id'], 'minion')


### PR DESCRIPTION
### What does this PR do?

It removes the need to specify `ipv6: true` in minion configuration for IPv6-only salt masters.

### What issues does this PR fix or reference?

This is related to #39118.

### Previous Behavior

IPv6 only master require setting `ipv6: true` in the config, otherwise minions fail to connect, because IPv6 is explicitly disabled by default.

### New Behavior

IPv6 only masters work out of the box. Yay future.

### Tests written?

Nope.