### PR TITLE
Add version control to SPM repo creation

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1611,6 +1611,7 @@ DEFAULT_SPM_OPTS = {
     'spm_build_exclude': ['CVS', '.hg', '.git', '.svn'],
     'spm_db': os.path.join(salt.syspaths.CACHE_DIR, 'spm', 'packages.db'),
     'cache': 'localfs',
+    'spm_repo_dups': 'ignore',
     # <---- Salt master settings overridden by SPM ----------------------
 }
 

--- a/tests/unit/spm_test.py
+++ b/tests/unit/spm_test.py
@@ -40,6 +40,7 @@ __opts__ = {
     'force': False,
     'verbose': False,
     'cache': 'localfs',
+    'spm_repo_dups': 'ignore',
 }
 
 _F1 = {


### PR DESCRIPTION
### What does this PR do?
When using the `create_repo` command, there was no control over how different versions of the same formula are handled. Now when said command is run, only the latest version of a package will be used.

This also adds a new configuration option for spm, `spm_repo_dups`. The default for this is `ignore`, which will cause spm to ignore old versions of packages. If set to `archive`, a directory called `archive/` will be created in the repo directory and old packages will be moved into it. If set to `delete`, then old versions of packages will be deleted instead.

### What issues does this PR fix or reference?
#39266

### Tests written?
No.