### PR TITLE
Ignore non-HTTP IIS bindings

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -217,7 +217,6 @@ pseudoxml: translations
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
 
-
 translations:
 	@if [ "$(SPHINXLANG)" = "en" ] || [ "x$(SPHINXLANG)" = "x" ]; then \
 		echo "No need to update translations. Skipping..."; \

--- a/doc/topics/development/hacking.rst
+++ b/doc/topics/development/hacking.rst
@@ -233,7 +233,7 @@ You can now call all of Salt's CLI tools without explicitly passing the configur
 Additional Options
 ..................
 
-In case you want to distribute your virtualenv, you probably don't want to
+If you want to distribute your virtualenv, you probably don't want to
 include Salt's clone ``.git/`` directory, and, without it, Salt won't report
 the accurate version. You can tell ``setup.py`` to generate the hardcoded
 version information which is distributable:

--- a/doc/topics/development/hacking.rst
+++ b/doc/topics/development/hacking.rst
@@ -233,10 +233,10 @@ You can now call all of Salt's CLI tools without explicitly passing the configur
 Additional Options
 ..................
 
-If you want to distribute your virtualenv, you probably don't want to
-include Salt's clone ``.git/`` directory, and, without it, Salt won't report
-the accurate version. You can tell ``setup.py`` to generate the hardcoded
-version information which is distributable:
+If you want to distribute your virtualenv, you probably don't want to include
+Salt's clone ``.git/`` directory, and, without it, Salt won't report the
+accurate version. You can tell ``setup.py`` to generate the hardcoded version
+information which is distributable:
 
 .. code-block:: bash
 

--- a/doc/topics/pillar/index.rst
+++ b/doc/topics/pillar/index.rst
@@ -150,6 +150,24 @@ And the actual pillar file at '/srv/pillar/common_pillar.sls':
     foo: bar
     boo: baz
 
+.. note::
+    When working with multiple pillar environments, assuming that each pillar
+    environment has its own top file, the jinja placeholder ``{{ saltenv }}``
+    can be used in place of the environment name:
+
+    .. code-block:: yaml
+
+        {{ saltenv }}:
+          '*':
+             - common_pillar
+
+    Yes, this is ``{{ saltenv }}``, and not ``{{ pillarenv }}``. The reason for
+    this is because the Pillar top files are parsed using some of the same code
+    which parses top files when :ref:`running states <running-highstate>`, so
+    the pillar environment takes the place of ``{{ saltenv }}`` in the jinja
+    context.
+
+
 Pillar Namespace Flattening
 ===========================
 

--- a/doc/topics/proxyminion/index.rst
+++ b/doc/topics/proxyminion/index.rst
@@ -263,7 +263,8 @@ the "name" of the device, and is used by the salt-master for targeting and key
 authentication.
 
 Here is an example proxymodule used to interface to a *very* simple REST
-server.  Code for the server is in the `salt-contrib GitHub repository <https://github.com/saltstack/salt-contrib/proxyminion_rest_example>`_
+server.  Code for the server is in the `salt-contrib GitHub repository
+<https://github.com/saltstack/salt-contrib/tree/master/proxyminion_rest_example>`_
 
 This proxymodule enables "service" enumeration, starting, stopping, restarting,
 and status; "package" installation, and a ping.

--- a/doc/topics/tutorials/writing_tests.rst
+++ b/doc/topics/tutorials/writing_tests.rst
@@ -316,7 +316,7 @@ call should return.
                 alias='fred')
         self.assertEqual(tgt_ret, 'bob')
 
-Using multiple Salt commands in this manor provides two useful benefits. The first is
+Using multiple Salt commands in this manner provides two useful benefits. The first is
 that it provides some additional coverage for the ``aliases.set_target`` function.
 The second benefit is the call to ``aliases.get_target`` is not dependent on the
 presence of any aliases set outside of this test. Tests should not be dependent on

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -179,8 +179,8 @@ ShowUnInstDetails show
 ; See http://blogs.msdn.com/b/astebner/archive/2009/01/29/9384143.aspx for more info
 Section -Prerequisites
 
-    ; VCRedist only needed on Server 2008/Vista and below
-    ${If} ${AtMostWin2008}
+    ; VCRedist only needed on Windows Server 2008R2/Windows 7 and below
+    ${If} ${AtMostWin2008r2}
 
         !define VC_REDIST_X64_GUID "{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
         !define VC_REDIST_X86_GUID "{9BE518E6-ECC6-35A9-88E4-87755C07200F}"

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -180,7 +180,7 @@ ShowUnInstDetails show
 Section -Prerequisites
 
     ; VCRedist only needed on Windows Server 2008R2/Windows 7 and below
