### PR TITLE
jnpr.junos.device.Device expects 'ssh_private_key_file' as optional a…

### DIFF
--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -90,7 +90,7 @@ def init(opts):
                      'baud',
                      'attempts',
                      'auto_probe',
-                     'ssh_private_key',
+                     'ssh_private_key_file',
                      'ssh_config',
                      'normalize'
                      ]


### PR DESCRIPTION
…rgument, not 'ssh_private_key'

### What does this PR do?

Change optional argument 'ssh_private_key' to 'ssh_private_key_file' as expected by 	jnpr.junos.device.Device

### What issues does this PR fix or reference?

Not being able to login to a proxy minion type Junos with SSH Key-Based Authentication

### Previous Behavior
Non working SSH Key-Based Authentication with a proxytype Junos

### New Behavior
Working SSH Key-Based Authentication with a proxytype Junos

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
