### PR TITLE
INFRA-4445 - sort policy docs so they compare equal when they in fact are

### DIFF
--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -269,11 +269,11 @@ def _role_present(
         if not policy_document:
             policy = __salt__['boto_iam.build_policy'](region, key, keyid,
                                                        profile)
-            if role['assume_role_policy_document'] != policy:
+            if _sort_policy(role['assume_role_policy_document']) != _sort_policy(policy):
                 update_needed = True
                 _policy_document = policy
         else:
-            if role['assume_role_policy_document'] != policy_document:
+            if _sort_policy(role['assume_role_policy_document']) != _sort_policy(policy_document):
                 update_needed = True
                 _policy_document = policy_document
         if update_needed:
@@ -355,6 +355,19 @@ def _instance_profile_associated(
             msg = 'Failed to associate {0} instance profile with {0} role.'
             ret['comment'] = msg.format(name)
     return ret
+
+
+def _sort_policy(doc):
+    # List-type sub-items in policies don't happen to be order-sensitive, but
+    # compare operations will render them unequal, leading to non-idempotent
+    # state runs.  We'll sort any list-type subitems before comparison to reduce
+    # the likelihood of false negatives.
+    if isinstance(doc, list):
+        return sorted([_sort_policy(i) for i in doc])
+    elif isinstance(doc, dict):
+        return dict([(k, _sort_policy(v)) for k, v in doc.items()])
+    else:
+        return doc
 
 
 def _policies_present(


### PR DESCRIPTION
Lists inside AWS policy docs are not order dependent, but AWS tends to return them in indeterminate orders.  This fix simply sorts them so that comparisons of current to desired are meaningful, and thus we avoid frequent unneeded policy updates.