### PR TITLE
Removes a redundant test case after removed 'batch' in 'netapi'.

### DIFF
--- a/tests/unit/netapi/rest_tornado/test_utils.py
+++ b/tests/unit/netapi/rest_tornado/test_utils.py
@@ -6,7 +6,6 @@ import os
 
 # Import Salt Testing Libs
 from salttesting.unit import skipIf
-from salttesting.case import TestCase
 from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../..')
 
@@ -35,17 +34,6 @@ except ImportError:
 
 # Import utility lib from tests
 from unit.utils.event_test import eventpublisher_process, event, SOCK_DIR  # pylint: disable=import-error
-
-
-@skipIf(HAS_TORNADO is False, 'The tornado package needs to be installed')
-class TestUtils(TestCase):
-    def test_batching(self):
-        self.assertEqual(1, saltnado.get_batch_size('1', 10))
-        self.assertEqual(2, saltnado.get_batch_size('2', 10))
-
-        self.assertEqual(1, saltnado.get_batch_size('10%', 10))
-        # TODO: exception in this case? The core doesn't so we shouldn't
-        self.assertEqual(11, saltnado.get_batch_size('110%', 10))
 
 
 @skipIf(HAS_TORNADO is False, 'The tornado package needs to be installed')
@@ -153,7 +141,3 @@ class TestEventListener(AsyncTestCase):
             self.assertTrue(event_future.done())
             with self.assertRaises(saltnado.TimeoutException):
                 event_future.result()
-
-if __name__ == '__main__':
-    from integration import run_tests  # pylint: disable=import-error
-    run_tests(TestUtils, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

Removes a redundant test case after removed 'batch' in 'netapi'.

### What issues does this PR fix or reference?

'batch' in 'netapi' was removed by this commit ( 3d8f3d18f6afa760c70db87cbbaaa71d877ca4d3 ), and cleaned up some test cases by this commit ( 34282322c0228f6464281262ced0db8871f3e31e ). But it is remained after removing 'batch', thus it causes test failure.

### Previous Behavior
Failed to run a test using following command, `python runtests.py --name=unit.netapi.rest_tornado.test_utils`.

### New Behavior
Succeeded to run a test using following command, `python runtests.py --name=unit.netapi.rest_tornado.test_utils`.

### Tests written?

Yes(?)

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
