### PR TITLE
Change boto_iam.user_absent state to delete IAM user's virtual MFA device after deactivation.

### DIFF
--- a/salt/states/boto_iam.py
+++ b/salt/states/boto_iam.py
@@ -250,12 +250,19 @@ def user_absent(name, delete_keys=True, delete_mfa_devices=True, delete_profile=
             for d in devices:
                 serial = d['serial_number']
                 if __opts__['test']:
-                    ret['comment'] = ' '.join([ret['comment'], 'IAM user {0} MFA device {1} is set to be deleted.'.format(name, serial)])
+                    ret['comment'] = ' '.join([ret['comment'], 'IAM user {0} MFA device {1} is set to be deactivated.'.format(name, serial)])
                     ret['result'] = None
                 else:
-                    mfa_deleted = __salt__['boto_iam.deactivate_mfa_device'](user_name=name, serial=serial, region=region, key=key, keyid=keyid, profile=profile)
+                    mfa_deactivated = __salt__['boto_iam.deactivate_mfa_device'](user_name=name, serial=serial, region=region, key=key, keyid=keyid, profile=profile)
+                    if mfa_deactivated:
+                        ret['comment'] = ' '.join([ret['comment'], 'IAM user {0} MFA device {1} is deactivated.'.format(name, serial)])
+                if __opts__['test']:
+                    ret['comment'] = ' '.join([ret['comment'], 'Virtual MFA device {0} is set to be deleted.'.format(serial)])
+                    ret['result'] = None
+                else:
+                    mfa_deleted = __salt__['boto_iam.delete_virtual_mfa_device'](serial=serial, region=region, key=key, keyid=keyid, profile=profile)
                     if mfa_deleted:
-                        ret['comment'] = ' '.join([ret['comment'], 'IAM user {0} MFA device {1} are deleted.'.format(name, serial)])
+                        ret['comment'] = ' '.join([ret['comment'], 'Virtual MFA device {0} is deleted.'.format(serial)])
     # delete the user's login profile
     if delete_profile:
         if __opts__['test']:


### PR DESCRIPTION
### What does this PR do?
Adds the `delete_virtual_mfa_device` function to the `boto_iam` module.

Changes the `boto_iam.user_absent` state to delete the IAM user's virtual MFA device after it's deactivated.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
For each MFA device associated with a user, call the `boto_iam.deactivate_mfa_device` module function to deactivate that MFA device.

### New Behavior
For each MFA device associated with a user, call the `boto_iam.deactivate_mfa_device` module function to deactivate that MFA device, then call the `boto_iam.delete_virtual_mfa_device` module function to delete that MFA device (assuming it is a virtual MFA device). If the MFA device is _not_ virtual the call to `DeleteVirtualMFADevice` will return a 404 which will be treated as a success (since the device does not exist).

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
