### PR TITLE
allow non-hostname characters in vmware obj name

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -116,7 +116,7 @@ configuration, run :py:func:`test_vcenter_connection`
 # Import python libs
 from __future__ import absolute_import
 from random import randint
-from re import findall
+from re import findall, split
 import pprint
 import logging
 import time
@@ -2570,8 +2570,8 @@ def create(vm_):
             global_ip = vim.vm.customization.GlobalIPSettings()
             if 'dns_servers' in list(vm_.keys()):
                 global_ip.dnsServerList = vm_['dns_servers']
-            hostName = vm_name.split('.')[0]
-            domainName = vm_name.split('.', 1)[-1]
+            hostName, domainName = split(r'[^\w-]', vm_name, maxsplit=1)
+            domainName = domainName.split('.', maxsplit=1)[-1]
             if 'Windows' not in object_ref.config.guestFullName:
                 identity = vim.vm.customization.LinuxPrep()
                 identity.hostName = vim.vm.customization.FixedName(name=hostName)


### PR DESCRIPTION
Hope this is a welcome change!

### What does this PR do?

Allows specification of non-hostname characters for node names without breaking the actual hostname of the machine.

Non-hostname characters are allowed in VMWare VM names, but will fail if used for a hostname. This splits out non-hostname characters (with the exception of underscores)

Example:

    # /etc/salt/cloud.maps.d/example.map
    profile:
        - node (some annotation here):
            domain: sun-and-sea.salt
            clonefrom: mycooltemplate
            devices:
                network:
                    Network adapter 1:
        ...

This would result in a VMWare VM with the name `node (some annotation here)`, but the machine will have the real FQDN of `node.sun-and-sea.salt`

### What issues does this PR fix or reference?

None that I am aware of

### Previous Behavior

`hostname` was all characters up to the first period in the node name
`domainname` was all characters up to the first period in the node name, but from the end of the name

### New Behavior

`hostname` is any character in the set `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_`, up until this no longer matches, which will always stop matching before the first period (as there is no period in the set) as above.
`domainname` has the same behavior

### Tests written?

No, I don't believe there are any tests for this currently, not sure if it is too granular or not. Happy to write a test if need be.