### PR TITLE
Fix logic for __virtual__ in win_dsc and win_psget

### DIFF
--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import, unicode_literals
 import logging
 import json
 import os
-import distutils.version
 
 # Import salt libs
 import salt.utils
@@ -32,14 +31,14 @@ def __virtual__():
     if not salt.utils.is_windows():
         return False, 'Module DSC: Only available on Windows systems'
 
-    # Verify PowerShell 5.0
+    # Verify PowerShell
     powershell_info = __salt__['cmd.shell_info']('powershell')
     if not powershell_info['installed']:
-        return False, 'Module DSC: Powershell not available'
+        return False, 'Module DSC: Requires PowerShell'
 
-    if distutils.version.StrictVersion(powershell_info['version']) < \
-            distutils.version.StrictVersion('5.0'):
-        return False, 'Module DSC: Requires Powershell 5 or later'
+    # Verify PowerShell 5.0 or greater
+    if salt.utils.compare_versions(powershell_info['version'], '<', '5.0'):
+        return False, 'Module DSC: Requires PowerShell 5 or later'
 
     return __virtualname__
 

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -29,15 +29,18 @@ def __virtual__():
     '''
     # Verify Windows
     if not salt.utils.is_windows():
+        log.debug('Module DSC: Only available on Windows systems')
         return False, 'Module DSC: Only available on Windows systems'
 
     # Verify PowerShell
     powershell_info = __salt__['cmd.shell_info']('powershell')
     if not powershell_info['installed']:
+        log.debug('Module DSC: Requires PowerShell')
         return False, 'Module DSC: Requires PowerShell'
 
     # Verify PowerShell 5.0 or greater
     if salt.utils.compare_versions(powershell_info['version'], '<', '5.0'):
+        log.debug('Module DSC: Requires PowerShell 5 or later')
         return False, 'Module DSC: Requires PowerShell 5 or later'
 
     return __virtualname__

--- a/salt/modules/win_psget.py
+++ b/salt/modules/win_psget.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import, unicode_literals
 import copy
 import logging
 import json
-import distutils.version
 
 # Import salt libs
 import salt.utils
@@ -31,16 +30,18 @@ def __virtual__():
     '''
     Set the system module of the kernel is Windows
     '''
+    # Verify Windows
     if not salt.utils.is_windows():
-        return False, 'Module PSGet: Module only works on Windows systems'
+        return False, 'Module PSGet: Only available on Windows systems'
 
-    # Verify PowerShell 5.0
+    # Verify PowerShell
     powershell_info = __salt__['cmd.shell_info']('powershell')
-    if not powershell_info['installed'] or \
-            distutils.version.StrictVersion(
-                powershell_info['version']) >= distutils.version.StrictVersion('5.0'):
-        return False, 'Module DSC: Module only works with PowerShell 5 or ' \
-                      'newer.'
+    if not powershell_info['installed']:
+        return False, 'Module PSGet: Requires PowerShell'
+
+    # Verify PowerShell 5.0 or greater
+    if salt.utils.compare_versions(powershell_info['version'], '<', '5.0'):
+        return False, 'Module PSGet: Requires PowerShell 5 or newer.'
 
     return __virtualname__
 

--- a/salt/modules/win_psget.py
+++ b/salt/modules/win_psget.py
@@ -32,15 +32,18 @@ def __virtual__():
     '''
     # Verify Windows
     if not salt.utils.is_windows():
+        log.debug('Module PSGet: Only available on Windows systems')
         return False, 'Module PSGet: Only available on Windows systems'
 
     # Verify PowerShell
     powershell_info = __salt__['cmd.shell_info']('powershell')
     if not powershell_info['installed']:
+        log.debug('Module PSGet: Requires PowerShell')
         return False, 'Module PSGet: Requires PowerShell'
 
     # Verify PowerShell 5.0 or greater
     if salt.utils.compare_versions(powershell_info['version'], '<', '5.0'):
+        log.debug('Module PSGet: Requires PowerShell 5 or newer')
         return False, 'Module PSGet: Requires PowerShell 5 or newer.'
 
     return __virtualname__


### PR DESCRIPTION
### What does this PR do?
Uses `salt.utils.version_compare` instead of distutils to compare powershell versions.
Seperates out the check for PowerShell and the check for version 5.0 or greater
Fixes logic error for the `win_psget.py` module, it wasn't being loaded on PS5.

### What issues does this PR fix or reference?
Found while troubleshooting another issue.

### Tests written?
No