### PR TITLE
salt/loader.py: Allow functools.partial functions to be loaded from m…

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1466,7 +1466,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 # private functions are skipped
                 continue
             func = getattr(mod, attr)
-            if not inspect.isfunction(func):
+            if not inspect.isfunction(func) and not isinstance(func, functools.partial):
                 # Not a function!? Skip it!!!
                 continue
             # Let's get the function name.


### PR DESCRIPTION
…odules.

### What does this PR do?
It allows partials (functool.partial) to be loaded from modules.

### What issues does this PR fix or reference?
I haven't made one for this.

### Previous Behavior
Partials are skipped by the loader

### New Behavior
Partials are loaded by the loader and made available in the __salt__-dict.

### Tests written?
No