### PR TITLE
Fix wheel tests

### DIFF
--- a/salt/wheel/key.py
+++ b/salt/wheel/key.py
@@ -357,6 +357,12 @@ def gen(id_=None, keysize=2048):
         ret['priv'] = fp_.read()
     with salt.utils.fopen(pub) as fp_:
         ret['pub'] = fp_.read()
+
+    # The priv key is given the Read-Only attribute. The causes `os.remove` to
+    # fail in Windows.
+    if salt.utils.is_windows():
+        os.chmod(priv, 128)
+
     os.remove(priv)
     os.remove(pub)
     return ret

--- a/tests/integration/wheel/test_client.py
+++ b/tests/integration/wheel/test_client.py
@@ -76,7 +76,10 @@ class WheelModuleTest(integration.TestCase, integration.AdaptedConfigurationTest
 
         self.wheel.cmd_sync(low)
 
-    @skipIf(salt.utils.is_windows(), 'Causes pickling error on Windows')
+    # Remove this skipIf when Issue #39616 is resolved
+    # https://github.com/saltstack/salt/issues/39616
+    @skipIf(salt.utils.is_windows(),
+            'Causes pickling error on Windows: Issue #39616')
     def test_cmd_async(self):
         low = {
             'client': 'wheel_async',

--- a/tests/integration/wheel/test_client.py
+++ b/tests/integration/wheel/test_client.py
@@ -5,10 +5,12 @@ from __future__ import absolute_import
 
 # Import Salt Testing libs
 import integration
+from salttesting import skipIf
 
 # Import Salt libs
 import salt.auth
 import salt.wheel
+import salt.utils
 
 
 class WheelModuleTest(integration.TestCase, integration.AdaptedConfigurationTestCaseMixIn):
@@ -74,6 +76,7 @@ class WheelModuleTest(integration.TestCase, integration.AdaptedConfigurationTest
 
         self.wheel.cmd_sync(low)
 
+    @skipIf(salt.utils.is_windows(), 'Causes pickling error on Windows')
     def test_cmd_async(self):
         low = {
             'client': 'wheel_async',

--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -1,5 +1,7 @@
 integration.client.runner
+integration.client.standard
 integration.fileserver.fileclient_test
+integration.fileserver.roots_test
 integration.loader.globals
 integration.loader.interfaces
 integration.loader.loader
@@ -26,3 +28,5 @@ integration.runners.winrepo
 integration.states.host
 integration.states.renderers
 integration.utils.testprogram
+integration.wheel.client
+integration.wheel.key


### PR DESCRIPTION
### What does this PR do?
Adds Wheel tests to the Windows Whitelist.
Fixes the `key.gen` function on Windows
Skips the `test_cmd_async` test in `integration.wheel.client` tests (#39616)
Adds other tests to the Whitelist that are now working.

### Tests written?
Yes