### PR TITLE
remove reference to auth_minion.

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -38,8 +38,6 @@ examples could be set up in the cloud configuration at
 .. code-block:: yaml
 
     my-openstack-config:
-      # The ID of the minion that will execute the salt nova functions
-      auth_minion: myminion
       # The name of the configuration profile to use on said minion
       config_profile: my_openstack_profile
 


### PR DESCRIPTION
Support for this option was removed years ago and is no longer needed.

### What does this PR do?
Removes stale documentation
### What issues does this PR fix or reference?
ZD 1272
