### PR TITLE
Fix regression in file.get_managed

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3768,13 +3768,13 @@ def get_managed(
         if cached_dest and (source_hash or skip_verify):
             htype = source_sum.get('hash_type', 'sha256')
             cached_sum = get_hash(cached_dest, form=htype)
-            if cached_sum != source_sum['hsum']:
-                cache_refetch = True
-            elif skip_verify:
+            if skip_verify:
                 # prev: if skip_verify or cached_sum == source_sum['hsum']:
                 # but `cached_sum == source_sum['hsum']` is elliptical as prev if
                 sfn = cached_dest
                 source_sum = {'hsum': cached_sum, 'hash_type': htype}
+            elif cached_sum != source_sum['hsum']:
+                cache_refetch = True
 
         # If we didn't have the template or remote file, let's get it
         # Similarly when the file has been updated and the cache has to be refreshed

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -897,17 +897,6 @@ def extracted(name,
                 ret['comment'] = '\n'.join([str(x) for x in file_result])
             return ret
 
-        # Get actual state result. The state.single return is a single-element
-        # dictionary with the state's unique ID at the top level, and its value
-        # being the state's return dictionary. next(iter(dict_name)) will give
-        # us the value of the first key, so
-        # file_result[next(iter(file_result))] will give us the results of the
-        # state.single we just ran.
-        try:
-            file_result = file_result[next(iter(file_result))]
-        except AttributeError:
-            pass
-
         try:
             if not file_result['result']:
                 log.debug('failed to download {0}'.format(source_match))


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/39438 broke file.get_managed when ``skip_verify=True``.

I didn't catch this when reviewing that PR, so I share part of the blame here. Another contributor to this issue is that we did not have integration tests to cover ``skip_verify``. I used a technique found elsewhere in the test suite (thanks @ch3ll!) to create a temporary tornado webserver, and wrote some tests to cover http file sources both with and without skip_verify.

CC: @mirceaulinic