### PR TITLE
Namespace 'status' functions in 'win_status'

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -4,7 +4,6 @@ Module for returning various status data about a minion.
 These data can be useful for compiling into stats later.
 '''
 
-
 # Import python libs
 from __future__ import absolute_import
 import datetime
@@ -38,6 +37,16 @@ __func_alias__ = {
 }
 
 
+def __virtual__():
+    '''
+    Not all functions supported by Windows
+    '''
+    if salt.utils.is_windows():
+        return False, 'Windows platform is not supported by this module'
+
+    return __virtualname__
+
+
 def _number(text):
     '''
     Convert a string to a number.
@@ -64,8 +73,6 @@ def procs():
         salt '*' status.procs
     '''
     # Get the user, pid and cmd
-    if salt.utils.is_windows():
-        raise CommandExecutionError('This platform is not supported')
     ret = {}
     uind = 0
     pind = 0
@@ -114,8 +121,6 @@ def custom():
 
         salt '*' status.custom
     '''
-    if salt.utils.is_windows():
-        raise CommandExecutionError('This platform is not supported')
     ret = {}
     conf = __salt__['config.dot_vals']('status')
     for key, val in six.iteritems(conf):
@@ -584,10 +589,6 @@ def diskusage(*args):
         salt '*' status.diskusage ext?    # usage for ext[234] filesystems
         salt '*' status.diskusage / ext?  # usage for / and all ext filesystems
     '''
-
-    if salt.utils.is_windows():
-        raise CommandExecutionError('This platform is not supported')
-
     selected = set()
     fstypes = set()
     if not args:
@@ -926,8 +927,6 @@ def w():  # pylint: disable=C0103
 
         salt '*' status.w
     '''
-    if salt.utils.is_windows():
-        raise CommandExecutionError('This platform is not supported')
     user_list = []
     users = __salt__['cmd.run']('w -h').splitlines()
     for row in users:

--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -28,7 +28,10 @@ import salt.ext.six as six
 import salt.utils.event
 from salt._compat import subprocess
 from salt.utils.network import host_to_ips as _host_to_ips
-from salt.modules.status import master, ping_master, time_
+# pylint: disable=W0611
+from salt.modules.status import ping_master, time_
+import copy
+# pylint: enable=W0611
 from salt.utils import namespaced_function as _namespaced_function
 
 # Import 3rd Party Libs

--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -17,7 +17,6 @@ import ctypes
 import sys
 import time
 import datetime
-from subprocess import list2cmdline
 import logging
 
 log = logging.getLogger(__name__)

--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -82,17 +82,11 @@ def cpuload():
     '''
 
     # Pull in the information from WMIC
-    cmd = list2cmdline(['wmic', 'cpu'])
-    info = __salt__['cmd.run'](cmd).split('\r\n')
-
-    # Find the location of LoadPercentage
-    column = info[0].index('LoadPercentage')
-
-    # Get the end of the number.
-    end = info[1].index(' ', column+1)
+    cmd = list2cmdline(['wmic', 'cpu', 'get', 'loadpercentage', '/value'])
+    info = __salt__['cmd.run'](cmd).split('=')
 
     # Return pull it out of the informatin and cast it to an int
-    return int(info[1][column:end])
+    return int(info[1])
 
 
 def diskusage(human_readable=False, path=None):
@@ -216,18 +210,9 @@ def uptime(human_readable=False):
     '''
 
     # Open up a subprocess to get information from WMIC
-    cmd = list2cmdline(['wmic', 'os', 'get', 'lastbootuptime'])
-    outs = __salt__['cmd.run'](cmd)
+    cmd = list2cmdline(['wmic', 'os', 'get', 'lastbootuptime', '/value'])
+    startup_time = __salt__['cmd.run'](cmd).split('=')[1][:14]
 
-    # Get the line that has when the computer started in it:
-    stats_line = ''
-    # use second line from output
-    stats_line = outs.split('\r\n')[1]
-
-    # Extract the time string from the line and parse
-    #
-    # Get string, just use the leading 14 characters
-    startup_time = stats_line[:14]
     # Convert to time struct
     startup_time = time.strptime(startup_time, '%Y%m%d%H%M%S')
     # Convert to datetime object

--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -82,11 +82,8 @@ def cpuload():
     '''
 
     # Pull in the information from WMIC
-    cmd = list2cmdline(['wmic', 'cpu', 'get', 'loadpercentage', '/value'])
-    info = __salt__['cmd.run'](cmd).split('=')
-
-    # Return pull it out of the informatin and cast it to an int
-    return int(info[1])
+    cmd = ['wmic', 'cpu', 'get', 'loadpercentage', '/value']
+    return int(__salt__['cmd.run'](cmd).split('=')[1])
 
 
 def diskusage(human_readable=False, path=None):
@@ -210,7 +207,7 @@ def uptime(human_readable=False):
     '''
 
     # Open up a subprocess to get information from WMIC
-    cmd = list2cmdline(['wmic', 'os', 'get', 'lastbootuptime', '/value'])
+    cmd = ['wmic', 'os', 'get', 'lastbootuptime', '/value']
     startup_time = __salt__['cmd.run'](cmd).split('=')[1][:14]
 
     # Convert to time struct


### PR DESCRIPTION
### What does this PR do?
This was caused by PR #39005 which fixed multi-master failover in Windows. The problem was that there was a new function in `status.py` that was being called to detect connectivity with the master (`ping_master`). The original fix was to remove the `__virtual__` from `status.py` and gate individual functions for Windows. This cause the loader to ignore `win_status.py`.

The fix was to restore the `__virtual__` function in `status.py` and then 'namespace` the functions from `status.py` in `win_status.py` like we do in the `win_file.py` module.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/39535

### Previous Behavior
`status.py` functions were running on Windows with a message that they were incompatible, some were stacktracing. `win_status.py` functions were ignored.

### New Behavior
`win_status.py` functions now run, as well as the needed `ping_master` function from `status.py`

### Tests written?
No