### PR TITLE
Cache the napalm object and fetched grains separately

### DIFF
--- a/salt/grains/napalm.py
+++ b/salt/grains/napalm.py
@@ -321,7 +321,7 @@ def host(proxy=None):
     provides the physical hostname of the network device,
     as it would be on an ordinary minion server.
     When running in a proxy minion, ``host`` points to the
-    value configured in the pillar: :mod:`NAPALM proxy module <salt.proxies.napalm>`.
+    value configured in the pillar: :mod:`NAPALM proxy module <salt.proxy.napalm>`.
 
     .. note::
 

--- a/salt/grains/napalm.py
+++ b/salt/grains/napalm.py
@@ -90,7 +90,7 @@ def _retrieve_device_cache(proxy=None):
                 DEVICE_CACHE = proxy['napalm.get_device']()
         elif not proxy and salt.utils.napalm.is_minion(__opts__):
             # if proxy var not passed and is running in a straight minion
-            DEVICE_CACHE = salt.utils.napalm.get_device(__opts__)
+            DEVICE_CACHE = salt.utils.napalm.get_device_opts(__opts__)
     return DEVICE_CACHE
 
 

--- a/salt/grains/napalm.py
+++ b/salt/grains/napalm.py
@@ -222,7 +222,7 @@ def uptime(proxy=None):
 
     CLI Example - select all devices started/restarted within the last hour:
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt -G 'uptime<3600' test.ping
     '''

--- a/salt/grains/napalm.py
+++ b/salt/grains/napalm.py
@@ -59,55 +59,63 @@ def __virtual__():
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-def _retrieve_grains(proxy=None):
+def _retrieve_grains_cache(proxy=None):
     '''
     Retrieves the grains from the network device if not cached already.
     '''
-
     global GRAINS_CACHE
-    global DEVICE_CACHE
-
     if not GRAINS_CACHE:
         if proxy and salt.utils.napalm.is_proxy(__opts__):
             # if proxy var passed and is NAPALM-type proxy minion
             GRAINS_CACHE = proxy['napalm.get_grains']()
-            if 'napalm.get_device' in proxy:
-                DEVICE_CACHE = proxy['napalm.get_device']()
         elif not proxy and salt.utils.napalm.is_minion(__opts__):
             # if proxy var not passed and is running in a straight minion
-            DEVICE_CACHE = salt.utils.napalm.get_device(__opts__)
             GRAINS_CACHE = salt.utils.napalm.call(
                 DEVICE_CACHE,
                 'get_facts',
                 **{}
             )
-
     return GRAINS_CACHE
+
+
+def _retrieve_device_cache(proxy=None):
+    '''
+    Loads the network device details if not cached already.
+    '''
+    global DEVICE_CACHE
+    if not DEVICE_CACHE:
+        if proxy and salt.utils.napalm.is_proxy(__opts__):
+            # if proxy var passed and is NAPALM-type proxy minion
+            if 'napalm.get_device' in proxy:
+                DEVICE_CACHE = proxy['napalm.get_device']()
+        elif not proxy and salt.utils.napalm.is_minion(__opts__):
+            # if proxy var not passed and is running in a straight minion
+            DEVICE_CACHE = salt.utils.napalm.get_device(__opts__)
+    return DEVICE_CACHE
 
 
 def _get_grain(name, proxy=None):
     '''
     Retrieves the grain value from the cached dictionary.
     '''
-    grains = _retrieve_grains(proxy=proxy)
+    grains = _retrieve_grains_cache(proxy=proxy)
     if grains.get('result', False) and grains.get('out', {}):
         return grains.get('out').get(name)
 
 
-def _get_device_grain(name):
+def _get_device_grain(name, proxy=None):
     '''
     Retrieves device-specific grains.
     '''
-    if not DEVICE_CACHE:
-        return
-    return DEVICE_CACHE.get(name.upper())
+    device = _retrieve_device_cache(proxy=proxy)
+    return device.get(name.upper())
 
 # ----------------------------------------------------------------------------------------------------------------------
 # actual grains
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-def getos():
+def getos(proxy=None):
     '''
     Returns the Operating System name running on the network device.
 
@@ -119,7 +127,7 @@ def getos():
 
         salt -G 'os:junos' test.ping
     '''
-    return {'os': _get_device_grain('driver_name')}
+    return {'os': _get_device_grain('driver_name', proxy=proxy)}
 
 
 def version(proxy=None):
@@ -277,7 +285,7 @@ def username(proxy=None):
     if proxy and salt.utils.napalm.is_proxy(__opts__):
         # only if proxy will override the username
         # otherwise will use the default Salt grains
-        return {'username': _get_device_grain('username')}
+        return {'username': _get_device_grain('username', proxy=proxy)}
 
 
 def hostname(proxy=None):
@@ -344,10 +352,10 @@ def host(proxy=None):
     if proxy and salt.utils.napalm.is_proxy(__opts__):
         # this grain is set only when running in a proxy minion
         # otherwise will use the default Salt grains
-        return {'host': _get_device_grain('hostname')}
+        return {'host': _get_device_grain('hostname', proxy=proxy)}
 
 
-def optional_args():
+def optional_args(proxy=None):
     '''
     Return the connection optional args.
 
@@ -372,7 +380,7 @@ def optional_args():
         device2:
             True
     '''
-    opt_args = _get_device_grain('optional_args')
+    opt_args = _get_device_grain('optional_args', proxy=proxy)
     if _FORBIDDEN_OPT_ARGS:
         for arg in _FORBIDDEN_OPT_ARGS:
             opt_args.pop(arg, None)

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -160,13 +160,12 @@ def call(napalm_device, method, *args, **kwargs):
     }
 
 
-def get_device(opts, salt_obj=None):
+def get_device_opts(opts, salt_obj=None):
     '''
-    Initialise the connection with the network device through NAPALM.
-    :param: opts
-    :return: the network device object
+    Returns the options of the napalm device.
+    :pram: opts
+    :return: the network device opts
     '''
-    log.debug('Setting up NAPALM connection')
     network_device = {}
     # by default, look in the proxy config details
     device_dict = opts.get('proxy', {}) or opts.get('napalm', {})
@@ -185,8 +184,19 @@ def get_device(opts, salt_obj=None):
     network_device['OPTIONAL_ARGS'] = device_dict.get('optional_args', {})
     network_device['UP'] = False
     # get driver object form NAPALM
-    if 'config_lock' not in list(network_device['OPTIONAL_ARGS'].keys()):
+    if 'config_lock' not in network_device['OPTIONAL_ARGS']:
         network_device['OPTIONAL_ARGS']['config_lock'] = False
+    return network_device
+
+
+def get_device(opts, salt_obj=None):
+    '''
+    Initialise the connection with the network device through NAPALM.
+    :param: opts
+    :return: the network device object
+    '''
+    log.debug('Setting up NAPALM connection')
+    network_device = get_device_opts(opts, salt_obj=salt_obj)
     _driver_ = napalm_base.get_network_driver(network_device.get('DRIVER_NAME'))
     try:
         network_device['DRIVER'] = _driver_(


### PR DESCRIPTION
### What issues does this PR fix or reference?

Closes #39983

### Previous Behavior

It cached grains object and device details at the firs call. It worked fine when the function providing the `os` grain was called `os`. But the function name has been changes pretty recently to `getos` which is actually the first function loaded under this module. Therefore the napalm object was not available up to that point, hence the `os` and `host` grains disappeared.

### New Behavior

Separate cache fetch of the network devices and of the grains retrieved from the NAPALM's `get_facts`, without extra load.
