### PR TITLE
Add cp.push test

### DIFF
--- a/tests/unit/modules/cp_test.py
+++ b/tests/unit/modules/cp_test.py
@@ -15,6 +15,7 @@ from salt.exceptions import CommandExecutionError
 from salttesting import skipIf, TestCase
 from salttesting.helpers import ensure_in_syspath
 from salttesting.mock import (
+    Mock,
     MagicMock,
     mock_open,
     patch,
@@ -129,6 +130,34 @@ class CpTestCase(TestCase):
         ret = False
 
         self.assertEqual(cp.push_dir(path), ret)
+
+    @patch(
+        'salt.modules.cp.os.path',
+        MagicMock(isfile=Mock(return_value=True), wraps=cp.os.path))
+    @patch.multiple(
+        'salt.modules.cp',
+        _auth=MagicMock(**{'return_value.gen_token.return_value': 'token'}),
+        __opts__={'id': 'abc', 'file_buffer_size': 10})
+    @patch('salt.utils.fopen', mock_open(read_data='content'))
+    @patch('salt.transport.Channel.factory', MagicMock())
+    def test_push(self):
+        '''
+        Test if push works with good posix path.
+        '''
+        import salt
+        response = cp.push('/saltines/test.file')
+        self.assertEqual(response, True)
+        self.assertEqual(salt.utils.fopen().read.call_count, 2)
+        salt.transport.Channel.factory({}).send.assert_called_once_with(
+            dict(
+                loc=salt.utils.fopen().tell(),
+                cmd='_file_recv',
+                tok='token',
+                path=('saltines', 'test.file'),
+                data='',  # data is empty here because load['data'] is overwritten
+                id='abc'
+            )
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Add test for calling cp.push with correct arguments.

### What issues does this PR fix or reference?

I've also found out that there's no test for checking that `cp.push` is working when passing the right arguments, so I wrote one.

### Tests written?

Yes