### PR TITLE
Remove global dunder definitions from tests

### DIFF
--- a/tests/unit/statemod_test.py
+++ b/tests/unit/statemod_test.py
@@ -20,12 +20,6 @@ import integration
 from salt.states import saltmod
 
 
-# Globals
-saltmod.__opts__ = dict()
-saltmod.__env__ = dict()
-saltmod.__salt__ = dict()
-
-
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class StatemodTests(TestCase):
     def setUp(self):
@@ -73,6 +67,7 @@ class StatemodTests(TestCase):
             'result': True
         }
         self.assertEqual(ret, expected)
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
These dunders are already being mocked appropriately below in the test, so we
don't need to define them in the test module's namespace.

The global definitions here were conflicting with the globals defined in
`saltmod_test.py`, and causing the following stacktrace in the test suite:

```
Traceback (most recent call last):
  File "/root/SaltStack/salt/tests/unit/saltmod_test.py", line 71, in test_state
    self.assertDictEqual(saltmod.state(name, tgt, highstate=True), test_ret)
  File "/root/SaltStack/salt/salt/states/saltmod.py", line 252, in state
    masterless = __opts__['__role'] == 'minion' and \
KeyError: '__role'
```