### PR TITLE
Cosmetic: support bool value for 'ssl' config option.

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -932,7 +932,7 @@ VALID_OPTS = {
     # http://docs.python.org/2/library/ssl.html#ssl.wrap_socket
     # Note: to set enum arguments values like `cert_reqs` and `ssl_version` use constant names
     # without ssl module prefix: `CERT_REQUIRED` or `PROTOCOL_SSLv23`.
-    'ssl': (dict, type(None)),
+    'ssl': (dict, bool, type(None)),
 
     # django auth
     'django_auth_path': str,
@@ -3106,7 +3106,11 @@ def _update_ssl_config(opts):
     '''
     Resolves string names to integer constant in ssl configuration.
     '''
-    if opts['ssl'] is None:
+    if opts['ssl'] in (None, False):
+        opts['ssl'] = None
+        return
+    if opts['ssl'] is True:
+        opts['ssl'] = {}
         return
     import ssl
     for key, prefix in (('cert_reqs', 'CERT_'),


### PR DESCRIPTION
### What does this PR do?
Makes possible to set `True` to `ssl` config option.
This is useful for minion config which doesn't need anything to be set in ssl opts, but needs to enable it. In this case `ssl: True` looks better than `ssl: {}` in yaml config.

### What issues does this PR fix or reference?
Related to #39528.

### Tests written?
No (manually tested)