### PR TITLE
win_dism: Return failure when package path does not exist

### DIFF
--- a/salt/states/win_dism.py
+++ b/salt/states/win_dism.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 
 # Import python libs
 import logging
+import os
 
 # Import salt libs
 import salt.utils
@@ -319,6 +320,15 @@ def package_installed(name,
            'comment': '',
            'changes': {}}
 
+    # Fail if using a non-existent package path
+    if '~' not in name and not os.path.exists(name):
+        if __opts__['test']:
+            ret['result'] = None
+        else:
+            ret['result'] = False
+        ret['comment'] = 'Package path {0} does not exist'.format(name)
+        return ret
+
     old = __salt__['dism.installed_packages']()
 
     # Get package info so we can see if it's already installed
@@ -386,6 +396,15 @@ def package_removed(name, image=None, restart=False):
            'result': True,
            'comment': '',
            'changes': {}}
+
+    # Fail if using a non-existent package path
+    if '~' not in name and not os.path.exists(name):
+        if __opts__['test']:
+            ret['result'] = None
+        else:
+            ret['result'] = False
+        ret['comment'] = 'Package path {0} does not exist'.format(name)
+        return ret
 
     old = __salt__['dism.installed_packages']()
 


### PR DESCRIPTION
### What does this PR do?
Adds checks in the win_dism state module, so that trying to install or remove a package using a non-existent path does not return failure.

### What issues does this PR fix or reference?
An exception is thrown when the package path isn't present, but is passed as the name to `win_dism.package_installed` or `win_dism.package_removed`. It's mostly an issue in test mode, because it's probably another function that is copying them to the disk, which would also be in test mode.

### Previous Behavior
<pre>          ID: install_Windows6.1-KB3212646-x64
    Function: dism.package_installed
        Name: C:\Updates\Windows6.1-KB3212646-x64\Windows6.1-KB3212646-x64.cab
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "c:\salt\bin\lib\site-packages\salt\state.py", line 1745, in call
                  **cdata['kwargs'])
                File "c:\salt\bin\lib\site-packages\salt\loader.py", line 1702, in wrapper
                  return f(*args, **kwargs)
                File "c:\salt\bin\lib\site-packages\salt\states\win_dism.py", line 337, in package_installed
                  if package_info['Package Identity'] in old:
              KeyError: 'Package Identity'
     Started: 17:07:16.447000
    Duration: 1466.0 ms
     Changes:  </pre>

### New Behavior
Test mode:
<pre>          ID: install_Windows6.1-KB3212646-x64
    Function: dism.package_installed
        Name: C:\Updates\Windows6.1-KB3212646-x64\Windows6.1-KB3212646-x64.cab
      Result: None
     Comment: Package path C:\Updates\Windows6.1-KB3212646-x64\Windows6.1-KB3212646-x64.cab does not exist
     Started: 17:35:55.028000
    Duration: 1.0 ms
     Changes:  </pre>
For real:
<pre>          ID: install_Windows6.1-KB3212646-x64
    Function: dism.package_installed
        Name: C:\Updates\Windows6.1-KB3212646-x64\Windows6.1-KB3212646-x64.cab
      Result: False
     Comment: Package path C:\Updates\Windows6.1-KB3212646-x64\Windows6.1-KB3212646-x64.cab does not exist
     Started: 17:36:46.323000
    Duration: 2.0 ms
     Changes: </pre>

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
