### PR TITLE
Support globbing in sources parameter of salt.modules.archive (#32356)

### DIFF
--- a/tests/integration/modules/archive.py
+++ b/tests/integration/modules/archive.py
@@ -126,7 +126,7 @@ class ArchiveTest(integration.ModuleCase):
 
         # Test create archive
         ret = self.run_function('archive.tar', ['-cvf', self.arch], sources=self.src)
-        self.assertTrue(isinstance(ret, list))
+        self.assertTrue(isinstance(ret, list), str(ret))
         self._assert_artifacts_in_ret(ret)
 
         self._tear_down()
@@ -141,7 +141,7 @@ class ArchiveTest(integration.ModuleCase):
 
         # Test extract archive
         ret = self.run_function('archive.tar', ['-xvf', self.arch], dest=self.dst)
-        self.assertTrue(isinstance(ret, list))
+        self.assertTrue(isinstance(ret, list), str(ret))
         self._assert_artifacts_in_ret(ret)
 
         self._tear_down()
@@ -155,7 +155,7 @@ class ArchiveTest(integration.ModuleCase):
 
         # Test create archive
         ret = self.run_function('archive.gzip', [self.src_file], options='-v')
-        self.assertTrue(isinstance(ret, list))
+        self.assertTrue(isinstance(ret, list), str(ret))
         self._assert_artifacts_in_ret(ret, file_only=True)
 
         self._tear_down()
@@ -171,7 +171,7 @@ class ArchiveTest(integration.ModuleCase):
 
         # Test extract archive
         ret = self.run_function('archive.gunzip', [self.src_file + '.gz'], options='-v')
-        self.assertTrue(isinstance(ret, list))
+        self.assertTrue(isinstance(ret, list), str(ret))
         self._assert_artifacts_in_ret(ret, file_only=True)
 
         self._tear_down()
@@ -185,7 +185,7 @@ class ArchiveTest(integration.ModuleCase):
 
         # Test create archive
         ret = self.run_function('archive.cmd_zip', [self.arch, self.src])
-        self.assertTrue(isinstance(ret, list))
+        self.assertTrue(isinstance(ret, list), str(ret))
         self._assert_artifacts_in_ret(ret)
 
         self._tear_down()
@@ -201,7 +201,7 @@ class ArchiveTest(integration.ModuleCase):
 
         # Test create archive
         ret = self.run_function('archive.cmd_unzip', [self.arch, self.dst])
-        self.assertTrue(isinstance(ret, list))
+        self.assertTrue(isinstance(ret, list), str(ret))
         self._assert_artifacts_in_ret(ret)
 
         self._tear_down()
@@ -215,7 +215,7 @@ class ArchiveTest(integration.ModuleCase):
 
         # Test create archive
         ret = self.run_function('archive.zip', [self.arch, self.src])
-        self.assertTrue(isinstance(ret, list))
+        self.assertTrue(isinstance(ret, list), str(ret))
         self._assert_artifacts_in_ret(ret)
 
         self._tear_down()
@@ -230,7 +230,7 @@ class ArchiveTest(integration.ModuleCase):
 
         # Test create archive
         ret = self.run_function('archive.unzip', [self.arch, self.dst])
-        self.assertTrue(isinstance(ret, list))
+        self.assertTrue(isinstance(ret, list), str(ret))
         self._assert_artifacts_in_ret(ret)
 
         self._tear_down()
@@ -244,7 +244,7 @@ class ArchiveTest(integration.ModuleCase):
 
         # Test create archive
         ret = self.run_function('archive.rar', [self.arch, self.src])
-        self.assertTrue(isinstance(ret, list))
+        self.assertTrue(isinstance(ret, list), str(ret))
         self._assert_artifacts_in_ret(ret)
 
         self._tear_down()
@@ -260,7 +260,7 @@ class ArchiveTest(integration.ModuleCase):
 
         # Test create archive
         ret = self.run_function('archive.unrar', [self.arch, self.dst])
-        self.assertTrue(isinstance(ret, list))
+        self.assertTrue(isinstance(ret, list), str(ret))
         self._assert_artifacts_in_ret(ret)
 
         self._tear_down()

--- a/tests/unit/modules/archive_test.py
+++ b/tests/unit/modules/archive_test.py
@@ -44,6 +44,7 @@ archive.__opts__ = {}
 class ArchiveTestCase(TestCase):
 
     @patch('salt.utils.which', lambda exe: exe)
+    @patch('glob.glob', lambda pathname: [pathname])
     def test_tar(self):
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
@@ -131,6 +132,7 @@ class ArchiveTestCase(TestCase):
             self.assertFalse(mock.called)
 
     @patch('salt.utils.which', lambda exe: exe)
+    @patch('glob.glob', lambda pathname: [pathname])
     def test_cmd_zip(self):
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
@@ -163,6 +165,7 @@ class ArchiveTestCase(TestCase):
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.path.isdir', MagicMock(return_value=False))
     @patch('zipfile.ZipFile', MagicMock())
+    @patch('glob.glob', lambda pathname: [pathname])
     def test_zip(self):
         ret = archive.zip_(
             '/tmp/salt.{{grains.id}}.zip',
@@ -323,6 +326,7 @@ class ArchiveTestCase(TestCase):
             self.assertFalse(mock.called)
 
     @patch('salt.utils.which', lambda exe: exe)
+    @patch('glob.glob', lambda pathname: [pathname])
     def test_rar(self):
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):


### PR DESCRIPTION
### What does this PR do?
Adds globbing support to tar, zip and rar.

### What issues does this PR fix or reference?
32356

### Previous Behavior
Globbing symbol (*) is interpreted as is.

### New Behavior
Globbing symbol is expanded using glob.glob().

### Tests written?
No