### PR TITLE
Fix gpg renderer when called without tty.

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -257,7 +257,8 @@ def _decrypt_ciphertext(cipher, translate_newlines=False):
     the cipher and return the decrypted string. If the cipher cannot be
     decrypted, log the error, and return the ciphertext back out.
     '''
-    cmd = [_get_gpg_exec(), '--homedir', _get_key_dir(), '-d']
+    cmd = [_get_gpg_exec(), '--homedir', _get_key_dir(), '--status-fd', '2',
+           '--no-tty', '-d']
     proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=False)
     decrypted_data, decrypt_error = proc.communicate(
         input=cipher.replace(r'\n', '\n') if translate_newlines else cipher


### PR DESCRIPTION
### What does this PR do?

Let gpg renderer call `gpg` without `/dev/tty`. Remember salt-master is usually daemonized. This is an attempt to fix a possible regression in 0db7670.

Moreover, if the call to `gpg` fails, the error is not detected and relayed, resulting in rendering ciphered text. This can have dramatic consequences like breaking services (think ssh). But this can be handled in a separate PR.

### What issues does this PR fix or reference?

#32207 which should probably be renamed to *gpg renderers failing*.

### Tests written?

No