### PR TITLE
adding librato metrics returner

### DIFF
--- a/salt/returners/librato_return.py
+++ b/salt/returners/librato_return.py
@@ -49,7 +49,6 @@ __virtualname__ = 'librato'
 
 log = logging.getLogger(__name__)
 
-
 def __virtual__():
     if not HAS_LIBRATO:
         log.error("Could not import librato module.")
@@ -58,7 +57,6 @@ def __virtual__():
     else:
         log.debug("Librato Module loaded.")
     return __virtualname__
-
 
 def _get_options(ret=None):
     '''
@@ -80,13 +78,11 @@ def _get_options(ret=None):
     log.debug("Retrieved Librato options: {0}".format(_options))
     return _options
 
-
 def _get_librato(ret=None):
     '''
     Return a librato connection object.
     '''
     _options = _get_options(ret)
-
 
     conn = librato.connect(
         _options.get('email'),
@@ -95,7 +91,6 @@ def _get_librato(ret=None):
         hostname=_options.get('api_url'))
     log.info("Connected to librato.")
     return conn
-
 
 def _calculate_runtimes(states):
     results = {
@@ -117,7 +112,6 @@ def _calculate_runtimes(states):
 
     log.debug("Parsed state metrics: {0}".format(results))
     return results
-
 
 def returner(ret):
     '''

--- a/salt/returners/librato_return.py
+++ b/salt/returners/librato_return.py
@@ -49,6 +49,7 @@ __virtualname__ = 'librato'
 
 log = logging.getLogger(__name__)
 
+
 def __virtual__():
     if not HAS_LIBRATO:
         log.error("Could not import librato module.")
@@ -57,6 +58,7 @@ def __virtual__():
     else:
         log.debug("Librato Module loaded.")
     return __virtualname__
+
 
 def _get_options(ret=None):
     '''
@@ -78,6 +80,7 @@ def _get_options(ret=None):
     log.debug("Retrieved Librato options: {0}".format(_options))
     return _options
 
+
 def _get_librato(ret=None):
     '''
     Return a librato connection object.
@@ -91,6 +94,7 @@ def _get_librato(ret=None):
         hostname=_options.get('api_url'))
     log.info("Connected to librato.")
     return conn
