### PR TITLE
Quick and dirty fix for GECOS fields with more than 3 commas

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -329,6 +329,7 @@ def present(name,
 
     homephone
         The user's home phone number (not supported in MacOS)
+        If GECOS field contains more than 3 commas, this field will have the rest of 'em
 
     .. versionchanged:: 2014.7.0
        Shadow attribute support added.
@@ -409,7 +410,7 @@ def present(name,
 
     # the comma is used to separate field in GECOS, thus resulting into
     # salt adding the end of fullname each time this function is called
-    for gecos_field in ['fullname', 'roomnumber', 'workphone', 'homephone']:
+    for gecos_field in ['fullname', 'roomnumber', 'workphone']: #, 'homephone']:
         if isinstance(gecos_field, string_types) and ',' in gecos_field:
             ret['comment'] = "Unsupported char ',' in {0}".format(gecos_field)
             ret['result'] = False

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -410,7 +410,7 @@ def present(name,
 
     # the comma is used to separate field in GECOS, thus resulting into
     # salt adding the end of fullname each time this function is called
-    for gecos_field in ['fullname', 'roomnumber', 'workphone']: #, 'homephone']:
+    for gecos_field in ['fullname', 'roomnumber', 'workphone']:
         if isinstance(gecos_field, string_types) and ',' in gecos_field:
             ret['comment'] = "Unsupported char ',' in {0}".format(gecos_field)
             ret['result'] = False


### PR DESCRIPTION
Issue #39203

### What does this PR do?

Allows for more than 3 commas in GECOS field in /etc/passwd

### What issues does this PR fix or reference?

#39203 

### Previous Behavior

Error adding user account when GECOS has 5 fields

### New Behavior

No error adding user account when GECOS has 5 fields

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
