### PR TITLE
Return the same value for a non-existent user as on other platforms.

### DIFF
--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -778,7 +778,7 @@ def info(name):
 
     else:
 
-        return False
+        return {}
 
 
 def _get_userprofile_from_registry(user, sid):


### PR DESCRIPTION
### What does this PR do?

Changes the null return value of the user.info function in the win_useradd execution module to match the defined behavior.

### What issues does this PR fix or reference?

Fixes #40419.

### Previous Behavior

win_useradd's version of the user.info function would return `False` instead of `{}` (empty dictionary) for non-existent users.

### New Behavior

win_useradd's version of the user.info function now returns `{}` for non-existent users, matching the documented behavior of the function as well as the null return value of similar functions on other platforms.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
