### PR TITLE
Vault: Handle patterns with non-existing keys

### DIFF
--- a/salt/runners/vault.py
+++ b/salt/runners/vault.py
@@ -118,8 +118,11 @@ def _get_policies(minion_id, config):
 
     policies = []
     for pattern in policy_patterns:
-        for expanded_pattern in _expand_pattern_lists(pattern, **mappings):
-            policies.append(expanded_pattern.format(**mappings))
+        try:
+            for expanded_pattern in _expand_pattern_lists(pattern, **mappings):
+                policies.append(expanded_pattern.format(**mappings))
+        except KeyError:
+            log.warning('Could not resolve policy pattern {0}'.format(pattern))
 
     log.debug('{0} policies: {1}'.format(minion_id, policies))
     return policies

--- a/tests/unit/runners/test_vault.py
+++ b/tests/unit/runners/test_vault.py
@@ -111,7 +111,8 @@ class VaultTest(TestCase):
                     'deeply-nested-list:{grains[deep][foo][bar][baz]}': [
                         'deeply-nested-list:hello',
                         'deeply-nested-list:world'
-                    ]
+                    ],
+                    'should-not-cause-an-exception,but-result-empty:{foo}': []
                 }
 
         with patch('salt.utils.minions.get_minion_data',


### PR DESCRIPTION
### What does this PR do?
If a Vault policy pattern references a variable which is not available, an exception is thrown. This PR handles this exception and logs a warning. Any other patterns are still processed as usual.

### Previous Behavior
Unhandled exception.

### New Behavior
Handled exception, logged warning. 

### Tests written?
Yes

