### PR TITLE
stat_file when keep is set, instead of mirroring all file permissions

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -787,22 +787,6 @@ class LocalClient(Client):
         if not fnd_path:
             return ''
 
-        try:
-            fnd_mode = fnd.get('stat', [])[0]
-        except (IndexError, TypeError):
-            fnd_mode = None
-
-        if not salt.utils.is_windows():
-            if fnd_mode is not None:
-                try:
-                    if os.stat(dest).st_mode != fnd_mode:
-                        try:
-                            os.chmod(dest, fnd_mode)
-                        except OSError as exc:
-                            log.warning('Failed to chmod %s: %s', dest, exc)
-                except Exception:
-                    pass
-
         return fnd_path
 
     def file_list(self, saltenv='base', prefix=''):
@@ -1054,47 +1038,7 @@ class RemoteClient(Client):
                 mode_local = None
 
             if hash_local == hash_server:
-                if not salt.utils.is_windows():
-                    if mode_server is None:
-                        log.debug('No file mode available for \'%s\'', path)
-                    elif mode_local is None:
-                        log.debug(
-                            'No file mode available for \'%s\'',
-                            dest2check
-                        )
-                    else:
-                        if mode_server == mode_local:
-                            log.info(
-                                'Fetching file from saltenv \'%s\', '
-                                '** skipped ** latest already in cache '
-                                '\'%s\', mode up-to-date', saltenv, path
-                            )
-                        else:
-                            try:
-                                os.chmod(dest2check, mode_server)
-                                log.info(
-                                    'Fetching file from saltenv \'%s\', '
-                                    '** updated ** latest already in cache, '
-                                    '\'%s\', mode updated from %s to %s',
-                                    saltenv,
-                                    path,
-                                    salt.utils.st_mode_to_octal(mode_local),
-                                    salt.utils.st_mode_to_octal(mode_server)
-                                )
-                            except OSError as exc:
-                                log.warning(
-                                    'Failed to chmod %s: %s', dest2check, exc
-                                )
-                    # We may not have been able to check/set the mode, but we
-                    # don't want to re-download the file because of a failure
-                    # in mode checking. Return the cached path.
-                    return dest2check
-                else:
-                    log.info(
-                        'Fetching file from saltenv \'%s\', ** skipped ** '
-                        'latest already in cache \'%s\'', saltenv, path
-                    )
-                    return dest2check
+                return dest2check
 
         log.debug(
             'Fetching file from saltenv \'%s\', ** attempting ** \'%s\'',
@@ -1211,23 +1155,6 @@ class RemoteClient(Client):
                 saltenv, path
             )
 
-        if not salt.utils.is_windows():
-            if mode_server is not None:
-                try:
-                    if os.stat(dest).st_mode != mode_server:
-                        try:
-                            os.chmod(dest, mode_server)
-                            log.info(
-                                'Fetching file from saltenv \'%s\', '
-                                '** done ** \'%s\', mode set to %s',
-                                saltenv,
-                                path,
-                                salt.utils.st_mode_to_octal(mode_server)
-                            )
-                        except OSError:
-                            log.warning('Failed to chmod %s: %s', dest, exc)
-                except OSError:
-                    pass
         return dest
 
     def file_list(self, saltenv='base', prefix=''):

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -631,6 +631,28 @@ def hash_file(path, saltenv='base'):
     return _client().hash_file(path, saltenv)
 
 
+def stat_file(path, saltenv='base', octal=True):
+    '''
+    Return the permissions of a file, to get the permissions of a file on the
+    salt master file server prepend the path with salt://<file on server>
+    otherwise, prepend the file with / for a local file.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cp.stat_file salt://path/to/file
+    '''
+    path, senv = salt.utils.url.split_env(path)
+    if senv:
+        saltenv = senv
+
+    stat = _client().hash_and_stat_file(path, saltenv)[1]
+    if stat is None:
+        return stat
+    return salt.utils.st_mode_to_octal(stat[0]) if octal is True else stat[0]
+
+
 def push(path, keep_symlinks=False, upload_path=None, remove_source=False):
     '''
     WARNING Files pushed to the master will have global read permissions..

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4349,7 +4349,7 @@ def check_managed_changes(
             if _urlparse(source).scheme in ('salt', 'file') \
                     or source.startswith('/'):
                 try:
-                    mode = salt.utils.st_mode_to_octal(os.stat(sfn).st_mode)
+                    mode = __salt__['cp.stat_file'](source, saltenv=saltenv, octal=True)
                 except Exception as exc:
                     log.warning('Unable to stat %s: %s', sfn, exc)
     changes = check_file_meta(name, sfn, source, source_sum, user,
@@ -4607,6 +4607,13 @@ def manage_file(name,
         a local file on the minion), the mode of the destination file will be
         set to the mode of the source file.
 
+        .. note:: keep_mode does not work with salt-ssh.
+
+            As a consequence of how the files are transfered to the minion, and
+            the inability to connect back to the master with salt-ssh, salt is
+            unable to stat the file as it exists on the fileserver and thus
+            cannot mirror the mode on the salt-ssh minion
+
     CLI Example:
 
     .. code-block:: bash
@@ -4641,7 +4648,7 @@ def manage_file(name,
             if _urlparse(source).scheme in ('salt', 'file') \
                     or source.startswith('/'):
                 try:
-                    mode = salt.utils.st_mode_to_octal(os.stat(sfn).st_mode)
+                    mode = __salt__['cp.stat_file'](source, saltenv=saltenv, octal=True)
                 except Exception as exc:
                     log.warning('Unable to stat %s: %s', sfn, exc)
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1336,6 +1336,13 @@ def managed(name,
             the ``contents`` options, setting the ``mode`` to ``keep`` is also
             incompatible with the ``contents`` options.
 
+        .. note:: keep does not work with salt-ssh.
+
+            As a consequence of how the files are transfered to the minion, and
+            the inability to connect back to the master with salt-ssh, salt is
+            unable to stat the file as it exists on the fileserver and thus
+            cannot mirror the mode on the salt-ssh minion
+
     template
         If this setting is applied, the named templating engine will be used to
         render the downloaded file. The following templates are supported:


### PR DESCRIPTION
### What does this PR do?

This changes the behavior of the fileserver which used to mirror permissions from the salt master to the minion cache when caching files.

### What issues does this PR fix or reference?
Fixes #40075

### Previous Behavior
Before this change, the file permissions from the fileserver were mirrored to the minion file cache.

### New Behavior
Now the cache is set to `600`, and we lookup the file permissions at the time of placing the file down on the filesystem.

### Tests written?

No