### PR TITLE
Add subnetwork support to GCE Cloud Module.

### DIFF
--- a/doc/topics/cloud/gce.rst
+++ b/doc/topics/cloud/gce.rst
@@ -530,9 +530,8 @@ not possible to add/remove existing instances to a network.
 
 Destroy network
 ---------------
-Destroy a network by specifying the name. Make sure that there are no
-instances associated with the network prior to deleting it or you'll have
-a bad day.
+Destroy a network by specifying the name. If a resource is currently using
+the target network an exception will be raised.
 
 .. code-block:: bash
 
@@ -562,9 +561,8 @@ not possible to add/remove existing instances to a subnetwork.
 
 Destroy subnetwork
 ---------------
-Destroy a subnetwork by specifying the name and region. Make sure that there are no
-instances associated with the network prior to deleting it or you'll have
-a bad day.
+Destroy a subnetwork by specifying the name and region. If a resource is currently using
+the target subnetwork an exception will be raised.
 
 .. code-block:: bash
 

--- a/doc/topics/cloud/gce.rst
+++ b/doc/topics/cloud/gce.rst
@@ -15,7 +15,10 @@ at https://cloud.google.com.
 
 Dependencies
 ============
-* LibCloud >= 0.14.1
+* LibCloud >= 1.0.0
+
+.. versionchanged:: Nitrogen
+
 * A Google Cloud Platform account with Compute Engine enabled
 * A registered Service Account for authorization
 * Oh, and obviously you'll need `salt <https://github.com/saltstack/salt>`_
@@ -219,9 +222,11 @@ network resource.
 subnetwork
 ----------
 
-Custom non-legacy network resources have subnetworks.
-the 'default' network has a 'default' subnetwork.
-Set a subnetwork when using custom network resources. Required.
+Use this setting to define the subnetwork an instance will be created in.
+This requires that the network your instance is created under has a mode of 'custom' or 'auto'.
+Additionally, the subnetwork your instance is created under is associated with the location you provide. Required.
+
+.. versionadded:: Nitrogen
 
 tags
 ----
@@ -510,13 +515,18 @@ is blocked.
 
 Create network
 --------------
-New networks require a name and CIDR range. New instances can be created
-and added to this network by setting the network name during create. It is
+New networks require a name and CIDR range if they don't have a 'mode'.
+Optionally, 'mode' can be provided. Supported modes are 'auto', 'custom', 'legacy'.
+Optionally, 'description' can be provided to add an extra note to your network.
+New instances can be created and added to this network by setting the network name during create. It is
 not possible to add/remove existing instances to a network.
 
 .. code-block:: bash
 
     salt-cloud -f create_network gce name=mynet cidr=10.10.10.0/24
+    salt-cloud -f create_network gce name=mynet mode=auto description=some optional info.
+
+.. versionchanged:: Nitrogen
 
 Destroy network
 ---------------
@@ -535,6 +545,42 @@ Specify the network name to view information about the network.
 .. code-block:: bash
 
     salt-cloud -f show_network gce name=mynet
+
+Create subnetwork
+--------------
+New subnetworks require a name, region, and CIDR range.
+Optionally, 'description' can be provided to add an extra note to your subnetwork.
+New instances can be created and added to this subnetwork by setting the subnetwork name during create. It is
+not possible to add/remove existing instances to a subnetwork.
+
+.. code-block:: bash
+
+    salt-cloud -f create_subnetwork gce name=mynet network=mynet region=us-central1 cidr=10.0.10.0/24
+    salt-cloud -f create_subnetwork gce name=mynet network=mynet region=us-central1 cidr=10.10.10.0/24 description=some info about my subnet.
+
+.. versionadded:: Nitrogen
+
+Destroy subnetwork
+---------------
+Destroy a subnetwork by specifying the name and region. Make sure that there are no
+instances associated with the network prior to deleting it or you'll have
+a bad day.
+
+.. code-block:: bash
+
+    salt-cloud -f delete_subnetwork gce name=mynet region=us-central1
+
+.. versionadded:: Nitrogen
+
+Show subnetwork
+------------
+Specify the subnetwork name to view information about the subnetwork.
+
+.. code-block:: bash
+
+    salt-cloud -f show_subnetwork gce name=mynet
+
+.. versionadded:: Nitrogen
 
 Create address
 --------------

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -569,15 +569,15 @@ def create_network(kwargs=None, call=None):
         )
         return False
 
