### PR TITLE
Fix 'salt-minion' service for Win 10 Creators Update 1703

### DIFF
--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -337,6 +337,7 @@ Section -Post
     nsExec::Exec "nssm.exe install salt-minion $INSTDIR\bin\python.exe $INSTDIR\bin\Scripts\salt-minion -c $INSTDIR\conf -l quiet"
     nsExec::Exec "nssm.exe set salt-minion AppEnvironmentExtra PYTHONHOME="
     nsExec::Exec "nssm.exe set salt-minion Description Salt Minion from saltstack.com"
+    nsExec::Exec "nssm.exe set salt-minion AppNoConsole 1"
 
     RMDir /R "$INSTDIR\var\cache\salt" ; removing cache from old version
 


### PR DESCRIPTION
### What does this PR do?
Fixes the problem where the `salt-minion` service fails to start on Windows 10 1703 or after getting the 1703 update. The problem is with services that try to create a Console Window, which the `salt-minion` service was set to do. This is now failing in Windows 10 1703.

The temporary fix is to run `nssm set salt-minion AppNoConsole 1` in the `C:\salt` directory. This will fix existing minions that get the 1703 update.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40657

### Previous Behavior
`salt-minion` service would fail to start after getting the "Creators Update" (1703).

### New Behavior
The `salt-minion` service starts correctly.

### Tests written?
NA