### PR TITLE
dockerng.get_client_args: Fix path for endpoint config for some versions of docker-py

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5557,11 +5557,15 @@ def get_client_args():
     except AttributeError:
         try:
             endpoint_config_args = \
-                _argspec(docker.utils.create_endpoint_config).args
+                _argspec(docker.utils.utils.create_endpoint_config).args
         except AttributeError:
-            raise CommandExecutionError(
-                'Failed to get create_host_config argspec'
-            )
+            try:
+                endpoint_config_args = \
+                    _argspec(docker.utils.create_endpoint_config).args
+            except AttributeError:
+                raise CommandExecutionError(
+                    'Failed to get create_endpoint_config argspec'
+                )
 
     for arglist in (config_args, host_config_args, endpoint_config_args):
         try:


### PR DESCRIPTION
This avoids a traceback in certain docker-py versions