### PR TITLE
Reduce fileclient latency by merging _file_hash and _find_file

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1275,10 +1275,10 @@ class RemoteClient(Client):
                 hash_type = self.opts.get('hash_type', 'md5')
                 ret['hsum'] = salt.utils.get_hash(path, form=hash_type)
                 ret['hash_type'] = hash_type
-                return ret
+                return ret, list(os.stat(path))
         load = {'path': path,
                 'saltenv': saltenv,
-                'cmd': '_file_hash'}
+                'cmd': '_file_hash_and_stat'}
         return self.channel.send(load)
 
     def hash_file(self, path, saltenv='base'):
@@ -1287,33 +1287,14 @@ class RemoteClient(Client):
         master file server prepend the path with salt://<file on server>
         otherwise, prepend the file with / for a local file.
         '''
-        return self.__hash_and_stat_file(path, saltenv)
+        return self.__hash_and_stat_file(path, saltenv)[0]
 
     def hash_and_stat_file(self, path, saltenv='base'):
         '''
         The same as hash_file, but also return the file's mode, or None if no
         mode data is present.
         '''
-        hash_result = self.hash_file(path, saltenv)
-        try:
-            path = self._check_proto(path)
-        except MinionError as err:
-            if not os.path.isfile(path):
-                return hash_result, None
-            else:
-                try:
-                    return hash_result, list(os.stat(path))
-                except Exception:
-                    return hash_result, None
-        load = {'path': path,
-                'saltenv': saltenv,
-                'cmd': '_file_find'}
-        fnd = self.channel.send(load)
-        try:
-            stat_result = fnd.get('stat')
-        except AttributeError:
-            stat_result = None
-        return hash_result, stat_result
+        return self.__hash_and_stat_file(path, saltenv)
 
     def list_env(self, saltenv='base'):
         '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -971,6 +971,7 @@ class AESFuncs(object):
         self._serve_file = self.fs_.serve_file
         self._file_find = self.fs_._find_file
         self._file_hash = self.fs_.file_hash
+        self._file_hash_and_stat = self.fs_.file_hash_and_stat
         self._file_list = self.fs_.file_list
         self._file_list_emptydirs = self.fs_.file_list_emptydirs
         self._dir_list = self.fs_.dir_list


### PR DESCRIPTION
### What does this PR do?

1. Creates new master function _file_hash_and_stat
(sadly that's backwards incompatible, which means you need to update your master before you update minions)
2. Changes fileclient.py to use one call to _file_hash_and_stat instead of calling _file_hash and then _find_file.

This reduces latency to access file's metadata in minion<-> master setup when they are in different datacenter - in my case the ping latency is 10ms.

This somehow added to closer to 40ms than 20ms when requesting file metadata from master.
This commit reduced our deploy times - 7 machines - from 27 seconds to 22 seconds, by cutting access times in half.
(both of these timings include my not-yet-finished ZeroMQ connection caching patch from #39338, which saves additional 50x50ms = 2500ms, around 50 re-connections per highstate with 50ms handshake time, as well as a the new WIP plugin loader)

There is still big room for improvement in near future - I'd like to add last modified dates to _file_list, update file list once when a job is requested, and then latency to check if file is up to date would be 0ms. 🙃 

Note: file_hash_and_stat was an already existing function in filesystem module, but wasn't hooked to the public API for some reason 😕 

### What issues does this PR fix or reference?

Related to #39338, though this is a seperate problem.

### Previous Behavior
For any requested file that is up-to-date in cache, _file_hash would be requested and then _file_find.

### New Behavior
For any requested file that is up-to-date in cache, only one API request _file_hash_and_stat would be send instead of two.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
