### PR TITLE
try to fix a modules.file.line bug

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1555,7 +1555,7 @@ def _regex_to_static(src, regex):
         return None
 
     try:
-        src = re.search(regex, src)
+        src = re.search(regex, src, re.M)
     except Exception as ex:
         raise CommandExecutionError("{0}: '{1}'".format(_get_error_message(ex), regex))
 


### PR DESCRIPTION
re.search in function _regex_to_static() should support re.MULTILINE or cause a bug

	modified:   file.py

### What does this PR do?

fix a regexp bug in modules.file.line

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/40838

### Tests written?

No