### PR TITLE
Add a function to simply refresh the grains

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1692,7 +1692,7 @@ class Minion(MinionBase):
         self.opts['grains'] = salt.loader.grains(
             self.opts,
             force_refresh=True,
-            proxy=salt.utils.is_proxy())
+            proxy=getattr(self, 'proxy', None))
 
     def module_refresh(self, force_refresh=False, notify=False):
         '''

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1685,6 +1685,15 @@ class Minion(MinionBase):
             tagify([self.opts['id'], 'start'], 'minion'),
         )
 
+    def grains_refresh_manual(self):
+        '''
+        Perform a manual grains refresh
+        '''
+        self.opts['grains'] = salt.loader.grains(
+            self.opts,
+            force_refresh=True,
+            proxy=salt.utils.is_proxy())
+
     def module_refresh(self, force_refresh=False, notify=False):
         '''
         Refresh the functions and returners.
@@ -1854,9 +1863,12 @@ class Minion(MinionBase):
         elif package.startswith('manage_beacons'):
             self.manage_beacons(tag, data)
         elif package.startswith('grains_refresh'):
+            if package == 'grains_refresh_manual':
+                self.grains_refresh_manual()
             if self.grains_cache != self.opts['grains']:
-                self.pillar_refresh(force_refresh=True)
                 self.grains_cache = self.opts['grains']
+                if package != 'grains_refresh_manual':
+                    self.pillar_refresh(force_refresh=True)
         elif package.startswith('environ_setenv'):
             self.environ_setenv(tag, data)
         elif package.startswith('_minion_mine'):

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -278,8 +278,8 @@ def setvals(grains, destructive=False, refresh=True):
         msg = 'Unable to write to cache file {0}. Check permissions.'
         log.error(msg.format(fn_))
     if not __opts__.get('local', False):
-        # Sync the grains
-        __salt__['saltutil.sync_grains'](refresh=refresh)
+        # Refresh the grains
+        __salt__['saltutil.refresh_grains'](refresh=refresh)
     # Return the grains we just set to confirm everything was OK
     return new_grains
 
@@ -412,7 +412,7 @@ def remove(key, val, delimiter=DEFAULT_TARGET_DELIM):
     return setval(key, grains)
 
 
-def delval(key, destructive=False):
+def delval(key, destructive=False, refresh=True):
     '''
     .. versionadded:: 0.17.0
 
@@ -424,6 +424,9 @@ def delval(key, destructive=False):
     destructive
         Delete the key, too. Defaults to False.
 
+    refresh
+        Refresh modules and pillar after removing the grain.
+
     CLI Example:
 
     .. code-block:: bash
@@ -431,7 +434,7 @@ def delval(key, destructive=False):
         salt '*' grains.delval key
     '''
 
-    setval(key, None, destructive=destructive)
+    setval(key, None, destructive=destructive, refresh=refresh)
 
 
 def ls():  # pylint: disable=C0103

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -310,6 +310,34 @@ def sync_states(saltenv=None, refresh=True):
     return ret
 
 
+def refresh_grains(refresh=True):
+    '''
+    .. versionadded:: 2016.3.6,2016.11.4,Nitrogen
+
+    Refresh the minion's grains without syncing custom grains modules from
+    ``salt://_grains``.
+
+    refresh : True
+        If ``True``, refresh the available execution modules and recompile
+        pillar data for the minion. Set to ``False`` to prevent this refresh.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' saltutil.refresh_grains
+    '''
+    try:
+        ret = __salt__['event.fire']({}, 'grains_refresh_manual')
+    except Exception:
+        log.error('Failed to refresh grains', exc_info=True)
+        return False
+    if refresh:
+        refresh_modules()
+        refresh_pillar()
+    return ret
+
+
 def sync_grains(saltenv=None, refresh=True):
     '''
     .. versionadded:: 0.10.0

--- a/tests/unit/modules/grains_test.py
+++ b/tests/unit/modules/grains_test.py
@@ -29,7 +29,7 @@ grainsmod.__opts__ = {
 grainsmod.__salt__ = {}
 
 
-@patch.dict(grainsmod.__salt__, {'saltutil.sync_grains': MagicMock()})
+@patch.dict(grainsmod.__salt__, {'saltutil.refresh_grains': MagicMock()})
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class GrainsModuleTestCase(TestCase):
 


### PR DESCRIPTION
Also use this function to refresh the grains when editing them using
grains.{delval,setval,setvals}, avoiding a full sync. This speeds up
these functions by skipping the syncing of custom grains modules. For
most use cases, walking all your fileserver environments (which could be
a lot if using gitfs) is unnecessary when you're simply using these
functions to add/remove grains from /etc/salt/grains.