### PR TITLE
Change file data to bytes before attempting to hash

### DIFF
--- a/salt/spm/pkgfiles/local.py
+++ b/salt/spm/pkgfiles/local.py
@@ -5,11 +5,15 @@ This module allows SPM to use the local filesystem to install files for SPM.
 .. versionadded:: 2015.8.0
 '''
 
+# Import Python libs
 from __future__ import absolute_import
 import os
 import os.path
 import logging
+
+# Import Salt libs
 import salt.syspaths
+import salt.utils
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -180,7 +184,7 @@ def hash_file(path, hashobj, conn=None):
         return ''
 
     with salt.utils.fopen(path, 'r') as f:
-        hashobj.update(f.read())
+        hashobj.update(salt.utils.to_bytes(f.read()))
         return hashobj.hexdigest()
 
 


### PR DESCRIPTION
### What does this PR do?
Changes the data read in from the spm file to bytes before attempting to hash the contents.

### What issues does this PR fix or reference?
#40435

### Previous Behavior
```
spm install apache
Installing packages:
	apache

Proceed? [N/y] y
... installing apache
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
TypeError: Unicode-objects must be encoded before hashing
Traceback (most recent call last):
  File "/usr/bin/spm", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/root/salt/scripts/spm", line 12, in <module>
    salt_spm()
  File "/root/salt/salt/scripts.py", line 487, in salt_spm
    spm.run()
  File "/root/salt/salt/cli/spm.py", line 34, in run
    client.run(self.args)
  File "/root/salt/salt/spm/__init__.py", line 114, in run
    self._install(args)
  File "/root/salt/salt/spm/__init__.py", line 365, in _install
    self._install_indv_pkg(package, out_file)
  File "/root/salt/salt/spm/__init__.py", line 522, in _install_indv_pkg
    self.files_conn)
  File "/root/salt/salt/spm/__init__.py", line 146, in _pkgfiles_fun
    return getattr(getattr(self.pkgfiles, self.files_prov), func)(*args, **kwargs)
  File "/root/salt/salt/spm/pkgfiles/local.py", line 183, in hash_file
    hashobj.update(f.read())
TypeError: Unicode-objects must be encoded before hashing
Traceback (most recent call last):
  File "/usr/bin/spm", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/root/salt/scripts/spm", line 12, in <module>
    salt_spm()
  File "/root/salt/salt/scripts.py", line 487, in salt_spm
    spm.run()
  File "/root/salt/salt/cli/spm.py", line 34, in run
    client.run(self.args)
  File "/root/salt/salt/spm/__init__.py", line 114, in run
    self._install(args)
  File "/root/salt/salt/spm/__init__.py", line 365, in _install
    self._install_indv_pkg(package, out_file)
  File "/root/salt/salt/spm/__init__.py", line 522, in _install_indv_pkg
    self.files_conn)
  File "/root/salt/salt/spm/__init__.py", line 146, in _pkgfiles_fun
    return getattr(getattr(self.pkgfiles, self.files_prov), func)(*args, **kwargs)
  File "/root/salt/salt/spm/pkgfiles/local.py", line 183, in hash_file
    hashobj.update(f.read())
TypeError: Unicode-objects must be encoded before hashing
```

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
