### PR TITLE
Use correct exec_driver in dockerng.sls module

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5744,7 +5744,7 @@ def sls(name, mods=None, saltenv='base', **kwargs):
         trans_tar_sha256 = salt.utils.get_hash(trans_tar, 'sha256')
         __salt__['dockerng.copy_to'](name, trans_tar,
                                      os.path.join(trans_dest_path, 'salt_state.tgz'),
-                                     exec_driver='nsenter',
+                                     exec_driver=_get_exec_driver(),
                                      overwrite=True)
 
         # Now execute the state into the container


### PR DESCRIPTION
Current version of dockerng.sls module use static 'nsenter' exec_driver for dockerng, without possibility to change it by config settings.

I have configured different exec_driver in minion config file:
> docker.exec_driver: docker-exec

I use salt-call and dockerng.sls module from unprivileged user and it always finish with errors like this:
> local:
    ----------
    comment:
        nsenter: cannot open /proc/16666/ns/ipc: Permission denied
    result:
        False

With proposed change salt-call works without problems.
