### PR TITLE
INFRA-4376 - Several boto_rds fixes and improvements

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -43,6 +43,8 @@ Connection module for Amazon RDS
 '''
 # keep lint from choking on _get_conn and _cache_id
 #pylint: disable=E0602
+# pylint whinging perfectly valid code
+#pylint: disable=W0106
 
 
 # Import Python libs

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -591,7 +591,13 @@ def describe_db_instances(name=None, filters=None, jmespath='DBInstances',
     args.update({'Filters': filters}) if filters else None
     pit = pag.paginate(**args)
     pit = pit.search(jmespath) if jmespath else pit
-    return [p for p in pit]
+    try:
+        return [p for p in pit]
+    except ClientError as e:
+        code = getattr(e, 'response', {}).get('Error', {}).get('Code')
+        if code != 'DBInstanceNotFound':
+            log.error(salt.utils.boto3.get_error(e))
+    return []
 
 
 def describe_db_subnet_groups(name=None, filters=None, jmespath='DBSubnetGroups',

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -229,23 +229,23 @@ def subnet_group_exists(name, tags=None, region=None, key=None, keyid=None,
 def create(name, allocated_storage, db_instance_class, engine,
            master_username, master_user_password, db_name=None,
            db_security_groups=None, vpc_security_group_ids=None,
-           availability_zone=None, db_subnet_group_name=None,
-           preferred_maintenance_window=None, db_parameter_group_name=None,
-           backup_retention_period=None, preferred_backup_window=None,
-           port=None, multi_az=None, engine_version=None,
-           auto_minor_version_upgrade=None, license_model=None, iops=None,
-           option_group_name=None, character_set_name=None,
-           publicly_accessible=None, wait_status=None, tags=None,
-           db_cluster_identifier=None, storage_type=None,
+           vpc_security_groups=None, availability_zone=None,
+           db_subnet_group_name=None, preferred_maintenance_window=None,
+           db_parameter_group_name=None, backup_retention_period=None,
+           preferred_backup_window=None, port=None, multi_az=None,
+           engine_version=None, auto_minor_version_upgrade=None,
+           license_model=None, iops=None, option_group_name=None,
+           character_set_name=None, publicly_accessible=None, wait_status=None,
+           tags=None, db_cluster_identifier=None, storage_type=None,
            tde_credential_arn=None, tde_credential_password=None,
            storage_encrypted=None, kms_key_id=None, domain=None,
            copy_tags_to_snapshot=None, monitoring_interval=None,
            monitoring_role_arn=None, domain_iam_role_name=None, region=None,
            promotion_tier=None, key=None, keyid=None, profile=None):
     '''
-    Create an RDS
+    Create an RDS Instance
 
