### PR TITLE
Keep network.py execution module

### DIFF
--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -222,8 +222,6 @@ If Exist "%BinDir%\Lib\site-packages\salt\modules\netbsd*"^
     del /Q "%BinDir%\Lib\site-packages\salt\modules\netbsd*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\modules\netscaler.py"^
     del /Q "%BinDir%\Lib\site-packages\salt\modules\netscaler.*" 1>nul
-If Exist "%BinDir%\Lib\site-packages\salt\modules\network.py"^
-    del /Q "%BinDir%\Lib\site-packages\salt\modules\network.*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\modules\neutron.py"^
     del /Q "%BinDir%\Lib\site-packages\salt\modules\neutron.*" 1>nul
 If Exist "%BinDir%\Lib\site-packages\salt\modules\nfs3.py"^


### PR DESCRIPTION
### What does this PR do?
Fixes the win_network execution module. The installation script removes `network.py` before creating the installer. The problem is that `win_network.py` namespaces some of the functions in `network.py` and therefore fails. Don't know why we haven't caught this before.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40508

### Previous Behavior
`network` functions failed, couldn't import `salt.modules.network`.

### New Behavior
`network` functions don't fail

### Tests written?
NA