### PR TITLE
Backport `Add support for specifying a datastore for new disks.` PR #36457

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -139,6 +139,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
           Hard disk 3:
             size: 5
             controller: SCSI controller 3
+            datastore: smalldiskdatastore
         network:
           Network adapter 1:
             name: 10.20.30-400-Test
@@ -284,6 +285,9 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
             Specify the SCSI controller label to which this disk should be attached.
             This should be specified only when creating both the specified SCSI
             controller as well as the hard disk at the same time.
+        datastore
+            The name of a valid datastore should you wish the new disk to be in
+            a datastore other than the default for the VM
 
     network
         Enter the network adapter specification here. If the network adapter doesn\'t

--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -287,7 +287,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
             controller as well as the hard disk at the same time.
         datastore
             The name of a valid datastore should you wish the new disk to be in
-            a datastore other than the default for the VM
+            a datastore other than the default for the VM.
 
     network
         Enter the network adapter specification here. If the network adapter doesn\'t

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -273,6 +273,8 @@ def _edit_existing_hard_disk_helper(disk, size_kb=None, size_gb=None, mode=None)
 
 
 def _add_new_hard_disk_helper(disk_label, size_gb, unit_number, controller_key=1000, thin_provision=False, datastore=None, vm_name=None):
+
+
     random_key = randint(-2099, -2000)
     size_kb = int(size_gb * 1024.0 * 1024.0)
 
@@ -604,6 +606,7 @@ def _set_network_adapter_mapping(adapter_specs):
     return adapter_mapping
 
 
+<<<<<<< HEAD
 def _get_mode_spec(device, mode, disk_spec):
     if device.backing.diskMode != mode:
         if not disk_spec:
@@ -623,6 +626,8 @@ def _get_size_spec(device, size_gb=None, size_kb=None):
     return disk_spec
 
 
+=======
+>>>>>>> Add support for specifying a datastore for new disks.
 def _manage_devices(devices, vm=None, container_ref=None, new_vm_name=None):
     unit_number = 0
     bus_number = 0
@@ -2570,7 +2575,11 @@ def create(vm_):
         config_spec.memoryMB = memory_mb
 
     if devices:
+<<<<<<< HEAD
         specs = _manage_devices(devices, vm=object_ref, new_vm_name=vm_name)
+=======
+        specs = _manage_devices(devices, vm=object_ref, new_vm_name=vm_['name'])
+>>>>>>> Add support for specifying a datastore for new disks.
         config_spec.deviceChange = specs['device_specs']
 
     if extra_config:

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2570,7 +2570,7 @@ def create(vm_):
         config_spec.memoryMB = memory_mb
 
     if devices:
-        specs = _manage_devices(devices, vm=object_ref, new_vm_name=vm_['name'])
+        specs = _manage_devices(devices, vm=object_ref, new_vm_name=vm_name)
         config_spec.deviceChange = specs['device_specs']
 
     if extra_config:

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -273,8 +273,6 @@ def _edit_existing_hard_disk_helper(disk, size_kb=None, size_gb=None, mode=None)
 
 
 def _add_new_hard_disk_helper(disk_label, size_gb, unit_number, controller_key=1000, thin_provision=False, datastore=None, vm_name=None):
-
-
     random_key = randint(-2099, -2000)
     size_kb = int(size_gb * 1024.0 * 1024.0)
 

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -606,7 +606,6 @@ def _set_network_adapter_mapping(adapter_specs):
     return adapter_mapping
 
 
-<<<<<<< HEAD
 def _get_mode_spec(device, mode, disk_spec):
     if device.backing.diskMode != mode:
         if not disk_spec:
@@ -626,8 +625,6 @@ def _get_size_spec(device, size_gb=None, size_kb=None):
     return disk_spec
 
 
-=======
->>>>>>> Add support for specifying a datastore for new disks.
 def _manage_devices(devices, vm=None, container_ref=None, new_vm_name=None):
     unit_number = 0
     bus_number = 0
@@ -2575,11 +2572,7 @@ def create(vm_):
         config_spec.memoryMB = memory_mb
 
     if devices:
-<<<<<<< HEAD
-        specs = _manage_devices(devices, vm=object_ref, new_vm_name=vm_name)
-=======
         specs = _manage_devices(devices, vm=object_ref, new_vm_name=vm_['name'])
->>>>>>> Add support for specifying a datastore for new disks.
         config_spec.deviceChange = specs['device_specs']
 
     if extra_config:


### PR DESCRIPTION
### What does this PR do?

Enables the vmware salt-cloud driver to indicate a specific datastore for a new disk.
