### PR TITLE
Fix #40137 (Problems with netacl.load_filter_config, load_policy_config, etc)

### DIFF
--- a/salt/modules/capirca_acl.py
+++ b/salt/modules/capirca_acl.py
@@ -445,7 +445,7 @@ def _get_policy_object(platform,
         ]
         filter_options = filter_config.pop('options', None)
         if filter_options:
-            filter_options = _make_it_list(filter_options, filter_name, filter_options)
+            filter_options = _make_it_list({}, filter_name, filter_options)
             # make sure the filter options are sent as list
             target_opts.extend(filter_options)
         target = aclgen.policy.Target(target_opts)
@@ -906,7 +906,7 @@ def get_filter_config(platform,
         # new terms won't be removed
     filters = {
         filter_name: {
-            'options': _make_it_list(filter_options, filter_name, filter_options)
+            'options': _make_it_list({}, filter_name, filter_options)
         }
     }
     filters[filter_name].update(terms)

--- a/salt/modules/napalm_acl.py
+++ b/salt/modules/napalm_acl.py
@@ -466,7 +466,8 @@ def load_filter_config(filter_name,
                        revision_date_format='%Y/%m/%d',
                        test=False,
                        commit=True,
-                       debug=False):
+                       debug=False,
+                       **kwargs):  # pylint: disable=unused-argument
     '''
     Generate and load the configuration of a policy filter.
 
@@ -656,7 +657,8 @@ def load_policy_config(filters=None,
                        revision_date_format='%Y/%m/%d',
                        test=False,
                        commit=True,
-                       debug=False):
+                       debug=False,
+                       **kwargs):  # pylint: disable=unused-argument
     '''
     Generate and load the configuration of the whole policy.
 


### PR DESCRIPTION
- add kwargs for all direct CLI calls for the NAPALM function
as the proxy wrapper requires
- adjust filter_options to the newest `_make_it_list` helper
which requires dict as first arg

### What does this PR do?

Fix #40137