### PR TITLE
Fix test_add_user_to_group for Windows

### DIFF
--- a/tests/integration/modules/test_useradd.py
+++ b/tests/integration/modules/test_useradd.py
@@ -183,8 +183,7 @@ class UseraddModuleTestWindows(integration.ModuleCase):
 
             # And create the user as a member of that group
             if self.run_function(
-                    'user.add',
-                    [user_name, 'groups={0}'.format(group_name)]) is False:
+                    'user.add', [user_name], groups=group_name) is False:
                 self.run_function('user.delete', [user_name, True, True])
                 self.skipTest('Failed to create user')
 


### PR DESCRIPTION
### What does this PR do?
Fixes the `test_add_user_to_group` test in the `modules.test_useradd` test on Windows.

### Previous Behavior
The `self.run_function` command was formatted incorrectly. It was trying to pass a kwarg in the args list.

### New Behavior
Passes the `groups=groupname` kwarg correctly.

### Tests written?
Yes
