### PR TITLE
Fixes related to cache directory argument changes in pip>=6.

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -344,6 +344,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             target=None,
             download=None,
             download_cache=None,
+            cache_dir=None,
             source=None,
             upgrade=False,
             force_reinstall=False,
@@ -440,8 +441,8 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
     download
         Download packages into ``download`` instead of installing them
 
-    download_cache
-        Cache downloaded packages in ``download_cache`` dir
+    download_cache | cache_dir
+        Cache downloaded packages in ``download_cache`` or ``cache_dir`` dir
 
     source
         Check out ``editable`` packages into ``source`` dir
@@ -678,8 +679,10 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
     if download:
         cmd.extend(['--download', download])
 
-    if download_cache:
-        cmd.extend(['--download-cache', download_cache])
+    if download_cache or cache_dir:
+        cmd.extend(['--cache-dir' if salt.utils.compare_versions(
+            ver1=version(bin_env), oper='>=', ver2='6.0.0'
+        ) else '--download-cache', download_cache or cache_dir])
 
     if source:
         cmd.extend(['--source', source])

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -237,6 +237,7 @@ def installed(name,
               target=None,
               download=None,
               download_cache=None,
+              cache_dir=None,
               source=None,
               upgrade=False,
               force_reinstall=False,
@@ -336,8 +337,8 @@ def installed(name,
     download
         Download packages into ``download`` instead of installing them
 
-    download_cache
-        Cache downloaded packages in ``download_cache`` dir
+    download_cache | cache_dir
+        Cache downloaded packages in ``download_cache`` or ``cache_dir`` dir
 
     source
         Check out ``editable`` packages into ``source`` dir
@@ -681,6 +682,7 @@ def installed(name,
         target=target,
         download=download,
         download_cache=download_cache,
+        cache_dir=cache_dir,
         source=source,
         upgrade=upgrade,
         force_reinstall=force_reinstall,

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -47,6 +47,7 @@ def managed(name,
             no_deps=False,
             pip_download=None,
             pip_download_cache=None,
+            pip_cache_dir=None,
             pip_exists_action=None,
             pip_ignore_installed=False,
             proxy=None,
@@ -54,7 +55,8 @@ def managed(name,
             env_vars=None,
             no_use_wheel=False,
             pip_upgrade=False,
-            pip_pkgs=None):
+            pip_pkgs=None,
+            pip_no_cache_dir=False):
     '''
     Create a virtualenv and optionally manage it with pip
 
@@ -270,6 +272,7 @@ def managed(name,
             extra_index_url=extra_index_url,
             download=pip_download,
             download_cache=pip_download_cache,
+            cache_dir=pip_cache_dir,
             no_chown=no_chown,
             pre_releases=pre_releases,
             exists_action=pip_exists_action,
@@ -278,7 +281,8 @@ def managed(name,
             no_deps=no_deps,
             proxy=proxy,
             use_vt=use_vt,
-            env_vars=env_vars
+            env_vars=env_vars,
+            no_cache_dir=pip_no_cache_dir
         )
         ret['result'] &= _ret['retcode'] == 0
         if _ret['retcode'] > 0:


### PR DESCRIPTION
### What does this PR do?

Fixes an error which occurs when the `pip.install` module function interacts with pip>=6.

### What issues does this PR fix or reference?

None.

### Reference SLS

```
devpi:
  pkg.installed:
    - refresh: true
    - refresh_modules: true
    - pkgs:
      - python-dev
      - python-virtualenv
  virtualenv.managed:
    - name: /var/tmp/devpi
    - python: /usr/bin/python2
    - pip_download_cache: /dev/shm/.cache/pip
    - pip_pkgs:
      - devpi-server
```

### Previous Behavior

```
  Name: devpi - Function: pkg.installed - Result: Clean Started: - 16:44:05.529937 Duration: 235.854 ms
----------
          ID: devpi
    Function: virtualenv.managed
        Name: /var/tmp/devpi
      Result: False
     Comment: virtualenv exists
              
              
              Usage:   
                pip install [options] <requirement specifier> [package-index-options] ...
                pip install [options] -r <requirements file> [package-index-options] ...
                pip install [options] [-e] <vcs project url> ...
                pip install [options] [-e] <local project path> ...
                pip install [options] <archive url/path> ...
              
              no such option: --download-cache
     Started: 16:44:05.807818
    Duration: 1676.966 ms
     Changes:
```

### New Behavior

```
  Name: devpi - Function: pkg.installed - Result: Clean Started: - 16:44:05.529937 Duration: 235.854 ms
  Name: /var/tmp/devpi - Function: virtualenv.managed - Result: Changed Started: - 16:48:02.730418 Duration: 7975.681 ms
```

### Tests written?

No.
