### PR TITLE
allow file_client to figure out cachedir

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -184,10 +184,10 @@ def prep_trans_tar(opts, file_client, chunks, file_refs, pillar=None, id_=None):
     if id_ is None:
         id_ = ''
     try:
-        cachedir = os.path.join(opts['cachedir'], 'salt-ssh', id_).rstrip(os.sep)
+        cachedir = os.path.join('salt-ssh', id_).rstrip(os.sep)
     except AttributeError:
         # Minion ID should always be a str, but don't let an int break this
-        cachedir = os.path.join(opts['cachedir'], 'salt-ssh', str(id_)).rstrip(os.sep)
+        cachedir = os.path.join('salt-ssh', str(id_)).rstrip(os.sep)
 
     for saltenv in file_refs:
         # Location where files in this saltenv will be cached


### PR DESCRIPTION
### What does this PR do?
We do not need to specify the entire path here.  _cache_loc in salt.fileclient
will do that for us.  If we specify cachedir here, it will use the
/var/tmp/*/running_data/var/cache path which we do not want to use when on the
master.

This is intelligent enough to use the /var/tmp path on the minion and a
/var/cache/salt/master type path on the master.

### What issues does this PR fix or reference?

Fixes #38458

### Tests written?

No