### PR TITLE
Initial support for sending message cards to Microsoft Teams

### DIFF
--- a/salt/modules/msteams.py
+++ b/salt/modules/msteams.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+'''
+Module for sending messages to MS Teams
+.. versionadded:: Nitrogen
+:configuration: This module can be used by either passing a hook_url
+    directly or by specifying it in a configuration profile in the salt
+    master/minion config.
+    For example:
+    .. code-block:: yaml
+        msteams:
+          hook_url: https://outlook.office.com/webhook/837
+'''
+
+
+# Import Python libs
+from __future__ import absolute_import
+import json
+import logging
+
+# Import 3rd-party libs
+# pylint: disable=import-error,no-name-in-module,redefined-builtin
+import salt.ext.six.moves.http_client
+
+from salt.exceptions import SaltInvocationError
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'msteams'
+
+
+def __virtual__():
+    '''
+    Return virtual name of the module.
+    :return: The virtual name of the module.
+    '''
+    return __virtualname__
+
+def _get_hook_url():
+    hook_url = __salt__['config.get']('msteams.hook_url') or \
+        __salt__['config.get']('msteams:hook_url')
+
+    if not hook_url:
+        raise SaltInvocationError('No MS Teams hook_url found.')
+
+    return hook_url
+
+
+def post_card( message,
+             hook_url=None,
+             title=None,
+             themeColor=None):
+    '''
+    Send a message to an MS Teams channel.
+    :param message:     The message to send to the MS Teams channel.
+    :param hook_url:    The Teams webhook URL, if not specified in the configuration.
+    :param title:       Optional title for the posted card
+    :param themeColor:  Optional hex color highlight for the posted card
+    :return:            Boolean if message was sent successfully.
+    CLI Example:
+    .. code-block:: bash
+        salt '*' msteams.post_card message="Build is done"
+    '''
+
+    if not hook_url:
+        hook_url = _get_hook_urly()
+
+    if not message:
+        log.error('message is a required option.')
+
+    payload = {
+        "text": message,
+        "title": title,
+        "themeColor": themeColor
+    }
+
+    '''
+    data = _urlencode(
+        {
+            'payload': jsondumps(payload, ensure_ascii=False)
+        }
+    )
+    '''
+
+    result = salt.utils.http.query(hook_url, method='POST', data=json.dumps(payload), status=True)
+
+    if result['status'] <= 201:
+        return True
+    else:
+        return {
+            'res': False,
+            'message': result.get('body', result['status'])
+        }

--- a/salt/modules/msteams.py
+++ b/salt/modules/msteams.py
@@ -35,7 +35,12 @@ def __virtual__():
     '''
     return __virtualname__
 
+
 def _get_hook_url():
+    '''
+    Return hook_url from minion/master config file
+    or from pillar
+    '''
     hook_url = __salt__['config.get']('msteams.hook_url') or \
         __salt__['config.get']('msteams:hook_url')
 
@@ -45,16 +50,16 @@ def _get_hook_url():
     return hook_url
 
 
-def post_card( message,
-             hook_url=None,
-             title=None,
-             themeColor=None):
+def post_card(message,
+              hook_url=None,
+              title=None,
+              theme_color=None):
     '''
     Send a message to an MS Teams channel.
     :param message:     The message to send to the MS Teams channel.
     :param hook_url:    The Teams webhook URL, if not specified in the configuration.
     :param title:       Optional title for the posted card
-    :param themeColor:  Optional hex color highlight for the posted card
+    :param theme_color:  Optional hex color highlight for the posted card
     :return:            Boolean if message was sent successfully.
     CLI Example:
     .. code-block:: bash
