### PR TITLE
Group checks for failhard setting in () in state.check_failhard function

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1825,8 +1825,7 @@ class State(object):
         tag = _gen_tag(low)
         if self.opts.get('test', False):
             return False
-        if (low.get('failhard', False) or self.opts['failhard']
-                and tag in running):
+        if (low.get('failhard', False) or self.opts['failhard']) and tag in running:
             if running[tag]['result'] is None:
                 return False
             return not running[tag]['result']

--- a/tests/integration/files/file/base/requisites/require_order_failhard_combo.sls
+++ b/tests/integration/files/file/base/requisites/require_order_failhard_combo.sls
@@ -1,0 +1,13 @@
+a:
+  test.show_notification:
+    - name: a
+    - text: message
+    - require:
+        - test: b
+    - order: 1
+    - failhard: True
+
+b:
+  test.fail_with_changes:
+    - name: b
+    - failhard: True

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -1112,6 +1112,27 @@ class StateModuleTest(integration.ModuleCase,
         self.assertEqual(state_run[bar_state]['comment'],
                          'Command "echo bar" run')
 
+    def test_issue_38683_require_order_failhard_combination(self):
+        '''
+        This tests the case where require, order, and failhard are all used together in a state definition.
+
+        Previously, the order option, which used in tandem with require and failhard, would cause the state
+        compiler to stacktrace. This exposed a logic error in the ``check_failhard`` function of the state
+        compiler. With the logic error resolved, this test should now pass.
+
+        See https://github.com/saltstack/salt/issues/38683 for more information.
+        '''
+        state_run = self.run_function(
+            'state.sls',
+            mods='requisites.require_order_failhard_combo'
+        )
+        state_id = 'test_|-b_|-b_|-fail_with_changes'
+
+        self.assertIn(state_id, state_run)
+        self.assertEqual(state_run[state_id]['comment'], 'Failure!')
+        self.assertFalse(state_run[state_id]['result'])
+
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(StateModuleTest)


### PR DESCRIPTION
### What does this PR do?
When two states combine the `require`, `failhard`, and `order` options, the `order` option should be ignored because `require` is present. Then the `failhard` option should make the state run fail. See the [order option docs](https://docs.saltstack.com/en/latest/ref/states/ordering.html#the-order-option) for more information.

The check for "failhard" in the `check_failhard` function in the state compiler was too broad. We want "failhard" to be true AND the state tag to be in the `running` dict. Without the parens around the first OR statement, we were bypassing the AND requirement because failhard was found from the previous state run that had failhard set to True.

Since the second state's tag was not found in the running dict, the state run stacktraces on a KeyError.

### What issues does this PR fix or reference?
Fixes #38683

### Previous Behavior
The state run stack traces in the state compiler:
```
# salt-call --local state.apply a -ldebug
<snipped>
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
KeyError: 'test_|-a_|-a_|-show_notification'
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/testing/salt/scripts.py", line 379, in salt_call
    client.run()
  File "/testing/salt/cli/call.py", line 58, in run
    caller.run()
  File "/testing/salt/cli/caller.py", line 134, in run
    ret = self.call()
  File "/testing/salt/cli/caller.py", line 197, in call
    ret['return'] = func(*args, **kwargs)
  File "/testing/salt/modules/state.py", line 550, in apply_
    return sls(mods, **kwargs)
  File "/testing/salt/modules/state.py", line 1053, in sls
    ret = st_.state.call_high(high_, orchestration_jid)
  File "/testing/salt/state.py", line 2306, in call_high
    ret = dict(list(disabled.items()) + list(self.call_chunks(chunks).items()))
  File "/testing/salt/state.py", line 1819, in call_chunks
    if self.check_failhard(low, running):
  File "/testing/salt/state.py", line 1837, in check_failhard
    if running[tag]['result'] is None:
KeyError: 'test_|-a_|-a_|-show_notification'
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/testing/salt/scripts.py", line 379, in salt_call
    client.run()
  File "/testing/salt/cli/call.py", line 58, in run
    caller.run()
  File "/testing/salt/cli/caller.py", line 134, in run
    ret = self.call()
  File "/testing/salt/cli/caller.py", line 197, in call
    ret['return'] = func(*args, **kwargs)
  File "/testing/salt/modules/state.py", line 550, in apply_
    return sls(mods, **kwargs)
  File "/testing/salt/modules/state.py", line 1053, in sls
    ret = st_.state.call_high(high_, orchestration_jid)
  File "/testing/salt/state.py", line 2306, in call_high
    ret = dict(list(disabled.items()) + list(self.call_chunks(chunks).items()))
  File "/testing/salt/state.py", line 1819, in call_chunks
    if self.check_failhard(low, running):
  File "/testing/salt/state.py", line 1837, in check_failhard
    if running[tag]['result'] is None:
KeyError: 'test_|-a_|-a_|-show_notification'
```

### New Behavior
State run completes as expected:
```
# salt-call --local state.apply a -ldebug
<snipped>
local:
----------
          ID: b
    Function: test.fail_with_changes
      Result: False
     Comment: Failure!
     Started: 20:14:20.811358
    Duration: 0.793 ms
     Changes:
              ----------
              testing:
                  ----------
                  new:
                      Something pretended to change
                  old:
                      Unchanged

Summary for local
------------
Succeeded: 0 (changed=1)
Failed:    1
------------
Total states run:     1
Total run time:   0.793 ms
```

### Tests written?
Yes!

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
