### PR TITLE
More proxy documentation

### DIFF
--- a/conf/proxy
+++ b/conf/proxy
@@ -31,6 +31,26 @@
 # Default to False for 2016.3 and 2016.11. Switch to True for Nitrogen.
 # proxy_merge_grains_in_module: True
 
+# If a proxymodule has a function called 'alive' returning a boolean
+# flag reflecting the state of the connection with the remove device,
+# when this option is set as True, a scheduled job on the proxy will
+# try restarting the connection. The polling frequency depends on the
+# next option, 'proxy_keep_alive_interval'. Added in Nitrogen.
+# proxy_keep_alive: True
+
+# The polling interval (in minutes) to check if the underlying connection
+# with the remote device is still alive. This option requires
+# 'proxy_keep_alive' to be configured as True and the proxymodule to
+# implement the 'alive' function. Added in Nitrogen.
+# proxy_keep_alive_interval: 1
+
+# By default, any proxy opens the connection with the remote device when
+# initialized. Some proxymodules allow throgh this option to open/close
+# the session per command. This requires the proxymodule to have this
+# capability. Please consult the documentation to see if the proxy type
+# used can be that flexible. Added in Nitrogen.
+# proxy_always_alive: True
+
 # If multiple masters are specified in the 'master' setting, the default behavior
 # is to always try to connect to them in the order they are listed. If random_master is
 # set to True, the order will be randomized instead. This can be helpful in distributing

--- a/conf/proxy
+++ b/conf/proxy
@@ -45,7 +45,7 @@
 # proxy_keep_alive_interval: 1
 
 # By default, any proxy opens the connection with the remote device when
-# initialized. Some proxymodules allow throgh this option to open/close
+# initialized. Some proxymodules allow through this option to open/close
 # the session per command. This requires the proxymodule to have this
 # capability. Please consult the documentation to see if the proxy type
 # used can be that flexible. Added in Nitrogen.

--- a/doc/ref/configuration/proxy.rst
+++ b/doc/ref/configuration/proxy.rst
@@ -91,7 +91,7 @@ otherwise the connection is considered alive.
 Default: ``1``
 
 The frequency of keepalive checks, in minutes. It requires the
-:conf_minion:`proxy_keep_alive` option to be enabled
+:conf_proxy:`proxy_keep_alive` option to be enabled
 (and the proxy module to implement the ``alive`` function).
 
 .. code-block:: yaml
@@ -109,9 +109,9 @@ The frequency of keepalive checks, in minutes. It requires the
 Default: ``True``
 
 Wheter the proxy should maintain the connection with the remote
-device. Similarly to :conf_minion:`proxy_keep_alive`, this option
+device. Similarly to :conf_proxy:`proxy_keep_alive`, this option
 is very specific to the design of the proxy module.
-When :conf_minion:`proxy_always_alive` is set to ``False``,
+When :conf_proxy:`proxy_always_alive` is set to ``False``,
 the connection with the remote device is not maintained and
 has to be closed after every command.
 

--- a/doc/topics/configuration/index.rst
+++ b/doc/topics/configuration/index.rst
@@ -10,6 +10,7 @@ secure and troubleshoot, and how to perform many other administrative tasks.
 
     ../../ref/configuration/master
     ../../ref/configuration/minion
+    ../../ref/configuration/proxy
     ../../ref/configuration/examples
     ../blackout/index
     ../eauth/access_control

--- a/doc/topics/proxyminion/index.rst
+++ b/doc/topics/proxyminion/index.rst
@@ -36,6 +36,18 @@ or more minions.
 See :ref:`Proxyminion Beacon <proxy-minion-beacon>` to help
 with easy configuration and management of ``salt-proxy`` processes.
 
+New in Nitrogen
+---------------
+
+The connection with the remote device is kept alive by default, when the
+module implements the ``alive`` function and :conf_proxy:`proxy_keep_alive`
+is set to ``True``. The polling interval is set using the
+:conf_proxy:`proxy_keep_alive_interval` option which defaults to 1 minute.
+
+The developers are also able to use the :conf_proxy:`proxy_always_alive`,
+when designing a proxy module flexible enough to open the
+connection with the remote device only when required.
+
 New in 2016.11.0
 ----------------
 

--- a/doc/topics/proxyminion/index.rst
+++ b/doc/topics/proxyminion/index.rst
@@ -39,6 +39,9 @@ with easy configuration and management of ``salt-proxy`` processes.
 New in Nitrogen
 ---------------
 
+The :conf_proxy:`proxy_merge_grains_in_module` configuration variable
+introduced in 2016.3, has been changed, defaulting to ``True``.
+
 The connection with the remote device is kept alive by default, when the
 module implements the ``alive`` function and :conf_proxy:`proxy_keep_alive`
 is set to ``True``. The polling interval is set using the

--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -129,6 +129,23 @@ Execution Module Changes
   :py:func:`Debian/Ubuntu <salt.modules.aptpkg.list_repo_pkgs>` and
   :py:func:`Arch Linux <salt.modules.pacman.list_repo_pkgs>`-based distros.
 
+
+Proxy Module Changes
+====================
+
+The :conf_proxy:`proxy_merge_grains_in_module` configuration variable
+introduced in 2016.3, has been changed, defaulting to ``True``.
+
+The connection with the remote device is kept alive by default, when the
+module implements the ``alive`` function and :conf_proxy:`proxy_keep_alive`
+is set to ``True``. The polling interval is set using the
+:conf_proxy:`proxy_keep_alive_interval` option which defaults to 1 minute.
+
+The developers are also able to use the :conf_proxy:`proxy_always_alive`,
+when designing a proxy module flexible enough to open the
+connection with the remote device only when required.
+
+
 Wildcard Versions in :py:func:`pkg.installed <salt.states.pkg.installed>` States
 ================================================================================
 


### PR DESCRIPTION
### What does this PR do?

Also adding the newest proxy opts in the conf. Ping @cro 

I have also noticed that `proxy.rst` is not indexed under https://docs.saltstack.com/en/develop/topics/configuration/index.html -- any idea what I missed?
EDIT: nvmd - found it: https://github.com/saltstack/salt/pull/40249/commits/0c8082949688d56c19f5101b92491418a589778d