### PR TITLE
fix OrderedDict being passed into _get_size_spec

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -656,10 +656,9 @@ def _manage_devices(devices, vm=None, container_ref=None, new_vm_name=None):
                     if device.deviceInfo.label in list(devices['disk'].keys()):
                         disk_spec = None
                         if 'size' in devices['disk'][device.deviceInfo.label]:
-                            disk_spec = _get_size_spec(device, devices)
-                            size_kb = float(
-                                devices['disk'][device.deviceInfo.label]['size']
-                            ) * 1024 * 1024
+                            size_gb = float(devices['disk'][disk_label]['size'])
+                            disk_spec = _get_size_spec(device, size_gb)
+                            size_kb = size_gb * 1024 * 1024
                         else:
                             # User didn't specify disk size
                             # in the cloud profile


### PR DESCRIPTION
### What does this PR do?

Fixes an issue when customizing a hard disk in vmware with a specific `size`

### What issues does this PR fix or reference?

No references

### Previous Behavior

`devices` was being passed into `_get_size_spec`

### New Behavior

The size in GB is passed into `_get_size_spec` as a float, which is then multiplied and converted to an int inside the function

### Tests written?

no

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
