### PR TITLE
Fix errno code for filecache test for other operating systems.

### DIFF
--- a/tests/unit/fileclient_test.py
+++ b/tests/unit/fileclient_test.py
@@ -48,7 +48,7 @@ class FileclientTestCase(TestCase):
         If makedirs raises other than EEXIST errno, an exception should be raised.
         '''
         with patch('os.path.isfile', lambda prm: False):
-            with patch('os.makedirs', self._fake_makedir(num=errno.EIO)):
+            with patch('os.makedirs', self._fake_makedir(num=errno.EROFS)):
                 with self.assertRaises(OSError):
                     with Client(self.opts)._cache_loc('testfile') as c_ref_itr:
                         assert c_ref_itr == '/__test__/files/base/testfile'

--- a/tests/unit/fileclient_test.py
+++ b/tests/unit/fileclient_test.py
@@ -10,7 +10,7 @@ from mock import Mock
 
 try:
     ERRIO = errno.EREMOTEIO
-except:
+except AttributeError:
     ERRIO = errno.EIO
 
 # Import Salt Testing libs

--- a/tests/unit/fileclient_test.py
+++ b/tests/unit/fileclient_test.py
@@ -5,13 +5,18 @@
 
 # Import Python libs
 from __future__ import absolute_import
+import errno
+from mock import Mock
+
+try:
+    ERRIO = errno.EREMOTEIO
+except:
+    ERRIO = errno.EIO
 
 # Import Salt Testing libs
 from salttesting import TestCase
 from salttesting.helpers import ensure_in_syspath
 from salttesting.mock import patch
-from mock import Mock
-import errno
 from salt.ext.six.moves import range
 
 ensure_in_syspath('../')
@@ -48,7 +53,7 @@ class FileclientTestCase(TestCase):
         If makedirs raises other than EEXIST errno, an exception should be raised.
         '''
         with patch('os.path.isfile', lambda prm: False):
-            with patch('os.makedirs', self._fake_makedir(num=errno.EREMOTEIO)):
+            with patch('os.makedirs', self._fake_makedir(num=ERRIO)):
                 with self.assertRaises(OSError):
                     with Client(self.opts)._cache_loc('testfile') as c_ref_itr:
                         assert c_ref_itr == '/__test__/files/base/testfile'

--- a/tests/unit/fileclient_test.py
+++ b/tests/unit/fileclient_test.py
@@ -8,11 +8,6 @@ from __future__ import absolute_import
 import errno
 from mock import Mock
 
-try:
-    ERRIO = errno.EREMOTEIO
-except AttributeError:
-    ERRIO = errno.EIO
-
 # Import Salt Testing libs
 from salttesting import TestCase
 from salttesting.helpers import ensure_in_syspath
@@ -53,7 +48,7 @@ class FileclientTestCase(TestCase):
         If makedirs raises other than EEXIST errno, an exception should be raised.
         '''
         with patch('os.path.isfile', lambda prm: False):
-            with patch('os.makedirs', self._fake_makedir(num=ERRIO)):
+            with patch('os.makedirs', self._fake_makedir(num=errno.EIO)):
                 with self.assertRaises(OSError):
                     with Client(self.opts)._cache_loc('testfile') as c_ref_itr:
                         assert c_ref_itr == '/__test__/files/base/testfile'


### PR DESCRIPTION
### What does this PR do?
Not all operating systems include the `EREMOTEIO` errno code so had to replace with `EIO` for operating systems. This test was failing on MacOSX with the folloinwg error:

```
*** unit.fileclient_test.FileclientTestCase.test_cache_raises_exception_on_non_eexist_ioerror Tests  ***********************************************************************
 --------  Tests with Errors  ----------------------------------------------------------------------------------------------------------------------------------------------
   -> unit.fileclient_test.FileclientTestCase.test_cache_raises_exception_on_non_eexist_ioerror  ...........................................................................
       Traceback (most recent call last):
         File "/testing/tests/unit/fileclient_test.py", line 51, in test_cache_raises_exception_on_non_eexist_ioerror
           with patch('os.makedirs', self._fake_makedir(num=errno.EREMOTEIO)):
       AttributeError: 'module' object has no attribute 'EREMOTEIO'
   .........................................................................................................................................................................
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
============================================================================================================================================================================
FAILED (total=1, skipped=0, passed=0, failures=0, errors=1) 
==========================================================================  Overall Tests Report  ==========================================================================

```

### Tests written?

Yes