### PR TITLE
minionswarm.py: allow random UUID

### DIFF
--- a/tests/minionswarm.py
+++ b/tests/minionswarm.py
@@ -19,6 +19,7 @@ import tempfile
 import shutil
 import sys
 import hashlib
+import uuid
 
 # Import salt libs
 import salt
@@ -96,6 +97,12 @@ def parse():
         default=False,
         action='store_true',
         help='Each Minion claims a different machine id grain')
+    parser.add_option(
+        '--rand-uuid',
+        dest='rand_uuid',
+        default=False,
+        action='store_true',
+        help='Each Minion claims a different UUID grain')
     parser.add_option(
         '-k',
         '--keep-modules',
@@ -347,6 +354,8 @@ class MinionSwarm(Swarm):
             data['grains']['saltversion'] = random.choice(VERS)
         if self.opts['rand_machine_id']:
             data['grains']['machine_id'] = hashlib.md5(minion_id).hexdigest()
+        if self.opts['rand_uuid']:
+            data['grains']['uuid'] = str(uuid.uuid4())
 
         with open(path, 'w+') as fp_:
             yaml.dump(data, fp_)


### PR DESCRIPTION
### What does this PR do?
It adds a `--rand-uuid` option to `minionswarm.py` that sets a pseudorandom UUID to minions.

This helped us testing SUSE Manager, which keeps track of this value assuming it is always different for different minions.

### What issues does this PR fix or reference?
None, it is a small new feature.

### Previous Behavior
The `uuid` grain was taken from the minion swarm host.

### New Behavior
The `uuid` grain is taken from the minion swarm host (by default) or specified by the user (with the newly added `--rand-uuid` option.

### Tests written?

No, changes are in test code itself.