### PR TITLE
Don't use `__salt__` in salt.utils.minion. Removed unneeded function.

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -25,8 +25,8 @@ import salt.config
 import salt.minion
 import salt.utils
 import salt.utils.event
-from salt.utils.minion import connected_masters as _connected_masters
 from salt.utils.network import host_to_ips as _host_to_ips
+from salt.utils.network import remote_port_tcp as _remote_port_tcp
 from salt.ext.six.moves import zip
 from salt.exceptions import CommandExecutionError
 
@@ -1055,7 +1055,8 @@ def master(master=None, connected=True):
         return
 
     master_connection_status = False
-    connected_ips = _connected_masters()
+    port = __salt__['config.get']('publish_port', default=4505)
+    connected_ips = _remote_port_tcp(port)
 
     # Get connection status for master
     for master_ip in master_ips:

--- a/salt/utils/minion.py
+++ b/salt/utils/minion.py
@@ -12,7 +12,6 @@ import threading
 # Import Salt Libs
 import salt.utils
 import salt.payload
-from salt.utils.network import remote_port_tcp as _remote_port_tcp
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -56,22 +55,6 @@ def cache_jobs(opts, jid, ret):
         os.makedirs(jdir)
     with salt.utils.fopen(fn_, 'w+b') as fp_:
         fp_.write(serial.dumps(ret))
-
-
-def connected_masters():
-    '''
-    Return current connected masters
-    '''
-    # default port
-    port = 4505
-
-    config_port = __salt__['config.get']('publish_port')
-    if config_port:
-        port = config_port
-
-    connected_masters_ips = _remote_port_tcp(port)
-
-    return connected_masters_ips
 
 
 def _read_proc_file(path, opts):


### PR DESCRIPTION
### What does this PR do?
Fixes `status.master` module function thus fixing multimaster failover.
More info in #39368

### What issues does this PR fix or reference?
Fixes #39368
Related to #37832 (partially reverts)

### Tests written?
No