### PR TITLE
Add Apache Libcloud Load Balancer State module

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -197,6 +197,9 @@ execution modules
     layman
     ldap3
     ldapmod
+    libcloud_dns
+    libcloud_loadbalancer
+    libcloud_storage
     linux_acl
     linux_ip
     linux_lvm

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -134,6 +134,7 @@ state modules
     layman
     ldap
     libcloud_dns
+    libcloud_storage
     linux_acl
     locale
     logadm

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -134,6 +134,7 @@ state modules
     layman
     ldap
     libcloud_dns
+    libcloud_loadbalancer
     libcloud_storage
     linux_acl
     locale

--- a/doc/ref/states/all/salt.states.libcloud_loadbalancer.rst
+++ b/doc/ref/states/all/salt.states.libcloud_loadbalancer.rst
@@ -1,0 +1,6 @@
+salt.states.libcloud_loadbalancer module
+========================================
+
+.. automodule:: salt.states.libcloud_loadbalancer
+    :members:
+    :undoc-members:

--- a/doc/ref/states/all/salt.states.libcloud_storage.rst
+++ b/doc/ref/states/all/salt.states.libcloud_storage.rst
@@ -1,5 +1,5 @@
 salt.states.libcloud_storage module
-===============================
+===================================
 
 .. automodule:: salt.states.libcloud_storage
     :members:

--- a/salt/modules/libcloud_loadbalancer.py
+++ b/salt/modules/libcloud_loadbalancer.py
@@ -37,6 +37,7 @@ import logging
 
 # Import salt libs
 import salt.utils.compat
+import salt.ext.six as six
 from salt.utils.versions import LooseVersion as _LooseVersion
 
 log = logging.getLogger(__name__)
@@ -70,6 +71,18 @@ def __virtual__():
 
 def __init__(opts):
     salt.utils.compat.pack_dunder(__name__)
+
+
+def _algorithm_maps():
+    return {
+        'RANDOM': Algorithm.RANDOM,
+        'ROUND_ROBIN':Algorithm.ROUND_ROBIN,
+        'LEAST_CONNECTIONS': Algorithm.LEAST_CONNECTIONS,
+        'WEIGHTED_ROUND_ROBIN': Algorithm.WEIGHTED_ROUND_ROBIN,
+        'WEIGHTED_LEAST_CONNECTIONS': Algorithm.WEIGHTED_LEAST_CONNECTIONS,
+        'SHORTEST_RESPONSE': Algorithm.SHORTEST_RESPONSE,
+        'PERSISTENT_IP': Algorithm.PERSISTENT_IP
+    }
 
 
 def _get_driver(profile):
@@ -139,8 +152,9 @@ def create_balancer(name, port, protocol, profile, algorithm=None, members=None)
     :param protocol: Loadbalancer protocol, defaults to http.
     :type  protocol: ``str``
 
-    :param algorithm: Load balancing algorithm, defaults to ROUND_ROBIN (1).
-    :type algorithm: ``int``
+    :param algorithm: Load balancing algorithm, defaults to ROUND_ROBIN. See Algorithm type
+        in Libcloud documentation for a full listing.
+    :type algorithm: ``str``
 
     :param profile: The profile key
     :type  profile: ``str``
@@ -155,6 +169,9 @@ def create_balancer(name, port, protocol, profile, algorithm=None, members=None)
     '''
     if algorithm is None:
         algorithm = Algorithm.ROUND_ROBIN
+    else:
+        if isinstance(algorithm, six.string_types):
+            algorithm = _algorithm_maps()[algorithm]
     if members is None:
         members = []
 

--- a/salt/modules/libcloud_loadbalancer.py
+++ b/salt/modules/libcloud_loadbalancer.py
@@ -280,9 +280,9 @@ def balancer_attach_member(balancer_id, ip, port, profile, extra=None):
 
         salt myminion libcloud_storage.balancer_attach_member balancer123 1.2.3.4 80 profile1
     '''
-    member = Member(id=None, ip=ip, port=port, balancer=None, extra=extra)
-    balancer = get_balancer(balancer_id, profile)
     conn = _get_driver(profile=profile)
+    member = Member(id=None, ip=ip, port=port, balancer=None, extra=extra)
+    balancer = conn.get_balancer(balancer_id)
     member_saved = conn.balancer_attach_member(balancer, member)
     return _simple_member(member_saved)
 
