### PR TITLE
Salt-vault: Fix handling of None-grains

### DIFF
--- a/salt/runners/vault.py
+++ b/salt/runners/vault.py
@@ -114,7 +114,7 @@ def _get_policies(minion_id, config):
                                  'policies',
                                  ['saltstack/minion/{minion}', 'saltstack/minions']
                                 )
-    mappings = {'minion': minion_id, 'grains': grains}
+    mappings = {'minion': minion_id, 'grains': grains or {}}
 
     policies = []
     for pattern in policy_patterns:

--- a/tests/unit/runners/test_vault.py
+++ b/tests/unit/runners/test_vault.py
@@ -110,7 +110,6 @@ class VaultTest(TestCase, LoaderModuleMockMixin):
                     log.debug('Difference:\n\t{0}'.format(diff))
                 self.assertEqual(output, correct_output)
 
-
     @skipIf(NO_MOCK, NO_MOCK_REASON)
     def test_get_policies(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Currently, if using state.orchestrate, some rendering is done on the master-minion, which does not return any grains. This in turn breaks the formatter when there is a None-value.

### Tests written?

Yes
