### PR TITLE
Default grains should contain kernel version

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1260,11 +1260,16 @@ def os_data():
     # pylint: disable=unpacking-non-sequence
     (grains['kernel'], grains['nodename'],
      grains['kernelrelease'], version, grains['cpuarch'], _) = platform.uname()
+
+    # pylint: enable=unpacking-non-sequence
+    grains['kernelversion'] = platform.version()
+
     # pylint: enable=unpacking-non-sequence
 
     if salt.utils.is_proxy():
         grains['kernel'] = 'proxy'
         grains['kernelrelease'] = 'proxy'
+        grains['kernelversion'] = 'proxy'
         grains['osrelease'] = 'proxy'
         grains['os'] = 'proxy'
         grains['os_family'] = 'proxy'


### PR DESCRIPTION
### What does this PR do?
Adds a kernelversion grain to helps Debian users when checking for security notifications amongst other things.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40763

### Previous Behavior
There was no kernelversion grain.

### New Behavior
```
$ sudo salt 'testvm' grains.ls | grep kernelversion
    - kernelversion

$ sudo salt 'work' grains.get kernelversion
testvm:
    #1 SMP Tue Mar 21 03:49:30 UTC 2017
```

### Tests written?
No, apologies. This is really one of my first times investigating production python code.
