### PR TITLE
Small docfix for the salt runner

### DIFF
--- a/salt/runners/salt.py
+++ b/salt/runners/salt.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 '''
-.. versionadded:: 2016.11.0
-
 This runner makes Salt's
 execution modules available
 on the salt master.
+
+.. versionadded:: 2016.11.0
 
 .. _salt_salt_runner:
 
@@ -79,8 +79,10 @@ def execute(tgt,
             kwarg=None,
             **kwargs):
     '''
-    Execute `fun` on all minions matched by `tgt` and `tgt_type`.
-    Parameter `fun` is the name of execution module function to call.
+    .. versionadded:: Nitrogen
+    
+    Execute ``fun`` on all minions matched by ``tgt`` and ``tgt_type``.
+    Parameter ``fun`` is the name of execution module function to call.
 
     This function should mainly be used as a helper for runner modules,
     in order to avoid redundant code.
@@ -92,7 +94,20 @@ def execute(tgt,
         ret1 = __salt__['salt.execute']('*', 'mod.fun')
         ret2 = __salt__['salt.execute']('my_nodegroup', 'mod2.fun2', tgt_type='nodegroup')
 
-    .. versionadded:: Nitrogen
+    It can also be used to schedule jobs directly on the master, for example:
+
+    .. code-block:: yaml
+
+        schedule:
+            collect_bgp_stats:
+                function: salt.execute
+                args:
+                    - edge-routers
+                    - bgp.neighbors
+                kwargs:
+                    tgt_type: nodegroup
+                days: 1
+                returner: redis
     '''
     client = salt.client.get_local_client(__opts__['conf_file'])
     try:

--- a/salt/runners/salt.py
+++ b/salt/runners/salt.py
@@ -80,7 +80,7 @@ def execute(tgt,
             **kwargs):
     '''
     .. versionadded:: Nitrogen
-    
+
     Execute ``fun`` on all minions matched by ``tgt`` and ``tgt_type``.
     Parameter ``fun`` is the name of execution module function to call.
 


### PR DESCRIPTION
### What does this PR do?

Documentation fixes for the `salt` runner:

- fix header, as displayed incorrectly at https://docs.saltstack.com/en/develop/ref/runners/all/ (because of the versionadded)
- move versionadded in `salt.execute` function: https://docs.saltstack.com/en/develop/ref/runners/all/salt.runners.salt.html#salt.runners.salt.execute
- add one more usage example for `salt.execute`