### PR TITLE
Quick patch to support SAN addition/removal

### DIFF
--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -135,13 +135,6 @@ def cert(name,
         log.debug('Certificate {0} will be renewed'.format(cert_file))
         cmd.append('--renew-by-default')
         renew = True
-    # else:
-    #     return {
-    #         'result': None,
-    #         'comment': 'Certificate {0} does not need renewal'.format(cert_file),
-    #         'not_after': expires(name)
-    #     }
-
     if server:
         cmd.append('--server {0}'.format(server))
 

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -172,12 +172,9 @@ def cert(name,
         return {'result': False, 'comment': 'Certificate {0} renewal failed with:\n{1}'.format(name, res['stderr'])}
 
     if 'no action taken' in res['stdout']:
-     return {
-         'result': None,
-         'comment': 'No action taken on certificate {0}'.format(cert_file),
-         'not_after': expires(name)
-     }
-
+        return {'result': None,
+                'comment': 'No action taken on certificate {0}'.format(cert_file),
+                'not_after': expires(name)}
 
     if renew:
         comment = 'Certificate {0} renewed'.format(name)

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -
 '''
 ACME / Let's Encrypt module
 ===========================
@@ -130,12 +130,12 @@ def cert(name,
         log.debug('Certificate {0} will be renewed'.format(cert_file))
         cmd.append('--renew-by-default')
         renew = True
-    else:
-        return {
-            'result': None,
-            'comment': 'Certificate {0} does not need renewal'.format(cert_file),
-            'not_after': expires(name)
-        }
+    # else:
+    #     return {
+    #         'result': None,
+    #         'comment': 'Certificate {0} does not need renewal'.format(cert_file),
+    #         'not_after': expires(name)
+    #     }
 
     if server:
         cmd.append('--server {0}'.format(server))
@@ -170,6 +170,14 @@ def cert(name,
 
     if res['retcode'] != 0:
         return {'result': False, 'comment': 'Certificate {0} renewal failed with:\n{1}'.format(name, res['stderr'])}
+
+    if 'no action taken' in res['stdout']:
+     return {
+         'result': None,
+         'comment': 'No action taken on certificate {0}'.format(cert_file),
+         'not_after': expires(name)
+     }
+
 
     if renew:
         comment = 'Certificate {0} renewed'.format(name)

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -1,11 +1,16 @@
-# -*- coding: utf-8 -
+# -*- coding: utf-8 -*-
 '''
 ACME / Let's Encrypt module
 ===========================
 
 .. versionadded: 2016.3
 
-This module currently uses letsencrypt-auto, which needs to be available in the path or in /opt/letsencrypt/.
+This module currently looks for certbot script in the $PATH as
+- certbot,
+- lestsencrypt,
+- certbot-auto,
+- letsencrypt-auto
+eventually falls back to /opt/letsencrypt/letsencrypt-auto
 
 .. note::
 


### PR DESCRIPTION
### What does this PR do?
Quick and dirty fix to acme.py to allow adding and removing SANs from/to a certificate

### What issues does this PR fix or reference?

### Previous Behavior
In case of addition/removal of a SAN the certificate would not be processed

### New Behavior
In case of addition/removal of a SAN the certificate will be renewed with the new SAN included/removed

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
