### PR TITLE
Add win_unicode_console dependency

### DIFF
--- a/pkg/windows/build_env_2.ps1
+++ b/pkg/windows/build_env_2.ps1
@@ -262,6 +262,17 @@ DownloadFileWithProgress $url $file
 Start_Process_and_test_exitcode  "$($ini['Settings']['Scripts2Dir'])\pip.exe" "install --no-index --find-links=$($ini['Settings']['DownloadDir']) $file " "pip install PyCrypto"
 
 #==============================================================================
+# Download sitecustomize.py
+#==============================================================================
+Write-Output " ----------------------------------------------------------------"
+Write-Output "   - $script_name :: Download sitecustomize . . ."
+Write-Output " ----------------------------------------------------------------"
+$file = "sitecustomize.py"
+$url  = "$($ini['Settings']['SaltRepo'])/$file"
+$file = "$($ini['Settings']['SitePkgs2Dir'])\$file"
+DownloadFileWithProgress $url $file
+
+#==============================================================================
 # Copy DLLs to Python Directory
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"

--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -132,6 +132,7 @@ If Defined ProgramFiles(x86) (
 "%PyDir%\python" "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip.exe"
 "%PyDir%\python" "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip%PyVerMajor%.%PyVerMinor%.exe"
 "%PyDir%\python" "%CurrDir%\portable.py" -f "%BinDir%\Scripts\pip%PyVerMajor%.exe"
+"%PyDir%\python" "%CurrDir%\portable.py" -f "%BinDir%\Scripts\wheel.exe"
 @echo.
 
 @echo Cleaning up unused files and directories...

--- a/pkg/windows/req_2.txt
+++ b/pkg/windows/req_2.txt
@@ -2,3 +2,4 @@
 
 lxml==3.6.0
 pypiwin32==219
+win-unicode-console==0.5


### PR DESCRIPTION
### What does this PR do?
Adds `win_unicode_console` dependency for Py2 on Windows
Enables `win_unicode_console` in the `sitecustomization.py` file

https://pypi.python.org/pypi/win_unicode_console

This needs to be discussed
@cachedout ^^^

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/36011

### Previous Behavior
In Windows with Python 2 parameters passed on the command line were not passed properly as Unicode.

### New Behavior
Unicode characters are now passed properly as Unicode.

### Tests written?
NA
