### PR TITLE
Introduce "module.xrun"

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -61,6 +61,47 @@ State Module Changes
   start/stop the service using the ``--no-block`` flag in the ``systemctl``
   command. On non-systemd minions, a warning will be issued.
 
+- The :py:func:`module.run <salt.states.module.run>` state dropped its previous
+  syntax with ``m_`` prefix for reserved keywords. Additionally, it allows
+  running several functions in a batch.
+  Before:
+
+.. code-block:: yaml
+
+    run_something:
+      module.run:
+        - name: mymodule.something
+        - m_name: 'some name'
+        - kwargs: {
+          first_arg: 'one',
+          second_arg: 'two',
+          do_stuff: 'True'
+        }
+
+  After:
+
+.. code-block:: yaml
+
+    run_something:
+      module.run:
+        mymodule.something:
+          - name: some name
+          - first_arg: one
+          - second_arg: two
+          - do_stuff: True
+
+  Previous behaviour of the function :py:func:`module.run <salt.states.module.run>` is
+  still supported and can be restored. Its implementation will be entirely removed in
+  version "Oxygen". In order to access "old" function behaviour and restore compatibility
+  with the current infrastructure, please add the following configuration to the minion setup:
+
+.. code-block:: yaml
+
+    use_deprecated:
+      - module.run
+
+  The configuration above you can also deploy separately to all your minions and restart them.
+
 Execution Module Changes
 ========================
 

--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -78,6 +78,7 @@ State Module Changes
           do_stuff: 'True'
         }
 
+
   After:
 
 .. code-block:: yaml
@@ -90,6 +91,7 @@ State Module Changes
           - second_arg: two
           - do_stuff: True
 
+
   Previous behaviour of the function :py:func:`module.run <salt.states.module.run>` is
   still supported and can be restored. Its implementation will be entirely removed in
   version "Oxygen". In order to access "old" function behaviour and restore compatibility
@@ -99,6 +101,7 @@ State Module Changes
 
     use_deprecated:
       - module.run
+
 
   The configuration above you can also deploy separately to all your minions and restart them.
 

--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -64,6 +64,7 @@ State Module Changes
 - The :py:func:`module.run <salt.states.module.run>` state dropped its previous
   syntax with ``m_`` prefix for reserved keywords. Additionally, it allows
   running several functions in a batch.
+  **NOTE: you need explicitly turn on new behaviour (see below how)**
   Before and after:
 
 .. code-block:: yaml
@@ -89,16 +90,16 @@ State Module Changes
           - do_stuff: True
 
 - Previous behaviour of the function :py:func:`module.run <salt.states.module.run>` is
-  still supported and can be restored. Its implementation will be entirely removed in
-  version "Oxygen". In order to access "old" function behaviour and restore compatibility
-  with the current infrastructure, please add the following configuration to the minion setup.
-  Note that the configuration below you can also deploy separately to all your minions and
-  restart them.
+  still kept by default and can be bypassed in case you want to use behaviour above.
+  Please keep in mind that old implementation will be entirely removed in version "Oxygen".
+  In order to access new function behaviour, please add the following configuration to the
+  minion setup. Note that the configuration below you can also deploy separately to all
+  your minions and restart them:
 
 
 .. code-block:: yaml
 
-    use_deprecated:
+    use_superseded:
       - module.run
 
 

--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -64,10 +64,11 @@ State Module Changes
 - The :py:func:`module.run <salt.states.module.run>` state dropped its previous
   syntax with ``m_`` prefix for reserved keywords. Additionally, it allows
   running several functions in a batch.
-  Before:
+  Before and after:
 
 .. code-block:: yaml
 
+    # Before
     run_something:
       module.run:
         - name: mymodule.something
@@ -78,11 +79,7 @@ State Module Changes
           do_stuff: 'True'
         }
 
-
-  After:
-
-.. code-block:: yaml
-
+    # After
     run_something:
       module.run:
         mymodule.something:
@@ -91,11 +88,13 @@ State Module Changes
           - second_arg: two
           - do_stuff: True
 
-
-  Previous behaviour of the function :py:func:`module.run <salt.states.module.run>` is
+- Previous behaviour of the function :py:func:`module.run <salt.states.module.run>` is
   still supported and can be restored. Its implementation will be entirely removed in
   version "Oxygen". In order to access "old" function behaviour and restore compatibility
-  with the current infrastructure, please add the following configuration to the minion setup:
+  with the current infrastructure, please add the following configuration to the minion setup.
+  Note that the configuration below you can also deploy separately to all your minions and
+  restart them.
+
 
 .. code-block:: yaml
 
@@ -103,7 +102,6 @@ State Module Changes
       - module.run
 
 
-  The configuration above you can also deploy separately to all your minions and restart them.
 
 Execution Module Changes
 ========================

--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -61,10 +61,13 @@ State Module Changes
   start/stop the service using the ``--no-block`` flag in the ``systemctl``
   command. On non-systemd minions, a warning will be issued.
 
-- The :py:func:`module.run <salt.states.module.run>` state dropped its previous
+- The :py:func:`module.run <salt.states.module.run>` state has dropped its previous
   syntax with ``m_`` prefix for reserved keywords. Additionally, it allows
   running several functions in a batch.
-  **NOTE: you need explicitly turn on new behaviour (see below how)**
+
+.. note::
+    It is nesessary to explicitly turn on the new behaviour (see below)
+
   Before and after:
 
 .. code-block:: yaml
@@ -91,10 +94,8 @@ State Module Changes
 
 - Previous behaviour of the function :py:func:`module.run <salt.states.module.run>` is
   still kept by default and can be bypassed in case you want to use behaviour above.
