### PR TITLE
[develop] Merge forward from 2016.11 to develop

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -268,7 +268,7 @@ Upgrade without automatic restart
 *********************************
 
 Doing the Minion upgrade seems to be a simplest state in your SLS file at
-first. But the operating systems such as Debian GNU/Linux, Ununtu and their
+first. But the operating systems such as Debian GNU/Linux, Ubuntu and their
 derivatives start the service after the package installation by default.
 To prevent this, we need to create policy layer which will prevent the Minion
 service to restart right after the upgrade:

--- a/salt/template.py
+++ b/salt/template.py
@@ -88,7 +88,7 @@ def compile_template(template,
             try:
                 input_data.seek(0)
             except Exception as exp:
-                log.error('error: {0}'.format(exp))
+                log.error('error while compiling template={1}: {0}'.format(exp,template))
 
         render_kwargs = dict(renderers=renderers, tmplpath=template)
         render_kwargs.update(kwargs)

--- a/salt/template.py
+++ b/salt/template.py
@@ -88,7 +88,7 @@ def compile_template(template,
             try:
                 input_data.seek(0)
             except Exception as exp:
-                log.error('error while compiling template={1}: {0}'.format(exp,template))
+                log.error('error while compiling template \'{0}\': {1}'.format(template, exp))
 
         render_kwargs = dict(renderers=renderers, tmplpath=template)
         render_kwargs.update(kwargs)

--- a/tests/unit/modules/dockerng_test.py
+++ b/tests/unit/modules/dockerng_test.py
@@ -37,7 +37,11 @@ class DockerngTestCase(TestCase):
     Validate dockerng module
     '''
 
-    docker_version = dockerng_mod.docker.version_info
+    try:
+        docker_version = dockerng_mod.docker.version_info
+    except AttributeError:
+        docker_version = 0,
+
     client_args_mock = MagicMock(return_value={
         'create_container': [
             'image', 'command', 'hostname', 'user', 'detach', 'stdin_open',


### PR DESCRIPTION
Conflicts:
  - salt/template.py
  - tests/unit/modules/dockerng_test.py