### PR TITLE
Some random salt-virt bug fixes and docs fixups

### DIFF
--- a/doc/topics/tutorials/cloud_controller.rst
+++ b/doc/topics/tutorials/cloud_controller.rst
@@ -216,39 +216,55 @@ Using Salt Virt
 ===============
 
 With hypervisors set up and virtual machine images ready, Salt can start
-issuing cloud commands.
+issuing cloud commands using the `virt runner`.
 
 Start by running a Salt Virt hypervisor info command:
 
 .. code-block:: bash
 
-    salt-run virt.hyper_info
+    salt-run virt.host_info
 
-This will query what the running hypervisor stats are and display information
-for all configured hypervisors. This command will also validate that the
-hypervisors are properly configured.
+This will query the running hypervisor(s) for stats and display useful
+information such as the number of cpus and amount of memory.
 
-Now that hypervisors are available a virtual machine can be provisioned. The
-``virt.init`` routine will create a new virtual machine:
+You can also list all VMs and their current states on all hypervisor
+nodes:
+
+.. code-block:: bash
+
+    salt-run virt.list
+
+Now that hypervisors are available a virtual machine can be provisioned.
+The ``virt.init`` routine will create a new virtual machine:
 
 .. code-block:: bash
 
     salt-run virt.init centos1 2 512 salt://centos.img
 
-This command assumes that the CentOS virtual machine image is sitting in the
-root of the Salt fileserver. Salt Virt will now select a hypervisor to deploy
-the new virtual machine on and copy the virtual machine image down to the
-hypervisor.
+The Salt Virt runner will now automatically select a hypervisor to deploy
+the new virtual machine on. Using ``salt://`` assumes that the CentOS virtual
+machine image is located in the root of the :ref:`file-server` on the master.
+When images are cloned (i.e. copied locatlly after retrieval from the file server)
+the destination directory on the hypervisor minion is determined by the ``virt.images``
+config option; by default this is ``/srv/salt/salt-images/``.
 
-Once the VM image has been copied down the new virtual machine will be seeded.
-Seeding the VMs involves setting pre-authenticated Salt keys on the new VM and
-if needed, will install the Salt Minion on the new VM before it is started.
+When a VM is initialized using ``virt.init`` the image is copied to the hypervisor
+using ``cp.cache_file`` and will be mounted and seeded with a minion. Seeding includes
+setting pre-authenticated keys on the new machine. A minion will only be installed if
+one can not be found on the image using the default arguments to ``seed.apply``.
 
 .. note::
 
     The biggest bottleneck in starting VMs is when the Salt Minion needs to be
     installed. Making sure that the source VM images already have Salt
     installed will GREATLY speed up virtual machine deployment.
+
+You can also deploy an image on a particular minion by directly calling the
+`virt` execution module with an absolute image path. This can be quite handy for testing:
+
+.. code-block:: bash
+
+    salt 'hypervisor*' virt.init centos1 2 512 image=/var/lib/libvirt/images/centos.img
 
 Now that the new VM has been prepared, it can be seen via the ``virt.query``
 command:
@@ -285,11 +301,12 @@ opened on hypervisors:
 
     :ref:`Opening the Firewall up for Salt <firewall>`
 
-Salt also needs an additional flag to be turned on as well. The ``virt.tunnel``
-option needs to be turned on. This flag tells Salt to run migrations securely
-via the libvirt TLS tunnel and to use port 16514. Without ``virt.tunnel`` libvirt
-tries to bind to random ports when running migrations. To turn on ``virt.tunnel``
-simple apply it to the master config file:
+Salt also needs the ``virt.tunnel`` option to be turned on.
+This flag tells Salt to run migrations securely via the libvirt TLS tunnel and to
+use port 16514. Without ``virt.tunnel`` libvirt tries to bind to random ports when
+running migrations.
+
+To turn on ``virt.tunnel`` simple apply it to the master config file:
 
 .. code-block:: yaml
 

--- a/doc/topics/tutorials/cloud_controller.rst
+++ b/doc/topics/tutorials/cloud_controller.rst
@@ -312,9 +312,11 @@ migrate routine:
 VNC Consoles
 ============
 