-  Please keep in mind that old implementation will be entirely removed in version "Oxygen".
-  In order to access new function behaviour, please add the following configuration to the
-  minion setup. Note that the configuration below you can also deploy separately to all
-  your minions and restart them:
+  Please keep in mind that the old syntax will no longer be supported in the ``Oxygen``
+  release of Salt. To enable the new behavior, add the following to the minion config file:
 
 
 .. code-block:: yaml

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -158,6 +158,7 @@ import salt.utils
 import salt.utils.jid
 from salt.ext.six.moves import range
 from salt.exceptions import SaltInvocationError
+from salt.utils.decorators import with_deprecated
 
 
 def wait(name, **kwargs):
@@ -191,7 +192,8 @@ def wait(name, **kwargs):
 watch = salt.utils.alias_function(wait, 'watch')
 
 
-def xrun(**kwargs):
+@with_deprecated(globals(), "Oxygen")
+def run(**kwargs):
     '''
     Run a single module function or a range of module functions in a batch.
     Supersedes `module.run` function, which requires `m_` prefix to function-specific parameters.
@@ -298,7 +300,7 @@ def _call_function(name, returner=None, **kwargs):
     return mret
 
 
-def run(name, **kwargs):
+def _run(name, **kwargs):
     '''
     Run a single module function
 

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -251,7 +251,8 @@ def xrun(**kwargs):
                                           func_args=kwargs.get(func))
                 if not _get_result(func_ret, ret['changes'].get('ret', {})):
                     if isinstance(func_ret, dict):
-                        failures.append("'{0}' failed: {1}".format(func_ret.get('comment', '(error message N/A)')))
+                        failures.append("'{0}' failed: {1}".format(
+                            func, func_ret.get('comment', '(error message N/A)')))
                 else:
                     success.append('{0}: {1}'.format(
                         func, func_ret.get('comment', 'Success') if isinstance(func_ret, dict) else func_ret))

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -207,8 +207,10 @@ def xrun(**kwargs):
             try:
                 func_ret = _call_function(func, returner=kwargs.get('returner'),
                                           func_args=kwargs.get(func))
-                success.append('{0}: {1}'.format(func, func_ret.get('comment', 'Success')))
-                ret['result'] = _get_result(func_ret, ret['changes'].get('ret', {}))
+                if not _get_result(func_ret, ret['changes'].get('ret', {})):
+                    failures.append("'{0}' failed: {1}".format(func_ret.get('comment', '(error message N/A)')))
+                else:
+                    success.append('{0}: {1}'.format(func, func_ret.get('comment', 'Success')))
             except SaltInvocationError as ex:
                 failures.append("'{0}' failed: {1}".format(func, ex))
         ret['comment'] = ', '.join(failures + success)

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -181,7 +181,7 @@ def xrun(**kwargs):
     :return:
     '''
 
-    kwargs.pop('name')
+    'name' in kwargs and kwargs.pop('name')
     ret = {
         'name': kwargs.keys(),
         'changes': {},

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -303,6 +303,9 @@ def _call_function(name, returner=None, **kwargs):
 
 def _run(name, **kwargs):
     '''
+    .. deprecated:: Nitrogen
+       Function name stays the same, behaviour will change.
+
     Run a single module function
 
     ``name``

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -185,7 +185,7 @@ def xrun(**kwargs):
         'name': kwargs.keys(),
         'changes': {},
         'comment': '',
-        'result': {}
+        'result': None,
     }
 
     for func in kwargs.keys():

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -181,7 +181,7 @@ def xrun(**kwargs):
     :return:
     '''
 
-    _id = kwargs.pop('name')
+    kwargs.pop('name')
     ret = {
         'name': kwargs.keys(),
         'changes': {},

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -258,6 +258,7 @@ def run(**kwargs):
                 else:
                     success.append('{0}: {1}'.format(
                         func, func_ret.get('comment', 'Success') if isinstance(func_ret, dict) else func_ret))
+                    ret['changes'][func] = func_ret
             except (SaltInvocationError, TypeError) as ex:
                 failures.append("'{0}' failed: {1}".format(func, ex))
         ret['comment'] = ', '.join(failures + success)

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -211,7 +211,7 @@ def xrun(**kwargs):
                     failures.append("'{0}' failed: {1}".format(func_ret.get('comment', '(error message N/A)')))
                 else:
                     success.append('{0}: {1}'.format(func, func_ret.get('comment', 'Success')))
-            except SaltInvocationError as ex:
+            except (SaltInvocationError, TypeError) as ex:
                 failures.append("'{0}' failed: {1}".format(func, ex))
         ret['comment'] = ', '.join(failures + success)
         ret['result'] = not bool(failures)

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -179,6 +179,41 @@ def xrun(**kwargs):
     :return:
     '''
 
