### PR TITLE
Add creation/configuration of Salt PKI dirs to hacking docs

### DIFF
--- a/doc/topics/development/hacking.rst
+++ b/doc/topics/development/hacking.rst
@@ -127,11 +127,15 @@ During development it is easiest to be able to run the Salt master and minion
 that are installed in the virtualenv you created above, and also to have all
 the configuration, log, and cache files contained in the virtualenv as well.
 
+The ``/path/to/your/virtualenv`` referenced multiple times below is also
+available in the variable ``$VIRTUAL_ENV`` once the virtual environment is
+activated.
+
 Copy the master and minion config files into your virtualenv:
 
 .. code-block:: bash
 
-    mkdir -p /path/to/your/virtualenv/etc/salt
+    mkdir -p /path/to/your/virtualenv/etc/salt/pki/{master,minion}
     cp ./salt/conf/master ./salt/conf/minion /path/to/your/virtualenv/etc/salt/
 
 Edit the master config file:
@@ -139,24 +143,28 @@ Edit the master config file:
 1.  Uncomment and change the ``user: root`` value to your own user.
 2.  Uncomment and change the ``root_dir: /`` value to point to
     ``/path/to/your/virtualenv``.
-3.  If you are running version 0.11.1 or older, uncomment, and change the
+3.  Uncomment and change the ``pki: /etc/salt/pki/master`` value to point to
+    ``/path/to/your/virtualenv/etc/salt/pki/master``
+4.  If you are running version 0.11.1 or older, uncomment, and change the
     ``pidfile: /var/run/salt-master.pid`` value to point to
     ``/path/to/your/virtualenv/salt-master.pid``.
-4.  If you are also running a non-development version of Salt you will have to
+5.  If you are also running a non-development version of Salt you will have to
     change the ``publish_port`` and ``ret_port`` values as well.
 
 Edit the minion config file:
 
 1.  Repeat the edits you made in the master config for the ``user`` and
     ``root_dir`` values as well as any port changes.
-2.  If you are running version 0.11.1 or older, uncomment, and change the
+2.  Uncomment and change the ``pki: /etc/salt/pki/minion`` value to point to
+    ``/path/to/your/virtualenv/etc/salt/pki/minion``
+3.  If you are running version 0.11.1 or older, uncomment, and change the
     ``pidfile: /var/run/salt-minion.pid`` value to point to
     ``/path/to/your/virtualenv/salt-minion.pid``.
-3.  Uncomment and change the ``master: salt`` value to point at ``localhost``.
-4.  Uncomment and change the ``id:`` value to something descriptive like
+4.  Uncomment and change the ``master: salt`` value to point at ``localhost``.
+5.  Uncomment and change the ``id:`` value to something descriptive like
     "saltdev". This isn't strictly necessary but it will serve as a reminder of
     which Salt installation you are working with.
-5.  If you changed the ``ret_port`` value in the master config because you are
+6.  If you changed the ``ret_port`` value in the master config because you are
     also running a non-development version of Salt, then you will have to
     change the ``master_port`` value in the minion config to match.
 


### PR DESCRIPTION
### What does this PR do?

Improves the hacking docs, so there's no error message during PKI generation.