### PR TITLE
Additional functionality to the haproxy module

### DIFF
--- a/salt/modules/haproxyconn.py
+++ b/salt/modules/haproxyconn.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import
 import stat
 import os
 import logging
+import time
 
 try:
     import haproxy.cmds
@@ -72,6 +73,38 @@ def list_servers(backend, socket=DEFAULT_SOCKET_URL, objectify=False):
     ha_cmd = haproxy.cmds.listServers(backend=backend)
     return ha_conn.sendCmd(ha_cmd, objectify=objectify)
 
+
+def wait_state(backend, server, value='up', timeout=60*5, socket=DEFAULT_SOCKET_URL):
+    '''
+
+    Wait for a specific server state
+
+    backend
+        haproxy backend
+
+    server
+        targeted server
+
+    value
+        state value
+
+    timeout
+        timeout before giving up state value, default 5 min
+
+    socket
+        haproxy stats socket
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' haproxy.wait_state mysql server01 up 60
+    '''
+    t = time.time() + timeout
+    while time.time() < t:
+        if get_backend(backend=backend, socket=socket)[server]["status"].lower() == value.lower():
+            return True
+    return False
 
 def get_backend(backend, socket=DEFAULT_SOCKET_URL):
     '''

--- a/salt/modules/haproxyconn.py
+++ b/salt/modules/haproxyconn.py
@@ -62,7 +62,7 @@ def list_servers(backend, socket=DEFAULT_SOCKET_URL, objectify=False):
         haproxy backend
 
     socket
-        haproxy stats socket
+        haproxy stats socket, default ``/var/run/haproxy.sock``
 
     CLI Example:
 
@@ -93,7 +93,7 @@ def wait_state(backend, server, value='up', timeout=60*5, socket=DEFAULT_SOCKET_
         timeout before giving up state value, default 5 min
 
     socket
-        haproxy stats socket
+        haproxy stats socket, default ``/var/run/haproxy.sock``
 
     CLI Example:
 
@@ -117,7 +117,7 @@ def get_backend(backend, socket=DEFAULT_SOCKET_URL):
         haproxy backend
 
     socket
-        haproxy stats socket
+        haproxy stats socket, default ``/var/run/haproxy.sock``
 
     CLI Example:
 
@@ -168,7 +168,7 @@ def enable_server(name, backend, socket=DEFAULT_SOCKET_URL):
         haproxy backend, or all backends if "*" is supplied
 
     socket
-        haproxy stats socket
+        haproxy stats socket, default ``/var/run/haproxy.sock``
 
     CLI Example:
 
@@ -203,7 +203,7 @@ def disable_server(name, backend, socket=DEFAULT_SOCKET_URL):
         haproxy backend, or all backends if "*" is supplied
 
     socket
-        haproxy stats socket
+        haproxy stats socket, default ``/var/run/haproxy.sock``
 
     CLI Example:
 
@@ -238,7 +238,7 @@ def get_weight(name, backend, socket=DEFAULT_SOCKET_URL):
         haproxy backend
 
     socket
-        haproxy stats socket
+        haproxy stats socket, default ``/var/run/haproxy.sock``
 
     CLI Example:
 
@@ -265,7 +265,7 @@ def set_weight(name, backend, weight=0, socket=DEFAULT_SOCKET_URL):
         Server Weight
 
     socket
-        haproxy stats socket
+        haproxy stats socket, default ``/var/run/haproxy.sock``
 
     CLI Example:
 
@@ -324,7 +324,7 @@ def show_frontends(socket=DEFAULT_SOCKET_URL):
     Show HaProxy frontends
 
     socket
-        haproxy stats socket
+        haproxy stats socket, default ``/var/run/haproxy.sock``
 
     CLI Example:
 
@@ -343,7 +343,7 @@ def list_frontends(socket=DEFAULT_SOCKET_URL):
     List HaProxy frontends
 
     socket
-        haproxy stats socket
+        haproxy stats socket, default ``/var/run/haproxy.sock``
 
     CLI Example:
 
@@ -359,7 +359,7 @@ def show_backends(socket=DEFAULT_SOCKET_URL):
     Show HaProxy Backends
 
     socket
-        haproxy stats socket
+        haproxy stats socket, default ``/var/run/haproxy.sock``
 
     CLI Example:
 
@@ -378,7 +378,7 @@ def list_backends(servers=True, socket=DEFAULT_SOCKET_URL):
     List HaProxy Backends
 
     socket
-        haproxy stats socket
+        haproxy stats socket, default ``/var/run/haproxy.sock``
 
     servers
         list backends with servers
@@ -411,7 +411,7 @@ def get_sessions(name, backend, socket=DEFAULT_SOCKET_URL):
         haproxy backend
 
     socket
-        haproxy stats socket
+        haproxy stats socket, default ``/var/run/haproxy.sock``
 
     CLI Example:
 

--- a/salt/modules/haproxyconn.py
+++ b/salt/modules/haproxyconn.py
@@ -248,6 +248,22 @@ def show_frontends(socket=DEFAULT_SOCKET_URL):
     ha_cmd = haproxy.cmds.showFrontends()
     return ha_conn.sendCmd(ha_cmd)
 
+def list_frontends(socket=DEFAULT_SOCKET_URL):
+    '''
+
+    List HaProxy frontends
+
+    socket
+        haproxy stats socket
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' haproxy.list_frontends
+    '''
+    return show_frontends(socket=socket).split('\n')
+
 
 def show_backends(socket=DEFAULT_SOCKET_URL):
     '''

