### PR TITLE
Minion key revoke cfg

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -175,6 +175,9 @@
 # a previous deleted minion ID.
 #preserve_minion_cache: False
 
+# Allow or deny minions from requesting their own key revocation
+#allow_minion_key_revoke: True
+
 # If max_minions is used in large installations, the master might experience
 # high-load situations because of having to check the number of connected
 # minions for every authentication. This cache provides the minion-ids of

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1006,6 +1006,22 @@ Do not disable this unless it is absolutely clear what this does.
     rotate_aes_key: True
 
 
+.. conf_master:: allow_minion_key_revoke
+
+``allow_minion_key_revoke``
+------------------
+
+Default: ``True``
+
+Controls whether a minion can request its own key revocation.  When True
+the master will honor the minion's request and revoke its key.  When False,
+the master will drop the request and the minion's key will remain accepted.
+
+
+.. code-block:: yaml
+
+    rotate_aes_key: True
+
 Master Module Management
 ========================
 

--- a/doc/topics/releases/2016.3.7.rst
+++ b/doc/topics/releases/2016.3.7.rst
@@ -3,3 +3,9 @@ Salt 2016.3.7 Release Notes
 ===========================
 
 Version 2016.3.7 is a bugfix release for :ref:`2016.3.0 <release-2016-3-0>`.
+
+New master configuration option `allow_minion_key_revoke`, defaults to True.  This option
+controls whether a minion can request that the master revoke its key.  When True, a minion
+can request a key revocation and the master will comply.  If it is False, the key will not
+be revoked by the msater.
+

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -868,6 +868,9 @@ VALID_OPTS = {
 
     # Default returners minion should use. List or comma-delimited string
     'return': (str, list),
+
+    # Permit or deny allowing minions to request revoke of its own key
+    'allow_minion_key_revoke': bool,
 }
 
 # default configurations
@@ -1346,6 +1349,7 @@ DEFAULT_MASTER_OPTS = {
     'python2_bin': 'python2',
     'python3_bin': 'python3',
     'thin_extra_mods': '',
+    'allow_minion_key_revoke': True,
 }
 
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -1543,6 +1543,11 @@ class AESFuncs(object):
         :return: True if key was revoked, False if not
         '''
         load = self.__verify_load(load, ('id', 'tok'))
+
+        if not self.opts.get('allow_minion_key_revoke', False):
+            log.debug('Minion {0} requested key revoke, but allow_minion_key_revoke is False'.format(load['id']))
+            return load
+
         if load is False:
             return load
         else:

--- a/salt/master.py
+++ b/salt/master.py
@@ -1545,7 +1545,7 @@ class AESFuncs(object):
         load = self.__verify_load(load, ('id', 'tok'))
 
         if not self.opts.get('allow_minion_key_revoke', False):
-            log.debug('Minion {0} requested key revoke, but allow_minion_key_revoke is False'.format(load['id']))
+            log.warning('Minion {0} requested key revoke, but allow_minion_key_revoke is False'.format(load['id']))
             return load
 
         if load is False:


### PR DESCRIPTION
### What does this PR do?

Adds a new configuration option `allow_minion__key_revoke` that controls whether
a minion's request to the master to revoke its own key will be honored.
