### PR TITLE
Added fix for empty overrides value in apply config methods

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3278,7 +3278,7 @@ def apply_minion_config(overrides=None,
     if 'beacons' not in opts:
         opts['beacons'] = {}
 
-    if overrides.get('ipc_write_buffer', '') == 'dynamic':
+    if (overrides or {}).get('ipc_write_buffer', '') == 'dynamic':
         opts['ipc_write_buffer'] = _DFLT_IPC_WBUFFER
     if 'ipc_write_buffer' not in overrides:
         opts['ipc_write_buffer'] = 0
@@ -3363,7 +3363,7 @@ def apply_master_config(overrides=None, defaults=None):
     )
     opts['token_dir'] = os.path.join(opts['cachedir'], 'tokens')
     opts['syndic_dir'] = os.path.join(opts['cachedir'], 'syndics')
-    if overrides.get('ipc_write_buffer', '') == 'dynamic':
+    if (overrides or {}).get('ipc_write_buffer', '') == 'dynamic':
         opts['ipc_write_buffer'] = _DFLT_IPC_WBUFFER
     if 'ipc_write_buffer' not in overrides:
         opts['ipc_write_buffer'] = 0


### PR DESCRIPTION
In `apply_minion_config` and `apply_master_config` there is a call to
`overrides.get` while the `overrides` value still has the potential of
being `None`. Updated the call to be `(overrides or {}).get` to
prevent unwarranted exceptions.

### What does this PR do?
Fixes an error with `apply_minion_config` and `apply_master_config` when the `overrides` parameter is not set.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Calling either of the mentioned methods without passing a dictionary as the `overrides` parameter would result in an `AttributeError`

### New Behavior
There is no error raised

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
