### PR TITLE
fix "create_binding"

### DIFF
--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -511,7 +511,7 @@ def list_bindings(site):
 
 
 def create_binding(site, hostheader='', ipaddress='*', port=80, protocol='http',
-                   sslflags=0):
+                   sslflags=None):
     '''
     Create an IIS Web Binding.
 
@@ -541,7 +541,6 @@ def create_binding(site, hostheader='', ipaddress='*', port=80, protocol='http',
         salt '*' win_iis.create_binding site='site0' hostheader='example.com' ipaddress='*' port='80'
     '''
     protocol = str(protocol).lower()
-    sslflags = int(sslflags)
     name = _get_binding_info(hostheader, ipaddress, port)
 
     if protocol not in _VALID_PROTOCOLS:
@@ -549,10 +548,12 @@ def create_binding(site, hostheader='', ipaddress='*', port=80, protocol='http',
                    ' {1}').format(protocol, _VALID_PROTOCOLS)
         raise SaltInvocationError(message)
 
-    if sslflags not in _VALID_SSL_FLAGS:
-        message = ("Invalid sslflags '{0}' specified. Valid sslflags range:"
-                   ' {1}..{2}').format(sslflags, _VALID_SSL_FLAGS[0], _VALID_SSL_FLAGS[-1])
-        raise SaltInvocationError(message)
+    if sslflags:
+        sslflags = int(sslflags)
+        if sslflags not in _VALID_SSL_FLAGS:
+            message = ("Invalid sslflags '{0}' specified. Valid sslflags range:"
+                       ' {1}..{2}').format(sslflags, _VALID_SSL_FLAGS[0], _VALID_SSL_FLAGS[-1])
+            raise SaltInvocationError(message)
 
     current_bindings = list_bindings(site)
 
@@ -560,13 +561,21 @@ def create_binding(site, hostheader='', ipaddress='*', port=80, protocol='http',
         log.debug('Binding already present: {0}'.format(name))
         return True
 
-    ps_cmd = ['New-WebBinding',
-              '-Name', "'{0}'".format(site),
-              '-HostHeader', "'{0}'".format(hostheader),
-              '-IpAddress', "'{0}'".format(ipaddress),
-              '-Port', "'{0}'".format(str(port)),
-              '-Protocol', "'{0}'".format(protocol),
-              '-SslFlags', '{0}'.format(sslflags)]
+    if sslflags:
+        ps_cmd = ['New-WebBinding',
+                  '-Name', "'{0}'".format(site),
+                  '-HostHeader', "'{0}'".format(hostheader),
+                  '-IpAddress', "'{0}'".format(ipaddress),
+                  '-Port', "'{0}'".format(str(port)),
+                  '-Protocol', "'{0}'".format(protocol),
+                  '-SslFlags', '{0}'.format(sslflags)]
+    else:
+        ps_cmd = ['New-WebBinding',
+                  '-Name', "'{0}'".format(site),
+                  '-HostHeader', "'{0}'".format(hostheader),
+                  '-IpAddress', "'{0}'".format(ipaddress),
+                  '-Port', "'{0}'".format(str(port)),
+                  '-Protocol', "'{0}'".format(protocol)]
 
     cmd_ret = _srvmgr(ps_cmd)
 


### PR DESCRIPTION
sslflags is not supported in server 2008.
Added an option to run "create_binding" without sslflags

### What does this PR do?
Create binding without ssl flags

### What issues does this PR fix or reference?
windows server 2008 PS doesn't support sslflags 

### Previous Behavior
PS IIS:\Sites\default web site> New-WebBinding -Name 'Default Web Site' -HostHeader 'Default Web Site.local' -IpAddress '2.2.2.2' -Port '80' -Protocol 'http' -SslFlags 0
**New-WebBinding : A parameter cannot be found that matches parameter name 'SslFlags'.**
At line:1 char:131
+ ... cal' -IpAddress '2.2.2.2' -Port '80' -Protocol 'http' -SslFlags 0
+                                                               ~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [New-WebBinding], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Microsoft.IIs.PowerShell.Provider.NewWebBindingCommand

### New Behavior
sslflags is not a required param

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
