### PR TITLE
modules: service: support Systemd on Cumulus Linux

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -45,7 +45,8 @@ def __virtual__():
         'Void',
         'Mint',
         'Raspbian',
-        'XenServer'
+        'XenServer',
+        'Cumulus'
     ))
     if __grains__.get('os', '') in disable:
         return (False, 'Your OS is on the disabled list')


### PR DESCRIPTION
Cumulus Linux is Debian-based and uses Systemd as its init system.

### What does this PR do?

This commit prevents the minion from trying to use SysVinit on Cumulus Linux
and failing with `ERROR: Unable to run command [...] No such file or
directory`.

### Previous Behavior

Running `salt -G os:Cumulus service.restart ntp@mgmt` would fail with

```
ERROR: Unable to run command '['/etc/init.d/ntp@mgmt', 'restart']' with the context '{'timeout': None, 'with_communicate': True, 'shell': False, 'bg': False, 'stderr': -2, 'env': {'LANG': 'en_US.UTF-8', 'LC_NUMERIC': 'C', 'NOTIFY_SOCKET': '/run/systemd/notify', 'LC_MESSAGES': 'C', 'LC_IDENTIFICATION': 'C', 'SHLVL': '1', 'LC_COLLATE': 'C', 'LC_MEASUREMENT': 'C', 'LC_CTYPE': 'C', 'LC_ADDRESS': 'C', 'LC_MONETARY': 'C', 'PWD': '/', 'LC_TELEPHONE': 'C', 'LC_PAPER': 'C', 'LC_NAME': 'C', 'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'LC_TIME': 'C', '_': '/usr/bin/cgexec'}, 'stdout': -1, 'close_fds': True, 'stdin': None, 'cwd': '/root'}', reason: [Errno 2] No such file or directory
```

### New Behavior

The same command now uses Systemd instead of SysVinit and succeeds.

### Tests written?

No