### PR TITLE
Saltify authtest

### DIFF
--- a/doc/topics/cloud/saltify.rst
+++ b/doc/topics/cloud/saltify.rst
@@ -119,3 +119,21 @@ Connectivity to the new "Salted" instances can now be verified with Salt:
 .. code-block:: bash
 
     salt 'my-instance-*' test.ping
+
+Credential Verification
+=======================
+
+Because the Saltify driver does not actually create VM's, unlike other
+salt-cloud drivers, it has special behaviour when the ``deploy`` option is set
+to ``False``. When the cloud configuration specifies ``deploy: False``, the
+Saltify driver will attept to authenticate to the target node(s) and return
+``True`` for each one that succeeds. This can be useful to verify ports,
+protocols, services and credentials are correctly configured before a live
+deployment.
+
+Return values:
+  - ``True``: Credential verification succeeded
+  - ``False``: Credential verification succeeded
+  - ``None``: Credential verification was not attempted.
+
+.. note:: This feature is not available for Windows targets.

--- a/salt/cloud/clouds/saltify.py
+++ b/salt/cloud/clouds/saltify.py
@@ -94,6 +94,7 @@ def _verify(vm_):
     if win_installer:
 
         # No support for Windows at this time
+        log.warning('Credential verification is not available for Windows targets')
         return None
 
     else:

--- a/tests/unit/cloud/clouds/test_saltify.py
+++ b/tests/unit/cloud/clouds/test_saltify.py
@@ -8,7 +8,10 @@ from __future__ import absolute_import
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase
-from tests.support.mock import MagicMock
+from tests.support.mock import (
+    MagicMock,
+    patch
+)
 
 # Import Salt Libs
 from salt.cloud.clouds import saltify
@@ -26,12 +29,13 @@ class SaltifyTestCase(TestCase):
     '''
     # 'create' function tests: 1
 
+    @patch('salt.cloud.clouds.saltify._verify', MagicMock(return_value=True))
     def test_create_no_deploy(self):
         '''
         Test if deployment fails. This is the most basic test as saltify doesn't contain much logic
         '''
         vm = {'deploy':  False,
-              'provider': 'saltify',
+              'driver': 'saltify',
               'name': 'dummy'
              }
-        self.assertTrue(saltify.create(vm)['Error']['No Deploy'])
+        self.assertTrue(saltify.create(vm))


### PR DESCRIPTION
### What does this PR do?
Adds the ability for the Saltify driver to verify credentials before a live deployment.

### What issues does this PR fix or reference?
None.

### Previous Behavior
Saltify does nothing with `deploy=False` in the cloud config.

### New Behavior
Use the `deploy` keyword, when set to `true`, to run a credential verification against all targets. Currently, this is only supported on SSH targets. There seem to be some problems with pywinrm and impacket, unrelated to this change, that need to be addressed before Windows can be supported.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
