### PR TITLE
Attempt to fix failing grains tests in 2016.3

### DIFF
--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -142,9 +142,8 @@ class GrainsAppendTestCase(integration.ModuleCase):
     GRAIN_VAL = 'my-grain-val'
 
     def tearDown(self):
-        test_grain = self.run_function('grains.get', [self.GRAIN_KEY])
-        if test_grain and test_grain == [self.GRAIN_VAL]:
-            self.run_function('grains.remove', [self.GRAIN_KEY, self.GRAIN_VAL])
+        for item in self.run_function('grains.get', [self.GRAIN_KEY])
+            self.run_function('grains.remove', [self.GRAIN_KEY, item])
 
     def test_grains_append(self):
         '''

--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -142,7 +142,7 @@ class GrainsAppendTestCase(integration.ModuleCase):
     GRAIN_VAL = 'my-grain-val'
 
     def tearDown(self):
-        for item in self.run_function('grains.get', [self.GRAIN_KEY])
+        for item in self.run_function('grains.get', [self.GRAIN_KEY]):
             self.run_function('grains.remove', [self.GRAIN_KEY, item])
 
     def test_grains_append(self):


### PR DESCRIPTION
The tearDown appears to only be removing the grain if it matches a
specific value. This may be leading to the grain value not being blank
at the time the next test is run.

Instead of only deleting the grain if it matches a specific value,
instead delete all items from that grain to ensure that it is empty for
the next test.

CC: @rallytime @ch3ll