### PR TITLE
salt-cloud: Do not pass userdata_file through yaml renderer

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1351,21 +1351,22 @@ The renderer to use on the minions to render the state data.
 
     renderer: yaml_jinja
 
-.. conf_master:: userdata_renderer
+.. conf_master:: userdata_template
 
-``userdata_renderer``
+``userdata_template``
 ---------------------
 
 .. versionadded:: 2016.11.4
 
-Default: ``jinja``
+Default: ``None``
 
 The renderer to use for templating userdata files in salt-cloud, if the
-``userdata_renderer`` is not set in the cloud profile.
+``userdata_template`` is not set in the cloud profile. If no value is set in
+the cloud profile or master config file, no templating will be performed.
 
 .. code-block:: yaml
 
-    userdata_renderer: jinja
+    userdata_template: jinja
 
 .. conf_master:: jinja_trim_blocks
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1351,6 +1351,22 @@ The renderer to use on the minions to render the state data.
 
     renderer: yaml_jinja
 
+.. conf_master:: userdata_renderer
+
+``userdata_renderer``
+---------------------
+
+.. versionadded:: 2016.11.4
+
+Default: ``jinja``
+
+The renderer to use for templating userdata files in salt-cloud, if the
+``userdata_renderer`` is not set in the cloud profile.
+
+.. code-block:: yaml
+
+    userdata_renderer: jinja
+
 .. conf_master:: jinja_trim_blocks
 
 ``jinja_trim_blocks``

--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -354,6 +354,13 @@ functionality was added to Salt in the 2015.5.0 release.
       # Pass userdata to the instance to be created
       userdata_file: /etc/salt/my-userdata-file
 
+.. note::
+    As of the 2016.11.0 release, this file can be templated, and as of the
+    2016.11.4 release, the renderer(s) used can be specified in the cloud
+    profile using the ``userdata_renderer`` option. If this option is not set
+    in the cloud profile, salt-cloud will fall back to the
+    :conf_master:`userdata_renderer` master configuration option.
+
 
 EC2 allows a location to be set for servers to be deployed in. Availability
 zones exist inside regions, and may be added to increase specificity.

--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -373,6 +373,16 @@ functionality was added to Salt in the 2015.5.0 release.
     If this is not set, then no templating will be performed on the
     userdata_file.
 
+    To disable templating in a cloud profile when a
+    :conf_master:`userdata_template` has been set in the master configuration
+    file, simply set ``userdata_template`` to ``False`` in the cloud profile:
+
+    .. code-block:: yaml
+
+        my-ec2-config:
+          # Pass userdata to the instance to be created
+          userdata_file: /etc/salt/my-userdata-file
+          userdata_template: False
 
 EC2 allows a location to be set for servers to be deployed in. Availability
 zones exist inside regions, and may be added to increase specificity.

--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -355,11 +355,23 @@ functionality was added to Salt in the 2015.5.0 release.
       userdata_file: /etc/salt/my-userdata-file
 
 .. note::
-    As of the 2016.11.0 release, this file can be templated, and as of the
-    2016.11.4 release, the renderer(s) used can be specified in the cloud
-    profile using the ``userdata_renderer`` option. If this option is not set
-    in the cloud profile, salt-cloud will fall back to the
-    :conf_master:`userdata_renderer` master configuration option.
+    From versions 2016.11.0 and 2016.11.3, this file was passed through the
+    master's :conf_master:`renderer` to template it. However, this caused
+    issues with non-YAML data, so templating is no longer performed by default.
+    To template the userdata_file, add a ``userdata_template`` option to the
+    cloud profile:
+
+    .. code-block:: yaml
+
+        my-ec2-config:
+          # Pass userdata to the instance to be created
+          userdata_file: /etc/salt/my-userdata-file
+          userdata_template: jinja
+
+    If no ``userdata_template`` is set in the cloud profile, then the master
+    configuration will be checked for a :conf_master:`userdata_template` value.
+    If this is not set, then no templating will be performed on the
+    userdata_file.
 
 
 EC2 allows a location to be set for servers to be deployed in. Availability

--- a/doc/topics/cloud/openstack.rst
+++ b/doc/topics/cloud/openstack.rst
@@ -156,8 +156,8 @@ cloud-init if available.
     userdata_file: /etc/salt/cloud-init/packages.yml
 
 .. note::
-    As of the 2016.11.0 release, this file can be templated, and as of the
-    2016.11.4 release, the renderer(s) used can be specified in the cloud
-    profile using the ``userdata_renderer`` option. If this option is not set
-    in the cloud profile, salt-cloud will fall back to the
-    :conf_master:`userdata_renderer` master configuration option.
+    As of the 2016.11.4 release, this file can be templated. The renderer(s)
+    used can be specified in the cloud profile using the ``userdata_renderer``
+    option. If this option is not set in the cloud profile, salt-cloud will
+    fall back to the :conf_master:`userdata_renderer` master configuration
+    option.

--- a/doc/topics/cloud/openstack.rst
+++ b/doc/topics/cloud/openstack.rst
@@ -153,11 +153,22 @@ cloud-init if available.
 
 .. code-block:: yaml
 
