### PR TITLE
Fix: Configs are read multiple times

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1735,6 +1735,10 @@ def _read_conf_file(path):
     '''
     Read in a config file from a given path and process it into a dictionary
     '''
+    if (not salt.utils.validate.path.exists(path, quiet=os.path.basename(path) == '.saltrc')
+            or not salt.utils.validate.path.is_readable(path)):
+        return {}
+
     log.debug('Reading configuration from {0}'.format(path))
     with salt.utils.fopen(path, 'r') as conf_file:
         try:

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1789,6 +1789,25 @@ def _absolute_path(path, relative_to=None):
     return path
 
 
+__config_refs__ = {}
+
+
+def _skip_known(conf_loader):
+    '''
+    Skip configs that are already has been read.
+
+    :param conf_loader:
+    :return: config or its cached ref
+    '''
+    def load_config_distinct(*args, **kwargs):
+        ptr = '-'.join(args) + '-'.join(['{0}:{1}'.format(x, y) for x, y in kwargs.items()])
+        if ptr not in __config_refs__:
+            __config_refs__[ptr] = conf_loader(*args, **kwargs)
+        return __config_refs__[ptr]
+    return load_config_distinct
+
+
+@_skip_known
 def load_config(path, env_var, default_path=None, exit_on_config_errors=True):
     '''
     Returns configuration dict from parsing either the file described by

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1839,14 +1839,13 @@ def load_config(path, env_var, default_path=None, exit_on_config_errors=True):
 
     opts = {}
 
-    if salt.utils.validate.path.is_readable(path):
-        try:
-            opts = _read_conf_file(path)
-            opts['conf_file'] = path
-        except salt.exceptions.SaltConfigurationError as error:
-            log.error(error)
-            if exit_on_config_errors:
-                sys.exit(salt.defaults.exitcodes.EX_GENERIC)
+    try:
+        opts = _read_conf_file(path)
+        opts['conf_file'] = path
+    except salt.exceptions.SaltConfigurationError as error:
+        log.error(error)
+        if exit_on_config_errors:
+            sys.exit(salt.defaults.exitcodes.EX_GENERIC)
     else:
         log.debug('Missing configuration file: {0}'.format(path))
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -10,7 +10,6 @@ import os
 import re
 import sys
 import glob
-import getpass
 import time
 import codecs
 import logging

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2126,13 +2126,8 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
     overrides = defaults
 
     # Load cloud configuration from any default or provided includes
-    overrides.update(
-        salt.config.include_config(overrides['default_include'], path, verbose=False)
-    )
-    include = overrides.get('include', [])
-    overrides.update(
-        salt.config.include_config(include, path, verbose=True)
-    )
+    overrides.update(include_config(overrides['default_include'], path, verbose=False))
+    overrides.update(include_config(overrides.get('include', []), path, verbose=True))
 
     # The includes have been evaluated, let's see if master, providers and
     # profiles configuration settings have been included and if not, set the

--- a/salt/utils/validate/path.py
+++ b/salt/utils/validate/path.py
@@ -54,6 +54,23 @@ def is_writeable(path, check_parent=False):
     return os.access(parent_dir, os.W_OK)
 
 
+def exists(path, quiet=False):
+    '''
+    Check if a given path exists.
+
+    :param path: The path to check
+    :param quiet: Suppresses the log message
+    :returns: True or False
+    '''
+
+    _exists = os.access(path, os.F_OK)
+    if not _exists:
+        if not quiet:
+            log.error('Failed to read configuration from {0} - file does not exists'.format(path))
+
+    return _exists
+
+
 def is_readable(path, quiet=False):
     '''
     Check if a given path is readable by the current user.

--- a/salt/utils/validate/path.py
+++ b/salt/utils/validate/path.py
@@ -12,6 +12,10 @@ from __future__ import absolute_import
 
 # Import python libs
 import os
+import logging
+
+
+log = logging.getLogger(__name__)
 
 
 def is_writeable(path, check_parent=False):
@@ -50,17 +54,18 @@ def is_writeable(path, check_parent=False):
     return os.access(parent_dir, os.W_OK)
 
 
-def is_readable(path):
+def is_readable(path, quiet=False):
     '''
     Check if a given path is readable by the current user.
 
     :param path: The path to check
+    :param quiet: Suppresses the log message
     :returns: True or False
     '''
 
-    if os.access(path, os.F_OK) and os.access(path, os.R_OK):
-        # The path exists and is readable
-        return True
+    _readable = os.access(path, os.R_OK)
+    if not _readable:
+        if not quiet:
+            log.error('Failed to read configuration from {0} - access denied'.format(path))
 
-    # The path does not exist
-    return False
+    return _readable

--- a/salt/utils/validate/path.py
+++ b/salt/utils/validate/path.py
@@ -64,9 +64,8 @@ def exists(path, quiet=False):
     '''
 
     _exists = os.access(path, os.F_OK)
-    if not _exists:
-        if not quiet:
-            log.error('Failed to read configuration from {0} - file does not exists'.format(path))
+    if not _exists and not quiet:
+        log.error('Failed to read configuration from {0} - file does not exists'.format(path))
 
     return _exists
 
@@ -81,8 +80,7 @@ def is_readable(path, quiet=False):
     '''
 
     _readable = os.access(path, os.R_OK)
-    if not _readable:
-        if not quiet:
-            log.error('Failed to read configuration from {0} - access denied'.format(path))
+    if not _readable and not quiet:
+        log.error('Failed to read configuration from {0} - access denied'.format(path))
 
     return _readable

--- a/salt/utils/validate/path.py
+++ b/salt/utils/validate/path.py
@@ -65,7 +65,7 @@ def exists(path, quiet=False):
 
     _exists = os.access(path, os.F_OK)
     if not _exists and not quiet:
-        log.error('Failed to read configuration from {0} - file does not exists'.format(path))
+        log.error('Failed to read configuration from {0} - file does not exist'.format(path))
 
     return _exists
 

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -882,10 +882,8 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
                 if not os.path.isdir(directory):
                     os.makedirs(directory)
 
-            default_config = sconfig.cloud_config(config_file_path)
-            default_config['deploy_scripts_search_path'] = deploy_dir_path
             with salt.utils.fopen(config_file_path, 'w') as cfd:
-                cfd.write(yaml.dump(default_config))
+                cfd.write(yaml.dump({'deploy_scripts_search_path': deploy_dir_path}))
 
             default_config = sconfig.cloud_config(config_file_path)
 


### PR DESCRIPTION
## What does this PR do?

### 1. Reduces number of time config was read
Salt unnecessarily reads same configs multiple times. E.g. five workers reading eight little configs more than 240 times!

The idea is to cache the `__opts__` in the reference and return it from there, instead of read and parse the whole YAML file all over again.

### 2. Fixes crash
 If one of configs is not readable (permission denied), Salt Master goes rock-n-roll. This happens when Salt Master, running as `salt:salt` meets config that is `root:root`.

### Tests written?

No
