### PR TITLE
When building up the 'master_uri_list', do not try to connect

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -541,7 +541,7 @@ class MinionBase(object):
             for master in opts['local_masters']:
                 opts['master'] = master
                 opts.update(prep_ip_port(opts))
-                opts['master_uri_list'].append(resolve_dns(opts)['master_uri'])
+                opts['master_uri_list'].append(resolve_dns(opts, connect=False)['master_uri'])
 
             while True:
                 if attempts != 0:


### PR DESCRIPTION
### What does this PR do?

The connection attempts will happen later, sequentially. This will
avoid a case where it can't connect to a salt-master later in the
list but can connect to an earlier one. Before the fix, it will take
extra time while the later connection attempts fail, even though
it won't need to use them.

### Tests written?

No