### PR TITLE
status should be an int

### DIFF
--- a/salt/states/http.py
+++ b/salt/states/http.py
@@ -60,7 +60,7 @@ def query(name, match=None, match_type='string', status=None, wait_for=None, **k
         query_example:
           http.query:
             - name: 'http://example.com/'
-            - status: '200'
+            - status: 200
 
     '''
     # Monitoring state, but changes may be made over HTTP


### PR DESCRIPTION
### What does this PR do?
Updates documentation to show that status in http.query state should be an int.


### Tests written?

No