### PR TITLE
Use the first address if cannot connect to any

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -133,7 +133,7 @@ log = logging.getLogger(__name__)
 # 6. Handle publications
 
 
-def resolve_dns(opts, fallback=True, connect=True):
+def resolve_dns(opts, fallback=True):
     '''
     Resolves the master_ip and master_uri options
     '''
@@ -150,7 +150,7 @@ def resolve_dns(opts, fallback=True, connect=True):
             if opts['master'] == '':
                 raise SaltSystemExit
             ret['master_ip'] = \
-                    salt.utils.dns_check(opts['master'], opts['master_port'], True, opts['ipv6'], connect)
+                    salt.utils.dns_check(opts['master'], opts['master_port'], True, opts['ipv6'])
         except SaltClientError:
             if opts['retry_dns']:
                 while True:
@@ -164,7 +164,7 @@ def resolve_dns(opts, fallback=True, connect=True):
                     time.sleep(opts['retry_dns'])
                     try:
                         ret['master_ip'] = salt.utils.dns_check(
-                            opts['master'], opts['master_port'], True, opts['ipv6'], connect
+                            opts['master'], opts['master_port'], True, opts['ipv6']
                         )
                         break
                     except SaltClientError:

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -364,7 +364,7 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
         syndic_opts = sconfig.syndic_config(
             syndic_conf_path, minion_conf_path
         )
-        syndic_opts.update(salt.minion.resolve_dns(syndic_opts, connect=False))
+        syndic_opts.update(salt.minion.resolve_dns(syndic_opts))
         root_dir = syndic_opts['root_dir']
         # id & pki dir are shared & so configured on the minion side
         self.assertEqual(syndic_opts['id'], 'minion')


### PR DESCRIPTION
### What issues does this PR fix or reference?

This fixes #39995. The previous work happened in #39289.

### Previous Behavior

If we can't connect to any address, we return error. Due to the fact that salt resolves master IPs before creating connections, we cannot endlessly retry one connection, because others will be blocked.

### New Behavior

If we can't connect to any address, we return the first one from DNS with respect to IPv6/IPv4 preference (no preference means IPv4 for backward compatibility). This fixes the case when the first master is down, but the second one is operational.

### Tests written?

Reused.