### PR TITLE
Add CLI Example for dockerng.get_client_args

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -6011,6 +6011,12 @@ def get_client_args():
 
     .. _`low-level API`: http://docker-py.readthedocs.io/en/stable/api.html
         salt myminion docker.get_client_args
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion docker.get_client_args
     '''
     try:
         config_args = _argspec(docker.types.ContainerConfig.__init__).args


### PR DESCRIPTION
This is in the 2016.3 branch, but got missed in one of my merge forwards. The code is the same and OK, just missed this part of the docs in a conflict resolution.