### PR TITLE
Proxy dunder injection gh

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1559,6 +1559,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
         self.loaded = True
 
+    def reload_modules(self):
+        self.loaded_files = set()
+        self._load_all()
+
     def _apply_outputter(self, func, mod):
         '''
         Apply the __outputter__ variable to the functions

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3109,6 +3109,9 @@ class ProxyMinion(Minion):
         self.utils = salt.loader.utils(self.opts, proxy=self.proxy)
         self.proxy.pack['__utils__'] = self.utils
 
+        # Reload all modules so all dunder variables are injected
+        self.proxy.reload_modules()
+
         # Start engines here instead of in the Minion superclass __init__
         # This is because we need to inject the __proxy__ variable but
         # it is not setup until now.


### PR DESCRIPTION
### What does this PR do?

Allow proxy module to access all dunders when invoking functions from the proxy module

### What issues does this PR fix or reference?

### Previous Behavior
The `__salt__` dunder was not injected in proxy modules

### New Behavior
The `__salt__` dunder and all others are defined when calling the init and all other proxy functions (will not be set when invoking the initial `__virtual__` function)

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
