### PR TITLE
Dockerng unit tests fixes: isolate global variables

### DIFF
--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -97,7 +97,7 @@ class DockerngTestCase(TestCase):
             mine_send.assert_called_with('dockerng.ps', verbose=True, all=True,
                                          host=True)
 
-    @skipIf(docker_version() < (1, 4, 0),
+    @skipIf(docker_version < (1, 4, 0),
             'docker module must be installed to run this test or is too old. >=1.4.0')
     @patch.object(dockerng_mod, 'images', MagicMock())
     @patch.object(dockerng_mod, 'inspect_image')
@@ -350,6 +350,8 @@ class DockerngTestCase(TestCase):
 
     @skipIf(docker_version < (1, 5, 0),
             'docker module must be installed to run this test or is too old. >=1.5.0')
+    @patch('salt.modules.dockerng._get_docker_py_versioninfo',
+           MagicMock(return_value=docker_version))
     def test_remove_network(self, *args):
         '''
         test remove network.
@@ -415,6 +417,8 @@ class DockerngTestCase(TestCase):
 
     @skipIf(docker_version < (1, 5, 0),
             'docker module must be installed to run this test or is too old. >=1.5.0')
+    @patch('salt.modules.dockerng._get_docker_py_versioninfo',
+           MagicMock(return_value=docker_version))
     def test_disconnect_container_from_network(self, *args):
         '''
         test inspect network.

--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -25,13 +25,9 @@ ensure_in_syspath('../../')
 import salt.modules.dockerng as dockerng_mod
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
-dockerng_mod.__context__ = {'docker.docker_version': ''}
+dockerng_mod.__context__ = {}
 dockerng_mod.__salt__ = {}
 dockerng_mod.__opts__ = {}
-
-
-def _docker_py_version():
-    return dockerng_mod.docker.version_info if dockerng_mod.HAS_DOCKER_PY else None
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -40,6 +36,8 @@ class DockerngTestCase(TestCase):
     '''
     Validate dockerng module
     '''
+
+    docker_version = dockerng_mod.docker.version_info
 
     def test_ps_with_host_true(self):
         '''
@@ -99,7 +97,7 @@ class DockerngTestCase(TestCase):
             mine_send.assert_called_with('dockerng.ps', verbose=True, all=True,
                                          host=True)
 
-    @skipIf(_docker_py_version() < (1, 4, 0),
+    @skipIf(docker_version() < (1, 4, 0),
             'docker module must be installed to run this test or is too old. >=1.4.0')
     @patch.object(dockerng_mod, 'images', MagicMock())
     @patch.object(dockerng_mod, 'inspect_image')
@@ -128,7 +126,7 @@ class DockerngTestCase(TestCase):
             image='image',
             name='ctn')
 
-    @skipIf(_docker_py_version() < (1, 4, 0),
+    @skipIf(docker_version < (1, 4, 0),
             'docker module must be installed to run this test or is too old. >=1.4.0')
     @patch.object(dockerng_mod, 'images', MagicMock())
     @patch.object(dockerng_mod, 'inspect_image')
@@ -156,7 +154,7 @@ class DockerngTestCase(TestCase):
             image='image',
             name='ctn')
 
-    @skipIf(_docker_py_version() < (1, 4, 0),
+    @skipIf(docker_version < (1, 4, 0),
             'docker module must be installed to run this test or is too old. >=1.4.0')
     @patch.object(dockerng_mod, 'images', MagicMock())
     @patch.object(dockerng_mod, 'inspect_image')
@@ -191,7 +189,7 @@ class DockerngTestCase(TestCase):
             name='ctn',
         )
 
-    @skipIf(_docker_py_version() < (1, 4, 0),
+    @skipIf(docker_version < (1, 4, 0),
             'docker module must be installed to run this test or is too old. >=1.4.0')
     @patch.object(dockerng_mod, 'images', MagicMock())
     @patch.object(dockerng_mod, 'inspect_image')
@@ -203,6 +201,7 @@ class DockerngTestCase(TestCase):
         __salt__ = {
             'config.get': Mock(),
             'mine.send': Mock(),
+            'dockerng.version': MagicMock(return_value={}),
         }
         host_config = {}
         client = Mock()
@@ -226,7 +225,7 @@ class DockerngTestCase(TestCase):
             name='ctn',
         )
 
-    @skipIf(_docker_py_version() < (1, 4, 0),
+    @skipIf(docker_version < (1, 4, 0),
             'docker module must be installed to run this test or is too old. >=1.4.0')
     @patch.object(dockerng_mod, 'images', MagicMock())
     @patch.object(dockerng_mod, 'inspect_image')
@@ -238,6 +237,7 @@ class DockerngTestCase(TestCase):
         __salt__ = {
             'config.get': Mock(),
             'mine.send': Mock(),
+            'dockerng.version': MagicMock(return_value={}),
         }
         host_config = {}
         client = Mock()
@@ -256,7 +256,7 @@ class DockerngTestCase(TestCase):
                                   validate_input=True,
                                   )
 
-    @skipIf(_docker_py_version() < (1, 4, 0),
+    @skipIf(docker_version < (1, 4, 0),
             'docker module must be installed to run this test or is too old. >=1.4.0')
     @patch.object(dockerng_mod, 'images', MagicMock())
     @patch.object(dockerng_mod, 'inspect_image')
@@ -268,6 +268,7 @@ class DockerngTestCase(TestCase):
         __salt__ = {
             'config.get': Mock(),
             'mine.send': Mock(),
+            'dockerng.version': MagicMock(return_value={}),
         }
         host_config = {}
         client = Mock()
@@ -291,8 +292,10 @@ class DockerngTestCase(TestCase):
             name='ctn',
         )
 
-    @skipIf(_docker_py_version() < (1, 5, 0),
+    @skipIf(docker_version < (1, 5, 0),
             'docker module must be installed to run this test or is too old. >=1.5.0')
+    @patch('salt.modules.dockerng._get_docker_py_versioninfo',
+           MagicMock(return_value=docker_version))
     def test_list_networks(self, *args):
         '''
         test list networks.
@@ -317,8 +320,10 @@ class DockerngTestCase(TestCase):
                     ids=['01234'],
         )
 
