### PR TITLE
Fixing simple issue 40081 - the key parameter of the method create ov…

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -276,10 +276,10 @@ def create(name, allocated_storage, db_instance_class, engine,
         kwargs = {}
         boto_params = set(boto3_param_map.keys())
         keys = set(locals().keys())
-        for key in keys.intersection(boto_params):
-            val = locals()[key]
+        for param_key in keys.intersection(boto_params):
+            val = locals()[param_key]
             if val is not None:
-                mapped = boto3_param_map[key]
+                mapped = boto3_param_map[param_key]
                 kwargs[mapped[0]] = mapped[1](val)
 
         taglist = _tag_doc(tags)


### PR DESCRIPTION
…erwritten by internal loop.

### What does this PR do?
The PR fix a very simple bug in boto_rds module, the key parameter of the method create() is overwritten by an internal loop that uses "key"

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40081


### Tests written?
No