### PR TITLE
Disallow modification of jobs from pillar with schedule execution module

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1822,17 +1822,17 @@ class Minion(MinionBase):
         elif func == 'add':
             self.schedule.add_job(schedule, persist)
         elif func == 'modify':
-            self.schedule.modify_job(name, schedule, persist, where)
+            self.schedule.modify_job(name, schedule, persist)
         elif func == 'enable':
             self.schedule.enable_schedule()
         elif func == 'disable':
             self.schedule.disable_schedule()
         elif func == 'enable_job':
-            self.schedule.enable_job(name, persist, where)
+            self.schedule.enable_job(name, persist)
         elif func == 'run_job':
             self.schedule.run_job(name)
         elif func == 'disable_job':
-            self.schedule.disable_job(name, persist, where)
+            self.schedule.disable_job(name, persist)
         elif func == 'reload':
             self.schedule.reload(schedule)
         elif func == 'list':

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -436,10 +436,16 @@ class Schedule(object):
         Return the schedule data structure
         '''
         schedule = {}
-        if include_pillar and 'schedule' in self.opts['pillar']:
-            schedule.update(self.opts['pillar']['schedule'])
+        if include_pillar:
+            pillar_schedule = self.opts['pillar'].get('schedule', {})
+            if not isinstance(pillar_schedule, dict):
+                raise ValueError('Schedule must be of type dict.')
+            schedule.update(pillar_schedule)
         if include_opts:
-            schedule.update(self.opts['schedule'])
+            opts_schedule = self.opts.get('schedule', {})
+            if not isinstance(opts_schedule, dict):
+                raise ValueError('Schedule must be of type dict.')
+            schedule.update(opts_schedule)
         return schedule
 
     def persist(self):
@@ -914,8 +920,6 @@ class Schedule(object):
         Evaluate and execute the schedule
         '''
         schedule = self._get_schedule()
-        if not isinstance(schedule, dict):
-            raise ValueError('Schedule must be of type dict.')
         if 'enabled' in schedule and not schedule['enabled']:
             return
         for job, data in six.iteritems(schedule):

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -437,7 +437,7 @@ class Schedule(object):
         '''
         schedule = {}
         if include_pillar:
-            pillar_schedule = self.opts['pillar'].get('schedule', {})
+            pillar_schedule = self.opts.get('pillar', {}).get('schedule', {})
             if not isinstance(pillar_schedule, dict):
                 raise ValueError('Schedule must be of type dict.')
             schedule.update(pillar_schedule)

--- a/tests/unit/utils/schedule_test.py
+++ b/tests/unit/utils/schedule_test.py
@@ -48,7 +48,7 @@ class ScheduleTestCase(TestCase):
         '''
         Tests ensuring the job exists and deleting it
         '''
-        self.schedule.opts.update({'schedule': {'foo': 'bar'}, 'pillar': ''})
+        self.schedule.opts.update({'schedule': {'foo': 'bar'}, 'pillar': {}})
         self.assertIn('foo', self.schedule.opts['schedule'])
         self.schedule.delete_job('foo')
         self.assertNotIn('foo', self.schedule.opts['schedule'])
@@ -57,7 +57,7 @@ class ScheduleTestCase(TestCase):
         '''
         Tests ignoring deletion job from pillar
         '''
-        self.schedule.opts.update({'pillar': {'schedule': {'foo': 'bar'}}, 'schedule': ''})
+        self.schedule.opts.update({'pillar': {'schedule': {'foo': 'bar'}}, 'schedule': {}})
         self.assertIn('foo', self.schedule.opts['pillar']['schedule'])
         self.schedule.delete_job('foo')
         self.assertIn('foo', self.schedule.opts['pillar']['schedule'])
@@ -66,7 +66,7 @@ class ScheduleTestCase(TestCase):
         '''
         Tests removing job from intervals
         '''
-        self.schedule.opts.update({'pillar': '', 'schedule': ''})
+        self.schedule.opts.update({'pillar': {}, 'schedule': {}})
         self.schedule.intervals = {'foo': 'bar'}
         self.schedule.delete_job('foo')
         self.assertNotIn('foo', self.schedule.intervals)
@@ -76,7 +76,7 @@ class ScheduleTestCase(TestCase):
         Tests ensuring jobs exists and deleting them by prefix
         '''
         self.schedule.opts.update({'schedule': {'foobar': 'bar', 'foobaz': 'baz', 'fooboo': 'boo'},
-                                   'pillar': ''})
+                                   'pillar': {}})
         ret = copy.deepcopy(self.schedule.opts)
         del ret['schedule']['foobar']
         del ret['schedule']['foobaz']
