### PR TITLE
Fix case when /etc/localtime is a file and it is not updated

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -89,6 +89,8 @@ def _get_zone_etc_localtime():
                 return get_zonecode()
             raise CommandExecutionError(tzfile + ' does not exist')
         elif exc.errno == errno.EINVAL:
+            if 'FreeBSD' in __grains__['os_family']:
+                return get_zonecode()
             log.warning(
                 tzfile + ' is not a symbolic link, attempting to match ' +
                 tzfile + ' to zoneinfo files'


### PR DESCRIPTION
### What does this PR do?

In fresh FreeBSD 10.3 installation, if you choose a timezone (In my case US/Pacific) and then update the system with `freebsd-update` it updates timezones [1] and break `timezone` module because the `/etc/localtime` is not a symlink and also doesn't match any of the files in `/usr/share/zoneinfo` because of timezones updates. 

### What issues does this PR fix or reference?

It handles a corner case of saltstack/salt#35869.

[1] https://www.freebsd.org/security/advisories/FreeBSD-EN-16:20.tzdata.asc