### PR TITLE
Add 'nologinit' option for useradd module and user.present state.

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -115,9 +115,9 @@ def add(name,
         workphone='',
         homephone='',
         createhome=True,
-        nologinit=False,
         loginclass=None,
-        root=None):
+        root=None,
+        nologinit=False):
     '''
     Add a user to the minion
 

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -115,6 +115,7 @@ def add(name,
         workphone='',
         homephone='',
         createhome=True,
+        nologinit=False,
         loginclass=None,
         root=None):
     '''
@@ -177,6 +178,9 @@ def add(name,
     elif (__grains__['kernel'] != 'NetBSD'
             and __grains__['kernel'] != 'OpenBSD'):
         cmd.append('-M')
+
+    if nologinit:
+        cmd.append('-l')
 
     if home is not None:
         cmd.extend(['-d', home])

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -200,7 +200,6 @@ def present(name,
             remove_groups=True,
             home=None,
             createhome=True,
-            nologinit=False,
             password=None,
             hash_password=False,
             enforce_password=True,
@@ -222,7 +221,8 @@ def present(name,
             win_homedrive=None,
             win_profile=None,
             win_logonscript=None,
-            win_description=None):
+            win_description=None,
+            nologinit=False):
     '''
     Ensure that the named user is present with the specified properties
 

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -279,7 +279,7 @@ def present(name,
         If set to ``True``, it will not add the user to lastlog and faillog
         databases.
 
-        -- note::
+        .. note::
             Not supported on Windows or Mac OS.
 
     password

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -279,6 +279,9 @@ def present(name,
         If set to ``True``, it will not add the user to lastlog and faillog
         databases.
 
+        -- note::
+            Not supported on Windows or Mac OS.
+
     password
         A password hash to set for the user. This field is only supported on
         Linux, FreeBSD, NetBSD, OpenBSD, and Solaris. If the ``empty_password``

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -200,6 +200,7 @@ def present(name,
             remove_groups=True,
             home=None,
             createhome=True,
+            nologinit=False,
             password=None,
             hash_password=False,
             enforce_password=True,
@@ -273,6 +274,10 @@ def present(name,
 
             Additionally, parent directories will *not* be created. The parent
             directory for ``home`` must already exist.
+
+    nologinit : False
+        If set to ``True``, it will not add the user to lastlog and faillog
+        databases.
 
     password
         A password hash to set for the user. This field is only supported on
@@ -635,6 +640,7 @@ def present(name,
                       'workphone': workphone,
                       'homephone': homephone,
                       'createhome': createhome,
+                      'nologinit': nologinit,
                       'loginclass': loginclass}
         else:
             params = ({'name': name,


### PR DESCRIPTION
### What does this PR do?
Adds a `nologinit` option to `user.present` state.

### What issues does this PR fix or reference?
In some circumstances, we do not want to touch the `/var/log/lastlog` file when adding users.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
