### PR TITLE
gpg.verify support for detached signatures

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -1076,7 +1076,9 @@ def verify(text=None,
         verified = gpg.verify(text)
     elif filename:
         if signature:
-            with salt.utils.flopen(signature, 'rb') as _fp:
+            # need to call with fopen instead of flopen due to:
+            # https://bitbucket.org/vinay.sajip/python-gnupg/issues/76/verify_file-closes-passed-file-handle
+            with salt.utils.fopen(signature, 'rb') as _fp:
                 verified = gpg.verify_file(_fp, filename)
         else:
             with salt.utils.flopen(filename, 'rb') as _fp:

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -1057,7 +1057,7 @@ def verify(text=None,
 
     signature
         Specify the filename of a detached signature.
-    .. versionadded:: 2017.FILLMEIN
+    .. versionadded:: Nitrogen
 
     CLI Example:
 

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -1036,7 +1036,8 @@ def sign(user=None,
 def verify(text=None,
            user=None,
            filename=None,
-           gnupghome=None):
+           gnupghome=None,
+           signature=None):
     '''
     Verify a message or file
 
@@ -1054,6 +1055,10 @@ def verify(text=None,
     gnupghome
         Specify the location where GPG keyring and related files are stored.
 
+    signature
+        Specify the filename of a detached signature.
+    .. versionadded:: 2017.FILLMEIN
+
     CLI Example:
 
     .. code-block:: bash
@@ -1070,8 +1075,12 @@ def verify(text=None,
     if text:
         verified = gpg.verify(text)
     elif filename:
-        with salt.utils.flopen(filename, 'rb') as _fp:
-            verified = gpg.verify_file(_fp)
+        if signature:
+            with salt.utils.flopen(signature, 'rb') as _fp:
+                verified = gpg.verify_file(_fp, filename)
+        else:
+            with salt.utils.flopen(filename, 'rb') as _fp:
+                verified = gpg.verify_file(_fp)
     else:
         raise SaltInvocationError('filename or text must be passed.')
 


### PR DESCRIPTION
### What does this PR do?
Implements verifying OpenPGP detached signatures in modules/gpg.verify. This was already supported by the upstream library in use (python-gnupg) but just not utilized in Salt.

### What issues does this PR fix or reference?
This is needed to support signature verification in file.managed that is being worked on in #40596 

### New Behavior
No change in the first part (but doesn't work off current develop due to #40682, fixed in nitrogen):
```
%> salt -c etc/salt '*' gpg.receive_keys keys='6D5B EF9A DD20 7580 5747 B70F 9F88 FB52 FAF7 B393'
saltdev:
    ----------
    changes:
        ----------
    message:
        - Unable to add key to keychain
        - Unable to add key to keychain
        - Key 6D5BEF9ADD2075805747B70F9F88FB52FAF7B393 added to keychain
    res:
        True
```
```
 %> salt -c etc/salt '*' gpg.verify signature=/home/artanicus/gpg/borg-linux32.asc filename=/home/artanicus/gpg/borg-linux32
saltdev:
    ----------
    key_id:
        243ACFA951F78E01
    message:
        The signature is verified.
    res:
        True
    trust_level:
        Undefined
    username:
        Thomas Waldmann <tw@waldmann-edv.de>
```
### Tests written?
No. modules/gpg doesn't seem to have any tests, would be happy to write a new test for this change but doing so when there's nothing to extend is beyond my skills right now.