### PR TITLE
[msgpack] look for `datetime.datetime` in keys also while packing

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -224,6 +224,10 @@ class Serial(object):
             def datetime_encoder(obj):
                 if isinstance(obj, dict):
                     for key, value in six.iteritems(obj.copy()):
+                        encodedkey = datetime_encoder(key)
+                        if key != encodedkey:
+                           del obj[key]
+                           key = encodedkey
                         obj[key] = datetime_encoder(value)
                     return dict(obj)
                 elif isinstance(obj, (list, tuple)):


### PR DESCRIPTION
`del` the old if the encoded key is different form the original one.

### What does this PR do?
datetime.datetime can appear in keys also, causing `TypeError` to be raised.
This PR fixes that behavior.

### What issues does this PR fix or reference?
Should I create one. Actually this fixes an old [pull-request-22118](https://github.com/saltstack/salt/pull/22118)

### Tests written?
No
