### PR TITLE
Fix comments about file backup directory

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -161,7 +161,7 @@
 # strip_colors: False
 
 # Backup files that are replaced by file.managed and file.recurse under
-# 'cachedir'/file_backups relative to their original location and appended
+# 'cachedir'/file_backup relative to their original location and appended
 # with a timestamp. The only valid setting is "minion". Disabled by default.
 #
 # Alternatively this can be specified for each file in state files:

--- a/conf/proxy
+++ b/conf/proxy
@@ -119,7 +119,7 @@
 # strip_colors: False
 
 # Backup files that are replaced by file.managed and file.recurse under
-# 'cachedir'/file_backups relative to their original location and appended
+# 'cachedir'/file_backup relative to their original location and appended
 # with a timestamp. The only valid setting is "minion". Disabled by default.
 #
 # Alternatively this can be specified for each file in state files:


### PR DESCRIPTION
### What does this PR do?
It changes the name of the file state backup directory from "file_backup**s**" to "file_backup" in config file comments and a manpage. "file_backup" (without a trailing 's') is what is actually used by the code and also documented [elsewhere](https://docs.saltstack.com/en/latest/ref/states/backup_mode.html).

### Tests written?
No