### PR TITLE
Add deprecation warnings to win_update state and execution modules

### DIFF
--- a/salt/modules/win_update.py
+++ b/salt/modules/win_update.py
@@ -2,6 +2,8 @@
 '''
 Module for running windows updates.
 
+This module is being deprecated. Please use the ``win_wua`` module instead.
+
 :depends:   - win32com
         - win32con
         - win32api
@@ -82,8 +84,15 @@ def __virtual__():
     '''
     Only works on Windows systems
     '''
+    salt.utils.warn_until(
+        'Oxygen',
+        'The \'win_update\' module is deprecated, and will be removed in Salt '
+        '{version}. Please use the \'win_wua\' module instead.'
+    )
+
     if salt.utils.is_windows() and HAS_DEPENDENCIES:
         return True
+
     return (False, "Module win_update: module has failed dependencies or is not on Windows client")
 
 

--- a/salt/modules/win_update.py
+++ b/salt/modules/win_update.py
@@ -2,7 +2,7 @@
 '''
 Module for running windows updates.
 
-This module is being deprecated and will be removed in Salt Flourine. Please use
+This module is being deprecated and will be removed in Salt Fluorine. Please use
 the ``win_wua`` module instead.
 
 :depends:   - win32com
@@ -87,7 +87,7 @@ def __virtual__():
     '''
     if salt.utils.is_windows() and HAS_DEPENDENCIES:
         salt.utils.warn_until(
-            'Flourine',
+            'Fluorine',
             'The \'win_update\' module is being deprecated and will be removed '
             'in Salt {version}. Please use the \'win_wua\' module instead.'
         )

--- a/salt/modules/win_update.py
+++ b/salt/modules/win_update.py
@@ -84,12 +84,12 @@ def __virtual__():
     '''
     Only works on Windows systems
     '''
-    salt.utils.warn_until(
-        'Oxygen',
-        'The \'win_update\' module is deprecated, and will be removed in Salt '
-        '{version}. Please use the \'win_wua\' module instead.'
-    )
     if salt.utils.is_windows() and HAS_DEPENDENCIES:
+        salt.utils.warn_until(
+            'Oxygen',
+            'The \'win_update\' module is deprecated, and will be removed in'
+            'Salt {version}. Please use the \'win_wua\' module instead.'
+        )
         return True
     return (False, "Module win_update: module has failed dependencies or is not on Windows client")
 

--- a/salt/modules/win_update.py
+++ b/salt/modules/win_update.py
@@ -89,10 +89,8 @@ def __virtual__():
         'The \'win_update\' module is deprecated, and will be removed in Salt '
         '{version}. Please use the \'win_wua\' module instead.'
     )
-
     if salt.utils.is_windows() and HAS_DEPENDENCIES:
         return True
-
     return (False, "Module win_update: module has failed dependencies or is not on Windows client")
 
 

--- a/salt/modules/win_update.py
+++ b/salt/modules/win_update.py
@@ -2,7 +2,8 @@
 '''
 Module for running windows updates.
 
-This module is being deprecated. Please use the ``win_wua`` module instead.
+This module is being deprecated and will be removed in Salt Flourine. Please use
+the ``win_wua`` module instead.
 
 :depends:   - win32com
         - win32con
