### PR TITLE
rsync.py: Don't return changes when clean

### DIFF
--- a/salt/states/rsync.py
+++ b/salt/states/rsync.py
@@ -62,10 +62,15 @@ def _get_changes(rsync_out):
         else:
             copied.append(line)
 
-    return {
+    ret = {
         'copied': os.linesep.join(sorted(copied)) or "N/A",
         'deleted': os.linesep.join(sorted(deleted)) or "N/A",
     }
+
+    # Return whether anything really changed
+    ret['changed'] = not ((ret['copied'] == 'N/A') and (ret['deleted'] == 'N/A'))
+
+    return ret
 
 
 def synchronized(name, source,
@@ -138,12 +143,18 @@ def synchronized(name, source,
             ret['comment'] = _get_summary(result['stdout'])
             return ret
 
+        # Failed
         if result.get('retcode'):
             ret['result'] = False
             ret['comment'] = result['stderr']
             ret['changes'] = result['stdout']
-        else:
+        # Changed
+        elif _get_changes(result['stdout'])['changed']:
             ret['comment'] = _get_summary(result['stdout'])
             ret['changes'] = _get_changes(result['stdout'])
-
+            del ret['changes']['changed'] # Don't need to print the boolean
+        # Clean
+        else:
+            ret['comment'] = _get_summary(result['stdout'])
+            ret['changes'] = {}
     return ret

--- a/salt/states/rsync.py
+++ b/salt/states/rsync.py
@@ -152,7 +152,7 @@ def synchronized(name, source,
         elif _get_changes(result['stdout'])['changed']:
             ret['comment'] = _get_summary(result['stdout'])
             ret['changes'] = _get_changes(result['stdout'])
-            del ret['changes']['changed'] # Don't need to print the boolean
+            del ret['changes']['changed']  # Don't need to print the boolean
         # Clean
         else:
             ret['comment'] = _get_summary(result['stdout'])


### PR DESCRIPTION
### What does this PR do?

rsync.synchronized no longer returns a changes dict 
when the changes are only "N/A".

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/37714

### Previous Behavior
rsync.synchronized would always return a changes dict,
and would be reported as "Changed" even when nothing was done.
This was due to the changes dict reporting "N/A" rather than being empty.

### New Behavior
Changes dict is now empty when nothing was done.

### Tests written?

No
