### PR TITLE
salt.utils.job: Fix bad KeyError handling

### DIFF
--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -110,7 +110,6 @@ def store_job(opts, load, event=None, mminion=None):
         mminion.returners[updateetfstr](load['jid'], endtime)
 
 
-
 def store_minions(opts, jid, minions, mminion=None, syndic_id=None):
     '''
     Store additional minions matched on lower-level masters using the configured


### PR DESCRIPTION
## Issue

Bad handling of `KeyError` which can catch `KeyError` from given returner.

In other words, if your returner `foo` exposes function `returner` raising a `KeyError` you will get: `Returner 'foo' does not support function returner`. This is disturbing because in fact your module exposes this method.

## Reproduce

1. Copy default returner as custom one (just to not have to code a whole returner): `cp salt/salt/returners/local_cache.py myapp/extmods/returners/foo.py`
2. Within the first line of `foo.returner` add `raise KeyError('spam spam egg')`.
3. Configure your master / minion to use this returner (/etc/salt/master: `master_job_cache: foo`)
4. Send command from master to minion

You should get: `KeyError: "Returner 'foo' does not support function returner"`. You now can exclaim "HA-HA !".

## Why this bug

Long story short, `utils.job.store_job` uses `mminion.returners` list to store loaded returner functions. When a function needs to be called it's done with something like: `mminion.returners[function_name](*args, **kwargs)` and wrap this in a `try / except KeyError`.

As expected if `mminion.returners[function_name]()` raises KeyError, this one is catched by `utils.job.store_job`.

Moreover, I do not tried this, but by reading code I think if another method than `returner` is missing, the same error will be raised, saying 'returner' is missing, but that can be `save_load` or `get_load` too.

## Fix

Just try to get returner's functions as object **before** calling it. Like it, we catch KeyError before executing the function, so we are sure if KeyError is raised here it's not from the returner's method.

It fix bad returner's function name displayed in error message too.
