### PR TITLE
[WIP] fix test_host.test_add_host_formatting for Py3

### DIFF
--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -276,4 +276,3 @@ def _write_hosts(hosts):
     else:
         with salt.utils.fopen(hfn, 'w+', newline='') as ofile:
             ofile.writelines(lines)
-

--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -265,15 +265,15 @@ def _write_hosts(hosts):
                 line = ''.join(aliases)
             else:
                 line = '{0}\t\t{1}'.format(
-                    ip,
-                    ' '.join(aliases)
-                    )
-        lines.append(line)
+                    ip, ' '.join(aliases))
+        lines.append(line.strip() + os.linesep)
 
     hfn = _get_or_create_hostfile()
-    with salt.utils.fopen(hfn, 'w+') as ofile:
-        for line in lines:
-            if line.strip():
-                # /etc/hosts needs to end with EOL so that some utils that read
-                # it do not break
-                ofile.write(line.strip() + os.linesep)
+
+    if six.PY2:
+        with salt.utils.fopen(hfn, 'w+') as ofile:
+            ofile.writelines(lines)
+    else:
+        with salt.utils.fopen(hfn, 'w+', newline='') as ofile:
+            ofile.writelines(lines)
+

--- a/tests/integration/modules/test_hosts.py
+++ b/tests/integration/modules/test_hosts.py
@@ -13,6 +13,9 @@ import tests.integration as integration
 # Import salt libs
 import salt.utils
 
+# Import 3rd party libs
+import salt.ext.six as six
+
 HFN = os.path.join(integration.TMP, 'hosts')
 
 
@@ -205,8 +208,13 @@ class HostsModuleTest(integration.ModuleCase):
         )
 
         # now read the lines and ensure they're formatted correctly
-        with salt.utils.fopen(HFN, 'r') as fp_:
-            lines = fp_.read().splitlines()
+        if six.PY2:
+            with salt.utils.fopen(HFN, 'r') as fp_:
+                lines = fp_.read().splitlines()
+        else:
+            with salt.utils.fopen(HFN, 'r', newline='') as fp_:
+                lines = fp_.read().splitlines()
+
         self.assertEqual(lines, [
             '192.168.1.3\t\thost3.fqdn.com',
             '192.168.1.1\t\thost1.fqdn.com host1 host1-reorder',


### PR DESCRIPTION
### What does this PR do?
Fixes tests and hosts module for Py3.

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1202

### Previous Behavior
Python 3 does some weird thing with line endings by default. It was ignoring `os.linesep` and setting `\n\n` as the line ending in Windows which wasn't being split correctly by the test. Using the `newline=''` option forces Universal line endings. This has to be done on both ends ('r' and 'w')

### New Behavior
Correct line endings are being set and returned.

### Tests written?
NA