### PR TITLE
Fix salt-ssh cp.get_url wapper bug

### DIFF
--- a/salt/client/ssh/wrapper/cp.py
+++ b/salt/client/ssh/wrapper/cp.py
@@ -68,7 +68,7 @@ def get_url(path, dest, saltenv='base'):
     '''
     retrieve a URL
     '''
-    src = __context__['fileclient'].get_url(
+    src = __context__['fileclient'].cache_file(
         path,
         saltenv,
         cachedir=os.path.join('salt-ssh', __salt__.kwargs['id_']))


### PR DESCRIPTION
### What does this PR do?

In `fileclient.get_url` function, the 2nd arg is "`dest`", not "`saltenv`".


### Tests written?

No