### PR TITLE
salt.fileserver.roots: Fix regression in symlink_list

### DIFF
--- a/tests/integration/fileserver/roots_test.py
+++ b/tests/integration/fileserver/roots_test.py
@@ -148,11 +148,12 @@ class RootsTest(integration.ModuleCase):
             self.assertIn('empty_dir', ret)
 
     def test_symlink_list(self):
-        with patch.dict(roots.__opts__, {'file_roots': self.master_opts['file_roots'],
-                         'fileserver_ignoresymlinks': False,
-                         'fileserver_followsymlinks': False,
-                         'file_ignore_regex': False,
-                         'file_ignore_glob': False}):
+        with patch.dict(roots.__opts__, {'cachedir': self.master_opts['cachedir'],
+                                         'file_roots': self.master_opts['file_roots'],
+                                         'fileserver_ignoresymlinks': False,
+                                         'fileserver_followsymlinks': False,
+                                         'file_ignore_regex': False,
+                                         'file_ignore_glob': False}):
             ret = roots.symlink_list({'saltenv': 'base'})
             self.assertDictEqual(ret, {'dest_sym': 'source_sym'})
 


### PR DESCRIPTION
A recent PR of mine (#39337) removed the logic in symlink_list and fell back to the cached file list generated in ``_file_lists()``. However, this code dates back from before the fileserver backends' ``symlink_list()`` functions were modified to return a dict mapping links to their destinations.

This fixes the code in ``_file_lists()`` so that it returns the correct data. It also fixes the fact that ``.`` was showing up in the dir list produced by ``_file_lists()``, and updates the associated integration test to include the cachedir in the mocked opts.