### PR TITLE
add get_or_set_hash to sdb

### DIFF
--- a/salt/modules/sdb.py
+++ b/salt/modules/sdb.py
@@ -5,6 +5,9 @@ Module for Manipulating Data via the Salt DB API
 '''
 from __future__ import absolute_import
 
+# Import python libs
+import random
+
 # Import salt libs
 import salt.utils.sdb
 
@@ -56,3 +59,45 @@ def delete(uri):
         salt '*' sdb.delete sdb://mymemcached/foo
     '''
     return salt.utils.sdb.sdb_delete(uri, __opts__, __utils__)
+
+
+def get_or_set_hash(uri,
+        length=8,
+        chars='abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'):
+    '''
+    Perform a one-time generation of a hash and write it to sdb.
+    If that value has already been set return the value instead.
+
+    This is useful for generating passwords or keys that are specific to
+    multiple minions that need to be stored somewhere centrally.
+
+    State Example:
+
+    .. code-block:: yaml
+
+        some_mysql_user:
+          mysql_user:
+            - present
+            - host: localhost
+            - password: '{{ salt['sdb.get_or_set_hash']('some_mysql_user_pass') }}'
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' sdb.get_or_set_hash 'SECRET_KEY' 50
+
+    .. warning::
+
+        This function could return strings which may contain characters which are reserved
+        as directives by the YAML parser, such as strings beginning with ``%``. To avoid
+        issues when using the output of this function in an SLS file containing YAML+Jinja,
+        surround the call with single quotes.
+    '''
+    ret = get(uri, None)
+
+    if ret is None:
+        val = ''.join([random.SystemRandom().choice(chars) for _ in range(length)])
+        set_(uri, val)
+
+    return ret or val


### PR DESCRIPTION
### What does this PR do?
Allows for generating random secrets in the state files and storing them centrally, instead of having to pull the hash from grains in the mine.

### What issues does this PR fix or reference?
Resolves #39763

### Tests written?

No