### PR TITLE
Add Glassfish/Payara 4.x support

### DIFF
--- a/salt/modules/glassfish.py
+++ b/salt/modules/glassfish.py
@@ -1,0 +1,648 @@
+# -*- coding: utf-8 -*-
+'''
+Module for working with the Glassfish/Payara 4.x management API
+.. versionadded:: Carbon
+:depends: requests
+'''
+from __future__ import absolute_import
+
+try:  # python2
+    from urllib import quote, unquote
+except ImportError:  # python3
+    from urllib.parse import quote, unquote
+
+try:
+    import json
+    import requests
+    import salt.defaults.exitcodes
+    from salt.exceptions import CommandExecutionError
+    HAS_LIBS = True
+except ImportError:
+    HAS_LIBS = False
+
+__virtualname__ = 'glassfish'
+
+# Default server
+DEFAULT_SERVER = {'ssl': False, 'url': 'localhost', 'port': 4848, 'user': None, 'password': None}
+
+
+def __virtual__():
+    '''
+    Only load if requests is installed
+    '''
+    if HAS_LIBS:
+        return __virtualname__
+    else:
+        return False, 'The "{0}" module could not be loaded: ' \
+                      '"requests" is not installed.'.format(__virtualname__)
+
+
+def _get_headers():
+    '''
+    Return fixed dict with headers (JSON data + mandatory "Requested by" header)
+    '''
+    return {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'X-Requested-By': 'GlassFish REST HTML interface'
+    }
+
+
+def _get_auth(username, password):
+    '''
+    Returns the HTTP auth header
+    '''
+    if username and password:
+        return requests.auth.HTTPBasicAuth(username, password)
+    else:
+        return None
+
+
+def _get_url(ssl, url, port, path):
+    '''
+    Returns the URL of the endpoint
+    '''
+    if ssl:
+        return 'https://{0}:{1}/management/domain/{2}'.format(url, port, path)
+    else:
+        return 'http://{0}:{1}/management/domain/{2}'.format(url, port, path)
+
+
+def _get_server(server):
+    '''
+    Returns the server information if provided, or the defaults
+    '''
+    return server if server else DEFAULT_SERVER
+
+
+def _clean_data(data):
+    '''
+    Removes SaltStack params from **kwargs
+    '''
+    for key in list(data):
+        if key.startswith('__pub'):
+            del data[key]
+    return data
+
+
+def _api_response(response):
+    '''
+    Check response status code + success_code returned by glassfish
+    '''
+    if response.status_code == 404:
+        __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
+        raise CommandExecutionError('Element doesn\'t exists')
+    if response.status_code == 401:
+        __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
+        raise CommandExecutionError('Bad username or password')
+    elif response.status_code == 200 or response.status_code == 500:
+        try:
+            data = json.loads(response.content)
+            if data['exit_code'] != 'SUCCESS':
+                __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
+                raise CommandExecutionError(data['message'])
+            return data
+        except ValueError:
+            __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
+            raise CommandExecutionError('The server returned no data')
+    else:
+        response.raise_for_status()
+
+
+def _api_get(path, server=None):
+    '''
+    Do a GET request to the API
+    '''
+    server = _get_server(server)
+    response = requests.get(
+            url=_get_url(server['ssl'], server['url'], server['port'], path),
+            auth=_get_auth(server['user'], server['password']),
+            headers=_get_headers(),
+            verify=False
+    )
+    return _api_response(response)
+
+
+def _api_post(path, data, server=None):
+    '''
+    Do a POST request to the API
+    '''
+    server = _get_server(server)
+    response = requests.post(
+            url=_get_url(server['ssl'], server['url'], server['port'], path),
+            auth=_get_auth(server['user'], server['password']),
+            headers=_get_headers(),
+            data=json.dumps(data),
+            verify=False
+    )
+    return _api_response(response)
+
+
+def _api_delete(path, data, server=None):
+    '''
+    Do a DELETE request to the API
+    '''
+    server = _get_server(server)
+    response = requests.delete(
+            url=_get_url(server['ssl'], server['url'], server['port'], path),
+            auth=_get_auth(server['user'], server['password']),
+            headers=_get_headers(),
+            params=data,
+            verify=False
+    )
+    return _api_response(response)
+
+
+# "Middle layer": uses _api_* functions to enum/get/create/update/delete elements
+def _enum_elements(name, server=None):
+    '''
+    Enum elements
+    '''
+    elements = []
+    data = _api_get(name, server)
+
+    if any(data['extraProperties']['childResources']):
+        for element in data['extraProperties']['childResources']:
+            elements.append(element)
+        return elements
+    return None
+
+
+def _get_element_properties(name, element_type, server=None):
+    '''
+    Get an element's properties
+    '''
+    properties = {}
+    data = _api_get('{0}/{1}/property'.format(element_type, name), server)
+
+    # Get properties into a dict
+    if any(data['extraProperties']['properties']):
+        for element in data['extraProperties']['properties']:
+            properties[element['name']] = element['value']
+        return properties
+    return {}
+
+
+def _get_element(name, element_type, server=None, with_properties=True):
+    '''
+    Get an element with or without properties
+    '''
+    element = {}
+    name = quote(name, safe='')
+    data = _api_get('{0}/{1}'.format(element_type, name), server)
+
+    # Format data, get properties if asked, and return the whole thing
+    if any(data['extraProperties']['entity']):
+        for key, value in data['extraProperties']['entity'].items():
+            element[key] = value
+        if with_properties:
+            element['properties'] = _get_element_properties(name, element_type)
+        return element
+    return None
+
+
+def _create_element(name, element_type, data, server=None):
+    '''
+    Create a new element
+    '''
+    # Define property and id from name and properties + remove SaltStack parameters
+    if 'properties' in data:
+        data['property'] = ''
+        for key, value in data['properties'].items():
+            if not data['property']:
+                data['property'] += '{0}={1}'.format(key, value.replace(':', '\\:'))
+            else:
+                data['property'] += ':{0}={1}'.format(key, value.replace(':', '\\:'))
+        del data['properties']
+
+    # Send request
+    _api_post(element_type, _clean_data(data), server)
+    return unquote(name)
+
+
+def _update_element(name, element_type, data, server=None):
+    '''
+    Update an element, including it's properties
+    '''
+    # Urlencode the name (names may have slashes)
+    name = quote(name, safe='')
+
+    # Update properties first
+    if 'properties' in data:
+        properties = []
+        for key, value in data['properties'].items():
+            properties.append({'name': key, 'value': value})
+        _api_post('{0}/{1}/property'.format(element_type, name), properties, server)
+        del data['properties']
+
+        # If the element only contained properties
+        if not data:
+            return unquote(name)
+
+    # Get the current data then merge updated data into it
+    update_data = _get_element(name, element_type, server, with_properties=False)
+    if update_data:
+        update_data.update(data)
+    else:
+        __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
+        raise CommandExecutionError('Cannot update {0}'.format(name))
+
+    # Finally, update the element
+    _api_post('{0}/{1}'.format(element_type, name), _clean_data(update_data), server)
+    return unquote(name)
+
+
+def _delete_element(name, element_type, data, server=None):
+    '''
+    Delete an element
+    '''
+    _api_delete('{0}/{1}'.format(element_type, quote(name, safe='')), data, server)
+    return name
+
+
+# Connector connection pools
+def enum_connector_c_pool(server=None):
+    '''
+    Enum connection pools
+    '''
+    return _enum_elements('resources/connector-connection-pool', server)
+
+
+def get_connector_c_pool(name, server=None):
+    '''
+    Get a specific connection pool
+    '''
+    return _get_element(name, 'resources/connector-connection-pool', server)
+
+
+def create_connector_c_pool(name, server=None, **kwargs):
+    '''
+    Create a connection pool
+    '''
+    defaults = {
+        'connectionDefinitionName': 'javax.jms.ConnectionFactory',
+        'resourceAdapterName': 'jmsra',
+        'associateWithThread': False,
+        'connectionCreationRetryAttempts': 0,
+        'connectionCreationRetryIntervalInSeconds': 0,
+        'connectionLeakReclaim': False,
+        'connectionLeakTimeoutInSeconds': 0,
+        'description': '',
+        'failAllConnections': False,
+        'id': name,
+        'idleTimeoutInSeconds': 300,
+        'isConnectionValidationRequired': False,
+        'lazyConnectionAssociation': False,
+        'lazyConnectionEnlistment': False,
+        'matchConnections': True,
+        'maxConnectionUsageCount': 0,
+        'maxPoolSize': 32,
+        'maxWaitTimeInMillis': 60000,
+        'ping': False,
+        'poolResizeQuantity': 2,
+        'pooling': True,
+        'steadyPoolSize': 8,
+        'target': 'server',
+        'transactionSupport': '',
+        'validateAtmostOncePeriodInSeconds': 0
+    }
+
+    # Data = defaults + merge kwargs + remove salt
+    data = defaults
+    data.update(kwargs)
+
+    # Check TransactionSupport against acceptable values
+    if data['transactionSupport'] and data['transactionSupport'] not in (
+               'XATransaction',
+               'LocalTransaction',
+               'NoTransaction'
+       ):
+        raise CommandExecutionError('Invalid transaction support')
+
+    return _create_element(name, 'resources/connector-connection-pool', data, server)
+
+
+def update_connector_c_pool(name, server=None, **kwargs):
+    '''
+    Update a connection pool
+    '''
+    if 'transactionSupport' in kwargs and kwargs['transactionSupport'] not in (
+               'XATransaction',
+               'LocalTransaction',
+               'NoTransaction'
+       ):
+        raise CommandExecutionError('Invalid transaction support')
+    return _update_element(name, 'resources/connector-connection-pool', kwargs, server)
+
+
+def delete_connector_c_pool(name, target='server', cascade=True, server=None):
+    '''
+    Delete a connection pool
+    '''
+    data = {'target': target, 'cascade': cascade}
+    return _delete_element(name, 'resources/connector-connection-pool', data, server)
+
+
+# Connector resources
+def enum_connector_resource(server=None):
+    '''
+    Enum connection resources
+    '''
+    return _enum_elements('resources/connector-resource', server)
+
+
+def get_connector_resource(name, server=None):
+    '''
+    Get a specific connection resource
+    '''
+    return _get_element(name, 'resources/connector-resource', server)
+
+
+def create_connector_resource(name, server=None, **kwargs):
+    '''
+    Create a connection resource
+    '''
+    defaults = {
+        'description': '',
+        'enabled': True,
+        'id': name,
+        'poolName': '',
+        'objectType': 'user',
+        'target': 'server'
+    }
+
+    # Data = defaults + merge kwargs + poolname
+    data = defaults
+    data.update(kwargs)
+
+    if not data['poolName']:
+        raise CommandExecutionError('No pool name!')
+
+    # Fix for lowercase vs camelCase naming differences
+    for key, value in list(data.items()):
+        del data[key]
+        data[key.lower()] = value
+
+    return _create_element(name, 'resources/connector-resource', data, server)
+
+
+def update_connector_resource(name, server=None, **kwargs):
+    '''
+    Update a connection resource
+    '''
+    # You're not supposed to update jndiName, if you do so, it will crash, silently
+    if 'jndiName' in kwargs:
+        del kwargs['jndiName']
+    return _update_element(name, 'resources/connector-resource', kwargs, server)
+
+
+def delete_connector_resource(name, target='server', server=None):
+    '''
+    Delete a connection resource
+    '''
+    return _delete_element(name, 'resources/connector-resource', {'target': target}, server)
+
+
+# JMS Destinations
+def enum_admin_object_resource(server=None):
+    '''
+    Enum JMS destinations
+    '''
+    return _enum_elements('resources/admin-object-resource', server)
+
+
+def get_admin_object_resource(name, server=None):
+    '''
+    Get a specific JMS destination
+    '''
+    return _get_element(name, 'resources/admin-object-resource', server)
+
+
+def create_admin_object_resource(name, server=None, **kwargs):
+    '''
+    Create a JMS destination
+    '''
+    defaults = {
+        'description': '',
+        'className': 'com.sun.messaging.Queue',
+        'enabled': True,
+        'id': name,
+        'resAdapter': 'jmsra',
+        'resType': 'javax.jms.Queue',
+        'target': 'server'
+    }
+
+    # Data = defaults + merge kwargs + poolname
+    data = defaults
+    data.update(kwargs)
+
+    # ClassName isn't optional, even if the API says so
+    if data['resType'] == 'javax.jms.Queue':
+        data['className'] = 'com.sun.messaging.Queue'
+    elif data['resType'] == 'javax.jms.Topic':
+        data['className'] = 'com.sun.messaging.Topic'
+    else:
+        raise CommandExecutionError('resType should be "javax.jms.Queue" or "javax.jms.Topic"!')
+
+    if data['resAdapter'] != 'jmsra':
+        raise CommandExecutionError('resAdapter should be "jmsra"!')
+
+    # Fix for lowercase vs camelCase naming differences
+    if 'resType' in data:
+        data['restype'] = data['resType']
+        del data['resType']
+    if 'className' in data:
+        data['classname'] = data['className']
+        del data['className']
+
+    return _create_element(name, 'resources/admin-object-resource', data, server)
+
+
+def update_admin_object_resource(name, server=None, **kwargs):
+    '''
+    Update a JMS destination
+    '''
+    if 'jndiName' in kwargs:
+        del kwargs['jndiName']
+    return _update_element(name, 'resources/admin-object-resource', kwargs, server)
+
+
+def delete_admin_object_resource(name, target='server', server=None):
+    '''
+    Delete a JMS destination
+    '''
+    return _delete_element(name, 'resources/admin-object-resource', {'target': target}, server)
+
+
+# JDBC Pools
+def enum_jdbc_connection_pool(server=None):
+    '''
+    Enum JDBC pools
+    '''
+    return _enum_elements('resources/jdbc-connection-pool', server)
+
+
+def get_jdbc_connection_pool(name, server=None):
+    '''
+    Get a specific JDBC pool
+    '''
+    return _get_element(name, 'resources/jdbc-connection-pool', server)
+
+
+def create_jdbc_connection_pool(name, server=None, **kwargs):
+    '''
+    Create a connection resource
+    '''
+    defaults = {
+        'allowNonComponentCallers': False,
+        'associateWithThread': False,
+        'connectionCreationRetryAttempts': '0',
+        'connectionCreationRetryIntervalInSeconds': '10',
+        'connectionLeakReclaim': False,
+        'connectionLeakTimeoutInSeconds': '0',
+        'connectionValidationMethod': 'table',
+        'datasourceClassname': '',
+        'description': '',
+        'driverClassname': '',
+        'failAllConnections': False,
+        'idleTimeoutInSeconds': '300',
+        'initSql': '',
+        'isConnectionValidationRequired': False,
+        'isIsolationLevelGuaranteed': True,
+        'lazyConnectionAssociation': False,
+        'lazyConnectionEnlistment': False,
+        'matchConnections': False,
+        'maxConnectionUsageCount': '0',
+        'maxPoolSize': '32',
+        'maxWaitTimeInMillis': 60000,
+        'name': name,
+        'nonTransactionalConnections': False,
+        'ping': False,
+        'poolResizeQuantity': '2',
+        'pooling': True,
+        'resType': '',
+        'sqlTraceListeners': '',
+        'statementCacheSize': '0',
+        'statementLeakReclaim': False,
+        'statementLeakTimeoutInSeconds': '0',
+        'statementTimeoutInSeconds': '-1',
+        'steadyPoolSize': '8',
+        'target': 'server',
+        'transactionIsolationLevel': '',
+        'validateAtmostOncePeriodInSeconds': '0',
+        'validationClassname': '',
+        'validationTableName': '',
+        'wrapJdbcObjects': True
+    }
+
+    # Data = defaults + merge kwargs + poolname
+    data = defaults
+    data.update(kwargs)
+
+    # Check resType against acceptable values
+    if data['resType'] not in (
+            'javax.sql.DataSource',
+            'javax.sql.XADataSource',
+            'javax.sql.ConnectionPoolDataSource',
+            'java.sql.Driver'
+       ):
+        raise CommandExecutionError('Invalid resource type')
+
+    # Check connectionValidationMethod against acceptable velues
+    if data['connectionValidationMethod'] not in (
+            'auto-commit',
+            'meta-data',
+            'table',
+            'custom-validation'
+       ):
+        raise CommandExecutionError('Invalid connection validation method')
+
+    if data['transactionIsolationLevel'] \
+       and data['transactionIsolationLevel'] not in (
+               'read-uncommitted',
+               'read-committed',
+               'repeatable-read',
+               'serializable'
+       ):
+        raise CommandExecutionError('Invalid transaction isolation level')
+
+    if not data['datasourceClassname'] \
+       and data['resType'] in (
+               'javax.sql.DataSource',
+               'javax.sql.ConnectionPoolDataSource',
+               'javax.sql.XADataSource'
+       ):
+        raise CommandExecutionError('No datasource class name while using datasource resType')
+    if not data['driverClassname'] and data['resType'] == 'java.sql.Driver':
+        raise CommandExecutionError('No driver class nime while using driver resType')
+
+    return _create_element(name, 'resources/jdbc-connection-pool', data, server)
+
+
+def update_jdbc_connection_pool(name, server=None, **kwargs):
+    '''
+    Update a JDBC pool
+    '''
+    return _update_element(name, 'resources/jdbc-connection-pool', kwargs, server)
+
+
+def delete_jdbc_connection_pool(name, target='server', cascade=False, server=None):
+    '''
+    Delete a JDBC pool
+    '''
+    data = {'target': target, 'cascade': cascade}
+    return _delete_element(name, 'resources/jdbc-connection-pool', data, server)
+
+
+# JDBC resources
+def enum_jdbc_resource(server=None):
+    '''
+    Enum JDBC resources
+    '''
+    return _enum_elements('resources/jdbc-resource', server)
+
+
+def get_jdbc_resource(name, server=None):
+    '''
+    Get a specific JDBC resource
+    '''
+    return _get_element(name, 'resources/jdbc-resource', server)
+
+
+def create_jdbc_resource(name, server=None, **kwargs):
+    '''
+    Create a JDBC resource
+    '''
+    defaults = {
+        'description': '',
+        'enabled': True,
+        'id': name,
+        'poolName': '',
+        'target': 'server'
+    }
+
+    # Data = defaults + merge kwargs + poolname
+    data = defaults
+    data.update(kwargs)
+
+    if not data['poolName']:
+        raise CommandExecutionError('No pool name!')
+
+    return _create_element(name, 'resources/jdbc-resource', data, server)
+
+
+def update_jdbc_resource(name, server=None, **kwargs):
+    '''
+    Update a JDBC resource
+    '''
+    # You're not supposed to update jndiName, if you do so, it will crash, silently
+    if 'jndiName' in kwargs:
+        del kwargs['jndiName']
+    return _update_element(name, 'resources/jdbc-resource', kwargs, server)
+
+
+def delete_jdbc_resource(name, target='server', server=None):
+    '''
+    Delete a JDBC resource
+    '''
+    return _delete_element(name, 'resources/jdbc-resource', {'target': target}, server)