+    _id = kwargs.pop('name')
+    ret = {
+        'name': kwargs.keys(),
+        'changes': {},
+        'comment': '',
+        'result': {}
+    }
+
+    for func in kwargs.keys():
+        if func not in __salt__:
+            ret['comment'] = "Module function '{0}' is not available".format(func)
+            ret['result'] = False
+        elif __opts__['test']:
+            ret['comment'] = "Module function '{0}' is set to execute".format(func)
+            ret['result'] = True
+
+    for func in kwargs.keys():
+        ret['result'][func] = _call_function(func)
+
+    return ret
+
+def _call_function(name, **kwargs):
+    '''
+    Calls a function from the specified module.
+
+    :param name:
+    :param kwargs:
+    :return:
+    '''
+
+    aspec = salt.utils.args.get_function_argspec(__salt__[name])
+
+    return None
+
+
 def run(name, **kwargs):
     '''
     Run a single module function

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -344,21 +344,27 @@ def run(name, **kwargs):
         if kwargs['returner'] in returners:
             returners[kwargs['returner']](ret_ret)
     ret['comment'] = 'Module function {0} executed'.format(name)
+    ret['result'] = _get_result(mret, ret['changes'].get('ret', {}))
 
-    ret['result'] = True
+    return ret
+
+
+def _get_result(func_ret, changes):
+    res = True
     # if mret is a dict and there is retcode and its non-zero
-    if isinstance(mret, dict) and mret.get('retcode', 0) != 0:
-        ret['result'] = False
-    # if its a boolean, return that as the result
-    elif isinstance(mret, bool):
-        ret['result'] = mret
+    if isinstance(func_ret, dict) and func_ret.get('retcode', 0) != 0:
+        res = False
+        # if its a boolean, return that as the result
+    elif isinstance(func_ret, bool):
+        res = func_ret
     else:
-        changes_ret = ret['changes'].get('ret', {})
+        changes_ret = changes.get('ret', {})
         if isinstance(changes_ret, dict):
             if isinstance(changes_ret.get('result', {}), bool):
-                ret['result'] = changes_ret.get('result', {})
+                res = changes_ret.get('result', {})
             elif changes_ret.get('retcode', 0) != 0:
-                ret['result'] = False
-    return ret
+                res = False
+
+    return res
 
 mod_watch = salt.utils.alias_function(run, 'mod_watch')

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -188,7 +188,8 @@ def xrun(**kwargs):
         'result': None,
     }
 
-    for func in kwargs.keys():
+    functions = [func for func in kwargs.keys() if '.' in func]
+    for func in functions:
         if func not in __salt__:
             ret['comment'] = "Module function '{0}' is not available".format(func)
             ret['result'] = False

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -222,7 +222,8 @@ def xrun(**kwargs):
     :return:
     '''
 