--- a/salt/modules/haproxyconn.py
+++ b/salt/modules/haproxyconn.py
@@ -29,9 +29,10 @@ __virtualname__ = 'haproxy'
 DEFAULT_SOCKET_URL = '/var/run/haproxy.sock'
 
 # Numeric fields returned by stats
-FIELD_NUMERIC = ["weight","bin","bout"]
+FIELD_NUMERIC = ["weight", "bin", "bout"]
 # Field specifying the actual server name
 FIELD_NODE_NAME = "name"
+
 
 def __virtual__():
     '''
@@ -106,6 +107,7 @@ def wait_state(backend, server, value='up', timeout=60*5, socket=DEFAULT_SOCKET_
             return True
     return False
 
+
 def get_backend(backend, socket=DEFAULT_SOCKET_URL):
     '''
 
@@ -124,8 +126,7 @@ def get_backend(backend, socket=DEFAULT_SOCKET_URL):
         salt '*' haproxy.get_backend mysql
     '''
 
-    backend_data = list_servers(backend=backend, socket=socket) \
-                    .replace('\n',' ').split(' ')
+    backend_data = list_servers(backend=backend, socket=socket).replace('\n', ' ').split(' ')
     result = {}
 
     # Convert given string to Integer
@@ -138,7 +139,7 @@ def get_backend(backend, socket=DEFAULT_SOCKET_URL):
     for data in backend_data:
         # Check if field or server name
         if ":" in data:
-            active_field = data.replace(':','').lower()
+            active_field = data.replace(':', '').lower()
             continue
         elif active_field.lower() == FIELD_NODE_NAME:
             active_server = data
@@ -154,6 +155,7 @@ def get_backend(backend, socket=DEFAULT_SOCKET_URL):
             result[active_server][active_field] = data
 
     return result
+
 
 def enable_server(name, backend, socket=DEFAULT_SOCKET_URL):
     '''
@@ -334,6 +336,7 @@ def show_frontends(socket=DEFAULT_SOCKET_URL):
     ha_cmd = haproxy.cmds.showFrontends()
     return ha_conn.sendCmd(ha_cmd)
 
+
 def list_frontends(socket=DEFAULT_SOCKET_URL):
     '''
 
@@ -367,6 +370,7 @@ def show_backends(socket=DEFAULT_SOCKET_URL):
     ha_conn = _get_conn(socket)
     ha_cmd = haproxy.cmds.showBackends()
     return ha_conn.sendCmd(ha_cmd)
+
 
 def list_backends(servers=True, socket=DEFAULT_SOCKET_URL):
     '''

--- a/salt/modules/haproxyconn.py
+++ b/salt/modules/haproxyconn.py
@@ -24,6 +24,9 @@ log = logging.getLogger(__name__)
 
 __virtualname__ = 'haproxy'
 
