### PR TITLE
Fix test_worktree_add_rm test for Windows

### DIFF
--- a/tests/integration/modules/test_git.py
+++ b/tests/integration/modules/test_git.py
@@ -48,7 +48,7 @@ def _git_version():
         log.debug('Git not installed')
         return False
     log.debug('Detected git version %s', git_version)
-    return LooseVersion(str(git_version.split()[-1]))
+    return LooseVersion(str(git_version.split()[-1]).encode())
 
 
 def _worktrees_supported():
@@ -56,7 +56,7 @@ def _worktrees_supported():
     Check if the git version is 2.5.0 or later
     '''
     try:
-        return _git_version() >= LooseVersion('2.5.0')
+        return _git_version() >= LooseVersion('2.5.0'.encode())
     except AttributeError:
         return False
 

--- a/tests/integration/modules/test_git.py
+++ b/tests/integration/modules/test_git.py
@@ -56,7 +56,7 @@ def _worktrees_supported():
     Check if the git version is 2.5.0 or later
     '''
     try:
-        return _git_version() >= LooseVersion('2.5.0').encode()
+        return _git_version() >= LooseVersion('2.5.0')
     except AttributeError:
         return False
 
@@ -931,10 +931,16 @@ class GitModuleTest(integration.ModuleCase):
             worktree_add_prefix = 'Preparing '
         else:
             worktree_add_prefix = 'Enter '
+
         worktree_path = tempfile.mkdtemp(dir=integration.TMP)
         worktree_basename = os.path.basename(worktree_path)
         worktree_path2 = tempfile.mkdtemp(dir=integration.TMP)
-        worktree_basename2 = os.path.basename(worktree_path2)
+
+        # Even though this is Windows, git commands return a unix style path
+        if salt.utils.is_windows():
+            worktree_path = worktree_path.replace('\\', '/')
+            worktree_path = worktree_path.replace('\\', '/')
+
         # Add the worktrees
         ret = self.run_function(
             'git.worktree_add', [self.repo, worktree_path],

--- a/tests/integration/modules/test_git.py
+++ b/tests/integration/modules/test_git.py
@@ -939,7 +939,7 @@ class GitModuleTest(integration.ModuleCase):
         # Even though this is Windows, git commands return a unix style path
         if salt.utils.is_windows():
             worktree_path = worktree_path.replace('\\', '/')
-            worktree_path = worktree_path.replace('\\', '/')
+            worktree_path2 = worktree_path2.replace('\\', '/')
 
         # Add the worktrees
         ret = self.run_function(


### PR DESCRIPTION
### What does this PR do?
Fixes the `test_worktree_add_rm` test in `modules.test_git`. The test was being skipped because the `_worktrees_supported` function was always getting an `AttributeError` due to the `.encode()`. This was a problem in Linux as well.

Fixed the actual test for Windows. The problem is that Git returns Unix style paths. Had to change the Windows paths to Unix style paths for comparison purposes.

Removed the `worktree_basename2` variable as it wasn't being used in the test.

### Tests written?
Yes
