### PR TITLE
Fix error in Saltstack's rest auth "Authentication module threw 'status' "

### DIFF
--- a/salt/auth/rest.py
+++ b/salt/auth/rest.py
@@ -58,7 +58,8 @@ def auth(username, password):
 
     # Post to the API endpoint. If 200 is returned then the result will be the ACLs
     # for this user
-    result = salt.utils.http.query(url, method='POST', data=data)
+    result = salt.utils.http.query(url, method='POST', data=data, status=True,
+                                   decode=True)
     if result['status'] == 200:
         log.debug('eauth REST call returned 200: {0}'.format(result))
         if result['dict'] is not None:


### PR DESCRIPTION
Fixes #39683

updated rest.auth method to get 'status' and 'dict' in the
http.query result

### What does this PR do?
Fix for rest eauth mechanism, currently it throws 401 error due to error mentioned above.

### Tests written?
No
Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
