### PR TITLE
Backport msi-conformant-version function

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -712,5 +712,27 @@ def versions_report(include_salt_cloud=False):
         yield line
 
 
+def msi_conformant_version():
+    '''
+    A msi conformant version consists of up to 4 numbers, each smaller than 256,
+    except the 4th. Therefore, the year must be represented as 'short year'.
+
+    Examples (depend on git checkout):
+      develop                2016.11.0-742-g5ca4d20     16.11.0.742
+      2016.11 (branch)       2016.11.2-78-gce1f01f      16.11.2.78
+      v2016.11.2 (tag)       2016.11.2                  16.11.2.0
+
+    Note that the commit count for tags is 0(zero)
+    '''
+    year2 = int(str(__saltstack_version__.major)[2:])
+    month = __saltstack_version__.minor
+    minor = __saltstack_version__.bugfix
+    commi = __saltstack_version__.noc
+    return '{0}.{1}.{2}.{3}'.format(year2, month, minor, commi)
+
 if __name__ == '__main__':
-    print(__version__)
+    if len(sys.argv) == 2 and sys.argv[1] == 'msi':
+        # Building the msi requires an msi-conformant version
+        print(msi_conformant_version())
+    else:
+        print(__version__)


### PR DESCRIPTION
### What does this PR do?
Backports the `msi_conformant_version` function inorder to build `msi` installers based off this branch. Needed for the https://github.com/saltstack/salt-windows-msi repo