### PR TITLE
fix case in os_family for Suse

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -53,7 +53,7 @@ def __virtual__():
     if __grains__['kernel'] != 'Linux':
         return (False, 'Non Linux OSes are not supported')
     # SUSE >=12.0 uses systemd
-    if __grains__.get('os_family', '') == 'SUSE':
+    if __grains__.get('os_family', '') == 'Suse':
         try:
             # osrelease might be in decimal format (e.g. "12.1"), or for
             # SLES might include service pack (e.g. "11 SP3"), so split on


### PR DESCRIPTION
### What does this PR do?

fix service handling for openSUSE

SUSE systems report os_family as "Suse". A compare with "SUSE" will fail and the wrong service type is used.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
