### PR TITLE
[WP] Get file_roots correctly

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1146,7 +1146,7 @@ class AESFuncs(object):
         :return: The master options
         '''
         mopts = {}
-        file_roots = {}
+        file_roots = dict(self.opts['file_roots'])
         envs = self._file_envs()
         for saltenv in envs:
             if saltenv not in file_roots:


### PR DESCRIPTION
### What does this PR do?

Bugfix: `file_roots` were always reset, no matter what.

@thatch45's [New Year's gift on 1 Jan 2013](https://github.com/saltstack/salt/commit/a76a2e6884a298e0fabca767557dbceca1a2ff41) resets the `file_roots` to an empty dictionary, and then code checks if there is an environment variable in that dictionary... OK, but I am still wondering why this was even done. The description of the commit is also questionable: does it really prevents _from_ unconfigured interfaces? What are they?..

@thatch45 is there a special meaning behind that change?

### Tests written?

No
