### PR TITLE
Ignore non-HTTP IIS bindings

### DIFF
--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -126,6 +126,11 @@ def list_sites():
         bindings = dict()
 
         for binding in item['bindings']['Collection']:
+
+            # Ignore bindings which do not have host names
+            if binding['protocol'] not in ['http', 'https']:
+                continue
+
             filtered_binding = dict()
 
             for key in binding:


### PR DESCRIPTION
### What does this PR do?

In my usage of this module I found it threw exceptions when trying to iterate over non-HTTP bindings (e.g. net.tcp). This PR add a filter to the binding retrieval loop to ignore bindings which don't have a host header. It seems that the original author's intent was to enumerate websites only.

### What issues does this PR fix or reference?

None.

### Previous Behavior
Throw exception when bindings without host names are present in IIS config.

### New Behavior
Ignore bindings which don't have a host header.

### Tests written?

No
