### PR TITLE
fix some test=True comments

### DIFF
--- a/salt/states/alternatives.py
+++ b/salt/states/alternatives.py
@@ -224,7 +224,7 @@ def set_(name, path):
         if __opts__['test']:
             ret['comment'] = (
                 'Alternative for {0} will be set to path {1}'
-            ).format(name, current)
+            ).format(name, path)
             ret['result'] = None
             return ret
         __salt__['alternatives.set'](name, path)

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -142,9 +142,9 @@ def _absent_test(user, name, enc, comment, options, source, config):
         if keys:
             comment = ''
             for key, status in list(keys.items()):
-                if status == 'exists':
+                if status == 'add':
                     continue
-                comment += 'Set to {0}: {1}\n'.format(status, key)
+                comment += 'Set to remove: {0}\n'.format(key)
             if comment:
                 return result, comment
         err = sys.modules[

--- a/tests/unit/states/alternatives_test.py
+++ b/tests/unit/states/alternatives_test.py
@@ -199,7 +199,7 @@ class AlternativesTestCase(TestCase):
             ret.update({'comment': comt})
             self.assertDictEqual(alternatives.set_(name, path), ret)
 
-            comt = ('Alternative for {0} will be set to path False'
+            comt = ('Alternative for {0} will be set to path /usr/bin/less'
                    ).format(name)
             ret.update({'comment': comt, 'result': None})
             with patch.dict(alternatives.__opts__, {'test': True}):


### PR DESCRIPTION
### What does this PR do?
Alternatives should say it is setting the symlink to `path` instead of
`current` which it is already set to

ssh_auth.absent should say it is going to remove the key, unless the status is
set to `add`, then it is already absent

### What issues does this PR fix or reference?
Fixes #40321
Fixes #40322


### Tests written?

No