@@ -309,7 +309,9 @@ def balancer_detach_member(balancer_id, member_id, profile):
 
         salt myminion libcloud_storage.balancer_detach_member balancer123 member123 profile1
     '''
-    members = list_balancer_members(balancer_id, profile)
+    conn = _get_driver(profile=profile)
+    balancer = conn.get_balancer(balancer_id)
+    members = conn.balancer_list_members(balancer=balancer)
     match = [member for member in members if member.id == member_id]
     if len(match) > 1:
         raise ValueError("Ambiguous argument, found mulitple records")
@@ -317,8 +319,6 @@ def balancer_detach_member(balancer_id, member_id, profile):
         raise ValueError("Bad argument, found no records")
     else:
         member = match[0]
-    balancer = get_balancer(balancer_id, profile)
-    conn = _get_driver(profile=profile)
     return conn.balancer_detach_member(balancer=balancer, member=member)
 
 
@@ -338,8 +338,8 @@ def list_balancer_members(balancer_id, profile):
 
         salt myminion libcloud_storage.list_balancer_members balancer123 profile1
     '''
-    balancer = get_balancer(balancer_id, profile)
     conn = _get_driver(profile=profile)
+    balancer = conn.get_balancer(balancer_id)
     members = conn.balancer_list_members(balancer=balancer)
     return [_simple_member(member) for member in members]
 

