### PR TITLE
fix "set_webapp_settings"

### DIFF
--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -1819,15 +1819,16 @@ def get_webapp_settings(name, site, settings):
         if setting in availableSettings:
             if setting == "userName" or setting == "password":
                 pscmd.append(" $Property = Get-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(site, name))
-                pscmd.append(" -Name \"{0}\" -ErrorAction Stop | select Value;".format(setting))
-                pscmd.append(" $Property = $Property | Select-Object -ExpandProperty Value;")
-                pscmd.append(" $Settings['{0}'] = [String] $Property;".format(setting))
+                pscmd.append(r' -Name "{0}" -ErrorAction Stop | select Value;'.format(setting))
+                pscmd.append(r' $Property = $Property | Select-Object -ExpandProperty Value;')
+                pscmd.append(r" $Settings['{0}'] = [String] $Property;".format(setting))
                 pscmd.append(r' $Property = $Null;')
 
             if setting == "physicalPath" or setting == "applicationPool":
                 pscmd.append(r" $Property = (get-webapplication {0}).{1};".format(name, setting))
                 pscmd.append(r" $Settings['{0}'] = [String] $Property;".format(setting))
                 pscmd.append(r' $Property = $Null;')
+
         else:
             availSetStr = ', '.join(availableSettings)
             message = 'Unexpected setting:' + setting + '. Available settings are: ' + availSetStr
@@ -1882,33 +1883,34 @@ def set_webapp_settings(name, site, settings):
 
     # Validate params
     if name not in current_apps:
-        log.debug("Application %s doesn't exist", name)
-        return False
+        msg = "Application" + name + "doesn't exist"
+        raise SaltInvocationError(msg)
 
     if site not in current_sites:
-        log.debug("Site %s doesn't exist", site)
-        return False
+        msg = "Site" + site + "doesn't exist"
+        raise SaltInvocationError(msg)
 
     if not settings:
-        log.warning('No settings provided')
-        return False
+        msg = "No settings provided"
+        raise SaltInvocationError(msg)
 
     # Treat all values as strings for the purpose of comparing them to existing values & validate settings exists in predefined settings list
     for setting in settings.keys():
         if setting in availableSettings:
             settings[setting] = str(settings[setting])
         else:
-            log.debug("Unexpected setting: %s ", setting)
             availSetStr = ', '.join(availableSettings)
-            log.debug("Available settings: %s", availSetStr)
-            return False
+            log.error("Unexpected setting: %s ", setting)
+            log.error("Available settings: %s", availSetStr)
+            msg="Unexpected setting:" + setting + " Available settings:" + availSetStr
+            raise SaltInvocationError(msg)
 
     # Check if settings already configured
     current_settings = get_webapp_settings(
         name=name, site=site, settings=settings.keys())
 
     if settings == current_settings:
-        log.debug('Settings already contain the provided values.')
+        log.warning('Settings already contain the provided values.')
         return True
 
     for setting in settings:
@@ -1925,11 +1927,11 @@ def set_webapp_settings(name, site, settings):
             pscmd.append(" -Name \"{0}\" -Value {1};".format(setting, value))
 
         if setting == "physicalPath" or setting == "applicationPool":
-            pscmd.append(" Set-ItemProperty \"IIS:\Sites\{0}\{1}\" -Name {2} -Value {3};".format(site, name, setting, value))
+            pscmd.append(r' Set-ItemProperty "IIS:\Sites\{0}\{1}" -Name {2} -Value {3};'.format(site, name, setting, value))
             if setting == "physicalPath":
-                if not os.path.isdir(value):
-                    log.error('Path is not present: {0}'.format(setting))
-                    return False
+                if not os.path.isdir(settings[setting]):
+                    msg = 'Path is not present: ' + settings[setting]
+                    raise SaltInvocationError(msg)
 
     # Run commands
     cmd_ret = _srvmgr(pscmd)

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -1902,7 +1902,7 @@ def set_webapp_settings(name, site, settings):
             availSetStr = ', '.join(availableSettings)
             log.error("Unexpected setting: %s ", setting)
             log.error("Available settings: %s", availSetStr)
-            msg="Unexpected setting:" + setting + " Available settings:" + availSetStr
+            msg = "Unexpected setting:" + setting + " Available settings:" + availSetStr
             raise SaltInvocationError(msg)
 
     # Check if settings already configured

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -1921,11 +1921,11 @@ def set_webapp_settings(name, site, settings):
 
         # Append relevant update command per setting key
         if setting == "userName" or setting == "password":
-            pscmd.append(r" Set-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(site, name))
-            pscmd.append(r" -Name \"{0}\" -Value {1};".format(setting, value))
+            pscmd.append(" Set-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(site, name))
+            pscmd.append(" -Name \"{0}\" -Value {1};".format(setting, value))
 
         if setting == "physicalPath" or setting == "applicationPool":
-            pscmd.append(r" Set-ItemProperty \"IIS:\Sites\{0}\{1}\" -Name {2} -Value {3};".format(site, name, setting, value))
+            pscmd.append(" Set-ItemProperty \"IIS:\Sites\{0}\{1}\" -Name {2} -Value {3};".format(site, name, setting, value))
             if setting == "physicalPath":
                 if not os.path.isdir(value):
                     log.error('Path is not present: {0}'.format(setting))


### PR DESCRIPTION
Removes 'r' prefix from this section cause the command is not working with it...
 if setting == "userName" or setting == "password":
            pscmd.append(r" Set-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(site, name))
            pscmd.append(r" -Name \"{0}\" -Value {1};".format(setting, value))

        if setting == "physicalPath" or setting == "applicationPool":
            pscmd.append(r" Set-ItemProperty \"IIS:\Sites\{0}\{1}\" -Name {2} -Value {3};".format(site, name, setting, value))

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
