### PR TITLE
Add slaves to bond master interface after it's set up

### DIFF
--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -419,7 +419,6 @@ def managed(name, type, enabled=True, **kwargs):
                         __salt__['ip.down'](name, type)
                         __salt__['ip.up'](name, type)
                         ret['changes']['status'] = 'Interface {0} restart to validate'.format(name)
-                        return ret
                 else:
                     __salt__['ip.up'](name, type)
                     ret['changes']['status'] = 'Interface {0} is up'.format(name)
@@ -431,6 +430,36 @@ def managed(name, type, enabled=True, **kwargs):
     except Exception as error:
         ret['result'] = False
         ret['comment'] = str(error)
+        return ret
+
+    # Try to enslave bonding interfaces after master was created
+    if type == 'bond' and 'noifupdown' not in kwargs:
+
+        if 'slaves' in kwargs and kwargs['slaves']:
+            # Check that there are new slaves for this master
+            present_slaves = __salt__['cmd.run'](
+                ['cat', '/sys/class/net/{0}/bonding/slaves'.format(name)]).split()
+            desired_slaves = kwargs['slaves'].split()
+            missing_slaves = set(desired_slaves) - set(present_slaves)
+
+            # Enslave only slaves missing in master
+            if missing_slaves:
+                ifenslave_path = __salt__['cmd.run'](['which', 'ifenslave']).strip()
+                if ifenslave_path:
+                    log.info("Adding slaves '{0}' to the master {1}".format(' '.join(missing_slaves), name))
+                    cmd = [ifenslave_path, name] + list(missing_slaves)
+                    __salt__['cmd.run'](cmd, python_shell=False)
+                else:
+                    log.error("Command 'ifenslave' not found")
+                ret['changes']['enslave'] = (
+                    "Added slaves '{0}' to master '{1}'"
+                    .format(' '.join(missing_slaves), name))
+            else:
+                log.info("All slaves '{0}' are already added to the master {1}"
+                         ", no actions required".format(' '.join(missing_slaves), name))
+
+    if enabled and interface_status:
+        # Interface was restarted, return
         return ret
 
     # TODO: create saltutil.refresh_grains that fires events to the minion daemon


### PR DESCRIPTION
Problem description:
--------------------

On Ubuntu, state 'network.managed' doesn't add slaves
to bonding master interface after it is UP

Example pillars:

linux_interface_bond0:
  network.managed:
  - enabled: True
  - name: bond0
  - type: bond
  - mode: active-backup
  - slaves: enp8s0f1
  - require:
    - network: linux_interface_enp8s0f1

linux_interface_enp8s0f1:
  network.managed:
  - enabled: True
  - name: enp8s0f1
  - type: slave
  - master: bond0

Example result:

$ ip link
3: enp8s0f1: <BROADCAST,MULTICAST> mtu 1500 qdisc mq state DOWN mode DEFAULT group default qlen 1000
    link/ether 0c:c4:7a:a8:d0:37 brd ff:ff:ff:ff:ff:ff
42: bond0: <NO-CARRIER,BROADCAST,MULTICAST,MASTER,UP> mtu 9000 qdisc noqueue master ovs-system state DOWN mode DEFAULT group default qlen 1000
    link/ether ee:ae:74:0d:17:29 brd ff:ff:ff:ff:ff:ff

$ cat /proc/net/bonding/bond0
...
Bonding Mode: fault-tolerance (active-backup)
Primary Slave: None
Currently Active Slave: None
...

Workarounds:
------------

For Ubuntu, it is suggested to restart 'networking' service
to make changes take effect.
Another common workaround is to reboot the machine.

These workarounds are not suitable in some cases, when only non-primary
interfaces are added to bonding interface, so the connectivity to
the salt minion is not broken during state execution.

Proposed solution:
------------------

Let's use 'ifenslave' tool to add slave interfaces to the bonding
interface right after the bonding interface is created/restarted.

### What does this PR do?
Extend 'network.managed' state for bond interfaces

### Previous Behavior
On Ubuntu, slaves were not added to bond master interface, but the state's report was "Ok".

### New Behavior
After bond interface was added / set up, add slave interfaces to it using 'ifenslave' tool.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
