### PR TITLE
Minor fixes on new pkg.list_downloaded 

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -18,6 +18,7 @@ Support for YUM/DNF
 from __future__ import absolute_import
 import contextlib
 import copy
+import datetime
 import fnmatch
 import itertools
 import logging

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -926,7 +926,13 @@ def list_downloaded():
         for filename in fnmatch.filter(filenames, '*.rpm'):
             package_path = os.path.join(root, filename)
             pkg_info = __salt__['lowpkg.bin_pkg_info'](package_path)
-            ret.setdefault(pkg_info['name'], {})[pkg_info['version']] = package_path
+            pkg_timestamp = int(os.path.getctime(package_path))
+            ret.setdefault(pkg_info['name'], {})[pkg_info['version']] = {
+                'path': package_path,
+                'size': os.path.getsize(package_path),
+                'creation_date_time_t': pkg_timestamp,
+                'creation_date_time': datetime.datetime.fromtimestamp(pkg_timestamp).isoformat(),
+            }
     return ret
 
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -19,7 +19,6 @@ from __future__ import absolute_import
 import contextlib
 import copy
 import fnmatch
-import glob
 import itertools
 import logging
 import os
@@ -923,9 +922,11 @@ def list_downloaded():
     CACHE_DIR = os.path.join('/var/cache/', _yum())
 
     ret = {}
-    for package_path in glob.glob(os.path.join(CACHE_DIR, '*/*/*/packages/*.rpm')):
-        pkg_info = __salt__['lowpkg.bin_pkg_info'](package_path)
-        ret.setdefault(pkg_info['name'], {})[pkg_info['version']] = package_path
+    for root, dirnames, filenames in os.walk(CACHE_DIR):
+        for filename in fnmatch.filter(filenames, '*.rpm'):
+            package_path = os.path.join(root, filename)
+            pkg_info = __salt__['lowpkg.bin_pkg_info'](package_path)
+            ret.setdefault(pkg_info['name'], {})[pkg_info['version']] = package_path
     return ret
 
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2939,7 +2939,7 @@ def _get_patches(installed_only=False):
     '''
     patches = {}
 
-    cmd = [_yum(), '--quiet', 'updateinfo', 'list', 'security', 'all']
+    cmd = [_yum(), '--quiet', 'updateinfo', 'list', 'all']
     ret = __salt__['cmd.run_stdout'](
         cmd,
         python_shell=False

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -15,7 +15,7 @@ Package support for openSUSE via the zypper package manager
 # Import python libs
 from __future__ import absolute_import
 import copy
-import glob
+import fnmatch
 import logging
 import re
 import os
@@ -1794,10 +1794,11 @@ def list_downloaded():
     CACHE_DIR = '/var/cache/zypp/packages/'
 
     ret = {}
-    # Zypper storage is repository_tag/arch/package-version.rpm
-    for package_path in glob.glob(os.path.join(CACHE_DIR, '*/*/*.rpm')):
-        pkg_info = __salt__['lowpkg.bin_pkg_info'](package_path)
-        ret.setdefault(pkg_info['name'], {})[pkg_info['version']] = package_path
+    for root, dirnames, filenames in os.walk(CACHE_DIR):
+        for filename in fnmatch.filter(filenames, '*.rpm'):
+            package_path = os.path.join(root, filename)
+            pkg_info = __salt__['lowpkg.bin_pkg_info'](package_path)
+            ret.setdefault(pkg_info['name'], {})[pkg_info['version']] = package_path
     return ret
 
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1798,7 +1798,13 @@ def list_downloaded():
         for filename in fnmatch.filter(filenames, '*.rpm'):
             package_path = os.path.join(root, filename)
             pkg_info = __salt__['lowpkg.bin_pkg_info'](package_path)
-            ret.setdefault(pkg_info['name'], {})[pkg_info['version']] = package_path
+            pkg_timestamp = int(os.path.getctime(package_path))
+            ret.setdefault(pkg_info['name'], {})[pkg_info['version']] = {
+                'path': package_path,
+                'size': os.path.getsize(package_path),
+                'creation_date_time_t': pkg_timestamp,
+                'creation_date_time': datetime.datetime.fromtimestamp(pkg_timestamp).isoformat(),
+            }
     return ret
 
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2106,7 +2106,8 @@ def patch_installed(name, advisory_ids=None, downloadonly=None, **kwargs):
     if not ret['changes'] and not ret['comment']:
         status = 'downloaded' if downloadonly else 'installed'
         ret['result'] = True
-        ret['comment'] = 'Related packages are already {}'.format(status)
+        ret['comment'] = ('Advisory patch is not needed or related packages '
+                          'are already {0}'.format(status))
 
     return ret
 

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -503,7 +503,8 @@ Repository 'DUMMY' not found by its alias, number, or URI.
             self.assertEqual(len(list_patches), 3)
             self.assertDictEqual(list_patches, PATCHES_RET)
 
-    @patch('glob.glob', MagicMock(return_value=['/var/cache/zypper/packages/foo/bar/test_package.rpm']))
+    @patch('os.walk', MagicMock(return_value=[('test', 'test', 'test')]))
+    @patch('fnmatch.filter', MagicMock(return_value=['/var/cache/zypper/packages/foo/bar/test_package.rpm']))
     def test_list_downloaded(self):
         '''
         Test downloaded packages listing.

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -504,6 +504,8 @@ Repository 'DUMMY' not found by its alias, number, or URI.
             self.assertDictEqual(list_patches, PATCHES_RET)
 
     @patch('os.walk', MagicMock(return_value=[('test', 'test', 'test')]))