@@ -86,9 +87,9 @@ def __virtual__():
     '''
     if salt.utils.is_windows() and HAS_DEPENDENCIES:
         salt.utils.warn_until(
-            'Oxygen',
-            'The \'win_update\' module is deprecated, and will be removed in'
-            'Salt {version}. Please use the \'win_wua\' module instead.'
+            'Flourine',
+            'The \'win_update\' module is being deprecated and will be removed '
+            'in Salt {version}. Please use the \'win_wua\' module instead.'
         )
         return True
     return (False, "Module win_update: module has failed dependencies or is not on Windows client")

--- a/salt/states/win_update.py
+++ b/salt/states/win_update.py
@@ -463,9 +463,9 @@ def installed(name, categories=None, skips=None, retries=10):
            'changes': {},
            'comment': ''}
     deprecation_msg = 'The \'win_update\' module is deprecated, and will be ' \
-                      'removed in Salt Oxygen. Please use the \'win_wua\' ' \
+                      'removed in Salt Fluorine. Please use the \'win_wua\' ' \
                       'module instead.'
-    salt.utils.warn_until('Oxygen', deprecation_msg)
+    salt.utils.warn_until('Fluorine', deprecation_msg)
     ret.setdefault('warnings', []).append(deprecation_msg)
     if not categories:
         categories = [name]
@@ -547,9 +547,9 @@ def downloaded(name, categories=None, skips=None, retries=10):
            'comment': ''}
 
     deprecation_msg = 'The \'win_update\' module is deprecated, and will be ' \
-                      'removed in Salt Oxygen. Please use the \'win_wua\' ' \
+                      'removed in Salt Fluorine. Please use the \'win_wua\' ' \
                       'module instead.'
-    salt.utils.warn_until('Oxygen', deprecation_msg)
+    salt.utils.warn_until('Fluorine', deprecation_msg)
     ret.setdefault('warnings', []).append(deprecation_msg)
 
     if not categories:

--- a/salt/states/win_update.py
+++ b/salt/states/win_update.py
@@ -3,7 +3,7 @@
 Management of the windows update agent
 ======================================
 
-This module is being deprecated and will be removed in Salt Flourine. Please use
+This module is being deprecated and will be removed in Salt Fluorine. Please use
 the ``win_wua`` state module instead.
 
 .. versionadded:: 2014.7.0

--- a/salt/states/win_update.py
+++ b/salt/states/win_update.py
@@ -3,7 +3,8 @@
 Management of the windows update agent
 ======================================
 
-This module is being deprecated. Please use the ``win_wua`` module instead.
+This module is being deprecated and will be removed in Salt Flourine. Please use
+the ``win_wua`` state module instead.
 
 .. versionadded:: 2014.7.0
 

--- a/salt/states/win_update.py
+++ b/salt/states/win_update.py
@@ -3,6 +3,8 @@
 Management of the windows update agent
 ======================================
 
+This module is being deprecated. Please use the ``win_wua`` module instead.
+
 .. versionadded:: 2014.7.0
 
 Set windows updates to run by category. Default behavior is to install
@@ -454,10 +456,16 @@ def installed(name, categories=None, skips=None, retries=10):
         Number of retries to make before giving up. This is total, not per
         step.
     '''
+
     ret = {'name': name,
            'result': True,
            'changes': {},
            'comment': ''}
+    deprecation_msg = 'The \'win_update\' module is deprecated, and will be ' \
+                      'removed in Salt Oxygen. Please use the \'win_wua\' ' \
+                      'module instead.'
+    salt.utils.warn_until('Oxygen', deprecation_msg)
+    ret.setdefault('warnings', []).append(deprecation_msg)
     if not categories:
         categories = [name]
     log.debug('categories to search for are: {0}'.format(categories))
@@ -536,6 +544,13 @@ def downloaded(name, categories=None, skips=None, retries=10):
            'result': True,
            'changes': {},
            'comment': ''}
+
+    deprecation_msg = 'The \'win_update\' module is deprecated, and will be ' \
+                      'removed in Salt Oxygen. Please use the \'win_wua\' ' \
+                      'module instead.'
+    salt.utils.warn_until('Oxygen', deprecation_msg)
+    ret.setdefault('warnings', []).append(deprecation_msg)
+
     if not categories:
         categories = [name]
     log.debug('categories to search for are: {0}'.format(categories))

--- a/tests/unit/states/test_win_update.py
+++ b/tests/unit/states/test_win_update.py
@@ -72,7 +72,10 @@ class WinUpdateTestCase(TestCase):
         ret = {'name': 'salt',
                'changes': {},
                'result': False,
-               'comment': ''}
+               'comment': '',
+               'warnings': ["The 'win_update' module is deprecated, and will "
+                            "be removed in Salt Fluorine. Please use the "
+                            "'win_wua' module instead."]}
 
         mock = MagicMock(side_effect=[['Saltstack', False, 5],
                                       ['Saltstack', True, 5],
@@ -105,7 +108,10 @@ class WinUpdateTestCase(TestCase):
         ret = {'name': 'salt',
                'changes': {},
                'result': False,
-               'comment': ''}
+               'comment': '',
+               'warnings': ["The 'win_update' module is deprecated, and will "
+                            "be removed in Salt Fluorine. Please use the "
+                            "'win_wua' module instead."]}
 
         mock = MagicMock(side_effect=[['Saltstack', False, 5],
                                       ['Saltstack', True, 5],


### PR DESCRIPTION
### What does this PR do?
Adds deprecation warning to the `win_update` state module and the `win_update` execution module. The `win_wua` module is replacing `win_update` in future versions of Salt.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/32828