-    'name' in kwargs and kwargs.pop('name')
+    if 'name' in kwargs:
+        kwargs.pop('name')
     ret = {
         'name': kwargs.keys(),
         'changes': {},

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -308,7 +308,8 @@ def _call_function(name, returner=None, **kwargs):
     :return:
     '''
     argspec = salt.utils.args.get_function_argspec(__salt__[name])
-    func_kw = dict(zip(argspec.args[-len(argspec.defaults or []):], argspec.defaults or []))
+    func_kw = dict(zip(argspec.args[-len(argspec.defaults or []):],  # pylint: disable=incompatible-py3-code
+                       argspec.defaults or []))
     func_args = []
     for funcset in kwargs.get('func_args') or {}:
         if isinstance(funcset, dict):

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -210,7 +210,7 @@ def xrun(**kwargs):
                 success.append('{0}: {1}'.format(func, func_ret.get('comment', 'Success')))
                 ret['result'] = _get_result(func_ret, ret['changes'].get('ret', {}))
             except SaltInvocationError as ex:
-                failures.append("Function '{0}' failed: {1}".format(func, ex))
+                failures.append("'{0}' failed: {1}".format(func, ex))
         if failures:
             ret['comment'] = ' '.join(failures)
             ret['result'] = False

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -178,6 +178,7 @@ import salt.loader
 import salt.utils
 import salt.utils.jid
 from salt.ext.six.moves import range
+from salt.ext.six.moves import zip
 from salt.exceptions import SaltInvocationError
 from salt.utils.decorators import with_deprecated
 

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -428,7 +428,7 @@ def run(name, **kwargs):
         if kwargs['returner'] in returners:
             returners[kwargs['returner']](ret_ret)
     ret['comment'] = 'Module function {0} executed'.format(name)
-    ret['result'] = _get_result(mret, ret['changes'].get('ret', {}))
+    ret['result'] = _get_result(mret, ret['changes'])
 
     return ret
 

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -210,7 +210,8 @@ def xrun(**kwargs):
                 if not _get_result(func_ret, ret['changes'].get('ret', {})):
                     failures.append("'{0}' failed: {1}".format(func_ret.get('comment', '(error message N/A)')))
                 else:
-                    success.append('{0}: {1}'.format(func, func_ret.get('comment', 'Success')))
+                    success.append('{0}: {1}'.format(
+                        func, func_ret.get('comment', 'Success') if isinstance(func_ret, dict) else func_ret))
             except (SaltInvocationError, TypeError) as ex:
                 failures.append("'{0}' failed: {1}".format(func, ex))
         ret['comment'] = ', '.join(failures + success)

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -248,13 +248,24 @@ def run(**kwargs):
     }
 
     functions = [func for func in kwargs.keys() if '.' in func]
+    missing = []
+    tests = []
     for func in functions:
         if func not in __salt__:
-            ret['comment'] = "Module function '{0}' is not available".format(func)
-            ret['result'] = False
+            missing.append(func)
         elif __opts__['test']:
-            ret['comment'] = "Module function '{0}' is set to execute".format(func)
-            ret['result'] = True
+            tests.append(func)
+
+    if tests or missing:
+        ret['comment'] = ' '.join([
+            missing and "Unavailable function{plr}: "
+                        "{func}.".format(plr=(len(missing) > 1 or ''),
+                                         func=(', '.join(missing) or '')) or '',
+            tests and "Function{plr} {func} to be "
+                      "executed.".format(plr=(len(tests) > 1 or ''),
+                                         func=(', '.join(tests)) or '') or '',
+        ]).strip()
+        ret['result'] = not (missing or not tests)
 
     if ret['result'] is None:
         ret['result'] = True

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -155,7 +155,10 @@ def xrun(**kwargs):
     Run a single module function or a range of module functions in a batch.
     Supersedes `module.run` function, which requires `m_` prefix to function-specific parameters.
 
-    ``kwargs``
+    :param returner:
+        Specify a common returner for the whole batch to send the return data
+
+    :param kwargs:
         Pass any arguments needed to execute the function(s)
 
     .. code-block:: yaml
@@ -175,8 +178,6 @@ def xrun(**kwargs):
             - delvol_on_destroy: True
 
 
-    :param call:
-    :param kwargs:
     :return:
     '''
 

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -3,8 +3,10 @@ r'''
 Execution of Salt modules from within states
 ============================================
 
-These states allow individual execution module calls to be made via states. To
-call a single module function use a :mod:`module.run <salt.states.module.run>`
+Here you have two options: `module.run` and `module.xrun`.
+
+With `module.run` these states allow individual execution module calls to be
+made via states. To call a single module function use a :mod:`module.run <salt.states.module.run>`
 state:
 
 .. code-block:: yaml
@@ -108,6 +110,45 @@ Windows system:
               start_date: '2017-1-20',
               start_time: '11:59PM'
         }
+
+Another option is to use the `module.xrun`. With which you can call one (or more!)
+functions at once the following way:
+
+.. code-block:: yaml
+
+    call_something:
+      module.xrun:
+        git.fetch:
+          - cwd: /path/to/my/repo
+          - user: myuser
+          - opts: '--all'
+
+Unlike `module.run`, the `module.xrun` does not have reserved words you should
+specially prefix to distinguish them. No need to extra-pass `kwargs` either.
+For example, this is the same example from `module.run`:
+
+.. code-block:: yaml
+
+    mine.send:
+      module.xrun:
+        network.ip_addrs:
+          - interface: eth0
+
+Or the examlpe above can be written as following:
+
+.. code-block:: yaml
+
+    eventsviewer:
+      module.xrun:
+        task.create_task:
+          - name: events-viewer
+          - user_name: System
+          - action_type: Execute
+          - cmd: 'c:\netops\scripts\events_viewer.bat'
+          - trigger_type: 'Daily'
+          - start_date: '2017-1-20'
+          - start_time: '11:59PM'
+
 '''
 from __future__ import absolute_import
 

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -116,6 +116,7 @@ import salt.loader
 import salt.utils
 import salt.utils.jid
 from salt.ext.six.moves import range
+from salt.exceptions import SaltInvocationError
 
 
 def wait(name, **kwargs):
@@ -208,6 +209,12 @@ def _call_function(name, **kwargs):
     :param kwargs:
     :return:
     '''
+    missing = []
+    for arg in argspec.args:
+        if arg not in func_args:
+            missing.append(arg)
+    if missing:
+        raise SaltInvocationError('Missing arguments: {0}'.format(', '.join(missing)))
 
     aspec = salt.utils.args.get_function_argspec(__salt__[name])
 

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -208,7 +208,8 @@ def xrun(**kwargs):
                 func_ret = _call_function(func, returner=kwargs.get('returner'),
                                           func_args=kwargs.get(func))
                 if not _get_result(func_ret, ret['changes'].get('ret', {})):
-                    failures.append("'{0}' failed: {1}".format(func_ret.get('comment', '(error message N/A)')))
+                    if isinstance(func_ret, dict):
+                        failures.append("'{0}' failed: {1}".format(func_ret.get('comment', '(error message N/A)')))
                 else:
                     success.append('{0}: {1}'.format(
                         func, func_ret.get('comment', 'Success') if isinstance(func_ret, dict) else func_ret))

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -211,11 +211,8 @@ def xrun(**kwargs):
                 ret['result'] = _get_result(func_ret, ret['changes'].get('ret', {}))
             except SaltInvocationError as ex:
                 failures.append("'{0}' failed: {1}".format(func, ex))
-        if failures:
-            ret['comment'] = ' '.join(failures)
-            ret['result'] = False
-        else:
-            ret['comment'] = ', '.join(success)
+        ret['comment'] = ', '.join(failures + success)
+        ret['result'] = not bool(failures)
 
     return ret
 

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -3,8 +3,6 @@ r'''
 Execution of Salt modules from within states
 ============================================
 
-Here you have two options: `module.run` and `module.xrun`.
-
 With `module.run` these states allow individual execution module calls to be
 made via states. To call a single module function use a :mod:`module.run <salt.states.module.run>`
 state:
@@ -13,15 +11,57 @@ state:
 
     mine.send:
       module.run:
-        - name: network.interfaces
+        - network.interfaces
 
 Note that this example is probably unnecessary to use in practice, since the
 ``mine_functions`` and ``mine_interval`` config parameters can be used to
-schedule updates for the mine (see :ref:`here <salt-mine>` for more
-info).
+schedule updates for the mine (see :ref:`here <salt-mine>` for more info).
 
 It is sometimes desirable to trigger a function call after a state is executed,
 for this the :mod:`module.wait <salt.states.module.wait>` state can be used:
+
+.. code-block:: yaml
+
+    fetch_out_of_band:
+      module.run:
+        git.fetch:
+          - cwd: /path/to/my/repo
+          - user: myuser
+          - opts: '--all'
+
+Another example:
+
+.. code-block:: yaml
+
+    mine.send:
+      module.xrun:
+        network.ip_addrs:
+          - interface: eth0
+
+And more complex example:
+
+.. code-block:: yaml
+
+    eventsviewer:
+      module.xrun:
+        task.create_task:
+          - name: events-viewer
+          - user_name: System
+          - action_type: Execute
+          - cmd: 'c:\netops\scripts\events_viewer.bat'
+          - trigger_type: 'Daily'
+          - start_date: '2017-1-20'
+          - start_time: '11:59PM'
+
+Please note, this is a new behaviour of `module.run` function.
+
+With the previous `module.run` there are several differences:
+
+- The need of `name` keyword
+- The need of `m_` prefix
+- No way to call more than one function at once
+
+For example:
 
 .. code-block:: yaml
 
@@ -122,32 +162,6 @@ functions at once the following way:
           - cwd: /path/to/my/repo
           - user: myuser
           - opts: '--all'
-
-Unlike `module.run`, the `module.xrun` does not have reserved words you should
-specially prefix to distinguish them. No need to extra-pass `kwargs` either.
-For example, this is the same example from `module.run`:
-
-.. code-block:: yaml
-
-    mine.send:
-      module.xrun:
-        network.ip_addrs:
-          - interface: eth0
-
-Or the examlpe above can be written as following:
-
-.. code-block:: yaml
-
-    eventsviewer:
-      module.xrun:
-        task.create_task:
-          - name: events-viewer
-          - user_name: System
-          - action_type: Execute
-          - cmd: 'c:\netops\scripts\events_viewer.bat'
-          - trigger_type: 'Daily'
-          - start_date: '2017-1-20'
-          - start_time: '11:59PM'
 
 '''
 from __future__ import absolute_import

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -34,7 +34,7 @@ Another example:
 .. code-block:: yaml
 
     mine.send:
-      module.xrun:
+      module.run:
         network.ip_addrs:
           - interface: eth0
 
@@ -43,7 +43,7 @@ And more complex example:
 .. code-block:: yaml
 
     eventsviewer:
-      module.xrun:
+      module.run:
         task.create_task:
           - name: events-viewer
           - user_name: System
@@ -151,17 +151,24 @@ Windows system:
               start_time: '11:59PM'
         }
 
-Another option is to use the `module.xrun`. With which you can call one (or more!)
+Another option is to use the new version of `module.run`. With which you can call one (or more!)
 functions at once the following way:
 
 .. code-block:: yaml
 
     call_something:
-      module.xrun:
+      module.run:
         git.fetch:
           - cwd: /path/to/my/repo
           - user: myuser
           - opts: '--all'
+
+By default this behaviour is not turned on. In ordder to do so, please add the following
+configuration to the minion:
+
+.. code-block:: yaml
+    use_superseded:
+      - module.run
 
 '''
 from __future__ import absolute_import

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -206,7 +206,7 @@ def wait(name, **kwargs):
 watch = salt.utils.alias_function(wait, 'watch')
 
 
-@with_deprecated(globals(), "Oxygen")
+@with_deprecated(globals(), "Oxygen", policy=with_deprecated.OPT_IN)
 def run(**kwargs):
     '''
     Run a single module function or a range of module functions in a batch.

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -149,6 +149,36 @@ def wait(name, **kwargs):
 watch = salt.utils.alias_function(wait, 'watch')
 
 
+def xrun(**kwargs):
+    '''
+    Run a single module function or a range of module functions in a batch.
+    Supersedes `module.run` function, which requires `m_` prefix to function-specific parameters.
+
+    ``kwargs``
+        Pass any arguments needed to execute the function(s)
+
+    .. code-block:: yaml
+      some_id_of_state:
+        module.xrun:
+          - network.ip_addrs:
+            - interface: eth0
+          - cloud.create:
+            - names:
+              - test-isbm-1
+              - test-isbm-2
+            - ssh_username: sles
+            - image: sles12sp2
+            - securitygroup: default
+            - size: 'c3.large'
+            - location: ap-northeast-1
+            - delvol_on_destroy: True
+
+
+    :param call:
+    :param kwargs:
+    :return:
+    '''
+
 def run(name, **kwargs):
     '''
     Run a single module function

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -532,8 +532,11 @@ class _WithDeprecated(_DeprecationDecorator):
 
         :return:
         '''
-        return "{m_name}.{f_name}".format(m_name=self._globals.get(self.MODULE_NAME, ''),
-                                          f_name=self._orig_f_name) in self._options.get(self.CFG_KEY, list())
+        func_path = "{m_name}.{f_name}".format(
+            m_name=self._globals.get(self.MODULE_NAME, '') or self._globals['__name__'].split('.')[-1],
+            f_name=self._orig_f_name)
+
+        return func_path in self._globals.get('__opts__', {}).get(self.CFG_KEY, list()), func_path
 
     def __call__(self, function):
         '''
@@ -554,7 +557,8 @@ class _WithDeprecated(_DeprecationDecorator):
             :return:
             '''
             self._set_function(function)
-            if self._is_used_deprecated():
+            is_deprecated, func_path = self._is_used_deprecated()
+            if is_deprecated:
                 if self._curr_version < self._exp_version:
                     msg = list()
                     if self._with_name:

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -311,7 +311,7 @@ class _DeprecationDecorator(object):
             try:
                 return self._function(*args, **kwargs)
             except TypeError as error:
-                error = str(error).replace(self._function.__name__, self._orig_f_name)  # Hide hidden functions
+                error = str(error).replace(self._function, self._orig_f_name)  # Hide hidden functions
                 log.error('Function "{f_name}" was not properly called: {error}'.format(f_name=self._orig_f_name,
                                                                                         error=error))
                 return self._function.__doc__

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -567,10 +567,10 @@ class _WithDeprecated(_DeprecationDecorator):
                                    'expire in version "{version_name}".'.format(
                                        f_name=self._with_name.startswith("_") and self._orig_f_name or self._with_name,
                                        version_name=self._exp_version_name))
+                        msg.append('Use its successor "{successor}" instead.'.format(successor=self._orig_f_name))
                     else:
                         msg.append('The function is using its deprecated version and will '
                                    'expire in version "{version_name}".'.format(version_name=self._exp_version_name))
-                    msg.append('Use its successor "{successor}" instead.'.format(successor=self._orig_f_name))
                     log.warning(' '.join(msg))
                 else:
                     msg_patt = 'The lifetime of the function "{f_name}" expired.'

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -569,8 +569,9 @@ class _WithDeprecated(_DeprecationDecorator):
                                        version_name=self._exp_version_name))
                         msg.append('Use its successor "{successor}" instead.'.format(successor=self._orig_f_name))
                     else:
-                        msg.append('The function is using its deprecated version and will '
-                                   'expire in version "{version_name}".'.format(version_name=self._exp_version_name))
+                        msg.append('The function "{f_name}" is using its deprecated version and will '
+                                   'expire in version "{version_name}".'.format(f_name=func_path,
+                                                                                version_name=self._exp_version_name))
                     log.warning(' '.join(msg))
                 else:
                     msg_patt = 'The lifetime of the function "{f_name}" expired.'

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -272,7 +272,6 @@ class _DeprecationDecorator(object):
         self._exp_version_name = version
         self._exp_version = SaltStackVersion.from_name(self._exp_version_name)
         self._curr_version = __saltstack_version__.info
-        self._options = self._globals['__opts__']
         self._raise_later = None
         self._function = None
         self._orig_f_name = None
@@ -523,7 +522,7 @@ class _WithDeprecated(_DeprecationDecorator):
             self._raise_later = CommandExecutionError('Module not found for function "{f_name}"'.format(
                 f_name=function.__name__))
 
-        if full_name in self._options.get(self.CFG_KEY, list()):
+        if full_name in self._globals.get('__opts__', '{}').get(self.CFG_KEY, list()):
             self._function = self._globals.get(self._with_name or "_{0}".format(function.__name__))
 
     def _is_used_deprecated(self):

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -516,8 +516,9 @@ class _WithDeprecated(_DeprecationDecorator):
         Based on the configuration, set to execute an old or a new function.
         :return:
         '''
-        full_name = "{m_name}.{f_name}".format(m_name=self._globals.get(self.MODULE_NAME, ''),
-                                               f_name=function.__name__)
+        full_name = "{m_name}.{f_name}".format(
+            m_name=self._globals.get(self.MODULE_NAME, '') or self._globals['__name__'].split('.')[-1],
+            f_name=function.__name__)
         if full_name.startswith("."):
             self._raise_later = CommandExecutionError('Module not found for function "{f_name}"'.format(
                 f_name=function.__name__))

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -286,11 +286,15 @@ class _DeprecationDecorator(object):
         _args = list()
         _kwargs = dict()
 
-        for arg_item in kwargs.get('__pub_arg', list()):
-            if type(arg_item) == dict:
-                _kwargs.update(arg_item.copy())
-            else:
-                _args.append(arg_item)
+        if '__pub_arg' in kwargs:  # For modules
+            for arg_item in kwargs.get('__pub_arg', list()):
+                if type(arg_item) == dict:
+                    _kwargs.update(arg_item.copy())
+                else:
+                    _args.append(arg_item)
+        else:
+            _kwargs = kwargs.copy()  # For states
+
         return _args, _kwargs
 
     def _call_function(self, kwargs):

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -556,8 +556,10 @@ class _WithDeprecated(_DeprecationDecorator):
             m_name=self._globals.get(self.MODULE_NAME, '') or self._globals['__name__'].split('.')[-1],
             f_name=self._orig_f_name)
 
