### PR TITLE
Remove some more raw string formatting forgotten in f4fb771.

### DIFF
--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -1151,8 +1151,6 @@ def upgrade(*names, **kwargs):
         opts += 'n'
     if not dryrun:
         opts += 'y'
-    if opts:
-        opts = '-' + opts
 
     cmd = _pkg(jail, chroot, root)
     cmd.append('upgrade')


### PR DESCRIPTION
### What does this PR do?
Removes raw string formatting.

### What issues does this PR fix or reference?
Running pkg.upgrade without arguments worked, it was generating `pkg upgrade --y` which is all right because the only possibility is `--yes`.  But when running, for example, with dryrun=True, it ended up generating `pkg upgrade --n` and `--n` and there are more than one option that starts with `n`, `--no-install-scripts`, `--dry-run` and `--no-repo-update`.

### Tests written?

No (there are not tests written for that module)