### PR TITLE
Fixes #40658: even clearer and working(!) Tomcat version handling

### DIFF
--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -72,6 +72,7 @@ import logging
 
 # Import 3rd-party libs
 # pylint: disable=no-name-in-module,import-error
+from salt.ext.six import string_types as _string_types
 from salt.ext.six.moves.urllib.parse import urlencode as _urlencode
 from salt.ext.six.moves.urllib.request import (
     urlopen as _urlopen,
@@ -526,7 +527,7 @@ def deploy_war(war,
                saltenv='base',
                timeout=180,
                temp_war_location=None,
-               version=''):
+               version=True):
     '''
     Deploy a WAR file
 
@@ -607,11 +608,11 @@ def deploy_war(war,
     }
 
     # If parallel versions are desired or not disabled
-    if version is True:
+    if version:
         # Set it to defined version or attempt extract
-        version = version or extract_war_version(war)
+        version = extract_war_version(war) if version is True else version
 
-        if version != ('' or None):
+        if isinstance(version, _string_types):
             # Only pass version to Tomcat if not undefined
             opts['version'] = version
 

--- a/salt/states/tomcat.py
+++ b/salt/states/tomcat.py
@@ -74,7 +74,7 @@ def war_deployed(name,
                  url='http://localhost:8080/manager',
                  timeout=180,
                  temp_war_location=None,
-                 version=''):
+                 version=True):
     '''
     Enforce that the WAR will be deployed and started in the context path,
     while making use of WAR versions in the filename.
@@ -105,7 +105,7 @@ def war_deployed(name,
 
         .. versionadded:: 2015.8.6
 
-        Use ``False`` to prevent guessing the version and keeping it blank.
+        Use ``False`` or blank value to prevent guessing the version and keeping it blank.
 
         .. versionadded:: 2016.11.0
 
@@ -115,7 +115,7 @@ def war_deployed(name,
 
         jenkins:
           tomcat.war_deployed:
-            - name: /ran
+            - name: /salt-powered-jenkins
             - war: salt://jenkins-1.2.4.war
             - require:
               - service: application-service
@@ -123,7 +123,7 @@ def war_deployed(name,
     .. note::
 
         Be aware that in the above example the WAR ``jenkins-1.2.4.war`` will
-        be deployed to the context path ``jenkins##1.2.4``. To avoid this
+        be deployed to the context path ``salt-powered-jenkins##1.2.4``. To avoid this
         either specify a version yourself, or set version to ``False``.
 
     '''
@@ -134,12 +134,10 @@ def war_deployed(name,
            'comment': ''}
 
     # if version is defined or False, we don't want to overwrite
-    if version == '':
+    if version is True:
         version = __salt__['tomcat.extract_war_version'](war) or ''
     elif not version:
         version = ''
-    else:
-        version = str(version)
 
     webapps = __salt__['tomcat.ls'](url, timeout)
     deploy = False
@@ -147,7 +145,7 @@ def war_deployed(name,
     status = True
 
     # Gathered/specified new WAR version string
-    specified_ver = 'version ' + version if version else 'no version'
+    specified_ver = 'version {}'.format(version) if version else 'no version'
 
     # Determine what to do
     try:

--- a/salt/states/tomcat.py
+++ b/salt/states/tomcat.py
@@ -145,7 +145,7 @@ def war_deployed(name,
     status = True
 
     # Gathered/specified new WAR version string
-    specified_ver = 'version {}'.format(version) if version else 'no version'
+    specified_ver = 'version {0}'.format(version) if version else 'no version'
 
     # Determine what to do
     try:


### PR DESCRIPTION
### What does this PR do?
A few minor improvements/fixes to the clarity of version handling from
both the states view, and the module.

Firstly, the main culprit: the module's check for the passed version
parameter was too strict, and would only work when the version was
explicitly True. This would never work for a string.
This has been changed to simply check if it's "true"-ish: if no
parameter is passed, the default is True, and it'll try to guess a
version number. If you pass a specific version, then it'll use that.

Should you pass False, or an empty string, it'll be viewed as blank,
which was the initial intent. It's not that *that* didn't work, it's
just that the other part didn't, which means no version at all did.
*cough*

Besides that, it's a bit clearer with different default named parameter
values for 'version', that doesn't otherwise change the behaviour in any
reasonable backwards way. A blank version for a Tomcat version is
nonsensical, per Apache's documentation.
https://tomcat.apache.org/tomcat-8.0-doc/config/context.html#Naming

Otherwise, it's all minor with an actual type checker before sending it
along in the module.

Plus, there was a minor mistake in the documentation for the state.

### What issues does this PR fix or reference?
Per the title, this fixes #40658.

### Tests written?
No, the current should suffice outside of creating a full test-suite for the modules to be used in integration tests.
