### PR TITLE
Remove dependency on win32gui

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -40,9 +40,9 @@ from salt.ext import six
 # Import third party libs
 try:
     from salt.ext.six.moves import winreg as _winreg  # pylint: disable=import-error,no-name-in-module
-    from win32gui import SendMessageTimeout
-    from win32con import HWND_BROADCAST, WM_SETTINGCHANGE, SMTO_ABORTIFHUNG
-    from win32api import RegCreateKeyEx, RegSetValueEx, RegFlushKey, RegCloseKey, error as win32apiError
+    from win32con import HWND_BROADCAST, WM_SETTINGCHANGE
+    from win32api import RegCreateKeyEx, RegSetValueEx, RegFlushKey, \
+        RegCloseKey, error as win32apiError, SendMessage
     HAS_WINDOWS_MODULES = True
 except ImportError:
     HAS_WINDOWS_MODULES = False
@@ -222,9 +222,7 @@ def broadcast_change():
         salt '*' reg.broadcast_change
     '''
     # https://msdn.microsoft.com/en-us/library/windows/desktop/ms644952(v=vs.85).aspx
-    _, res = SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0, 0,
-                                SMTO_ABORTIFHUNG, 5000)
-    return not bool(res)
+    return bool(SendMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0, 0))
 
 
 def list_keys(hive, key=None, use_32bit_registry=False):

--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -16,8 +16,8 @@ from salt.ext.six.moves import map
 
 # Third party libs
 try:
-    import win32gui
-    import win32con
+    from win32con import HWND_BROADCAST, WM_SETTINGCHANGE
+    from win32api import SendMessage
     HAS_WIN32 = True
 except ImportError:
     HAS_WIN32 = False
@@ -55,12 +55,7 @@ def rehash():
 
         salt '*' win_path.rehash
     '''
-    return win32gui.SendMessageTimeout(win32con.HWND_BROADCAST,
-                                       win32con.WM_SETTINGCHANGE,
-                                       0,
-                                       'Environment',
-                                       0,
-                                       10000)[0] == 1
+    return bool(SendMessage(HWND_BROADCAST, WM_SETTINGCHANGE, 0, 'Environment'))
 
 
 def get_path():

--- a/tests/unit/modules/test_win_path.py
+++ b/tests/unit/modules/test_win_path.py
@@ -20,9 +20,9 @@ from tests.support.mock import (
 import salt.modules.win_path as win_path
 
 
-class MockWin32Gui(object):
+class MockWin32API(object):
     '''
-        Mock class for win32gui
+        Mock class for win32api
     '''
     def __init__(self):
         pass
@@ -52,7 +52,7 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
         Test cases for salt.modules.win_path
     '''
     def setup_loader_modules(self):
-        return {win_path: {'win32gui': MockWin32Gui, 'win32con': MockWin32Con}}
+        return {win_path: {'win32api': MockWin32API, 'win32con': MockWin32Con}}
 
     def test_rehash(self):
         '''

--- a/tests/unit/modules/test_win_path.py
+++ b/tests/unit/modules/test_win_path.py
@@ -28,9 +28,9 @@ class MockWin32Gui(object):
         pass
 
     @staticmethod
-    def SendMessageTimeout(*args):
+    def SendMessage(*args):
         '''
-            Mock method for SendMessageTimeOut
+            Mock method for SendMessage
         '''
         return [args[0]]
 

--- a/tests/unit/modules/test_win_path.py
+++ b/tests/unit/modules/test_win_path.py
@@ -52,7 +52,11 @@ class WinPathTestCase(TestCase, LoaderModuleMockMixin):
         Test cases for salt.modules.win_path
     '''
     def setup_loader_modules(self):
-        return {win_path: {'win32api': MockWin32API, 'win32con': MockWin32Con}}
+        return {win_path: {'win32api': MockWin32API,
+                           'win32con': MockWin32Con,
+                           'SendMessage': MagicMock,
+                           'HWND_BROADCAST': MagicMock,
+                           'WM_SETTINGCHANGE': MagicMock}}
 
     def test_rehash(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Removes dependency on win32gui

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-windows-msi/issues/16

### Previous Behavior
Used the SendMessageTimeout method from win32gui

### New Behavior
Uses the SendMessage method from win32api

### Tests written?
No
