### PR TITLE
Link to minion start reactor example from FAQ.

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -147,7 +147,7 @@ should be opened on our tracker_, with the following information:
 Why aren't my custom modules/states/etc. available on my Minions?
 -----------------------------------------------------------------
 
-Custom modules are synced to Minions when 
+Custom modules are synced to Minions when
 :mod:`saltutil.sync_modules <salt.modules.saltutil.sync_modules>`,
 or :mod:`saltutil.sync_all <salt.modules.saltutil.sync_all>` is run.
 Custom modules are also synced by :mod:`state.apply` when run without
@@ -165,6 +165,11 @@ when run without any arguments.
 Other custom types (renderers, outputters, etc.) have similar behavior, see the
 documentation for the :mod:`saltutil <salt.modules.saltutil>` module for more
 information.
+
+:ref:`This reactor example <minion-start-reactor>` can be used to automatically
+sync custom types when the minion connects to the master, to help with this
+chicken-and-egg issue.
+
 
 Module ``X`` isn't available, even though the shell command it uses is installed. Why?
 --------------------------------------------------------------------------------------

--- a/doc/topics/reactor/index.rst
+++ b/doc/topics/reactor/index.rst
@@ -602,7 +602,7 @@ And in the master config file, add the following reactor configuration:
 .. code-block:: yaml
 
     reactor:
-      - 'minion_start':
+      - 'salt/minion/*/start':
         - /srv/reactor/sync_grains.sls
 
 This will cause the master to instruct each minion to sync its custom grains
@@ -612,3 +612,8 @@ when it starts, making these grains available when the initial :ref:`highstate
 Other types can be synced by replacing ``local.saltutil.sync_grains`` with
 ``local.saltutil.sync_modules``, ``local.saltutil.sync_all``, or whatever else
 suits the intended use case.
+
+Also, if it is not desirable that *every* minion syncs on startup, the ``*``
+can be replaced with a different glob to narrow down the set of minions which
+will match that reactor (e.g. ``salt/minion/appsrv*/start``, which would only
+match minion IDs beginning with ``appsrv``).


### PR DESCRIPTION
This provides a natural solution to the chicken-and-egg problem
identified in the FAQ. It also changes the name of the event in the
reactor example, as I think we may have stopped sending the legacy
(i.e. not-namespaced) events, so the "minion_start" event in the example
would be incorrect.