### PR TITLE
Fix grains.setval performance

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -200,6 +200,10 @@ def setvals(grains, destructive=False, refresh=True):
         If an operation results in a key being removed, delete the key, too.
         Defaults to False.
 
+    refresh
+        Refresh minion grains using saltutil.sync_grains.
+        Defaults to True.
+
     CLI Example:
 
     .. code-block:: bash
@@ -293,6 +297,10 @@ def setval(key, val, destructive=False, refresh=True):
     destructive
         If an operation results in a key being removed, delete the key, too.
         Defaults to False.
+
+    refresh
+        Refresh minion grains using saltutil.sync_grains.
+        Defaults to True.
 
     CLI Example:
 

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -192,7 +192,7 @@ def item(*args, **kwargs):
     return ret
 
 
-def setvals(grains, destructive=False):
+def setvals(grains, destructive=False, refresh=True):
     '''
     Set new grains values in the grains config file
 
@@ -275,12 +275,12 @@ def setvals(grains, destructive=False):
         log.error(msg.format(fn_))
     if not __opts__.get('local', False):
         # Sync the grains
-        __salt__['saltutil.sync_grains']()
+        __salt__['saltutil.sync_grains'](refresh=refresh)
     # Return the grains we just set to confirm everything was OK
     return new_grains
 
 
-def setval(key, val, destructive=False):
+def setval(key, val, destructive=False, refresh=True):
     '''
     Set a grains value in the grains config file
 
@@ -301,7 +301,7 @@ def setval(key, val, destructive=False):
         salt '*' grains.setval key val
         salt '*' grains.setval key "{'sub-key': 'val', 'sub-key2': 'val2'}"
     '''
-    return setvals({key: val}, destructive)
+    return setvals({key: val}, destructive, refresh)
 
 
 def append(key, val, convert=False, delimiter=DEFAULT_TARGET_DELIM):


### PR DESCRIPTION
### What does this PR do?
Adds a `refresh` option to `grains.setval` and `grains.setvals`. Setting `refresh=False` will cause the grain to be set, but `saltutil.sync_grains` will not be called.

### What issues does this PR fix or reference?
ZD-1207

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
