### PR TITLE
Fix problems with the test suite on Py3

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -121,15 +121,13 @@ def _get_pip_bin(bin_env):
         which_result = __salt__['cmd.which_bin'](['pip', 'pip2', 'pip3', 'pip-python'])
         if which_result is None:
             raise CommandNotFoundError('Could not find a `pip` binary')
-        if salt.utils.is_windows():
-            return which_result.encode('string-escape')
         return which_result
 
     # try to get pip bin from virtualenv, bin_env
     if os.path.isdir(bin_env):
         if salt.utils.is_windows():
             pip_bin = os.path.join(
-                bin_env, 'Scripts', 'pip.exe').encode('string-escape')
+                bin_env, 'Scripts', 'pip.exe')
         else:
             pip_bin = os.path.join(bin_env, 'bin', 'pip')
         if os.path.isfile(pip_bin):

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -120,7 +120,7 @@ def _get_pip_bin(bin_env):
     '''
     if not bin_env:
         which_result = __salt__['cmd.which_bin'](['pip', 'pip2', 'pip3', 'pip-python'])
-        if salt.utils.is_windows() and six.py2:
+        if salt.utils.is_windows() and six.PY2:
             which_result.encode('string-escape')
         if which_result is None:
             raise CommandNotFoundError('Could not find a `pip` binary')
@@ -129,7 +129,7 @@ def _get_pip_bin(bin_env):
     # try to get pip bin from virtualenv, bin_env
     if os.path.isdir(bin_env):
         if salt.utils.is_windows():
-            if six.py2:
+            if six.PY2:
                 pip_bin = os.path.join(
                     bin_env, 'Scripts', 'pip.exe').encode('string-escape')
             else:

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -87,6 +87,7 @@ import salt.utils
 import tempfile
 import salt.utils.locales
 import salt.utils.url
+import salt.ext.six as six
 from salt.ext.six import string_types, iteritems
 from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
@@ -119,6 +120,8 @@ def _get_pip_bin(bin_env):
     '''
     if not bin_env:
         which_result = __salt__['cmd.which_bin'](['pip', 'pip2', 'pip3', 'pip-python'])
+        if salt.utils.is_windows() and six.py2:
+            which_result.encode('string-escape')
         if which_result is None:
             raise CommandNotFoundError('Could not find a `pip` binary')
         return which_result
@@ -126,8 +129,11 @@ def _get_pip_bin(bin_env):
     # try to get pip bin from virtualenv, bin_env
     if os.path.isdir(bin_env):
         if salt.utils.is_windows():
-            pip_bin = os.path.join(
-                bin_env, 'Scripts', 'pip.exe')
+            if six.py2:
+                pip_bin = os.path.join(
+                    bin_env, 'Scripts', 'pip.exe').encode('string-escape')
+            else:
+                pip_bin = os.path.join(bin_env, 'Scripts', 'pip.exe')
         else:
             pip_bin = os.path.join(bin_env, 'bin', 'pip')
         if os.path.isfile(pip_bin):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -287,6 +287,7 @@ from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 if salt.utils.is_windows():
     import salt.utils.win_dacl
+    import salt.utils.win_functions
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -2598,7 +2599,7 @@ def directory(name,
 
         # If win_owner not passed, use user
         if win_owner is None:
-            win_owner = user if user else None
+            win_owner = user if user else salt.utils.win_functions.get_current_user()
 
         # Group isn't relevant to Windows, use win_perms/win_deny_perms
         if group is not None:

--- a/salt/utils/win_dacl.py
+++ b/salt/utils/win_dacl.py
@@ -913,7 +913,7 @@ def dacl(obj_name=None, obj_type='file'):
                             self.ace_perms[obj_type]['advanced'][perm])
 
             # If still nothing, it must be undefined
-            if not ace_perms[0]:
+            if not ace_perms:
                 ace_perms = ['Undefined Permission: {0}'.format(ace[1])]
 
             return principal, ace_type, ace_prop, ace_perms, inherited
@@ -1035,6 +1035,10 @@ def get_sid(principal):
         # Verify that the sid is valid
         salt.utils.win_dacl.get_sid('S-1-5-32-544')
     '''
+    # If None is passed, use the Universal Well-known SID "Null SID"
+    if principal is None:
+        principal = 'NULL SID'
+
     # Test if the user passed a sid or a name
     try:
         sid = salt.utils.win_functions.get_sid_from_name(principal)
@@ -1074,6 +1078,10 @@ def get_sid_string(principal):
         # Get the string version of the SID
         salt.utils.win_dacl.get_sid_string(py_sid)
     '''
+    # If None is passed, use the Universal Well-known SID "Null SID"
+    if principal is None:
+        principal = 'NULL SID'
+
     try:
         return win32security.ConvertSidToStringSid(principal)
     except TypeError:
@@ -1104,6 +1112,10 @@ def get_name(principal):
         salt.utils.win_dacl.get_name('S-1-5-32-544')
         salt.utils.win_dacl.get_name('adminisTrators')
     '''
+    # If None is passed, use the Universal Well-known SID for "Null SID"
+    if principal is None:
+        principal = 'S-1-0-0'
+
     # Assume PySID object
     sid_obj = principal
 

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -100,6 +100,10 @@ def get_sid_from_name(name):
     Returns:
         str: The corresponding SID
     '''
+    # If None is passed, use the Universal Well-known SID "Null SID"
+    if name is None:
+        name = 'NULL SID'
+
     try:
         sid = win32security.LookupAccountName(None, name)[0]
     except pywintypes.error as exc:


### PR DESCRIPTION
### What does this PR do?
Fixes some problems discovered during the initialization of the test suite on Py3.
- `.encode('string-escape`)` is not a thing in Python 3
- `file.directory` would try to make None the owner in Windows... If None is passed as the User it will now use the Current User.
- There was a logic error in `win_dacl.py` where if the current ace permission is unknown it would fail... it was checking for an item inside a list instead of checking for an empty list.
- There was an issue with username and sid lookup functions where they didn't handle `None` as an input. Now they return the value for `NULL SID`

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1176

### Previous Behavior
Tests failed to start due to these issues. Additional problems with salt-jenkins will be coming in another PR.

### New Behavior
Tests now start...

### Tests written?
No