### PR TITLE
Set virtual grain for OpenBSD on KVM

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -701,7 +701,7 @@ def _virtual(osdata):
                 'to execute them. Grains output might not be accurate.'
             )
 
-    choices = ('Linux', 'OpenBSD', 'HP-UX')
+    choices = ('Linux', 'HP-UX')
     isdir = os.path.isdir
     sysctl = salt.utils.which('sysctl')
     if osdata['kernel'] in choices:
@@ -827,6 +827,9 @@ def _virtual(osdata):
                 grains['virtual_subtype'] = 'jail'
             if 'QEMU Virtual CPU' in model:
                 grains['virtual'] = 'kvm'
+    elif osdata['kernel'] == 'OpenBSD':
+        if osdata['manufacturer'] == 'QEMU':
+            grains['virtual'] = 'kvm'
     elif osdata['kernel'] == 'SunOS':
         # Check if it's a "regular" zone. (i.e. Solaris 10/11 zone)
         zonename = salt.utils.which('zonename')


### PR DESCRIPTION
### What does this PR do?

None of the file system tests for `/sys` or `/proc` can succeed on OpenBSD; use a new branch for determining the `virtual` grain

### What issues does this PR fix or reference?

#40498

### Previous Behavior

The `virtual` grain always returns `physical` on OpenBSD

### New Behavior

`kvm` is reported if running in a hyperviser that reports the manufacturer `QEMU`

### Tests written?

No, tested manually as follows:

Output on a KVM host:

    $ salt-call --local grains.items | egrep -A1 'kernel|productname|manufacturer|virtual'

        kernel:
            OpenBSD
        kernelrelease:
            6.1
        manufacturer:
            QEMU
        productname:
            CloudSigma
        virtual:
            kvm

Output on bare metal:

    $ salt-call --local grains.items | egrep -A1 'kernel|productname|manufacturer|virtual'

        kernel:
            OpenBSD
        kernelrelease:
            6.1
        manufacturer:
            LENOVO
        productname:
            417152U
        virtual:
            physical

