### PR TITLE
Fix race condition on cache directory creation

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -153,7 +153,7 @@ class Client(object):
         try:
             os.makedirs(destdir)
         except OSError as exc:
-            if exc.errno != errno.EEXIST: # ignore if it was there already
+            if exc.errno != errno.EEXIST:  # ignore if it was there already
                 raise
 
         yield dest


### PR DESCRIPTION
### What does this PR do?

`fileclient.py`: a race condition will result in a stack trace.

Details: in general `os.makedirs()` will raise `OSError` in case the directory passed as argument
already exists. What we do in `_cache_loc` is to check for directory existence a few instructions before the
call, which leaves a tiny time window in which the directory might
be concurrently created between the `isdir()` check and the `makedirs()` call, which can result in the race condition.

In some unlucky cases under heavy I/O the following stack trace is produced:

The minion function caused an exception: Traceback (most recent call last):
...
  File "/usr/lib/python2.7/site-packages/salt/fileclient.py", line 165, in cache_file
    return self.get_url(path, '', True, saltenv, cachedir=cachedir)
...
  File "/usr/lib/python2.7/site-packages/salt/fileclient.py", line 126, in _cache_loc
    os.makedirs(destdir)
  File "/usr/lib64/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 17] File exists: <PATH>

I can reliably reproduce this with `minionswarm.py` in an AWS install.

This PR contains a fix for that problem.

### What issues does this PR fix or reference?

The issue described above, I can open one if needed.

### Previous Behavior

Stack trace above.

### New Behavior

No stack trace.

### Tests written?

No.
