### PR TITLE
Fixed minion keys remaining pending after auto signing and fixed two typos

### DIFF
--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -361,7 +361,7 @@ class AESReqServerMixin(object):
                         return {'enc': 'clear',
                                 'load': {'ret': False}}
                     else:
-                        pass
+                        os.remove(pubfn_pend)
 
         else:
             # Something happened that I have not accounted for, FAIL!
@@ -410,8 +410,8 @@ class AESReqServerMixin(object):
                'pub_key': self.master_key.get_pub_str(),
                'publish_port': self.opts['publish_port']}
 
-        # sign the masters pubkey (if enabled) before it is
-        # send to the minion that was just authenticated
+        # sign the master's pubkey (if enabled) before it is
+        # sent to the minion that was just authenticated
         if self.opts['master_sign_pubkey']:
             # append the pre-computed signature to the auth-reply
             if self.master_key.pubkey_signature():


### PR DESCRIPTION
### What does this PR do?
This fixes a bug, where minion keys would be shown as unaccepted (and also accepted at the same time) after they got accepted via autosign, when they were pending before.

Also fixed two typos in comments in `salt/transport/mixins/auth.py`.

The bug and typos are present at least in all releases since 2015.8. If the same code was in another file before they might also exist in releases before 2015.8.

### Steps to reproduce
Create a new salt minion and wait for it to ask for authentication.

Output of `salt-key`:
```
Accepted Keys:
Denied Keys:
Unaccepted Keys:
my-minion
Rejected Keys:
```

Now add the minion-id to the autosign file (`/etc/salt/autosign.conf` per default)

On the next request (usually after 10 seconds) the minion will get accepted and a key_file will get created in `/etc/salt/pki/master/minions/`, but the old file (`/etc/salt/pki/minions_pre/` won`t get deleted.

### Previous Behavior
Result of the `salt-key` command after the steps above:
```
Accepted Keys:
my-minion
Denied Keys:
Unaccepted Keys:
my-minion
Rejected Keys:
```
The minion is shown as accepted and unaccepted at the same time. There is a key file in `pki/minions/` and `pki/minions_pre`

### New Behavior
Result of the `salt-key` command after the steps above:
```
Accepted Keys:
my-minion
Denied Keys:
Unaccepted Keys:
Rejected Keys:
```
The old file in `pki/minions_pre` will get deleted, so there is only one file for the minion and it is correctly shown only as accepted.

### Tests written?
No