### PR TITLE
Prevents 'OSError' exception in case certain job cache path doesn't exist

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -74,6 +74,9 @@ def _walk_through(job_dir):
     for top in os.listdir(job_dir):
         t_path = os.path.join(job_dir, top)
 
+        if not os.path.exists(t_path):
+            continue
+
         for final in os.listdir(t_path):
             load_path = os.path.join(t_path, final, LOAD_P)
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue that may occur when exploring the local salt jobs cache.

If `master` has certain workload, or salt job cache is cleaned while i.a. `jobs.list_jobs` is running, then we're going to get an `OSError` exception due non-existing path.

```
salt/run/20170212133049657941/new	{
    "_stamp": "2017-02-12T11:30:50.125548", 
    "fun": "runner.jobs.list_jobs", 
    "jid": "20170212133049657941", 
    "user": "admin"
}
salt/run/20170212133049657941/ret	{
    "_stamp": "2017-02-12T11:30:51.183745", 
    "fun": "runner.jobs.list_jobs", 
    "jid": "20170212133049657941", 
    "return": "Exception occurred in runner jobs.list_jobs: Traceback (most recent call last):\n  File \"/usr/lib/python2.7/site-packages/salt/client/mixins.py\", line 348, in low\n    data['return'] = self.functions[fun](*args, **kwargs)\n  File \"/usr/lib/python2.7/site-packages/salt/runners/jobs.py\", line 333, in list_jobs\n    ret = mminion.returners['{0}.get_jids'.format(returner)]()\n  File \"/usr/lib/python2.7/site-packages/salt/returners/local_cache.py\", line 343, in get_jids\n    for jid, job, _, _ in _walk_through(_job_dir()):\n  File \"/usr/lib/python2.7/site-packages/salt/returners/local_cache.py\", line 69, in _walk_through\n    for final in os.listdir(t_path):\nOSError: [Errno 2] No such file or directory: '/var/cache/salt/master/jobs/32'\n", 
    "success": false, 
    "user": "admin"
}
```

The `_walk_through` loop is not checking the actual existence of the `t_path` before accessing it. We should ensure that such path is existing just before calling `os.listdir()`.

Same is already done for the final job file just before open it.

### Tests written?

No

/cc @moio 