### PR TITLE
Fix boto_vpc.create_route() to work with interface_id

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -2283,7 +2283,7 @@ def create_route(route_table_id=None, destination_cidr_block=None,
                                   'must be provided.')
 
     if not _exactly_one((gateway_id, internet_gateway_name, instance_id, interface_id, vpc_peering_connection_id,
-                         interface_id, nat_gateway_id, nat_gateway_subnet_id, nat_gateway_subnet_name)):
+                         nat_gateway_id, nat_gateway_subnet_id, nat_gateway_subnet_name)):
         raise SaltInvocationError('Only one of gateway_id, internet_gateway_name, instance_id, '
                                   'interface_id, vpc_peering_connection_id, nat_gateway_id, '
                                   'nat_gateway_subnet_id or nat_gateway_subnet_name may be provided.')


### PR DESCRIPTION
### What does this PR do?

It fixes boto_vpc.create_route() function to work correctly with provided `interface_id`.

Seems like it was broken in 4611a9c5 merge commit.

### What issues does this PR fix or reference?

None that I'm aware of.

### Previous Behavior

Example state:

```
Test Routing Table:
  boto_vpc.route_table_present:
    - name: test-rtb
    - vpc_name: my_vpc
    - profile: my_profile
    - subnet_names:
      - test-subnet
    - routes:
      - destination_cidr_block: 10.10.0.0/24
        gateway_id: local
      - destination_cidr_block: 0.0.0.0/0
        nat_gateway_id: nat-xxxxxxxxxxxxxxxxx
      - destination_cidr_block: 172.10.0.0/24
        interface_id: eni-xxxxxxxx
      - destination_cidr_block: 192.168.20.0/24
        interface_id: eni-xxxxxxxx
      - destination_cidr_block: 10.200.200.0/24
        vpc_peering_connection_name: my_peer_conn
      - destination_cidr_block: 172.24.24.0/24
        interface_id: eni-xxxxxxxx
```

Error on applying:

```
local:
----------
          ID: Test Routing Table
    Function: boto_vpc.route_table_present
        Name: test-rtb
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1746, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1703, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/boto_vpc.py", line 952, in route_table_present
                  region=region, key=key, keyid=keyid, profile=profile)
                File "/usr/lib/python2.7/dist-packages/salt/states/boto_vpc.py", line 1123, in _routes_present
                  keyid=keyid, profile=profile, **r)
                File "/usr/lib/python2.7/dist-packages/salt/modules/boto_vpc.py", line 2287, in create_route
                  raise SaltInvocationError('Only one of gateway_id, internet_gateway_name, instance_id, '
              SaltInvocationError: Only one of gateway_id, internet_gateway_name, instance_id, interface_id, vpc_peering_connection_id, nat_gateway_id, nat_gateway_subnet_id or nat_gateway_subnet_name may be provided.
     Started: 09:24:43.466666
    Duration: 1525.55 ms
     Changes:   
```

### New Behavior

The same state applies clearly.

### Tests written?

No.