### PR TITLE
Fix vultrpy

### DIFF
--- a/salt/cloud/clouds/vultrpy.py
+++ b/salt/cloud/clouds/vultrpy.py
@@ -296,7 +296,8 @@ def create(vm_):
         '''
         data = show_instance(vm_['name'], call='action')
         pprint.pprint(data)
-        if str(data.get('main_ip', '0')) == '0':
+        main_ip = str(data.get('main_ip', '0'))
+        if main_ip.startswith('0'):
             time.sleep(3)
             return False
         return data['main_ip']

--- a/tests/integration/cloud/providers/vultr.py
+++ b/tests/integration/cloud/providers/vultr.py
@@ -158,10 +158,12 @@ class VultrTest(integration.ShellCase):
         '''
         # check if instance with salt installed returned
         try:
+            create_vm = self.run_cloud('-p vultr-test {0}'.format(INSTANCE_NAME), timeout=500)
             self.assertIn(
                 INSTANCE_NAME,
-                [i.strip() for i in self.run_cloud('-p vultr-test {0}'.format(INSTANCE_NAME), timeout=500)]
+                [i.strip() for i in create_vm]
             )
+            self.assertNotIn('Failed to start', str(create_vm))
         except AssertionError:
             self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=500)
             raise


### PR DESCRIPTION
### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/39993

### Previous Behavior
On creation of a VM in vultr the ip address starts with 0.0.0.0 until the network has started. The previous code wouldn't hit the code that helps wait for this condition because it was matching on '0' and salt would not be installed because it would try to remote into 0.0.0.0.

### New Behavior
You can now create a VM and salt installs.

### Tests written?

Yes there are tests. The tests did not catch this because this returns with exit code 0, when salt is not deployed correctly. I think this is a bigger part of this issue: https://github.com/saltstack/salt/issues/18510 that would need to be resolved. If i'm wrong abut that assumption please let me know and I can write a separate issue to track this. I also added a test to refine the check for salt being installed