### PR TITLE
Fixed rawfile_json returner output format.

### DIFF
--- a/salt/returners/rawfile_json.py
+++ b/salt/returners/rawfile_json.py
@@ -58,7 +58,7 @@ def returner(ret):
     opts = _get_options({})  # Pass in empty ret, since this is a list of events
     try:
         with salt.utils.flopen(opts['filename'], 'a') as logfile:
-            logfile.write(str(ret)+'\n')
+            logfile.write(json.dumps(ret)+'\n')
     except:
         log.error('Could not write to rawdata_json file {0}'.format(opts['filename']))
         raise


### PR DESCRIPTION
### What does this PR do?
The rawfile_json returner fixed to output standard json instead of python object format.

### Previous Behavior
The rawfile_json returner outputs python object format.

### New Behavior
The rawfile_json returner outputs standard json format.

### Tests written?
No