### PR TITLE
Keep all return-related values in the job cache.

### DIFF
--- a/tests/integration/runners/test_runner_returns.py
+++ b/tests/integration/runners/test_runner_returns.py
@@ -120,15 +120,15 @@ class RunnerReturnsTest(ShellCase):
         with salt.utils.fopen(serialized_return, 'rb') as fp_:
             deserialized = serial.loads(fp_.read())
 
-        self.clean_return(deserialized)
+        self.clean_return(deserialized['return'])
 
         # Now we have something sane we can reliably compare in an assert.
         self.assertEqual(
             deserialized,
-            {'fun': 'runner.test.arg',
-             'fun_args': ['foo', {'bar': 'hello world!'}],
-             'jid': jid,
-             'return': {'args': ['foo'], 'kwargs': {'bar': 'hello world!'}},
-             'success': True,
-             'user': 'root'}
+            {'return': {'fun': 'runner.test.arg',
+                        'fun_args': ['foo', {'bar': 'hello world!'}],
+                        'jid': jid,
+                        'return': {'args': ['foo'], 'kwargs': {'bar': 'hello world!'}},
+                        'success': True,
+                        'user': 'root'}}
         )


### PR DESCRIPTION
### What does this PR do?
Change the job cache `return.p` format from the single `return` value to the dict of `return`, `retcode` and `success` values.

### What issues does this PR fix or reference?
#35691

### Tests written?
No