-    CLI example to create an RDS::
+    CLI example to create an RDS Instance::
 
         salt myminion boto_rds.create myrds 10 db.t2.micro MySQL sqlusr sqlpassw
     '''
@@ -263,16 +263,23 @@ def create(name, allocated_storage, db_instance_class, engine,
         raise SaltInvocationError('availability_zone and multi_az are mutually'
                                   ' exclusive arguments.')
     if wait_status:
-        wait_statuses = ['available', 'modifying', 'backing-up']
-        if wait_status not in wait_statuses:
+        wait_stati = ['available', 'modifying', 'backing-up']
+        if wait_status not in wait_stati:
             raise SaltInvocationError('wait_status can be one of: '
-                                      '{0}'.format(wait_statuses))
+                                      '{0}'.format(wait_stati))
+    if vpc_security_groups:
+        v_tmp = __salt__['boto_secgroup.convert_to_group_ids'](
+                groups=vpc_security_groups, region=region, key=key, keyid=keyid,
+                profile=profile)
+        vpc_security_group_ids = (vpc_security_group_ids + v_tmp
+                                  if vpc_security_group_ids else v_tmp)
 
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         if not conn:
             return {'results': bool(conn)}
 
+        taglist = _tag_doc(tags)
         kwargs = {}
         boto_params = set(boto3_param_map.keys())
         keys = set(locals().keys())
@@ -281,8 +288,6 @@ def create(name, allocated_storage, db_instance_class, engine,
             if val is not None:
                 mapped = boto3_param_map[param_key]
                 kwargs[mapped[0]] = mapped[1](val)
-
-        taglist = _tag_doc(tags)
 
         # Validation doesn't want parameters that are None
         # https://github.com/boto/boto3/issues/400
@@ -294,21 +299,26 @@ def create(name, allocated_storage, db_instance_class, engine,
             return {'created': False}
         if not wait_status:
             return {'created': True, 'message':
-                    'Created RDS instance {0}.'.format(name)}
+                    'RDS instance {0} created.'.format(name)}
 
         while True:
-            log.info('Waiting 10 secs...')
+            jmespath = 'DBInstances[*].DBInstanceStatus'
+            status = describe_db_instances(name=name, jmespath=jmespath,
+                                           region=region, key=key, keyid=keyid,
+                                           profile=profile)
+            if len(status):
+                stat = status[0]
+            else:
+                # Whoops, something is horribly wrong...
+                return {'created': False,
+                        'error': "RDS instance {0} should have been created but"
+                                 " now I can't find it.".format(name)}
+            if stat == wait_status:
+                return {'created': True,
+                        'message': 'RDS instance {0} created (current status '
+                        '{1})'.format(name, stat)}
             time.sleep(10)
-            _describe = describe(name=name, tags=tags, region=region, key=key,
-                                 keyid=keyid, profile=profile)['rds']
-            if not _describe:
-                return {'created': True}
-            if _describe['DBInstanceStatus'] == wait_status:
-                return {'created': True, 'message':
-                        'Created RDS {0} with current status '
-                        '{1}'.format(name, _describe['DBInstanceStatus'])}
-
-            log.info('Current status: {0}'.format(_describe['DBInstanceStatus']))
+            log.info('Instance status after 10 seconds is: {0}'.format(stat))
 
     except ClientError as e:
         return {'error': salt.utils.boto3.get_error(e)}
@@ -560,6 +570,50 @@ def describe(name, tags=None, region=None, key=None, keyid=None,
         return {'rds': None}
 
 
+def describe_db_instances(name=None, filters=None, jmespath='DBInstances',
+                          region=None, key=None, keyid=None, profile=None):
+    '''
+    Return a detailed listing of some, or all, DB Instances visible in the
+    current scope.  Arbitrary subelements or subsections of the returned dataset
+    can be selected by passing in a valid JMSEPath filter as well.
+
+    CLI example::
+
+        salt myminion boto_rds.describe_db_instances jmespath='DBInstances[*].DBInstanceIdentifier'
+
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    pag = conn.get_paginator('describe_db_instances')
+    args = {}
+    args.update({'DBInstanceIdentifier': name}) if name else None
+    args.update({'Filters': filters}) if filters else None
+    pit = pag.paginate(**args)
+    pit = pit.search(jmespath) if jmespath else pit
+    return [p for p in pit]
+
+
+def describe_db_subnet_groups(name=None, filters=None, jmespath='DBSubnetGroups',
+                              region=None, key=None, keyid=None, profile=None):
+    '''
+    Return a detailed listing of some, or all, DB Subnet Groups visible in the
+    current scope.  Arbitrary subelements or subsections of the returned dataset
+    can be selected by passing in a valid JMSEPath filter as well.
+
+    CLI example::
+
+        salt myminion boto_rds.describe_db_subnet_groups
+
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    pag = conn.get_paginator('describe_db_subnet_groups')
+    args = {}
+    args.update({'DBSubnetGroupName': name}) if name else None
+    args.update({'Filters': filters}) if filters else None
+    pit = pag.paginate(**args)
+    pit = pit.search(jmespath) if jmespath else pit
+    return [p for p in pit]
+
+
 def get_endpoint(name, tags=None, region=None, key=None, keyid=None,
                  profile=None):
     '''
