### PR TITLE
add get_or_set_hash to sdb

### DIFF
--- a/salt/modules/sdb.py
+++ b/salt/modules/sdb.py
@@ -56,3 +56,39 @@ def delete(uri):
         salt '*' sdb.delete sdb://mymemcached/foo
     '''
     return salt.utils.sdb.sdb_delete(uri, __opts__, __utils__)
+
+
+def get_or_set_hash(uri,
+        length=8,
+        chars='abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'):
+    '''
+    Perform a one-time generation of a hash and write it to sdb.
+    If that value has already been set return the value instead.
+
+    This is useful for generating passwords or keys that are specific to
+    multiple minions that need to be stored somewhere centrally.
+
+    State Example:
+
+    .. code-block:: yaml
+
+        some_mysql_user:
+          mysql_user:
+            - present
+            - host: localhost
+            - password: '{{ salt['sdb.get_or_set_hash']('some_mysql_user_pass') }}'
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' sdb.get_or_set_hash 'SECRET_KEY' 50
+
+    .. warning::
+
+        This function could return strings which may contain characters which are reserved
+        as directives by the YAML parser, such as strings beginning with ``%``. To avoid
+        issues when using the output of this function in an SLS file containing YAML+Jinja,
+        surround the call with single quotes.
+    '''
+    return salt.utils.sdb.sdb_get_or_set_hash(uri, __opts__, length, chars, __utils__)

--- a/salt/runners/sdb.py
+++ b/salt/runners/sdb.py
@@ -55,3 +55,29 @@ def delete(uri):
         salt '*' sdb.delete sdb://mymemcached/foo
     '''
     return salt.utils.sdb.sdb_delete(uri, __opts__, __utils__)
+
+
+def get_or_set_hash(uri,
+        length=8,
+        chars='abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'):
+    '''
+    Perform a one-time generation of a hash and write it to sdb.
+    If that value has already been set return the value instead.
+
+    This is useful for generating passwords or keys that are specific to
+    multiple minions that need to be stored somewhere centrally.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run sdb.get_or_set_hash 'SECRET_KEY' 50
+
+    .. warning::
+
+        This function could return strings which may contain characters which are reserved
+        as directives by the YAML parser, such as strings beginning with ``%``. To avoid
+        issues when using the output of this function in an SLS file containing YAML+Jinja,
+        surround the call with single quotes.
+    '''
+    return salt.utils.sdb.sdb_get_or_set_hash(uri, __opts__, length, chars, __utils__)

--- a/salt/utils/sdb.py
+++ b/salt/utils/sdb.py
@@ -13,6 +13,7 @@ import random
 # Import salt libs
 import salt.loader
 from salt.ext.six import string_types
+from salt.ext.six.moves import range
 
 
 def sdb_get(uri, opts, utils=None):

--- a/salt/utils/sdb.py
+++ b/salt/utils/sdb.py
@@ -20,10 +20,7 @@ def sdb_get(uri, opts, utils=None):
     Get a value from a db, using a uri in the form of ``sdb://<profile>/<key>``. If
     the uri provided does not start with ``sdb://``, then it will be returned as-is.
     '''
-    if not isinstance(uri, string_types):
-        return uri
-
-    if not uri.startswith('sdb://'):
+    if not isinstance(uri, string_types) or not uri.startswith('sdb://'):
         return uri
 
     if utils is None:
@@ -54,10 +51,7 @@ def sdb_set(uri, value, opts, utils=None):
     If the uri provided does not start with ``sdb://`` or the value is not
     successfully set, return ``False``.
     '''
-    if not isinstance(uri, string_types):
-        return False
-
-    if not uri.startswith('sdb://'):
+    if not isinstance(uri, string_types) or not uri.startswith('sdb://'):
         return False
 
     if utils is None:
@@ -88,10 +82,7 @@ def sdb_delete(uri, opts, utils=None):
     the uri provided does not start with ``sdb://`` or the value is not successfully
     deleted, return ``False``.
     '''
-    if not isinstance(uri, string_types):
-        return False
-
-    if not uri.startswith('sdb://'):
+    if not isinstance(uri, string_types) or not uri.startswith('sdb://'):
         return False
 
     if utils is None:
@@ -126,10 +117,7 @@ def sdb_get_or_set_hash(uri,
     random string and store it.  This can be used for storing secrets in a
     centralized place.
     '''
-    if not isinstance(uri, string_types):
-        return False
-
-    if not uri.startswith('sdb://'):
+    if not isinstance(uri, string_types) or not uri.startswith('sdb://'):
         return False
 
     if utils is None:


### PR DESCRIPTION
### What does this PR do?
Allows for generating random secrets in the state files and storing them centrally, instead of having to pull the hash from grains in the mine.

### What issues does this PR fix or reference?
Resolves https://github.com/saltstack/salt/issues/39763

### Tests written?

No