+
 
 def _calculate_runtimes(states):
     results = {
@@ -112,6 +116,7 @@ def _calculate_runtimes(states):
 
     log.debug("Parsed state metrics: {0}".format(results))
     return results
+
 
 def returner(ret):
     '''

--- a/salt/returners/librato_return.py
+++ b/salt/returners/librato_return.py
@@ -77,7 +77,7 @@ def _get_options(ret=None):
 
     _options['api_url'] = _options.get('api_url', 'metrics-api.librato.com')
 
-    log.debug("Retrieved Librato options: {}".format(_options))
+    log.debug("Retrieved Librato options: {0}".format(_options))
     return _options
 
 
@@ -118,7 +118,7 @@ def _calculate_runtimes(states):
             # Count durations
             results['runtime'] += resultset['duration']
 
-    log.debug("Parsed state metrics: {}".format(results))
+    log.debug("Parsed state metrics: {0}".format(results))
     return results
 
 
@@ -134,25 +134,25 @@ def returner(ret):
         log.debug("Found returned Highstate data.")
         # Calculate the runtimes and number of failed states.
         stats = _calculate_runtimes(ret['return'])
-        log.debug("Batching Metric retcode with {}".format(ret['retcode']))
+        log.debug("Batching Metric retcode with {0}".format(ret['retcode']))
         q.add("saltstack.highstate.retcode", ret[
               'retcode'], tags={'Name': ret['id']})
 
-        log.debug("Batching Metric num_failed_jobs with {}".format(
+        log.debug("Batching Metric num_failed_jobs with {0}".format(
             stats['num_failed_states']))
         q.add("saltstack.highstate.failed_states",
               stats['num_failed_states'], tags={'Name': ret['id']})
 
-        log.debug("Batching Metric num_passed_states with {}".format(
+        log.debug("Batching Metric num_passed_states with {0}".format(
             stats['num_passed_states']))
         q.add("saltstack.highstate.passed_states",
               stats['num_passed_states'], tags={'Name': ret['id']})
 
-        log.debug("Batching Metric runtime with {}".format(stats['runtime']))
+        log.debug("Batching Metric runtime with {0}".format(stats['runtime']))
         q.add("saltstack.highstate.runtime",
               stats['runtime'], tags={'Name': ret['id']})
 
-        log.debug("Batching Metric runtime with {}".format(
+        log.debug("Batching Metric runtime with {0}".format(
             stats['num_failed_states'] + stats['num_passed_states']))
         q.add("saltstack.highstate.total_states", stats[
               'num_failed_states'] + stats['num_passed_states'], tags={'Name': ret['id']})

--- a/salt/returners/librato_return.py
+++ b/salt/returners/librato_return.py
@@ -19,11 +19,12 @@ other tags.
 
 Adding EC2 Tags example:
 If ec2_tags:region were desired within the tags for multi-dimension. The tags
-could be modified to include the ec2 tags.
+could be modified to include the ec2 tags. Multiple dimensions are added simply
+by adding more tags to the submission.
 
 .. code-block:: python
     pillar_data = __salt__['pillar.raw']()
-    q.add(metric.name, value, tags={'Region': pillar_data['ec2_tags']['Name']})
+    q.add(metric.name, value, tags={'Name': ret['id'],'Region': pillar_data['ec2_tags']['Name']})
 
 '''
 

--- a/salt/returners/librato_return.py
+++ b/salt/returners/librato_return.py
@@ -87,17 +87,14 @@ def _get_librato(ret=None):
     '''
     _options = _get_options(ret)
 
-    try:
-        conn = librato.connect(
-            _options.get('email'),
-            _options.get('api_token'),
-            sanitizer=librato.sanitize_metric_name,
-            hostname=_options.get('api_url'))
-        log.info("Connected to librato.")
-        return conn
-    except:
-        log.error("Could not connect to librato.")
-        return False
+
+    conn = librato.connect(
+        _options.get('email'),
+        _options.get('api_token'),
+        sanitizer=librato.sanitize_metric_name,
+        hostname=_options.get('api_url'))
+    log.info("Connected to librato.")
+    return conn
 
 
 def _calculate_runtimes(states):

--- a/salt/returners/librato_return.py
+++ b/salt/returners/librato_return.py
@@ -30,12 +30,9 @@ by adding more tags to the submission.
 
 # Import python libs
 from __future__ import absolute_import, print_function
-import json
-import sys
 import logging
 
 # Import Salt libs
-import salt.ext.six as six
 import salt.utils
 import salt.utils.jid
 import salt.returners
@@ -80,7 +77,7 @@ def _get_options(ret=None):
 
     _options['api_url'] = _options.get('api_url', 'metrics-api.librato.com')
 
-    log.debug("Retrieved Librato options: %s" % _options)
+    log.debug("Retrieved Librato options: {}".format(_options))
     return _options
 
 
@@ -121,7 +118,7 @@ def _calculate_runtimes(states):
             # Count durations
             results['runtime'] += resultset['duration']
 
-    log.debug("Parsed state metrics: %s" % results)
+    log.debug("Parsed state metrics: {}".format(results))
     return results
 
 
@@ -137,25 +134,26 @@ def returner(ret):
         log.debug("Found returned Highstate data.")
         # Calculate the runtimes and number of failed states.
         stats = _calculate_runtimes(ret['return'])
-        log.debug("Batching Metric retcode with %s" % ret['retcode'])
-        q.add("saltstack.highstate.retcode", ret['retcode'], tags={'Name': ret['id']})
+        log.debug("Batching Metric retcode with {}".format(ret['retcode']))
+        q.add("saltstack.highstate.retcode", ret[
+              'retcode'], tags={'Name': ret['id']})
 
-        log.debug("Batching Metric num_failed_jobs with %s" %
-                  stats['num_failed_states'])
+        log.debug("Batching Metric num_failed_jobs with {}".format(
+            stats['num_failed_states']))
         q.add("saltstack.highstate.failed_states",
               stats['num_failed_states'], tags={'Name': ret['id']})
 
-        log.debug("Batching Metric num_passed_states with %s" %
-                  stats['num_passed_states'])
+        log.debug("Batching Metric num_passed_states with {}".format(
+            stats['num_passed_states']))
         q.add("saltstack.highstate.passed_states",
               stats['num_passed_states'], tags={'Name': ret['id']})
 
-        log.debug("Batching Metric runtime with %s" % stats['runtime'])
+        log.debug("Batching Metric runtime with {}".format(stats['runtime']))
         q.add("saltstack.highstate.runtime",
               stats['runtime'], tags={'Name': ret['id']})
 
-        log.debug("Batching Metric runtime with %s" %
-                  (stats['num_failed_states'] + stats['num_passed_states']))
+        log.debug("Batching Metric runtime with {}".format(
+            stats['num_failed_states'] + stats['num_passed_states']))
         q.add("saltstack.highstate.total_states", stats[
               'num_failed_states'] + stats['num_passed_states'], tags={'Name': ret['id']})
 

--- a/salt/returners/librato_return.py
+++ b/salt/returners/librato_return.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+'''
+Salt returner to return highstate stats to librato
+
+To enable this returner the minion will need the librato
+client importable on the python path and the following
+values configured in the minion or master config.
+
+The librato python client can be found at:
+https://github.com/librato/python-librato
+
+.. code-block:: yaml
+    librato.email: example@librato.com
+    librato.api_token: abc12345def
+
+This return supports multi-dimension metrics for librato. To enable
+support for more metrics, the tags JSON object can be modified to include
+other tags.
+
+Adding EC2 Tags example:
+If ec2_tags:region were desired within the tags for multi-dimension. The tags
+could be modified to include the ec2 tags.
+
+.. code-block:: python
+    pillar_data = __salt__['pillar.raw']()
+    q.add(metric.name, value, tags={'Region': pillar_data['ec2_tags']['Name']})
+
+'''
+
+# Import python libs
+from __future__ import absolute_import, print_function
+import json
+import sys
+import logging
+
+# Import Salt libs
+import salt.ext.six as six
+import salt.utils
+import salt.utils.jid
+import salt.returners
+
+# Import third party libs
+try:
+    import librato
+    HAS_LIBRATO = True
+except ImportError:
+    HAS_LIBRATO = False
+
+# Define the module's Virtual Name
+__virtualname__ = 'librato'
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    if not HAS_LIBRATO:
+        log.error("Could not import librato module.")
+        return False, 'Could not import librato module; ' \
+            'librato python client is not installed.'
+    else:
+        log.debug("Librato Module loaded.")
+    return __virtualname__
+
+
+def _get_options(ret=None):
+    '''
+    Get the librato options from salt.
+    '''
+    attrs = {'email': 'email',
+             'api_token': 'api_token',
+             'api_url': 'api_url'
+             }
+
+    _options = salt.returners.get_returner_options(__virtualname__,
+                                                   ret,
+                                                   attrs,
+                                                   __salt__=__salt__,
+                                                   __opts__=__opts__)
+
+    _options['api_url'] = _options.get('api_url', 'metrics-api.librato.com')
+
+    log.debug("Retrieved Librato options: %s" % _options)
+    return _options
+
+
+def _get_librato(ret=None):
+    '''
+    Return a librato connection object.
+    '''
+    _options = _get_options(ret)
+
+    try:
+        conn = librato.connect(
+            _options.get('email'),
+            _options.get('api_token'),
+            sanitizer=librato.sanitize_metric_name,
+            hostname=_options.get('api_url'))
+        log.info("Connected to librato.")
+        return conn
+    except:
+        log.error("Could not connect to librato.")
+        return False
+
+
+def _calculate_runtimes(states):
+    results = {
+        'runtime': 0.00,
+        'num_failed_states': 0,
+        'num_passed_states': 0
+    }
+
+    for state, resultset in states.items():
+        if isinstance(resultset, dict) and 'duration' in resultset:
+            # Count the pass vs failures
+            if resultset['result']:
+                results['num_passed_states'] += 1
+            else:
+                results['num_failed_states'] += 1
+
+            # Count durations
+            results['runtime'] += resultset['duration']
+
+    log.debug("Parsed state metrics: %s" % results)
+    return results
+
+
+def returner(ret):
+    '''
+    Parse the return data and return metrics to librato.
+    '''
+    librato_conn = _get_librato(ret)
+
+    q = librato_conn.new_queue()
+
+    if ret['fun'] == 'state.highstate':
+        log.debug("Found returned Highstate data.")
+        # Calculate the runtimes and number of failed states.
+        stats = _calculate_runtimes(ret['return'])
+        log.debug("Batching Metric retcode with %s" % ret['retcode'])
+        q.add("saltstack.highstate.retcode", ret['retcode'], tags={'Name': ret['id']})
+
+        log.debug("Batching Metric num_failed_jobs with %s" %
+                  stats['num_failed_states'])
+        q.add("saltstack.highstate.failed_states",
+              stats['num_failed_states'], tags={'Name': ret['id']})
+
+        log.debug("Batching Metric num_passed_states with %s" %
+                  stats['num_passed_states'])
+        q.add("saltstack.highstate.passed_states",
+              stats['num_passed_states'], tags={'Name': ret['id']})
+
+        log.debug("Batching Metric runtime with %s" % stats['runtime'])
+        q.add("saltstack.highstate.runtime",
+              stats['runtime'], tags={'Name': ret['id']})
+
+        log.debug("Batching Metric runtime with %s" %
+                  (stats['num_failed_states'] + stats['num_passed_states']))
+        q.add("saltstack.highstate.total_states", stats[
+              'num_failed_states'] + stats['num_passed_states'], tags={'Name': ret['id']})
+
+    log.info("Sending Metrics to librato.")
+    q.submit()

--- a/tests/integration/returners/librato_return.py
+++ b/tests/integration/returners/librato_return.py
@@ -5,7 +5,6 @@ Tests for the librato returner
 # Import Python libs
 from __future__ import absolute_import
 import logging
-import os
 
 # Import Salt Testing libs
 from salttesting.helpers import ensure_in_syspath
@@ -13,8 +12,6 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
-from integration import TMP
-import salt.utils.job
 from salt.returners import librato_return
 
 log = logging.getLogger(__name__)

--- a/tests/integration/returners/librato_return.py
+++ b/tests/integration/returners/librato_return.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for the librato returner
+'''
+# Import Python libs
+from __future__ import absolute_import
+import logging
+import os
+
+# Import Salt Testing libs
+from salttesting.helpers import ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+from integration import TMP
+import salt.utils.job
+from salt.returners import librato_return
+
+log = logging.getLogger(__name__)
+
+# JOBS DIR and FILES
+MOCK_RET_OBJ = {
+    "fun_args": [],
+    "return": {
+        "test-return-state": {
+            "comment": "insertcommenthere",
+            "name": "test-state-1",
+            "start_time": "01: 19: 51.105566",
+            "result": True,
+            "duration": 3.645,
+            "__run_num__": 193,
+            "changes": {},
+            "__id__": "test-return-state"
+        },
+        "test-return-state2": {
+            "comment": "insertcommenthere",
+            "name": "test-state-2",
+            "start_time": "01: 19: 51.105566",
+            "result": False,
+            "duration": 3.645,
+            "__run_num__": 194,
+            "changes": {},
+            "__id__": "test-return-state"
+        }
+    },
+    "retcode": 2,
+    "success": True,
+    "fun": "state.highstate",
+    "id": "Librato-Test",
+    "out": "highstate"
+}
+
+
+class libratoTest(integration.ShellCase):
+    '''
+    Test the librato returner
+    '''
+
+    def test_count_runtimes(self):
+        '''
+        Test the calculations
+        '''
+        results = librato_return._calculate_runtimes(MOCK_RET_OBJ['return'])
+        self.assertEqual(results['num_failed_states'], 1)
+        self.assertEqual(results['num_passed_states'], 1)
+        self.assertEqual(results['runtime'], 7.29)
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(libratoTest)


### PR DESCRIPTION
### What does this PR do?
This PR add a new feature which will add a returner for users to submit Salt-Minion metrics directly to librato. These metrics can be used for tracking, optimizing and alerting upon salt minion runs.

### What issues does this PR fix or reference?
N/a

### Tests written?

Yes/No
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