-        return self._policy == self.OPT_IN and not (func_path in self._globals.get('__opts__', {}).get(
-            self.CFG_USE_SUPERSEDED, list())), func_path
+        return func_path in self._globals.get('__opts__').get(
+            self.CFG_USE_DEPRECATED, list()) or (self._policy == self.OPT_IN
+                                                 and not (func_path in self._globals.get('__opts__', {}).get(
+                                                          self.CFG_USE_SUPERSEDED, list()))), func_path
 
     def __call__(self, function):
         '''

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -41,10 +41,9 @@ class ModuleStateTest(TestCase):
         Tests the return of module.run state when the module function
         name isn't available
         '''
-        with patch.dict(module.__salt__, {}):
-            cmd = 'hello.world'
-            ret = module.run(cmd)
-            comment = 'Module function {0} is not available'.format(cmd)
+        with patch.dict(module.__salt__, {}, clear=True):
+            ret = module.run(CMD)
+            comment = 'Module function {0} is not available'.format(CMD)
             self.assertEqual(ret['comment'], comment)
             self.assertFalse(ret['result'])
 

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -52,9 +52,8 @@ class ModuleStateTest(TestCase):
         :return:
         '''
         with patch.dict(module.__salt__, {}, clear=True):
-            cmd = {CMD: None}
-            ret = module.xrun(**cmd)
-            assert ret['comment'] == "Module function '{0}' is not available".format(cmd.keys()[0])
+            ret = module.xrun(**{CMD: None})
+            assert ret['comment'] == "Module function '{0}' is not available".format(CMD)
             assert not ret['result']
 
     def test_xrun_testmode(self):
@@ -63,8 +62,7 @@ class ModuleStateTest(TestCase):
         :return:
         '''
         with patch.dict(module.__opts__, {'test': True}):
