### PR TITLE
dockerng: fix documentation for detach's default value

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -2836,10 +2836,10 @@ def create(image,
 
         Example: ``tty=True``
 
-    detach : True
+    detach : False
         If ``True``, run ``command`` in the background (daemon mode)
 
-        Example: ``detach=False``
+        Example: ``detach=True``
 
     user
         User under which to run docker

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -980,7 +980,7 @@ def running(name,
                 - image: bar/baz:latest
                 - tty: True
 
-    detach : True
+    detach : False
         If ``True``, run the container's command in the background (daemon
         mode)
 
@@ -989,7 +989,7 @@ def running(name,
             foo:
               dockerng.running:
                 - image: bar/baz:latest
-                - detach: False
+                - detach: True
 
     user
         User under which to run docker


### PR DESCRIPTION
### What does this PR do?

Fix documentation for detach's default value
 
### What issues does this PR fix or reference?

The documentation should state that the default value is False.

### Previous Behavior
Documentation states that detach's default value is True

### New Behavior
Documentation states that detach's default value is False

### Tests written?

No
