### PR TITLE
Fix orch state when no minions return

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -296,6 +296,11 @@ def state(name,
         )
         fail_minions = ()
 
+    if not cmd_ret and expect_minions:
+        state_ret['result'] = False
+        state_ret['comment'] = 'No minions returned'
+        return state_ret
+
     for minion, mdata in six.iteritems(cmd_ret):
         if mdata.get('out', '') != 'highstate':
             log.warning('Output from salt state not highstate')

--- a/tests/unit/states/test_saltmod.py
+++ b/tests/unit/states/test_saltmod.py
@@ -81,9 +81,9 @@ class SaltmodTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(saltmod.__opts__, {'test': True}):
             self.assertDictEqual(saltmod.state(name, tgt, highstate=True), test_ret)
 
-        ret.update({'comment': 'States ran successfully.', 'result': True})
+        ret.update({'comment': 'States ran successfully. No changes made to silver.', 'result': True, '__jid__': '20170406104341210934'})
         with patch.dict(saltmod.__opts__, {'test': False}):
-            mock = MagicMock(return_value={})
+            mock = MagicMock(return_value={'silver': {'jid': '20170406104341210934', 'retcode': 0, 'ret': {'test_|-notify_me_|-this is a name_|-show_notification': {'comment': 'Notify me', 'name': 'this is a name', 'start_time': '10:43:41.487565', 'result': True, 'duration': 0.35, '__run_num__': 0, '__sls__': 'demo', 'changes': {}, '__id__': 'notify_me'}}, 'out': 'highstate'}})
             with patch.dict(saltmod.__salt__, {'saltutil.cmd': mock}):
                 self.assertDictEqual(saltmod.state(name, tgt, highstate=True),
                                      ret)


### PR DESCRIPTION
If we expect minions but no minions return, we should fail the state
