### PR TITLE
Add full_return arg to LocalClient and RunnerClient

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -576,6 +576,7 @@ class LocalClient(object):
             tgt_type='glob',
             ret='',
             jid='',
+            full_return=False,
             kwarg=None,
             **kwargs):
         '''
@@ -664,6 +665,9 @@ class LocalClient(object):
 
         :param kwarg: A dictionary with keyword arguments for the function.
 
+        :param full_return: Output the job return only (default) or the full
+            return including exit code and other job metadata.
+
         :param kwargs: Optional keyword arguments.
             Authentication credentials may be passed when using
             :conf_master:`external_auth`.
@@ -714,7 +718,8 @@ class LocalClient(object):
 
                 if fn_ret:
                     for mid, data in six.iteritems(fn_ret):
-                        ret[mid] = data.get('ret', {})
+                        ret[mid] = (data if full_return
+                                else data.get('ret', {}))
 
             for failed in list(set(pub_data['minions']) ^ set(ret.keys())):
                 ret[failed] = False

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -138,7 +138,7 @@ class SyncClientMixin(object):
                 salt.utils.error.raise_error(**ret['error'])
         return ret
 
-    def cmd_sync(self, low, timeout=None):
+    def cmd_sync(self, low, timeout=None, full_return=False):
         '''
         Execute a runner function synchronously; eauth is respected
 
@@ -166,7 +166,7 @@ class SyncClientMixin(object):
                 "RunnerClient job '{0}' timed out".format(job['jid']),
                 jid=job['jid'])
 
-        return ret['data']['return']
+        return ret if full_return else ret['data']['return']
 
     def cmd(self, fun, arg=None, pub_data=None, kwarg=None, print_event=True, full_return=False):
         '''

--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -125,7 +125,7 @@ class NetapiClient(object):
                                                       disable_custom_roster=True)
         return ssh_client.cmd_sync(kwargs)
 
-    def runner(self, fun, timeout=None, **kwargs):
+    def runner(self, fun, timeout=None, full_return=False, **kwargs):
         '''
         Run `runner modules <all-salt.runners>` synchronously
 
@@ -138,7 +138,7 @@ class NetapiClient(object):
         '''
         kwargs['fun'] = fun
         runner = salt.runner.RunnerClient(self.opts)
-        return runner.cmd_sync(kwargs, timeout=timeout)
+        return runner.cmd_sync(kwargs, timeout=timeout, full_return=full_return)
 
     def runner_async(self, fun, **kwargs):
         '''

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -113,7 +113,7 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
 
         return mixins.AsyncClientMixin.cmd_async(self, reformatted_low)
 
-    def cmd_sync(self, low, timeout=None):
+    def cmd_sync(self, low, timeout=None, full_return=False):
         '''
         Execute a runner function synchronously; eauth is respected
 
@@ -130,7 +130,7 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
             })
         '''
         reformatted_low = self._reformat_low(low)
-        return mixins.SyncClientMixin.cmd_sync(self, reformatted_low, timeout)
+        return mixins.SyncClientMixin.cmd_sync(self, reformatted_low, timeout, full_return)
 
     def cmd(self, fun, arg=None, pub_data=None, kwarg=None, print_event=True, full_return=False):
         '''

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -75,7 +75,7 @@ class WheelClient(salt.client.mixins.SyncClientMixin,
                 salt.utils.error.raise_error(**ret['error'])
         return ret
 
-    def cmd_sync(self, low, timeout=None):
+    def cmd_sync(self, low, timeout=None, full_return=False):
         '''
         Execute a wheel function synchronously; eauth is respected
 

--- a/tests/integration/client/test_kwarg.py
+++ b/tests/integration/client/test_kwarg.py
@@ -89,3 +89,8 @@ class StdTest(integration.ModuleCase):
         self.assertIn('int', data['args'][1])
         self.assertIn('dict', data['kwargs']['outer'])
         self.assertIn('str', data['kwargs']['inner'])
+
+    def test_full_return_kwarg(self):
+        ret = self.client.cmd('minion', 'test.ping', full_return=True)
+        for mid, data in ret.items():
+            self.assertIn('retcode', data)

--- a/tests/integration/client/test_runner.py
+++ b/tests/integration/client/test_runner.py
@@ -100,3 +100,9 @@ class RunnerModuleTest(integration.TestCase, integration.AdaptedConfigurationTes
             'bar': 'Bar!',
         }
         self.runner.cmd_sync(low)
+
+    def test_full_return_kwarg(self):
+        low = {'fun': 'test.arg'}
+        low.update(self.eauth_creds)
+        ret = self.runner.cmd_sync(low, full_return=True)
+        self.assertIn('success', ret['data'])


### PR DESCRIPTION
### What does this PR do?

Add (or expose) `full_return` argument to LocalClient and RunnerClient so the exit code can be visible from salt-api or Salt's Python API if the user opts-in.

### What issues does this PR fix or reference?

#39452

### New Behavior

No changes to existing interfaces. If the new kwarg is given the the return structure is different.

### Tests written?

Yes