### PR TITLE
Call tornado.httputil.url_concat compatibly

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -179,7 +179,7 @@ def query(url,
 
     # Some libraries don't support separation of url and GET parameters
     # Don't need a try/except block, since Salt depends on tornado
-    url_full = tornado.httputil.url_concat(url, params)
+    url_full = tornado.httputil.url_concat(url, params) if params else url
 
     if ca_bundle is None:
         ca_bundle = get_ca_bundle(opts)


### PR DESCRIPTION
See https://github.com/tornadoweb/tornado/pull/1899.

### What does this PR do?

Makes `salt.utils.http.query` compatible with [Tornado 4.5.0](https://github.com/tornadoweb/tornado/releases/tag/v4.5.0).

### What issues does this PR fix or reference?

None

### Previous Behavior

Failure when `params` was `None`.

```text
[DEBUG   ] Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/salt/states/file.py", line 1737, in managed
    follow_symlinks)
  File "/usr/local/lib/python2.7/dist-packages/salt/modules/file.py", line 4291, in manage_file
    sfn = __salt__['cp.cache_file'](source, saltenv)
  File "/usr/local/lib/python2.7/dist-packages/salt/modules/cp.py", line 393, in cache_file
    result = _client().cache_file(path, saltenv)
  File "/usr/local/lib/python2.7/dist-packages/salt/fileclient.py", line 165, in cache_file
    return self.get_url(path, '', True, saltenv, cachedir=cachedir)
  File "/usr/local/lib/python2.7/dist-packages/salt/fileclient.py", line 678, in get_url
    **get_kwargs
  File "/usr/local/lib/python2.7/dist-packages/salt/utils/http.py", line 173, in query
    url_full = tornado.httputil.url_concat(url, params)
  File "/usr/local/lib/python2.7/dist-packages/tornado/httputil.py", line 616, in url_concat
    raise TypeError(err)
TypeError: 'args' parameter should be dict, list or tuple. Not <type 'NoneType'>

[ERROR   ] Unable to manage file: 'args' parameter should be dict, list or tuple. Not <type 'NoneType'>
```

### New Behavior

Now should work, I haven't tested this at all!

### Tests written?

No.
