### PR TITLE
Add act entry when a key is denied

### DIFF
--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -243,6 +243,7 @@ class AESReqServerMixin(object):
                         fp_.write(load['pub'])
                     eload = {'result': False,
                              'id': load['id'],
+                             'act': 'denied',
                              'pub': load['pub']}
                     self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
                     return {'enc': 'clear',
@@ -331,6 +332,7 @@ class AESReqServerMixin(object):
                             fp_.write(load['pub'])
                         eload = {'result': False,
                                  'id': load['id'],
+                                 'act': 'denied',
                                  'pub': load['pub']}
                         self.event.fire_event(eload, salt.utils.event.tagify(prefix='auth'))
                         return {'enc': 'clear',


### PR DESCRIPTION
### What does this PR do?

Adds an explicit action for auth events resulting from a denied key. This will allow reactions specifically to denied keys, which could be useful since there is no salt/key event when a key is denied.

### Previous Behavior

Auth event on denied key:
```
salt/auth       {
    "_stamp": "2017-02-27T17:53:12.545436",
    "id": "minion-id",
    "pub": "...",
    "result": false
}
```

### New Behavior

Auth event on denied key:
```
salt/auth       {
    "_stamp": "2017-02-27T17:53:12.545436",
    "act": "denied",
    "id": "minion-id",
    "pub": "...",
    "result": false
}
```

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
