### PR TITLE
add encoding support to file.manage and file.serialize (module and state)

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4567,6 +4567,8 @@ def manage_file(name,
                 follow_symlinks=True,
                 skip_verify=False,
                 keep_mode=False,
+                encoding=None,
+                encoding_errors='strict',
                 **kwargs):
     '''
     Checks the destination against what was retrieved with get_managed and
@@ -4632,6 +4634,21 @@ def manage_file(name,
         If ``True``, and the ``source`` is a file from the Salt fileserver (or
         a local file on the minion), the mode of the destination file will be
         set to the mode of the source file.
+
+    encoding : None
+        If None, str() will be applied to contents.
+        If not None, specified encoding will be used.
+        See https://docs.python.org/3/library/codecs.html#standard-encodings
+        for the list of available encodings.
+
+        .. versionadded:: Nitrogen
+
+    encoding_errors : 'strict'
+        Default is ```'strict'```.
+        See https://docs.python.org/2/library/codecs.html#codec-base-classes
+        for the error handling schemes.
+
+        .. versionadded:: Nitrogen
 
     CLI Example:
 
@@ -4751,7 +4768,11 @@ def manage_file(name,
             if salt.utils.is_windows():
                 contents = os.linesep.join(contents.splitlines())
             with salt.utils.fopen(tmp, 'w') as tmp_:
-                tmp_.write(str(contents))
+                if encoding:
+                    log.debug('File will be encoded with {0}'.format(encoding))
+                    tmp_.write(contents.encode(encoding=encoding, errors=encoding_errors))
+                else:
+                    tmp_.write(str(contents))
 
             # Compare contents of files to know if we need to replace
             with salt.utils.fopen(tmp, 'r') as src:
@@ -4955,7 +4976,12 @@ def manage_file(name,
             if salt.utils.is_windows():
                 contents = os.linesep.join(contents.splitlines())
             with salt.utils.fopen(tmp, 'w') as tmp_:
-                tmp_.write(str(contents))
+                if encoding:
+                    log.debug('File will be encoded with {0}'.format(encoding))
+                    tmp_.write(contents.encode(encoding=encoding, errors=encoding_errors))
+                else:
+                    tmp_.write(str(contents))
+
             # Copy into place
             salt.utils.files.copyfile(tmp,
                                 name,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1414,6 +1414,8 @@ def managed(name,
             contents_grains=None,
             contents_newline=True,
             contents_delimiter=':',
+            encoding=None,
+            encoding_errors='strict',
             allow_empty=True,
             follow_symlinks=True,
             check_cmd=None,
@@ -1774,6 +1776,22 @@ def managed(name,
         or ``contents_grains``. This delimiter will be passed through to
         :py:func:`pillar.get <salt.modules.pillar.get>` or :py:func:`grains.get
         <salt.modules.grains.get>` when retrieving the contents.
+
+    encoding
+        Encoding used for the file, e.g. ```UTF-8```, ```base64```.
+        Default is None, which means str() will be applied to contents to
+        ensure an ascii encoded file and backwards compatibility.
+        See https://docs.python.org/3/library/codecs.html#standard-encodings
+        for available encodings.
+
+        .. versionadded:: Nitrogen
+
+    encoding_errors : 'strict'
+        Error encoding scheme. Default is ```'strict'```.
+        See https://docs.python.org/2/library/codecs.html#codec-base-classes
+        for the list of available schemes.
+
+        .. versionadded:: Nitrogen
 
     allow_empty : True
         .. versionadded:: 2015.8.4
@@ -2243,6 +2261,8 @@ def managed(name,
                 win_perms=win_perms,
                 win_deny_perms=win_deny_perms,
                 win_inheritance=win_inheritance,
+                encoding=encoding,
+                encoding_errors=encoding_errors,
                 **kwargs)
         except Exception as exc:
             ret['changes'] = {}
@@ -2310,6 +2330,8 @@ def managed(name,
                 win_perms=win_perms,
                 win_deny_perms=win_deny_perms,
                 win_inheritance=win_inheritance,
+                encoding=encoding,
+                encoding_errors=encoding_errors,
                 **kwargs)
         except Exception as exc:
             ret['changes'] = {}
@@ -5347,6 +5369,8 @@ def serialize(name,
               show_changes=True,
               create=True,
               merge_if_exists=False,
+              encoding=None,
+              encoding_errors='strict',
               **kwargs):
     '''
     Serializes dataset and store it into managed file. Useful for sharing
@@ -5371,6 +5395,22 @@ def serialize(name,
     formatter
         Write the data as this format. See the list of :py:mod:`serializer
         modules <salt.serializers>` for supported output formats.
+
+    encoding
+        Encoding used for the file, e.g. ```UTF-8```, ```base64```.
+        Default is None, which means str() will be applied to contents to
+        ensure an ascii encoded file.
+        See https://docs.python.org/3/library/codecs.html#standard-encodings
+        for available encodings.
+
+        .. versionadded:: Nitrogen
+
+    encoding_errors : 'strict'
+        Error encoding scheme. Default is ```'strict'```.
+        See https://docs.python.org/2/library/codecs.html#codec-base-classes
+        for the list of available schemes.
+
+        .. versionadded:: Nitrogen
 
     user
         The user to own the directory, this defaults to the user salt is
@@ -5466,6 +5506,10 @@ def serialize(name,
                                        'separators': (',', ': '),
                                        'sort_keys': True}
                               }
+    if encoding:
+        default_serializer_opts['yaml.serialize'].update({'allow_unicode': True})
+        default_serializer_opts['json.serialize'].update({'ensure_ascii': False})
+
     ret = {'changes': {},
            'comment': '',
            'name': name,
@@ -5589,6 +5633,8 @@ def serialize(name,
                                         makedirs=makedirs,
                                         template=None,
                                         show_changes=show_changes,
+                                        encoding=encoding,
+                                        encoding_errors=encoding_errors,
                                         contents=contents)
 
 


### PR DESCRIPTION
### What does this PR do?

This PR allows file.serialize and file.managed states to create non-ascii encoded files if needed. It defines a new ```encoding``` option in the states and modules to enforce another encoding method for the created files.

### What issues does this PR fix or reference?

This fixes https://github.com/saltstack/salt/issues/26633

### Previous Behavior

Previously, Python Unicode objects are serialized as escaped strings by YAML (\x) and JSON (\u) libraries. Content was then written to file using str().

### New Behavior

if encoding is not None, Python Unicode objects will be serialized using specified encoding. Otherwise, str() will still be used for backwards compatibility.

### Tests written?

No