### PR TITLE
Fix comments about the "hash_type" option

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -549,11 +549,11 @@
 #default_top: base
 
 # The hash_type is the hash to use when discovering the hash of a file on
-# the master server. The default is md5 but sha1, sha224, sha256, sha384
-# and sha512 are also supported.
+# the master server. The default is sha256, but md5, sha1, sha224, sha384 and
+# sha512 are also supported.
 #
-# WARNING: While md5 is also supported, do not use it due to the high chance
-# of possible collisions and thus security breach.
+# WARNING: While md5 and sha1 are also supported, do not use them due to the
+# high chance of possible collisions and thus security breach.
 #
 # Prior to changing this value, the master should be stopped and all Salt
 # caches should be cleared.

--- a/conf/minion
+++ b/conf/minion
@@ -574,14 +574,11 @@
 #fileserver_limit_traversal: False
 
 # The hash_type is the hash to use when discovering the hash of a file on
-# the local fileserver. The default is md5, but sha1, sha224, sha256, sha384
+# the local fileserver. The default is sha256, but md5, sha1, sha224, sha384
 # and sha512 are also supported.
 #
-# WARNING: While md5 and sha1 are also supported, do not use it due to the high chance
-# of possible collisions and thus security breach.
-#
-# WARNING: While md5 is also supported, do not use it due to the high chance
-# of possible collisions and thus security breach.
+# WARNING: While md5 and sha1 are also supported, do not use them due to the
+# high chance of possible collisions and thus security breach.
 #
 # Warning: Prior to changing this value, the minion should be stopped and all
 # Salt caches should be cleared.


### PR DESCRIPTION
### What does this PR do?
It fixes the mentions of the default value for "hash_type" in config file comments and a manpage.

Previous mentions of the correct default value (it really is sha256, as documted [elsewhere](https://docs.saltstack.com/en/latest/ref/configuration/master.html#hash-type)) somehow got lost along the way. Also, some comments seem to have gotten duplicated instead of updated.

### Tests written?
No