### PR TITLE
Fix confusing typo in thorium start page

### DIFF
--- a/doc/topics/thorium/index.rst
+++ b/doc/topics/thorium/index.rst
@@ -105,7 +105,7 @@ the key from the master when the minion has been gone for 60 seconds:
       key.timeout:
         - delete: 60
         - require:
-          - status: startreg
+          - status: statreg
 
 There are two stanzas in this formula, whose IDs are ``statreg`` and
 ``keydel``. The first stanza, ``statreg``, tells Thorium to keep track of


### PR DESCRIPTION
The thorium auto deregistration example has a slightly confusing typo.  From my read of the docs it should `s/startreg/statreg` so I'm submitting this PR to make that effective.

### What does this PR do?

Doc fix

### What issues does this PR fix or reference?

This PR contains the issue.

### Previous Behavior
Remove this section if not relevant

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
