### PR TITLE
Use file for non aix systems to check filesystem

### DIFF
--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -481,7 +481,7 @@ def fstype(device):
                 fs_type = df_out[2]
                 if fs_type:
                     return fs_type
-                
+
     if salt.utils.which('file'):
         file_out = __salt__['cmd.run']('file -s {0}'.format(device)).split()
         if len(file_out) > 4:

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -481,12 +481,13 @@ def fstype(device):
                 fs_type = df_out[2]
                 if fs_type:
                     return fs_type
-        else:
-            df_out = __salt__['cmd.run']('df -T {0}'.format(device)).splitlines()
-            if len(df_out) > 1:
-                fs_type = df_out[1]
-                if fs_type:
-                    return fs_type
+                
+    if salt.utils.which('file'):
+        file_out = __salt__['cmd.run']('file -s {0}'.format(device)).split()
+        if len(file_out) > 4:
+            fs_type = file_out[4]
+            if fs_type:
+                return fs_type
 
     return ''
 


### PR DESCRIPTION
This change might be better applied across AIX systems as well, but I don't have one to test so I don't want to change that path until I can be sure.

### What does this PR do?
Fix a bug on disk.fstype detection for unmounted file systems

### What issues does this PR fix or reference?
If a file system isn't mounted df doesn't report on it so the current logic doesn't return the fstype

### Previous Behavior
Would report that the device wasn't formatted

### New Behavior
Now it will properly report that it has been formatted

### Tests written?
No
