### PR TITLE
Reduce scope of try except StopIteration wrapping

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -58,21 +58,21 @@ class Batch(object):
         # Broadcast to targets
         fret = set()
         nret = set()
-        try:
-            for ret in ping_gen:
-                if ('minions' and 'jid') in ret:
-                    for minion in ret['minions']:
-                        nret.add(minion)
-                    continue
-                else:
+        for ret in ping_gen:
+            if ('minions' and 'jid') in ret:
+                for minion in ret['minions']:
+                    nret.add(minion)
+                continue
+            else:
+                try:
                     m = next(six.iterkeys(ret))
-                    if m is not None:
-                        fret.add(m)
-            return (list(fret), ping_gen, nret.difference(fret))
-        except StopIteration:
-            if not self.quiet:
-                print_cli('No minions matched the target.')
-        return list(fret), ping_gen
+                except StopIteration:
+                    if not self.quiet:
+                        print_cli('No minions matched the target.')
+                    break
+                if m is not None:
+                    fret.add(m)
+        return (list(fret), ping_gen, nret.difference(fret))
 
     def get_bnum(self):
         '''


### PR DESCRIPTION
Aimed to reduce <strike>amount of code</strike> scope of try except where in one hand a 3 tuple were
returned and in the other hand a 2 tuple value.

@cachedout 
There was 2 contradictory refactoring happening at different period.

https://github.com/saltstack/salt/commit/74e1803111c7d6d016e3adc54e916f1573661a5a
and
https://github.com/saltstack/salt/commit/fe338ff41f35f274cd2fb9410e4b1816775cede0

There were both correct taken separately but ended up being wrong when used together.
Something probably get lost during backporting. I didn't investigating further.

### What does this PR do?
refactoring some code to simplify it. 

### Previous Behavior
sometimes a tuple of 2 items were returned while we expect 3 items.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
