### PR TITLE
get config_dir based off conf_file if __opts__['config_dir'] doesn't exist

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -244,11 +244,16 @@ def _get_key_dir():
     '''
     return the location of the GPG key directory
     '''
+    gpg_keydir = None
     if 'config.get' in __salt__:
         gpg_keydir = __salt__['config.get']('gpg_keydir')
-    else:
+    if not gpg_keydir:
         gpg_keydir = __opts__.get('gpg_keydir')
-    return gpg_keydir or os.path.join(__opts__['config_dir'], 'gpgkeys')
+    if not gpg_keydir and 'config_dir' in __opts__:
+        gpg_keydir = os.path.join(__opts__['config_dir'], 'gpgkeys')
+    else:
+        gpg_keydir = os.path.join(os.path.split(__opts__['conf_file'])[0], 'gpgkeys')
+    return gpg_keydir
 
 
 def _decrypt_ciphertext(cipher, translate_newlines=False):


### PR DESCRIPTION
get config_dir based off conf_file if config_dir not in `__opts__`

ZD 1353

### What does this PR do?
Determines the config dir based off `__opts__['conf_file']` if `__opts__['config_dir']` doesn't exist.
'config_dir' sometimes doesn't exist when running salt from a python script, for some reason. It's not being initialized.  I tested with `--config-dir` on the CLI and it was correctly picked up.

### What issues does this PR fix or reference?
ZD 1353
