### PR TITLE
Adding "pkg.install downloadonly=True" support to yum/dnf execution module

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -913,6 +913,7 @@ def install(name=None,
             skip_verify=False,
             pkgs=None,
             sources=None,
+            downloadonly=False,
             reinstall=False,
             normalize=True,
             **kwargs):
@@ -969,6 +970,9 @@ def install(name=None,
 
     skip_verify
         Skip the GPG verification check (e.g., ``--nogpgcheck``)
+
+    downloadonly
+        Only download the packages, do not install.
 
     version
         Install a specific version of the package, e.g. 1.2.3-4.el5. Ignored
@@ -1200,6 +1204,8 @@ def install(name=None,
                 cmd.extend(args)
         if skip_verify:
             cmd.append('--nogpgcheck')
+        if downloadonly:
+            cmd.append('--downloadonly')
 
     errors = []
 


### PR DESCRIPTION
### What does this PR do?
This PR adds the `downloadonly` parameter to the `yumpkg.install` function, so `yum` or `dnf` could be called using `--downloadonly` parameter.

This would allow to execute `pkg.install fooPackage downloadonly=True` to only download a package without actually install it. That's the same we already do in the `zypper` module.

### Tests written?

No