### PR TITLE
DOCS: add 2nd level header for advanced targeting methods

### DIFF
--- a/doc/topics/targeting/index.rst
+++ b/doc/topics/targeting/index.rst
@@ -33,7 +33,7 @@ be called to execute a function, or a specific kernel.
 
 Calling via a grain is done by passing the -G option to salt, specifying
 a grain and a glob expression to match the value of the grain. The syntax for
-the target is the grain key followed by a globexpression: "os:Arch*".
+the target is the grain key followed by a glob expression: "os:Arch*".
 
 .. code-block:: bash
 
@@ -48,7 +48,7 @@ grains.item salt function:
 
     salt '*' grains.items
 
-more info on using targeting with grains can be found :ref:`here
+More info on using targeting with grains can be found :ref:`here
 <targeting-grains>`.
 
 Compound Targeting
@@ -73,7 +73,7 @@ is used with ``G@`` as well as a regular expression with ``E@``. The
 ``webser*`` target does not need to be prefaced with a target type specifier
 because it is a glob.
 
-more info on using compound targeting can be found :ref:`here
+More info on using compound targeting can be found :ref:`here
 <targeting-compound>`.
 
 Node Group Targeting
@@ -93,6 +93,10 @@ shorthand for having to type out complicated compound expressions.
       group1: 'L@foo.domain.com,bar.domain.com,baz.domain.com and bl*.domain.com'
       group2: 'G@os:Debian and foo.domain.com'
       group3: 'G@os:Debian and N@group1'
+
+
+Advanced Targeting Methods
+==========================
 
 There are many ways to target individual minions or groups of minions in Salt:
 


### PR DESCRIPTION
### What does this PR do?
It adds intermediate second level subsection to describe advanced targeting methods to the targeting index page.

### Previous Behavior
Before that, it looks little bit of confusing to see topics "Matching the minion id", "Targeting using Grains", "Targeting using Pillar", etc to fall under the "Node Group Targeting" upper section. My first thought is they all can be used only for nodegroups configuration, but actually they are independent.

### New Behavior
The comprehensive description of targeting methods is now located under the separate "Advanced Targeting Methods" header to express that all the methods below are not tighten to the nodegroups functionality.  
