### PR TITLE
salt.returners.local_cache:prep_jid useless recursive function ?

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -116,6 +116,12 @@ def prep_jid(nocache=False, passed_jid=None):
         jid = passed_jid
 
     jid_dir = _prep_jid_dir(jid)
+    # Check for eventual jid conflict
+    if os.path.exists(jid_dir):
+        new_jid = salt.utils.jid.gen_jid()
+        log.warning('Conflicting jids, {0} already exists, switching to {1}.'.format(jid, new_jid))
+        jid = new_jid
+        jid_dir = _prep_jid_dir(jid)
 
     # Try to write in jid path
     try:
@@ -130,7 +136,7 @@ def prep_jid(nocache=False, passed_jid=None):
 
     # If write failed
     except IOError:
-        log.warning('Could not write out jid file for job {0} (nocache={1}). Retrying.'.format(jid, nocache))
+        log.warning('Could not write out jid file for job {0} (nocache={1}).'.format(jid, nocache))
         raise
 
     return jid

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -25,7 +25,6 @@ import salt.exceptions
 # Import 3rd-party libs
 import msgpack
 import salt.ext.six as six
-from salt.ext.six.moves import range
 
 
 log = logging.getLogger(__name__)
@@ -58,6 +57,7 @@ def _jid_dir(jid):
     Return jid directory for given `jid`
     '''
     return salt.utils.jid.jid_dir(jid, _job_dir(), __opts__['hash_type'])
+
 
 def _walk_through(job_dir):
     '''
@@ -109,7 +109,7 @@ def prep_jid(nocache=False, passed_jid=None):
     it is passed a jid).
     So do what you have to do to make sure that stays the case
     '''
-     # Generate new jid for each try if no passed jid as parameter.
+    # Generate new jid for each try if no passed jid as parameter.
     if passed_jid is None:
         jid = salt.utils.jid.gen_jid()
     else:


### PR DESCRIPTION
## Issue

`salt.returners.local_cache` seems to struggle with jid directories.

There are two functions (`prep_jid` and `save_load`) trying to write in jid directories and if one of them try to add a non existing file in an existing directory (which should be an accepted behavior I think), it will recurse up to 5 time asking for new jid each time.

This may create unconsistents jids (because `prep_jid` is responsible for generating jid) and because before each recursion these functions sleeps for 0.1 seconds, it could be bad for performances.

I mostly packaged jid directory creation in func `_prep_jid_dir` and removed recursions.