### PR TITLE
Fix gitfs w/pygit2 for windows (masterless)

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1599,9 +1599,15 @@ class Pygit2(GitProvider):
             _traverse(tree, blobs, self.root(tgt_env))
         add_mountpoint = lambda path: salt.utils.path_join(self.mountpoint(tgt_env), path)
         for repo_path in blobs.get('files', []):
-            files.add(add_mountpoint(relpath(repo_path)))
+            if not salt.utils.is_windows():
+                files.add(add_mountpoint(relpath(repo_path)))
+            else:
+                files.add('/'.join(repo_path.replace('.:\\', '', 1).split(os.sep)))
         for repo_path, link_tgt in six.iteritems(blobs.get('symlinks', {})):
-            symlinks[add_mountpoint(relpath(repo_path))] = link_tgt
+            if not salt.utils.is_windows():
+                symlinks[add_mountpoint(relpath(repo_path))] = link_tgt
+            else:
+                symlinks['/'.join(repo_path.replace('.:\\', '', 1).split(os.sep))] = link_tgt
         return files, symlinks
 
     def find_file(self, path, tgt_env):


### PR DESCRIPTION
In [hubble](https://github.com/HubbleStack/Hubble) we use the fileserver in masterless mode to serve files. On windows with pygit2, we were seeing all of the files in a `cp.list_master` with a mysterious `.:\` prefix, and windows path separators. As a result, `cp.cache_dir` was caching no files, because it couldn't match the files from the `file_list()` function to actual files to cache. (`cp.cache_file` was working properly, when you passed proper `salt://forward/slashes/are/king` paths)

This fix forces the paths returned by `file_list()` to posix paths and removes the mysterious prefix. It has fixed the problems we were seeing.

However, since we only really use `cp.cache_file` and `cp.cache_dir`, it's possible there are other locations where similar changes need to be made. I figure this is a good start but I haven't done thorough testing of other operations on Windows.

I should also note we don't use symlinks, so I haven't tested that code path. But I am pretty sure that line suffered from the same problems.

### Tests written?

No