### PR TITLE
prepend ssh_log_file with root_dir

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3318,7 +3318,7 @@ def apply_master_config(overrides=None, defaults=None):
     ]
 
     # These can be set to syslog, so, not actual paths on the system
-    for config_key in ('log_file', 'key_logfile'):
+    for config_key in ('log_file', 'key_logfile', 'ssh_log_file'):
         log_setting = opts.get(config_key, '')
         if log_setting is None:
             continue


### PR DESCRIPTION
### What does this PR do?
Prepend ssh_log_file with the root_dir so that it doesn't use /var/log/salt/ssh

### Tests written?

No