### PR TITLE
Prevent spurious "Template does not exist" error

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -390,20 +390,21 @@ class Pillar(object):
         # Gather initial top files
         try:
             if self.opts['pillarenv']:
-                tops[self.opts['pillarenv']] = [
-                        compile_template(
-                            self.client.cache_file(
-                                self.opts['state_top'],
-                                self.opts['pillarenv']
-                                ),
-                            self.rend,
-                            self.opts['renderer'],
-                            self.opts['renderer_blacklist'],
-                            self.opts['renderer_whitelist'],
-                            self.opts['pillarenv'],
-                            _pillar_rend=True,
-                            )
-                        ]
+                top = self.client.cache_file(
+                    self.opts['state_top'], self.opts['pillarenv'])
+
+                if top:
+                    tops[self.opts['pillarenv']] = [
+                            compile_template(
+                                top,
+                                self.rend,
+                                self.opts['renderer'],
+                                self.opts['renderer_blacklist'],
+                                self.opts['renderer_whitelist'],
+                                self.opts['pillarenv'],
+                                _pillar_rend=True,
+                                )
+                            ]
             else:
                 for saltenv in self._get_envs():
                     if self.opts.get('pillar_source_merging_strategy', None) == "none":


### PR DESCRIPTION
### What does this PR do?

I don't think a lot of people use pillarenv=whatever in their minion configs, or this would have been patched long ago.

### What issues does this PR fix or reference?

I'm not aware of any issue.

### Previous Behavior

Billions of lines of no template errors in logs in certain contexts, despite still usually rendering the top files where they're found. These lines are generated in salt/template.py in compile_template()

    > 17:32 salt.template DEBUG compile template:
    > 17:32 salt.template ERROR Template does not exist:

But they are caused by a silly call in pillar/__init__.py asking for a template named ''

### New Behavior
Not the above

### Tests written?

No

