### PR TITLE
Add warnings to test suite when requisites are not installed

### DIFF
--- a/requirements/dev_python27.txt
+++ b/requirements/dev_python27.txt
@@ -7,3 +7,4 @@ boto3>=1.2.1
 moto>=0.3.6
 SaltTesting
 SaltPyLint>=v2017.2.22
+GitPython>=0.3


### PR DESCRIPTION
Since we have recently changed the test suite to use new-style
git_pillar, GitPython or Pygit2 is a hard dep for the test suite.

Additionally, when starting up the daemons, if no IPv4 addresses can be
detected (which can happen on docker containers which tend to have
minimal installs) then the suite will time out trying to detect whether
or not the minion/sub-minion has connected, which while it does not
prove fatal for the test suite, it does make the suite take several
minutes to start up and begin running tests. This is because the test
suite invokes the ``manage.joined`` runner, which in turn invokes
``salt.utils.network.ip_addrs()`` to get the system's IP addresses to match
against those which are connected. If it can't get the IP addresses,
then the ``manage.joined`` runner returns an empty list, and the test suite
believes that no minions have connected, and the function that
periodically runs ``manage.joined`` will eventually time out.

This commit adds messages to the console when no suitable gitfs provider
is installed, and when ``salt.utils.network.ip_addrs()`` returns an empty
list, to hopefully prompt the user to install the missing requisites.