### PR TITLE
Use dict-comprehension compatible with Python 2.6

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -439,7 +439,7 @@ def _run(cmd,
                     env_encoded = env_encoded.encode(__salt_system_encoding__)
                 env_runas = dict(list(zip(*[iter(env_encoded.split(b'\0'))]*2)))
 
-            env_runas = {sdecode(k): sdecode(v) for k, v in six.iteritems(env_runas)}
+            env_runas = dict((sdecode(k), sdecode(v)) for k, v in six.iteritems(env_runas))
             env_runas.update(env)
             env = env_runas
             # Encode unicode kwargs to filesystem encoding to avoid a


### PR DESCRIPTION
### What does this PR do?

Fix one instance where that breaks salt on systems running Python 2.6

### Previous Behavior

          File "/var/tmp/.root_17e69b_salt/py2/salt/modules/cmdmod.py", line 442
            env_runas = {sdecode(k): sdecode(v) for k, v in six.iteritems(env_runas)}
                                                  ^
        SyntaxError: invalid syntax

### Tests written?

No, tested manually using `salt-ssh` on CentOS 6.7
