### PR TITLE
Add new missing params to s3 fileclient

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -524,7 +524,9 @@ class Client(object):
                                        keyid=s3_opt('keyid'),
                                        service_url=s3_opt('service_url'),
                                        verify_ssl=s3_opt('verify_ssl', True),
-                                       location=s3_opt('location'))
+                                       location=s3_opt('location'),
+                                       path_style=s3_opt('path_style', False),
+                                       https_enable=s3_opt('https_enable', True))
                 return dest
             except Exception as exc:
                 raise MinionError(


### PR DESCRIPTION
### What does this PR do?
Add two new missing parameters to s3 fileclient (https_enable and path_style). They allow to use s3 compatible object storages with path style and http protocol.

### What issues does this PR fix or reference?
#39877 

### Previous Behavior
Files couldn't be fetched from s3 compatible object storage because new parameters (https_enable and path_style) hadn't been passed to s3 module.

### New Behavior
Files can be fetched from s3 compatible object storage.

### Tests written?

No
