### PR TITLE
Add OpenRC init scripts for bootstrapping Alpine Linux from Git

### DIFF
--- a/pkg/alpine/README.rst
+++ b/pkg/alpine/README.rst
@@ -1,0 +1,6 @@
+========================
+Support for Alpine Linux
+========================
+
+This directory contains initialization scripts for Salt services which intended
+to be used during the bootstrap process on Alpine Linux (OpenRC init system).

--- a/pkg/alpine/salt-api
+++ b/pkg/alpine/salt-api
@@ -1,0 +1,11 @@
+#!/sbin/openrc-run
+command="/usr/bin/salt-api"
+command_args="--daemon"
+pidfile="/var/run/salt-api.pid"
+name="Salt API daemon"
+
+depend() {
+	need localmount
+	use net
+	after bootmisc
+}

--- a/pkg/alpine/salt-master
+++ b/pkg/alpine/salt-master
@@ -1,0 +1,11 @@
+#!/sbin/openrc-run
+command="/usr/bin/salt-master"
+command_args="--daemon"
+pidfile="/var/run/salt-master.pid"
+name="Salt Master"
+
+depend() {
+	need localmount
+	use net
+	after bootmisc
+}

--- a/pkg/alpine/salt-minion
+++ b/pkg/alpine/salt-minion
@@ -1,0 +1,11 @@
+#!/sbin/openrc-run
+command="/usr/bin/salt-minion"
+command_args="--daemon"
+pidfile="/var/run/salt-minion.pid"
+name="Salt Minion"
+
+depend() {
+	need localmount
+	use net
+	after bootmisc
+}

--- a/pkg/alpine/salt-syndic
+++ b/pkg/alpine/salt-syndic
@@ -1,0 +1,11 @@
+#!/sbin/openrc-run
+command="/usr/bin/salt-syndic"
+command_args="--daemon"
+pidfile="/var/run/salt-syndic.pid"
+name="Salt Syndic"
+
+depend() {
+	need localmount
+	use net
+	after bootmisc
+}


### PR DESCRIPTION
### What does this PR do?
This PR adds initscripts consumed by OpenRC init system on Alpine Linux to be able to complete bootstrapping Salt from Git (GitHub) using `bootstrap-salt.sh`. I will file another PR to saltstack/salt-bootstrap repo once this would be merged.

The main reason for this is that Alpine upstream doesn't provide a reliable source where we can get the scripts, i.e. using HTTPS or using other methods of files integrity verification.

The scripts were written from scratch.