### PR TITLE
Skip 2 junos module unit tests: "salt.modules.junos.getattr" patch stacktraces

### DIFF
--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -1571,6 +1571,7 @@ class Test_Junos_Module(TestCase):
         ret['out'] = False
         self.assertEqual(junos.rpc(), ret)
 
+    @skipIf(True, 'This @patch decorator stacktraces as written. This test needs to be updated.')
     @patch('salt.modules.junos.getattr')
     def test_rpc_get_config_exception(self, mock_attr):
         mock_attr.return_value = self.raise_exception
@@ -1641,6 +1642,7 @@ class Test_Junos_Module(TestCase):
         mock_warning.assert_called_with(
             'Filter ignored as it is only used with "get-config" rpc')
 
+    @skipIf(True, 'This @patch decorator stacktraces as written. This test needs to be updated.')
     @patch('salt.modules.junos.getattr')
     def test_rpc_get_interface_information_exception(
             self, mock_attr):


### PR DESCRIPTION
### What does this PR do?
Disables two failing tests in the `unit.modules.test_junos.py` file. 

I spent some time yesterday trying to find a way to re-write these tests without completely disabling them, but I ran into some trouble. The piece that is causing the problem is [here](https://github.com/saltstack/salt/blob/develop/tests/unit/modules/test_junos.py#L1574). That isn't valid syntax since the function is just using the builtin `getattr` function [here](https://github.com/saltstack/salt/blob/develop/salt/modules/junos.py#L197), and not something specific to the junos execution module.

The next problem comes from the fact that you can't directly mock `getattr` as it is a python builtin and is specifically not supported by the mock lib to mock. See the bottom of [this section](https://docs.python.org/3/library/unittest.mock.html#mocking-magic-methods).

I tried patching the call to `conn = __proxy__['junos.conn']()` with something that will specifically raise an `AttributeError` so we can at least hit the error section that these two tests are trying to hit. The problem here is that we have to use a patch with a `Mock()` value in order to get passed some of the other calls in the function. Which then means we won't hit an error when we get to the `try/except` block containing the `getattr` call since `Mock()` takes care of this for us.

@vnitinv Since these were your tests, I wanted to bring this to your attention. The rest of the tests look great! But now that we have the testing dependencies all set up on our test-boxes (see [this PR](https://github.com/saltstack/salt-jenkins/pull/293)) _and_ your tests running at once, we are seeing these failures. (When we merged your PR before, the tests hadn't run against test boxes with the correct dependencies installed.)

I might be missing something here, so perhaps @vnitinv has a better solution since they are more familiar with this code.

### What issues does this PR fix or reference?
PR #39884

### Previous Behavior
Two tests were failing with the following stacktraces:
```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/usr/local/lib/python2.7/dist-packages/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/usr/local/lib/python2.7/dist-packages/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'salt.modules.junos' from '/testing/salt/modules/junos.pyc'> does not have the attribute 'getattr'
```

### New Behavior
These tests are skipped until the tests can be re-written.

### Tests written?
N/A

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
