### PR TITLE
Make pkg execution/state modules work on Py3 on Windows

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -44,12 +44,6 @@ import time
 import salt.ext.six as six
 # pylint: disable=import-error,no-name-in-module
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse
-# pylint: disable=import-error
-try:
-    import msgpack
-except ImportError:
-    import msgpack_pure as msgpack
-# pylint: enable=import-error
 
 # Import salt libs
 from salt.exceptions import (CommandExecutionError,
@@ -57,8 +51,8 @@ from salt.exceptions import (CommandExecutionError,
                              SaltRenderError)
 import salt.utils
 import salt.syspaths
+import salt.payload
 from salt.exceptions import MinionError
-from salt.utils.versions import LooseVersion as _LooseVersion
 
 log = logging.getLogger(__name__)
 
@@ -84,16 +78,22 @@ def latest_version(*names, **kwargs):
     If the latest version of a given package is already installed, an empty
     string will be returned for that package.
 
+    Args:
+        names (str): A single or multiple names to lookup
+
+    Kwargs:
+        saltenv (str): Salt environment. Default ``base``
+        refresh (bool): Refresh package metadata. Default ``True``
+
+    Returns:
+        dict: A dictionary of packages with the latest version available
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' pkg.latest_version <package name>
         salt '*' pkg.latest_version <package1> <package2> <package3> ...
-
-    *Keyword Arguments (kwargs)*
-    :param str saltenv: Salt environment. Default ``base``
-    :param bool refresh: Refresh package metadata. Default ``True``
     '''
     if len(names) == 0:
         return ''
@@ -120,8 +120,7 @@ def latest_version(*names, **kwargs):
         if name in installed_pkgs:
             log.trace('Determining latest installed version of %s', name)
             try:
-                latest_installed = sorted(
-                    installed_pkgs[name], cmp=_reverse_cmp_pkg_versions).pop()
+                latest_installed = sorted(installed_pkgs[name]).pop()
             except IndexError:
                 log.warning(
                     '%s was empty in pkg.list_pkgs return data, this is '
@@ -157,17 +156,17 @@ def latest_version(*names, **kwargs):
     return ret
 
 
-def upgrade_available(name, **kwargs):
+def upgrade_available(name, refresh=True, saltenv='base'):
     '''
     Check whether or not an upgrade is available for a given package
 
-    :param name: The name of a single package
-    :return: Return True if newer version available
-    :rtype: bool
+    Args:
+        name (str): The name of a single package
+        refresh (bool): Refresh package metadata. Default ``True``
+        saltenv (str): The salt environment. Default ``base``
 
-    *Keyword Arguments (kwargs)*
-    :param str saltenv: Salt environment
-    :param bool refresh: Refresh package metadata. Default ``True``
+    Returns:
+        bool: True if new version available, otherwise False
 
     CLI Example:
 
@@ -175,22 +174,26 @@ def upgrade_available(name, **kwargs):
 
         salt '*' pkg.upgrade_available <package name>
     '''
-    saltenv = kwargs.get('saltenv', 'base')
     # Refresh before looking for the latest version available,
     # same default as latest_version
-    refresh = salt.utils.is_true(kwargs.get('refresh', True))
+    refresh = salt.utils.is_true(refresh)
 
-    return latest_version(name, saltenv=saltenv, refresh=refresh) != ''
+    current = version(name, saltenv=saltenv, refresh=refresh).get(name)
+    latest = latest_version(name, saltenv=saltenv, refresh=False)
+
+    return compare_versions(latest, '>', current)
 
 
-def list_upgrades(refresh=True, **kwargs):  # pylint: disable=W0613
+def list_upgrades(refresh=True, saltenv='base'):
     '''
     List all available package upgrades on this system
 
-    :param bool refresh: Refresh package metadata. Default ``True``
+    Args:
+        refresh (bool): Refresh package metadata. Default ``True``
+        saltenv (str): Salt environment. Default ``base``
 
-    *Keyword Arguments (kwargs)*
-    :param str saltenv: Salt environment. Default ``base``
+    Returns:
+        dict: A dictionary of packages with available upgrades
 
     CLI Example:
 
@@ -198,38 +201,49 @@ def list_upgrades(refresh=True, **kwargs):  # pylint: disable=W0613
 
         salt '*' pkg.list_upgrades
     '''
-    saltenv = kwargs.get('saltenv', 'base')
     refresh = salt.utils.is_true(refresh)
     _refresh_db_conditional(saltenv, force=refresh)
 
-    ret = {}
-    for name, data in six.iteritems(get_repo_data(saltenv).get('repo', {})):
-        if version(name):
-            latest = latest_version(name, refresh=False, saltenv=saltenv)
-            if latest:
-                ret[name] = latest
-    return ret
+    installed_pkgs = list_pkgs(refresh=False)
+    available_pkgs = get_repo_data(saltenv).get('repo')
+    pkgs = {}
+    for pkg in installed_pkgs:
+        if pkg in available_pkgs:
+            latest_ver = latest_version(pkg, refresh=False)
+            install_ver = installed_pkgs[pkg]
+            if compare_versions(latest_ver, '>', install_ver):
+                pkgs[pkg] = latest_ver
+
+    return pkgs
 
 
 def list_available(*names, **kwargs):
     '''
     Return a list of available versions of the specified package.
 
-    :param str name: One or more package names
-    :return:
-        For multiple package names listed returns dict of package names and versions
-        For single package name returns a version string
-    :rtype: dict or string
+    Args:
+        names (str): One or more package names
+
+    Kwargs:
+
+        saltenv (str): The salt environment to use. Default ``base``.
+
+        refresh (bool): Refresh package metadata. Default ``True``.
+
+        return_dict_always (bool):
+            Default ``False`` dict when a single package name is queried.
+
+    Returns:
+        dict: The package name with its available versions
+
     .. code-block:: cfg
+
         {'<package name>': ['<version>', '<version>', ]}
 
-    *Keyword Arguments (kwargs)*
-    :param str saltenv: The salt environment to use. Default ``base``.
-    :param bool refresh: Refresh package metadata. Default ``True``.
-    :param bool return_dict_always: Default ``False`` dict when a single package name is queried.
-
     CLI Example:
+
     .. code-block:: bash
+
         salt '*' pkg.list_available <package name> return_dict_always=True
         salt '*' pkg.list_available <package name01> <package name02>
     '''
@@ -245,16 +259,14 @@ def list_available(*names, **kwargs):
         pkginfo = _get_package_info(names[0], saltenv=saltenv)
         if not pkginfo:
             return ''
-        versions = list(pkginfo.keys())
-        versions = sorted(versions, cmp=_reverse_cmp_pkg_versions)
+        versions = sorted(list(pkginfo.keys()))
     else:
         versions = {}
         for name in names:
             pkginfo = _get_package_info(name, saltenv=saltenv)
             if not pkginfo:
                 continue
-            verlist = list(pkginfo.keys()) if pkginfo else []
-            verlist = sorted(verlist, cmp=_reverse_cmp_pkg_versions)
+            verlist = sorted(list(pkginfo.keys())) if pkginfo else []
             versions[name] = verlist
     return versions
 
@@ -263,52 +275,57 @@ def version(*names, **kwargs):
     '''
     Returns a version if the package is installed, else returns an empty string
 
-    :param str name: One or more package names
-    :return:
-        For multiple package names listed returns dict of package names and current version
-        For single package name returns a current version string
-    :rtype: dict or string
+    Args:
+        name (str): One or more package names
+
+    Kwargs:
+        saltenv (str): The salt environment to use. Default ``base``.
+        refresh (bool): Refresh package metadata. Default ``False``.
+
+    Returns:
+        dict: The package name(s) with the installed versions.
+
     .. code-block:: cfg
+
         {'<package name>': ['<version>', '<version>', ]}
 
-    *Keyword Arguments (kwargs)*
-    :param str saltenv: The salt environment to use. Default ``base``.
-    :param bool refresh: Refresh package metadata. Default ``False``.
-
     CLI Example:
+
     .. code-block:: bash
+
         salt '*' pkg.version <package name>
         salt '*' pkg.version <package name01> <package name02>
     '''
-    # pkg_resource calls list_pkgs refresh kwargs will be passed on
+    saltenv = kwargs.get('saltenv', 'base')
+
+    installed_pkgs = list_pkgs(refresh=kwargs.get('refresh', False))
+    available_pkgs = get_repo_data(saltenv).get('repo')
+
     ret = {}
-    if len(names) == 1:
-        val = __salt__['pkg_resource.version'](*names, **kwargs)
-        if len(val):
-            return val
-        return ''
-    if len(names) > 1:
-        reverse_dict = {}
-        nums = __salt__['pkg_resource.version'](*names, **kwargs)
-        if len(nums):
-            for num, val in six.iteritems(nums):
-                if len(val) > 0:
-                    try:
-                        ret[reverse_dict[num]] = val
-                    except KeyError:
-                        ret[num] = val
-            return ret
-        return dict([(x, '') for x in names])
+    for name in names:
+        if name in available_pkgs:
+            ret[name] = installed_pkgs.get(name, '')
+        else:
+            ret[name] = 'not available'
+
     return ret
 
 
 def list_pkgs(versions_as_list=False, **kwargs):
     '''
-    List the packages currently installed in a dict::
+    List the packages currently installed
 
-    *Keyword Arguments (kwargs)*
-    :param str saltenv: The salt environment to use. Default ``base``.
-    :param bool refresh: Refresh package metadata. Default ``False`.
+    Args:
+        version_as_list (bool): Returns the versions as a list
+
+    Kwargs:
+        saltenv (str): The salt environment to use. Default ``base``.
+        refresh (bool): Refresh package metadata. Default ``False`.
+
+    Returns:
+        dict: A dictionary of installed software with versions installed
+
+    .. code-block:: cfg
 
         {'<package_name>': '<version>'}
 
@@ -353,9 +370,9 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
 def _search_software(target):
     '''
-    This searches the msi product databases for name matches
-    of the list of target products, it will return a dict with
-    values added to the list passed in
+    This searches the msi product databases for name matches of the list of
+    target products, it will return a dict with values added to the list passed
+    in
     '''
     search_results = {}
     software = dict(_get_reg_software().items())
@@ -368,9 +385,9 @@ def _search_software(target):
 
 def _get_reg_software():
     '''
-    This searches the uninstall keys in the registry to find
-    a match in the sub keys, it will return a dict with the
-    display name as the key and the version as the value
+    This searches the uninstall keys in the registry to find a match in the sub
+    keys, it will return a dict with the display name as the key and the
+    version as the value
     '''
     ignore_list = ['AddressBook',
                    'Connection Manager',
@@ -428,9 +445,11 @@ def _refresh_db_conditional(saltenv, **kwargs):
     returns True or False. And supports check the age of the existing
     generated metadata db, as well as ensure metadata db exists to begin with
 
-    :param str saltenv: Salt environment
-    :return: True Fetched or Cache uptodate, False to indicate an issue
-    :rtype: bool
+    Args:
+        saltenv (str): Salt environment
+
+    Returns:
+        bool: True Fetched or Cache uptodate, False to indicate an issue
 
     :codeauthor: Damon Atkins <https://github.com/damon-atkins>
     '''
@@ -485,11 +504,14 @@ def refresh_db(**kwargs):
     <salt.modules.win_pkg.genrepo>` to compile updated repository metadata.
 
     Kwargs:
+
         saltenv (str): Salt environment. Default: ``base``
+
         verbose (bool):
             Return verbose data structure which includes 'success_list', a list
             of all sls files and the package names contained within. Default
             'False'
+
         failhard (bool):
             If ``True``, an error will be raised if any repo SLS files failed to
             process. If ``False``, no error will be raised, and a dictionary
@@ -635,6 +657,23 @@ def genrepo(**kwargs):
     '''
     Generate package metedata db based on files within the winrepo_source_dir
 
+    Kwargs:
+
+        saltenv (str): Salt environment. Default: ``base``
+
+        verbose (bool):
+            Return verbose data structure which includes 'success_list', a list
+            of all sls files and the package names contained within. Default
+            'False'
+
+        failhard (bool):
+            If ``True``, an error will be raised if any repo SLS files failed
+            to process. If ``False``, no error will be raised, and a dictionary
+            containing the full results will be returned.
+
+    Returns:
+        dict: A dictionary of the results of the command
+
     CLI Example:
 
     .. code-block:: bash
@@ -642,19 +681,6 @@ def genrepo(**kwargs):
         salt-run pkg.genrepo
         salt -G 'os:windows' pkg.genrepo verbose=true failhard=false
         salt -G 'os:windows' pkg.genrepo saltenv=base
-
-    *Keyword Arguments (kwargs)*
-
-    :param str saltenv: Salt environment. Default: ``base``
-
-    :param bool verbose:
-        Return verbose data structure which includes 'success_list', a list of
-        all sls files and the package names contained within. Default 'False'
-
-    :param bool failhard:
-        If ``True``, an error will be raised if any repo SLS files failed to
-        proess. If ``False``, no error will be raised, and a dictionary
-        containing the full results will be returned.
     '''
     saltenv = kwargs.pop('saltenv', 'base')
     verbose = salt.utils.is_true(kwargs.pop('verbose', False))
@@ -680,8 +706,10 @@ def genrepo(**kwargs):
                     ret,
                     successful_verbose
                     )
-    with salt.utils.fopen(repo_details.winrepo_file, 'w+b') as repo_cache:
-        repo_cache.write(msgpack.dumps(ret))
+    serial = salt.payload.Serial(__opts__)
+    mode = 'wb+' if six.PY3 else 'w+'
+    with salt.utils.fopen(repo_details.winrepo_file, mode) as repo_cache:
+        repo_cache.write(serial.dumps(ret))
     # save reading it back again. ! this breaks due to utf8 issues
     #__context__['winrepo.data'] = ret
     successful_count = len(successful_verbose)
@@ -832,56 +860,57 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
     r'''
     Install the passed package(s) on the system using winrepo
 
-    :param name:
-        The name of a single package, or a comma-separated list of packages to
-        install. (no spaces after the commas)
-    :type name: str, list, or None
+    Args:
 
-    :param bool refresh: Boolean value representing whether or not to refresh
-        the winrepo db
+        name (str):
+            The name of a single package, or a comma-separated list of packages
+            to install. (no spaces after the commas)
 
-    :param pkgs: A list of packages to install from a software repository.
-        All packages listed under ``pkgs`` will be installed via a single
-        command.
+        refresh (bool):
+            Boolean value representing whether or not to refresh the winrepo db
 
-    :type pkgs: list or None
+        pkgs (list):
+            A list of packages to install from a software repository. All
+            packages listed under ``pkgs`` will be installed via a single
+            command.
 
-    *Keyword Arguments (kwargs)*
+    Kwargs:
 
-    :param str version:
-        The specific version to install. If omitted, the latest version will be
-        installed. If passed with multiple install, the version will apply to
-        all packages. Recommended for single installation only.
+        version (str):
+            The specific version to install. If omitted, the latest version
+            will be installed. If passed with multiple install, the version
+            will apply to all packages. Recommended for single installation
+            only.
 
-    :param str cache_file:
-        A single file to copy down for use with the installer. Copied to the
-        same location as the installer. Use this over ``cache_dir`` if there
-        are many files in the directory and you only need a specific file and
-        don't want to cache additional files that may reside in the installer
-        directory. Only applies to files on ``salt://``
+        cache_file (str):
+            A single file to copy down for use with the installer. Copied to
+            the same location as the installer. Use this over ``cache_dir`` if
+            there are many files in the directory and you only need a specific
+            file and don't want to cache additional files that may reside in
+            the installer directory. Only applies to files on ``salt://``
 
-    :param bool cache_dir:
-        True will copy the contents of the installer directory. This is useful
-        for installations that are not a single file. Only applies to
-        directories on ``salt://``
+        cache_dir (bool):
+            True will copy the contents of the installer directory. This is
+            useful for installations that are not a single file. Only applies
+            to directories on ``salt://``
 
-    :param str saltenv: Salt environment. Default 'base'
+        saltenv (str): Salt environment. Default 'base'
 
-    :param bool report_reboot_exit_codes:
-        If the installer exits with a recognized exit code indicating that
-        a reboot is required, the module function
+        report_reboot_exit_codes (bool):
+            If the installer exits with a recognized exit code indicating that
+            a reboot is required, the module function
 
-           *win_system.set_reboot_required_witnessed*
+               *win_system.set_reboot_required_witnessed*
 
-        will be called, preserving the knowledge of this event
-        for the remainder of the current boot session. For the time being,
-        3010 is the only recognized exit code. The value of this param
-        defaults to True.
+            will be called, preserving the knowledge of this event for the
+            remainder of the current boot session. For the time being, 3010 is
+            the only recognized exit code. The value of this param defaults to
+            True.
 
-        .. versionadded:: 2016.11.0
+            .. versionadded:: 2016.11.0
 
-    :return: Return a dict containing the new package names and versions::
-    :rtype: dict
+    Returns:
+        dict: Return a dict containing the new package names and versions
 
         If the package is installed by ``pkg.install``:
 
@@ -896,8 +925,8 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
 
             {'<package>': {'current': '<current-version>'}}
 
-    The following example will refresh the winrepo and install a single package,
-    7zip.
+    The following example will refresh the winrepo and install a single
+    package, 7zip.
 
     CLI Example:
 
@@ -916,8 +945,8 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
     WinRepo Definition File Examples:
 
     The following example demonstrates the use of ``cache_file``. This would be
-    used if you have multiple installers in the same directory that use the same
-    ``install.ini`` file and you don't want to download the additional
+    used if you have multiple installers in the same directory that use the
+    same ``install.ini`` file and you don't want to download the additional
     installers.
 
     .. code-block:: bash
@@ -949,6 +978,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
     '''
     ret = {}
     saltenv = kwargs.pop('saltenv', 'base')
+
     refresh = salt.utils.is_true(refresh)
     # no need to call _refresh_db_conditional as list_pkgs will do it
 
@@ -994,14 +1024,15 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         # Get the version number passed or the latest available
         version_num = ''
         if options:
-            version_num = options.get('version', False)
+            if options.get('version') is not None:
+                version_num = str(options.get('version'))
 
         if not version_num:
             version_num = _get_latest_pkg_version(pkginfo)
 
         # Check if the version is already installed
         if version_num in old.get(pkg_name, '').split(',') \
-                or (pkg_name in old and old[pkg_name] == 'Not Found'):
+                or (pkg_name in old and old.get(pkg_name) is None):
             # Desired version number already installed
             ret[pkg_name] = {'current': version_num}
             continue
@@ -1017,9 +1048,9 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             latest.append(pkg_name)
 
         # Get the installer settings from winrepo.p
-        installer = pkginfo[version_num].get('installer', False)
+        installer = pkginfo[version_num].get('installer', '')
         cache_dir = pkginfo[version_num].get('cache_dir', False)
-        cache_file = pkginfo[version_num].get('cache_file', False)
+        cache_file = pkginfo[version_num].get('cache_file', '')
 
         # Is there an installer configured?
         if not installer:
@@ -1083,8 +1114,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                 if __salt__['cp.hash_file'](installer, saltenv) != \
                         __salt__['cp.hash_file'](cached_pkg):
                     try:
-                        cached_pkg = __salt__['cp.cache_file'](installer,
-                                                               saltenv)
+                        cached_pkg = __salt__['cp.cache_file'](installer, saltenv)
                     except MinionError as exc:
                         return '{0}: {1}'.format(exc, installer)
 
@@ -1121,7 +1151,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             log.debug('Source hash matches package hash.')
 
         # Get install flags
-        install_flags = '{0}'.format(pkginfo[version_num].get('install_flags'))
+        install_flags = pkginfo[version_num].get('install_flags', '')
         if options and options.get('extra_install_flags'):
             install_flags = '{0} {1}'.format(
                 install_flags,
@@ -1133,7 +1163,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         if pkginfo[version_num].get('use_scheduler', False):
 
             # Build Scheduled Task Parameters
-            if pkginfo[version_num].get('msiexec'):
+            if pkginfo[version_num].get('msiexec', False):
                 cmd = 'msiexec.exe'
                 arguments = ['/i', cached_pkg]
                 if pkginfo['version_num'].get('allusers', True):
@@ -1164,7 +1194,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         else:
             # Build the install command
             cmd = []
-            if pkginfo[version_num].get('msiexec'):
+            if pkginfo[version_num].get('msiexec', False):
                 cmd.extend(['msiexec', '/i', cached_pkg])
                 if pkginfo[version_num].get('allusers', True):
                     cmd.append('ALLUSERS="1"')
@@ -1183,9 +1213,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             elif result['retcode'] == 3010:
                 # 3010 is ERROR_SUCCESS_REBOOT_REQUIRED
                 report_reboot_exit_codes = kwargs.pop(
-                    'report_reboot_exit_codes',
-                    True
-                    )
+                    'report_reboot_exit_codes', True)
                 if report_reboot_exit_codes:
                     __salt__['system.set_reboot_required_witnessed']()
                 ret[pkg_name] = {'install status': 'success, reboot required'}
@@ -1222,12 +1250,15 @@ def upgrade(**kwargs):
     '''
     Upgrade all software. Currently not implemented
 
-    *Keyword Arguments (kwargs)*
-    :param str saltenv: The salt environment to use. Default ``base``.
-    :param bool refresh: Refresh package metadata. Default ``True``.
+    Kwargs:
+        saltenv (str): The salt environment to use. Default ``base``.
+        refresh (bool): Refresh package metadata. Default ``True``.
 
     .. note::
         This feature is not yet implemented for Windows.
+
+    Returns:
+        dict: Empty dict, until implemented
 
     CLI Example:
 
@@ -1249,32 +1280,27 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
     '''
     Remove the passed package(s) from the system using winrepo
 
-    :param name:
-        The name of the package to be uninstalled.
-    :type name: str, list, or None
-
-    :param str version:
-        The version of the package to be uninstalled. If this option is used to
-        to uninstall multiple packages, then this version will be applied to all
-        targeted packages. Recommended using only when uninstalling a single
-        package. If this parameter is omitted, the latest version will be
-        uninstalled.
-
-    Multiple Package Options:
-
-    :param pkgs:
-        A list of packages to delete. Must be passed as a python list. The
-        ``name`` parameter will be ignored if this option is passed.
-    :type pkgs: list or None
-
     .. versionadded:: 0.16.0
 
-    *Keyword Arguments (kwargs)*
-    :param str saltenv: Salt environment. Default ``base``
-    :param bool refresh: Refresh package metadata. Default ``False``
+    Args:
+        name (str): The name(s) of the package(s) to be uninstalled. Can be a
+            single package or a comma delimted list of packages, no spaces.
+        version (str):
+            The version of the package to be uninstalled. If this option is
+            used to to uninstall multiple packages, then this version will be
+            applied to all targeted packages. Recommended using only when
+            uninstalling a single package. If this parameter is omitted, the
+            latest version will be uninstalled.
+        pkgs (list):
+            A list of packages to delete. Must be passed as a python list. The
+            ``name`` parameter will be ignored if this option is passed.
 
-    :return: Returns a dict containing the changes.
-    :rtype: dict
+    Kwargs:
+        saltenv (str): Salt environment. Default ``base``
+        refresh (bool): Refresh package metadata. Default ``False``
+
+    Returns:
+        dict: Returns a dict containing the changes.
 
         If the package is removed by ``pkg.remove``:
 
@@ -1322,9 +1348,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             ret[pkgname] = msg
             continue
 
-        if version_num is not None \
-                and version_num not in pkginfo \
-                and 'latest' in pkginfo:
+        if version_num is None and 'latest' in pkginfo:
             version_num = 'latest'
 
         # Check to see if package is installed on the system
@@ -1337,7 +1361,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             if version_num is None:
                 removal_targets.extend(old[pkgname])
             elif version_num not in old[pkgname] \
-                    and 'Not Found' not in old['pkgname'] \
+                    and 'Not Found' not in old[pkgname] \
                     and version_num != 'latest':
                 log.error('%s %s not installed', pkgname, version)
                 ret[pkgname] = {
@@ -1348,12 +1372,13 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
                 removal_targets.append(version_num)
 
         for target in removal_targets:
+
             # Get the uninstaller
-            uninstaller = pkginfo[target].get('uninstaller')
+            uninstaller = pkginfo[target].get('uninstaller', '')
 
             # If no uninstaller found, use the installer
             if not uninstaller:
-                uninstaller = pkginfo[target].get('installer')
+                uninstaller = pkginfo[target].get('installer', '')
 
             # If still no uninstaller found, fail
             if not uninstaller:
@@ -1390,21 +1415,18 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             expanded_cached_pkg = str(os.path.expandvars(cached_pkg))
 
             # Get uninstall flags
-            uninstall_flags = '{0}'.format(
-                pkginfo[target].get('uninstall_flags', '')
-            )
+            uninstall_flags = pkginfo[target].get('uninstall_flags', '')
+
             if kwargs.get('extra_uninstall_flags'):
                 uninstall_flags = '{0} {1}'.format(
-                    uninstall_flags,
-                    kwargs.get('extra_uninstall_flags', "")
-                )
+                    uninstall_flags, kwargs.get('extra_uninstall_flags', ''))
 
             # Uninstall the software
             # Check Use Scheduler Option
             if pkginfo[target].get('use_scheduler', False):
 
                 # Build Scheduled Task Parameters
-                if pkginfo[target].get('msiexec'):
+                if pkginfo[target].get('msiexec', False):
                     cmd = 'msiexec.exe'
                     arguments = ['/x']
                     arguments.extend(salt.utils.shlex_split(uninstall_flags))
@@ -1433,16 +1455,17 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             else:
                 # Build the install command
                 cmd = []
-                if pkginfo[target].get('msiexec'):
+                if pkginfo[target].get('msiexec', False):
                     cmd.extend(['msiexec', '/x', expanded_cached_pkg])
                 else:
                     cmd.append(expanded_cached_pkg)
                 cmd.extend(salt.utils.shlex_split(uninstall_flags))
                 # Launch the command
-                result = __salt__['cmd.run_all'](cmd,
-                                                 output_loglevel='trace',
-                                                 python_shell=False,
-                                                 redirect_stderr=True)
+                result = __salt__['cmd.run_all'](
+                        cmd,
+                        output_loglevel='trace',
+                        python_shell=False,
+                        redirect_stderr=True)
                 if not result['retcode']:
                     ret[pkgname] = {'uninstall status': 'success'}
                     changed.append(pkgname)
@@ -1480,29 +1503,26 @@ def purge(name=None, pkgs=None, version=None, **kwargs):
     Package purges are not supported, this function is identical to
     ``remove()``.
 
-    name
-        The name of the package to be deleted.
-
-    version
-        The version of the package to be deleted. If this option is used in
-        combination with the ``pkgs`` option below, then this version will be
-        applied to all targeted packages.
-
-
-    Multiple Package Options:
-
-    pkgs
-        A list of packages to delete. Must be passed as a python list. The
-        ``name`` parameter will be ignored if this option is passed.
-
-    *Keyword Arguments (kwargs)*
-    :param str saltenv: Salt environment. Default ``base``
-    :param bool refresh: Refresh package metadata. Default ``False``
-
     .. versionadded:: 0.16.0
 
+    Args:
 
-    Returns a dict containing the changes.
+        name (str): The name of the package to be deleted.
+
+        version (str): The version of the package to be deleted. If this option
+            is used in combination with the ``pkgs`` option below, then this
+            version will be applied to all targeted packages.
+
+        pkgs (list): A list of packages to delete. Must be passed as a python
+            list. The ``name`` parameter will be ignored if this option is
+            passed.
+
+    Kwargs:
+        saltenv (str): Salt environment. Default ``base``
+        refresh (bool): Refresh package metadata. Default ``False``
+
+    Returns:
+        dict: A dict containing the changes.
 
     CLI Example:
 
@@ -1520,13 +1540,14 @@ def purge(name=None, pkgs=None, version=None, **kwargs):
 
 def get_repo_data(saltenv='base'):
     '''
-    Returns the existing package meteadata db.
-    Will create it, if it does not exist, however will not refresh it.
+    Returns the existing package meteadata db. Will create it, if it does not
+    exist, however will not refresh it.
 
-    :param str saltenv: Salt environment. Default ``base``
+    Args:
+        saltenv (str): Salt environment. Default ``base``
 
-    :return: Returns a dict containing contents of metadata db.
-    :rtype: dict
+    Returns:
+        dict: A dict containing contents of metadata db.
 
     CLI Example:
 
@@ -1538,6 +1559,7 @@ def get_repo_data(saltenv='base'):
     # the existing data even if its old, other parts of the code call this,
     # but they will call refresh if they need too.
     repo_details = _get_repo_details(saltenv)
+
     if repo_details.winrepo_age == -1:
         # no repo meta db
         log.debug('No winrepo.p cache file. Refresh pkg db now.')
@@ -1550,9 +1572,10 @@ def get_repo_data(saltenv='base'):
         log.trace('get_repo_data called reading from disk')
 
     try:
+        serial = salt.payload.Serial(__opts__)
         with salt.utils.fopen(repo_details.winrepo_file, 'rb') as repofile:
             try:
-                repodata = msgpack.loads(repofile.read()) or {}
+                repodata = serial.loads(repofile.read()) or {}
                 __context__['winrepo.data'] = repodata
                 return repodata
             except Exception as exc:
@@ -1570,6 +1593,10 @@ def _get_name_map(saltenv='base'):
     '''
     u_name_map = {}
     name_map = get_repo_data(saltenv).get('name_map', {})
+
+    if six.PY3:
+        return name_map
+
     for k in name_map:
         u_name_map[k.decode('utf-8')] = name_map[k]
     return u_name_map
@@ -1577,28 +1604,17 @@ def _get_name_map(saltenv='base'):
 
 def _get_package_info(name, saltenv='base'):
     '''
-    Return package info.
-    Returns empty map if package not available
+    Return package info. Returns empty map if package not available
     TODO: Add option for version
     '''
     return get_repo_data(saltenv).get('repo', {}).get(name, {})
-
-
-def _reverse_cmp_pkg_versions(pkg1, pkg2):
-    '''
-    Compare software package versions
-    '''
-    if _LooseVersion(pkg1) > _LooseVersion(pkg2):
-        return 1
-    else:
-        return -1
 
 
 def _get_latest_pkg_version(pkginfo):
     if len(pkginfo) == 1:
         return next(six.iterkeys(pkginfo))
     try:
-        return sorted(pkginfo, cmp=_reverse_cmp_pkg_versions).pop()
+        return sorted(list(pkginfo.keys())).pop()
     except IndexError:
         return ''
 
@@ -1612,7 +1628,8 @@ def compare_versions(ver1='', oper='==', ver2=''):
         oper (str): The operand to use to compare
         ver2 (str): A software version to compare
 
-    Returns (bool): True if the comparison is valid, otherwise False
+    Returns:
+        bool: True if the comparison is valid, otherwise False
 
     CLI Example:
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -115,7 +115,6 @@ if salt.utils.is_windows():
     from salt.modules.win_pkg import genrepo
     from salt.modules.win_pkg import _repo_process_pkg_sls
     from salt.modules.win_pkg import _get_latest_pkg_version
-    from salt.modules.win_pkg import _reverse_cmp_pkg_versions
     _get_package_info = _namespaced_function(_get_package_info, globals())
     get_repo_data = _namespaced_function(get_repo_data, globals())
     _get_repo_details = \
@@ -128,8 +127,6 @@ if salt.utils.is_windows():
         _namespaced_function(_repo_process_pkg_sls, globals())
     _get_latest_pkg_version = \
         _namespaced_function(_get_latest_pkg_version, globals())
-    _reverse_cmp_pkg_versions = \
-        _namespaced_function(_reverse_cmp_pkg_versions, globals())
     # The following imports are used by the namespaced win_pkg funcs
     # and need to be included in their globals.
     # pylint: disable=import-error,unused-import


### PR DESCRIPTION
### What does this PR do?
Makes the pkg module and state work on Windows
Fixed docs
Fixed broken functions:
- upgrade_available
- list_upgrades
- version

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/770

### Previous Behavior
Didn't work

### New Behavior
Now it works

### Tests written?
No
