### PR TITLE
Handle AttributeError for dockerng_mod.docker attempt fails and docker is installed

### DIFF
--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -37,7 +37,11 @@ class DockerngTestCase(TestCase):
     Validate dockerng module
     '''
 
-    docker_version = dockerng_mod.docker.version_info
+    try:
+        docker_version = dockerng_mod.docker.version_info
+    except AttributeError:
+        docker_version = 0,
+
     client_args_mock = MagicMock(return_value={
         'create_container': [
             'image', 'command', 'hostname', 'user', 'detach', 'stdin_open',


### PR DESCRIPTION
When we hit that attribute error, we need to set the docker version variable to a tuple starting with 0 so we can use it in other test comparisons. If docker is installed, but at a lower version, we will see this attribute error.

Fixes the test failure on the 2016.11 branch on CentOS 6 VMs.