--- a/salt/modules/libcloud_loadbalancer.py
+++ b/salt/modules/libcloud_loadbalancer.py
@@ -76,7 +76,7 @@ def __init__(opts):
 def _algorithm_maps():
     return {
         'RANDOM': Algorithm.RANDOM,
-        'ROUND_ROBIN':Algorithm.ROUND_ROBIN,
+        'ROUND_ROBIN': Algorithm.ROUND_ROBIN,
         'LEAST_CONNECTIONS': Algorithm.LEAST_CONNECTIONS,
         'WEIGHTED_ROUND_ROBIN': Algorithm.WEIGHTED_ROUND_ROBIN,
         'WEIGHTED_LEAST_CONNECTIONS': Algorithm.WEIGHTED_LEAST_CONNECTIONS,

--- a/salt/modules/libcloud_loadbalancer.py
+++ b/salt/modules/libcloud_loadbalancer.py
@@ -182,8 +182,8 @@ def destroy_balancer(balancer_id, profile):
 
         salt myminion libcloud_storage.destroy_balancer balancer_1 profile1
     '''
-    balancer = get_balancer(balancer_id, profile)
     conn = _get_driver(profile=profile)
+    balancer = conn.get_balancer(balancer_id)
     return conn.destroy_balancer(balancer)
 
 

--- a/salt/states/libcloud_loadbalancer.py
+++ b/salt/states/libcloud_loadbalancer.py
@@ -98,3 +98,49 @@ def balancer_absent(name, profile):
         return state_result(result, "Deleted load balancer")
 
 
+def member_present(ip, port, balancer_id, profile):
+    '''
+    Ensure a load balancer member is present
+
+    :param ip: IP address for the new member
+    :type  ip: ``str``
+
+    :param port: Port for the new member
+    :type  port: ``int``
+
+    :param balancer_id: id of a load balancer you want to attach the member to
+    :type  balancer_id: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+    '''
+    existing_members = __salt__['libcloud_loadbalancer.list_balancer_members'](balancer_id, profile)
+    for member in existing_members:
+        if member['ip'] == ip and member['port'] == port:
+            return state_result(True, "Member already present")
+    member = __salt__['libcloud_loadbalancer.balancer_attach_member'](balancer_id, ip, port, profile)
+    return state_result(True, "Member added to balancer, id: {0}".format(member['id']))
+
+
+def member_absent(ip, port, balancer_id, profile):
+    '''
+    Ensure a load balancer member is absent, based on IP and Port
+
+    :param ip: IP address for the member
+    :type  ip: ``str``
+
+    :param port: Port for the member
+    :type  port: ``int``
+
+    :param balancer_id: id of a load balancer you want to detach the member from
+    :type  balancer_id: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+    '''
+    existing_members = __salt__['libcloud_loadbalancer.list_balancer_members'](balancer_id, profile)
+    for member in existing_members:
+        if member['ip'] == ip and member['port'] == port:
+            result = __salt__['libcloud_loadbalancer.balancer_detach_member'](balancer_id, member['id'], profile)
+            return state_result(result, "Member removed")
+    return state_result(True, "Member already absent")

--- a/salt/states/libcloud_loadbalancer.py
+++ b/salt/states/libcloud_loadbalancer.py
@@ -54,7 +54,7 @@ def state_result(result, message):
     return {'result': result, 'comment': message}
 
 
-def balancer_present(name, port, protocol, profile):
+def balancer_present(name, port, protocol, profile, algorithm=None):
     '''
     Ensures a load balancer is present.
 
@@ -69,13 +69,17 @@ def balancer_present(name, port, protocol, profile):
 
     :param profile: The profile key
     :type  profile: ``str``
+
+    :param algorithm: Load balancing algorithm, defaults to ROUND_ROBIN. See Algorithm type
+        in Libcloud documentation for a full listing.
+    :type algorithm: ``str``
     '''
     balancers = __salt__['libcloud_loadbalancer.list_balancers'](profile)
     match = [z for z in balancers if z['name'] == name]
     if len(match) > 0:
         return state_result(True, "Balancer already exists")
     else:
-        result = __salt__['libcloud_loadbalancer.create_balancer'](name, port, protocol, profile)
+        result = __salt__['libcloud_loadbalancer.create_balancer'](name, port, protocol, profile, algorithm=algorithm)
         return state_result(result, "Created new load balancer")
 
 

--- a/salt/states/libcloud_loadbalancer.py
+++ b/salt/states/libcloud_loadbalancer.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+'''
+Apache Libcloud Load Balancer State
+===================================
+
+Manage load balancers using libcloud
+
+    :codeauthor: :email:`Anthony Shaw <anthonyshaw@apache.org>`
+
+Apache Libcloud load balancer management for a full list
+of supported clouds, see http://libcloud.readthedocs.io/en/latest/loadbalancer/supported_providers.html
+
+Clouds include Amazon ELB, ALB, Google, Aliyun, CloudStack, Softlayer
+
+.. versionadded:: Oxygen
+
+:configuration:
+    This module uses a configuration profile for one or multiple Cloud providers
+
+    .. code-block:: yaml
+
+        libcloud_loadbalancer:
+            profile_test1:
+              driver: gce
+              key: GOOG0123456789ABCXYZ
+              secret: mysecret
+            profile_test2:
+              driver: alb
+              key: 12345
+              secret: mysecret
+
+:depends: apache-libcloud
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import logging
+
+# Import salt libs
+import salt.utils
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    return True
+
+
+def __init__(opts):
+    salt.utils.compat.pack_dunder(__name__)
+
+
+def state_result(result, message):
+    return {'result': result, 'comment': message}
+
+
+def balancer_present(name, port, protocol, profile):
+    '''
+    Ensures a load balancer is present.
+
+    :param name: Load Balancer name
+    :type  name: ``str``
+
+    :param port: Port the load balancer should listen on, defaults to 80
+    :type  port: ``str``
+
+    :param protocol: Loadbalancer protocol, defaults to http.
+    :type  protocol: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+    '''
+    balancers = __salt__['libcloud_loadbalancer.list_balancers'](profile)
+    match = [z for z in balancers if z['name'] == name]
+    if len(match) > 0:
+        return state_result(True, "Balancer already exists")
+    else:
+        result = __salt__['libcloud_loadbalancer.create_balancer'](name, port, protocol, profile)
+        return state_result(result, "Created new load balancer")
+
+
+def balancer_absent(name, profile):
+    '''
+    Ensures a load balancer is absent.
+
+    :param name: Load Balancer name
+    :type  name: ``str``
+
+    :param profile: The profile key
+    :type  profile: ``str``
+    '''
+    balancers = __salt__['libcloud_loadbalancer.list_balancers'](profile)
+    match = [z for z in balancers if z['name'] == name]
+    if len(match) == 0:
+        return state_result(True, "Balancer already absent")
+    else:
+        result = __salt__['libcloud_loadbalancer.delete_balancer'](match['id'], profile)
+        return state_result(result, "Deleted load balancer")
+
+

--- a/salt/states/libcloud_storage.py
+++ b/salt/states/libcloud_storage.py
@@ -97,7 +97,7 @@ def container_present(name, profile):
     :type  profile: ``str``
     '''
     containers = __salt__['libcloud_storage.list_containers'](profile)
-    match = [z for z in containers if z.name == name]
+    match = [z for z in containers if z['name'] == name]
     if len(match) > 0:
         return state_result(True, "Container already exists")
     else:
@@ -116,7 +116,7 @@ def container_absent(name, profile):
     :type  profile: ``str``
     '''
     containers = __salt__['libcloud_storage.list_containers'](profile)
-    match = [z for z in containers if z.name == name]
+    match = [z for z in containers if z['name'] == name]
     if len(match) == 0:
         return state_result(True, "Container already absent")
     else:

--- a/tests/unit/modules/test_libcloud_loadbalancer.py
+++ b/tests/unit/modules/test_libcloud_loadbalancer.py
@@ -130,6 +130,10 @@ class LibcloudLoadBalancerModuleTestCase(TestCase, LoaderModuleMockMixin):
         balancer = libcloud_loadbalancer.create_balancer('new_test_balancer', 80, 'http', 'test')
         self._validate_balancer(balancer)
 
+    def test_create_balancer_custom_algorithm(self):
+        balancer = libcloud_loadbalancer.create_balancer('new_test_balancer', 80, 'http', 'test', algorithm='LEAST_CONNECTIONS')
+        self._validate_balancer(balancer)
+
     def test_destroy_balancer(self):
         result = libcloud_loadbalancer.destroy_balancer('test_id', 'test')
         self.assertTrue(result)

--- a/tests/unit/modules/test_libcloud_loadbalancer.py
+++ b/tests/unit/modules/test_libcloud_loadbalancer.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Anthony Shaw <anthonyshaw@apache.org>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    patch,
+    MagicMock,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+import salt.modules.libcloud_loadbalancer as libcloud_loadbalancer
+
+from libcloud.loadbalancer.base import BaseDriver, LoadBalancer, Algorithm
+
+
+class MockLBDriver(BaseDriver):
+    def __init__(self):
+        self._TEST_BALANCER = LoadBalancer(
+            id='test_id', name='test_balancer', 
+            state=0,  # RUNNING
+            ip='1.2.3.4', 
+            port=80, driver=self, 
+            extra={})
+
+    def get_balancer(self, balancer_id):
+        assert balancer_id == 'test_balancer'
+        return self._TEST_BALANCER
+
+    def list_balancers(self):
+        return [self._TEST_BALANCER]
+
+    def list_protocols(self):
+        return ['http', 'https']
+
+    def create_balancer(self, name, port, protocol, algorithm, members):
+        assert name == 'new_test_balancer'
+        assert port == 80
+        assert protocol == 'http'
+        assert isinstance(algorithm, (Algorithm, int))
+        assert isinstance(members, list)
+        return self._TEST_BALANCER
+
+    def destroy_balancer(self, balancer):
+        assert balancer == self._TEST_BALANCER
+        return True
+
+def get_mock_driver():
+    return MockLBDriver()
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.modules.libcloud_loadbalancer._get_driver',
+       MagicMock(return_value=MockLBDriver()))
+class LibcloudLoadBalancerModuleTestCase(TestCase, LoaderModuleMockMixin):
+
+    def setup_loader_modules(self):
+        module_globals = {
+            '__salt__': {
+                'config.option': MagicMock(return_value={
+                    'test': {
+                        'driver': 'test',
+                        'key': '2orgk34kgk34g'
+                    }
+                })
+            }
+        }
+        if libcloud_loadbalancer.HAS_LIBCLOUD is False:
+            module_globals['sys.modules'] = {'libcloud': MagicMock()}
+
+        return {libcloud_loadbalancer: module_globals}
+
+    def test_module_creation(self):
+        client = libcloud_loadbalancer._get_driver('test')
+        self.assertFalse(client is None)
+
+    def test_init(self):
+        with patch('salt.utils.compat.pack_dunder', return_value=False) as dunder:
+            libcloud_loadbalancer.__init__(None)
+            dunder.assert_called_with('salt.modules.libcloud_loadbalancer')
+
+    def _validate_balancer(self, balancer):
+        self.assertEqual(balancer['name'], 'test_balancer')
+
+    def test_list_balancers(self):
+        balancers = libcloud_loadbalancer.list_balancers('test')
+        self.assertEqual(len(balancers), 1)
+        self._validate_balancer(balancers[0])
+
+    def test_list_protocols(self):
+        protocols = libcloud_loadbalancer.list_protocols('test')
+        self.assertEqual(len(protocols), 2)
+        self.assertTrue('http' in protocols)
+
+    def test_create_balancer(self):
+        balancer = libcloud_loadbalancer.create_balancer('new_test_balancer', 80, 'http', 'test')
+        self._validate_balancer(balancer)
+
+    def test_destroy_balancer(self):
+        result = libcloud_loadbalancer.destroy_balancer('test_balancer', 'test')
+        self.assertTrue(result)

