### PR TITLE
Fix _build_parent_list function for Py3

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3865,7 +3865,7 @@ def _build_parent_list(policy_definition,
     policy
     '''
     parent_list = []
-    policy_namespace = policy_definition.nsmap.keys()[0]
+    policy_namespace = list(policy_definition.nsmap.keys())[0]
     parent_category = policy_definition.xpath('{0}:parentCategory/@ref'.format(policy_namespace),
                                               namespaces=policy_definition.nsmap)
     if parent_category:


### PR DESCRIPTION
### What does this PR do?
Fixes a Py3 compatibility issue with the `_build_parent_list` function. It was throwing an error: `TypeError: 'dict_keys' object does not support indexing`

In Py3 `dict.keys()` returns an iterable view instead of a list. The easiest fix in this case is just to convert to a list, ie `list(dict.keys())`. It works in this case because the dict in question only has one element. We just need the name of its key, so `list(dict.keys())[0]` will work fine.

### What issues does this PR fix or reference?
Issue found by @rdutch in testing nitrogen

### Previous Behavior
Stack trace:
```
An exception occurred in this state: Traceback (most recent call last):
                File "c:\salt\bin\lib\site-packages\salt\state.py", line 1822, in call
                  **cdata['kwargs'])
                File "c:\salt\bin\lib\site-packages\salt\loader.py", line 1727, in wrapper
                  return f(*args, **kwargs)
                File "c:\salt\bin\lib\site-packages\salt\states\win_lgpo.py", line 233, in set_
                  adml_language=adml_language)
                File "c:\salt\bin\lib\site-packages\salt\modules\win_lgpo.py", line 4737, in get_policy_info
                  adml_policy_resources=adml_policy_resources)
                File "c:\salt\bin\lib\site-packages\salt\modules\win_lgpo.py", line 4637, in _lookup_admin_template
                  adml_policy_resources)
                File "c:\salt\bin\lib\site-packages\salt\modules\win_lgpo.py", line 3868, in _build_parent_list
                  policy_namespace = policy_definition.nsmap.keys()[0]
              TypeError: 'dict_keys' object does not support indexing
```

### Tests written?
No
