### PR TITLE
Update win_iis.py - fixed "get_webapp_settings"

### DIFF
--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -1809,10 +1809,10 @@ def get_webapp_settings(name, site, settings):
     for setting in settings:
         if setting in availableSettings:
             if setting == "userName" or setting == "password":
-                pscmd.append(r" $Property = Get-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(site, name))
-                pscmd.append(r" -Name \"{0}\" -ErrorAction Stop | select Value;".format(setting))
-                pscmd.append(r" $Property = $Property | Select-Object -ExpandProperty Value;")
-                pscmd.append(r" $Settings['{0}'] = [String] $Property;".format(setting))
+                pscmd.append(" $Property = Get-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(site, name))
+                pscmd.append(" -Name \"{0}\" -ErrorAction Stop | select Value;".format(setting))
+                pscmd.append(" $Property = $Property | Select-Object -ExpandProperty Value;")
+                pscmd.append(" $Settings['{0}'] = [String] $Property;".format(setting))
                 pscmd.append(r' $Property = $Null;')
 
             if setting == "physicalPath" or setting == "applicationPool":


### PR DESCRIPTION
Removed the 'r' prefix from this section cause it's not working with it:
                pscmd.append(r" $Property = Get-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(site, name))
                pscmd.append(r" -Name \"{0}\" -ErrorAction Stop | select Value;".format(setting))
                pscmd.append(r" $Property = $Property | Select-Object -ExpandProperty Value;")
                pscmd.append(r" $Settings['{0}'] = [String] $Property;".format(setting))
                pscmd.append(r' $Property = $Null;')

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
