### PR TITLE
More complete fix for 39692

### DIFF
--- a/salt/modules/tuned.py
+++ b/salt/modules/tuned.py
@@ -51,7 +51,7 @@ def list_():
     result.pop()
     # Output can be : " - <profile name> - <description>" (v2.7.1)
     # or " - <profile name> " (v2.4.1)
-    result = [i.split('-')[1].strip() for i in result]
+    result = [i.split('- ')[1].strip() for i in result]
     return result
 
 

--- a/tests/unit/modules/tuned_test.py
+++ b/tests/unit/modules/tuned_test.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from salt.modules import tuned
+
+from salttesting import skipIf, TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch, call
+
+
+tuned.__salt__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class TunedListTestCase(TestCase):
+    def test_v_241(self):
+        """
+        Test the list_ function for older tuned-adm (v2.4.1)
+        as shipped with CentOS-6
+        """
+        tuned_list = '''Available profiles:
+- throughput-performance
+- virtual-guest
+- latency-performance
+- laptop-battery-powersave
+- laptop-ac-powersave
+- virtual-host
+- desktop-powersave
+- server-powersave
+- spindown-disk
+- sap
+- enterprise-storage
+- default
+Current active profile: throughput-performance'''
+        mock_cmd = MagicMock(return_value=tuned_list)
+        with patch.dict(tuned.__salt__, {'cmd.run': mock_cmd}):
+            self.assertEqual(
+                tuned.list_(),
+                ['throughput-performance', 'virtual-guest',
+                 'latency-performance', 'laptop-battery-powersave',
+                 'laptop-ac-powersave', 'virtual-host',
+                 'desktop-powersave', 'server-powersave',
+                 'spindown-disk', 'sap', 'enterprise-storage', 'default'])
+
+    def test_v_271(self):
+        """
+        Test the list_ function for older tuned-adm (v2.7.1)
+        as shipped with CentOS-7
+        """
+        tuned_list = '''Available profiles:
+- balanced                    - General non-specialized tuned profile
+- desktop                     - Optmize for the desktop use-case
+- latency-performance         - Optimize for deterministic performance
+- network-latency             - Optimize for deterministic performance
+- network-throughput          - Optimize for streaming network throughput.
+- powersave                   - Optimize for low power-consumption
+- throughput-performance      - Broadly applicable tuning that provides--
+- virtual-guest               - Optimize for running inside a virtual-guest.
+- virtual-host                - Optimize for running KVM guests
+Current active profile: virtual-guest
+'''
+        mock_cmd = MagicMock(return_value=tuned_list)
+        with patch.dict(tuned.__salt__, {'cmd.run': mock_cmd}):
+            self.assertEqual(
+                tuned.list_(),
+                ['balanced', 'desktop', 'latency-performance',
+                 'network-latency', 'network-throughput', 'powersave',
+                 'throughput-performance', 'virtual-guest',
+                 'virtual-host'])

--- a/tests/unit/modules/tuned_test.py
+++ b/tests/unit/modules/tuned_test.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from salt.modules import tuned
 
 from salttesting import skipIf, TestCase
-from salttesting.helpers import ensure_in_syspath
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch, call
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
 
 tuned.__salt__ = {}
@@ -11,6 +12,9 @@ tuned.__salt__ = {}
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class TunedListTestCase(TestCase):
+    """
+    Test the tuned.list_() method for different versions of tuned-adm
+    """
     def test_v_241(self):
         """
         Test the list_ function for older tuned-adm (v2.4.1)
@@ -42,7 +46,7 @@ Current active profile: throughput-performance'''
 
     def test_v_271(self):
         """
-        Test the list_ function for older tuned-adm (v2.7.1)
+        Test the list_ function for newer tuned-adm (v2.7.1)
         as shipped with CentOS-7
         """
         tuned_list = '''Available profiles:


### PR DESCRIPTION
The existing fix did not work if the profile name itself had a dash `-`.
For example - `virtual-guest`. This commit fixes that by using `split('- ')`
rather than `split('-')`. This commit also provides two simple tests for the
`list_()` function to emulate behaviour of both old and new tuned-adm versions

Fixes #39692

### What does this PR do?

Split the tuned-adm list output properly irrespective of the tuned-adm version.
Tests are also provided

### What issues does this PR fix or reference?

#39692 

### Previous Behavior
The profile names were split using `'-'`, so names like `virtual-guest` were reduced to `virtual`

### New Behavior
The profile names are split using `'- '`, so names like `virtual-guest` remain the same

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
