### PR TITLE
[WIP] Fix integration.modules.test_cp on Windows Py3

### DIFF
--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -60,7 +60,8 @@ class CPModuleTest(integration.ModuleCase):
         '''
         tgt = os.path.join(paths.TMP, 'file.big')
         src = os.path.join(paths.FILES, 'file', 'base', 'file.big')
-        with salt.utils.fopen(src, 'r') as fp_:
+        mode = 'rb' if salt.utils.is_windows() else 'r'
+        with salt.utils.fopen(src, mode) as fp_:
             data = fp_.read()
             if six.PY3:
                 data = salt.utils.to_bytes(data)
@@ -74,10 +75,10 @@ class CPModuleTest(integration.ModuleCase):
             ],
             gzip=5
         )
-        with salt.utils.fopen(tgt, 'r') as scene:
+        with salt.utils.fopen(tgt, mode) as scene:
             data = scene.read()
-            self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
-            self.assertNotIn('bacon', data)
+            self.assertIn(b'KNIGHT:  They\'re nervous, sire.', data)
+            self.assertNotIn(b'bacon', data)
             if six.PY3:
                 data = salt.utils.to_bytes(data)
             self.assertEqual(hash_str, hashlib.md5(data).hexdigest())

--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -60,8 +60,7 @@ class CPModuleTest(integration.ModuleCase):
         '''
         tgt = os.path.join(paths.TMP, 'file.big')
         src = os.path.join(paths.FILES, 'file', 'base', 'file.big')
-        mode = 'rb' if salt.utils.is_windows() else 'r'
-        with salt.utils.fopen(src, mode) as fp_:
+        with salt.utils.fopen(src, 'r') as fp_:
             data = fp_.read()
             if six.PY3:
                 data = salt.utils.to_bytes(data)
@@ -75,10 +74,10 @@ class CPModuleTest(integration.ModuleCase):
             ],
             gzip=5
         )
-        with salt.utils.fopen(tgt, mode) as scene:
+        with salt.utils.fopen(tgt, 'r') as scene:
             data = scene.read()
-            self.assertIn(b'KNIGHT:  They\'re nervous, sire.', data)
-            self.assertNotIn(b'bacon', data)
+            self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
+            self.assertNotIn('bacon', data)
             if six.PY3:
                 data = salt.utils.to_bytes(data)
             self.assertEqual(hash_str, hashlib.md5(data).hexdigest())

--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -481,13 +481,18 @@ class CPModuleTest(integration.ModuleCase):
                 [
                     'salt://grail/scene33',
                 ])
-        mode = 'rb' if salt.utils.is_windows() else 'r'
-        with salt.utils.fopen(path, mode) as fn_:
-            data = fn_.read()
-            if six.PY3:
-                data = salt.utils.to_bytes(data)
-            self.assertEqual(
-                sha256_hash['hsum'], hashlib.sha256(data).hexdigest())
+
+
+        if six.PY2:
+            with salt.utils.fopen(path, 'r') as fn_:
+                data = fn_.read()
+        else:
+            with salt.utils.fopen(path, 'r', newline='') as fn_:
+                data = fn_.read()
+            data = salt.utils.to_bytes(data)
+
+        self.assertEqual(
+            sha256_hash['hsum'], hashlib.sha256(data).hexdigest())
 
     def test_get_file_from_env_predefined(self):
         '''

--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -482,7 +482,6 @@ class CPModuleTest(integration.ModuleCase):
                     'salt://grail/scene33',
                 ])
 
-
         if six.PY2:
             with salt.utils.fopen(path, 'r') as fn_:
                 data = fn_.read()

--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -60,7 +60,8 @@ class CPModuleTest(integration.ModuleCase):
         '''
         tgt = os.path.join(paths.TMP, 'file.big')
         src = os.path.join(paths.FILES, 'file', 'base', 'file.big')
-        with salt.utils.fopen(src, 'r') as fp_:
+        mode = 'rb' if salt.utils.is_windows() else 'r'
+        with salt.utils.fopen(src, mode) as fp_:
             data = fp_.read()
             if six.PY3:
                 data = salt.utils.to_bytes(data)
@@ -74,10 +75,10 @@ class CPModuleTest(integration.ModuleCase):
             ],
             gzip=5
         )
-        with salt.utils.fopen(tgt, 'r') as scene:
+        with salt.utils.fopen(tgt, mode) as scene:
             data = scene.read()
-            self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
-            self.assertNotIn('bacon', data)
+            self.assertIn(b'KNIGHT:  They\'re nervous, sire.', data)
+            self.assertNotIn(b'bacon', data)
             if six.PY3:
                 data = salt.utils.to_bytes(data)
             self.assertEqual(hash_str, hashlib.md5(data).hexdigest())
@@ -481,7 +482,8 @@ class CPModuleTest(integration.ModuleCase):
                 [
                     'salt://grail/scene33',
                 ])
-        with salt.utils.fopen(path, 'r') as fn_:
+        mode = 'rb' if salt.utils.is_windows() else 'r'
+        with salt.utils.fopen(path, mode) as fn_:
             data = fn_.read()
             if six.PY3:
                 data = salt.utils.to_bytes(data)


### PR DESCRIPTION
### What does this PR do?
Fixes `integration.modules.test_cp` on Windows with Py3. Open files with `'rb'` in Windows.

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1200

@s0undt3ch Could you look at the Py3 stuff? Specifically lines 80 and 81:
```
+            self.assertIn(b'KNIGHT:  They\'re nervous, sire.', data)
+            self.assertNotIn(b'bacon', data)
```