### PR TITLE
make sure both variables are strings.

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -561,9 +561,9 @@ def filter_by(lookup_dict, grain='os_family', merge=None, default='default', bas
     # Iterate over the list of grain values to match against patterns in the lookup_dict keys
     for each in val if isinstance(val, list) else [val]:
         for key in sorted(lookup_dict):
-            if key not in six.string_types:
-                key = str(key)
-            if fnmatch.fnmatchcase(each, key):
+            test_key = key if isinstance(key, six.string_types) else str(key)
+            test_each = each if isinstance(each, six.string_types) else str(each)
+            if fnmatch.fnmatchcase(test_each, test_key):
                 ret = lookup_dict[key]
                 break
         if ret is not None:


### PR DESCRIPTION
### What does this PR do?

With changing majorosversion and other stuff to integers, we need to
make sure to cast them to strings when running through fnmatch in
grains.filter_by

### What issues does this PR fix or reference?
Fixes #39321

### Tests written?

No