### PR TITLE
[develop] Adding "pkg.downloaded" state and support for installing patches/erratas

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -119,6 +119,13 @@ def parse_targets(name=None,
         log.error('Only one of "pkgs" and "sources" can be used.')
         return None, None
 
+    elif 'advisory_ids' in kwargs:
+        if pkgs:
+            log.error('Cannot use "advisory_ids" and "pkgs" at the same time')
+            return None, None
+        else:
+            return kwargs['advisory_ids'], 'advisory'
+
     elif pkgs:
         pkgs = _repack_pkgs(pkgs, normalize=normalize)
         if not pkgs:

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -123,8 +123,10 @@ def parse_targets(name=None,
         if pkgs:
             log.error('Cannot use "advisory_ids" and "pkgs" at the same time')
             return None, None
-        else:
+        elif kwargs['advisory_ids']:
             return kwargs['advisory_ids'], 'advisory'
+        else:
+            return [name], 'advisory'
 
     elif pkgs:
         pkgs = _repack_pkgs(pkgs, normalize=normalize)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -920,7 +920,7 @@ def list_downloaded():
 
         salt '*' pkg.list_downloaded
     '''
-    CACHE_DIR = '/var/cache/yum/'
+    CACHE_DIR = os.path.join('/var/cache/', _yum())
 
     ret = {}
     for package_path in glob.glob(os.path.join(CACHE_DIR, '*/*/*/packages/*.rpm')):
@@ -2926,7 +2926,7 @@ def diff(*paths):
     return ret
 
 
-def _get_patches(installed_only=None):
+def _get_patches(installed_only=False):
     '''
     List all known patches in repos.
     '''

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -910,6 +910,8 @@ list_updates = salt.utils.alias_function(list_upgrades, 'list_updates')
 
 def list_downloaded():
     '''
+    .. versionadded:: Oxygen
+
     List prefetched packages downloaded by Yum in the local disk.
 
     CLI example:
@@ -2949,6 +2951,8 @@ def _get_patches(installed_only=None):
 
 def list_patches(refresh=False):
     '''
+    .. versionadded:: Oxygen
+
     List all known advisory patches from available repos.
 
     refresh
@@ -2970,6 +2974,8 @@ def list_patches(refresh=False):
 
 def list_installed_patches():
     '''
+    .. versionadded:: Oxygen
+
     List installed advisory patches on the system.
 
     CLI Examples:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1242,7 +1242,7 @@ def install(name=None,
         pkg_params_items = []
         cur_patches = list_patches()
         for advisory_id in pkg_params:
-            if not advisory_id in cur_patches:
+            if advisory_id not in cur_patches:
                 raise CommandExecutionError(
                     'Advisory id "{0}" not found'.format(advisory_id)
                 )
@@ -2936,10 +2936,10 @@ def _get_patches(installed_only=None):
         python_shell=False
     )
     for line in salt.utils.itertools.split(ret, os.linesep):
-        inst, advisory_id, sev, pkg = re.match('([i|\s]) ([^\s]+) +([^\s]+) +([^\s]+)',
+        inst, advisory_id, sev, pkg = re.match(r'([i|\s]) ([^\s]+) +([^\s]+) +([^\s]+)',
                                                line).groups()
         if inst != 'i' and installed_only:
-           continue
+            continue
         patches[advisory_id] = {
             'installed': True if inst == 'i' else False,
             'summary': pkg

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1191,14 +1191,9 @@ def install(name=None,
     reinstall = salt.utils.is_true(reinstall)
 
     try:
-        if "advisory_ids" in kwargs:
-            if pkgs:
-                raise SaltInvocationError('Cannot use "advisory_ids" and "pkgs" at the same time')
-            pkg_params, pkg_type = kwargs['advisory_ids'], 'advisory'
-        else:
-            pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](
-                name, pkgs, sources, normalize=normalize, **kwargs
-            )
+        pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](
+            name, pkgs, sources, normalize=normalize, **kwargs
+        )
     except MinionError as exc:
         raise CommandExecutionError(exc)
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -993,12 +993,7 @@ def install(name=None,
         refresh_db()
 
     try:
-        if 'advisory_ids' in kwargs:
-            if pkgs:
-                raise SaltInvocationError('Cannot use "advisory_ids" and "pkgs" at the same time')
-            pkg_params, pkg_type = kwargs['advisory_ids'], 'advisory'
-        else:
-            pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name, pkgs, sources, **kwargs)
+        pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name, pkgs, sources, **kwargs)
     except MinionError as exc:
         raise CommandExecutionError(exc)
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1840,7 +1840,7 @@ def diff(*paths):
     return ret
 
 
-def _get_patches(installed_only=None):
+def _get_patches(installed_only=False):
     '''
     List all known patches in repos.
     '''

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1781,6 +1781,8 @@ def download(*packages, **kwargs):
 
 def list_downloaded():
     '''
+    .. versionadded:: Oxygen
+
     List prefetched packages downloaded by Zypper in the local disk.
 
     CLI example:
@@ -1856,6 +1858,8 @@ def _get_patches(installed_only=None):
 
 def list_patches(refresh=False):
     '''
+    .. versionadded:: Oxygen
+
     List all known advisory patches from available repos.
 
     refresh
@@ -1877,6 +1881,8 @@ def list_patches(refresh=False):
 
 def list_installed_patches():
     '''
+    .. versionadded:: Oxygen
+
     List installed advisory patches on the system.
 
     CLI Examples:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1821,7 +1821,47 @@ def installed(
 
 def downloaded(name, version=None, pkgs=None, **kwargs):
     '''
-    Ensure that the package is downloaded.
+    Ensure that the package is downloaded, and that it is the correct version
+    (if specified).
+
+    Currently supported for the following pkg providers:
+    :mod:`yumpkg <salt.modules.yumpkg>` and :mod:`zypper <salt.modules.zypper>`
+
+    :param str name:
+        The name of the package to be downloaded. This parameter is ignored if
+        either "pkgs" is used. Additionally, please note that this option can
+        only be used to download packages from a software repository.
+
+    :param str version:
+        Download a specific version of a package.
+
+        .. important::
+            As of version 2015.8.7, for distros which use yum/dnf, packages
+            which have a version with a nonzero epoch (that is, versions which
+            start with a number followed by a colon must have the epoch included
+            when specifying the version number. For example:
+
+            .. code-block:: yaml
+
+                vim-enhanced:
+                  pkg.downloaded:
+                    - version: 2:7.4.160-1.el7
+
+            An **ignore_epoch** argument has been added to which causes the
+            epoch to be disregarded when the state checks to see if the desired
+            version was installed.
+
+            You can install a specific version when using the ``pkgs`` argument by
+            including the version after the package:
+
+            .. code-block:: yaml
+
+                common_packages:
+                  pkg.downloaded:
+                    - pkgs:
+                      - unzip
+                      - dos2unix
+                      - salt-minion: 2015.8.5-1.el6
 
     CLI Example:
 
@@ -1829,6 +1869,7 @@ def downloaded(name, version=None, pkgs=None, **kwargs):
 
         zsh:
           pkg.downloaded:
+            - version: 5.0.5-4.63
             - fromrepo: "myrepository"
     '''
     # It doesn't make sense here to received 'downloadonly' as kwargs

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2073,7 +2073,7 @@ def patch_installed(name, advisory_ids=None, downloadonly=None, **kwargs):
         return ret
 
     if not changes and not comment:
-        status= 'downloaded' if downloadonly else 'installed'
+        status = 'downloaded' if downloadonly else 'installed'
         comment.append('Related packages are already {}'.format(status))
 
     ret = {'name': name,

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1897,6 +1897,8 @@ def downloaded(name,
                ignore_epoch=None,
                **kwargs):
     '''
+    .. versionadded:: Oxygen
+
     Ensure that the package is downloaded, and that it is the correct version
     (if specified).
 
@@ -2032,6 +2034,8 @@ def downloaded(name,
 
 def patch_installed(name, advisory_ids=None, downloadonly=None, **kwargs):
     '''
+    .. versionadded:: Oxygen
+
     Ensure that packages related to certain advisory ids are installed.
 
     Currently supported for the following pkg providers:
@@ -2108,6 +2112,8 @@ def patch_installed(name, advisory_ids=None, downloadonly=None, **kwargs):
 
 def patch_downloaded(name, advisory_ids=None, **kwargs):
     '''
+    .. versionadded:: Oxygen
+
     Ensure that packages related to certain advisory ids are downloaded.
 
     Currently supported for the following pkg providers:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -316,15 +316,15 @@ def _find_advisory_targets(name=None,
                            advisory_ids=None,
                            **kwargs):
     '''
-    Inspect the arguments to pkg.patched and discover what advisory patches need to
-    be installed. Return a dict of advisory patches to install.
+    Inspect the arguments to pkg.patch_installed and discover what advisory
+    patches need to be installed. Return a dict of advisory patches to install.
     '''
-    cur_patched = __salt__['pkg.list_installed_patches']()
+    cur_patches = __salt__['pkg.list_installed_patches']()
     if advisory_ids:
         to_download = advisory_ids
     else:
         to_download = [name]
-        if cur_patched.get(name, {}):
+        if cur_patches.get(name, {}):
             # Advisory patch already installed, no need to install it again
             return {'name': name,
                     'changes': {},
@@ -335,7 +335,7 @@ def _find_advisory_targets(name=None,
     # Find out which advisory patches will be targeted in the call to pkg.install
     targets = []
     for patch_name in to_download:
-        cver = cur_patched.get(patch_name, {})
+        cver = cur_patches.get(patch_name, {})
         # Advisory patch not yet installed, so add to targets
         if not cver:
             targets.append(patch_name)
@@ -1972,7 +1972,7 @@ def downloaded(name, version=None, pkgs=None, **kwargs):
     return ret
 
 
-def patched(name, advisory_ids=None, downloadonly=None, **kwargs):
+def patch_installed(name, advisory_ids=None, downloadonly=None, **kwargs):
     '''
     Ensure that packages related to certain advisory ids are installed.
 
@@ -1984,7 +1984,7 @@ def patched(name, advisory_ids=None, downloadonly=None, **kwargs):
     .. code-block:: yaml
 
         issue-foo-fixed:
-          pkg.patched:
+          pkg.patch_installed:
             - advisory_ids:
               - SUSE-SLE-SERVER-12-SP2-2017-185
               - SUSE-SLE-SERVER-12-SP2-2017-150
@@ -2070,7 +2070,7 @@ def patch_downloaded(name, advisory_ids=None, **kwargs):
     # as we're explicitely passing 'downloadonly=True' to execution module.
     if 'downloadonly' in kwargs:
         del kwargs['downloadonly']
-    return patched(name=name, advisory_ids=advisory_ids, downloadonly=True, **kwargs)
+    return patch_installed(name=name, advisory_ids=advisory_ids, downloadonly=True, **kwargs)
 
 
 def latest(

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1964,6 +1964,7 @@ def downloaded(name,
                                      version,
                                      pkgs,
                                      fromrepo=fromrepo,
+                                     ignore_epoch=ignore_epoch,
                                      **kwargs)
     if isinstance(targets, dict) and 'result' in targets:
         return targets
@@ -1991,6 +1992,8 @@ def downloaded(name,
                                           pkgs=pkgs,
                                           version=version,
                                           downloadonly=True,
+                                          fromrepo=fromrepo,
+                                          ignore_epoch=ignore_epoch,
                                           **kwargs)
         changes.update(pkg_ret)
     except CommandExecutionError as exc:

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -512,7 +512,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         '''
         DOWNLOADED_RET = {
             'test-package': {
-                '1.0' : '/var/cache/zypper/packages/foo/bar/test_package.rpm'
+                '1.0': '/var/cache/zypper/packages/foo/bar/test_package.rpm'
             }
         }
 

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -504,6 +504,83 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 test_out['_error'] = "The following package(s) failed to download: foo"
                 self.assertEqual(zypper.download("nmap", "foo"), test_out)
 
+    @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
+    @patch('salt.modules.zypper.list_downloaded', MagicMock(side_effect=[{}, {'vim': {'1.1': '/foo/bar/test.rpm'}}]))
+    def test_install_with_downloadonly(self):
+        '''
+        Test a package installation with downloadonly=True.
+
+        :return:
+        '''
+        with patch.dict(zypper.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'vim': None}, 'repository'))}):
+            with patch('salt.modules.zypper.__zypper__.noraise.call', MagicMock()) as zypper_mock:
+                ret = zypper.install(pkgs=['vim'], downloadonly=True)
+                zypper_mock.assert_called_once_with(
+                    '--no-refresh',
+                    'install',
+                    '--name',
+                    '--auto-agree-with-licenses',
+                    '--download-only',
+                    'vim'
+                )
+                self.assertDictEqual(ret, {'vim': {'new': {'1.1': '/foo/bar/test.rpm'}, 'old': ''}})
+
+    @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
+    @patch('salt.modules.zypper.list_downloaded', MagicMock(return_value={'vim': {'1.1': '/foo/bar/test.rpm'}}))
+    def test_install_with_downloadonly_already_downloaded(self):
+        '''
+        Test a package installation with downloadonly=True when package is already downloaded.
+
+        :return:
+        '''
+        with patch.dict(zypper.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'vim': None}, 'repository'))}):
+            with patch('salt.modules.zypper.__zypper__.noraise.call', MagicMock()) as zypper_mock:
+                ret = zypper.install(pkgs=['vim'], downloadonly=True)
+                zypper_mock.assert_called_once_with(
+                    '--no-refresh',
+                    'install',
+                    '--name',
+                    '--auto-agree-with-licenses',
+                    '--download-only',
+                    'vim'
+                )
+                self.assertDictEqual(ret, {})
+
+    @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
+    @patch('salt.modules.zypper._get_patches', MagicMock(return_value={'SUSE-PATCH-1234': {'installed': False, 'summary': 'test'}}))
+    @patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}]))
+    def test_install_advisory_patch_ok(self):
+        '''
+        Test successfully advisory patch installation.
+
+        :return:
+        '''
+        with patch.dict(zypper.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'SUSE-PATCH-1234': None}, 'advisory'))}):
+            with patch('salt.modules.zypper.__zypper__.noraise.call', MagicMock()) as zypper_mock:
+                ret = zypper.install(advisory_ids=['SUSE-PATCH-1234'])
+                zypper_mock.assert_called_once_with(
+                    '--no-refresh',
+                    'install',
+                    '--name',
+                    '--auto-agree-with-licenses',
+                    'patch:SUSE-PATCH-1234'
+                )
+                self.assertDictEqual(ret, {"vim": {"old": "1.1", "new": "1.2"}})
+
+    @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
+    @patch('salt.modules.zypper._get_patches', MagicMock(return_value={'SUSE-PATCH-1234': {'installed': False, 'summary': 'test'}}))
+    @patch('salt.modules.zypper.list_pkgs', MagicMock(return_value={"vim": "1.1"}))
+    def test_install_advisory_patch_failure(self):
+        '''
+        Test failing advisory patch installation because patch does not exist.
+
+        :return:
+        '''
+        with patch.dict(zypper.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'SUSE-PATCH-XXX': None}, 'advisory'))}):
+            with patch('salt.modules.zypper.__zypper__.noraise.call', MagicMock()) as zypper_mock:
+                with self.assertRaisesRegex(CommandExecutionError, '^Advisory id "SUSE-PATCH-XXX" not found$'):
+                    zypper.install(advisory_ids=['SUSE-PATCH-XXX'])
+
     def test_remove_purge(self):
         '''
         Test package removal

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -479,6 +479,48 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                             self.assertTrue(pkgs.get(pkg_name))
                             self.assertEqual(pkgs[pkg_name], pkg_version)
 
+    def test_list_patches(self):
+        '''
+        Test advisory patches listing.
+
+        :return:
+        '''
+
+        ref_out = {
+            'stdout': get_test_data('zypper-patches.xml'),
+            'stderr': None,
+            'retcode': 0
+        }
+
+        PATCHES_RET = {
+            'SUSE-SLE-SERVER-12-SP2-2017-97': {'installed': False, 'summary': 'Recommended update for ovmf'},
+            'SUSE-SLE-SERVER-12-SP2-2017-98': {'installed': True, 'summary': 'Recommended update for kmod'},
+            'SUSE-SLE-SERVER-12-SP2-2017-99': {'installed': False, 'summary': 'Security update for apache2'}
+        }
+
+        with patch.dict(zypper.__salt__, {'cmd.run_all': MagicMock(return_value=ref_out)}):
+            list_patches = zypper.list_patches(refresh=False)
+            self.assertEqual(len(list_patches), 3)
+            self.assertDictEqual(list_patches, PATCHES_RET)
+
+    @patch('glob.glob', MagicMock(return_value=['/var/cache/zypper/packages/foo/bar/test_package.rpm']))
+    def test_list_downloaded(self):
+        '''
+        Test downloaded packages listing.
+
+        :return:
+        '''
+        DOWNLOADED_RET = {
+            'test-package': {
+                '1.0' : '/var/cache/zypper/packages/foo/bar/test_package.rpm'
+            }
+        }
+
+        with patch.dict(zypper.__salt__, {'lowpkg.bin_pkg_info': MagicMock(return_value={'name': 'test-package', 'version': '1.0'})}):
+            list_downloaded = zypper.list_downloaded()
+            self.assertEqual(len(list_downloaded), 1)
+            self.assertDictEqual(list_downloaded, DOWNLOADED_RET)
+
     def test_download(self):
         '''
         Test package download

