### PR TITLE
Use linux_distribution from distro if not in platform

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -28,10 +28,16 @@ __proxyenabled__ = ['*']
 __FQDN__ = None
 
 # Extend the default list of supported distros. This will be used for the
-# /etc/DISTRO-release checking that is part of platform.linux_distribution()
+# /etc/DISTRO-release checking that is part of linux_distribution()
 from platform import _supported_dists
 _supported_dists += ('arch', 'mageia', 'meego', 'vmware', 'bluewhite64',
                      'slamd64', 'ovs', 'system', 'mint', 'oracle', 'void')
+
+# linux_distribution deprecated in py3.7
+try:
+    from platform import linux_distribution
+except ImportError:
+    from distro import linux_distribution
 
 # Import salt libs
 import salt.log
@@ -1496,12 +1502,12 @@ def os_data():
         # (though apparently it's not intelligent enough to strip quotes)
         (osname, osrelease, oscodename) = \
             [x.strip('"').strip("'") for x in
-             platform.linux_distribution(supported_dists=_supported_dists)]
+             linux_distribution(supported_dists=_supported_dists)]
         # Try to assign these three names based on the lsb info, they tend to
         # be more accurate than what python gets from /etc/DISTRO-release.
         # It's worth noting that Ubuntu has patched their Python distribution
-        # so that platform.linux_distribution() does the /etc/lsb-release
-        # parsing, but we do it anyway here for the sake for full portability.
+        # so that linux_distribution() does the /etc/lsb-release parsing, but
+        # we do it anyway here for the sake for full portability.
         if 'osfullname' not in grains:
             grains['osfullname'] = \
                 grains.get('lsb_distrib_id', osname).strip()

--- a/salt/version.py
+++ b/salt/version.py
@@ -9,6 +9,12 @@ import re
 import sys
 import platform
 
+# linux_distribution depreacted in py3.7
+try:
+    from platform import linux_distribution
+except ImportError:
+    from distro import linux_distribution
+
 # pylint: disable=invalid-name,redefined-builtin
 # Import 3rd-party libs
 from salt.ext import six
@@ -625,7 +631,7 @@ def system_information():
         '''
         Return host system version.
         '''
-        lin_ver = platform.linux_distribution()
+        lin_ver = linux_distribution()
         mac_ver = platform.mac_ver()
         win_ver = platform.win32_ver()
 
@@ -660,7 +666,7 @@ def system_information():
 
     system = [
         ('system', platform.system()),
-        ('dist', ' '.join(platform.dist())),
+        ('dist', ' '.join(linux_distribution(full_distribution_name=False))),
         ('release', release),
         ('machine', platform.machine()),
         ('version', version),

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -79,13 +79,13 @@ class CoreGrainsTestCase(TestCase):
                                side_effect=_import_mock):
                         # Skip all the /etc/*-release stuff (not pertinent)
                         with patch.object(os.path, 'isfile', path_isfile_mock):
-                            # Mock platform.linux_distribution to give us the
-                            # OS name that we want.
+                            # Mock linux_distribution to give us the OS name
+                            # that we want.
                             distro_mock = MagicMock(
                                 return_value=('Debian GNU/Linux', '8.3', '')
                             )
                             with patch.object(
-                                    platform,
+                                    core,
                                     'linux_distribution',
                                     distro_mock):
                                 # Make a bunch of functions return empty dicts,
@@ -177,12 +177,12 @@ class CoreGrainsTestCase(TestCase):
                         # Skip all the /etc/*-release stuff (not pertinent)
                         with patch.object(os.path, 'isfile', path_isfile_mock):
                             with patch.object(core, '_parse_os_release', os_release_mock):
-                                # Mock platform.linux_distribution to give us the
-                                # OS name that we want.
+                                # Mock linux_distribution to give us the OS
+                                # name that we want.
                                 distro_mock = MagicMock(
                                     return_value=('SUSE Linux Enterprise Server ', '12', 'x86_64')
                                 )
-                                with patch.object(platform, 'linux_distribution', distro_mock):
+                                with patch.object(core, 'linux_distribution', distro_mock):
                                     with patch.object(core, '_linux_gpu_data', empty_mock):
                                         with patch.object(core, '_linux_cpudata', empty_mock):
                                             with patch.object(core, '_virtual', empty_mock):
