### PR TITLE
Squelch warning for pygit2 import

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -74,7 +74,11 @@ except ImportError:
     HAS_GITPYTHON = False
 
 try:
-    import pygit2
+    # Squelch warning on cent7 due to them upgrading cffi
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        import pygit2
     HAS_PYGIT2 = True
     try:
         GitError = pygit2.errors.GitError


### PR DESCRIPTION
RedHat updated cffi for RHEL/CentOS 7.3, which causes a pair of warnings
on the pygit2 import. This warning is spit out to the CLI on several
commands, when they result in the git fileserver backend to be loaded.

This commit squelches that warning as it is just noise. Upgrading
pygit2/libgit2 would solve this, but that is not likely to happen in
RHEL/CentOS 7.