### PR TITLE
Adding safe batch sizes; automatically switch to batch mode if >X min…

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -89,7 +89,7 @@ class Batch(object):
                 else:
                     return int(res)
             else:
-                return int(self.opts['batch'])
+                return int(float(self.opts['batch']))
         except ValueError:
             if not self.quiet:
                 print_cli('Invalid batch data sent: {0}\nData must be in the '
@@ -103,7 +103,7 @@ class Batch(object):
         if i:
             del wait[:i]
 
-    def run(self):
+    def run(self, safe_batch = False):
         '''
         Execute the batch run
         '''
@@ -113,6 +113,8 @@ class Batch(object):
                 self.opts['timeout'],
                 'list',
                 ]
+        if safe_batch:
+            self.opts['batch'] = str(safe_batch)
         bnum = self.get_bnum()
         # No targets to run
         if not self.minions:

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -94,8 +94,12 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                     safe_batch = 8
                 elif int(self.options.batch_safe_size) <= 1:
                     safe_batch = 1
-                else:
+                elif self.options.batch_safe_size:
                     safe_batch = self.options.batch_safe_size
+                elif self.options.batch_size:
+                    safe_batch = self.options.batch_size
+                else:
+                    safe_batch = 5
                 self._run_batch(safe_batch)
                 return
 

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -219,7 +219,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         '''
         return self.local_client.gather_minions(self.config['tgt'], self.selected_target_option or 'glob')
 
-    def _run_batch(self, safe_batch = False):
+    def _run_batch(self, safe_batch=False):
         import salt.cli.batch
         eauth = {}
         if 'token' in self.config:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1913,6 +1913,23 @@ class SaltCMDOptionParser(six.with_metaclass(OptionParserMeta,
                   'before freeing the slot in the batch for the next one.')
         )
         self.add_option(
+            '--batch-safe-limit',
+            default=0,
+            dest='batch_safe_limit',
+            type=float,
+            help=('When set, verify that a glob will not execute on more than '
+                  'this many minions. If this trigger is hit, then the '
+                  'requested job will be executed as a batch job.')
+        )
+        self.add_option(
+            '--batch-safe-size',
+            default=8,
+            dest='batch_safe_size',
+            type=float,
+            help=('Executions that have triggered the batch safe limit will '
+                  'be run in batches of this size.')
+        )
+        self.add_option(
             '--return',
             default='',
             metavar='RETURNER',

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1926,8 +1926,10 @@ class SaltCMDOptionParser(six.with_metaclass(OptionParserMeta,
             default=8,
             dest='batch_safe_size',
             type=float,
-            help=('Executions that have triggered the batch safe limit will '
-                  'be run in batches of this size.')
+            help=('If a the safe batch limit (target > safe-limit), then '
+                  'silently transition to batch size of --batch-safe-size '
+                  'if set or else use default batch size. If no option is '
+                  'set a default batch size of five (5) will be used.')
         )
         self.add_option(
             '--return',


### PR DESCRIPTION
…ions are targeted.

^ Is this an automatic thing that means something?

### What does this PR do?

This creates two option that allow automatic batch executions.

### What issues does this PR fix or reference?

Issue #19054

### New Behavior

Instead of accidentally running one command on 500 (or many more) systems, this patch creates the ability to set safety limits so that when greater than <safe_limit> minions are specified, the command is passively shifted to a batch execution.

### Tests written?

No