### PR TITLE
Decode test names in names-file

### DIFF
--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -306,7 +306,7 @@ class SaltTestingParser(optparse.OptionParser):
             with open(self.options.names_file, 'rb') as fp_:
                 lines = []
                 for line in fp_.readlines():
-                    lines.append(line.strip())
+                    lines.append(line.strip().decode())
             if self.options.name:
                 self.options.name.extend(lines)
             else:

--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -306,11 +306,11 @@ class SaltTestingParser(optparse.OptionParser):
             with open(self.options.names_file, 'rb') as fp_:
                 lines = []
                 for line in fp_.readlines():
-                    if six.PY3:
+                    if six.PY2:
+                        lines.append(line.strip())
+                    else:
                         lines.append(
                             line.decode(__salt_system_encoding__).split())
-                    else:
-                        lines.append(line.strip())
             if self.options.name:
                 self.options.name.extend(lines)
             else:

--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -306,7 +306,11 @@ class SaltTestingParser(optparse.OptionParser):
             with open(self.options.names_file, 'rb') as fp_:
                 lines = []
                 for line in fp_.readlines():
-                    lines.append(line.strip().decode())
+                    if six.PY3:
+                        lines.append(
+                            line.decode(__salt_system_encoding__).split())
+                    else:
+                        lines.append(line.strip())
             if self.options.name:
                 self.options.name.extend(lines)
             else:


### PR DESCRIPTION
### What does this PR do?
Fixes problem with the test names in the `names-file` being passed as bytestrings. It just decodes them when it builds the dict. Is this the way readlines works in Python 3? Is there a better way to do this?

With this fix, the tests run and many tests pass.

https://github.com/saltstack/zh/issues/1175