### PR TITLE
Netconfig added in Nitrogen not 2016.11.1

### DIFF
--- a/salt/states/netconfig.py
+++ b/salt/states/netconfig.py
@@ -15,7 +15,7 @@ Dependencies
 - :mod:`NAPALM proxy minion <salt.proxy.napalm>`
 - :mod:`Network-related basic features execution module <salt.modules.napalm_network>`
 
-.. versionadded: 2016.11.1
+.. versionadded:: Nitrogen
 '''
 
 from __future__ import absolute_import


### PR DESCRIPTION
### What does this PR do?

Just correcting the versionadded field for this new state.