### PR TITLE
Add config runner (config.get for master settings)

### DIFF
--- a/salt/runners/config.py
+++ b/salt/runners/config.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import salt.utils
+import salt.utils.sdb
 
 
 def get(key, default='', delimiter=':'):
@@ -33,4 +34,8 @@ def get(key, default='', delimiter=':'):
         salt-run config.get file_roots:base
         salt-run config.get file_roots,base delimiter=','
     '''
-    return salt.utils.traverse_dict_and_list(__opts__, key, delimiter=delimiter)
+    ret = salt.utils.traverse_dict_and_list(__opts__, key, default='_|-', delimiter=delimiter)
+    if ret == '_|-':
+        return default
+    else:
+        return salt.utils.sdb.sdb_get(ret, __opts__)

--- a/salt/runners/config.py
+++ b/salt/runners/config.py
@@ -30,5 +30,7 @@ def get(key, default='', delimiter=':'):
     .. code-block:: bash
 
         salt-run config.get gitfs_remotes
+        salt-run config.get file_roots:base
+        salt-run config.get file_roots,base delimiter=','
     '''
     return salt.utils.traverse_dict_and_list(__opts__, key, delimiter=delimiter)

--- a/salt/runners/config.py
+++ b/salt/runners/config.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+'''
+This runner is designed to mirror the execution module config.py, but for
+master settings
+'''
+from __future__ import absolute_import
+from __future__ import print_function
+
+import salt.utils
+
+
+def get(key, default='', delimiter=':'):
+    '''
+    Retrieve master config options, with optional nesting via the delimiter
+    argument.
+
+    **Arguments**
+
+    default
+
+        If the key is not found, the default will be returned instead
+
+    delimiter
+
+        Override the delimiter used to separate nested levels of a data
+        structure.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run config.get gitfs_remotes
+    '''
+    return salt.utils.traverse_dict_and_list(__opts__, key, delimiter=delimiter)


### PR DESCRIPTION
### What does this PR do?

Adds config.py runner, so you can do `salt-run config.get file_roots` for master config. This used to be queryable back in the day when master config was included in pillar data by default, but that day is long gone. We need a way to quickly determine master settings, and if you have multiple `master.d/` config files, it can be difficult to know what the final config looks like in `__opts__`.

### Tests written?

No