### PR TITLE
Fix 'clean_pub_auth' maintenance job

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -180,7 +180,8 @@ def clean_pub_auth(opts):
                     auth_file_path = os.path.join(dirpath, auth_file)
                     if not os.path.isfile(auth_file_path):
                         continue
-                    if os.path.getmtime(auth_file_path) - time.time() > opts['keep_jobs']:
+                    if (time.time() - os.path.getmtime(auth_file_path) >
+                            (opts['keep_jobs'] * 3600)):
                         os.remove(auth_file_path)
     except (IOError, OSError):
         log.error('Unable to delete pub auth file')

--- a/salt/master.py
+++ b/salt/master.py
@@ -225,8 +225,6 @@ class Maintenance(SignalHandlingMultiprocessingProcess):
         last = int(time.time())
         # Clean out the fileserver backend cache
         salt.daemons.masterapi.clean_fsbackend(self.opts)
-        # Clean out pub auth
-        salt.daemons.masterapi.clean_pub_auth(self.opts)
 
         old_present = set()
         while True:
@@ -234,6 +232,7 @@ class Maintenance(SignalHandlingMultiprocessingProcess):
             if (now - last) >= self.loop_interval:
                 salt.daemons.masterapi.clean_old_jobs(self.opts)
                 salt.daemons.masterapi.clean_expired_tokens(self.opts)
+                salt.daemons.masterapi.clean_pub_auth(self.opts)
             self.handle_search(now, last)
             self.handle_git_pillar()
             self.handle_schedule()


### PR DESCRIPTION
### What does this PR do?
Fixes the 'clean_pub_auth' maintenance job.

### What issues does this PR fix or reference?
#17124

### Previous Behavior
'clean_pub_auth' did not work and messed up the /var/cache/salt/master/publish_auth/ directory with tons of orphaned files resulting in inode shortage in the long run.

### New Behavior
Delete orphaned files as expected by a regular maintenance job.

### Tests written?
No