### PR TITLE
intialize the Client stuff in FSClient

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1356,8 +1356,7 @@ class FSClient(RemoteClient):
     the FSChan object
     '''
     def __init__(self, opts):  # pylint: disable=W0231
-        self.opts = opts
-        self.utils = salt.loader.utils(opts)
+        Client.__init__(self, opts)  # pylint: disable=W0233
         self.channel = salt.fileserver.FSChan(opts)
         self.auth = DumbAuth()
 


### PR DESCRIPTION
### What does this PR do?
Initialize the Client class inside FSClient like LocalClient and RemoteClient do.  This will allow for self.utils to be available.

### What issues does this PR fix or reference?
#38836

### Tests written?
No