### PR TITLE
Add changes suggested by contributer

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1404,7 +1404,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
 
             # Get the uninstaller
             uninstaller = pkginfo[target].get('uninstaller', '')
-            cache_dir = pkginfo[version_num].get('cache_dir', False)
+            cache_dir = pkginfo[target].get('cache_dir', False)
 
             # If no uninstaller found, use the installer
             if not uninstaller:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -115,6 +115,7 @@ if salt.utils.is_windows():
     from salt.modules.win_pkg import genrepo
     from salt.modules.win_pkg import _repo_process_pkg_sls
     from salt.modules.win_pkg import _get_latest_pkg_version
+    from salt.modules.win_pkg import _reverse_cmp_pkg_versions
     _get_package_info = _namespaced_function(_get_package_info, globals())
     get_repo_data = _namespaced_function(get_repo_data, globals())
     _get_repo_details = \
@@ -127,6 +128,8 @@ if salt.utils.is_windows():
         _namespaced_function(_repo_process_pkg_sls, globals())
     _get_latest_pkg_version = \
         _namespaced_function(_get_latest_pkg_version, globals())
+    _reverse_cmp_pkg_versions = \
+        _namespaced_function(_reverse_cmp_pkg_versions, globals())
     # The following imports are used by the namespaced win_pkg funcs
     # and need to be included in their globals.
     # pylint: disable=import-error,unused-import


### PR DESCRIPTION
### What does this PR do?
Reverts changes suggested by @damon-atkins 
- Adds back the `_reverse_cmp_package_versions` functions. 
- Modifies `sorted()` to use the `_revers_cmp_package_version` function using `cmp_to_key` from `functools`
- Uses `**kwargs` where necessary to maintain uniformity with other `pkg` execution modules
- Fixes function calls that were missing the `saltenv` parameter
- Uses `six.PY2` instead of `six.PY3` to handle Python2 specific cases.

Additional:
- Adds `saltenv` to the `pkg.remove`
- Adds `cachedir` to `pkg.remove`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/pull/40029
https://github.com/saltstack/salt/issues/40134
https://github.com/saltstack/salt/issues/39607
https://github.com/saltstack/salt/issues/33119

### Previous Behavior
- Function parameters were not consistent with other package modules.
- `saltenv` was ignored for `pkg.remove`
- `cachedir` was ignored for `pkg.remove`

### New Behavior
- Function parameters now consistent
- `saltenv` and `cachedir` now used for `pkg.remove`

### Tests written?
No
