### PR TITLE
New dependency mfc90.dll (the content of existing vcredist_x##_2008_mfc.exe)

### DIFF
--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -72,6 +72,7 @@ Function Get-Settings {
             "SSLeay"     = "ssleay32.dll"
             "OpenSSLLic" = "OpenSSL_License.txt"
             "libsodium"  = "libsodium.dll"
+            "mfc90"      = "mfc90.dll"
             "msvcr"      = "msvcr120.dll"
         }
         $ini.Add("64bitDLLs", $64bitDLLs)
@@ -82,6 +83,7 @@ Function Get-Settings {
             "SSLeay"     = "ssleay32.dll"
             "OpenSSLLic" = "OpenSSL_License.txt"
             "libsodium"  = "libsodium.dll"
+            "mfc90"      = "mfc90.dll"
             "msvcr"      = "msvcr120.dll"
         }
         $ini.Add("32bitDLLs", $32bitDLLs)


### PR DESCRIPTION
### What does this PR do?
Add `mfc90.dll`, the content of 
 - dependencies/32/`vcredist_32_2008_mfc.exe`  
 - dependencies/64/`vcredist_64_2008_mfc.exe`

### What issues does this PR fix or reference?
The msi-installer cannot run executables, but it can use the existing infrastructure for dll’s (libeav32.dll, libsodium.dll, ssleay32.dll).

See discussion https://github.com/saltstack/salt-windows-msi/pull/12

### Note
Merge modules are not an option here because Microsoft released a security update after the last merge module update.
Also, Merge modules are heavyweight in comparison with a dll.

