### PR TITLE
Add special token to insert the minion id into the default_include path

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -2110,6 +2110,17 @@ file.
     files are prefixed with an underscore. A common example of this is the
     ``_schedule.conf`` file.
 
+.. note::
+
+    The configuration system supports adding the special token ``{id}`` to this
+    option.  At startup ``{id}`` will be replaced by the minion's ID, and the
+    default_include directory will be set here.  For example, if the minion's
+    ID is 'webserver' and ``default_include`` is set to ``minion.d/{id}/*.conf``
+    then the default_include directive will be set to ``minion.d/webserver/*.conf``.
+    This is for situations when there are multiple minions or proxy minions
+    running on a single machine that need different configurations, specifically for
+    their schedulers.
+
 
 ``include``
 -----------

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1930,6 +1930,7 @@ def minion_config(path,
     overrides = load_config(path, env_var, DEFAULT_MINION_OPTS['conf_file'])
     default_include = overrides.get('default_include',
                                     defaults['default_include'])
+
     include = overrides.get('include', [])
 
     overrides.update(include_config(default_include, path, verbose=False,
@@ -3161,6 +3162,9 @@ def apply_minion_config(overrides=None,
         if directory in ['pki_dir', 'cachedir', 'extension_modules']:
             newdirectory = os.path.join(opts[directory], opts['id'])
             opts[directory] = newdirectory
+
+    if 'default_include' in overrides and '{id}' in overrides['default_include']:
+        opts['default_include'] = overrides['default_include'].replace('{id}', opts['id'])
 
     # pidfile can be in the list of append_minionid_config_dirs, but pidfile
     # is the actual path with the filename, not a directory.

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -443,9 +443,6 @@ class Schedule(object):
             config_dir,
             os.path.dirname(self.opts.get('default_include',
                                           salt.config.DEFAULT_MINION_OPTS['default_include'])))
-        if salt.utils.is_proxy():
-            # each proxy will have a separate _schedule.conf file
-            minion_d_dir = os.path.join(minion_d_dir, self.opts['proxyid'])
 
         if not os.path.isdir(minion_d_dir):
             os.makedirs(minion_d_dir)


### PR DESCRIPTION
### What does this PR do?

Adds support for including the special token `{id}` into the default_include configuration directive.  `{id}` will be replaced by the minion or proxy minion ID at startup.  This facilitates running multiple minions or proxies on a single machine when they need different configurations, especially different scheduled functions.

### What issues does this PR fix or reference?

#39775

### Previous Behavior

All proxies on a single machine had to share the exact same configuration unless `-c` was used.
