### PR TITLE
correct method of getting 'text' of the XML object to compare to the …

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -4600,7 +4600,7 @@ def _lookup_admin_template(policy_name,
             if len(adml_search_results) > 1:
                 multiple_adml_entries = True
                 for adml_search_result in adml_search_results:
-                    if not adml_search_result.attrib['text'].strip() == policy_name:
+                    if not getattr(adml_search_result, 'text', '').strip() == policy_name:
                         adml_search_results.remove(adml_search_result)
             for adml_search_result in adml_search_results:
                 dmsg = 'found an ADML entry matching the string! {0} -- {1}'


### PR DESCRIPTION
…policy_name

### What does this PR do?
fixes the method of getting the text attribute of the ADML XML object when verifying the "long" policy name matches the policy being set

### What issues does this PR fix or reference?
#39976 

### Previous Behavior
Policies whose name matched multiple ADML entries (due to "startswith" searching) could not be set

### New Behavior
Policies can be set correctly

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
