### PR TITLE
Introducing the kubernetes modules

### DIFF
--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -133,6 +133,34 @@ def nodes(**kwargs):
     return ret
 
 
+def node(name, **kwargs):
+    '''
+    Return the details of the node identified by the specified name
+
+    CLI Examples::
+
+        salt '*' kubernetes.node name="minikube"
+    '''
+    _setup_conn(**kwargs)
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.list_node()
+    except (ApiException, HTTPError) as exc:
+        if isinstance(exc, ApiException) and exc.status == 404:
+            return None
+        else:
+            log.exception(
+                "Exception when calling CoreV1Api->list_node: {0}".format(exc)
+            )
+            raise CommandExecutionError(exc)
+
+    for node in api_response.items:
+        if node.metadata.name == name:
+            return node
+
+    return None
+
+
 def deployments(namespace="default", **kwargs):
     '''
     Return a list of kubernetes deployments defined in the namespace

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -692,6 +692,8 @@ def create_secret(
     elif data is None:
         data = {}
 
+    data = __enforce_only_strings_dict(data)
+
     # encode the secrets using base64 as required by kubernetes
     for key in data:
         data[key] = base64.b64encode(data[key])
@@ -862,6 +864,8 @@ def replace_secret(name,
     elif data is None:
         data = {}
 
+    data = __enforce_only_strings_dict(data)
+
     # encode the secrets using base64 as required by kubernetes
     for key in data:
         data[key] = base64.b64encode(data[key])
@@ -1020,3 +1024,15 @@ def __dict_to_service_spec(spec):
             setattr(spec_obj, key, value)
 
     return spec_obj
+
+
+def __enforce_only_strings_dict(dictionary):
+    '''
+    Returns a dictionary that has string keys and values.
+    '''
+    ret = {}
+
+    for key, value in iteritems(dictionary):
+        ret[str(key)] = str(value)
+
+    return ret

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -117,6 +117,8 @@ def nodes(**kwargs):
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.list_node()
+
+        return [k8s_node['metadata']['name'] for k8s_node in api_response.to_dict().get('items')]
     except (ApiException, HTTPError) as exc:
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
@@ -125,13 +127,6 @@ def nodes(**kwargs):
                 'Exception when calling CoreV1Api->list_node: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
-
-    ret = []
-
-    for k8s_node in api_response.items:
-        ret.append(k8s_node.metadata.name)
-
-    return ret
 
 
 def node(name, **kwargs):
@@ -175,6 +170,9 @@ def namespaces(**kwargs):
     try:
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.list_namespace()
+
+
+        return [nms['metadata']['name'] for nms in api_response.to_dict().get('items')]
     except (ApiException, HTTPError) as exc:
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
@@ -183,13 +181,6 @@ def namespaces(**kwargs):
                 'Exception when calling CoreV1Api->list_node: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
-
-    ret = []
-
-    for namespace in api_response.items:
-        ret.append(namespace.metadata.name)
-
-    return ret
 
 
 def deployments(namespace='default', **kwargs):
@@ -206,7 +197,7 @@ def deployments(namespace='default', **kwargs):
         api_instance = kubernetes.client.ExtensionsV1beta1Api()
         api_response = api_instance.list_namespaced_deployment(namespace)
 
-        return api_response.to_dict().get('items')
+        return [dep['metadata']['name'] for dep in api_response.to_dict().get('items')]
     except (ApiException, HTTPError) as exc:
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
@@ -233,7 +224,7 @@ def services(namespace='default', **kwargs):
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.list_namespaced_service(namespace)
 
-        return api_response.to_dict().get('items')
+        return [srv['metadata']['name'] for srv in api_response.to_dict().get('items')]
     except (ApiException, HTTPError) as exc:
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
@@ -259,7 +250,7 @@ def pods(namespace='default', **kwargs):
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.list_namespaced_pod(namespace)
 
-        return api_response.to_dict().get('items')
+        return [pod['metadata']['name'] for pod in api_response.to_dict().get('items')]
     except (ApiException, HTTPError) as exc:
         if isinstance(exc, ApiException) and exc.status == 404:
             return None

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 '''
 Module for handling kubernetes calls.
 
@@ -11,6 +12,7 @@ Module for handling kubernetes calls.
 '''
 # Import Python Futures
 from __future__ import absolute_import
+import logging
 from salt.ext.six import iteritems
 from salt.exceptions import CommandExecutionError
 import salt.utils
@@ -27,7 +29,6 @@ except ImportError:
     HAS_LIBS = False
 
 
-import logging
 log = logging.getLogger(__name__)
 
 __virtualname__ = 'kubernetes'
@@ -399,7 +400,7 @@ def __create_object_body(kind,
                         # Failed to render the template
                         raise CommandExecutionError(
                             'Failed to render file path with error: '
-                            '%s' % data['data'])
+                            '{0}'.format(data['data']))
 
                     contents = data['data'].encode('utf-8')
                 else:
@@ -413,9 +414,9 @@ def __create_object_body(kind,
                     'kind' not in src_obj or
                     src_obj['kind'] != kind
                ):
-                    raise CommandExecutionError(
-                        'The source file should define only '
-                        'a {0} object'.format(kind))
+                raise CommandExecutionError(
+                    'The source file should define only '
+                    'a {0} object'.format(kind))
 
             if 'metadata' in src_obj:
                 metadata = src_obj['metadata']

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -177,7 +177,8 @@ def namespaces(**kwargs):
             return None
         else:
             log.exception(
-                'Exception when calling CoreV1Api->list_node: {0}'.format(exc)
+                'Exception when calling CoreV1Api->list_namespace: '
+                '{0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -412,7 +413,7 @@ def show_namespace(name, **kwargs):
         else:
             log.exception(
                 'Exception when calling '
-                'CoreV1Api->read_namespaced_pod: {0}'.format(exc)
+                'CoreV1Api->read_namespace: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -446,7 +447,7 @@ def show_secret(name, namespace='default', decode=False, **kwargs):
         else:
             log.exception(
                 'Exception when calling '
-                'ExtensionsV1beta1Api->read_namespaced_secret: '
+                'CoreV1Api->read_namespaced_secret: '
                 '{0}'.format(exc)
             )
             raise CommandExecutionError(exc)
@@ -475,7 +476,7 @@ def show_configmap(name, namespace='default', **kwargs):
         else:
             log.exception(
                 'Exception when calling '
-                'ExtensionsV1beta1Api->read_namespaced_config_map: '
+                'CoreV1Api->read_namespaced_config_map: '
                 '{0}'.format(exc)
             )
             raise CommandExecutionError(exc)

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -11,7 +11,7 @@ Module for handling kubernetes calls.
 '''
 # Import Python Futures
 from __future__ import absolute_import
-from six import iteritems
+from salt.ext.six import iteritems
 from salt.exceptions import CommandExecutionError
 import salt.utils
 import salt.utils.templates
@@ -54,7 +54,7 @@ def ping():
     status = True
     try:
         nodes()
-    except:
+    except Exception:
         status = False
 
     return status
@@ -113,9 +113,7 @@ def show_deployment(name, namespace):
         if exc.status == 404:
             return None
         else:
-            print(
-                "Exception when calling "
-                "ExtensionsV1beta1Api->read_namespaced_deployment: %s\n" % exc)
+            log.exception(exc)
             raise exc
 
 
@@ -138,9 +136,7 @@ def show_service(name, namespace):
         if exc.status == 404:
             return None
         else:
-            print(
-                "Exception when calling CoreV1Api->read_namespaced_service: "
-                "%s\n" % exc)
+            log.exception(exc)
             raise exc
 
 
@@ -168,10 +164,7 @@ def delete_deployment(name, namespace):
         if exc.status == 404:
             return None
         else:
