### PR TITLE
Remove the dev_python26.txt install file

### DIFF
--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -85,8 +85,8 @@ the lines below, depending on the relevant Python version:
 
 .. code-block:: bash
 
-    pip install -r requirements/dev_python26.txt
     pip install -r requirements/dev_python27.txt
+    pip install -r requirements/dev_python34.txt
 
 To be able to run integration tests which utilizes ZeroMQ transport, you also
 need to install additional requirements for it. Make sure you have installed

--- a/doc/topics/tutorials/writing_tests.rst
+++ b/doc/topics/tutorials/writing_tests.rst
@@ -39,8 +39,8 @@ depending on your relevant version of Python:
 
 .. code-block:: bash
 
-    pip install -r requirements/dev_python26.txt
     pip install -r requirements/dev_python27.txt
+    pip install -r requirements/dev_python34.txt
 
 To be able to run integration tests which utilizes ZeroMQ transport, you also
 need to install additional requirements for it. Make sure you have installed

--- a/requirements/dev_python26.txt
+++ b/requirements/dev_python26.txt
@@ -1,3 +1,0 @@
--r dev_python27.txt
-
-unittest2


### PR DESCRIPTION
Since we're moving to support Python 2.7 and 3.4 in Nitrogen, we shouldn't need the 2.6 requirements file any longer.

Also updates the doc instructions to use the dev_python34 file instead of dev_python26, depending on your Python version.