### PR TITLE
Refactor processing return data from network.load_config

### DIFF
--- a/salt/states/netacl.py
+++ b/salt/states/netacl.py
@@ -49,6 +49,8 @@ try:
 except ImportError:
     HAS_NAPALM = False
 
+import salt.utils.napalm
+
 # ------------------------------------------------------------------------------
 # state properties
 # ------------------------------------------------------------------------------
@@ -77,49 +79,6 @@ def __virtual__():
 # ------------------------------------------------------------------------------
 # helper functions -- will not be exported
 # ------------------------------------------------------------------------------
-
-
-def _default_ret(name):
-    '''
-    Return the default dict of the state output.
-    '''
-    ret = {
-        'name': name,
-        'changes': {},
-        'already_configured': False,
-        'result': False,
-        'comment': ''
-    }
-    return ret
-
-
-def _loaded_ret(ret, loaded, test, debug):
-    '''
-    Return the final state output.
-
-    ret
-        The initial state output structure.
-
-    loaded
-        The loaded dictionary.
-    '''
-    applied = loaded.get('result', False)
-    result = (applied if not applied else None) if test else applied
-    _comment = loaded.get('comment', '')
-    comment = _comment if not test else 'Testing mode: {tail}'.format(tail=_comment)
-    if result is True and not comment:
-        comment = 'Configuration changed!'
-    ret.update({
-        'changes': {
-            'diff': loaded.get('diff', '')
-        },
-        'already_configured': loaded.get('already_configured', False),
-        'result': result,
-        'comment': comment,
-    })
-    if debug:
-        ret['changes']['loaded'] = loaded.get('loaded_config', '')
-    return ret
 
 # ------------------------------------------------------------------------------
 # callable functions
@@ -433,7 +392,7 @@ def term(name,
     recommended to use the json serializer explicitly (`` | json``),
     instead of relying on the default Python serializer.
     '''
-    ret = _default_ret(name)
+    ret = salt.utils.napalm.default_ret(name)
     test = __opts__['test'] or test
     if not filter_options:
         filter_options = []
@@ -454,7 +413,7 @@ def term(name,
                                                  commit=commit,
                                                  debug=debug,
                                                  **term_fields)
-    return _loaded_ret(ret, loaded, test, debug)
+    return salt.utils.napalm.loaded_ret(ret, loaded, test, debug)
 
 
 def filter(name,  # pylint: disable=redefined-builtin
@@ -625,7 +584,7 @@ def filter(name,  # pylint: disable=redefined-builtin
     recommended to use the json serializer explicitly (`` | json``),
     instead of relying on the default Python serializer.
     '''
-    ret = _default_ret(name)
+    ret = salt.utils.napalm.default_ret(name)
     test = __opts__['test'] or test
     if not filter_options:
         filter_options = []
@@ -646,7 +605,7 @@ def filter(name,  # pylint: disable=redefined-builtin
                                                    test=test,
                                                    commit=commit,
                                                    debug=debug)
-    return _loaded_ret(ret, loaded, test, debug)
+    return salt.utils.napalm.loaded_ret(ret, loaded, test, debug)
 
 
 def managed(name,
@@ -886,7 +845,7 @@ def managed(name,
     recommended to use the json serializer explicitly (`` | json``),
     instead of relying on the default Python serializer.
     '''
-    ret = _default_ret(name)
+    ret = salt.utils.napalm.default_ret(name)
     test = __opts__['test'] or test
     if not filters:
         filters = {}
@@ -903,4 +862,4 @@ def managed(name,
                                                    test=test,
                                                    commit=commit,
                                                    debug=debug)
-    return _loaded_ret(ret, loaded, test, debug)
+    return salt.utils.napalm.loaded_ret(ret, loaded, test, debug)

--- a/salt/states/netconfig.py
+++ b/salt/states/netconfig.py
@@ -52,21 +52,6 @@ def __virtual__():
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-def _default_ret(name):
-    '''
-    Return the default dict of the state output.
-    '''
-    ret = {
-        'name': name,
-        'changes': {},
-        'already_configured': False,
-        'loaded_config': '',
-        'result': False,
-        'comment': ''
-    }
-    return ret
-
-
 def _update_config(template_name,
                    template_source=None,
                    template_path=None,
@@ -334,7 +319,7 @@ def managed(name,
         }
     '''
 
-    ret = _default_ret(name)
+    ret = salt.utils.napalm.default_ret(name)
 
     # the user can override the flags the equivalent CLI args
     # which have higher precedence
@@ -362,24 +347,4 @@ def managed(name,
                                        replace=replace,
                                        **template_vars)
 
-    _apply_res = config_update_ret.get('result', False)
-    result = (_apply_res if not _apply_res else None) if test else _apply_res
-    _comment = config_update_ret.get('comment', '')
-    comment = _comment if not test else 'Testing mode: {tail}'.format(tail=_comment)
-
-    if result is True and not comment:
-        comment = 'Configuration changed!'
-
-    ret.update({
-        'changes': {
-            'diff': config_update_ret.get('diff', '')
-        },
-        'already_configured': config_update_ret.get('already_configured', False),
-        'result': result,
-        'comment': comment
-    })
-
-    if debug:
-        ret['changes']['loaded'] = config_update_ret.get('loaded_config', '')
-
-    return ret
+    return salt.utils.napalm.loaded_ret(ret, config_update_ret, test, debug)

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -364,6 +364,9 @@ def loaded_ret(ret, loaded, test, debug):
             'comment': loaded.get('comment', '')
         })
         return ret
+    if debug:
+        # Always check for debug
+        ret['changes']['loaded'] = loaded.get('loaded_config', '')
     if not loaded.get('already_configured', True):
         # We're making changes
         ret.update({
@@ -372,7 +375,7 @@ def loaded_ret(ret, loaded, test, debug):
             }
         })
         if test:
