### PR TITLE
Switch SPM to salt.cache

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1609,6 +1609,7 @@ DEFAULT_SPM_OPTS = {
     'spm_build_dir': '/srv/spm_build',
     'spm_build_exclude': ['CVS', '.hg', '.git', '.svn'],
     'spm_db': os.path.join(salt.syspaths.CACHE_DIR, 'spm', 'packages.db'),
+    'cache': 'localfs',
     # <---- Salt master settings overridden by SPM ----------------------
 }
 

--- a/salt/spm/__init__.py
+++ b/salt/spm/__init__.py
@@ -22,6 +22,7 @@ import sys
 # Import Salt libs
 import salt.config
 import salt.loader
+import salt.cache
 import salt.utils
 import salt.utils.http as http
 import salt.syspaths as syspaths
@@ -152,6 +153,8 @@ class SPMClient(object):
         '''
         if len(args) < 2:
             raise SPMInvocationError('A package must be specified')
+
+        cache = salt.cache.Cache(self.opts)
 
         packages = args[1:]
         file_map = {}
@@ -450,9 +453,6 @@ class SPMClient(object):
                     continue
                 repo_files.append(repo_file)
 
-        if not os.path.exists(self.opts['spm_cache_dir']):
-            os.makedirs(self.opts['spm_cache_dir'])
-
         for repo_file in repo_files:
             repo_path = '{0}.d/{1}'.format(self.opts['spm_repos_config'], repo_file)
             with salt.utils.fopen(repo_path) as rph:
@@ -468,6 +468,7 @@ class SPMClient(object):
         '''
         Connect to all repos and download metadata
         '''
+        cache = salt.cache.Cache(self.opts, self.opts['spm_cache_dir'])
         def _update_metadata(repo, repo_info):
             dl_path = '{0}/SPM-METADATA'.format(repo_info['url'])
             if dl_path.startswith('file://'):
@@ -477,13 +478,8 @@ class SPMClient(object):
             else:
                 response = http.query(dl_path, text=True)
                 metadata = yaml.safe_load(response.get('text', '{}'))
-            cache_path = '{0}/{1}.p'.format(
-                self.opts['spm_cache_dir'],
-                repo
-            )
 
-            with salt.utils.fopen(cache_path, 'w') as cph:
-                msgpack.dump(metadata, cph)
+            cache.store('.', repo, metadata)
 
         repo_name = args[1] if len(args) > 1 else None
         self._traverse_repos(_update_metadata, repo_name)
@@ -492,25 +488,18 @@ class SPMClient(object):
         '''
         Return cached repo metadata
         '''
+        cache = salt.cache.Cache(self.opts, self.opts['spm_cache_dir'])
         metadata = {}
 
-        if not os.path.exists(self.opts['spm_cache_dir']):
-            os.makedirs(self.opts['spm_cache_dir'])
-
         def _read_metadata(repo, repo_info):
-            cache_path = '{0}/{1}.p'.format(
-                self.opts['spm_cache_dir'],
-                repo
-            )
+            if cache.updated('.', repo) is None:
+                log.warn('Updating repo metadata')
+                self._download_repo_metadata({})
 
-            if not os.path.exists(cache_path):
-                raise SPMPackageError('SPM cache {0} not found'.format(cache_path))
-
-            with salt.utils.fopen(cache_path, 'r') as cph:
-                metadata[repo] = {
-                    'info': repo_info,
-                    'packages': msgpack.load(cph),
-                }
+            metadata[repo] = {
+                'info': repo_info,
+                'packages': cache.fetch('.', repo),
+            }
 
         self._traverse_repos(_read_metadata)
         return metadata

--- a/salt/spm/__init__.py
+++ b/salt/spm/__init__.py
@@ -469,6 +469,7 @@ class SPMClient(object):
         Connect to all repos and download metadata
         '''
         cache = salt.cache.Cache(self.opts, self.opts['spm_cache_dir'])
+
         def _update_metadata(repo, repo_info):
             dl_path = '{0}/SPM-METADATA'.format(repo_info['url'])
             if dl_path.startswith('file://'):

--- a/tests/unit/spm_test.py
+++ b/tests/unit/spm_test.py
@@ -39,6 +39,7 @@ __opts__ = {
     'assume_yes': True,
     'force': False,
     'verbose': False,
+    'cache': 'localfs',
 }
 
 _F1 = {


### PR DESCRIPTION
### What does this PR do?
Switch as much of SPM as possible to `salt.cache`. At the moment, `salt.cache` doesn't cache individual files; it only caches data using its own mechanism. That means we can't switch package caching over, but we can switch data over.

### Tests written?
No. The current tests are expected to catch any of my follies here.