### PR TITLE
Added execution and state modules for Apache Libcloud

### DIFF
--- a/doc/ref/modules/all/salt.modules.libcloud_storage.rst
+++ b/doc/ref/modules/all/salt.modules.libcloud_storage.rst
@@ -1,0 +1,6 @@
+salt.modules.libcloud_storage module
+================================
+
+.. automodule:: salt.modules.libcloud_storage
+    :members:
+    :undoc-members:

--- a/doc/ref/states/all/salt.states.libcloud_storage.rst
+++ b/doc/ref/states/all/salt.states.libcloud_storage.rst
@@ -1,0 +1,6 @@
+salt.states.libcloud_storage module
+===============================
+
+.. automodule:: salt.states.libcloud_storage
+    :members:
+    :undoc-members:

--- a/salt/modules/libcloud_dns.py
+++ b/salt/modules/libcloud_dns.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
+Apache Libcloud DNS Management
+==============================
+
 Connection module for Apache Libcloud DNS management
 
 .. versionadded:: 2016.11.0

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+'''
+Connection module for Apache Libcloud Storage (object/blob) management for a full list
+of supported clouds, see http://libcloud.readthedocs.io/en/latest/storage/supported_providers.html
+
+.. versionadded:: Nitrogen
+
+:configuration:
+    This module uses a configuration profile for one or multiple Storage providers
+
+    .. code-block:: yaml
+
+        libcloud_storage:
+            profile_test1:
+              driver: google_storage
+              key: GOOG0123456789ABCXYZ
+              secret: mysecret
+            profile_test2:
+              driver: s3
+              key: 12345
+              secret: mysecret
+
+:depends: apache-libcloud
+'''
+# keep lint from choking on _get_conn and _cache_id
+#pylint: disable=E0602
+
+from __future__ import absolute_import
+
+# Import Python libs
+import logging
+
+# Import salt libs
+import salt.utils.compat
+from salt.utils.versions import LooseVersion as _LooseVersion
+
+log = logging.getLogger(__name__)
+
+# Import third party libs
+REQUIRED_LIBCLOUD_VERSION = '2.0.0'
+try:
+    #pylint: disable=unused-import
+    import libcloud
+    from libcloud.storage.providers import get_driver
+    #pylint: enable=unused-import
+    if hasattr(libcloud, '__version__') and _LooseVersion(libcloud.__version__) < _LooseVersion(REQUIRED_LIBCLOUD_VERSION):
+        raise ImportError()
+    logging.getLogger('libcloud').setLevel(logging.CRITICAL)
+    HAS_LIBCLOUD = True
+except ImportError:
+    HAS_LIBCLOUD = False
+
+
+def __virtual__():
+    '''
+    Only load if libcloud libraries exist.
+    '''
+    if not HAS_LIBCLOUD:
+        msg = ('A apache-libcloud library with version at least {0} was not '
+               'found').format(REQUIRED_LIBCLOUD_VERSION)
+        return (False, msg)
+    return True
+
+
+def __init__(opts):
+    salt.utils.compat.pack_dunder(__name__)
+
+
+def _get_driver(profile):
+    config = __salt__['config.option']('libcloud_storage')[profile]
+    cls = get_driver(config['driver'])
+    args = config
+    del args['driver']
+    args['key'] = config.get('key')
+    args['secret'] = config.get('secret', None)
+    args['secure'] = config.get('secure', True)
+    args['host'] = config.get('host', None)
+    args['port'] = config.get('port', None)
+    return cls(**args)

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -254,7 +254,6 @@ def download_object(container_name, object_name, destination_path, profile,
 
     """
     conn = _get_driver(profile=profile)
-    container = conn.get_container(container_name)
     obj = conn.get_object(container_name, object_name)
     return conn.download_object(obj, destination_path, overwrite_existing, delete_on_failure)
 
@@ -324,7 +323,6 @@ def delete_object(container_name, object_name, profile):
         salt myminion libcloud_storage.delete_object MyFolder me.jpg profile1
     """
     conn = _get_driver(profile=profile)
-    container = conn.get_container(container_name)
     obj = conn.get_object(container_name, object_name)
     return conn.delete_object(obj)
 

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -102,6 +102,7 @@ def list_containers(profile):
         })
     return ret
 
+
 def list_container_objects(container_name, profile):
     '''
     List container objects (e.g. files) for the given container_id on the given profile
@@ -133,6 +134,31 @@ def list_container_objects(container_name, profile):
         })
     return ret
 
+
+def get_container(container_name, profile):
+    '''
+    Create a container in the cloud
+
+    :param container_name: Container name
+    :type  container_name: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion libcloud_storage.get_container MyFolder profile1
+    '''
+    conn = _get_driver(profile=profile)
+    container = conn.create_container(container_name)
+    return {
+            'name': container.name,
+            'extra': container.extra
+            }
+
+
 def get_container(container_name, profile):
     '''
     List container details for the given container_name on the given profile
@@ -155,6 +181,37 @@ def get_container(container_name, profile):
             'name': container.name,
             'extra': container.extra
             }
