### PR TITLE
Strip shabang line from rendered HTTP data

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -762,7 +762,11 @@ def _render(template, render, renderer, template_dict, opts):
         rend = salt.loader.render(opts, {})
         blacklist = opts.get('renderer_blacklist')
         whitelist = opts.get('renderer_whitelist')
-        return compile_template(template, rend, renderer, blacklist, whitelist, **template_dict)
+        ret = compile_template(template, rend, renderer, blacklist, whitelist, **template_dict)
+        ret = ret.read()
+        if str(ret).startswith('#!') and not str(ret).startswith('#!/'):
+            ret = str(ret).split('\n', 1)[1]
+        return ret
     with salt.utils.fopen(template, 'r') as fh_:
         return fh_.read()
 


### PR DESCRIPTION
### What does this PR do?
When a file is rendered using a shabang line (such as #!jinja), the resulting data still has the shabang line at the beginning. That data might end up looking like:
```
#!jinja
{"data":"this is some json data"}
```
This is a definite problem for HTTP queries that need to contain, say, a JSON string, but not have that string be processed as JSON through Salt. This will generally manifest itself as an issue with POST queries.

This patch will strip that line from the content, making for clean JSON data that looks like:
```
{"data":"this is some json data"}
```

### Tests written?
No.