### PR TITLE
Remove max version check on dockercompose

### DIFF
--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -124,7 +124,6 @@ except ImportError:
     USE_FILTERCLASS = False
 
 MIN_DOCKERCOMPOSE = (1, 5, 0)
-MAX_DOCKERCOMPOSE = (1, 9, 0)
 VERSION_RE = r'([\d.]+)'
 
 log = logging.getLogger(__name__)
@@ -139,7 +138,7 @@ def __virtual__():
         match = re.match(VERSION_RE, str(compose.__version__))
         if match:
             version = tuple([int(x) for x in match.group(1).split('.')])
-            if version >= MIN_DOCKERCOMPOSE and version <= MAX_DOCKERCOMPOSE:
+            if version >= MIN_DOCKERCOMPOSE:
                 return __virtualname__
     return (False, 'The dockercompose execution module not loaded: '
             'compose python library not available.')


### PR DESCRIPTION
Some time ago someone complained about the version check, I was against removing it. 

After some more thoughts I realise that we should check only the minimum version and get rid fo the max version check. 

The pace at which docker-compose is going is way too fast to keep it up to speed in that module and 99% of the time all we need to do is bump the version number. So it is blocking people for not much benefit.

