### PR TITLE
Support for default item in match.filter_by 

### DIFF
--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -309,7 +309,8 @@ def glob(tgt, minion_id=None):
 def filter_by(lookup,
               tgt_type='compound',
               minion_id=None,
-              expr_form=None):
+              expr_form=None,
+              default=None):
     '''
     Return the first match in a dictionary of target patterns
 
@@ -329,7 +330,7 @@ def filter_by(lookup,
         {% set roles = salt['match.filter_by']({
             'web*': ['app', 'caching'],
             'db*': ['db'],
-        }) %}
+        }, default=['other']) %}
 
         # Make the filtered data available to Pillar:
         roles: {{ roles | yaml() }}
@@ -353,7 +354,7 @@ def filter_by(lookup,
         if expr_funcs[tgt_type](*params):
             return lookup[key]
 
-    return None
+    return default
 
 
 def search_by(lookup, tgt_type='compound', minion_id=None):

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -310,7 +310,7 @@ def filter_by(lookup,
               tgt_type='compound',
               minion_id=None,
               expr_form=None,
-              default=None):
+              default='default'):
     '''
     Return the first match in a dictionary of target patterns
 
@@ -330,7 +330,7 @@ def filter_by(lookup,
         {% set roles = salt['match.filter_by']({
             'web*': ['app', 'caching'],
             'db*': ['db'],
-        }, default=['other']) %}
+        }, default='web*') %}
 
         # Make the filtered data available to Pillar:
         roles: {{ roles | yaml() }}
@@ -354,7 +354,7 @@ def filter_by(lookup,
         if expr_funcs[tgt_type](*params):
             return lookup[key]
 
-    return default
+    return lookup.get(default, None)
 
 
 def search_by(lookup, tgt_type='compound', minion_id=None):


### PR DESCRIPTION
### What does this PR do?
Adds a default parameter to the match.filter_by function.  This allows custom return for no matches found.
### What issues does this PR fix or reference?
#23050
### Previous Behavior
Returns None on no matches.

### Tests written?
No
