### PR TITLE
Back-port #38835 to 2016.11

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -23,6 +23,7 @@ Salt Table of Contents
     ref/index
     topics/api
     topics/topology/index
+    topics/cache/index
     topics/windows/index
     topics/development/index
     topics/releases/index

--- a/doc/ref/cache/all/index.rst
+++ b/doc/ref/cache/all/index.rst
@@ -1,0 +1,14 @@
+.. _all-salt.cache:
+
+=============
+cache modules
+=============
+
+.. currentmodule:: salt.cache
+
+.. autosummary::
+    :toctree:
+    :template: autosummary.rst.tmpl
+
+    localfs
+    consul

--- a/doc/ref/cache/all/salt.cache.consul.rst
+++ b/doc/ref/cache/all/salt.cache.consul.rst
@@ -1,0 +1,5 @@
+salt.cache.consul module
+========================
+
+.. automodule:: salt.cache.consul
+    :members:

--- a/doc/ref/cache/all/salt.cache.localfs.rst
+++ b/doc/ref/cache/all/salt.cache.localfs.rst
@@ -1,0 +1,5 @@
+salt.cache.localfs module
+=========================
+
+.. automodule:: salt.cache.localfs
+    :members:

--- a/doc/ref/index.rst
+++ b/doc/ref/index.rst
@@ -10,6 +10,7 @@ This section contains a list of the Python modules that are used to extend the v
 
     ../ref/auth/all/index
     ../ref/beacons/all/index
+    ../ref/cache/all/index
     ../ref/engines/all/index
     ../ref/file_server/all/index
     ../ref/grains/all/index

--- a/doc/topics/cache/index.rst
+++ b/doc/topics/cache/index.rst
@@ -1,0 +1,33 @@
+.. _cache:
+
+=================
+Minion Data Cache
+=================
+
+The Minion Data Cache contains the Salt Mine data and other minion info cached
+on the Salt master.  By default Salt uses the `localfs` cache module to save
+the data in a msgpack file on the Salt master.  Other external data stores can
+also be used to store this data such as the `Consul` module.
+
+See :ref:`cache modules <all-salt.cache>` for a current list.
+
+
+Configuring the Minion Data Cache
+=================================
+
+The default `localfs` Minion data cache module doesn't require any
+configuration.  External data cache modules with external data stores such as
+Consul require a configuration setting in the master config.
+
+Here's an exampls config for Consul:
+
+.. code-block:: yaml
+
+    consul.host: 127.0.0.1
+    consul.port: 8500
+    consul.token: None
+    consul.scheme: http
+    consul.consistency: default
+    consul.dc: dc1
+    consul.verify: True
+

--- a/doc/topics/cache/index.rst
+++ b/doc/topics/cache/index.rst
@@ -4,10 +4,10 @@
 Minion Data Cache
 =================
 
-The Minion data cache contains the Salt Mine data and other minion info cached
-on the Salt master.  By default Salt uses the `localfs` cache module to save
-the data in a msgpack file on the Salt master.  Other external data stores can
-also be used to store this data such as the `Consul` module.
+The Minion data cache contains the Salt Mine data, minion grains and minion
+pillar info cached on the Salt master. By default Salt uses the `localfs` cache
+module to save the data in a msgpack file on the Salt master.  Other external
+data stores can also be used to store this data such as the `Consul` module.
 
 See :ref:`cache modules <all-salt.cache>` for a current list.
 

--- a/doc/topics/cache/index.rst
+++ b/doc/topics/cache/index.rst
@@ -4,7 +4,7 @@
 Minion Data Cache
 =================
 
-The Minion Data Cache contains the Salt Mine data and other minion info cached
+The Minion data cache contains the Salt Mine data and other minion info cached
 on the Salt master.  By default Salt uses the `localfs` cache module to save
 the data in a msgpack file on the Salt master.  Other external data stores can
 also be used to store this data such as the `Consul` module.
@@ -19,7 +19,7 @@ The default `localfs` Minion data cache module doesn't require any
 configuration.  External data cache modules with external data stores such as
 Consul require a configuration setting in the master config.
 
-Here's an exampls config for Consul:
+Here's an example config for Consul:
 
 .. code-block:: yaml
 
@@ -31,3 +31,4 @@ Here's an exampls config for Consul:
     consul.dc: dc1
     consul.verify: True
 
+    cache: consul

--- a/salt/cache/consul.py
+++ b/salt/cache/consul.py
@@ -21,7 +21,7 @@ could be set in the master config, these are the defaults:
     consul.token: None
     consul.scheme: http
     consul.consistency: default
-    consul.dc: None
+    consul.dc: dc1
     consul.verify: True
 
 Related docs could be found here:

--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -4,6 +4,9 @@ Cache data in filesystem.
 
 .. versionadded:: 2016.11.0
 
+The `localfs` Minion cache module is the default cache module and does not
+require any configuration.
+
 Expirations can be set in the relevant config file (``/etc/salt/master`` for
 the master, ``/etc/salt/cloud`` for Salt Cloud, etc).
 '''


### PR DESCRIPTION
Back-port #38835 to 2016.11

The minion cache changes were added for the feature release of 2016.11.0 (localfs only) and consul was added in 2016.11.2. This will be helpful to have in the 2016.11 docs.