### PR TITLE
Add filerserver test to whitelist, skip symlink test

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -25,6 +25,7 @@ import logging
 # Import salt libs
 import salt.fileserver
 import salt.utils
+import salt.utils.win_symlink
 from salt.utils.event import tagify
 import salt.ext.six as six
 
@@ -340,7 +341,7 @@ def _file_lists(load, form):
             for item in items:
                 abs_path = os.path.join(parent_dir, item)
                 log.trace('roots: Processing %s', abs_path)
-                is_link = os.path.islink(abs_path)
+                is_link = salt.utils.win_symlink.is_link(abs_path)
                 log.trace(
                     'roots: %s is %sa link',
                     abs_path, 'not ' if not is_link else ''
@@ -361,7 +362,10 @@ def _file_lists(load, form):
                     # WindowsError on Windows.
                     pass
                 if is_link:
-                    link_dest = os.readlink(abs_path)
+                    if salt.utils.is_windows():
+                        link_dest = salt.utils.win_symlink.read_link(abs_path)
+                    else:
+                        link_dest = os.readlink(abs_path)
                     log.trace(
                         'roots: %s symlink destination is %s',
                         abs_path, link_dest

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -341,7 +341,10 @@ def _file_lists(load, form):
             for item in items:
                 abs_path = os.path.join(parent_dir, item)
                 log.trace('roots: Processing %s', abs_path)
-                is_link = salt.utils.win_symlink.is_link(abs_path)
+                if salt.utils.is_windows():
+                    is_link = salt.utils.win_symlink.is_link(abs_path)
+                else:
+                    is_link = os.path.islink(abs_path)
                 log.trace(
                     'roots: %s is %sa link',
                     abs_path, 'not ' if not is_link else ''

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -53,6 +53,7 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+import salt.utils.win_symlink
 from salt.modules.file import (check_hash,  # pylint: disable=W0611
         directory_exists, get_managed,
         check_managed, check_managed_changes, source_list,
@@ -1163,24 +1164,6 @@ def symlink(src, link):
         )
 
 
-def _is_reparse_point(path):
-    '''
-    Returns True if path is a reparse point; False otherwise.
-    '''
-    if sys.getwindowsversion().major < 6:
-        raise SaltInvocationError('Symlinks are only supported on Windows Vista or later.')
-
-    result = win32file.GetFileAttributesW(path)
-
-    if result == -1:
-        raise SaltInvocationError('The path given is not valid, symlink or not. (does it exist?)')
-
-    if result & 0x400:  # FILE_ATTRIBUTE_REPARSE_POINT
-        return True
-    else:
-        return False
-
-
 def is_link(path):
     '''
     Check if the path is a symlink
@@ -1197,78 +1180,7 @@ def is_link(path):
 
        salt '*' file.is_link /path/to/link
     '''
-    if sys.getwindowsversion().major < 6:
-        return False
-
-    try:
-        if not _is_reparse_point(path):
-            return False
-    except SaltInvocationError:
-        return False
-
-    # check that it is a symlink reparse point (in case it is something else,
-    # like a mount point)
-    reparse_data = _get_reparse_data(path)
-
-    # sanity check - this should not happen
-    if not reparse_data:
-        # not a reparse point
-        return False
-
-    # REPARSE_DATA_BUFFER structure - see
-    # http://msdn.microsoft.com/en-us/library/ff552012.aspx
-
-    # parse the structure header to work out which type of reparse point this is
-    header_parser = struct.Struct('L')
-    ReparseTag, = header_parser.unpack(reparse_data[:header_parser.size])
-    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa365511.aspx
-    if not ReparseTag & 0xA000FFFF == 0xA000000C:
-        return False
-    else:
-        return True
-
-
-def _get_reparse_data(path):
-    '''
-    Retrieves the reparse point data structure for the given path.
-
-    If the path is not a reparse point, None is returned.
-
-    See http://msdn.microsoft.com/en-us/library/ff552012.aspx for details on the
-    REPARSE_DATA_BUFFER structure returned.
-    '''
-    if sys.getwindowsversion().major < 6:
-        raise SaltInvocationError('Symlinks are only supported on Windows Vista or later.')
-
-    # ensure paths are using the right slashes
-    path = os.path.normpath(path)
-
-    if not _is_reparse_point(path):
-        return None
-
-    fileHandle = None
-    try:
-        fileHandle = win32file.CreateFileW(
-            path,
-            0x80000000,  # GENERIC_READ
-            1,  # share with other readers
-            None,  # no inherit, default security descriptor
-            3,  # OPEN_EXISTING
-            0x00200000 | 0x02000000  # FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS
-        )
-
-        reparseData = win32file.DeviceIoControl(
-            fileHandle,
-            0x900a8,  # FSCTL_GET_REPARSE_POINT
-            None,  # in buffer
-            16384  # out buffer size (MAXIMUM_REPARSE_DATA_BUFFER_SIZE)
-        )
-
-    finally:
-        if fileHandle:
-            win32file.CloseHandle(fileHandle)
-
-    return reparseData
+    return salt.utils.win_symlink(path)
 
 
 def readlink(path):
@@ -1287,52 +1199,7 @@ def readlink(path):
 
         salt '*' file.readlink /path/to/link
     '''
-    if sys.getwindowsversion().major < 6:
-        raise SaltInvocationError('Symlinks are only supported on Windows Vista or later.')
-
-    if not os.path.isabs(path):
-        raise SaltInvocationError('Path to link must be absolute.')
-
-    reparse_data = _get_reparse_data(path)
-
-    if not reparse_data:
-        raise SaltInvocationError('The path specified is not a reparse point (symlinks are a type of reparse point).')
-
-    # REPARSE_DATA_BUFFER structure - see
-    # http://msdn.microsoft.com/en-us/library/ff552012.aspx
-
-    # parse the structure header to work out which type of reparse point this is
-    header_parser = struct.Struct('L')
-    ReparseTag, = header_parser.unpack(reparse_data[:header_parser.size])
-    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa365511.aspx
-    if not ReparseTag & 0xA000FFFF == 0xA000000C:
-        raise SaltInvocationError('The path specified is not a symlink, but another type of reparse point (0x{0:X}).'.format(ReparseTag))
-
-    # parse as a symlink reparse point structure (the structure for other
-    # reparse points is different)
-    data_parser = struct.Struct('LHHHHHHL')
-    ReparseTag, ReparseDataLength, Reserved, SubstituteNameOffset, \
-    SubstituteNameLength, PrintNameOffset, \
-    PrintNameLength, Flags = data_parser.unpack(reparse_data[:data_parser.size])
-
-    path_buffer_offset = data_parser.size
-    absolute_substitute_name_offset = path_buffer_offset + SubstituteNameOffset
-    target_bytes = reparse_data[absolute_substitute_name_offset:absolute_substitute_name_offset+SubstituteNameLength]
-    target = target_bytes.decode('UTF-16')
-
-    if target.startswith('\\??\\'):
-        target = target[4:]
-
-    try:
-        # comes out in 8.3 form; convert it to LFN to make it look nicer
-        target = win32file.GetLongPathName(target)
-    except pywinerror as exc:
-        # if file is not found (i.e. bad symlink), return it anyway like on *nix
-        if exc.winerror == 2:
-            return target
-        raise
-
-    return target
+    return salt.utils.win_symlink.read_link(path)
 
 
 def mkdir(path,

--- a/salt/utils/win_symlink.py
+++ b/salt/utils/win_symlink.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+'''
+Functions for working with Symlinks on Windows
+
+:requires: pywin32
+'''
+from __future__ import absolute_import
+import os
+import struct
+import sys
+
+# Import Salt Libs
+import salt.utils
+from salt.exceptions import SaltInvocationError
+
+if salt.utils.is_windows():
+    import win32file
+    from pywintypes import error as pywinerror
+    HAS_WIN32 = True
+else:
+    HAS_WIN32 = False
+
+
+
+# Although utils are often directly imported, it is also possible to use the
+# loader.
+def __virtual__():
+    '''
+    Only load if Win32 Libraries are installed
+    '''
+    if not salt.utils.is_windows():
+        return False, 'This Salt util only runs on Windows'
+
+    if not HAS_WIN32:
+        return False, 'This Salt util requires pywin32'
+
+    return 'win_symlink'
+
+
+def _is_reparse_point(path):
+    '''
+    Returns True if path is a reparse point; False otherwise.
+    '''
+    if sys.getwindowsversion().major < 6:
+        raise SaltInvocationError(
+            'Symlinks are only supported on Windows Vista or later.')
+
+    result = win32file.GetFileAttributesW(path)
+
+    if result == -1:
+        raise SaltInvocationError('Invalid path: {0}'.format(path))
+
+    if result & 0x400:  # FILE_ATTRIBUTE_REPARSE_POINT
+        return True
+    else:
+        return False
+
+
+def _get_reparse_data(path):
+    '''
+    Retrieves the reparse point data structure for the given path.
+
+    If the path is not a reparse point, None is returned.
+
+    See http://msdn.microsoft.com/en-us/library/ff552012.aspx for details on the
+    REPARSE_DATA_BUFFER structure returned.
+    '''
+    if sys.getwindowsversion().major < 6:
+        raise SaltInvocationError(
+            'Symlinks are only supported on Windows Vista or later.')
+
+    # ensure paths are using the right slashes
+    path = os.path.normpath(path)
+
+    if not _is_reparse_point(path):
+        return None
+
+    fileHandle = None
+    try:
+        fileHandle = win32file.CreateFileW(
+            path,
+            0x80000000,  # GENERIC_READ
+            1,  # share with other readers
+            None,  # no inherit, default security descriptor
+            3,  # OPEN_EXISTING
+            0x00200000 | 0x02000000  # FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS
+        )
+
+        reparseData = win32file.DeviceIoControl(
+            fileHandle,
+            0x900a8,  # FSCTL_GET_REPARSE_POINT
+            None,  # in buffer
+            16384  # out buffer size (MAXIMUM_REPARSE_DATA_BUFFER_SIZE)
+        )
+
+    finally:
+        if fileHandle:
+            win32file.CloseHandle(fileHandle)
+
+    return reparseData
+
+
+def is_link(path):
+    '''
+    Check if the path is a symlink
+
+    This is only supported on Windows Vista or later.
+
+    Inline with Unix behavior, this function will raise an error if the path
+    is not a symlink, however, the error raised will be a SaltInvocationError,
+    not an OSError.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+       salt '*' file.is_link /path/to/link
+    '''
+    try:
+        if not _is_reparse_point(path):
+            return False
+    except SaltInvocationError:
+        return False
+
+    # check that it is a symlink reparse point (in case it is something else,
+    # like a mount point)
+    reparse_data = _get_reparse_data(path)
+
+    # sanity check - this should not happen
+    if not reparse_data:
+        # not a reparse point
+        return False
+
+    # REPARSE_DATA_BUFFER structure - see
+    # http://msdn.microsoft.com/en-us/library/ff552012.aspx
+
+    # parse the structure header to work out which type of reparse point this is
+    header_parser = struct.Struct('L')
+    ReparseTag, = header_parser.unpack(reparse_data[:header_parser.size])
+
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa365511.aspx
+    if not ReparseTag & 0xA000FFFF == 0xA000000C:
+        return False
+    else:
+        return True
+
+
+def read_link(path):
+    '''
+    Return the path that a symlink points to
+
+    This is only supported on Windows Vista or later.
+
+    Inline with Unix behavior, this function will raise an error if the path is
+    not a symlink, however, the error raised will be a SaltInvocationError, not
+    an OSError.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' file.readlink /path/to/link
+    '''
+    if sys.getwindowsversion().major < 6:
+        raise SaltInvocationError(
+            'Symlinks are only supported on Windows Vista or later.')
+
+    if not os.path.isabs(path):
+        raise SaltInvocationError('Path to link must be absolute.')
+
+    reparse_data = _get_reparse_data(path)
+
+    if not reparse_data:
+        raise SaltInvocationError(
+            'The path specified is not a reparse point (symlinks are a type of '
+            'reparse point).')
+
+    # REPARSE_DATA_BUFFER structure - see
+    # http://msdn.microsoft.com/en-us/library/ff552012.aspx
+
+    # parse the structure header to work out which type of reparse point this is
+    header_parser = struct.Struct('L')
+    ReparseTag, = header_parser.unpack(reparse_data[:header_parser.size])
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa365511.aspx
+    if not ReparseTag & 0xA000FFFF == 0xA000000C:
+        raise SaltInvocationError(
+            'The path specified is not a symlink, but another type of reparse '
+            'point (0x{0:X}).'.format(ReparseTag))
+
+    # parse as a symlink reparse point structure (the structure for other
+    # reparse points is different)
+    data_parser = struct.Struct('LHHHHHHL')
+    ReparseTag, ReparseDataLength, Reserved, SubstituteNameOffset, \
+    SubstituteNameLength, PrintNameOffset, \
+    PrintNameLength, Flags = data_parser.unpack(reparse_data[:data_parser.size])
+
+    path_buffer_offset = data_parser.size
+    absolute_substitute_name_offset = path_buffer_offset + SubstituteNameOffset
+    target_bytes = reparse_data[absolute_substitute_name_offset:absolute_substitute_name_offset+SubstituteNameLength]
+    target = target_bytes.decode('UTF-16')
+
+    if target.startswith('\\??\\'):
+        target = target[4:]
+
+    try:
+        # comes out in 8.3 form; convert it to LFN to make it look nicer
+        target = win32file.GetLongPathName(target)
+    except pywinerror as exc:
+        # if file is not found (i.e. bad symlink), return it anyway like on *nix
+        if exc.winerror == 2:
+            return target
+        raise
+
+    return target

--- a/tests/integration/fileserver/test_roots.py
+++ b/tests/integration/fileserver/test_roots.py
@@ -179,10 +179,6 @@ class RootsTest(integration.ModuleCase):
             ret = roots.dir_list({'saltenv': 'base'})
             self.assertIn('empty_dir', ret)
 
-    # Git doesn't handle symlinks in Windows. See the thread below:
-    # http://stackoverflow.com/questions/5917249/git-symlinks-in-windows
-    @skipIf(salt.utils.is_windows(),
-            'Git doesn\'t handle symlinks properly on Windows')
     def test_symlink_list(self):
         with patch.dict(roots.__opts__, {'cachedir': self.master_opts['cachedir'],
                                          'file_roots': self.master_opts['file_roots'],

--- a/tests/integration/runners/test_fileserver.py
+++ b/tests/integration/runners/test_fileserver.py
@@ -163,10 +163,6 @@ class FileserverTest(integration.ShellCase):
         self.assertIsInstance(ret['return'], list)
         self.assertTrue('grail/scene33' in ret['return'])
 
-    # Git doesn't handle symlinks in Windows. See the thread below:
-    # http://stackoverflow.com/questions/5917249/git-symlinks-in-windows
-    @skipIf(salt.utils.is_windows(),
-            'Git doesn\'t handle symlinks properly on Windows')
     def test_symlink_list(self):
         '''
         fileserver.symlink_list

--- a/tests/integration/runners/test_fileserver.py
+++ b/tests/integration/runners/test_fileserver.py
@@ -7,11 +7,13 @@ from __future__ import absolute_import
 import contextlib
 
 # Import Salt Testing libs
+from salttesting import skipIf
 from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
+import salt.utils
 
 
 class FileserverTest(integration.ShellCase):
@@ -161,6 +163,10 @@ class FileserverTest(integration.ShellCase):
         self.assertIsInstance(ret['return'], list)
         self.assertTrue('grail/scene33' in ret['return'])
 
+    # Git doesn't handle symlinks in Windows. See the thread below:
+    # http://stackoverflow.com/questions/5917249/git-symlinks-in-windows
+    @skipIf(salt.utils.is_windows(),
+            'Git doesn\'t handle symlinks properly on Windows')
     def test_symlink_list(self):
         '''
         fileserver.symlink_list

--- a/tests/integration/runners/test_fileserver.py
+++ b/tests/integration/runners/test_fileserver.py
@@ -7,13 +7,11 @@ from __future__ import absolute_import
 import contextlib
 
 # Import Salt Testing libs
-from salttesting import skipIf
 from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
-import salt.utils
 
 
 class FileserverTest(integration.ShellCase):

--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -22,6 +22,7 @@ integration.modules.state
 integration.modules.sysmod
 integration.modules.test
 integration.modules.useradd
+integration.runners.test_fileserver
 integration.runners.jobs
 integration.runners.salt
 integration.runners.winrepo

--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -1,7 +1,7 @@
 integration.client.runner
 integration.client.standard
-integration.fileserver.fileclient_test
-integration.fileserver.roots_test
+integration.fileserver.test_fileclient
+integration.fileserver.test_roots
 integration.loader.globals
 integration.loader.interfaces
 integration.loader.loader


### PR DESCRIPTION
### What does this PR do?
Creates a new salt util `win_symlinks`. The `_file_lists` function in `filerserver.roots` now uses the functions in `win_symlinks` to detect and follow symlinks on Windows.
Add `runners.test_fileserver` to the Windows whitelist.
This also fixed the same problem on the `fileserver.test_roots`, that is added as well.

### Tests written?
Yes