### PR TITLE
Fix issue-40243: schedule.purge only purge single job

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -215,7 +215,7 @@ def purge(**kwargs):
                         else:
                             ret['comment'].append('Failed to delete job {0} from schedule.'.format(name))
                             ret['result'] = True
-                        return ret
+
             except KeyError:
                 # Effectively a no-op, since we can't really return without an event system
                 ret['comment'] = 'Event module not available. Schedule add failed.'


### PR DESCRIPTION
schedule.purge return result too early in the purge loop.

https://github.com/saltstack/salt/issues/40243

### What does this PR do?

remove the early return and till all purge jobs done.

### What issues does this PR fix or reference?

### Previous Behavior

remove only one job on each purge command.

### New Behavior

remove all scheduled jobs in single purge command

### Tests written?

Yes - local tested.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
