### PR TITLE
Update to libcloud_dns module to allow custom kwargs for DNS drivers

### DIFF
--- a/salt/modules/libcloud_dns.py
+++ b/salt/modules/libcloud_dns.py
@@ -10,13 +10,15 @@ Connection module for Apache Libcloud DNS management
     .. code-block:: yaml
 
         libcloud_dns:
-          profile1:
-            driver: godaddy
-            key: 2orgk34kgk34g
-          profile2:
-            driver: route53
-            key: blah
-            secret: blah
+            profile_test1:
+              driver: cloudflare
+              key: 12345
+              secret: mysecret
+            profile_test2:
+              driver: godaddy
+              key: 12345
+              secret: mysecret
+              shopper_id: 12345
 
 :depends: apache-libcloud
 '''

--- a/salt/modules/libcloud_dns.py
+++ b/salt/modules/libcloud_dns.py
@@ -68,12 +68,14 @@ def __init__(opts):
 def _get_driver(profile):
     config = __salt__['config.option']('libcloud_dns')[profile]
     cls = get_driver(config['driver'])
-    key = config.get('key')
-    secret = config.get('secret', None)
-    secure = config.get('secure', True)
-    host = config.get('host', None)
-    port = config.get('port', None)
-    return cls(key, secret, secure, host, port)
+    args = config
+    del args['driver']
+    args['key'] = config.get('key')
+    args['secret'] = config.get('secret', None)
+    args['secure'] = config.get('secure', True)
+    args['host'] = config.get('host', None)
+    args['port'] = config.get('port', None)
+    return cls(**args)
 
 
 def list_record_types(profile):

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -92,3 +92,14 @@ mysql.user: 'salt'
 mysql.pass: 'salt'
 mysql.db: 'salt'
 mysql.port: 3306
+
+libcloud_dns:
+  profile_test1:
+    driver: cloudflare
+    key: 12345
+    secret: mysecret
+  profile_test2:
+    driver: godaddy
+    key: 12345
+    secret: mysecret
+    shopper_id: 12345

--- a/tests/integration/modules/test_libcloud_dns.py
+++ b/tests/integration/modules/test_libcloud_dns.py
@@ -1,17 +1,17 @@
-import integration
+import tests.integration as integration
 
 
 class LibcloudDNSTest(integration.ModuleCase):
     '''
-    Validate the test module
+    Validate the libcloud_dns module
     '''
     def test_list_record_types(self):
         '''
-        test.ping
+        libcloud_dns.list_record_types
         '''
         # Simple profile (no special kwargs)
         self.assertTrue('SPF' in self.run_function('libcloud_dns.list_record_types', ['profile_test1']))
-        
+
         # Complex profile (special kwargs)
         accepted_record_types = self.run_function('libcloud_dns.list_record_types', ['profile_test2'])
 

--- a/tests/integration/modules/test_libcloud_dns.py
+++ b/tests/integration/modules/test_libcloud_dns.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 import tests.integration as integration
 
 

--- a/tests/integration/modules/test_libcloud_dns.py
+++ b/tests/integration/modules/test_libcloud_dns.py
@@ -14,4 +14,5 @@ class LibcloudDNSTest(integration.ModuleCase):
         
         # Complex profile (special kwargs)
         accepted_record_types = self.run_function('libcloud_dns.list_record_types', ['profile_test2'])
-        self.assertTrue(isinstance(accepted_record_types, list) and 'SPF' in accepted_record_types)
+
+        self.assertTrue(isinstance(accepted_record_types, list) and 'SRV' in accepted_record_types)

--- a/tests/integration/modules/test_libcloud_dns.py
+++ b/tests/integration/modules/test_libcloud_dns.py
@@ -1,0 +1,17 @@
+import integration
+
+
+class LibcloudDNSTest(integration.ModuleCase):
+    '''
+    Validate the test module
+    '''
+    def test_list_record_types(self):
+        '''
+        test.ping
+        '''
+        # Simple profile (no special kwargs)
+        self.assertTrue('SPF' in self.run_function('libcloud_dns.list_record_types', ['profile_test1']))
+        
+        # Complex profile (special kwargs)
+        accepted_record_types = self.run_function('libcloud_dns.list_record_types', ['profile_test2'])
+        self.assertTrue(isinstance(accepted_record_types, list) and 'SPF' in accepted_record_types)

--- a/tests/integration/modules/test_libcloud_dns.py
+++ b/tests/integration/modules/test_libcloud_dns.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import tests.integration as integration
 
 


### PR DESCRIPTION
### What does this PR do?
As reported by user @eldadru in https://github.com/saltstack/salt/issues/40179

Some DNS drivers in libcloud require extra args or kwargs to be instantiated. This update allows users to put the kwargs for the module driver into the libcloud_dns config section for each DNS profile and they will get carried over to the driver.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40179

### Previous Behavior
Drivers, like GoDaddy could not be used with the `libcloud_dns` module

### New Behavior
All drivers can be used

### Tests written?

Yes

Added new integration test module, which uses `list_record_types`, this is the only method that doesn't call any APIs but does require an instantiated module driver.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
