### PR TITLE
Require SaltPyLint >= v2017.2.22

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,15 +4,7 @@
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-init-hook="
-  exec 'aW1wb3J0IG9zLCBzeXMKCmlmICdWSVJUVUFMX0VOVicgaW4gb3MuZW52aXJvbjoKCiAgICB2ZV9k \
-  aXIgPSBvcy5lbnZpcm9uWydWSVJUVUFMX0VOViddCiAgICB2ZV9kaXIgaW4gc3lzLnBhdGggb3Ig \
-  c3lzLnBhdGguaW5zZXJ0KDAsIHZlX2RpcikKICAgIGFjdGl2YXRlX3RoaXMgPSBvcy5wYXRoLmpv \
-  aW4ob3MucGF0aC5qb2luKHZlX2RpciwgJ2JpbicpLCAnYWN0aXZhdGVfdGhpcy5weScpCgogICAg \
-  IyBGaXggZm9yIHdpbmRvd3MKICAgIGlmIG5vdCBvcy5wYXRoLmV4aXN0cyhhY3RpdmF0ZV90aGlz \
-  KToKICAgICAgICBhY3RpdmF0ZV90aGlzID0gb3MucGF0aC5qb2luKG9zLnBhdGguam9pbih2ZV9k \
-  aXIsICdTY3JpcHRzJyksICdhY3RpdmF0ZV90aGlzLnB5JykKCiAgICBleGVjZmlsZShhY3RpdmF0 \
-  ZV90aGlzLCBkaWN0KF9fZmlsZV9fPWFjdGl2YXRlX3RoaXMpKQo='.decode('base64')"
+#init-hook=
 
 # Profiled execution.
 profile=no
@@ -51,11 +43,8 @@ extension-pkg-whitelist=
 fileperms-default=0644
 fileperms-ignore-paths=tests/runtests.py,tests/jenkins*.py,tests/saltsh.py,tests/buildpackage.py
 
-# Py3 Modernize PyLint Plugin Settings
-modernize-nofix = libmodernize.fixes.fix_dict_six
-
 # Minimum Python Version To Enforce
-minimum-python-version = 2.6
+minimum-python-version = 2.7
 
 [MESSAGES CONTROL]
 # Only show warnings with the listed confidence levels. Leave empty to show

--- a/.testing.pylintrc
+++ b/.testing.pylintrc
@@ -4,15 +4,7 @@
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-init-hook="
-  exec 'aW1wb3J0IG9zLCBzeXMKCmlmICdWSVJUVUFMX0VOVicgaW4gb3MuZW52aXJvbjoKCiAgICB2ZV9k \
-  aXIgPSBvcy5lbnZpcm9uWydWSVJUVUFMX0VOViddCiAgICB2ZV9kaXIgaW4gc3lzLnBhdGggb3Ig \
-  c3lzLnBhdGguaW5zZXJ0KDAsIHZlX2RpcikKICAgIGFjdGl2YXRlX3RoaXMgPSBvcy5wYXRoLmpv \
-  aW4ob3MucGF0aC5qb2luKHZlX2RpciwgJ2JpbicpLCAnYWN0aXZhdGVfdGhpcy5weScpCgogICAg \
-  IyBGaXggZm9yIHdpbmRvd3MKICAgIGlmIG5vdCBvcy5wYXRoLmV4aXN0cyhhY3RpdmF0ZV90aGlz \
-  KToKICAgICAgICBhY3RpdmF0ZV90aGlzID0gb3MucGF0aC5qb2luKG9zLnBhdGguam9pbih2ZV9k \
-  aXIsICdTY3JpcHRzJyksICdhY3RpdmF0ZV90aGlzLnB5JykKCiAgICBleGVjZmlsZShhY3RpdmF0 \
-  ZV90aGlzLCBkaWN0KF9fZmlsZV9fPWFjdGl2YXRlX3RoaXMpKQo='.decode('base64')"
+#init-hook=
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
@@ -48,11 +40,8 @@ extension-pkg-whitelist=
 fileperms-default=0644
 fileperms-ignore-paths=tests/runtests.py,tests/jenkins*.py,tests/saltsh.py,tests/buildpackage.py
 
-# Py3 Modernize PyLint Plugin Settings
-modernize-nofix = libmodernize.fixes.fix_dict_six
-
 # Minimum Python Version To Enforce
-minimum-python-version = 2.6
+minimum-python-version = 2.7
 
 [MESSAGES CONTROL]
 # Only show warnings with the listed confidence levels. Leave empty to show

--- a/pkg/windows/req_testing.txt
+++ b/pkg/windows/req_testing.txt
@@ -2,7 +2,7 @@ mock
 boto
 boto3
 moto
-SaltPyLint
+SaltPyLint>=v2017.2.22
 apache-libcloud
 virtualenv
 

--- a/requirements/dev_python27.txt
+++ b/requirements/dev_python27.txt
@@ -6,4 +6,4 @@ boto>=2.32.1
 boto3>=1.2.1
 moto>=0.3.6
 SaltTesting
-SaltPyLint
+SaltPyLint>=v2017.2.22

--- a/requirements/dev_python34.txt
+++ b/requirements/dev_python34.txt
@@ -6,4 +6,4 @@ boto>=2.32.1
 boto3>=1.2.1
 moto>=0.3.6
 SaltTesting
-SaltPyLint
+SaltPyLint>=v2017.2.22


### PR DESCRIPTION
Minimal Python version for develop is now 2.7
With the new SaltPyLint release, we enable the 2to3/modernize dict fixes but only for the `.iter<items|keys|values>()` calls.