### PR TITLE
Add option to expand disk size in nebula

### DIFF
--- a/doc/topics/cloud/opennebula.rst
+++ b/doc/topics/cloud/opennebula.rst
@@ -102,6 +102,8 @@ OpenNebula uses an image --> template --> virtual machine paradigm where the tem
 and virtual machines are created from templates. Because of this, there is no need to define a ``size`` in the cloud
 profile. The size of the virtual machine is defined in the template.
 
+Change Disk Size
+================
 
 You can now change the size of a VM on creation by cloning an image and expanding the size. You can accomplish this by
 the following cloud profile settings below.

--- a/doc/topics/cloud/opennebula.rst
+++ b/doc/topics/cloud/opennebula.rst
@@ -109,6 +109,7 @@ You can now change the size of a VM on creation by cloning an image and expandin
 the following cloud profile settings below.
 
 .. code-block:: yaml
+
     my-opennebula-profile:
       provider: my-opennebula-provider
       image: Ubuntu-14.04
@@ -134,6 +135,7 @@ the image attached to the template specified in the profile but a user can add t
 For example the profile below will not use Ubuntu-14.04 for the cloned disk image. It will use the centos7-base-image image:
 
 .. code-block:: yaml
+
     my-opennebula-profile:
       provider: my-opennebula-provider
       image: Ubuntu-14.04
@@ -147,6 +149,7 @@ If you want to use the image attached to the template set in the profile you can
 The profile below will clone the image Ubuntu-14.04 and expand the disk to 8GB.:
 
 .. code-block:: yaml
+
     my-opennebula-profile:
       provider: my-opennebula-provider
       image: Ubuntu-14.04
@@ -158,6 +161,7 @@ The profile below will clone the image Ubuntu-14.04 and expand the disk to 8GB.:
 A user can also currently specify swap or fs disks. Below is an example of this profile setting:
 
 .. code-block:: yaml
+
     my-opennebula-profile:
       provider: my-opennebula-provider
       image: Ubuntu-14.04

--- a/doc/topics/cloud/opennebula.rst
+++ b/doc/topics/cloud/opennebula.rst
@@ -103,6 +103,79 @@ and virtual machines are created from templates. Because of this, there is no ne
 profile. The size of the virtual machine is defined in the template.
 
 
+You can now change the size of a VM on creation by cloning an image and expanding the size. You can accomplish this by
+the following cloud profile settings below.
+
+.. code-block:: yaml
+    my-opennebula-profile:
+      provider: my-opennebula-provider
+      image: Ubuntu-14.04
+      disk:
+        disk0:
+          disk_type: clone
+          size: 8096
+          image: centos7-base-image-v2
+        disk1:
+          disk_type: volatile
+          type: swap
+          size: 4096
+        disk2:
+          disk_type: volatile
+          size: 4096
+          type: fs
+          format: ext3
+
+There are currently two different disk_types a user can use: volatile and clone. Clone which is required when specifying devices
+will clone an image in open nebula and will expand it to the size specified in the profile settings. By default this will clone
+the image attached to the template specified in the profile but a user can add the `image` argument under the disk definition.
+
+For example the profile below will not use Ubuntu-14.04 for the cloned disk image. It will use the centos7-base-image image:
+
+.. code-block:: yaml
+    my-opennebula-profile:
+      provider: my-opennebula-provider
+      image: Ubuntu-14.04
+      disk:
+        disk0:
+          disk_type: clone
+          size: 8096
+          image: centos7-base-image
+
+If you want to use the image attached to the template set in the profile you can simply remove the image argument as show below.
+The profile below will clone the image Ubuntu-14.04 and expand the disk to 8GB.:
+
+.. code-block:: yaml
+    my-opennebula-profile:
+      provider: my-opennebula-provider
+      image: Ubuntu-14.04
+      disk:
+        disk0:
+          disk_type: clone
+          size: 8096
+
+A user can also currently specify swap or fs disks. Below is an example of this profile setting:
+
+.. code-block:: yaml
+    my-opennebula-profile:
+      provider: my-opennebula-provider
+      image: Ubuntu-14.04
+      disk:
+        disk0:
+          disk_type: clone
+          size: 8096
+        disk1:
+          disk_type: volatile
+          type: swap
+          size: 4096
+        disk2:
+          disk_type: volatile
+          size: 4096
+          type: fs
+          format: ext3
+
+The example above will attach both a swap disk and a ext3 filesystem with a size of 4GB. To note if you define other disks you have
+to define the image disk to clone because the template will write over the entire 'DISK=[]' template definition on creation.
+
 .. _opennebula-required-settings:
 
 Required Settings

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -1049,11 +1049,12 @@ def create(vm_):
         for disk in get_disks:
             template.append(_get_device_template(disk, get_disks[disk],
                                  template=template_name))
+        if 'CLONE' not in str(template):
+            raise SaltCloudSystemExit(
+                'Missing an image disk to clone. Must define a clone disk alongside all other disk definitions.'
+            )
+
     template_args = "\n".join(template)
