### PR TITLE
Add support for "stopped" state to dockerng's mod_watch

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -2428,6 +2428,9 @@ def mod_watch(name, sfun=None, **kwargs):
             watch_kwargs['force'] = False
         return running(name, **watch_kwargs)
 
+    if sfun == 'stopped':
+        return stopped(name, **salt.utils.clean_kwargs(**kwargs))
+
     if sfun == 'image_present':
         # Force image to be updated
         kwargs['force'] = True


### PR DESCRIPTION
This was caught by @ticosax in an unrelated review, it turns out this state
module never got mod_watch support added for the "stopped" state. This PR adds
it in the 2016.3 branch so it can merge forward.