### PR TITLE
[CLOUD] Log error when private/public IP was not detected

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2122,14 +2122,21 @@ def query_instance(vm_=None, call=None):
 
         log.debug('Returned query data: {0}'.format(data))
 
-        if ssh_interface(vm_) == 'public_ips' and 'ipAddress' in data[0]['instancesSet']['item']:
-            log.error(
-                'Public IP not detected.'
-            )
-            return data
-        if ssh_interface(vm_) == 'private_ips' and \
-           'privateIpAddress' in data[0]['instancesSet']['item']:
-            return data
+        if ssh_interface(vm_) == 'public_ips':
+            if 'ipAddress' in data[0]['instancesSet']['item']:
+                return data
+            else:
+                log.error(
+                    'Public IP not detected.'
+                )
+
+        if ssh_interface(vm_) == 'private_ips':
+            if 'privateIpAddress' in data[0]['instancesSet']['item']:
+                return data
+            else:
+                log.error(
+                    'Private IP not detected.'
+                )
 
     try:
         data = salt.utils.cloud.wait_for_ip(


### PR DESCRIPTION
### What does this PR do?
It corrects the logging output of instance IP detection in `salt-cloud` when working with AWS EC2 driver.

### Previous Behavior
* If instance SSH interface configured as `public_ips` and actually a public IP was detected, `salt-cloud` logs the `Public IP not detected.` error message and continue to bootstrap an instance.
* If public IP still was not detected, `salt-cloud` just remains silent, so operator unable to identify why the process entered execution loop. 

### New Behavior
* If public IP still was not detected, `salt-cloud` logs out error message `Public IP not detected.` on each probing iteration.
* Same way, if private IP was configured as the main SSH interface and was not detected, `salt-cloud` logs out `Private IP not detected.`

### Tests written?
No
