### PR TITLE
VRF arg and better doc for ping and traceroute

### DIFF
--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -378,13 +378,13 @@ def traceroute(destination, source=None, ttl=None, timeout=None, vrf=None):
 
     destination
         Hostname or address of remote host
-    
+
     source
         Source address to use in outgoing traceroute packets
-    
+
     ttl
         IP maximum time-to-live value (or IPv6 maximum hop-limit value)
-    
+
     timeout
         Number of seconds to wait for response (seconds)
 
@@ -420,22 +420,22 @@ def ping(destination, source=None, ttl=None, timeout=None, size=None, count=None
 
     destination
         Hostname or IP address of remote host
-    
+
     source
         Source address of echo request
-    
+
     ttl
         IP time-to-live value (IPv6 hop-limit value) (1..255 hops)
-    
+
     timeout
         Maximum wait time after sending final packet (seconds)
-    
+
     size
         Size of request packets (0..65468 bytes)
-    
+
     count
         Number of ping requests to send (1..2000000000 packets)
-    
+
     vrf
         VRF (routing instance) for ping attempt
 

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -370,16 +370,28 @@ def cli(*commands):
     # in case of errors, they'll be catched in the proxy
 
 
-def traceroute(destination, source=None, ttl=None, timeout=None):
+def traceroute(destination, source=None, ttl=None, timeout=None, vrf=None):
 
     '''
     Calls the method traceroute from the NAPALM driver object and returns a dictionary with the result of the traceroute
     command executed on the device.
 
-    :param destination: Hostname or address of remote host
-    :param source: Source address to use in outgoing traceroute packets
-    :param ttl: IP maximum time-to-live value (or IPv6 maximum hop-limit value)
-    :param timeout: Number of seconds to wait for response (seconds)
+    destination
+        Hostname or address of remote host
+    
+    source
+        Source address to use in outgoing traceroute packets
+    
+    ttl
+        IP maximum time-to-live value (or IPv6 maximum hop-limit value)
+    
+    timeout
+        Number of seconds to wait for response (seconds)
+
+    vrf
+        VRF (routing instance) for traceroute attempt
+
+        .. versionadded:: 2016.11.4
 
     CLI Example:
 
@@ -395,22 +407,39 @@ def traceroute(destination, source=None, ttl=None, timeout=None):
             'destination': destination,
             'source': source,
             'ttl': ttl,
-            'timeout': timeout
+            'timeout': timeout,
+            'vrf': vrf
         }
     )
 
 
-def ping(destination, source=None, ttl=None, timeout=None, size=None, count=None):
+def ping(destination, source=None, ttl=None, timeout=None, size=None, count=None, vrf=None):
 
     '''
     Executes a ping on the network device and returns a dictionary as a result.
 
-    :param destination: Hostname or IP address of remote host
-    :param source: Source address of echo request
-    :param ttl: IP time-to-live value (IPv6 hop-limit value) (1..255 hops)
-    :param timeout: Maximum wait time after sending final packet (seconds)
-    :param size: Size of request packets (0..65468 bytes)
-    :param count: Number of ping requests to send (1..2000000000 packets)
+    destination
+        Hostname or IP address of remote host
+    
+    source
+        Source address of echo request
+    
+    ttl
+        IP time-to-live value (IPv6 hop-limit value) (1..255 hops)
+    
+    timeout
+        Maximum wait time after sending final packet (seconds)
+    
+    size
+        Size of request packets (0..65468 bytes)
+    
+    count
+        Number of ping requests to send (1..2000000000 packets)
+    
+    vrf
+        VRF (routing instance) for ping attempt
+
+        .. versionadded:: 2016.11.4
 
     CLI Example:
 
@@ -429,7 +458,8 @@ def ping(destination, source=None, ttl=None, timeout=None, size=None, count=None
             'ttl': ttl,
             'timeout': timeout,
             'size': size,
-            'count': count
+            'count': count,
+            'vrf': vrf
         }
     )
 


### PR DESCRIPTION
### What does this PR do?

Add VRF arg and better doc for ping and traceroute under the napalm_network (net) execution module.