### PR TITLE
Allows overriding 'timeout' and 'gather_job_timeout' to 'manage.up' runner call

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -220,7 +220,7 @@ class LocalClient(object):
         Return the information about a given job
         '''
         log.debug('Checking whether jid {0} is still running'.format(jid))
-        timeout = self.opts['gather_job_timeout']
+        timeout = kwargs.get('gather_job_timeout', self.opts['gather_job_timeout'])
 
         pub_data = self.run_job(tgt,
                                 'saltutil.find_job',
@@ -921,6 +921,7 @@ class LocalClient(object):
 
         if timeout is None:
             timeout = self.opts['timeout']
+        gather_job_timeout = kwargs.get('gather_job_timeout', self.opts['gather_job_timeout'])
         start = int(time.time())
 
         # timeouts per minion, id_ -> timeout time
@@ -1019,7 +1020,7 @@ class LocalClient(object):
                     jinfo_iter = []
                 else:
                     jinfo_iter = self.get_returns_no_block('salt/job/{0}'.format(jinfo['jid']))
-                timeout_at = time.time() + self.opts['gather_job_timeout']
+                timeout_at = time.time() + gather_job_timeout
                 # if you are a syndic, wait a little longer
                 if self.opts['order_masters']:
                     timeout_at += self.opts.get('syndic_wait', 1)

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -30,7 +30,7 @@ from salt.exceptions import SaltClientError
 FINGERPRINT_REGEX = re.compile(r'^([a-f0-9]{2}:){15}([a-f0-9]{2})$')
 
 
-def status(output=True):
+def status(output=True, timeout=None, gather_job_timeout=None):
     '''
     Print the status of all known salt minions
 
@@ -42,8 +42,14 @@ def status(output=True):
     '''
     ret = {}
     client = salt.client.get_local_client(__opts__['conf_file'])
+
+    if not timeout:
+        timeout = __opts__['timeout']
+    if not gather_job_timeout:
+        gather_job_timeout = __opts__['gather_job_timeout']
+
     try:
-        minions = client.cmd('*', 'test.ping', timeout=__opts__['timeout'])
+        minions = client.cmd('*', 'test.ping', timeout=timeout, gather_job_timeout=gather_job_timeout)
     except SaltClientError as client_error:
         print(client_error)
         return ret
@@ -128,7 +134,7 @@ def down(removekeys=False):
     return ret
 
 
-def up():  # pylint: disable=C0103
+def up(timeout=None, gather_job_timeout=None):  # pylint: disable=C0103
     '''
     Print a list of all of the minions that are up
 
@@ -137,8 +143,13 @@ def up():  # pylint: disable=C0103
     .. code-block:: bash
 
         salt-run manage.up
+        salt-run manage.up timeout=5 gather_job_timeout=5
     '''
-    ret = status(output=False).get('up', [])
+    ret = status(
+        output=False,
+        timeout=timeout,
+        gather_job_timeout=gather_job_timeout
+    ).get('up', [])
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?
This PR allows overriding `timeout` and `gather_job_timeout` parameters to `manage.up` and `manage.status` runners. These two parameters are set in our master configuration with a high value, as we want to wait by default for jobs that takes long to execute:

```
timeout: 120
gather_job_timeout: 120
```

When dealing with an scenario where some minions are down, if we execute `manage.up` runner to check for minions that are up and running, it will end up after reaching the two timeouts. This makes `manage.up` runner unusable as presence mechanism because we cannot get a response in some short and fixed time.

With this PR, we are able to call `manage.up` runner passing `timeout` and `gather_job_timeout` parameters which are used to perform the upcoming `test.ping` job that the runner is going to trigger.

This way we can get a quick response of `manage.up` runner in case of unreachable minions. Even if we call the runner via API.

### Previous Behavior
```
$ time salt-run manage.up
- headref-minsles12sp2.tf.local

real	4m1.052s
user	0m3.729s
sys	0m0.264s
```

### New Behavior
```
$ time salt-run manage.up timeout=2 gather_job_timeout=1
- headref-minsles12sp2.tf.local

real	0m3.964s
user	0m0.693s
sys	0m0.119s
```

### Tests written?
No

What do you think about this?

I also tried with `manage.present` runner but it doesn't fit well in our scenario. Is there another quick way to check for the actual presence of minions in a context with unreachable minions?

Any feedback or opinions are more than welcome! :smile:
Thanks

/cc @moio 
