### PR TITLE
Makes sure "gather_job_timeout" is an Integer

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -220,7 +220,7 @@ class LocalClient(object):
         Return the information about a given job
         '''
         log.debug('Checking whether jid {0} is still running'.format(jid))
-        timeout = kwargs.get('gather_job_timeout', self.opts['gather_job_timeout'])
+        timeout = int(kwargs.get('gather_job_timeout', self.opts['gather_job_timeout']))
 
         pub_data = self.run_job(tgt,
                                 'saltutil.find_job',
@@ -921,7 +921,7 @@ class LocalClient(object):
 
         if timeout is None:
             timeout = self.opts['timeout']
-        gather_job_timeout = kwargs.get('gather_job_timeout', self.opts['gather_job_timeout'])
+        gather_job_timeout = int(kwargs.get('gather_job_timeout', self.opts['gather_job_timeout']))
         start = int(time.time())
 
         # timeouts per minion, id_ -> timeout time


### PR DESCRIPTION
### What does this PR do?
This PR makes sure that `gather_job_timeout` is an Integer in order to prevent `TypeError` if it's received as unicode.