### PR TITLE
Correct comment lines output from execution module's host.list_hosts

### DIFF
--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -53,7 +53,7 @@ def _list_hosts():
             if not line:
                 continue
             if line.startswith('#'):
-                ret.setdefault('comment-{0}'.format(count), []).extend(line)
+                ret.setdefault('comment-{0}'.format(count), []).append(line)
                 count += 1
                 continue
             if '#' in line:


### PR DESCRIPTION
### What does this PR do?
Corrects the output of comments lines using execution module host.list_hosts

### What issues does this PR fix or reference?
None

### Previous Behavior
The comment line was output as a list of single characters rather than a string
    comment-0:
        - #
        -  
        - t
        - h
        - i
        - s
        .
        .

### New Behavior
The comment line is now output as a string, for example:
    comment-0:
        - # this is comment line 1

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
