### PR TITLE
also return data from queue

### DIFF
--- a/salt/runners/queue.py
+++ b/salt/runners/queue.py
@@ -190,3 +190,4 @@ def process_queue(queue, quantity=1, backend='sqlite'):
             'queue': queue,
             }
     event.fire_event(data, tagify([queue, 'process'], prefix='queue'))
+    return data


### PR DESCRIPTION
### What does this PR do?

Instead of only firing events with the data in it, return the data so it
can be used elsewhere if it is needed.

### Previous Behavior
Only place the event data on the event stream.

### New Behavior
Place data on the event stream, and return the data

### Tests written?

No