### PR TITLE
Fix open filehandles

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -862,7 +862,8 @@ class AsyncAuth(object):
         m_pub_fn = os.path.join(self.opts['pki_dir'], self.mpub)
         m_pub_exists = os.path.isfile(m_pub_fn)
         if m_pub_exists and master_pub and not self.opts['open_mode']:
-            local_master_pub = salt.utils.fopen(m_pub_fn).read()
+            with salt.utils.fopen(m_pub_fn) as fp_:
+                local_master_pub = fp_.read()
 
             if payload['pub_key'].replace('\n', '').replace('\r', '') != \
                     local_master_pub.replace('\n', '').replace('\r', ''):
@@ -912,7 +913,8 @@ class AsyncAuth(object):
                 if not m_pub_exists:
                     # the minion has not received any masters pubkey yet, write
                     # the newly received pubkey to minion_master.pub
-                    salt.utils.fopen(m_pub_fn, 'wb+').write(payload['pub_key'])
+                    with salt.utils.fopen(m_pub_fn, 'wb+') as fp_:
+                        fp_.write(payload['pub_key'])
                 return self.extract_aes(payload, master_pub=False)
 
     def _finger_fail(self, finger, master_key):


### PR DESCRIPTION
This fixes two cases of filehandles being left open by failing to use a
with clause.