### PR TITLE
Fix check for empty minions bank (venafi)

### DIFF
--- a/salt/runners/venafiapi.py
+++ b/salt/runners/venafiapi.py
@@ -352,7 +352,7 @@ def _id_map(minion_id, dns_name):
     bank = 'venafi/minions'
     cache = salt.cache.Cache(__opts__, syspaths.CACHE_DIR)
     dns_names = cache.fetch(bank, minion_id)
-    if dns_names is None:
+    if not isinstance(dns_names, list):
         dns_names = []
     if dns_name not in dns_names:
         dns_names.append(dns_name)


### PR DESCRIPTION
### What does this PR do?
When checking the `venafi/minions` cache, an empty cache was expected to return `None`. However, it may return an empty `dict` instead. This will check for non-`list` type data and replace it with an empty list.

### Tests written?
No.