### PR TITLE
Use Salt's SaltYamlSafeLoader and SafeOrderedDumper classes for yaml.load/dump

### DIFF
--- a/doc/ref/renderers/index.rst
+++ b/doc/ref/renderers/index.rst
@@ -145,10 +145,14 @@ Here is a simple YAML renderer example:
 .. code-block:: python
 
     import yaml
+    from salt.utils.yamlloader import SaltYamlSafeLoader
     def render(yaml_data, saltenv='', sls='', **kws):
         if not isinstance(yaml_data, basestring):
             yaml_data = yaml_data.read()
-        data = yaml.load(yaml_data)
+        data = yaml.load(
+            yaml_data,
+            Loader=SaltYamlSafeLoader
+        )
         return data if data else {}
 
 Full List of Renderers

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -670,6 +670,7 @@ class SMinion(MinionBase):
         # If configured, cache pillar data on the minion
         if self.opts['file_client'] == 'remote' and self.opts.get('minion_pillar_cache', False):
             import yaml
+            from salt.utils.yamldumper import SafeOrderedDumper
             pdir = os.path.join(self.opts['cachedir'], 'pillar')
             if not os.path.isdir(pdir):
                 os.makedirs(pdir, 0o700)
@@ -680,11 +681,21 @@ class SMinion(MinionBase):
                 penv = 'base'
             cache_top = {penv: {self.opts['id']: ['cache']}}
             with salt.utils.fopen(ptop, 'wb') as fp_:
-                fp_.write(yaml.dump(cache_top))
+                fp_.write(
+                    yaml.dump(
+                        cache_top,
+                        Dumper=SafeOrderedDumper
+                    )
+                )
                 os.chmod(ptop, 0o600)
             cache_sls = os.path.join(pdir, 'cache.sls')
             with salt.utils.fopen(cache_sls, 'wb') as fp_:
-                fp_.write(yaml.dump(self.opts['pillar']))
+                fp_.write(
+                    yaml.dump(
+                        self.opts['pillar'],
+                        Dumper=SafeOrderedDumper
+                    )
+                )
                 os.chmod(cache_sls, 0o600)
 
     def gen_modules(self, initial_load=False):

--- a/salt/output/yaml_out.py
+++ b/salt/output/yaml_out.py
@@ -24,7 +24,7 @@ import logging
 import yaml
 
 # Import salt libs
-from salt.utils.yamldumper import OrderedDumper
+from salt.utils.yamldumper import SafeOrderedDumper
 
 # Define the module's virtual name
 __virtualname__ = 'yaml'
