### PR TITLE
Allow masterless minions to pull files from S3

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1340,7 +1340,8 @@ class FSClient(RemoteClient):
     the FSChan object
     '''
     def __init__(self, opts):  # pylint: disable=W0231
-        RemoteClient.__init__(self, opts)
+        self.opts = opts
+        self.utils = salt.loader.utils(opts)
         self.channel = salt.fileserver.FSChan(opts)
         self.auth = DumbAuth()
 

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1340,7 +1340,7 @@ class FSClient(RemoteClient):
     the FSChan object
     '''
     def __init__(self, opts):  # pylint: disable=W0231
-        self.opts = opts
+        RemoteClient.__init__(self, opts)
         self.channel = salt.fileserver.FSChan(opts)
         self.auth = DumbAuth()
 


### PR DESCRIPTION
This PR is to fix an issue which occurs when a masterless minion tries to pull files from S3. In the past, the s3.query function was being called using salt.utils. but there has been a change to make utils a property of the file client object, but the FSClient class did not have a corresponding change made to set this property.

It would be good to get this fixed in v2016.11 as this issue currently affects our ability to use Salt in a masterless setup.

### What issues does this PR fix or reference?
#38836 

### Previous Behavior
Would get an error that looks like this:
```
local:
----------
      ID: cfn-signal-install
Function: archive.extracted
    Name: /opt/cfn-bootstrap
  Result: False
 Comment: An exception occurred in this state: Traceback (most recent call last):
File "/usr/lib/python2.7/site-packages/salt/state.py", line 1745, in call
**cdata['kwargs'])
File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1702, in wrapper
return f(*args, **kwargs)
File "/usr/lib/python2.7/site-packages/salt/states/archive.py", line 858, in extracted
__env__)
File "/usr/lib/python2.7/site-packages/salt/modules/file.py", line 620, in get_source_sum
hash_fn = __salt__['cp.cache_file'](source_hash, saltenv)
File "/usr/lib/python2.7/site-packages/salt/modules/cp.py", line 402, in cache_file
result = _client().cache_file(path, saltenv)
File "/usr/lib/python2.7/site-packages/salt/fileclient.py", line 178, in cache_file
return self.get_url(path, '', True, saltenv, cachedir=cachedir)
File "/usr/lib/python2.7/site-packages/salt/fileclient.py", line 530, in get_url
'Could not fetch from {0}. Exception: {1}'.format(url, exc)
MinionError: Could not fetch from s3://some-bucket-in-s3/pkgs/aws-cfn-bootstrap-latest.tar.gz.sha1. Exception: 'FSClient' object has no attribute 'utils'
```

### New Behavior
This should no longer explode.

### Tests written?
No