### PR TITLE
Handle stacktraces in cloud.action function in module and runner

### DIFF
--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -238,7 +238,7 @@ def action(
     try:
         info = client.action(fun, cloudmap, names, provider, instance, kwargs)
     except SaltCloudConfigError as err:
-        log.err(err)
+        log.error(err)
         return None
 
     return info

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -18,6 +18,7 @@ except ImportError:
     HAS_SALTCLOUD = False
 
 import salt.utils
+from salt.exceptions import SaltCloudConfigError
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -234,7 +235,12 @@ def action(
         salt '*' cloud.action show_image provider=my-ec2-config image=ami-1624987f
     '''
     client = _get_client()
-    info = client.action(fun, cloudmap, names, provider, instance, kwargs)
+    try:
+        info = client.action(fun, cloudmap, names, provider, instance, kwargs)
+    except SaltCloudConfigError as err:
+        log.err(err)
+        return None
+
     return info
 
 

--- a/salt/runners/cloud.py
+++ b/salt/runners/cloud.py
@@ -14,6 +14,7 @@ import os
 
 # Import Salt libs
 import salt.cloud
+from salt.exceptions import SaltCloudConfigError
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -150,8 +151,12 @@ def action(func=None,
 
         salt-run cloud.action start my-salt-vm
     '''
+    info = {}
     client = _get_client()
-    info = client.action(func, cloudmap, instances, provider, instance, **_filter_kwargs(kwargs))
+    try:
+        info = client.action(func, cloudmap, instances, provider, instance, **_filter_kwargs(kwargs))
+    except SaltCloudConfigError as err:
+        log.error(err)
     return info
 
 


### PR DESCRIPTION
### What does this PR do?
The `action` function in `salt.cloud.__init__.py` throws a `SaltCloudConfigError` when function parameters are passed in incorrectly. The `cloud.action` functions in both the `salt.runners.cloud.py` and the `salt.modules.cloud.py` files were not handling this error and stacktracing at the CLI. This PR cleans up those traces and logs the error.

### What issues does this PR fix or reference?
Refs #29602

### Previous Behavior
```
# salt-run cloud.action start instance=rally-test-1 provider=linode
Exception occurred in runner cloud.action: Traceback (most recent call last):
  File "/root/SaltStack/salt/salt/client/mixins.py", line 395, in _low
    data['return'] = self.functions[fun](*args, **kwargs)
  File "/root/SaltStack/salt/salt/runners/cloud.py", line 154, in action
    info = client.action(func, cloudmap, instances, provider, instance, **_filter_kwargs(kwargs))
  File "/root/SaltStack/salt/salt/cloud/__init__.py", line 496, in action
    'Either an instance (or list of names) or a provider must be '
SaltCloudConfigError: Either an instance (or list of names) or a provider must be specified, but not both.
```

### New Behavior
```
# salt-run cloud.action start instance=rally-test-1 provider=linode
[ERROR   ] Either an instance (or list of names) or a provider must be specified, but not both.
```

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