-    ${If} ${AtMostWin2008r2}
+    ${If} ${AtMostWin2008R2}
 
         !define VC_REDIST_X64_GUID "{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
         !define VC_REDIST_X86_GUID "{9BE518E6-ECC6-35A9-88E4-87755C07200F}"

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2015,7 +2015,7 @@ def replace(path,
 
     found = False
     temp_file = None
-    content = str(not_found_content) if not_found_content and \
+    content = salt.utils.to_str(not_found_content) if not_found_content and \
                                        (prepend_if_not_found or
                                         append_if_not_found) \
                                      else salt.utils.to_str(repl)
@@ -2122,7 +2122,7 @@ def replace(path,
         if not_found_content is None:
             not_found_content = repl
         if prepend_if_not_found:
-            new_file.insert(0, not_found_content + '\n')
+            new_file.insert(0, not_found_content + b'\n')
         else:
             # append_if_not_found
             # Make sure we have a newline at the end of the file

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1598,7 +1598,6 @@ def line(path, content, match=None, mode=None, location=None,
     elif mode == 'ensure':
         after = after and after.strip()
         before = before and before.strip()
-        content = content and content.strip()
 
         if before and after:
             _assert_occurrence(body, before, 'before')

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1395,7 +1395,7 @@ def _get_line_indent(src, line, indent):
     '''
     Indent the line with the source line.
     '''
-    if not (indent or line):
+    if not indent:
         return line
 
     idt = []

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2188,8 +2188,8 @@ def replace(path,
         check_perms(path, None, pre_user, pre_group, pre_mode)
 
     if show_changes:
-        orig_file_as_str = ''.join(map(lambda x: salt.utils.to_str(x), orig_file))
-        new_file_as_str = ''.join(map(lambda x: salt.utils.to_str(x), new_file))
+        orig_file_as_str = ''.join([salt.utils.to_str(x) for x in orig_file])
+        new_file_as_str = ''.join([salt.utils.to_str(x) for x in new_file])
         return ''.join(difflib.unified_diff(orig_file_as_str, new_file_as_str))
 
     return has_changes

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1993,7 +1993,7 @@ def replace(path,
         )
 
     flags_num = _get_flags(flags)
-    cpattern = re.compile(str(pattern), flags_num)
+    cpattern = re.compile(salt.utils.to_bytes(pattern), flags_num)
     filesize = os.path.getsize(path)
     if bufsize == 'file':
         bufsize = filesize
@@ -2007,15 +2007,18 @@ def replace(path,
         pre_group = get_group(path)
         pre_mode = salt.utils.normalize_mode(get_mode(path))
 
-    # Avoid TypeErrors by forcing repl to be a string
-    repl = str(repl)
+    # Avoid TypeErrors by forcing repl to be bytearray related to mmap
+    # Replacement text may contains integer: 123 for example
+    repl = salt.utils.to_bytes(str(repl))
+    if not_found_content:
+        not_found_content = salt.utils.to_bytes(not_found_content)
 
     found = False
     temp_file = None
     content = str(not_found_content) if not_found_content and \
                                        (prepend_if_not_found or
                                         append_if_not_found) \
-                                     else repl
+                                     else salt.utils.to_str(repl)
 
     try:
         # First check the whole file, determine whether to make the replacement
@@ -2032,7 +2035,7 @@ def replace(path,
                                    access=mmap.ACCESS_READ)
             except (ValueError, mmap.error):
                 # size of file in /proc is 0, but contains data
-                r_data = "".join(r_file)
+                r_data = salt.utils.to_bytes("".join(r_file))
             if search_only:
                 # Just search; bail as early as a match is found
                 if re.search(cpattern, r_data):
@@ -2049,7 +2052,7 @@ def replace(path,
                 if prepend_if_not_found or append_if_not_found:
                     # Search for content, to avoid pre/appending the
                     # content if it was pre/appended in a previous run.
-                    if re.search('^{0}$'.format(re.escape(content)),
+                    if re.search(salt.utils.to_bytes('^{0}$'.format(re.escape(content))),
                                  r_data,
                                  flags=flags_num):
                         # Content was found, so set found.
@@ -2060,7 +2063,7 @@ def replace(path,
                 if show_changes or append_if_not_found or \
                    prepend_if_not_found:
                     orig_file = r_data.read(filesize).splitlines(True) \
-                        if hasattr(r_data, 'read') \
+                        if isinstance(r_data, mmap.mmap) \
                         else r_data.splitlines(True)
                     new_file = result.splitlines(True)
 
@@ -2099,7 +2102,7 @@ def replace(path,
                         result, nrepl = re.subn(cpattern, repl,
                                                 r_data, count)
                         try:
-                            w_file.write(result)
+                            w_file.write(salt.utils.to_str(result))
                         except (OSError, IOError) as exc:
                             raise CommandExecutionError(
                                 "Unable to write file '{0}'. Contents may "
@@ -2124,9 +2127,9 @@ def replace(path,
             # append_if_not_found
             # Make sure we have a newline at the end of the file
             if 0 != len(new_file):
-                if not new_file[-1].endswith('\n'):
-                    new_file[-1] += '\n'
-            new_file.append(not_found_content + '\n')
+                if not new_file[-1].endswith(b'\n'):
+                    new_file[-1] += b'\n'
+            new_file.append(not_found_content + b'\n')
         has_changes = True
         if not dry_run:
             try:
@@ -2139,7 +2142,7 @@ def replace(path,
             try:
                 fh_ = salt.utils.atomicfile.atomic_open(path, 'w')
                 for line in new_file:
-                    fh_.write(line)
+                    fh_.write(salt.utils.to_str(line))
             finally:
                 fh_.close()
 
@@ -2185,7 +2188,9 @@ def replace(path,
         check_perms(path, None, pre_user, pre_group, pre_mode)
 
     if show_changes:
-        return ''.join(difflib.unified_diff(orig_file, new_file))
+        orig_file_as_str = ''.join(map(lambda x: salt.utils.to_str(x), orig_file))
+        new_file_as_str = ''.join(map(lambda x: salt.utils.to_str(x), new_file))
+        return ''.join(difflib.unified_diff(orig_file_as_str, new_file_as_str))
 
     return has_changes
 
@@ -3606,7 +3611,9 @@ def apply_template_on_contents(
             grains=__grains__,
             pillar=__pillar__,
             salt=__salt__,
-            opts=__opts__)['data'].encode('utf-8')
+            opts=__opts__)['data']
+        if six.PY2:
+            contents = contents.encode('utf-8')
     else:
         ret = {}
         ret['result'] = False

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -126,6 +126,11 @@ def list_sites():
         bindings = dict()
 
         for binding in item['bindings']['Collection']:
+
+            # Ignore bindings which do not have host names
+            if binding['protocol'] not in ['http', 'https']:
+                continue
+
             filtered_binding = dict()
 
             for key in binding:

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -372,11 +372,14 @@ class Pillar(object):
             opts['grains'] = {}
         else:
             opts['grains'] = grains
-        if not opts.get('environment'):
-            opts['environment'] = saltenv
+        # Allow minion/CLI saltenv/pillarenv to take precedence over master
+        opts['environment'] = saltenv \
+            if saltenv is not None \
+            else opts.get('environment')
+        opts['pillarenv'] = pillarenv \
+            if pillarenv is not None \
+            else opts.get('pillarenv')
         opts['id'] = self.minion_id
-        if not opts.get('pillarenv'):
-            opts['pillarenv'] = pillarenv
         if opts['state_top'].startswith('salt://'):
             opts['state_top'] = opts['state_top']
         elif opts['state_top'].startswith('/'):

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -11,7 +11,7 @@ Return data to a PostgreSQL server with json data stored in Pg's jsonb data type
     There are three PostgreSQL returners.  Any can function as an external
     :ref:`master job cache <external-master-cache>`. but each has different
     features.  SaltStack recommends
-    :mod:`returners.pgjsonb <salt.returners.pgjsonb` if you are working with
+    :mod:`returners.pgjsonb <salt.returners.pgjsonb>` if you are working with
     a version of PostgreSQL that has the appropriate native binary JSON types.
     Otherwise, review
     :mod:`returners.postgres <salt.returners.postgres>` and

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -3,9 +3,20 @@
 Return data to a PostgreSQL server with json data stored in Pg's jsonb data type
 
 :maintainer:    Dave Boucha <dave@saltstack.com>, Seth House <shouse@saltstack.com>, C. R. Oldham <cr@saltstack.com>
-:maturity:      new
+:maturity:      Stable
 :depends:       python-psycopg2
 :platform:      all
+
+.. note::
+    There are three PostgreSQL returners.  Any can function as an external
+    :ref:`master job cache <external-master-cache>`. but each has different
+    features.  SaltStack recommends
+    :mod:`returners.pgjsonb <salt.returners.pgjsonb` if you are working with
+    a version of PostgreSQL that has the appropriate native binary JSON types.
+    Otherwise, review
+    :mod:`returners.postgres <salt.returners.postgres>` and
+    :mod:`returners.postgres_local_cache <salt.returners.postgres_local_cache>`
+    to see which module best suits your particular needs.
 
 To enable this returner, the minion will need the python client for PostgreSQL
 installed and the following values configured in the minion or master

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -3,11 +3,15 @@
 Return data to a postgresql server
 
 .. note::
+    There are three PostgreSQL returners.  Any can function as an external
+    :ref:`master job cache <external-master-cache>`. but each has different
+    features.  SaltStack recommends
+    :mod:`returners.pgjsonb <salt.returners.pgjsonb` if you are working with
+    a version of PostgreSQL that has the appropriate native binary JSON types.
+    Otherwise, review
+    :mod:`returners.postgres <salt.returners.postgres>` and
     :mod:`returners.postgres_local_cache <salt.returners.postgres_local_cache>`
-    is recommended instead of this module when using PostgreSQL as a
-    :ref:`master job cache <external-master-cache>`. These two modules
-    provide different functionality so you should compare each to see which
-    module best suits your particular needs.
+    to see which module best suits your particular needs.
 
 :maintainer:    None
 :maturity:      New

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -6,7 +6,7 @@ Return data to a postgresql server
     There are three PostgreSQL returners.  Any can function as an external
     :ref:`master job cache <external-master-cache>`. but each has different
     features.  SaltStack recommends
-    :mod:`returners.pgjsonb <salt.returners.pgjsonb` if you are working with
+    :mod:`returners.pgjsonb <salt.returners.pgjsonb>` if you are working with
     a version of PostgreSQL that has the appropriate native binary JSON types.
     Otherwise, review
     :mod:`returners.postgres <salt.returners.postgres>` and

--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -4,14 +4,18 @@ Use a postgresql server for the master job cache. This helps the job cache to
 cope with scale.
 
 .. note::
-    :mod:`returners.postgres <salt.returners.postgres>` is also available if
-    you are not using PostgreSQL as a :ref:`master job cache
-    <external-master-cache>`.  These two modules provide different
-    functionality so you should compare each to see which module best suits
-    your particular needs.
+    There are three PostgreSQL returners.  Any can function as an external
+    :ref:`master job cache <external-master-cache>`. but each has different
+    features.  SaltStack recommends
+    :mod:`returners.pgjsonb <salt.returners.pgjsonb` if you are working with
+    a version of PostgreSQL that has the appropriate native binary JSON types.
+    Otherwise, review
+    :mod:`returners.postgres <salt.returners.postgres>` and
+    :mod:`returners.postgres_local_cache <salt.returners.postgres_local_cache>`
+    to see which module best suits your particular needs.
 
 :maintainer:    gjredelinghuys@gmail.com
-:maturity:      New
+:maturity:      Stable
 :depends:       psycopg2
 :platform:      all
 

--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -7,7 +7,7 @@ cope with scale.
     There are three PostgreSQL returners.  Any can function as an external
     :ref:`master job cache <external-master-cache>`. but each has different
     features.  SaltStack recommends
-    :mod:`returners.pgjsonb <salt.returners.pgjsonb` if you are working with
+    :mod:`returners.pgjsonb <salt.returners.pgjsonb>` if you are working with
     a version of PostgreSQL that has the appropriate native binary JSON types.
     Otherwise, review
     :mod:`returners.postgres <salt.returners.postgres>` and

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -218,7 +218,8 @@ def clean_old_jobs():
         load_key = ret_key.replace('ret:', 'load:', 1)
         if load_key not in living_jids:
             to_remove.append(ret_key)
-    serv.delete(*to_remove)
+    if len(to_remove) != 0:
+        serv.delete(*to_remove)
 
 
 def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1611,6 +1611,11 @@ class Dulwich(GitProvider):  # pylint: disable=abstract-method
     '''
     def __init__(self, opts, remote, per_remote_defaults,
                  override_params, cache_root, role='gitfs'):
+        salt.utils.warn_until(
+            'Nitrogen',
+            'Dulwich will no longer be supported for {0} beginning in the '
+            'Nitrogen release of Salt.'.format(role)
+        )
         self.get_env_refs = lambda refs: [
             x for x in refs if re.match('refs/(remotes|tags)', x)
             and not x.endswith('^{}')


### PR DESCRIPTION
### What does this PR do?

In my usage of this module I found it threw exceptions when trying to iterate over non-HTTP bindings (e.g. net.tcp). This PR add a filter to the binding retrieval loop to ignore bindings which don't have a host header. It seems that the original author's intent was to enumerate websites only.

### What issues does this PR fix or reference?

None.

### Previous Behavior
Throw exception when bindings without host names are present in IIS config.

### New Behavior
Ignore bindings which don't have a host header.

### Tests written?

No
