### PR TITLE
change InfluxDB get_version to expect status code 204

### DIFF
--- a/salt/returners/influxdb_return.py
+++ b/salt/returners/influxdb_return.py
@@ -110,7 +110,7 @@ def _get_version(host, port, user, password):
     # check the InfluxDB version via the HTTP API
     try:
         result = requests.get("http://{0}:{1}/ping".format(host, port), auth=(user, password))
-        if result.status_code == 200 and influxDBVersionHeader in result.headers:
+        if result.status_code == 204 and influxDBVersionHeader in result.headers:
             version = result.headers[influxDBVersionHeader]
     except Exception as ex:
         log.critical('Failed to query InfluxDB version from HTTP API within InfluxDB returner: {0}'.format(ex))


### PR DESCRIPTION
### What does this PR do?
change InfluxDB get_version to expect status code 204

### What issues does this PR fix or reference?
#40204 

### Previous Behavior
InfluxDB returner wasn't working because the status code expected was wrong(200 instead of 204)


### New Behavior
The new expected status code is 204

### Tests written?

No 