### PR TITLE
Optimize FileClient for latency vol2

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1226,6 +1226,13 @@ class RemoteClient(Client):
                 saltenv, path
             )
 
+        if mtime_server is not None:
+            try:
+                os.utime(dest, (mtime_server, mtime_server,))
+                log.debug('Applied remote modification date to file %s', dest)
+            except OSError:
+                log.warning('Failed to override modification date for file %s', dest)
+
         if not salt.utils.is_windows():
             if mode_server is not None:
                 try:

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -984,9 +984,9 @@ class RemoteClient(Client):
 
     def _get_remote_file_list(self, saltenv):
         if saltenv in self.remote_file_list:
-            log.debug("Using cached file list for saltenv {0}".format(saltenv))
+            log.debug('Using cached file list for saltenv %s', saltenv)
         else:
-            log.debug("Fetching remote file list for saltenv {0}".format(saltenv))
+            log.debug('Fetching remote file list for saltenv %s', saltenv)
             res = self.file_stats(saltenv)
             if res:
                 self.remote_file_list[saltenv] = res
@@ -1018,6 +1018,8 @@ class RemoteClient(Client):
 
         # if cached_list is non empty, we know that all used filesystems
         # support extended file stats and there's no need to check hashes
+        hash_server = None
+        stat_server = None
         if not cached_list:
             # if the fs backend doesn't support _file_stats, use old _file_find
             hash_server, stat_server = self.hash_and_stat_file(path, saltenv)
@@ -1033,6 +1035,9 @@ class RemoteClient(Client):
         # In such case we need to fallback to comparing file hashes
         support_mtime = len(stat_server) > 8
         mode_server = stat_server[0]
+        mtime_server = None
+        size_server = None
+
         if support_mtime:
             mtime_server = stat_server[8]
             size_server = stat_server[6]
@@ -1063,7 +1068,7 @@ class RemoteClient(Client):
             if support_mtime:
                 stat_local = self.stat_file(dest2check, saltenv)
             else:
-                stat_local, hash_local = self.hash_and_stat_file(dest2check, saltenv)
+                hash_local, stat_local = self.hash_and_stat_file(dest2check, saltenv)
 
             mode_local = stat_local[0]
             mtime_local = stat_local[8]
@@ -1262,7 +1267,6 @@ class RemoteClient(Client):
         if not ret:
             return ret
 
-
         return {sdecode(fn_): v for fn_, v in ret.items()}
 
     def file_list_emptydirs(self, saltenv='base', prefix=''):
@@ -1328,7 +1332,7 @@ class RemoteClient(Client):
                 return list(os.stat(path))
 
         if saltenv in self.remote_file_list and path in self.remote_file_list[saltenv]:
-            log.debug("*** Found cached stat! for file: " + path)
+            log.debug("*** Found cached stat for file: " + path)
             return self.remote_file_list[saltenv][path]
 
         return False

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -768,15 +768,19 @@ class Fileserver(object):
         if not isinstance(load['saltenv'], six.string_types):
             load['saltenv'] = six.text_type(load['saltenv'])
 
+        funcs = []
         for fsb in self._gen_back(load.pop('fsbackend', None)):
             fstr = '{0}.file_stats'.format(fsb)
             if fstr in self.servers:
-                ret.update(self.servers[fstr](load)) # merging dicts here
-            else:
-                # if any of used fs backend doesn't support new file_stats
-                # we return False, so that client can use old _file_find function
-                # gitfs is not yet supported
-                return False
+                funcs.append(fstr)
+
+        if len(funcs) != len(self.opts['fileserver_backend']):
+            # if any of used fs backend doesn't support new file_stats
+            # we return False, so that client can use old _file_find function
+            # gitfs is not yet supported
+            return False
+        for fstr in funcs:
+            ret.update(self.servers[fstr](load)) # merging dicts here
 
         # upgrade all set elements to a common encoding
 

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -324,7 +324,8 @@ def _file_lists(load, form):
             'files': [],
             'dirs': [],
             'empty_dirs': [],
-            'links': []
+            'links': [],
+            'files_stat': {}
         }
         for path in __opts__['file_roots'][load['saltenv']]:
             for root, dirs, files in os.walk(
@@ -352,8 +353,12 @@ def _file_lists(load, form):
                                 path
                             )
                     if not salt.fileserver.is_file_ignored(__opts__, rel_fn):
+                        stat = list(os.stat(os.path.join(root, fname)))
+
                         if __opts__.get('file_client', 'remote') == 'local' and os.path.sep == "\\":
                             rel_fn = rel_fn.replace('\\', '/')
+
+                        ret['files_stat'][rel_fn] = stat
                         ret['files'].append(rel_fn)
         if save_cache:
             try:
@@ -389,6 +394,8 @@ def dir_list(load):
     '''
     return _file_lists(load, 'dirs')
 
+def file_stats(load):
+    return _file_lists(load, 'files_stat')
 
 def symlink_list(load):
     '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -973,6 +973,7 @@ class AESFuncs(object):
         self._file_hash = self.fs_.file_hash
         self._file_hash_and_stat = self.fs_.file_hash_and_stat
         self._file_list = self.fs_.file_list
+        self._file_stats = self.fs_.file_stats
         self._file_list_emptydirs = self.fs_.file_list_emptydirs
         self._dir_list = self.fs_.dir_list
         self._symlink_list = self.fs_.symlink_list


### PR DESCRIPTION
### What does this PR do?

* Added new master function _file_stats which provides a list of files with stat(..) info for them
* Changed FileClient to avoid hashing remote and local files (helps a lot when you deal with binary files!)
* Changed FileClient to stop contacting the master for every requested file, if it's up-to-date based on cached last-modified dates, which are fetched only once with _file_stats
* Currently only the 'roots' filesystem is fully supported with this new feature and other filesystems like 'gitfs' will fallback to comparing hashes and using _file_hash_and_stat for every request

I tried really hard to avoid breaking any functionality I might personally not use, like gitfs or Windows support, and cleaned the get_file function a bit.
If I could have missed some really edge case please let me know 😄 
(Note: according to https://docs.python.org/2/library/os.html os.stat is supported without problems for windows with file size and modification time. We just need to ignore the chmod part)

This PR depends on #39412 - the fix of FileClient caching - to show real performance increase.
**Combination of this and #39412 reduced our deploy times today from 18 seconds to 12 seconds(!)
(master-minion latency - 10 ms ping) - sounds cool, huh?**

**Note: currently a combination of FileClient + file.managed is very buggy for big binary files, or at least it was 3 months ago when I last checked. (jars, tars....etc)
It was so bad I just decided that I don't care and made a formula to make a nice rsync server, and rsync the files.
I'll try to make support for binary files better to the point where it would be on-par with rsync and I could remove rsync server.
Surely removing the hashing here is a big improvement itself, because previously it could take several seconds just to check if some binary files is up-to-date
There were some bugs(big performance problems) in binary portion of file.managed itself and I'll try to get back to that bugs soon.**

### What issues does this PR fix or reference?

As a follow-up to my previous PR, there's still room for improvement in FileClient's latency that I aim to fix now.

### Previous Behavior
Call _file_hash_and_stat for every requested file (ping-pong with master), hash local and remote files even if they are up-to-date.

### New Behavior
Call _file_stats once and cache the result in FileClient.
Fail fast with "file not found" if file is not in cached list of files.
Up-to-date check will now compare local and remote modification dates as well as file size instead of using hashes.

If the file is up-to-date, master will not be queried for this file, thus the latency to check if it's up-to-date will now be 0ms.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
