### PR TITLE
Fix problem with too many connection attempts in Windows

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -534,6 +534,10 @@ class MinionBase(object):
                 opts['master_uri_list'].append(resolve_dns(opts)['master_uri'])
 
             while True:
+                if attempts != 0:
+                    # Give up a little time between connection attempts
+                    # to allow the IOLoop to run any other scheduled tasks.
+                    yield tornado.gen.sleep(opts['acceptance_wait_time'])
                 attempts += 1
                 if tries > 0:
                     log.debug('Connecting to master. Attempt {0} '
@@ -588,6 +592,10 @@ class MinionBase(object):
             if opts['random_master']:
                 log.warning('random_master is True but there is only one master specified. Ignoring.')
             while True:
+                if attempts != 0:
+                    # Give up a little time between connection attempts
+                    # to allow the IOLoop to run any other scheduled tasks.
+                    yield tornado.gen.sleep(opts['acceptance_wait_time'])
                 attempts += 1
                 if tries > 0:
                     log.debug('Connecting to master. Attempt {0} '


### PR DESCRIPTION
### What does this PR do?
Fixes problem where the Windows minion would try to connect too frequently when the master key changed.

Adds the lines from 6c8b8048e6c5902df0fd76cd37b24fa77281192e to 2016.11, but changed the sleep time from `1` to `opts['acceptance_wait_time']`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/39394

### Previous Behavior
In Windows, the minion would continuously try to connect to the master in a DoS manner.

### New Behavior
The minion now waits the amount of time set in the `acceptance_wait_time` config option, default is 10 seconds.

### Tests written?
No