+# Default socket location
+DEFAULT_SOCKET_URL = '/var/run/haproxy.sock'
+
 
 def __virtual__():
     '''
@@ -34,7 +37,7 @@ def __virtual__():
     return (False, 'The haproxyconn execution module cannot be loaded: haproxyctl module not available')
 
 
-def _get_conn(socket='/var/run/haproxy.sock'):
+def _get_conn(socket=DEFAULT_SOCKET_URL):
     '''
     Get connection to haproxy socket.
     '''
@@ -45,7 +48,7 @@ def _get_conn(socket='/var/run/haproxy.sock'):
     return ha_conn
 
 
-def list_servers(backend, socket='/var/run/haproxy.sock', objectify=False):
+def list_servers(backend, socket=DEFAULT_SOCKET_URL, objectify=False):
     '''
     List servers in haproxy backend.
 
@@ -66,7 +69,7 @@ def list_servers(backend, socket='/var/run/haproxy.sock', objectify=False):
     return ha_conn.sendCmd(ha_cmd, objectify=objectify)
 
 
-def enable_server(name, backend, socket='/var/run/haproxy.sock'):
+def enable_server(name, backend, socket=DEFAULT_SOCKET_URL):
     '''
     Enable Server in haproxy
 
@@ -101,7 +104,7 @@ def enable_server(name, backend, socket='/var/run/haproxy.sock'):
     return results
 
 
-def disable_server(name, backend, socket='/var/run/haproxy.sock'):
+def disable_server(name, backend, socket=DEFAULT_SOCKET_URL):
     '''
     Disable server in haproxy.
 
@@ -136,7 +139,7 @@ def disable_server(name, backend, socket='/var/run/haproxy.sock'):
     return results
 
 
-def get_weight(name, backend, socket='/var/run/haproxy.sock'):
+def get_weight(name, backend, socket=DEFAULT_SOCKET_URL):
     '''
     Get server weight
 
@@ -160,7 +163,7 @@ def get_weight(name, backend, socket='/var/run/haproxy.sock'):
     return ha_conn.sendCmd(ha_cmd)
 
 
-def set_weight(name, backend, weight=0, socket='/var/run/haproxy.sock'):
+def set_weight(name, backend, weight=0, socket=DEFAULT_SOCKET_URL):
     '''
     Set server weight
 
@@ -188,7 +191,7 @@ def set_weight(name, backend, weight=0, socket='/var/run/haproxy.sock'):
     return get_weight(name, backend, socket=socket)
 
 
-def set_state(name, backend, state, socket='/var/run/haproxy.sock'):
+def set_state(name, backend, state, socket=DEFAULT_SOCKET_URL):
     '''
     Force a server's administrative state to a new state. This can be useful to
     disable load balancing and/or any traffic to a server. Setting the state to
@@ -228,7 +231,7 @@ def set_state(name, backend, state, socket='/var/run/haproxy.sock'):
     return ha_conn.sendCmd(ha_cmd)
 
 
-def show_frontends(socket='/var/run/haproxy.sock'):
+def show_frontends(socket=DEFAULT_SOCKET_URL):
     '''
     Show HaProxy frontends
 
@@ -246,7 +249,7 @@ def show_frontends(socket='/var/run/haproxy.sock'):
     return ha_conn.sendCmd(ha_cmd)
 
 
-def show_backends(socket='/var/run/haproxy.sock'):
+def show_backends(socket=DEFAULT_SOCKET_URL):
     '''
     Show HaProxy Backends
 
@@ -264,7 +267,7 @@ def show_backends(socket='/var/run/haproxy.sock'):
     return ha_conn.sendCmd(ha_cmd)
 
 
-def get_sessions(name, backend, socket='/var/run/haproxy.sock'):
+def get_sessions(name, backend, socket=DEFAULT_SOCKET_URL):
     '''
     .. versionadded:: 2016.11.0
 

--- a/salt/modules/haproxyconn.py
+++ b/salt/modules/haproxyconn.py
@@ -299,6 +299,9 @@ def set_state(name, backend, state, socket=DEFAULT_SOCKET_URL):
     state
         A string of the state to set. Must be 'ready', 'drain', or 'maint'
 
