### PR TITLE
win_pkg: backport 2016.11 add msiexec override to enable selection of 32 or 64 msiexec.exe

### DIFF
--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -460,8 +460,22 @@ Alternatively the ``uninstaller`` can also simply repeat the URL of the msi file
         uninstaller: salt://win/repo/7zip/7z920-x64.msi
         uninstall_flags: '/qn /norestart'
 
-:param bool msiexec: This tells salt to use ``msiexec /i`` to install the
+:param msiexec: This tells salt to use ``msiexec /i`` to install the
     package and ``msiexec /x`` to uninstall. This is for `.msi` installations.
+    Possible options are: True, False or path to msiexec on your system
+
+    7zip:
+      '9.20.00.0':
+        installer: salt://win/repo/7zip/7z920-x64.msi
+        full_name: 7-Zip 9.20 (x64 edition)
+        reboot: False
+        install_flags: '/qn /norestart'
+        msiexec: 'C:\Windows\System32\msiexec.exe'
+        uninstaller: salt://win/repo/7zip/7z920-x64.msi
+        uninstall_flags: '/qn /norestart'
+
+:param str arch: This selects which ``msiexec.exe`` to use. Possible values:
+    ``x86``, ``x64``
 
 :param bool allusers: This parameter is specific to `.msi` installations. It
     tells `msiexec` to install the software for all users. The default is True.


### PR DESCRIPTION
This is a backport for 2016.11 of the #40716 