### PR TITLE
Add files section to FORMULA files

### DIFF
--- a/doc/topics/spm/spm_formula.rst
+++ b/doc/topics/spm/spm_formula.rst
@@ -107,6 +107,45 @@ A comma-separated list of optional packages that are recommended to be
 installed with the package. This list is displayed in an informational message
 when the package is installed to SPM.
 
+files
+~~~~~
+A files section can be added, to specify a list of files to add to the SPM.
+Such a section might look like:
+
+.. code-block:: yaml
+
+    files:
+      - _pillar
+      - FORMULA
+      - _runners
+      - d|mymodule/index.rst
+      - r|README.rst
+
+When ``files`` are specified, then only those files will be added to the SPM,
+regardless of what other files exist in the directory. They will also be added
+in the order specified, which is useful if you have a need to lay down files in
+a specific order.
+
+As can be seen in the example above, you may also tag files as being a specific
+type. This is done by pre-pending a filename with its type, followed by a pipe
+(``|``) character. The above example contains a document file and a readme. The
+available file types are:
+
+* ``c``: config file
+* ``d``: documentation file
+* ``g``: ghost file (i.e. the file contents are not included in the package payload)
+* ``l``: license file
+* ``r``: readme file
+* ``s``: SLS file
+* ``m``: Salt module
+
+The first 5 of these types (``c``, ``d``, ``g``, ``l``, ``r``) will be placed in
+``/usr/share/salt/spm/`` by default. This can be changed by setting an
+``spm_share_dir`` value in your ``/etc/salt/spm`` configuration file.
+
+The last two types (``s`` and ``m``) are currently ignored, but they are
+reserved for future use.
+
 Building a Package
 ------------------
 Once a ``FORMULA`` file has been created, it is placed into the root of the

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1621,7 +1621,7 @@ DEFAULT_SPM_OPTS = {
     # If set, spm_node_type will be either master or minion, but they should
     # NOT be a default
     'spm_node_type': '',
-    'spm_share_dir': '/usr/share/salt/spm'
+    'spm_share_dir': os.path.join(salt.syspaths.SHARE_DIR, 'spm'),
     # <---- Salt master settings overridden by SPM ----------------------
 }
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1621,6 +1621,7 @@ DEFAULT_SPM_OPTS = {
     # If set, spm_node_type will be either master or minion, but they should
     # NOT be a default
     'spm_node_type': '',
+    'spm_share_dir': '/usr/share/salt/spm'
     # <---- Salt master settings overridden by SPM ----------------------
 }
 

--- a/salt/spm/pkgfiles/local.py
+++ b/salt/spm/pkgfiles/local.py
@@ -13,6 +13,14 @@ import salt.syspaths
 
 # Get logging started
 log = logging.getLogger(__name__)
+FILE_TYPES = ('c', 'd', 'g', 'l', 'r', 's', 'm')
+# c: config file
+# d: documentation file
+# g: ghost file (i.e. the file contents are not included in the package payload)
+# l: license file
+# r: readme file
+# s: SLS file
+# m: Salt module
 
 
 def init(**kwargs):
@@ -100,9 +108,22 @@ def install_file(package, formula_tar, member, formula_def, conn=None):
 
     tld = formula_def.get('top_level_dir', package)
     new_name = member.name.replace('{0}/'.format(package), '', 1)
-    if not new_name.startswith(tld) and not new_name.startswith('_') and not new_name.startswith('pillar.example'):
-        log.debug('{0} not in top level directory, not installing'.format(new_name))
-        return False
+    if not new_name.startswith(tld) and not new_name.startswith('_') \
+        and not new_name.startswith('pillar.example') and not new_name.startswith('README'):
+            log.debug('{0} not in top level directory, not installing'.format(new_name))
+            return False
+
+    for line in formula_def.get('files', []):
+        tag = ''
+        for ftype in FILE_TYPES:
+            if line.startswith('{0}|'.format(ftype)):
+                tag = line.split('|', 1)[0]
+                line = line.split('|', 1)[1]
+        if tag and new_name == line:
+            if tag in ('c', 'd', 'g', 'l', 'r'):
+                out_path = __opts__['spm_share_dir']
+            elif tag in ('s', 'm'):
+                pass
 
     if new_name.startswith('{0}/_'.format(package)):
         if node_type in ('master', 'minion'):

--- a/salt/spm/pkgfiles/local.py
+++ b/salt/spm/pkgfiles/local.py
@@ -108,10 +108,10 @@ def install_file(package, formula_tar, member, formula_def, conn=None):
 
     tld = formula_def.get('top_level_dir', package)
     new_name = member.name.replace('{0}/'.format(package), '', 1)
