### PR TITLE
use salt-cloud to create vm and vm name is different with minion id

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1296,7 +1296,9 @@ class Cloud(object):
                     client = salt.client.get_local_client(mopts=self.opts)
 
                     ret = client.cmd(
-                        vm_['name'],
+                        # if vm name is different with minion id
+                        # key_id represent vm name or minion id
+                        key_id,
                         'saltutil.sync_{0}'.format(self.opts['sync_after_install']),
                         timeout=self.opts['timeout']
                     )
@@ -1327,7 +1329,9 @@ class Cloud(object):
             )
             client = salt.client.get_local_client(mopts=self.opts)
             action_out = client.cmd(
-                vm_['name'],
+                # if vm name is different with minion id
+                # key_id represent vm name or minion id
+                key_id,
                 self.opts['start_action'],
                 timeout=self.opts['timeout'] * 60
             )


### PR DESCRIPTION
### What does this PR do?
When use salt-cloud to create vm and vm name is different with minion id,i find that i can set minion id
in profile file, if i set minion id different with the vm name,there will have some error.
This PR will fix it.

### Tests written?
i test it in my env