### PR TITLE
Add minionfs_restrict option

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2486,6 +2486,24 @@ exposed.
       - dev*
       - 'mail\d+.mydomain.tld'
 
+.. conf_master:: minionfs_whitelist
+
+``minionfs_restrict``
+**********************
+
+.. versionadded:: TODO
+
+Default: ``False``
+
+Used to restrict that minions can only access their own files in minionfs.
+
+If used, a minion is only allowed access to its *own* files, meaning files that the minion itself pushed with `cp.push`.
+
+
+.. code-block:: yaml
+
+    minionfs_restrict: True
+
 
 .. _pillar-configuration-master:
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -575,6 +575,7 @@ VALID_OPTS = {
     'minionfs_mountpoint': str,
     'minionfs_whitelist': list,
     'minionfs_blacklist': list,
+    'minionfs_restrict': bool,
 
     # Specify a list of external pillar systems to use
     'ext_pillar': list,
@@ -1266,6 +1267,7 @@ DEFAULT_MASTER_OPTS = {
     'minionfs_mountpoint': '',
     'minionfs_whitelist': [],
     'minionfs_blacklist': [],
+    'minionfs_restrict': False,
     'ext_pillar': [],
     'pillar_version': 2,
     'pillar_opts': False,


### PR DESCRIPTION
Add an option to restrict minionfs file access of minions.
When `minionfs_restrict` is True, a minion is only allowed access to
files of its own. It can no longer read/retrieve files of other minions.

### What does this PR do?
This pull requests adds an option to restrict file access of minions through minionfs.

This allows a minion to `cp.push` files that are confidential (confidential in way, that other minions have no business looking at them).

A use case is that minions backup configuration files/settings to the master.

### What issues does this PR fix or reference?
None 

### Previous Behavior
Minions could access all files of other minions.

### New Behavior
If `minionfs_restrict` is `True` in master configuration, any minion can only access its own files.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
