### PR TITLE
Fix relpath handling in file.recurse

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -368,7 +368,7 @@ def _is_valid_relpath(
     # Check relpath surrounded by slashes, so that `..` can be caught as
     # a path component at the start, end, and in the middle of the path.
     sep, pardir = posixpath.sep, posixpath.pardir
-    if (sep + pardir + sep) in (sep + relpath + sep):
+    if sep + pardir + sep in sep + relpath + sep:
         return False
 
     # Check that the relative path's depth does not exceed maxdepth

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -372,12 +372,8 @@ def _is_valid_relpath(
     # Check that the relative path's depth does not exceed maxdepth
     if maxdepth is not None:
         # Since paths are all master, just use POSIX separator
-        relpieces = relpath.split('/')
-        # Handle empty directories (include_empty==true) by removing the
-        # the last piece if it is an empty string
-        if not relpieces[-1]:
-            relpieces.pop()
-        if len(relpieces) > maxdepth + 1:
+        path_depth = relpath.strip('/').count('/')
+        if path_depth > maxdepth:
             return False
 
     return True


### PR DESCRIPTION
### What does this PR do?

From commit message:

> # Fix relpath handling in file.recurse
>
> * Ensure that the "maxdepth" checks are performed on all relative paths
>   encountered during the file.recurse call, including symlink and
>   directory paths.
> * Ensure that directory transversal does not occur.
> 
> No attempt is made to address the issue of master nodes sending more
> files/directories than requested via the cp.list_master family of
> functions.

### What issues does this PR fix or reference?

#39915 

### Previous Behavior

* Symlink handling:
  * No check for directory transversal (use of the `..` path component)
* File handling:
  * Directory transversal check skips directories whose names begin with `..`.
* Empty directory handling:
  * No check for directory transversal
  * No check for max depth being exceeded

### New Behavior

* All three of the above now check the same things:
  * Directory transversal (`..` path component) must not be present anywhere in the path
  * Path components containing `..` are allowed, as long as they are not exactly `..`
  * Max depth is always checked

### Tests written?

No

This fixes the issue with manual testing, but manual testing is not very comprehensive ;)