### PR TITLE
Add gpg ext pillar to decrypt all pillar data

### DIFF
--- a/salt/pillar/gpg.py
+++ b/salt/pillar/gpg.py
@@ -11,7 +11,7 @@ this:
 
     ext_pillar:
       - stack: /path/to/stack.cfg
-      - decrypt: {}
+      - gpg: {}
 
 Set ``gpg_keydir`` in your config to adjust the homedir the renderer uses.
 

--- a/salt/pillar/gpg.py
+++ b/salt/pillar/gpg.py
@@ -20,6 +20,7 @@ Set ``gpg_keydir`` in your config to adjust the homedir the renderer uses.
 from __future__ import absolute_import
 import salt.utils
 
+
 def ext_pillar(minion_id, pillar, *args, **kwargs):
     render_function = salt.loader.render(__opts__, __salt__).get("gpg")
     return render_function(pillar)

--- a/salt/pillar/gpg.py
+++ b/salt/pillar/gpg.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+'''
+Decrypt pillar data through the builtin GPG renderer
+
+In most cases, you'll want to make this the last external pillar used. For
+example, to pair with the builtin stack pillar you could do something like
+this:
+
+.. code:: yaml
+
+    ext_pillar:
+      - stack: /path/to/stack.cfg
+      - decrypt: {}
+
+Set ``gpg_keydir`` in your config to adjust the homedir the renderer uses.
+
+'''
+
+from __future__ import absolute_import
+import salt.utils
+
+def ext_pillar(minion_id, pillar, *args, **kwargs):
+    render_function = salt.loader.render(__opts__, __salt__).get("gpg")
+    return render_function(pillar)


### PR DESCRIPTION
This allows use of the builtin gpg renderer on external pillar data, which is helpful when using something like the stack external pillar as the primary pillar data source.