### PR TITLE
fix redis returner clean_old_jobs

### DIFF
--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -49,6 +49,7 @@ To override individual configuration items, append --return_kwargs '{"key:": "va
 # Import python libs
 from __future__ import absolute_import
 import json
+import logging
 
 # Import Salt libs
 import salt.ext.six as six
@@ -62,6 +63,8 @@ try:
     HAS_REDIS = True
 except ImportError:
     HAS_REDIS = False
+
+log = logging.getLogger(__name__)
 
 # Define the module's virtual name
 __virtualname__ = 'redis'
@@ -221,14 +224,16 @@ def clean_old_jobs():
     do manually cleaning here.
     '''
     serv = _get_serv(ret=None)
+    ret_jids = serv.keys('ret:*')
     living_jids = set(serv.keys('load:*'))
     to_remove = []
-    for ret_key in serv.keys('ret:*'):
+    for ret_key in ret_jids:
         load_key = ret_key.replace('ret:', 'load:', 1)
         if load_key not in living_jids:
             to_remove.append(ret_key)
     if len(to_remove) != 0:
         serv.delete(*to_remove)
+        log.debug('clean old jobs: {0}'.format(to_remove))
 
 
 def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument


### PR DESCRIPTION
### What does this PR do?
Fix redis returner clean_old_jobs will delete new jid bug

### What issues does this PR fix or reference?
As the code shows, first, `serv.keys('load:*')` gets all the jobs' load from the redis.
Then `serv.keys('ret:*')` gets all the jobs' return from the redis, it will take some time.

When the `serv.keys('ret:*')` is running, if a new job load and return are set into redis, 
then `serv.keys('ret:*')` will get this new jid, but the new jid is not in the `living_jids`. 
So this new jid will be appended to `to_remove` list and will be deleted.
The redis `clean_old_job` cleans a new job.
This is not what we want to see.
