### PR TITLE
Use markers when s3 bucket list is truncated

### DIFF
--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -403,15 +403,23 @@ def _refresh_buckets_cache_file(cache_file):
 
     # helper s3 query function
     def __get_s3_meta(bucket, key=key, keyid=keyid):
-        return __utils__['s3.query'](
-                key=key,
-                keyid=keyid,
-                kms_keyid=keyid,
-                bucket=bucket,
-                service_url=service_url,
-                verify_ssl=verify_ssl,
-                location=location,
-                return_bin=False)
+        ret, marker = [], ''
+        while True:
+            tmp = __utils__['s3.query'](key=key, keyid=keyid, kms_keyid=keyid,
+                                        bucket=bucket, service_url=service_url,
+                                        verify_ssl=verify_ssl,
+                                        location=location, return_bin=False,
+                                        params={'marker': marker})
+            headers = []
+            for header in tmp:
+                if 'Key' in header:
+                    break
+                headers.append(header)
+            ret.extend(tmp)
+            if all([header.get('IsTruncated', 'false') == 'false' for header in headers]):
+                break
+            marker = tmp[-1]['Key']
+        return ret
 
     if _is_env_per_bucket():
         # Single environment per bucket


### PR DESCRIPTION
### What does this PR do?
This PR implements using markers to iterate over buckets with long lists of files

### What issues does this PR fix or reference?
Fixes #36967

### Previous Behavior
S3 has a maximum of 1000 keys returned from each api call.  So if a bucket has over 1000 items in it, we will only see the first 1000, and the rest will be truncated.

### New Behavior
Continually call the api, updating the `marker` with the last key in the previous return as the marker, if `'IsTruncated'` is set to `'true'`.

### Tests written?

No