### PR TITLE
Fixes wrong compared extra_mount_ignore_fs_keys key.

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -365,6 +365,9 @@ def mounted(name,
                     if fstype in ['cifs'] and opt.split('=')[0] == 'user':
                         opt = "username={0}".format(opt.split('=')[1])
 
+                    if opt.split('=')[0] in mount_ignore_fs_keys.get(fstype, []):
+                        opt = opt.split('=')[0]
+
                     # convert uid/gid to numeric value from user/group name
                     name_id_opts = {'uid': 'user.info',
                                     'gid': 'group.info'}


### PR DESCRIPTION
### What does this PR do?
Fixes wrong compared `extra_mount_ignore_fs_keys`.


### What issues does this PR fix or reference?
`extra_mount_ignore_fs_keys` dict which includes the size (e.g. { 'tmpfs': ['size'] }) will always be compared to the full value (e.g. size=1048576k) instead of key (e.g. size). Because size always gets converted to kB.


### Previous Behavior
Even with configured `extra_mount_ignore_fs_keys` option a remount would be forced:

```
ramdisktest:
  mount.mounted:
    - name: /var/cache/ramdisktest
    - device: tmpfs
    - fstype: tmpfs
    - opts:
      - late
      - rw
      - mode=0770
      - size=1g
    - extra_mount_invisible_options:
      - late
      - rw
      - mode=0770
      - size=1g
    - extra_mount_ignore_fs_keys: { 'tmpfs': ['size'] }
    - dump: 0
    - pass_num: 0
    - match_on: name
    - mkmnt: True
```

### New Behavior
Remount won't be forced with the same state above.


### Tests written?
No


