### PR TITLE
Backport libcloudfuncs list_nodes fix to 2015.8

### DIFF
--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -55,16 +55,31 @@ def node_state(id_):
     '''
     Libcloud supported node states
     '''
-    states = {0: 'RUNNING',
-              1: 'REBOOTING',
-              2: 'TERMINATED',
-              3: 'PENDING',
-              4: 'UNKNOWN',
-              5: 'STOPPED',
-              6: 'SUSPENDED',
-              7: 'ERROR',
-              8: 'PAUSED'}
-    return states[id_]
+    states_int = {
+        0: 'RUNNING',
+        1: 'REBOOTING',
+        2: 'TERMINATED',
+        3: 'PENDING',
+        4: 'UNKNOWN',
+        5: 'STOPPED',
+        6: 'SUSPENDED',
+        7: 'ERROR',
+        8: 'PAUSED'}
+    states_str = {
+        'running': 'RUNNING',
+        'rebooting': 'REBOOTING',
+        'starting': 'STARTING',
+        'terminated': 'TERMINATED',
+        'pending': 'PENDING',
+        'unknown': 'UNKNOWN',
+        'stopping': 'STOPPING',
+        'stopped': 'STOPPED',
+        'suspended': 'SUSPENDED',
+        'error': 'ERROR',
+        'paused': 'PAUSED',
+        'reconfiguring': 'RECONFIGURING'
+    }
+    return states_str[id_] if isinstance(id_, string_types) else states_int[id_]
 
 
 def check_libcloud_version(reqver=LIBCLOUD_MINIMAL_VERSION, why=None):


### PR DESCRIPTION
### What does this PR do?

Commit be41a400fa8c from 2016.3 feature release fixes salt.cloud.libcloudfuncs.list_nodes. Backport it to 2015.8 where the same issue exists.

### What issues does this PR fix or reference?

Fixes #40050

### Tests written?

No