### PR TITLE
Check salt.utils.win_functions.HAS_WIN32 in salt.utils.get_user

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -290,7 +290,7 @@ def get_user():
     '''
     if HAS_PWD:
         return pwd.getpwuid(os.geteuid()).pw_name
-    elif HAS_WIN32:
+    elif HAS_WIN32 and salt.utils.win_functions.HAS_WIN32:
         return salt.utils.win_functions.get_current_user()
     else:
         raise CommandExecutionError("Required external libraries not found. Need 'pwd' or 'win32api")

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -86,9 +86,9 @@ except ImportError:
 
 try:
     import salt.utils.win_functions
-    HAS_WIN32 = True
+    HAS_WIN_FUNCTIONS = True
 except ImportError:
-    HAS_WIN32 = False
+    HAS_WIN_FUNCTIONS = False
 
 try:
     import grp
@@ -290,7 +290,7 @@ def get_user():
     '''
     if HAS_PWD:
         return pwd.getpwuid(os.geteuid()).pw_name
-    elif HAS_WIN32 and salt.utils.win_functions.HAS_WIN32:
+    elif HAS_WIN_FUNCTIONS and salt.utils.win_functions.HAS_WIN32:
         return salt.utils.win_functions.get_current_user()
     else:
         raise CommandExecutionError("Required external libraries not found. Need 'pwd' or 'win32api")


### PR DESCRIPTION
### What does this PR do?

Commit f3b010e ("Fix imports") fixed an import issue introduced in commit 96afc0b ("fix: no more test against SYSTEM user") by removing salt.utils.win_functions.HAS_WIN32 check from
salt/utils/__init__.py and setting HAS_WIN32 to True if salt.utils.win_functions was successfully imported. However, salt.utils.win_functions doesn't raise ImportError if required libs aren't available but sets salt.utils.win_functions.HAS_WIN32 to False in such a case.

So after commit f3b010e ("Fix imports") salt.utils.HAS_WIN32 is always true:

    (py2-env) salt-test@tommynaut:~> uname -a
    Linux tommynaut 4.9.11-1-default #1 SMP PREEMPT Sat Feb 18 17:59:27 UTC 2017 (cf9c670) x86_64 x86_64 x86_64 GNU/Linux
    (py2-env) salt-test@tommynaut:~> python
    Python 2.7.13 (default, Jan 03 2017, 17:41:54) [GCC] on linux2
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import salt.utils
    >>> salt.utils.HAS_WIN32
    True

salt.utils.get_user thus calls salt.utils.win_functions.get_current_user without ensuring that all required libs were imported.

The first commit adds missing salt.utils.win_functions.HAS_WIN32 check to get_user(), so get_user() would do proper error reporting if required win libs are missing.
The second commit renames HAS_WIN32 to HAS_WIN_FUNCTIONS.

### What issues does this PR fix or reference?

 #40236 #39279

### Tests written?

No


I also see a similar issue with HAS_WIN_DACL in salt/modules/win_file.py, but I don't have a win environment to check it. Maybe @twangboy or @martintamare could take a look on that? And BTW should those imports be enclosed into try-except blocks at all, keeping in mind that they don't raise ImportError?