### PR TITLE
if grain is defined as None still convert in append

### DIFF
--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -400,7 +400,7 @@ def append(name, value, convert=False,
            'result': True,
            'comment': ''}
     grain = __salt__['grains.get'](name, None)
-    if grain:
+    if grain or name in __grains__:
         if isinstance(grain, list):
             if value in grain:
                 ret['comment'] = 'Value {1} is already in the list ' \
@@ -425,7 +425,10 @@ def append(name, value, convert=False,
                                      'added'.format(name, value)
                     ret['changes'] = {'added': value}
                     return ret
-                grain = [grain]
+                if grain is None:
+                    grain = []
+                else:
+                    grain = [grain]
                 grain.append(value)
                 __salt__['grains.setval'](name, grain)
                 ret['comment'] = 'Value {1} was added to grain {0}'\

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -400,6 +400,10 @@ def append(name, value, convert=False,
            'result': True,
            'comment': ''}
     grain = __salt__['grains.get'](name, None)
+
+    # Check if bool(grain) is False or if the grain is specified in the minions
+    # grains. Grains can be set to a None value by omitting a value in the
+    # definition.
     if grain or name in __grains__:
         if isinstance(grain, list):
             if value in grain:
@@ -425,10 +429,7 @@ def append(name, value, convert=False,
                                      'added'.format(name, value)
                     ret['changes'] = {'added': value}
                     return ret
-                if grain is None:
-                    grain = []
-                else:
-                    grain = [grain]
+                grain = [] if grain is None else [grain]
                 grain.append(value)
                 __salt__['grains.setval'](name, grain)
                 ret['comment'] = 'Value {1} was added to grain {0}'\

--- a/tests/unit/states/grains_test.py
+++ b/tests/unit/states/grains_test.py
@@ -828,6 +828,23 @@ class GrainsTestCase(TestCase):
             grains.__grains__,
             {'a': 'aval'})
 
+    def test_append_convert_to_list_empty(self):
+        # Append to an existing list
+        self.setGrains({'foo': None})
+        ret = grains.append(
+            name='foo',
+            value='baz',
+            convert=True)
+        self.assertEqual(ret['result'], True)
+        self.assertEqual(ret['comment'], 'Value baz was added to grain foo')
+        self.assertEqual(ret['changes'], {'added': 'baz'})
+        self.assertEqual(
+            grains.__grains__,
+            {'foo': ['baz']})
+        self.assertGrainFileContent("foo:\n"
+                                  + "- baz\n"
+        )
+
     # 'list_present' function tests: 7
 
     def test_list_present(self):


### PR DESCRIPTION
### What issues does this PR fix or reference?
Fixes #40624

### Previous Behavior
If grain was just empty in /etc/salt/grains, we acted like it wasn't set at all

```
[root@salt salt]# cat /srv/salt/test.sls
update_grains:
  grains.append:
    - name: package
    - value: mongodb
    - convert: True
[root@salt salt]# salt-call state.apply test
[ERROR   ] Grain package does not exist
local:
----------
          ID: update_grains
    Function: grains.append
        Name: package
      Result: False
     Comment: Grain package does not exist
     Started: 15:49:11.708804
    Duration: 1.212 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   1.212 ms
[root@salt salt]# cat /etc/salt/grains
package:
```

### New Behavior
Convert None to an empty list and then append the new value.

```
[root@salt salt]# salt-call state.apply test
local:
----------
          ID: update_grains
    Function: grains.append
        Name: package
      Result: True
     Comment: Value mongodb was added to grain package
     Started: 15:51:16.288833
    Duration: 5.677 ms
     Changes:
              ----------
              added:
                  mongodb

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:   5.677 ms
[root@salt salt]# cat /etc/salt/grains
package:
- mongodb
```

### Tests written?

No