### PR TITLE
Quote numeric user names so pwd.getpwnam handles them properly

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -41,11 +41,18 @@ def __virtual__():
     return (False, 'useradd execution module not loaded: either pwd python library not available or system not one of Linux, OpenBSD or NetBSD')
 
 
+def _quote_username(name):
+    if isinstance(name, int):
+        name = "{0}".format(name)
+
+    return name
+
+
 def _get_gecos(name):
     '''
     Retrieve GECOS field info and return it in dictionary form
     '''
-    gecos_field = pwd.getpwnam(name).pw_gecos.split(',', 3)
+    gecos_field = pwd.getpwnam(_quote_username(name)).pw_gecos.split(',', 3)
     if not gecos_field:
         return {}
     else:
@@ -521,7 +528,7 @@ def info(name):
         salt '*' user.info root
     '''
     try:
-        data = pwd.getpwnam(name)
+        data = pwd.getpwnam(_quote_username(name))
     except KeyError:
         return {}
     else:


### PR DESCRIPTION
### What does this PR do?

In one environment i'm working with, Linux server user names are integers. I found that the getpwnam function interprets these as uids, which causes Salt states making use of useradd.py to fail due to unknown users.

### What issues does this PR fix or reference?

This fix formats user names which are integers with surrounding double quotes.

### Previous Behavior
User names which are integers are treated as ints and interpreted as Linux uids.

### New Behavior
User names which are integers are treated as strings and interpreted as user names.

### Tests written?

No