### PR TITLE
Add group func to yubikey auth

### DIFF
--- a/salt/auth/yubico.py
+++ b/salt/auth/yubico.py
@@ -78,13 +78,14 @@ def auth(username, password):
     client = Yubico(_cred['id'], _cred['key'])
 
     try:
-        if client.verify(password):
-            return True
-        else:
-            return False
+        return client.verify(password)
     except yubico_exceptions.StatusCodeError as e:
         log.info('Unable to verify YubiKey `{0}`'.format(e))
         return False
+
+
+def groups(username, *args, **kwargs):
+    return False
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Because we don't support groups with yubikeys (and can't, in fact)
we need to dummy up this to always return false. This allows individual
user auths to work, whereas they would fail prior to this change.
