### PR TITLE
correctly parse "pkg_name===version" from pip freeze

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1082,6 +1082,9 @@ def list_(prefix=None,
         elif line.startswith('-e'):
             line = line.split('-e ')[1]
             version_, name = line.split('#egg=')
+        elif len(line.split('===')) >= 2:
+            name = line.split('===')[0]
+            version_ = line.split('===')[1]
         elif len(line.split('==')) >= 2:
             name = line.split('==')[0]
             version_ = line.split('==')[1]


### PR DESCRIPTION
### What does this PR do?
In some cases `pip freeze` returns lines like `pkg_name===version`
It's mean that states like
```
"Install pip packages":
  pip.installed:
    - pkgs:
      - my-pkg == 0.23-version-2748
```
always return `changes=True`

My PR add additional `if` for three equal symbols

### Previous Behavior
```
# salt-call pip.freeze
local:
    - my-pkg===0.23-version-2748
# salt-call pip.list my-pkg
local:
    ----------
    my-pkg:
        =0.23-version-2748
```

### New Behavior
```
# salt-call pip.freeze
local:
    - my-pkg===0.23-version-2748
# salt-call pip.list my-pkg
local:
    ----------
    my-pkg:
        0.23-version-2748
```

### Tests written?

No