### PR TITLE
win_lgpo re-add .keys() usage in places needed due to dict modifications durin…

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3820,7 +3820,9 @@ def _checkAllAdmxPolicies(policy_class,
     if policy_vals and return_full_policy_names and not hierarchical_return:
         unpathed_dict = {}
         pathed_dict = {}
-        for policy_item in policy_vals:
+        # keys needs to be called here b/c we are changing the policy_vals 
+        # dict during the for loop
+        for policy_item in policy_vals.keys():
             if full_names[policy_item] in policy_vals:
                 # add this item with the path'd full name
                 full_path_list = hierarchy[policy_item]

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3820,9 +3820,9 @@ def _checkAllAdmxPolicies(policy_class,
     if policy_vals and return_full_policy_names and not hierarchical_return:
         unpathed_dict = {}
         pathed_dict = {}
-        # keys needs to be called here b/c we are changing the policy_vals 
+        # keys needs to be called here b/c we are changing the policy_vals
         # dict during the for loop
-        for policy_item in policy_vals.keys():
+        for policy_item in policy_vals.keys(): # pylint: disable=C0201
             if full_names[policy_item] in policy_vals:
                 # add this item with the path'd full name
                 full_path_list = hierarchy[policy_item]

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3822,7 +3822,7 @@ def _checkAllAdmxPolicies(policy_class,
         pathed_dict = {}
         # keys needs to be called here b/c we are changing the policy_vals
         # dict during the for loop
-        for policy_item in policy_vals.keys(): # pylint: disable=C0201
+        for policy_item in policy_vals.keys():  # pylint: disable=C0201
             if full_names[policy_item] in policy_vals:
                 # add this item with the path'd full name
                 full_path_list = hierarchy[policy_item]


### PR DESCRIPTION
…g for loop

### What does this PR do?
adds the .keys() usage in places required due to dict modification during loops back ( #39843 )

### What issues does this PR fix or reference?
#39976 - removal of .keys() found during troubleshooting that issue

### Previous Behavior
win_lgpo could not loop through policies properly b/c dict was being modified during the loop

### New Behavior
win_lgpo can properly loop through policies where .keys() has been added back

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
