### PR TITLE
Fix for fixtures in the djangomod module

### DIFF
--- a/salt/modules/djangomod.py
+++ b/salt/modules/djangomod.py
@@ -161,18 +161,19 @@ def loaddata(settings_module,
         salt '*' django.loaddata <settings_module> <comma delimited list of fixtures>
 
     '''
-
+    args = []
     kwargs = {}
     if database:
         kwargs['database'] = database
 
+    cmd = '{0} {1}'.format('loaddata', ' '.join(fixtures.split(',')))
+
     return command(settings_module,
-                   'loaddata',
+                   cmd,
                    bin_env,
                    pythonpath,
                    env,
-                   *fixtures.split(','),
-                   **kwargs)
+                   *args, **kwargs)
 
 
 def collectstatic(settings_module,


### PR DESCRIPTION
### What does this PR do?
Fixes #7287, stops prepending each of the fixtures with '--' when using `djangomod.loaddata`.

According to the [Django documentation](https://docs.djangoproject.com/en/1.10/ref/django-admin/#loaddata) the fixtures should be added in the following format:

```python
django-admin loaddata fixture [fixture ...]
```

### What issues does this PR fix or reference?
Fixes #7287

### Previous Behavior
The `django.loaddata` treats fixture list as arguments and prepends '--' for each.

### New Behavior
The `django.loaddata` still treats the fixture list as arguments. But instead of prepending each of the arguments with '--', it will parse the fixtures as part of the command instead of via the args.

### Tests written?

No
