### PR TITLE
Add archive.extracted with use_cmd_unzip argument

### DIFF
--- a/tests/integration/states/archive.py
+++ b/tests/integration/states/archive.py
@@ -205,6 +205,23 @@ class ArchiveTest(integration.ModuleCase,
 
         self._check_extracted(UNTAR_FILE)
 
+    def test_archive_extracted_with_cmd_unzip_false(self):
+        '''
+        test archive.extracted using use_cmd_unzip argument as false
+        '''
+
+        ret = self.run_state('archive.extracted', name=ARCHIVE_DIR,
+                             source=ARCHIVE_TAR_SOURCE,
+                             source_hash=ARCHIVE_TAR_HASH,
+                             use_cmd_unzip=False,
+                             archive_format='tar')
+        log.debug('ret = %s', ret)
+        if 'Timeout' in ret:
+            self.skipTest('Timeout talking to local tornado server.')
+        self.assertSaltTrueReturn(ret)
+
+        self._check_extracted(UNTAR_FILE)
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?
Currently there are already some unit tests for the cmd_unzip and cmd_zip methods in this pr: https://github.com/saltstack/salt/pull/37368

This will just add an integration test for the `use_cmd_unzip` argument equal to False since the default is True to test functionality of this argument.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/pull/37368

### Tests written?
Yes
