### PR TITLE
A random startup delay option for minions

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -193,6 +193,15 @@
 # The wait-time will be a random number of seconds between 0 and the defined value.
 #random_reauth_delay: 60
 
+
+# To avoid overloading a master when many minions startup at once, a randomized
+# delay may be set to tell the minions to wait before connecting to the master.
+# This value is the number of seconds to choose from for a random number. For
+# example, setting this value to 60 will choose a random number of seconds to delay
+# on startup between zero seconds and sixty seconds. Setting to '0' will disable
+# this feature.
+#random_startup_delay: 0
+
 # When waiting for a master to accept the minion's public key, salt will
 # continuously attempt to reconnect until successful. This is the timeout value,
 # in seconds, for each individual attempt. After this timeout expires, the minion

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -805,6 +805,24 @@ restart.
 
 .. conf_minion:: recon_default
 
+``random_startup_delay``
+------------------------
+
+Default: ``0``
+
+The maximum bound for an interval in which a minion will randomly sleep upon starting
+up prior to attempting to connect to a master. This can be used to splay connection attempts
+for cases where many minions starting up at once may place undue load on a master.
+
+For example, setting this to ``5`` will tell a minion to sleep for a value between ``0``
+and ``5`` seconds.
+
+.. code-block:: yaml
+
+    random_startup_delay: 5
+
+.. conf_minion:: random_startup_delay
+
 ``recon_default``
 -----------------
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -786,6 +786,12 @@ VALID_OPTS = {
     # The logfile location for salt-key
     'key_logfile': str,
 
+    # The upper bound for the random number of seconds that a minion should
+    # delay when starting in up before it connects to a master. This can be
+    # used to mitigate a thundering-herd scenario when many minions start up
+    # at once and attempt to all connect immediately to the master
+    'random_startup_delay': int,
+
     # The source location for the winrepo sls files
     # (used by win_pkg.py, minion only)
     'winrepo_source_dir': str,
@@ -1064,6 +1070,7 @@ DEFAULT_MINION_OPTS = {
     'renderer': 'yaml_jinja',
     'renderer_whitelist': [],
     'renderer_blacklist': [],
+    'random_startup_delay': 0,
     'failhard': False,
     'autoload_dynamic_modules': True,
     'environment': None,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -11,6 +11,7 @@ import copy
 import time
 import types
 import signal
+import random
 import fnmatch
 import logging
 import threading
@@ -968,6 +969,14 @@ class Minion(MinionBase):
             self.opts['grains'] = salt.loader.grains(opts)
 
         log.info('Creating minion process manager')
+
+        if self.opts['random_startup_delay']:
+            sleep_time = random.randint(0, self.opts['random_startup_delay'])
+            log.info('Minion sleeping for {0} seconds due to configured '
+                    'startup_delay between 0 and {1} seconds'.format(sleep_time,
+                        self.opts['random_startup_delay']))
+            time.sleep(sleep_time)
+
         self.process_manager = ProcessManager(name='MinionProcessManager')
         self.io_loop.spawn_callback(self.process_manager.run, async=True)
         # We don't have the proxy setup yet, so we can't start engines

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -63,8 +63,7 @@ class MinionTestCase(TestCase):
         return None BEFORE any of the processes are spun up because we should be avoiding firing duplicate
         jobs.
         '''
-        mock_opts = {'cachedir': '',
-                     'extension_modules': ''}
+        mock_opts = salt.config.DEFAULT_MINION_OPTS
         mock_data = {'fun': 'foo.bar',
                      'jid': 123}
         mock_jid_queue = [123]
@@ -85,9 +84,7 @@ class MinionTestCase(TestCase):
         jid isn't already present in the jid_queue.
         '''
         mock_jid = 11111
-        mock_opts = {'cachedir': '',
-                     'extension_modules': '',
-                     'minion_jid_queue_hwm': 100}
+        mock_opts = salt.config.DEFAULT_MINION_OPTS
         mock_data = {'fun': 'foo.bar',
                      'jid': mock_jid}
         mock_jid_queue = [123, 456]
@@ -115,9 +112,8 @@ class MinionTestCase(TestCase):
         Tests that the _handle_decoded_payload function removes a jid from the minion's jid_queue when the
         minion's jid_queue high water mark (minion_jid_queue_hwm) is hit.
         '''
-        mock_opts = {'cachedir': '',
-                     'extension_modules': '',
-                     'minion_jid_queue_hwm': 2}
+        mock_opts = salt.config.DEFAULT_MINION_OPTS
+        mock_opts['minion_jid_queue_hwm'] = 2
         mock_data = {'fun': 'foo.bar',
                      'jid': 789}
         mock_jid_queue = [123, 456]


### PR DESCRIPTION
This allows minions to spread out the load to the master if a large number
of them start up at once.