-            cmd = {CMD: None}
-            ret = module.xrun(**cmd)
+            ret = module.xrun(**{CMD: None})
             assert ret['comment'] == "Module function '{0}' is set to execute".format(CMD)
             assert ret['result']
 

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -25,6 +25,16 @@ module.__salt__ = {CMD: MOCK}
 module.__opts__ = {'test': False}
 
 
+def _mocked_func_named(name, names=('Fred', 'Swen',)):
+    '''
+    Mocked function with named defaults.
+
+    :param name:
+    :param names:
+    :return:
+    '''
+    return {'name': name, 'names': names}
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class ModuleStateTest(TestCase):
     '''
@@ -57,6 +67,16 @@ class ModuleStateTest(TestCase):
             ret = module.xrun(**cmd)
             assert ret['comment'] == "Module function '{0}' is set to execute".format(CMD)
             assert ret['result']
+
+    def test_xrun_missing_arg(self):
+        '''
+        Tests the return of module.xrun state when arguments are missing
+        :return:
+        '''
+        with patch.dict(module.__salt__, {CMD: _mocked_func_named}):
+            ret = module.xrun(**{CMD: None})
+            assert ret['comment'] == "'{0}' failed: Missing arguments: name".format(CMD)
+
 
     def test_module_run_module_not_available(self):
         '''

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -137,6 +137,18 @@ class ModuleStateTest(TestCase):
             with patch.dict(module.__salt__, {CMD: _mocked_none_return}):
                 assert module.xrun(**{CMD: [{'ret': val}]})['result']
 
