### PR TITLE
improve salt-run salt.cmd test

### DIFF
--- a/tests/integration/runners/salt.py
+++ b/tests/integration/runners/salt.py
@@ -21,10 +21,14 @@ class SaltRunnerTest(integration.ShellCase):
     '''
     def test_salt_cmd(self):
         '''
-        salt.cmd
+        test return values of salt.cmd
         '''
         ret = self.run_run_plus('salt.cmd', 'test.ping')
-        self.assertTrue(ret.get('out')[0])
+        out_ret = ret.get('out')[0]
+        return_ret = ret.get('return')
+
+        self.assertEqual(out_ret, 'True')
+        self.assertTrue(return_ret)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?
improves the `salt-run salt.cmd` test. There was an issue on 2016.11.2 where `out` was returning:

```
'out': ['Exception occurred in runner salt.cmd:                                           
         Traceback (most recent call last):', '  File                                                                  
         "/home/ch3ll/git/salt/salt/client/mixins.py", line 397, in _low', "                                           
         if 'data' in data['return']:", "TypeError: argument of type 'bool' is                                         
         not iterable"]}
```

See issue https://github.com/saltstack/salt/issues/38638 
This pr improves the test to make sure we catch this. 

### Tests written?

Yes