### PR TITLE
cache roster: Add SDB support, improve documentation

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -299,10 +299,12 @@ New SSH Cache Roster
 ====================
 
 The :mod:`SSH cache Roster <salt.roster.cache>` has been rewritten from scratch to increase its usefulness.
-The new roster supports all minion matchers, so it is now possible to target minions identically through `salt` and `salt-ssh`.
-The new configuration syntax allows for flexible combinations of arbitrary grains, pillar and mine data.
-This applies not just for the `host` of a minion, but also for other configuration data.
-The new release is also fully IPv4 and IPv6 enabled and even allows for the selection of certain CIDR ranges for connecting.
+The new roster supports all minion matchers,
+so it is now possible to target minions identically through `salt` and `salt-ssh`.
+
+Using the new ``roster_order`` configuration syntax it's now possible to compose a roster out of any combination
+of grains, pillar and mine data and even Salt SDB URLs.
+The new release is also fully IPv4 and IPv6 enabled and even has support for CIDR ranges.
 
 Deprecations
 ============

--- a/salt/roster/cache.py
+++ b/salt/roster/cache.py
@@ -6,7 +6,6 @@ to access regular minions over ``salt-ssh``.
 .. versionadded:: Nitrogen
 
     - grains, pillar, mine data matching
-    - environment variables
     - SDB URLs
     - IPv6 support
     - roster_order per config key
@@ -86,7 +85,7 @@ roster_order:
 
   user:
     - pillar: ssh:auth:user          # Lookup this pillar key
-    - env: USER                      # Lookup this env var
+    - sdb://osenv/USER               # Lookup this env var through sdb
 
   priv:
     - pillar:                        # Lists are also supported
@@ -225,7 +224,6 @@ def _minion_lookup(minion_id, key, minion):
                 'pillar': pillar,
                 'grain': grains,
                 'mine': mine,
-                'env': os.environ,
             }[data_id]
 
             for k in _data_lookup(ref, lookup):

--- a/salt/roster/cache.py
+++ b/salt/roster/cache.py
@@ -97,7 +97,6 @@ from __future__ import absolute_import
 
 # Python
 import logging
-import os
 import re
 
 # Salt libs

--- a/salt/roster/cache.py
+++ b/salt/roster/cache.py
@@ -7,6 +7,7 @@ to access regular minions over ``salt-ssh``.
 
     - grains, pillar, mine data matching
     - environment variables
+    - SDB URLs
     - IPv6 support
     - roster_order per config key
     - default order changed to industry-wide best practices

--- a/salt/roster/cache.py
+++ b/salt/roster/cache.py
@@ -69,7 +69,7 @@ Using cached data
 =================
 
 Several cached libraries can be selected using the ``library: `` prefix, followed by the library key.
-This can be referenced using the same ``:`` syntax as e.g. ``pillar.get()``.
+This can be referenced using the same ``:`` syntax as e.g. :py:func:`pillar.get <salt.modules.pillar.get>`.
 Lists of references are also supported during the lookup, as are Salt SDB URLs.
 
 This should be especially useful for the other roster keys:

--- a/salt/roster/cache.py
+++ b/salt/roster/cache.py
@@ -218,9 +218,6 @@ def _minion_lookup(minion_id, key, minion):
     if key == 'id':
         # Just paste in the minion ID
         return minion_id
-    elif key.startswith('sdb://'):
-        # It's a Salt SDB url
-        return salt['sdb.get'](key)
     elif isinstance(key, dict):
         # Lookup the key in the dict
         for data_id, lookup in key.items():
@@ -236,6 +233,9 @@ def _minion_lookup(minion_id, key, minion):
                     return k
 
             return None
+    elif key.startswith('sdb://'):
+        # It's a Salt SDB url
+        return salt['sdb.get'](key)
     elif re.match(r'^[0-9a-fA-F:./]+$', key):
         # It smells like a CIDR block
         try:


### PR DESCRIPTION
### What does this PR do?
Improve the documentation for the new Salt SSH cache roster, add the system environment and salt sdb URLs to the filters.

### What issues does this PR fix or reference?
#39050 

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
