### PR TITLE
Fix regression in archive.extracted when it runs file.directory

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -1333,10 +1333,6 @@ def extracted(name,
                                                           group=group,
                                                           recurse=recurse,
                                                           test=__opts__['test'])
-                try:
-                    dir_result = dir_result[next(iter(dir_result))]
-                except AttributeError:
-                    pass
                 log.debug('file.directory: %s', dir_result)
 
                 if __opts__['test']:


### PR DESCRIPTION
This is similar to the change made in 28651a6, we no longer need this
code since we're invoking the state function directly instead of via the
state compiler.

See https://github.com/saltstack/salt/issues/39751#issuecomment-284190792.