### PR TITLE
Add cache.store to the runners

### DIFF
--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -413,6 +413,26 @@ def cloud(tgt, provider=None):
     return ret
 
 
+def store(bank, key, data, cachedir=None):
+    '''
+    Lists entries stored in the specified bank.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cache.store mycache mykey 'The time has come the walrus said'
+    '''
+    if cachedir is None:
+        cachedir = __opts__['cachedir']
+
+    try:
+        cache = salt.cache.Cache(__opts__, cachedir=cachedir)
+    except TypeError:
+        cache = salt.cache.Cache(__opts__)
+    return cache.store(bank, key, data)
+
+
 def list_(bank, cachedir=None):
     '''
     Lists entries stored in the specified bank.
@@ -427,7 +447,7 @@ def list_(bank, cachedir=None):
         cachedir = __opts__['cachedir']
 
     try:
-        cache = salt.cache.Cache(__opts__, cachedir)
+        cache = salt.cache.Cache(__opts__, cachedir=cachedir)
     except TypeError:
         cache = salt.cache.Cache(__opts__)
     return cache.list(bank)
@@ -447,7 +467,7 @@ def fetch(bank, key, cachedir=None):
         cachedir = __opts__['cachedir']
 
     try:
-        cache = salt.cache.Cache(__opts__, cachedir)
+        cache = salt.cache.Cache(__opts__, cachedir=cachedir)
     except TypeError:
         cache = salt.cache.Cache(__opts__)
     return cache.fetch(bank, key)
@@ -469,7 +489,7 @@ def flush(bank, key=None, cachedir=None):
         cachedir = __opts__['cachedir']
 
     try:
-        cache = salt.cache.Cache(__opts__, cachedir)
+        cache = salt.cache.Cache(__opts__, cachedir=cachedir)
     except TypeError:
         cache = salt.cache.Cache(__opts__)
     return cache.flush(bank, key)

--- a/tests/integration/runners/test_cache.py
+++ b/tests/integration/runners/test_cache.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for the salt-run command
+'''
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+import tests.integration as integration
+
+
+class ManageTest(integration.ShellCase):
+    '''
+    Test the manage runner
+    '''
+    def test_cache(self):
+        '''
+        Store, list, fetch, then flush data
+        '''
+        # Store the data
+        ret = self.run_run_plus(
+            'cache.store',
+            bank='test/runner',
+            key='test_cache',
+            data='The time has come the walrus said',
+        )
+        # Make sure we can see the new key
+        ret = self.run_run_plus('cache.list', bank='test/runner')
+        self.assertIn('test_cache', ret['return'])
+        # Make sure we can see the new data
+        ret = self.run_run_plus('cache.fetch', bank='test/runner', key='test_cache')
+        self.assertIn('The time has come the walrus said', ret['return'])
+        # Make sure we can delete the data
+        ret = self.run_run_plus('cache.flush', bank='test/runner', key='test_cache')
+        ret = self.run_run_plus('cache.list', bank='test/runner')
+        self.assertNotIn('test_cache', ret['return'])

--- a/tests/integration/runners/test_cache.py
+++ b/tests/integration/runners/test_cache.py
@@ -20,17 +20,17 @@ class ManageTest(integration.ShellCase):
         # Store the data
         ret = self.run_run_plus(
             'cache.store',
-            bank='test/runner',
+            bank='cachetest/runner',
             key='test_cache',
             data='The time has come the walrus said',
         )
         # Make sure we can see the new key
-        ret = self.run_run_plus('cache.list', bank='test/runner')
+        ret = self.run_run_plus('cache.list', bank='cachetest/runner')
         self.assertIn('test_cache', ret['return'])
         # Make sure we can see the new data
-        ret = self.run_run_plus('cache.fetch', bank='test/runner', key='test_cache')
+        ret = self.run_run_plus('cache.fetch', bank='cachetest/runner', key='test_cache')
         self.assertIn('The time has come the walrus said', ret['return'])
         # Make sure we can delete the data
-        ret = self.run_run_plus('cache.flush', bank='test/runner', key='test_cache')
-        ret = self.run_run_plus('cache.list', bank='test/runner')
+        ret = self.run_run_plus('cache.flush', bank='cachetest/runner', key='test_cache')
+        ret = self.run_run_plus('cache.list', bank='cachetest/runner')
         self.assertNotIn('test_cache', ret['return'])


### PR DESCRIPTION
### What does this PR do?
The `cache` runner could perform the most basic `cache` functions before, except for actually storing data. This adds the `cache.store` function.

### Tests written?
Yes.