### PR TITLE
ticket #40348: fix pillar include key nested support

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -688,9 +688,11 @@ class Pillar(object):
                                         )
                                 if nstate:
                                     if key:
-                                        nstate = {
-                                            key: nstate
-                                        }
+                                        # If key is x:y, convert it to {x: {y: nstate}}
+                                        for key_fragment in reversed(key.split(":")):
+                                            nstate = {
+                                                key_fragment: nstate
+                                            }
 
                                     state = merge(
                                         state,

--- a/tests/unit/test_pillar.py
+++ b/tests/unit/test_pillar.py
@@ -121,6 +121,36 @@ class PillarTestCase(TestCase):
             ({'foo': 'bar2'}, [])
         )
 
+        # Test includes using empty key directive
+        compile_template.side_effect = [
+            {'foo': 'bar', 'include': [{'blah': {'key': ''}}]},
+            {'foo': 'bar2'}
+        ]
+        self.assertEqual(
+            pillar.render_pillar({'base': ['foo.sls']}),
+            ({'foo': 'bar2'}, [])
+        )
+
+        # Test includes using simple non-nested key
+        compile_template.side_effect = [
+            {'foo': 'bar', 'include': [{'blah': {'key': 'nested'}}]},
+            {'foo': 'bar2'}
+        ]
+        self.assertEqual(
+            pillar.render_pillar({'base': ['foo.sls']}),
+            ({'foo': 'bar', 'nested': {'foo': 'bar2'}}, [])
+        )
+
+        # Test includes using nested key
+        compile_template.side_effect = [
+            {'foo': 'bar', 'include': [{'blah': {'key': 'nested:level'}}]},
+            {'foo': 'bar2'}
+        ]
+        self.assertEqual(
+            pillar.render_pillar({'base': ['foo.sls']}),
+            ({'foo': 'bar', 'nested': {'level': {'foo': 'bar2'}}}, [])
+        )
+
     @patch('salt.pillar.salt.fileclient.get_file_client', autospec=True)
     @patch('salt.pillar.salt.minion.Matcher')  # autospec=True disabled due to py3 mock bug
     def test_topfile_order(self, Matcher, get_file_client):


### PR DESCRIPTION
Extend pillar include support so that nesting is possible for the key directive.

Given the following pillar files:

foo1.sls:
```
include:
- foo:
    key: two:levels
```

foo2.sls:
```
foon: blah
```

This should render to pillar data like thus:
```
two:
  levels:
    foon: blah
```

### What does this PR do?
Extend pillar include support for the 'key' directive so it can nest the resultant dict.  See the setup above.

### What issues does this PR fix or reference?
#40348 

### Previous Behavior
Currently, it results in the following data which is far less useful
for usage, and in ability to be addressed:
```
two:levels:
  foon: blah
```

### New Behavior
After this commit, it'll result in the following pillar data:

```
two:
  levels:
    foon: blah
```

### Tests written?
yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