-    if 'CLONE' not in template_args:
-        raise SaltCloudSystemExit(
-            'Missing an image disk to clone. Must define a clone disk alongside all other disk definitions.'
-        )
 
     try:
         server, user, password = _get_xml_rpc()

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -752,6 +752,40 @@ def get_secgroup_id(kwargs=None, call=None):
     return ret
 
 
+def get_template_image(kwargs=None, call=None):
+    '''
+    Returns a template's image from the given template name.
+
+    .. versionadded:: oxygen
+
+    .. code-block:: bash
+
+        salt-cloud -f get_template_image opennebula name=my-template-name
+    '''
+    if call == 'action':
+        raise SaltCloudSystemExit(
+            'The get_template_image function must be called with -f or --function.'
+        )
+
+    if kwargs is None:
+        kwargs = {}
+
+    name = kwargs.get('name', None)
+    if name is None:
+        raise SaltCloudSystemExit(
+            'The get_template_image function requires a \'name\'.'
+        )
+
+    try:
+        ret = list_templates()[name]['template']['disk']['image']
+    except KeyError:
+        raise SaltCloudSystemExit(
+            'The image for template \'{1}\' could not be found.'.format(name)
+        )
+
+    return ret
+
+
 def get_template_id(kwargs=None, call=None):
     '''
     Returns a template's ID from the given template name.
@@ -766,7 +800,7 @@ def get_template_id(kwargs=None, call=None):
     '''
     if call == 'action':
         raise SaltCloudSystemExit(
-            'The list_nodes_full function must be called with -f or --function.'
+            'The get_template_id function must be called with -f or --function.'
         )
 
     if kwargs is None:
@@ -782,7 +816,7 @@ def get_template_id(kwargs=None, call=None):
         ret = list_templates()[name]['id']
     except KeyError:
         raise SaltCloudSystemExit(
-            'The template \'{0}\' could not be foound.'.format(name)
+            'The template \'{0}\' could not be found.'.format(name)
         )
 
     return ret
@@ -881,6 +915,53 @@ def get_vn_id(kwargs=None, call=None):
     return ret
 
 
+def _get_device_template(disk, disk_info, template=None):
+    '''
+    Returns the template format to create a disk in open nebula
+
+    .. versionadded:: oxygen
+
+    '''
+    def _require_disk_opts(*args):
+        for arg in args:
+            if arg not in disk_info:
+                raise SaltCloudSystemExit(
+                    'The disk {0} requires a {1}\
+                    argument'.format(disk, arg)
+                )
+
+    _require_disk_opts('disk_type', 'size')
+
+    size = disk_info['size']
+    disk_type = disk_info['disk_type']
+
+    if disk_type == 'clone':
+        if 'image' in disk_info:
+            clone_image = disk_info['image']
+        else:
+            clone_image = get_template_image(kwargs={'name':
+                                                    template})
+
+        clone_image_id = get_image_id(kwargs={'name': clone_image})
+        temp = 'DISK=[IMAGE={0}, IMAGE_ID={1}, CLONE=YES,\
+                        SIZE={2}]'.format(clone_image, clone_image_id,
+                                          size)
+        return temp
+
+    if disk_type == 'volatile':
+        _require_disk_opts('type')
+        v_type = disk_info['type']
+        temp = 'DISK=[TYPE={0}, SIZE={1}]'.format(v_type, size)
+
+        if v_type == 'fs':
+            _require_disk_opts('format')
+            format = disk_info['format']
+            temp = 'DISK=[TYPE={0}, SIZE={1}, FORMAT={2}]'.format(v_type,
+                                                                  size, format)
+        return temp
+    #TODO add persistant disk_type
+
+
 def create(vm_):
     r'''
     Create a single VM from a data dict.
@@ -962,7 +1043,17 @@ def create(vm_):
         template.append('CPU={0}'.format(vm_.get('cpu')))
     if vm_.get('vcpu'):
         template.append('VCPU={0}'.format(vm_.get('vcpu')))
+    if vm_.get('disk'):
+        get_disks = vm_.get('disk')
+        template_name = vm_['image']
+        for disk in get_disks:
+            template.append(_get_device_template(disk, get_disks[disk],
+                                 template=template_name))
     template_args = "\n".join(template)
+    if 'CLONE' not in template_args:
+        raise SaltCloudSystemExit(
+            'Missing an image disk to clone. Must define a clone disk alongside all other disk definitions.'
+        )
 
     try:
         server, user, password = _get_xml_rpc()


### PR DESCRIPTION
### What does this PR do?
Adds the ability for users to clone an image from a template  in open nebula and expand the disk size. Also users can now add additional filesystem disks and larger swap disks. If disks are defined then the user needs to ensure they always include the clone'd image settings because the entire 'DISK=[]' template will get written over on creation in open nebula. 

TODO: Still want to add definition to add a persistent disk. 

### Tests written?
No
