### PR TITLE
Address issue 39622

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -1313,6 +1313,12 @@ def _maybe_set_name_tag(name, obj):
 
 def _maybe_set_tags(tags, obj):
     if tags:
-        obj.add_tags(tags)
+        # Not all objects in Boto have an 'add_tags()' method.
+        try:
+          obj.add_tags(tags)
+
+        except AttributeError:
+          for tag, value in tags.items():
+            obj.add_tag(tag, value)
 
         log.debug('The following tags: {0} were added to {1}'.format(', '.join(tags), obj))

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -1315,10 +1315,10 @@ def _maybe_set_tags(tags, obj):
     if tags:
         # Not all objects in Boto have an 'add_tags()' method.
         try:
-          obj.add_tags(tags)
+            obj.add_tags(tags)
 
         except AttributeError:
-          for tag, value in tags.items():
-            obj.add_tag(tag, value)
+            for tag, value in tags.items():
+                obj.add_tag(tag, value)
 
         log.debug('The following tags: {0} were added to {1}'.format(', '.join(tags), obj))


### PR DESCRIPTION
Worked with @rkgrunt to get this one figured out.

The docs say to branch off of the oldest branch with the bug in question, which is why I'm requesting a PR into the `2015.5` branch. Apologies if I've misunderstood the protocol.

### What does this PR do?
Fix `boto_vpc.create_subnet()` to correctly apply user-defined tags for subnets.

### What issues does this PR fix or reference?
issue #39622 

### Previous Behavior
`boto_vpc.create_subnet()` fails if the user specifies tags.

### New Behavior
Tags are correctly applied to new subnets.

### Tests written?

No, but has been tested in our dev environment against AWS.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
