### PR TITLE
Clarify the master_tops documentation

### DIFF
--- a/doc/topics/master_tops/index.rst
+++ b/doc/topics/master_tops/index.rst
@@ -9,7 +9,7 @@ subsystems to be used to generate the top file data for a :ref:`highstate
 <running-highstate>` run on the master.
 
 The old `external_nodes` option has been removed. The master tops system
-provides an pluggable and extendable replacement for it, allowing for multiple
+provides a pluggable and extendable replacement for it, allowing for multiple
 different subsystems to provide top file data.
 
 Using the new `master_tops` option is simple:

--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -43,6 +43,7 @@ def sync_all(saltenv='base'):
     ret['engines'] = sync_engines(saltenv=saltenv)
     ret['queues'] = sync_queues(saltenv=saltenv)
     ret['pillar'] = sync_pillar(saltenv=saltenv)
+    ret['tops'] = sync_tops(saltenv=saltenv)
     return ret
 
 
@@ -248,3 +249,22 @@ def sync_pillar(saltenv='base'):
         salt-run saltutil.sync_pillar
     '''
     return salt.utils.extmods.sync(__opts__, 'pillar', saltenv=saltenv)[0]
+
+
+def sync_tops(saltenv='base'):
+    '''
+    .. versionadded:: 2016.3.7,2016.11.4,Nitrogen
+
+    Sync master_tops modules from ``salt://_tops`` to the master
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run saltutil.sync_tops
+    '''
+    return salt.utils.extmods.sync(__opts__, 'tops', saltenv=saltenv)[0]


### PR DESCRIPTION
1. Explicitly state that master_tops only augments the top file, it does not replace it.
2. We have runner support for syncing to the master's extmods dir, so dispense with the examples telling people to manually set ``extension_modules`` and then place their custom type into that dir.
3. Add a runner function to the saltutil runner which syncs master_tops modules from ``salt://_tops``.

Refs: #37322.