### PR TITLE
Skip tsl unit test when we hit an error due to OpenSSL and junos-eznc packaging conflict.

### DIFF
--- a/tests/unit/modules/test_tls.py
+++ b/tests/unit/modules/test_tls.py
@@ -292,6 +292,15 @@ class TLSAddTestCase(TestCase, LoaderModuleMockMixin):
                             err
                         )
                     )
+                # python-openssl version 0.14, when installed with the "junos-eznc" pip
+                # package, causes an error on this test. Newer versions of PyOpenSSL do not have
+                # this issue. If 0.14 is installed and we hit this error, skip the test.
+                if LooseVersion(OpenSSL.__version__) == LooseVersion('0.14'):
+                    log.exception(err)
+                    self.skipTest(
+                        'Encountered a package conflict. OpenSSL version 0.14 cannot be used with '
+                        'the "junos-eznc" pip package on this test. Skipping.'
+                    )
                 result = {}
 
         remove_not_in_result(ret, result)


### PR DESCRIPTION
The pip junos-eznc package, when installed with PyOpenSSL version 0.14 causes this test failure. If you either remove junos-eznc, or upgrade PyOpenSSL (current is 0.17) the test is happy. So, we need to handle this case in the test.
