### PR TITLE
Missing parameter in the schedule.add function

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -359,8 +359,9 @@ def build_schedule_item(name, **kwargs):
         else:
             schedule[name]['splay'] = kwargs['splay']
 
-    for item in ['range', 'when', 'once', 'once_fmt', 'cron', 'returner',
-                 'return_config', 'return_kwargs', 'until', 'run_on_start']:
+    for item in ['range', 'when', 'once', 'once_fmt', 'cron',
+                 'returner', 'after', 'return_config', 'return_kwargs',
+                 'until', 'run_on_start']:
         if item in kwargs:
             schedule[name][item] = kwargs[item]
 


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where the `after` parameter is ignored when using schedule.add

### What issues does this PR fix or reference?
#39710

### Previous Behavior
When using the schedule.add to insert an item into the Salt scheduler, if the `after` parameter is specified 
it is ignored.

### New Behavior
The `after` parameter is able to be used.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
