### PR TITLE
Fix table outputter opts

### DIFF
--- a/salt/output/table_out.py
+++ b/salt/output/table_out.py
@@ -339,8 +339,8 @@ def output(ret, **kwargs):
     for argk in argks:
         argv = kwargs.get(argk) \
             or __opts__.get('out.table.{key}'.format(key=argk))
-        if argv:
-            class_kvargs[argv] = argk
+        if argv is not None:
+            class_kvargs[argk] = argv
 
     table = TableDisplay(**class_kvargs)
 


### PR DESCRIPTION
### What does this PR do?

This is going to allow the user request display options such as whitspaces.
Also, the key-value was reversed.