### PR TITLE
Move "redis" to "redis_cache" references in docs

### DIFF
--- a/doc/ref/cache/all/index.rst
+++ b/doc/ref/cache/all/index.rst
@@ -12,4 +12,4 @@ cache modules
 
     localfs
     consul
-    redis
+    redis_cache

--- a/doc/ref/cache/all/salt.cache.redis.rst
+++ b/doc/ref/cache/all/salt.cache.redis.rst
@@ -1,5 +1,0 @@
-salt.cache.redis module
-========================
-
-.. automodule:: salt.cache.redis_cache
-    :members:

--- a/doc/ref/cache/all/salt.cache.redis_cache.rst
+++ b/doc/ref/cache/all/salt.cache.redis_cache.rst
@@ -1,0 +1,5 @@
+salt.cache.redis_cache module
+=============================
+
+.. automodule:: salt.cache.redis_cache
+    :members:


### PR DESCRIPTION
### What does this PR do?
Updates the `redis` references to be `redis_cache` in the doc ref files. The name of the file is `salt.cache.redis_cache`:
```
WARNING: [autosummary] failed to import u'salt.cache.redis': no module named salt.cache.redis
```

### What issues does this PR fix or reference?
Refs #39027

### Previous Behavior
No redis cache docs were building on the develop branch builds.

### New Behavior
The redis cache docs now build.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
