### PR TITLE
Fix two mod_aggregate bugs in pkg states

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2431,9 +2431,11 @@ def mod_aggregate(low, chunks, running):
                         pkgs.extend(chunk['pkgs'])
                         chunk['__agg__'] = True
                     elif 'name' in chunk:
-                        pkgs.append(chunk['name'])
+                        if 'version' in chunk:
+                            pkgs.append({chunk['name']: chunk['version']})
+                        else:
+                            pkgs.append(chunk['name'])
                         chunk['__agg__'] = True
-
     if pkg_type is not None and pkgs:
         if pkg_type in low:
             low[pkg_type].extend(pkgs)

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2431,8 +2431,9 @@ def mod_aggregate(low, chunks, running):
                         pkgs.extend(chunk['pkgs'])
                         chunk['__agg__'] = True
                     elif 'name' in chunk:
-                        if 'version' in chunk:
-                            pkgs.append({chunk['name']: chunk['version']})
+                        version = chunk.pop('version', None)
+                        if version is not None:
+                            pkgs.append({chunk['name']: version})
                         else:
                             pkgs.append(chunk['name'])
                         chunk['__agg__'] = True

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2394,6 +2394,7 @@ def mod_aggregate(low, chunks, running):
     low chunks and merges them into a single pkgs ref in the present low data
     '''
     pkgs = []
+    pkg_type = None
     agg_enabled = [
         'installed',
         'latest',
@@ -2413,18 +2414,31 @@ def mod_aggregate(low, chunks, running):
             # Check for the same function
             if chunk.get('fun') != low.get('fun'):
                 continue
-            # Pull out the pkg names!
-            if 'pkgs' in chunk:
-                pkgs.extend(chunk['pkgs'])
-                chunk['__agg__'] = True
-            elif 'name' in chunk:
-                pkgs.append(chunk['name'])
-                chunk['__agg__'] = True
-    if pkgs:
-        if 'pkgs' in low:
-            low['pkgs'].extend(pkgs)
+            # Check first if 'sources' was passed so we don't aggregate pkgs
+            # and sources together.
+            if 'sources' in chunk:
+                if pkg_type is None:
+                    pkg_type = 'sources'
+                if pkg_type == 'sources':
+                    pkgs.extend(chunk['sources'])
+                    chunk['__agg__'] = True
+            else:
+                if pkg_type is None:
+                    pkg_type = 'pkgs'
+                if pkg_type == 'pkgs':
+                    # Pull out the pkg names!
+                    if 'pkgs' in chunk:
+                        pkgs.extend(chunk['pkgs'])
+                        chunk['__agg__'] = True
+                    elif 'name' in chunk:
+                        pkgs.append(chunk['name'])
+                        chunk['__agg__'] = True
+
+    if pkg_type is not None and pkgs:
+        if pkg_type in low:
+            low[pkg_type].extend(pkgs)
         else:
-            low['pkgs'] = pkgs
+            low[pkg_type] = pkgs
     return low
 
 


### PR DESCRIPTION
1. Don't aggregate both ``name``/``pkgs`` and ``sources`` with one another in pkg states

   Doing so will cause problems trying to install as Salt does not support installing from both binary packages and repository packages in the same call to ``pkg.install``.

   The fix here is to aggregate ``name``/``pkgs`` and ``sources`` separately. Resolves #40219.

2. Properly aggregate ``version`` when passed with ``name``

   This fixes an issue in which states which contained a single package name (no ``pkgs`` or ``sources``) paired with a ``version`` argument, were having the version ignored. This is because just the name was being added to the aggregated ``pkgs``.

   Since we're munging low data to aggregate states, this bug wouldn't even result in the state failing if a different version were installed.