### PR TITLE
dns_check should not try to connect when connect=False

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -774,6 +774,7 @@ def dns_check(addr, port, safe=False, ipv6=None, connect=True):
 
                 if not connect:
                     resolved = candidate_addr
+                    break
 
                 s = socket.socket(h[0], socket.SOCK_STREAM)
                 try:


### PR DESCRIPTION
### What does this PR do?

`dns_check` was still attempting to connect when `connect=False`
was used. Fix this use case.

### Tests written?

No