### PR TITLE
Change boto_lambda module to use __utils__ instead of salt.utils to allow overriding modules

### DIFF
--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -712,7 +712,7 @@ def delete_alias(FunctionName, Name, region=None, key=None, keyid=None, profile=
         conn.delete_alias(FunctionName=FunctionName, Name=Name)
         return {'deleted': True}
     except ClientError as e:
-        return {'deleted': False, 'error': __utils__['.boto3.get_error'](e)}
+        return {'deleted': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def _find_alias(FunctionName, Name, FunctionVersion=None,
@@ -756,7 +756,7 @@ def alias_exists(FunctionName, Name, region=None, key=None,
                             region=region, key=key, keyid=keyid, profile=profile)
         return {'exists': bool(alias)}
     except ClientError as e:
-        return {'error': __utils__['boto3.get_error(e)']}
+        return {'error': __utils__['boto3.get_error'](e)}
 
 
 def describe_alias(FunctionName, Name, region=None, key=None,

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -88,7 +88,6 @@ import random
 
 # Import Salt libs
 import salt.ext.six as six
-import salt.utils.boto3
 import salt.utils.compat
 import salt.utils
 from salt.utils.versions import LooseVersion as _LooseVersion
@@ -156,7 +155,7 @@ def _find_function(name,
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
-    for funcs in salt.utils.boto3.paged_call(conn.list_functions):
+    for funcs in __utils__['boto3.paged_call'](conn.list_functions):
         for func in funcs['Functions']:
             if func['FunctionName'] == name:
                 return func
@@ -184,7 +183,7 @@ def function_exists(FunctionName, region=None, key=None,
                               region=region, key=key, keyid=keyid, profile=profile)
         return {'exists': bool(func)}
     except ClientError as e:
-        return {'error': salt.utils.boto3.get_error(e)}
+        return {'error': __utils__['boto3.get_error'](e)}
 
 
 def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
@@ -309,7 +308,7 @@ def create_function(FunctionName, Runtime, Role, Handler, ZipFile=None,
             log.warning('Function was not created')
             return {'created': False}
     except ClientError as e:
-        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'created': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def delete_function(FunctionName, Qualifier=None, region=None, key=None, keyid=None, profile=None):
@@ -336,7 +335,7 @@ def delete_function(FunctionName, Qualifier=None, region=None, key=None, keyid=N
             conn.delete_function(FunctionName=FunctionName)
         return {'deleted': True}
     except ClientError as e:
-        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'deleted': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def describe_function(FunctionName, region=None, key=None,
@@ -365,7 +364,7 @@ def describe_function(FunctionName, region=None, key=None,
         else:
             return {'function': None}
     except ClientError as e:
-        return {'error': salt.utils.boto3.get_error(e)}
+        return {'error': __utils__['boto3.get_error'](e)}
 
 
 def update_function_config(FunctionName, Role=None, Handler=None,
@@ -443,7 +442,7 @@ def update_function_config(FunctionName, Role=None, Handler=None,
             log.warning('Function was not updated')
             return {'updated': False}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def update_function_code(FunctionName, ZipFile=None, S3Bucket=None, S3Key=None,
@@ -493,7 +492,7 @@ def update_function_code(FunctionName, ZipFile=None, S3Bucket=None, S3Key=None,
             log.warning('Function was not updated')
             return {'updated': False}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def add_permission(FunctionName, StatementId, Action, Principal, SourceArn=None,
@@ -526,7 +525,7 @@ def add_permission(FunctionName, StatementId, Action, Principal, SourceArn=None,
                             **kwargs)
         return {'updated': True}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def remove_permission(FunctionName, StatementId, Qualifier=None,
@@ -554,7 +553,7 @@ def remove_permission(FunctionName, StatementId, Qualifier=None,
                                **kwargs)
         return {'updated': True}
     except ClientError as e:
-        return {'updated': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'updated': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def get_permissions(FunctionName, Qualifier=None,
@@ -608,7 +607,7 @@ def get_permissions(FunctionName, Qualifier=None,
             permissions[statement.get('Sid')] = permission
         return {'permissions': permissions}
     except ClientError as e:
-        err = salt.utils.boto3.get_error(e)
+        err = __utils__['boto3.get_error'](e)
         if e.response.get('Error', {}).get('Code') == 'ResourceNotFoundException':
             return {'permissions': None}
         return {'permissions': None, 'error': err}
@@ -628,7 +627,7 @@ def list_functions(region=None, key=None, keyid=None, profile=None):
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
 
     ret = []
-    for funcs in salt.utils.boto3.paged_call(conn.list_functions):
+    for funcs in __utils__['boto3.paged_call'](conn.list_functions):
         ret += funcs['Functions']
     return ret
 
@@ -652,14 +651,14 @@ def list_function_versions(FunctionName,
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         vers = []
-        for ret in salt.utils.boto3.paged_call(conn.list_versions_by_function,
-                                               FunctionName=FunctionName):
+        for ret in __utils__['boto3.paged_call'](conn.list_versions_by_function,
+                                                 FunctionName=FunctionName):
             vers.extend(ret['Versions'])
         if not bool(vers):
             log.warning('No versions found')
         return {'Versions': vers}
     except ClientError as e:
-        return {'error': salt.utils.boto3.get_error(e)}
+        return {'error': __utils__['boto3.get_error'](e)}
 
 
 def create_alias(FunctionName, Name, FunctionVersion, Description="",
@@ -690,7 +689,7 @@ def create_alias(FunctionName, Name, FunctionVersion, Description="",
             log.warning('Alias was not created')
             return {'created': False}
     except ClientError as e:
-        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'created': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def delete_alias(FunctionName, Name, region=None, key=None, keyid=None, profile=None):
@@ -713,7 +712,7 @@ def delete_alias(FunctionName, Name, region=None, key=None, keyid=None, profile=
         conn.delete_alias(FunctionName=FunctionName, Name=Name)
         return {'deleted': True}
     except ClientError as e:
-        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'deleted': False, 'error': __utils__['.boto3.get_error'](e)}
 
 
 def _find_alias(FunctionName, Name, FunctionVersion=None,
@@ -729,7 +728,7 @@ def _find_alias(FunctionName, Name, FunctionVersion=None,
     if FunctionVersion:
         args['FunctionVersion'] = FunctionVersion
 
-    for aliases in salt.utils.boto3.paged_call(conn.list_aliases, **args):
+    for aliases in __utils__['boto3.paged_call'](conn.list_aliases, **args):
         for alias in aliases.get('Aliases'):
             if alias['Name'] == Name:
                 return alias
@@ -757,7 +756,7 @@ def alias_exists(FunctionName, Name, region=None, key=None,
                             region=region, key=key, keyid=keyid, profile=profile)
         return {'exists': bool(alias)}
     except ClientError as e:
-        return {'error': salt.utils.boto3.get_error(e)}
+        return {'error': __utils__['boto3.get_error(e)']}
 
 
 def describe_alias(FunctionName, Name, region=None, key=None,
@@ -784,7 +783,7 @@ def describe_alias(FunctionName, Name, region=None, key=None,
         else:
             return {'alias': None}
     except ClientError as e:
-        return {'error': salt.utils.boto3.get_error(e)}
+        return {'error': __utils__['boto3.get_error'](e)}
 
 
 def update_alias(FunctionName, Name, FunctionVersion=None, Description=None,
@@ -818,7 +817,7 @@ def update_alias(FunctionName, Name, FunctionVersion=None, Description=None,
             log.warning('Alias was not updated')
             return {'updated': False}
     except ClientError as e:
-        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'created': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def create_event_source_mapping(EventSourceArn, FunctionName, StartingPosition,
@@ -855,7 +854,7 @@ def create_event_source_mapping(EventSourceArn, FunctionName, StartingPosition,
             log.warning('Event source mapping was not created')
             return {'created': False}
     except ClientError as e:
-        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'created': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def get_event_source_mapping_ids(EventSourceArn, FunctionName,
@@ -874,14 +873,14 @@ def get_event_source_mapping_ids(EventSourceArn, FunctionName,
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     try:
         mappings = []
-        for maps in salt.utils.boto3.paged_call(conn.list_event_source_mappings,
-                                                EventSourceArn=EventSourceArn,
-                                                FunctionName=FunctionName):
+        for maps in s__utils__['boto3.paged_call'](conn.list_event_source_mappings,
+                                                   EventSourceArn=EventSourceArn,
+                                                   FunctionName=FunctionName):
             mappings.extend([mapping['UUID']
                              for mapping in maps['EventSourceMappings']])
         return mappings
     except ClientError as e:
-        return {'error': salt.utils.boto3.get_error(e)}
+        return {'error': __utils__['boto3.get_error'](e)}
 
 
 def _get_ids(UUID=None, EventSourceArn=None, FunctionName=None,
@@ -924,7 +923,7 @@ def delete_event_source_mapping(UUID=None, EventSourceArn=None, FunctionName=Non
             conn.delete_event_source_mapping(UUID=id)
         return {'deleted': True}
     except ClientError as e:
-        return {'deleted': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'deleted': False, 'error': __utils__['boto3.get_error'](e)}
 
 
 def event_source_mapping_exists(UUID=None, EventSourceArn=None,
@@ -989,7 +988,7 @@ def describe_event_source_mapping(UUID=None, EventSourceArn=None,
         else:
             return {'event_source_mapping': None}
     except ClientError as e:
-        return {'error': salt.utils.boto3.get_error(e)}
+        return {'error': __utils__['boto3.get_error'](e)}
 
 
 def update_event_source_mapping(UUID,
@@ -1028,4 +1027,4 @@ def update_event_source_mapping(UUID,
             log.warning('Mapping was not updated')
             return {'updated': False}
     except ClientError as e:
-        return {'created': False, 'error': salt.utils.boto3.get_error(e)}
+        return {'created': False, 'error': __utils__['boto3.get_error'](e)}

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -873,7 +873,7 @@ def get_event_source_mapping_ids(EventSourceArn, FunctionName,
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     try:
         mappings = []
-        for maps in s__utils__['boto3.paged_call'](conn.list_event_source_mappings,
+        for maps in __utils__['boto3.paged_call'](conn.list_event_source_mappings,
                                                    EventSourceArn=EventSourceArn,
                                                    FunctionName=FunctionName):
             mappings.extend([mapping['UUID']


### PR DESCRIPTION
### What does this PR do?
Changes `boto_lambda` module to use `__utils__` instead of `salt.utils` to allow overriding modules so that backported modules can be used.

### What issues does this PR fix or reference?
N/A

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
