### PR TITLE
Update cleanup function for azure

### DIFF
--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -1591,7 +1591,7 @@ def cleanup_unattached_disks(kwargs=None, conn=None, call=None):
     for disk in disks:
         if disks[disk]['attached_to'] is None:
             del_kwargs = {
-                'name': disks[disk]['name'][0],
+                'name': disks[disk]['name'],
                 'delete_vhd': kwargs.get('delete_vhd', False)
             }
             log.info('Deleting disk {name}, deleting VHD: {delete_vhd}'.format(**del_kwargs))


### PR DESCRIPTION
### What does this PR do?
It appears that while the `name` included a `list` in the past, it is now just a bare `str`. This causes the `delete_unattached_disks` function to fail (at least, on any disks with more than one character in their name).

### Tests written?
Not for this PR, but this bug is affecting the test suite.

This PR is for 2016.3 and needs to be merged forward.