### PR TITLE
Add ImportError to exception instead of bare "except"

### DIFF
--- a/tests/integration/grains/test_core.py
+++ b/tests/integration/grains/test_core.py
@@ -15,7 +15,7 @@ import salt.utils
 if salt.utils.is_windows():
     try:
         import salt.modules.reg
-    except:
+    except ImportError:
         pass
 
 


### PR DESCRIPTION
Fixes lint error on develop.
