### PR TITLE
Fix use of correct tail on Solaris for active_tcp

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -308,10 +308,15 @@ def _netstat_sunos():
     Return netstat information for SunOS flavors
     '''
     log.warning('User and program not (yet) supported on SunOS')
+
+    tailpath = '/usr/xpg4/bin/tail'
+    if not os.path.exists(tailpath):
+        return 'required version of command tail does not exist: {0}'.format(tailpath)
+
     ret = []
     for addr_family in ('inet', 'inet6'):
         # Lookup TCP connections
-        cmd = 'netstat -f {0} -P tcp -an | tail -n+5'.format(addr_family)
+        cmd = 'netstat -f {0} -P tcp -an | {1} -n +5'.format(addr_family, tailpath)
         out = __salt__['cmd.run'](cmd, python_shell=True)
         for line in out.splitlines():
             comps = line.split()
@@ -323,7 +328,7 @@ def _netstat_sunos():
                 'remote-address': comps[1],
                 'state': comps[6]})
         # Lookup UDP connections
-        cmd = 'netstat -f {0} -P udp -an | tail -n+5'.format(addr_family)
+        cmd = 'netstat -f {0} -P udp -an | {1} -n +5'.format(addr_family, tailpath)
         out = __salt__['cmd.run'](cmd, python_shell=True)
         for line in out.splitlines():
             comps = line.split()


### PR DESCRIPTION
### What does this PR do?
Fixes support for net.work.active_tcp on Solaris

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40161

### Previous Behavior
Failed to output expect information, produced error
root@unknown:~# /opt/salt/salt-call --local network.active_tcp
[WARNING ] User and program not (yet) supported on SunOS
[ERROR   ] Command 'netstat -f inet -P tcp -an | tail -n+5' failed with return code: 2
[ERROR   ] output: usage: tail [+/-[n][lbc][f]] [file]
       tail [+/-[n][l][r|f]] [file]
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
IndexError: list index out of range
Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File "__main__.py", line 128, in <module>
  File "__main__salt-call__.py", line 14, in <module>
  File "salt/scripts.py", line 379, in salt_call
  File "salt/cli/call.py", line 58, in run
  File "salt/cli/caller.py", line 134, in run
  File "salt/cli/caller.py", line 197, in call
  File "salt/modules/network.py", line 556, in active_tcp
  File "salt/modules/network.py", line 320, in _netstat_sunos
IndexError: list index out of range
Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File "__main__.py", line 128, in <module>
  File "__main__salt-call__.py", line 14, in <module>
  File "salt/scripts.py", line 379, in salt_call
  File "salt/cli/call.py", line 58, in run
  File "salt/cli/caller.py", line 134, in run
  File "salt/cli/caller.py", line 197, in call
  File "salt/modules/network.py", line 556, in active_tcp
  File "salt/modules/network.py", line 320, in _netstat_sunos
IndexError: list index out of range
root@unknown:~#

### New Behavior
Outputs expected information

### Tests written?
No, hand tested

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