+    @patch('os.path.getsize', MagicMock(return_value=123456))
+    @patch('os.path.getmtime', MagicMock(return_value=1234567890.123456))
     @patch('fnmatch.filter', MagicMock(return_value=['/var/cache/zypper/packages/foo/bar/test_package.rpm']))
     def test_list_downloaded(self):
         '''
@@ -513,7 +515,11 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         '''
         DOWNLOADED_RET = {
             'test-package': {
-                '1.0': '/var/cache/zypper/packages/foo/bar/test_package.rpm'
+                '1.0': {
+                    'path': '/var/cache/zypper/packages/foo/bar/test_package.rpm',
+                    'size': 123456,
+                    'timestamp': 1234567890.123456,
+                }
             }
         }
 
@@ -548,7 +554,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 self.assertEqual(zypper.download("nmap", "foo"), test_out)
 
     @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
-    @patch('salt.modules.zypper.list_downloaded', MagicMock(side_effect=[{}, {'vim': {'1.1': '/foo/bar/test.rpm'}}]))
+    @patch('salt.modules.zypper.list_downloaded', MagicMock(side_effect=[{}, {'vim': {'1.1': {'path': '/foo/bar/test.rpm', 'size': 1234, 'timestamp': 1234567890}}}]))
     def test_install_with_downloadonly(self):
         '''
         Test a package installation with downloadonly=True.
@@ -566,10 +572,10 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                     '--download-only',
                     'vim'
                 )
-                self.assertDictEqual(ret, {'vim': {'new': {'1.1': '/foo/bar/test.rpm'}, 'old': ''}})
+                self.assertDictEqual(ret, {'vim': {'new': {'1.1': {'path': '/foo/bar/test.rpm', 'size': 1234, 'timestamp': 1234567890}}, 'old': ''}})
 
     @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
-    @patch('salt.modules.zypper.list_downloaded', MagicMock(return_value={'vim': {'1.1': '/foo/bar/test.rpm'}}))
+    @patch('salt.modules.zypper.list_downloaded', MagicMock(return_value={'vim': {'1.1': {'path': '/foo/bar/test.rpm', 'size': 1234, 'timestamp': 1234567890}}}))
     def test_install_with_downloadonly_already_downloaded(self):
         '''
         Test a package installation with downloadonly=True when package is already downloaded.

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -505,7 +505,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
 
     @patch('os.walk', MagicMock(return_value=[('test', 'test', 'test')]))
     @patch('os.path.getsize', MagicMock(return_value=123456))
-    @patch('os.path.getmtime', MagicMock(return_value=1234567890.123456))
+    @patch('os.path.getctime', MagicMock(return_value=1234567890.123456))
     @patch('fnmatch.filter', MagicMock(return_value=['/var/cache/zypper/packages/foo/bar/test_package.rpm']))
     def test_list_downloaded(self):
         '''
@@ -518,7 +518,8 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 '1.0': {
                     'path': '/var/cache/zypper/packages/foo/bar/test_package.rpm',
                     'size': 123456,
-                    'timestamp': 1234567890.123456,
+                    'creation_date_time_t': 1234567890,
+                    'creation_date_time': '2009-02-13T23:31:30',
                 }
             }
         }
@@ -554,7 +555,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 self.assertEqual(zypper.download("nmap", "foo"), test_out)
 
     @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
-    @patch('salt.modules.zypper.list_downloaded', MagicMock(side_effect=[{}, {'vim': {'1.1': {'path': '/foo/bar/test.rpm', 'size': 1234, 'timestamp': 1234567890}}}]))
+    @patch('salt.modules.zypper.list_downloaded', MagicMock(side_effect=[{}, {'vim': {'1.1': {'path': '/foo/bar/test.rpm', 'size': 1234, 'creation_date_time_t': 1234567890, 'creation_date_time': '2009-02-13T23:31:30'}}}]))
     def test_install_with_downloadonly(self):
         '''
         Test a package installation with downloadonly=True.
@@ -572,10 +573,10 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                     '--download-only',
                     'vim'
                 )
-                self.assertDictEqual(ret, {'vim': {'new': {'1.1': {'path': '/foo/bar/test.rpm', 'size': 1234, 'timestamp': 1234567890}}, 'old': ''}})
+                self.assertDictEqual(ret, {'vim': {'new': {'1.1': {'path': '/foo/bar/test.rpm', 'size': 1234, 'creation_date_time_t': 1234567890, 'creation_date_time': '2009-02-13T23:31:30'}}, 'old': ''}})
 
     @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
-    @patch('salt.modules.zypper.list_downloaded', MagicMock(return_value={'vim': {'1.1': {'path': '/foo/bar/test.rpm', 'size': 1234, 'timestamp': 1234567890}}}))
+    @patch('salt.modules.zypper.list_downloaded', MagicMock(return_value={'vim': {'1.1': {'path': '/foo/bar/test.rpm', 'size': 1234, 'creation_date_time_t': 1234567890, 'creation_date_time': '2017-01-01T11:00:00'}}}))
     def test_install_with_downloadonly_already_downloaded(self):
         '''
         Test a package installation with downloadonly=True when package is already downloaded.


### PR DESCRIPTION
### What does this PR do?
This PR fixes some minor issues after merging #40266:

- In older SLE versions, Zypper stores downloaded RPM packages using a different path structure. This PR searches into the entire `CACHE_DIR` instead of looking for certain fixed paths.

- Prevents an error with Python version 2.6 due zero length value while string formatting.

### Tests written?

No
