### PR TITLE
Fixes bug that prevents syslog returner from working under Python 2.6

### DIFF
--- a/salt/returners/syslog_return.py
+++ b/salt/returners/syslog_return.py
@@ -192,10 +192,14 @@ def returner(ret):
         logoption = logoption | getattr(syslog, opt)
 
     # Open syslog correctly based on options and tag
-    if 'tag' in _options:
-        syslog.openlog(ident=_options['tag'], logoption=logoption)
-    else:
-        syslog.openlog(logoption=logoption)
+    try:
+        if 'tag' in _options:
+            syslog.openlog(ident=_options['tag'], logoption=logoption)
+        else:
+            syslog.openlog(logoption=logoption)
+    except TypeError:
+        # Python 2.6 syslog.openlog does not accept keyword args
+        syslog.openlog(_options.get('tag', 'salt-minion'), logoption)
 
     # Send log of given level and facility
     syslog.syslog(facility | level, '{0}'.format(json.dumps(ret)))


### PR DESCRIPTION
Fixes #40688

### What does this PR do?
Adds an exception handler around syslog.openlog to pass arguments as positional rather than keyword in Python 2.6.

### What issues does this PR fix or reference?
[Issue #40688 ](https://github.com/saltstack/salt/issues/40688)

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
