### PR TITLE
Fix gpg renderer breakage from bef5e66

### DIFF
--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -175,11 +175,8 @@ import salt.loader
 import salt.utils
 import salt.utils.dictupdate
 import salt.utils.minions
+import salt.utils.stringio
 import salt.template
-
-# Import 3rd-party libs
-from salt.ext.six.moves import cStringIO
-
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -275,7 +272,7 @@ def _construct_pillar(top_dir,
                                                           default=render_default,
                                                           blacklist=renderer_blacklist,
                                                           whitelist=renderer_whitelist)
-                if isinstance(data, cStringIO.InputType):
+                if salt.utils.stringio.is_readable(data):
                     pillar_node[file_name] = data.getvalue()
                 else:
                     pillar_node[file_name] = data

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -217,12 +217,12 @@ from subprocess import Popen, PIPE
 
 # Import salt libs
 import salt.utils
+import salt.utils.stringio
 import salt.syspaths
 from salt.exceptions import SaltRenderError
 
 # Import 3rd-party libs
 import salt.ext.six as six
-from salt.ext.six.moves import cStringIO
 
 log = logging.getLogger(__name__)
 
@@ -279,7 +279,7 @@ def _decrypt_object(obj, translate_newlines=False):
     (string or unicode), and it contains a valid GPG header, decrypt it,
     otherwise keep going until a string is found.
     '''
-    if isinstance(obj, cStringIO.InputType):
+    if salt.utils.stringio.is_readable(obj):
         return _decrypt_object(obj.getvalue(), translate_newlines)
     if isinstance(obj, six.string_types):
         if GPG_HEADER.search(obj):

--- a/salt/utils/stringio.py
+++ b/salt/utils/stringio.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+'''
+Functions for StringIO objects
+'''
+
+from __future__ import absolute_import
+
+# Import 3rd-party libs
+from salt.ext import six
+
+# Not using six's fake cStringIO since we need to be able to tell if the object
+# is readable, and this can't be done via what six exposes.
+if six.PY2:
+    import StringIO
+    import cStringIO
+    readable_types = (StringIO.StringIO, cStringIO.InputType)
+    writable_types = (StringIO.StringIO, cStringIO.OutputType)
+else:
+    import io
+    readable_types = (io.StringIO,)
+    writable_types = (io.StringIO,)
+
+
+def is_stringio(obj):
+    return isinstance(obj, readable_types)
+
+
+def is_readable(obj):
+    if six.PY2:
+        return isinstance(obj, readable_types)
+    else:
+        return isinstance(obj, readable_types) and obj.readable()
+
+
+def is_writable(obj):
+    if six.PY2:
+        return isinstance(obj, writable_types)
+    else:
+        return isinstance(obj, writable_types) and obj.writable()


### PR DESCRIPTION
bef5e66 sought to make a PY3 compatibility change, but the attribute
from Python2's cStringIO module is not available via the "fake"
cStringIO which six exposes, as six's cStringIO is just the
cStringIO.StringIO function. The other cStringIO class attributes are
not available via six.

This commit adds a new module with a few functions to get information on
StringIO objects both in Python2 and 3, and modifies the files edited in
bef5e66 to use this new module to determine if the object is a readable
StringIO.

Fixes #39334.