### PR TITLE
 Slack Engine Access Groups

### DIFF
--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -105,8 +105,8 @@ def _get_users(token):
 
 def start(token,
           aliases=None,
-          valid_users=[],
-          valid_commands=[],
+          valid_users=None,
+          valid_commands=None,
           control=False,
           trigger="!",
           groups=None,
@@ -114,6 +114,13 @@ def start(token,
     '''
     Listen to Slack events and forward them to Salt
     '''
+
+    if valid_users is None:
+        valid_users = []
+
+    if valid_commands is None:
+        valid_commands = []
+
     if __opts__.get('__role') == 'master':
         fire_master = salt.utils.event.get_master_event(
             __opts__,


### PR DESCRIPTION
Finally getting around to adding a PR for something I started working on at the last Salt conference.  

### What does this PR do?
Adding in the ability to include access groups for the Slack engine, then specify what commands those groups have access to run.

### What issues does this PR fix or reference?
#35267

### Previous Behavior
All Slack users had access to all defined Salt commands.

### New Behavior
Command access can be broken up into groups.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
