### PR TITLE
Update verify.py

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -486,7 +486,7 @@ def valid_id(opts, id_):
     '''
     try:
         return bool(clean_path(opts['pki_dir'], id_))
-    except (AttributeError, KeyError) as e:
+    except (AttributeError, KeyError, TypeError) as e:
         return False
 
 


### PR DESCRIPTION
### What does this PR do?
Returns false if id_ fails due to TypeError

### What issues does this PR fix or reference?
#40366
#40394 

### Previous Behavior
Hosts with null character in name would cause TypeError to be thrown, preventing minion from executing states

### New Behavior
Hosts with null character in name will be identified as having an invalid host ID

### Tests written?
No
This should not impact existing implementations.  If an ID throws a TypeError, it should be recognized as invalid.