### PR TITLE
Document how to install Python 2 on an Ubuntu 16.04 host with salt-ssh

### DIFF
--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -110,6 +110,17 @@ Calling Salt SSH
 
         salt-ssh centos-5-minion -r 'yum -y install epel-release ; yum -y install python26'
 
+.. note:: ``salt-ssh`` on systems with Python 3.x
+
+    Salt, before the Nitrogen release, does not support Python 3.x which is the
+    default on for example the popular 16.04 LTS release of Ubuntu. An easy
+    workaround for this scenario is to use the ``-r`` option similar to the
+    example above:
+
+    .. code-block:: bash
+
+        salt-ssh ubuntu-1604-minion -r 'apt update ; apt install -y python-minimal'
+
 The ``salt-ssh`` command can be easily executed in the same way as a salt
 command:
 


### PR DESCRIPTION
Similar to the above Note-box on how to handle the situation on Centos 5.