@@ -41,7 +41,7 @@ def output(data, **kwargs):  # pylint: disable=unused-argument
     Print out YAML using the block mode
     '''
 
-    params = dict(Dumper=OrderedDumper)
+    params = dict(Dumper=SafeOrderedDumper)
     if 'output_indent' not in __opts__:
         # default indentation
         params.update(default_flow_style=False)

--- a/salt/pillar/consul_pillar.py
+++ b/salt/pillar/consul_pillar.py
@@ -126,10 +126,11 @@ from __future__ import absolute_import
 import logging
 import re
 import yaml
-import salt.utils.minions
 
 from salt.exceptions import CommandExecutionError
 from salt.utils.dictupdate import update as dict_merge
+import salt.utils.minions
+from salt.utils.yamlloader import SaltYamlSafeLoader
 
 # Import third party libs
 try:
@@ -251,7 +252,10 @@ def pillar_format(ret, keys, value):
     # If value is not None then it's a string
     # Use YAML to parse the data
     # YAML strips whitespaces unless they're surrounded by quotes
-    pillar_value = yaml.load(value)
+    pillar_value = yaml.load(
+        value,
+        Loader=SaltYamlSafeLoader
+    )
 
     keyvalue = keys.pop()
     pil = {keyvalue: pillar_value}

--- a/salt/returners/slack_returner.py
+++ b/salt/returners/slack_returner.py
@@ -91,6 +91,7 @@ import salt.ext.six.moves.http_client
 # Import Salt Libs
 import salt.returners
 import salt.utils.slack
+from salt.utils.yamldumper import SafeOrderedDumper
 
 log = logging.getLogger(__name__)
 
@@ -211,7 +212,7 @@ def returner(ret):
         returns = dict((key, value) for key, value in returns.items() if value['result'] is not True or value['changes'])
 
     if yaml_format is True:
-        returns = yaml.dump(returns)
+        returns = yaml.dump(returns, Dumper=SafeOrderedDumper)
     else:
         returns = pprint.pformat(returns)
 

--- a/salt/spm/__init__.py
+++ b/salt/spm/__init__.py
@@ -12,7 +12,6 @@ import yaml
 import tarfile
 import shutil
 import msgpack
-import datetime
 import hashlib
 import logging
 import pwd
@@ -28,8 +27,8 @@ import salt.syspaths as syspaths
 import salt.ext.six as six
 from salt.ext.six import string_types
 from salt.ext.six.moves import input
-from salt.ext.six.moves import zip
 from salt.ext.six.moves import filter
+from salt.utils.yamldumper import SafeOrderedDumper
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -548,7 +547,14 @@ class SPMClient(object):
 
         metadata_filename = '{0}/SPM-METADATA'.format(repo_path)
         with salt.utils.fopen(metadata_filename, 'w') as mfh:
-            yaml.dump(repo_metadata, mfh, indent=4, canonical=False, default_flow_style=False)
+            yaml.dump(
+                repo_metadata,
+                mfh,
+                indent=4,
+                canonical=False,
+                default_flow_style=False,
+                Dumper=SafeOrderedDumper
+            )
 
         log.debug('Wrote {0}'.format(metadata_filename))
 

--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -59,6 +59,7 @@ import yaml
 # Import Salt Libs
 import salt.ext.six as six
 import salt.utils
+from salt.utils.yamlloader import SaltYamlSafeLoader
 
 log = logging.getLogger(__name__)
 
@@ -675,7 +676,10 @@ class _Swagger(object):
                 self._swagger_file = swagger_file_path
                 self._md5_filehash = _gen_md5_filehash(self._swagger_file)
                 with salt.utils.fopen(self._swagger_file, 'rb') as sf:
-                    self._cfg = yaml.load(sf)
+                    self._cfg = yaml.load(
+                        sf,
+                        Loader=SaltYamlSafeLoader
+                    )
                 self._swagger_version = ''
             else:
                 raise IOError('Invalid swagger file path, {0}'.format(swagger_file_path))

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -37,7 +37,7 @@ __all__ = [
 
 # To dump OrderedDict objects as regular dicts. Used by the yaml
 # template filter.
-class OrderedDictDumper(yaml.SafeDumper):  # pylint: disable=W0232
+class OrderedDictDumper(yaml.Dumper):  # pylint: disable=W0232
     pass
 
 

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -37,7 +37,7 @@ __all__ = [
 
 # To dump OrderedDict objects as regular dicts. Used by the yaml
 # template filter.
-class OrderedDictDumper(yaml.Dumper):  # pylint: disable=W0232
+class OrderedDictDumper(yaml.SafeDumper):  # pylint: disable=W0232
     pass
 
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -44,6 +44,7 @@ import salt.ext.six as six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from salt.utils.yamldumper import SafeOrderedDumper
 
+
 def _sorted(mixins_or_funcs):
     return sorted(
         mixins_or_funcs, key=lambda mf: getattr(mf, '_mixin_prio_', 1000)

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -42,7 +42,7 @@ from salt.utils.verify import verify_files
 import salt.exceptions
 import salt.ext.six as six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
-
+from salt.utils.yamldumper import SafeOrderedDumper
 
 def _sorted(mixins_or_funcs):
     return sorted(
@@ -1996,7 +1996,13 @@ class SaltCMDOptionParser(six.with_metaclass(OptionParserMeta,
         # Dump the master configuration file, exit normally at the end.
         if self.options.config_dump:
             cfg = config.master_config(self.get_config_file_path())
-            sys.stdout.write(yaml.dump(cfg, default_flow_style=False))
+            sys.stdout.write(
+                yaml.dump(
+                    cfg,
+                    default_flow_style=False,
+                    Dumper=SafeOrderedDumper
+                )
+            )
             sys.exit(salt.defaults.exitcodes.EX_OK)
 
         if self.options.doc:

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -349,6 +349,7 @@ import salt.log.setup as log_setup
 import salt.defaults.exitcodes
 from salt.utils.odict import OrderedDict
 from salt.utils.process import os_is_running, default_signals, SignalHandlingMultiprocessingProcess
+from salt.utils.yamldumper import SafeOrderedDumper
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -476,7 +477,10 @@ class Schedule(object):
             with salt.utils.fopen(schedule_conf, 'wb+') as fp_:
                 fp_.write(
                     salt.utils.to_bytes(
-                        yaml.dump({'schedule': self._get_schedule(include_pillar=False)})
+                        yaml.dump(
+                            {'schedule': self._get_schedule(include_pillar=False)},
+                            Dumper=SafeOrderedDumper
+                        )
                     )
                 )
         except (IOError, OSError):

--- a/salt/wheel/config.py
+++ b/salt/wheel/config.py
@@ -13,6 +13,7 @@ import yaml
 
 # Import salt libs
 import salt.config
+from salt.utils.yamldumper import SafeOrderedDumper
 
 log = logging.getLogger(__name__)
 
@@ -39,7 +40,13 @@ def apply(key, value):
     data = values()
     data[key] = value
     with salt.utils.fopen(path, 'w+') as fp_:
-        fp_.write(yaml.dump(data, default_flow_style=False))
+        fp_.write(
+            yaml.dump(
+                data,
+                default_flow_style=False,
+                Dumper=SafeOrderedDumper
+            )
+        )
 
 
 def update_config(file_name, yaml_contents):


### PR DESCRIPTION
### What does this PR do?
Updates several references where `yaml.load` and `yaml.dump` are being used to also include calling `Loader=SaltYamlSafeLoader` and `Dumper=SafeOrderedDumper`, respectively, as needed.

### What issues does this PR fix or reference?
Fixes #39531

### Tests written?
No - I want to add a check to the linter for these situations, but I need to learn how to do that first. 

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.