### PR TITLE
Squelch warning for virtual grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -688,7 +688,7 @@ def _virtual(osdata):
             break
     else:
         if osdata['kernel'] not in skip_cmds:
-            log.warning(
+            log.debug(
                 'All tools for virtual hardware identification failed to '
                 'execute because they do not exist on the system running this '
                 'instance or the user does not have the necessary permissions '


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/39504 fixed what was a legitimate bug, but in turn this causes this warning to be logged hundreds of times in the minion log on unprivileged containers.

This commit changes the log level for this message to ``debug``.