### PR TITLE
Additional functions for win_iis module & state

### DIFF
--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -20,6 +20,7 @@ import decimal
 # Import salt libs
 from salt.ext.six.moves import range
 from salt.exceptions import SaltInvocationError, CommandExecutionError
+from salt.ext import six
 import salt.utils
 
 log = logging.getLogger(__name__)
@@ -1777,7 +1778,7 @@ def list_worker_processes(apppool):
 
 
 def get_webapp_settings(name, site, settings):
-    '''
+    r'''
     Get the value of the setting for the IIS web application.
     .. note::
         Params are case sensitive.
@@ -1808,15 +1809,15 @@ def get_webapp_settings(name, site, settings):
     for setting in settings:
         if setting in availableSettings:
             if setting == "userName" or setting == "password":
-                pscmd.append(" $Property = Get-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(site, name))
-                pscmd.append(" -Name \"{0}\" -ErrorAction Stop | select Value;".format(setting))
-                pscmd.append(" $Property = $Property | Select-Object -ExpandProperty Value;")
-                pscmd.append(" $Settings['{0}'] = [String] $Property;".format(setting))
-                pscmd.append(' $Property = $Null;')
+                pscmd.append(r" $Property = Get-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(site, name))
+                pscmd.append(r" -Name \"{0}\" -ErrorAction Stop | select Value;".format(setting))
+                pscmd.append(r" $Property = $Property | Select-Object -ExpandProperty Value;")
+                pscmd.append(r" $Settings['{0}'] = [String] $Property;".format(setting))
+                pscmd.append(r' $Property = $Null;')
 
             if setting == "physicalPath" or setting == "applicationPool":
-                pscmd.append(" $Property = (get-webapplication {0}).{1};".format(name, setting))
-                pscmd.append(" $Settings['{0}'] = [String] $Property;".format(setting))
+                pscmd.append(r" $Property = (get-webapplication {0}).{1};".format(name, setting))
+                pscmd.append(r" $Settings['{0}'] = [String] $Property;".format(setting))
                 pscmd.append(r' $Property = $Null;')
         else:
             availSetStr = ', '.join(availableSettings)
@@ -1838,7 +1839,7 @@ def get_webapp_settings(name, site, settings):
     except ValueError:
         log.error('Unable to parse return data as Json.')
 
-    if None in ret.viewvalues():
+    if None in six.viewvalues(ret):
         message = 'Some values are empty - please validate site and web application names. Some commands are case sensitive'
         raise SaltInvocationError(message)
 
@@ -1846,7 +1847,7 @@ def get_webapp_settings(name, site, settings):
 
 
 def set_webapp_settings(name, site, settings):
-    '''
+    r'''
     Configure an IIS application.
     .. note::
         This function only configures existing app.
@@ -1867,7 +1868,7 @@ def set_webapp_settings(name, site, settings):
     '''
     pscmd = list()
     current_apps = list_apps(site)
-    current_sites= list_sites()
+    current_sites = list_sites()
     availableSettings = ('physicalPath', 'applicationPool', 'userName', 'password')
 
     # Validate params
@@ -1911,11 +1912,11 @@ def set_webapp_settings(name, site, settings):
 
         # Append relevant update command per setting key
         if setting == "userName" or setting == "password":
-            pscmd.append(" Set-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(site, name))
-            pscmd.append(" -Name \"{0}\" -Value {1};".format(setting, value))
+            pscmd.append(r" Set-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(site, name))
+            pscmd.append(r" -Name \"{0}\" -Value {1};".format(setting, value))
 
         if setting == "physicalPath" or setting == "applicationPool":
-            pscmd.append(" Set-ItemProperty \"IIS:\Sites\{0}\{1}\" -Name {2} -Value {3};".format(site, name, setting, value))
+            pscmd.append(r" Set-ItemProperty \"IIS:\Sites\{0}\{1}\" -Name {2} -Value {3};".format(site, name, setting, value))
             if setting == "physicalPath":
                 if not os.path.isdir(value):
                     log.error('Path is not present: {0}'.format(setting))

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -1775,20 +1775,20 @@ def list_worker_processes(apppool):
 
     return ret
 
+
 def get_webapp_settings(name, site, settings):
     '''
     Get the value of the setting for the IIS web application.
-    .. note:
-        Params are case sensitive are case sensitive
+    .. note::
+        Params are case sensitive.
     :param str name: The name of the IIS web application.
     :param str site: The site name contains the web application.
-        Example: Default web site
+        Example: Default Web Site
     :param str settings: A dictionary of the setting names and their values.
         Available settings: physicalPath, applicationPool, userName, password
-    :return: A dictionary of the provided settings and their values.
     Returns:
         dict: A dictionary of the provided settings and their values.
-    .. versionadded:: 2016.11.0
+    .. versionadded:: Nitrogen
     CLI Example:
     .. code-block:: bash
         salt '*' win_iis.get_webapp_settings name='app0' site='Default Web Site'
@@ -1820,7 +1820,6 @@ def get_webapp_settings(name, site, settings):
                 pscmd.append(r' $Property = $Null;')
         else:
             availSetStr = ', '.join(availableSettings)
-
             message = 'Unexpected setting:' + setting + '. Available settings are: ' + availSetStr
             raise SaltInvocationError(message)
 
@@ -1846,12 +1845,12 @@ def get_webapp_settings(name, site, settings):
     return ret
 
 
-
 def set_webapp_settings(name, site, settings):
     '''
     Configure an IIS application.
-    .. note:
-        This function only configures existing app
+    .. note::
+        This function only configures existing app.
+        Params are case sensitive.
     :param str name: The IIS application.
     :param str site: The IIS site name.
     :param str settings: A dictionary of the setting names and their values.
@@ -1861,6 +1860,7 @@ def set_webapp_settings(name, site, settings):
     :                       password: "connectAs" password for user
     :return: A boolean representing whether all changes succeeded.
     :rtype: bool
+    .. versionadded:: Nitrogen
     CLI Example:
     .. code-block:: bash
         salt '*' win_iis.set_webapp_settings name='app0' site='site0' settings="{'physicalPath': 'C:\site0', 'apppool': 'site0'}"
@@ -1893,12 +1893,9 @@ def set_webapp_settings(name, site, settings):
             log.debug("Available settings: %s", availSetStr)
             return False
 
-
-
     # Check if settings already configured
     current_settings = get_webapp_settings(
         name=name, site=site, settings=settings.keys())
-
 
     if settings == current_settings:
         log.debug('Settings already contain the provided values.')
@@ -1912,17 +1909,15 @@ def set_webapp_settings(name, site, settings):
         except ValueError:
             value = "'{0}'".format(settings[setting])
 
-
         # Append relevant update command per setting key
         if setting == "userName" or setting == "password":
             pscmd.append(" Set-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(site, name))
             pscmd.append(" -Name \"{0}\" -Value {1};".format(setting, value))
 
-
         if setting == "physicalPath" or setting == "applicationPool":
             pscmd.append(" Set-ItemProperty \"IIS:\Sites\{0}\{1}\" -Name {2} -Value {3};".format(site, name, setting, value))
             if setting == "physicalPath":
-                if not os.path.isdir(settings[setting]):
+                if not os.path.isdir(value):
                     log.error('Path is not present: {0}'.format(setting))
                     return False
 
@@ -1949,5 +1944,3 @@ def set_webapp_settings(name, site, settings):
 
     log.debug('Settings configured successfully: {0}'.format(settings.keys()))
     return True
-
-

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -1791,7 +1791,7 @@ def get_webapp_settings(name, site, settings):
     .. versionadded:: 2016.11.0
     CLI Example:
     .. code-block:: bash
-        salt '*' win_iisV2.get_webapp_settings name='app0' site='Default Web Site'
+        salt '*' win_iis.get_webapp_settings name='app0' site='Default Web Site'
             settings="['physicalPath','applicationPool']"
     '''
     ret = dict()

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -769,11 +769,13 @@ def remove_vdir(name, site, app='/'):
 
     return ret
 
+
 def set_app(name, site, settings=None):
     '''
     Set the value of the setting for an IIS web application.
-    .. note:
-        This function only configures existing app
+    .. note::
+        This function only configures existing app.
+        Params are case sensitive.
     :param str name: The IIS application.
     :param str site: The IIS site name.
     :param str settings: A dictionary of the setting names and their values.
@@ -782,6 +784,7 @@ def set_app(name, site, settings=None):
     :                       userName: "connectAs" user
     :                       password: "connectAs" password for user
     :rtype: bool
+    .. versionadded:: Nitrogen
     Example of usage:
 
     .. code-block:: yaml

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -768,3 +768,82 @@ def remove_vdir(name, site, app='/'):
         ret['result'] = __salt__['win_iis.remove_vdir'](name, site, app)
 
     return ret
+
+def set_app(name, site, settings=None):
+    '''
+    Set the value of the setting for an IIS web application.
+    .. note:
+        This function only configures existing app
+    :param str name: The IIS application.
+    :param str site: The IIS site name.
+    :param str settings: A dictionary of the setting names and their values.
+    :available settings:    physicalPath: The physical path of the webapp.
+    :                       applicationPool: The application pool for the webapp.
+    :                       userName: "connectAs" user
+    :                       password: "connectAs" password for user
+    :rtype: bool
+    Example of usage:
+
+    .. code-block:: yaml
+
+        site0-webapp-setting:
+            win_iis.set_app:
+                - name: app0
+                - site: Default Web Site
+                - settings:
+                    userName: domain\user
+                    password: pass
+                    physicalPath: c:\inetpub\wwwroot
+                    applicationPool: appPool0
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'comment': str(),
+           'result': None}
+
+    if not settings:
+        ret['comment'] = 'No settings to change provided.'
+        ret['result'] = True
+        return ret
+
+    ret_settings = {
+        'changes': {},
+        'failures': {},
+    }
+
+    current_settings = __salt__['win_iis.get_webapp_settings'](name=name,
+                                                                 site=site,
+                                                                 settings=settings.keys())
+    for setting in settings:
+        if str(settings[setting]) != str(current_settings[setting]):
+            ret_settings['changes'][setting] = {'old': current_settings[setting],
+                                                'new': settings[setting]}
+    if not ret_settings['changes']:
+        ret['comment'] = 'Settings already contain the provided values.'
+        ret['result'] = True
+        return ret
+    elif __opts__['test']:
+        ret['comment'] = 'Settings will be changed.'
+        ret['changes'] = ret_settings
+        return ret
+
+    __salt__['win_iis.set_webapp_settings'](name=name, site=site,
+                                              settings=settings)
+    new_settings = __salt__['win_iis.get_webapp_settings'](name=name, site=site, settings=settings.keys())
+
+    for setting in settings:
+        if str(settings[setting]) != str(new_settings[setting]):
+            ret_settings['failures'][setting] = {'old': current_settings[setting],
+                                                 'new': new_settings[setting]}
+            ret_settings['changes'].pop(setting, None)
+
+    if ret_settings['failures']:
+        ret['comment'] = 'Some settings failed to change.'
+        ret['changes'] = ret_settings
+        ret['result'] = False
+    else:
+        ret['comment'] = 'Set settings to contain the provided values.'
+        ret['changes'] = ret_settings['changes']
+        ret['result'] = True
+
+    return ret

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -771,7 +771,7 @@ def remove_vdir(name, site, app='/'):
 
 
 def set_app(name, site, settings=None):
-    '''
+    r'''
     Set the value of the setting for an IIS web application.
     .. note::
         This function only configures existing app.


### PR DESCRIPTION
### What does this PR do?
Updates existing web application

### What issues does this PR fix or reference?
No open requests found

### Tests written?
No


State set_app usage:
```   
    '''
    Set the value of the setting for an IIS web application.
    .. note:
        This function only configures existing app
    :param str name: The IIS application.
    :param str site: The IIS site name.
    :param str settings: A dictionary of the setting names and their values.
    :available settings:    physicalPath: The physical path of the webapp.
    :                       applicationPool: The application pool for the webapp.
    :                       userName: "connectAs" user
    :                       password: "connectAs" password for user
    :rtype: bool
    Example of usage:

    .. code-block:: yaml

        site0-webapp-setting:
            win_iisV2.set_app:
                - name: app0
                - site: Default Web Site
                - settings:
                    userName: domain\user
                    password: pass
                    physicalPath: c:\inetpub\wwwroot
                    applicationPool: appPool0
```
Module function get_webapp_settings usage:
```
    '''
    Get the value of the setting for the IIS web application.
    .. note:
        Params are case sensitive are case sensitive
    :param str name: The name of the IIS web application.
    :param str site: The site name contains the web application.
        Example: Default web site
    :param str settings: A dictionary of the setting names and their values.
        Available settings: physicalPath, applicationPool, userName, password
    :return: A dictionary of the provided settings and their values.
    Returns:
        dict: A dictionary of the provided settings and their values.
    .. versionadded:: 2016.11.0
    CLI Example:
    .. code-block:: bash
        salt '*' win_iisV2.get_webapp_settings name='app0' site='Default Web Site'
            settings="['physicalPath','applicationPool']"
    '''
```
Module function get_webapp_settings usage:
```
    '''
    Configure an IIS application.
    .. note:
        This function only configures existing app
    :param str name: The IIS application.
    :param str site: The IIS site name.
    :param str settings: A dictionary of the setting names and their values.
    :available settings:    physicalPath: The physical path of the webapp.
    :                       applicationPool: The application pool for the webapp.
    :                       userName: "connectAs" user
    :                       password: "connectAs" password for user
    :return: A boolean representing whether all changes succeeded.
    :rtype: bool
    CLI Example:
    .. code-block:: bash
        salt '*' win_iis.set_webapp_settings name='app0' site='site0' settings="{'physicalPath': 'C:\site0', 'apppool': 'site0'}"
    '''
```
Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.


