### PR TITLE
Fix service.running when test=true

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -351,7 +351,7 @@ def running(name,
         if not _available(name, ret):
             if __opts__['test']:
                 ret['result'] = None
-                ret['comment'] = 'Service {0} would have been started'.format(name)
+                ret['comment'] = 'Service {0} not present; if created in this state run, it would have been started'.format(name)
             return ret
     except CommandExecutionError as exc:
         ret['result'] = False
@@ -486,9 +486,13 @@ def dead(name,
     # Check if the service is available
     try:
         if not _available(name, ret):
-            # A non-available service is OK here, don't let the state fail
-            # because of it.
-            ret['result'] = True
+            if __opts__['test']:
+                ret['result'] = None
+                ret['comment'] = 'Service {0} not present; if created in this state run, it would have been stopped'.format(name)
+            else:
+                # A non-available service is OK here, don't let the state fail
+                # because of it.
+                ret['result'] = True
             return ret
     except CommandExecutionError as exc:
         ret['result'] = False

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -349,7 +349,7 @@ def running(name,
     # Check if the service is available
     try:
         if not _available(name, ret):
-            if 'test' in __opts__ and __opts__['test']:
+            if __opts__.get('test'):
                 ret['result'] = None
                 ret['comment'] = 'Service {0} not present; if created in this state run, it would have been started'.format(name)
             return ret
@@ -486,7 +486,7 @@ def dead(name,
     # Check if the service is available
     try:
         if not _available(name, ret):
-            if 'test' in __opts__ and __opts__['test']:
+            if __opts__.get('test'):
                 ret['result'] = None
                 ret['comment'] = 'Service {0} not present; if created in this state run, it would have been stopped'.format(name)
             else:

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -349,7 +349,7 @@ def running(name,
     # Check if the service is available
     try:
         if not _available(name, ret):
-            if __opts__['test']:
+            if 'test' in __opts__ and __opts__['test']:
                 ret['result'] = None
                 ret['comment'] = 'Service {0} not present; if created in this state run, it would have been started'.format(name)
             return ret
@@ -486,7 +486,7 @@ def dead(name,
     # Check if the service is available
     try:
         if not _available(name, ret):
-            if __opts__['test']:
+            if 'test' in __opts__ and __opts__['test']:
                 ret['result'] = None
                 ret['comment'] = 'Service {0} not present; if created in this state run, it would have been stopped'.format(name)
             else:

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -349,6 +349,9 @@ def running(name,
     # Check if the service is available
     try:
         if not _available(name, ret):
+            if __opts__['test']:
+                ret['result'] = None
+                ret['comment'] = 'Service {0} would have been started'.format(name)
             return ret
     except CommandExecutionError as exc:
         ret['result'] = False


### PR DESCRIPTION
### What does this PR do?
It fixes the service.running call when using test=true and when the service isn't available (the common case is a new satefile that installs and runs a service being tested for the first time).

### What issues does this PR fix or reference?
Fixes #34171 and partialy fixes #34019

### Previous Behavior
When using test=true, it will return a failed state if the service is not available

### New Behavior
When using test=true, il will return none and a message if the service is not available

### Tests written?
No