### PR TITLE
Minion:Salt master can be a list or a string

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -356,7 +356,8 @@ def eval_master_func(opts):
                 raise KeyError
             # we take whatever the module returns as master address
             opts['master'] = master_mod[mod_fun]()
-            if not isinstance(opts['master'], str):
+            # Check for valid types
+            if not isinstance(opts['master'], (str, list)):
                 raise TypeError
             opts['__master_func_evaluated'] = True
         except KeyError:


### PR DESCRIPTION
When you configure the salt minion you can set a single salt master, or a list
of salt masters. When using a function to provide the salt master it should not
be any different.

Signed-off-by: Owen Synge <osynge@googlemail.com>

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
