### PR TITLE
Correctly resolve relative cache path to absolute.

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -217,7 +217,7 @@ def prep_trans_tar(opts, file_client, chunks, file_refs, pillar=None, id_=None):
                     files = ''
                 if files:
                     for filename in files:
-                        fn = filename[len(cache_dest):].strip('/')
+                        fn = filename[len(file_client.get_cachedir(cache_dest)):].strip('/')
                         tgt = os.path.join(
                                 env_root,
                                 short,

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -132,11 +132,7 @@ class Client(object):
         '''
         Return the local location to cache the file, cache dirs will be made
         '''
-        if cachedir is None:
-            cachedir = self.opts['cachedir']
-        elif not os.path.isabs(cachedir):
-            cachedir = os.path.join(self.opts['cachedir'], cachedir)
-
+        cachedir = self.get_cachedir(cachedir)
         dest = salt.utils.path_join(cachedir,
                                     'files',
                                     saltenv,
@@ -158,6 +154,13 @@ class Client(object):
 
         yield dest
         os.umask(cumask)
+
+    def get_cachedir(self, cachedir=None):
+        if cachedir is None:
+            cachedir = self.opts['cachedir']
+        elif not os.path.isabs(cachedir):
+            cachedir = os.path.join(self.opts['cachedir'], cachedir)
+        return cachedir
 
     def get_file(self,
                  path,
@@ -250,10 +253,7 @@ class Client(object):
             #     prefix = ''
             # else:
             #     prefix = separated[0]
-            if cachedir is None:
-                cachedir = self.opts['cachedir']
-            elif not os.path.isabs(cachedir):
-                cachedir = os.path.join(self.opts['cachedir'], cachedir)
+            cachedir = self.get_cachedir(cachedir)
 
             dest = salt.utils.path_join(cachedir, 'files', saltenv)
             for fn_ in self.file_list_emptydirs(saltenv):


### PR DESCRIPTION
### What does this PR do?
Fixes the incorrect behavior of `file.recurse` when it's used via `salt-ssh` and creates a number of unneeded subdirectories. The bug was introduced in #40442, when the cachedir was changed to a relative path. Details are here: #40594.

### What issues does this PR fix or reference?
Fixes: #40594
Complements: #40442

### Tests written?
No