### PR TITLE
first pass at adding support for pycryptodome installed as

### DIFF
--- a/salt/auth/pki.py
+++ b/salt/auth/pki.py
@@ -22,7 +22,10 @@ import logging
 # Import third party libs
 # pylint: disable=import-error
 try:
-    from Crypto.Util import asn1
+    try:
+        from Cryptodome.Util import asn1
+    except ImportError:
+        from Crypto.Util import asn1
     import OpenSSL
     HAS_DEPS = True
 except ImportError:

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -39,9 +39,12 @@ from salt.template import compile_template
 
 # Import third party libs
 try:
-    import Crypto.Random
+    import Cryptodome.Random
 except ImportError:
-    pass  # pycrypto < 2.1
+    try:
+        import Crypto.Random
+    except ImportError:
+        pass  # pycrypto < 2.1
 import yaml
 import salt.ext.six as six
 from salt.ext.six.moves import input  # pylint: disable=import-error,redefined-builtin

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -24,15 +24,25 @@ import getpass
 import salt.ext.six as six
 from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
 try:
-    from Crypto.Cipher import AES, PKCS1_OAEP
-    from Crypto.Hash import SHA
-    from Crypto.PublicKey import RSA
-    from Crypto.Signature import PKCS1_v1_5
-    # let this be imported, if possible
-    import Crypto.Random  # pylint: disable=W0611
+    from Cryptodome.Cipher import AES, PKCS1_OAEP
+    from Cryptodome.Hash import SHA
+    from Cryptodome.PublicKey import RSA
+    from Cryptodome.Signature import PKCS1_v1_5
+    import Cryptodome.Random  # pylint: disable=W0611
+    CDOME = True
 except ImportError:
-    # No need for crypt in local mode
-    pass
+    CDOME = False
+if not CDOME:
+    try:
+        from Crypto.Cipher import AES, PKCS1_OAEP
+        from Crypto.Hash import SHA
+        from Crypto.PublicKey import RSA
+        from Crypto.Signature import PKCS1_v1_5
+        # let this be imported, if possible
+        import Crypto.Random  # pylint: disable=W0611
+    except ImportError:
+        # No need for crypt in local mode
+        pass
 
 # Import salt libs
 import salt.defaults.exitcodes

--- a/salt/master.py
+++ b/salt/master.py
@@ -20,7 +20,11 @@ import multiprocessing
 import traceback
 
 # Import third party libs
-from Crypto.PublicKey import RSA
+try:
+    from Cryptodome.PublicKey import RSA
+except ImportError:
+    # Fall back to pycrypto
+    from Crypto.PublicKey import RSA
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
 from salt.ext.six.moves import range

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -21,8 +21,12 @@ from salt.utils.cache import CacheCli
 
 # Import Third Party Libs
 import tornado.gen
-from Crypto.Cipher import PKCS1_OAEP
-from Crypto.PublicKey import RSA
+try:
+    from Cryptodome.Cipher import PKCS1_OAEP
+    from Cryptodome.PublicKey import RSA
+except ImportError:
+    from Crypto.Cipher import PKCS1_OAEP
+    from Crypto.PublicKey import RSA
 
 
 log = logging.getLogger(__name__)

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -50,7 +50,10 @@ else:
 # pylint: enable=import-error,no-name-in-module
 
 # Import third party libs
-from Crypto.Cipher import PKCS1_OAEP
+try:
+    from Cryptodome.Cipher import PKCS1_OAEP
+except ImportError:
+    from Crypto.Cipher import PKCS1_OAEP
 
 if six.PY3 and salt.utils.is_windows():
     USE_LOAD_BALANCER = True

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -47,7 +47,10 @@ import tornado.concurrent
 
 # Import third party libs
 import salt.ext.six as six
-from Crypto.Cipher import PKCS1_OAEP
+try:
+    from Cryptodome.Cipher import PKCS1_OAEP
+except ImportError:
+    from Crypto.Cipher import PKCS1_OAEP
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/pycrypto.py
+++ b/salt/utils/pycrypto.py
@@ -13,9 +13,9 @@ import random
 # Import 3rd-party libs
 try:
     try:
