### PR TITLE
dockerng: compare sets instead of lists of security_opt

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -450,6 +450,21 @@ def _compare(actual, create_kwargs, defaults_from_image):
             if data != actual_data:
                 ret.update({item: {'old': actual_data, 'new': data}})
                 continue
+        elif item == 'security_opt':
+            if actual_data is None:
+                actual_data = []
+            if data is None:
+                data = []
+            actual_data = sorted(set(actual_data))
+            desired_data = sorted(set(data))
+            log.trace('dockerng.running ({0}): munged actual value: {1}'
+                      .format(item, actual_data))
+            log.trace('dockerng.running ({0}): munged desired value: {1}'
+                      .format(item, desired_data))
+            if actual_data != desired_data:
+                ret.update({item: {'old': actual_data,
+                                   'new': desired_data}})
+            continue
         elif item in ('cmd', 'command', 'entrypoint'):
             if (actual_data is None and item not in create_kwargs and
                     _image_get(config['image_path'])):


### PR DESCRIPTION
### What does this PR do?
Apparently some versions of docker add label=disabled to security_opt when the container is launched as privileged. This causes Salt to relaunch the container to remove it on next run.
Container started as privileged and with the security_opt set, causes it to have the option set twice and makes salt want to remove one instance. With this fix, dockerng will compare just (non-)existence of the flag. So containers started with privileged flag and security_opt set to label=disabled will not get relaunched on every salt run.


### What issues does this PR fix or reference?
Fixes #39447

### Previous Behavior
security_opt lists were compared as sorted lists. Having one option multiple times being seen as a difference

### New Behavior
security_opt lists are compared as sorted sets, effectively just comparing (non-)existence of the flag regardless of count.

### Tests written?
No

- [X] Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
