### PR TITLE
Add shutdown and reboot functions to win_system state module

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -158,20 +158,18 @@ def reboot(timeout=5, in_seconds=False, wait_for_reboot=False,  # pylint: disabl
 
     :param bool wait_for_reboot:
 
-        Sleeps for timeout + 30 seconds after reboot has been initiated.
-        This is useful for use in a highstate for example where
-        you have many states that could be ran after this one. Which you don't want
-        to start until after the restart i.e You could end up with a half finished state.
+        Sleeps for timeout + 30 seconds after reboot has been initiated. This
+        may be useful for use in a highstate if a reboot should be performed
+        and the return data of the highstate is not required. If return data is
+        required, consider using the reboot state instead of this module.
 
         .. versionadded:: 2015.8.0
 
     :param bool only_on_pending_reboot:
 
-        If this is set to True, then then the reboot will only proceed
-        if the system reports a pending reboot. Setting this paramater to
-        True could be useful when calling this function from a final housekeeping
-        state intended to be executed
-        at the end of a state run (using *order: last*).
+        If this is set to True, then the reboot will only proceed if the system
+        reports a pending reboot. To optionally reboot in a highstate, consider
+        using the reboot state instead of this module.
 
     :return: True if successful
     :rtype: bool
@@ -248,8 +246,9 @@ def shutdown(message=None, timeout=5, force_close=True, reboot=False,  # pylint:
         False caches to disk and safely powers down the system.
 
     :param bool only_on_pending_reboot:
-        If this is set to True, then then shutdown will only proceed
-        if the system reports a pending reboot.
+        If this is set to True, then the shutdown will only proceed if the
+        system reports a pending reboot. To optionally shutdown in a highstate,
+        consider using the shutdown state instead of this module.
 
     :return: True if successful
     :rtype: bool

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -235,12 +235,13 @@ def join_domain(name, username=None, password=None, account_ou=None,
         ret['result'] = False
     return ret
 
+
 def reboot(name, message=None, timeout=5, force_close=True, in_seconds=False,
            only_on_pending_reboot=True):
     '''
     Reboot the computer
 
-	:param str message:
+    :param str message:
         An optional message to display to users. It will also be used as a
         comment in the event log entry.
 
@@ -279,6 +280,7 @@ def reboot(name, message=None, timeout=5, force_close=True, in_seconds=False,
                     force_close=force_close, reboot=True,
                     in_seconds=in_seconds,
                     only_on_pending_reboot=only_on_pending_reboot)
+
 
 def shutdown(name, message=None, timeout=5, force_close=True, reboot=False,
              in_seconds=False, only_on_pending_reboot=False):
@@ -341,10 +343,10 @@ def shutdown(name, message=None, timeout=5, force_close=True, reboot=False,
     if only_on_pending_reboot and not __salt__['system.get_pending_reboot']():
         if __opts__['test']:
             ret['comment'] = ('System {0} will be skipped because '
-			                  'no reboot is pending').format(action)
+                              'no reboot is pending').format(action)
         else:
             ret['comment'] = ('System {0} has been skipped because '
-			                  'no reboot was pending').format(action)
+                              'no reboot was pending').format(action)
         return ret
 
     if __opts__['test']:
@@ -360,9 +362,9 @@ def shutdown(name, message=None, timeout=5, force_close=True, reboot=False,
                                                 only_on_pending_reboot=False)
 
     if ret['result']:
-	    ret['changes'] = {'old': 'No reboot or shutdown was scheduled',
-		                  'new': 'A {0} has been scheduled'.format(action)}
-	    ret['comment'] = 'Request to {0} was successful'.format(action)
+        ret['changes'] = {'old': 'No reboot or shutdown was scheduled',
+                          'new': 'A {0} has been scheduled'.format(action)}
+        ret['comment'] = 'Request to {0} was successful'.format(action)
     else:
-	    ret['comment'] = 'Request to {0} failed'.format(action)
+        ret['comment'] = 'Request to {0} failed'.format(action)
     return ret

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -234,3 +234,135 @@ def join_domain(name, username=None, password=None, account_ou=None,
         ret['comment'] = 'Computer failed to join \'{0}\''.format(name)
         ret['result'] = False
     return ret
+
+def reboot(name, message=None, timeout=5, force_close=True, in_seconds=False,
+           only_on_pending_reboot=True):
+    '''
+    Reboot the computer
+
+	:param str message:
+        An optional message to display to users. It will also be used as a
+        comment in the event log entry.
+
+        The default value is None.
+
+    :param int timeout:
+        The number of minutes or seconds before a reboot will occur. Whether
+        this number represents minutes or seconds depends on the value of
+        ``in_seconds``.
+
+        The default value is 5.
+
+    :param bool in_seconds:
+        If this is True, the value of ``timeout`` will be treated as a number
+        of seconds. If this is False, the value of ``timeout`` will be treated
+        as a number of minutes.
+
+        The default value is False.
+
+    :param bool force_close:
+        If this is True, running applications will be forced to close without
+        warning. If this is False, running applications will not get the
+        opportunity to prompt users about unsaved data.
+
+        The default value is True.
+
+    :param bool only_on_pending_reboot:
+
+        If this is True, the reboot will only occur if the system reports a
+        pending reboot. If this is False, the reboot will always occur.
+
+        The default value is True.
+    '''
+
+    return shutdown(name, message=message, timeout=timeout,
+                    force_close=force_close, reboot=True,
+                    in_seconds=in_seconds,
+                    only_on_pending_reboot=only_on_pending_reboot)
+
+def shutdown(name, message=None, timeout=5, force_close=True, reboot=False,
+             in_seconds=False, only_on_pending_reboot=False):
+    '''
+    Shutdown the computer
+
+    :param str message:
+        An optional message to display to users. It will also be used as a
+        comment in the event log entry.
+
+        The default value is None.
+
+    :param int timeout:
+        The number of minutes or seconds before a shutdown will occur. Whether
+        this number represents minutes or seconds depends on the value of
+        ``in_seconds``.
+
+        The default value is 5.
+
+    :param bool in_seconds:
+        If this is True, the value of ``timeout`` will be treated as a number
+        of seconds. If this is False, the value of ``timeout`` will be treated
+        as a number of minutes.
+
+        The default value is False.
+
+    :param bool force_close:
+        If this is True, running applications will be forced to close without
+        warning. If this is False, running applications will not get the
+        opportunity to prompt users about unsaved data.
+
+        The default value is True.
+
+    :param bool reboot:
+
+        If this is True, the computer will restart immediately after shutting
+        down. If False the system flushes all caches to disk and safely powers
+        down the system.
+
+        The default value is False.
+
+    :param bool only_on_pending_reboot:
+
+        If this is True, the shutdown will only occur if the system reports a
+        pending reboot. If this is False, the shutdown will always occur.
+
+        The default value is False.
+    '''
+
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    if reboot:
+        action = 'reboot'
+    else:
+        action = 'shutdown'
+
+    if only_on_pending_reboot and not __salt__['system.get_pending_reboot']():
+        if __opts__['test']:
+            ret['comment'] = ('System {0} will be skipped because '
+			                  'no reboot is pending').format(action)
+        else:
+            ret['comment'] = ('System {0} has been skipped because '
+			                  'no reboot was pending').format(action)
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Will attempt to schedule a {0}'.format(action)
+        return ret
+
+    ret['result'] = __salt__['system.shutdown'](message=message,
+                                                timeout=timeout,
+                                                force_close=force_close,
+                                                reboot=reboot,
+                                                in_seconds=in_seconds,
+                                                only_on_pending_reboot=False)
+
+    if ret['result']:
+	    ret['changes'] = {'old': 'No reboot or shutdown was scheduled',
+		                  'new': 'A {0} has been scheduled'.format(action)}
+	    ret['comment'] = 'Request to {0} was successful'.format(action)
+    else:
+	    ret['comment'] = 'Request to {0} failed'.format(action)
+    return ret


### PR DESCRIPTION
### What does this PR do?
- Adds shutdown and reboot functions to win_system state module.
- Changes the documentation of the win_system execution module to suggest use of the state module instead, for some use cases.

### What issues does this PR fix or reference?
As discussed in #39243.

Allows optional reboot or shutdown from a highstate run. A shutdown or reboot returns changes so that a dependant state may prevent additional functions from running.

e.g.
<pre>reboot_if_needed:
  system.reboot:
    - timeout: 60
    - in_seconds: True

failhard_for_reboot:
  test.fail_without_changes:
    - failhard: True
    - onchanges:
      - system: reboot_if_needed

something_else:
  test.succeed_without_changes</pre>

Default values were chosen to be similar to the win_system execution module.

### Tests written?

No