+    def test_xrun_batch_call(self):
+        '''
+        Test batch call
+        :return:
+        '''
+        with patch.dict(module.__salt__,
+                        {'first': _mocked_none_return,
+                         'second': _mocked_none_return,
+                         'third': _mocked_none_return}, clear=True):
+            for f_name in module.__salt__:
+                assert module.xrun(**{f_name: None})['result']
+
     def test_module_run_module_not_available(self):
         '''
         Tests the return of module.run state when the module function

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -105,6 +105,10 @@ class ModuleStateTest(TestCase):
             assert not ret['result']
 
     def test_xrun_args(self):
+        '''
+        Test unnamed args.
+        :return:
+        '''
         with patch.dict(module.__salt__, {CMD: _mocked_func_args}):
             assert module.xrun(**{CMD: ['foo', 'bar']})['result']
 

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -113,7 +113,7 @@ class ModuleStateTest(TestCase):
             with patch.dict(module.__opts__, {'use_superseded': ['module.run']}):
                 ret = module.run(**{CMD: [{'foo': 'bar'}]})
                 assert ret['comment'] == "'{0}' failed: {1}() got an unexpected keyword argument " \
-                                         "'foo'".format(CMD, module.__salt__[CMD].func_name)
+                                         "'foo'".format(CMD, module.__salt__[CMD].__name__)
                 assert not ret['result']
 
     def test_run_args(self):

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -47,6 +47,17 @@ class ModuleStateTest(TestCase):
             assert ret['comment'] == "Module function '{0}' is not available".format(cmd.keys()[0])
             assert not ret['result']
 
+    def test_xrun_testmode(self):
+        '''
+        Tests the return of the module.xrun state when test=True is passed.
+        :return:
+        '''
+        with patch.dict(module.__opts__, {'test': True}):
+            cmd = {CMD: None}
+            ret = module.xrun(**cmd)
+            assert ret['comment'] == "Module function '{0}' is set to execute".format(CMD)
+            assert ret['result']
+
     def test_module_run_module_not_available(self):
         '''
         Tests the return of module.run state when the module function

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -35,6 +35,17 @@ def _mocked_func_named(name, names=('Fred', 'Swen',)):
     '''
     return {'name': name, 'names': names}
 
+
+def _mocked_func_args(*args):
+    '''
+    Mocked function with args.
+
+    :param args:
+    :return:
+    '''
+    return {'args': args}
+
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class ModuleStateTest(TestCase):
     '''
@@ -84,6 +95,13 @@ class ModuleStateTest(TestCase):
             ret = module.xrun(**{CMD: [{'name': 'Fred'}]})
             assert ret['comment'] == '{0}: Success'.format(CMD)
             assert ret['result']
+
+    def test_xrun_unexpected_keywords(self):
+        with patch.dict(module.__salt__, {CMD: _mocked_func_args}):
+            ret = module.xrun(**{CMD: [{'foo': 'bar'}]})
+            assert ret['comment'] == "'{0}' failed: {1}() got an unexpected keyword argument 'foo'".format(
+                CMD, module.__salt__[CMD].func_name)
+            assert not ret['result']
 
 
     def test_module_run_module_not_available(self):

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -36,6 +36,17 @@ class ModuleStateTest(TestCase):
                     keywords=None,
                     defaults=False)
 
+    def test_xrun_module_not_available(self):
+        '''
+        Tests the return of module.xrun state when the module function is not available.
+        :return:
+        '''
+        with patch.dict(module.__salt__, {}, clear=True):
+            cmd = {CMD: None}
+            ret = module.xrun(**cmd)
+            assert ret['comment'] == "Module function '{0}' is not available".format(cmd.keys()[0])
+            assert not ret['result']
+
     def test_module_run_module_not_available(self):
         '''
         Tests the return of module.run state when the module function

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -43,6 +43,7 @@ def _mocked_func_args(*args):
     :param args:
     :return:
     '''
+    assert args == ('foo', 'bar')
     return {'args': args}
 
 
@@ -103,6 +104,9 @@ class ModuleStateTest(TestCase):
                 CMD, module.__salt__[CMD].func_name)
             assert not ret['result']
 
+    def test_xrun_args(self):
+        with patch.dict(module.__salt__, {CMD: _mocked_func_args}):
+            assert module.xrun(**{CMD: ['foo', 'bar']})['result']
 
     def test_module_run_module_not_available(self):
         '''

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -75,6 +75,16 @@ class ModuleStateTest(TestCase):
             ret = module.xrun(**{CMD: None})
             assert ret['comment'] == "'{0}' failed: Missing arguments: name".format(CMD)
 
+    def test_xrun_correct_arg(self):
+        '''
+        Tests the return of module.xrun state when arguments are correct
+        :return:
+        '''
+        with patch.dict(module.__salt__, {CMD: _mocked_func_named}):
+            ret = module.xrun(**{CMD: [{'name': 'Fred'}]})
+            assert ret['comment'] == '{0}: Success'.format(CMD)
+            assert ret['result']
+
 
     def test_module_run_module_not_available(self):
         '''

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -47,11 +47,12 @@ def _mocked_func_args(*args):
     return {'args': args}
 
 
-def _mocked_none_return():
+def _mocked_none_return(ret=None):
     '''
     Mocked function returns None
     :return:
     '''
+    return ret
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -126,6 +127,15 @@ class ModuleStateTest(TestCase):
         '''
         with patch.dict(module.__salt__, {CMD: _mocked_none_return}):
             assert module.xrun(**{CMD: None})['result']
+
+    def test_xrun_typed_return(self):
+        '''
+        Test handling of a broken function that returns any type.
+        :return:
+        '''
+        for val in [1, 0, 'a', '', (1, 2,), (), [1, 2], [], {'a': 'b'}, {}, True, False]:
+            with patch.dict(module.__salt__, {CMD: _mocked_none_return}):
+                assert module.xrun(**{CMD: [{'ret': val}]})['result']
 
     def test_module_run_module_not_available(self):
         '''

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -47,6 +47,13 @@ def _mocked_func_args(*args):
     return {'args': args}
 
 
