### PR TITLE
INFRA-4506 - boto_lambda: add ability to pass SecurityGroupNames and SubnetNames in VpcConfig dict

### DIFF
--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -206,6 +206,22 @@ def _filedata(infile):
         return f.read()
 
 
+def _resolve_vpcconfig(conf, region=None, key=None, keyid=None, profile=None):
+    if isinstance(conf, six.string_types):
+        conf = json.loads(conf)
+    if not conf:
+        return {}
+    if not isinstance(conf, dict):
+        raise SaltInvocationError('VpcConfig must be a dict.')
+    sns = [__salt__['boto_vpc.get_resource_id']('subnet', s, region=region, key=key,
+            keyid=keyid, profile=profile).get('id') for s in conf.pop('SubnetNames', [])]
+    sgs = [__salt__['boto_secgroup.get_group_id'](s, region=region, key=key, keyid=keyid,
+            profile=profile) for s in conf.pop('SecurityGroupNames', [])]
+    conf.setdefault('SubnetIds', []).extend(sns)
+    conf.setdefault('SecurityGroupIds', []).extend(sgs)
+    return conf
+
+
 def create_function(FunctionName, Runtime, Role, Handler, ZipFile=None,
                     S3Bucket=None, S3Key=None, S3ObjectVersion=None,
                     Description="", Timeout=3, MemorySize=128, Publish=False,
@@ -260,7 +276,7 @@ def create_function(FunctionName, Runtime, Role, Handler, ZipFile=None,
                 code['S3ObjectVersion'] = S3ObjectVersion
         kwargs = {}
         if VpcConfig is not None:
-            kwargs['VpcConfig'] = VpcConfig
+            kwargs['VpcConfig'] = _resolve_vpcconfig(VpcConfig, region=region, key=key, keyid=keyid, profile=profile)
         if Environment is not None:
             kwargs['Environment'] = Environment
         if WaitForRole:
@@ -390,14 +406,15 @@ def update_function_config(FunctionName, Role=None, Handler=None,
                'VpcConfig': VpcConfig,
                'Environment': Environment}
 
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     for val, var in six.iteritems(options):
         if var:
             args[val] = var
     if Role:
-        role_arn = _get_role_arn(Role, region, key, keyid, profile)
-        args['Role'] = role_arn
+        args['Role'] = _get_role_arn(Role, region, key, keyid, profile)
+    if VpcConfig:
+        args['VpcConfig'] = _resolve_vpcconfig(VpcConfig, region=region, key=key, keyid=keyid, profile=profile)
     try:
-        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         if WaitForRole:
             retrycount = RoleRetries
         else:

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -210,7 +210,7 @@ def _resolve_vpcconfig(conf, region=None, key=None, keyid=None, profile=None):
     if isinstance(conf, six.string_types):
         conf = json.loads(conf)
     if not conf:
-        return {}
+        return None
     if not isinstance(conf, dict):
         raise SaltInvocationError('VpcConfig must be a dict.')
     sns = [__salt__['boto_vpc.get_resource_id']('subnet', s, region=region, key=key,

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -321,7 +321,7 @@ def _resolve_vpcconfig(conf, region=None, key=None, keyid=None, profile=None):
     if isinstance(conf, six.string_types):
         conf = json.loads(conf)
     if not conf:
-        return {}
+        return None
     if not isinstance(conf, dict):
         raise SaltInvocationError('VpcConfig must be a dict.')
     sns = [__salt__['boto_vpc.get_resource_id']('subnet', s, region=region, key=key,

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -147,12 +147,24 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None,
         64 MB.
 
     VpcConfig
-        If your Lambda function accesses resources in a VPC, you provide this
-        parameter identifying the list of security group IDs and subnet IDs.
-        These must belong to the same VPC. You must provide at least one
-        security group and one subnet ID.
+        If your Lambda function accesses resources in a VPC, you must provide this parameter
+        identifying the list of security group IDs/Names and subnet IDs/Name.  These must all belong
+        to the same VPC.  This is a dict of the form:
 
-        .. versionadded:: 2016.11.0
+        .. code-block:: yaml
+            VpcConfig:
+                SecurityGroupNames:
+                - mysecgroup1
+                - mysecgroup2
+                SecurityGroupIds:
+                - sg-abcdef1234
+                SubnetNames:
+                - mysubnet1
+                SubnetIds:
+                - subnet-1234abcd
+                - subnet-abcd1234
+
+        If VpcConfig is provided at all, you MUST pass at least one security group and one subnet.
 
     Permissions
         A list of permission definitions to be added to the function's policy
@@ -329,7 +341,7 @@ def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
     oldval = func.get('VpcConfig')
     if oldval is not None:
         oldval.pop('VpcId', None)
-    if oldval != VpcConfig:
+    if __utils__['boto3.ordered'](oldval) != __utils__['boto3.ordered'](VpcConfig):
         need_update = True
         ret['changes'].setdefault('new', {})['VpcConfig'] = VpcConfig
         ret['changes'].setdefault(

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -73,7 +73,6 @@ import salt.ext.six as six
 import salt.utils.dictupdate as dictupdate
 import salt.utils
 from salt.exceptions import SaltInvocationError
-from salt.utils.odict import OrderedDict
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
VpcConfig only accepts SubnetIds and SecurityGroupIds, which is problematic when you don't know these ahead of time in a state run, but DO know the expected NAMES of those resources.

This adds the option to have the create and update functions resolve the *Names to their Ids for you, making writing states without hardcodes much, much easier :)