### PR TITLE
Change error to warning for DBUS

### DIFF
--- a/salt/modules/snapper.py
+++ b/salt/modules/snapper.py
@@ -64,7 +64,7 @@ if HAS_DBUS:
     try:
         bus = dbus.SystemBus()
     except dbus.DBusException as exc:
-        log.error(exc)
+        log.warning(exc)
         system_bus_error = exc
     else:
         if SNAPPER_DBUS_OBJECT in bus.list_activatable_names():
@@ -73,7 +73,7 @@ if HAS_DBUS:
                                                         SNAPPER_DBUS_PATH),
                                          dbus_interface=SNAPPER_DBUS_INTERFACE)
             except (dbus.DBusException, ValueError) as exc:
-                log.error(exc)
+                log.warning(exc)
                 snapper_error = exc
         else:
             snapper_error = 'snapper is missing'


### PR DESCRIPTION
When DBUS is not running it's not necessary to mark is as error since You can easily run salt without it. Logging it as error makes only unnecessary log mess.

### What does this PR do?
Changes error to warning if DBUS is stopped

### What issues does this PR fix or reference?
Fixes #39479

### Previous Behavior
When DBUS is not started by running any salt state You got error message in logs.

### New Behavior
When DBUS is not started by running any salt state You got warning message in logs.


### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
