### PR TITLE
Fix status.diskusage for Windows on Py3

### DIFF
--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -108,7 +108,7 @@ def diskusage(human_readable=False, path=None):
     _, total, free = \
         ctypes.c_ulonglong(), ctypes.c_ulonglong(), ctypes.c_longlong()
     if sys.version_info >= (3, ) or isinstance(path, six.text_type):
-        fun = ctypes.windll.kernel32.GetDiskFreeSpaceExw
+        fun = ctypes.windll.kernel32.GetDiskFreeSpaceExW
     else:
         fun = ctypes.windll.kernel32.GetDiskFreeSpaceExA
     ret = fun(path, ctypes.byref(_), ctypes.byref(total), ctypes.byref(free))


### PR DESCRIPTION
### What does this PR do?
Fixes the `status.diskusage` function for Windows on Py3. The API call was calling `GetDiskFreeSpaceExw`. The API call needed to be `GetDiskFreeSpaceExW` (Capital 'W').

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40506

### Previous Behavior
`status.diskusage` would fail with `AttributeError: function 'GetDiskFreeSpaceExw' not found`

### New Behavior
`status.diskusage` completes successfully

### Tests written?
NA