### PR TITLE
The Reactor docs should use pillar='{}' instead of 'pillar={}'

### DIFF
--- a/doc/topics/reactor/index.rst
+++ b/doc/topics/reactor/index.rst
@@ -480,7 +480,7 @@ The above command is equivalent to the following command at the CLI:
 
 .. code-block:: bash
 
-    salt 'haproxy*' state.apply haproxy.refresh_pool 'pillar={new_minion: minionid}'
+    salt 'haproxy*' state.apply haproxy.refresh_pool pillar='{new_minion: minionid}'
 
 This works with Orchestrate files as well:
 


### PR DESCRIPTION
### What does this PR do?

Fixes incorrect documentation. 

### What issues does this PR fix or reference?

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
