### PR TITLE
Allow SPM to install all module types

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1615,6 +1615,9 @@ DEFAULT_SPM_OPTS = {
     'spm_db': os.path.join(salt.syspaths.CACHE_DIR, 'spm', 'packages.db'),
     'cache': 'localfs',
     'spm_repo_dups': 'ignore',
+    # If set, spm_node_type will be either master or minion, but they should
+    # NOT be a default
+    'spm_node_type': '',
     # <---- Salt master settings overridden by SPM ----------------------
 }
 


### PR DESCRIPTION
### What does this PR do?
Normally SPM will install files whose path starts with `_` into the formula directory. These files are `modules`, `states`, etc. However, not every module type is supported by this scheme.

Now when `spm_node_type` is set to either `master` or `minion`, those files will instead be installed in the `extension_modules` directory, normally `/var/cache/salt/[master|minion]/extmods/`.

### Tests written?
No.