### PR TITLE
Return runner return code in a way compatible with check_state_result

### DIFF
--- a/salt/cli/run.py
+++ b/salt/cli/run.py
@@ -39,7 +39,15 @@ class SaltRun(parsers.SaltRunOptionParser):
                 pr = activate_profile(profiling_enabled)
                 try:
                     ret = runner.run()
-                    if isinstance(ret, dict) and 'retcode' in ret.get('data', {}):
+                    # In older versions ret['data']['retcode'] was used
+                    # for signaling the return code. This has been
+                    # changed for the orchestrate runner, but external
+                    # runners might still use it. For this reason, we
+                    # also check ret['data']['retcode'] if
+                    # ret['retcode'] is not available.
+                    if isinstance(ret, dict) and 'retcode' in ret:
+                        self.exit(ret['retcode'])
+                    elif isinstance(ret, dict) and 'retcode' in ret.get('data', {}):
                         self.exit(ret['data']['retcode'])
                 finally:
                     output_profile(

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -57,9 +57,9 @@ def orchestrate(mods, saltenv='base', test=None, exclude=None, pillar=None):
     ret = {'data': {minion.opts['id']: running}, 'outputter': 'highstate'}
     res = salt.utils.check_state_result(ret['data'])
     if res:
-        ret['data']['retcode'] = 0
+        ret['retcode'] = 0
     else:
-        ret['data']['retcode'] = 1
+        ret['retcode'] = 1
     return ret
 
 # Aliases for orchestrate runner


### PR DESCRIPTION
### What does this PR do?

This PR changes how a runner returns return code that should be returned on the command-line. Before this change, it was returned in `ret['data']['retcode']`, after the change it is returned in `ret['retcode']`. The code in `salt/cli/run.py` was changed in a way so that it can still deal with runners using the old format. The only runner in the core distribution (`salt.orchestrate`) is also changed by this PR so that it uses the new format.

### What issues does this PR fix or reference?

This PR fixed #39169. The problems described in #39169 happended when a runner (currently only `state.orchestrate`) included a return code in the `ret['data']` dict. When `ret['data']` was later processed by `check_state_result`, the check failed because `ret['data']['retcode']` is an integer and not a dict, but only dicts are expected as values in `ret['data']`.

### Previous Behavior
`salt-run` expected a runner to return an (optional) return code in `ret['data']['retcode']`. `state.orchestrate` used this feature.

### New Behavior
`salt-run` expectes a runner to return an (optional) return code in `ret['retcode']`, but will fall back to `ret['data']['retcode']` if `ret['retcode']` is not present. `state.orchestrate` uses the new format.

### Tests written?

No
