### PR TITLE
Call out to _pki_minions() once, rather than in a loop in _check_list_minions()

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -207,7 +207,8 @@ class CkMinions(object):
         '''
         if isinstance(expr, six.string_types):
             expr = [m for m in expr.split(',') if m]
-        return [x for x in expr if x in self._pki_minions()]
+        minions = self._pki_minions()
+        return [x for x in expr if x in minions]
 
     def _check_pcre_minions(self, expr, greedy):  # pylint: disable=unused-argument
         '''


### PR DESCRIPTION
### What does this PR do?
Moves the call of `self._pki_minions()` out of the `_check_list_minions()` loop in the `salt.utils.minions._check_list_minions` function in order to avoid a large spike in CPU, which then causes the CLI to exit when run against many minions.

### What issues does this PR fix or reference?
- Fixes #39863 
- Refs #34920

### Previous Behavior
The salt CLI incurs a massive hit and causes the CPU to spike (anywhere from 45 to 90% in my testing) when running against a larger list of minions (I tested against 600). After the CPU spikes, it causes the CLI to exit which results in a large list of minions that didn't return. However, when the master is running in debug mode, you can see events still coming through for these minions that allegedly didn't return. Note that the CPU spike does not occur when running with the `--async` flag.

### New Behavior
CPU no longer spikes and the CLI waits for all minions to return.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
