### PR TITLE
Use locale_search_str variable in locale.gen_locale and add error handling to integration test

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -268,6 +268,7 @@ def gen_locale(locale, **kwargs):
         return locale in __salt__['locale.list_avail']()
 
     locale_info = salt.utils.locales.split_locale(locale)
+    locale_search_str = '{0}_{1}'.format(locale['language'], locale_info['territory'])
 
     # if the charmap has not been supplied, normalize by appening it
     if not locale_info['charmap'] and not on_ubuntu:
@@ -284,9 +285,9 @@ def gen_locale(locale, **kwargs):
             search = '/usr/share/locale'
         else:
             search = '/usr/share/i18n/locales'
+
         try:
-            valid = "{0}_{1}".format(locale_info['language'],
-                                     locale_info['territory']) in os.listdir(search)
+            valid = locale_search_str in os.listdir(search)
         except OSError as ex:
             log.error(ex)
             raise CommandExecutionError(
@@ -315,7 +316,7 @@ def gen_locale(locale, **kwargs):
             append_if_not_found=True
         )
 
-    if salt.utils.which("locale-gen") is not None:
+    if salt.utils.which('locale-gen') is not None:
         cmd = ['locale-gen']
         if on_gentoo:
             cmd.append('--generate')
@@ -323,15 +324,11 @@ def gen_locale(locale, **kwargs):
             cmd.append(salt.utils.locales.normalize_locale(locale))
         else:
             cmd.append(locale)
-    elif salt.utils.which("localedef") is not None:
-        cmd = ['localedef', '--force',
-               '-i', "{0}_{1}".format(locale_info['language'],
-                                      locale_info['territory']),
-               '-f', locale_info['codeset'],
-               '{0}_{1}.{2}'.format(locale_info['language'],
-                                    locale_info['territory'],
-                                    locale_info['codeset'])]
-        cmd.append(kwargs.get('verbose', False) and '--verbose' or '--quiet')
+    elif salt.utils.which('localedef') is not None:
+        cmd = ['localedef', '--force', '-i', locale_search_str, '-f', locale_info['codeset'],
+               '{0}.{1}'.format(locale_search_str,
+                                locale_info['codeset']),
+               kwargs.get('verbose', False) and '--verbose' or '--quiet']
     else:
         raise CommandExecutionError(
             'Command "locale-gen" or "localedef" was not found on this system.')

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -316,7 +316,7 @@ def gen_locale(locale, **kwargs):
             append_if_not_found=True
         )
 
-    if salt.utils.which('locale-gen') is not None:
+    if salt.utils.which('locale-gen'):
         cmd = ['locale-gen']
         if on_gentoo:
             cmd.append('--generate')
@@ -324,7 +324,7 @@ def gen_locale(locale, **kwargs):
             cmd.append(salt.utils.locales.normalize_locale(locale))
         else:
             cmd.append(locale)
-    elif salt.utils.which('localedef') is not None:
+    elif salt.utils.which('localedef'):
         cmd = ['localedef', '--force', '-i', locale_search_str, '-f', locale_info['codeset'],
                '{0}.{1}'.format(locale_search_str,
                                 locale_info['codeset']),

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -268,7 +268,7 @@ def gen_locale(locale, **kwargs):
         return locale in __salt__['locale.list_avail']()
 
     locale_info = salt.utils.locales.split_locale(locale)
-    locale_search_str = '{0}_{1}'.format(locale['language'], locale_info['territory'])
+    locale_search_str = '{0}_{1}'.format(locale_info['language'], locale_info['territory'])
 
     # if the charmap has not been supplied, normalize by appening it
     if not locale_info['charmap'] and not on_ubuntu:

--- a/tests/integration/modules/test_locale.py
+++ b/tests/integration/modules/test_locale.py
@@ -27,7 +27,6 @@ class LocaleModuleTest(ModuleCase):
     def test_get_locale(self):
         locale = self.run_function('locale.get_locale')
         self.assertNotIn('Unsupported platform!', locale)
-        self.assertNotEqual('', locale)
 
     @destructiveTest
     def test_gen_locale(self):

--- a/tests/integration/modules/test_locale.py
+++ b/tests/integration/modules/test_locale.py
@@ -31,6 +31,15 @@ class LocaleModuleTest(ModuleCase):
 
     @destructiveTest
     def test_gen_locale(self):
+        # Make sure charmaps are available on test system before attempting
+        # call gen_locale. We log this error to the user in the function, but
+        # we don't want to fail this test if this is missing on the test system.
+        char_maps = self.run_function('cmd.run_all', ['locale -m'])
+        err_msg = 'cannot read character map directory'
+        if char_maps['retcode'] != 0 and err_msg in char_maps['stderr']:
+            self.skipTest('{0}. Cannot generate locale. Skipping test.'.format(
+                char_maps['stderr'])
+            )
         locale = self.run_function('locale.get_locale')
         new_locale = _find_new_locale(locale)
         ret = self.run_function('locale.gen_locale', [new_locale])

--- a/tests/integration/modules/test_locale.py
+++ b/tests/integration/modules/test_locale.py
@@ -37,8 +37,7 @@ class LocaleModuleTest(ModuleCase):
         if char_maps['stdout'] == '':
             self.skipTest('locale charmaps not available. Skipping test.')
 
-        err_msg = 'cannot read character map directory'
-        if char_maps['retcode'] != 0 and err_msg in char_maps['stderr']:
+        if char_maps['retcode'] and char_maps['stderr']:
             self.skipTest('{0}. Cannot generate locale. Skipping test.'.format(
                 char_maps['stderr'])
             )

--- a/tests/integration/modules/test_locale.py
+++ b/tests/integration/modules/test_locale.py
@@ -34,11 +34,15 @@ class LocaleModuleTest(ModuleCase):
         # call gen_locale. We log this error to the user in the function, but
         # we don't want to fail this test if this is missing on the test system.
         char_maps = self.run_function('cmd.run_all', ['locale -m'])
+        if char_maps['stdout'] == '':
+            self.skipTest('locale charmaps not available. Skipping test.')
+
         err_msg = 'cannot read character map directory'
         if char_maps['retcode'] != 0 and err_msg in char_maps['stderr']:
             self.skipTest('{0}. Cannot generate locale. Skipping test.'.format(
                 char_maps['stderr'])
             )
+
         locale = self.run_function('locale.get_locale')
         new_locale = _find_new_locale(locale)
         ret = self.run_function('locale.gen_locale', [new_locale])


### PR DESCRIPTION
### What does this PR do?
Adds the `locale_search_str` variable to the locale.gen_locale function, rather that having to parse what the `{0}_[1}` string should be in a couple of different places. 

This PR also adds some error checking to the gen_locale execution module integration test. These tests were previously unit tests in the 2016.11 branch and earlier, but were changed to integration tests in the `nitrogen` branch. There are some distributions that don't have charmap files available, which we are logging and returning correctly in the localemod.py file. So some checks have been added to skip the tests when the charmaps are not available.

The assertion that was removed in the `get_locale` test was removed because returning an empty string is a valid return in the function. I added this assertion in #40834, but this caused a new test failure in Fedora 24 where the `get_locale` returns an empty string.

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
