### PR TITLE
S3 bucket path broken

### DIFF
--- a/salt/modules/s3.py
+++ b/salt/modules/s3.py
@@ -103,7 +103,7 @@ def delete(bucket, path=None, action=None, key=None, keyid=None,
                                  role_arn=role_arn)
 
 
-def get(bucket=None, path=None, return_bin=False, action=None,
+def get(bucket='', path='', return_bin=False, action=None,
         local_file=None, key=None, keyid=None, service_url=None,
         verify_ssl=None, kms_keyid=None, location=None, role_arn=None):
     '''

--- a/salt/modules/s3.py
+++ b/salt/modules/s3.py
@@ -182,7 +182,7 @@ def get(bucket='', path='', return_bin=False, action=None,
                                  role_arn=role_arn)
 
 
-def head(bucket, path=None, key=None, keyid=None, service_url=None,
+def head(bucket, path='', key=None, keyid=None, service_url=None,
          verify_ssl=None, kms_keyid=None, location=None, role_arn=None):
     '''
     Return the metadata for a bucket, or an object in a bucket.

--- a/salt/modules/s3.py
+++ b/salt/modules/s3.py
@@ -15,6 +15,9 @@ Connection module for Amazon S3
         s3.keyid: GKTADJGHEIQSXMKKRBJ08H
         s3.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
 
+    (Note: this is literally the pillar key 's3.keyid' or the config option 's3.keyid',
+    not "s3:\\n  keyid: blah".)
+
     A service_url may also be specified in the configuration::
 
         s3.service_url: s3.amazonaws.com


### PR DESCRIPTION
### What does this PR do?

The docs say once you get the pillar or config items setup, you can do these to list buckets and list the contents of the buckets

```
salt-call s3.get
salt-call s3.get bucketname

```
This is actually false if bucket and path default to `None`. The correct calls would have to be this instead

```
salt-call s3.get '' ''
salt-call s3.get bucketname ''

```

I fixed the bucket and path defaults to be `''` instead of `None`

I also added a comment to the top hear doc, that we mean this for the configs

```
s3.keyid: keyidhere
````

not this

```
s3:
  keyid: wrongthisiswrong

```


### What issues does this PR fix or reference?

I have a hunch something got missed when `__utils__['s3.query']` became a thing circa 2016.x, but I didn't actually go back and track that down.

### Previous Behavior
Crash with None defaults (404, 403, or stacktrace, depending on the mix of args).

### New Behavior
List things like the doc says will happen.

