### PR TITLE
Make file perms check Python 3 compatible

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2495,10 +2495,8 @@ def _validate_key_path_and_mode(key_filename):
             )
         )
 
-    key_mode = str(
-        oct(stat.S_IMODE(os.stat(key_filename).st_mode))
-    )
-    if key_mode not in ('0400', '0600'):
+    key_mode = stat.S_IMODE(os.stat(key_filename).st_mode)
+    if key_mode not in (0o400, 0o600):
         raise SaltCloudSystemExit(
             'The EC2 key file \'{0}\' needs to be set to mode 0400 or 0600.\n'.format(
                 key_filename

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2511,10 +2511,9 @@ def create(vm_=None, call=None):
     key_filename = config.get_cloud_config_value(
         'private_key', vm_, __opts__, search_global=False, default=None
     )
-    if deploy or (deploy and win_password == 'auto'):
+    if deploy:
         # The private_key and keyname settings are only needed for bootstrapping
-        # new instances when deploy is True, or when win_password is set to 'auto'
-        # and deploy is also True.
+        # new instances when deploy is True
         if key_filename is None:
             raise SaltCloudSystemExit(
                 'The required \'private_key\' configuration setting is missing from the '

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -3207,8 +3207,8 @@ def check_key_path_and_mode(provider, key_path):
         )
         return False
 
-    key_mode = str(oct(stat.S_IMODE(os.stat(key_path).st_mode)))
-    if key_mode not in ('0400', '0600'):
+    key_mode = stat.S_IMODE(os.stat(key_path).st_mode)
+    if key_mode not in (0o400, 0o600):
         log.error(
             'The key file \'{0}\' used in the \'{1}\' provider configuration '
             'needs to be set to mode 0400 or 0600.\n'.format(

--- a/tests/unit/cloud/clouds/ec2_test.py
+++ b/tests/unit/cloud/clouds/ec2_test.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+import os
+import tempfile
+
+# Import Salt Libs
+from salt.cloud.clouds import ec2
+from salt.exceptions import SaltCloudSystemExit
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import MagicMock, NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../../')
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class EC2TestCase(TestCase):
+    '''
+    Unit TestCase for salt.cloud.clouds.ec2 module.
+    '''
+    def test__validate_key_path_and_mode(self):
+        with tempfile.NamedTemporaryFile() as f:
+            key_file = f.name
+
+            os.chmod(key_file, 0o644)
+            self.assertRaises(SaltCloudSystemExit,
+                              ec2._validate_key_path_and_mode,
+                              key_file)
+            os.chmod(key_file, 0o600)
+            self.assertTrue(ec2._validate_key_path_and_mode(key_file))
+            os.chmod(key_file, 0o400)
+            self.assertTrue(ec2._validate_key_path_and_mode(key_file))
+
+        # tmp file removed
+        self.assertRaises(SaltCloudSystemExit,
+                          ec2._validate_key_path_and_mode,
+                          key_file)
+
+if __name__ == '__main__':
+    from unit import run_tests
+    run_tests(EC2TestCase, needs_daemon=False)

--- a/tests/unit/utils/cloud_test.py
+++ b/tests/unit/utils/cloud_test.py
@@ -12,6 +12,7 @@
 # Import Python libs
 from __future__ import absolute_import
 import os
+import tempfile
 
 # Import Salt Testing libs
 from salttesting import TestCase, skipIf
@@ -123,6 +124,20 @@ class CloudUtilsTestCase(TestCase):
             cloud.sftp_file("/tmp/test", "ТЕСТ test content")
         # we successful pass the place with os.write(tmpfd, ...
         self.assertNotEqual("a bytes-like object is required, not 'str'", str(context.exception))
+
+    def test_check_key_path_and_mode(self):
+        with tempfile.NamedTemporaryFile() as f:
+            key_file = f.name
+
+            os.chmod(key_file, 0o644)
+            self.assertFalse(cloud.check_key_path_and_mode('foo', key_file))
+            os.chmod(key_file, 0o600)
+            self.assertTrue(cloud.check_key_path_and_mode('foo', key_file))
+            os.chmod(key_file, 0o400)
+            self.assertTrue(cloud.check_key_path_and_mode('foo', key_file))
+
+        # tmp file removed
+        self.assertFalse(cloud.check_key_path_and_mode('foo', key_file))
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?

Use Python 2-3 compatible octal constants when checking file mode.

The first commit does not relate to the pull requests' subject, but I decided to include it as it textually relates to the same block of code as the subsequent patch and it's a trivial fix.

### Tests written?

Yes