--- a/salt/states/glassfish.py
+++ b/salt/states/glassfish.py
@@ -1,0 +1,545 @@
+# -*- coding: utf-8 -*-
+'''
+Manage Glassfish/Payara server
+.. versionadded:: Carbon
+
+Management of glassfish using it's RESTful API
+You can setup connection parameters like this
+
+.. code-block:: yaml
+    - server:
+      - ssl: true
+      - url: localhost
+      - port: 4848
+      - user: admin
+      - password: changeit
+'''
+from __future__ import absolute_import
+
+try:
+    import json
+    from salt.ext import six
+    from salt.exceptions import CommandExecutionError
+    HAS_LIBS = True
+except ImportError:
+    HAS_LIBS = False
+
+
+def __virtual__():
+    '''
+    Only load if glassfish module is available
+    '''
+    return 'glassfish.enum_connector_c_pool' in __salt__ and HAS_LIBS
+
+
+def _json_to_unicode(data):
+    '''
+    Encode json values in unicode to match that of the API
+    '''
+    ret = {}
+    for key, value in data.items():
+        if not isinstance(value, six.text_type):
+            if isinstance(value, dict):
+                ret[key] = _json_to_unicode(value)
+            else:
+                ret[key] = six.u(str(value).lower())
+        else:
+            ret[key] = value
+    return ret
+
+
+def _is_updated(old_conf, new_conf):
+    '''
+    Compare the API results to the current statefile data
+    '''
+    changed = {}
+
+    # Dirty json hacking to get parameters in the same format
+    new_conf = _json_to_unicode(json.loads(json.dumps(new_conf, ensure_ascii=False)))
+    old_conf = json.loads(json.dumps(old_conf, ensure_ascii=False))
+
+    for key, value in old_conf.items():
+        oldval = str(value).lower()
+        if key in new_conf:
+            newval = str(new_conf[key]).lower()
+        if oldval == 'null' or oldval == 'none':
+            oldval = ''
+        if key in new_conf and newval != oldval:
+            changed[key] = {'old': oldval, 'new': newval}
+    return changed
+
+
+def _do_element_present(name, elem_type, data, server=None):
+    '''
+    Generic function to create or update an element
+    '''
+    ret = {'changes': {}, 'update': False, 'create': False, 'error': None}
+    elements = __salt__['glassfish.enum_{0}'.format(elem_type)]()
+
+    if not elements or name not in elements:
+        ret['changes'] = {'Name': name, 'Params': data}
+        ret['create'] = True
+        if not __opts__['test']:
+            try:
+                __salt__['glassfish.create_{0}'.format(elem_type)](name, server=server, **data)
+            except CommandExecutionError as error:
+                ret['error'] = error
+                return ret
+    elif elements and any(data):
+        current_data = __salt__['glassfish.get_{0}'.format(elem_type)](name, server=server)
+        data_diff = _is_updated(current_data, data)
+        if data_diff:
+            ret['update'] = True
+            ret['changes'] = data_diff
+            if not __opts__['test']:
+                try:
+                    __salt__['glassfish.update_{0}'.format(elem_type)](name, server=server, **data)
+                except CommandExecutionError as error:
+                    ret['error'] = error
+    return ret
+
+
+def _do_element_absent(name, elem_type, data, server=None):
+    '''
+    Generic function to delete an element
+    '''
+    ret = {'delete': False, 'error': None}
+    elements = __salt__['glassfish.enum_{0}'.format(elem_type)]()
+
+    if elements and name in elements:
+        ret['delete'] = True
+        if not __opts__['test']:
+            try:
+                __salt__['glassfish.delete_{0}'.format(elem_type)](name, server=server, **data)
+            except CommandExecutionError as error:
+                ret['error'] = error
+    return ret
+
+
+def connection_factory_present(name,
+                               restype='connection_factory',
+                               description='',
+                               enabled=True,
+                               min_size=1,
+                               max_size=250,
+                               resize_quantity=2,
+                               idle_timeout=300,
+                               wait_timeout=60,
+                               reconnect_on_failure=False,
+                               transaction_support='',
+                               connection_validation=False,
+                               server=None):
+    '''
+    Ensures that the Connection Factory is present
+
+    name
+        Name of the connection factory
+
+    restype
+        Type of the connection factory, can be either ``connection_factory``,
+        ``queue_connection_factory` or ``topic_connection_factory``,
+        defaults to ``connection_factory``
+
+    description
+        Description of the connection factory
+
+    enabled
+        Is the connection factory enabled? defaults to ``true``
+
+    min_size
+        Minimum and initial number of connections in the pool, defaults to ``1``
+
+    max_size
+        Maximum number of connections that can be created in the pool, defaults to ``250``
+
+    resize_quantity
+        Number of connections to be removed when idle_timeout expires, defaults to ``2``
+
+    idle_timeout
+        Maximum time a connection can remain idle in the pool, in seconds, defaults to ``300``
+
+    wait_timeout
+        Maximum time a caller can wait before timeout, in seconds, defaults to ``60``
+
+    reconnect_on_failure
+        Close all connections and reconnect on failure (or reconnect only when used), defaults to ``false``
+    transaction_support
+        Level of transaction support, can be either ``XATransaction``, ``LocalTransaction`` or ``NoTransaction``
+
+    connection_validation
+        Connection validation is required, defaults to ``false``
+    '''
+    ret = {'name': name, 'result': None, 'comment': None, 'changes': {}}
+
+    # Manage parameters
+    pool_data = {}
+    res_data = {}
+    pool_name = '{0}-Connection-Pool'.format(name)
+    if restype == 'topic_connection_factory':
+        pool_data['connectionDefinitionName'] = 'javax.jms.TopicConnectionFactory'
+    elif restype == 'queue_connection_factory':
+        pool_data['connectionDefinitionName'] = 'javax.jms.QueueConnectionFactory'
+    elif restype == 'connection_factory':
+        pool_data['connectionDefinitionName'] = 'javax.jms.ConnectionFactory'
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Invalid restype'
+        return ret
+    pool_data['description'] = description
+    res_data['description'] = description
+    res_data['enabled'] = enabled
+    res_data['poolName'] = pool_name
+    pool_data['steadyPoolSize'] = min_size
+    pool_data['maxPoolSize'] = max_size
+    pool_data['poolResizeQuantity'] = resize_quantity
+    pool_data['idleTimeoutInSeconds'] = idle_timeout
+    pool_data['maxWaitTimeInMillis'] = wait_timeout*1000
+    pool_data['failAllConnections'] = reconnect_on_failure
+    if transaction_support:
+        if transaction_support == 'xa_transaction':
+            pool_data['transactionSupport'] = 'XATransaction'
+        elif transaction_support == 'local_transaction':
+            pool_data['transactionSupport'] = 'LocalTransaction'
+        elif transaction_support == 'no_transaction':
+            pool_data['transactionSupport'] = 'NoTransaction'
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Invalid transaction_support'
+            return ret
+    pool_data['isConnectionValidationRequired'] = connection_validation
+
+    pool_ret = _do_element_present(pool_name, 'connector_c_pool', pool_data, server)
+    res_ret = _do_element_present(name, 'connector_resource', res_data, server)
+
+    if not pool_ret['error'] and not res_ret['error']:
+        if not __opts__['test']:
+            ret['result'] = True
+
+        if pool_ret['create'] or res_ret['create']:
+            ret['changes']['pool'] = pool_ret['changes']
+            ret['changes']['resource'] = res_ret['changes']
+            if __opts__['test']:
+                ret['comment'] = 'Connection factory set to be created'
+            else:
+                ret['comment'] = 'Connection factory created'
+        elif pool_ret['update'] or res_ret['update']:
+            ret['changes']['pool'] = pool_ret['changes']
+            ret['changes']['resource'] = res_ret['changes']
+            if __opts__['test']:
+                ret['comment'] = 'Connection factory set to be updated'
+            else:
+                ret['comment'] = 'Connection factory updated'
+        else:
+            ret['result'] = True
+            ret['changes'] = None
+            ret['comment'] = 'Connection factory is already up-to-date'
+    else:
+        ret['result'] = False
+        ret['comment'] = 'ERROR: {0} // {1}'.format(pool_ret['error'], res_ret['error'])
+
+    return ret
+
+
+def connection_factory_absent(name, both=True, server=None):
+    '''
+    Ensures the transaction factory is absent.
+
+    name
+        Name of the connection factory
+
+    both
+        Delete both the pool and the resource, defaults to ``true``
+    '''
+    ret = {'name': name, 'result': None, 'comment': None, 'changes': {}}
+    pool_name = '{0}-Connection-Pool'.format(name)
+    pool_ret = _do_element_absent(pool_name, 'connector_c_pool', {'cascade': both}, server)
+
+    if not pool_ret['error']:
+        if __opts__['test'] and pool_ret['delete']:
+            ret['comment'] = 'Connection Factory set to be deleted'
+        elif pool_ret['delete']:
+            ret['result'] = True
+            ret['comment'] = 'Connection Factory deleted'
+        else:
+            ret['result'] = True
+            ret['comment'] = 'Connection Factory doesn\'t exist'
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Error: {0}'.format(pool_ret['error'])
+    return ret
+
+
+def destination_present(name,
+                        physical,
+                        restype='queue',
+                        description='',
+                        enabled=True,
+                        server=None):
+    '''
+    Ensures that the JMS Destination Resource (queue or topic) is present
+
+    name
+        The JMS Queue/Topic name
+
+    physical
+        The Physical destination name
+
+    restype
+        The JMS Destination resource type, either ``queue`` or ``topic``, defaults is ``queue``
+
+    description
+        A description of the resource
+
+    enabled
+        Defaults to ``True``
+    '''
+    ret = {'name': name, 'result': None, 'comment': None, 'changes': {}}
+
+    params = {}
+    # Set parameters dict
+    if restype == 'queue':
+        params['resType'] = 'javax.jms.Queue'
+        params['className'] = 'com.sun.messaging.Queue'
+    elif restype == 'topic':
+        params['resType'] = 'javax.jms.Topic'
+        params['className'] = 'com.sun.messaging.Topic'
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Invalid restype'
+        return ret
+    params['properties'] = {'Name': physical}
+    params['description'] = description
+    params['enabled'] = enabled
+
+    jms_ret = _do_element_present(name, 'admin_object_resource', params, server)
+    if not jms_ret['error']:
+        if not __opts__['test']:
+            ret['result'] = True
+        if jms_ret['create'] and __opts__['test']:
+            ret['comment'] = 'JMS Queue set to be created'
+        elif jms_ret['create']:
+            ret['changes'] = jms_ret['changes']
+            ret['comment'] = 'JMS queue created'
+        elif jms_ret['update'] and __opts__['test']:
+            ret['comment'] = 'JMS Queue set to be updated'
+        elif jms_ret['update']:
+            ret['changes'] = jms_ret['changes']
+            ret['comment'] = 'JMS Queue updated'
+        else:
+            ret['result'] = True
+            ret['comment'] = 'JMS Queue already up-to-date'
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Error from API: {0}'.format(jms_ret['error'])
+    return ret
+
+
+def destination_absent(name, server=None):
+    '''
+    Ensures that the JMS Destination doesn't exists
+
+    name
+        Name of the JMS Destination
+    '''
+    ret = {'name': name, 'result': None, 'comment': None, 'changes': {}}
+    jms_ret = _do_element_absent(name, 'admin_object_resource', {}, server)
+    if not jms_ret['error']:
+        if __opts__['test'] and jms_ret['delete']:
+            ret['comment'] = 'JMS Queue set to be deleted'
+        elif jms_ret['delete']:
+            ret['result'] = True
+            ret['comment'] = 'JMS Queue deleted'
+        else:
+            ret['result'] = True
+            ret['comment'] = 'JMS Queue doesn\'t exist'
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Error: {0}'.format(jms_ret['error'])
+    return ret
+
+
+def jdbc_datasource_present(name,
+                            description='',
+                            enabled=True,
+                            restype='datasource',
+                            vendor='mysql',
+                            sql_url='',
+                            sql_user='',
+                            sql_password='',
+                            min_size=8,
+                            max_size=32,
+                            resize_quantity=2,
+                            idle_timeout=300,
+                            wait_timeout=60,
+                            non_transactional=False,
+                            transaction_isolation='',
+                            isolation_guaranteed=True,
+                            server=None):
+    '''
+    Ensures that the JDBC Datasource exists
+
+    name
+        Name of the datasource
+
+    description
+        Description of the datasource
+
+    enabled
+        Is the datasource enabled? defaults to ``true``
+
+    restype
+        Resource type, can be ``datasource``, ``xa_datasource``,
+        ``connection_pool_datasource`` or ``driver``, defaults to ``datasource``
+
+    vendor
+        SQL Server type, currently supports ``mysql``,
+        ``postgresql`` and ``mssql``, defaults to ``mysql``
+
+    sql_url
+        URL of the server in jdbc form
+
+    sql_user
+        Username for the server
+
+    sql_password
+        Password for that username
+
+    min_size
+        Minimum and initial number of connections in the pool, defaults to ``8``
+
+    max_size
+        Maximum number of connections that can be created in the pool, defaults to ``32``
+
+    resize_quantity
+        Number of connections to be removed when idle_timeout expires, defaults to ``2``
+
+    idle_timeout
+        Maximum time a connection can remain idle in the pool, in seconds, defaults to ``300``
+
+    wait_timeout
+        Maximum time a caller can wait before timeout, in seconds, defaults to ``60``
+
+    non_transactional
+        Return non-transactional connections
+
+    transaction_isolation
+        Defaults to the JDBC driver default
+
+    isolation_guaranteed
+        All connections use the same isolation level
+    '''
+    ret = {'name': name, 'result': None, 'comment': None, 'changes': {}}
+
+    # Manage parameters
+    res_name = 'jdbc/{0}'.format(name)
+    pool_data = {}
+    pool_data_properties = {}
+    res_data = {}
+    if restype == 'datasource':
+        pool_data['resType'] = 'javax.sql.DataSource'
+    elif restype == 'xa_datasource':
+        pool_data['resType'] = 'javax.sql.XADataSource'
+    elif restype == 'connection_pool_datasource':
+        pool_data['resType'] = 'javax.sql.ConnectionPoolDataSource'
+    elif restype == 'driver':
+        pool_data['resType'] = 'javax.sql.Driver'
+
+    datasources = {}
+    datasources['mysql'] = {
+        'driver': 'com.mysql.jdbc.Driver',
+        'datasource': 'com.mysql.jdbc.jdbc2.optional.MysqlDataSource',
+        'xa_datasource': 'com.mysql.jdbc.jdbc2.optional.MysqlXADataSource',
+        'connection_pool_datasource': 'com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource'
+    }
+    datasources['postgresql'] = {
+        'driver': 'org.postgresql.Driver',
+        'datasource': 'org.postgresql.ds.PGSimpleDataSource',
+        'xa_datasource': 'org.postgresql.xa.PGXADataSource',
+        'connection_pool_datasource': 'org.postgresql.ds.PGConnectionPoolDataSource'
+    }
+    datasources['mssql'] = {
+        'driver': 'com.microsoft.sqlserver.jdbc.SQLServerDriver',
+        'datasource': 'com.microsoft.sqlserver.jdbc.SQLServerDataSource',
+        'xa_datasource': 'com.microsoft.sqlserver.jdbc.SQLServerXADataSource',
+        'connection_pool_datasource': 'com.microsoft.sqlserver.jdbc.SQLServerConnectionPoolDataSource'
+    }
+
+    if restype == 'driver':
+        pool_data['driverClassname'] = datasources[vendor]['driver']
+    else:
+        pool_data['datasourceClassname'] = datasources[vendor][restype]
+
+    pool_data_properties['url'] = sql_url
+    pool_data_properties['user'] = sql_user
+    pool_data_properties['password'] = sql_password
+    pool_data['properties'] = pool_data_properties
+    pool_data['description'] = description
+    res_data['description'] = description
+    res_data['poolName'] = name
+    res_data['enabled'] = enabled
+    pool_data['steadyPoolSize'] = min_size
+    pool_data['maxPoolSize'] = max_size
+    pool_data['poolResizeQuantity'] = resize_quantity
+    pool_data['idleTimeoutInSeconds'] = idle_timeout
+    pool_data['maxWaitTimeInMillis'] = wait_timeout*1000
+    pool_data['nonTransactionalConnections'] = non_transactional
+    pool_data['transactionIsolationLevel'] = transaction_isolation
+    pool_data['isIsolationLevelGuaranteed'] = isolation_guaranteed
+
+    pool_ret = _do_element_present(name, 'jdbc_connection_pool', pool_data, server)
+    res_ret = _do_element_present(res_name, 'jdbc_resource', res_data, server)
+
+    if not pool_ret['error'] and not res_ret['error']:
+        if not __opts__['test']:
+            ret['result'] = True
+
+        if pool_ret['create'] or res_ret['create']:
+            ret['changes']['pool'] = pool_ret['changes']
+            ret['changes']['resource'] = res_ret['changes']
+            if __opts__['test']:
+                ret['comment'] = 'JDBC Datasource set to be created'
+            else:
+                ret['comment'] = 'JDBC Datasource created'
+        elif pool_ret['update'] or res_ret['update']:
+            ret['changes']['pool'] = pool_ret['changes']
+            ret['changes']['resource'] = res_ret['changes']
+            if __opts__['test']:
+                ret['comment'] = 'JDBC Datasource set to be updated'
+            else:
+                ret['comment'] = 'JDBC Datasource updated'
+        else:
+            ret['result'] = True
+            ret['changes'] = None
+            ret['comment'] = 'JDBC Datasource is already up-to-date'
+    else:
+        ret['result'] = False
+        ret['comment'] = 'ERROR: {0} // {1}'.format(pool_ret['error'], res_ret['error'])
+
+    return ret
+
+
+def jdbc_datasource_absent(name, both=True, server=None):
+    '''
+    Ensures the JDBC Datasource doesn't exists
+
+    name
+        Name of the datasource
+    both
+        Delete both the pool and the resource, defaults to ``true``
+    '''
+    ret = {'name': name, 'result': None, 'comment': None, 'changes': {}}
+    pool_ret = _do_element_absent(name, 'jdbc_connection_pool', {'cascade': both}, server)
+
+    if not pool_ret['error']:
+        if __opts__['test'] and pool_ret['delete']:
+            ret['comment'] = 'JDBC Datasource set to be deleted'
+        elif pool_ret['delete']:
+            ret['result'] = True
+            ret['comment'] = 'JDBC Datasource deleted'
+        else:
+            ret['result'] = True
+            ret['comment'] = 'JDBC Datasource doesn\'t exist'
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Error: {0}'.format(pool_ret['error'])
+    return ret


### PR DESCRIPTION
### What does this PR do?

It add support for Glassfish/Payara 4.x JavaEE application servers, using it's RESTful API.
There's 2 new files: an execution module, that is kinda "low-level", it only wraps around the glassfish API and try to workaround it's idiosyncrasies, and a state module, that provides a set of simple parameters and do the translation between these simple parameters and the execution module's. it was tested against Glassfish 4.1.1 and Payara 4.1.1.171.1, but may work with Glassfish 3.x as i didn't saw any major differences in the API.
For now, it only provides a way to add/delete JMS Destinations (Topics and Queues), JDBC Resources and Pools, and Connection factories, but more features may be
 added in the future.

### Tests written?

No (manual testing against Glassfish 4.1.1 and Payara 4.1.1.171.1 APIs)