-        import Cryptodome.Random as CRand # pylint: disable=E0611
+        import Cryptodome.Random as CRand  # pylint: disable=E0611
     except ImportError:
-        import Crypto.Random as CRand # pylint: disable=E0611
+        import Crypto.Random as CRand  # pylint: disable=E0611
     HAS_RANDOM = True
 except ImportError:
     HAS_RANDOM = False

--- a/salt/utils/pycrypto.py
+++ b/salt/utils/pycrypto.py
@@ -12,7 +12,10 @@ import random
 
 # Import 3rd-party libs
 try:
-    import Crypto.Random  # pylint: disable=E0611
+    try:
+        import Crypto.Random as CRand # pylint: disable=E0611
+    except ImportError:
+        import Crypto.Random as CRand # pylint: disable=E0611
     HAS_RANDOM = True
 except ImportError:
     HAS_RANDOM = False
@@ -36,7 +39,7 @@ def secure_password(length=20, use_random=True):
     pw = ''
     while len(pw) < length:
         if HAS_RANDOM and use_random:
-            pw += re.sub(r'\W', '', Crypto.Random.get_random_bytes(1))
+            pw += re.sub(r'\W', '', CRand.get_random_bytes(1))
         else:
             pw += random.SystemRandom().choice(string.ascii_letters + string.digits)
     return pw

--- a/salt/utils/pycrypto.py
+++ b/salt/utils/pycrypto.py
@@ -13,7 +13,7 @@ import random
 # Import 3rd-party libs
 try:
     try:
-        import Crypto.Random as CRand # pylint: disable=E0611
+        import Cryptodome.Random as CRand # pylint: disable=E0611
     except ImportError:
         import Crypto.Random as CRand # pylint: disable=E0611
     HAS_RANDOM = True

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -134,6 +134,7 @@ class RSAX931Verifier(object):
         :param str pubdata: The RSA public key in PEM format
         '''
         pubdata = salt.utils.to_bytes(pubdata, 'ascii')
+        pubdata = pubdata.replace('RSA ', '')
         self._bio = libcrypto.BIO_new_mem_buf(pubdata, len(pubdata))
         self._rsa = c_void_p(libcrypto.RSA_new())
         if not libcrypto.PEM_read_bio_RSA_PUBKEY(self._bio, pointer(self._rsa), None, None):

--- a/salt/version.py
+++ b/salt/version.py
@@ -574,6 +574,7 @@ def dependency_information(include_salt_cloud=False):
         ('msgpack-python', 'msgpack', 'version'),
         ('msgpack-pure', 'msgpack_pure', 'version'),
         ('pycrypto', 'Crypto', '__version__'),
+        ('pycryptodome', 'Cryptodome', '__version__'),
         ('libnacl', 'libnacl', '__version__'),
         ('PyYAML', 'yaml', '__version__'),
         ('ioflo', 'ioflo', '__version__'),

--- a/salt/version.py
+++ b/salt/version.py
@@ -574,7 +574,7 @@ def dependency_information(include_salt_cloud=False):
         ('msgpack-python', 'msgpack', 'version'),
         ('msgpack-pure', 'msgpack_pure', 'version'),
         ('pycrypto', 'Crypto', '__version__'),
-        ('pycryptodome', 'Cryptodome', '__version__'),
+        ('pycryptodome', 'Cryptodome', 'version_info'),
         ('libnacl', 'libnacl', '__version__'),
         ('PyYAML', 'yaml', '__version__'),
         ('ioflo', 'ioflo', '__version__'),


### PR DESCRIPTION
pycryptodomex, this allows us to maintain compat with pycrypto being
installed on the system without introducing a module library dependency
This should fix the issues with using the outdated pycrypto library by supporting the new cryptodome library. This assumes that the cryptodome package is installed in the pycryptodomex approach to pick up pycryptodome as a separate lib.

I am still running tests