### PR TITLE
Better protect hardware clock test comparison

### DIFF
--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -157,10 +157,14 @@ def _date_bin_set_datetime(new_date):
     return True
 
 
-def _has_settable_hwclock():
+def has_settable_hwclock():
     '''
-    Returns True if the system has a harware clock capable of being
+    Returns True if the system has a hardware clock capable of being
     set from software.
+
+    CLI Example:
+
+    salt '*' system.has_settable_hwclock
     '''
     if salt.utils.which_bin(['hwclock']) is not None:
         res = __salt__['cmd.run_all'](['hwclock', '--test', '--systohc'], python_shell=False)
@@ -378,7 +382,7 @@ def set_system_date_time(years=None,
     if not _date_bin_set_datetime(new_datetime):
         return False
 
-    if _has_settable_hwclock():
+    if has_settable_hwclock():
         # Now that we've successfully set the software clock, we should
         # update hardware clock for time to persist though reboot.
         return _swclock_to_hwclock()

--- a/tests/integration/modules/system.py
+++ b/tests/integration/modules/system.py
@@ -88,7 +88,7 @@ class SystemModuleTest(integration.ModuleCase):
         '''
         Check that hw and sw clocks are sync'd.
         '''
-        if not self.run_function('system._has_settable_hwclock'):
+        if not self.run_function('system.has_settable_hwclock'):
             return None
         if not self._hwclock_has_compare():
             return None


### PR DESCRIPTION
In #39060, some tests were added to check for the hardware clock
getting reset when possible. The test attempted to gate the test
when access to the hardware clock was impossible, but the check
wasn't quite right and caused problems with the resulting tests.

This change makes the `has_settable_hwclock()` function public
in order to make the test gate work correctly. This function
could also be useful at the CLI level.

When running `self.run_function('status._has_settable_hwclock()')`
from the test suite, the return is a string noting that the
function is unavailable. This change allows for the `if not` check
to evaluate the return of the function.
