### PR TITLE
Pass in direct map_data instead of path to map

### DIFF
--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -209,12 +209,12 @@ Normally when using these modules, the path to the map file is passed in using:
 
 .. code-block:: bash
 
-    salt-run cloud.run_map /path/to/cloud.map
+    salt-run cloud.map_run /path/to/cloud.map
 
 To pass in the actual map data, use the ``map_data`` argument:
 
 .. code-block:: bash
 
-    salt-run cloud.run_map map_data='{"centos7": [{"saltmaster": {"minion": \
+    salt-run cloud.map_run map_data='{"centos7": [{"saltmaster": {"minion": \
         {"transport": "tcp"}, "make_master": true, "master": {"transport": \
         "tcp"}}}, {"minion001": {"minion": {"transport": "tcp"}}}]}'

--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -197,3 +197,24 @@ Another example:
 
 The above example makes the ``web3`` minion answer to the local master, not the
 newly created master.
+
+
+Using Direct Map Data
+=====================
+When using modules that access the ``CloudClient`` directly (notably, the
+``cloud`` execution and runner modules), it is possible to pass in the contents
+of a map file, rather than a path to the location of the map file.
+
+Normally when using these modules, the path to the map file is passed in using:
+
+.. code-block:: bash
+
+    salt-run cloud.run_map /path/to/cloud.map
+
+To pass in the actual map data, use the ``map_data`` argument:
+
+.. code-block:: bash
+
+    salt-run cloud.run_map map_data='{"centos7": [{"saltmaster": {"minion": \
+        {"transport": "tcp"}, "make_master": true, "master": {"transport": \
+        "tcp"}}}, {"minion001": {"minion": {"transport": "tcp"}}}]}'

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -57,7 +57,7 @@ def list_sizes(provider='all'):
 
     .. code-block:: bash
 
-        salt '*' cloud.list_sizes my-gce-config
+        salt minionname cloud.list_sizes my-gce-config
     '''
     client = _get_client()
     sizes = client.list_sizes(provider)
@@ -72,7 +72,7 @@ def list_images(provider='all'):
 
     .. code-block:: bash
 
-        salt '*' cloud.list_images my-gce-config
+        salt minionname cloud.list_images my-gce-config
     '''
     client = _get_client()
     images = client.list_images(provider)
@@ -87,7 +87,7 @@ def list_locations(provider='all'):
 
     .. code-block:: bash
 
-        salt '*' cloud.list_locations my-gce-config
+        salt minionname cloud.list_locations my-gce-config
     '''
     client = _get_client()
     locations = client.list_locations(provider)
@@ -102,9 +102,9 @@ def query(query_type='list_nodes'):
 
     .. code-block:: bash
 
-        salt '*' cloud.query
-        salt '*' cloud.query list_nodes_full
-        salt '*' cloud.query list_nodes_select
+        salt minionname cloud.query
+        salt minionname cloud.query list_nodes_full
+        salt minionname cloud.query list_nodes_select
     '''
     client = _get_client()
     info = client.query(query_type)
@@ -119,7 +119,7 @@ def full_query(query_type='list_nodes_full'):
 
     .. code-block:: bash
 
-        salt '*' cloud.full_query
+        salt minionname cloud.full_query
     '''
     return query(query_type=query_type)
 
@@ -132,7 +132,7 @@ def select_query(query_type='list_nodes_select'):
 
     .. code-block:: bash
 
-        salt '*' cloud.select_query
+        salt minionname cloud.select_query
     '''
     return query(query_type=query_type)
 
@@ -145,7 +145,7 @@ def has_instance(name, provider=None):
 
     .. code-block:: bash
 
-        salt '*' cloud.has_instance myinstance
+        salt minionname cloud.has_instance myinstance
     '''
     data = get_instance(name, provider)
     if data is None:
@@ -164,7 +164,7 @@ def get_instance(name, provider=None):
 
     .. code-block:: bash
 
-        salt '*' cloud.get_instance myinstance
+        salt minionname cloud.get_instance myinstance
 
     SLS Example:
 
@@ -191,12 +191,28 @@ def profile_(profile, names, vm_overrides=None, opts=None, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' cloud.profile my-gce-config myinstance
+        salt minionname cloud.profile my-gce-config myinstance
     '''
     client = _get_client()
     if isinstance(opts, dict):
         client.opts.update(opts)
     info = client.profile(profile, names, vm_overrides=vm_overrides, **kwargs)
+    return info
+
+
+def map_run(path=None, **kwargs):
+    '''
+    Execute a salt cloud map file
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt minionname cloud.map_run /path/to/cloud.map
+        salt minionname cloud.map_run map_data='<actual map data>'
+    '''
+    client = _get_client()
+    info = client.map_run(path, **_filter_kwargs(kwargs))
     return info
 
 
@@ -208,7 +224,7 @@ def destroy(names):
 
     .. code-block:: bash
 
-        salt '*' cloud.destroy myinstance
+        salt minionname cloud.destroy myinstance
     '''
     client = _get_client()
     info = client.destroy(names)
@@ -229,9 +245,9 @@ def action(
 
     .. code-block:: bash
 
-        salt '*' cloud.action start instance=myinstance
-        salt '*' cloud.action stop instance=myinstance
-        salt '*' cloud.action show_image provider=my-ec2-config image=ami-1624987f
+        salt minionname cloud.action start instance=myinstance
+        salt minionname cloud.action stop instance=myinstance
+        salt minionname cloud.action show_image provider=my-ec2-config image=ami-1624987f
     '''
     client = _get_client()
     info = client.action(fun, cloudmap, names, provider, instance, kwargs)

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -212,7 +212,7 @@ def map_run(path=None, **kwargs):
         salt minionname cloud.map_run map_data='<actual map data>'
     '''
     client = _get_client()
-    info = client.map_run(path, **_filter_kwargs(kwargs))
+    info = client.map_run(path, **kwargs)
     return info
 
 

--- a/salt/runners/cloud.py
+++ b/salt/runners/cloud.py
@@ -117,7 +117,7 @@ def profile(prof=None, instances=None, opts=None, **kwargs):
     return info
 
 
-def map_run(path, **kwargs):
+def map_run(path=None, **kwargs):
     '''
     Execute a salt cloud map file
     '''


### PR DESCRIPTION
### What does this PR do?
Previously only the path to a cloud map could be passed in. The `CloudClient` can now accept `map_data` instead of `map`, which contains the contents of a map, as a `dict`. This primarily affects the `cloud` execution and runner modules.

### Tests written?
No.