-    if 'cidr' not in kwargs and 'mode' not in kwargs:
+    mode = kwargs.get('mode', 'legacy')
+    cidr = kwargs.get('cidr', None)
+    if cidr is None and mode == 'legacy':
         log.error(
             'A network CIDR range must be specified when creating a legacy network.'
         )
         return False
 
     name = kwargs['name']
-    cidr = kwargs['cidr']
-    mode = kwargs.get('mode', 'legacy')
     desc = kwargs.get('description', None)
     conn = get_conn()
 

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -654,8 +654,7 @@ def delete_network(kwargs=None, call=None):
         )
     except ResourceNotFoundError as exc:
         log.error(
-            'Nework {0} could not be found.\n'
-            'The following exception was thrown by libcloud:\n{1}'.format(
+            'Nework {0} was not found. Exception was: {1}'.format(
                 name, exc),
             exc_info_on_loglevel=logging.DEBUG
         )
@@ -828,8 +827,7 @@ def delete_subnetwork(kwargs=None, call=None):
         result = conn.ex_destroy_subnetwork(name, region)
     except ResourceNotFoundError as exc:
         log.error(
-            'Subnework {0} could not be found.\n'
-            'The following exception was thrown by libcloud:\n{1}'.format(
+            'Subnetwork {0} was not found. Exception was: {1}'.format(
                 name, exc),
             exc_info_on_loglevel=logging.DEBUG
         )
@@ -1002,8 +1000,7 @@ def delete_fwrule(kwargs=None, call=None):
         )
     except ResourceNotFoundError as exc:
         log.error(
-            'Rule {0} could not be found.\n'
-            'The following exception was thrown by libcloud:\n{1}'.format(
+            'Rule {0} was not found. Exception was: {1}'.format(
                 name, exc),
             exc_info_on_loglevel=logging.DEBUG
         )
@@ -1163,8 +1160,7 @@ def delete_hc(kwargs=None, call=None):
         )
     except ResourceNotFoundError as exc:
         log.error(
-            'Health check {0} could not be found.\n'
-            'The following exception was thrown by libcloud:\n{1}'.format(
+            'Health check {0} was not found. Exception was: {1}'.format(
                 name, exc),
             exc_info_on_loglevel=logging.DEBUG
         )
@@ -1313,8 +1309,7 @@ def delete_address(kwargs=None, call=None):
         )
     except ResourceNotFoundError as exc:
         log.error(
-            'Address {0} could not be found (region {1})\n'
-            'The following exception was thrown by libcloud:\n{2}'.format(
+            'Address {0} in region {1} was not found. Exception was: {2}'.format(
                 name, ex_region, exc),
             exc_info_on_loglevel=logging.DEBUG
         )
@@ -1490,8 +1485,7 @@ def delete_lb(kwargs=None, call=None):
         )
     except ResourceNotFoundError as exc:
         log.error(
-            'Load balancer {0} could not be found.\n'
-            'The following exception was thrown by libcloud:\n{1}'.format(
+            'Load balancer {0} was not found. Exception was: {1}'.format(
                 name, exc),
             exc_info_on_loglevel=logging.DEBUG
         )
@@ -1696,8 +1690,7 @@ def delete_snapshot(kwargs=None, call=None):
         )
     except ResourceNotFoundError as exc:
         log.error(
-            'Snapshot {0} could not be found.\n'
-            'The following exception was thrown by libcloud:\n{1}'.format(
+            'Snapshot {0} was not found. Exception was: {1}'.format(
                 name, exc),
             exc_info_on_loglevel=logging.DEBUG
         )
@@ -1902,8 +1895,7 @@ def create_snapshot(kwargs=None, call=None):
         disk = conn.ex_get_volume(disk_name)
     except ResourceNotFoundError as exc:
         log.error(
-            'Disk {0} could not be found.\n'
-            'The following exception was thrown by libcloud:\n{1}'.format(
+            'Disk {0} was not found. Exception was: {1}'.format(
                 disk_name, exc),
             exc_info_on_loglevel=logging.DEBUG
         )

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -41,7 +41,8 @@ Example Provider Configuration
       ssh_interface: public_ips
 
 :maintainer: Eric Johnson <erjohnso@google.com>
-:depends: libcloud >= 0.14.1
+:maintainer: Russell Tolle <russ.tolle@gmail.com>
+:depends: libcloud >= 1.0.0
 '''
 # pylint: disable=invalid-name,function-redefined
 
@@ -457,6 +458,16 @@ def __get_subnetwork(vm_):
     return ex_subnetwork
 
 
+def __get_region(conn, vm_):
+    '''
+    Return a GCE libcloud region object with matching name.
+    '''
+    location = __get_location(conn, vm_)
+    region = '-'.join(location.name.split('-')[:2])
+
+    return conn.ex_get_region(region)
+
+
 def __get_ssh_interface(vm_):
     '''
     Return the ssh_interface type to connect to. Either 'public_ips' (default)
@@ -537,13 +548,15 @@ def __get_ssh_credentials(vm_):
 
 def create_network(kwargs=None, call=None):
     '''
-    Create a GCE network.
+    ... versionchanged:: Nitrogen
+    Create a GCE network. Must specify name and cidr.
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt-cloud -f create_network gce name=mynet cidr=10.10.10.0/24
+        salt-cloud -f create_network gce name=mynet cidr=10.10.10.0/24 mode=legacy description=optional
+        salt-cloud -f create_network gce name=mynet description=optional
     '''
     if call != 'function':
         raise SaltCloudSystemExit(
@@ -555,29 +568,34 @@ def create_network(kwargs=None, call=None):
             'A name must be specified when creating a network.'
         )
         return False
-    if 'cidr' not in kwargs:
+
+    if 'cidr' not in kwargs and 'mode' not in kwargs:
         log.error(
-            'A network CIDR range must be specified when creating a network.'
+            'A network CIDR range must be specified when creating a legacy network.'
         )
-        return
+        return False
 
     name = kwargs['name']
     cidr = kwargs['cidr']
+    mode = kwargs.get('mode', 'legacy')
+    desc = kwargs.get('description', None)
     conn = get_conn()
 
     __utils__['cloud.fire_event'](
         'event',
-        'create network',
+        'creating network',
         'salt/cloud/net/creating',
         args={
             'name': name,
             'cidr': cidr,
+            'description': desc,
+            'mode': mode
         },
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
     )
 
-    network = conn.ex_create_network(name, cidr)
+    network = conn.ex_create_network(name, cidr, desc, mode)
 
     __utils__['cloud.fire_event'](
         'event',
@@ -586,6 +604,8 @@ def create_network(kwargs=None, call=None):
         args={
             'name': name,
             'cidr': cidr,
+            'description': desc,
+            'mode': mode
         },
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
@@ -619,7 +639,7 @@ def delete_network(kwargs=None, call=None):
 
     __utils__['cloud.fire_event'](
         'event',
-        'delete network',
+        'deleting network',
         'salt/cloud/net/deleting',
         args={
             'name': name,
@@ -676,6 +696,192 @@ def show_network(kwargs=None, call=None):
 
     conn = get_conn()
     return _expand_item(conn.ex_get_network(kwargs['name']))
+
+
+def create_subnetwork(kwargs=None, call=None):
+    '''
+    ... versionadded:: Nitrogen
+    Create a GCE Subnetwork. Must specify name, cidr, network, and region.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-cloud -f create_subnetwork gce name=mysubnet network=mynet1 region=us-west1 cidr=10.0.0.0/24 description=optional
+    '''
+    if call != 'function':
+        raise SaltCloudSystemExit(
+            'The create_subnetwork function must be called with -f or --function.'
+        )
+
+    if not kwargs or 'name' not in kwargs:
+        log.error(
+            'Must specify name of subnet.'
+        )
+        return False
+
+    if 'network' not in kwargs:
+        log.errror(
+            'Must specify name of network to create subnet under.'
+        )
+        return False
+
+    if 'cidr' not in kwargs:
+        log.errror(
+            'A network CIDR range must be specified when creating a subnet.'
+        )
+        return False
+
+    if 'region' not in kwargs:
+        log.error(
+            'A region must be specified when creating a subnetwork.'
+        )
+        return False
+
+    name = kwargs['name']
+    cidr = kwargs['cidr']
+    network = kwargs['network']
+    region = kwargs['region']
+    desc = kwargs.get('description', None)
+    conn = get_conn()
+
+    __utils__['cloud.fire_event'](
+        'event',
+        'create subnetwork',
+        'salt/cloud/subnet/creating',
+        args={
+            'name': name,
+            'network': network,
+            'cidr': cidr,
+            'region': region,
+            'description': desc
+        },
+        sock_dir=__opts__['sock_dir'],
+        transport=__opts__['transport']
+    )
+
+    subnet = conn.ex_create_subnetwork(name, cidr, network, region, desc)
+
+    __utils__['cloud.fire_event'](
+        'event',
+        'created subnetwork',
+        'salt/cloud/subnet/created',
+        args={
+            'name': name,
+            'network': network,
+            'cidr': cidr,
+            'region': region,
+            'description': desc
+        },
+        sock_dir=__opts__['sock_dir'],
+        transport=__opts__['transport']
+    )
+
+    return _expand_item(subnet)
+
+
+def delete_subnetwork(kwargs=None, call=None):
+    '''
+    ... versionadded:: Nitrogen
+    Delete a GCE Subnetwork. Must specify name and region.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-cloud -f delete_subnetwork gce name=mysubnet network=mynet1 region=us-west1
+    '''
+    if call != 'function':
+        raise SaltCloudSystemExit(
+            'The delete_subnet function must be called with -f or --function.'
+        )
+
+    if not kwargs or 'name' not in kwargs:
+        log.error(
+            'Must specify name of subnet.'
+        )
+        return False
+
+    if 'region' not in kwargs:
+        log.error(
+            'Must specify region of subnet.'
+        )
+        return False
+
+    name = kwargs['name']
+    region = kwargs['region']
+    conn = get_conn()
+
+    __utils__['cloud.fire_event'](
+        'event',
+        'deleting subnetwork',
+        'salt/cloud/subnet/deleting',
+        args={
+            'name': name,
+            'region': region
+        },
+        sock_dir=__opts__['sock_dir'],
+        transport=__opts__['transport']
+    )
+
+    try:
+        result = conn.ex_destroy_subnetwork(name, region)
+    except ResourceNotFoundError as exc:
+        log.error(
+            'Subnework {0} could not be found.\n'
+            'The following exception was thrown by libcloud:\n{1}'.format(
+                name, exc),
+            exc_info_on_loglevel=logging.DEBUG
+        )
+        return False
+
+    __utils__['cloud.fire_event'](
+        'event',
+        'deleted subnetwork',
+        'salt/cloud/subnet/deleted',
+        args={
+            'name': name,
+            'region': region
+        },
+        sock_dir=__opts__['sock_dir'],
+        transport=__opts__['transport']
+    )
+    return result
+
+
+def show_subnetwork(kwargs=None, call=None):
+    '''
+    ... versionadded:: Nitrogen
+    Show details of an existing GCE Subnetwork. Must specify name and region.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-cloud -f show_subnetwork gce name=mysubnet region=us-west1
+
+    '''
+    if call != 'function':
+        raise SaltCloudSystemExit(
+            'The show_subnetwork function must be called with -f or --function.'
+        )
+
+    if not kwargs or 'name' not in kwargs:
+        log.error(
+            'Must specify name of subnet.'
+        )
+        return False
+
+    if 'region' not in kwargs:
+        log.error(
+            'Must specify region of subnet.'
+        )
+        return False
+
+    name = kwargs['name']
+    region = kwargs['region']
+    conn = get_conn()
+    return _expand_item(conn.ex_get_subnetwork(name, region))
 
 
 def create_fwrule(kwargs=None, call=None):
@@ -2212,6 +2418,8 @@ def create_attach_volumes(name, kwargs, call=None):
 def request_instance(vm_):
     '''
     Request a single GCE instance from a data dict.
+
+    .. versionchanged: Nitrogen
     '''
     if not GCE_VM_NAME_REGEX.match(vm_['name']):
         raise SaltCloudSystemExit(
@@ -2250,7 +2458,7 @@ def request_instance(vm_):
     elif external_ip == 'None':
         external_ip = None
     else:
-        region = '-'.join(kwargs['location'].name.split('-')[:2])
+        region = __get_region(conn, vm_)
         external_ip = __create_orget_address(conn, external_ip, region)
     kwargs['external_ip'] = external_ip
     vm_['external_ip'] = external_ip
@@ -2269,8 +2477,7 @@ def request_instance(vm_):
             'ex_can_ip_forward': config.get_cloud_config_value(
                 'ip_forwarding', vm_, __opts__, default=False),
             'ex_preemptible': config.get_cloud_config_value(
-                'preemptible', vm_, __opts__, default=False
-            )
+                'preemptible', vm_, __opts__, default=False)
         })
         if kwargs.get('ex_disk_type') not in ('pd-standard', 'pd-ssd'):
             raise SaltCloudSystemExit(


### PR DESCRIPTION
What does this PR do?

Add create, delete, and show functions for subnetworks.
Add libcloud overridden __get_region function that gets a region object from a zone.
Add __get_subnetwork function to allow subnetwork key in cloud.profiles.
Update existing network implementation to support mode and description.
Update and add documentation.

What issues does this PR fix or reference?

#39258

Tests written?

No