### PR TITLE
modules.file: Return true when a symlink is already in desired state

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3013,6 +3013,13 @@ def symlink(src, path):
     '''
     path = os.path.expanduser(path)
 
+    try:
+        if os.path.normpath(os.readlink(path)) == os.path.normpath(src):
+            log.debug('link already in correct state: %s -> %s', path, src)
+            return True
+    except OSError:
+        pass
+
     if not os.path.isabs(path):
         raise SaltInvocationError('File path must be absolute.')
 

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -696,6 +696,7 @@ class FileModuleTestCase(TestCase):
         empty_file.close()
         os.remove(empty_file.name)
 
+
 class FileBasicsTestCase(TestCase):
     def setUp(self):
         self.directory = tempfile.mkdtemp()

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -696,6 +696,23 @@ class FileModuleTestCase(TestCase):
         empty_file.close()
         os.remove(empty_file.name)
 
+class FileBasicsTestCase(TestCase):
+    def setUp(self):
+        self.directory = tempfile.mkdtemp()
+        with tempfile.NamedTemporaryFile(delete=False, mode='w+') as self.tfile:
+            self.tfile.write('Hi hello! I am a file.')
+            self.tfile.close()
+
+    def tearDown(self):
+        os.remove(self.tfile.name)
+        os.remove(self.directory + '/a_link')
+        os.rmdir(self.directory)
+
+    def test_symlink_already_in_desired_state(self):
+        os.symlink(self.tfile.name, self.directory + '/a_link')
+        result = filemod.symlink(self.tfile.name, self.directory + '/a_link')
+        self.assertTrue(result)
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?
Return true when a symlink is already in desired state.

### What issues does this PR fix or reference?
✨¯\_("3)_/¯ ✨ 

### Previous Behavior
Returns false with: `CommandExecutionError: Could not create '<link_file>'`

### New Behavior
Returns true if a viable symlink exists.

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
