### PR TITLE
Ensure batch uses passed eauth token or credentials

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -567,10 +567,14 @@ class LocalClient(object):
         if 'gather_job_timeout' in kwargs:
             opts['gather_job_timeout'] = kwargs['gather_job_timeout']
 
+        eauth=kwargs.get('eauth', {})
+        if 'token' in kwargs:
+            eauth['token'] = kwargs['token']
+
         for key, val in six.iteritems(self.opts):
             if key not in opts:
                 opts[key] = val
-        batch = salt.cli.batch.Batch(opts, quiet=True)
+        batch = salt.cli.batch.Batch(opts, eauth=eauth, quiet=True)
         for ret in batch.run():
             yield ret
 

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -568,6 +568,10 @@ class LocalClient(object):
             opts['gather_job_timeout'] = kwargs['gather_job_timeout']
 
         eauth=kwargs.get('eauth', {})
+        if 'username' in kwargs:
+            eauth['username'] = kwargs['username']
+        if 'password' in kwargs:
+            eauth['password'] = kwargs['password']
         if 'token' in kwargs:
             eauth['token'] = kwargs['token']
 

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -567,13 +567,15 @@ class LocalClient(object):
         if 'gather_job_timeout' in kwargs:
             opts['gather_job_timeout'] = kwargs['gather_job_timeout']
 
-        eauth=kwargs.get('eauth', {})
+        eauth = {}
+        if 'eauth' in kwargs:
+            eauth['eauth'] = kwargs.pop('eauth')
         if 'username' in kwargs:
-            eauth['username'] = kwargs['username']
+            eauth['username'] = kwargs.pop('username')
         if 'password' in kwargs:
-            eauth['password'] = kwargs['password']
+            eauth['password'] = kwargs.pop('password')
         if 'token' in kwargs:
-            eauth['token'] = kwargs['token']
+            eauth['token'] = kwargs.pop('token')
 
         for key, val in six.iteritems(self.opts):
             if key not in opts:

--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -113,6 +113,20 @@ class NetapiClient(object):
         local = salt.client.get_local_client(mopts=self.opts)
         return local.cmd_subset(*args, **kwargs)
 
+    def local_batch(self, *args, **kwargs):
+         '''
+         Run :ref:`execution modules <all-salt.modules>` against batches of minions
+ 
+         .. versionadded:: 0.8.4
+ 
+         Wraps :py:meth:`salt.client.LocalClient.cmd_batch`
+ 
+         :return: Returns the result from the exeuction module for each batch of
+             returns
+         '''
+         local = salt.client.get_local_client(mopts=self.opts)
+         return local.cmd_batch(*args, **kwargs)
+
     def ssh(self, *args, **kwargs):
         '''
         Run salt-ssh commands synchronously


### PR DESCRIPTION
### What does this PR do?
Pass eauth credentials to the batch client.

### What issues does this PR fix or reference?
Batch support was removed from saltapi due to not honoring eauth in #38497

### Previous Behavior
Before batch support was removed from saltapi, eauth creds like
```
external_auth:
  pam:
    jenkins:
      - state.*
      - '@runner'
```
Would still allow running a cmd.run in batch mode

### New Behavior
Now saltapi returns 401 Unauthorized as expected


### Tests written?
No

@whiteinge Please test and review. This seems to do the trick for me, but as it involves enabling a potential security hole, I'd like lots of eyes on it.