### PR TITLE
Pass sig to service.status in after_toggle

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -387,7 +387,7 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
         time.sleep(init_delay)
 
     # only force a change state if we have explicitly detected them
-    after_toggle_status = __salt__['service.status'](name)
+    after_toggle_status = __salt__['service.status'](name, sig)
     if 'service.enabled' in __salt__:
         after_toggle_enable_status = __salt__['service.enabled'](name)
     else:


### PR DESCRIPTION
As on line 350, pass `sig` to `service.status` to ensure that the correct behavior is used. If we don't pass `sig`, upstart/sysv jobs that do not implement `service <name> status` will fail.

### What does this PR do?
Fix the second call to `system.service` after setting the service to `enabled`

### What issues does this PR fix or reference?
#39365

### Tests written?

No
