### PR TITLE
git.latest with force_clone fails when it can't create a target directory that already exists

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -1612,7 +1612,7 @@ def latest(name,
                 for target_object in target_contents:
                     target_path = os.path.join(target, target_object)
                     try:
-                        salt.utils.rm_rf(target)
+                        salt.utils.rm_rf(target_path)
                     except OSError as exc:
                         removal_errors[target_path] = exc
                 if removal_errors:


### PR DESCRIPTION
### What does this PR do?
Fixes the `force_clone` option in `git.latest` state, by removing the target directory's contents, instead of target directory. Previous behavior runs into a corner case where target directory can't be recreated due to user's lacking priviledges to write in target's parent dir.

### What issues does this PR fix or reference?
#31363

### Reference SLS
```
{% set target_dir = '/tmp/asdf/asdf' %}
{% set username = 'asdf' %}

step1:
  pkg.installed:
    - name: git
    - refresh: true
    - reload_modules: true
  user.present:
    - name: {{ username }}
  file.directory:
    - name: {{ target_dir.split('/')[:-1]|join('/') }}
    - user: root

step2:
  file.directory:
    - name: {{ target_dir }}
    - user: {{ username }}
    - require:
      - user: step1
      - file: step1

step3:
  file.managed:
    - name: {{ target_dir }}/asdf
    - user: root
    - require:
      - file: step2
  git.latest:
    - name: https://github.com/saltstack/salt
    - target: {{ target_dir }}
    - user: {{ username }}
    - force_clone: true
    - require:
      - file: step3
      - pkg: step1
```

### Previous Behavior
```
ubuntu1:
  Name: git - Function: pkg.installed - Result: Clean Started: - 14:31:53.923285 Duration: 57.604 ms
  Name: asdf - Function: user.present - Result: Clean Started: - 14:31:53.987073 Duration: 8.299 ms
  Name: /tmp/asdf - Function: file.directory - Result: Changed Started: - 14:31:54.018710 Duration: 0.787 ms
  Name: /tmp/asdf/asdf - Function: file.directory - Result: Changed Started: - 14:31:54.019846 Duration: 0.832 ms
  Name: /tmp/asdf/asdf/asdf - Function: file.managed - Result: Changed Started: - 14:31:54.020933 Duration: 1.0 ms
----------
          ID: step3
    Function: git.latest
        Name: https://github.com/saltstack/salt
      Result: False
     Comment: Clone failed: fatal: could not create work tree dir '/tmp/asdf/asdf': Permission denied
     Started: 14:31:54.045517
    Duration: 1799.632 ms
     Changes:   
              ----------
              forced clone:
                  True

Summary for ubuntu1
------------
Succeeded: 5 (changed=4)
Failed:    1
------------
Total states run:     6
Total run time:   1.868 s
```

### New Behavior
```
ubuntu1:
  Name: git - Function: pkg.installed - Result: Clean Started: - 14:34:23.310340 Duration: 58.718 ms
  Name: asdf - Function: user.present - Result: Clean Started: - 14:34:23.371201 Duration: 8.656 ms
  Name: /tmp/asdf - Function: file.directory - Result: Changed Started: - 14:34:23.381185 Duration: 0.752 ms
  Name: /tmp/asdf/asdf - Function: file.directory - Result: Changed Started: - 14:34:23.382278 Duration: 0.777 ms
  Name: /tmp/asdf/asdf/asdf - Function: file.managed - Result: Changed Started: - 14:34:23.383309 Duration: 1.013 ms
  Name: https://github.com/saltstack/salt - Function: git.latest - Result: Changed Started: - 14:34:23.396015 Duration: 57662.77 ms

Summary for ubuntu1
------------
Succeeded: 6 (changed=4)
Failed:    0
------------
Total states run:     6
Total run time:  57.733 s
```

### Tests written?
No

Given how the issue remained untouched for over a year, I wouldn't expect the fix to be trivial, so I'm welcoming any feedback related to this issue.