### PR TITLE
Fix Py3 Installer

### DIFF
--- a/pkg/windows/build_env_3.ps1
+++ b/pkg/windows/build_env_3.ps1
@@ -245,6 +245,18 @@ DownloadFileWithProgress $url $file
 # Install
 Start_Process_and_test_exitcode  "$($ini['Settings']['Scripts3Dir'])\pip.exe" "install --no-index --find-links=$($ini['Settings']['DownloadDir']) $file " "pip install PyWin32"
 
+# Move DLL's to Python Root
+Write-Output " - $script_name :: Moving PyWin32 DLLs . . ."
+Move-Item "$($ini['Settings']['SitePkgs3Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['Python3Dir'])" -Force
+
+# Remove pywin32_system32 directory
+Write-Output " - $script_name :: Removing pywin32_system32 Directory . . ."
+Remove-Item "$($ini['Settings']['SitePkgs3Dir'])\pywin32_system32"
+
+# Remove pythonwin directory
+Write-Output " - $script_name :: Removing pythonwin Directory . . ."
+Remove-Item "$($ini['Settings']['SitePkgs3Dir'])\pythonwin" -Force -Recurse
+
 #==============================================================================
 # Fix PyCrypto
 #==============================================================================

--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -18,8 +18,10 @@ Function Get-Settings {
             "SaltDir"     = "C:\salt"
             "Python2Dir"   = "C:\Python27"
             "Scripts2Dir"  = "C:\Python27\Scripts"
+            "SitePkgs2Dir" = "C:\Python27\Lib\site-packages"
             "Python3Dir"   = "C:\Program Files\Python35"
             "Scripts3Dir"  = "C:\Program Files\Python35\Scripts"
+            "SitePkgs3Dir" = "C:\Program Files\Python35\Lib\site-packages"
             "DownloadDir" = "$env:Temp\DevSalt"
             }
         # The script deletes the DownLoadDir (above) for each install.


### PR DESCRIPTION
### What does this PR do?
The PyWin32 installer copies 2 DLLs to the `Windows\System32` directory. This will copy those DLLs to the python installation directory which will later become `salt\bin`. It also removes the `pythonwin` and `pywin32_system32` directories from `site-packages`.

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1220

### Previous Behavior
Salt installation would fail because the 2 DLLs weren't found in `Windows\System32`

### Tests written?
NA