### PR TITLE
Fix adb beacon when there are no devices

### DIFF
--- a/salt/beacons/adb.py
+++ b/salt/beacons/adb.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 __virtualname__ = 'adb'
 
 last_state = {}
-last_state_extra = {'value': False}
+last_state_extra = {'value': False, 'no_devices': False}
 
 
 def __virtual__():
@@ -125,11 +125,11 @@ def beacon(config):
 
     # Maybe send an event if we don't have any devices
     if 'no_devices_event' in config and config['no_devices_event'] is True:
-        if len(lines) == 0 and not last_state_extra['no_devices']:
+        if len(found_devices) == 0 and not last_state_extra['no_devices']:
             ret.append({'tag': 'no_devices'})
 
     # Did we have no devices listed this time around?
 
-    last_state_extra['no_devices'] = len(lines) == 0
+    last_state_extra['no_devices'] = len(found_devices) == 0
 
     return ret

--- a/tests/unit/beacons/adb_beacon_test.py
+++ b/tests/unit/beacons/adb_beacon_test.py
@@ -138,6 +138,27 @@ class ADBBeaconTestCase(TestCase):
         config = {'states': ['offline', 'device'], 'no_devices_event': True}
 
         out = [
+            'List of devices attached\nHTC\tdevice',
+            'List of devices attached',
+            'List of devices attached'
+        ]
+
+        mock = Mock(side_effect=out)
+        with patch.dict(adb.__salt__, {'cmd.run': mock}):
+
+            ret = adb.beacon(config)
+            self.assertEqual(ret, [{'device': 'HTC', 'state': 'device', 'tag': 'device'}])
+
+            ret = adb.beacon(config)
+            self.assertEqual(ret, [{'tag': 'no_devices'}])
+
+            ret = adb.beacon(config)
+            self.assertEqual(ret, [])
+
+    def test_no_devices(self):
+        config = {'states': ['offline', 'device'], 'no_devices_event': True}
+
+        out = [
             'List of devices attached',
             'List of devices attached'
         ]


### PR DESCRIPTION
- Changed the assumption that having 0 lines means there are no devices, to actually checking there are no devices

### What does this PR do?
Fix adb beacon when there are no devices

### What issues does this PR fix or reference?
Beacon would fail when there are actually no devices
### Tests written?

Yes

