### PR TITLE
add warning when no host/dns record is found for fqdn_ip

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1688,6 +1688,8 @@ def ip_fqdn():
                 info = socket.getaddrinfo(_fqdn, None, socket_type)
                 ret[key] = list(set(item[4][0] for item in info))
             except socket.error:
+                log.warning('Unable to find IPv{0} record for "{1}" causing a 10 second timeout when rendering grains. '
+                            'Set the dns or /etc/hosts for IPv{0} to clear this.'.format(ipv_num, _fqdn))
                 ret[key] = []
 
     return ret


### PR DESCRIPTION
### What does this PR do?

We appear to be running across an upstream bug of socket.getaddrinfo. If the
ipv4 address is set for the hostname in /etc/hosts, but the ipv6 address is
not, we run into the timeout.  If the ipv6 is set, but the ipv4 is not, then
everything works as expected.  If neither are set, and you don't have
`myhostname` in nsswitch.conf for hosts, then it will fail for both if dns is
not setup.

There is not much else we can do besides log a warning so that users make sure
that their hostname lookups are setup correctly.

```
root@saltmaster:~# cat /etc/hosts
::1 saltmaster.local saltmaster
root@saltmaster:~# grep hosts /etc/nsswitch.conf
hosts:          files myhostname dns
root@saltmaster:~# time salt-call --local grains.item fqdn_ip4 fqdn_ip6
local:
    ----------
    fqdn_ip4:
        - 127.0.0.1
    fqdn_ip6:
        - ::1

real	0m0.299s
user	0m0.217s
sys	0m0.074s
root@saltmaster:~# vi /etc/hosts
root@saltmaster:~# cat /etc/hosts
127.0.0.1 localhost saltmaster.local saltmaster
root@saltmaster:~# time salt-call --local grains.item fqdn_ip4 fqdn_ip6
[WARNING ] Unable to find IPv6 record for saltmaster.local. Create a dns record or add to /etc/hosts to clear this message.
local:
    ----------
    fqdn_ip4:
        - 127.0.0.1
    fqdn_ip6:

real	0m10.323s
user	0m0.214s
sys	0m0.066s
root@saltmaster:~# vi /etc/hosts
root@saltmaster:~# cat /etc/hosts
root@saltmaster:~# time salt-call --local grains.item fqdn_ip4 fqdn_ip6
local:
    ----------
    fqdn_ip4:
        - 192.168.50.10
        - 10.0.2.15
    fqdn_ip6:
        - ::1

real	0m0.310s
user	0m0.244s
sys	0m0.058s
root@saltmaster:~# vi /etc/nsswitch.conf
root@saltmaster:~# grep hosts /etc/nsswitch.conf
hosts:          files dns
root@saltmaster:~# time salt-call --local grains.item fqdn_ip4 fqdn_ip6
[WARNING ] Unable to find IPv4 record for saltmaster. Create a dns record or add to /etc/hosts to clear this message.
[WARNING ] Unable to find IPv6 record for saltmaster. Create a dns record or add to /etc/hosts to clear this message.
local:
    ----------
    fqdn_ip4:
    fqdn_ip6:

real	0m0.343s
user	0m0.186s
sys	0m0.110s
```

### What issues does this PR fix or reference?
#37972

### Tests written?

No