### PR TITLE
This makes the sls requisite_in system work

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -207,6 +207,20 @@ def find_name(name, state, high):
     return ext_id
 
 
+def find_sls_ids(sls, high):
+    '''
+    Scan for all ids in the given sls and return them in a dict; {name: state}
+    '''
+    ret = []
+    for nid, item in six.iteritems(high):
+        if item['__sls__'] == sls:
+            for st_ in item:
+                if st_.startswith('__'):
+                    continue
+                ret.append((nid, st_))
+    return ret
+
+
 def format_log(ret):
     '''
     Format the state into a log message
@@ -1520,124 +1534,132 @@ class State(object):
 
                         if isinstance(items, list):
                             # Formed as a list of requisite additions
+                            hinges = []
                             for ind in items:
                                 if not isinstance(ind, dict):
                                     # Malformed req_in
                                     continue
                                 if len(ind) < 1:
                                     continue
-                                _state = next(iter(ind))
-                                name = ind[_state]
-                                if '.' in _state:
+                                pstate = next(iter(ind))
+                                pname = ind[pstate]
+                                if pstate == 'sls':
+                                    # Expand hinges here
+                                    hinges = find_sls_ids(pname, high)
+                                else:
+                                    hinges.append((pname, pstate))
+                                if '.' in pstate:
                                     errors.append((
                                         'Invalid requisite in {0}: {1} for '
                                         '{2}, in SLS \'{3}\'. Requisites must '
                                         'not contain dots, did you mean \'{4}\'?'
                                         .format(
                                             rkey,
-                                            _state,
-                                            name,
+                                            pstate,
+                                            pname,
                                             body['__sls__'],
-                                            _state[:_state.find('.')]
+                                            pstate[:pstate.find('.')]
                                         )
                                     ))
-                                    _state = _state.split(".")[0]
-                                if key == 'prereq_in':
-                                    # Add prerequired to origin
-                                    if id_ not in extend:
-                                        extend[id_] = {}
-                                    if state not in extend[id_]:
-                                        extend[id_][state] = []
-                                    extend[id_][state].append(
-                                            {'prerequired': [{_state: name}]}
-                                            )
-                                if key == 'prereq':
-                                    # Add prerequired to prereqs
-                                    ext_ids = find_name(name, _state, high)
-                                    for ext_id, _req_state in ext_ids:
-                                        if ext_id not in extend:
-                                            extend[ext_id] = {}
-                                        if _req_state not in extend[ext_id]:
-                                            extend[ext_id][_req_state] = []
-                                        extend[ext_id][_req_state].append(
-                                                {'prerequired': [{state: id_}]}
-                                                )
-                                    continue
-                                if key == 'use_in':
-                                    # Add the running states args to the
-                                    # use_in states
-                                    ext_ids = find_name(name, _state, high)
-                                    for ext_id, _req_state in ext_ids:
-                                        if not ext_id:
-                                            continue
-                                        ext_args = state_args(ext_id, _state, high)
-                                        if ext_id not in extend:
-                                            extend[ext_id] = {}
-                                        if _req_state not in extend[ext_id]:
-                                            extend[ext_id][_req_state] = []
-                                        ignore_args = req_in_all.union(ext_args)
-                                        for arg in high[id_][state]:
-                                            if not isinstance(arg, dict):
-                                                continue
-                                            if len(arg) != 1:
-                                                continue
-                                            if next(iter(arg)) in ignore_args:
-                                                continue
-                                            # Don't use name or names
-                                            if next(six.iterkeys(arg)) == 'name':
-                                                continue
-                                            if next(six.iterkeys(arg)) == 'names':
-                                                continue
-                                            extend[ext_id][_req_state].append(arg)
-                                    continue
-                                if key == 'use':
-                                    # Add the use state's args to the
-                                    # running state
-                                    ext_ids = find_name(name, _state, high)
-                                    for ext_id, _req_state in ext_ids:
-                                        if not ext_id:
-                                            continue
-                                        loc_args = state_args(id_, state, high)
+                                    pstate = pstate.split(".")[0]
+                                for tup in hinges:
+                                    name, _state = tup
+                                    if key == 'prereq_in':
+                                        # Add prerequired to origin
                                         if id_ not in extend:
                                             extend[id_] = {}
                                         if state not in extend[id_]:
                                             extend[id_][state] = []
-                                        ignore_args = req_in_all.union(loc_args)
-                                        for arg in high[ext_id][_req_state]:
-                                            if not isinstance(arg, dict):
-                                                continue
-                                            if len(arg) != 1:
-                                                continue
-                                            if next(iter(arg)) in ignore_args:
-                                                continue
-                                            # Don't use name or names
-                                            if next(six.iterkeys(arg)) == 'name':
-                                                continue
-                                            if next(six.iterkeys(arg)) == 'names':
-                                                continue
-                                            extend[id_][state].append(arg)
-                                    continue
-                                found = False
-                                if name not in extend:
-                                    extend[name] = {}
-                                if _state not in extend[name]:
-                                    extend[name][_state] = []
-                                extend[name]['__env__'] = body['__env__']
-                                extend[name]['__sls__'] = body['__sls__']
-                                for ind in range(len(extend[name][_state])):
-                                    if next(iter(
-                                        extend[name][_state][ind])) == rkey:
-                                        # Extending again
-                                        extend[name][_state][ind][rkey].append(
-                                                {state: id_}
+                                        extend[id_][state].append(
+                                                {'prerequired': [{_state: name}]}
                                                 )
-                                        found = True
-                                if found:
-                                    continue
-                                # The rkey is not present yet, create it
-                                extend[name][_state].append(
-                                        {rkey: [{state: id_}]}
-                                        )
+                                    if key == 'prereq':
+                                        # Add prerequired to prereqs
+                                        ext_ids = find_name(name, _state, high)
+                                        for ext_id, _req_state in ext_ids:
+                                            if ext_id not in extend:
+                                                extend[ext_id] = {}
+                                            if _req_state not in extend[ext_id]:
+                                                extend[ext_id][_req_state] = []
+                                            extend[ext_id][_req_state].append(
+                                                    {'prerequired': [{state: id_}]}
+                                                    )
+                                        continue
+                                    if key == 'use_in':
+                                        # Add the running states args to the
+                                        # use_in states
+                                        ext_ids = find_name(name, _state, high)
+                                        for ext_id, _req_state in ext_ids:
+                                            if not ext_id:
+                                                continue
+                                            ext_args = state_args(ext_id, _state, high)
+                                            if ext_id not in extend:
+                                                extend[ext_id] = {}
+                                            if _req_state not in extend[ext_id]:
+                                                extend[ext_id][_req_state] = []
+                                            ignore_args = req_in_all.union(ext_args)
+                                            for arg in high[id_][state]:
+                                                if not isinstance(arg, dict):
+                                                    continue
+                                                if len(arg) != 1:
+                                                    continue
+                                                if next(iter(arg)) in ignore_args:
+                                                    continue
+                                                # Don't use name or names
+                                                if next(six.iterkeys(arg)) == 'name':
+                                                    continue
+                                                if next(six.iterkeys(arg)) == 'names':
+                                                    continue
+                                                extend[ext_id][_req_state].append(arg)
+                                        continue
+                                    if key == 'use':
+                                        # Add the use state's args to the
+                                        # running state
+                                        ext_ids = find_name(name, _state, high)
+                                        for ext_id, _req_state in ext_ids:
+                                            if not ext_id:
+                                                continue
+                                            loc_args = state_args(id_, state, high)
+                                            if id_ not in extend:
+                                                extend[id_] = {}
+                                            if state not in extend[id_]:
+                                                extend[id_][state] = []
+                                            ignore_args = req_in_all.union(loc_args)
+                                            for arg in high[ext_id][_req_state]:
+                                                if not isinstance(arg, dict):
+                                                    continue
+                                                if len(arg) != 1:
+                                                    continue
+                                                if next(iter(arg)) in ignore_args:
+                                                    continue
+                                                # Don't use name or names
+                                                if next(six.iterkeys(arg)) == 'name':
+                                                    continue
+                                                if next(six.iterkeys(arg)) == 'names':
+                                                    continue
+                                                extend[id_][state].append(arg)
+                                        continue
+                                    found = False
+                                    if name not in extend:
+                                        extend[name] = {}
+                                    if _state not in extend[name]:
+                                        extend[name][_state] = []
+                                    extend[name]['__env__'] = body['__env__']
+                                    extend[name]['__sls__'] = body['__sls__']
+                                    for ind in range(len(extend[name][_state])):
+                                        if next(iter(
+                                            extend[name][_state][ind])) == rkey:
+                                            # Extending again
+                                            extend[name][_state][ind][rkey].append(
+                                                    {state: id_}
+                                                    )
+                                            found = True
+                                    if found:
+                                        continue
+                                    # The rkey is not present yet, create it
+                                    extend[name][_state].append(
+                                            {rkey: [{state: id_}]}
+                                            )
         high['__extend__'] = []
         for key, val in six.iteritems(extend):
             high['__extend__'].append({key: val})


### PR DESCRIPTION
Basically, this now works per #22852:

```
include:
  - stuff

ls -l:
  cmd.run:
    - require_in:
      - sls: stuff
```

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
