### PR TITLE
Update _reformat_low to not run kwarg dicts through parse_input

### DIFF
--- a/salt/runner.py
+++ b/salt/runner.py
@@ -62,36 +62,33 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         '''
         Format the low data for RunnerClient()'s master_call() function
 
-        The master_call function here has a different function signature than
-        on WheelClient. So extract all the eauth keys and the fun key and
-        assume everything else is a kwarg to pass along to the runner function
-        to be called.
+        This also normalizes the following low data formats to a single, common
+        low data structure.
+
+        Old-style low: ``{'fun': 'jobs.lookup_jid', 'jid': '1234'}``
+        New-style: ``{'fun': 'jobs.lookup_jid', 'kwarg': {'jid': '1234'}}``
+        CLI-style: ``{'fun': 'jobs.lookup_jid', 'arg': ['jid="1234"']}``
         '''
-        auth_creds = dict([(i, low.pop(i)) for i in [
-                'username', 'password', 'eauth', 'token', 'client', 'user', 'key'
-            ] if i in low])
         fun = low.pop('fun')
-        reformatted_low = {'fun': fun}
-        reformatted_low.update(auth_creds)
-        # Support old style calls where arguments could be specified in 'low' top level
-        if not low.get('arg') and not low.get('kwarg'):  # not specified or empty
-            verify_fun(self.functions, fun)
-            merged_args_kwargs = salt.utils.args.condition_input([], low)
-            parsed_input = salt.utils.args.parse_input(merged_args_kwargs)
-            args, kwargs = salt.minion.load_args_and_kwargs(
-                self.functions[fun],
-                parsed_input,
-                self.opts,
-                ignore_invalid=True
-            )
-            low['arg'] = args
-            low['kwarg'] = kwargs
-        if 'kwarg' not in low:
-            low['kwarg'] = {}
-        if 'arg' not in low:
-            low['arg'] = []
-        reformatted_low['kwarg'] = low
-        return reformatted_low
+        verify_fun(self.functions, fun)
+
+        reserved_kwargs = dict([(i, low.pop(i)) for i in [
+            'username', 'password', 'eauth', 'token', 'client', 'user', 'key',
+        ] if i in low])
+
+        # Run name=value args through parse_input. We don't need to run kwargs
+        # through because there is no way to send name=value strings in the low
+        # dict other than by including an `arg` array.
+        arg, kwarg = salt.utils.args.parse_input(
+                low.pop('arg', []), condition=False)
+        kwarg.update(low.pop('kwarg', {}))
+
+        # If anything hasn't been pop()'ed out of low by this point it must be
+        # an old-style kwarg.
+        kwarg.update(low)
+
+        return dict(fun=fun, kwarg={'kwarg': kwarg, 'arg': arg},
+                **reserved_kwargs)
 
     def cmd_async(self, low):
         '''

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -61,8 +61,7 @@ def parse_input(args, condition=True):
             # condition_input is called below, but this is the only way to
             # gracefully handle both CLI and API input.
             if arg.pop('__kwarg__', False) is True:
-                for key, val in six.iteritems(arg):
-                    _kwargs[key] = yamlify_arg(val)
+                _kwargs.update(arg)
             else:
                 _args.append(arg)
         else:

--- a/tests/integration/client/runner.py
+++ b/tests/integration/client/runner.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 # Import Salt Testing libs
 import integration
-from salttesting import skipIf
 
 # Import Salt libs
 import salt.runner
@@ -57,7 +56,6 @@ class RunnerModuleTest(integration.TestCase, integration.AdaptedConfigurationTes
             'token': token['token'],
         })
 
-    @skipIf(True, 'to be reenabled when #23623 is merged')
     def test_cmd_sync(self):
         low = {
             'client': 'runner',
@@ -76,7 +74,6 @@ class RunnerModuleTest(integration.TestCase, integration.AdaptedConfigurationTes
 
         self.runner.cmd_async(low)
 
-    @skipIf(True, 'to be reenabled when #23623 is merged')
     def test_cmd_sync_w_arg(self):
         low = {
             'fun': 'test.arg',
@@ -89,7 +86,6 @@ class RunnerModuleTest(integration.TestCase, integration.AdaptedConfigurationTes
         self.assertEqual(ret['kwargs']['foo'], 'Foo!')
         self.assertEqual(ret['kwargs']['bar'], 'Bar!')
 
-    @skipIf(True, 'to be reenabled when #23623 is merged')
     def test_wildcard_auth(self):
         low = {
             'username': 'the_s0und_of_t3ch',

--- a/tests/integration/client/runner.py
+++ b/tests/integration/client/runner.py
@@ -97,6 +97,35 @@ class RunnerModuleTest(integration.TestCase, integration.AdaptedConfigurationTes
         }
         self.runner.cmd_sync(low)
 
+    def test_cmd_sync_arg_kwarg_parsing(self):
+        low = {
+            'client': 'runner',
+            'fun': 'test.arg',
+            'arg': [
+                'foo',
+                'bar=off',
+                'baz={qux: 123}'
+            ],
+            'kwarg': {
+                'quux': 'Quux',
+            },
+            'quuz': 'on',
+        }
+        low.update(self.eauth_creds)
+
+        ret = self.runner.cmd_sync(low)
+        self.assertEqual(ret, {
+            'args': ['foo'],
+            'kwargs': {
+                'bar': False,
+                'baz': {
+                    'qux': 123,
+                },
+                'quux': 'Quux',
+                'quuz': 'on',
+            },
+        })
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?

Keyword args were incorrectly getting run through `parse_input`. E.g., `{'fun': 'jobs.list_jobs', 'jid': '1234'}` would run the `jid` kwarg through that function and then YAML would try to parse the argument as a number.

load_args_and_kwargs() call already calls parse_input() which already
calls condition_input() so I think we can do with just the one call.

This also removes a duplicate `{..., 'kwarg': {'kwarg': {...}}}` in the output.

### What issues does this PR fix or reference?

#38962

### New Behavior

I'm 43% sure this doesn't regress anything...

### Tests written?

No

@DmitryKuzmenko you've done some work here, do you mind giving this a look?