### PR TITLE
Fix service.create, fix docs

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -901,7 +901,8 @@ def create(name,
 
         exe_args (str): Any additional arguments required by the service binary.
 
-        display_name (str): the name to be displayed in the service manager
+        display_name (str): the name to be displayed in the service manager. If
+            not passed, the ``name`` will be used
 
         description (str): A description of the service
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -240,6 +240,9 @@ def get_service_name(*args):
 
     If arguments are passed, create a dict of Display Names and Service Names
 
+    Returns:
+        dict: A dictionary of display names and service names
+
     CLI Examples:
 
     .. code-block:: bash
@@ -268,7 +271,7 @@ def info(name):
 
     Args:
         name (str): The name of the service. This is not the display name. Use
-        ``get_service_name`` to find the service name.
+            ``get_service_name`` to find the service name.
 
     Returns:
         dict: A dictionary containing information about the service.
@@ -484,6 +487,9 @@ def create_win_salt_restart_task():
     '''
     Create a task in Windows task scheduler to enable restarting the salt-minion
 
+    Returns:
+        bool: ``True`` if successful, otherwise ``False``
+
     CLI Example:
 
     .. code-block:: bash
@@ -507,6 +513,9 @@ def create_win_salt_restart_task():
 def execute_salt_restart_task():
     '''
     Run the Windows Salt restart task
+
+    Returns:
+        bool: ``True`` if successful, otherwise ``False``
 
     CLI Example:
 
@@ -581,10 +590,10 @@ def modify(name,
 
     Args:
         name (str): The name of the service. Can be found using the
-        ``service.get_service_name`` function
+            ``service.get_service_name`` function
 
         bin_path (str): The path to the service executable. Backslashes must be
-        escaped, eg: C:\\path\\to\\binary.exe
+            escaped, eg: C:\\path\\to\\binary.exe
 
         exe_args (str): Any arguments required by the service executable
 
@@ -593,7 +602,8 @@ def modify(name,
         description (str): The description to display for the service
 
         service_type (str): Specifies the service type. Default is ``own``.
-        Valid options are as follows:
+            Valid options are as follows:
+
             - kernel: Driver service
             - filesystem: File system driver service
             - adapter: Adapter driver service (reserved)
@@ -603,6 +613,7 @@ def modify(name,
 
         start_type (str): Specifies the service start type. Valid options are as
             follows:
+
             - boot: Device driver that is loaded by the boot loader
             - system: Device driver that is started during kernel initialization
             - auto: Service that automatically starts
@@ -610,11 +621,13 @@ def modify(name,
             - disabled: Service cannot be started
 
         start_delayed (bool): Set the service to Auto(Delayed Start). Only valid
-        if the start_type is set to ``Auto``. If service_type is not passed, but
-        the service is already set to ``Auto``, then the flag will be set.
+            if the start_type is set to ``Auto``. If service_type is not passed,
+            but the service is already set to ``Auto``, then the flag will be
+            set.
 
         error_control (str): The severity of the error, and action taken, if
-        this service fails to start. Valid options are as follows:
+            this service fails to start. Valid options are as follows:
+
             - normal: Error is logged and a message box is displayed
             - severe: Error is logged and computer attempts a restart with the
               last known good configuration
@@ -627,26 +640,28 @@ def modify(name,
             belongs
 
         dependencies (list): A list of services or load ordering groups that
-        must start before this service
+            must start before this service
 
         account_name (str): The name of the account under which the service
-        should run. For ``own`` type services this should be in the
-        ``domain\username`` format. The following are examples of valid built-in
-        service accounts:
+            should run. For ``own`` type services this should be in the
+            ``domain\username`` format. The following are examples of valid
+            built-in service accounts:
+
             - NT Authority\\LocalService
             - NT Authority\\NetworkService
             - NT Authority\\LocalSystem
             - .\LocalSystem
 
         account_password (str): The password for the account name specified in
-        ``account_name``. For the above built-in accounts, this can be None.
-        Otherwise a password must be specified.
+            ``account_name``. For the above built-in accounts, this can be None.
+            Otherwise a password must be specified.
 
         run_interactive (bool): If this setting is True, the service will be
-        allowed to interact with the user. Not recommended for services that run
-        with elevated privileges.
+            allowed to interact with the user. Not recommended for services that
+            run with elevated privileges.
 
-    Returns (dict): A dictionary of changes made
+    Returns:
+        dict: a dictionary of changes made
 
     CLI Example:
 
@@ -882,7 +897,7 @@ def create(name,
         name (str): Specifies the service name. This is not the display_name
 
         bin_path (str): Specifies the path to the service binary file.
-        Backslashes must be escaped, eg: C:\\path\\to\\binary.exe
+            Backslashes must be escaped, eg: C:\\path\\to\\binary.exe
 
         exe_args (str): Any additional arguments required by the service binary.
 
@@ -891,7 +906,8 @@ def create(name,
         description (str): A description of the service
 
         service_type (str): Specifies the service type. Default is ``own``.
-        Valid options are as follows:
+            Valid options are as follows:
+
             - kernel: Driver service
             - filesystem: File system driver service
             - adapter: Adapter driver service (reserved)
@@ -900,7 +916,8 @@ def create(name,
             - share: Service shares a process with one or more other services
 
         start_type (str): Specifies the service start type. Valid options are as
-        follows:
+            follows:
+
             - boot: Device driver that is loaded by the boot loader
             - system: Device driver that is started during kernel initialization
             - auto: Service that automatically starts
@@ -908,12 +925,13 @@ def create(name,
             - disabled: Service cannot be started
 
         start_delayed (bool): Set the service to Auto(Delayed Start). Only valid
-        if the start_type is set to ``Auto``. If service_type is not passed, but
-        the service is already set to ``Auto``, then the flag will be set.
-        Default is ``False``
+            if the start_type is set to ``Auto``. If service_type is not passed,
+            but the service is already set to ``Auto``, then the flag will be
+            set. Default is ``False``
 
         error_control (str): The severity of the error, and action taken, if
-        this service fails to start. Valid options are as follows:
+            this service fails to start. Valid options are as follows:
+
             - normal (normal): Error is logged and a message box is displayed
             - severe: Error is logged and computer attempts a restart with the
               last known good configuration
@@ -926,24 +944,25 @@ def create(name,
             belongs
 
         dependencies (list): A list of services or load ordering groups that
-        must start before this service
+            must start before this service
 
         account_name (str): The name of the account under which the service
-        should run. For ``own`` type services this should be in the
-        ``domain\username`` format. The following are examples of valid built-in
-        service accounts:
+            should run. For ``own`` type services this should be in the
+            ``domain\username`` format. The following are examples of valid
+            built-in service accounts:
+
             - NT Authority\\LocalService
             - NT Authority\\NetworkService
             - NT Authority\\LocalSystem
             - .\\LocalSystem
 
         account_password (str): The password for the account name specified in
-        ``account_name``. For the above built-in accounts, this can be None.
-        Otherwise a password must be specified.
+            ``account_name``. For the above built-in accounts, this can be None.
+            Otherwise a password must be specified.
 
         run_interactive (bool): If this setting is True, the service will be
-        allowed to interact with the user. Not recommended for services that run
-        with elevated privileges.
+            allowed to interact with the user. Not recommended for services that
+            run with elevated privileges.
 
     Returns:
         dict: A dictionary containing information about the new service
@@ -974,6 +993,9 @@ def create(name,
         )
         if display_name is None:
             display_name = kwargs.pop('DisplayName')
+
+    if display_name is None:
+        display_name = name
 
     if 'type' in kwargs:
         salt.utils.warn_until(
@@ -1080,7 +1102,9 @@ def create(name,
             raise CommandExecutionError(
                 'Invalid Parameter: start_delayed requires start_type "auto"')
 
-    if account_name in ['LocalSystem', 'LocalService', 'NetworkService']:
+    if account_name in ['LocalSystem', '.\\LocalSystem',
+                        'LocalService', '.\\LocalService',
+                        'NetworkService', '.\\NetworkService']:
         account_password = ''
 
     # Connect to Service Control Manager
@@ -1144,12 +1168,13 @@ def config(name,
         name (str): Specifies the service name. This is not the display_name
 
         bin_path (str): Specifies the path to the service binary file.
-        Backslashes must be escaped, eg: C:\\path\\to\\binary.exe
+            Backslashes must be escaped, eg: C:\\path\\to\\binary.exe
 
         display_name (str): the name to be displayed in the service manager
 
         svc_type (str): Specifies the service type. Default is ``own``.
-        Valid options are as follows:
+            Valid options are as follows:
+
             - kernel: Driver service
             - filesystem: File system driver service
             - adapter: Adapter driver service (reserved)
@@ -1159,6 +1184,7 @@ def config(name,
 
         start_type (str): Specifies the service start type. Valid options are as
             follows:
+
             - boot: Device driver that is loaded by the boot loader
             - system: Device driver that is started during kernel initialization
             - auto: Service that automatically starts
@@ -1166,7 +1192,8 @@ def config(name,
             - disabled: Service cannot be started
 
         error (str): The severity of the error, and action taken, if this
-        service fails to start. Valid options are as follows:
+            service fails to start. Valid options are as follows:
+
             - normal (normal): Error is logged and a message box is displayed
             - severe: Error is logged and computer attempts a restart with the
               last known good configuration
@@ -1179,22 +1206,24 @@ def config(name,
             belongs
 
         depend (list): A list of services or load ordering groups that
-        must start before this service
+            must start before this service
 
-        obj (str): The name of the account under which the service
-        should run. For ``own`` type services this should be in the
-        ``domain\username`` format. The following are examples of valid built-in
-        service accounts:
+        obj (str): The name of the account under which the service should run.
+            For ``own`` type services this should be in the ``domain\username``
+            format. The following are examples of valid built-in service
+            accounts:
+
             - NT Authority\\LocalService
             - NT Authority\\NetworkService
             - NT Authority\\LocalSystem
             - .\\LocalSystem
 
         password (str): The password for the account name specified in
-        ``account_name``. For the above built-in accounts, this can be None.
-        Otherwise a password must be specified.
+            ``account_name``. For the above built-in accounts, this can be None.
+            Otherwise a password must be specified.
 
-
+    Returns:
+        dict: a dictionary of changes made
 
     CLI Example:
 


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where the service would fail to be created if `display_name` is not passed.

Fixes formatting for Documentation in all functions.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40318

### Previous Behavior
The function would fail saying `None` is an invalid value.

### New Behavior
If `display_name` is `None`, set `display_name` to the `name` of the service

### Tests written?
No