### PR TITLE
WIP: Add "Edit on GitHub" link to the docs

### DIFF
--- a/doc/_themes/saltstack2/layout.html
+++ b/doc/_themes/saltstack2/layout.html
@@ -164,6 +164,9 @@
                     <!--start navbar-->
                     <div class="row">
                         <div class="col-sm-12 col-md-11 col-md-offset-1 col-lg-10 col-lg-offset-1">
+                            <nav class="pull-left text-muted">
+                                <a href="https://github.com/saltstack/salt/edit/develop/doc/{{pagename}}.rst">Edit on GitHub</a>
+                            </nav>
                             <nav id="localnav">
                                 <ul class="nav navbar-nav">
                                     {%- block relbar_small %}{{ relbar() }}{% endblock %}


### PR DESCRIPTION
Adds a link to make it easy for anyone to improve the documentation.

Clicking the link will walk you through the process of editing the file in their browser and creating a PR. For non-committers this works by creating a fork if none exists yet.

By displaying such a link prominently, you are encouraging the community to become more active in maintaining the documentation, and crowdsourcing a lot of the work that needs to be done.

Some sites I know of that do this:

 * http://www.scala-lang.org/documentation/ (right sidebar)
 * https://www.playframework.com/documentation/2.5.x/Home (in the footer)
 * http://slick.lightbend.com/doc/3.2.0/ (in the top right nav)
 * https://docs.readthedocs.io/en/latest/ (top right)

It's not 100% finished yet, but it's enough to get a discussion going:

![image](https://cloud.githubusercontent.com/assets/98384/23447197/4829663e-fe17-11e6-8114-b2c73d8db8f0.png)

Remaining issues that come to mind:

- [ ] Vertical alignment is wrong
- [ ] Styling and markup is up for critiquing. For example it probably shouldn't be a `<nav>` element. I put the `text-muted` class on it (it looked like it's using Bootstrap) but (presumably because it's a link) it doesn't seem to have any effect.
- [ ] Perhaps the URL prefix shouldn't be hardcoded (I don't know Sphinx enough to factor it out)

