### PR TITLE
Check if vm_name is splittable before altering

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -116,7 +116,7 @@ configuration, run :py:func:`test_vcenter_connection`
 # Import python libs
 from __future__ import absolute_import
 from random import randint
-from re import findall, split
+from re import findall, split, search, compile
 import pprint
 import logging
 import time
@@ -2562,8 +2562,14 @@ def create(vm_):
             global_ip = vim.vm.customization.GlobalIPSettings()
             if 'dns_servers' in list(vm_.keys()):
                 global_ip.dnsServerList = vm_['dns_servers']
-            hostName = split(r'[^\w-]', vm_name, maxsplit=1)[0]
-            domainName = vm_name.split('.', 1)[-1]
+                
+            non_hostname_chars = compile(r'[^\w-]')
+            if search(non_hostname_chars, vm_name):
+                hostName = split(non_hostname_chars, vm_name, maxsplit=1)[0]
+            else:
+                hostName = vm_name
+            domainName = hostName.split('.', 1)[-1]
+            
             if 'Windows' not in object_ref.config.guestFullName:
                 identity = vim.vm.customization.LinuxPrep()
                 identity.hostName = vim.vm.customization.FixedName(name=hostName)

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2562,14 +2562,14 @@ def create(vm_):
             global_ip = vim.vm.customization.GlobalIPSettings()
             if 'dns_servers' in list(vm_.keys()):
                 global_ip.dnsServerList = vm_['dns_servers']
-                
+
             non_hostname_chars = compile(r'[^\w-]')
             if search(non_hostname_chars, vm_name):
                 hostName = split(non_hostname_chars, vm_name, maxsplit=1)[0]
             else:
                 hostName = vm_name
             domainName = hostName.split('.', 1)[-1]
-            
+
             if 'Windows' not in object_ref.config.guestFullName:
                 identity = vim.vm.customization.LinuxPrep()
                 identity.hostName = vim.vm.customization.FixedName(name=hostName)


### PR DESCRIPTION
### What does this PR do?

This prevents an issue on non-Windows machines where the line `identity.domain = domainName if hostName != domainName else domain` produces an FQDN like `hostname.hostname` instead of `hostname.domainname.tld`

### Previous Behavior
Split `vm_name` by non-hostname chars and assign it to `hostName` to be used when setting the object identity

`domainName` is derived from `vm_name`, unaltered.

The ternary operator above would sometimes not pick `domainName`, due to the names being different when they should have been the same.

### New Behavior
Check if `vm_name` contains the characters to be split, before splitting. If it does not contain them, leave it intact.

`domainName` is derived from the result, whether altered or unaltered. This allows the ternary operator `domainName if hostName != domainName else domain` to evaluate as expected