### PR TITLE
file.manage_file: uppercase checksums now work

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4450,6 +4450,11 @@ def manage_file(name,
                'comment': '',
                'result': True}
 
+
+    # Ensure that user-provided hash string is lowercase
+    if source_sum and ('hsum' in source_sum):
+        source_sum['hsum'] = source_sum['hsum'].lower()
+
     if source and not sfn:
         # File is not present, cache it
         sfn = __salt__['cp.cache_file'](source, saltenv)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4449,8 +4449,6 @@ def manage_file(name,
                'changes': {},
                'comment': '',
                'result': True}
-
-
     # Ensure that user-provided hash string is lowercase
     if source_sum and ('hsum' in source_sum):
         source_sum['hsum'] = source_sum['hsum'].lower()


### PR DESCRIPTION
### What does this PR do?
file.manage_file() in modules/file.py now correctly matches 
user-supplied uppercase hashes with equivalent lowercase hashes.
 
### What issues does this PR fix or reference?
Fixes #38914

### Previous Behavior
get_hash supplied a lowercase hexadecimal hash, eg
"637dbd6281672de432758da6d22af802"
which was compared to the string the user provided with, eg:
 file.managed: 
    \- source_hash: 637DBD6281672DE432758DA6D22AF802

If the user supplied an uppercase-formatted hash, case-sensitive string compares would fail.

### New Behavior
user-supplied hashes are internally converted to lower-case immediately after being received as arguments.

### Tests written?

No
