### PR TITLE
Ensure user/group/file_mode after line edit

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3178,8 +3178,7 @@ def line(name, content, match=None, mode=None, location=None,
     if not name:
         return _error(ret, 'Must provide name to file.line')
 
-    if create and not os.path.isfile(name):
-        managed(name, create=create, user=user, group=group, mode=file_mode)
+    managed(name, create=create, user=user, group=group, mode=file_mode)
 
     check_res, check_msg = _check_file(name)
     if not check_res:


### PR DESCRIPTION
### What does this PR do?
Fix handling of file ownership and mode in line editing states.

### What issues does this PR fix or reference?
Can be used as a workaround for #38452

### Previous Behavior
`user`, `group` and `mode` are used only when file is newly created. If it exists and needs to be edited, it is saved with default ownership.

### New Behavior
Proper ownership and mode is maintained after line edits.

### Tests written?
No
