### PR TITLE
Clean out kwargs dict in cloud.action before calling cloud driver function

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1527,6 +1527,11 @@ class Cloud(object):
                         if driver not in ret[alias]:
                             ret[alias][driver] = {}
 
+                        # Clean kwargs of "__pub_*" data before running the cloud action call.
+                        # Prevents calling positional "kwarg" arg before "call" when no kwarg
+                        # argument is present in the cloud driver function's arg spec.
+                        kwargs = salt.utils.clean_kwargs(**kwargs)
+
                         if kwargs:
                             ret[alias][driver][vm_name] = self.clouds[fun](
                                 vm_name, kwargs, call='action'

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1628,7 +1628,7 @@ def clean_kwargs(**kwargs):
     Return a dict without any of the __pub* keys (or any other keys starting
     with a dunder) from the kwargs dict passed into the execution module
     functions. These keys are useful for tracking what was used to invoke
-    the function call, but they may not be desierable to have if passing the
+    the function call, but they may not be desirable to have if passing the
     kwargs forward wholesale.
     '''
     ret = {}


### PR DESCRIPTION
### What does this PR do?
When we run a cloud.action function from the CLI, the various __pub_* keys and values populate the "kwargs" arg. Then, when we attempt to call out to a cloud driver's function that *does not* accept a "kwargs" arg, we get an error.

If the cloud function only takes "name" and "call", we should not be passing in "kwargs", too.

Also fixed a small spelling error.

### What issues does this PR fix or reference?
Fixes #40278

### Previous Behavior
```
# salt-call --local cloud.action show_instance instance=test-1

Passed invalid arguments: show_instance() got multiple values for keyword argument 'call'.

Usage:

    Execute a single action on the given provider/instance

    CLI Example:

    .. code-block:: bash

        salt '*' cloud.action start instance=myinstance
        salt '*' cloud.action stop instance=myinstance
        salt '*' cloud.action show_image provider=my-ec2-config image=ami-1624987f
```

### New Behavior
```
# salt-call --local cloud.action show_instance instance=test-1
local:
    ----------
    linode-config:
        ----------
        linode:
            ----------
            test-1:
                ----------
<snipped>
```

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
