### PR TITLE
Add the "fingerprint_hash_type" option to ssh state and module

### DIFF
--- a/salt/states/ssh_known_hosts.py
+++ b/salt/states/ssh_known_hosts.py
@@ -50,7 +50,8 @@ def present(
         enc=None,
         config=None,
         hash_known_hosts=True,
-        timeout=5):
+        timeout=5,
+        fingerprint_hash_type=None):
     '''
     Verifies that the specified host is known by the specified user
 
@@ -96,6 +97,18 @@ def present(
         and the host in question considered unavailable.  Default is 5 seconds.
 
         .. versionadded:: 2016.3.0
+
+    fingerprint_hash_type
+        The public key fingerprint hash type that the public key fingerprint
+        was originally hashed with. This defaults to ``md5`` if not specified.
+
+        .. versionadded:: 2016.11.4
+
+        .. note::
+
+            The default value of the ``fingerprint_hash_type`` will change to
+            ``sha256`` in Salt Nitrogen.
+
     '''
     ret = {'name': name,
            'changes': {},
@@ -127,7 +140,8 @@ def present(
                                                       key=key,
                                                       fingerprint=fingerprint,
                                                       config=config,
-                                                      port=port)
+                                                      port=port,
+                                                      fingerprint_hash_type=fingerprint_hash_type)
         except CommandNotFoundError as err:
             ret['result'] = False
             ret['comment'] = 'ssh.check_known_host error: {0}'.format(err)
@@ -146,14 +160,17 @@ def present(
                                                                      config)
             return dict(ret, comment=comment)
 
-    result = __salt__['ssh.set_known_host'](user=user, hostname=name,
-                fingerprint=fingerprint,
-                key=key,
-                port=port,
-                enc=enc,
-                config=config,
-                hash_known_hosts=hash_known_hosts,
-                timeout=timeout)
+    result = __salt__['ssh.set_known_host'](
+        user=user,
+        hostname=name,
+        fingerprint=fingerprint,
+        key=key,
+        port=port,
+        enc=enc,
+        config=config,
+        hash_known_hosts=hash_known_hosts,
+        timeout=timeout,
+        fingerprint_hash_type=fingerprint_hash_type)
     if result['status'] == 'exists':
         return dict(ret,
                     comment='{0} already exists in {1}'.format(name, config))


### PR DESCRIPTION
This new option allows the user to specify what kind of hash was used when the public key was hashed to a fingerprint. The default hash is md5, but the user should be able to specify this if they know what the fingerprint was originally hashed with.

Fixes #40005