### PR TITLE
Update :depends: docs for boto states and modules

### DIFF
--- a/salt/modules/boto_cloudtrail.py
+++ b/salt/modules/boto_cloudtrail.py
@@ -4,6 +4,12 @@ Connection module for Amazon CloudTrail
 
 .. versionadded:: 2016.3.0
 
+:depends:
+    - boto
+    - boto3
+
+The dependencies listed above can be installed via package or pip.
+
 :configuration: This module accepts explicit Lambda credentials but can also
     utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
@@ -38,8 +44,6 @@ Connection module for Amazon CloudTrail
             keyid: GKTADJGHEIQSXMKKRBJ08H
             key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
             region: us-east-1
-
-:depends: boto3
 
 '''
 # keep lint from choking on _get_conn and _cache_id

--- a/salt/modules/boto_iot.py
+++ b/salt/modules/boto_iot.py
@@ -4,6 +4,12 @@ Connection module for Amazon IoT
 
 .. versionadded:: 2016.3.0
 
+:depends:
+    - boto
+    - boto3
+
+The dependencies listed above can be installed via package or pip.
+
 :configuration: This module accepts explicit Lambda credentials but can also
     utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
@@ -38,8 +44,6 @@ Connection module for Amazon IoT
           keyid: GKTADJGHEIQSXMKKRBJ08H
           key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
           region: us-east-1
-
-:depends: boto3
 
 '''
 # keep lint from choking on _get_conn and _cache_id

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -4,6 +4,12 @@ Connection module for Amazon Lambda
 
 .. versionadded:: 2016.3.0
 
+:depends:
+    - boto
+    - boto3
+
+The dependencies listed above can be installed via package or pip.
+
 :configuration: This module accepts explicit Lambda credentials but can also
     utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
@@ -68,8 +74,6 @@ Connection module for Amazon Lambda
 
         error:
           message: error message
-
-:depends: boto3
 
 '''
 # keep lint from choking on _get_conn and _cache_id

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -4,6 +4,12 @@ Connection module for Amazon S3 Buckets
 
 .. versionadded:: 2016.3.0
 
+:depends:
+    - boto
+    - boto3
+
+The dependencies listed above can be installed via package or pip.
+
 :configuration: This module accepts explicit Lambda credentials but can also
     utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
@@ -38,8 +44,6 @@ Connection module for Amazon S3 Buckets
             keyid: GKTADJGHEIQSXMKKRBJ08H
             key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
             region: us-east-1
-
-:depends: boto3
 
 '''
 # keep lint from choking on _get_conn and _cache_id

--- a/salt/states/boto_cloudtrail.py
+++ b/salt/states/boto_cloudtrail.py
@@ -8,7 +8,11 @@ Manage CloudTrail Objects
 Create and destroy CloudTrail objects. Be aware that this interacts with Amazon's services,
 and so may incur charges.
 
-This module uses ``boto3``, which can be installed via package, or pip.
+:depends:
+    - boto
+    - boto3
+
+The dependencies listed above can be installed via package or pip.
 
 This module accepts explicit vpc credentials but can also utilize
 IAM roles assigned to the instance through Instance Profiles. Dynamic

--- a/salt/states/boto_iot.py
+++ b/salt/states/boto_iot.py
@@ -8,7 +8,11 @@ Manage IoT Objects
 Create and destroy IoT objects. Be aware that this interacts with Amazon's services,
 and so may incur charges.
 
-This module uses ``boto3``, which can be installed via package, or pip.
+:depends:
+    - boto
+    - boto3
+
+The dependencies listed above can be installed via package or pip.
 
 This module accepts explicit vpc credentials but can also utilize
 IAM roles assigned to the instance through Instance Profiles. Dynamic

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -8,7 +8,11 @@ Manage Lambda Functions
 Create and destroy Lambda Functions. Be aware that this interacts with Amazon's services,
 and so may incur charges.
 
-This module uses ``boto3``, which can be installed via package, or pip.
+:depends:
+    - boto
+    - boto3
+
+The dependencies listed above can be installed via package or pip.
 
 This module accepts explicit vpc credentials but can also utilize
 IAM roles assigned to the instance through Instance Profiles. Dynamic

--- a/salt/states/boto_s3_bucket.py
+++ b/salt/states/boto_s3_bucket.py
@@ -8,7 +8,11 @@ Manage S3 Buckets
 Create and destroy S3 buckets. Be aware that this interacts with Amazon's services,
 and so may incur charges.
 
-This module uses ``boto3``, which can be installed via package, or pip.
+:depends:
+    - boto
+    - boto3
+
+The dependencies listed above can be installed via package or pip.
 
 This module accepts explicit vpc credentials but can also utilize
 IAM roles assigned to the instance through Instance Profiles. Dynamic


### PR DESCRIPTION
Some boto states and modules declare that they depend on the
boto3 lib. That's all good. But some of these states and modules
_also_ depend on the regular boto lib. This updates the docs
to reflect this.

Fixes #39304