@@ -224,14 +224,14 @@ class CoreGrainsTestCase(TestCase):
                         # Skip all the /etc/*-release stuff (not pertinent)
                         with patch.object(os.path, 'isfile', path_isfile_mock):
                             with patch.object(core, '_parse_os_release', os_release_mock):
-                                # Mock platform.linux_distribution to give us the
-                                # OS name that we want.
+                                # Mock linux_distribution to give us the OS
+                                # name that we want.
                                 distro_mock = MagicMock(
                                     return_value=('SUSE test', 'version', 'arch')
                                 )
                                 with patch("salt.utils.fopen", mock_open()) as suse_release_file:
                                     suse_release_file.return_value.__iter__.return_value = os_release_map.get('suse_release_file', '').splitlines()
-                                    with patch.object(platform, 'linux_distribution', distro_mock):
+                                    with patch.object(core, 'linux_distribution', distro_mock):
                                         with patch.object(core, '_linux_gpu_data', empty_mock):
                                             with patch.object(core, '_linux_cpudata', empty_mock):
                                                 with patch.object(core, '_virtual', empty_mock):
@@ -440,13 +440,13 @@ PATCHLEVEL = 3
                         # Skip all the /etc/*-release stuff (not pertinent)
                         with patch.object(os.path, 'isfile', path_isfile_mock):
                             with patch.object(core, '_parse_os_release', os_release_mock):
-                                # Mock platform.linux_distribution to give us the
-                                # OS name that we want.
+                                # Mock linux_distribution to give us the OS
+                                # name that we want.
                                 distro_mock = MagicMock(return_value=('Ubuntu', '16.04', 'xenial'))
                                 with patch("salt.utils.fopen", mock_open()) as suse_release_file:
                                     suse_release_file.return_value.__iter__.return_value = os_release_map.get(
                                         'suse_release_file', '').splitlines()
-                                    with patch.object(platform, 'linux_distribution', distro_mock):
+                                    with patch.object(core, 'linux_distribution', distro_mock):
                                         with patch.object(core, '_linux_gpu_data', empty_mock):
                                             with patch.object(core, '_linux_cpudata', empty_mock):
                                                 with patch.object(core, '_virtual', empty_mock):

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -6,7 +6,6 @@
 # Import Python libs
 from __future__ import absolute_import
 import os
-import platform
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf

--- a/tests/unit/modules/test_boto_lambda.py
+++ b/tests/unit/modules/test_boto_lambda.py
@@ -2,9 +2,14 @@
 
 # Import Python libs
 from __future__ import absolute_import
-import platform
 import random
 import string
+
+# linux_distribution deprecated in py3.7
+try:
+    from platform import linux_distribution
+except ImportError:
+    from distro import linux_distribution
 
 # Import Salt Testing libs
 from tests.support.unit import skipIf, TestCase
@@ -40,7 +45,7 @@ except ImportError:
     HAS_BOTO = False
 
 ON_SUSE = False
-if 'SuSE' in platform.dist():
+if 'SuSE' in linux_distribution(full_distribution_name=False):
     ON_SUSE = True
 
 # pylint: enable=import-error,no-name-in-module

--- a/tests/unit/transport/test_zeromq.py
+++ b/tests/unit/transport/test_zeromq.py
@@ -8,7 +8,12 @@ from __future__ import absolute_import
 import os
 import time
 import threading
-import platform
+
+# linux_distribution deprecated in py3.7
+try:
+    from platform import linux_distribution
+except ImportError:
+    from distro import linux_distribution
 
 # Import 3rd-party libs
 import zmq.eventloop.ioloop
@@ -34,7 +39,7 @@ from tests.unit.transport.test_req import ReqChannelMixin
 from tests.unit.transport.test_pub import PubChannelMixin
 
 ON_SUSE = False
-if 'SuSE' in platform.dist():
+if 'SuSE' in linux_distribution(full_distribution_name=False):
     ON_SUSE = True
 
 


### PR DESCRIPTION
### What does this PR do?
http://bugs.python.org/issue1322

python 3.7 is deprecating the platform.{linux_distribution,dist}
functions.  They are being moved to the `distro` module on pypi.  This
adds support for using the distro module if platform does not have the
needed functions.

### What issues does this PR fix or reference?
Closes #37070