### PR TITLE
Upgrade SaltTesting to run test suite for 2016.11 and add SaltPyLint

### DIFF
--- a/requirements/dev_python27.txt
+++ b/requirements/dev_python27.txt
@@ -5,4 +5,5 @@ apache-libcloud>=0.14.0
 boto>=2.32.1
 boto3>=1.2.1
 moto>=0.3.6
-SaltTesting==2015.2.16
+SaltTesting>=2016.10.26
+SaltPyLint

--- a/requirements/dev_python34.txt
+++ b/requirements/dev_python34.txt
@@ -5,4 +5,5 @@ apache-libcloud>=0.14.0
 boto>=2.32.1
 boto3>=1.2.1
 moto>=0.3.6
-SaltTesting>=2015.2.16
+SaltTesting>=2016.10.26
+SaltPyLint


### PR DESCRIPTION
### What does this PR do?
This is the backport of PR #37366 to make Salt test suite ~~great~~ work again in `2016.11`.