### PR TITLE
Add doc to recommend pgjsonb for master job caches

### DIFF
--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -11,7 +11,7 @@ Return data to a PostgreSQL server with json data stored in Pg's jsonb data type
     There are three PostgreSQL returners.  Any can function as an external
     :ref:`master job cache <external-master-cache>`. but each has different
     features.  SaltStack recommends
-    :mod:`returners.pgjsonb <salt.returners.pgjsonb` if you are working with
+    :mod:`returners.pgjsonb <salt.returners.pgjsonb>` if you are working with
     a version of PostgreSQL that has the appropriate native binary JSON types.
     Otherwise, review
     :mod:`returners.postgres <salt.returners.postgres>` and

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -3,9 +3,20 @@
 Return data to a PostgreSQL server with json data stored in Pg's jsonb data type
 
 :maintainer:    Dave Boucha <dave@saltstack.com>, Seth House <shouse@saltstack.com>, C. R. Oldham <cr@saltstack.com>
-:maturity:      new
+:maturity:      Stable
 :depends:       python-psycopg2
 :platform:      all
+
+.. note::
+    There are three PostgreSQL returners.  Any can function as an external
+    :ref:`master job cache <external-master-cache>`. but each has different
+    features.  SaltStack recommends
+    :mod:`returners.pgjsonb <salt.returners.pgjsonb` if you are working with
+    a version of PostgreSQL that has the appropriate native binary JSON types.
+    Otherwise, review
+    :mod:`returners.postgres <salt.returners.postgres>` and
+    :mod:`returners.postgres_local_cache <salt.returners.postgres_local_cache>`
+    to see which module best suits your particular needs.
 
 To enable this returner, the minion will need the python client for PostgreSQL
 installed and the following values configured in the minion or master

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -3,11 +3,15 @@
 Return data to a postgresql server
 
 .. note::
+    There are three PostgreSQL returners.  Any can function as an external
+    :ref:`master job cache <external-master-cache>`. but each has different
+    features.  SaltStack recommends
+    :mod:`returners.pgjsonb <salt.returners.pgjsonb` if you are working with
+    a version of PostgreSQL that has the appropriate native binary JSON types.
+    Otherwise, review
+    :mod:`returners.postgres <salt.returners.postgres>` and
     :mod:`returners.postgres_local_cache <salt.returners.postgres_local_cache>`
-    is recommended instead of this module when using PostgreSQL as a
-    :ref:`master job cache <external-master-cache>`. These two modules
-    provide different functionality so you should compare each to see which
-    module best suits your particular needs.
+    to see which module best suits your particular needs.
 
 :maintainer:    None
 :maturity:      New

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -6,7 +6,7 @@ Return data to a postgresql server
     There are three PostgreSQL returners.  Any can function as an external
     :ref:`master job cache <external-master-cache>`. but each has different
     features.  SaltStack recommends
-    :mod:`returners.pgjsonb <salt.returners.pgjsonb` if you are working with
+    :mod:`returners.pgjsonb <salt.returners.pgjsonb>` if you are working with
     a version of PostgreSQL that has the appropriate native binary JSON types.
     Otherwise, review
     :mod:`returners.postgres <salt.returners.postgres>` and

--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -4,14 +4,18 @@ Use a postgresql server for the master job cache. This helps the job cache to
 cope with scale.
 
 .. note::
-    :mod:`returners.postgres <salt.returners.postgres>` is also available if
-    you are not using PostgreSQL as a :ref:`master job cache
-    <external-master-cache>`.  These two modules provide different
-    functionality so you should compare each to see which module best suits
-    your particular needs.
+    There are three PostgreSQL returners.  Any can function as an external
+    :ref:`master job cache <external-master-cache>`. but each has different
+    features.  SaltStack recommends
+    :mod:`returners.pgjsonb <salt.returners.pgjsonb` if you are working with
+    a version of PostgreSQL that has the appropriate native binary JSON types.
+    Otherwise, review
+    :mod:`returners.postgres <salt.returners.postgres>` and
+    :mod:`returners.postgres_local_cache <salt.returners.postgres_local_cache>`
+    to see which module best suits your particular needs.
 
 :maintainer:    gjredelinghuys@gmail.com
-:maturity:      New
+:maturity:      Stable
 :depends:       psycopg2
 :platform:      all
 

--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -7,7 +7,7 @@ cope with scale.
     There are three PostgreSQL returners.  Any can function as an external
     :ref:`master job cache <external-master-cache>`. but each has different
     features.  SaltStack recommends
-    :mod:`returners.pgjsonb <salt.returners.pgjsonb` if you are working with
+    :mod:`returners.pgjsonb <salt.returners.pgjsonb>` if you are working with
     a version of PostgreSQL that has the appropriate native binary JSON types.
     Otherwise, review
     :mod:`returners.postgres <salt.returners.postgres>` and


### PR DESCRIPTION
### What does this PR do?

Edits the notes at the top of each of the three postgres returners to lay out the different options that Pg users have for master_job_cache returners.
