### PR TITLE
Add __func_alias__ back in

### DIFF
--- a/salt/cache/consul.py
+++ b/salt/cache/consul.py
@@ -61,6 +61,8 @@ api = None
 # Define the module's virtual name
 __virtualname__ = 'consul'
 
+__func_alias__ = {'ls': 'list'}
+
 
 def __virtual__():
     '''

--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -23,7 +23,7 @@ import salt.utils.atomicfile
 
 log = logging.getLogger(__name__)
 
-__func_alias__ = {'ls': 'list'}
+__func_alias__ = {'list': 'ls'}
 
 
 def __cachedir(kwargs=None):

--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -23,6 +23,8 @@ import salt.utils.atomicfile
 
 log = logging.getLogger(__name__)
 
+__func_alias__ = {'ls': 'list'}
+
 
 def __cachedir(kwargs=None):
     if kwargs and 'cachedir' in kwargs:


### PR DESCRIPTION
### What does this PR do?
#40429 changed the `list_()` functions to `ls()` and removed the `__func_alias__` declarations. This will break the `cache` runner when the changes get merged forward, since it relies on a `list` function.

### What issues does this PR fix or reference?
#40429

### Tests written?
No.