### PR TITLE
[develop] Fix some pylint errors that snuck into develop

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2481,6 +2481,7 @@ def wait_for_instance(
 
     return vm_
 
+
 def _validate_key_path_and_mode(key_filename):
     if key_filename is None:
         raise SaltCloudSystemExit(
@@ -2504,6 +2505,7 @@ def _validate_key_path_and_mode(key_filename):
         )
 
     return True
+
 
 def create(vm_=None, call=None):
     '''

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -226,8 +226,8 @@ class Serial(object):
                     for key, value in six.iteritems(obj.copy()):
                         encodedkey = datetime_encoder(key)
                         if key != encodedkey:
-                           del obj[key]
-                           key = encodedkey
+                            del obj[key]
+                            key = encodedkey
                         obj[key] = datetime_encoder(value)
                     return dict(obj)
                 elif isinstance(obj, (list, tuple)):

--- a/salt/states/boto_iam.py
+++ b/salt/states/boto_iam.py
@@ -141,10 +141,10 @@ import os
 import salt.utils
 import salt.utils.odict as odict
 import salt.utils.dictupdate as dictupdate
-
-# Import 3rd party libs
 import salt.ext.six as six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
+
+# Import 3rd party libs
 try:
     from salt._compat import ElementTree as ET
     HAS_ELEMENT_TREE = True

--- a/tests/unit/cloud/clouds/ec2_test.py
+++ b/tests/unit/cloud/clouds/ec2_test.py
@@ -11,10 +11,11 @@ from salt.exceptions import SaltCloudSystemExit
 
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
-from salttesting.mock import MagicMock, NO_MOCK, NO_MOCK_REASON, patch
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON
 from salttesting.helpers import ensure_in_syspath
 
 ensure_in_syspath('../../../')
+
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class EC2TestCase(TestCase):
@@ -39,6 +40,7 @@ class EC2TestCase(TestCase):
                           ec2._validate_key_path_and_mode,
                           key_file)
 
+
 if __name__ == '__main__':
-    from unit import run_tests
+    from integration import run_tests
     run_tests(EC2TestCase, needs_daemon=False)


### PR DESCRIPTION
There is still one py3 compatibility error for pylint that i am not sure why it is happening:
```
20:59:04  import salt.ext.six as six
20:59:04  from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
20:59:04 +from salt.ext import six
```
Clearly the `six` import is already there, so I am not sure why it would be picky about that, and only in this particular file. We have the import defined as `import salt.ext.six as six` all over, so that is odd.

Any thoughts on that one @s0undt3ch, based on some of the changes you've made in the linter lately?