@@ -639,6 +693,8 @@ def delete(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
                 raise SaltInvocationError('RDS instance {0} has not been '
                                           'deleted completely after {1} '
                                           'seconds'.format(name, timeout))
+            log.info('Waiting up to {0} seconds for RDS instance {1} to be '
+                     'deleted.'.format(timeout, name))
             time.sleep(10)
     except ClientError as e:
         return {'error': salt.utils.boto3.get_error(e)}

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -101,6 +101,7 @@ def present(name,
             storage_type=None,
             db_security_groups=None,
             vpc_security_group_ids=None,
+            vpc_security_groups=None,
             availability_zone=None,
             db_subnet_group_name=None,
             preferred_maintenance_window=None,
@@ -174,7 +175,10 @@ def present(name,
         A list of DB security groups to associate with this DB instance.
 
     vpc_security_group_ids
-        A list of EC2 VPC security groups to associate with this DB instance.
+        A list of EC2 VPC security group IDs to associate with this DB instance.
+
+    vpc_security_groups
+        A list of EC2 VPC security groups (IDs or Name tags) to associate with this DB instance.
 
     availability_zone
         The EC2 Availability Zone that the database instance will be created
@@ -296,7 +300,7 @@ def present(name,
         A dict with region, key and keyid, or a pillar key (string) that
         contains a dict with region, key and keyid.
 
-    .. _create_dbinstance: https://boto3.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.create_db_instance
+    .. _create_db_instance: https://boto3.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.create_db_instance
     '''
     ret = {'name': name,
            'result': True,
@@ -308,7 +312,7 @@ def present(name,
 
     if not r.get('exists'):
         if __opts__['test']:
-            ret['comment'] = 'RDS instance {0} is set to be created.'.format(name)
+            ret['comment'] = 'RDS instance {0} would be created.'.format(name)
             ret['result'] = None
             return ret
 
@@ -318,6 +322,7 @@ def present(name,
                                         master_user_password,
                                         db_name, db_security_groups,
                                         vpc_security_group_ids,
+                                        vpc_security_groups,
                                         availability_zone,
                                         db_subnet_group_name,
                                         preferred_maintenance_window,
@@ -345,9 +350,11 @@ def present(name,
             ret['comment'] = 'Failed to create RDS instance {0}.'.format(r['error']['message'])
             return ret
 
-        _describe = __salt__['boto_rds.describe'](name, tags, region, key, keyid, profile)
         ret['changes']['old'] = {'instance': None}
-        ret['changes']['new'] = _describe
+        ret['changes']['new'] = {
+              'instance': __salt__['boto_rds.describe_db_instances'](
+              name=name, jmespath='DBInstances[0]', region=region, key=key,
+              keyid=keyid, profile=profile)}
         ret['comment'] = 'RDS instance {0} created.'.format(name)
     else:
         ret['comment'] = 'RDS instance {0} exists.'.format(name)
@@ -391,18 +398,19 @@ def replica_present(name, source, db_instance_class=None,
                                                            tags, region, key,
                                                            keyid, profile)
         if created:
-            config = __salt__['boto_rds.describe'](name, tags, region,
-                                                   key, keyid, profile)
             ret['result'] = True
             ret['comment'] = 'RDS replica {0} created.'.format(name)
-            ret['changes']['old'] = None
-            ret['changes']['new'] = config
+            ret['changes']['old'] = {'instance': None}
+            ret['changes']['new'] = {
+                  'instance': __salt__['boto_rds.describe_db_instances'](
+                  name=name, jmespath='DBInstances[0]', region=region,
+                  key=key, keyid=keyid, profile=profile)}
         else:
             ret['result'] = False
             ret['comment'] = 'Failed to create RDS replica {0}.'.format(name)
     else:
-        _describe = __salt__['boto_rds.describe'](name, tags, region, key,
-                                                  keyid, profile)
+        current = __salt__['boto_rds.describe_db_instances'](
+              name=name, region=region, key=key, keyid=keyid, profile=profile)
         if db_parameter_group_name is not None and _describe['db_parameter_groups'][0]['DBParameterGroupName'] != db_parameter_group_name:
             modified = __salt__['boto_rds.modify_db_instance'](name, db_parameter_group_name=db_parameter_group_name, region=region,
                                                                key=key, keyid=keyid, profile=profile)
@@ -512,8 +520,8 @@ def subnet_group_present(name, description, subnet_ids=None, subnet_names=None,
 
 
 def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
-           tags=None, region=None, key=None, keyid=None, profile=None,
-           wait_for_deletion=True, timeout=180):
+           tags=None, wait_for_deletion=True, timeout=180,
+           region=None, key=None, keyid=None, profile=None):
     '''
     Ensure RDS instance is absent.
 
@@ -532,6 +540,13 @@ def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
     tags
         A dict of tags.
 
+    wait_for_deletion (bool)
+        Wait for the RDS instance to be deleted completely before finishing
+        the state.
+
+    timeout (in seconds)
+        The amount of time that can pass before raising an Exception.
+
     region
         Region to connect to.
 
@@ -544,15 +559,6 @@ def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
     profile
         A dict with region, key and keyid, or a pillar key (string) that
         contains a dict with region, key and keyid.
-
-    .. _create_db_instance: https://boto3.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.create_db_instance
-
-    wait_for_deletion (bool)
-        Wait for the RDS instance to be deleted completely before finishing
-        the state.
-
-    timeout (in seconds)
-        The amount of time that can pass before raising an Exception.
     '''
     ret = {'name': name,
            'result': True,
@@ -560,15 +566,15 @@ def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
            'changes': {}
            }
 
-    exists = __salt__['boto_rds.exists'](name, tags, region, key, keyid,
-                                         profile)
-    if not exists.get('exists'):
+    current = __salt__['boto_rds.describe_db_instances'](
+            name=name, region=region, key=key, keyid=keyid, profile=profile)
+    if not len(current):
         ret['result'] = True
-        ret['comment'] = '{0} RDS does not exist.'.format(name)
+        ret['comment'] = '{0} RDS already absent.'.format(name)
         return ret
 
     if __opts__['test']:
-        ret['comment'] = 'RDS {0} is set to be removed.'.format(name)
+        ret['comment'] = 'RDS {0} would be removed.'.format(name)
         ret['result'] = None
         return ret
     deleted = __salt__['boto_rds.delete'](name, skip_final_snapshot,
@@ -579,8 +585,8 @@ def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
         ret['result'] = False
         ret['comment'] = 'Failed to delete {0} RDS.'.format(name)
         return ret
-    ret['changes']['old'] = name
-    ret['changes']['new'] = None
+    ret['changes']['old'] = {'instance': current[0]}
+    ret['changes']['new'] = {'instance': None}
     ret['comment'] = 'RDS {0} deleted.'.format(name)
     return ret
 

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -408,10 +408,11 @@ def replica_present(name, source, db_instance_class=None,
             ret['result'] = False
             ret['comment'] = 'Failed to create RDS replica {0}.'.format(name)
     else:
-        jmespath='DBInstances[0].DBParameterGroups[0].DBParameterGroupName'
+        jmespath = 'DBInstances[0].DBParameterGroups[0].DBParameterGroupName'
         pmg_name = __salt__['boto_rds.describe_db_instances'](name=name,
               jmespath=jmespath, region=region, key=key, keyid=keyid,
               profile=profile)
+        pmg_name = pmg_name[0] if len(pmg_name) else None
         if pmg_name != db_parameter_group_name:
             modified = __salt__['boto_rds.modify_db_instance'](
                   name=name, db_parameter_group_name=db_parameter_group_name,


### PR DESCRIPTION
- New functions in `modules/boto_rds.py`:
  `describe_db_instances()`
  `describe_db_subnet_groups()`
- Add option `vpc_security_groups` to `create()` in `modules/boto_rds.py` which permits passing either sec group Names or IDs
- Fix failure to set supplied tags on newly created RDS instances
- Fix state change message for create() to actually report something
- Normalize and improve detail for state change messages
- Docstring normalization and cleanup
- Tiny pedantic variable name change `wait_statuses` -> `wait_stati` ;-P