### PR TITLE
Add AIX support for user and group execution modules

### DIFF
--- a/doc/topics/releases/2016.11.4.rst
+++ b/doc/topics/releases/2016.11.4.rst
@@ -4,3 +4,10 @@ Salt 2016.11.4 Release Notes
 
 Version 2016.11.4 is a bugfix release for :ref:`2016.11.0 <release-2016-11-0>`.
 
+
+AIX Fixes
+=========
+
+Added module execution support for user and group
+
+

--- a/salt/modules/aix_group.py
+++ b/salt/modules/aix_group.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+'''
+Manage groups on Solaris
+
+.. important::
+    If you feel that Salt should be using this module to manage groups on a
+    minion, and it is using a different module (or gives an error similar to
+    *'group.info' is not available*), see :ref:`here
+    <module-provider-override>`.
+'''
+from __future__ import absolute_import
+
+# Import python libs
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
+try:
+    import grp
+except ImportError:
+    pass
+
+# Define the module's virtual name
+__virtualname__ = 'group'
+
+
+def __virtual__():
+    '''
+    Set the group module if the kernel is AIX
+    '''
+    if __grains__['kernel'] == 'AIX':
+        return __virtualname__
+    return (False, 'The aix_group execution module failed to load: '
+            'only available on AIX systems.')
+
+
+def add(name, gid=None, system=False, root=None):
+    '''
+    Add the specified group
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' group.add foo 3456
+    '''
+    cmd = 'mkgroup '
+    if system and root is not None:
+        cmd += '-a '
+
+    if gid:
+        cmd += 'id={0} '.format(gid)
+
+    cmd += name
+
+    ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+
+    return not ret['retcode']
+
+
+def delete(name):
+    '''
+    Remove the named group
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' group.delete foo
+    '''
+    ret = __salt__['cmd.run_all']('rmgroup {0}'.format(name), python_shell=False)
+
+    return not ret['retcode']
+
+
+def info(name):
+    '''
+    Return information about a group
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' group.info foo
+    '''
+    try:
+        grinfo = grp.getgrnam(name)
+    except KeyError:
+        return {}
+    else:
+        return {'name': grinfo.gr_name,
+                'passwd': grinfo.gr_passwd,
+                'gid': grinfo.gr_gid,
+                'members': grinfo.gr_mem}
+
+
+def getent(refresh=False):
+    '''
+    Return info on all groups
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' group.getent
+    '''
+    if 'group.getent' in __context__ and not refresh:
+        return __context__['group.getent']
+
+    ret = []
+    for grinfo in grp.getgrall():
+        ret.append(info(grinfo.gr_name))
+
+    __context__['group.getent'] = ret
+    return ret
+
+
+def chgid(name, gid):
+    '''
+    Change the gid for a named group
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' group.chgid foo 4376
+    '''
+    pre_gid = __salt__['file.group_to_gid'](name)
+    if gid == pre_gid:
+        return True
+    cmd = 'chgroup id={0} {1}'.format(gid, name)
+    __salt__['cmd.run'](cmd, python_shell=False)
+    post_gid = __salt__['file.group_to_gid'](name)
+    if post_gid != pre_gid:
+        return post_gid == gid
+    return False
+
+
+def adduser(name, username, root=None):
+    '''
+    Add a user in the group.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+         salt '*' group.adduser foo bar
+
+    Verifies if a valid username 'bar' as a member of an existing group 'foo',
+    if not then adds it.
+    '''
+    cmd = 'chgrpmem -m + {0} {1}'.format(username, name)
+
+    retcode = __salt__['cmd.retcode'](cmd, python_shell=False)
+
+    return not retcode
+
+
+def deluser(name, username, root=None):
+    '''
+    Remove a user from the group.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+         salt '*' group.deluser foo bar
+
+    Removes a member user 'bar' from a group 'foo'. If group is not present
+    then returns True.
+    '''
+    grp_info = __salt__['group.info'](name)
+    try:
+        if username in grp_info['members']:
+            cmd = 'chgrpmem -m - {0} {1}'.format(username, name)
+            ret = __salt__['cmd.run'](cmd, python_shell=False)
+            return not ret['retcode']
+        else:
+            return True
+    except Exception:
+        return True
+
+
+def members(name, members_list, root=None):
+    '''
+    Replaces members of the group with a provided list.
+
+    CLI Example:
+
+        salt '*' group.members foo 'user1,user2,user3,...'
+
+    Replaces a membership list for a local group 'foo'.
+        foo:x:1234:user1,user2,user3,...
+    '''
+    cmd = 'chgrpmem -m = {0} {1}'.format(members_list, name)
+    retcode = __salt__['cmd.retcode'](cmd, python_shell=False)
+
+    return not retcode

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -33,12 +33,12 @@ __virtualname__ = 'user'
 
 def __virtual__():
     '''
-    Set the user module if the kernel is Linux, OpenBSD or NetBSD
+    Set the user module if the kernel is Linux, OpenBSD, NetBSD or AIX
     '''
 
