### PR TITLE
fix test_fstype test for mac

### DIFF
--- a/tests/unit/modules/disk_test.py
+++ b/tests/unit/modules/disk_test.py
@@ -149,8 +149,9 @@ class DiskTestCase(TestCase):
         device = '/dev/sdX1'
         fs_type = 'ext4'
         mock = MagicMock(return_value='FSTYPE\n{0}'.format(fs_type))
-        with patch.dict(disk.__salt__, {'cmd.run': mock}):
-            self.assertEqual(disk.fstype(device), fs_type)
+        with patch.dict(disk.__grains__, {'kernel': 'Linux'}):
+            with patch.dict(disk.__salt__, {'cmd.run': mock}):
+                self.assertEqual(disk.fstype(device), fs_type)
 
     @skipIf(not salt.utils.which('resize2fs'), 'resize2fs not found')
     def test_resize2fs(self):


### PR DESCRIPTION
### What does this PR do?
Checking for grains in the disk module for the fstype method was added here: https://github.com/saltstack/salt/pull/39238/files

This adds the grain dict to the test so it passes now instead of getting a keyerror. This was failing on Mac test. It was passing on linux because it returns before hitting this check.

### Previous Behavior

```
*** unit.modules.disk_test.DiskTestCase.test_fstype Tests  *****************************************************************************************************************
 --------  Tests with Errors  ----------------------------------------------------------------------------------------------------------------------------------------------
   -> unit.modules.disk_test.DiskTestCase.test_fstype  .....................................................................................................................
       Traceback (most recent call last):
         File "/testing/tests/unit/modules/disk_test.py", line 153, in test_fstype
           self.assertEqual(disk.fstype(device), fs_type)
         File "<string>", line 2, in fstype
         File "/testing/salt/utils/decorators/__init__.py", line 202, in wrapped
           return function(*args, **kwargs)
         File "/testing/salt/modules/disk.py", line 478, in fstype
           if __grains__['kernel'] == 'AIX' and os.path.isfile('/usr/sysv/bin/df'):
       KeyError: 'kernel'
   .........................................................................................................................................................................
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### New Behavior
Test pass

### Tests written?

Yes