### PR TITLE
Changed "Template is an empty file" to debug.

### DIFF
--- a/salt/template.py
+++ b/salt/template.py
@@ -68,7 +68,7 @@ def compile_template(template,
             return ret
         # Template is an empty file
         if salt.utils.is_empty(template):
-            log.warning('Template is an empty file: {0}'.format(template))
+            log.debug('Template is an empty file: {0}'.format(template))
             return ret
 
         with codecs.open(template, encoding=SLS_ENCODING) as ifile:


### PR DESCRIPTION
### What does this PR do?
Change log.warn() to log.info() for message "'Template is an empty file"

### What issues does this PR fix or reference?
#39684

### Previous Behavior

warning was visible. But there are valid use cases for empty files. See referenced issue.

### New Behavior

Use does not sees nothing (unix-like: no output, everything is fine)
