### PR TITLE
INFRA-4506 - various fixes as detailed below

### DIFF
--- a/salt/states/boto_asg.py
+++ b/salt/states/boto_asg.py
@@ -201,7 +201,6 @@ import copy
 # Import Salt libs
 import salt.utils.dictupdate as dictupdate
 import salt.ext.six as six
-from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
 from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)

--- a/salt/states/boto_s3_bucket.py
+++ b/salt/states/boto_s3_bucket.py
@@ -144,8 +144,8 @@ import logging
 from copy import deepcopy
 import json
 
-# Import Salt Libs
-from salt.ext.six import string_types  # pylint: disable=import-error
+# Import Salt libs
+from salt.ext import six
 
 log = logging.getLogger(__name__)
 
@@ -318,20 +318,7 @@ def _compare_acl(current, desired, region, key, keyid, profile):
 
 
 def _compare_policy(current, desired, region, key, keyid, profile):
-    '''
-    Policy description is always returned as a JSON string. Comparison
-    should be object-to-object, since order is not significant in JSON
-    '''
-    if isinstance(desired, string_types):
-        desired = json.loads(desired)
-
-    if current is not None:
-        temp = current.get('Policy')
-        if isinstance(temp, string_types):
-            current = {'Policy': json.loads(temp)}
-        else:
-            current = None
-    return __utils__['boto3.json_objs_equal'](current, desired)
+    return current == desired
 
 
 def _compare_replication(current, desired, region, key, keyid, profile):
@@ -434,6 +421,10 @@ def present(name, Bucket,
         NotificationConfiguration = {}
     if RequestPayment is None:
         RequestPayment = {'Payer': 'BucketOwner'}
+    if Policy:
+        if isinstance(Policy, six.string_types):
+            Policy = json.loads(Policy)
+        Policy = __utils__['boto3.ordered'](Policy)
 
     r = __salt__['boto_s3_bucket.exists'](Bucket=Bucket,
            region=region, key=key, keyid=keyid, profile=profile)
@@ -552,14 +543,17 @@ def present(name, Bucket,
         config_items.append(replication_item)
         config_items.append(versioning_item)
 
+    update = False
     for varname, setter, current, comparator, desired, deleter in config_items:
+        if varname == 'Policy':
+            if current is not None:
+                temp = current.get('Policy')
+                # Policy description is always returned as a JSON string.
+                # Convert it to JSON now for ease of comparisons later.
+                if isinstance(temp, six.string_types):
+                    current = __utils__['boto3.ordered']({'Policy': json.loads(temp)})
         if not comparator(current, desired, region, key, keyid, profile):
-            # current state and desired state differ
-            if __opts__['test']:
-                msg = 'S3 bucket {0} set to be modified.'.format(Bucket)
-                ret['comment'] = msg
-                ret['result'] = None
-                return ret
+            update = True
             if varname == 'ACL':
                 ret['changes'].setdefault('new', {})[varname] = _acl_to_grant(
                         desired, _get_canonical_id(region, key, keyid, profile))
@@ -567,24 +561,30 @@ def present(name, Bucket,
                 ret['changes'].setdefault('new', {})[varname] = desired
             ret['changes'].setdefault('old', {})[varname] = current
 
-            if deleter and desired is None:
-                # Setting can be deleted, so use that to unset it
-                r = __salt__['boto_s3_bucket.{0}'.format(deleter)](Bucket=Bucket,
-                   region=region, key=key, keyid=keyid, profile=profile)
-                if not r.get('deleted'):
-                    ret['result'] = False
-                    ret['comment'] = 'Failed to update bucket: {0}.'.format(r['error']['message'])
-                    ret['changes'] = {}
-                    return ret
-            else:
-                r = __salt__['boto_s3_bucket.{0}'.format(setter)](Bucket=Bucket,
-                   region=region, key=key, keyid=keyid, profile=profile,
-                   **(desired or {}))
-                if not r.get('updated'):
-                    ret['result'] = False
-                    ret['comment'] = 'Failed to update bucket: {0}.'.format(r['error']['message'])
-                    ret['changes'] = {}
-                    return ret
+            if not __opts__['test']:
+                if deleter and desired is None:
+                    # Setting can be deleted, so use that to unset it
+                    r = __salt__['boto_s3_bucket.{0}'.format(deleter)](Bucket=Bucket,
+                      region=region, key=key, keyid=keyid, profile=profile)
+                    if not r.get('deleted'):
+                        ret['result'] = False
+                        ret['comment'] = 'Failed to update bucket: {0}.'.format(r['error']['message'])
+                        ret['changes'] = {}
+                        return ret
+                else:
+                    r = __salt__['boto_s3_bucket.{0}'.format(setter)](Bucket=Bucket,
+                      region=region, key=key, keyid=keyid, profile=profile,
+                      **(desired or {}))
+                    if not r.get('updated'):
+                        ret['result'] = False
+                        ret['comment'] = 'Failed to update bucket: {0}.'.format(r['error']['message'])
+                        ret['changes'] = {}
+                        return ret
+    if update and __opts__['test']:
+        msg = 'S3 bucket {0} set to be modified.'.format(Bucket)
+        ret['comment'] = msg
+        ret['result'] = None
+        return ret
 
     # Since location can't be changed, try that last so at least the rest of
     # the things are correct by the time we fail here. Fail so the user will

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -338,11 +338,11 @@ def get_role_arn(name, region=None, key=None, keyid=None, profile=None):
     return 'arn:aws:iam::{0}:role/{1}'.format(account_id, name)
 
 
-def _ordered(obj):
+def ordered(obj):
     if isinstance(obj, (list, tuple)):
-        return sorted(_ordered(x) for x in obj)
+        return sorted(ordered(x) for x in obj)
     elif isinstance(obj, dict):
-        return dict((six.text_type(k) if isinstance(k, six.string_types) else k, _ordered(v)) for k, v in obj.items())
+        return dict((six.text_type(k) if isinstance(k, six.string_types) else k, ordered(v)) for k, v in obj.items())
     elif isinstance(obj, six.string_types):
         return six.text_type(obj)
     return obj
@@ -351,4 +351,4 @@ def _ordered(obj):
 def json_objs_equal(left, right):
     """ Compare two parsed JSON objects, given non-ordering in JSON objects
     """
-    return _ordered(left) == _ordered(right)
+    return ordered(left) == ordered(right)


### PR DESCRIPTION
- utils/boto3.py:
  - \_ordered() -> ordered() because this function is generally useful
- modules/boto_asg.py:
  - update() was not deleting tags NOT in the requested list, leading to non-idempotent runs
- states/boto_asg.py:
  - update test=True code to provide details of proposed changes when an update is indicated
  - replace \_recursive_compare() with \_\_utils__['boto3.json_objs_equal'] and / or \_\_utils__['boto3.ordered']
- states/boto_s3_bucket.py:
  - \_compare_policy() was not reliable, leading to unneeded policy updates, fix so updates can be idempotent
  - update test=True code to provide details of proposed changes when an update is indicated