### PR TITLE
Don't use docker.Client instance from context if missing attributes

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -775,7 +775,8 @@ def _get_client(timeout=None):
         - docker.url: URL to the docker service
         - docker.version: API version to use (default: "auto")
     '''
-    if 'docker.client' not in __context__:
+    if 'docker.client' not in __context__ \
+            or not hasattr(__context__['docker.client'], 'timeout'):
         client_kwargs = {}
         for key, val in (('base_url', 'docker.url'),
                          ('version', 'docker.version')):


### PR DESCRIPTION
Under some circumstances (which I can't reliably reproduce), the
docker.Client() instance does not have a timeout attribute, causing
anything that needs to use the docker client to result in a traceback.

This fixes this corner case (later branches initialize the timeout
differently).