-    if not new_name.startswith(tld) and not new_name.startswith('_') \
-        and not new_name.startswith('pillar.example') and not new_name.startswith('README'):
-            log.debug('{0} not in top level directory, not installing'.format(new_name))  # pylint: disable=W0311
-            return False  # pylint: disable=W0311
+    if not new_name.startswith(tld) and not new_name.startswith('_') and not \
+            new_name.startswith('pillar.example') and not new_name.startswith('README'):
+        log.debug('{0} not in top level directory, not installing'.format(new_name))
+        return False
 
     for line in formula_def.get('files', []):
         tag = ''

--- a/salt/spm/pkgfiles/local.py
+++ b/salt/spm/pkgfiles/local.py
@@ -110,8 +110,8 @@ def install_file(package, formula_tar, member, formula_def, conn=None):
     new_name = member.name.replace('{0}/'.format(package), '', 1)
     if not new_name.startswith(tld) and not new_name.startswith('_') \
         and not new_name.startswith('pillar.example') and not new_name.startswith('README'):
-            log.debug('{0} not in top level directory, not installing'.format(new_name))
-            return False
+            log.debug('{0} not in top level directory, not installing'.format(new_name))  # pylint: disable=W0311
+            return False  # pylint: disable=W0311
 
     for line in formula_def.get('files', []):
         tag = ''

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -36,7 +36,8 @@ except ImportError:
                 'SRV_ROOT_DIR', 'BASE_FILE_ROOTS_DIR',
                 'BASE_PILLAR_ROOTS_DIR', 'BASE_THORIUM_ROOTS_DIR',
                 'BASE_MASTER_ROOTS_DIR', 'LOGS_DIR', 'PIDFILE_DIR',
-                'SPM_FORMULA_PATH', 'SPM_PILLAR_PATH', 'SPM_REACTOR_PATH'):
+                'SPM_FORMULA_PATH', 'SPM_PILLAR_PATH', 'SPM_REACTOR_PATH',
+                'SHARE_DIR'):
         setattr(__generated_syspaths, key, None)
 
 

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -74,6 +74,19 @@ if CONFIG_DIR is None:
     else:
         CONFIG_DIR = os.path.join(ROOT_DIR, 'etc', 'salt')
 
+SHARE_DIR = __generated_syspaths.SHARE_DIR
+if SHARE_DIR is None:
+    if __PLATFORM.startswith('win'):
+        SHARE_DIR = os.path.join(ROOT_DIR, 'share')
+    elif 'freebsd' in __PLATFORM:
+        SHARE_DIR = os.path.join(ROOT_DIR, 'usr', 'local', 'share', 'salt')
+    elif 'netbsd' in __PLATFORM:
+        SHARE_DIR = os.path.join(ROOT_DIR, 'usr', 'share', 'salt')
+    elif 'sunos5' in __PLATFORM:
+        SHARE_DIR = os.path.join(ROOT_DIR, 'usr', 'share', 'salt')
+    else:
+        SHARE_DIR = os.path.join(ROOT_DIR, 'usr', 'share', 'salt')
+
 CACHE_DIR = __generated_syspaths.CACHE_DIR
 if CACHE_DIR is None:
     CACHE_DIR = os.path.join(ROOT_DIR, 'var', 'cache', 'salt')

--- a/tests/unit/test_spm.py
+++ b/tests/unit/test_spm.py
@@ -41,7 +41,7 @@ __opts__ = {
     'verbose': False,
     'cache': 'localfs',
     'spm_repo_dups': 'ignore',
-    'spm_share_dir': '/usr/share/salt/spm',
+    'spm_share_dir': os.path.join(_TMP_SPM, 'share'),
 }
 
 _F1 = {

--- a/tests/unit/test_spm.py
+++ b/tests/unit/test_spm.py
@@ -41,6 +41,7 @@ __opts__ = {
     'verbose': False,
     'cache': 'localfs',
     'spm_repo_dups': 'ignore',
+    'spm_share_dir': '/usr/share/salt/spm',
 }
 
 _F1 = {


### PR DESCRIPTION
### What does this PR do?
You can now add a `files` section to a `FORMULA` file! For example, it might look like:
```
files:
  - _pillar
  - FORMULA
  - _runners
  - d|mymodule/index.rst
  - r|README.rst
```
When `files` are specified, then only those files will be added to the SPM, regardless of what other files exist in the directory. They will also be added in the order specified, which is useful if you have a need to lay down files in a specific order.

As can be seen in the example above, you may also tag files as being a specific type. This is done by pre-pending a filename with its type, followed by a pipe (`|`) character. The above example contains a document file and a readme. The available file types are:
* c: config file
* d: documentation file
* g: ghost file (i.e. the file contents are not included in the package payload)
* l: license file
* r: readme file
* s: SLS file
* m: Salt module

The first 5 of these types (c, d, g, l, r) will be placed in `/usr/share/salt/spm/` by default. This can be changed by setting an `spm_share_dir` value in your `/etc/salt/spm` configuration file.

The last two types (s and m) are currently ignored, but they are reserved for future use.

### Tests written?
No.