### PR TITLE
Support defining nodegroups as a dictlist as well as a dict

### DIFF
--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -28,6 +28,15 @@ nodegroups. Here's an example nodegroup configuration within
     group2 is matching specific grains. See the :ref:`compound matchers
     <targeting-compound>` documentation for more details.
 
+    As of the Nitrogen release of Salt, group names can also be prepended with
+    a dash. This brings the usage in line with many other areas of Salt. For
+    example:
+
+    .. code-block:: yaml
+
+        nodegroups:
+          - group1: 'L@foo.domain.com,bar.domain.com,baz.domain.com or bl*.domain.com'
+
 .. versionadded:: 2015.8.0
 
 .. note::

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -767,7 +767,7 @@ VALID_OPTS = {
 
     # A compound target definition.
     # See: http://docs.saltstack.com/en/latest/topics/targeting/nodegroups.html
-    'nodegroups': dict,
+    'nodegroups': (dict, list),
 
     # List-only nodegroups for salt-ssh. Each group must be formed as either a
     # comma-separated list, or a YAML list.
@@ -3365,6 +3365,8 @@ def master_config(path, env_var='SALT_MASTER_CONFIG', defaults=None, exit_on_con
     # out or not present.
     if opts.get('nodegroups') is None:
         opts['nodegroups'] = DEFAULT_MASTER_OPTS.get('nodegroups', {})
+    if salt.utils.is_dictlist(opts['nodegroups']):
+        opts['nodegroups'] = salt.utils.repack_dictlist(opts['nodegroups'])
     if opts.get('transport') == 'raet' and 'aes' in opts:
         opts.pop('aes')
     apply_sdb(opts)


### PR DESCRIPTION
Much of salt uses these "dictlist" structures, because it looks pretty
when rendered as YAML. This adds this support to nodegroups as well.

Refs: https://github.com/saltstack/salt/issues/40355