### PR TITLE
Add Docker Swarm standalone support

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -2467,7 +2467,16 @@ def list_containers(**kwargs):
             continue
         for c_name in [x.lstrip('/') for x in names or []]:
             ret.add(c_name)
-    return sorted(ret)
+
+    #  When using Docker Swarm standalone, only return the container name
+    #  portion, and exclude the portion from the node that is hosting the
+    #  container.
+    #
+    #  For example, two containers running under Docker Swarm standalone as (as
+    #  shown by `docker ps`) `node0/foo` and `node1/bar`, will be returned as
+    #  `['foo', 'bar']`.
+    return sorted(map((lambda x: x if '/' not in x else x.partition('/')[2]),
+                      ret))
 
 
 def list_tags():

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -421,7 +421,13 @@ def _compare(actual, create_kwargs, defaults_from_image):
                     data = dict((k, '') for k in data)
                 image_labels.update(data)
                 data = image_labels
-            if actual_data != data:
+
+            def _filter_swarm_labels(_api_data):
+                return { k: v for k, v in _api_data.iteritems()
+                        if k != 'com.docker.swarm.id' }
+
+            if (_filter_swarm_labels(actual_data) !=
+                    _filter_swarm_labels(data)):
                 ret.update({item: {'old': actual_data, 'new': data}})
                 continue
         elif item == 'log_config':

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -423,8 +423,20 @@ def _compare(actual, create_kwargs, defaults_from_image):
                 data = image_labels
 
             def _filter_swarm_labels(_api_data):
-                return { k: v for k, v in _api_data.iteritems()
-                        if k != 'com.docker.swarm.id' }
+                _filtered = dict(_api_data)
+
+                #  The swarm ID is irrelevant.  If a container is running
+                #  anywhere in the cluster, it's valid.
+                if 'com.docker.swarm.id' in _filtered:
+                    del _filtered['com.docker.swarm.id']
+
+                #  No explicit affinities, as represented in the label as '[]',
+                #  is equivalent to no label at all.
+                if ('com.docker.swarm.affinities' in _filtered and
+                        _filtered['com.docker.swarm.affinities'] == '[]'):
+                    del _filtered['com.docker.swarm.affinities']
+
+                return _filtered
 
             if (_filter_swarm_labels(actual_data) !=
                     _filter_swarm_labels(data)):


### PR DESCRIPTION
### What does this PR do?

Updates the `dockerng` modules and states with support for [Docker Swarm standalone](https://github.com/docker/swarm).

### What issues does this PR fix or reference?

None.

### Tests written?

No.

----

FWIW, I've been using these same changes for several months against several `2015.8.10` production installations, some which use Docker Swarm standalone, some with just a traditional Docker engine.  We're preparing to move to `2016.11.x`, and I thought I should make an attempt to make these available to the community.  If they're too risky, that's OK.  :)