### PR TITLE
Add support for user roles in present state

### DIFF
--- a/salt/states/mongodb_user.py
+++ b/salt/states/mongodb_user.py
@@ -118,8 +118,8 @@ def present(name,
 
     # if the check does not return a boolean, return an error
     # this may be the case if there is a database connection error
-    if not isinstance(user_exists, bool):
-        ret['comment'] = user_exists
+    if not isinstance(users, list):
+        ret['comment'] = users
         ret['result'] = False
         return ret
 

--- a/salt/states/mongodb_user.py
+++ b/salt/states/mongodb_user.py
@@ -95,9 +95,9 @@ def present(name,
         return ret
 
     # check if user exists
-    user_exists = __salt__['mongodb.user_exists'](name, user, password, host, port, database, authdb)
-    if user_exists is True:
-        # obtain users specified by name query
+    users = __salt__['mongodb.user_find'](name, user, password, host, port, database, authdb)
+    if len(users) > 0:
+        # check each user occurrence
         users = __salt__['mongodb.user_find'](name, user, password, host, port, database, authdb)
         # check each user occurrence
         for usr in users:

--- a/tests/unit/states/test_mongodb_user.py
+++ b/tests/unit/states/test_mongodb_user.py
@@ -47,13 +47,16 @@ class MongodbUserTestCase(TestCase):
         ret.update({'comment': comt})
         self.assertDictEqual(mongodb_user.present(name, passwd, port={}), ret)
 
-        mock = MagicMock(side_effect=[True, False, False])
         mock_t = MagicMock(return_value=True)
+        mock_f = MagicMock(return_value=[])
         with patch.dict(mongodb_user.__salt__,
-                        {'mongodb.user_exists': mock,
-                         'mongodb.user_create': mock_t}):
-            comt = ('User {0} is already present'.format(name))
-            ret.update({'comment': comt, 'result': True})
+                        {
+                         'mongodb.user_create': mock_t,
+                         'mongodb.user_find': mock_f
+                        }):
+            comt = ('User {0} is not present and needs to be created'
+                ).format(name)
+            ret.update({'comment': comt, 'result': None})
             self.assertDictEqual(mongodb_user.present(name, passwd), ret)
 
             with patch.dict(mongodb_user.__opts__, {'test': True}):
@@ -66,6 +69,7 @@ class MongodbUserTestCase(TestCase):
                 comt = ('User {0} has been created'.format(name))
                 ret.update({'comment': comt, 'result': True,
                             'changes': {name: 'Present'}})
+                print ret
                 self.assertDictEqual(mongodb_user.present(name, passwd), ret)
 
     # 'absent' function tests: 1

--- a/tests/unit/states/test_mongodb_user.py
+++ b/tests/unit/states/test_mongodb_user.py
@@ -21,7 +21,7 @@ ensure_in_syspath('../../')
 from salt.states import mongodb_user
 
 mongodb_user.__salt__ = {}
-mongodb_user.__opts__ = {}
+mongodb_user.__opts__ = {'test': True}
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -69,7 +69,6 @@ class MongodbUserTestCase(TestCase):
                 comt = ('User {0} has been created'.format(name))
                 ret.update({'comment': comt, 'result': True,
                             'changes': {name: 'Present'}})
-                print ret
                 self.assertDictEqual(mongodb_user.present(name, passwd), ret)
 
     # 'absent' function tests: 1


### PR DESCRIPTION
## What does this PR do?

Adds support for user roles in present state

## What issues does this PR fix or reference?
#39681

## New Behavior

sls file:
```
  mongodb_user.present:
    - name: myapp
    - passwd: admin
    - user: root
    - host: mongo-data-02
    - port: 27017
    - authdb: admin
    - password: admin
    - roles:
        - readWrite
        - userAdmin
        - dbOwner
```
```
salt mongo-data-01 state.apply mongo-test
mongo-data-01:
----------
          ID: mongouser-myapp
    Function: mongodb_user.present
        Name: myapp
      Result: True
     Comment: User myapp is already present
     Started: 11:01:22.007496
    Duration: 55.557 ms
     Changes:   
              ----------
              myapp:
                  ----------
                  database:
                      admin
                  roles:
                      ----------
                      new:
                          - readWrite
                          - userAdmin
                          - dbOwner
                      old:

Summary for mongo-data-01
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:  55.557 ms
```

```
rsdata1:PRIMARY> db.getUser("myapp")
{
	"_id" : "admin.myapp",
	"user" : "myapp",
	"db" : "admin",
	"roles" : [
		{
			"role" : "readWrite",
			"db" : "admin"
		},
		{
			"role" : "userAdmin",
			"db" : "admin"
		},
		{
			"role" : "dbOwner",
			"db" : "admin"
		}
	]
}
rsdata1:PRIMARY> 
```

sls file:
```
  mongodb_user.present:
    - name: myapp
    - passwd: admin
    - user: root
    - host: mongo-data-02
    - port: 27017
    - authdb: admin
    - password: admin
    - roles:
        - readWrite
```
```
salt mongo-data-01 state.apply mongo-test
mongo-data-01:
----------
          ID: mongouser-myapp
    Function: mongodb_user.present
        Name: myapp
      Result: True
     Comment: User myapp is already present
     Started: 11:02:33.549042
    Duration: 55.897 ms
     Changes:   
              ----------
              myapp:
                  ----------
                  database:
                      admin
                  roles:
                      ----------
                      new:
                          - readWrite
                      old:
                          - readWrite
                          - userAdmin
                          - dbOwner

Summary for mongo-data-01
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:  55.897 ms
```
```
rsdata1:PRIMARY> db.getUser("myapp")
{
	"_id" : "admin.myapp",
	"user" : "myapp",
	"db" : "admin",
	"roles" : [
		{
			"role" : "readWrite",
			"db" : "admin"
		}
	]
}
rsdata1:PRIMARY> 
```

Tests written?
No

Please review Salt's Contributing Guide for best practices.