-Salt Virt also sets up VNC consoles by default, allowing for remote visual
-consoles to be oped up. The information from a ``virt.query`` routine will
-display the vnc console port for the specific vms:
+Although not enabled by default, Salt Virt can also set up VNC consoles allowing for remote visual
+consoles to be opened up. When creating a new VM using ``virt.init`` pass the ``enable_vnc=True``
+parameter to have a console configured for the new VM.
+
+The information from a ``virt.query`` routine will display the vnc console port for the specific vms:
 
 .. code-block:: yaml
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -237,7 +237,7 @@ def _gen_xml(name,
     Generate the XML string to define a libvirt VM
     '''
     hypervisor = 'vmware' if hypervisor == 'esxi' else hypervisor
-    mem = mem * 1024  # MB
+    mem = int(mem) * 1024  # MB
     context = {
         'hypervisor': hypervisor,
         'name': name,

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -570,6 +570,7 @@ def init(name,
     .. code-block:: bash
 
         salt 'hypervisor' virt.init vm_name 4 512 salt://path/to/image.raw
+        salt 'hypervisor' virt.init vm_name 4 512 /var/lib/libvirt/images/img.raw
         salt 'hypervisor' virt.init vm_name 4 512 nic=profile disk=profile
     '''
     hypervisor = __salt__['config.get']('libvirt:hypervisor', hypervisor)
@@ -603,14 +604,17 @@ def init(name,
             )
         elif hypervisor in ['qemu', 'kvm']:
             img_dir = __salt__['config.option']('virt.images')
+            log.debug('Image directory from config option `virt.images` is {0}'
+                      .format(img_dir))
             img_dest = os.path.join(
                 img_dir,
                 name,
                 disk_file_name
             )
+            log.debug('Image destination will be {0}'.format(img_dest))
             img_dir = os.path.dirname(img_dest)
+            log.debug('Image destination directory is  {0}'.format(img_dir))
             sfn = __salt__['cp.cache_file'](image, saltenv)
-            log.debug('Image directory is {0}'.format(img_dir))
 
             try:
                 os.makedirs(img_dir)
@@ -667,7 +671,7 @@ def init(name,
     if seed and seedable:
         log.debug('Seed command is {0}'.format(seed_cmd))
         __salt__[seed_cmd](
-            img_dest,
+           img_dest,
            id_=name,
            config=kwargs.get('config'),
            install=install,

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -664,9 +664,13 @@ def init(name,
     xml = _gen_xml(name, cpu, mem, diskp, nicp, hypervisor, **kwargs)
     try:
         define_xml_str(xml)
-    except libvirtError:
-        # This domain already exists
-        pass
+    except libvirtError as err:
+        # check if failure is due to this domain already existing
+        if "domain '{}' already exists".format(name) in str(err):
+            # continue on to seeding
+            log.warn(err)
+        else:
+            raise err  # a real error we should report upwards
 
     if seed and seedable:
         log.debug('Seed command is {0}'.format(seed_cmd))

--- a/salt/runners/virt.py
+++ b/salt/runners/virt.py
@@ -185,7 +185,7 @@ def init(
         The number of cpus to allocate to this new virtual machine.
 
     mem
-        The amount of memory to allocate tot his virtual machine. The number
+        The amount of memory to allocate to this virtual machine. The number
         is interpreted in megabytes.
 
     image

--- a/salt/runners/virt.py
+++ b/salt/runners/virt.py
@@ -370,7 +370,7 @@ def force_off(name):
     try:
         cmd_ret = client.cmd_iter(
                 host,
-                'virt.destroy',
+                'virt.stop',
                 [name],
                 timeout=600)
     except SaltClientError as client_error:


### PR DESCRIPTION
### What does this PR do?
Fixes a few bugs in the `virt` execution and runner modules as well as some out of date docs.

The bug fix list includes: 
- don't suppress errors from `libvirt` other then the duplicate domain case
- ensure the `mem` argument to `virt._gen_xml()` is always cast to an `int` to avoid strange XML config errors (see a mention in saltstack/pepper#99)
- fix an API mismatch in the virt runner: `virt.force_off` which still calls the now deprecated `virt.destroy`; `virt.stop` must be used instead.

The docs fix list includes:
- correction to that VNC consoles are **not** enabled by default based on the default arguments to `virt.init` in the execution module
- the runner no longer contains a `virt.hyper_info` function; it's now `host_info`

I also filled out the docs a bit more explaining the details of how images are copied to/on the hypervisor and how the execution module can be used directly for testing local cloning.
 
### What issues does this PR fix or reference?
I didn't make individual issues. If this is desired I can happily add them.

### Tests written?
No. 
Does the `salt-virt` stuff even have tests?
I'd be interesting in giving that a go if there's interest.
We've recently released a project for testing systems like `salt` called [pytestlab](https://github.com/sangoma/pytestlab). 
It's still very alpha but I think writing some tests for `salt-virt` might help with solidifying/finalizing some of the lingering design decisions.

Let me know!