### PR TITLE
Add sorted to requisite recurse detection

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -488,7 +488,7 @@ class Compiler(object):
                                         # I am going beyond 80 chars on
                                         # purpose, this is just too much
                                         # of a pain to deal with otherwise
-                                        if req_val in reqs:
+                                        if req_val in sorted(reqs):
                                             if name in reqs[req_val]:
                                                 if reqs[req_val][name] == state:
                                                     if reqs[req_val]['state'] == reqs[name][req_val]:


### PR DESCRIPTION
### What does this PR do?
The tests are expecting the return for recursive requisite detection to be in a certain order. This adds `sorted` to the "for loop" on reqs.... Not sure if this is the right fix, but it's A fix.

I'm not sure the order of the detection is important, maybe just change the test?

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1203
