### PR TITLE
Fix incorrect conditional for AIX in Salt 2016.11.4 timezone.get_offset

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -198,7 +198,7 @@ def get_offset():
 
         salt '*' timezone.get_offset
     '''
-    if 'AIX' not in __grains__['os_family']:
+    if 'AIX' in __grains__['os_family']:
         return __salt__['cmd.run'](['date', '+%z'], python_shell=False)
 
     salt_path = '/opt/salt/bin/date'


### PR DESCRIPTION
### What does this PR do?
Fixes wrong conditional check for AIX in timezone.get_offset

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40831

### Previous Behavior
Tried to use non-existant /opt/salt/bin/date on AIX insterd of OS's date

### New Behavior
Use AIX OS's date from /usr/bin/date

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