@@ -88,7 +88,7 @@ class ScheduleTestCase(TestCase):
         Tests ignoring deletion jobs by prefix from pillar
         '''
         self.schedule.opts.update({'pillar': {'schedule': {'foobar': 'bar', 'foobaz': 'baz', 'fooboo': 'boo'}},
-                                   'schedule': ''})
+                                   'schedule': {}})
         ret = copy.deepcopy(self.schedule.opts)
         self.schedule.delete_job_prefix('fooba')
         self.assertEqual(self.schedule.opts, ret)
@@ -117,9 +117,9 @@ class ScheduleTestCase(TestCase):
         ret = copy.deepcopy(self.schedule.opts)
         ret.update({'schedule': {'foo': {'bar': 'baz', 'enabled': True},
                                  'hello': {'world': 'peace', 'enabled': True}},
-                    'pillar': ''})
+                    'pillar': {}})
         self.schedule.opts.update({'schedule': {'hello': {'world': 'peace', 'enabled': True}},
-                                   'pillar': ''})
+                                   'pillar': {}})
         Schedule.add_job(self.schedule, data)
         self.assertEqual(self.schedule.opts, ret)
 

--- a/tests/unit/utils/schedule_test.py
+++ b/tests/unit/utils/schedule_test.py
@@ -55,12 +55,12 @@ class ScheduleTestCase(TestCase):
 
     def test_delete_job_in_pillar(self):
         '''
-        Tests deleting job in pillar
+        Tests ignoring deletion job from pillar
         '''
         self.schedule.opts.update({'pillar': {'schedule': {'foo': 'bar'}}, 'schedule': ''})
         self.assertIn('foo', self.schedule.opts['pillar']['schedule'])
-        self.schedule.delete_job('foo', where='pillar')
-        self.assertNotIn('foo', self.schedule.opts['pillar']['schedule'])
+        self.schedule.delete_job('foo')
+        self.assertIn('foo', self.schedule.opts['pillar']['schedule'])
 
     def test_delete_job_intervals(self):
         '''
@@ -85,14 +85,12 @@ class ScheduleTestCase(TestCase):
 
     def test_delete_job_prefix_in_pillar(self):
         '''
-        Tests deleting jobs by prefix in pillar
+        Tests ignoring deletion jobs by prefix from pillar
         '''
         self.schedule.opts.update({'pillar': {'schedule': {'foobar': 'bar', 'foobaz': 'baz', 'fooboo': 'boo'}},
                                    'schedule': ''})
         ret = copy.deepcopy(self.schedule.opts)
-        del ret['pillar']['schedule']['foobar']
-        del ret['pillar']['schedule']['foobaz']
-        self.schedule.delete_job_prefix('fooba', where='pillar')
+        self.schedule.delete_job_prefix('fooba')
         self.assertEqual(self.schedule.opts, ret)
 
     # add_job tests
@@ -118,8 +116,10 @@ class ScheduleTestCase(TestCase):
         data = {'foo': {'bar': 'baz'}}
         ret = copy.deepcopy(self.schedule.opts)
         ret.update({'schedule': {'foo': {'bar': 'baz', 'enabled': True},
-                                 'hello': {'world': 'peace', 'enabled': True}}})
-        self.schedule.opts.update({'schedule': {'hello': {'world': 'peace', 'enabled': True}}})
+                                 'hello': {'world': 'peace', 'enabled': True}},
+                    'pillar': ''})
+        self.schedule.opts.update({'schedule': {'hello': {'world': 'peace', 'enabled': True}},
+                                   'pillar': ''})
         Schedule.add_job(self.schedule, data)
         self.assertEqual(self.schedule.opts, ret)
 
@@ -135,11 +135,11 @@ class ScheduleTestCase(TestCase):
 
     def test_enable_job_pillar(self):
         '''
-        Tests enabling a job in pillar
+        Tests ignoring enable a job from pillar
         '''
-        self.schedule.opts.update({'pillar': {'schedule': {'name': {'enabled': 'foo'}}}})
-        Schedule.enable_job(self.schedule, 'name', persist=False, where='pillar')
-        self.assertTrue(self.schedule.opts['pillar']['schedule']['name']['enabled'])
+        self.schedule.opts.update({'pillar': {'schedule': {'name': {'enabled': False}}}})
+        Schedule.enable_job(self.schedule, 'name', persist=False)
+        self.assertFalse(self.schedule.opts['pillar']['schedule']['name']['enabled'])
 
     # disable_job tests
 
@@ -147,17 +147,17 @@ class ScheduleTestCase(TestCase):
         '''
         Tests disabling a job
         '''
-        self.schedule.opts.update({'schedule': {'name': {'enabled': 'foo'}}})
+        self.schedule.opts.update({'schedule': {'name': {'enabled': 'foo'}}, 'pillar': {}})
         Schedule.disable_job(self.schedule, 'name')
         self.assertFalse(self.schedule.opts['schedule']['name']['enabled'])
 
     def test_disable_job_pillar(self):
         '''
-        Tests disabling a job in pillar
+        Tests ignoring disable a job in pillar
         '''
