### PR TITLE
[WIP] Adding "pkg.downloaded" state and support for installing patches/erratas

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -89,6 +89,7 @@ def pack_sources(sources, normalize=True):
 def parse_targets(name=None,
                   pkgs=None,
                   sources=None,
+                  patches=None,
                   saltenv='base',
                   normalize=True,
                   **kwargs):
@@ -116,8 +117,8 @@ def parse_targets(name=None,
     if __grains__['os'] == 'MacOS' and sources:
         log.warning('Parameter "sources" ignored on MacOS hosts.')
 
-    if pkgs and sources:
-        log.error('Only one of "pkgs" and "sources" can be used.')
+    if len(filter(lambda x: bool(x), [pkgs, sources, patches])) > 1:
+        log.error('Only one of "pkgs", "sources" or "patches" can be used.')
         return None, None
 
     elif pkgs:
@@ -126,6 +127,13 @@ def parse_targets(name=None,
             return None, None
         else:
             return pkgs, 'repository'
+
+    elif patches:
+        patches = _repack_pkgs(patches, normalize=normalize)
+        if not patches:
+            return None, None
+        else:
+            return patches, 'repository'
 
     elif sources and __grains__['os'] != 'MacOS':
         sources = pack_sources(sources, normalize=normalize)

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -117,7 +117,7 @@ def parse_targets(name=None,
     if __grains__['os'] == 'MacOS' and sources:
         log.warning('Parameter "sources" ignored on MacOS hosts.')
 
-    if len(filter(lambda x: bool(x), [pkgs, sources, patches])) > 1:
+    if len([True for x in [pkgs, sources, patches] if x]) > 1:
         log.error('Only one of "pkgs", "sources" or "patches" can be used.')
         return None, None
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -887,6 +887,7 @@ def install(name=None,
             fromrepo=None,
             pkgs=None,
             sources=None,
+            patches=None,
             downloadonly=None,
             skip_verify=False,
             version=None,
@@ -985,7 +986,7 @@ def install(name=None,
         refresh_db()
 
     try:
-        pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name, pkgs, sources, **kwargs)
+        pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name, pkgs, sources, patches, **kwargs)
     except MinionError as exc:
         raise CommandExecutionError(exc)
 
@@ -1040,6 +1041,8 @@ def install(name=None,
         cmd_install.extend(fromrepoopt)
 
     errors = []
+    if patches:
+        targets = ["patch:{0}".format(t) for t in targets]
 
     # Split the targets into batches of 500 packages each, so that
     # the maximal length of the command line is not broken

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1524,6 +1524,25 @@ def installed(
     return ret
 
 
+def downloaded(**kwargs):
+    '''
+    Ensure that the package is downloaded.
+    Functionally identical to :mod:`installed <salt.states.pkg.installed>`
+    but only downloads the packages without actually installing them.
+
+    CLI Example:
+
+    .. code-block:: yaml
+
+        zsh:
+          pkg.downloaded:
+            - fromrepo: "myrepository"
+    '''
+    if 'downloadonly' in kwargs:
+        del kwargs['downloadonly']
+    return installed(downloadonly=True, **kwargs)
+
+
 def latest(
         name,
         refresh=None,

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -635,6 +635,7 @@ def installed(
         normalize=True,
         ignore_epoch=False,
         reinstall=False,
+        downloadonly=False,
         **kwargs):
     '''
     Ensure that the package is installed, and that it is the correct version
@@ -1282,6 +1283,7 @@ def installed(
                                               pkgs=pkgs,
                                               sources=sources,
                                               reinstall=bool(to_reinstall),
+                                              downloadonly=downloadonly,
                                               normalize=normalize,
                                               **kwargs)
         except CommandExecutionError as exc:
@@ -1436,7 +1438,7 @@ def installed(
 
     result = True
 
-    if failed:
+    if failed and not downloadonly:
         if sources:
             summary = ', '.join(failed)
         else:
@@ -1446,7 +1448,7 @@ def installed(
                           'install/update: {0}'.format(summary))
         result = False
 
-    if failed_hold:
+    if failed_hold and not downloadonly:
         for i in failed_hold:
             comment.append(i['comment'])
         result = False
@@ -1496,7 +1498,7 @@ def installed(
             else:
                 comment.append(msg)
 
-    if failed:
+    if failed and not downloadonly:
         # Add a comment for each package in failed with its pkg.verify output
         for failed_pkg in failed:
             if sources:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -911,6 +911,20 @@ def installed(
 
         .. versionadded:: 2015.8.9
 
+    :param bool downloadonly:
+        Ensures package is only downloaded without actually installing it.
+
+        Example:
+
+        .. code-block:: yaml
+
+            vim-enhanced:
+              pkg.installed:
+                - fromrepo: mycustomrepo
+                - skip_verify: True
+                - refresh: True
+                - downloadonly: True
+
     |
 
     **MULTIPLE PACKAGE INSTALLATION OPTIONS: (not supported in pkgng)**
@@ -991,6 +1005,19 @@ def installed(
                   - bar: http://somesite.org/bar.rpm
                   - baz: ftp://someothersite.org/baz.rpm
                   - qux: /minion/path/to/qux.rpm
+
+    :param list patches:
+        A list of patches/erratas to install.
+        CLI commands.
+
+        .. code-block:: yaml
+
+            my-suse-patches:
+              pkg.installed:
+                - patches:
+                  - SUSE-SLE-SERVER-12-SP1-2016-942
+                  - SUSE-SLE-SERVER-12-SP1-2016-1048
+                  - SUSE-SLE-SERVER-12-SP1-2016-1853
 
     **PLATFORM-SPECIFIC ARGUMENTS**
 
@@ -1534,8 +1561,9 @@ def installed(
 def downloaded(**kwargs):
     '''
     Ensure that the package is downloaded.
-    Functionally identical to :mod:`installed <salt.states.pkg.installed>`
-    but only downloads the packages without actually installing them.
+
+    Functionally identical to :mod:`installed <salt.states.pkg.installed>` but
+    forcing `downloadonly=True`.
 
     CLI Example:
 
@@ -1545,6 +1573,8 @@ def downloaded(**kwargs):
           pkg.downloaded:
             - fromrepo: "myrepository"
     '''
+    # It doesn't make sense here to received 'downloadonly' as kwargs
+    # as we're explicitely using 'downloadonly=True'
     if 'downloadonly' in kwargs:
         del kwargs['downloadonly']
     return installed(downloadonly=True, **kwargs)

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -292,7 +292,7 @@ def _find_install_targets(name=None,
     Inspect the arguments to pkg.installed and discover what packages need to
     be installed. Return a dict of desired packages
     '''
-    if len(filter(lambda x: bool(x), [pkgs, sources, patches])) > 1:
+    if len([True for x in [pkgs, sources, patches] if x]) > 1:
         return {'name': name,
                 'changes': {},
                 'result': False,


### PR DESCRIPTION
### What does this PR do?
This PR adds
1. Allowing `downloadonly=True` on a `pkg.installed` state:
```
vim:
  pkg.installed:
    - downloadonly: True
```
2. Adds new "pkg.downloaded" state function which is a wrapper of `pkg.installed` with `downloadonly=True`:
```
vim:
  pkg.downloaded: []
```
3. Adding support for installing patches/erratas using `zypper` or `yum` module.
```
$ salt 'minion' pkg.install patches='["SUSE-SLE-SERVER-12-SP1-2016-942", "SUSE-SLE-SERVER-12-SP1-2016-1048"]'
minion:
    ----------
    dhcp:
        ----------
        new:
            4.3.3-9.1
        old:
            4.3.3-2.2
    dhcp-client:
        ----------
        new:
            4.3.3-9.1
        old:
            4.3.3-2.2
    ----------
    dmidecode:
        ----------
        new:
            2.12-7.1
        old:
            2.12-5.20
```

**This PR is still WIP. I'll add some more fixes and unit tests for this**

### Tests written?

Yes/No