### PR TITLE
gce: Exclude GCENodeDriver objects from _expand_node result

### DIFF
--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -199,6 +199,13 @@ def _expand_node(node):
     zone = ret['extra']['zone']
     ret['extra']['zone'] = {}
     ret['extra']['zone'].update(zone.__dict__)
+
+    # Remove unserializable GCENodeDriver objects
+    if 'driver' in ret:
+        del ret['driver']
+    if 'driver' in ret['extra']['zone']:
+        del ret['extra']['zone']['driver']
+
     return ret
 
 


### PR DESCRIPTION
The dictionary returned by _expand_node contains libcloud's GCENodeDriver
objects which arent't properly serialized. With 'update_cachedir: True' setting
in salt-cloud config file show_instance fails because
__utils__['cloud.cache_node'] submits that dictionary to msgpack:

    (py2-env) salt-test@tommynaut:~> salt-cloud -l debug -a show_instance foo
    ...
    [ERROR   ] There was an error actioning machines: Cannot serialize <libcloud.compute.drivers.gce.GCENodeDriver object at 0x7ff3817cca10>
    Traceback (most recent call last):
      File "/home/salt-test/salt/salt/cloud/cli.py", line 252, in run
        ret = mapper.do_action(names, kwargs)
      File "/home/salt-test/salt/salt/cloud/__init__.py", line 1527, in do_action
        vm_name, call='action'
      File "/home/salt-test/salt/salt/cloud/clouds/gce.py", line 277, in show_instance
        __utils__['cloud.cache_node'](node, __active_provider_name__, __opts__)
      File "/home/salt-test/salt/salt/utils/cloud.py", line 2921, in cache_node
        msgpack.dump(node, fh_)
      File "/home/salt-test/py2-env/lib/python2.7/site-packages/msgpack/__init__.py", line 38, in pack
        stream.write(packer.pack(o))
      File "/home/salt-test/py2-env/lib/python2.7/site-packages/msgpack/fallback.py", line 738, in pack
        self._pack(obj)
      File "/home/salt-test/py2-env/lib/python2.7/site-packages/msgpack/fallback.py", line 730, in _pack
        nest_limit - 1)
      File "/home/salt-test/py2-env/lib/python2.7/site-packages/msgpack/fallback.py", line 828, in _fb_pack_map_pairs
        self._pack(v, nest_limit - 1)
      File "/home/salt-test/py2-env/lib/python2.7/site-packages/msgpack/fallback.py", line 730, in _pack
        nest_limit - 1)
      File "/home/salt-test/py2-env/lib/python2.7/site-packages/msgpack/fallback.py", line 828, in _fb_pack_map_pairs
        self._pack(v, nest_limit - 1)
      File "/home/salt-test/py2-env/lib/python2.7/site-packages/msgpack/fallback.py", line 730, in _pack
        nest_limit - 1)
      File "/home/salt-test/py2-env/lib/python2.7/site-packages/msgpack/fallback.py", line 828, in _fb_pack_map_pairs
        self._pack(v, nest_limit - 1)
      File "/home/salt-test/py2-env/lib/python2.7/site-packages/msgpack/fallback.py", line 735, in _pack
        raise TypeError("Cannot serialize %r" % obj)
    TypeError: Cannot serialize <libcloud.compute.drivers.gce.GCENodeDriver object at 0x7ff3817cca10>

Those GCENodeDriver objects don't contain info on the node itself so may be
safely excluded from _expand_node result. Remove ret['driver'] and
ret['extra']['zone']['driver'] keys containing them.


NOTE: As the purpose of _expand_node is to serialize libcloud node object, those GCENodeDriver objects at ret['driver'] and ret['extra']['zone']['driver'] are useless, so from my point of view removing them doesn't hurt backward compatibility. But I'm not pretty sure and would appreciate feedback on this. Maybe a correct solution would be setting those keys to None instead...