-        self.schedule.opts.update({'pillar': {'schedule': {'name': {'enabled': 'foo'}}}})
-        Schedule.disable_job(self.schedule, 'name', persist=False, where='pillar')
-        self.assertFalse(self.schedule.opts['pillar']['schedule']['name']['enabled'])
+        self.schedule.opts.update({'pillar': {'schedule': {'name': {'enabled': True}}}, 'schedule': {}})
+        Schedule.disable_job(self.schedule, 'name', persist=False)
+        self.assertTrue(self.schedule.opts['pillar']['schedule']['name']['enabled'])
 
     # modify_job tests
 
@@ -165,22 +165,32 @@ class ScheduleTestCase(TestCase):
         '''
         Tests modifying a job in the scheduler
         '''
-        schedule = {'schedule': {'foo': 'bar'}}
+        schedule = {'foo': 'bar'}
+        self.schedule.opts.update({'schedule': {'name': 'baz'}, 'pillar': {}})
         ret = copy.deepcopy(self.schedule.opts)
-        ret.update({'schedule': {'foo': 'bar', 'name': {'schedule': {'foo': 'bar'}}}})
-        self.schedule.opts.update({'schedule': {'foo': 'bar'}})
+        ret.update({'schedule': {'name': {'foo': 'bar'}}})
+        Schedule.modify_job(self.schedule, 'name', schedule)
+        self.assertEqual(self.schedule.opts, ret)
+
+    def test_modify_job_not_exists(self):
+        '''
+        Tests modifying a job in the scheduler if jobs not exists
+        '''
+        schedule = {'foo': 'bar'}
+        self.schedule.opts.update({'schedule': {}, 'pillar': {}})
+        ret = copy.deepcopy(self.schedule.opts)
+        ret.update({'schedule': {'name':  {'foo': 'bar'}}})
         Schedule.modify_job(self.schedule, 'name', schedule)
         self.assertEqual(self.schedule.opts, ret)
 
     def test_modify_job_pillar(self):
         '''
-        Tests modifying a job in the scheduler in pillar
+        Tests ignoring modification of job from pillar
         '''
         schedule = {'foo': 'bar'}
+        self.schedule.opts.update({'schedule': {}, 'pillar': {'schedule': {'name': 'baz'}}})
         ret = copy.deepcopy(self.schedule.opts)
-        ret.update({'pillar': {'schedule': {'name': {'foo': 'bar'}}}})
-        self.schedule.opts.update({'pillar': {'schedule': {'name': {'foo': 'bar'}}}})
-        Schedule.modify_job(self.schedule, 'name', schedule, persist=False, where='pillar')
+        Schedule.modify_job(self.schedule, 'name', schedule, persist=False)
         self.assertEqual(self.schedule.opts, ret)
 
     maxDiff = None
@@ -191,7 +201,7 @@ class ScheduleTestCase(TestCase):
         '''
         Tests enabling the scheduler
         '''
-        self.schedule.opts.update({'schedule': {'enabled': 'foo'}})
+        self.schedule.opts.update({'schedule': {'enabled': 'foo'}, 'pillar': {}})
         Schedule.enable_schedule(self.schedule)
         self.assertTrue(self.schedule.opts['schedule']['enabled'])
 
@@ -201,7 +211,7 @@ class ScheduleTestCase(TestCase):
         '''
         Tests disabling the scheduler
         '''
-        self.schedule.opts.update({'schedule': {'enabled': 'foo'}})
+        self.schedule.opts.update({'schedule': {'enabled': 'foo'}, 'pillar': {}})
         Schedule.disable_schedule(self.schedule)
         self.assertFalse(self.schedule.opts['schedule']['enabled'])
 
@@ -259,11 +269,17 @@ class ScheduleTestCase(TestCase):
 
     def test_eval_schedule_is_not_dict(self):
         '''
-        Tests if the schedule is a dictionary
+        Tests eval if the schedule is not a dictionary
         '''
-        self.schedule.opts.update({'schedule': ''})
+        self.schedule.opts.update({'schedule': '', 'pillar': {'schedule': {}}})
         self.assertRaises(ValueError, Schedule.eval, self.schedule)
 
+    def test_eval_schedule_is_not_dict_in_pillar(self):
+        '''
+        Tests eval if the schedule from pillar is not a dictionary
+        '''
+        self.schedule.opts.update({'schedule': {}, 'pillar': {'schedule': ''}})
+        self.assertRaises(ValueError, Schedule.eval, self.schedule)
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?
This PR disallows modification of jobs received from pillar with `schedule` execution module.
This PR reverts some changes made in #36437 and takes different approach to the problem highlighted there.

### What issues does this PR fix or reference?
Fixes #39779 #38523
Reference #36437

### Previous Behavior
Output of function `config.merge` is used for job management (creating/updating/deleting).

### New Behavior
Function `config.merge` is no longer used to obtain schedule data, in favor for explicit merging of opts['schedule'] and opts['pillar']['schedule'], so that job source can be find out.

### Tests written?
Tests updated to match new behaviour.

