### PR TITLE
Utils aws sig4 header fix

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -24,7 +24,6 @@ import re
 # Import Salt libs
 import salt.utils.xmlutil as xml
 from salt._compat import ElementTree as ET
-import salt.ext.six as six
 
 # Import 3rd-party libs
 try:

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -238,10 +238,16 @@ def sig4(method, endpoint, params, prov_dict,
 
     amzdate = timenow.strftime('%Y%m%dT%H%M%SZ')
     datestamp = timenow.strftime('%Y%m%d')
-
     new_headers = {}
+
+    # Create payload hash (hash of the request body content). For GET
+    # requests, the payload is an empty string ('').
+    if not payload_hash:
+        payload_hash = hashlib.sha256(data).hexdigest()
+
     new_headers['X-Amz-date'] = amzdate
     new_headers['host'] = endpoint
+    new_headers['x-amz-content-sha256'] = payload_hash
     a_canonical_headers = []
     a_signed_headers = []
     if isinstance(headers, dict):
@@ -259,11 +265,6 @@ def sig4(method, endpoint, params, prov_dict,
     signed_headers = ';'.join(a_signed_headers)
 
     algorithm = 'AWS4-HMAC-SHA256'
-
-    # Create payload hash (hash of the request body content). For GET
-    # requests, the payload is an empty string ('').
-    if not payload_hash:
-        payload_hash = hashlib.sha256(data).hexdigest()
 
     # Combine elements to create create canonical request
     canonical_request = '\n'.join((
@@ -309,7 +310,6 @@ def sig4(method, endpoint, params, prov_dict,
             signature,
         )
 
-    new_headers['x-amz-content-sha256'] = payload_hash
     new_headers['Authorization'] = authorization_header
 
     requesturl = '{0}?{1}'.format(requesturl, querystring)

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -239,6 +239,8 @@ def sig4(method, endpoint, params, prov_dict,
     amzdate = timenow.strftime('%Y%m%dT%H%M%SZ')
     datestamp = timenow.strftime('%Y%m%d')
     new_headers = {}
+    if isinstance(headers, dict):
+        new_headers = headers.copy()
 
     # Create payload hash (hash of the request body content). For GET
     # requests, the payload is an empty string ('').
@@ -250,9 +252,6 @@ def sig4(method, endpoint, params, prov_dict,
     new_headers['x-amz-content-sha256'] = payload_hash
     a_canonical_headers = []
     a_signed_headers = []
-    if isinstance(headers, dict):
-        for key, value in six.iteritems(headers):
-            new_headers[key] = value
 
     if token != '':
         new_headers['X-Amz-security-token'] = token


### PR DESCRIPTION
### What does this PR do?
It fixes the case where headers end up out-of-order in SignedHeaders, invalidating the sig4 signature.
It signs all headers, which is not required, but recommended (and it does make things easier to code anyway).

### What issues does this PR fix or reference?
Haven't looked for an official issue, haven't created one for this either :)

### Previous Behavior
Example: the Authorization-header contained: "SignedHeaders=host;x-amz-date;x-amz-tagging;x-amz-security-token"

### New Behavior
All headers are sorted lowercase and added to the SignedHeaders
Example: the Authorization-header contains: "SignedHeaders=host;x-amz-date;x-amz-security-token;x-amz-tagging"

### Tests written?
No, though my S3 bucket put-object-with-tags test works.