### PR TITLE
Set True instead of 1

### DIFF
--- a/doc/topics/cloud/proxmox.rst
+++ b/doc/topics/cloud/proxmox.rst
@@ -212,7 +212,7 @@ QEMU profile file (for a clone):
 
   proxmox-win7:
     # Enable Clone
-    clone: 1
+    clone: True
 
     # New VM description
     clone_description: 'description'


### PR DESCRIPTION
### What does this PR do?

Replace "1" with "True"

### What issues does this PR fix or reference?

When using technology: qemu and clone: 1, Salt do not clone but create a new VM
L774 of cloud/clouds/proxmox.py is : if 'clone' in vm_ and vm_['clone'] is True and vm_['technology'] == 'qemu':

Comparison fails on "vm_['clone'] is True"

### Previous Behavior
When using technology: qemu and clone: 1, Salt do not clone but create a new VM.

### New Behavior
When using technology: qemu and clone: True, Salt do create a clone

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
