### PR TITLE
Added the ability to manage Zabbix usergroup permissions

### DIFF
--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -726,11 +726,17 @@ def usergroup_get(name=None, usrgrpids=None, userids=None, **connection_args):
         salt '*' zabbix.usergroup_get Guests
     '''
     conn_args = _login(**connection_args)
+    zabbix_version = apiinfo_version(**connection_args)
     ret = False
     try:
         if conn_args:
             method = 'usergroup.get'
-            params = {"output": "extend", "filter": {}}
+            # Versions above 2.4 allow retrieving user group permissions
+            if _LooseVersion(zabbix_version) > _LooseVersion("2.5"):
+                #params = {"selectRights": "extend", "output": "extend", "filter": {}}
+                params = {"output": "extend", "filter": {}}
+            else:
+                params = {"output": "extend", "filter": {}}
             if not name and not usrgrpids and not userids:
                 return False
             if name:

--- a/salt/states/zabbix_usergroup.py
+++ b/salt/states/zabbix_usergroup.py
@@ -22,7 +22,7 @@ def present(name, **kwargs):
     https://www.zabbix.com/documentation/2.0/manual/appendix/api/usergroup/definitions#user_group
 
     .. versionadded:: 2016.3.0
-
+    
     :param name: name of the user group
     :param _connection_user: Optional - zabbix user (can also be set in opts or pillar, see module's docstring)
     :param _connection_password: Optional - zabbix password (can also be set in opts or pillar, see module's docstring)
@@ -66,6 +66,7 @@ def present(name, **kwargs):
         update_debug_mode = False
         update_gui_access = False
         update_users_status = False
+        update_rights = False
 
         if 'debug_mode' in kwargs:
             if int(kwargs['debug_mode']) != int(usergroup['debug_mode']):
@@ -75,6 +76,22 @@ def present(name, **kwargs):
             if int(kwargs['gui_access']) != int(usergroup['gui_access']):
                 update_gui_access = True
 
+        if 'rights' in kwargs:
+            # Older versions of Zabbix do not return the list of rights for the user group, handle this gracefully 
+            try:
+                if usergroup['rights']:
+                    # Make sure right values are strings so we can compare them with the current user group rights 
+                    for right in kwargs['rights']:
+                        for key in right:
+                            right[key] = str(right[key])
+                    if cmp(sorted(kwargs['rights']), sorted(usergroup['rights'])) != 0:
+                        update_rights = True
+                else:
+                    update_rights = True
+            except KeyError:
+                # As we don't know the current permissions, overwrite them as provided in the state.
+                update_rights = True
+
         if 'users_status' in kwargs:
             if int(kwargs['users_status']) != int(usergroup['users_status']):
                 update_users_status = True
@@ -82,7 +99,7 @@ def present(name, **kwargs):
     # Dry run, test=true mode
     if __opts__['test']:
         if usergroup_exists:
-            if update_debug_mode or update_gui_access or update_users_status:
+            if update_debug_mode or update_gui_access or update_rights or update_users_status:
                 ret['result'] = None
                 ret['comment'] = comment_usergroup_updated
             else:
@@ -96,7 +113,7 @@ def present(name, **kwargs):
     error = []
 
     if usergroup_exists:
-        if update_debug_mode or update_gui_access or update_users_status:
+        if update_debug_mode or update_gui_access or update_rights or update_users_status:
             ret['result'] = True
             ret['comment'] = comment_usergroup_updated
 
@@ -117,6 +134,15 @@ def present(name, **kwargs):
                     error.append(updated_gui['error'])
                 else:
                     ret['changes']['gui_access'] = kwargs['gui_access']
+
+            if update_rights:
+                updated_rights = __salt__['zabbix.usergroup_update'](usrgrpid,
+                                                                     rights=kwargs['rights'],
+                                                                     **connection_args)
+                if 'error' in updated_rights:
+                    error.append(updated_rights['error'])
+                else:
+                    ret['changes']['rights'] = kwargs['rights']
 
             if update_users_status:
                 updated_status = __salt__['zabbix.usergroup_update'](usrgrpid,


### PR DESCRIPTION
### What does this PR do?
Zabbix 3.0.0 and newer have the ability to list user group permissions via the usergroup.get method.
Using this, we can detect if user group permissions should be updated while applying a state.

This PR adds the ability to manage Zabbix user group permissions via the rights attributes.

### What issues does this PR fix or reference?
None

### Previous Behavior
User group rights were only setup during user group creation and changes in the state files would not be propagated.

### New Behavior
User group rights are compared to the desired state and updated if needed.

### Tests written?
No
