### PR TITLE
Add salt.utils.path

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -305,7 +305,7 @@ def _file_lists(load, form):
     if load['saltenv'] not in __opts__['file_roots']:
         return []
 
-    list_cachedir = os.path.join(__opts__['cachedir'], 'file_lists/roots')
+    list_cachedir = os.path.join(__opts__['cachedir'], 'file_lists', 'roots')
     if not os.path.isdir(list_cachedir):
         try:
             os.makedirs(list_cachedir)
@@ -373,9 +373,11 @@ def _file_lists(load, form):
                         joined = os.path.join(
                             os.path.dirname(abs_path), link_dest
                         )
-                    rel_dest = os.path.relpath(
-                        os.path.realpath(os.path.normpath(joined)),
-                        fs_root
+                    rel_dest = _translate_sep(
+                        os.path.relpath(
+                            os.path.realpath(os.path.normpath(joined)),
+                            fs_root
+                        )
                     )
                     log.trace(
                         'roots: %s relative path is %s',

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -25,6 +25,7 @@ import logging
 # Import salt libs
 import salt.fileserver
 import salt.utils
+import salt.utils.path
 from salt.utils.event import tagify
 import salt.ext.six as six
 
@@ -340,7 +341,7 @@ def _file_lists(load, form):
             for item in items:
                 abs_path = os.path.join(parent_dir, item)
                 log.trace('roots: Processing %s', abs_path)
-                is_link = os.path.islink(abs_path)
+                is_link = salt.utils.path.islink(abs_path)
                 log.trace(
                     'roots: %s is %sa link',
                     abs_path, 'not ' if not is_link else ''
@@ -361,7 +362,7 @@ def _file_lists(load, form):
                     # WindowsError on Windows.
                     pass
                 if is_link:
-                    link_dest = os.readlink(abs_path)
+                    link_dest = salt.utils.path.readlink(abs_path)
                     log.trace(
                         'roots: %s symlink destination is %s',
                         abs_path, link_dest

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -15,7 +15,6 @@ import os
 import stat
 import os.path
 import logging
-import struct
 # pylint: disable=W0611
 import operator  # do not remove
 from collections import Iterable, Mapping  # do not remove
@@ -43,6 +42,7 @@ from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 # Import salt libs
 import salt.utils
+import salt.utils.path
 from salt.modules.file import (check_hash,  # pylint: disable=W0611
         directory_exists, get_managed,
         check_managed, check_managed_changes, source_list,
@@ -1116,24 +1116,6 @@ def symlink(src, link):
         )
 
 
-def _is_reparse_point(path):
-    '''
-    Returns True if path is a reparse point; False otherwise.
-    '''
-    if sys.getwindowsversion().major < 6:
-        raise SaltInvocationError('Symlinks are only supported on Windows Vista or later.')
-
-    result = win32file.GetFileAttributesW(path)
-
-    if result == -1:
-        raise SaltInvocationError('The path given is not valid, symlink or not. (does it exist?)')
-
-    if result & 0x400:  # FILE_ATTRIBUTE_REPARSE_POINT
-        return True
-    else:
-        return False
-
-
 def is_link(path):
     '''
     Check if the path is a symlink
@@ -1157,77 +1139,12 @@ def is_link(path):
        salt '*' file.is_link /path/to/link
     '''
     if sys.getwindowsversion().major < 6:
-        return False
-
-    try:
-        if not _is_reparse_point(path):
-            return False
-    except SaltInvocationError:
-        return False
-
-    # check that it is a symlink reparse point (in case it is something else,
-    # like a mount point)
-    reparse_data = _get_reparse_data(path)
-
-    # sanity check - this should not happen
-    if not reparse_data:
-        # not a reparse point
-        return False
-
-    # REPARSE_DATA_BUFFER structure - see
-    # http://msdn.microsoft.com/en-us/library/ff552012.aspx
-
-    # parse the structure header to work out which type of reparse point this is
-    header_parser = struct.Struct('L')
-    ReparseTag, = header_parser.unpack(reparse_data[:header_parser.size])
-    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa365511.aspx
-    if not ReparseTag & 0xA000FFFF == 0xA000000C:
-        return False
-    else:
-        return True
-
-
-def _get_reparse_data(path):
-    '''
-    Retrieves the reparse point data structure for the given path.
-
-    If the path is not a reparse point, None is returned.
-
-    See http://msdn.microsoft.com/en-us/library/ff552012.aspx for details on the
-    REPARSE_DATA_BUFFER structure returned.
-    '''
-    if sys.getwindowsversion().major < 6:
         raise SaltInvocationError('Symlinks are only supported on Windows Vista or later.')
 
-    # ensure paths are using the right slashes
-    path = os.path.normpath(path)
-
-    if not _is_reparse_point(path):
-        return None
-
-    fileHandle = None
     try:
-        fileHandle = win32file.CreateFileW(
-            path,
-            0x80000000,  # GENERIC_READ
-            1,  # share with other readers
-            None,  # no inherit, default security descriptor
-            3,  # OPEN_EXISTING
-            0x00200000 | 0x02000000  # FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS
-        )
-
-        reparseData = win32file.DeviceIoControl(
-            fileHandle,
-            0x900a8,  # FSCTL_GET_REPARSE_POINT
-            None,  # in buffer
-            16384  # out buffer size (MAXIMUM_REPARSE_DATA_BUFFER_SIZE)
-        )
-
-    finally:
-        if fileHandle:
-            win32file.CloseHandle(fileHandle)
-
-    return reparseData
+        return salt.utils.path.islink(path)
+    except Exception as exc:
+        raise CommandExecutionError(exc)
 
 
 def readlink(path):
@@ -1255,49 +1172,14 @@ def readlink(path):
     if sys.getwindowsversion().major < 6:
         raise SaltInvocationError('Symlinks are only supported on Windows Vista or later.')
 
-    if not os.path.isabs(path):
-        raise SaltInvocationError('Path to link must be absolute.')
-
-    reparse_data = _get_reparse_data(path)
-
-    if not reparse_data:
-        raise SaltInvocationError('The path specified is not a reparse point (symlinks are a type of reparse point).')
-
-    # REPARSE_DATA_BUFFER structure - see
-    # http://msdn.microsoft.com/en-us/library/ff552012.aspx
-
-    # parse the structure header to work out which type of reparse point this is
-    header_parser = struct.Struct('L')
-    ReparseTag, = header_parser.unpack(reparse_data[:header_parser.size])
-    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa365511.aspx
-    if not ReparseTag & 0xA000FFFF == 0xA000000C:
-        raise SaltInvocationError('The path specified is not a symlink, but another type of reparse point (0x{0:X}).'.format(ReparseTag))
-
-    # parse as a symlink reparse point structure (the structure for other
-    # reparse points is different)
-    data_parser = struct.Struct('LHHHHHHL')
-    ReparseTag, ReparseDataLength, Reserved, SubstituteNameOffset, \
-    SubstituteNameLength, PrintNameOffset, \
-    PrintNameLength, Flags = data_parser.unpack(reparse_data[:data_parser.size])
-
-    path_buffer_offset = data_parser.size
-    absolute_substitute_name_offset = path_buffer_offset + SubstituteNameOffset
-    target_bytes = reparse_data[absolute_substitute_name_offset:absolute_substitute_name_offset+SubstituteNameLength]
-    target = target_bytes.decode('UTF-16')
-
-    if target.startswith('\\??\\'):
-        target = target[4:]
-
     try:
-        # comes out in 8.3 form; convert it to LFN to make it look nicer
-        target = win32file.GetLongPathName(target)
-    except pywinerror as exc:
-        # if file is not found (i.e. bad symlink), return it anyway like on *nix
-        if exc.winerror == 2:
-            return target
-        raise
-
-    return target
+        return salt.utils.path.readlink(path)
+    except OSError as exc:
+        if exc.errno == errno.EINVAL:
+            raise CommandExecutionError('{0} is not a symbolic link'.format(path))
+        raise CommandExecutionError(exc.__str__())
+    except Exception as exc:
+        raise CommandExecutionError(exc)
 
 
 def mkdir(path,

--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+'''
+Platform independent versions of some os/os.path functions. Gets around PY2's
+lack of support for reading NTFS links.
+'''
+
+# Import python lib
+from __future__ import absolute_import
+import errno
+import logging
+import os
+import struct
+
+# Import 3rd-party libs
+import salt.utils
+from salt.ext import six
+
+try:
+    import win32file
+    from pywintypes import error as pywinerror
+    HAS_WIN32FILE = True
+except ImportError:
+    HAS_WIN32FILE = False
+
+log = logging.getLogger(__name__)
+
+
+def islink(path):
+    '''
+    Equivalent to os.path.islink()
+    '''
+    if six.PY3 or not salt.utils.is_windows():
+        return os.path.islink(path)
+
+    if not HAS_WIN32FILE:
+        log.error('Cannot check if %s is a link, missing required modules', path)
+
+    if not _is_reparse_point(path):
+        return False
+
+    # check that it is a symlink reparse point (in case it is something else,
+    # like a mount point)
+    reparse_data = _get_reparse_data(path)
+
+    # sanity check - this should not happen
+    if not reparse_data:
+        # not a reparse point
+        return False
+
+    # REPARSE_DATA_BUFFER structure - see
+    # http://msdn.microsoft.com/en-us/library/ff552012.aspx
+
+    # parse the structure header to work out which type of reparse point this is
+    header_parser = struct.Struct('L')
+    ReparseTag, = header_parser.unpack(reparse_data[:header_parser.size])
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa365511.aspx
+    if not ReparseTag & 0xA000FFFF == 0xA000000C:
+        return False
+    else:
+        return True
+
+
+def readlink(path):
+    '''
+    Equivalent to os.readlink()
+    '''
+    if six.PY3 or not salt.utils.is_windows():
+        return os.readlink(path)
+
+    if not HAS_WIN32FILE:
+        log.error('Cannot read %s, missing required modules', path)
+
+    reparse_data = _get_reparse_data(path)
+
+    if not reparse_data:
+        # Reproduce *NIX behavior when os.readlink is performed on a path that
+        # is not a symbolic link.
+        raise OSError(errno.EINVAL, 'Invalid argument: \'{0}\''.format(path))
+
+    # REPARSE_DATA_BUFFER structure - see
+    # http://msdn.microsoft.com/en-us/library/ff552012.aspx
+
+    # parse the structure header to work out which type of reparse point this is
+    header_parser = struct.Struct('L')
+    ReparseTag, = header_parser.unpack(reparse_data[:header_parser.size])
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa365511.aspx
+    if not ReparseTag & 0xA000FFFF == 0xA000000C:
+        raise OSError(
+            errno.EINVAL,
+            '{0} is not a symlink, but another type of reparse point '
+            '(0x{0:X}).'.format(ReparseTag)
+        )
+
+    # parse as a symlink reparse point structure (the structure for other
+    # reparse points is different)
+    data_parser = struct.Struct('LHHHHHHL')
+    ReparseTag, ReparseDataLength, Reserved, SubstituteNameOffset, \
+    SubstituteNameLength, PrintNameOffset, \
+    PrintNameLength, Flags = data_parser.unpack(reparse_data[:data_parser.size])
+
+    path_buffer_offset = data_parser.size
+    absolute_substitute_name_offset = path_buffer_offset + SubstituteNameOffset
+    target_bytes = reparse_data[absolute_substitute_name_offset:absolute_substitute_name_offset+SubstituteNameLength]
+    target = target_bytes.decode('UTF-16')
+
+    if target.startswith('\\??\\'):
+        target = target[4:]
+
+    try:
+        # comes out in 8.3 form; convert it to LFN to make it look nicer
+        target = win32file.GetLongPathName(target)
+    except pywinerror as exc:
+        # if file is not found (i.e. bad symlink), return it anyway like on *nix
+        if exc.winerror == 2:
+            return target
+        raise
+
+    return target
+
+
+def _is_reparse_point(path):
+    '''
+    Returns True if path is a reparse point; False otherwise.
+    '''
+    result = win32file.GetFileAttributesW(path)
+
+    if result == -1:
+        return False
+
+    return True if result & 0x400 else False
+
+
+def _get_reparse_data(path):
+    '''
+    Retrieves the reparse point data structure for the given path.
+
+    If the path is not a reparse point, None is returned.
+
+    See http://msdn.microsoft.com/en-us/library/ff552012.aspx for details on the
+    REPARSE_DATA_BUFFER structure returned.
+    '''
+    # ensure paths are using the right slashes
+    path = os.path.normpath(path)
+
+    if not _is_reparse_point(path):
+        return None
+
+    fileHandle = None
+    try:
+        fileHandle = win32file.CreateFileW(
+            path,
+            0x80000000,  # GENERIC_READ
+            1,  # share with other readers
+            None,  # no inherit, default security descriptor
+            3,  # OPEN_EXISTING
+            0x00200000 | 0x02000000  # FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS
+        )
+
+        reparseData = win32file.DeviceIoControl(
+            fileHandle,
+            0x900a8,  # FSCTL_GET_REPARSE_POINT
+            None,  # in buffer
+            16384  # out buffer size (MAXIMUM_REPARSE_DATA_BUFFER_SIZE)
+        )
+
+    finally:
+        if fileHandle:
+            win32file.CloseHandle(fileHandle)
+
+    return reparseData

--- a/tests/integration/runners/test_fileserver.py
+++ b/tests/integration/runners/test_fileserver.py
@@ -8,8 +8,7 @@ import contextlib
 
 # Import Salt Testing libs
 import tests.integration as integration
-from salttesting import skipIf
-from salttesting.helpers import ensure_in_syspath
+from tests.support.unit import skipIf
 
 # Import salt libs
 import salt.utils

--- a/tests/integration/runners/test_fileserver.py
+++ b/tests/integration/runners/test_fileserver.py
@@ -8,6 +8,11 @@ import contextlib
 
 # Import Salt Testing libs
 import tests.integration as integration
+from salttesting import skipIf
+from salttesting.helpers import ensure_in_syspath
+
+# Import salt libs
+import salt.utils
 
 
 class FileserverTest(integration.ShellCase):
@@ -157,6 +162,10 @@ class FileserverTest(integration.ShellCase):
         self.assertIsInstance(ret['return'], list)
         self.assertTrue('grail/scene33' in ret['return'])
 
+    # Git doesn't handle symlinks in Windows. See the thread below:
+    # http://stackoverflow.com/questions/5917249/git-symlinks-in-windows
+    @skipIf(salt.utils.is_windows(),
+            'Git doesn\'t handle symlinks properly on Windows')
     def test_symlink_list(self):
         '''
         fileserver.symlink_list

--- a/tests/integration/runners/test_fileserver.py
+++ b/tests/integration/runners/test_fileserver.py
@@ -165,7 +165,7 @@ class FileserverTest(integration.ShellCase):
     # Git doesn't handle symlinks in Windows. See the thread below:
     # http://stackoverflow.com/questions/5917249/git-symlinks-in-windows
     @skipIf(salt.utils.is_windows(),
-            'Git doesn\'t handle symlinks properly on Windows')
+            'Git for Windows does not preserve symbolic links when cloning')
     def test_symlink_list(self):
         '''
         fileserver.symlink_list

--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -27,6 +27,7 @@ integration.modules.test_useradd
 integration.renderers.test_pydsl
 integration.returners.test_librato_return
 integration.returners.test_local_cache
+integration.runners.test_fileserver
 integration.runners.test_jobs
 integration.runners.test_salt
 integration.runners.test_winrepo


### PR DESCRIPTION
This module provides a unified interface for symlink handling for code which needs to run on both Windows and non-Windows platforms. This will allow for Windows masters to successfully handle Windows symbolic links in the roots fileserver backend.

Code for reading and detecting links has been moved from win_file.py into this new module, and modified slightly to behave more like its *NIX counterpart.

EDIT: I've also cherry-picked @twangboy's initial commit from #39698 and made some changes on top of it, including a rewritten symlink test in the roots fileserver integration tests. This makes #39698 obsolete.

I don't have the means to test the code I wrote for Windows in the test suite, so we'll have to see how it works once this test is run on a Windows box.