### PR TITLE
Use url_path instead of url_data.path

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -477,7 +477,7 @@ class Client(object):
                     'Path \'{0}\' is not absolute'.format(url_path)
                 )
             if dest is None:
-                with salt.utils.fopen(url_data.path, 'r') as fp_:
+                with salt.utils.fopen(url_path, 'r') as fp_:
                     data = fp_.read()
                 return data
             return url_path


### PR DESCRIPTION
### What does this PR do?
Fixes a problem with the following test in Windows:
`integration.modules.cp.CPModuleTest.test_get_url_file_no_dest`

We had to do some dancing around the return from `urlparse(url)` and it looks like we missed this one. There was a problem with how `urlparse()` handles windows file paths (C:\). It saw them as url schemes.

This fixes the above test on Windows. Tested on Linux.

### Tests written?
Yes
