### PR TITLE
Closes handle to temporary file before returning the path

### DIFF
--- a/salt/modules/temp.py
+++ b/salt/modules/temp.py
@@ -10,6 +10,7 @@ This is a thin wrapper around Pythons tempfile module
 from __future__ import absolute_import
 
 import logging
+import os
 import tempfile
 
 log = logging.getLogger(__name__)
@@ -40,4 +41,6 @@ def file(suffix='', prefix='tmp', parent=None):
         salt '*' temp.file
         salt '*' temp.file prefix='mytemp-' parent='/var/run/'
     '''
-    return tempfile.mkstemp(suffix, prefix, parent)[1]
+    fh_, tmp_ = tempfile.mkstemp(suffix, prefix, parent)
+    os.close(fh_)
+    return tmp_


### PR DESCRIPTION
### What does this PR do?

Close the handle to the temporary file before returning the path

### What issues does this PR fix or reference?

Fixes #40417

### Previous Behavior

The open file handle prevented the file from being removed until after the python process exited. Made it difficult to manage and remove temporary files within a salt state (on Windows).

### New Behavior

File handle is closed, allowing the temporary file to be removed by the salt state (on Windows.