### PR TITLE
Fix RuntimeError in state.py

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -3441,7 +3441,7 @@ class BaseHighState(object):
                     ext[name]['__sls__'] = sls
                 if '__env__' not in ext[name]:
                     ext[name]['__env__'] = saltenv
-                for key in ext[name]:
+                for key in list(ext[name]):
                     if key.startswith('_'):
                         continue
                     if not isinstance(ext[name][key], list):


### PR DESCRIPTION
### What does this PR do?
Fixes RuntimeError in `state.py`: `RuntimeError: OrderedDict mutated during iteration`. It needs to work off a copy instead of the actual dict. Apparently it's only a problem in Windows...

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1204