### PR TITLE
Artifactory Execution & State Module: Fixup Error Handling

### DIFF
--- a/salt/modules/artifactory.py
+++ b/salt/modules/artifactory.py
@@ -14,6 +14,7 @@ import salt.utils
 import salt.ext.six.moves.http_client  # pylint: disable=import-error,redefined-builtin,no-name-in-module
 from salt.ext.six.moves import urllib  # pylint: disable=no-name-in-module
 from salt.ext.six.moves.urllib.error import HTTPError, URLError  # pylint: disable=no-name-in-module
+from salt.exceptions import CommandExecutionError
 
 # Import 3rd party libs
 try:
@@ -295,13 +296,23 @@ def _get_artifact_metadata_url(artifactory_url, repository, group_id, artifact_i
 
 
 def _get_artifact_metadata_xml(artifactory_url, repository, group_id, artifact_id, headers):
-    artifact_metadata_url = _get_artifact_metadata_url(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id)
+
+    artifact_metadata_url = _get_artifact_metadata_url(
+        artifactory_url=artifactory_url,
+        repository=repository,
+        group_id=group_id,
+        artifact_id=artifact_id
+    )
+
     try:
         request = urllib.request.Request(artifact_metadata_url, None, headers)
         artifact_metadata_xml = urllib.request.urlopen(request).read()
-    except HTTPError as http_error:
-        message = 'Could not fetch data from url: {url}, HTTPError: {error}'
-        raise Exception(message.format(url=artifact_metadata_url, error=http_error))
+    except (HTTPError, URLError) as err:
+        message = 'Could not fetch data from url: {0}. ERROR: {1}'.format(
+            artifact_metadata_url,
+            err
+        )
+        raise CommandExecutionError(message)
 
     log.debug('artifact_metadata_xml=%s', artifact_metadata_xml)
     return artifact_metadata_xml
@@ -334,13 +345,25 @@ def _get_snapshot_version_metadata_url(artifactory_url, repository, group_id, ar
 
 
 def _get_snapshot_version_metadata_xml(artifactory_url, repository, group_id, artifact_id, version, headers):
-    snapshot_version_metadata_url = _get_snapshot_version_metadata_url(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id, version=version)
+
+    snapshot_version_metadata_url = _get_snapshot_version_metadata_url(
+        artifactory_url=artifactory_url,
+        repository=repository,
+        group_id=group_id,
+        artifact_id=artifact_id,
+        version=version
+    )
+
     try:
         request = urllib.request.Request(snapshot_version_metadata_url, None, headers)
         snapshot_version_metadata_xml = urllib.request.urlopen(request).read()
-    except HTTPError as http_error:
-        message = 'Could not fetch data from url: {url}, HTTPError: {error}'
-        raise Exception(message.format(url=snapshot_version_metadata_url, error=http_error))
+    except (HTTPError, URLError) as err:
+        message = 'Could not fetch data from url: {0}. ERROR: {1}'.format(
+            snapshot_version_metadata_url,
+            err
+        )
+        raise CommandExecutionError(message)
+
     log.debug('snapshot_version_metadata_xml=%s', snapshot_version_metadata_xml)
     return snapshot_version_metadata_xml
 
@@ -378,13 +401,23 @@ def __get_latest_version_url(artifactory_url, repository, group_id, artifact_id)
 
 
 def __find_latest_version(artifactory_url, repository, group_id, artifact_id, headers):
-    latest_version_url = __get_latest_version_url(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id)
+
+    latest_version_url = __get_latest_version_url(
+        artifactory_url=artifactory_url,
+        repository=repository,
+        group_id=group_id,
+        artifact_id=artifact_id
+    )
+
     try:
         request = urllib.request.Request(latest_version_url, None, headers)
         version = urllib.request.urlopen(request).read()
-    except HTTPError as http_error:
-        message = 'Could not fetch data from url: {url}, HTTPError: {error}'
-        raise Exception(message.format(url=latest_version_url, error=http_error))
+    except (HTTPError, URLError) as err:
+        message = 'Could not fetch data from url: {0}. ERROR: {1}'.format(
+            latest_version_url,
+            err
+        )
+        raise CommandExecutionError(message)
 
     log.debug("Response of: %s", version)
 

--- a/salt/states/artifactory.py
+++ b/salt/states/artifactory.py
@@ -85,18 +85,19 @@ def downloaded(name, artifact, target_dir='/tmp', target_file=None):
 
     try:
         fetch_result = __fetch_from_artifactory(artifact, target_dir, target_file)
-        log.debug("fetch_result=%s", str(fetch_result))
-
-        ret['result'] = fetch_result['status']
-        ret['comment'] = fetch_result['comment']
-        ret['changes'] = fetch_result['changes']
-        log.debug("ret=%s", str(ret))
-
-        return ret
     except Exception as exc:
         ret['result'] = False
-        ret['comment'] = exc
+        ret['comment'] = str(exc)
         return ret
+
+    log.debug("fetch_result=%s", str(fetch_result))
+
+    ret['result'] = fetch_result['status']
+    ret['comment'] = fetch_result['comment']
+    ret['changes'] = fetch_result['changes']
+    log.debug("ret=%s", str(ret))
+
+    return ret
 
 
 def __fetch_from_artifactory(artifact, target_dir, target_file):

--- a/tests/unit/states/artifactory_test.py
+++ b/tests/unit/states/artifactory_test.py
@@ -56,7 +56,7 @@ class ArtifactoryTestCase(TestCase):
                           MagicMock(side_effect=Exception('error'))):
             ret = artifactory.downloaded(name, artifact)
             self.assertEqual(ret['result'], False)
-            self.assertEqual(repr(ret['comment']), repr(Exception('error')))
+            self.assertEqual(ret['comment'], 'error')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?
Artifactory Execution Module changes:
- Adds `URLError`s to the places where we're also catching `HTTPError`s 
- Changes the bare `Exception`s that are raised in these affected helper functions to `CommandExecutionError`s
- Made some of the function calls a little more vertical. This module is extremely horizontally written, which makes it hard to see what is going on.

Atrifactory State Module Changes:
- Moved the log lines and dictionary manipulation lines out of the try/except block
- Wrapped the `exc` variable in`str()` to ensure to avoid a `TypeError` further on in the process. The URLError being passed up to the exception to print as a comment in the state file comes back as a different type.

### What issues does this PR fix or reference?
Fixes #37699

### Previous Behavior
The error message couldn't be serialized, so the docs for the state execution module would print and then a final stacktrace:
```
Passed invalid arguments: Cannot serialize CommandExecutionError('Error: <urlopen error [Errno -2] Name or service not known>',).

Usage:

    Execute the states in one or more SLS files

    test
        Run states in test-only (dry-run) mode

    pillar
        Custom Pillar values, passed as a dictionary of key-value pairs

        .. code-block:: bash

            salt '*' state.apply test pillar='{"foo": "bar"}'

        .. note::
            Values passed this way will override Pillar values set via
            ``pillar_roots`` or an external Pillar source.

        .. versionchanged:: 2016.3.0
            GPG-encrypted CLI Pillar data is now supported via the GPG
            renderer. See :ref:`here <encrypted-cli-pillar-data>` for details.

    pillar_enc
        Specify which renderer to use to decrypt encrypted data located within
        the ``pillar`` value. Currently, only ``gpg`` is supported.

        .. versionadded:: 2016.3.0

    queue : False
        Instead of failing immediately when another state run is in progress,
        queue the new state run to begin running once the other has finished.

        This option starts a new thread for each queued state run, so use this
        option sparingly.

    concurrent : False
        Execute state runs concurrently instead of serially

        .. warning::

            This flag is potentially dangerous. It is designed for use when
            multiple state runs can safely be run at the same time. Do *not*
            use this flag for performance optimization.

    saltenv : None
        Specify a salt fileserver environment to be used when applying states

        .. versionchanged:: 0.17.0
            Argument name changed from ``env`` to ``saltenv``.

        .. versionchanged:: 2014.7.0
            If no saltenv is specified, the minion config will be checked for an
            ``environment`` parameter and if found, it will be used. If none is
            found, ``base`` will be used. In prior releases, the minion config
            was not checked and ``base`` would always be assumed when the
            saltenv was not explicitly set.

    pillarenv

        Specify a Pillar environment to be used when applying states. By
        default, all Pillar environments will be merged together and used.

    localconfig

        Optionally, instead of using the minion config, load minion opts from
        the file specified by this argument, and then merge them with the
        options from the minion config. This functionality allows for specific
        states to be run with their own custom minion configuration, including
        different pillars, file_roots, etc.

    mock:
        The mock option allows for the state run to execute without actually
        calling any states. This then returns a mocked return which will show
        the requisite ordering as well as fully validate the state run.

        .. versionadded:: 2015.8.4

    CLI Example:

    .. code-block:: bash

        salt '*' state.sls core,edit.vim dev
        salt '*' state.sls core exclude="[{'id': 'id_to_exclude'}, {'sls': 'sls_to_exclude'}]"

        salt '*' state.sls myslsfile pillar="{foo: 'Foo!', bar: 'Bar!'}"

Traceback (most recent call last):
  File "/root/SaltStack/salt/salt/cli/caller.py", line 197, in call
    ret['return'] = func(*args, **kwargs)
  File "/root/SaltStack/salt/salt/modules/state.py", line 1065, in sls
    serial.dump(ret, fp_)
  File "/root/SaltStack/salt/salt/payload.py", line 295, in dump
    fn_.write(self.dumps(msg))
  File "/root/SaltStack/salt/salt/payload.py", line 181, in dumps
    return msgpack.dumps(msg, use_bin_type=use_bin_type)
  File "/usr/local/lib/python2.7/dist-packages/msgpack/__init__.py", line 47, in packb
    return Packer(**kwargs).pack(o)
  File "/usr/local/lib/python2.7/dist-packages/msgpack/fallback.py", line 734, in pack
    self._pack(obj)
  File "/usr/local/lib/python2.7/dist-packages/msgpack/fallback.py", line 726, in _pack
    nest_limit - 1)
  File "/usr/local/lib/python2.7/dist-packages/msgpack/fallback.py", line 824, in _fb_pack_map_pairs
    self._pack(v, nest_limit - 1)
  File "/usr/local/lib/python2.7/dist-packages/msgpack/fallback.py", line 726, in _pack
    nest_limit - 1)
  File "/usr/local/lib/python2.7/dist-packages/msgpack/fallback.py", line 824, in _fb_pack_map_pairs
    self._pack(v, nest_limit - 1)
  File "/usr/local/lib/python2.7/dist-packages/msgpack/fallback.py", line 731, in _pack
    raise TypeError("Cannot serialize %r" % obj)
TypeError: Cannot serialize CommandExecutionError('Error: <urlopen error [Errno -2] Name or service not known>',)
root@rallytime:~#
```

### New Behavior
Propagates the error message that is raised to the state report:
```
local:
----------
          ID: download_from_artifactory
    Function: artifactory.downloaded
      Result: False
     Comment: Could not fetch data from url: http://some.url.that.i.removed/libs-snapshots/com/example/webapp/webapp/1.0-SNAPSHOT/maven-metadata.xml. ERROR: <urlopen error [Errno -2] Name or service not known>
     Started: 20:03:59.576973
    Duration: 8.414 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   8.414 ms
```