### PR TITLE
Fixing roster grains by copying the grains generated on the local machine to the remote machine

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -158,7 +158,7 @@ def salt_refs(data, ret=None):
     return ret
 
 
-def prep_trans_tar(opts, file_client, chunks, file_refs, pillar=None, id_=None):
+def prep_trans_tar(opts, file_client, chunks, file_refs, pillar=None, id_=None, roster_grains=None):
     '''
     Generate the execution package from the saltenv file refs and a low state
     data structure
@@ -167,6 +167,7 @@ def prep_trans_tar(opts, file_client, chunks, file_refs, pillar=None, id_=None):
     trans_tar = salt.utils.files.mkstemp()
     lowfn = os.path.join(gendir, 'lowstate.json')
     pillarfn = os.path.join(gendir, 'pillar.json')
+    roster_grainsfn = os.path.join(gendir, 'roster_grains.json')
     sync_refs = [
             [salt.utils.url.create('_modules')],
             [salt.utils.url.create('_states')],
@@ -181,6 +182,9 @@ def prep_trans_tar(opts, file_client, chunks, file_refs, pillar=None, id_=None):
     if pillar:
         with salt.utils.fopen(pillarfn, 'w+') as fp_:
             fp_.write(json.dumps(pillar))
+    if roster_grains:
+        with salt.utils.fopen(roster_grainsfn, 'w+') as fp_:
+            fp_.write(json.dumps(roster_grains))
 
     if id_ is None:
         id_ = ''

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -85,6 +85,10 @@ def sls(mods, saltenv='base', test=None, exclude=None, **kwargs):
                 __opts__.get('extra_filerefs', '')
                 )
             )
+
+    roster = salt.roster.Roster(__opts__, __opts__.get('roster', 'flat'))
+    roster_grains = roster.opts['grains']
+
     # Create the tar containing the state pkg and relevant files.
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
@@ -92,7 +96,8 @@ def sls(mods, saltenv='base', test=None, exclude=None, **kwargs):
             chunks,
             file_refs,
             __pillar__,
-            st_kwargs['id_'])
+            st_kwargs['id_'],
+            roster_grains)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg {0}/salt_state.tgz test={1} pkg_sum={2} hash_type={3}'.format(
             __opts__['thin_dir'],
@@ -158,6 +163,9 @@ def low(data, **kwargs):
                 __opts__.get('extra_filerefs', '')
                 )
             )
+    roster = salt.roster.Roster(__opts__, __opts__.get('roster', 'flat'))
+    roster_grains = roster.opts['grains']
+
     # Create the tar containing the state pkg and relevant files.
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
@@ -165,7 +173,8 @@ def low(data, **kwargs):
             chunks,
             file_refs,
             __pillar__,
-            st_kwargs['id_'])
+            st_kwargs['id_'],
+            roster_grains)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg {0}/salt_state.tgz pkg_sum={1} hash_type={2}'.format(
             __opts__['thin_dir'],
@@ -226,6 +235,10 @@ def high(data, **kwargs):
                 __opts__.get('extra_filerefs', '')
                 )
             )
+
+    roster = salt.roster.Roster(__opts__, __opts__.get('roster', 'flat'))
+    roster_grains = roster.opts['grains']
+
     # Create the tar containing the state pkg and relevant files.
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
@@ -233,7 +246,8 @@ def high(data, **kwargs):
             chunks,
             file_refs,
             __pillar__,
-            st_kwargs['id_'])
+            st_kwargs['id_'],
+            roster_grains)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg {0}/salt_state.tgz pkg_sum={1} hash_type={2}'.format(
             __opts__['thin_dir'],
@@ -305,6 +319,7 @@ def highstate(test=None, **kwargs):
     __pillar__.update(kwargs.get('pillar', {}))
     st_kwargs = __salt__.kwargs
     __opts__['grains'] = __grains__
+
     st_ = salt.client.ssh.state.SSHHighState(
             __opts__,
             __pillar__,
@@ -323,6 +338,10 @@ def highstate(test=None, **kwargs):
         if not isinstance(chunk, dict):
             __context__['retcode'] = 1
             return chunks
+
+    roster = salt.roster.Roster(__opts__, __opts__.get('roster', 'flat'))
+    roster_grains = roster.opts['grains']
+
     # Create the tar containing the state pkg and relevant files.
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
@@ -330,7 +349,8 @@ def highstate(test=None, **kwargs):
             chunks,
             file_refs,
             __pillar__,
-            st_kwargs['id_'])
+            st_kwargs['id_'],
+            roster_grains)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg {0}/salt_state.tgz test={1} pkg_sum={2} hash_type={3}'.format(
             __opts__['thin_dir'],
@@ -398,6 +418,10 @@ def top(topfn, test=None, **kwargs):
                 __opts__.get('extra_filerefs', '')
                 )
             )
+
+    roster = salt.roster.Roster(__opts__, __opts__.get('roster', 'flat'))
+    roster_grains = roster.opts['grains']
+
     # Create the tar containing the state pkg and relevant files.
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
@@ -405,7 +429,8 @@ def top(topfn, test=None, **kwargs):
             chunks,
             file_refs,
             __pillar__,
-            st_kwargs['id_'])
+            st_kwargs['id_'],
+            roster_grains)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg {0}/salt_state.tgz test={1} pkg_sum={2} hash_type={3}'.format(
             __opts__['thin_dir'],
@@ -654,6 +679,9 @@ def single(fun, name, test=None, **kwargs):
                 )
             )
 
+    roster = salt.roster.Roster(__opts__, __opts__.get('roster', 'flat'))
+    roster_grains = roster.opts['grains']
+
     # Create the tar containing the state pkg and relevant files.
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
@@ -661,7 +689,8 @@ def single(fun, name, test=None, **kwargs):
             chunks,
             file_refs,
             __pillar__,
-            st_kwargs['id_'])
+            st_kwargs['id_'],
+            roster_grains)
 
     # Create a hash so we can verify the tar on the target system
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1731,7 +1731,14 @@ def pkg(pkg_path, pkg_sum, hash_type, test=None, **kwargs):
             pillar = json.load(fp_)
     else:
         pillar = None
+    roster_grains_json = os.path.join(root, 'roster_grains.json')
+    if os.path.isfile(roster_grains_json):
+        with salt.utils.fopen(roster_grains_json, 'r') as fp_:
+            roster_grains = json.load(fp_, object_hook=salt.utils.decode_dict)
+
     popts = _get_opts(kwargs.get('localconfig'))
+    if os.path.isfile(roster_grains_json):
+        popts['grains'] = roster_grains
     popts['fileclient'] = 'local'
     popts['file_roots'] = {}
     popts['test'] = _get_test_value(test, **kwargs)


### PR DESCRIPTION
### What does this PR do?
It fixes an issue where roster grains worked for processing on the machine where salt-ssh is run from, but didn't work for any process, like jinja templates, that is processed on the remote machine.

### What issues does this PR fix or reference?
#36313

### Previous Behavior
Roster grains would be missing in jinja templates

### New Behavior
Remove this section if not relevant
Roster grains are not missing in jinja templates
### Tests written?
No