### PR TITLE
Don't use our own six dictionary fixes in this branch

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -52,7 +52,8 @@ fileperms-default=0644
 fileperms-ignore-paths=tests/runtests.py,tests/jenkins*.py,tests/saltsh.py,tests/buildpackage.py
 
 # Py3 Modernize PyLint Plugin Settings
-modernize-nofix = libmodernize.fixes.fix_dict_six
+modernize-nofix = libmodernize.fixes.fix_dict_six,
+  saltpylint.py3modernize.fixes.fix_dict_salt_six
 
 # Minimum Python Version To Enforce
 minimum-python-version = 2.6

--- a/.testing.pylintrc
+++ b/.testing.pylintrc
@@ -52,7 +52,8 @@ fileperms-default=0644
 fileperms-ignore-paths=tests/runtests.py,tests/jenkins*.py,tests/saltsh.py,tests/buildpackage.py
 
 # Py3 Modernize PyLint Plugin Settings
-modernize-nofix = libmodernize.fixes.fix_dict_six
+modernize-nofix = libmodernize.fixes.fix_dict_six,
+  saltpylint.py3modernize.fixes.fix_dict_salt_six
 
 # Minimum Python Version To Enforce
 minimum-python-version = 2.6


### PR DESCRIPTION
The recent release of SaltPyLint properly fixes just `.iter<items|keys|values>()`.
Previously it was disabled because it provided some unnecessary fixes.
These fixes will however still be disabled in all branches except develop which we target to run on Python 3.
