### PR TITLE
Update mocking for unit.test_statemod tests

### DIFF
--- a/tests/unit/test_statemod.py
+++ b/tests/unit/test_statemod.py
@@ -10,7 +10,7 @@ import os.path
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON
+from tests.support.mock import MagicMock, NO_MOCK, NO_MOCK_REASON
 
 # Import Salt libs
 import tests.integration as integration
@@ -22,13 +22,15 @@ class StatemodTests(TestCase):
     def setUp(self):
         self.tmp_cachedir = tempfile.mkdtemp(dir=integration.TMP)
 
-    @patch('salt.states.saltmod.__salt__', MagicMock())
     def test_statemod_state(self):
-        ''' Smoke test for for salt.states.statemod.state().  Ensures that we
+        '''
+            Smoke test for for salt.states.statemod.state(). Ensures that we
             don't take an exception if optional parameters are not specified in
             __opts__ or __env__.
         '''
         argv = []
+        saltmod.__env__ = {}
+        saltmod.__salt__ = {'saltutil.cmd': MagicMock()}
         saltmod.__opts__ = {
             'id': 'webserver2',
             'argv': argv,


### PR DESCRIPTION
The way the `unit.test_statemod.StatemodTests.test_statemod_state` test was patched with the decorator throws an AttributeError with the following stacktrace:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/mock.py", line 1193, in patched
    arg = patching.__enter__()
  File "/usr/lib/python2.7/site-packages/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/usr/lib/python2.7/site-packages/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'salt.states.saltmod' from '/testing/salt/states/saltmod.pyc'> does not have the attribute '__salt__'
```

By setting some of the dunder dicts directly in the test, we can more accurately isolate the test and avoid hitting the attribute error.