### PR TITLE
make sure userdata is always defined in ec2

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1676,6 +1676,7 @@ def request_instance(vm_=None, call=None):
     image_id = vm_['image']
     params[spot_prefix + 'ImageId'] = image_id
 
+    userdata = None
     userdata_file = config.get_cloud_config_value(
         'userdata_file', vm_, __opts__, search_global=False, default=None
     )


### PR DESCRIPTION
### What does this PR do?
If this is not set, it fails to run the userdata_template because the userdata variable is undefined.

### Tests written?

No