### PR TITLE
fix Ubuntu notation in docs/faq.rst

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -268,7 +268,7 @@ Upgrade without automatic restart
 *********************************
 
 Doing the Minion upgrade seems to be a simplest state in your SLS file at
-first. But the operating systems such as Debian GNU/Linux, Ununtu and their
+first. But the operating systems such as Debian GNU/Linux, Ubuntu and their
 derivatives start the service after the package installation by default.
 To prevent this, we need to create policy layer which will prevent the Minion
 service to restart right after the upgrade:


### PR DESCRIPTION
### What does this PR do?

Fixed Ubuntu notation in docs/faq.rst: changed `Ununtu` to `Ubuntu`.

### What issues does this PR fix or reference?

None

### Tests written?

No

