### PR TITLE
[salt-cloud] Don't use dict.keys()[x] in PY3 since dicts cannot be indexed

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1403,8 +1403,8 @@ class Cloud(object):
         mapped_providers = self.map_providers_parallel()
         profile_details = self.opts['profiles'][profile]
         vms = {}
-        for prov in mapped_providers:
-            prov_name = mapped_providers[prov].keys()[0]
+        for prov, val in six.iteritems(mapped_providers):
+            prov_name = next(iter(val))
             for node in mapped_providers[prov][prov_name]:
                 vms[node] = mapped_providers[prov][prov_name][node]
                 vms[node]['provider'] = prov


### PR DESCRIPTION
Fixes #40437

Using 'dict.keys()' in Python 3 returns a view iterator instead of a list like in Python 2. Therefore, we cannot get an indexed item from a dict.

We could wrap that up in a list, but this is slower and somewhat sloppy since PY3 is trying to help us out and be efficient with dict views. We can get the key name by using next(iter(dict)), which works both in python 2 and 3. The order of getting the key names doesn't matter, as long as we get use them all.