### PR TITLE
Handle deprecation of passing string args to load_args_and_kwargs

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -29,6 +29,7 @@ import salt.minion
 import salt.search
 import salt.key
 import salt.fileserver
+import salt.utils.args
 import salt.utils.atomicfile
 import salt.utils.event
 import salt.utils.verify
@@ -845,7 +846,7 @@ class RemoteFuncs(object):
         opts = {}
         opts.update(self.opts)
         opts.update({'fun': load['fun'],
-                'arg': load['arg'],
+                'arg': salt.utils.args.parse_input(load['arg']),
                 'id': load['id'],
                 'doc': False,
                 'conf_file': self.opts['conf_file']})
@@ -895,7 +896,7 @@ class RemoteFuncs(object):
         # Set up the publication payload
         pub_load = {
             'fun': load['fun'],
-            'arg': load['arg'],
+            'arg': salt.utils.args.parse_input(load['arg']),
             'tgt_type': load.get('tgt_type', 'glob'),
             'tgt': load['tgt'],
             'ret': load['ret'],
@@ -948,7 +949,7 @@ class RemoteFuncs(object):
         # Set up the publication payload
         pub_load = {
             'fun': load['fun'],
-            'arg': load['arg'],
+            'arg': salt.utils.args.parse_input(load['arg']),
             'tgt_type': load.get('tgt_type', 'glob'),
             'tgt': load['tgt'],
             'ret': load['ret'],
@@ -1524,7 +1525,7 @@ class LocalFuncs(object):
                 'tgt': load['tgt'],
                 'user': load['user'],
                 'fun': load['fun'],
-                'arg': load['arg'],
+                'arg': salt.utils.args.parse_input(load['arg']),
                 'minions': minions,
             }
 
@@ -1576,7 +1577,7 @@ class LocalFuncs(object):
         # way that won't have a negative impact.
         pub_load = {
             'fun': load['fun'],
-            'arg': load['arg'],
+            'arg': salt.utils.args.parse_input(load['arg']),
             'tgt': load['tgt'],
             'jid': load['jid'],
             'ret': load['ret'],

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -285,24 +285,15 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
                 # above, that would result in a 2nd call to
                 # salt.utils.cli.yamlify_arg(), which could mangle the input.
                 _args.append(arg)
-            elif string_kwarg:
-                salt.utils.warn_until(
-                    'Nitrogen',
-                    'The list of function args and kwargs should be parsed '
-                    'by salt.utils.args.parse_input() before calling '
-                    'salt.minion.load_args_and_kwargs().'
+            if string_kwarg:
+                log.critical(
+                    'String kwarg(s) %s passed to '
+                    'salt.minion.load_args_and_kwargs(). This is no longer '
+                    'supported, so the kwarg(s) will be ignored. Arguments '
+                    'passed to salt.minion.load_args_and_kwargs() should be '
+                    'passed to salt.utils.args.parse_input() first to load '
+                    'and condition them properly.', string_kwarg
                 )
-                if argspec.keywords or next(six.iterkeys(string_kwarg)) in argspec.args:
-                    # Function supports **kwargs or is a positional argument to
-                    # the function.
-                    _kwargs.update(string_kwarg)
-                else:
-                    # **kwargs not in argspec and parsed argument name not in
-                    # list of positional arguments. This keyword argument is
-                    # invalid.
-                    for key, val in six.iteritems(string_kwarg):
-                        invalid_kwargs.append('{0}={1}'.format(key, val))
-                continue
 
         # if the arg is a dict with __kwarg__ == True, then its a kwarg
         elif isinstance(arg, dict) and arg.pop('__kwarg__', False) is True:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1741,6 +1741,10 @@ class ModuleCase(TestCase, SaltClientTestCaseMixIn):
         know_to_return_none = (
             'file.chown', 'file.chgrp', 'ssh.recv_known_host'
         )
+        if 'f_arg' in kwargs:
+            kwargs['arg'] = kwargs.pop('f_arg')
+        if 'f_timeout' in kwargs:
+            kwargs['timeout'] = kwargs.pop('f_timeout')
         orig = self.client.cmd(
             minion_tgt, function, arg, timeout=timeout, kwarg=kwargs
         )

--- a/tests/integration/client/test_kwarg.py
+++ b/tests/integration/client/test_kwarg.py
@@ -21,18 +21,14 @@ class StdTest(integration.ModuleCase):
         '''
         cmd_iter = self.client.cmd_cli(
                 'minion',
-                'test.kwarg',
-                ['foo=bar', 'baz=quo'],
+                'test.arg',
+                ['foo', 'bar', 'baz'],
                 kwarg={'qux': 'quux'}
                 )
         for ret in cmd_iter:
             data = ret['minion']['ret']
-            self.assertIn('foo', data)
-            self.assertIn('baz', data)
-            self.assertIn('qux', data)
-            self.assertEqual(data['foo'], 'bar')
-            self.assertEqual(data['baz'], 'quo')
-            self.assertEqual(data['qux'], 'quux')
+            self.assertEqual(data['args'], ['foo', 'bar', 'baz'])
+            self.assertEqual(data['kwargs']['qux'], 'quux')
 
     def test_iter(self):
         '''
@@ -40,18 +36,14 @@ class StdTest(integration.ModuleCase):
         '''
         cmd_iter = self.client.cmd_iter(
                 'minion',
-                'test.kwarg',
-                ['foo=bar', 'baz=quo'],
+                'test.arg',
+                ['foo', 'bar', 'baz'],
                 kwarg={'qux': 'quux'}
                 )
         for ret in cmd_iter:
             data = ret['minion']['ret']
-            self.assertIn('foo', data)
-            self.assertIn('baz', data)
-            self.assertIn('qux', data)
-            self.assertEqual(data['foo'], 'bar')
-            self.assertEqual(data['baz'], 'quo')
-            self.assertEqual(data['qux'], 'quux')
+            self.assertEqual(data['args'], ['foo', 'bar', 'baz'])
+            self.assertEqual(data['kwargs']['qux'], 'quux')
 
     def test_iter_no_block(self):
         '''
@@ -59,20 +51,16 @@ class StdTest(integration.ModuleCase):
         '''
         cmd_iter = self.client.cmd_iter_no_block(
                 'minion',
-                'test.kwarg',
-                ['foo=bar', 'baz=quo'],
+                'test.arg',
+                ['foo', 'bar', 'baz'],
                 kwarg={'qux': 'quux'}
                 )
         for ret in cmd_iter:
             if ret is None:
                 continue
             data = ret['minion']['ret']
-            self.assertIn('foo', data)
-            self.assertIn('baz', data)
-            self.assertIn('qux', data)
-            self.assertEqual(data['foo'], 'bar')
-            self.assertEqual(data['baz'], 'quo')
-            self.assertEqual(data['qux'], 'quux')
+            self.assertEqual(data['args'], ['foo', 'bar', 'baz'])
+            self.assertEqual(data['kwargs']['qux'], 'quux')
 
     def test_full_returns(self):
         '''
@@ -80,17 +68,13 @@ class StdTest(integration.ModuleCase):
         '''
         ret = self.client.cmd_full_return(
                 'minion',
-                'test.kwarg',
-                ['foo=bar', 'baz=quo'],
+                'test.arg',
+                ['foo', 'bar', 'baz'],
                 kwarg={'qux': 'quux'}
                 )
-        data = ret['minion']
-        self.assertIn('foo', data['ret'])
-        self.assertIn('baz', data['ret'])
-        self.assertIn('qux', data['ret'])
-        self.assertEqual(data['ret']['foo'], 'bar')
-        self.assertEqual(data['ret']['baz'], 'quo')
-        self.assertEqual(data['ret']['qux'], 'quux')
+        data = ret['minion']['ret']
+        self.assertEqual(data['args'], ['foo', 'bar', 'baz'])
+        self.assertEqual(data['kwargs']['qux'], 'quux')
 
     def test_kwarg_type(self):
         '''

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -262,19 +262,21 @@ class CMDModuleTest(integration.ModuleCase):
         '''
         cmd.run trigger timeout
         '''
-        out = self.run_function('cmd.run', ['sleep 2 && echo hello', 'timeout=1'])
-
-        self.assertTrue(
-            'Timed out' in self.run_function(
-                'cmd.run', ['sleep 2 && echo hello', 'timeout=1'], python_shell=True))
+        out = self.run_function('cmd.run',
+                                ['sleep 2 && echo hello'],
+                                f_timeout=1,
+                                python_shell=True)
+        self.assertTrue('Timed out' in out)
 
     def test_timeout_success(self):
         '''
         cmd.run sufficient timeout to succeed
         '''
-        self.assertTrue(
-            'hello' == self.run_function(
-                'cmd.run', ['sleep 1 && echo hello', 'timeout=2'], python_shell=True))
+        out = self.run_function('cmd.run',
+                                ['sleep 1 && echo hello'],
+                                f_timeout=2,
+                                python_shell=True)
+        self.assertEqual(out, 'hello')
 
     def test_run_cwd_doesnt_exist_issue_7154(self):
         '''

--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -106,11 +106,8 @@ class CPModuleTest(integration.ModuleCase):
         tgt = os.path.join(integration.TMP, 'scene33')
         self.run_function(
                 'cp.get_template',
-                [
-                    'salt://grail/scene33',
-                    tgt,
-                    'spam=bacon',
-                ])
+                ['salt://grail/scene33', tgt],
+                spam='bacon')
         with salt.utils.fopen(tgt, 'r') as scene:
             data = scene.read()
             self.assertIn('bacon', data)

--- a/tests/integration/modules/test_publish.py
+++ b/tests/integration/modules/test_publish.py
@@ -25,7 +25,8 @@ class PublishModuleTest(integration.ModuleCase,
 
         ret = self.run_function(
             'publish.publish',
-            ['minion', 'test.kwarg', 'arg="cheese=spam"']
+            ['minion', 'test.kwarg'],
+            f_arg='cheese=spam'
         )
         ret = ret['minion']
 
@@ -45,7 +46,7 @@ class PublishModuleTest(integration.ModuleCase,
             self.assertTrue(name in ret)
 
         self.assertEqual(ret['cheese'], 'spam')
-        self.assertEqual(ret['__pub_arg'], ['cheese=spam'])
+        self.assertEqual(ret['__pub_arg'], [{'cheese': 'spam'}])
         self.assertEqual(ret['__pub_id'], 'minion')
         self.assertEqual(ret['__pub_fun'], 'test.kwarg')
 
@@ -99,7 +100,8 @@ class PublishModuleTest(integration.ModuleCase,
         '''
         ret = self.run_function(
             'publish.full_data',
-            ['minion', 'test.kwarg', 'arg="cheese=spam"']
+            ['minion', 'test.kwarg'],
+            f_arg='cheese=spam'
         )
         ret = ret['minion']['ret']
 
@@ -119,13 +121,14 @@ class PublishModuleTest(integration.ModuleCase,
             self.assertTrue(name in ret)
 
         self.assertEqual(ret['cheese'], 'spam')
-        self.assertEqual(ret['__pub_arg'], ['cheese=spam'])
+        self.assertEqual(ret['__pub_arg'], [{'cheese': 'spam'}])
         self.assertEqual(ret['__pub_id'], 'minion')
         self.assertEqual(ret['__pub_fun'], 'test.kwarg')
 
         ret = self.run_function(
             'publish.full_data',
-            ['minion', 'test.kwarg', 'cheese=spam']
+            ['minion', 'test.kwarg'],
+            cheese='spam'
         )
         self.assertIn(
             'The following keyword arguments are not valid', ret

--- a/tests/integration/shell/test_arguments.py
+++ b/tests/integration/shell/test_arguments.py
@@ -13,6 +13,7 @@ ensure_in_syspath('../../')
 
 # Import Salt libs
 import integration
+import salt.utils.args
 
 
 @requires_salt_modules('test.ping', 'test.arg')
@@ -25,7 +26,7 @@ class ArgumentTestCase(integration.ModuleCase):
         '''
         self.assertIn(
             ("ERROR executing 'test.ping': The following keyword arguments"),
-            self.run_function('test.ping', ['foo=bar'])
+            self.run_function('test.ping', foo='bar')
         )
 
     def test_kwarg_name_containing_dashes(self):
@@ -34,9 +35,12 @@ class ArgumentTestCase(integration.ModuleCase):
         are properly identified as kwargs. If this fails, then the KWARG_REGEX
         variable in salt/utils/__init__.py needs to be fixed.
         '''
+        # We need to use parse_input here because run_function now requires
+        # kwargs to be passed in as *actual* kwargs, and dashes are not valid
+        # characters in Python kwargs.
         self.assertEqual(
             self.run_function(
-                'test.arg', ['foo-bar=baz']
+                'test.arg', salt.utils.args.parse_input(['foo-bar=baz'])
             ).get('kwargs', {}).get('foo-bar'),
             'baz'
         )


### PR DESCRIPTION
I've checked all of the refs and confirmed that they already properly
parse the input before passing the args to this function. We will now be
ignoring unconditioned string kwargs passed to this function, and
logging these incorrectly passed kwarg(s).