### PR TITLE
Use sls_build for building docker images

### DIFF
--- a/salt/modules/docker.py
+++ b/salt/modules/docker.py
@@ -5981,7 +5981,6 @@ def sls_build(name, base='opensuse/python', mods=None, saltenv='base',
 
     # start a new container
     ret = create(image=base,
-                 name=name,
                  cmd='sleep infinity',
                  interactive=True, tty=True,
                  **create_kwargs)
@@ -5994,13 +5993,12 @@ def sls_build(name, base='opensuse/python', mods=None, saltenv='base',
         # fail if the state was not successful
         if not dryrun and not salt.utils.check_state_result(ret):
             raise CommandExecutionError(ret)
+        if dryrun is False:
+            ret = commit(id_, name)
     finally:
         stop(id_)
-
-    if dryrun:
         rm_(id_)
-        return ret
-    return commit(id_, name)
+    return ret
 
 
 def get_client_args():

--- a/tests/unit/modules/test_docker.py
+++ b/tests/unit/modules/test_docker.py
@@ -641,6 +641,7 @@ class DockerTestCase(TestCase):
         docker_stop_mock = MagicMock(
             return_value={'state': {'old': 'running', 'new': 'stopped'},
                           'result': True})
+        docker_rm_mock = MagicMock(return_value={})
         docker_commit_mock = MagicMock(
             return_value={'Id': 'ID2', 'Image': 'foo', 'Time_Elapsed': 42})
 
@@ -672,16 +673,18 @@ class DockerTestCase(TestCase):
                 with patch.object(docker_mod, 'stop', docker_stop_mock):
                     with patch.object(docker_mod, 'commit', docker_commit_mock):
                         with patch.object(docker_mod, 'sls', docker_sls_mock):
-                            ret = docker_mod.sls_build(
-                                'foo',
-                                mods='foo',
-                            )
+                            with patch.object(docker_mod, 'rm_', docker_rm_mock):
+                                ret = docker_mod.sls_build(
+                                    'foo',
+                                    mods='foo',
+                                )
         docker_create_mock.assert_called_once_with(
             cmd='sleep infinity',
-            image='opensuse/python', interactive=True, name='foo', tty=True)
+            image='opensuse/python', interactive=True, tty=True)
         docker_start_mock.assert_called_once_with('ID')
         docker_sls_mock.assert_called_once_with('ID', 'foo', 'base')
         docker_stop_mock.assert_called_once_with('ID')
+        docker_rm_mock.assert_called_once_with('ID')
         docker_commit_mock.assert_called_once_with('ID', 'foo')
         self.assertEqual(
             {'Id': 'ID2', 'Image': 'foo', 'Time_Elapsed': 42}, ret)
@@ -735,7 +738,7 @@ class DockerTestCase(TestCase):
                             )
         docker_create_mock.assert_called_once_with(
             cmd='sleep infinity',
-            image='opensuse/python', interactive=True, name='foo', tty=True)
+            image='opensuse/python', interactive=True, tty=True)
         docker_start_mock.assert_called_once_with('ID')
         docker_sls_mock.assert_called_once_with('ID', 'foo', 'base')
         docker_stop_mock.assert_called_once_with('ID')


### PR DESCRIPTION
### What does this PR do?
Allows the use of `docker.sls_build` with building images for `docker.image_present`.

Also fix some bad logic with clearing out the created docker containers after a build was finished.  Without the reorganization around the dryrun check, we would leave behind the container that was used to create the image.  The logic is fixed here.  https://github.com/saltstack/salt/pull/39467/commits/5eed60b8867a8d6f9769befc9932dd8cf5406cec?diff=split#diff-8f4981346bb8d093255737c1cd281ef6R5986

### Tests written?

No