-    userdata_file: /etc/salt/cloud-init/packages.yml
+    my-openstack-config:
+      # Pass userdata to the instance to be created
+      userdata_file: /etc/salt/cloud-init/packages.yml
 
 .. note::
-    As of the 2016.11.4 release, this file can be templated. The renderer(s)
-    used can be specified in the cloud profile using the ``userdata_renderer``
-    option. If this option is not set in the cloud profile, salt-cloud will
-    fall back to the :conf_master:`userdata_renderer` master configuration
-    option.
+    As of the 2016.11.4 release, this file can be templated. To use templating,
+    simply specify a ``userdata_template`` option in the cloud profile:
+
+    .. code-block:: yaml
+
+        my-openstack-config:
+          # Pass userdata to the instance to be created
+          userdata_file: /etc/salt/cloud-init/packages.yml
+          userdata_template: jinja
+
+    If no ``userdata_template`` is set in the cloud profile, then the master
+    configuration will be checked for a :conf_master:`userdata_template` value.
+    If this is not set, then no templating will be performed on the
+    userdata_file.

--- a/doc/topics/cloud/openstack.rst
+++ b/doc/topics/cloud/openstack.rst
@@ -154,3 +154,10 @@ cloud-init if available.
 .. code-block:: yaml
 
     userdata_file: /etc/salt/cloud-init/packages.yml
+
+.. note::
+    As of the 2016.11.0 release, this file can be templated, and as of the
+    2016.11.4 release, the renderer(s) used can be specified in the cloud
+    profile using the ``userdata_renderer`` option. If this option is not set
+    in the cloud profile, salt-cloud will fall back to the
+    :conf_master:`userdata_renderer` master configuration option.

--- a/doc/topics/cloud/openstack.rst
+++ b/doc/topics/cloud/openstack.rst
@@ -172,3 +172,14 @@ cloud-init if available.
     configuration will be checked for a :conf_master:`userdata_template` value.
     If this is not set, then no templating will be performed on the
     userdata_file.
+
+    To disable templating in a cloud profile when a
+    :conf_master:`userdata_template` has been set in the master configuration
+    file, simply set ``userdata_template`` to ``False`` in the cloud profile:
+
+    .. code-block:: yaml
+
+        my-openstack-config:
+          # Pass userdata to the instance to be created
+          userdata_file: /etc/salt/cloud-init/packages.yml
+          userdata_template: False

--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -73,14 +73,28 @@ profile configuration as `userdata_file`. For instance:
 
 .. code-block:: yaml
 
-    userdata_file: /etc/salt/windows-firewall.ps1
+    my-ec2-config:
+      # Pass userdata to the instance to be created
+      userdata_file: /etc/salt/windows-firewall.ps1
 
 .. note::
-    As of the 2016.11.0 release, this file can be templated, and as of the
-    2016.11.4 release, the renderer(s) used can be specified in the cloud
-    profile using the ``userdata_renderer`` option. If this option is not set
-    in the cloud profile, salt-cloud will fall back to the
-    :conf_master:`userdata_renderer` master configuration option.
+    From versions 2016.11.0 and 2016.11.3, this file was passed through the
+    master's :conf_master:`renderer` to template it. However, this caused
+    issues with non-YAML data, so templating is no longer performed by default.
+    To template the userdata_file, add a ``userdata_template`` option to the
+    cloud profile:
+
+    .. code-block:: yaml
+
+        my-ec2-config:
+          # Pass userdata to the instance to be created
+          userdata_file: /etc/salt/windows-firewall.ps1
+          userdata_template: jinja
+
+    If no ``userdata_template`` is set in the cloud profile, then the master
+    configuration will be checked for a :conf_master:`userdata_template` value.
+    If this is not set, then no templating will be performed on the
+    userdata_file.
 
 
 If you are using WinRM on EC2 the HTTPS port for the WinRM service must also be

--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -75,10 +75,18 @@ profile configuration as `userdata_file`. For instance:
 
     userdata_file: /etc/salt/windows-firewall.ps1
 
-If you are using WinRM on EC2 the HTTPS port for the WinRM service must also be enabled
-in your userdata. By default EC2 Windows images only have insecure HTTP enabled. To
-enable HTTPS and basic authentication required by pywinrm consider the following
-userdata example:
+.. note::
+    As of the 2016.11.0 release, this file can be templated, and as of the
+    2016.11.4 release, the renderer(s) used can be specified in the cloud
+    profile using the ``userdata_renderer`` option. If this option is not set
+    in the cloud profile, salt-cloud will fall back to the
+    :conf_master:`userdata_renderer` master configuration option.
+
+
+If you are using WinRM on EC2 the HTTPS port for the WinRM service must also be
+enabled in your userdata. By default EC2 Windows images only have insecure HTTP
+enabled. To enable HTTPS and basic authentication required by pywinrm consider
+the following userdata example:
 
 .. code-block:: powershell
 

--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -96,6 +96,17 @@ profile configuration as `userdata_file`. For instance:
     If this is not set, then no templating will be performed on the
     userdata_file.
 
