### PR TITLE
Allow states to declare _connection_ keys as documented

### DIFF
--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -256,7 +256,7 @@ def present(host, groups, interfaces, **kwargs):
     return ret
 
 
-def absent(name):
+def absent(name, **kwargs):
     """
     Ensures that the host does not exists, eventually deletes host.
 

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -62,6 +62,14 @@ def present(host, groups, interfaces, **kwargs):
 
 
     '''
+    connection_args = {}
+    if '_connection_user' in kwargs:
+        connection_args['_connection_user'] = kwargs['_connection_user']
+    if '_connection_password' in kwargs:
+        connection_args['_connection_password'] = kwargs['_connection_password']
+    if '_connection_url' in kwargs:
+        connection_args['_connection_url'] = kwargs['_connection_url']
+
     ret = {'name': host, 'changes': {}, 'result': False, 'comment': ''}
 
     # Comment and change messages
@@ -130,7 +138,7 @@ def present(host, groups, interfaces, **kwargs):
     groupids = []
     for group in groups:
         if isinstance(group, six.string_types):
-            groupid = __salt__['zabbix.hostgroup_get'](name=group)
+            groupid = __salt__['zabbix.hostgroup_get'](name=group, **connection_args)
             try:
                 groupids.append(int(groupid[0]['groupid']))
             except TypeError:
@@ -140,16 +148,16 @@ def present(host, groups, interfaces, **kwargs):
             groupids.append(group)
     groups = groupids
 
-    host_exists = __salt__['zabbix.host_exists'](host)
+    host_exists = __salt__['zabbix.host_exists'](host, **connection_args)
 
     if host_exists:
-        host = __salt__['zabbix.host_get'](name=host)[0]
+        host = __salt__['zabbix.host_get'](name=host, **connection_args)[0]
         hostid = host['hostid']
 
         update_hostgroups = False
         update_interfaces = False
 
-        hostgroups = __salt__['zabbix.hostgroup_get'](hostids=hostid)
+        hostgroups = __salt__['zabbix.hostgroup_get'](hostids=hostid, **connection_args)
         cur_hostgroups = list()
 
         for hostgroup in hostgroups:
@@ -158,7 +166,7 @@ def present(host, groups, interfaces, **kwargs):
         if set(groups) != set(cur_hostgroups):
             update_hostgroups = True
 
-        hostinterfaces = __salt__['zabbix.hostinterface_get'](hostids=hostid)
+        hostinterfaces = __salt__['zabbix.hostinterface_get'](hostids=hostid, **connection_args)
 
         if hostinterfaces:
             hostinterfaces = sorted(hostinterfaces, key=lambda k: k['main'])
@@ -197,16 +205,16 @@ def present(host, groups, interfaces, **kwargs):
         if update_hostgroups or update_interfaces:
 
             if update_hostgroups:
-                hostupdate = __salt__['zabbix.host_update'](hostid, groups=groups)
+                hostupdate = __salt__['zabbix.host_update'](hostid, groups=groups, **connection_args)
                 ret['changes']['groups'] = str(groups)
                 if 'error' in hostupdate:
                     error.append(hostupdate['error'])
             if update_interfaces:
                 if hostinterfaces:
                     for interface in hostinterfaces:
-                        __salt__['zabbix.hostinterface_delete'](interfaceids=interface['interfaceid'])
+                        __salt__['zabbix.hostinterface_delete'](interfaceids=interface['interfaceid'], **connection_args)
 
-                hostid = __salt__['zabbix.host_get'](name=host)[0]['hostid']
+                hostid = __salt__['zabbix.host_get'](name=host, **connection_args)[0]['hostid']
 
                 for interface in interfaces_formated:
                     updatedint = __salt__['zabbix.hostinterface_create'](hostid=hostid,
@@ -215,7 +223,8 @@ def present(host, groups, interfaces, **kwargs):
                                                                          main=interface['main'],
                                                                          type=interface['type'],
                                                                          useip=interface['useip'],
-                                                                         port=interface['port'])
+                                                                         port=interface['port'],
+                                                                         **connection_args)
 
                     if 'error' in updatedint:
                         error.append(updatedint['error'])
@@ -227,7 +236,7 @@ def present(host, groups, interfaces, **kwargs):
         else:
             ret['comment'] = comment_host_exists
     else:
-        host_create = __salt__['zabbix.host_create'](host, groups, interfaces_formated, **kwargs)
+        host_create = __salt__['zabbix.host_create'](host, groups, interfaces_formated, **connection_args)
 
         if 'error' not in host_create:
             ret['result'] = True
@@ -273,8 +282,15 @@ def absent(name):
                                    'new': 'Host {0} deleted.'.format(name),
                                    }
                             }
+    connection_args = {}
+    if '_connection_user' in kwargs:
+        connection_args['_connection_user'] = kwargs['_connection_user']
+    if '_connection_password' in kwargs:
+        connection_args['_connection_password'] = kwargs['_connection_password']
+    if '_connection_url' in kwargs:
+        connection_args['_connection_url'] = kwargs['_connection_url']
 
-    host_exists = __salt__['zabbix.host_exists'](name)
+    host_exists = __salt__['zabbix.host_exists'](name, **connection_args)
 
     # Dry run, test=true mode
     if __opts__['test']:
@@ -286,7 +302,7 @@ def absent(name):
             ret['comment'] = comment_host_deleted
         return ret
 
-    host_get = __salt__['zabbix.host_get'](name)
+    host_get = __salt__['zabbix.host_get'](name, **connection_args)
 
     if not host_get:
         ret['result'] = True
@@ -294,7 +310,7 @@ def absent(name):
     else:
         try:
             hostid = host_get[0]['hostid']
-            host_delete = __salt__['zabbix.host_delete'](hostid)
+            host_delete = __salt__['zabbix.host_delete'](hostid, **connection_args)
         except KeyError:
             host_delete = False
 
@@ -325,11 +341,19 @@ def assign_templates(host, templates, **kwargs):
         add_zabbix_templates_to_host:
             zabbix_host.assign_templates:
                 - host: TestHost
-                    - templates:
-                        - "Template OS Linux"
-                        - "Template App MySQL"
+                - templates:
+                    - "Template OS Linux"
+                    - "Template App MySQL"
 
     '''
+    connection_args = {}
+    if '_connection_user' in kwargs:
+        connection_args['_connection_user'] = kwargs['_connection_user']
+    if '_connection_password' in kwargs:
+        connection_args['_connection_password'] = kwargs['_connection_password']
+    if '_connection_url' in kwargs:
+        connection_args['_connection_url'] = kwargs['_connection_url']
+
     ret = {'name': host, 'changes': {}, 'result': False, 'comment': ''}
 
     # Set comments
@@ -342,7 +366,7 @@ def assign_templates(host, templates, **kwargs):
     requested_template_ids = list()
     hostid = ''
 
-    host_exists = __salt__['zabbix.host_exists'](host)
+    host_exists = __salt__['zabbix.host_exists'](host, **connection_args)
 
     # Fail out if host does not exist
     if not host_exists:
@@ -350,7 +374,7 @@ def assign_templates(host, templates, **kwargs):
         ret['comment'] = comment_host_templates_notupdated
         return ret
 
-    host_info = __salt__['zabbix.host_get'](name=host)[0]
+    host_info = __salt__['zabbix.host_get'](name=host, **connection_args)[0]
     hostid = host_info['hostid']
 
     if not templates:
@@ -358,14 +382,16 @@ def assign_templates(host, templates, **kwargs):
 
     # Get current templateids for host
     host_templates = __salt__['zabbix.host_get'](hostids=hostid,
-                                                 output='[{"hostid"}]', selectParentTemplates='["templateid"]')
+                                                 output='[{"hostid"}]',
+                                                 selectParentTemplates='["templateid"]',
+                                                 **connection_args)
     for template_id in host_templates[0]['parentTemplates']:
         curr_template_ids.append(template_id['templateid'])
 
     # Get requested templateids
     for template in templates:
         try:
-            template_id = __salt__['zabbix.template_get'](host=template)[0]['templateid']
+            template_id = __salt__['zabbix.template_get'](host=template, **connection_args)[0]['templateid']
             requested_template_ids.append(template_id)
         except TypeError:
             ret['result'] = False
@@ -395,8 +421,9 @@ def assign_templates(host, templates, **kwargs):
     # Attempt to perform update
     ret['result'] = True
     if update_host_templates:
-        update_output = __salt__['zabbix.host_update'](hostid, templates=(requested_template_ids))
+        update_output = __salt__['zabbix.host_update'](hostid, templates=(requested_template_ids), **connection_args)
         if update_output is False:
+            print("Failing out: update_output fale")
             ret['result'] = False
             ret['comment'] = comment_host_templates_notupdated
             return ret

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -212,7 +212,8 @@ def present(host, groups, interfaces, **kwargs):
             if update_interfaces:
                 if hostinterfaces:
                     for interface in hostinterfaces:
-                        __salt__['zabbix.hostinterface_delete'](interfaceids=interface['interfaceid'], **connection_args)
+                        __salt__['zabbix.hostinterface_delete'](interfaceids=interface['interfaceid'],
+                                                                **connection_args)
 
                 hostid = __salt__['zabbix.host_get'](name=host, **connection_args)[0]['hostid']
 
@@ -423,7 +424,6 @@ def assign_templates(host, templates, **kwargs):
     if update_host_templates:
         update_output = __salt__['zabbix.host_update'](hostid, templates=(requested_template_ids), **connection_args)
         if update_output is False:
-            print("Failing out: update_output fale")
             ret['result'] = False
             ret['comment'] = comment_host_templates_notupdated
             return ret

--- a/salt/states/zabbix_hostgroup.py
+++ b/salt/states/zabbix_hostgroup.py
@@ -15,7 +15,7 @@ def __virtual__():
     return 'zabbix.hostgroup_create' in __salt__
 
 
-def present(name):
+def present(name, **kwargs):
     '''
     Ensures that the host group exists, eventually creates new host group.
 
@@ -34,6 +34,13 @@ def present(name):
 
 
     '''
+    connection_args = {}
+    if '_connection_user' in kwargs:
+        connection_args['_connection_user'] = kwargs['_connection_user']
+    if '_connection_password' in kwargs:
+        connection_args['_connection_password'] = kwargs['_connection_password']
+    if '_connection_url' in kwargs:
+        connection_args['_connection_url'] = kwargs['_connection_url']
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
     # Comment and change messages
@@ -45,7 +52,7 @@ def present(name):
                                         }
                                  }
 
-    hostgroup_exists = __salt__['zabbix.hostgroup_exists'](name)
+    hostgroup_exists = __salt__['zabbix.hostgroup_exists'](name, **connection_args)
 
     # Dry run, test=true mode
     if __opts__['test']:
@@ -62,7 +69,7 @@ def present(name):
         ret['result'] = True
         ret['comment'] = comment_hostgroup_exists
     else:
-        hostgroup_create = __salt__['zabbix.hostgroup_create'](name)
+        hostgroup_create = __salt__['zabbix.hostgroup_create'](name, **connection_args)
 
         if 'error' not in hostgroup_create:
             ret['result'] = True
@@ -75,7 +82,7 @@ def present(name):
     return ret
 
 
-def absent(name):
+def absent(name, **kwargs):
     '''
     Ensures that the host group does not exist, eventually delete host group.
 
@@ -105,7 +112,15 @@ def absent(name):
                                         }
                                  }
 
-    hostgroup_exists = __salt__['zabbix.hostgroup_exists'](name)
+    connection_args = {}
+    if '_connection_user' in kwargs:
+        connection_args['_connection_user'] = kwargs['_connection_user']
+    if '_connection_password' in kwargs:
+        connection_args['_connection_password'] = kwargs['_connection_password']
+    if '_connection_url' in kwargs:
+        connection_args['_connection_url'] = kwargs['_connection_url']
+
+    hostgroup_exists = __salt__['zabbix.hostgroup_exists'](name, **connection_args)
 
     # Dry run, test=true mode
     if __opts__['test']:
@@ -118,7 +133,7 @@ def absent(name):
             ret['changes'] = changes_hostgroup_deleted
         return ret
 
-    hostgroup_get = __salt__['zabbix.hostgroup_get'](name)
+    hostgroup_get = __salt__['zabbix.hostgroup_get'](name, **connection_args)
 
     if not hostgroup_get:
         ret['result'] = True
@@ -126,7 +141,7 @@ def absent(name):
     else:
         try:
             groupid = hostgroup_get[0]['groupid']
-            hostgroup_delete = __salt__['zabbix.hostgroup_delete'](groupid)
+            hostgroup_delete = __salt__['zabbix.hostgroup_delete'](groupid, **connection_args)
         except KeyError:
             hostgroup_delete = False
 

--- a/salt/states/zabbix_usergroup.py
+++ b/salt/states/zabbix_usergroup.py
@@ -101,21 +101,27 @@ def present(name, **kwargs):
             ret['comment'] = comment_usergroup_updated
 
             if update_debug_mode:
-                updated_debug = __salt__['zabbix.usergroup_update'](usrgrpid, debug_mode=kwargs['debug_mode'], **connection_args)
+                updated_debug = __salt__['zabbix.usergroup_update'](usrgrpid,
+                                                                    debug_mode=kwargs['debug_mode'],
+                                                                    **connection_args)
                 if 'error' in updated_debug:
                     error.append(updated_debug['error'])
                 else:
                     ret['changes']['debug_mode'] = kwargs['debug_mode']
 
             if update_gui_access:
-                updated_gui = __salt__['zabbix.usergroup_update'](usrgrpid, gui_access=kwargs['gui_access'], **connection_args)
+                updated_gui = __salt__['zabbix.usergroup_update'](usrgrpid,
+                                                                  gui_access=kwargs['gui_access'],
+                                                                  **connection_args)
                 if 'error' in updated_gui:
                     error.append(updated_gui['error'])
                 else:
                     ret['changes']['gui_access'] = kwargs['gui_access']
 
             if update_users_status:
-                updated_status = __salt__['zabbix.usergroup_update'](usrgrpid, users_status=kwargs['users_status'], **connection_args)
+                updated_status = __salt__['zabbix.usergroup_update'](usrgrpid,
+                                                                     users_status=kwargs['users_status'],
+                                                                     **connection_args)
                 if 'error' in updated_status:
                     error.append(updated_status['error'])
                 else:

--- a/salt/states/zabbix_usergroup.py
+++ b/salt/states/zabbix_usergroup.py
@@ -38,6 +38,14 @@ def present(name, **kwargs):
                 - users_status: 0
 
     '''
+    connection_args = {}
+    if '_connection_user' in kwargs:
+        connection_args['_connection_user'] = kwargs['_connection_user']
+    if '_connection_password' in kwargs:
+        connection_args['_connection_password'] = kwargs['_connection_password']
+    if '_connection_url' in kwargs:
+        connection_args['_connection_url'] = kwargs['_connection_url']
+
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
     # Comment and change messages
@@ -50,10 +58,10 @@ def present(name, **kwargs):
                                         }
                                  }
 
-    usergroup_exists = __salt__['zabbix.usergroup_exists'](name)
+    usergroup_exists = __salt__['zabbix.usergroup_exists'](name, **connection_args)
 
     if usergroup_exists:
-        usergroup = __salt__['zabbix.usergroup_get'](name)[0]
+        usergroup = __salt__['zabbix.usergroup_get'](name, **connection_args)[0]
         usrgrpid = int(usergroup['usrgrpid'])
         update_debug_mode = False
         update_gui_access = False
@@ -93,21 +101,21 @@ def present(name, **kwargs):
             ret['comment'] = comment_usergroup_updated
 
             if update_debug_mode:
-                updated_debug = __salt__['zabbix.usergroup_update'](usrgrpid, debug_mode=kwargs['debug_mode'])
+                updated_debug = __salt__['zabbix.usergroup_update'](usrgrpid, debug_mode=kwargs['debug_mode'], **connection_args)
                 if 'error' in updated_debug:
                     error.append(updated_debug['error'])
                 else:
                     ret['changes']['debug_mode'] = kwargs['debug_mode']
 
             if update_gui_access:
-                updated_gui = __salt__['zabbix.usergroup_update'](usrgrpid, gui_access=kwargs['gui_access'])
+                updated_gui = __salt__['zabbix.usergroup_update'](usrgrpid, gui_access=kwargs['gui_access'], **connection_args)
                 if 'error' in updated_gui:
                     error.append(updated_gui['error'])
                 else:
                     ret['changes']['gui_access'] = kwargs['gui_access']
 
             if update_users_status:
-                updated_status = __salt__['zabbix.usergroup_update'](usrgrpid, users_status=kwargs['users_status'])
+                updated_status = __salt__['zabbix.usergroup_update'](usrgrpid, users_status=kwargs['users_status'], **connection_args)
                 if 'error' in updated_status:
                     error.append(updated_status['error'])
                 else:
@@ -136,7 +144,7 @@ def present(name, **kwargs):
     return ret
 
 
-def absent(name):
+def absent(name, **kwargs):
     '''
     Ensures that the user group does not exist, eventually delete user group.
 
@@ -152,8 +160,15 @@ def absent(name):
         delete_thai_monks_usrgrp:
             zabbix_usergroup.absent:
                 - name: 'Thai monks'
-
     '''
+    connection_args = {}
+    if '_connection_user' in kwargs:
+        connection_args['_connection_user'] = kwargs['_connection_user']
+    if '_connection_password' in kwargs:
+        connection_args['_connection_password'] = kwargs['_connection_password']
+    if '_connection_url' in kwargs:
+        connection_args['_connection_url'] = kwargs['_connection_url']
+
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
     # Comment and change messages
@@ -165,7 +180,7 @@ def absent(name):
                                         }
                                  }
 
-    usergroup_exists = __salt__['zabbix.usergroup_exists'](name)
+    usergroup_exists = __salt__['zabbix.usergroup_exists'](name, **connection_args)
 
     # Dry run, test=true mode
     if __opts__['test']:
@@ -177,7 +192,7 @@ def absent(name):
             ret['comment'] = comment_usergroup_deleted
         return ret
 
-    usergroup_get = __salt__['zabbix.usergroup_get'](name)
+    usergroup_get = __salt__['zabbix.usergroup_get'](name, **connection_args)
 
     if not usergroup_get:
         ret['result'] = True
@@ -185,7 +200,7 @@ def absent(name):
     else:
         try:
             usrgrpid = usergroup_get[0]['usrgrpid']
-            usergroup_delete = __salt__['zabbix.usergroup_delete'](usrgrpid)
+            usergroup_delete = __salt__['zabbix.usergroup_delete'](usrgrpid, **connection_args)
         except KeyError:
             usergroup_delete = False
 


### PR DESCRIPTION
### What does this PR do?
The state documentation refers to allowing _connection_user, password, and url keys but does not actually use them. This commit corrects that. 

### Previous Behavior
Connection information was only passed via salt pillar. 

### New Behavior
Connection information is now defined by the state if available. Otherwise, it falls back on the standard pillar.

### Tests written?
No

@jirikotlin
@mmoono - This may possibly conflict with some of your recent updates as well. If you'd like to re-push your changes we can see how to resolve.