-            comment = "To be changed: {}\n{}".format(ret.get('pchanges', '').get('diff', ''),
+            comment = "To be changed:\n{}\n{}".format(ret.get('pchanges', '').get('diff', ''),
                                                      loaded.get('comment', ''))
             ret.update({
                 'result': None,
@@ -387,10 +390,7 @@ def loaded_ret(ret, loaded, test, debug):
             },
             'comment': loaded.get('comment', "Configuration changed!")
         })
-        if debug:
-            ret['changes']['loaded'] = loaded.get('loaded_config', '')
         return ret
-
     # No changes
     ret.update({
         'result': True,

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -333,6 +333,7 @@ def proxy_napalm_wrap(func):
         return func(*args, **kwargs)
     return func_wrapper
 
+
 def default_ret(name):
     '''
     Return the default dict of the state output.
@@ -345,6 +346,7 @@ def default_ret(name):
         'comment': ''
     }
     return ret
+
 
 def loaded_ret(ret, loaded, test, debug):
     '''

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -362,36 +362,39 @@ def loaded_ret(ret, loaded, test, debug):
     ret.update({
         'comment': loaded.get('comment', '')
     })
+    pchanges = {}
     if not loaded.get('result', False):
         # Failure of some sort
         return ret
     if debug:
         # Always check for debug
+        pchanges.update({
+            'loaded_config': loaded.get('loaded_config', '')
+        })
         ret.update({
-            "comment": "Debug loaded_config:\n{}\n{}".format(loaded.get('loaded_config', ''),
-                                                ret.get('comment', ''))
+            "pchanges": pchanges
         })
     if not loaded.get('already_configured', True):
         # We're making changes
+        pchanges.update({
+            "diff": loaded.get('diff', '')
+        })
         ret.update({
-            'pchanges': {
-                'diff': loaded.get('diff', '')
-            }
+            'pchanges': pchanges
         })
         if test:
-            comment = "To be changed:\n{}\n{}".format(ret.get('pchanges', '').get('diff', ''),
-                                                     ret.get('comment', ''))
+            for k, v in pchanges.items():
+                ret.update({
+                    "comment": "{}:\n{}\n\n{}".format(k, v, ret.get("comment", ''))
+                })
             ret.update({
                 'result': None,
-                'comment': comment
             })
             return ret
         # Not test, changes were applied
         ret.update({
             'result': True,
-            'changes': {
-                'diff': loaded.get('diff', '')
-            },
+            'changes': pchanges,
             'comment': "Configuration changed!\n{}".format(ret.get('comment', ''))
         })
         return ret

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -358,15 +358,19 @@ def loaded_ret(ret, loaded, test, debug):
     loaded
         The loaded dictionary.
     '''
+    # Always get the comment
+    ret.update({
+        'comment': loaded.get('comment', '')
+    })
     if not loaded.get('result', False):
         # Failure of some sort
-        ret.update({
-            'comment': loaded.get('comment', '')
-        })
         return ret
     if debug:
         # Always check for debug
-        ret['changes']['loaded'] = loaded.get('loaded_config', '')
+        ret.update({
+            "comment": "Debug loaded_config:\n{}\n{}".format(loaded.get('loaded_config', ''),
+                                                ret.get('comment', ''))
+        })
     if not loaded.get('already_configured', True):
         # We're making changes
         ret.update({
@@ -376,7 +380,7 @@ def loaded_ret(ret, loaded, test, debug):
         })
         if test:
             comment = "To be changed:\n{}\n{}".format(ret.get('pchanges', '').get('diff', ''),
-                                                     loaded.get('comment', ''))
+                                                     ret.get('comment', ''))
             ret.update({
                 'result': None,
                 'comment': comment
@@ -388,12 +392,11 @@ def loaded_ret(ret, loaded, test, debug):
             'changes': {
                 'diff': loaded.get('diff', '')
             },
-            'comment': loaded.get('comment', "Configuration changed!")
+            'comment': "Configuration changed!\n{}".format(ret.get('comment', ''))
         })
         return ret
     # No changes
     ret.update({
-        'result': True,
-        'comment': loaded.get('comment', '')
+        'result': True
     })
     return ret


### PR DESCRIPTION
### What does this PR do?
Move default_ret and loaded_ret into salt.utils.napalm, and update the
dictionary returned based on discussions in #40208. Diffs are copied
into comment if this is a dry-run, and changes are only set if an
actual change is made on the device.

### Previous Behavior
```yaml
[root@saltmaster:~] # salt --out=yaml veos1 state.apply test=True
veos1:
  netacl_|-test_|-test_|-managed:
    __id__: test
    __run_num__: 1
    __sls__: router.mcast.acl
    already_configured: false
    changes:
      diff: "@@ -26,6 +26,18 @@\n interface Management1\n    ip address 10.0.2.15/24\n
        !\n+ip access-list standard a-mcast\n+   10 remark $Id: test $\n+   20
        remark term1\n+   30 permit host 233.252.21.1\n+   40 permit host 233.252.21.2\n+!\n+ip
        access-list standard b-mcast\n+   10 remark $Id: test $\n+   20 remark
        term1\n+   30 permit host 233.252.21.129\n+   40 permit host 233.252.21.130\n+!\n
        ip route 0.0.0.0/0 10.0.2.2\n !\n no ip routing"
    comment: 'Testing mode: Configuration discarded.'
    duration: 2490.159
    name: test
    result: null
    start_time: '19:04:19.338984'
  netconfig_|-mcast-base_|-mcast-base_|-managed:
    __id__: mcast-base
    __run_num__: 0
    __sls__: router.mcast
    already_configured: true
    changes:
      diff: ''
    comment: 'Testing mode: Configuration discarded.'
    duration: 1699.846
    loaded_config: ''
    name: mcast-base
    result: null
    start_time: '19:04:17.637968'
  netconfig_|-pim-rps_|-pim-rps_|-managed:
    __id__: pim-rps
    __run_num__: 2
    __sls__: router.mcast.pim
    already_configured: false
    changes:
      diff: "@@ -32,6 +32,10 @@\n !\n ip multicast-routing\n !\n+router pim sparse-mode\n+
        \  ip pim rp-address 192.0.2.1 access-list a-mcast\n+   ip pim rp-address
        192.0.2.2 access-list b-mcast\n+!\n management api http-commands\n    no
        shutdown\n !"
    comment: 'Testing mode: Configuration discarded.'
    duration: 1958.6
    loaded_config: ''
    name: pim-rps
    result: null
    start_time: '19:04:21.829395'
[root@saltmaster:~] # salt --out=yaml veos1 state.apply
veos1:
  netacl_|-test_|-test_|-managed:
    __id__: test
    __run_num__: 1
    __sls__: router.mcast.acl
    already_configured: false
    changes:
      diff: "@@ -26,6 +26,18 @@\n interface Management1\n    ip address 10.0.2.15/24\n
        !\n+ip access-list standard a-mcast\n+   10 remark $Id: test $\n+   20
        remark term1\n+   30 permit host 233.252.21.1\n+   40 permit host 233.252.21.2\n+!\n+ip
        access-list standard b-mcast\n+   10 remark $Id: test $\n+   20 remark
        term1\n+   30 permit host 233.252.21.129\n+   40 permit host 233.252.21.130\n+!\n
        ip route 0.0.0.0/0 10.0.2.2\n !\n no ip routing"
    comment: Configuration changed!
    duration: 2524.962
    name: test
    result: true
    start_time: '19:04:43.764291'
  netconfig_|-mcast-base_|-mcast-base_|-managed:
    __id__: mcast-base
    __run_num__: 0
    __sls__: router.mcast
    already_configured: true
    changes:
      diff: ''
    comment: Already configured.
    duration: 2094.271
    loaded_config: ''
    name: mcast-base
    result: true
    start_time: '19:04:41.668861'
  netconfig_|-pim-rps_|-pim-rps_|-managed:
    __id__: pim-rps
    __run_num__: 2
    __sls__: router.mcast.pim
    already_configured: false
    changes:
      diff: "@@ -44,6 +44,10 @@\n !\n ip multicast-routing\n !\n+router pim sparse-mode\n+
        \  ip pim rp-address 192.0.2.1 access-list a-mcast\n+   ip pim rp-address
        192.0.2.2 access-list b-mcast\n+!\n management api http-commands\n    no
        shutdown\n !"
    comment: Configuration changed!
    duration: 2615.863
    loaded_config: ''
    name: pim-rps
    result: true
    start_time: '19:04:46.289470'
```
### New Behavior
```yaml
[root@saltmaster:~] # salt --out=yaml veos1 state.apply test=True
veos1:
  netacl_|-test_|-test_|-managed:
    __id__: test
    __run_num__: 1
    __sls__: router.mcast.acl
    changes: {}
    comment: "To be changed: @@ -26,6 +26,18 @@\n interface Management1\n    ip address
      10.0.2.15/24\n !\n+ip access-list standard a-mcast\n+   10 remark $Id: test
      $\n+   20 remark term1\n+   30 permit host 233.252.21.1\n+   40 permit host
      233.252.21.2\n+!\n+ip access-list standard b-mcast\n+   10 remark $Id: test
      $\n+   20 remark term1\n+   30 permit host 233.252.21.129\n+   40 permit host
      233.252.21.130\n+!\n ip route 0.0.0.0/0 10.0.2.2\n !\n no ip routing\nConfiguration
      discarded."
    duration: 2122.099
    name: test
    pchanges:
      diff: "@@ -26,6 +26,18 @@\n interface Management1\n    ip address 10.0.2.15/24\n
        !\n+ip access-list standard a-mcast\n+   10 remark $Id: test $\n+   20
        remark term1\n+   30 permit host 233.252.21.1\n+   40 permit host 233.252.21.2\n+!\n+ip
        access-list standard b-mcast\n+   10 remark $Id: test $\n+   20 remark
        term1\n+   30 permit host 233.252.21.129\n+   40 permit host 233.252.21.130\n+!\n
        ip route 0.0.0.0/0 10.0.2.2\n !\n no ip routing"
    result: null
    start_time: '18:48:58.539133'
  netconfig_|-mcast-base_|-mcast-base_|-managed:
    __id__: mcast-base
    __run_num__: 0
    __sls__: router.mcast
    changes: {}
    comment: Configuration discarded.
    duration: 1694.58
    name: mcast-base
    pchanges: {}
    result: true
    start_time: '18:48:56.843249'
  netconfig_|-pim-rps_|-pim-rps_|-managed:
    __id__: pim-rps
    __run_num__: 2
    __sls__: router.mcast.pim
    changes: {}
    comment: "To be changed: @@ -32,6 +32,10 @@\n !\n ip multicast-routing\n !\n+router
      pim sparse-mode\n+   ip pim rp-address 192.0.2.1 access-list a-mcast\n+
      \  ip pim rp-address 192.0.2.2 access-list b-mcast\n+!\n management api
      http-commands\n    no shutdown\n !\nConfiguration discarded."
    duration: 2306.993
    name: pim-rps
    pchanges:
      diff: "@@ -32,6 +32,10 @@\n !\n ip multicast-routing\n !\n+router pim sparse-mode\n+
        \  ip pim rp-address 192.0.2.1 access-list a-mcast\n+   ip pim rp-address
        192.0.2.2 access-list b-mcast\n+!\n management api http-commands\n    no
        shutdown\n !"
    result: null
    start_time: '18:49:00.661585'
[root@saltmaster:~] # salt --out=yaml veos1 state.apply
veos1:
  netacl_|-test_|-test_|-managed:
    __id__: test
    __run_num__: 1
    __sls__: router.mcast.acl
    changes:
      diff: "@@ -26,6 +26,18 @@\n interface Management1\n    ip address 10.0.2.15/24\n
        !\n+ip access-list standard a-mcast\n+   10 remark $Id: test $\n+   20
        remark term1\n+   30 permit host 233.252.21.1\n+   40 permit host 233.252.21.2\n+!\n+ip
        access-list standard b-mcast\n+   10 remark $Id: test $\n+   20 remark
        term1\n+   30 permit host 233.252.21.129\n+   40 permit host 233.252.21.130\n+!\n
        ip route 0.0.0.0/0 10.0.2.2\n !\n no ip routing"
    comment: ''
    duration: 2677.044
    name: test
    pchanges:
      diff: "@@ -26,6 +26,18 @@\n interface Management1\n    ip address 10.0.2.15/24\n
        !\n+ip access-list standard a-mcast\n+   10 remark $Id: test $\n+   20
        remark term1\n+   30 permit host 233.252.21.1\n+   40 permit host 233.252.21.2\n+!\n+ip
        access-list standard b-mcast\n+   10 remark $Id: test $\n+   20 remark
        term1\n+   30 permit host 233.252.21.129\n+   40 permit host 233.252.21.130\n+!\n
        ip route 0.0.0.0/0 10.0.2.2\n !\n no ip routing"
    result: true
    start_time: '18:49:26.936205'
  netconfig_|-mcast-base_|-mcast-base_|-managed:
    __id__: mcast-base
    __run_num__: 0
    __sls__: router.mcast
    changes: {}
    comment: Already configured.
    duration: 1720.124
    name: mcast-base
    pchanges: {}
    result: true
    start_time: '18:49:25.214744'
  netconfig_|-pim-rps_|-pim-rps_|-managed:
    __id__: pim-rps
    __run_num__: 2
    __sls__: router.mcast.pim
    changes:
      diff: "@@ -44,6 +44,10 @@\n !\n ip multicast-routing\n !\n+router pim sparse-mode\n+
        \  ip pim rp-address 192.0.2.1 access-list a-mcast\n+   ip pim rp-address
        192.0.2.2 access-list b-mcast\n+!\n management api http-commands\n    no
        shutdown\n !"
    comment: ''
    duration: 2303.705
    name: pim-rps
    pchanges:
      diff: "@@ -44,6 +44,10 @@\n !\n ip multicast-routing\n !\n+router pim sparse-mode\n+
        \  ip pim rp-address 192.0.2.1 access-list a-mcast\n+   ip pim rp-address
        192.0.2.2 access-list b-mcast\n+!\n management api http-commands\n    no
        shutdown\n !"
    result: true
    start_time: '18:49:29.613658'
```

### Tests written?
No

