### PR TITLE
INFRA-4728 - boto3_sns execution and state modules

### DIFF
--- a/salt/modules/boto3_sns.py
+++ b/salt/modules/boto3_sns.py
@@ -93,6 +93,13 @@ def list_topics(region=None, key=None, keyid=None, profile=None):
 
 
 def describe_topic(name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Returns details about a specific SNS topic, specified by name or ARN.
+
+    CLI example::
+
+        salt my_favorite_client boto3_sns.describe_topic a_sns_topic_of_my_choice
+    '''
     topics = list_topics(region=region, key=key, keyid=keyid, profile=profile)
     ret = {}
     for topic, arn in topics.items():

--- a/salt/modules/boto3_sns.py
+++ b/salt/modules/boto3_sns.py
@@ -1,0 +1,334 @@
+# -*- coding: utf-8 -*-
+'''
+Connection module for Amazon SNS
+
+:configuration: This module accepts explicit sns credentials but can also
+    utilize IAM roles assigned to the instance through Instance Profiles. Dynamic
+    credentials are then automatically obtained from AWS API and no further
+    configuration is necessary. More Information available at:
+
+    .. code-block:: text
+
+        http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file:
+
+    .. code-block:: yaml
+
+        sns.keyid: GKTADJGHEIQSXMKKRBJ08H
+        sns.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration:
+
+    .. code-block:: yaml
+
+        sns.region: us-east-1
+
+    If a region is not specified, the default is us-east-1.
+
+    It's also possible to specify key, keyid and region via a profile, either
+    as a passed in dict, or as a string to pull from pillars or minion config:
+
+    .. code-block:: yaml
+
+        myprofile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+:depends: boto3
+'''
+# keep lint from choking on _get_conn and _cache_id
+#pylint: disable=E0602
+
+from __future__ import absolute_import
+
+import logging
+import jmespath
+
+log = logging.getLogger(__name__)
+
+# Import third party libs
+try:
+    #pylint: disable=unused-import
+    import botocore
+    import boto3
+    #pylint: enable=unused-import
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist.
+    '''
+    if not HAS_BOTO:
+        return (False, 'The boto3_sns module could not be loaded: boto3 libraries not found')
+    __utils__['boto3.assign_funcs'](__name__, 'sns')
+    return True
+
+
+def list_topics(region=None, key=None, keyid=None, profile=None):
+    '''
+    Returns a list of the requester's topics
+
+    CLI example::
+
+        salt myminion boto3_sns.list_topics
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    res = {}
+    NextToken = ''
+    while NextToken is not None:
+        ret = conn.list_topics(NextToken=NextToken)
+        NextToken = ret.get('NextToken', None)
+        arns = jmespath.search('Topics[*].TopicArn', ret)
+        for t in arns:
+            short_name = t.split(':')[-1]
+            res[short_name] = t
+    return res
+
+
+def describe_topic(name, region=None, key=None, keyid=None, profile=None):
+    topics = list_topics(region=region, key=key, keyid=keyid, profile=profile)
+    ret = {}
+    for topic, arn in topics.items():
+        if name in (topic, arn):
+            ret = {'TopicArn': arn}
+            ret['Subscriptions'] = list_subscriptions_by_topic(arn, region=region, key=key,
+                                                               keyid=keyid, profile=profile)
+            ret['Attributes'] = get_topic_attributes(arn, region=region, key=key, keyid=keyid,
+                                                     profile=profile)
+    return ret
+
+
+def topic_exists(name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Check to see if an SNS topic exists.
+
+    CLI example::
+
+        salt myminion boto3_sns.topic_exists mytopic region=us-east-1
+    '''
+    topics = list_topics(region=region, key=key, keyid=keyid, profile=profile)
+    return name in list(topics.values() + topics.keys())
+
+
+def create_topic(Name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Create an SNS topic.
+
+    CLI example::
+
+        salt myminion boto3_sns.create_topic mytopic region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        ret = conn.create_topic(Name=Name)
+        log.info('SNS topic {0} created with ARN {1}'.format(Name, ret['TopicArn']))
+        return ret['TopicArn']
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to create SNS topic {0}: {1}'.format(Name, e))
+        return None
+    except KeyError:
+        log.error('Failed to create SNS topic {0}'.format(Name))
+        return None
+
+
+def delete_topic(TopicArn, region=None, key=None, keyid=None, profile=None):
+    '''
+    Delete an SNS topic.
+
+    CLI example::
+
+        salt myminion boto3_sns.delete_topic mytopic region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        conn.delete_topic(TopicArn=TopicArn)
+        log.info('SNS topic {0} deleted'.format(TopicArn))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to delete SNS topic {0}: {1}'.format(name, e))
+        return False
+
+
+def get_topic_attributes(TopicArn, region=None, key=None, keyid=None, profile=None):
+    '''
+    Returns all of the properties of a topic.  Topic properties returned might differ based on the
+    authorization of the user.
+
+    CLI example::
+
+        salt myminion boto3_sns.get_topic_attributes someTopic region=us-west-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        return conn.get_topic_attributes(TopicArn=TopicArn).get('Attributes')
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to garner attributes for SNS topic {0}: {1}'.format(TopicArn, e))
+        return None
+
+
+def set_topic_attributes(TopicArn, AttributeName, AttributeValue, region=None, key=None, keyid=None,
+                         profile=None):
+    '''
+    Set an attribute of a topic to a new value.
+
+    CLI example::
+
+        salt myminion boto3_sns.set_topic_attributes someTopic DisplayName myDisplayNameValue
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        conn.set_topic_attributes(TopicArn=TopicArn, AttributeName=AttributeName,
+                                  AttributeValue=AttributeValue)
+        log.debug('Set attribute {0}={1} on SNS topic {2}'.format(AttributeName, AttributeValue,
+                                                                  TopicArn))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to set attribute {0}={1} for SNS topic {2}: {3}'.format(AttributeName,
+                                                                                  AttributeValue,
+                                                                                  TopicArn, e))
+        return False
+
+
+def list_subscriptions_by_topic(TopicArn, region=None, key=None, keyid=None, profile=None):
+    '''
+    Returns a list of the subscriptions to a specific topic
+
+    CLI example::
+
+        salt myminion boto3_sns.list_subscriptions_by_topic mytopic region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    NextToken = ''
+    res = []
+    try:
+        while NextToken is not None:
+            ret = conn.list_subscriptions_by_topic(TopicArn=TopicArn, NextToken=NextToken)
+            NextToken = ret.get('NextToken', None)
+            subs = ret.get('Subscriptions', [])
+            res += subs
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to list subscriptions for SNS topic {0}: {1}'.format(TopicArn, e))
+        return None
+    return res
+
+
+def list_subscriptions(region=None, key=None, keyid=None, profile=None):
+    '''
+    Returns a list of the requester's topics
+
+    CLI example::
+
+        salt myminion boto3_sns.list_subscriptions region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    NextToken = ''
+    res = []
+    try:
+        while NextToken is not None:
+            ret = conn.list_subscriptions(NextToken=NextToken)
+            NextToken = ret.get('NextToken', None)
+            subs = ret.get('Subscriptions', [])
+            res += subs
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to list SNS subscriptions: {0}'.format(e))
+        return None
+    return res
+
+
+def get_subscription_attributes(SubscriptionArn, region=None, key=None, keyid=None, profile=None):
+    '''
+    Returns all of the properties of a subscription.
+
+    CLI example::
+
+        salt myminion boto3_sns.get_subscription_attributes somesubscription region=us-west-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        ret = conn.get_subscription_attributes(SubscriptionArn=SubscriptionArn)
+        return ret['Attributes']
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to list attributes for SNS subscription {0}: {1}'.format(SubscriptionArn,
+                                                                                   e))
+        return None
+    except KeyError:
+        log.error('Failed to list attributes for SNS subscription {0}'.format(SubscriptionArn))
+        return None
+
+
+def set_subscription_attributes(SubscriptionArn, AttributeName, AttributeValue, region=None,
+                                key=None, keyid=None, profile=None):
+    '''
+    Set an attribute of a subscription to a new value.
+
+    CLI example::
+
+        salt myminion boto3_sns.set_subscription_attributes someSubscription RawMessageDelivery jsonStringValue
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        conn.set_subscription_attributes(SubscriptionArn=SubscriptionArn,
+                                         AttributeName=AttributeName, AttributeValue=AttributeValue)
+        log.debug('Set attribute {0}={1} on SNS subscription {2}'.format(AttributeName,
+                                                                         AttributeValue,
+                                                                         SubscriptionArn))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to set attribute {0}={1} for SNS subscription {2}: {3}'.format(
+                  AttributeName, AttributeValue, SubscriptionArn, e))
+        return False
+
+
+def subscribe(TopicArn, Protocol, Endpoint, region=None, key=None, keyid=None, profile=None):
+    '''
+    Subscribe to a Topic.
+
+    CLI example::
+
+        salt myminion boto3_sns.subscribe mytopic https https://www.example.com/sns-endpoint
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        ret = conn.subscribe(TopicArn=TopicArn, Protocol=Protocol, Endpoint=Endpoint)
+        log.info('Subscribed {0} {1} to topic {2} with SubscriptionArn {3]'.format(
+                 Protocol, Endpoint, TopicArn, ret['SubscriptionArn']))
+        return ret['SubscriptionArn']
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to create subscription to SNS topic {0}: {1}'.format(TopicArn, e))
+        return None
+    except KeyError:
+        log.error('Failed to create subscription to SNS topic {0}'.format(TopicArn))
+        return None
+
+
+def unsubscribe(SubscriptionArn, region=None, key=None, keyid=None, profile=None):
+    '''
+    Unsubscribe a specific SubscriptionArn of a topic.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion boto3_sns.unsubscribe my_subscription_arn region=us-east-1
+    '''
+    subs = list_subscriptions(region=region, key=key, keyid=keyid, profile=profile)
+    sub = [s for s in subs if s.get('SubscriptionArn') == SubscriptionArn]
+    if not sub:
+        log.error('Subscription ARN {0} not found'.format(SubscriptionArn))
+        return False
+    TopicArn = sub[0]['TopicArn']
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        conn.unsubscribe(SubscriptionArn=SubscriptionArn)
+        log.info('Deleted subscription {0} from SNS topic {1}'.format(SubscriptionArn, TopicArn))
+        return True
+    except botocore.exceptions.ClientError as e:
+        log.error('Failed to delete subscription {0}: {1}'.format(SubscriptionArn, e))
+        return False

