### PR TITLE
Remove encode

### DIFF
--- a/tests/integration/modules/test_git.py
+++ b/tests/integration/modules/test_git.py
@@ -48,7 +48,7 @@ def _git_version():
         log.debug('Git not installed')
         return False
     log.debug('Detected git version %s', git_version)
-    return LooseVersion(str(git_version.split()[-1]).encode())
+    return LooseVersion(str(git_version.split()[-1]))
 
 
 def _worktrees_supported():
@@ -56,7 +56,7 @@ def _worktrees_supported():
     Check if the git version is 2.5.0 or later
     '''
     try:
-        return _git_version() >= LooseVersion('2.5.0'.encode())
+        return _git_version() >= LooseVersion('2.5.0')
     except AttributeError:
         return False
 


### PR DESCRIPTION
### What does this PR do?
Fixes `integration.modules.test_git` so that it will run. The encode was causing problems in Python 3. I tested removing the encode on Py2 and it didn't have any problems. I introduced this problem myself (https://github.com/saltstack/salt/pull/39797)

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1201

### Previous Behavior
Test fails on Py3 with an error similar to the following:
```
Traceback (most recent call last):
  File "version.py", line 18, in <module>
    print(LooseVersion('2.5.0'.encode()))
  File "C:\Program Files\Python35\lib\distutils\version.py", line 304, in __init__
    self.parse(vstring)
  File "c:\salt-dev\salt\salt\utils\versions.py", line 41, in parse
    _LooseVersion.parse(self, vstring)
  File "C:\Program Files\Python35\lib\distutils\version.py", line 312, in parse
    components = [x for x in self.component_re.split(vstring)
TypeError: cannot use a string pattern on a bytes-like object
```

### New Behavior
test_git test runs

### Tests written?
No
