### PR TITLE
Clean up temporary file in net.load_template

### DIFF
--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -1257,6 +1257,7 @@ def load_template(template_name,
                     _loaded['comment'] = 'Error while rendering the template.'
                     return _loaded
                 _rendered = open(_temp_tpl_file).read()
+                __salt__['file.remove'](_temp_tpl_file)
             else:
                 return _loaded  # exit
 


### PR DESCRIPTION
### What does this PR do?
Makes net.load_template() clean up after itself.

### Previous Behavior
Lots of __salt.tmp files in /tmp

### New Behavior
Salt removes the temporary file from disk after its contents are loaded.

### Tests written?
No