### PR TITLE
Allow filename to be part of a cache bank

### DIFF
--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -61,13 +61,22 @@ def fetch(bank, key, cachedir):
     '''
     Fetch information from a file.
     '''
+    inkey = False
     key_file = os.path.join(cachedir, os.path.normpath(bank), '{0}.p'.format(key))
+    if not os.path.isfile(key_file):
+        # The bank includes the full filename, and the key is inside the file
+        key_file = os.path.join(cachedir, os.path.normpath(bank) + '.p')
+        inkey = True
+
     if not os.path.isfile(key_file):
         log.debug('Cache file "%s" does not exist', key_file)
         return {}
     try:
         with salt.utils.fopen(key_file, 'rb') as fh_:
-            return __context__['serial'].load(fh_)
+            if inkey:
+                return __context__['serial'].load(fh_)[key]
+            else:
+                return __context__['serial'].load(fh_)
     except IOError as exc:
         raise SaltCacheError(
             'There was an error reading the cache file "{0}": {1}'.format(


### PR DESCRIPTION
### What does this PR do?
Normally in the `localfs` module, the name of a cache `bank` is only the directory in which a key exists. But there are times when we want the bank name to include the filename as well (when fetching data). This allows the `localfs` to do that.

### Tests written?
No.