### PR TITLE
SUSE specific changes to salt-api.service

### DIFF
--- a/pkg/suse/salt-api.service
+++ b/pkg/suse/salt-api.service
@@ -1,1 +1,14 @@
-../salt-api.service
+[Unit]
+Description=The Salt API
+After=network.target
+
+[Service]
+User=salt
+Type=simple
+Environment=SHELL=/bin/bash
+LimitNOFILE=8192
+ExecStart=/usr/bin/salt-api
+TimeoutStopSec=3
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### What does this PR do?

Replaces symlink to `pkg/salt-api.service` with SUSE specific service file.

 * run service under user salt
 * change type from notify to simple
 * set SHELL env var. When passing a ProxyCommand option to salt-ssh a valid $SHELL is needed to execute the given command

### What issues does this PR fix or reference?
* push SUSE specific changes upstream
* `ProxyCommand` not working with `salt-api` and `salt-ssh` because on SUSE the `salt` user has the shell set to `/bin/false`

### Tests written?
No


