### PR TITLE
Vault: Always lowercase policies

### DIFF
--- a/salt/runners/vault.py
+++ b/salt/runners/vault.py
@@ -120,7 +120,10 @@ def _get_policies(minion_id, config):
     for pattern in policy_patterns:
         try:
             for expanded_pattern in _expand_pattern_lists(pattern, **mappings):
-                policies.append(expanded_pattern.format(**mappings))
+                policies.append(
+                                expanded_pattern.format(**mappings)
+                                                .lower()  # Vault requirement
+                               )
         except KeyError:
             log.warning('Could not resolve policy pattern {0}'.format(pattern))
 

--- a/tests/unit/runners/test_vault.py
+++ b/tests/unit/runners/test_vault.py
@@ -45,6 +45,7 @@ class VaultTest(TestCase):
                                 }
                             }
                         },
+                        'mixedcase': 'UP-low-UP',
                         'dictlist': [
                             {'foo': 'bar'},
                             {'baz': 'qux'}
@@ -111,7 +112,10 @@ class VaultTest(TestCase):
                         'deeply-nested-list:hello',
                         'deeply-nested-list:world'
                     ],
-                    'should-not-cause-an-exception,but-result-empty:{foo}': []
+                    'should-not-cause-an-exception,but-result-empty:{foo}': [],
+                    'Case-Should-Be-Lowered:{grains[mixedcase]}': [
+                        'case-should-be-lowered:up-low-up'
+                    ]
                 }
 
         with patch('salt.utils.minions.get_minion_data',


### PR DESCRIPTION
### What does this PR do?
Vault lowercases all policies. For clarity, we should lowercase the policies as well.

### New Behavior
Always lower-case policies when processing policy templates.

### Tests written?
Yes