### PR TITLE
Gate ssh_known_hosts state against Windows

### DIFF
--- a/salt/states/ssh_known_hosts.py
+++ b/salt/states/ssh_known_hosts.py
@@ -38,12 +38,6 @@ def __virtual__():
     if salt.utils.is_windows():
         return False, 'ssh_known_hosts: Does not support Windows'
 
-    if 'ssh.set_known_host' not in __salt__ \
-            or 'ssh.check_known_host' not in __salt__ \
-            or 'ssh.get_known_host' not in __salt__ \
-            or 'ssh.rm_known_host' not in __salt__:
-        return False, 'ssh_known_hosts: Missing required module "ssh"'
-
     return __virtualname__
 
 

--- a/salt/states/ssh_known_hosts.py
+++ b/salt/states/ssh_known_hosts.py
@@ -27,6 +27,25 @@ import os
 import salt.utils
 from salt.exceptions import CommandNotFoundError
 
+# Define the state's virtual name
+__virtualname__ = 'ssh_known_hosts'
+
+
+def __virtual__():
+    '''
+    Does not work on Windows, requires ssh module functions
+    '''
+    if salt.utils.is_windows():
+        return False, 'ssh_known_hosts: Does not support Windows'
+
+    if 'ssh.set_known_host' not in __salt__ \
+            or 'ssh.check_known_host' not in __salt__ \
+            or 'ssh.get_known_host' not in __salt__ \
+            or 'ssh.rm_known_host' not in __salt__:
+        return False, 'ssh_known_hosts: Missing required module "ssh"'
+
+    return __virtualname__
+
 
 def present(
         name,


### PR DESCRIPTION
### What does this PR do?
Adds a `__virtual__` function to the `ssh_known_hosts` state module to prevent the loader from loading it on Windows. Checks for Windows. Also checks for the required functions in `__salt__`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/19573

### Previous Behavior
The execution module is gated, but the state module is not.

### New Behavior
State module is also gated

### Tests written?
No