### PR TITLE
Fix deleteed message when key is deleted

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -271,7 +271,8 @@ class KeyCLI(object):
                         ret = list_ret
                     for minions in ret.values():
                         for minion in minions:
-                            print('Key for minion {0} {1}ed.'.format(minion, cmd))
+                            print('Key for minion {0} {1}ed.'.format(minion,
+                                                                     cmd.rstrip('e')))
                 elif isinstance(ret, dict):
                     salt.output.display_output(ret, 'key', opts=self.opts)
                 else:


### PR DESCRIPTION
### What does this PR do?
There was a PR added here: https://github.com/saltstack/salt/pull/38232 to close the issue #38231 but the message after the key is deleted is still showing as deleteed. This fixes that last misspelling 

```
Accepted Keys:
ch3ll_62
Proceed? [N/y] y
Key for minion ch3ll_62 deleteed.
```

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/38231
