### PR TITLE
Fix issue with stdin when running salt under PyDev

### DIFF
--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -424,7 +424,11 @@ class Terminal(object):
 
             if self.pid == 0:
                 # Child
-                self.stdin = sys.stdin.fileno()
+                try:
+                    self.stdin = sys.stdin.fileno()
+                except AttributeError:
+                    # Work around PyDev replacing sys.stdin with a wrapper object.
+                    self.stdin = sys.stdin.original_stdin.fileno()
                 self.stdout = sys.stdout.fileno()
                 self.stderr = sys.stderr.fileno()
 


### PR DESCRIPTION
### What does this PR do?
Allows running salt under PyDev

### What issues does this PR fix or reference?
None

### Previous Behavior
Trying to run salt under PyDev fails with AttributeError

### New Behavior
Salt runs under PyDev normally

### Tests written?
No