### PR TITLE
Cloud roster and cache runner fixes for develop

### DIFF
--- a/salt/roster/__init__.py
+++ b/salt/roster/__init__.py
@@ -74,7 +74,9 @@ class Roster(object):
             self.backends = backends
         if not backends:
             self.backends = ['flat']
-        self.rosters = salt.loader.roster(opts, runner=salt.loader.runner(self.opts))
+        utils = salt.loader.utils(self.opts)
+        runner = salt.loader.runner(self.opts, utils=utils)
+        self.rosters = salt.loader.roster(self.opts, runner=runner)
 
     def _gen_back(self):
         '''

--- a/salt/roster/cloud.py
+++ b/salt/roster/cloud.py
@@ -20,6 +20,7 @@ usually located at /etc/salt/cloud. For example, add the following:
 
 # Import python libs
 from __future__ import absolute_import
+import os
 
 # Import Salt libs
 import salt.loader
@@ -37,7 +38,9 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
     '''
     ret = {}
 
-    cloud_opts = salt.config.cloud_config('/etc/salt/cloud')
+    cloud_opts = salt.config.cloud_config(
+        os.path.join(os.path.dirname(__opts__['conf_file']), 'cloud')
+    )
 
     minions = __runner__['cache.cloud'](tgt)
     for minion_id, full_info in minions.items():

--- a/salt/roster/cloud.py
+++ b/salt/roster/cloud.py
@@ -43,7 +43,7 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
     for minion_id, full_info in minions.items():
         profile, provider = full_info.get('profile', None), full_info.get('provider', None)
         vm_ = {
-            'provider': provider,
+            'driver': provider,
             'profile': profile,
         }
         public_ips = full_info.get('public_ips', [])

--- a/salt/roster/cloud.py
+++ b/salt/roster/cloud.py
@@ -66,7 +66,7 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
         ret[minion_id] = __opts__.get('roster_defaults', {})
         ret[minion_id].update({'host': preferred_ip})
 
-        ssh_username = salt.utils.cloud.ssh_usernames({}, cloud_opts)
+        ssh_username = salt.utils.cloud.ssh_usernames(vm_, cloud_opts)
         if isinstance(ssh_username, string_types):
             ret[minion_id]['user'] = ssh_username
         elif isinstance(ssh_username, list):

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -388,7 +388,7 @@ def cloud(tgt, provider=None):
     '''
     if not isinstance(tgt, six.string_types):
         return {}
-    ret = {}
+
     opts = salt.config.cloud_config(
         os.path.join(os.path.dirname(__opts__['conf_file']), 'cloud')
     )
@@ -398,6 +398,8 @@ def cloud(tgt, provider=None):
     cloud_cache = __utils__['cloud.list_cache_nodes_full'](opts=opts, provider=provider)
     if cloud_cache is None:
         return {}
+
+    ret = {}
     for driver, providers in cloud_cache.items():
         for provider, servers in providers.items():
             for name, data in servers.items():

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -400,9 +400,9 @@ def cloud(tgt, provider=None):
         return {}
 
     ret = {}
-    for driver, providers in cloud_cache.items():
-        for provider, servers in providers.items():
-            for name, data in servers.items():
+    for driver, providers in six.iteritems(cloud_cache):
+        for provider, servers in six.iteritems(providers):
+            for name, data in six.iteritems(servers):
                 if fnmatch.fnmatch(name, tgt):
                     ret[name] = data
                     ret['name']['provider'] = provider

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -392,7 +392,12 @@ def cloud(tgt, provider=None):
     opts = salt.config.cloud_config(
         os.path.join(os.path.dirname(__opts__['conf_file']), 'cloud')
     )
+    if not opts.get('update_cachedir'):
+        return {}
+
     cloud_cache = __utils__['cloud.list_cache_nodes_full'](opts=opts, provider=provider)
+    if cloud_cache is None:
+        return {}
     for driver, providers in cloud_cache.items():
         for provider, servers in providers.items():
             for name, data in servers.items():

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -405,7 +405,7 @@ def cloud(tgt, provider=None):
             for name, data in six.iteritems(servers):
                 if fnmatch.fnmatch(name, tgt):
                     ret[name] = data
-                    ret['name']['provider'] = provider
+                    ret[name]['provider'] = provider
     return ret
 
 

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 # Import python libs
 import fnmatch
 import logging
+import os
 
 # Import salt libs
 import salt.config
@@ -388,7 +389,9 @@ def cloud(tgt, provider=None):
     if not isinstance(tgt, six.string_types):
         return {}
     ret = {}
-    opts = salt.config.cloud_config('/etc/salt/cloud')
+    opts = salt.config.cloud_config(
+        os.path.join(os.path.dirname(__opts__['conf_file']), 'cloud')
+    )
     cloud_cache = __utils__['cloud.list_cache_nodes_full'](opts=opts, provider=provider)
     for driver, providers in cloud_cache.items():
         for provider, servers in providers.items():


### PR DESCRIPTION
### What does this PR do?

This fixes the cloud roster and runners.cache.cloud which it uses as a data source. Tested with EC2. After 9d0fbe7e0147 gets its way into develop, the cloud roster will be usable with GCE. Fixes for Digital Ocean and Joyent are coming.

### What issues does this PR fix or reference?

 #40251, #31005

### Tests written?

No