+
+
+def get_container_object(container_name, object_name, profile):
+    '''
+    Get the details for a container object (file or object in the cloud)
+
+    :param container_name: Container name
+    :type  container_name: ``str``
+
+    :param object_name: Object name
+    :type  object_name: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion libcloud_storage.get_container_object MyFolder MyFile.xyz profile1
+    '''
+    conn = _get_driver(profile=profile)
+    obj = conn.get_container_object(container_name, object_name)
+    return {
+        'name': obj.name,
+        'size': obj.size,
+        'hash': obj.hash,
+        'container': obj.container.name,
+        'extra': obj.extra,
+        'meta_data': obj.meta_data}
+
 
 def download_object(container_name, object_name, destination_path, profile, 
                     overwrite_existing=False, delete_on_failure=True):
@@ -192,6 +249,7 @@ def download_object(container_name, object_name, destination_path, profile,
     obj = conn.get_object(container_name, object_name)
     return conn.download_object(obj, destination_path, overwrite_existing, delete_on_failure)
 
+
 def upload_object(file_path, container_name, object_name, profile, extra=None,
                       verify_hash=True, headers=None):
     """
@@ -226,3 +284,26 @@ def upload_object(file_path, container_name, object_name, profile, extra=None,
     container = conn.get_container(container_name)
     obj = conn.upload_object(file_path, container, object_name, extra, verify_hash, headers)
     return obj.name
+
+
+def delete_object(container_name, object_name, profile):
+    """
+    Delete an object in the cloud
+
+    :param container_name: Container name
+    :type  container_name: ``str``
+
+    :param object_name: Object name
+    :type  object_name: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+
+    :return: True if an object has been successfully deleted, False
+                otherwise.
+    :rtype: ``bool``
+    """
+    conn = _get_driver(profile=profile)
+    container = conn.get_container(container_name)
+    obj = conn.get_object(container_name, object_name)
+    return conn.delete_object(obj)

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -77,3 +77,125 @@ def _get_driver(profile):
     args['host'] = config.get('host', None)
     args['port'] = config.get('port', None)
     return cls(**args)
+
+def list_containers(profile):
+    '''
+    Return a list of containers.
+
+    :param profile: The profile key
+    :type  profile: ``str``
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion libcloud_storage.list_containers profile1
+    '''
+    conn = _get_driver(profile=profile)
+    return conn.list_containers()
+
+def list_container_objects(container_name, profile):
+    '''
+    List container objects (e.g. files) for the given container_id on the given profile
+
+    :param container_name: Container name
+    :type  container_name: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion libcloud_storage.list_container_objects MyFolder profile1
+    '''
+    conn = _get_driver(profile=profile)
+    container = conn.get_container(container_name)
+    return conn.list_container_objects(container)
+
+def get_container(container_name, profile):
+    '''
+    List container details for the given container_name on the given profile
+
+    :param container_name: Container name
+    :type  container_name: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion libcloud_storage.get_container MyFolder profile1
+    '''
+    conn = _get_driver(profile=profile)
+    return conn.get_container(container_name)
+
+def download_object(container_name, object_name, destination_path, overwrite_existing=False,
+                        delete_on_failure=True, profile):
+    """
+    Download an object to the specified destination path.
+
+    :param container_name: Container name
+    :type  container_name: ``str``
+
+    :param object_name: Object name
+    :type  object_name: ``str``
+
+    :param destination_path: Full path to a file or a directory where the
+                                incoming file will be saved.
+    :type destination_path: ``str``
+
+    :param overwrite_existing: True to overwrite an existing file,
+                                defaults to False.
+    :type overwrite_existing: ``bool``
+
+    :param delete_on_failure: True to delete a partially downloaded file if
+                                the download was not successful (hash
+                                mismatch / file size).
+    :type delete_on_failure: ``bool``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+
+    :return: True if an object has been successfully downloaded, False
+                otherwise.
+    :rtype: ``bool``
+    """
+    conn = _get_driver(profile=profile)
+    container = conn.get_container(container_name)
+    obj = conn.get_object(container_name, object_name)
+    return conn.download_object(obj, destination_path, overwrite_existing, delete_on_failure)
+
+def upload_object(self, file_path, container, object_name, extra=None,
+                      verify_hash=True, headers=None):
+    """
+    Upload an object currently located on a disk.
+
+    :param file_path: Path to the object on disk.
+    :type file_path: ``str``
+
+    :param container_name: Destination container.
+    :type container_name: ``str``
+
+    :param object_name: Object name.
+    :type object_name: ``str``
+
+    :param verify_hash: Verify hash
+    :type verify_hash: ``bool``
+
+    :param extra: Extra attributes (driver specific). (optional)
+    :type extra: ``dict``
+
+    :param headers: (optional) Additional request headers,
+        such as CORS headers. For example:
+        headers = {'Access-Control-Allow-Origin': 'http://mozilla.com'}
+    :type headers: ``dict``
+
+    :rtype: :class:`Object`
+    """
+    conn = _get_driver(profile=profile)
+    container = conn.get_container(container_name)
+    return conn.upload_object(file_path, container, object_name, extra, verify_hash, headers)

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -137,7 +137,7 @@ def list_container_objects(container_name, profile):
     return ret
 
 
-def get_container(container_name, profile):
+def create_container(container_name, profile):
     '''
     Create a container in the cloud
 
@@ -151,7 +151,7 @@ def get_container(container_name, profile):
 
     .. code-block:: bash
 
-        salt myminion libcloud_storage.get_container MyFolder profile1
+        salt myminion libcloud_storage.create_container MyFolder profile1
     '''
     conn = _get_driver(profile=profile)
     container = conn.create_container(container_name)
@@ -215,7 +215,7 @@ def get_container_object(container_name, object_name, profile):
         'meta_data': obj.meta_data}
 
 
-def download_object(container_name, object_name, destination_path, profile, 
+def download_object(container_name, object_name, destination_path, profile,
                     overwrite_existing=False, delete_on_failure=True):
     """
     Download an object to the specified destination path.
@@ -245,6 +245,13 @@ def download_object(container_name, object_name, destination_path, profile,
     :return: True if an object has been successfully downloaded, False
                 otherwise.
     :rtype: ``bool``
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion libcloud_storage.download_object MyFolder me.jpg /tmp/me.jpg profile1
+
     """
     conn = _get_driver(profile=profile)
     container = conn.get_container(container_name)
@@ -280,7 +287,12 @@ def upload_object(file_path, container_name, object_name, profile, extra=None,
         headers = {'Access-Control-Allow-Origin': 'http://mozilla.com'}
     :type headers: ``dict``
 
-    :rtype: :class:`Object`
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion libcloud_storage.upload_object /file/to/me.jpg MyFolder me.jpg profile1
+
     """
     conn = _get_driver(profile=profile)
     container = conn.get_container(container_name)
@@ -304,6 +316,12 @@ def delete_object(container_name, object_name, profile):
     :return: True if an object has been successfully deleted, False
                 otherwise.
     :rtype: ``bool``
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion libcloud_storage.delete_object MyFolder me.jpg profile1
     """
     conn = _get_driver(profile=profile)
     container = conn.get_container(container_name)
@@ -324,6 +342,12 @@ def delete_container(container_name, object_name, profile):
     :return: True if an object container has been successfully deleted, False
                 otherwise.
     :rtype: ``bool``
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion libcloud_storage.delete_container MyFolder profile1
     """
     conn = _get_driver(profile=profile)
     container = conn.get_container(container_name)

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -133,8 +133,8 @@ def get_container(container_name, profile):
     conn = _get_driver(profile=profile)
     return conn.get_container(container_name)
 
-def download_object(container_name, object_name, destination_path, overwrite_existing=False,
-                        delete_on_failure=True, profile):
+def download_object(container_name, object_name, destination_path, profile, 
+                    overwrite_existing=False, delete_on_failure=True):
     """
     Download an object to the specified destination path.
 
@@ -148,6 +148,9 @@ def download_object(container_name, object_name, destination_path, overwrite_exi
                                 incoming file will be saved.
     :type destination_path: ``str``
 
+    :param profile: The profile key
+    :type  profile: ``str``
+
     :param overwrite_existing: True to overwrite an existing file,
                                 defaults to False.
     :type overwrite_existing: ``bool``
@@ -156,9 +159,6 @@ def download_object(container_name, object_name, destination_path, overwrite_exi
                                 the download was not successful (hash
                                 mismatch / file size).
     :type delete_on_failure: ``bool``
-
-    :param profile: The profile key
-    :type  profile: ``str``
 
     :return: True if an object has been successfully downloaded, False
                 otherwise.
@@ -169,7 +169,7 @@ def download_object(container_name, object_name, destination_path, overwrite_exi
     obj = conn.get_object(container_name, object_name)
     return conn.download_object(obj, destination_path, overwrite_existing, delete_on_failure)
 
-def upload_object(self, file_path, container, object_name, extra=None,
+def upload_object(self, file_path, container_name, object_name, profile, extra=None,
                       verify_hash=True, headers=None):
     """
     Upload an object currently located on a disk.
@@ -182,6 +182,9 @@ def upload_object(self, file_path, container, object_name, extra=None,
 
     :param object_name: Object name.
     :type object_name: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
 
     :param verify_hash: Verify hash
     :type verify_hash: ``bool``

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 '''
+Apache Libcloud Storage Management
+==================================
+
 Connection module for Apache Libcloud Storage (object/blob) management for a full list
 of supported clouds, see http://libcloud.readthedocs.io/en/latest/storage/supported_providers.html
 
 Clouds include Amazon S3, Google Storage, Aliyun, Azure Blobs, Ceph, OpenStack swift
 
-.. versionadded:: Nitrogen
+.. versionadded:: Oxygen
 
 :configuration:
     This module uses a configuration profile for one or multiple Storage providers
@@ -217,7 +220,7 @@ def get_container_object(container_name, object_name, profile):
 
 def download_object(container_name, object_name, destination_path, profile,
                     overwrite_existing=False, delete_on_failure=True):
-    """
+    '''
     Download an object to the specified destination path.
 
     :param container_name: Container name
@@ -252,7 +255,7 @@ def download_object(container_name, object_name, destination_path, profile,
 
         salt myminion libcloud_storage.download_object MyFolder me.jpg /tmp/me.jpg profile1
 
-    """
+    '''
     conn = _get_driver(profile=profile)
     obj = conn.get_object(container_name, object_name)
     return conn.download_object(obj, destination_path, overwrite_existing, delete_on_failure)
@@ -260,7 +263,7 @@ def download_object(container_name, object_name, destination_path, profile,
 
 def upload_object(file_path, container_name, object_name, profile, extra=None,
                       verify_hash=True, headers=None):
-    """
+    '''
     Upload an object currently located on a disk.
 
     :param file_path: Path to the object on disk.
@@ -286,13 +289,16 @@ def upload_object(file_path, container_name, object_name, profile, extra=None,
         headers = {'Access-Control-Allow-Origin': 'http://mozilla.com'}
     :type headers: ``dict``
 
+    :return: The object name in the cloud
+    :rtype: ``str``
+
     CLI Example:
 
     .. code-block:: bash
 
         salt myminion libcloud_storage.upload_object /file/to/me.jpg MyFolder me.jpg profile1
 
-    """
+    '''
     conn = _get_driver(profile=profile)
     container = conn.get_container(container_name)
     obj = conn.upload_object(file_path, container, object_name, extra, verify_hash, headers)
@@ -300,7 +306,7 @@ def upload_object(file_path, container_name, object_name, profile, extra=None,
 
 
 def delete_object(container_name, object_name, profile):
-    """
+    '''
     Delete an object in the cloud
 
     :param container_name: Container name
@@ -321,14 +327,14 @@ def delete_object(container_name, object_name, profile):
     .. code-block:: bash
 
         salt myminion libcloud_storage.delete_object MyFolder me.jpg profile1
-    """
+    '''
     conn = _get_driver(profile=profile)
     obj = conn.get_object(container_name, object_name)
     return conn.delete_object(obj)
 
 
 def delete_container(container_name, object_name, profile):
-    """
+    '''
     Delete an object container in the cloud
 
     :param container_name: Container name
@@ -346,7 +352,7 @@ def delete_container(container_name, object_name, profile):
     .. code-block:: bash
 
         salt myminion libcloud_storage.delete_container MyFolder profile1
-    """
+    '''
     conn = _get_driver(profile=profile)
     container = conn.get_container(container_name)
     return conn.delete_container(container)

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -78,6 +78,12 @@ def _get_driver(profile):
     args['port'] = config.get('port', None)
     return cls(**args)
 
+
+def list_profiles():
+    keys, _ = __salt__['config.option']('libcloud_storage').items()
+    return keys
+
+
 def list_containers(profile):
     '''
     Return a list of containers.

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -3,6 +3,8 @@
 Connection module for Apache Libcloud Storage (object/blob) management for a full list
 of supported clouds, see http://libcloud.readthedocs.io/en/latest/storage/supported_providers.html
 
+Clouds include Amazon S3, Google Storage, Aliyun, Azure Blobs, Ceph, OpenStack swift
+
 .. versionadded:: Nitrogen
 
 :configuration:
@@ -37,7 +39,7 @@ from salt.utils.versions import LooseVersion as _LooseVersion
 log = logging.getLogger(__name__)
 
 # Import third party libs
-REQUIRED_LIBCLOUD_VERSION = '2.0.0'
+REQUIRED_LIBCLOUD_VERSION = '1.5.0
 try:
     #pylint: disable=unused-import
     import libcloud
@@ -307,3 +309,22 @@ def delete_object(container_name, object_name, profile):
     container = conn.get_container(container_name)
     obj = conn.get_object(container_name, object_name)
     return conn.delete_object(obj)
+
+
+def delete_container(container_name, object_name, profile):
+    """
+    Delete an object container in the cloud
+
+    :param container_name: Container name
+    :type  container_name: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+
+    :return: True if an object container has been successfully deleted, False
+                otherwise.
+    :rtype: ``bool``
+    """
+    conn = _get_driver(profile=profile)
+    container = conn.get_container(container_name)
+    return conn.delete_container(container)

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -333,7 +333,7 @@ def delete_object(container_name, object_name, profile):
     return conn.delete_object(obj)
 
 
-def delete_container(container_name, object_name, profile):
+def delete_container(container_name, profile):
     '''
     Delete an object container in the cloud
 

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -39,7 +39,7 @@ from salt.utils.versions import LooseVersion as _LooseVersion
 log = logging.getLogger(__name__)
 
 # Import third party libs
-REQUIRED_LIBCLOUD_VERSION = '1.5.0
+REQUIRED_LIBCLOUD_VERSION = '1.5.0'
 try:
     #pylint: disable=unused-import
     import libcloud

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -192,7 +192,7 @@ def download_object(container_name, object_name, destination_path, profile,
     obj = conn.get_object(container_name, object_name)
     return conn.download_object(obj, destination_path, overwrite_existing, delete_on_failure)
 
-def upload_object(self, file_path, container_name, object_name, profile, extra=None,
+def upload_object(file_path, container_name, object_name, profile, extra=None,
                       verify_hash=True, headers=None):
     """
     Upload an object currently located on a disk.

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -217,7 +217,7 @@ def get_container_object(container_name, object_name, profile):
 
 def download_object(container_name, object_name, destination_path, profile,
                     overwrite_existing=False, delete_on_failure=True):
-    """
+    '''
     Download an object to the specified destination path.
 
     :param container_name: Container name
@@ -252,7 +252,7 @@ def download_object(container_name, object_name, destination_path, profile,
 
         salt myminion libcloud_storage.download_object MyFolder me.jpg /tmp/me.jpg profile1
 
-    """
+    '''
     conn = _get_driver(profile=profile)
     obj = conn.get_object(container_name, object_name)
     return conn.download_object(obj, destination_path, overwrite_existing, delete_on_failure)
@@ -260,7 +260,7 @@ def download_object(container_name, object_name, destination_path, profile,
 
 def upload_object(file_path, container_name, object_name, profile, extra=None,
                       verify_hash=True, headers=None):
-    """
+    '''
     Upload an object currently located on a disk.
 
     :param file_path: Path to the object on disk.
@@ -292,7 +292,7 @@ def upload_object(file_path, container_name, object_name, profile, extra=None,
 
         salt myminion libcloud_storage.upload_object /file/to/me.jpg MyFolder me.jpg profile1
 
-    """
+    '''
     conn = _get_driver(profile=profile)
     container = conn.get_container(container_name)
     obj = conn.upload_object(file_path, container, object_name, extra, verify_hash, headers)
@@ -300,7 +300,7 @@ def upload_object(file_path, container_name, object_name, profile, extra=None,
 
 
 def delete_object(container_name, object_name, profile):
-    """
+    '''
     Delete an object in the cloud
 
     :param container_name: Container name
@@ -321,14 +321,14 @@ def delete_object(container_name, object_name, profile):
     .. code-block:: bash
 
         salt myminion libcloud_storage.delete_object MyFolder me.jpg profile1
-    """
+    '''
     conn = _get_driver(profile=profile)
     obj = conn.get_object(container_name, object_name)
     return conn.delete_object(obj)
 
 
 def delete_container(container_name, object_name, profile):
-    """
+    '''
     Delete an object container in the cloud
 
     :param container_name: Container name
@@ -346,7 +346,7 @@ def delete_container(container_name, object_name, profile):
     .. code-block:: bash
 
         salt myminion libcloud_storage.delete_container MyFolder profile1
-    """
+    '''
     conn = _get_driver(profile=profile)
     container = conn.get_container(container_name)
     return conn.delete_container(container)

--- a/salt/states/libcloud_storage.py
+++ b/salt/states/libcloud_storage.py
@@ -39,7 +39,7 @@ Creating a container and uploading a file
 
     web_things:
       libcloud_storage.container_present:
-        name: my_container_name  
+        name: my_container_name
         profile: profile1
       libcloud_storage.object_present:
         name: my_file.jpg
@@ -97,7 +97,6 @@ def container_present(name, profile):
     :type  profile: ``str``
     '''
     containers = __salt__['libcloud_storage.list_containers'](profile)
-    
     match = [z for z in containers if z.name == name]
     if len(match) > 0:
         return state_result(True, "Container already exists")
@@ -117,7 +116,6 @@ def container_absent(name, profile):
     :type  profile: ``str``
     '''
     containers = __salt__['libcloud_storage.list_containers'](profile)
-    
     match = [z for z in containers if z.name == name]
     if len(match) == 0:
         return state_result(True, "Container already absent")
@@ -143,7 +141,6 @@ def object_present(container, name, path, profile):
     :type  profile: ``str``
     '''
     existing_object = __salt__['libcloud_storage.get_container_object'](container, name, profile)
-    
     if existing_object is not None:
         return state_result(True, "Object already present")
     else:
@@ -165,7 +162,6 @@ def object_absent(container, name, profile):
     :type  profile: ``str``
     '''
     existing_object = __salt__['libcloud_storage.get_container_object'](container, name, profile)
-    
     if existing_object is None:
         return state_result(True, "Object already absent")
     else:

--- a/salt/states/libcloud_storage.py
+++ b/salt/states/libcloud_storage.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+'''
+Apache Libcloud Storage State
+=============================
+
+Manage cloud storage using libcloud
+
+    :codeauthor: :email:`Anthony Shaw <anthonyshaw@apache.org>`
+
+Apache Libcloud Storage (object/blob) management for a full list
+of supported clouds, see http://libcloud.readthedocs.io/en/latest/storage/supported_providers.html
+
+Clouds include Amazon S3, Google Storage, Aliyun, Azure Blobs, Ceph, OpenStack swift
+
+.. versionadded:: Oxygen
+
+:configuration:
+    This module uses a configuration profile for one or multiple Storage providers
+
+    .. code-block:: yaml
+
+        libcloud_storage:
+            profile_test1:
+              driver: google_storage
+              key: GOOG0123456789ABCXYZ
+              secret: mysecret
+            profile_test2:
+              driver: s3
+              key: 12345
+              secret: mysecret
+
+Examples
+--------
+
+Creating a container and uploading a file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+    web_things:
+      libcloud_storage.container_present:
+        name: my_container_name  
+        profile: profile1
+      libcloud_storage.object_present:
+        name: my_file.jpg
+        container: my_container_name
+        path: /path/to/local/file.jpg
+        profile: profile1
+
+Downloading a file
+~~~~~~~~~~~~~~~~~~
+
+This example will download the file from the remote cloud and keep it locally
+
+.. code-block:: yaml
+
+    web_things:
+      libcloud_storage.file_present:
+        object_name: my_file.jpg
+        container: my_container_name
+        path: /path/to/local/file.jpg
+        profile: profile1
+
+:depends: apache-libcloud
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import logging
+
+# Import salt libs
+import salt.utils
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    return True
+
+
+def __init__(opts):
+    salt.utils.compat.pack_dunder(__name__)
+
+
+def state_result(result, message):
+    return {'result': result, 'comment': message}
+
+
+def container_present(name, profile):
+    '''
+    Ensures a record is present.
+
+    :param domain: Zone name, i.e. the domain name
+    :type  domain: ``str``
+
+    :param type: Zone type (master / slave), defaults to master
+    :type  type: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+    '''
+    zones = __salt__['libcloud_dns.list_containers'](profile)
+    if not type:
+        type = 'master'
+    matching_zone = [z for z in zones if z.domain == domain]
+    if len(matching_zone) > 0:
+        return state_result(True, "Zone already exists")
+    else:
+        result = __salt__['libcloud_dns.create_zone'](domain, profile, type)
+        return state_result(result, "Created new zone")
+
+
+def zone_absent(domain, profile):
+    '''
+    Ensures a record is absent.
+
+    :param domain: Zone name, i.e. the domain name
+    :type  domain: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+    '''
+    zones = __salt__['libcloud_dns.list_zones'](profile)
+    matching_zone = [z for z in zones if z.domain == domain]
+    if len(matching_zone) == 0:
+        return state_result(True, "Zone already absent")
+    else:
+        result = __salt__['libcloud_dns.delete_zone'](matching_zone[0].id, profile)
+        return state_result(result, "Deleted zone")
+
+
+def record_present(name, zone, type, data, profile):
+    '''
+    Ensures a record is present.
+
+    :param name: Record name without the domain name (e.g. www).
+                 Note: If you want to create a record for a base domain
+                 name, you should specify empty string ('') for this
+                 argument.
+    :type  name: ``str``
+
+    :param zone: Zone where the requested record is created, the domain name
+    :type  zone: ``str``
+
+    :param type: DNS record type (A, AAAA, ...).
+    :type  type: ``str``
+
+    :param data: Data for the record (depends on the record type).
+    :type  data: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+    '''
+    zones = __salt__['libcloud_dns.list_zones'](profile)
+    try:
+        matching_zone = [z for z in zones if z.domain == zone][0]
+    except IndexError:
+        return state_result(False, "Could not locate zone")
+    records = __salt__['libcloud_dns.list_records'](matching_zone.id, profile)
+    matching_records = [record for record in records
+                        if record.name == name and
+                        record.type == type and
+                        record.data == data]
+    if len(matching_records) == 0:
+        result = __salt__['libcloud_dns.create_record'](
+            name, matching_zone.id,
+            type, data, profile)
+        return state_result(result, "Created new record")
+    else:
+        return state_result(True, "Record already exists")
+
+
+def record_absent(name, zone, type, data, profile):
+    '''
+    Ensures a record is absent.
+
+    :param name: Record name without the domain name (e.g. www).
+                 Note: If you want to create a record for a base domain
+                 name, you should specify empty string ('') for this
+                 argument.
+    :type  name: ``str``
+
+    :param zone: Zone where the requested record is created, the domain name
+    :type  zone: ``str``
+
+    :param type: DNS record type (A, AAAA, ...).
+    :type  type: ``str``
+
+    :param data: Data for the record (depends on the record type).
+    :type  data: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+    '''
+    zones = __salt__['libcloud_dns.list_zones'](profile)
+    try:
+        matching_zone = [z for z in zones if z.domain == zone][0]
+    except IndexError:
+        return state_result(False, "Zone could not be found")
+    records = __salt__['libcloud_dns.list_records'](matching_zone.id, profile)
+    matching_records = [record for record in records
+                        if record.name == name and
+                        record.type == type and
+                        record.data == data]
+    if len(matching_records) > 0:
+        result = []
+        for record in matching_records:
+            result.append(__salt__['libcloud_dns.delete_record'](
+                matching_zone.id,
+                record.id,
+                profile))
+        return state_result(all(result), "Removed {0} records".format(len(result)))
+    else:
+        return state_result(True, "Records already absent")

--- a/salt/states/libcloud_storage.py
+++ b/salt/states/libcloud_storage.py
@@ -56,7 +56,7 @@ This example will download the file from the remote cloud and keep it locally
 
     web_things:
       libcloud_storage.file_present:
-        object_name: my_file.jpg
+        name: my_file.jpg
         container: my_container_name
         path: /path/to/local/file.jpg
         profile: profile1
@@ -96,13 +96,13 @@ def container_present(name, profile):
     :param profile: The profile key
     :type  profile: ``str``
     '''
-    containers = __salt__['libcloud_dns.list_containers'](profile)
+    containers = __salt__['libcloud_storage.list_containers'](profile)
     
     match = [z for z in containers if z.name == name]
     if len(match) > 0:
         return state_result(True, "Container already exists")
     else:
-        result = __salt__['libcloud_dns.create_container'](name, profile)
+        result = __salt__['libcloud_storage.create_container'](name, profile)
         return state_result(result, "Created new container")
 
 
@@ -116,11 +116,81 @@ def container_absent(name, profile):
     :param profile: The profile key
     :type  profile: ``str``
     '''
-    containers = __salt__['libcloud_dns.list_containers'](profile)
+    containers = __salt__['libcloud_storage.list_containers'](profile)
     
     match = [z for z in containers if z.name == name]
     if len(match) == 0:
         return state_result(True, "Container already absent")
     else:
-        result = __salt__['libcloud_dns.delete_container'](name, profile)
+        result = __salt__['libcloud_storage.delete_container'](name, profile)
         return state_result(result, "Deleted container")
+
+
+def object_present(container, name, path, profile):
+    '''
+    Ensures a object is presnt.
+
+    :param container: Container name
+    :type  container: ``str``
+
+    :param name: Object name in cloud
+    :type  name: ``str``
+
+    :param path: Local path to file
+    :type  path: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+    '''
+    existing_object = __salt__['libcloud_storage.get_container_object'](container, name, profile)
+    
+    if existing_object is not None:
+        return state_result(True, "Object already present")
+    else:
+        result = __salt__['libcloud_storage.upload_object'](path, container, name, profile
+        return state_result(result, "Uploaded object")
+
+
+def object_absent(container, name, profile):
+    '''
+    Ensures a object is absent.
+
+    :param container: Container name
+    :type  container: ``str``
+
+    :param name: Object name in cloud
+    :type  name: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+    '''
+    existing_object = __salt__['libcloud_storage.get_container_object'](container, name, profile)
+    
+    if existing_object is None:
+        return state_result(True, "Object already absent")
+    else:
+        result = __salt__['libcloud_storage.delete_object'](container, name, profile
+        return state_result(result, "Deleted object")
+
+
+def file_present(container, name, path, profile, overwrite_existing=False):
+    '''
+    Ensures a object is downloaded locally.
+
+    :param container: Container name
+    :type  container: ``str``
+
+    :param name: Object name in cloud
+    :type  name: ``str``
+
+    :param path: Local path to file
+    :type  path: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+
+    :param overwrite_existing: Replace if already exists
+    :type  overwrite_existing: ``bool``
+    '''
+    result = __salt__['libcloud_storage.download_object'](path, container, name, profile, overwrite_existing)
+    return state_result(result, "Downloaded object")

--- a/salt/states/libcloud_storage.py
+++ b/salt/states/libcloud_storage.py
@@ -147,7 +147,7 @@ def object_present(container, name, path, profile):
     if existing_object is not None:
         return state_result(True, "Object already present")
     else:
-        result = __salt__['libcloud_storage.upload_object'](path, container, name, profile
+        result = __salt__['libcloud_storage.upload_object'](path, container, name, profile)
         return state_result(result, "Uploaded object")
 
 
@@ -169,7 +169,7 @@ def object_absent(container, name, profile):
     if existing_object is None:
         return state_result(True, "Object already absent")
     else:
-        result = __salt__['libcloud_storage.delete_object'](container, name, profile
+        result = __salt__['libcloud_storage.delete_object'](container, name, profile)
         return state_result(result, "Deleted object")
 
 

--- a/salt/states/libcloud_storage.py
+++ b/salt/states/libcloud_storage.py
@@ -88,127 +88,39 @@ def state_result(result, message):
 
 def container_present(name, profile):
     '''
-    Ensures a record is present.
+    Ensures a container is present.
 
-    :param domain: Zone name, i.e. the domain name
-    :type  domain: ``str``
-
-    :param type: Zone type (master / slave), defaults to master
-    :type  type: ``str``
-
-    :param profile: The profile key
-    :type  profile: ``str``
-    '''
-    zones = __salt__['libcloud_dns.list_containers'](profile)
-    if not type:
-        type = 'master'
-    matching_zone = [z for z in zones if z.domain == domain]
-    if len(matching_zone) > 0:
-        return state_result(True, "Zone already exists")
-    else:
-        result = __salt__['libcloud_dns.create_zone'](domain, profile, type)
-        return state_result(result, "Created new zone")
-
-
-def zone_absent(domain, profile):
-    '''
-    Ensures a record is absent.
-
-    :param domain: Zone name, i.e. the domain name
-    :type  domain: ``str``
-
-    :param profile: The profile key
-    :type  profile: ``str``
-    '''
-    zones = __salt__['libcloud_dns.list_zones'](profile)
-    matching_zone = [z for z in zones if z.domain == domain]
-    if len(matching_zone) == 0:
-        return state_result(True, "Zone already absent")
-    else:
-        result = __salt__['libcloud_dns.delete_zone'](matching_zone[0].id, profile)
-        return state_result(result, "Deleted zone")
-
-
-def record_present(name, zone, type, data, profile):
-    '''
-    Ensures a record is present.
-
-    :param name: Record name without the domain name (e.g. www).
-                 Note: If you want to create a record for a base domain
-                 name, you should specify empty string ('') for this
-                 argument.
+    :param name: Container name
     :type  name: ``str``
 
-    :param zone: Zone where the requested record is created, the domain name
-    :type  zone: ``str``
-
-    :param type: DNS record type (A, AAAA, ...).
-    :type  type: ``str``
-
-    :param data: Data for the record (depends on the record type).
-    :type  data: ``str``
-
     :param profile: The profile key
     :type  profile: ``str``
     '''
-    zones = __salt__['libcloud_dns.list_zones'](profile)
-    try:
-        matching_zone = [z for z in zones if z.domain == zone][0]
-    except IndexError:
-        return state_result(False, "Could not locate zone")
-    records = __salt__['libcloud_dns.list_records'](matching_zone.id, profile)
-    matching_records = [record for record in records
-                        if record.name == name and
-                        record.type == type and
-                        record.data == data]
-    if len(matching_records) == 0:
-        result = __salt__['libcloud_dns.create_record'](
-            name, matching_zone.id,
-            type, data, profile)
-        return state_result(result, "Created new record")
+    containers = __salt__['libcloud_dns.list_containers'](profile)
+    
+    match = [z for z in containers if z.name == name]
+    if len(match) > 0:
+        return state_result(True, "Container already exists")
     else:
-        return state_result(True, "Record already exists")
+        result = __salt__['libcloud_dns.create_container'](name, profile)
+        return state_result(result, "Created new container")
 
 
-def record_absent(name, zone, type, data, profile):
+def container_absent(name, profile):
     '''
-    Ensures a record is absent.
+    Ensures a container is absent.
 
-    :param name: Record name without the domain name (e.g. www).
-                 Note: If you want to create a record for a base domain
-                 name, you should specify empty string ('') for this
-                 argument.
+    :param name: Container name
     :type  name: ``str``
 
-    :param zone: Zone where the requested record is created, the domain name
-    :type  zone: ``str``
-
-    :param type: DNS record type (A, AAAA, ...).
-    :type  type: ``str``
-
-    :param data: Data for the record (depends on the record type).
-    :type  data: ``str``
-
     :param profile: The profile key
     :type  profile: ``str``
     '''
-    zones = __salt__['libcloud_dns.list_zones'](profile)
-    try:
-        matching_zone = [z for z in zones if z.domain == zone][0]
-    except IndexError:
-        return state_result(False, "Zone could not be found")
-    records = __salt__['libcloud_dns.list_records'](matching_zone.id, profile)
-    matching_records = [record for record in records
-                        if record.name == name and
-                        record.type == type and
-                        record.data == data]
-    if len(matching_records) > 0:
-        result = []
-        for record in matching_records:
-            result.append(__salt__['libcloud_dns.delete_record'](
-                matching_zone.id,
-                record.id,
-                profile))
-        return state_result(all(result), "Removed {0} records".format(len(result)))
+    containers = __salt__['libcloud_dns.list_containers'](profile)
+    
+    match = [z for z in containers if z.name == name]
+    if len(match) == 0:
+        return state_result(True, "Container already absent")
     else:
-        return state_result(True, "Records already absent")
+        result = __salt__['libcloud_dns.delete_container'](name, profile)
+        return state_result(result, "Deleted container")

--- a/tests/unit/modules/test_libcloud_storage.py
+++ b/tests/unit/modules/test_libcloud_storage.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Anthony Shaw <anthonyshaw@apache.org>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    patch,
+    MagicMock,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+import salt.modules.libcloud_storage as libcloud_storage
+
+
+class MockStorageDriver(object):
+    def __init__(self):
+        pass
+
+
+def get_mock_driver():
+    return MockStorageDriver()
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.modules.libcloud_storage._get_driver',
+       MagicMock(return_value=MockStorageDriver()))
+class LibcloudStorageModuleTestCase(TestCase, LoaderModuleMockMixin):
+
+    def setup_loader_modules(self):
+        module_globals = {
+            '__salt__': {
+                'config.option': MagicMock(return_value={
+                    'test': {
+                        'driver': 'test',
+                        'key': '2orgk34kgk34g'
+                    }
+                })
+            }
+        }
+        if libcloud_storage.HAS_LIBCLOUD is False:
+            module_globals['sys.modules'] = {'libcloud': MagicMock()}
+
+        return {libcloud_storage: module_globals}
+
+    def test_module_creation(self):
+        client = libcloud_storage._get_driver('test')
+        self.assertFalse(client is None)
+
+    def test_init(self):
+        with patch('salt.utils.compat.pack_dunder', return_value=False) as dunder:
+            libcloud_storage.__init__(None)
+            dunder.assert_called_with('salt.modules.libcloud_storage')


### PR DESCRIPTION
### What does this PR do?

This module adds functionality to talk to all of the clouds that libcloud supports for object storage and CDN. You can iterate containers (folders or buckets), iterate objects (normally files), upload and download as well as create and delete files and buckets.

Also included a state module to use for uploading and downloading files from containers. This module would help for easily getting files onto minions from a number of platforms.

# Execution module examples

```
(salt)azureuser@salt-dev-master:~/salt$ salt-call -c ./etc/salt libcloud_storage.list_containers google

local:
    |_
      ----------
      extra:
          ----------
          creation_date:
              2017-01-05T05:44:56.324Z
      name:
          anthonypjshaw
(salt)azureuser@salt-dev-master:~/salt$ salt-call -c ./etc/salt libcloud_storage.list_container_objects anthonypjshaw google

local:
    |_
      ----------
      container:
          anthonypjshaw
      extra:
          ----------
          last_modified:
              2017-01-05T05:45:23.897Z
      hash:
          6075c9e7aa0da628b06c2e382f692771
      meta_data:
          ----------
          owner:
              ----------
              display_name:
                  anthony shaw
              id:
                  00b4903a97b0b2f2c7cdf26874faba0cbef5874a22208899a0d6ad184ae921f9
      name:
          C1Rl109VIAEUupS.jpg
      size:
          213535
    |_
      ----------
      container:
          anthonypjshaw
      extra:
          ----------
          last_modified:
              2017-01-13T03:24:28.360Z
      hash:
          2381ab336f6e73591784f7849932cdf7
      meta_data:
          ----------
          owner:
              ----------
              display_name:
                  anthony shaw
              id:
                  00b4903a97b0b2f2c7cdf26874faba0cbef5874a22208899a0d6ad184ae921f9
      name:
          me.jpg
      size:
          6594

(salt)azureuser@salt-dev-master:~/salt$ salt-call -c ./etc/salt libcloud_storage.download_object anthonypjshaw me.jpg /tmp/me.jpg google

local:
    True
(salt)azureuser@salt-dev-master:~/salt$ file /tmp/me.jpg
/tmp/me.jpg: JPEG image data, JFIF standard 1.01
```

# State examples:

## Creating a container and uploading a file

```yaml
    web_things:
      libcloud_storage.container_present:
        name: my_container_name  
        profile: profile1
      libcloud_storage.object_present:
        name: my_file.jpg
        container: my_container_name
        path: /path/to/local/file.jpg
        profile: profile1
```

## Downloading a file

This example will download the file from the remote cloud and keep it locally

```yaml
    web_things:
      libcloud_storage.file_present:
        name: my_file.jpg
        container: my_container_name
        path: /path/to/local/file.jpg
        profile: profile1
```
