### PR TITLE
Update docs for file.set_selinux_context

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3541,7 +3541,8 @@ def set_selinux_context(path,
 
     .. code-block:: bash
 
-        salt '*' file.set_selinux_context path <role> <type> <range>
+        salt '*' file.set_selinux_context path <user> <role> <type> <range>
+        salt '*' file.set_selinux_context /etc/yum.repos.d/epel-release system_u object_r system_conf_t s0
     '''
     if not any((user, role, type, range)):
         return False

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3543,16 +3543,6 @@ def set_selinux_context(path,
 
         salt '*' file.set_selinux_context path <user> <role> <type> <range>
         salt '*' file.set_selinux_context /etc/yum.repos.d/epel.repo system_u object_r system_conf_t s0
-
-    .. code-block:: yaml
-
-        /etc/yum.repos.d/epel.repo:
-          file.set_selinux_context:
-            - path: /etc/yum.repos.d/epel.repo
-            - user: system_u
-            - role: object_r
-            - type: system_conf_t
-            - range: s0
     '''
     if not any((user, role, type, range)):
         return False

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3542,7 +3542,17 @@ def set_selinux_context(path,
     .. code-block:: bash
 
         salt '*' file.set_selinux_context path <user> <role> <type> <range>
-        salt '*' file.set_selinux_context /etc/yum.repos.d/epel-release system_u object_r system_conf_t s0
+        salt '*' file.set_selinux_context /etc/yum.repos.d/epel.repo system_u object_r system_conf_t s0
+
+    .. code-block:: yaml
+
+        /etc/yum.repos.d/epel.repo:
+          file.set_selinux_context:
+            - path: /etc/yum.repos.d/epel.repo
+            - user: system_u
+            - role: object_r
+            - type: system_conf_t
+            - range: s0
     '''
     if not any((user, role, type, range)):
         return False


### PR DESCRIPTION
…tion. Added an example of the module actually being used.

### What does this PR do?
The `set_selinux_context` was missing the <user> declaration in the documentation. The actual salt code was already written to handle it.

### What issues does this PR fix or reference?
This is a result of me looking to set selinux contexts and finding that the Salt documentation was inaccurate.

https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Security-Enhanced_Linux/chap-Security-Enhanced_Linux-SELinux_Contexts.html

### New Behavior
Documents the module as it's intended to be used and gives an example.

### Tests written?
No. This is strictly a documentation update.