### PR TITLE
Fix the documentation for AWS

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -57,7 +57,7 @@ parameters are discussed in more detail below.
       id: 'use-instance-role-credentials'
       key: 'use-instance-role-credentials'
 
-      # Make sure this key is owned by root with permissions 0400.
+      # Make sure this key is owned by corresponding user (default 'salt') with permissions 0400.
       #
       private_key: /etc/salt/my_test_key.pem
       keyname: my_test_key


### PR DESCRIPTION
Salt Master is (better) running from `salt` user and some distribution does that already. This PR fixes the confusion where private keys chowned to `root` no longer accessible by a Master that is not running as a `root`.