### PR TITLE
Add vmware cloud tests

### DIFF
--- a/tests/integration/cloud/providers/test_vmware.py
+++ b/tests/integration/cloud/providers/test_vmware.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Megan Wilhite <mwilhite@saltstack.com>`
+'''
+
+# Import Python Libs
+import os
+import random
+import string
+
+# Import Salt Libs
+from salt.config import cloud_providers_config
+
+# Import Salt Testing LIbs
+import tests.integration as integration
+from tests.support.helpers import expensiveTest
+
+def __random_name(size=6):
+    '''
+    Generates a radom cloud instance name
+    '''
+    return 'CLOUD-TEST-' + ''.join(
+        random.choice(string.ascii_uppercase + string.digits)
+        for x in range(size)
+    )
+
+# Create the cloud instance name to be used throughout the tests
+INSTANCE_NAME = __random_name()
+PROVIDER_NAME = 'vmware'
+
+class VMWareTest(integration.ShellCase):
+    '''
+    Integration tests for the vmware cloud provider in Salt-Cloud
+    '''
+
+    @expensiveTest
+    def setUp(self):
+        '''
+        Sets up the test requirements
+        '''
+     #   super(EC2Test, self).setUp()
+
+        # check if appropriate cloud provider and profile files are present
+        profile_str = 'vmware-config'
+        providers = self.run_cloud('--list-providers')
+
+        if profile_str + ':' not in providers:
+            self.skipTest(
+                'Configuration file for {0} was not found. Check {0}.conf files '
+                'in tests/integration/files/conf/cloud.*.d/ to run these tests.'
+                .format(PROVIDER_NAME)
+            )
+
+        # check if id, key, keyname, securitygroup, private_key, location,
+        # and provider are present
+        config = cloud_providers_config(
+            os.path.join(
+                integration.FILES,
+                'conf',
+                'cloud.providers.d',
+                PROVIDER_NAME + '.conf'
+            )
+        )
+
+        user = config[profile_str][PROVIDER_NAME]['user']
+        password = config[profile_str][PROVIDER_NAME]['password']
+        url = config[profile_str][PROVIDER_NAME]['url']
+
+        conf_items = [user, password, url]
+        missing_conf_item = []
+
+        for item in conf_items:
+            if item == '':
+                missing_conf_item.append(item)
+
+        if missing_conf_item:
+            self.skipTest(
+                'A user, password, and url must be provided to run these tests.'
+                'One or more of these elements is missing. Check'
+                'tests/integration/files/conf/cloud.providers.d/{0}.conf'
+                .format(PROVIDER_NAME)
+            )
+
+    def test_instance(self):
+        '''
+        Tests creating and deleting an instance on vmware
+        '''
+        # create the instance
+        instance = self.run_cloud('-p vmware-test {0}'.format(INSTANCE_NAME), timeout=500)
+        ret_str = '{0}:'.format(INSTANCE_NAME)
+
+        # check if instance returned with salt installed
+        try:
+            self.assertIn(ret_str, instance)
+        except AssertionError:
+            self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
+            raise
+
+        # delete the instance
+        delete = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
+        ret_str = '                    shutting-down'
+
+        # check if deletion was performed appropriately
+        try:
+            self.assertIn(ret_str, delete)
+        except AssertionError:
+            raise

--- a/tests/integration/cloud/providers/test_vmware.py
+++ b/tests/integration/cloud/providers/test_vmware.py
@@ -104,10 +104,7 @@ class VMWareTest(integration.ShellCase):
         ret_str = '{0}:\', \'            True'.format(INSTANCE_NAME)
 
         # check if deletion was performed appropriately
-        try:
-            self.assertIn(ret_str, str(delete))
-        except AssertionError:
-            raise
+        self.assertIn(ret_str, str(delete))
 
     def test_snapshot(self):
         '''
@@ -137,10 +134,7 @@ class VMWareTest(integration.ShellCase):
         delete = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=TIMEOUT)
         ret_str = '{0}:\', \'            True'.format(INSTANCE_NAME)
 
-        try:
-            self.assertIn(ret_str, str(delete))
-        except AssertionError:
-            raise
+        self.assertIn(ret_str, str(delete))
 
     def tearDown(self):
         '''

--- a/tests/integration/cloud/providers/test_vmware.py
+++ b/tests/integration/cloud/providers/test_vmware.py
@@ -4,6 +4,7 @@
 '''
 
 # Import Python Libs
+from __future__ import absolute_import
 import os
 import random
 import string
@@ -14,6 +15,8 @@ from salt.config import cloud_providers_config
 # Import Salt Testing LIbs
 import tests.integration as integration
 from tests.support.helpers import expensiveTest
+from salt.ext.six.moves import range
+
 
 def __random_name(size=6):
     '''
@@ -28,6 +31,7 @@ def __random_name(size=6):
 INSTANCE_NAME = __random_name()
 PROVIDER_NAME = 'vmware'
 TIMEOUT = 500
+
 
 class VMWareTest(integration.ShellCase):
     '''
@@ -82,7 +86,7 @@ class VMWareTest(integration.ShellCase):
 
     def test_instance(self):
         '''
-        Tests creating and deleting an instance on vmware
+        Tests creating and deleting an instance on vmware and installing salt
         '''
         # create the instance
         instance = self.run_cloud('-p vmware-test {0}'.format(INSTANCE_NAME), timeout=TIMEOUT)
@@ -107,7 +111,7 @@ class VMWareTest(integration.ShellCase):
 
     def test_snapshot(self):
         '''
-        Tests creating and deleting an instance on vmware
+        Tests creating snapshot and creating vm with --no-deploy
         '''
         # create the instance
         instance = self.run_cloud('-p vmware-test {0} --no-deploy'.format(INSTANCE_NAME),
@@ -121,18 +125,22 @@ class VMWareTest(integration.ShellCase):
             self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=TIMEOUT)
             raise
 
-        create_snapshot = self.run_cloud('-a create_snapshot {0} snapshot_name=\'Test Cloud\' memdump=True'.format(INSTANCE_NAME),
+        create_snapshot = self.run_cloud('-a create_snapshot {0} \
+                                         snapshot_name=\'Test Cloud\' \
+                                         memdump=True -y'.format(INSTANCE_NAME),
                                          timeout=TIMEOUT)
+        s_ret_str = 'Snapshot created successfully'
+
+        self.assertIn(s_ret_str, str(create_snapshot))
 
         # delete the instance
         delete = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=TIMEOUT)
         ret_str = '{0}:\', \'            True'.format(INSTANCE_NAME)
 
         try:
-            self.assertIn(ret_str, delete)
+            self.assertIn(ret_str, str(delete))
         except AssertionError:
             raise
-
 
     def tearDown(self):
         '''

--- a/tests/integration/files/conf/cloud.profiles.d/vmware.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/vmware.conf
@@ -7,16 +7,10 @@ vmware-test:
     disk:
       Hard disk 1:
         size: 30
-    network:
-      Network adapter 1:
-        name: ''
-        adapter_type: e1000
-        switch_type: standard
-        ip: 192.168.0.5
-        gateway: [192.168.0.1]
-        subnet_mask: 255.255.255.0
-        domain: ''
+        datastore: ''
   resourcepool: ''
   datastore: ''
   datacenter: ''
   host: ''
+  ssh_username: ''
+  password: ''

--- a/tests/integration/files/conf/cloud.profiles.d/vmware.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/vmware.conf
@@ -1,0 +1,22 @@
+vmware-test:
+  provider: vmware-config
+  clonefrom: ''
+  num_cpus: 1
+  memory: 2GB
+  devices:
+    disk:
+      Hard disk 1:
+        size: 30
+    network:
+      Network adapter 1:
+        name: ''
+        adapter_type: e1000
+        switch_type: standard
+        ip: 192.168.0.5
+        gateway: [192.168.0.1]
+        subnet_mask: 255.255.255.0
+        domain: ''
+  resourcepool: ''
+  datastore: ''
+  datacenter: ''
+  host: ''

--- a/tests/integration/files/conf/cloud.providers.d/vmware.conf
+++ b/tests/integration/files/conf/cloud.providers.d/vmware.conf
@@ -1,0 +1,7 @@
+vmware-config:
+  driver: vmware
+  user: ''
+  password: ''
+  url: ''
+  protocol: 'https'
+  port: 443


### PR DESCRIPTION
### What does this PR do?
Add integration test for vmware cloud driver. This adds two tests:

   - create VM with salt installed
   - create VM with --no-deploy and create snapshot (note: this is currently broken as documented in https://github.com/saltstack/salt/issues/40439 , so will need to get that fixed before this test runs properly. Just need community input)

### Tests written?

Yes
