### PR TITLE
Make salt.modules.pw_user.get_loginclass return string rather than dict

### DIFF
--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -475,7 +475,7 @@ def get_loginclass(name):
     userinfo = __salt__['cmd.run_stdout'](['pw', 'usershow', '-n', name])
     userinfo = userinfo.split(':')
 
-    return {'loginclass': userinfo[4] if len(userinfo) == 10 else ''}
+    return userinfo[4] if len(userinfo) == 10 else ''
 
 
 def list_groups(name):


### PR DESCRIPTION
### What does this PR do?
Make salt.modules.pw_user.get_loginclass return string rather than dict

### What issues does this PR fix or reference?

#37787

This aligns with salt.modules.useradd.get_loginclass which is used
for OpenBSD.

This fixes salt.modules.pw_user.chloginclass which is used for FreeBSD
and expects a string to be returned. This was therefore returning False
even after successfully changing the loginclass.

This also fixes salt.states.user.present on FreeBSD when loginclass is
set.

### Tests written?

No