### PR TITLE
Adds support for inet_pton in Windows to network util

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -25,6 +25,10 @@ except ImportError:
 import salt.utils
 from salt._compat import subprocess, ipaddress
 
+# inet_pton does not exist in Windows, this is a workaround
+if salt.utils.is_windows():
+    from salt.ext import win_inet_pton  # pylint: disable=unused-import
+
 log = logging.getLogger(__name__)
 
 # pylint: disable=C0103


### PR DESCRIPTION
### What does this PR do?
Fixes problem with the minion unable to start due to lack of support for `inet_pton`. Introduced by https://github.com/saltstack/salt/pull/39766

### Previous Behavior
Minion wouldn't start.

### New Behavior
Minion starts

### Tests written?
No