### PR TITLE
Update managed.sls test file: osmajorrelease grain is an int now

### DIFF
--- a/tests/integration/files/file/base/pkgrepo/managed.sls
+++ b/tests/integration/files/file/base/pkgrepo/managed.sls
@@ -1,7 +1,7 @@
 {% if grains['os'] == 'CentOS' %}
 
 # START CentOS pkgrepo tests
-{% if grains['osmajorrelease'] == '7' %}
+{% if grains['osmajorrelease'] == 7 %}
 epel-salttest:
   pkgrepo.managed:
     - humanname: Extra Packages for Enterprise Linux 7 - $basearch (salttest)


### PR DESCRIPTION
### What does this PR do?
We need to make the comparison in the file to `7` instead of `'7'`, otherwise the state doesn't execute correctly and the test_pkgrepo test will fail because the state didn't run.

### What issues does this PR fix or reference?
The change to make the osmajorrelease grain an integer was made in #40581.

### Previous Behavior
`integration.states.test_pkgrepo.PkgrepoTest.test_pkgrepo_01_managed` failed with the following assertion error:
```
Traceback (most recent call last):
  File "//testing/tests/support/helpers.py", line 81, in wrap
    return caller(cls)
  File "//testing/tests/support/helpers.py", line 959, in decorator
    return func(cls, grains=cls.run_function('grains.items'))
  File "/testing/tests/integration/states/test_pkgrepo.py", line 55, in test_pkgrepo_01_managed
    self.assertReturnNonEmptySaltType(ret)
  File "//testing/tests/support/mixins.py", line 492, in assertReturnNonEmptySaltType
    '{} is equal to {}. Salt returned an empty dictionary.'
AssertionError: {} is equal to {}. Salt returned an empty dictionary.
```

### New Behavior
State file is run because the grain is compared appropriately and the test is happy.

### Tests written?

Yes - this is already a test.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
