### PR TITLE
Update and refresh logadm module

### DIFF
--- a/salt/modules/logadm.py
+++ b/salt/modules/logadm.py
@@ -14,7 +14,7 @@ import salt.utils
 log = logging.getLogger(__name__)
 default_conf = '/etc/logadm.conf'
 option_toggles = {
-    '-c': 'copy_and_truncate',
+    '-c': 'copy',
     '-l': 'localtime',
     '-N': 'skip_missing',
 }
@@ -205,6 +205,8 @@ def rotate(name,
            conf_file=default_conf):
     '''
     Set up pattern for logging.
+
+    .. versionchanged:: Nitrogen
 
     CLI Example:
 

--- a/salt/modules/logadm.py
+++ b/salt/modules/logadm.py
@@ -67,7 +67,7 @@ def _parse_conf(conf_file=default_conf):
     return ret
 
 
-def _parse_options(entry, options):
+def _parse_options(entry, options, include_unset=True):
     '''
     Parse a logadm options string
     '''
@@ -79,6 +79,8 @@ def _parse_options(entry, options):
     # handle toggle options
     for flag, name in option_toggles.items():
         log_cfg[name] = flag in options
+        if not include_unset and not log_cfg[name]:
+            del log_cfg[name]
         if flag in options:
             options.remove(flag)
 
@@ -90,7 +92,8 @@ def _parse_options(entry, options):
                 value = options[options.index(flag)+1]
             options.remove(flag)
 
-        log_cfg[name] = value
+        if value or include_unset:
+            log_cfg[name] = value
         if value:
             options.remove(value)
 
@@ -139,7 +142,7 @@ def show_conf(conf_file=default_conf, name=None):
         return cfg
 
 
-def list_conf(conf_file=default_conf, log_file=None):
+def list_conf(conf_file=default_conf, log_file=None, include_unset=False):
     '''
     Show parsed configuration
 
@@ -149,6 +152,8 @@ def list_conf(conf_file=default_conf, log_file=None):
         path to logadm.conf, defaults to /etc/logadm.conf
     log_file : string
         optional show only one log file
+    include_unset : boolean
+        include unset flags in output
 
     CLI Example:
 
@@ -156,13 +161,14 @@ def list_conf(conf_file=default_conf, log_file=None):
 
         salt '*' logadm.list_conf
         salt '*' logadm.list_conf log=/var/log/syslog
+        salt '*' logadm.list_conf include_unset=False
     '''
     cfg = _parse_conf(conf_file)
     cfg_parsed = {}
 
     ## parse all options
     for entry in cfg:
-        log_cfg = _parse_options(entry, cfg[entry])
+        log_cfg = _parse_options(entry, cfg[entry], include_unset)
         cfg_parsed[log_cfg['log_file'] if log_cfg['log_file'] else log_cfg['entryname']] = log_cfg
 
     ## filter

--- a/salt/modules/logadm.py
+++ b/salt/modules/logadm.py
@@ -41,17 +41,32 @@ def _parse_conf(conf_file=default_conf):
     return ret
 
 
-def show_conf(conf_file=default_conf):
+def show_conf(conf_file=default_conf, name=None):
     '''
     Show parsed configuration
+
+    .. versionchanged:: Nitrogen
+
+    conf_file : string
+        path to logadm.conf, defaults to /etc/logadm.conf
+    name : string
+        optional show only a single entry
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' logadm.show_conf
+        salt '*' logadm.show_conf log_file=/var/log/syslog
     '''
-    return _parse_conf(conf_file)
+    cfg = _parse_conf(conf_file)
+
+    if name and name in cfg:
+        return {name: cfg[name]}
+    elif name:
+        return {name: 'not found in {}'.format(conf_file)}
+    else:
+        return cfg
 
 
 def rotate(name,


### PR DESCRIPTION
### What does this PR do?
Updates and refreshes the logadm execution module in preparation for creating a logadm state.

### What issues does this PR fix or reference?
N/a

### Previous Behavior
Not all flags and options could be passed with logadm.rotate

### New Behavior
All flags and options can be passed to logadm.rotate, additionally a logadm.list_conf was added that outputs a dict.

This should make the configuration more readable and much more easier to work with in a state module.

A lot of work was done on logadm.rotate, so far those changes did not break anything in my configuration. It even made a few ones that didn't work before to work now.

### Tests written?
No, existing tests still passed.