### PR TITLE
Fixes 'timeout' and 'gather_job_timeout' kwargs parameters for 'local_batch' client

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -51,7 +51,9 @@ class Batch(object):
         else:
             args.append(self.opts.get('expr_form', 'glob'))
 
-        ping_gen = self.local.cmd_iter(*args, **self.eauth)
+        ping_gen = self.local.cmd_iter(*args,
+                                       gather_job_timeout=self.opts['gather_job_timeout'],
+                                       **self.eauth)
 
         # Broadcast to targets
         fret = set()
@@ -160,6 +162,7 @@ class Batch(object):
                                 ret=self.opts.get('return', ''),
                                 show_jid=show_jid,
                                 verbose=show_verbose,
+                                gather_job_timeout=self.opts['gather_job_timeout'],
                                 **self.eauth)
                 # add it to our iterators and to the minion_tracker
                 iters.append(new_iter)

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -442,6 +442,12 @@ class LocalClient(object):
                 'ret': ret,
                 'batch': batch,
                 'raw': kwargs.get('raw', False)}
+
+        if 'timeout' in kwargs:
+            opts['timeout'] = kwargs['timeout']
+        if 'gather_job_timeout' in kwargs:
+            opts['gather_job_timeout'] = kwargs['gather_job_timeout']
+
         for key, val in six.iteritems(self.opts):
             if key not in opts:
                 opts[key] = val

--- a/tests/unit/cli/batch_test.py
+++ b/tests/unit/cli/batch_test.py
@@ -24,7 +24,13 @@ class BatchTestCase(TestCase):
     '''
 
     def setUp(self):
-        opts = {'batch': '', 'conf_file': {}, 'tgt': '', 'transport': '', 'timeout': 5}
+        opts = {'batch': '',
+                'conf_file': {},
+                'tgt': '',
+                'transport': '',
+                'timeout': 5,
+                'gather_job_timeout': 5}
+
         mock_client = MagicMock()
         with patch('salt.client.get_local_client', MagicMock(return_value=mock_client)):
             with patch('salt.client.LocalClient.cmd_iter', MagicMock(return_value=[])):


### PR DESCRIPTION
### What does this PR do?
This PR fixes `local_batch` client to be aware of `timeout` and `gather_job_timeout` parameters when they're coming as kwargs. Same behavior as per `local` clients.

### What issues does this PR fix or reference?
Prior to this PR, `timeout` and `gather_job_timeout` supplied via kwargs to `LocalClient.cmd_batch()` are not being taken in care by the `Batch` class, so global master timeouts are not bypassed here.

Changes included on this PR handle the custom timeouts kwargs parameters to be used by `Batch` class and then be able to get the expected behavior for the `local_batch` client.

### Tests written?
No