### PR TITLE
Add always_alive option for napalm proxy

### DIFF
--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -870,7 +870,7 @@ def load_config(filename=None,
         # after running the other features:
         # compare_config, discard / commit
         # which have to be over the same session
-        napalm_device['CLOSE'] = False
+        napalm_device['CLOSE'] = False  # pylint: disable=undefined-variable
     _loaded = salt.utils.napalm.call(
         napalm_device,  # pylint: disable=undefined-variable
         fun,
@@ -1245,7 +1245,7 @@ def load_template(template_name,
                 # after running the other features:
                 # compare_config, discard / commit
                 # which have to be over the same session
-                napalm_device['CLOSE'] = False
+                napalm_device['CLOSE'] = False  # pylint: disable=undefined-variable
             _loaded = salt.utils.napalm.call(
                 napalm_device,  # pylint: disable=undefined-variable
                 fun,
@@ -1276,7 +1276,7 @@ def load_template(template_name,
             # compare_config, discard / commit
             # which have to be over the same session
             # so we'll set the CLOSE global explicitely as False
-            napalm_device['CLOSE'] = False
+            napalm_device['CLOSE'] = False  # pylint: disable=undefined-variable
         _loaded = salt.utils.napalm.call(
             napalm_device,  # pylint: disable=undefined-variable
             'load_template',

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -98,7 +98,7 @@ def _filter_dict(input_dict, search_key, search_value):
 def _explicit_close(napalm_device):
     '''
     Will explicitely close the config session with the network device,
-    when runnin in a now-always-alive proxy minion or regular minion.
+    when running in a now-always-alive proxy minion or regular minion.
     This helper must be used in configuration-related functions,
     as the session is preserved and not closed before making any changes.
     '''

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -95,6 +95,25 @@ def _filter_dict(input_dict, search_key, search_value):
     return output_dict
 
 
+def _explicit_close(napalm_device):
+    '''
+    Will explicitely close the config session with the network device,
+    when runnin in a now-always-alive proxy minion or regular minion.
+    This helper must be used in configuration-related functions,
+    as the session is preserved and not closed before making any changes.
+    '''
+    if salt.utils.napalm.not_always_alive(__opts__):
+        # force closing the configuration session
+        # when running in a non-always-alive proxy
+        # or regular minion
+        try:
+            napalm_device['DRIVER'].close()
+        except Exception as err:
+            log.error('Unable to close the temp connection with the device:')
+            log.error(err)
+            log.error('Please report.')
+
+
 def _config_logic(napalm_device,
                   loaded_result,
                   test=False,
@@ -131,7 +150,6 @@ def _config_logic(napalm_device,
         loaded_result.pop('out', '')  # not needed
 
     _loaded_res = loaded_result.get('result', False)
-
     if not _loaded_res or test:
         # if unable to load the config (errors / warnings)
         # or in testing mode,
@@ -147,11 +165,13 @@ def _config_logic(napalm_device,
             loaded_result['result'] = False
             # make sure it notifies
             # that something went wrong
+            _explicit_close(napalm_device)
             return loaded_result
 
         loaded_result['comment'] += 'Configuration discarded.'
         # loaded_result['result'] = False not necessary
         # as the result can be true when test=True
+        _explicit_close(napalm_device)
         return loaded_result
 
     if not test and commit_config:
@@ -181,20 +201,11 @@ def _config_logic(napalm_device,
                                                                   else 'Unable to discard config.'
                 loaded_result['result'] = False
                 # notify if anything goes wrong
+                _explicit_close(napalm_device)
                 return loaded_result
             loaded_result['already_configured'] = True
             loaded_result['comment'] = 'Already configured.'
-
-    if salt.utils.napalm.not_always_alive(__opts__):
-        # force closing the configuration session
-        # when running in a non-always-alive proxy
-        # or regular minion
-        try:
-            napalm_device['DRIVER'].close()
-        except Exception as err:
-            log.error('Unable to close the temp connection with the device:')
-            log.error(err)
-            log.error('Please report.')
+    _explicit_close(napalm_device)
     return loaded_result
 
 
@@ -852,6 +863,13 @@ def load_config(filename=None,
     if replace:
         fun = 'load_replace_candidate'
     if salt.utils.napalm.not_always_alive(__opts__):
+        # if a not-always-alive proxy
+        # or regular minion
+        # do not close the connection after loading the config
+        # this will be handled in _config_logic
+        # after running the other features:
+        # compare_config, discard / commit
+        # which have to be over the same session
         napalm_device['CLOSE'] = False
     _loaded = salt.utils.napalm.call(
         napalm_device,  # pylint: disable=undefined-variable
@@ -1220,6 +1238,13 @@ def load_template(template_name,
             if replace:  # replace requested
                 fun = 'load_replace_candidate'
             if salt.utils.napalm.not_always_alive(__opts__):
+                # if a not-always-alive proxy
+                # or regular minion
+                # do not close the connection after loading the config
+                # this will be handled in _config_logic
+                # after running the other features:
+                # compare_config, discard / commit
+                # which have to be over the same session
                 napalm_device['CLOSE'] = False
             _loaded = salt.utils.napalm.call(
                 napalm_device,  # pylint: disable=undefined-variable
@@ -1243,6 +1268,14 @@ def load_template(template_name,
             }
         )
         if salt.utils.napalm.not_always_alive(__opts__):
+            # if a not-always-alive proxy
+            # or regular minion
+            # do not close the connection after loading the config
+            # this will be handled in _config_logic
+            # after running the other features:
+            # compare_config, discard / commit
+            # which have to be over the same session
+            # so we'll set the CLOSE global explicitely as False
             napalm_device['CLOSE'] = False
         _loaded = salt.utils.napalm.call(
             napalm_device,  # pylint: disable=undefined-variable

--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -129,8 +129,9 @@ def alive(opts):
 
     .. versionadded:: Nitrogen
     '''
-    if not opts.get('proxy', {}).get('always_alive', True):
-        return True
+    if salt.utils.napalm.not_always_alive(opts):
+        return True  # don't force reconnection for not-always alive proxies
+        # or regular minion
     is_alive_ret = call('is_alive', **{})
     if not is_alive_ret.get('result', False):
         log.debug('[{proxyid}] Unable to execute `is_alive`: {comment}'.format(

--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -129,6 +129,8 @@ def alive(opts):
 
     .. versionadded:: Nitrogen
     '''
+    if not opts.get('proxy', {}).get('always_alive', True):
+        return True
     is_alive_ret = call('is_alive', **{})
     if not is_alive_ret.get('result', False):
         log.debug('[{proxyid}] Unable to execute `is_alive`: {comment}'.format(

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 
 import traceback
 import logging
+from functools import wraps
 log = logging.getLogger(__file__)
 
 import salt.utils
@@ -249,6 +250,7 @@ def proxy_napalm_wrap(func):
     :param func:
     :return:
     '''
+    @wraps(func)
     def func_wrapper(*args, **kwargs):
         wrapped_global_namespace = func.__globals__
         # get __opts__ and __proxy__ from func_globals


### PR DESCRIPTION
### What does this PR do?

As you may recall, the NAPALM modules have been migrated to be available in both proxies and regular minions: https://github.com/saltstack/salt/pull/38339

Although having the connection always alive it's a great benefit in terms of speed, there are a few challenges as many devices such as Cisco IOS do not provide any kind of capability to handle parallel requests over the same SSH session.
In addition, in some environments that are not very dynamic, having a connection always alive proved to not be beneficial.

With these changes, the behaviour of the proxies will be even closer to a regular minion: each command spawns another SSH session (or whatever is used to connect to the network device).

Ref: https://github.com/saltstack/salt/issues/39811

Challenge: on a network device, the configuration is stored in three different places:

- running config
- startup config (the configuration loaded when starting the device)
- candidate config: any configuration change is applied in this entity. This is then copied into running or startup config after executing a _commit_. If commit is not executed, the changes will be lost.

Every configuration change is glued to a SSH session. Both regular minions and not-always-alive proxies, as previously said, start a new connection per command. But to apply a configuration change, as per above, there are, at least, two commands required and it's mandatory to be over the same session. I have found the solution to pass the `inherit_napalm_device` through the `proxy_napalm_wrap` decorator, which passes the connection object between functions, without closing.

Now, the connection has to be closed at the end of this long process (load config -> compare config -> commit). I have introduced the `_explicit_close` helper inside the execution module (see https://github.com/saltstack/salt/pull/39896/commits/554734d79027f6cee60865d8f197b372a9d83c45) which explicitly closes the SSH session when done with the config changes (for any other type of command that does not touch the config, the connection is automatically closed).

While I made some extensive checks and it looked fine, this feels like a bit of hack to me.
With these said, I am waiting for more feedback. No rush on this, the target is to have these in Nitrogen.

Ping @cro @cachedout @jejenone. 

Please let me know if I wasn't able to explain the logic behind & if there's anything else I'd need to expand on.

Thank you!