### PR TITLE
Fix job cache tests, add librato return tests

### DIFF
--- a/tests/integration/returners/test_local_cache.py
+++ b/tests/integration/returners/test_local_cache.py
@@ -129,7 +129,7 @@ class Local_CacheTest(integration.ShellCase):
                     time.sleep(1)
                     os.rename(lock_dir, new_jid_dir)
                     break
-                except WindowsError:
+                except WindowsError:  # pylint: disable=E0602
                     continue
 
         # check dir exists

--- a/tests/integration/returners/test_local_cache.py
+++ b/tests/integration/returners/test_local_cache.py
@@ -110,6 +110,28 @@ class Local_CacheTest(integration.ShellCase):
         EMPTY_JID_DIR.append(new_jid_dir)
         os.makedirs(new_jid_dir)
 
+        # This needed due to a race condition in Windows
+        # `os.makedirs` hasn't released the handle before
+        # `local_cache.clean_old_jobs` tries to delete the new_jid_dir
+        if salt.utils.is_windows():
+            import time
+            lock_dir = new_jid_dir + '.lckchk'
+            tries = 0
+            while True:
+                tries += 1
+                if tries > 10:
+                    break
+                # Rename the directory and name it back
+                # If it fails, the directory handle is not released, try again
+                # If it succeeds, break and continue test
+                try:
+                    os.rename(new_jid_dir, lock_dir)
+                    time.sleep(1)
+                    os.rename(lock_dir, new_jid_dir)
+                    break
+                except WindowsError:
+                    continue
+
         # check dir exists
         self._check_dir_files('new_jid_dir was not created',
                               EMPTY_JID_DIR,

--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -22,6 +22,8 @@ integration.modules.state
 integration.modules.sysmod
 integration.modules.test
 integration.modules.useradd
+integration.returners.test_librato_return
+integration.returners.test_local_cache
 integration.runners.jobs
 integration.runners.salt
 integration.runners.winrepo


### PR DESCRIPTION
### What does this PR do?
Adds returners tests to the Windows whitelist.
Fixes a failing test in `test_local_cache.py` for Windows

### Tests written?
Yes