### PR TITLE
Null byte in id is invalid

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -484,6 +484,9 @@ def valid_id(opts, id_):
     '''
     Returns if the passed id is valid
     '''
+    # Null byte in id is invalid
+    if b'\x00' in id_:
+        return False
     try:
         return bool(clean_path(opts['pki_dir'], id_))
     except (AttributeError, KeyError) as e:


### PR DESCRIPTION
### What does this PR do?

Checks for null byte in minion id

### What issues does this PR fix or reference?

#40366 

### Previous Behavior

Salt would stop working and all the minions start timing out

### New Behavior

Minion id with null byte in them becomes invalid id

### Tests written?

No