+    To disable templating in a cloud profile when a
+    :conf_master:`userdata_template` has been set in the master configuration
+    file, simply set ``userdata_template`` to ``False`` in the cloud profile:
+
+    .. code-block:: yaml
+
+        my-ec2-config:
+          # Pass userdata to the instance to be created
+          userdata_file: /etc/salt/windows-firewall.ps1
+          userdata_template: False
+
 
 If you are using WinRM on EC2 the HTTPS port for the WinRM service must also be
 enabled in your userdata. By default EC2 Windows images only have insecure HTTP

--- a/doc/topics/releases/2016.11.4.rst
+++ b/doc/topics/releases/2016.11.4.rst
@@ -32,14 +32,27 @@ templating, followed by loading the data as a YAML dictionary, this results in
 unpredictable results when userdata files are comprised of non-YAML data (which
 they generally are).
 
-2016.11.4 fixes this by setting the default renderer used to template userdata
-files to ``jinja``, and adding a new cloud profile config parameter called
-``userdata_renderer``. If this option is not set, then salt-cloud will fall
-back to using the new master configuration parameter
-:conf_master:`userdata_renderer`.
+2016.11.4 fixes this by only templating the userdata_file when it is explicitly
+configured to do so. This is done by adding a new optional parameter to the
+cloud profile called ``userdata_template``. This option is used in the same way
+as the ``template`` argument in :py:func:`file.managed
+<salt.states.file.managed>` states, it is simply set to the desired templating
+renderer:
+
+.. code-block:: yaml
+
+    my-ec2-config:
+      # Pass userdata to the instance to be created
+      userdata_file: /etc/salt/my-userdata-file
+      userdata_template: jinja
+
+If no ``userdata_template``  option is set in the cloud profile, then
+salt-cloud will check for the presence of the master configuration parameter
+:conf_master:`userdata_renderer`. If this is also not set, then no templating
+will be performed on the userdata_file.
 
 In addition, the other cloud drivers which support setting a ``userdata_file``
 (:mod:`azurearm <salt.cloud.clouds.azurearm>`, :mod:`nova
 <salt.cloud.clouds.nova>`, and :mod:`openstack <salt.cloud.clouds.openstack>`)
-have had templating support added to bring them to feature parity with ec2's
-implementation of the ``userdata_file`` param.
+have had templating support added to bring them to feature parity with the ec2
+driver's implementation of the ``userdata_file`` option.

--- a/doc/topics/releases/2016.11.4.rst
+++ b/doc/topics/releases/2016.11.4.rst
@@ -21,3 +21,25 @@ makes cache operations faster. It doesn't make much sence for the ``localfs``
 cache driver but helps for more complex drivers like ``consul``.
 For more details see ``memcache_expire_seconds`` and other ``memcache_*``
 options in the master config reverence.
+
+Salt-Cloud Fixes
+================
+
+2016.11.0 added support for templating userdata files for the :mod:`ec2
+<salt.cloud.clouds.ec2>` driver, using the :conf_master:`renderer` option from
+the master config file. However, as the default renderer first evaluates jinja
+templating, followed by loading the data as a YAML dictionary, this results in
+unpredictable results when userdata files are comprised of non-YAML data (which
+they generally are).
+
+2016.11.4 fixes this by setting the default renderer used to template userdata
+files to ``jinja``, and adding a new cloud profile config parameter called
+``userdata_renderer``. If this option is not set, then salt-cloud will fall
+back to using the new master configuration parameter
+:conf_master:`userdata_renderer`.
+
+In addition, the other cloud drivers which support setting a ``userdata_file``
+(:mod:`azurearm <salt.cloud.clouds.azurearm>`, :mod:`nova
+<salt.cloud.clouds.nova>`, and :mod:`openstack <salt.cloud.clouds.openstack>`)
+have had templating support added to bring them to feature parity with ec2's
+implementation of the ``userdata_file`` param.

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -905,7 +905,15 @@ def request_instance(call=None, kwargs=None):  # pylint: disable=unused-argument
                 input_data=userdata,
             )
 
-        os_kwargs['custom_data'] = base64.b64encode(userdata)
+        try:
+            # template renderers like "jinja" should return a StringIO
+            os_kwargs['custom_data'] = \
+                ''.join(base64.b64encode(userdata).readlines())
+        except AttributeError:
+            try:
+                os_kwargs['custom_data'] = base64.b64encode(userdata)
+            except Exception as exc:
+                log.exception('Failed to encode userdata: %s')
 
     iface_data = create_interface(kwargs=vm_)
     vm_['iface_id'] = iface_data['id']

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -872,8 +872,8 @@ def request_instance(call=None, kwargs=None):  # pylint: disable=unused-argument
     userdata_file = config.get_cloud_config_value(
         'userdata_file', vm_, __opts__, search_global=False, default=None
     )
