### PR TITLE
Allow aptpkg.info_installed on package names that aren't installed

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2464,7 +2464,7 @@ def owner(*paths):
     return ret
 
 
-def info_installed(*names):
+def info_installed(failhard=True, *names):
     '''
     Return the information of the named package(s) installed on the system.
 
@@ -2473,15 +2473,20 @@ def info_installed(*names):
     names
         The names of the packages for which to return information.
 
+    failhard
+        Whether to throw an exception if none of the packages are installed.
+        Defaults to True.
+
     CLI example:
 
     .. code-block:: bash
 
         salt '*' pkg.info_installed <package1>
         salt '*' pkg.info_installed <package1> <package2> <package3> ...
+        salt '*' pkg.info_installed <package1> failhard=false
     '''
     ret = dict()
-    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names).items():
+    for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names, failhard=failhard).items():
         t_nfo = dict()
         # Translate dpkg-specific keys to a common structure
         for key, value in pkg_nfo.items():


### PR DESCRIPTION
Currently, it's not possible to query for info on packages that may not be installed. With an added failhard argument, the user can specify if they just want an empty result set back instead of an exception being raised.

Personally I think not throwing an exception should be the default behaviour, but that would be a breaking change. Maybe for the next major release?

```
$ sudo salt-call pkg.info_installed 'php5*'
[ERROR   ] [salt.loaded.int.module.cmdmod] Command 'dpkg-query -W -f='package:${Package}\nrevision:${binary:Revision}\narchitecture:${Architecture}\nmaintainer:${Maintainer}\nsummary:${Summary}\nsource:${source:Package}\nversion:${Version}\nsection:${Section}\ninstalled_size:${Installed-size}\nsize:${Size}\nMD5:${MD5sum}\nSHA1:${SHA1}\nSHA256:${SHA256}\norigin:${Origin}\nhomepage:${Homepage}\n======\ndescription:${Description}\n------\n' php5*' failed with return code: 1
[ERROR   ] [salt.loaded.int.module.cmdmod] stderr: dpkg-query: no packages found matching php5*
[ERROR   ] [salt.loaded.int.module.cmdmod] retcode: 1
Error running 'pkg.info_installed': Error getting packages information: dpkg-query: no packages found matching php5*

$ sudo salt-call pkg.info_installed 'php7*'
local:
    ----------
    php7.1-calendar:
        ----------
        description:
            
        name:
            php7.1-calendar
        source:
            php7.1-calendar
...
```