### PR TITLE
We need to match on .p not just strip '.p' otherwise it will remove a…

### DIFF
--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -135,7 +135,10 @@ def list_(bank, cachedir):
         )
     ret = []
     for item in items:
-        ret.append(item.rstrip('.p'))
+        if item.endswith('.p'):
+            ret.append(item.rstrip(item[-2:]))
+        else:
+            ret.append(item)
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?

At the moment when we check for the connected minions we list the minions from the cache and in the case of localfs we look for the data.p file. 

Inside the list function we strip out any .p from the minion name. Only problem is that since we do a rsrtrip('.p') we will endup stripping any p even if the dot is not present. We need to match on that sequence.

Quite a few headaches to try to understand why all of my servers ending with p were not considered as present.


 
