### PR TITLE
Added range for minute and hour in cron module

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -408,6 +408,10 @@ def _get_cron_date_time(**kwargs):
         value = str(kwargs.get(param, '1')).lower()
         if value == 'random':
             ret[param] = str(random.sample(range_max[param], 1)[0])
+        elif len(value.split(":")) == 2:
+            cron_range = sorted(value.split(":"))
+            start, end = int(cron_range[0]), int(cron_range[1])
+            ret[param] = str(random.randint(start, end))
         else:
             ret[param] = value
 

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -408,7 +408,7 @@ def _get_cron_date_time(**kwargs):
         value = str(kwargs.get(param, '1')).lower()
         if value == 'random':
             ret[param] = str(random.sample(range_max[param], 1)[0])
-        elif len(value.split(":")) == 2:
+        elif len(value.split(':')) == 2:
             cron_range = sorted(value.split(":"))
             start, end = int(cron_range[0]), int(cron_range[1])
             ret[param] = str(random.randint(start, end))

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -409,7 +409,7 @@ def _get_cron_date_time(**kwargs):
         if value == 'random':
             ret[param] = str(random.sample(range_max[param], 1)[0])
         elif len(value.split(':')) == 2:
-            cron_range = sorted(value.split(":"))
+            cron_range = sorted(value.split(':'))
             start, end = int(cron_range[0]), int(cron_range[1])
             ret[param] = str(random.randint(start, end))
         else:


### PR DESCRIPTION
### What does this PR do?
Adds a range feature for minute and hour values in the cron module

### New Behavior
Enter a string range (e.g., "2:5") for hour or minute in the cron module to use a random value  of that range.

### Tests written?
Yeah

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
