### PR TITLE
Add `env` support for rvm.installed and rvm.do, `opts` support for .installed

### DIFF
--- a/salt/states/rvm.py
+++ b/salt/states/rvm.py
@@ -116,13 +116,13 @@ def _check_rvm(ret, user=None):
     return ret
 
 
-def _check_and_install_ruby(ret, ruby, default=False, user=None):
+def _check_and_install_ruby(ret, ruby, default=False, user=None, opts=None, env=None):
     '''
     Verify that ruby is installed, install if unavailable
     '''
     ret = _check_ruby(ret, ruby, user=user)
     if not ret['result']:
-        if __salt__['rvm.install_ruby'](ruby, runas=user):
+        if __salt__['rvm.install_ruby'](ruby, runas=user, opts=opts, env=env):
             ret['result'] = True
             ret['changes'][ruby] = 'Installed'
             ret['comment'] = 'Successfully installed ruby.'
@@ -166,7 +166,7 @@ def _check_ruby(ret, ruby, user=None):
     return ret
 
 
-def installed(name, default=False, user=None):
+def installed(name, default=False, user=None, opts=None, env=None):
     '''
     Verify that the specified ruby is installed with RVM. RVM is
     installed when necessary.
@@ -179,6 +179,12 @@ def installed(name, default=False, user=None):
 
     user: None
         The user to run rvm as.
+
+    env: None
+        A list of environment variables to set (ie, RUBY_CONFIGURE_OPTS)
+
+    opts: None
+        A list of option flags to pass to RVM (ie -C, --patch)
 
         .. versionadded:: 0.17.0
     '''
@@ -194,9 +200,9 @@ def installed(name, default=False, user=None):
             ret['comment'] = 'RVM failed to install.'
             return ret
         else:
-            return _check_and_install_ruby(ret, name, default, user=user)
+            return _check_and_install_ruby(ret, name, default, user=user, opts=opts, env=env)
     else:
-        return _check_and_install_ruby(ret, name, default, user=user)
+        return _check_and_install_ruby(ret, name, default, user=user, opts=opts, env=env)
 
 
 def gemset_present(name, ruby='default', user=None):

--- a/tests/unit/states/test_rvm.py
+++ b/tests/unit/states/test_rvm.py
@@ -50,7 +50,7 @@ class TestRvmState(TestCase, LoaderModuleMockMixin):
                 with patch.dict(rvm.__salt__,
                                 {'rvm.install_ruby': mock_install_ruby}):
                     rvm._check_and_install_ruby({'changes': {}}, '1.9.3')
-        mock_install_ruby.assert_called_once_with('1.9.3', runas=None)
+        mock_install_ruby.assert_called_once_with('1.9.3', runas=None, opts=None, env=None)
 
     def test__check_ruby(self):
         mock = MagicMock(return_value=[['ruby', '1.9.3-p125', False],
@@ -97,4 +97,22 @@ class TestRvmState(TestCase, LoaderModuleMockMixin):
             with patch.object(rvm, '_check_and_install_ruby', new=mock):
                 rvm.installed('1.9.3', default=True)
         mock.assert_called_once_with(
-            {'result': True}, '1.9.3', True, user=None)
+            {'result': True}, '1.9.3', True, user=None, opts=None, env=None)
+
+    def test_installed_with_env(self):
+        mock = MagicMock()
+        with patch.object(rvm, '_check_rvm') as mock_method:
+            mock_method.return_value = {'result': True}
+            with patch.object(rvm, '_check_and_install_ruby', new=mock):
+                rvm.installed('1.9.3', default=True, env=[{'RUBY_CONFIGURE_OPTS': '--foobar'}])
+        mock.assert_called_once_with(
+            {'result': True}, '1.9.3', True, user=None, opts=None, env=[{'RUBY_CONFIGURE_OPTS': '--foobar'}])
+
+    def test_installed_with_opts(self):
+        mock = MagicMock()
+        with patch.object(rvm, '_check_rvm') as mock_method:
+            mock_method.return_value = {'result': True}
+            with patch.object(rvm, '_check_and_install_ruby', new=mock):
+                rvm.installed('1.9.3', default=True, opts=[{'-C': '--enable-shared,--with-readline-dir=$HOME/.rvm/usr'}])
+        mock.assert_called_once_with(
+            {'result': True}, '1.9.3', True, user=None, opts=[{'-C': '--enable-shared,--with-readline-dir=$HOME/.rvm/usr'}], env=None)


### PR DESCRIPTION
### What does this PR do?

Currently, the RVM state has no way to pass environment variables (ie, RUBY_CONFIGURE_OPTS)
or compilation flags (-C, --patch) to the Ruby installer. This patch enables this
functionality, permitting installation of customized Ruby installs. For example, the following
should now work:

    ruby-2.3.0:
      rvm.installed:
        - env:
            - RUBY_CONFIGURE_OPTS: --with-jemalloc
        - opts:
            - '--patch /path/to/my.patch'
            - '-C --enable-shared,--with-readline-dir=$HOME/.rvm/usr'

### What issues does this PR fix or reference?

None, discussed in IRC

### Previous Behavior

The RVM module is unable to customize Ruby installs and cannot use `rvm do` to start Ruby scripts in a given Ruby install with custom environment parameters.

### New Behavior

* The RVM module is able to customize Ruby installs by exporting RVM options and build flag environment variables
* The RVM module is able to pass arbitrary environment variables to `rvm do` (ie, so you can start up a process in a specific RVM with GC tuning variables (ie, `RUBY_GC_HEAP_INIT_SLOTS=660850,RUBY_GC_HEAP_FREE_SLOTS=546925`, etc)

### Tests written?

Yes