### PR TITLE
Add package version control to SPM

### DIFF
--- a/salt/spm/__init__.py
+++ b/salt/spm/__init__.py
@@ -248,11 +248,11 @@ class SPMClient(object):
 
         repo_metadata = self._get_repo_metadata()
 
+        dl_list = {}
         for package in to_install:
             if package in file_map:
                 self._install_indv_pkg(package, file_map[package])
             else:
-                dl_list = {}
                 for repo in repo_metadata:
                     repo_info = repo_metadata[repo]
                     if package in repo_info['packages']:


### PR DESCRIPTION
### What does this PR do?
Rather than just looping through packages and installing them as it sees them, SPM will now build a list of packages to install, along with their sources, before installing them. While building this list, package version will be evaluated, and if the version is the same, then package release. If that is also the same, then SPM will check to see if the source is has a `file://` URL. If one has a `file://` URL and the other doesn't, then the `file://` source will be given precedence.

### What issues does this PR fix or reference?
#39266

### Tests written?
No.