### PR TITLE
Fix copypasta in the pw_user docstring

### DIFF
--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Manage users with the useradd command
+Manage users with the pw command
 
 .. important::
     If you feel that Salt should be using this module to manage users on a


### PR DESCRIPTION
The pw_user module uses the ``pw`` command, not ``useradd``