--- a/salt/modules/boto3_sns.py
+++ b/salt/modules/boto3_sns.py
@@ -297,7 +297,7 @@ def subscribe(TopicArn, Protocol, Endpoint, region=None, key=None, keyid=None, p
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     try:
         ret = conn.subscribe(TopicArn=TopicArn, Protocol=Protocol, Endpoint=Endpoint)
-        log.info('Subscribed {0} {1} to topic {2} with SubscriptionArn {3]'.format(
+        log.info('Subscribed {0} {1} to topic {2} with SubscriptionArn {3}'.format(
                  Protocol, Endpoint, TopicArn, ret['SubscriptionArn']))
         return ret['SubscriptionArn']
     except botocore.exceptions.ClientError as e:

--- a/salt/states/boto3_sns.py
+++ b/salt/states/boto3_sns.py
@@ -61,7 +61,6 @@ import logging
 import json
 import copy
 import salt.ext.six as six
-from salt.utils.odict import OrderedDict
 
 log = logging.getLogger(__name__)
 
@@ -261,7 +260,6 @@ def topic_absent(name, unsubscribe=False, region=None, key=None, keyid=None, pro
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     something_changed = False
-    log.info('%s, %s, %s, %s, %s' % (name, region, key, keyid, profile))
     current = __salt__['boto3_sns.describe_topic'](name, region, key, keyid, profile)
     if not current:
         ret['comment'] = 'AWS SNS topic {0} absent.'.format(name)
@@ -279,7 +277,7 @@ def topic_absent(name, unsubscribe=False, region=None, key=None, keyid=None, pro
                 if sub['SubscriptionArn'] == 'PendingConfirmation':
                     # The API won't let you delete subscriptions in pending status...
                     log.warning('Ignoring PendingConfirmation subscription {0} {1} on topic '
-                                '{2}'.format( sub['Protocol'], sub['Endpoint'], sub['TopicArn']))
+                                '{2}'.format(sub['Protocol'], sub['Endpoint'], sub['TopicArn']))
                     continue
                 if __salt__['boto3_sns.unsubscribe'](sub['SubscriptionArn'], region=region, key=key,
                                                      keyid=keyid, profile=profile):

--- a/salt/states/boto3_sns.py
+++ b/salt/states/boto3_sns.py
@@ -1,0 +1,314 @@
+# -*- coding: utf-8 -*-
+'''
+Manage SNS Topics
+
+
+Create and destroy SNS topics. Be aware that this interacts with Amazon's
+services, and so may incur charges.
+
+This module uses ``boto``, which can be installed via package, or pip.
+
+This module accepts explicit AWS credentials but can also utilize
+IAM roles assigned to the instance through Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More information available `here
+<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_.
+
+If IAM roles are not used you need to specify them either in a pillar file or
+in the minion's config file:
+
+.. code-block:: yaml
+
+    sns.keyid: GKTADJGHEIQSXMKKRBJ08H
+    sns.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+It's also possible to specify ``key``, ``keyid`` and ``region`` via a profile, either
+passed in as a dict, or as a string to pull from pillars or minion config:
+
+.. code-block:: yaml
+
+    myprofile:
+        keyid: GKTADJGHEIQSXMKKRBJ08H
+        key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+        region: us-east-1
+
+.. code-block:: yaml
+
+    mytopic:
+        boto3_sns.topic_present:
+            - region: us-east-1
+            - keyid: GKTADJGHEIQSXMKKRBJ08H
+            - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    # Using a profile from pillars
+    mytopic:
+        boto3_sns.topic_present:
+            - region: us-east-1
+            - profile: mysnsprofile
+
+    # Passing in a profile
+    mytopic:
+        boto3_sns.topic_present:
+            - region: us-east-1
+            - profile:
+                keyid: GKTADJGHEIQSXMKKRBJ08H
+                key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+'''
+from __future__ import absolute_import
+
+import re
+import logging
+import json
+import copy
+import salt.ext.six as six
+from salt.utils.odict import OrderedDict
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if boto is available.
+    '''
+    return 'boto3_sns' if 'boto3_sns.topic_exists' in __salt__ else False
+
+
+def topic_present(name, subscriptions=None, attributes=None,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure the SNS topic exists.
+
+    name
+        Name of the SNS topic.
+
+    subscriptions
+        List of SNS subscriptions.
+
+        Each subscription is a dictionary with a protocol and endpoint key:
+
+        .. code-block:: yaml
+
+            subscriptions:
+            - Protocol: https
+              Endpoint: https://www.example.com/sns-endpoint
+            - Protocol: sqs
+              Endpoint: arn:aws:sqs:us-west-2:123456789012:MyQueue
+
+    attributes
+        Dictionary of attributes to set on the SNS topic
+        Valid attribute keys are:
+          - Policy:  the JSON serialization of the topic's access control policy
+          - DisplayName:  the human-readable name used in the "From" field for notifications
+                to email and email-json endpoints
+          - DeliveryPolicy:  the JSON serialization of the topic's delivery policy
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    something_changed = False
+    current = __salt__['boto3_sns.describe_topic'](name, region, key, keyid, profile)
+    if current:
+        ret['comment'] = 'AWS SNS topic {0} present.'.format(name)
+        TopicArn = current['TopicArn']
+    else:
+        if __opts__['test']:
+            ret['comment'] = 'AWS SNS topic {0} would be created.'.format(name)
+            ret['result'] = None
+            return ret
+        else:
+            TopicArn = __salt__['boto3_sns.create_topic'](name, region=region, key=key,
+                                                          keyid=keyid, profile=profile)
+            if TopicArn:
+                ret['comment'] = 'AWS SNS topic {0} created with ARN {1}.'.format(name, TopicArn)
+                something_changed = True
+            else:
+                ret['comment'] = 'Failed to create AWS SNS topic {0}'.format(name)
+                log.error(ret['comment'])
+                ret['result'] = False
+                return ret
+
+    ### Update any explicitly defined attributes
+    want_attrs = attributes if attributes else {}
+    # Freshen these in case we just created it above
+    current_attrs = __salt__['boto3_sns.get_topic_attributes'](TopicArn, region=region, key=key,
+                                                               keyid=keyid, profile=profile)
+    for attr in ['DisplayName', 'Policy', 'DeliveryPolicy']:
+        curr_val = current_attrs.get(attr)
+        want_val = want_attrs.get(attr)
+        # Some get default values if not set, so it's not safe to enforce absense if they're
+        # not provided at all.  This implies that if you want to clear a value, you must explicitly
+        # set it to an empty string.
+        if want_val is None:
+            continue
+        if _json_objs_equal(want_val, curr_val):
+            continue
+        if __opts__['test']:
+            ret['comment'] += '  Attribute {0} would be updated on topic {1}.'.format(attr, TopicArn)
+            ret['result'] = None
+            continue
+        want_val = want_val if isinstance(want_val, six.string_types) else json.dumps(want_val)
+        if __salt__['boto3_sns.set_topic_attributes'](TopicArn, attr, want_val, region=region,
+                                                      key=key, keyid=keyid, profile=profile):
+            ret['comment'] += '  Attribute {0} set to {1} on topic {2}.'.format(attr, want_val,
+                                                                                   TopicArn)
+            something_changed = True
+        else:
+            ret['comment'] += '  Failed to update {0} on topic {1}.'.format(attr, TopicArn)
+            ret['result'] = False
+            return ret
+
+    ### Add / remove subscriptions
+    want_subs = subscriptions if subscriptions else []
+    obfuscated_subs = []
+    current_subs = current.get('Subscriptions', [])
+    current_slim = [{'Protocol': s['Protocol'], 'Endpoint': s['Endpoint']} for s in current_subs]
+    subscribe = []
+    unsubscribe = []
+    for sub in want_subs:
+        # If the subscription contains inline digest auth, AWS will obfuscate the password with
+        # '****'.  Thus we need to do the same with ours to permit 1-to-1 comparison.
+        # Example: https://user:****@my.endpoiint.com/foo/bar
+        endpoint = sub['Endpoint']
+        matches = re.search(r'https://(?P<user>\w+):(?P<pass>\w+)@', endpoint)
+        if matches is not None:
+            sub['Endpoint'] = endpoint.replace(':' + matches.groupdict()['pass'], ':****')
+        obfuscated_subs += [copy.deepcopy(sub)]
+        # Now set it back...
+        if sub not in current_slim:
+            sub['Endpoint'] = endpoint
+            subscribe += [sub]
+    for sub in current_subs:
+        minimal = {'Protocol': sub['Protocol'], 'Endpoint': sub['Endpoint']}
+        if minimal not in obfuscated_subs:
+            unsubscribe += [sub['SubscriptionArn']]
+    for sub in subscribe:
+        prot = sub['Protocol']
+        endp = sub['Endpoint']
+        if __opts__['test']:
+            msg = ' Subscription {0}:{1} would be set on topic {2}.'.format(prot, endp, TopicArn)
+            ret['comment'] += msg
+            ret['result'] = None
+            continue
+        subbed = __salt__['boto3_sns.subscribe'](TopicArn, prot, endp, region=region, key=key,
+                                                 keyid=keyid, profile=profile)
+        if subbed:
+            msg = ' Subscription {0}:{1} set on topic {2}.'.format(prot, endp, TopicArn)
+            ret['comment'] += msg
+            something_changed = True
+        else:
+            msg = ' Failed to set subscription {0}:{1} on topic {2}.'.format(prot, endp, TopicArn)
+            ret['comment'] += msg
+            ret['result'] = False
+            return ret
+    for sub in unsubscribe:
+        if __opts__['test']:
+            msg = '  Subscription {0} would be removed from topic {1}.'.format(sub, TopicArn)
+            ret['comment'] += msg
+            ret['result'] = None
+            continue
+        unsubbed = __salt__['boto3_sns.unsubscribe'](sub, region=region, key=key, keyid=keyid,
+                                                     profile=profile)
+        if unsubbed:
+            ret['comment'] += '  Subscription {0} removed from topic {1}.'.format(sub, TopicArn)
+            something_changed = True
+        else:
+            msg = '  Failed to remove subscription {0} from topic {1}.'.format(sub, TopicArn)
+            ret['comment'] += msg
+            ret['result'] = False
+            return ret
+    if something_changed:
+        ret['changes']['old'] = current
+        ret['changes']['new'] = __salt__['boto3_sns.describe_topic'](name, region, key, keyid, profile)
+    return ret
+
+
+def topic_absent(name, unsubscribe=False, region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure the named sns topic is deleted.
+
+    name
+        Name of the SNS topic.
+
+    unsubscribe
+        If True, unsubscribe all subcriptions to the SNS topic before
+        deleting the SNS topic
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    something_changed = False
+    log.info('%s, %s, %s, %s, %s' % (name, region, key, keyid, profile))
+    current = __salt__['boto3_sns.describe_topic'](name, region, key, keyid, profile)
+    if not current:
+        ret['comment'] = 'AWS SNS topic {0} absent.'.format(name)
+    else:
+        TopicArn = current['TopicArn']
+        if __opts__['test']:
+            ret['comment'] = 'AWS SNS topic {0} would be removed.'.format(TopicArn)
+            if unsubscribe:
+                ret['comment'] += '  {0} subscription(s) would be removed.'.format(
+                        len(current['Subscriptions']))
+            ret['result'] = None
+            return ret
+        if unsubscribe:
+            for sub in current['Subscriptions']:
+                if sub['SubscriptionArn'] == 'PendingConfirmation':
+                    # The API won't let you delete subscriptions in pending status...
+                    log.warning('Ignoring PendingConfirmation subscription {0} {1} on topic '
+                                '{2}'.format( sub['Protocol'], sub['Endpoint'], sub['TopicArn']))
+                    continue
+                if __salt__['boto3_sns.unsubscribe'](sub['SubscriptionArn'], region=region, key=key,
+                                                     keyid=keyid, profile=profile):
+                    log.debug('Deleted subscription {0} for SNS topic {1}'.format(sub, TopicArn))
+                    something_changed = True
+                else:
+                    ret['comment'] = 'Failed to delete subscription {0} for SNS topic {1}'.format(
+                            sub, TopicArn)
+                    ret['result'] = False
+                    return ret
+        if not __salt__['boto3_sns.delete_topic'](TopicArn, region=region, key=key, keyid=keyid,
+                                                  profile=profile):
+            ret['comment'] = 'Failed to delete SNS topic {0}'.format(TopicArn)
+            log.error(ret['comment'])
+            ret['result'] = False
+        else:
+            ret['comment'] = 'AWS SNS topic {0} deleted.'.format(TopicArn)
+            if unsubscribe:
+                ret['comment'] += '  '.join(['Subscription {0} deleted'.format(s)
+                                              for s in current['Subscriptions']])
+            something_changed = True
+
+    if something_changed:
+        ret['changes']['old'] = current
+        ret['changes']['new'] = __salt__['boto3_sns.describe_topic'](name, region, key, keyid, profile)
+    return ret
+
+
+def _json_objs_equal(left, right):
+    left = __utils__['boto3.ordered'](json.loads(left) if isinstance(left, six.string_types) else left)
+    right = __utils__['boto3.ordered'](json.loads(right) if isinstance(right, six.string_types) else right)
+    return left == right


### PR DESCRIPTION
Adds new boto3 versions of the boto_sns execution and state modules.  These provide a few additional functions, and a few new parameters for existing functions.  The specific itch this scratched in my use-case was the need to set configuration attributes (Policy in particular) on the SNS topic resources.

These are by no means feature complete (though they do happen to be marginally moreso than the original boto2 based modules) but I've written them to be easily extensible so anyone needing more capabilities (which could very well be me, next week :) ) should find it easy to do so.