### PR TITLE
Fix regression in docker module when client is spawned

### DIFF
--- a/salt/modules/docker.py
+++ b/salt/modules/docker.py
@@ -807,9 +807,8 @@ def _get_client(timeout=None):
         - docker.version: API version to use (default: "auto")
     '''
     if 'docker.client' not in __context__:
-        if timeout is None:
-            client_kwargs = {}
-        else:
+        client_kwargs = {}
+        if timeout is not None:
             client_kwargs['timeout'] = timeout
         for key, val in (('base_url', 'docker.url'),
                          ('version', 'docker.version')):


### PR DESCRIPTION
PR #39597 broke this module by introducing an UnboundLocalError. This
fixes that error.

CC: @ticosax

Note: this only affected develop and happened 8 days ago. This regression did not make it into a release.