### PR TITLE
in zabbix returner do not split the minion_id

### DIFF
--- a/salt/returners/zabbix_return.py
+++ b/salt/returners/zabbix_return.py
@@ -63,7 +63,7 @@ def returner(ret):
     changes = False
     errors = False
     job_minion_id = ret['id']
-    host = job_minion_id.split('.')[0]
+    host = job_minion_id
 
     if type(ret['return']) is dict:
         for state, item in six.iteritems(ret['return']):


### PR DESCRIPTION
### What does this PR do?
Previously the minion id was split to get the host item to pass to zabbix_sender. This doesn't make any sense if you use fqdn or if you have hosts with the same subdomain in a different domain. Why don't use the minion id since it is already unique on salt.

### New Behavior
With this PR the minion id is not split anymore. We pass the minion id as is to zabbix_sender.

Tested this in production environment.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.