### PR TITLE
minionswarm.py: add flag to delay starts

### DIFF
--- a/tests/minionswarm.py
+++ b/tests/minionswarm.py
@@ -131,6 +131,12 @@ def parse():
         default='zeromq',
         help='Declare which transport to use, default is zeromq')
     parser.add_option(
+        '--start-delay',
+        dest='start_delay',
+        default=0.0,
+        type='float',
+        help='Seconds to wait between minion starts')
+    parser.add_option(
         '-c', '--config-dir', default='',
         help=('Pass in a configuration directory containing base configuration.')
         )
@@ -276,6 +282,7 @@ class MinionSwarm(Swarm):
             else:
                 cmd += ' -d &'
             subprocess.call(cmd, shell=True)
+            time.sleep(self.opts['start_delay'])
 
     def mkconf(self, idx):
         '''


### PR DESCRIPTION
### What does this PR do?

It adds a `--start-delay` option to `minionswarm.py` that sets an amount of seconds to wait between starts of minion processes. This can help to avoid overloading the minion swarm host in certain tests.

### What issues does this PR fix or reference?
None, it is a small new feature.

### Previous Behavior
New processes are started immediately one after another.

### New Behavior
There is a delay between the start of a process and the start of the following one, default zero.

### Tests written?

No, changes are in test code itself.