### PR TITLE
Allow for nightly build designations in Salt versions

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -60,7 +60,7 @@ class SaltStackVersion(object):
         r'\.(?P<minor>[\d]{1,2})'
         r'(?:\.(?P<bugfix>[\d]{0,2}))?'
         r'(?:\.(?P<mbugfix>[\d]{0,2}))?'
-        r'(?:(?P<pre_type>rc|a|b|alpha|beta)(?P<pre_num>[\d]{1}))?'
+        r'(?:(?P<pre_type>rc|a|b|alpha|beta|nb)(?P<pre_num>[\d]{1}))?'
         r'(?:(?:.*)-(?P<noc>(?:[\d]+|n/a))-(?P<sha>[a-z0-9]{8}))?'
     )
     git_sha_regex = re.compile(r'(?P<sha>[a-z0-9]{7})')


### PR DESCRIPTION
### What does this PR do?
Allows for a night build (nb) designation for Salt build versions, similar to those already existing for alpha and beta

### What issues does this PR fix or reference?
Nightly builds are patching the version.py file to produce a 'night;y build' version.
This would remove the need to patch.

### New Behavior
allows for a 'nb' designation in the Salt version to indicate a 'nightly build', 
for example: salt-2016.11.0nb201704041406029067186.tar.gz

### Tests written?
No - already being used by patching in current nightly builds

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
