### PR TITLE
Add a salt-standard interface to openscap xccdf eval

### DIFF
--- a/salt/modules/openscap.py
+++ b/salt/modules/openscap.py
@@ -107,3 +107,7 @@ def xccdf(params):
         upload_dir=upload_dir,
         error=error,
         returncode=returncode)
+
+
+def xccdf_eval(profile=None, policy=None):
+    return xccdf('eval --profile {0} {1}'.format(profile, policy))

--- a/tests/unit/modules/openscap_test.py
+++ b/tests/unit/modules/openscap_test.py
@@ -203,3 +203,9 @@ class OpenscapTestCase(TestCase):
                 'returncode': None
             }
         )
+
+    @patch('salt.modules.openscap.xccdf', Mock())
+    def test_openscap_eval(self):
+        response = openscap.xccdf_eval('Default', self.policy_file)
+        openscap.xccdf.assert_called_once_with(
+            'eval --profile Default {0}'.format(self.policy_file))


### PR DESCRIPTION
### What does this PR do?
Make it possible to call the oscap xccdf eval like this:

`salt '*' openscap.xccdf_eval Default /usr/share/openscap/scap-yast2sec-xccdf.xml` and like this
`salt '*' openscap.xccdf_eval profile=Default policy=/usr/share/openscap/scap-yast2sec-xccdf.xml`

in addition to the generic way of calling xccdf:

`salt '*' openscap.xccdf "eval --profile Default /usr/share/openscap/scap-yast2sec-xccdf.xml"`

### Tests written?

Yes