### PR TITLE
file.get_managed: refetch source when file hashsum is changed

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3740,16 +3740,22 @@ def get_managed(
 
     if source and (template or parsed_scheme in salt.utils.files.REMOTE_PROTOS):
         # Check if we have the template or remote file cached
+        cache_refetch = False
         cached_dest = __salt__['cp.is_cached'](source, saltenv)
         if cached_dest and (source_hash or skip_verify):
             htype = source_sum.get('hash_type', 'sha256')
             cached_sum = get_hash(cached_dest, form=htype)
-            if skip_verify or cached_sum == source_sum['hsum']:
+            if cached_sum != source_sum['hsum']:
+                cache_refetch = True
+            elif skip_verify:
+                # prev: if skip_verify or cached_sum == source_sum['hsum']:
+                # but `cached_sum == source_sum['hsum']` is elliptical as prev if
                 sfn = cached_dest
                 source_sum = {'hsum': cached_sum, 'hash_type': htype}
 
         # If we didn't have the template or remote file, let's get it
-        if not sfn:
+        # Similarly when the file has been updated and the cache has to be refreshed
+        if not sfn or cache_refetch:
             try:
                 sfn = __salt__['cp.cache_file'](source, saltenv)
             except Exception as exc:


### PR DESCRIPTION
### What does this PR do?

Fixes a bug when the cached source template under the `file_roots` is not refreshed after the file is changed.
Please someone test this branch & let me know if my changes do make sense. I have tested, but we must be careful to not break other features.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/39422

### Previous Behavior

Cached template under `salt://` did not refresh - see https://github.com/saltstack/salt/issues/39422#issuecomment-280069688

### New Behavior

Does refresh:

```bash
root@ip-172-31-13-136:/etc/salt/templates# cat ntp.jinja
{%- if grains.vendor|lower == 'juniper' -%}
system{
  replace:
  ntp {
    {%- for peer in peers -%}
    peer {{ peer }};
    {%- endfor -%}
  }
}
{%- endif -%}
root@ip-172-31-13-136:/etc/salt/templates# salt device1 file.get_managed name=/tmp/stuff source=salt://ntp.jinja source_hash=None source_hash_name=None user=root group=root mode='755' template=jinja saltenv=base skip_verify=True context=None defaults=None peers="['172.17.17.1']" servers="['1.2.3.4']"
device1:
    - /tmp/__salt.tmp.8dp6oo
    |_
      ----------
      hash_type:
          sha256
      hsum:
          c7c87ea2b758d904377e8e81eb7673d9db72d6e2c37362a1facbd0300a7e6a84
root@ip-172-31-13-136:/etc/salt/templates# cat /tmp/__salt.tmp.8dp6oo
system{
  replace:
  ntp {peer 172.17.17.1;}
}
root@ip-172-31-13-136:/etc/salt/templates# vi ntp.jinja
root@ip-172-31-13-136:/etc/salt/templates# cat ntp.jinja
{%- if grains.vendor|lower == 'juniper' -%}
system{
  ntp {
    {%- for peer in peers -%}
    peer {{ peer }};
    {%- endfor -%}
  }
}
{%- endif -%}
root@ip-172-31-13-136:/etc/salt/templates# salt device1 file.get_managed name=/tmp/stuff source=salt://ntp.jinja source_hash=None source_hash_name=None user=root group=root mode='755' template=jinja saltenv=base skip_verify=True context=None defaults=None peers="['172.17.17.1']" servers="['1.2.3.4']"
device1:
    - /tmp/__salt.tmp.PEzh1d
    |_
      ----------
      hash_type:
          sha256
      hsum:
          f8bd6d17fd383170d0640852397d82731a671b878db36c3b9ca216b8dda53dcc
root@ip-172-31-13-136:/etc/salt/templates# cat /tmp/__salt.tmp.PEzh1d
system{
  ntp {peer 172.17.17.1;}
}
root@ip-172-31-13-136:/etc/salt/templates#
```
