### PR TITLE
Openscap

### DIFF
--- a/salt/modules/openscap.py
+++ b/salt/modules/openscap.py
@@ -93,7 +93,7 @@ def xccdf(params):
         tempdir = tempfile.mkdtemp()
         proc = Popen(
             shlex.split(cmd), stdout=PIPE, stderr=PIPE, cwd=tempdir)
-        (stdoutdata, stderrdata) = proc.communicate()
+        (stdoutdata, error) = proc.communicate()
         success = _OSCAP_EXIT_CODES_MAP[proc.returncode]
         returncode = proc.returncode
         if success:
@@ -101,8 +101,6 @@ def xccdf(params):
             caller.cmd('cp.push_dir', tempdir)
             shutil.rmtree(tempdir, ignore_errors=True)
             upload_dir = tempdir
-        else:
-            error = stderrdata
 
     return dict(
         success=success,

--- a/salt/modules/openscap.py
+++ b/salt/modules/openscap.py
@@ -78,6 +78,7 @@ def xccdf(params):
     error = None
     upload_dir = None
     action = None
+    returncode = None
 
     try:
         parser = _ArgumentParser()
@@ -94,6 +95,7 @@ def xccdf(params):
             shlex.split(cmd), stdout=PIPE, stderr=PIPE, cwd=tempdir)
         (stdoutdata, stderrdata) = proc.communicate()
         success = _OSCAP_EXIT_CODES_MAP[proc.returncode]
+        returncode = proc.returncode
         if success:
             caller = Caller()
             caller.cmd('cp.push_dir', tempdir)
@@ -102,4 +104,8 @@ def xccdf(params):
         else:
             error = stderrdata
 
-    return dict(success=success, upload_dir=upload_dir, error=error)
+    return dict(
+        success=success,
+        upload_dir=upload_dir,
+        error=error,
+        returncode=returncode)

--- a/tests/unit/modules/openscap_test.py
+++ b/tests/unit/modules/openscap_test.py
@@ -72,7 +72,8 @@ class OpenscapTestCase(TestCase):
             response,
             {
                 'upload_dir': self.random_temp_dir,
-                'error': None, 'success': True
+                'error': None, 'success': True,
+                'returncode': 0
             }
         )
 
@@ -112,7 +113,8 @@ class OpenscapTestCase(TestCase):
             {
                 'upload_dir': self.random_temp_dir,
                 'error': None,
-                'success': True
+                'success': True,
+                'returncode': 2
             }
         )
 
@@ -124,7 +126,8 @@ class OpenscapTestCase(TestCase):
             {
                 'error': 'argument --profile is required',
                 'upload_dir': None,
-                'success': False
+                'success': False,
+                'returncode': None
             }
         )
 
@@ -144,7 +147,8 @@ class OpenscapTestCase(TestCase):
             {
                 'upload_dir': self.random_temp_dir,
                 'error': None,
-                'success': True
+                'success': True,
+                'returncode': 2
             }
         )
         expected_cmd = [
@@ -181,7 +185,8 @@ class OpenscapTestCase(TestCase):
             {
                 'upload_dir': None,
                 'error': 'evaluation error',
-                'success': False
+                'success': False,
+                'returncode': 1
             }
         )
 
@@ -189,7 +194,6 @@ class OpenscapTestCase(TestCase):
        'salt.modules.openscap.Popen',
        MagicMock(
            return_value=Mock(**{
-               'returncode': 1,
                'communicate.return_value': ('', 'evaluation error')
            })
        )
@@ -202,6 +206,7 @@ class OpenscapTestCase(TestCase):
             {
                 'upload_dir': None,
                 'error': "argument action: invalid choice: 'info' (choose from 'eval')",
-                'success': False
+                'success': False,
+                'returncode': None
             }
         )

--- a/tests/unit/modules/openscap_test.py
+++ b/tests/unit/modules/openscap_test.py
@@ -72,7 +72,8 @@ class OpenscapTestCase(TestCase):
             response,
             {
                 'upload_dir': self.random_temp_dir,
-                'error': None, 'success': True,
+                'error': '',
+                'success': True,
                 'returncode': 0
             }
         )
@@ -81,7 +82,7 @@ class OpenscapTestCase(TestCase):
        'salt.modules.openscap.Popen',
        MagicMock(
            return_value=Mock(
-               **{'returncode': 2, 'communicate.return_value': ('', '')}
+               **{'returncode': 2, 'communicate.return_value': ('', 'some error')}
            )
        )
     )
@@ -112,7 +113,7 @@ class OpenscapTestCase(TestCase):
             response,
             {
                 'upload_dir': self.random_temp_dir,
-                'error': None,
+                'error': 'some error',
                 'success': True,
                 'returncode': 2
             }
@@ -135,7 +136,7 @@ class OpenscapTestCase(TestCase):
        'salt.modules.openscap.Popen',
        MagicMock(
            return_value=Mock(
-               **{'returncode': 2, 'communicate.return_value': ('', '')}
+               **{'returncode': 2, 'communicate.return_value': ('', 'some error')}
            )
        )
     )
@@ -146,7 +147,7 @@ class OpenscapTestCase(TestCase):
             response,
             {
                 'upload_dir': self.random_temp_dir,
-                'error': None,
+                'error': 'some error',
                 'success': True,
                 'returncode': 2
             }
@@ -190,14 +191,6 @@ class OpenscapTestCase(TestCase):
             }
         )
 
-    @patch(
-       'salt.modules.openscap.Popen',
-       MagicMock(
-           return_value=Mock(**{
-               'communicate.return_value': ('', 'evaluation error')
-           })
-       )
-    )
     def test_openscap_xccdf_eval_fail_not_implemented_action(self):
         response = openscap.xccdf('info {0}'.format(self.policy_file))
 


### PR DESCRIPTION
### What does this PR do?
Oscap module small improvements

### What issues does this PR fix or reference?
Return oscap returncode and stderr in response.

### New Behavior
- `salt-call --local openscap.xccdf "eval --profile Default /usr/share/openscap/scap-rhel6-xccdf.xml" --output=json`
```
{
    "local": {
        "upload_dir": null,
        "returncode": 1,
        "success": false,
        "error": "Profile \"Default\" was not found.\n"
    }
}
```

- `salt-call --local openscap.xccdf "eval --profile Default /usr/share/openscap/scap-yast2sec-xccdf.xml" --output=json`
```
{
    "local": {
        "upload_dir": "/tmp/tmpubfZqF",
        "returncode": 2,
        "success": true,
        "error": ""
    }
}
```

### Tests written?

Yes
