### PR TITLE
Add mocks to allow keyboard tests to function on non-Linux systems

### DIFF
--- a/tests/unit/modules/test_keyboard.py
+++ b/tests/unit/modules/test_keyboard.py
@@ -35,8 +35,9 @@ class KeyboardTestCase(TestCase, LoaderModuleMockMixin):
         Test if it get current system keyboard setting
         '''
         mock = MagicMock(return_value='X11 Layout=us')
-        with patch.dict(keyboard.__salt__, {'cmd.run': mock}):
-            self.assertEqual(keyboard.get_sys(), 'us')
+        with patch.dict(keyboard.__grains__, {'os_family': 'RedHat'}):
+            with patch.dict(keyboard.__salt__, {'cmd.run': mock}):
+                self.assertEqual(keyboard.get_sys(), 'us')
 
     # 'set_sys' function tests: 1
 
@@ -45,8 +46,10 @@ class KeyboardTestCase(TestCase, LoaderModuleMockMixin):
         Test if it set current system keyboard setting
         '''
         mock = MagicMock(return_value='us')
-        with patch.dict(keyboard.__salt__, {'cmd.run': mock}):
-            self.assertEqual(keyboard.set_sys('us'), 'us')
+        with patch.dict(keyboard.__grains__, {'os_family': 'RedHat'}):
+            with patch.dict(keyboard.__salt__, {'cmd.run': mock}):
+                with patch.dict(keyboard.__salt__, {'file.sed': MagicMock()}):
+                    self.assertEqual(keyboard.set_sys('us'), 'us')
 
     # 'get_x' function tests: 1
 


### PR DESCRIPTION
### What does this PR do?

Fix `unit.modules.test_keyboard` for systems that do not have *localectl(1)* and the pathname `/etc/default/keyboard`

### Previous Behavior

Test relied on `salt.utils.which('localectl')` succeeding

    -> unit.modules.test_keyboard.KeyboardTestCase.test_set_sys  ................
        Traceback (most recent call last):
          File "/home/eradman/git/salt/tests/unit/modules/test_keyboard.py", line 50, in test_set_sys
            self.assertEqual(keyboard.set_sys('us'), 'us')
          File "/home/eradman/git/salt/salt/modules/keyboard.py", line 64, in set_sys
            elif 'RedHat' in __grains__['os_family']:
        KeyError: 'os_family'