+    socket
+        haproxy stats socket, default ``/var/run/haproxy.sock``
+
     CLI Example:
 
     .. code-block:: bash

--- a/tests/unit/modules/test_haproxyconn.py
+++ b/tests/unit/modules/test_haproxyconn.py
@@ -18,6 +18,7 @@ from tests.support.mock import (
 # Import Salt Libs
 import salt.modules.haproxyconn as haproxyconn
 
+
 class Mockcmds(object):
     """
     Mock of cmds
@@ -165,9 +166,7 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test listing all frontends
         '''
-        self.assertItemsEqual(haproxyconn.list_frontends(),
-                ['frontend-alpha','frontend-beta','frontend-gamma'])
-
+        self.assertItemsEqual(haproxyconn.list_frontends(), ['frontend-alpha', 'frontend-beta', 'frontend-gamma'])
 
     # 'show_backends' function tests: 1
 
@@ -181,10 +180,9 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test listing of all backends
         '''
-        self.assertItemsEqual(haproxyconn.list_backends(),
-                ['backend-alpha','backend-beta','backend-gamma'])
+        self.assertItemsEqual(haproxyconn.list_backends(), ['backend-alpha', 'backend-beta', 'backend-gamma'])
 
-    def test_get_backend(self,mock):
+    def test_get_backend(self, mock):
         '''
         Test get_backend and compare returned value
         '''
@@ -202,16 +200,16 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
                 'bout': 0
             }
         }
-        self.assertDictEqual(haproxyconn.get_backend('test'),expected_data)
+        self.assertDictEqual(haproxyconn.get_backend('test'), expected_data)
 
-    def test_wait_state_true(self,mock):
+    def test_wait_state_true(self, mock):
         '''
         Test a successful wait for state
         '''
-        self.assertTrue(haproxyconn.wait_state('test','server01'))
+        self.assertTrue(haproxyconn.wait_state('test', 'server01'))
 
-    def test_wait_state_false(self,mock):
+    def test_wait_state_false(self, mock):
         '''
         Test a failed wait for state, with a timeout of 0
         '''
-        self.assertFalse(haproxyconn.wait_state('test','server02','up', 0))
+        self.assertFalse(haproxyconn.wait_state('test', 'server02', 'up', 0))

--- a/tests/unit/modules/test_haproxyconn.py
+++ b/tests/unit/modules/test_haproxyconn.py
@@ -32,7 +32,8 @@ class Mockcmds(object):
         Mock of listServers method
         """
         self.backend = backend
-        return 'salt'
+        return 'Name: server01 Status: UP Weight: 1 bIn: 22 bOut: 12\n' \
+               'Name: server02 Status: MAINT Weight: 2 bIn: 0 bOut: 0'
 
     def enableServer(self, server, backend):
         """
@@ -73,7 +74,9 @@ class Mockcmds(object):
         """
         Mock of showBackends method
         """
-        return 'server backend'
+        return 'backend-alpha\n' \
+               'backend-beta\n' \
+               'backend-gamma'
 
 
 class Mockhaproxy(object):
@@ -173,3 +176,30 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
         Test print all backends received from the HAProxy socket
         '''
         self.assertTrue(haproxyconn.show_backends())
+
+    def test_list_backends(self, mock):
+        '''
+        Test listing of all backends
+        '''
+        self.assertItemsEqual(haproxyconn.list_backends(),
+                ['backend-alpha','backend-beta','backend-gamma'])
+
+    def test_get_backend(self,mock):
+        '''
+        Test get_backend and compare returned value
+        '''
+        expected_data = {
+            'server01': {
+                'status': 'UP',
+                'weight': 1,
+                'bin': 22,
+                'bout': 12
+            },
+            'server02': {
+                'status': 'MAINT',
+                'weight': 2,
+                'bin': 0,
+                'bout': 0
+            }
+        }
+        self.assertDictEqual(haproxyconn.get_backend('test'),expected_data)

--- a/tests/unit/modules/test_haproxyconn.py
+++ b/tests/unit/modules/test_haproxyconn.py
@@ -203,3 +203,15 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
             }
         }
         self.assertDictEqual(haproxyconn.get_backend('test'),expected_data)
+
+    def test_wait_state_true(self,mock):
+        '''
+        Test a successful wait for state
+        '''
+        self.assertTrue(haproxyconn.wait_state('test','server01'))
+
+    def test_wait_state_false(self,mock):
+        '''
+        Test a failed wait for state, with a timeout of 0
+        '''
+        self.assertFalse(haproxyconn.wait_state('test','server02','up', 0))

--- a/tests/unit/modules/test_haproxyconn.py
+++ b/tests/unit/modules/test_haproxyconn.py
@@ -18,7 +18,6 @@ from tests.support.mock import (
 # Import Salt Libs
 import salt.modules.haproxyconn as haproxyconn
 
-
 class Mockcmds(object):
     """
     Mock of cmds
@@ -112,7 +111,7 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_list_servers(self, mock):
         '''
-        Test if it get a value from etcd, by direct path
+        Test list_servers
         '''
         self.assertTrue(haproxyconn.list_servers('mysql'))
 
@@ -120,7 +119,7 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_enable_server(self, mock):
         '''
-        Test if it get a value from etcd, by direct path
+        Test enable_server
         '''
         self.assertTrue(haproxyconn.enable_server('web1.salt.com', 'www'))
 
@@ -128,7 +127,7 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_disable_server(self, mock):
         '''
-        Test if it get a value from etcd, by direct path
+        Test disable_server
         '''
         self.assertTrue(haproxyconn.disable_server('db1.salt.com', 'mysql'))
 
@@ -136,7 +135,7 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_get_weight(self, mock):
         '''
-        Test if it get a value from etcd, by direct path
+        Test get the weight of a server
         '''
         self.assertTrue(haproxyconn.get_weight('db1.salt.com', 'mysql'))
 
@@ -144,7 +143,7 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_set_weight(self, mock):
         '''
-        Test if it get a value from etcd, by direct path
+        Test setting the weight of a given server
         '''
         self.assertTrue(haproxyconn.set_weight('db1.salt.com', 'mysql',
                                                weight=11))
@@ -153,7 +152,7 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_show_frontends(self, mock):
         '''
-        Test if it get a value from etcd, by direct path
+        Test print all frontends received from the HAProxy socket
         '''
         self.assertTrue(haproxyconn.show_frontends())
 
@@ -161,6 +160,6 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_show_backends(self, mock):
         '''
-        Test if it get a value from etcd, by direct path
+        Test print all backends received from the HAProxy socket
         '''
         self.assertTrue(haproxyconn.show_backends())

--- a/tests/unit/modules/test_haproxyconn.py
+++ b/tests/unit/modules/test_haproxyconn.py
@@ -64,7 +64,9 @@ class Mockcmds(object):
         """
         Mock of showFrontends method
         """
-        return 'server frontend'
+        return 'frontend-alpha\n' \
+               'frontend-beta\n' \
+               'frontend-gamma'
 
     @staticmethod
     def showBackends():
@@ -95,7 +97,7 @@ class MockHaConn(object):
         """
         self.ha_cmd = ha_cmd
         self.objectify = objectify
-        return True
+        return ha_cmd
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -155,6 +157,14 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
         Test print all frontends received from the HAProxy socket
         '''
         self.assertTrue(haproxyconn.show_frontends())
+
+    def test_list_frontends(self, mock):
+        '''
+        Test listing all frontends
+        '''
+        self.assertItemsEqual(haproxyconn.list_frontends(),
+                ['frontend-alpha','frontend-beta','frontend-gamma'])
+
 
     # 'show_backends' function tests: 1
 


### PR DESCRIPTION
### What does this PR do?
New functions and minor typo fixes in the _haproxyconn_ module.
- Fixed unit-test comments that was previously referred to etcd.
- Added two additional functions for listing backends and frontends.
- Function for getting backend information as formated dictionary.
- Function that waits for a specific server state.

### Tests written?
Yes

### Additional notes
Tested with haproxy version _1.7.5_, _1.6.12_ and _1.5.19_
