### PR TITLE
Merge output from master_tops

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -563,7 +563,7 @@ class RemoteFuncs(object):
             if fun not in self.opts.get('master_tops', {}):
                 continue
             try:
-                ret.update(self.tops[fun](opts=opts, grains=grains))
+                ret = salt.utils.dictupdate.merge(ret, self.tops[fun](opts=opts, grains=grains), merge_lists=True)
             except Exception as exc:
                 # If anything happens in the top generation, log it and move on
                 log.error(


### PR DESCRIPTION
### What does this PR do?

Equalises expectations vs reality.

### What issues does this PR fix or reference?

Allows merging tops!

### Previous Behavior

If you have `/etc/salt/master.d/tops.conf` with the following content:
```yaml
extension_modules: /srv/salt/extensions
master_tops:
  networking: True
  storage: True
  inventory: True
```
...then it will not work :cry: because each output from each extension script will be killed in place with the output of the next, and only last will will win:

```
saltdevel:
    ----------
    base:
        - storage
```

This voids co-existence of independent parts in the system that utilising the same Master via the `master_tops` mechanism.

### New Behavior

Data is merged, tops are functioning as needed. :sunglasses: 

```
saltdevel:
    ----------
    base:
        - networking
        - storage
        - inventory
```

### Tests written?

No

