### PR TITLE
Fix four issues in archive.extracted state

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -555,8 +555,6 @@ def get_source_sum(file_name='',
         Optional file name being managed, for matching with
         :py:func:`file.extract_hash <salt.modules.file.extract_hash>`.
 
-        .. versionadded:: 2016.11.0
-
     source
         Source file, as used in :py:mod:`file <salt.states.file>` and other
         states. If ``source_hash`` refers to a file containing hashes, then
@@ -574,8 +572,6 @@ def get_source_sum(file_name='',
     source_hash_name
         Specific file name to look for when ``source_hash`` refers to a remote
         file, used to disambiguate ambiguous matches.
-
-        .. versionadded:: 2016.11.0
 
     saltenv : base
         Salt fileserver environment from which to retrive the source_hash. This

--- a/tests/unit/states/archive_test.py
+++ b/tests/unit/states/archive_test.py
@@ -26,7 +26,7 @@ from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-bui
 # Globals
 archive.__salt__ = {}
 archive.__grains__ = {'os': 'FooOS!'}
-archive.__opts__ = {"cachedir": "/tmp", "test": False}
+archive.__opts__ = {'cachedir': '/tmp', 'test': False, 'hash_type': 'sha256'}
 archive.__env__ = 'test'
 
 


### PR DESCRIPTION
1. The trim_output argument was ignored for archives extracted using tarfile.

2. ``file.get_source_sum`` would fail if ``source`` is a list.

3. The checksum was being updated before we checked to see if it matched, effectively keeping us from detecting changes to the hash.

4. When ``source_hash_update`` is ``True``, and the archive is extracted, and files are later removed from the extraction dir, the state would not re-extract the archive unless the ``source_hash`` had changed (#39868).

Resolves #39868.