### PR TITLE
Add `key_text` option to apt `pkgrepo.managed` (closes #37936)

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2106,6 +2106,9 @@ def mod_repo(repo, saltenv='base', **kwargs):
         key_url
             URL to a GPG key to add to the APT GPG keyring
 
+        key_text
+            GPG key in string form to add to the APT GPG keyring
+
         consolidate
             if ``True``, will attempt to de-dup and consolidate sources
 
@@ -2303,6 +2306,16 @@ def mod_repo(repo, saltenv='base', **kwargs):
         if not out.upper().startswith('OK'):
             raise CommandExecutionError(
                 'Error: failed to add key from {0}'.format(key_url)
+            )
+
+    elif 'key_text' in kwargs:
+        key_text = kwargs['key_text']
+        cmd = ['apt-key', 'add', '-']
+        out = __salt__['cmd.run_stdout'](cmd, stdin=key_text,
+                                         python_shell=False, **kwargs)
+        if not out.upper().startswith('OK'):
+            raise CommandExecutionError(
+                'Error: failed to add key:\n{0}'.format(key_text)
             )
 
     if 'comps' in kwargs:


### PR DESCRIPTION
### What does this PR do?
It may not always possible or desirable to upload a GPG key to a keyserver (`keyid`/`keyserver`) or to host it on remote server (`key_url`). This just leaves storing the key in a state using a `salt://` URL.

It seems like the states is the wrong place to hold this sort of data, and would be more suited to being in the pillar.

Adding a `key_text` option to the apt `pkgrepo.managed` module, which accepts a GPG key in string form, can assist in importing a GPG key from pillar data.

**Note:** The original issue suggested using `key_contents` as the option name, but `key_text` seemed to be more consistent with the `text` argument used by `add_repo_key()`.

### What issues does this PR fix or reference?
#37936

### New Behavior
Adds a `key_text` option to apt `pkgrepo.managed` to allow adding of a GPG key using a string representation of the key.

### Tests written?

No
