### PR TITLE
issue 39642 - boto_vpc.nat_gateway_present should accept parameter al…

### DIFF
--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -1279,7 +1279,7 @@ def route_table_absent(name, region=None,
 
 
 def nat_gateway_present(name, subnet_name=None, subnet_id=None,
-                        region=None, key=None, keyid=None, profile=None):
+                        region=None, key=None, keyid=None, profile=None, allocation_id=None):
     '''
     Ensure a nat gateway exists within the specified subnet
 
@@ -1303,6 +1303,10 @@ def nat_gateway_present(name, subnet_name=None, subnet_id=None,
     subnet_id
         Id of the subnet within which the nat gateway should exist.
         Either subnet_name or subnet_id must be provided.
+
+    allocation_id
+        If specified, the elastic IP address referenced by the ID is
+        associated with the gateway. Otherwise, a new allocation_id is created and used.
 
     region
         Region to connect to.
@@ -1337,7 +1341,8 @@ def nat_gateway_present(name, subnet_name=None, subnet_id=None,
         r = __salt__['boto_vpc.create_nat_gateway'](subnet_name=subnet_name,
                                                     subnet_id=subnet_id,
                                                     region=region, key=key,
-                                                    keyid=keyid, profile=profile)
+                                                    keyid=keyid, profile=profile,
+                                                    allocation_id=allocation_id)
         if not r.get('created'):
             ret['result'] = False
             ret['comment'] = 'Failed to create nat gateway: {0}.'.format(r['error']['message'])


### PR DESCRIPTION
### What does this PR do?
Fix issue #39642 

### What issues does this PR fix or reference?
Issue #39642 

### Previous Behavior
Providing the `allocation_id` parameter to `boto_vpc.nat_gateway_present` threw a warning and the state function ignored the parameter.

### New Behavior
The `allocation_id` is properly handled and given to the underlying `boto_vpc.create_nat_gateway` module function. 

### Tests written?

No. 
Tested in our AWS environment with success.

### Notes
I just added the parameter explicitly for this PR but I've seen, in a lot of other portion of the Salt codebase, that `**kwargs` is used pretty frequently. I didn't want to go that route for this PR since I'm not familiar with the patterns used in the salt cloud / boto area. Is that something to keep in mind for the future?

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
