### PR TITLE
Avoid listing all sysctl in linux_sysctl module

### DIFF
--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -177,7 +177,6 @@ def persist(name, value, config=None):
     '''
     if config is None:
         config = default_config()
-    running = show()
     edited = False
     # If the sysctl.conf is not present, add it
     if not os.path.isfile(config):
@@ -229,15 +228,11 @@ def persist(name, value, config=None):
             # This is the line to edit
             if str(comps[1]) == str(value):
                 # It is correct in the config, check if it is correct in /proc
-                if name in running:
-                    if str(running[name]) != str(value):
-                        assign(name, value)
-                        return 'Updated'
-                    else:
-                        return 'Already set'
-                # It is missing from the running config. We can not set it.
+                if str(get(name)) != str(value):
+                    assign(name, value)
+                    return 'Updated'
                 else:
-                    raise CommandExecutionError('sysctl {0} does not exist'.format(name))
+                    return 'Already set'
 
             nlines.append('{0} = {1}\n'.format(name, value))
             edited = True


### PR DESCRIPTION
System with a lot of network interfaces needs a few seconds to list all sysctl entries. It is faster to get only single entry especially if tens of sysctl needs to be set.

### What does this PR do?
Reduce sysctl.persist module execution time

### Previous Behavior
All sysctl entries were fetched which takes time on system with a lot of network interfaces

### New Behavior
Only one sysctl entry is fetched

### Tests written?
No