-    userdata_renderer = config.get_cloud_config_value(
-        'userdata_renderer', vm_, __opts__, search_global=False, default=None
+    userdata_template = config.get_cloud_config_value(
+        'userdata_template', vm_, __opts__, search_global=False, default=None
     )
     if userdata_file is None:
         userdata = config.get_cloud_config_value(
@@ -885,19 +885,25 @@ def request_instance(call=None, kwargs=None):  # pylint: disable=unused-argument
                 userdata = fh_.read()
 
     if userdata is not None:
-        render_opts = __opts__.copy()
-        render_opts.update(vm_)
-        # Use the cloud profile's userdata_renderer, otherwise get it from the
+        # Use the cloud profile's userdata_template, otherwise get it from the
         # master configuration file.
-        renderer = __opts__.get('userdata_renderer', 'jinja') \
-            if userdata_renderer is None
-            else userdata_renderer
-        rend = salt.loader.render(render_opts, {})
-        blacklist = __opts__['renderer_blacklist']
-        whitelist = __opts__['renderer_whitelist']
-        userdata = compile_template(
-            ':string:', rend, renderer, blacklist, whitelist, input_data=userdata,
-        )
+        renderer = __opts__.get('userdata_template') \
+            if userdata_template is None
+            else userdata_template
+        if renderer is not None:
+            render_opts = __opts__.copy()
+            render_opts.update(vm_)
+            rend = salt.loader.render(render_opts, {})
+            blacklist = __opts__['renderer_blacklist']
+            whitelist = __opts__['renderer_whitelist']
+            userdata = compile_template(
+                ':string:',
+                rend,
+                renderer,
+                blacklist,
+                whitelist,
+                input_data=userdata,
+            )
 
         os_kwargs['custom_data'] = base64.b64encode(userdata)
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -93,8 +93,6 @@ import salt.utils
 from salt._compat import ElementTree as ET
 import salt.utils.http as http
 import salt.utils.aws as aws
-import salt.loader
-from salt.template import compile_template
 
 # Import salt.cloud libs
 import salt.utils.cloud
@@ -1681,9 +1679,6 @@ def request_instance(vm_=None, call=None):
     userdata_file = config.get_cloud_config_value(
         'userdata_file', vm_, __opts__, search_global=False, default=None
     )
-    userdata_template = config.get_cloud_config_value(
-        'userdata_template', vm_, __opts__, search_global=False, default=None
-    )
     if userdata_file is None:
         userdata = config.get_cloud_config_value(
             'userdata', vm_, __opts__, search_global=False, default=None
@@ -1694,36 +1689,13 @@ def request_instance(vm_=None, call=None):
             with salt.utils.fopen(userdata_file, 'r') as fh_:
                 userdata = fh_.read()
 
-    if userdata is not None:
-        # Use the cloud profile's userdata_template, otherwise get it from the
-        # master configuration file.
-        renderer = __opts__.get('userdata_template') \
-            if userdata_template is None
-            else userdata_template
-        if renderer is not None:
-            render_opts = __opts__.copy()
-            render_opts.update(vm_)
-            rend = salt.loader.render(render_opts, {})
-            blacklist = __opts__['renderer_blacklist']
-            whitelist = __opts__['renderer_whitelist']
-            userdata = compile_template(
-                ':string:',
-                rend,
-                renderer,
-                blacklist,
-                whitelist,
-                input_data=userdata,
-            )
+    userdata = salt.utils.cloud.userdata_template(__opts__, vm_, userdata)
 
+    if userdata is not None:
         try:
-            # template renderers like "jinja" should return a StringIO
-            params[spot_prefix + 'UserData'] = \
-                ''.join(base64.b64encode(userdata).readlines())
-        except AttributeError:
-            try:
-                params[spot_prefix + 'UserData'] = base64.b64encode(userdata)
-            except Exception as exc:
-                log.exception('Failed to encode userdata: %s')
+            params[spot_prefix + 'UserData'] = base64.b64encode(userdata)
+        except Exception as exc:
+            log.exception('Failed to encode userdata: %s', exc)
 
     vm_size = config.get_cloud_config_value(
         'size', vm_, __opts__, search_global=False

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1681,6 +1681,9 @@ def request_instance(vm_=None, call=None):
     userdata_file = config.get_cloud_config_value(
         'userdata_file', vm_, __opts__, search_global=False, default=None
     )
+    userdata_renderer = config.get_cloud_config_value(
+        'userdata_renderer', vm_, __opts__, search_global=False, default=None
+    )
     if userdata_file is None:
         userdata = config.get_cloud_config_value(
             'userdata', vm_, __opts__, search_global=False, default=None
@@ -1694,7 +1697,11 @@ def request_instance(vm_=None, call=None):
     if userdata is not None:
         render_opts = __opts__.copy()
         render_opts.update(vm_)
-        renderer = __opts__.get('renderer', 'yaml_jinja')
+        # Use the cloud profile's userdata_renderer, otherwise get it from the
+        # master configuration file.
+        renderer = __opts__.get('userdata_renderer', 'jinja') \
+            if userdata_renderer is None
+            else userdata_renderer
         rend = salt.loader.render(render_opts, {})
         blacklist = __opts__['renderer_blacklist']
         whitelist = __opts__['renderer_whitelist']

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1715,7 +1715,15 @@ def request_instance(vm_=None, call=None):
                 input_data=userdata,
             )
 
-        params[spot_prefix + 'UserData'] = base64.b64encode(userdata)
+        try:
+            # template renderers like "jinja" should return a StringIO
+            params[spot_prefix + 'UserData'] = \
+                ''.join(base64.b64encode(userdata).readlines())
+        except AttributeError:
+            try:
+                params[spot_prefix + 'UserData'] = base64.b64encode(userdata)
+            except Exception as exc:
+                log.exception('Failed to encode userdata: %s')
 
     vm_size = config.get_cloud_config_value(
         'size', vm_, __opts__, search_global=False

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1681,8 +1681,8 @@ def request_instance(vm_=None, call=None):
     userdata_file = config.get_cloud_config_value(
         'userdata_file', vm_, __opts__, search_global=False, default=None
     )
-    userdata_renderer = config.get_cloud_config_value(
-        'userdata_renderer', vm_, __opts__, search_global=False, default=None
+    userdata_template = config.get_cloud_config_value(
+        'userdata_template', vm_, __opts__, search_global=False, default=None
     )
     if userdata_file is None:
         userdata = config.get_cloud_config_value(
@@ -1695,19 +1695,25 @@ def request_instance(vm_=None, call=None):
                 userdata = fh_.read()
 
     if userdata is not None:
-        render_opts = __opts__.copy()
-        render_opts.update(vm_)
-        # Use the cloud profile's userdata_renderer, otherwise get it from the
+        # Use the cloud profile's userdata_template, otherwise get it from the
         # master configuration file.
-        renderer = __opts__.get('userdata_renderer', 'jinja') \
-            if userdata_renderer is None
-            else userdata_renderer
-        rend = salt.loader.render(render_opts, {})
-        blacklist = __opts__['renderer_blacklist']
-        whitelist = __opts__['renderer_whitelist']
-        userdata = compile_template(
-            ':string:', rend, renderer, blacklist, whitelist, input_data=userdata,
-        )
+        renderer = __opts__.get('userdata_template') \
+            if userdata_template is None
+            else userdata_template
+        if renderer is not None:
+            render_opts = __opts__.copy()
+            render_opts.update(vm_)
+            rend = salt.loader.render(render_opts, {})
+            blacklist = __opts__['renderer_blacklist']
+            whitelist = __opts__['renderer_whitelist']
+            userdata = compile_template(
+                ':string:',
+                rend,
+                renderer,
+                blacklist,
+                whitelist,
+                input_data=userdata,
+            )
 
         params[spot_prefix + 'UserData'] = base64.b64encode(userdata)
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -645,12 +645,31 @@ def request_instance(vm_=None, call=None):
                 kwargs['files'][src_path] = files[src_path]
 
     userdata_file = config.get_cloud_config_value(
-        'userdata_file', vm_, __opts__, search_global=False
+        'userdata_file', vm_, __opts__, search_global=False, default=None
+    )
+    userdata_renderer = config.get_cloud_config_value(
+        'userdata_renderer', vm_, __opts__, search_global=False, default=None
     )
 
     if userdata_file is not None:
-        with salt.utils.fopen(userdata_file, 'r') as fp:
-            kwargs['userdata'] = fp.read()
+        with salt.utils.fopen(userdata_file, 'r') as fp_:
+            userdata = fp_.read()
+
+        render_opts = __opts__.copy()
+        render_opts.update(vm_)
+        # Use the cloud profile's userdata_renderer, otherwise get it from the
+        # master configuration file.
+        renderer = __opts__.get('userdata_renderer', 'jinja') \
+            if userdata_renderer is None
+            else userdata_renderer
+        rend = salt.loader.render(render_opts, {})
+        blacklist = __opts__['renderer_blacklist']
+        whitelist = __opts__['renderer_whitelist']
+        userdata = compile_template(
+            ':string:', rend, renderer, blacklist, whitelist, input_data=userdata,
+        )
+
+        kwargs['userdata'] = userdata
 
     kwargs['config_drive'] = config.get_cloud_config_value(
         'config_drive', vm_, __opts__, search_global=False

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -647,27 +647,33 @@ def request_instance(vm_=None, call=None):
     userdata_file = config.get_cloud_config_value(
         'userdata_file', vm_, __opts__, search_global=False, default=None
     )
-    userdata_renderer = config.get_cloud_config_value(
-        'userdata_renderer', vm_, __opts__, search_global=False, default=None
+    userdata_template = config.get_cloud_config_value(
+        'userdata_template', vm_, __opts__, search_global=False, default=None
     )
 
     if userdata_file is not None:
         with salt.utils.fopen(userdata_file, 'r') as fp_:
             userdata = fp_.read()
 
-        render_opts = __opts__.copy()
-        render_opts.update(vm_)
-        # Use the cloud profile's userdata_renderer, otherwise get it from the
+        # Use the cloud profile's userdata_template, otherwise get it from the
         # master configuration file.
-        renderer = __opts__.get('userdata_renderer', 'jinja') \
-            if userdata_renderer is None
-            else userdata_renderer
-        rend = salt.loader.render(render_opts, {})
-        blacklist = __opts__['renderer_blacklist']
-        whitelist = __opts__['renderer_whitelist']
-        userdata = compile_template(
-            ':string:', rend, renderer, blacklist, whitelist, input_data=userdata,
-        )
+        renderer = __opts__.get('userdata_template') \
+            if userdata_template is None
+            else userdata_template
+        if renderer is not None:
+            render_opts = __opts__.copy()
+            render_opts.update(vm_)
+            rend = salt.loader.render(render_opts, {})
+            blacklist = __opts__['renderer_blacklist']
+            whitelist = __opts__['renderer_whitelist']
+            userdata = compile_template(
+                ':string:',
+                rend,
+                renderer,
+                blacklist,
+                whitelist,
+                input_data=userdata,
+            )
 
         kwargs['userdata'] = userdata
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -675,7 +675,14 @@ def request_instance(vm_=None, call=None):
                 input_data=userdata,
             )
 
-        kwargs['userdata'] = userdata
+        try:
+            # template renderers like "jinja" should return a StringIO
+            kwargs['userdata'] = ''.join(base64.b64encode(userdata).readlines())
+        except AttributeError:
+            try:
+                kwargs['userdata'] = base64.b64encode(userdata)
+            except Exception as exc:
+                log.exception('Failed to encode userdata: %s')
 
     kwargs['config_drive'] = config.get_cloud_config_value(
         'config_drive', vm_, __opts__, search_global=False

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -648,14 +648,14 @@ def request_instance(vm_=None, call=None):
         'userdata_file', vm_, __opts__, search_global=False, default=None
     )
     if userdata_file is not None:
-        with salt.utils.fopen(userdata_file, 'r') as fp_:
-            userdata = salt.utils.cloud.userdata_template(
-                __opts__, vm_, fp_.read()
-            )
         try:
-            kwargs['userdata'] = base64.b64encode(userdata)
+            with salt.utils.fopen(userdata_file, 'r') as fp_:
+                kwargs['userdata'] = salt.utils.cloud.userdata_template(
+                    __opts__, vm_, fp_.read()
+                )
         except Exception as exc:
-            log.exception('Failed to encode userdata: %s', exc)
+            log.exception(
+                'Failed to read userdata from %s: %s', userdata_file, exc)
 
     kwargs['config_drive'] = config.get_cloud_config_value(
         'config_drive', vm_, __opts__, search_global=False

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -529,14 +529,14 @@ def request_instance(vm_=None, call=None):
         'userdata_file', vm_, __opts__, search_global=False, default=None
     )
     if userdata_file is not None:
-        with salt.utils.fopen(userdata_file, 'r') as fp_:
-            userdata = salt.utils.cloud.userdata_template(
-                __opts__, vm_, fp_.read()
-            )
         try:
-            kwargs['ex_userdata'] = base64.b64encode(userdata)
+            with salt.utils.fopen(userdata_file, 'r') as fp_:
+                kwargs['ex_userdata'] = salt.utils.cloud.userdata_template(
+                    __opts__, vm_, fp_.read()
+                )
         except Exception as exc:
-            log.exception('Failed to encode userdata: %s', exc)
+            log.exception(
+                'Failed to read userdata from %s: %s', userdata_file, exc)
 
     config_drive = config.get_cloud_config_value(
         'config_drive', vm_, __opts__, default=None, search_global=False

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -528,42 +528,15 @@ def request_instance(vm_=None, call=None):
     userdata_file = config.get_cloud_config_value(
         'userdata_file', vm_, __opts__, search_global=False, default=None
     )
-    userdata_template = config.get_cloud_config_value(
-        'userdata_template', vm_, __opts__, search_global=False, default=None
-    )
-
     if userdata_file is not None:
         with salt.utils.fopen(userdata_file, 'r') as fp_:
-            userdata = fp_.read()
-
-        # Use the cloud profile's userdata_template, otherwise get it from the
-        # master configuration file.
-        renderer = __opts__.get('userdata_template') \
-            if userdata_template is None
-            else userdata_template
-        if renderer is not None:
-            render_opts = __opts__.copy()
-            render_opts.update(vm_)
-            rend = salt.loader.render(render_opts, {})
-            blacklist = __opts__['renderer_blacklist']
-            whitelist = __opts__['renderer_whitelist']
-            userdata = compile_template(
-                ':string:',
-                rend,
-                renderer,
-                blacklist,
-                whitelist,
-                input_data=userdata,
+            userdata = salt.utils.cloud.userdata_template(
+                __opts__, vm_, fp_.read()
             )
-
         try:
-            # template renderers like "jinja" should return a StringIO
-            kwargs['ex_userdata'] = ''.join(base64.b64encode(userdata).readlines())
-        except AttributeError:
-            try:
-                kwargs['ex_userdata'] = base64.b64encode(userdata)
-            except Exception as exc:
-                log.exception('Failed to encode userdata: %s')
+            kwargs['ex_userdata'] = base64.b64encode(userdata)
+        except Exception as exc:
+            log.exception('Failed to encode userdata: %s', exc)
 
     config_drive = config.get_cloud_config_value(
         'config_drive', vm_, __opts__, default=None, search_global=False

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -528,27 +528,33 @@ def request_instance(vm_=None, call=None):
     userdata_file = config.get_cloud_config_value(
         'userdata_file', vm_, __opts__, search_global=False, default=None
     )
-    userdata_renderer = config.get_cloud_config_value(
-        'userdata_renderer', vm_, __opts__, search_global=False, default=None
+    userdata_template = config.get_cloud_config_value(
+        'userdata_template', vm_, __opts__, search_global=False, default=None
     )
 
     if userdata_file is not None:
         with salt.utils.fopen(userdata_file, 'r') as fp_:
             userdata = fp_.read()
 
-        render_opts = __opts__.copy()
-        render_opts.update(vm_)
-        # Use the cloud profile's userdata_renderer, otherwise get it from the
+        # Use the cloud profile's userdata_template, otherwise get it from the
         # master configuration file.
-        renderer = __opts__.get('userdata_renderer', 'jinja') \
-            if userdata_renderer is None
-            else userdata_renderer
-        rend = salt.loader.render(render_opts, {})
-        blacklist = __opts__['renderer_blacklist']
-        whitelist = __opts__['renderer_whitelist']
-        userdata = compile_template(
-            ':string:', rend, renderer, blacklist, whitelist, input_data=userdata,
-        )
+        renderer = __opts__.get('userdata_template') \
+            if userdata_template is None
+            else userdata_template
+        if renderer is not None:
+            render_opts = __opts__.copy()
+            render_opts.update(vm_)
+            rend = salt.loader.render(render_opts, {})
+            blacklist = __opts__['renderer_blacklist']
+            whitelist = __opts__['renderer_whitelist']
+            userdata = compile_template(
+                ':string:',
+                rend,
+                renderer,
+                blacklist,
+                whitelist,
+                input_data=userdata,
+            )
 
         kwargs['ex_userdata'] = userdata
 

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -556,7 +556,14 @@ def request_instance(vm_=None, call=None):
                 input_data=userdata,
             )
 
-        kwargs['ex_userdata'] = userdata
+        try:
+            # template renderers like "jinja" should return a StringIO
+            kwargs['ex_userdata'] = ''.join(base64.b64encode(userdata).readlines())
+        except AttributeError:
+            try:
+                kwargs['ex_userdata'] = base64.b64encode(userdata)
+            except Exception as exc:
+                log.exception('Failed to encode userdata: %s')
 
     config_drive = config.get_cloud_config_value(
         'config_drive', vm_, __opts__, default=None, search_global=False

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -212,9 +212,6 @@ VALID_OPTS = {
     # Rendrerer blacklist. Renderers from this list are disalloed even if specified in whitelist.
     'renderer_blacklist': list,
 
-    # A default renderer for userdata files in salt-cloud
-    'userdata_renderer': str,
-
     # A flag indicating that a highstate run should immediately cease if a failure occurs.
     'failhard': bool,
 
@@ -1323,7 +1320,6 @@ DEFAULT_MASTER_OPTS = {
     'renderer': 'yaml_jinja',
     'renderer_whitelist': [],
     'renderer_blacklist': [],
-    'userdata_renderer': 'jinja',
     'failhard': False,
     'state_top': 'top.sls',
     'state_top_saltenv': None,

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -212,6 +212,9 @@ VALID_OPTS = {
     # Rendrerer blacklist. Renderers from this list are disalloed even if specified in whitelist.
     'renderer_blacklist': list,
 
+    # A default renderer for userdata files in salt-cloud
+    'userdata_renderer': str,
+
     # A flag indicating that a highstate run should immediately cease if a failure occurs.
     'failhard': bool,
 
@@ -1320,6 +1323,7 @@ DEFAULT_MASTER_OPTS = {
     'renderer': 'yaml_jinja',
     'renderer_whitelist': [],
     'renderer_blacklist': [],
+    'userdata_renderer': 'jinja',
     'failhard': False,
     'state_top': 'top.sls',
     'state_top_saltenv': None,

--- a/salt/template.py
+++ b/salt/template.py
@@ -80,6 +80,8 @@ def compile_template(template,
     # Get the list of render funcs in the render pipe line.
     render_pipe = template_shebang(template, renderers, default, blacklist, whitelist, input_data)
 
+    windows_newline = '\r\n' in input_data
+
     input_data = string_io(input_data)
     for render, argline in render_pipe:
         # For GPG renderer, input_data can be an OrderedDict (from YAML) or dict (from py renderer).
@@ -120,6 +122,11 @@ def compile_template(template,
                 # structure. We don't want to log this, so ignore this
                 # exception.
                 pass
+
+    # Preserve newlines from original template
+    if windows_newline and '\r\n' not in ret:
+        return ret.replace('\n', '\r\n')
+
     return ret
 
 

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -3222,6 +3222,8 @@ def userdata_template(opts, vm_, userdata):
     userdata_template = salt.config.get_cloud_config_value(
         'userdata_template', vm_, opts, search_global=False, default=None
     )
+    if userdata_template is False:
+        return userdata
     # Use the cloud profile's userdata_template, otherwise get it from the
     # master configuration file.
     renderer = opts.get('userdata_template') \

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -55,6 +55,8 @@ except ImportError:
 import salt.crypt
 import salt.client
 import salt.config
+import salt.loader
+import salt.template
 import salt.utils
 import salt.utils.event
 from salt.utils import vt
@@ -3207,3 +3209,49 @@ def check_key_path_and_mode(provider, key_path):
         return False
 
     return True
+
+
+def userdata_template(opts, vm_, userdata):
+    '''
+    Use the configured templating engine to template the userdata file
+    '''
+    # No userdata, no need to template anything
+    if userdata is None:
+        return userdata
+
+    userdata_template = salt.config.get_cloud_config_value(
+        'userdata_template', vm_, opts, search_global=False, default=None
+    )
+    # Use the cloud profile's userdata_template, otherwise get it from the
+    # master configuration file.
+    renderer = opts.get('userdata_template') \
+        if userdata_template is None \
+        else userdata_template
+    if renderer is None:
+        return userdata
+    else:
+        render_opts = opts.copy()
+        render_opts.update(vm_)
+        rend = salt.loader.render(render_opts, {})
+        blacklist = opts['renderer_blacklist']
+        whitelist = opts['renderer_whitelist']
+        templated = salt.template.compile_template(
+            ':string:',
+            rend,
+            renderer,
+            blacklist,
+            whitelist,
+            input_data=userdata,
+        )
+        if not isinstance(templated, six.string_types):
+            # template renderers like "jinja" should return a StringIO
+            try:
+                templated = ''.join(templated.readlines())
+            except AttributeError:
+                log.warning(
+                    'Templated userdata resulted in non-string result (%s), '
+                    'converting to string', templated
+                )
+                templated = str(templated)
+
+        return templated

--- a/salt/utils/stringio.py
+++ b/salt/utils/stringio.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+'''
+Functions for StringIO objects
+'''
+
+from __future__ import absolute_import
+
+# Import 3rd-party libs
+from salt.ext import six
+
+# Not using six's fake cStringIO since we need to be able to tell if the object
+# is readable, and this can't be done via what six exposes.
+if six.PY2:
+    import StringIO
+    import cStringIO
+    readable_types = (StringIO.StringIO, cStringIO.InputType)
+    writable_types = (StringIO.StringIO, cStringIO.OutputType)
+else:
+    import io
+    readable_types = (io.StringIO,)
+    writable_types = (io.StringIO,)
+
+
+def is_stringio(obj):
+    return isinstance(obj, readable_types)
+
+
+def is_readable(obj):
+    if six.PY2:
+        return isinstance(obj, readable_types)
+    else:
+        return isinstance(obj, readable_types) and obj.readable()
+
+
+def is_writable(obj):
+    if six.PY2:
+        return isinstance(obj, writable_types)
+    else:
+        return isinstance(obj, writable_types) and obj.writable()


### PR DESCRIPTION
2016.11.0 added support for templating the ``userdata_file`` in the ec2 salt-cloud driver (see #32698). However, this feature used the master's ``renderer`` config option, which first evaluates jinja templating, followed by passing the data through the YAML loader. The problem with doing this, however, is that PyYAML does unpredictable things when you attempt to load non-YAML data through it. For example:

```python
% python
Python 2.7.13 (default, Dec 21 2016, 07:16:46)
[GCC 6.2.1 20160830] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> x = '''\
... #!/bin/bash
...
... echo "a" >> /var/tmp/a
... echo "b" >> /var/tmp/b
... echo "c" >> /var/tmp/c
... echo "d" >> /var/tmp/d
...
... echo "e" >> /var/tmp/e
... echo "f" >> /var/tmp/f
...
... echo "g" >> /var/tmp/g
... echo "h" >> /var/tmp/h
... '''
>>> import yaml
>>> print(x)

echo "a" >> /var/tmp/a
echo "b" >> /var/tmp/b
echo "c" >> /var/tmp/c
echo "d" >> /var/tmp/d

echo "e" >> /var/tmp/e
echo "f" >> /var/tmp/f

echo "g" >> /var/tmp/g
echo "h" >> /var/tmp/h

>>> print(yaml.safe_load(x))
echo "a" >> /var/tmp/a echo "b" >> /var/tmp/b echo "c" >> /var/tmp/c echo "d" >> /var/tmp/d
echo "e" >> /var/tmp/e echo "f" >> /var/tmp/f
echo "g" >> /var/tmp/g echo "h" >> /var/tmp/h
>>>
```

This PR fixes the issue by only templating when explicitly configured to do so. It does this by adding an optional cloud profile config paramter called ``userdata_template``, designed to work like the ``template`` param in ``file.managed`` states. For example:

```yaml
my-ec2-config:
  # Pass userdata to the instance to be created
  userdata_file: /etc/salt/my-userdata-file
  userdata_template: jinja
```

This option can also be set globally in the master configuration file.

Additionally, the other cloud drivers which support ``userdata_file`` (azurearm, nova, openstack) have had templating support added.

Finally, this PR addresses the fact that jinja will eat Windows newlines and spit out unix newlines:

```python
>>> import jinja2
>>> jinja2.Template('foo\r\nbar\r\nbaz\r\n').render()
u'foo\nbar\nbaz'
```

It fixes this by checking the template input for Windows newlines (``\r\n``) before processing the render pipe, and then checking the rendered template afterwards and replacing the newlines with Windows newlines if necessary.


CC: @techhat