### PR TITLE
Allow pillar.get to merge list as well as dictionaries

### DIFF
--- a/tests/unit/modules/pillar_test.py
+++ b/tests/unit/modules/pillar_test.py
@@ -54,16 +54,57 @@ class PillarModuleTestCase(TestCase):
     def test_ls(self):
         self.assertEqual(pillarmod.ls(), ['a', 'b'])
 
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
     def test_pillar_get_default_merge(self):
+        defaults = {'int': 1,
+                    'string': 'foo',
+                    'list': ['foo'],
+                    'dict': {'foo': 'bar', 'subkey': {'foo': 'bar'}}}
+
         pillarmod.__opts__ = {}
-        pillarmod.__pillar__ = {'key': 'value'}
-        default = {'default': 'plop'}
+        pillarmod.__pillar__ = {'int': 2,
+                                'string': 'bar',
+                                'list': ['bar', 'baz'],
+                                'dict': {'baz': 'qux', 'subkey': {'baz': 'qux'}}}
 
-        res = pillarmod.get(key='key', default=default)
-        self.assertEqual("value", res)
+        # Test that we raise a KeyError when pillar_raise_on_missing is True
+        with patch.dict(pillarmod.__opts__, {'pillar_raise_on_missing': True}):
+            self.assertRaises(KeyError, pillarmod.get, 'missing')
+        # Test that we return an empty string when it is not
+        self.assertEqual(pillarmod.get('missing'), '')
 
-        res = pillarmod.get(key='missing pillar', default=default)
-        self.assertEqual({'default': 'plop'}, res)
+        # Test with no default passed (it should be KeyError) and merge=True.
+        # The merge should be skipped and the value returned from __pillar__
+        # should be returned.
+        for item in pillarmod.__pillar__:
+            self.assertEqual(
+                pillarmod.get(item, merge=True),
+                pillarmod.__pillar__[item]
+            )
+
+        # Test merging when the type of the default value is not the same as
+        # what was returned. Merging should be skipped and the value returned
+        # from __pillar__ should be returned.
+        for default_type in defaults:
+            for data_type in ('dict', 'list'):
+                if default_type == data_type:
+                    continue
+                self.assertEqual(
+                    pillarmod.get(item, default=defaults[default_type], merge=True),
+                    pillarmod.__pillar__[item]
+                )
+
+        # Test recursive dict merging
+        self.assertEqual(
+            pillarmod.get('dict', default=defaults['dict'], merge=True),
+            {'foo': 'bar', 'baz': 'qux', 'subkey': {'foo': 'bar', 'baz': 'qux'}}
+        )
+
+        # Test list merging
+        self.assertEqual(
+            pillarmod.get('list', default=defaults['list'], merge=True),
+            ['foo', 'bar', 'baz']
+        )
 
     def test_pillar_get_default_merge_regression_38558(self):
         """Test for pillar.get(key=..., default=..., merge=True)


### PR DESCRIPTION
This also gets rid of the exception that used to be raised when the
default was not of the proper type, and instead skips merging in those
cases.