--- a/tests/unit/modules/zypp/zypper-patches.xml
+++ b/tests/unit/modules/zypp/zypper-patches.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0'?>
+<stream>
+  <search-result version="0.0">
+    <solvable-list>
+      <solvable status="not-installed" name="SUSE-SLE-SERVER-12-SP2-2017-97" summary="Recommended update for ovmf" kind="patch"/>
+      <solvable status="installed" name="SUSE-SLE-SERVER-12-SP2-2017-98" summary="Recommended update for kmod" kind="patch"/>
+      <solvable status="not-installed" name="SUSE-SLE-SERVER-12-SP2-2017-99" summary="Security update for apache2" kind="patch"/>
+    </solvable-list>
+  </search-result>
+</stream>


### PR DESCRIPTION
As discussed, this PR brings #40195 to `develop` branch, as this is the right target for the PR.

### What does this PR do?
This PR adds some improvements to Zypper and Yum execution module to support patches/errata installation and `downloadonly` parameter as well as new `pkg.downloaded` state. 

1. Allowing `downloadonly=True` on a `pkg.installed` state:
```
vim:
  pkg.installed:
    - downloadonly: True
```
2. Adds new "pkg.downloaded" state function which is a wrapper of `pkg.installed` with `downloadonly=True`:
```
vim:
  pkg.downloaded: []
```
3. Adding support for installing patches/erratas using `zypper` or `yum` module.
```
$ salt 'minion' pkg.install patches='["SUSE-SLE-SERVER-12-SP1-2016-942", "SUSE-SLE-SERVER-12-SP1-2016-1048"]'
minion:
    ----------
    dhcp:
        ----------
        new:
            4.3.3-9.1
        old:
            4.3.3-2.2
    dhcp-client:
        ----------
        new:
            4.3.3-9.1
        old:
            4.3.3-2.2
    ----------
    dmidecode:
        ----------
        new:
            2.12-7.1
        old:
            2.12-5.20
```
4. Support patches/erratas with `pkg.installed` and `pkg.downloaded`:
```
my-suse-patches:
  pkg.installed:
    - patches:
      - SUSE-SLE-SERVER-12-SP1-2016-942
      - SUSE-SLE-SERVER-12-SP1-2016-1048
```

### Tests written?

Yes