### PR TITLE
Make sure OrderedDict order is preserved in nested output

### DIFF
--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -25,6 +25,7 @@ Example output::
 '''
 from __future__ import absolute_import
 # Import python libs
+import collections
 from numbers import Number
 
 # Import salt libs
@@ -127,7 +128,14 @@ class NestDisplay(object):
                         '----------'
                     )
                 )
-            for key in sorted(ret):
+
+            # respect key ordering of ordered dicts
+            if isinstance(ret, collections.OrderedDict):
+                keys = ret.keys()
+            else:
+                keys = sorted(ret)
+
+            for key in keys:
                 val = ret[key]
                 out.append(
                     self.ustring(


### PR DESCRIPTION
`sorted(ret)` will sort the keys on their own, discarding the original order of the OrderedDict.