### PR TITLE
Fix potential unbound local error

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2066,8 +2066,7 @@ def request_instance(vm_=None, call=None):
 
             log.debug('Returned query data: {0}'.format(data))
 
-            if 'state' in data[0]:
-                state = data[0]['state']
+            state = data[0].get('state')
 
             if state == 'active':
                 return data


### PR DESCRIPTION
If the condition is false, the 'state' var will not be defined and
referencing it in the subsequent code will produce UnboundLocalError.
Use dict.get() to initialize the 'state' variable.