-    @skipIf(_docker_py_version() < (1, 5, 0),
+    @skipIf(docker_version < (1, 5, 0),
             'docker module must be installed to run this test or is too old. >=1.5.0')
+    @patch('salt.modules.dockerng._get_docker_py_versioninfo',
+           MagicMock(return_value=docker_version))
     def test_create_network(self, *args):
         '''
         test create network.
@@ -343,7 +348,7 @@ class DockerngTestCase(TestCase):
                     driver='bridge',
         )
 
-    @skipIf(_docker_py_version() < (1, 5, 0),
+    @skipIf(docker_version < (1, 5, 0),
             'docker module must be installed to run this test or is too old. >=1.5.0')
     def test_remove_network(self, *args):
         '''
@@ -363,8 +368,10 @@ class DockerngTestCase(TestCase):
                 dockerng_mod.remove_network('foo')
         client.remove_network.assert_called_once_with('foo')
 
-    @skipIf(_docker_py_version() < (1, 5, 0),
+    @skipIf(docker_version < (1, 5, 0),
             'docker module must be installed to run this test or is too old. >=1.5.0')
+    @patch('salt.modules.dockerng._get_docker_py_versioninfo',
+           MagicMock(return_value=docker_version))
     def test_inspect_network(self, *args):
         '''
         test inspect network.
@@ -383,8 +390,10 @@ class DockerngTestCase(TestCase):
                 dockerng_mod.inspect_network('foo')
         client.inspect_network.assert_called_once_with('foo')
 
-    @skipIf(_docker_py_version() < (1, 5, 0),
+    @skipIf(docker_version < (1, 5, 0),
             'docker module must be installed to run this test or is too old. >=1.5.0')
+    @patch('salt.modules.dockerng._get_docker_py_versioninfo',
+           MagicMock(return_value=docker_version))
     def test_connect_container_to_network(self, *args):
         '''
         test inspect network.
@@ -404,7 +413,7 @@ class DockerngTestCase(TestCase):
         client.connect_container_to_network.assert_called_once_with(
             'container', 'foo')
 
-    @skipIf(_docker_py_version() < (1, 5, 0),
+    @skipIf(docker_version < (1, 5, 0),
             'docker module must be installed to run this test or is too old. >=1.5.0')
     def test_disconnect_container_from_network(self, *args):
         '''
@@ -425,8 +434,10 @@ class DockerngTestCase(TestCase):
         client.disconnect_container_from_network.assert_called_once_with(
             'container', 'foo')
 
-    @skipIf(_docker_py_version() < (1, 5, 0),
+    @skipIf(docker_version < (1, 5, 0),
             'docker module must be installed to run this test or is too old. >=1.5.0')
+    @patch('salt.modules.dockerng._get_docker_py_versioninfo',
+           MagicMock(return_value=docker_version))
     def test_list_volumes(self, *args):
         '''
         test list volumes.
@@ -448,8 +459,10 @@ class DockerngTestCase(TestCase):
             filters={'dangling': [True]},
         )
 
-    @skipIf(_docker_py_version() < (1, 5, 0),
+    @skipIf(docker_version < (1, 5, 0),
             'docker module must be installed to run this test or is too old. >=1.5.0')
+    @patch('salt.modules.dockerng._get_docker_py_versioninfo',
+           MagicMock(return_value=docker_version))
     def test_create_volume(self, *args):
         '''
         test create volume.
@@ -475,8 +488,10 @@ class DockerngTestCase(TestCase):
                     driver_opts={},
         )
 
-    @skipIf(_docker_py_version() < (1, 5, 0),
+    @skipIf(docker_version < (1, 5, 0),
             'docker module must be installed to run this test or is too old. >=1.5.0')
+    @patch('salt.modules.dockerng._get_docker_py_versioninfo',
+           MagicMock(return_value=docker_version))
     def test_remove_volume(self, *args):
         '''
         test remove volume.
@@ -494,8 +509,10 @@ class DockerngTestCase(TestCase):
                 dockerng_mod.remove_volume('foo')
         client.remove_volume.assert_called_once_with('foo')
 
-    @skipIf(_docker_py_version() < (1, 5, 0),
+    @skipIf(docker_version < (1, 5, 0),
             'docker module must be installed to run this test or is too old. >=1.5.0')
+    @patch('salt.modules.dockerng._get_docker_py_versioninfo',
+           MagicMock(return_value=docker_version))
     def test_inspect_volume(self, *args):
         '''
         test inspect volume.

--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -166,6 +166,7 @@ class DockerngTestCase(TestCase):
         __salt__ = {
             'config.get': Mock(),
             'mine.send': Mock(),
+            'dockerng.version': MagicMock(return_value={}),
         }
         host_config = {}
         client = Mock()

--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -38,6 +38,32 @@ class DockerngTestCase(TestCase):
     '''
 
     docker_version = dockerng_mod.docker.version_info
+    client_args_mock = MagicMock(return_value={
+        'create_container': [
+            'image', 'command', 'hostname', 'user', 'detach', 'stdin_open',
+            'tty', 'ports', 'environment', 'volumes', 'network_disabled',
+            'name', 'entrypoint', 'working_dir', 'domainname', 'cpuset',
+            'host_config', 'mac_address', 'labels', 'volume_driver',
+            'stop_signal', 'networking_config', 'healthcheck',
+            'stop_timeout'],
+        'host_config': [
+            'binds', 'port_bindings', 'lxc_conf', 'publish_all_ports',
+            'links', 'privileged', 'dns', 'dns_search', 'volumes_from',
+            'network_mode', 'restart_policy', 'cap_add', 'cap_drop',
+            'devices', 'extra_hosts', 'read_only', 'pid_mode', 'ipc_mode',
+            'security_opt', 'ulimits', 'log_config', 'mem_limit',
+            'memswap_limit', 'mem_reservation', 'kernel_memory',
+            'mem_swappiness', 'cgroup_parent', 'group_add', 'cpu_quota',
+            'cpu_period', 'blkio_weight', 'blkio_weight_device',
+            'device_read_bps', 'device_write_bps', 'device_read_iops',
+            'device_write_iops', 'oom_kill_disable', 'shm_size', 'sysctls',
+            'tmpfs', 'oom_score_adj', 'dns_opt', 'cpu_shares',
+            'cpuset_cpus', 'userns_mode', 'pids_limit', 'isolation',
+            'auto_remove', 'storage_opt'],
+        'networking_config': [
+            'aliases', 'links', 'ipv4_address', 'ipv6_address',
+            'link_local_ips'],
+    })
 
     def test_ps_with_host_true(self):
         '''
@@ -91,9 +117,9 @@ class DockerngTestCase(TestCase):
                             {'mine.send': mine_send,
                              'container_resource.run': MagicMock(),
                              'cp.cache_file': MagicMock(return_value=False)}):
-                with patch.dict(dockerng_mod.__context__,
-                                {'docker.client': docker_client}):
-                    command('container', *args)
+                with patch.object(dockerng_mod, 'get_client_args', self.client_args_mock):
+                    with patch.dict(dockerng_mod.__context__, {'docker.client': docker_client}):
+                        command('container', *args)
             mine_send.assert_called_with('dockerng.ps', verbose=True, all=True,
                                          host=True)
 
@@ -115,11 +141,10 @@ class DockerngTestCase(TestCase):
         client.api_version = '1.19'
         client.create_host_config.return_value = host_config
         client.create_container.return_value = {}
-        with patch.dict(dockerng_mod.__dict__,
-                        {'__salt__': __salt__}):
-            with patch.dict(dockerng_mod.__context__,
-                            {'docker.client': client}):
-                dockerng_mod.create('image', cmd='ls', name='ctn')
+        with patch.dict(dockerng_mod.__dict__, {'__salt__': __salt__}):
+            with patch.object(dockerng_mod, 'get_client_args', self.client_args_mock):
+                with patch.dict(dockerng_mod.__context__, {'docker.client': client}):
+                    dockerng_mod.create('image', cmd='ls', name='ctn')
         client.create_container.assert_called_once_with(
             command='ls',
             host_config=host_config,
@@ -144,11 +169,10 @@ class DockerngTestCase(TestCase):
         client.api_version = '1.19'
         client.create_host_config.return_value = host_config
         client.create_container.return_value = {}
-        with patch.dict(dockerng_mod.__dict__,
-                        {'__salt__': __salt__}):
-            with patch.dict(dockerng_mod.__context__,
-                            {'docker.client': client}):
-                dockerng_mod.create('image', name='ctn', publish_all_ports=True)
+        with patch.dict(dockerng_mod.__dict__, {'__salt__': __salt__}):
+            with patch.object(dockerng_mod, 'get_client_args', self.client_args_mock):
+                with patch.dict(dockerng_mod.__context__, {'docker.client': client}):
+                    dockerng_mod.create('image', name='ctn', publish_all_ports=True)
         client.create_container.assert_called_once_with(
             host_config=host_config,
             image='image',
@@ -173,16 +197,15 @@ class DockerngTestCase(TestCase):
         client.api_version = '1.19'
         client.create_host_config.return_value = host_config
         client.create_container.return_value = {}
-        with patch.dict(dockerng_mod.__dict__,
-                        {'__salt__': __salt__}):
-            with patch.dict(dockerng_mod.__context__,
-                            {'docker.client': client}):
-                dockerng_mod.create(
-                    'image',
-                    name='ctn',
-                    labels={'KEY': 'VALUE'},
-                    validate_input=True,
-                )
+        with patch.dict(dockerng_mod.__dict__, {'__salt__': __salt__}):
+            with patch.object(dockerng_mod, 'get_client_args', self.client_args_mock):
+                with patch.dict(dockerng_mod.__context__, {'docker.client': client}):
+                    dockerng_mod.create(
+                        'image',
+                        name='ctn',
+                        labels={'KEY': 'VALUE'},
+                        validate_input=True,
+                    )
         client.create_container.assert_called_once_with(
             labels={'KEY': 'VALUE'},
             host_config=host_config,
@@ -209,16 +232,15 @@ class DockerngTestCase(TestCase):
         client.api_version = '1.19'
         client.create_host_config.return_value = host_config
         client.create_container.return_value = {}
-        with patch.dict(dockerng_mod.__dict__,
-                        {'__salt__': __salt__}):
-            with patch.dict(dockerng_mod.__context__,
-                            {'docker.client': client}):
-                dockerng_mod.create(
-                    'image',
-                    name='ctn',
-                    labels=['KEY1', 'KEY2'],
-                    validate_input=True,
-                )
+        with patch.dict(dockerng_mod.__dict__, {'__salt__': __salt__}):
+            with patch.object(dockerng_mod, 'get_client_args', self.client_args_mock):
+                with patch.dict(dockerng_mod.__context__, {'docker.client': client}):
+                    dockerng_mod.create(
+                        'image',
+                        name='ctn',
+                        labels=['KEY1', 'KEY2'],
+                        validate_input=True,
+                    )
         client.create_container.assert_called_once_with(
             labels=['KEY1', 'KEY2'],
             host_config=host_config,
@@ -276,16 +298,15 @@ class DockerngTestCase(TestCase):
         client.api_version = '1.19'
         client.create_host_config.return_value = host_config
         client.create_container.return_value = {}
-        with patch.dict(dockerng_mod.__dict__,
-                        {'__salt__': __salt__}):
-            with patch.dict(dockerng_mod.__context__,
-                            {'docker.client': client}):
-                dockerng_mod.create(
-                    'image',
-                    name='ctn',
-                    labels=[{'KEY1': 'VALUE1'}, {'KEY2': 'VALUE2'}],
-                    validate_input=True,
-                )
+        with patch.dict(dockerng_mod.__dict__, {'__salt__': __salt__}):
+            with patch.object(dockerng_mod, 'get_client_args', self.client_args_mock):
+                with patch.dict(dockerng_mod.__context__, {'docker.client': client}):
+                    dockerng_mod.create(
+                        'image',
+                        name='ctn',
+                        labels=[{'KEY1': 'VALUE1'}, {'KEY2': 'VALUE2'}],
+                        validate_input=True,
+                    )
         client.create_container.assert_called_once_with(
             labels={'KEY1': 'VALUE1', 'KEY2': 'VALUE2'},
             host_config=host_config,

--- a/tests/unit/states/dockerng_test.py
+++ b/tests/unit/states/dockerng_test.py
@@ -25,7 +25,7 @@ from salt.exceptions import CommandExecutionError
 import salt.modules.dockerng as dockerng_mod
 import salt.states.dockerng as dockerng_state
 
-dockerng_mod.__context__ = {'docker.docker_version': ''}
+dockerng_mod.__context__ = {}
 dockerng_mod.__salt__ = {}
 dockerng_state.__context__ = {}
 dockerng_state.__opts__ = {'test': False}
@@ -131,12 +131,13 @@ class DockerngTestCase(TestCase):
                     'dockerng.create': dockerng_create,
                     'dockerng.start': dockerng_start,
                     }
-        with patch.dict(dockerng_state.__dict__,
-                        {'__salt__': __salt__}):
-            dockerng_state.running(
-                'cont',
-                image='image:latest',
-                port_bindings=['9090:9797/tcp'])
+        with patch.dict(dockerng_state.__dict__, {'__salt__': __salt__}):
+            with patch.dict(dockerng_mod.__salt__,
+                            {'dockerng.version': MagicMock(return_value={})}):
+                dockerng_state.running(
+                    'cont',
+                    image='image:latest',
+                    port_bindings=['9090:9797/tcp'])
         dockerng_create.assert_called_with(
             'image:latest',
             validate_input=False,
@@ -185,12 +186,13 @@ class DockerngTestCase(TestCase):
                     'dockerng.create': dockerng_create,
                     'dockerng.start': dockerng_start,
                     }
-        with patch.dict(dockerng_state.__dict__,
-                        {'__salt__': __salt__}):
-            dockerng_state.running(
-                'cont',
-                image='image:latest',
-                port_bindings=['9090:9797/tcp'])
+        with patch.dict(dockerng_state.__dict__, {'__salt__': __salt__}):
+            with patch.dict(dockerng_mod.__salt__,
+                            {'dockerng.version': MagicMock(return_value={})}):
+                dockerng_state.running(
+                    'cont',
+                    image='image:latest',
+                    port_bindings=['9090:9797/tcp'])
         dockerng_create.assert_called_with(
             'image:latest',
             validate_input=False,
@@ -243,12 +245,13 @@ class DockerngTestCase(TestCase):
                     'dockerng.create': dockerng_create,
                     'dockerng.start': dockerng_start,
                     }
-        with patch.dict(dockerng_state.__dict__,
-                        {'__salt__': __salt__}):
-            dockerng_state.running(
-                'cont',
-                image='image:latest',
-                port_bindings=['9090:9797/udp'])
+        with patch.dict(dockerng_state.__dict__, {'__salt__': __salt__}):
+            with patch.dict(dockerng_mod.__salt__,
+                            {'dockerng.version': MagicMock(return_value={})}):
+                dockerng_state.running(
+                    'cont',
+                    image='image:latest',
+                    port_bindings=['9090:9797/udp'])
         dockerng_create.assert_called_with(
             'image:latest',
             validate_input=False,
@@ -291,14 +294,15 @@ class DockerngTestCase(TestCase):
                     'dockerng.stop': dockerng_stop,
                     'dockerng.rm': dockerng_rm,
                     }
-        with patch.dict(dockerng_state.__dict__,
-                        {'__salt__': __salt__}):
-            ret = dockerng_state.running(
-                'cont',
-                image='image:latest',
-                )
-            dockerng_stop.assert_called_with('cont', timeout=10, unpause=True)
-            dockerng_rm.assert_called_with('cont')
+        with patch.dict(dockerng_state.__dict__, {'__salt__': __salt__}):
+            with patch.dict(dockerng_mod.__salt__,
+                            {'dockerng.version': MagicMock(return_value={})}):
+                ret = dockerng_state.running(
+                    'cont',
+                    image='image:latest',
+                    )
+                dockerng_stop.assert_called_with('cont', timeout=10, unpause=True)
+                dockerng_rm.assert_called_with('cont')
         self.assertEqual(ret, {'name': 'cont',
                                'comment': "Container 'cont' was replaced",
                                'result': True,
@@ -465,13 +469,14 @@ class DockerngTestCase(TestCase):
                     'dockerng.create': dockerng_create,
                     'dockerng.start': dockerng_start,
                     }
-        with patch.dict(dockerng_state.__dict__,
-                        {'__salt__': __salt__}):
-            ret = dockerng_state.running(
-                'cont',
-                image='image:latest',
-                start=False,
-                )
+        with patch.dict(dockerng_state.__dict__, {'__salt__': __salt__}):
+            with patch.dict(dockerng_mod.__salt__,
+                            {'dockerng.version': MagicMock(return_value={})}):
+                ret = dockerng_state.running(
+                    'cont',
+                    image='image:latest',
+                    start=False,
+                    )
         self.assertEqual(ret, {'name': 'cont',
                                'comment': "Container 'cont' is already "
                                "configured as specified",
@@ -599,19 +604,20 @@ class DockerngTestCase(TestCase):
                     'dockerng.create': MagicMock(),
                     'dockerng.start': MagicMock(),
                     }
-        with patch.dict(dockerng_state.__dict__,
-                        {'__salt__': __salt__}):
-            for wrong_value in (1, .2, (), [], {}):
-                ret = dockerng_state.running(
-                    'cont',
-                    image='image:latest',
-                    environment=[{'KEY': wrong_value}])
-                self.assertEqual(ret,
-                                 {'changes': {},
-                                  'comment': 'Environment values must'
-                                  ' be strings KEY=\'{0}\''.format(wrong_value),
-                                  'name': 'cont',
-                                  'result': False})
+        with patch.dict(dockerng_state.__dict__, {'__salt__': __salt__}):
+            with patch.dict(dockerng_mod.__salt__,
+                            {'dockerng.version': MagicMock(return_value={})}):
+                for wrong_value in (1, .2, (), [], {}):
+                    ret = dockerng_state.running(
+                        'cont',
+                        image='image:latest',
+                        environment=[{'KEY': wrong_value}])
+                    self.assertEqual(ret,
+                                     {'changes': {},
+                                      'comment': 'Environment values must'
+                                      ' be strings KEY=\'{0}\''.format(wrong_value),
+                                      'name': 'cont',
+                                      'result': False})
 
     def test_running_with_labels(self):
         '''
@@ -625,13 +631,14 @@ class DockerngTestCase(TestCase):
                     'dockerng.inspect_image': MagicMock(),
                     'dockerng.create': dockerng_create,
                     }
-        with patch.dict(dockerng_state.__dict__,
-                        {'__salt__': __salt__}):
-            dockerng_state.running(
-                'cont',
-                image='image:latest',
-                labels=['LABEL1', 'LABEL2'],
-                )
+        with patch.dict(dockerng_state.__dict__, {'__salt__': __salt__}):
+            with patch.dict(dockerng_mod.__salt__,
+                            {'dockerng.version': MagicMock(return_value={})}):
+                dockerng_state.running(
+                    'cont',
+                    image='image:latest',
+                    labels=['LABEL1', 'LABEL2'],
+                    )
         dockerng_create.assert_called_with(
             'image:latest',
             validate_input=False,


### PR DESCRIPTION
### What does this PR do?
This fixes 10 of the 16 failing tests currently happening in the `unit.modules.dockerng_test` file. The `unit.states.dockerng_test` file set some global variables that were adversely affecting the module test run and causing the dockerng tests to fail. 

This isolates some of the versioning information/mocking so that the dockerng state and module unit test files won't step on each others toes by isolating some of these global variables using mocks.

There are still 6 test failures remaining, but I can't isolate the problem for the remaining 6 tests yet.

I will still keep trying to find the problem with these remaining 6 tests, but I wanted to get this in for now since the changes seem to be related to different global setting issues. (This one was with the docker version calls, the other is related to the `_refresh_mine_cache` decorator.)

### Previous Behavior
16 test failures in the `unit.modules.dockerng_test` file.

### New Behavior
10 tests are now passing, 6 are still failing for a different, unknown reason. 

### Tests written?

No - fixes existing tests.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
