### PR TITLE
Stop returning `None`

### DIFF
--- a/salt/engines/stalekey.py
+++ b/salt/engines/stalekey.py
@@ -40,6 +40,7 @@ log = logging.getLogger(__name__)
 def __virtual__():
     if not __opts__.get('minion_data_cache'):
         return (False, 'stalekey engine requires minion_data_cache to be enabled')
+    return True
 
 
 def _get_keys():


### PR DESCRIPTION
### What does this PR do?

Prevents:
```
23:21:32,673 [salt.loader                                :1634][WARNING ] salt.loaded.int.engines.stalekey.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'stalekey', please fix this.
```