### PR TITLE
Improve error handling for Grains virtual hardware identification

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -685,14 +685,14 @@ def _virtual(osdata):
                 grains['virtual'] = 'kvm'
             elif 'joyent smartdc hvm' in model:
                 grains['virtual'] = 'kvm'
+            break
     else:
-        if osdata['kernel'] in skip_cmds:
+        if osdata['kernel'] not in skip_cmds:
             log.warning(
-                "The tools 'dmidecode' and 'lspci' failed to "
-                'execute because they do not exist on the system of the user '
-                'running this instance or the user does not have the '
-                'necessary permissions to execute them. Grains output might '
-                'not be accurate.'
+                'All tools for virtual hardware identification failed to '
+                'execute because they do not exist on the system running this '
+                'instance or the user does not have the necessary permissions '
+                'to execute them. Grains output might not be accurate.'
             )
 
     choices = ('Linux', 'OpenBSD', 'HP-UX')

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -851,7 +851,7 @@ def _virtual(osdata):
                     grains['virtual_subtype'] = 'Xen Dom0'
 
     for command in failed_commands:
-        log.warning(
+        log.info(
             "Although '{0}' was found in path, the current user "
             'cannot execute it. Grains output might not be '
             'accurate.'.format(command)


### PR DESCRIPTION
### What does this PR do?
This should mitigate the "Although 'dmidecode' was found in path, the current user cannot execute it" warning, which is a frequent annoyance when running Salt as non-root user (#2494, [Thread](https://groups.google.com/d/topic/salt-users/aM11D1mIV4c/discussion), #5249, #39184). It also fixes some other flaws in the function's error handling which appear to have creeped in over time.

### Previous Behavior
Message gets logged with level "warning".

### New Behavior
Message gets logged with level "info".

Changing the loglevel is more of an ugly hack, but loglevels aren't consistent within the module anyway and fixing the error detection would probably require major refactoring of the whole function.

Speaking of that, the logic and error handling are a bit of a mess anyway, so the function might actually be a good candidate for refactoring. For example, the general error message is logged before and the error messages for individual commands and further identification logic.

### Tests written?
No.