### PR TITLE
Restore ipv6 connectivity and "master: <ip>:<port>" support

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -40,6 +40,33 @@ Default: ``salt``
 
     master: salt
 
+master:port Syntax
+~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2015.8.0
+
+The ``master`` config option can also be set to use the master's IP in
+conjunction with a port number by default.
+
+.. code-block:: yaml
+
+    master: localhost:1234
+
+For IPv6 formatting with a port, remember to add brackets around the IP address
+before adding the port and enclose the line in single quotes to make it a string:
+
+.. code-block:: yaml
+
+    master: '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:1234'
+
+.. note::
+
+    If a port is specified in the ``master`` as well as :conf_minion:`master_port`,
+    the ``master_port`` setting will be overridden by the ``master`` configuration.
+
+List of Masters Syntax
+~~~~~~~~~~~~~~~~~~~~~~
+
 The option can can also be set to a list of masters, enabling
 :ref:`multi-master <tutorial-multi-master>` mode.
 
@@ -89,6 +116,22 @@ will try to automatically detect IPv6 connectivity to master.
 .. code-block:: yaml
 
     ipv6: True
+
+.. conf_minion:: master_uri_format
+
+``master_uri_format``
+---------------------
+
+.. versionadded:: 2015.8.0
+
+Specify the format in which the master address will be evaluated. Valid options
+are ``default`` or ``ip_only``. If ``ip_only`` is specified, then the master
+address will not be split into IP and PORT, so be sure that only an IP (or domain
+name) is set in the :conf_minion:`master` configuration setting.
+
+.. code-block:: yaml
+
+    master_uri_format: ip_only
 
 .. conf_minion:: master_type
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -88,6 +88,7 @@ import salt.utils.jid
 import salt.pillar
 import salt.utils.args
 import salt.utils.event
+import salt.utils.network
 import salt.utils.minion
 import salt.utils.minions
 import salt.utils.schedule
@@ -179,9 +180,11 @@ def resolve_dns(opts, fallback=True, connect=True):
             if master == '':
                 master = unknown_str
             if opts.get('__role') == 'syndic':
-                err = 'Master address: \'{0}\' could not be resolved. Invalid or unresolveable address. Set \'syndic_master\' value in minion config.'.format(master)
+                err = 'Master address: \'{0}\' could not be resolved. Invalid or unresolveable address. ' \
+                      'Set \'syndic_master\' value in minion config.'.format(master)
             else:
-                err = 'Master address: \'{0}\' could not be resolved. Invalid or unresolveable address. Set \'master\' value in minion config.'.format(master)
+                err = 'Master address: \'{0}\' could not be resolved. Invalid or unresolveable address. ' \
+                      'Set \'master\' value in minion config.'.format(master)
             log.error(err)
             raise SaltSystemExit(code=42, msg=err)
     else:
@@ -199,7 +202,10 @@ def resolve_dns(opts, fallback=True, connect=True):
 
 def prep_ip_port(opts):
     ret = {}
-    if opts['master_uri_format'] == 'ip_only':
+    # Use given master IP if "ip_only" is set or if master_ip is an ipv6 address without
+    # a port specified. The is_ipv6 check returns False if brackets are used in the IP
+    # definition such as master: '[::1]:1234'.
+    if opts['master_uri_format'] == 'ip_only' or salt.utils.network.is_ipv6(opts['master']):
         ret['master'] = opts['master']
     else:
         ip_port = opts['master'].rsplit(":", 1)
@@ -209,9 +215,13 @@ def prep_ip_port(opts):
         else:
             # e.g. master: localhost:1234
             # e.g. master: 127.0.0.1:1234
-            # e.g. master: ::1:1234
-            ret['master'] = ip_port[0]
-            ret['master_port'] = ip_port[1]
+            # e.g. master: [::1]:1234
+            # Strip off brackets for ipv6 support
+            ret['master'] = ip_port[0].strip('[]')
+
+            # Cast port back to an int! Otherwise a TypeError is thrown
+            # on some of the socket calls elsewhere in the minion and utils code.
+            ret['master_port'] = int(ip_port[1])
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?
Restores IPv6 connectivity, as well as the ability to specify `master: <ipv4>:<port>` support for IPv4 and also establishes support for `master: '[<ipv6>]:port'` now that IPv6 connectivity is working. This also adds some documentation for how to use these different config options.

🎉 

### What issues does this PR fix or reference?
As best as I can tell, IPv6 connectivity was broken with the addition of the `salt.minion.prep_ip_port` function with #25021. The purpose of that function strips the last group of the IP address off and uses it as the new `master_port`. This works well for IPv4, but does not work for IPv6 as the address is incomplete, and the last group incorrectly becomes the `master_port` value.

With the recent addition of #39289, it became clear that the `master: <ip>:<port>` support was broken for both IPv4 and IPv6 addresses. This PR fixes the breakage that was caused there by casting the `master_port` back to an integer instead of a string.

Fixes #39336 

### Previous Behavior
The minion could not connect to a master using IPv6. The minion using the `master: <ip>:<port>` syntax also could not connect.

### New Behavior
The minion can now connect over IPv6, the IPv4 `master: <ip>:<port>` functionality has been restored, and IPv6 `master: '[<ipv6>]:<port>'` functionality is now supported.

### Tests written?

not yet

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
