### PR TITLE
Adds some missing file functions on Windows

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -65,7 +65,9 @@ from salt.modules.file import (check_hash,  # pylint: disable=W0611
         RE_FLAG_TABLE, blockreplace, prepend, seek_read, seek_write, rename,
         lstat, path_exists_glob, write, pardir, join, HASHES, HASHES_REVMAP,
         comment, uncomment, _add_flags, comment_line, _regex_to_static,
-        _get_line_indent, apply_template_on_contents)
+        _get_line_indent, apply_template_on_contents, dirname, basename,
+        list_backups_dir)
+from salt.modules.file import normpath as normpath_
 
 from salt.utils import namespaced_function as _namespaced_function
 
@@ -93,7 +95,8 @@ def __virtual__():
             global blockreplace, prepend, seek_read, seek_write, rename, lstat
             global write, pardir, join, _add_flags, apply_template_on_contents
             global path_exists_glob, comment, uncomment, _mkstemp_copy
-            global _regex_to_static, _get_line_indent
+            global _regex_to_static, _get_line_indent, dirname, basename
+            global list_backups_dir, normpath_
 
             replace = _namespaced_function(replace, globals())
             search = _namespaced_function(search, globals())
@@ -154,6 +157,10 @@ def __virtual__():
             _mkstemp_copy = _namespaced_function(_mkstemp_copy, globals())
             _add_flags = _namespaced_function(_add_flags, globals())
             apply_template_on_contents = _namespaced_function(apply_template_on_contents, globals())
+            dirname = _namespaced_function(dirname, globals())
+            basename = _namespaced_function(basename, globals())
+            list_backups_dir = _namespaced_function(list_backups_dir, globals())
+            normpath_ = _namespaced_function(normpath_, globals())
 
             return __virtualname__
     return (False, "Module win_file: module only works on Windows systems")
@@ -164,7 +171,8 @@ __outputter__ = {
 }
 
 __func_alias__ = {
-    'makedirs_': 'makedirs'
+    'makedirs_': 'makedirs',
+    'normpath_': 'normpath',
 }
 
 


### PR DESCRIPTION
### What does this PR do?

Adds a few `file` functions that were missing on Windows:

- dirname
- basename
- list_backups_dir
- normpath

I attempted to go through the list of all the `file` functions and add the ones that were not explicitly incompatible. I've tested these four manually by updating win_file.py on a box with salt 2016.11.2 and they worked fine.