### PR TITLE
Fix some test instability in develop

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2027,8 +2027,8 @@ class GitBase(object):
                     changed = True
             except Exception as exc:
                 log.error(
-                    'Exception \'{0}\' caught while fetching {1} remote '
-                    '\'{2}\''.format(exc, self.role, repo.id),
+                    'Exception caught while fetching %s remote \'%s\': %s',
+                    self.role, repo.id, exc,
                     exc_info_on_loglevel=logging.DEBUG
                 )
         return changed

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -110,24 +110,37 @@ def enforce_types(key, val):
         'insecure_auth': bool,
         'env_whitelist': 'stringlist',
         'env_blacklist': 'stringlist',
-        'gitfs_env_whitelist': 'stringlist',
-        'gitfs_env_blacklist': 'stringlist',
         'refspecs': 'stringlist',
-        'gitfs_refspecs': 'stringlist',
     }
 
+    def _find_global(key):
+        for item in non_string_params:
+            try:
+                if key.endswith('_' + item):
+                    ret = item
+                    break
+            except TypeError:
+                if key.endswith('_' + str(item)):
+                    ret = item
+                    break
+        else:
+            ret = None
+        return ret
+
     if key not in non_string_params:
-        return six.text_type(val)
-    else:
-        expected = non_string_params[key]
-        if expected is bool:
-            return val
-        elif expected == 'stringlist':
-            if not isinstance(val, (six.string_types, list)):
-                val = six.text_type(val)
-            if isinstance(val, six.string_types):
-                return [x.strip() for x in val.split(',')]
-            return [six.text_type(x) for x in val]
+        key = _find_global(key)
+        if key is None:
+            return six.text_type(val)
+
+    expected = non_string_params[key]
+    if expected is bool:
+        return val
+    elif expected == 'stringlist':
+        if not isinstance(val, (six.string_types, list)):
+            val = six.text_type(val)
+        if isinstance(val, six.string_types):
+            return [x.strip() for x in val.split(',')]
+        return [six.text_type(x) for x in val]
 
 
 def failhard(role):

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -446,7 +446,7 @@ class GitProvider(object):
         cmd = subprocess.Popen(
             shlex.split(cmd_str),
             close_fds=not salt.utils.is_windows(),
-            cwd=self.repo.workdir,
+            cwd=os.path.dirname(self.gitdir),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT)
         output = cmd.communicate()[0]
@@ -538,7 +538,7 @@ class GitProvider(object):
             cmd = subprocess.Popen(
                 shlex.split(cmd_str),
                 close_fds=not salt.utils.is_windows(),
-                cwd=self.repo.workdir,
+                cwd=os.path.dirname(self.gitdir),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT)
             output = cmd.communicate()[0]

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -31,9 +31,11 @@ peer:
     - 'test.*'
 
 ext_pillar:
-  - git: master https://github.com/saltstack/pillar1.git
-  - git: master https://github.com/saltstack/pillar2.git
-  - git: dev:testing https://github.com/saltstack/pillar1.git
+  - git:
+    - master https://github.com/saltstack/pillar1.git
+    - master https://github.com/saltstack/pillar2.git
+    - dev https://github.com/saltstack/pillar1.git:
+      - env: testing
   - test_ext_pillar_opts:
     - test_issue_5951_actual_file_roots_in_opts
 


### PR DESCRIPTION
Setting the system time really far back in the past (in one test as far back as
1981) was causing errors when git_pillar would refresh, as the git command
would refuse to refresh due to an invalid SSL certificate. Additionally,
sometimes ``/dev/rtc`` would apparently become unresponsive after syncing the
hwclock to the system time, which caused the ``hwclock --compare`` command used
to check the time sync to hang indefinitely, ultimately causing the entire test
run to fail. This changeset uses a SIGALRM handler to abort the hwclock
command if no output is seen within 3 seconds and try a second time. If it
times out the second time as well, then an error will be logged but it will not
be fatal to the test (or hang it indefinitely).

Additionally, in the course of troubleshooting these test issues I tried
updating the git_pillar configuration in the test suite's master config file to
use the new-style git_pillar config schema. Previously it had been using the
legacy git_pillar code to provide pillar data for tests. Honestly, we should
have made this change months ago, since we are planning on removing legacy
git_pillar in Oxygen. I will probably have to come back to this before merging
to also take care of updating the git_pillar tests, but I'm opening the PR now
to give jenkins a crack at running through the system module integration tests
and confirming that the hwclock issue is fixed. **Actually, the git_pillar tests
pass just fine. I opened #39349 to get new tests written**.