### PR TITLE
Added split to cut off debian_revision from rabbitmq-server version

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -318,7 +318,7 @@ def check_password(name, password, runas=None):
         if server_version is None:
             raise ValueError
 
-        server_version = server_version.group(1)
+        server_version = server_version.group(1).split('-')[0]
         version = [int(i) for i in server_version.split('.')]
     except ValueError:
         version = (0, 0, 0)


### PR DESCRIPTION
Fixes #40396

### What does this PR do?
Adds split('-')[0] to remove debian_revision from rabbitmq-server version
### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40396

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
