### PR TITLE
Fixing issue # 40167

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2231,8 +2231,8 @@ def replace(path,
         check_perms(path, None, pre_user, pre_group, pre_mode)
 
     if show_changes:
-        orig_file_as_str = ''.join([salt.utils.to_str(x) for x in orig_file])
-        new_file_as_str = ''.join([salt.utils.to_str(x) for x in new_file])
+        orig_file_as_str = [salt.utils.to_str(x) for x in orig_file]
+        new_file_as_str = [salt.utils.to_str(x) for x in new_file]
         return ''.join(difflib.unified_diff(orig_file_as_str, new_file_as_str))
 
     return has_changes


### PR DESCRIPTION
### What does this PR do?

fixes issue#40167 where output of file.replace has characters separated by extra '+' '-' signs


file.replace uses difflib.unified_diff(a,b). a and b should be lists of strings. removed 'join' from lines 2244 and 2245 fixes the issue.

Tested on 2016.11.3.

### What issues does this PR fix or reference?
fixes issue 40167

### Previous Behavior
```
----------
          ID: /etc/selinux/config
    Function: file.replace
      Result: True
     Comment: Changes were made
     Started: 09:18:12.123673
    Duration: 3.742 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -277,16 +277,14 @@
                   U X =-s-o-m-e-t-h-i-o-n-g+d+i+s+a+b+l+e+d 
                   #  
```
### New Behavior
```
----------
          ID: /etc/selinux/config
    Function: file.replace
      Result: True
     Comment: Changes were made
     Started: 10:08:19.502201
    Duration: 3.167 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -4,7 +4,7 @@
                   #     enforcing - SELinux security policy is enforced.
                   #     permissive - SELinux prints warnings instead of enforcing.
                   #     disabled - No SELinux policy is loaded.
                  -SELINUX=something
                  +SELINUX=disabled
                   # SELINUXTYPE= can take one of these two values:
                   #     targeted - Targeted processes are protected,
                   #     minimum - Modification of targeted policy. Only selected processes are protected. 

```
### Tests written?

No