+def _mocked_none_return():
+    '''
+    Mocked function returns None
+    :return:
+    '''
+
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class ModuleStateTest(TestCase):
     '''
@@ -111,6 +118,14 @@ class ModuleStateTest(TestCase):
         '''
         with patch.dict(module.__salt__, {CMD: _mocked_func_args}):
             assert module.xrun(**{CMD: ['foo', 'bar']})['result']
+
+    def test_xrun_none_return(self):
+        '''
+        Test handling of a broken function that returns None.
+        :return:
+        '''
+        with patch.dict(module.__salt__, {CMD: _mocked_none_return}):
+            assert module.xrun(**{CMD: None})['result']
 
     def test_module_run_module_not_available(self):
         '''

--- a/tests/unit/utils/test_decorators.py
+++ b/tests/unit/utils/test_decorators.py
@@ -222,3 +222,17 @@ class DecoratorsTest(TestCase):
                           'an alias "old_function" is configured as its deprecated version. '
                           'The lifetime of the function "old_function" expired. '
                           'Please use its successor "new_function" instead.'])
+
+    def test_with_deprecated_opt_in_default(self):
+        '''
+        Test with_deprecated using opt-in policy,
+        where newer function is not used, unless configured.
+
+        :return:
+        '''
+        depr = decorators.with_deprecated(self.globs, "Beryllium", policy=decorators._DeprecationDecorator.OPT_IN)
+        depr._curr_version = self._mk_version("Helium")[1]
+        assert depr(self.new_function)() == self.old_function()
+        assert self.messages == ['The function "test.new_function" is using its '
+                                 'deprecated version and will expire in version "Beryllium".']
+

--- a/tests/unit/utils/test_decorators.py
+++ b/tests/unit/utils/test_decorators.py
@@ -135,8 +135,8 @@ class DecoratorsTest(TestCase):
         with self.assertRaises(CommandExecutionError):
             depr(self.new_function)()
         self.assertEqual(self.messages,
-                         ['The function is using its deprecated version and will expire in version "Beryllium". '
-                          'Use its successor "new_function" instead.'])
+                         ['The function "test.new_function" is using its deprecated '
+                          'version and will expire in version "Beryllium".'])
 
     def test_with_deprecated_found(self):
         '''
@@ -151,8 +151,8 @@ class DecoratorsTest(TestCase):
         depr = decorators.with_deprecated(self.globs, "Beryllium")
         depr._curr_version = self._mk_version("Helium")[1]
         self.assertEqual(depr(self.new_function)(), self.old_function())
-        log_msg = ['The function is using its deprecated version and will expire in version "Beryllium". '
-                   'Use its successor "new_function" instead.']
+        log_msg = ['The function "test.new_function" is using its deprecated version '
+                   'and will expire in version "Beryllium".']
         self.assertEqual(self.messages, log_msg)
 
     def test_with_deprecated_found_eol(self):

--- a/tests/unit/utils/test_decorators.py
+++ b/tests/unit/utils/test_decorators.py
@@ -133,6 +133,7 @@ class DecoratorsTest(TestCase):
 
         :return:
         '''
+        del self.globs['_new_function']
         self.globs['__opts__']['use_deprecated'] = ['test.new_function']
         depr = decorators.with_deprecated(self.globs, "Beryllium")
         depr._curr_version = self._mk_version("Helium")[1]

--- a/tests/unit/utils/test_decorators.py
+++ b/tests/unit/utils/test_decorators.py
@@ -236,3 +236,16 @@ class DecoratorsTest(TestCase):
         assert self.messages == ['The function "test.new_function" is using its '
                                  'deprecated version and will expire in version "Beryllium".']
 
+    def test_with_deprecated_opt_in_use_superseded(self):
+        '''
+        Test with_deprecated using opt-in policy,
+        where newer function is used as per configuration.
+
+        :return:
+        '''
+        self.globs['__opts__']['use_superseded'] = ['test.new_function']
+        depr = decorators.with_deprecated(self.globs, "Beryllium", policy=decorators._DeprecationDecorator.OPT_IN)
+        depr._curr_version = self._mk_version("Helium")[1]
+        assert depr(self.new_function)() == self.new_function()
+        assert not self.messages
+


### PR DESCRIPTION
### What does this PR do?

Adds a feature: `module.xrun` for states.

### Motivation

Current way of calling Salt modules with `module.run` has pretty cumbersome interface along with the fact it has also reserved words. This leads to a strange states, something like:

```yaml
show_friends:
  module.run:
    - name: facebook.list_friends
    - m_name: thatch
```

Or even worse:

```yaml
list_states:
  module.run:
    - name: united.states
    - m_states: Florida, Arizona, California
    - m_names: Tallahassee, Phoenix, Sacramento
    - m_fun: Bowling
    - kwargs: {
      'drink_beer': True,
      'visit': [
        'Florida State Capitol',
        'Arizona Science Center',
        'California Railroad State Museum'
      ],
      'call': thatch
    }
```

This led to the reasoning make it easier and simpler to use, throw away `m_` prefix (this just sucks, sorry). Also write better unit tests. :smile: So the above can be done something like this:

```yaml
show_friends:
  module.xrun:
    facebook.list_friends:
      - name: thatch
```

Look, Ma! No `m_` prefix! How about another example:

```yaml
list_states:
  module.xrun:
    united.states:
      - states: Florida, Arizona, California
      - names: Tallahassee, Phoenix, Sacramento
      - fun: Bowling
      - drink_beer: True
      - visit:
        - Florida State Capitol
        - Arizona Science Center
        - California Railroad State Museum
      - call: thatch
```

**One more thing** you can do (optionally, of course, you don't _have_ to):

```yaml
this_calls_it_at_once:
  module.xrun:
    some.function:
      - foo
      - bar
    another.function:
      - wow
      - that's handy
```

:sunglasses: 

### Tests written?

Yes
