### PR TITLE
Handle edge case: password and empty_password both set

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -497,6 +497,9 @@ def present(name,
             if key == 'passwd' and not empty_password:
                 __salt__['shadow.set_password'](name, password)
                 continue
+            if key == 'passwd' and empty_password:
+                log.warn("No password will be set when empty_password=True")
+                continue
             if key == 'date':
                 __salt__['shadow.set_date'](name, date)
                 continue


### PR DESCRIPTION
### What does this PR do?
Handle the case where a user mistakenly passes both the
`password` and `empty_password=True` arguments. Instead of throwing
as weird key error, simply log a warning message and fail gracefully.

Fixes #39741

### Previous Behavior
can be found in  #39741

### New Behavior
A nice graceful failure + warning message:
```bash
(envsalt)  >>> sudo salt-call --local state.sls salt_virt/users
[WARNING ] All tools for virtual hardware identification failed to execute because they do not exist on the system running this instance or the user does not have the necessary permissions to execute them. Grains output might not be accurate.
[WARNING ] No password will be set when empty_password=True
[ERROR   ] These values could not be changed: {'passwd': 'virty'}
local:
----------
          ID: saltvirt
    Function: user.present
      Result: False
     Comment: These values could not be changed: {'passwd': 'virty'}
     Started: 17:57:39.460309
    Duration: 65.521 ms
     Changes:   

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:  65.521 ms
```

### Tests written?
No. If necessary I'll gladly add it.