@@ -62,7 +67,7 @@ def post_card( message,
     '''
 
     if not hook_url:
-        hook_url = _get_hook_urly()
+        hook_url = _get_hook_url()
 
     if not message:
         log.error('message is a required option.')
@@ -70,16 +75,8 @@ def post_card( message,
     payload = {
         "text": message,
         "title": title,
-        "themeColor": themeColor
+        "theme_color": theme_color
     }
-
-    '''
-    data = _urlencode(
-        {
-            'payload': jsondumps(payload, ensure_ascii=False)
-        }
-    )
-    '''
 
     result = salt.utils.http.query(hook_url, method='POST', data=json.dumps(payload), status=True)
 

--- a/salt/states/msteams.py
+++ b/salt/states/msteams.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+'''
+Send a message card to Microsoft Teams
+=======================
+This state is useful for sending messages to Teams during state runs.
+.. versionadded:: Nitrogen
+.. code-block:: yaml
+    teams-message:
+      msteams.post_card:
+        - message: 'This state was executed successfully.'
+        - hook_url:  https://outlook.office.com/webhook/837
+The hook_url can be specified in the master or minion configuration like below:
+.. code-block:: yaml
+    msteams:
+      hook_url: https://outlook.office.com/webhook/837
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt libs
+from salt.exceptions import SaltInvocationError
+
+
+def __virtual__():
+    '''
+    Only load if the msteams module is available in __salt__
+    '''
+    return 'msteams' if 'msteams.post_card' in __salt__ else False
+
+
+def post_card(name,
+              message,
+              hook_url=None,
+              title=None,
+              themeColor=None):
+    '''
+    Send a message to a Microsft Teams channel.
+    .. code-block:: yaml
+        send-msteams-message:
+          msteams.post_card:
+            - message: 'This state was executed successfully.'
+            - hook_url: https://outlook.office.com/webhook/837
+    The following parameters are required:
+    message
+        The message that is to be sent to the MS Teams channel.
+    The following parameters are optional:
+    hook_url
+        The webhook URL given configured in Teams interface,
+        if not specified in the configuration options of master or minion.
+    title
+        The title for the card posted to the channel
+    themeColor
+        A hex code for the desired highlight color
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if __opts__['test']:
+        ret['comment'] = 'The following message is to be sent to Teams: {0}'.format(message)
+        ret['result'] = None
+        return ret
+
+    if not message:
+        ret['comment'] = 'Teams message is missing: {0}'.format(message)
+        return ret
+
+    try:
+        result = __salt__['msteams.post_card'](
+            message=message,
+            hook_url=hook_url,
+            title=title,
+            themeColor=themeColor,
+        )
+    except SaltInvocationError as sie:
+        ret['comment'] = 'Failed to send message ({0}): {1}'.format(sie, name)
+    else:
+        if isinstance(result, bool) and result:
+            ret['result'] = True
+            ret['comment'] = 'Sent message: {0}'.format(name)
+        else:
+            ret['comment'] = 'Failed to send message ({0}): {1}'.format(result['message'], name)
+
+    return ret

--- a/salt/states/msteams.py
+++ b/salt/states/msteams.py
@@ -33,7 +33,7 @@ def post_card(name,
               message,
               hook_url=None,
               title=None,
-              themeColor=None):
+              theme_color=None):
     '''
     Send a message to a Microsft Teams channel.
     .. code-block:: yaml
@@ -50,7 +50,7 @@ def post_card(name,
         if not specified in the configuration options of master or minion.
     title
         The title for the card posted to the channel
-    themeColor
+    theme_color
         A hex code for the desired highlight color
     '''
     ret = {'name': name,
@@ -72,7 +72,7 @@ def post_card(name,
             message=message,
             hook_url=hook_url,
             title=title,
-            themeColor=themeColor,
+            theme_color=theme_color,
         )
     except SaltInvocationError as sie:
         ret['comment'] = 'Failed to send message ({0}): {1}'.format(sie, name)


### PR DESCRIPTION
using incoming webhook interface

### What does this PR do?
Allows salt to send message to a Microsoft Teams chat using the "incoming webhook" interface. 
Steps for use:
1. In your channel, add the incoming webhook connector
2. Set the connector name and image, and copy the webhook url
3. Use the webhook url in the salt state/module

Currently this supports the text, title, and color options listed at [https://dev.outlook.com/connectors/reference](https://dev.outlook.com/connectors/reference)

### Tests written?
No