### PR TITLE
salt-minion.service: Start after salt-master.service

### DIFF
--- a/pkg/deb/salt-minion.service
+++ b/pkg/deb/salt-minion.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=The Salt Minion daemon
-After=network.target
+After=network.target salt-master.service
 
 [Service]
 Type=notify

--- a/pkg/salt-minion.service
+++ b/pkg/salt-minion.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=The Salt Minion
-After=network.target
+After=network.target salt-master.service
 
 [Service]
 Type=notify

--- a/pkg/suse/salt-minion.service
+++ b/pkg/suse/salt-minion.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=The Salt Minion
-After=network.target
+After=network.target salt-master.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
### What does this PR do?
When you merge this PR, systemd will make sure that salt-minion.service starts after salt-master.service (of course only when *salt-master.service* is enabled, i.e. this PR does **not** add a dependency on salt-master).

### What issues does this PR fix or reference?
When you have both services, *salt-master* and *salt-minion*, enabled on the same system, you normally want that the *salt-minion.service* connects to the *salt-master.service* on the same system.

Currently you will see edge cases where *salt-minion.service* launches before *salt-master.service* starts. While this isn't critical, i.e. the salt minion will try to reconnect, this can be avoided when we add *salt-master.service* to salt-minion.service's *after* section.
