### PR TITLE
Make sure the tornado web server is stopped at the end of the test class

### DIFF
--- a/tests/integration/states/archive.py
+++ b/tests/integration/states/archive.py
@@ -10,6 +10,7 @@ import os
 import platform
 import socket
 import threading
+import tornado.httpserver
 import tornado.ioloop
 import tornado.web
 
@@ -35,7 +36,6 @@ PORT = 9999
 ARCHIVE_TAR_SOURCE = 'http://localhost:{0}/custom.tar.gz'.format(PORT)
 UNTAR_FILE = os.path.join(ARCHIVE_DIR, 'custom/README')
 ARCHIVE_TAR_HASH = 'md5=7643861ac07c30fe7d2310e9f25ca514'
-STATE_DIR = os.path.join(integration.FILES, 'file', 'base')
 
 REDHAT7 = False
 QUERY_OS = platform.dist()
@@ -59,7 +59,8 @@ class ArchiveTest(integration.ModuleCase,
         '''
         application = tornado.web.Application([(r"/(.*)", tornado.web.StaticFileHandler,
                                               {"path": STATE_DIR})])
-        application.listen(PORT)
+        cls.server = tornado.httpserver.HTTPServer(application)
+        cls.server.listen(PORT)
         tornado.ioloop.IOLoop.instance().start()
 
     @classmethod
@@ -83,6 +84,7 @@ class ArchiveTest(integration.ModuleCase,
     def tearDownClass(cls):
         tornado.ioloop.IOLoop.instance().stop()
         cls.server_thread.join()
+        cls.server.stop()
 
     def setUp(self):
         self._clear_archive_dir()

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -19,6 +19,7 @@ import stat
 import tempfile
 import textwrap
 import threading
+import tornado.httpserver
 import tornado.ioloop
 import tornado.web
 import filecmp
@@ -2403,7 +2404,6 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
 PORT = 9999
 FILE_SOURCE = 'http://localhost:{0}/grail/scene33'.format(PORT)
 FILE_HASH = 'd2feb3beb323c79fc7a0f44f1408b4a3'
-STATE_DIR = os.path.join(integration.FILES, 'file', 'base')
 
 
 class RemoteFileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
@@ -2419,7 +2419,8 @@ class RemoteFileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn)
         application = tornado.web.Application([
             (r'/(.*)', tornado.web.StaticFileHandler, {'path': STATE_DIR})
         ])
-        application.listen(PORT)
+        cls.server = tornado.httpserver.HTTPServer(application)
+        cls.server.listen(PORT)
         tornado.ioloop.IOLoop.instance().start()
 
     @classmethod
@@ -2442,6 +2443,7 @@ class RemoteFileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn)
     def tearDownClass(cls):
         tornado.ioloop.IOLoop.instance().stop()
         cls.server_thread.join()
+        cls.server.stop()
 
     def setUp(self):
         fd_, self.name = tempfile.mkstemp(dir=integration.TMP)
@@ -2499,4 +2501,4 @@ class RemoteFileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn)
 
 if __name__ == '__main__':
     from integration import run_tests
-    run_tests(FileTest)
+    run_tests(FileTest, RemoteFileTest)


### PR DESCRIPTION
The tornado web application that was set up in the archive tests, and then duplicated in the remote file integration tests, starts the web server, but never stops it. This creates a stacktrace that hangs the other test file that attempts to start the web server. (In this case, the `file.py` tests run first, causing the `archive.py` tests to hang on the `application.listen()` line.)

The Application class has a `listen()` function, but not a `stop()` function. The change uses the `HTTPServer` class to set up the listening server, but also has the necessary `stop()` function. (The `listen()` function from the `Application` class just calls out to the `HTTPServer`'s `listen()` function, so this works nicely here.)

We can then call the `stop()` function in the `tearDownClass` class method.

I also removed some duplicate STATE_DIR definitions.