--- a/tests/unit/modules/test_libcloud_storage.py
+++ b/tests/unit/modules/test_libcloud_storage.py
@@ -23,11 +23,11 @@ from libcloud.storage.base import Container, BaseDriver, Object
 class MockStorageDriver(BaseDriver):
     def __init__(self):
         self._TEST_CONTAINER = Container(name='test_container', extra={}, driver=self)
-        self._TEST_OBJECT = Object(name='test_obj', 
-                                   size=1234, 
-                                   hash='123sdfsdf', 
-                                   extra={}, 
-                                   meta_data={'key': 'value'}, 
+        self._TEST_OBJECT = Object(name='test_obj',
+                                   size=1234,
+                                   hash='123sdfsdf',
+                                   extra={},
+                                   meta_data={'key': 'value'},
                                    container=self._TEST_CONTAINER,
                                    driver=self)
 

--- a/tests/unit/modules/test_libcloud_storage.py
+++ b/tests/unit/modules/test_libcloud_storage.py
@@ -17,10 +17,39 @@ from tests.support.mock import (
 )
 import salt.modules.libcloud_storage as libcloud_storage
 
+from libcloud.storage.base import Container, BaseDriver, Object
 
-class MockStorageDriver(object):
+
+class MockStorageDriver(BaseDriver):
     def __init__(self):
-        pass
+        self._TEST_CONTAINER = Container(name='test_container', extra={}, driver=self)
+        self._TEST_OBJECT = Object(name='test_obj', 
+                                   size=1234, 
+                                   hash='123sdfsdf', 
+                                   extra={}, 
+                                   meta_data={'key': 'value'}, 
+                                   container=self._TEST_CONTAINER,
+                                   driver=self)
+
+    def list_containers(self):
+        return [self._TEST_CONTAINER]
+
+    def get_container(self, container_name):
+        assert container_name == 'test_container'
+        return self._TEST_CONTAINER
+
+    def list_container_objects(self, container):
+        assert container.name == 'test_container'
+        return [self._TEST_OBJECT]
+
+    def create_container(self, container_name):
+        assert container_name == 'new_test_container'
+        return self._TEST_CONTAINER
+
+    def get_container_object(self, container_name, object_name):
+        assert container_name == 'test_container'
+        assert object_name == 'test_obj'
+        return self._TEST_OBJECT
 
 
 def get_mock_driver():
@@ -56,3 +85,27 @@ class LibcloudStorageModuleTestCase(TestCase, LoaderModuleMockMixin):
         with patch('salt.utils.compat.pack_dunder', return_value=False) as dunder:
             libcloud_storage.__init__(None)
             dunder.assert_called_with('salt.modules.libcloud_storage')
+
+    def test_list_containers(self):
+        containers = libcloud_storage.list_containers('test')
+        self.assertEqual(len(containers), 1)
+        self.assertEqual(containers[0]['name'], 'test_container')
+
+    def test_list_container_objects(self):
+        objects = libcloud_storage.list_container_objects('test_container', 'test')
+        self.assertEqual(len(objects), 1)
+        self.assertEqual(objects[0]['name'], 'test_obj')
+        self.assertEqual(objects[0]['size'], 1234)
+
+    def test_create_container(self):
+        container = libcloud_storage.create_container('new_test_container', 'test')
+        self.assertEqual(container['name'], 'test_container')
+
+    def test_get_container(self):
+        container = libcloud_storage.get_container('test_container', 'test')
+        self.assertEqual(container['name'], 'test_container')
+
+    def test_get_container_object(self):
+        obj = libcloud_storage.get_container_object('test_container', 'test_obj', 'test')
+        self.assertEqual(obj['name'], 'test_obj')
+        self.assertEqual(obj['size'], 1234)


### PR DESCRIPTION
This PR introduces a state module for the Apache Libcloud Load Balancer execution module.

The state module enables you to apply balancers and members across the supported clouds as well as remove where appropriate.

This PR also includes unit tests for the `libcloud_storage` and `libcloud_loadbalancer` modules, which I added yesterday and bug fixes where appropriate.