### PR TITLE
Add missing import to win_file, remove missing tests from whitelist

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -18,6 +18,7 @@ import logging
 # pylint: disable=W0611
 import operator  # do not remove
 from collections import Iterable, Mapping  # do not remove
+from functools import reduce  # do not remove
 import datetime  # do not remove.
 import tempfile  # do not remove. Used in salt.modules.file.__clean_tmp
 import itertools  # same as above, do not remove, it's used in __clean_tmp

--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -4,9 +4,6 @@ integration.fileserver.test_fileclient
 integration.fileserver.test_roots
 integration.loader.test_ext_grains
 integration.loader.test_ext_modules
-integration.loader.test_globals
-integration.loader.test_interfaces
-integration.loader.test_loader
 integration.modules.test_aliases
 integration.modules.test_beacons
 integration.modules.test_config


### PR DESCRIPTION
### What does this PR do?
Adds missing import to `modules\win_file.py` that was causing some tests to fail. (`from functools import reduce`)
A few integration tests were removed by @s0undt3ch 's PR; removed those from the whitelist.

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1203