### PR TITLE
Add wait_for_fun() to set_tags()

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2567,9 +2567,11 @@ def create(vm_=None, call=None):
         transport=__opts__['transport']
     )
 
-    set_tags(
-        vm_['name'],
-        tags,
+    salt.utils.cloud.wait_for_fun(
+        set_tags,
+        timeout=30,
+        name=vm_['name'],
+        tags=tags,
         instance_id=vm_['instance_id'],
         call='action',
         location=location


### PR DESCRIPTION
### What does this PR do?
Sometimes `set_tags()` doesn't work during the creation process because not all of the required data is available yet. This causes a wait of up to 30 seconds for that function to happen.

### What issues does this PR fix or reference?
#40225 done right. ZD-1239

### Tests written?
No.