### PR TITLE
INFRA-4487 - 'test=True' should return True rather than None if no changes are scheduled.

### DIFF
--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -506,7 +506,6 @@ def present(
             if __salt__['boto_elb.set_instances'](name, instance_ids, True, region,
                                                   key, keyid, profile):
                 ret['comment'] += ' ELB {0} instances would be updated.'.format(name)
-                ret['result'] = None
                 return ret
         _ret = __salt__['boto_elb.set_instances'](name, instance_ids, False, region,
                                                   key, keyid, profile)
@@ -565,7 +564,6 @@ def register_instances(name, instances, region=None, key=None, keyid=None,
         else:
             if __opts__['test']:
                 ret['comment'] = 'ELB {0} is set to register : {1}.'.format(name, new)
-                ret['result'] = None
                 return ret
             state = __salt__['boto_elb.register_instances'](name,
                                                             instances,
@@ -677,7 +675,6 @@ def _elb_present(
     if not exists:
         if __opts__['test']:
             ret['comment'] = 'ELB {0} is set to be created.'.format(name)
-            ret['result'] = None
             return ret
         created = __salt__['boto_elb.create'](name=name,
                                               availability_zones=availability_zones,
@@ -780,7 +777,6 @@ def _listeners_present(
         else:
             msg.append('Listeners already set on ELB {0}.'.format(name))
         ret['comment'] = ' '.join(msg)
-        ret['result'] = None
         return ret
 
     if to_delete:
@@ -843,7 +839,6 @@ def _security_groups_present(
         if __opts__['test']:
             msg = 'ELB {0} set to have security groups modified.'.format(name)
             ret['comment'] = msg
-            ret['result'] = None
             return ret
         changed = __salt__['boto_elb.apply_security_groups'](
             name, security_groups, region, key, keyid, profile
@@ -907,7 +902,6 @@ def _attributes_present(
     if attrs_to_set:
         if __opts__['test']:
             ret['comment'] = 'ELB {0} set to have attributes set.'.format(name)
-            ret['result'] = None
             return ret
         was_set = __salt__['boto_elb.set_attributes'](name, attributes,
                                                       region, key, keyid,
@@ -950,7 +944,6 @@ def _health_check_present(
     if need_to_set:
         if __opts__['test']:
             msg = 'ELB {0} set to have health check set.'.format(name)
-            ret['result'] = True
             ret['comment'] = msg
             return ret
         was_set = __salt__['boto_elb.set_health_check'](name, health_check,
@@ -1000,7 +993,6 @@ def _zones_present(
         if __opts__['test']:
             msg = 'ELB {0} to have availability zones set.'.format(name)
             ret['comment'] = msg
-            ret['result'] = None
             return ret
         if to_enable:
             enabled = __salt__['boto_elb.enable_availability_zones'](name,
@@ -1072,7 +1064,6 @@ def _subnets_present(
         if __opts__['test']:
             msg = 'ELB {0} to have subnets set.'.format(name)
             ret['comment'] = msg
-            ret['result'] = None
             return ret
         if to_enable:
             attached = __salt__['boto_elb.attach_subnets'](name, to_enable,
@@ -1286,15 +1277,12 @@ def _policies_present(
                 msg.append('Policy {0} added.'.format(policy))
             for policy in to_delete:
                 msg.append('Policy {0} deleted.'.format(policy))
-            ret['result'] = None
         else:
             msg.append('Policies already set on ELB {0}.'.format(name))
         for listener in listeners_to_update:
             msg.append('Listener {0} policies updated.'.format(listener))
-            ret['result'] = None
         for backend in backends_to_update:
             msg.append('Backend {0} policies updated.'.format(backend))
-            ret['result'] = None
         ret['comment'] = ' '.join(msg)
         return ret
 
@@ -1415,7 +1403,6 @@ def absent(
     if exists:
         if __opts__['test']:
             ret['comment'] = 'ELB {0} is set to be removed.'.format(name)
-            ret['result'] = None
             return ret
         deleted = __salt__['boto_elb.delete'](name, region, key, keyid,
                                               profile)
@@ -1461,7 +1448,6 @@ def _tags_present(name,
                 msg = 'The following tag{0} set to be removed: {1}.'.format(
                         ('s are' if len(tags_to_remove) > 1 else ' is'), ', '.join(tags_to_remove))
                 ret['comment'] = ' '.join([ret['comment'], msg])
-                ret['result'] = None
             else:
                 _ret = __salt__['boto_elb.delete_tags'](
                             name,
@@ -1486,13 +1472,11 @@ def _tags_present(name,
                             ('s are' if len(tags_to_add.keys()) > 1 else ' is'),
                             ', '.join(tags_to_add.keys()))
                     ret['comment'] = ' '. join([ret['comment'], msg])
-                    ret['result'] = None
                 if tags_to_update:
                     msg = 'The following tag {0} set to be updated: {1}.'.format(
                             ('values are' if len(tags_to_update.keys()) > 1 else 'value is'),
                             ', '.join(tags_to_update.keys()))
                     ret['comment'] = ' '.join([ret['comment'], msg])
-                    ret['result'] = None
             else:
                 all_tag_changes = dictupdate.update(tags_to_add, tags_to_update)
                 _ret = __salt__['boto_elb.set_tags'](

--- a/tests/unit/states/test_boto_elb.py
+++ b/tests/unit/states/test_boto_elb.py
@@ -178,7 +178,7 @@ class BotoElbTestCase(TestCase):
 
             with patch.dict(boto_elb.__opts__, {'test': True}):
                 comt = ('ELB {0} is set to be removed.'.format(name))
-                ret.update({'comment': comt, 'result': None})
+                ret.update({'comment': comt, 'result': True})
                 self.assertDictEqual(boto_elb.absent(name), ret)
 
 


### PR DESCRIPTION
No changes are scheduled, yet the boto_elb state returns None (causing salt to tag them as "will be changed") during a 'test=True' state run.