### PR TITLE
rabbitmq: Do not use `__context__` for persistent globals

### DIFF
--- a/tests/unit/modules/test_rabbitmq.py
+++ b/tests/unit/modules/test_rabbitmq.py
@@ -21,11 +21,6 @@ from salt.exceptions import CommandExecutionError
 
 # Globals
 rabbitmq.__salt__ = {}
-rabbitmq.__context__ = {}
-
-# These are set by rabbitmq.__virtual__()
-rabbitmq.__context__['rabbitmqctl'] = None
-rabbitmq.__context__['rabbitmq-plugins'] = None
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)


### PR DESCRIPTION
### What does this PR do?

The rabbitmq module was using `__context__` to store paths of
rabbitmq executables. `__context__` may be cleared but the module
still could remain in use, in which case it would fail to work
correctly. Move the paths of the rabbitmq executables to their own
global variables so that they are not affected by the lifespan of
`__context__`.

### Tests written?

No