### PR TITLE
only look at stdout when doing pip --version

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1101,7 +1101,7 @@ def version(bin_env=None):
     '''
     pip_bin = _get_pip_bin(bin_env)
 
-    output = __salt__['cmd.run'](
+    output = __salt__['cmd.run_stdout'](
         '{0} --version'.format(pip_bin), python_shell=False)
     try:
         return re.match(r'^pip (\S+)', output).group(1)

--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -1124,7 +1124,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
 
         mock_run = MagicMock(return_value='pip 1.4.1 /path/to/site-packages/pip')
         mock_run_all = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(pip.__salt__, {'cmd.run': mock_run,
+        with patch.dict(pip.__salt__, {'cmd.run_stdout': mock_run,
                                        'cmd.run_all': mock_run_all}):
             with patch('salt.modules.pip._get_pip_bin',
                        MagicMock(return_value='pip')):


### PR DESCRIPTION
### What does this PR do?
This fixes and issue where if running `pip --version` also returns anything to stderr, like a depreciation warning, the version is still retrieved. 

### What issues does this PR fix or reference?

### Previous Behavior
```
An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.6/site-packages/salt/state.py", line 1746, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.6/site-packages/salt/loader.py", line 1703, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.6/site-packages/salt/states/pip_state.py", line 755, in installed
                  user=user, cwd=cwd)
                File "/usr/lib/python2.6/site-packages/salt/modules/pip.py", line 1050, in list_
                  for line in freeze(bin_env=bin_env, user=user, cwd=cwd):
                File "/usr/lib/python2.6/site-packages/salt/modules/pip.py", line 1013, in freeze
                  raise CommandExecutionError(result['stderr'])
              CommandExecutionError: /usr/local/lib64/python2.6/site-packages/cryptography/__init__.py:26: DeprecationWarning: Python 2.6 is no longer supported by the Python core team, please upgrade your Python. A future version of cryptography will drop support for Python 2.6
                DeprecationWarning

              Usage:
                pip freeze [options]

              no such option: --all
```

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
