### PR TITLE
Py3 compat: Force minions to be a list for local serialized caches

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -239,7 +239,9 @@ def save_minions(jid, minions, syndic_id=None):
     '''
     Save/update the serialized list of minions for a given job
     '''
+    # Ensure we have a list for Python 3 compatability
     minions = list(minions)
+
     log.debug(
         'Adding minions for job %s%s: %s',
         jid,

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -239,6 +239,7 @@ def save_minions(jid, minions, syndic_id=None):
     '''
     Save/update the serialized list of minions for a given job
     '''
+    minions = list(minions)
     log.debug(
         'Adding minions for job %s%s: %s',
         jid,


### PR DESCRIPTION
When running `salt-ssh` under Python 3, it tries to save load to the local_cache by passing a `dict.keys()`.
This fails horribly:

```
[DEBUG   ] Adding minions for job 20170226002946722433: dict_keys(['pampus1.example.com'])
[ERROR   ] can't serialize dict_keys(['pampus1.example.com'])
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/salt/client/ssh/__init__.py", line 607, in run
    self.returners['{0}.save_load'.format(self.opts['master_job_cache'])](jid, job_load, minions=self.targets.keys())
  File "/usr/local/lib/python3.5/dist-packages/salt/returners/local_cache.py", line 235, in save_load
    save_minions(jid, minions)
  File "/usr/local/lib/python3.5/dist-packages/salt/returners/local_cache.py", line 277, in save_minions
    serial.dump(minions, salt.utils.fopen(minions_path, 'w+b'))
  File "/usr/local/lib/python3.5/dist-packages/salt/payload.py", line 300, in dump
    fn_.write(self.dumps(msg, use_bin_type=True))
  File "/usr/local/lib/python3.5/dist-packages/salt/payload.py", line 181, in dumps
    return msgpack.dumps(msg, use_bin_type=use_bin_type)
  File "/usr/local/lib/python3.5/dist-packages/msgpack/__init__.py", line 47, in packb
    return Packer(**kwargs).pack(o)
  File "msgpack/_packer.pyx", line 231, in msgpack._packer.Packer.pack (msgpack/_packer.cpp:3661)
  File "msgpack/_packer.pyx", line 233, in msgpack._packer.Packer.pack (msgpack/_packer.cpp:3503)
  File "msgpack/_packer.pyx", line 228, in msgpack._packer.Packer._pack (msgpack/_packer.cpp:3382)
TypeError: can't serialize dict_keys(['pampus1.example.com'])
[ERROR   ] Could not save load with returner local_cache: can't serialize dict_keys(['pampus1.example.com'])
``` 

### What does this PR do?
Fix the problem by forcing `minions` arg to be(come) a `list`

