### PR TITLE
Don't try to run the dockerng unit tests if docker-py is missing

### DIFF
--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -35,6 +35,7 @@ def _docker_py_version():
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(dockerng_mod.HAS_DOCKER_PY is False, 'docker-py must be installed to run these tests. Skipping.')
 class DockerngTestCase(TestCase):
     '''
     Validate dockerng module
@@ -66,7 +67,6 @@ class DockerngTestCase(TestCase):
                 all=True,
                 filters={'label': 'KEY'})
 
-    @skipIf(_docker_py_version() is None, 'docker-py needs to be installed for this test to run')
     @patch.object(dockerng_mod, '_get_exec_driver')
     def test_check_mine_cache_is_refreshed_on_container_change_event(self, _):
         '''


### PR DESCRIPTION
There are checks on each test for the _version_ of docker-py that is needed to run the affected tests, but there isn't an overarching `@skipIf` for the whole test case class for when docker-py is absent. 