### PR TITLE
Fix incorrect test name

### DIFF
--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -33,6 +33,6 @@ integration.runners.test_winrepo
 integration.sdb.test_env
 integration.states.test_host
 integration.states.test_renderers
-integration.utils.test_testprogram
+integration.utils.testprogram
 integration.wheel.test_client
 integration.wheel.test_key


### PR DESCRIPTION
### What does this PR do?
Fixes problem with incorrect name for `integration.utils.testprogram`

### Previous Behavior
Test was at one time named `test_testprogram.py`. Somewhere along the lines it got changed back to `testprogram.py`. This was causing the test suite to die on Windows on this test...

### New Behavior
White list now has the correct test.

### Tests written?
No
