### PR TITLE
Rework MongoDB execution module due to eval deprecation

### DIFF
--- a/salt/modules/mongodb.py
+++ b/salt/modules/mongodb.py
@@ -155,6 +155,33 @@ def db_remove(name, user=None, password=None, host=None, port=None, authdb=None)
 
     return True
 
+def _version(mdb):
+    return mdb.command('buildInfo')['version']
+
+def version(user=None, password=None, host=None, port=None, database='admin', authdb=None):
+    '''
+    Get MongoDB instance version
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mongodb.version <user> <password> <host> <port> <database>
+    '''
+    conn = _connect(user, password, host, port, authdb=authdb)
+    if not conn:
+        return 'Failed to connect to mongo database'
+
+    try:
+        mdb = pymongo.database.Database(conn, database)
+        return _version(mdb)
+    except pymongo.errors.PyMongoError as err:
+        log.error(
+            'Listing users failed with error: {0}'.format(
+                str(err)
+            )
+        )
+        return str(err)
 
 def user_list(user=None, password=None, host=None, port=None, database='admin', authdb=None):
     '''
@@ -175,20 +202,20 @@ def user_list(user=None, password=None, host=None, port=None, database='admin', 
         mdb = pymongo.database.Database(conn, database)
 
         output = []
-        mongodb_version = mdb.eval('db.version()')
+        mongodb_version = _version(mdb)
 
         if LooseVersion(mongodb_version) >= LooseVersion('2.6'):
-            for user in mdb.eval('db.getUsers()'):
-                output.append([
-                    ('user', user['user']),
-                    ('roles', user['roles'])
-                ])
+            for user in mdb.command('usersInfo')['users']:
+                output.append(
+                    {'user': user['user'],
+                     'roles': user['roles']}
+                )
         else:
             for user in mdb.system.users.find():
-                output.append([
-                    ('user', user['user']),
-                    ('readOnly', user.get('readOnly', 'None'))
-                ])
+                output.append(
+                    {'user': user['user'],
+                     'readOnly': user.get('readOnly', 'None')}
+                )
         return output
 
     except pymongo.errors.PyMongoError as err:
@@ -223,7 +250,7 @@ def user_exists(name, user=None, password=None, host=None, port=None,
     return False
 
 
-def user_create(name, passwd, user=None, password=None, host=None, port=None,
+def user_create(name, passwd, roles=None, user=None, password=None, host=None, port=None,
                 database='admin', authdb=None):
     '''
     Create a Mongodb user
@@ -232,16 +259,19 @@ def user_create(name, passwd, user=None, password=None, host=None, port=None,
 
     .. code-block:: bash
 
-        salt '*' mongodb.user_create <name> <user> <password> <host> <port> <database>
+        salt '*' mongodb.user_create <user_name> <user_password> <roles> <user> <password> <host> <port> <database>
     '''
     conn = _connect(user, password, host, port, authdb=authdb)
     if not conn:
         return 'Failed to connect to mongo database'
 
+    if not roles:
+        roles = []
+
     try:
         log.info('Creating user {0}'.format(name))
         mdb = pymongo.database.Database(conn, database)
-        mdb.add_user(name, passwd)
+        mdb.add_user(name, passwd, roles=roles)
     except pymongo.errors.PyMongoError as err:
         log.error(
             'Creating database {0} failed with error: {1}'.format(
@@ -347,7 +377,7 @@ def user_grant_roles(name, roles, database, user=None, password=None, host=None,
     try:
         log.info('Granting roles {0} to user {1}'.format(roles, name))
         mdb = pymongo.database.Database(conn, database)
-        mdb.eval("db.grantRolesToUser('{0}', {1})".format(name, roles))
+        mdb.command("grantRolesToUser", name, roles=roles)
     except pymongo.errors.PyMongoError as err:
         log.error(
             'Granting roles {0} to user {1} failed with error: {2}'.format(
@@ -386,7 +416,7 @@ def user_revoke_roles(name, roles, database, user=None, password=None, host=None
     try:
         log.info('Revoking roles {0} from user {1}'.format(roles, name))
         mdb = pymongo.database.Database(conn, database)
-        mdb.eval("db.revokeRolesFromUser('{0}', {1})".format(name, roles))
+        mdb.command("revokeRolesFromUser", name, roles=roles)
     except pymongo.errors.PyMongoError as err:
         log.error(
             'Revoking roles {0} from user {1} failed with error: {2}'.format(

--- a/salt/modules/mongodb.py
+++ b/salt/modules/mongodb.py
@@ -155,8 +155,10 @@ def db_remove(name, user=None, password=None, host=None, port=None, authdb=None)
 
     return True
 
+
 def _version(mdb):
     return mdb.command('buildInfo')['version']
+
 
 def version(user=None, password=None, host=None, port=None, database='admin', authdb=None):
     '''
@@ -182,6 +184,7 @@ def version(user=None, password=None, host=None, port=None, database='admin', au
             )
         )
         return str(err)
+
 
 def user_list(user=None, password=None, host=None, port=None, database='admin', authdb=None):
     '''

--- a/salt/modules/mongodb.py
+++ b/salt/modules/mongodb.py
@@ -172,8 +172,8 @@ def version(user=None, password=None, host=None, port=None, database='admin', au
     '''
     conn = _connect(user, password, host, port, authdb=authdb)
     if not conn:
-	err_msg = "Failed to connect to MongoDB database {0}:{1}".format(host, port)
-	log.error(err_msg)
+        err_msg = "Failed to connect to MongoDB database {0}:{1}".format(host, port)
+        log.error(err_msg)
         return (False, err_msg)
 
     try:

--- a/salt/modules/mongodb.py
+++ b/salt/modules/mongodb.py
@@ -172,7 +172,9 @@ def version(user=None, password=None, host=None, port=None, database='admin', au
     '''
     conn = _connect(user, password, host, port, authdb=authdb)
     if not conn:
-        return 'Failed to connect to mongo database'
+	err_msg = "Failed to connect to MongoDB database {0}:{1}".format(host, port)
+	log.error(err_msg)
+        return (False, err_msg)
 
     try:
         mdb = pymongo.database.Database(conn, database)
@@ -253,8 +255,8 @@ def user_exists(name, user=None, password=None, host=None, port=None,
     return False
 
 
-def user_create(name, passwd, roles=None, user=None, password=None, host=None, port=None,
-                database='admin', authdb=None):
+def user_create(name, passwd, user=None, password=None, host=None, port=None,
+                database='admin', authdb=None, roles=None):
     '''
     Create a Mongodb user
 


### PR DESCRIPTION
### What does this PR do?
Uses command instead of eval, adds new mongodb.version method, modifies output of mongodb.user_list and doesn't grant any roles to newly created user

### What issues does this PR fix or reference?
#39594 #33364

### Previous Behavior
mongodb.user_list returned array of arrays (each containing two tuples)
mongodb.user_create implicitly granted roles for the database (as per https://api.mongodb.com/python/current/api/pymongo/database.html#pymongo.database.Database.add_user)
mongodb.version doesn't exist

### New Behavior
mongodb.user_list returns array of dicts (keys user, roles)
mongodb.user_create grants no roles if none supplied
mongodb.version returns version of mongodb instance

### Tests written?
No
