### PR TITLE
Allow passing a test module path to runtests.py to run its tests

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -600,6 +600,17 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
         with TestDaemon(self):
             if self.options.name:
                 for name in self.options.name:
+                    if os.path.isfile(name):
+                        if not name.endswith('.py'):
+                            continue
+                        if name.startswith(os.path.join('tests', 'unit')):
+                            continue
+                        results = self.run_suite(os.path.dirname(name),
+                                                 name,
+                                                 suffix=os.path.basename(name),
+                                                 load_from_name=False)
+                        status.append(results)
+                        continue
                     if name.startswith('unit.'):
                         continue
                     results = self.run_suite('', name, suffix='test_*.py', load_from_name=True)

--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -311,6 +311,17 @@ class SaltTestingParser(optparse.OptionParser):
                 self.options.name.extend(lines)
             else:
                 self.options.name = lines
+        if self.args:
+            if not self.options.name:
+                self.options.name = []
+            for fpath in self.args:
+                if not os.path.isfile(fpath):
+                    continue
+                if not fpath.endswith('.py'):
+                    continue
+                if not os.path.basename(fpath).startswith('test_'):
+                    continue
+                self.options.name.append(fpath)
 
         print_header(u'', inline=True, width=self.options.output_columns)
         self.pre_execution_cleanup()


### PR DESCRIPTION
### What does this PR do?
Allow passing a test module path to runtests.py to run its tests.
Example:

```
python tests/runtests.py -v tests/integration/states/test_alternatives.py
```