-    if HAS_PWD and __grains__['kernel'] in ('Linux', 'OpenBSD', 'NetBSD'):
+    if HAS_PWD and __grains__['kernel'] in ('Linux', 'OpenBSD', 'NetBSD', 'AIX'):
         return __virtualname__
-    return (False, 'useradd execution module not loaded: either pwd python library not available or system not one of Linux, OpenBSD or NetBSD')
+    return (False, 'useradd execution module not loaded: either pwd python library not available or system not one of Linux, OpenBSD, NetBSD or AIX')
 
 
 def _quote_username(name):
@@ -94,7 +94,7 @@ def _update_gecos(name, key, value, root=None):
 
     cmd = ['usermod', '-c', _build_gecos(gecos_data), name]
 
-    if root is not None:
+    if root is not None and __grains__['kernel'] != 'AIX':
         cmd.extend(('-R', root))
 
     __salt__['cmd.run'](cmd, python_shell=False)
@@ -181,7 +181,7 @@ def add(name,
     if home is not None:
         cmd.extend(['-d', home])
 
-    if not unique:
+    if not unique and __grains__['kernel'] != 'AIX':
         cmd.append('-o')
 
     if (system
@@ -195,7 +195,7 @@ def add(name,
 
     cmd.append(name)
 
-    if root is not None:
+    if root is not None and __grains__['kernel'] != 'AIX':
         cmd.extend(('-R', root))
 
     ret = __salt__['cmd.run_all'](cmd, python_shell=False)
@@ -244,7 +244,7 @@ def delete(name, remove=False, force=False, root=None):
 
     cmd.append(name)
 
-    if root is not None:
+    if root is not None and __grains__['kernel'] != 'AIX':
         cmd.extend(('-R', root))
 
     ret = __salt__['cmd.run_all'](cmd, python_shell=False)
@@ -324,7 +324,7 @@ def chgid(name, gid, root=None):
         return True
     cmd = ['usermod', '-g', '{0}'.format(gid), name]
 
-    if root is not None:
+    if root is not None and __grains__['kernel'] != 'AIX':
         cmd.extend(('-R', root))
 
     __salt__['cmd.run'](cmd, python_shell=False)
@@ -346,7 +346,7 @@ def chshell(name, shell, root=None):
         return True
     cmd = ['usermod', '-s', shell, name]
 
-    if root is not None:
+    if root is not None and __grains__['kernel'] != 'AIX':
         cmd.extend(('-R', root))
 
     __salt__['cmd.run'](cmd, python_shell=False)
@@ -369,7 +369,7 @@ def chhome(name, home, persist=False, root=None):
         return True
     cmd = ['usermod', '-d', '{0}'.format(home)]
 
-    if root is not None:
+    if root is not None and __grains__['kernel'] != 'AIX':
         cmd.extend(('-R', root))
 
     if persist and __grains__['kernel'] != 'OpenBSD':
@@ -420,7 +420,7 @@ def chgroups(name, groups, append=False, root=None):
         cmd.append('-G')
     cmd.extend([','.join(groups), name])
 
-    if root is not None:
+    if root is not None and __grains__['kernel'] != 'AIX':
         cmd.extend(('-R', root))
 
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
@@ -652,7 +652,7 @@ def rename(name, new_name, root=None):
 
     cmd = ['usermod', '-l', '{0}'.format(new_name), '{0}'.format(name)]
 
-    if root is not None:
+    if root is not None and __grains__['kernel'] != 'AIX':
         cmd.extend(('-R', root))
 
     __salt__['cmd.run'](cmd, python_shell=False)


### PR DESCRIPTION
### What does this PR do?
Adds support on AIX for Salt execution module useradd and groupadd functionality

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/35953

### Previous Behavior
user and group commands were not supported

### New Behavior
support for user and group with execution modules on AIX

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
