### PR TITLE
Mark ssh_auth.present state as failure when public key is invalid

### DIFF
--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -356,9 +356,9 @@ def present(
             ret['comment'] = ('Failed to add the ssh key. Is the home '
                               'directory available, and/or does the key file '
                               'exist?')
-    elif data == 'invalid':
+    elif data == 'invalid' or data == 'Invalid public key':
         ret['result'] = False
-        ret['comment'] = 'Invalid public ssh key, most likely has spaces'
+        ret['comment'] = 'Invalid public ssh key, most likely has spaces or invalid syntax'
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?
Properly marks ssh_auth.present highstate as failure.

### What issues does this PR fix or reference?
Fixes #40114

### Previous Behavior
```
          ID: AAAABtest
    Function: ssh_auth.present
      Result: True
     Comment: 
     Started: 18:19:16.371595
    Duration: 5.127 ms
     Changes:   
```

### New Behavior
```
          ID: AAAABtest
    Function: ssh_auth.present
      Result: False
     Comment: Invalid public ssh key, most likely has spaces or invalid syntax
     Started: 18:20:35.081300
    Duration: 5.509 ms
     Changes:   
```

### Tests written?

No (WIP)
