### PR TITLE
Add conf_proxy cross reference

### DIFF
--- a/doc/_ext/saltdomain.py
+++ b/doc/_ext/saltdomain.py
@@ -305,5 +305,7 @@ def setup(app):
             indextemplate="pair: %s; conf/master")
     app.add_crossref_type(directivename="conf_minion", rolename="conf_minion",
             indextemplate="pair: %s; conf/minion")
+    app.add_crossref_type(directivename="conf_proxy", rolename="conf_proxy",
+            indextemplate="pair: %s; conf/proxy")
     app.add_crossref_type(directivename="conf_log", rolename="conf_log",
             indextemplate="pair: %s; conf/logging")


### PR DESCRIPTION
### What does this PR do?

Currently the options are not nicely displayed and referenced under https://docs.saltstack.com/en/develop/ref/configuration/proxy.html -- hope this is what needs to be added.