### PR TITLE
Enable soft reboot a VM via salt-cloud & VMware driver

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1983,15 +1983,22 @@ def start(name, call=None):
     return 'powered on'
 
 
-def stop(name, call=None):
+def stop(name, call=None, soft=False):
     '''
     To stop/power off a VM using its name
+
+    .. note::
+
+        If ``soft=True`` issues a command to the guest operating system
+        asking it to perform a clean shutdown of all services.
+        Default is soft=False
 
     CLI Example:
 
     .. code-block:: bash
 
         salt-cloud -a stop vmname
+        salt-cloud -a stop vmname soft=True
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
@@ -2014,7 +2021,10 @@ def stop(name, call=None):
                 return ret
             try:
                 log.info('Stopping VM {0}'.format(name))
-                task = vm["object"].PowerOff()
+                if soft:
+                    task = vm["object"].ShutdownGuest()
+                else:
+                    task = vm["object"].PowerOff()
                 salt.utils.vmware.wait_for_task(task, name, 'power off')
             except Exception as exc:
                 log.error(
@@ -2081,15 +2091,22 @@ def suspend(name, call=None):
     return 'suspended'
 
 
-def reset(name, call=None):
+def reset(name, call=None, soft=False):
     '''
     To reset a VM using its name
+
+    .. note::
+
+        If ``soft=True`` Issues a command to the guest operating system
+        asking it to perform a reboot. Otherwise hypervisor will terminate VM and start it again.
+        Default is soft=False
 
     CLI Example:
 
     .. code-block:: bash
 
         salt-cloud -a reset vmname
+        salt-cloud -a reset vmname soft=True
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
@@ -2112,7 +2129,10 @@ def reset(name, call=None):
                 return ret
             try:
                 log.info('Resetting VM {0}'.format(name))
-                task = vm["object"].ResetVM_Task()
+                if soft:
+                    task = vm["object"].RebootGuest()
+                else:
+                    task = vm["object"].ResetVM_Task()
                 salt.utils.vmware.wait_for_task(task, name, 'reset')
             except Exception as exc:
                 log.error(

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1983,7 +1983,7 @@ def start(name, call=None):
     return 'powered on'
 
 
-def stop(name, call=None, soft=False):
+def stop(name, soft=False, call=None):
     '''
     To stop/power off a VM using its name
 
@@ -2091,7 +2091,7 @@ def suspend(name, call=None):
     return 'suspended'
 
 
-def reset(name, call=None, soft=False):
+def reset(name, soft=False, call=None):
     '''
     To reset a VM using its name
 

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1993,6 +1993,8 @@ def stop(name, soft=False, call=None):
         asking it to perform a clean shutdown of all services.
         Default is soft=False
 
+        For ``soft=True`` vmtools should be installed on guest system.
+
     CLI Example:
 
     .. code-block:: bash
@@ -2100,6 +2102,8 @@ def reset(name, soft=False, call=None):
         If ``soft=True`` then issues a command to the guest operating system
         asking it to perform a reboot. Otherwise hypervisor will terminate VM and start it again.
         Default is soft=False
+
+        For ``soft=True`` vmtools should be installed on guest system.
 
     CLI Example:
 

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2022,10 +2022,10 @@ def stop(name, soft=False, call=None):
             try:
                 log.info('Stopping VM {0}'.format(name))
                 if soft:
-                    task = vm["object"].ShutdownGuest()
+                    vm["object"].ShutdownGuest()
                 else:
                     task = vm["object"].PowerOff()
-                salt.utils.vmware.wait_for_task(task, name, 'power off')
+                    salt.utils.vmware.wait_for_task(task, name, 'power off')
             except Exception as exc:
                 log.error(
                     'Error while powering off VM {0}: {1}'.format(
@@ -2130,10 +2130,10 @@ def reset(name, soft=False, call=None):
             try:
                 log.info('Resetting VM {0}'.format(name))
                 if soft:
-                    task = vm["object"].RebootGuest()
+                    vm["object"].RebootGuest()
                 else:
                     task = vm["object"].ResetVM_Task()
-                salt.utils.vmware.wait_for_task(task, name, 'reset')
+                    salt.utils.vmware.wait_for_task(task, name, 'reset')
             except Exception as exc:
                 log.error(
                     'Error while resetting VM {0}: {1}'.format(

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -1989,7 +1989,7 @@ def stop(name, soft=False, call=None):
 
     .. note::
 
-        If ``soft=True`` issues a command to the guest operating system
+        If ``soft=True`` then issues a command to the guest operating system
         asking it to perform a clean shutdown of all services.
         Default is soft=False
 
@@ -2097,7 +2097,7 @@ def reset(name, soft=False, call=None):
 
     .. note::
 
-        If ``soft=True`` Issues a command to the guest operating system
+        If ``soft=True`` then issues a command to the guest operating system
         asking it to perform a reboot. Otherwise hypervisor will terminate VM and start it again.
         Default is soft=False
 


### PR DESCRIPTION
### What does this PR do?
Implement reboot of the VM from guest os

### What issues does this PR fix or reference?
None

### Previous Behavior
salt-cloud -a reset vm_name - only hard

### New Behavior
salt-cloud -a reset vm_name - the same
salt-cloud -a reset vm_name soft=True - correctly restart the VM

### Tests written?
No
