### PR TITLE
Remove usually-wrong advice to raise worker threads

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1764,9 +1764,8 @@ class LocalClient(object):
             payload = channel.send(payload_kwargs, timeout=timeout)
         except SaltReqTimeoutError:
             raise SaltReqTimeoutError(
-                'Salt request timed out. The master is not responding. '
-                'If this error persists after verifying the master is up, '
-                'worker_threads may need to be increased.'
+                'Salt request timed out. The master is not responding. You '
+                'may need to run your command with `--async`.'
             )
 
         if not payload:
@@ -1869,9 +1868,8 @@ class LocalClient(object):
             payload = yield channel.send(payload_kwargs, timeout=timeout)
         except SaltReqTimeoutError:
             raise SaltReqTimeoutError(
-                'Salt request timed out. The master is not responding. '
-                'If this error persists after verifying the master is up, '
-                'worker_threads may need to be increased.'
+                'Salt request timed out. The master is not responding. You '
+                'may need to run your command with `--async`.'
             )
 
         if not payload:

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1765,7 +1765,12 @@ class LocalClient(object):
         except SaltReqTimeoutError:
             raise SaltReqTimeoutError(
                 'Salt request timed out. The master is not responding. You '
-                'may need to run your command with `--async`.'
+                'may need to run your command with `--async` in order to '
+                'bypass the congested event bus. With `--async`, the CLI tool '
+                'will print the job id (jid) and exit immediately without '
+                'listening for responses. You can then use '
+                '`salt-run jobs.lookup_jid` to look up the results of the job '
+                'in the job cache later.'
             )
 
         if not payload:
@@ -1869,7 +1874,12 @@ class LocalClient(object):
         except SaltReqTimeoutError:
             raise SaltReqTimeoutError(
                 'Salt request timed out. The master is not responding. You '
-                'may need to run your command with `--async`.'
+                'may need to run your command with `--async` in order to '
+                'bypass the congested event bus. With `--async`, the CLI tool '
+                'will print the job id (jid) and exit immediately without '
+                'listening for responses. You can then use '
+                '`salt-run jobs.lookup_jid` to look up the results of the job '
+                'in the job cache later.'
             )
 
         if not payload:


### PR DESCRIPTION
This removes the suggestion to increase `worker_threads` when you get the "master not responding" error.

The problem is that that suggestion is usually wrong. At large scale, salt will usually fail to respond to '*'-targeted jobs on the command line as the event bus gets overloaded. Most large scale deployments standardize on using `--async` to avoid these issues, and then look at the job cache afterwards.

But for people new to salt or who don't understand what's happening, this error often misdiagnoses the issue. I've seen multiple instances where admins have increased that setting way above reasonable limits (i.e. `worker_threads: 50` on a 4 or 8 core machine).

We could also add more potential solutions to this error. Recommendations to increase the resources on your master (cores/ram) or maybe a more qualified suggestion about worker_threads (making it clear that you should never set it to more than 2x the number of cores on your master).

Thoughts?