-            print(
-                "Exception when calling "
-                "ExtensionsV1beta1Api->delete_namespaced_deployment: "
-                "%s\n" % exc)
+            log.exception(exc)
             raise exc
 
 
@@ -197,9 +190,7 @@ def delete_service(name, namespace):
         if exc.status == 404:
             return None
         else:
-            print(
-                "Exception when calling CoreV1Api->delete_namespaced_service: "
-                "%s\n" % exc)
+            log.exception(exc)
             raise exc
 
 
@@ -238,10 +229,7 @@ def create_deployment(
         if exc.status == 404:
             return None
         else:
-            print(
-                "Exception when calling "
-                "ExtensionsV1beta1Api->create_namespaced_deployment: "
-                "%s\n" % exc)
+            log.exception(exc)
             raise exc
 
 
@@ -282,9 +270,7 @@ def create_service(
         if exc.status == 404:
             return None
         else:
-            print(
-                "Exception when calling CoreV1Api->create_namespaced_service: "
-                "%s\n" % exc)
+            log.exception(exc)
             raise exc
 
 
@@ -323,10 +309,7 @@ def replace_deployment(name,
         if exc.status == 404:
             return None
         else:
-            print(
-                "Exception when calling "
-                "ExtensionsV1beta1Api->replace_namespaced_deployment: "
-                "%s\n" % exc)
+            log.exception(exc)
             raise exc
 
 
@@ -356,8 +339,8 @@ def replace_service(name,
 
     # Some attributes have to be preserved
     # otherwise exceptions will be thrown
-    body.spec.cluster_ip = old_service["spec"]["cluster_ip"]
-    body.metadata.resource_version = old_service["metadata"]["resource_version"]
+    body.spec.cluster_ip = old_service['spec']['cluster_ip']
+    body.metadata.resource_version = old_service['metadata']['resource_version']
 
     _setup_conn()
 
@@ -371,9 +354,7 @@ def replace_service(name,
         if exc.status == 404:
             return None
         else:
-            print(
-                "Exception when calling "
-                "CoreV1Api->replace_namespaced_service: %s\n" % exc)
+            log.exception(exc)
             raise exc
 
 
@@ -394,7 +375,7 @@ def __create_object_body(kind,
         sfn = __salt__['cp.cache_file'](source, saltenv)
         if not sfn:
             raise CommandExecutionError(
-                "Source file \'{0}\' not found".format(source))
+                'Source file \'{0}\' not found'.format(source))
 
         with salt.utils.fopen(sfn, 'r') as src:
             contents = src.read()
@@ -417,8 +398,8 @@ def __create_object_body(kind,
                     if not data['result']:
                         # Failed to render the template
                         raise CommandExecutionError(
-                            "Failed to render file path with error: "
-                            "%s" % data['data'])
+                            'Failed to render file path with error: '
+                            '%s' % data['data'])
 
                     contents = data['data'].encode('utf-8')
                 else:
@@ -433,8 +414,8 @@ def __create_object_body(kind,
                     src_obj['kind'] != kind
                ):
                     raise CommandExecutionError(
-                        "The source file should define only "
-                        "a {0} object".format(kind))
+                        'The source file should define only '
+                        'a {0} object'.format(kind))
 
             if 'metadata' in src_obj:
                 metadata = src_obj['metadata']
@@ -447,9 +428,9 @@ def __create_object_body(kind,
 
 
 def __dict_to_object_meta(name, namespace, metadata):
-    """
+    '''
     Converts a dictionary into kubernetes ObjectMetaV1 instance.
-    """
+    '''
     meta_obj = kubernetes.client.V1ObjectMeta()
     meta_obj.namespace = namespace
     for key, value in iteritems(metadata):
@@ -458,17 +439,17 @@ def __dict_to_object_meta(name, namespace, metadata):
 
     if meta_obj.name != name:
         log.warning(
-            "The object already has a name attribute, overwriting it with "
-            "the one defined inside of salt")
+            'The object already has a name attribute, overwriting it with '
+            'the one defined inside of salt')
         meta_obj.name = name
 
     return meta_obj
 
 
 def __dict_to_deployment_spec(spec):
-    """
+    '''
     Converts a dictionary into kubernetes V1beta1DeploymentSpec instance.
-    """
+    '''
     spec_obj = kubernetes.client.V1beta1DeploymentSpec()
     for key, value in iteritems(spec):
         if hasattr(spec_obj, key):
@@ -478,12 +459,12 @@ def __dict_to_deployment_spec(spec):
 
 
 def __dict_to_service_spec(spec):
-    """
+    '''
     Converts a dictionary into kubernetes V1ServiceSpec instance.
-    """
+    '''
     spec_obj = kubernetes.client.V1ServiceSpec()
     for key, value in iteritems(spec):
-        if key == "ports":
+        if key == 'ports':
             spec_obj.ports = []
             for port in value:
                 kube_port = kubernetes.client.V1ServicePort()

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -121,7 +121,7 @@ def nodes(**kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling CoreV1Api->list_node: {0}".format(exc)
+                'Exception when calling CoreV1Api->list_node: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -139,7 +139,7 @@ def node(name, **kwargs):
 
     CLI Examples::
 
-        salt '*' kubernetes.node name="minikube"
+        salt '*' kubernetes.node name='minikube'
     '''
     _setup_conn(**kwargs)
     try:
@@ -150,7 +150,7 @@ def node(name, **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling CoreV1Api->list_node: {0}".format(exc)
+                'Exception when calling CoreV1Api->list_node: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -179,7 +179,7 @@ def namespaces(**kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling CoreV1Api->list_node: {0}".format(exc)
+                'Exception when calling CoreV1Api->list_node: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -191,7 +191,7 @@ def namespaces(**kwargs):
     return ret
 
 
-def deployments(namespace="default", **kwargs):
+def deployments(namespace='default', **kwargs):
     '''
     Return a list of kubernetes deployments defined in the namespace
 
@@ -211,14 +211,14 @@ def deployments(namespace="default", **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "ExtensionsV1beta1Api->list_namespaced_deployment: "
-                "{0}".format(exc)
+                'Exception when calling '
+                'ExtensionsV1beta1Api->list_namespaced_deployment: '
+                '{0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
 
-def services(namespace="default", **kwargs):
+def services(namespace='default', **kwargs):
     '''
     Return a list of kubernetes services defined in the namespace
 
@@ -238,13 +238,13 @@ def services(namespace="default", **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "CoreV1Api->list_namespaced_service: {0}".format(exc)
+                'Exception when calling '
+                'CoreV1Api->list_namespaced_service: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
 
-def pods(namespace="default", **kwargs):
+def pods(namespace='default', **kwargs):
     '''
     Return a list of kubernetes pods defined in the namespace
 
@@ -264,13 +264,13 @@ def pods(namespace="default", **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "CoreV1Api->list_namespaced_pod: {0}".format(exc)
+                'Exception when calling '
+                'CoreV1Api->list_namespaced_pod: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
 
-def secrets(namespace="default", **kwargs):
+def secrets(namespace='default', **kwargs):
     '''
     Return a list of kubernetes secrets defined in the namespace
 
@@ -284,19 +284,19 @@ def secrets(namespace="default", **kwargs):
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.list_namespaced_secret(namespace)
 
-        return [secret["metadata"]["name"] for secret in api_response.to_dict().get('items')]
+        return [secret['metadata']['name'] for secret in api_response.to_dict().get('items')]
     except (ApiException, HTTPError) as exc:
         if isinstance(exc, ApiException) and exc.status == 404:
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "CoreV1Api->list_namespaced_secret: {0}".format(exc)
+                'Exception when calling '
+                'CoreV1Api->list_namespaced_secret: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
 
-def show_deployment(name, namespace="default", **kwargs):
+def show_deployment(name, namespace='default', **kwargs):
     '''
     Return the kubernetes deployment defined by name and namespace
 
@@ -316,14 +316,14 @@ def show_deployment(name, namespace="default", **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "ExtensionsV1beta1Api->read_namespaced_deployment: "
-                "{0}".format(exc)
+                'Exception when calling '
+                'ExtensionsV1beta1Api->read_namespaced_deployment: '
+                '{0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
 
-def show_service(name, namespace="default", **kwargs):
+def show_service(name, namespace='default', **kwargs):
     '''
     Return the kubernetes service defined by name and namespace
 
@@ -343,13 +343,13 @@ def show_service(name, namespace="default", **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "CoreV1Api->read_namespaced_service: {0}".format(exc)
+                'Exception when calling '
+                'CoreV1Api->read_namespaced_service: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
 
-def show_pod(name, namespace="default", **kwargs):
+def show_pod(name, namespace='default', **kwargs):
     '''
     Return POD information for a given pod name defined in the namespace
 
@@ -369,8 +369,8 @@ def show_pod(name, namespace="default", **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "CoreV1Api->read_namespaced_pod: {0}".format(exc)
+                'Exception when calling '
+                'CoreV1Api->read_namespaced_pod: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -394,13 +394,13 @@ def show_namespace(name, **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "CoreV1Api->read_namespaced_pod: {0}".format(exc)
+                'Exception when calling '
+                'CoreV1Api->read_namespaced_pod: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
 
-def show_secret(name, namespace="default", decode=False, **kwargs):
+def show_secret(name, namespace='default', decode=False, **kwargs):
     '''
     Return the kubernetes secret defined by name and namespace.
     The secrets can be decoded if specified by the user. Warning: this has
@@ -417,7 +417,7 @@ def show_secret(name, namespace="default", decode=False, **kwargs):
         api_instance = kubernetes.client.CoreV1Api()
         api_response = api_instance.read_namespaced_secret(name, namespace)
 
-        if api_response.data and (decode or decode == "True"):
+        if api_response.data and (decode or decode == 'True'):
             for key in api_response.data:
                 value = api_response.data[key]
                 api_response.data[key] = base64.b64decode(value)
@@ -428,14 +428,14 @@ def show_secret(name, namespace="default", decode=False, **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "ExtensionsV1beta1Api->read_namespaced_deployment: "
-                "{0}".format(exc)
+                'Exception when calling '
+                'ExtensionsV1beta1Api->read_namespaced_deployment: '
+                '{0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
 
-def delete_deployment(name, namespace="default", **kwargs):
+def delete_deployment(name, namespace='default', **kwargs):
     '''
     Deletes the kubernetes deployment defined by name and namespace
 
@@ -459,14 +459,14 @@ def delete_deployment(name, namespace="default", **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "ExtensionsV1beta1Api->delete_namespaced_deployment: "
-                "{0}".format(exc)
+                'Exception when calling '
+                'ExtensionsV1beta1Api->delete_namespaced_deployment: '
+                '{0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
 
-def delete_service(name, namespace="default", **kwargs):
+def delete_service(name, namespace='default', **kwargs):
     '''
     Deletes the kubernetes service defined by name and namespace
 
@@ -489,13 +489,13 @@ def delete_service(name, namespace="default", **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling CoreV1Api->delete_namespaced_service: "
-                "{0}".format(exc)
+                'Exception when calling CoreV1Api->delete_namespaced_service: '
+                '{0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
 
-def delete_pod(name, namespace="default", **kwargs):
+def delete_pod(name, namespace='default', **kwargs):
     '''
     Deletes the kubernetes pod defined by name and namespace
 
@@ -520,8 +520,8 @@ def delete_pod(name, namespace="default", **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "CoreV1Api->delete_namespaced_pod: {0}".format(exc)
+                'Exception when calling '
+                'CoreV1Api->delete_namespaced_pod: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -547,14 +547,14 @@ def delete_namespace(name, **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "CoreV1Api->delete_namespace: "
-                "{0}".format(exc)
+                'Exception when calling '
+                'CoreV1Api->delete_namespace: '
+                '{0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
 
-def delete_secret(name, namespace="default", **kwargs):
+def delete_secret(name, namespace='default', **kwargs):
     '''
     Deletes the kubernetes secret rvice defined by name and namespace
 
@@ -579,8 +579,8 @@ def delete_secret(name, namespace="default", **kwargs):
             return None
         else:
             log.exception(
-                "Exception when calling CoreV1Api->delete_namespaced_secret: "
-                "{0}".format(exc)
+                'Exception when calling CoreV1Api->delete_namespaced_secret: '
+                '{0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -622,9 +622,9 @@ def create_deployment(
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "ExtensionsV1beta1Api->create_namespaced_deployment: "
-                "{0}".format(exc)
+                'Exception when calling '
+                'ExtensionsV1beta1Api->create_namespaced_deployment: '
+                '{0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -666,8 +666,8 @@ def create_service(
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "CoreV1Api->create_namespaced_service: {0}".format(exc)
+                'Exception when calling '
+                'CoreV1Api->create_namespaced_service: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -707,8 +707,8 @@ def create_secret(
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "CoreV1Api->create_namespaced_secret: {0}".format(exc)
+                'Exception when calling '
+                'CoreV1Api->create_namespaced_secret: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -740,9 +740,9 @@ def create_namespace(
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "CoreV1Api->create_namespace: "
-                "{0}".format(exc)
+                'Exception when calling '
+                'CoreV1Api->create_namespace: '
+                '{0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -753,7 +753,7 @@ def replace_deployment(name,
                        source,
                        template,
                        saltenv,
-                       namespace="default",
+                       namespace='default',
                        **kwargs):
     '''
     Replaces an existing deployment with a new one defined by name and
@@ -784,9 +784,9 @@ def replace_deployment(name,
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "ExtensionsV1beta1Api->replace_namespaced_deployment: "
-                "{0}".format(exc)
+                'Exception when calling '
+                'ExtensionsV1beta1Api->replace_namespaced_deployment: '
+                '{0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -798,7 +798,7 @@ def replace_service(name,
                     template,
                     old_service,
                     saltenv,
-                    namespace="default",
+                    namespace='default',
                     **kwargs):
     '''
     Replaces an existing service with a new one defined by name and namespace,
@@ -834,8 +834,8 @@ def replace_service(name,
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "CoreV1Api->replace_namespaced_service: {0}".format(exc)
+                'Exception when calling '
+                'CoreV1Api->replace_namespaced_service: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 
@@ -845,7 +845,7 @@ def replace_secret(name,
                    source,
                    template,
                    saltenv,
-                   namespace="default",
+                   namespace='default',
                    **kwargs):
     '''
     Replaces an existing secret with a new one defined by name and namespace,
@@ -875,8 +875,8 @@ def replace_secret(name,
             return None
         else:
             log.exception(
-                "Exception when calling "
-                "CoreV1Api->replace_namespaced_secret: {0}".format(exc)
+                'Exception when calling '
+                'CoreV1Api->replace_namespaced_secret: {0}'.format(exc)
             )
             raise CommandExecutionError(exc)
 

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -1,0 +1,500 @@
+'''
+Module for handling kubernetes calls.
+
+:optdepends:    - kubernetes Python client
+:configuration: This module is not usable until the following are specified
+    either in a pillar or in the minion's config file::
+
+        kubernetes.user: admin
+        kubernetes.password: verybadpass
+        kubernetes.api_url: 'http://127.0.0.1:8080'
+'''
+# Import Python Futures
+from __future__ import absolute_import
+from six import iteritems
+from salt.exceptions import CommandExecutionError
+import salt.utils
+import salt.utils.templates
+import yaml
+
+try:
+    import kubernetes
+    import kubernetes.client
+    from kubernetes.client.rest import ApiException
+
+    HAS_LIBS = True
+except ImportError:
+    HAS_LIBS = False
+
+
+import logging
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'kubernetes'
+
+
+def __virtual__():
+    '''
+    Check dependencies
+    '''
+    if HAS_LIBS:
+        return __virtualname__
+
+    return False
+
+
+def ping():
+    '''
+    Checks connections with the kubernetes API server.
+    Returns True if the connection can be established, False otherwise.
+
+    CLI Example:
+        salt '*' kubernetes.ping
+    '''
+    status = True
+    try:
+        nodes()
+    except:
+        status = False
+
+    return status
+
+
+def nodes():
+    '''
+    Return the names of the nodes composing the kubernetes cluster
+
+    CLI Examples::
+
+        salt '*' kubernetes.nodes
+    '''
+    _setup_conn()
+
+    api_instance = kubernetes.client.CoreV1Api()
+    api_response = api_instance.list_node()
+
+    ret = []
+
+    for node in api_response.items:
+        ret.append(node.metadata.name)
+
+    return ret
+
+
+def _setup_conn():
+    '''
+    Setup kubernetes API connection singleton
+    '''
+    host = __salt__['config.option']('kubernetes.api_url',
+                                     'http://localhost:8080')
+    username = __salt__['config.option']('kubernetes.user')
+    password = __salt__['config.option']('kubernetes.password')
+    kubernetes.client.configuration.host = host
+    kubernetes.client.configuration.user = username
+    kubernetes.client.configuration.passwd = password
+
+
+def show_deployment(name, namespace):
+    '''
+    Return the kubernetes deployment defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.show_deployment my-nginx,default
+        salt '*' kubernetes.show_deployment name=my-nginx,namespace=default
+    '''
+    _setup_conn()
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.read_namespaced_deployment(name, namespace)
+
+        return api_response.to_dict()
+    except ApiException as exc:
+        if exc.status == 404:
+            return None
+        else:
+            print(
+                "Exception when calling "
+                "ExtensionsV1beta1Api->read_namespaced_deployment: %s\n" % exc)
+            raise exc
+
+
+def show_service(name, namespace):
+    '''
+    Return the kubernetes service defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.show_service my-nginx,default
+        salt '*' kubernetes.show_service name=my-nginx,namespace=default
+    '''
+    _setup_conn()
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.read_namespaced_service(name, namespace)
+
+        return api_response.to_dict()
+    except ApiException as exc:
+        if exc.status == 404:
+            return None
+        else:
+            print(
+                "Exception when calling CoreV1Api->read_namespaced_service: "
+                "%s\n" % exc)
+            raise exc
+
+
+def delete_deployment(name, namespace):
+    '''
+    Deletes the kubernetes deployment defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.delete_deployment my-nginx,default
+        salt '*' kubernetes.delete_deployment name=my-nginx,namespace=default
+    '''
+    _setup_conn()
+    body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
+
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.delete_namespaced_deployment(
+            name=name,
+            namespace=namespace,
+            body=body)
+
+        return api_response.to_dict()
+    except ApiException as exc:
+        if exc.status == 404:
+            return None
+        else:
+            print(
+                "Exception when calling "
+                "ExtensionsV1beta1Api->delete_namespaced_deployment: "
+                "%s\n" % exc)
+            raise exc
+
+
+def delete_service(name, namespace):
+    '''
+    Deletes the kubernetes service defined by name and namespace
+
+    CLI Examples::
+
+        salt '*' kubernetes.delete_service my-nginx,default
+        salt '*' kubernetes.delete_service name=my-nginx,namespace=default
+    '''
+    _setup_conn()
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.delete_namespaced_service(
+            name=name,
+            namespace=namespace)
+
+        return api_response.to_dict()
+    except ApiException as exc:
+        if exc.status == 404:
+            return None
+        else:
+            print(
+                "Exception when calling CoreV1Api->delete_namespaced_service: "
+                "%s\n" % exc)
+            raise exc
+
+
+def create_deployment(
+        name,
+        namespace,
+        metadata,
+        spec,
+        source,
+        template,
+        saltenv):
+    '''
+    Creates the kubernetes deployment as defined by the user.
+    '''
+    body = __create_object_body(
+        kind='Deployment',
+        obj_class=kubernetes.client.V1beta1Deployment,
+        spec_creator=__dict_to_deployment_spec,
+        name=name,
+        namespace=namespace,
+        metadata=metadata,
+        spec=spec,
+        source=source,
+        template=template,
+        saltenv=saltenv)
+
+    _setup_conn()
+
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.create_namespaced_deployment(
+            namespace, body)
+
+        return api_response.to_dict()
+    except ApiException as exc:
+        if exc.status == 404:
+            return None
+        else:
+            print(
+                "Exception when calling "
+                "ExtensionsV1beta1Api->create_namespaced_deployment: "
+                "%s\n" % exc)
+            raise exc
+
+
+def create_service(
+        name,
+        namespace,
+        metadata,
+        spec,
+        source,
+        template,
+        saltenv):
+    '''
+    Creates the kubernetes service as defined by the user.
+    '''
+    body = __create_object_body(
+        kind='Service',
+        obj_class=kubernetes.client.V1Service,
+        spec_creator=__dict_to_service_spec,
+        name=name,
+        namespace=namespace,
+        metadata=metadata,
+        spec=spec,
+        source=source,
+        template=template,
+        saltenv=saltenv)
+
+    _setup_conn()
+
+    log.warning(body)
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.create_namespaced_service(
+            namespace, body)
+
+        return api_response.to_dict()
+    except ApiException as exc:
+        if exc.status == 404:
+            return None
+        else:
+            print(
+                "Exception when calling CoreV1Api->create_namespaced_service: "
+                "%s\n" % exc)
+            raise exc
+
+
+def replace_deployment(name,
+                       namespace,
+                       metadata,
+                       spec,
+                       source,
+                       template,
+                       saltenv):
+    '''
+    Replaces an existing deployment with a new one defined by name and
+    namespace, having the specificed metadata and spec.
+    '''
+    body = __create_object_body(
+        kind='Deployment',
+        obj_class=kubernetes.client.V1beta1Deployment,
+        spec_creator=__dict_to_deployment_spec,
+        name=name,
+        namespace=namespace,
+        metadata=metadata,
+        spec=spec,
+        source=source,
+        template=template,
+        saltenv=saltenv)
+
+    _setup_conn()
+
+    try:
+        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_response = api_instance.replace_namespaced_deployment(
+            name, namespace, body)
+
+        return api_response.to_dict()
+    except ApiException as exc:
+        if exc.status == 404:
+            return None
+        else:
+            print(
+                "Exception when calling "
+                "ExtensionsV1beta1Api->replace_namespaced_deployment: "
+                "%s\n" % exc)
+            raise exc
+
+
+def replace_service(name,
+                    namespace,
+                    metadata,
+                    spec,
+                    source,
+                    template,
+                    old_service,
+                    saltenv):
+    '''
+    Replaces an existing service with a new one defined by name and namespace,
+    having the specificed metadata and spec.
+    '''
+    body = __create_object_body(
+        kind='Service',
+        obj_class=kubernetes.client.V1Service,
+        spec_creator=__dict_to_service_spec,
+        name=name,
+        namespace=namespace,
+        metadata=metadata,
+        spec=spec,
+        source=source,
+        template=template,
+        saltenv=saltenv)
+
+    # Some attributes have to be preserved
+    # otherwise exceptions will be thrown
+    body.spec.cluster_ip = old_service["spec"]["cluster_ip"]
+    body.metadata.resource_version = old_service["metadata"]["resource_version"]
+
+    _setup_conn()
+
+    try:
+        api_instance = kubernetes.client.CoreV1Api()
+        api_response = api_instance.replace_namespaced_service(
+            name, namespace, body)
+
+        return api_response.to_dict()
+    except ApiException as exc:
+        if exc.status == 404:
+            return None
+        else:
+            print(
+                "Exception when calling "
+                "CoreV1Api->replace_namespaced_service: %s\n" % exc)
+            raise exc
+
+
+def __create_object_body(kind,
+                         obj_class,
+                         spec_creator,
+                         name,
+                         namespace,
+                         metadata,
+                         spec,
+                         source,
+                         template,
+                         saltenv):
+    '''
+    Create a Kubernetes Object body instance.
+    '''
+    if source:
+        sfn = __salt__['cp.cache_file'](source, saltenv)
+        if not sfn:
+            raise CommandExecutionError(
+                "Source file \'{0}\' not found".format(source))
+
+        with salt.utils.fopen(sfn, 'r') as src:
+            contents = src.read()
+
+            if template:
+                if template in salt.utils.templates.TEMPLATE_REGISTRY:
+                    # TODO: should we allow user to set also `context` like
+                    # `file.managed` does?
+                    # Apply templating
+                    data = salt.utils.templates.TEMPLATE_REGISTRY[template](
+                        contents,
+                        from_str=True,
+                        to_str=True,
+                        saltenv=saltenv,
+                        grains=__grains__,
+                        pillar=__pillar__,
+                        salt=__salt__,
+                        opts=__opts__)
+
+                    if not data['result']:
+                        # Failed to render the template
+                        raise CommandExecutionError(
+                            "Failed to render file path with error: "
+                            "%s" % data['data'])
+
+                    contents = data['data'].encode('utf-8')
+                else:
+                    raise CommandExecutionError(
+                        'Unknown template specified: {0}'.format(
+                            template))
+
+            src_obj = yaml.load(contents)
+            if (
+                    not isinstance(src_obj, dict) or
+                    'kind' not in src_obj or
+                    src_obj['kind'] != kind
+               ):
+                    raise CommandExecutionError(
+                        "The source file should define only "
+                        "a {0} object".format(kind))
+
+            if 'metadata' in src_obj:
+                metadata = src_obj['metadata']
+            if 'spec' in src_obj:
+                spec = src_obj['spec']
+
+    return obj_class(
+        metadata=__dict_to_object_meta(name, namespace, metadata),
+        spec=spec_creator(spec))
+
+
+def __dict_to_object_meta(name, namespace, metadata):
+    """
+    Converts a dictionary into kubernetes ObjectMetaV1 instance.
+    """
+    meta_obj = kubernetes.client.V1ObjectMeta()
+    meta_obj.namespace = namespace
+    for key, value in iteritems(metadata):
+        if hasattr(meta_obj, key):
+            setattr(meta_obj, key, value)
+
+    if meta_obj.name != name:
+        log.warning(
+            "The object already has a name attribute, overwriting it with "
+            "the one defined inside of salt")
+        meta_obj.name = name
+
+    return meta_obj
+
+
+def __dict_to_deployment_spec(spec):
+    """
+    Converts a dictionary into kubernetes V1beta1DeploymentSpec instance.
+    """
+    spec_obj = kubernetes.client.V1beta1DeploymentSpec()
+    for key, value in iteritems(spec):
+        if hasattr(spec_obj, key):
+            setattr(spec_obj, key, value)
+
+    return spec_obj
+
+
+def __dict_to_service_spec(spec):
+    """
+    Converts a dictionary into kubernetes V1ServiceSpec instance.
+    """
+    spec_obj = kubernetes.client.V1ServiceSpec()
+    for key, value in iteritems(spec):
+        if key == "ports":
+            spec_obj.ports = []
+            for port in value:
+                kube_port = kubernetes.client.V1ServicePort()
+                if isinstance(port, dict):
+                    for port_key, port_value in iteritems(port):
+                        if hasattr(kube_port, port_key):
+                            setattr(kube_port, port_key, port_value)
+                else:
+                    kube_port.port = port
+                spec_obj.ports.append(kube_port)
+        elif hasattr(spec_obj, key):
+            setattr(spec_obj, key, value)
+
+    return spec_obj

--- a/salt/states/k8s.py
+++ b/salt/states/k8s.py
@@ -25,6 +25,11 @@ Manage Kubernetes
         - node: myothernodename
         - apiserver: http://mykubeapiserer:8080
 '''
+from __future__ import absolute_import
+
+# Import salt libs
+import salt.utils
+
 
 __virtualname__ = 'k8s'
 
@@ -42,6 +47,10 @@ def label_present(
         node=None,
         apiserver=None):
     '''
+    .. deprecated:: Nitrogen
+        This state has been moved to :py:func:`kubernetes.node_label_present
+        <salt.states.kubernetes.node_label_present`.
+
     Ensure the label exists on the kube node.
 
     name
@@ -60,6 +69,14 @@ def label_present(
     # Use salt k8s module to set label
     ret = __salt__['k8s.label_present'](name, value, node, apiserver)
 
+    msg = (
+        'The k8s.label_present state has been replaced by '
+        'kubernetes.node_label_present. Update your SLS to use the new '
+        'function name to get rid of this warning.'
+    )
+    salt.utils.warn_until('Fluorine', msg)
+    ret.setdefault('warnings', []).append(msg)
+
     return ret
 
 
@@ -68,6 +85,10 @@ def label_absent(
         node=None,
         apiserver=None):
     '''
+    .. deprecated:: Nitrogen
+        This state has been moved to :py:func:`kubernetes.node_label_absent
+        <salt.states.kubernetes.node_label_absent`.
+
     Ensure the label doesn't exist on the kube node.
 
     name
@@ -83,6 +104,14 @@ def label_absent(
     # Use salt k8s module to set label
     ret = __salt__['k8s.label_absent'](name, node, apiserver)
 
+    msg = (
+        'The k8s.label_absent state has been replaced by '
+        'kubernetes.node_label_absent. Update your SLS to use the new '
+        'function name to get rid of this warning.'
+    )
+    salt.utils.warn_until('Fluorine', msg)
+    ret.setdefault('warnings', []).append(msg)
+
     return ret
 
 
@@ -91,6 +120,9 @@ def label_folder_absent(
         node=None,
         apiserver=None):
     '''
+    .. deprecated:: Nitrogen
+        This state is going to be dropped.
+
     Ensure the label folder doesn't exist on the kube node.
 
     name
@@ -105,5 +137,13 @@ def label_folder_absent(
     '''
     # Use salt k8s module to set label
     ret = __salt__['k8s.folder_absent'](name, node, apiserver)
+
+    msg = (
+        'The k8s.folder_present state has been dropped. '
+        'Update your SLS to use the new '
+        'function name to get rid of this warning.'
+    )
+    salt.utils.warn_until('Fluorine', msg)
+    ret.setdefault('warnings', []).append(msg)
 
     return ret

--- a/salt/states/k8s.py
+++ b/salt/states/k8s.py
@@ -121,7 +121,8 @@ def label_folder_absent(
         apiserver=None):
     '''
     .. deprecated:: Nitrogen
-        This state is going to be dropped.
+        This state has been moved to :py:func:`kubernetes.node_label_folder_absent
+        <salt.states.kubernetes.node_label_folder_absent`.
 
     Ensure the label folder doesn't exist on the kube node.
 
@@ -139,9 +140,10 @@ def label_folder_absent(
     ret = __salt__['k8s.folder_absent'](name, node, apiserver)
 
     msg = (
-        'The k8s.folder_present state has been dropped. '
-        'Update your SLS to use the new '
+        'The k8s.label_folder_absent state has been replaced by '
+        'kubernetes.node_label_folder_absent. Update your SLS to use the new '
         'function name to get rid of this warning.'
+
     )
     salt.utils.warn_until('Fluorine', msg)
     ret.setdefault('warnings', []).append(msg)

--- a/salt/states/kubernetes.py
+++ b/salt/states/kubernetes.py
@@ -131,8 +131,10 @@ def deployment_absent(name, namespace='default', **kwargs):
         ret['changes'] = {
             'kubernetes.deployment': {
                 'new': 'absent', 'old': 'present'}}
+        ret['comment'] = res['message']
+    else:
+        ret['comment'] = 'Something went wrong, response: {0}'.format(res)
 
-    ret['comment'] = res['message']
     return ret
 
 
@@ -361,7 +363,10 @@ def service_absent(name, namespace='default', **kwargs):
         ret['changes'] = {
             'kubernetes.service': {
                 'new': 'absent', 'old': 'present'}}
-    ret['comment'] = res['message']
+        ret['comment'] = res['message']
+    else:
+        ret['comment'] = 'Something went wrong, response: {0}'.format(res)
+
     return ret
 
 
@@ -410,7 +415,7 @@ def namespace_absent(name, **kwargs):
         else:
             ret['comment'] = 'Terminating'
     else:
-        ret['comment'] = 'Unknown state: {0}'.format(res)
+        ret['comment'] = 'Something went wrong, response: {0}'.format(res)
 
     return ret
 
@@ -435,6 +440,7 @@ def namespace_present(name, **kwargs):
             ret['result'] = None
             ret['comment'] = 'The namespace is going to be created'
             return ret
+
         res = __salt__['kubernetes.create_namespace'](name, **kwargs)
         ret['changes']['namespace'] = {
             'old': {},
@@ -569,6 +575,7 @@ def secret_present(
         'data': res['data'].keys()
     }
     ret['result'] = True
+
     return ret
 
 
@@ -732,7 +739,7 @@ def pod_absent(name, namespace='default', **kwargs):
         else:
             ret['comment'] = res['message']
     else:
-        ret['comment'] = 'Something went wrong: {0}'.format(res)
+        ret['comment'] = 'Something went wrong, response: {0}'.format(res)
 
     return ret
 

--- a/salt/states/kubernetes.py
+++ b/salt/states/kubernetes.py
@@ -400,8 +400,7 @@ def namespace_absent(name, **kwargs):
             (
                 isinstance(res['status'], dict) and
                 res['status']['phase'] == 'Terminating'
-            )
-       ):
+            )):
         ret['result'] = True
         ret['changes'] = {
             'kubernetes.namespace': {
@@ -411,7 +410,7 @@ def namespace_absent(name, **kwargs):
         else:
             ret['comment'] = 'Terminating'
     else:
-        ret['comment'] = 'Unknown state: {}'.format(res)
+        ret['comment'] = 'Unknown state: {0}'.format(res)
 
     return ret
 
@@ -475,7 +474,7 @@ def secret_absent(name, namespace='default', **kwargs):
         ret['result'] = None
         return ret
 
-    res = __salt__['kubernetes.delete_secret'](name, namespace, **kwargs)
+    __salt__['kubernetes.delete_secret'](name, namespace, **kwargs)
 
     # As for kubernetes 1.6.4 doesn't set a code when deleting a secret
     # The kubernetes module will raise an exception if the kubernetes
@@ -491,7 +490,7 @@ def secret_absent(name, namespace='default', **kwargs):
 def secret_present(
         name,
         namespace='default',
-        data={},
+        data=None,
         source='',
         template='',
         **kwargs):
@@ -530,6 +529,9 @@ def secret_present(
     secret = __salt__['kubernetes.show_secret'](name, namespace, **kwargs)
 
     if secret is None:
+        if data is None:
+            data = {}
+
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = 'The secret is going to be created'

--- a/salt/states/kubernetes.py
+++ b/salt/states/kubernetes.py
@@ -87,7 +87,7 @@ def _error(ret, err_msg):
     return ret
 
 
-def deployment_absent(name, namespace="default"):
+def deployment_absent(name, namespace='default'):
     '''
     Ensures that the named deployment is absent from the given namespace.
 
@@ -128,11 +128,11 @@ def deployment_absent(name, namespace="default"):
 
 def deployment_present(
         name,
-        namespace="default",
+        namespace='default',
         metadata=None,
         spec=None,
-        source="",
-        template=""):
+        source='',
+        template=''):
     '''
     Ensures that the named deployment is present inside of the specified
     namespace with the given metadata and spec.
@@ -142,7 +142,7 @@ def deployment_present(
         The name of the deployment.
 
     namespace
-        The namespace holding the deployment. The "default" one is going to be
+        The namespace holding the deployment. The 'default' one is going to be
         used unless a different one is specified.
 
     metadata
@@ -190,7 +190,7 @@ def deployment_present(
                                                        source=source,
                                                        template=template,
                                                        saltenv=__env__)
-        ret['changes']["{}.{}".format(namespace, name)] = {
+        ret['changes']['{}.{}'.format(namespace, name)] = {
             'old': {},
             'new': res}
     else:
@@ -202,7 +202,7 @@ def deployment_present(
             ret['result'] = None
             return ret
         # TODO: improve checks
-        log.info("Forcing the recreation of the deploymentv")
+        log.info('Forcing the recreation of the deploymentv')
         res = __salt__['kubernetes.replace_deployment'](
             name=name,
             namespace=namespace,
@@ -219,11 +219,11 @@ def deployment_present(
 
 def service_present(
         name,
-        namespace="default",
+        namespace='default',
         metadata=None,
         spec=None,
-        source="",
-        template=""):
+        source='',
+        template=''):
     '''
     Ensures that the named service is present inside of the specified namespace
     with the given metadata and spec.
@@ -233,7 +233,7 @@ def service_present(
         The name of the service.
 
     namespace
-        The namespace holding the service. The "default" one is going to be
+        The namespace holding the service. The 'default' one is going to be
         used unless a different one is specified.
 
     metadata
@@ -281,7 +281,7 @@ def service_present(
                                                     source=source,
                                                     template=template,
                                                     saltenv=__env__)
-        ret['changes']["{}.{}".format(namespace, name)] = {
+        ret['changes']['{}.{}'.format(namespace, name)] = {
             'old': {},
             'new': res}
     else:
@@ -293,7 +293,7 @@ def service_present(
             ret['result'] = None
             return ret
         # TODO: improve checks
-        log.info("Forcing the recreation of the service")
+        log.info('Forcing the recreation of the service')
         res = __salt__['kubernetes.replace_service'](
             name=name,
             namespace=namespace,
@@ -309,7 +309,7 @@ def service_present(
     return ret
 
 
-def service_absent(name, namespace="default"):
+def service_absent(name, namespace='default'):
     '''
     Ensures that the named service is absent from the given namespace.
 

--- a/salt/states/kubernetes.py
+++ b/salt/states/kubernetes.py
@@ -212,6 +212,7 @@ def deployment_present(
 
         # TODO: improve checks  # pylint: disable=fixme
         log.info('Forcing the recreation of the deployment')
+        ret['comment'] = 'The deployment is already present. Forcing recreation'
         res = __salt__['kubernetes.replace_deployment'](
             name=name,
             namespace=namespace,
@@ -226,7 +227,6 @@ def deployment_present(
         'metadata': metadata,
         'spec': spec
     }
-    ret['comment'] = 'The deployment is already present. Forcing recreation'
     ret['result'] = True
     return ret
 
@@ -307,6 +307,7 @@ def service_present(
 
         # TODO: improve checks  # pylint: disable=fixme
         log.info('Forcing the recreation of the service')
+        ret['comment'] = 'The service is already present. Forcing recreation'
         res = __salt__['kubernetes.replace_service'](
             name=name,
             namespace=namespace,
@@ -322,7 +323,6 @@ def service_present(
         'metadata': metadata,
         'spec': spec
     }
-    ret['comment'] = 'The service is already present. Forcing recreation'
     ret['result'] = True
     return ret
 
@@ -553,6 +553,7 @@ def secret_present(
 
         # TODO: improve checks  # pylint: disable=fixme
         log.info('Forcing the recreation of the service')
+        ret['comment'] = 'The secret is already present. Forcing recreation'
         res = __salt__['kubernetes.replace_secret'](
             name=name,
             namespace=namespace,
@@ -567,7 +568,6 @@ def secret_present(
         # and can contain sensitive data.
         'data': data.keys()
     }
-    ret['comment'] = 'The secret is already present. Forcing recreation'
     ret['result'] = True
     return ret
 

--- a/salt/states/kubernetes.py
+++ b/salt/states/kubernetes.py
@@ -566,7 +566,7 @@ def secret_present(
     ret['changes'] = {
         # Omit values from the return. They are unencrypted
         # and can contain sensitive data.
-        'data': data.keys()
+        'data': res['data'].keys()
     }
     ret['result'] = True
     return ret

--- a/salt/states/kubernetes.py
+++ b/salt/states/kubernetes.py
@@ -1,0 +1,348 @@
+'''
+Manage kubernetes resources as salt states
+==========================================
+
+NOTE: This module requires the proper pillar values set. See
+salt.modules.kubernetes for more information.
+
+The kubernetes module is used to manage different kubernetes resources.
+
+
+.. code-block:: yaml
+
+    my-nginx:
+      kubernetes.deployment_present:
+        - namespace: default
+          metadata:
+            app: frontend
+          spec:
+            replicas: 1
+            template:
+              metadata:
+                labels:
+                  run: my-nginx
+              spec:
+                containers:
+                - name: my-nginx
+                  image: nginx
+                  ports:
+                  - containerPort: 80
+
+    my-mariadb:
+      kubernetes.deployment_absent:
+        - namespace: default
+
+    # kubernetes deployment as specified inside of
+    # a file containing the definition of the the
+    # deployment using the official kubernetes format
+    redis-master-deployment:
+      kubernetes.deployment_present:
+        - name: redis-master
+        - source: salt://k8s/redis-master-deployment.yml
+      require:
+        - pip: kubernetes-python-module
+
+    # kubernetes service as specified inside of
+    # a file containing the definition of the the
+    # service using the official kubernetes format
+    redis-master-service:
+      kubernetes.service_present:
+        - name: redis-master
+        - source: salt://k8s/redis-master-service.yml
+      require:
+        - kubernetes.deployment_present: redis-master
+
+    # kubernetes deployment as specified inside of
+    # a file containing the definition of the the
+    # deployment using the official kubernetes format
+    # plus some jinja directives
+     nginx-source-template:
+      kubernetes.deployment_present:
+        - source: salt://k8s/nginx.yml.jinja
+        - template: jinja
+      require:
+        - pip: kubernetes-python-module
+
+'''
+from __future__ import absolute_import
+
+import logging
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if the kubernetes module is available in __salt__
+    '''
+    return 'kubernetes.ping' in __salt__
+
+
+def _error(ret, err_msg):
+    '''
+    Helper function to propagate errors to
+    the end user.
+    '''
+    ret['result'] = False
+    ret['comment'] = err_msg
+    return ret
+
+
+def deployment_absent(name, namespace="default"):
+    '''
+    Ensures that the named deployment is absent from the given namespace.
+
+    name
+        The name of the deployment
+
+    namespace
+        The name of the namespace
+    '''
+
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    deployment = __salt__['kubernetes.show_deployment'](name, namespace)
+
+    if deployment is None:
+        ret['result'] = True
+        ret['comment'] = 'The deployment does not exist'
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'The deployment is not absent'
+        ret['result'] = None
+        return ret
+
+    res = __salt__['kubernetes.delete_deployment'](name, namespace)
+    if res['code'] == 200:
+        ret['result'] = True
+        ret['changes'] = {
+            'kubernetes.deployment': {
+                'new': 'absent', 'old': 'present'}}
+    ret['comment'] = res['message']
+
+    return ret
+
+
+def deployment_present(
+        name,
+        namespace="default",
+        metadata=None,
+        spec=None,
+        source="",
+        template=""):
+    '''
+    Ensures that the named deployment is present inside of the specified
+    namespace with the given metadata and spec.
+    If the deployment exists it will be replaced.
+
+    name
+        The name of the deployment.
+
+    namespace
+        The namespace holding the deployment. The "default" one is going to be
+        used unless a different one is specified.
+
+    metadata
+        The metadata of the deployment object.
+
+    spec
+        The spec of the deployment object.
+
+    source
+        A file containing the definition of the deployment (metadata and
+        spec) in the official kubernetes format.
+
+    template
+        Template engine to be used to render the source file.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if (metadata or spec) and source:
+        return _error(
+            ret,
+            '\'source\' cannot be used in combination with \'metadata\' or '
+            '\'spec\''
+        )
+
+    if metadata is None:
+        metadata = {}
+
+    if spec is None:
+        spec = {}
+
+    deployment = __salt__['kubernetes.show_deployment'](name, namespace)
+
+    if deployment is None:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The deployment does not exist'
+            return ret
+        res = __salt__['kubernetes.create_deployment'](name=name,
+                                                       namespace=namespace,
+                                                       metadata=metadata,
+                                                       spec=spec,
+                                                       source=source,
+                                                       template=template,
+                                                       saltenv=__env__)
+        ret['changes']["{}.{}".format(namespace, name)] = {
+            'old': {},
+            'new': res}
+    else:
+        ret['changes'] = {
+            'metadata': metadata,
+            'spec': spec}
+        if __opts__['test']:
+            ret['comment'] = 'The deployment is already present'
+            ret['result'] = None
+            return ret
+        # TODO: improve checks
+        log.info("Forcing the recreation of the deploymentv")
+        res = __salt__['kubernetes.replace_deployment'](
+            name=name,
+            namespace=namespace,
+            metadata=metadata,
+            spec=spec,
+            source=source,
+            template=template,
+            saltenv=__env__)
+
+    ret['result'] = True
+
+    return ret
+
+
+def service_present(
+        name,
+        namespace="default",
+        metadata=None,
+        spec=None,
+        source="",
+        template=""):
+    '''
+    Ensures that the named service is present inside of the specified namespace
+    with the given metadata and spec.
+    If the deployment exists it will be replaced.
+
+    name
+        The name of the service.
+
+    namespace
+        The namespace holding the service. The "default" one is going to be
+        used unless a different one is specified.
+
+    metadata
+        The metadata of the service object.
+
+    spec
+        The spec of the service object.
+
+    source
+        A file containing the definition of the service (metadata and
+        spec) in the official kubernetes format.
+
+    template
+        Template engine to be used to render the source file.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if (metadata or spec) and source:
+        return _error(
+            ret,
+            '\'source\' cannot be used in combination with \'metadata\' or '
+            '\'spec\''
+        )
+
+    if metadata is None:
+        metadata = {}
+
+    if spec is None:
+        spec = {}
+
+    service = __salt__['kubernetes.show_service'](name, namespace)
+
+    if service is None:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The service does not exist'
+            return ret
+        res = __salt__['kubernetes.create_service'](name=name,
+                                                    namespace=namespace,
+                                                    metadata=metadata,
+                                                    spec=spec,
+                                                    source=source,
+                                                    template=template,
+                                                    saltenv=__env__)
+        ret['changes']["{}.{}".format(namespace, name)] = {
+            'old': {},
+            'new': res}
+    else:
+        ret['changes'] = {
+            'metadata': metadata,
+            'spec': spec}
+        if __opts__['test']:
+            ret['comment'] = 'The service is already present'
+            ret['result'] = None
+            return ret
+        # TODO: improve checks
+        log.info("Forcing the recreation of the service")
+        res = __salt__['kubernetes.replace_service'](
+            name=name,
+            namespace=namespace,
+            metadata=metadata,
+            spec=spec,
+            source=source,
+            template=template,
+            old_service=service,
+            saltenv=__env__)
+
+    ret['result'] = True
+
+    return ret
+
+
+def service_absent(name, namespace="default"):
+    '''
+    Ensures that the named service is absent from the given namespace.
+
+    name
+        The name of the service
+
+    namespace
+        The name of the namespace
+    '''
+
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    service = __salt__['kubernetes.show_service'](name, namespace)
+
+    if service is None:
+        ret['result'] = True
+        ret['comment'] = 'The service does not exist'
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'The service is not absent'
+        ret['result'] = None
+        return ret
+
+    res = __salt__['kubernetes.delete_service'](name, namespace)
+    if res['code'] == 200:
+        ret['result'] = True
+        ret['changes'] = {
+            'kubernetes.service': {
+                'new': 'absent', 'old': 'present'}}
+    ret['comment'] = res['message']
+
+    return ret

--- a/salt/states/kubernetes.py
+++ b/salt/states/kubernetes.py
@@ -64,6 +64,15 @@ The kubernetes module is used to manage different kubernetes resources.
       require:
         - pip: kubernetes-python-module
 
+
+    # Kubernetes secret
+    k8s-secret:
+      kubernetes.secret_present:
+        - name: top-secret
+          data:
+            key1: value1
+            key2: value2
+            key3: value3
 '''
 from __future__ import absolute_import
 
@@ -436,3 +445,127 @@ def namespace_present(name, **kwargs):
         ret['comment'] = 'The namespace already exists'
 
     return ret
+
+
+def secret_absent(name, namespace='default', **kwargs):
+    '''
+    Ensures that the named secret is absent from the given namespace.
+
+    name
+        The name of the secret
+
+    namespace
+        The name of the namespace
+    '''
+
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    secret = __salt__['kubernetes.show_secret'](name, namespace, **kwargs)
+
+    if secret is None:
+        ret['result'] = True if not __opts__['test'] else None
+        ret['comment'] = 'The secret does not exist'
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'The secret is going to be deleted'
+        ret['result'] = None
+        return ret
+
+    res = __salt__['kubernetes.delete_secret'](name, namespace, **kwargs)
+
+    # As for kubernetes 1.6.4 doesn't set a code when deleting a secret
+    # The kubernetes module will raise an exception if the kubernetes
+    # server will return an error
+    ret['result'] = True
+    ret['changes'] = {
+        'kubernetes.secret': {
+            'new': 'absent', 'old': 'present'}}
+    ret['comment'] = 'Secret deleted'
+    return ret
+
+
+def secret_present(
+        name,
+        namespace='default',
+        data={},
+        source='',
+        template='',
+        **kwargs):
+    '''
+    Ensures that the named secret is present inside of the specified namespace
+    with the given data.
+    If the secret exists it will be replaced.
+
+    name
+        The name of the secret.
+
+    namespace
+        The namespace holding the secret. The 'default' one is going to be
+        used unless a different one is specified.
+
+    data
+        The dictionary holding the secrets.
+
+    source
+        A file containing the data of the secret in plain format.
+
+    template
+        Template engine to be used to render the source file.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if data and source:
+        return _error(
+            ret,
+            '\'source\' cannot be used in combination with \'data\''
+        )
+
+    secret = __salt__['kubernetes.show_secret'](name, namespace, **kwargs)
+
+    if secret is None:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'The secret is going to be created'
+            return ret
+        res = __salt__['kubernetes.create_secret'](name=name,
+                                                   namespace=namespace,
+                                                   data=data,
+                                                   source=source,
+                                                   template=template,
+                                                   saltenv=__env__,
+                                                   **kwargs)
+        ret['changes']['{0}.{1}'.format(namespace, name)] = {
+            'old': {},
+            'new': res}
+    else:
+        if __opts__['test']:
+            ret['result'] = None
+            return ret
+
+        # TODO: improve checks  # pylint: disable=fixme
+        log.info('Forcing the recreation of the service')
+        res = __salt__['kubernetes.replace_secret'](
+            name=name,
+            namespace=namespace,
+            data=data,
+            source=source,
+            template=template,
+            saltenv=__env__,
+            **kwargs)
+
+    ret['changes'] = {
+        # Omit values from the return. They are unencrypted
+        # and can contain sensitive data.
+        'data': data.keys()
+    }
+    ret['comment'] = 'The secret is already present. Forcing recreation'
+    ret['result'] = True
+    return ret
+

--- a/salt/states/kubernetes.py
+++ b/salt/states/kubernetes.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 '''
 Manage kubernetes resources as salt states
 ==========================================
@@ -190,7 +191,7 @@ def deployment_present(
                                                        source=source,
                                                        template=template,
                                                        saltenv=__env__)
-        ret['changes']['{}.{}'.format(namespace, name)] = {
+        ret['changes']['{0}.{1}'.format(namespace, name)] = {
             'old': {},
             'new': res}
     else:
@@ -281,7 +282,7 @@ def service_present(
                                                     source=source,
                                                     template=template,
                                                     saltenv=__env__)
-        ret['changes']['{}.{}'.format(namespace, name)] = {
+        ret['changes']['{0}.{1}'.format(namespace, name)] = {
             'old': {},
             'new': res}
     else:


### PR DESCRIPTION
### What does this PR do?

This PR leads the foundation to manage Kubernetes resources right from salt.

Currently it's possible to manage Kubernetes [deployments](https://kubernetes.io/docs/user-guide/deployments/) and [services](https://kubernetes.io/docs/user-guide/services/).

This allows for example to deploy a relatively complex kubernetes 101 example like the [guestbook](https://github.com/kubernetes/kubernetes/tree/master/examples/guestbook) one.

The interaction with kubernetes is achieved using the [official python library for kubernetes](https://github.com/kubernetes-incubator/client-python).

### What issues does this PR fix or reference?

This is an idea @dmacvicar and I had at @SUSE. You can find more about it inside of this [RFC](https://gist.github.com/dmacvicar/1793395c2284e23e9cac8d210d239dab).

### Tests written?

No.

### Demo

I created a demo repository containing all the resources needed to play around with this code. It also includes some asciicast showing the integration.

You can find it [here](https://github.com/flavio/salt-kubernetes-demo).

### RFC

This PR is a work in progress. I created that to gather feedback from more experienced Salt users and developers. Actually this is the first time I extend Salt 😅 

These are the open questions I have:

  * What do you think about the way to declare kubernetes resources inside of `.sls` files? I wanted to allow users to simply copy & paste kubernetes manifests into the `.sls` files. At the same time I didn't want to specify all the possible attributes of all the resources. That's why I decided to take just the resource `meta` and `spec`.
  * I don't like how the code deals when a service/deployment is already present: it just replaces it. The code should be changed to compare the actual object with the one specified by the user, find the differences and then fix them. This would provide more meaningful diff reports.
  * Right now the kubernetes state files have to be assigned against a minion. However this does not make sense because the interaction with the kubernetes cluster could be done even by the salt-master node. It's just a matter of installing the kubernetes-python library on the salt-master and then put the address of the kubernetes API server into the pillar. Is there a smart way to achieve that?
  * I wanted to make the code as generic as possible when dealing with kubernetes objects. However I think we will have to end up dealing with specific code for each object. Isn't there the risk of having huge `kubernetes.py` files?
