### PR TITLE
Fix fileserver roots tests for Windows

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -356,9 +356,10 @@ class Client(object):
                         del dirs[:]
                     else:
                         for found_file in files:
-                            stripped_root = os.path.relpath(root, path).replace('/', '.')
+                            stripped_root = os.path.relpath(root, path)
                             if salt.utils.is_windows():
                                 stripped_root = stripped_root.replace('\\', '/')
+                            stripped_root = stripped_root.replace('/', '.')
                             if found_file.endswith(('.sls')):
                                 if found_file.endswith('init.sls'):
                                     if stripped_root.endswith('.'):


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in `fileclient.py` on Windows. It was erroneously returning a state in a subdirectory with a `/` instead of a `.`
Fixes `test_file_hash` in `integration.fileserver.roots_test`. Git adds Windows style line endings to files in Windows. Therefore the hash in Windows is different than the hash in other OSs.
Fixes `test_serve_file` in `integration.fileserver.roots_test`. Again, file comparison fails because Git addes Windows style line endings in Windows.
Skips `test_symlink_list` in `integration.fileserver.roots_test`. The problem lies with Git. Unix style symlinks do not translate in Windows. I attempted the newest version of Git (2.11.1) and though the symlink is created, there's something wrong with it (there is no content). See the following for more details:  http://stackoverflow.com/questions/5917249/git-symlinks-in-windows

### Previous Behavior
Several tests failed either due to Git/Windows issues or a bug in `fileclient.py`

### New Behavior
Tests either pass or are skipped.

### Tests written?
Yes