### PR TITLE
Use xz -t instead of xz -l to test if archive is packed with xz

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -186,7 +186,7 @@ def list_(name,
                         raise CommandExecutionError('Invalid CLI options')
                 else:
                     if salt.utils.which('xz') \
-                            and __salt__['cmd.retcode'](['xz', '-l', cached],
+                            and __salt__['cmd.retcode'](['xz', '-t', cached],
                                                         python_shell=False,
                                                         ignore_retcode=True) == 0:
                         decompress_cmd = 'xz --decompress --stdout'

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -1193,7 +1193,7 @@ def extracted(name,
                     except tarfile.ReadError:
                         if salt.utils.which('xz'):
                             if __salt__['cmd.retcode'](
-                                    ['xz', '-l', cached_source],
+                                    ['xz', '-t', cached_source],
                                     python_shell=False,
                                     ignore_retcode=True) == 0:
                                 # XZ-compressed data


### PR DESCRIPTION
lzma v4, which comes with CentOS 6, does not support -l

### What does this PR do?
Allows working with xz archives on CentOS 6

### What issues does this PR fix or reference?
None

### Previous Behavior
Operations with xz archives fail with "cannot list" error

### New Behavior
Operations with xz archives work

### Tests written?
No