### PR TITLE
Correction of error logging for zabbix state

### DIFF
--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -160,8 +160,7 @@ def present(host, groups, interfaces, **kwargs):
                                                             "filter": {"host": "{0}".format(kwargs['proxy_host'])}},
                                                             **connection_args)[0]['proxyid']
             except TypeError:
-                # pylint: disable=E0602
-                ret['comment'] = 'Invalid proxy_host {0}'.format(proxy_host)
+                ret['comment'] = 'Invalid proxy_host {0}'.format(kwargs['proxy_host'])
                 return ret
         else:
             try:
@@ -170,8 +169,7 @@ def present(host, groups, interfaces, **kwargs):
                                                             "output": "proxyid"},
                                                             **connection_args)[0]['proxyid']
             except TypeError:
-                # pylint: disable=E0602
-                ret['comment'] = 'Invalid proxy_host {0}'.format(proxy_host)
+                ret['comment'] = 'Invalid proxy_host {0}'.format(kwargs['proxy_host'])
                 return ret
 
     host_exists = __salt__['zabbix.host_exists'](host, **connection_args)


### PR DESCRIPTION
### What does this PR do?
Recent PR for zabbix state didn't print missing zabbix proxyid correctly.

### What issues does this PR fix or reference?
None

### Previous Behavior
An invalid zabbix proxy would cause a missing global argument error

### New Behavior
An invalid zabbix proxy now causes a proper return message from the zabbix_host salt state

### Tests written?

No