### PR TITLE
Add ip protocol to logstash engine

### DIFF
--- a/doc/topics/engines/index.rst
+++ b/doc/topics/engines/index.rst
@@ -25,6 +25,7 @@ Salt engines are configured under an ``engines`` top-level section in your Salt 
      - logstash:
          host: log.my_network.com
          port: 5959
+         proto: tcp
 
 Salt engines must be in the Salt path, or you can add the ``engines_dirs`` option in your Salt master configuration with a list of directories under which Salt attempts to find Salt engines.
 

--- a/salt/engines/logstash.py
+++ b/salt/engines/logstash.py
@@ -41,7 +41,7 @@ def __virtual__():
 log = logging.getLogger(__name__)
 
 
-def start(host, port=5959, proto='tcp', tag='salt/engine/logstash'):
+def start(host, port=5959, tag='salt/engine/logstash', proto='tcp'):
     '''
     Listen to salt events and forward them to logstash
     '''

--- a/salt/engines/logstash.py
+++ b/salt/engines/logstash.py
@@ -12,6 +12,7 @@ them onto a logstash endpoint.
           - logstash:
             host: log.my_network.com
             port: 5959
+            proto: tcp
 
 :depends: logstash
 '''
@@ -40,13 +41,19 @@ def __virtual__():
 log = logging.getLogger(__name__)
 
 
-def start(host, port=5959, tag='salt/engine/logstash'):
+def start(host, port=5959, proto='tcp', tag='salt/engine/logstash'):
     '''
     Listen to salt events and forward them to logstash
     '''
+
+    if proto == 'tcp':
+        logstashHandler = logstash.TCPLogstashHandler
+    elif proto == 'udp':
+        logstashHandler = logstash.UDPLogstashHandler
+
     logstash_logger = logging.getLogger('python-logstash-logger')
     logstash_logger.setLevel(logging.INFO)
-    logstash_logger.addHandler(logstash.LogstashHandler(host, port, version=1))
+    logstash_logger.addHandler(logstashHandler(host, port, version=1))
 
     if __opts__.get('id').endswith('_master'):
         event_bus = salt.utils.event.get_master_event(


### PR DESCRIPTION
### What does this PR do?
This adds the ability to choose the protocol when using the logstash engine.

### What issues does this PR fix or reference?
#40257 

### Previous Behavior
Engine was using udp no matter what. Was not documented though.

### New Behavior
Add proto option to engine config and choose whether to use udp or tcp in your logstash input config.