### PR TITLE
states: sqlite3: fix table_present with multi-line schema

### DIFF
--- a/salt/states/sqlite3.py
+++ b/salt/states/sqlite3.py
@@ -394,7 +394,7 @@ def table_present(name, db, schema, force=False):
         if len(tables) == 1:
             sql = None
             if isinstance(schema, str):
-                sql = schema
+                sql = schema.strip()
             else:
                 sql = _get_sql_from_schema(name, schema)
 


### PR DESCRIPTION
### What does this PR do?

With a sqlite3 database containing a table with this schema:

```
CREATE TABLE `user` (
`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
, `login` TEXT NOT NULL)
```

using `sqlite3.table_present` with this definition:

```yaml
user:
  sqlite3.table_present:
    - db: /tmp/sqlite.db
    - schema: |
        CREATE TABLE `user` (
        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
        , `login` TEXT NOT NULL)
```

returns an error indicating that the schemas do not match. That's
because the `schema` variable in the YAML ends with a newline, while the
schema returned by python-sqlite3 doesn't.

This commit strips leading and trailing whitespace from the YAML schema.

### Previous Behavior

```
----------
          ID: user
    Function: sqlite3.table_present
      Result: False
     Comment: Expected schema=CREATE TABLE `user` (
              `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
              , `login` TEXT NOT NULL)
              
              actual schema=CREATE TABLE `user` (
              `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
              , `login` TEXT NOT NULL)
     Started: 11:41:30.984781
    Duration: 1.423 ms
     Changes:   
```

### New Behavior

State applies successfully.

### Tests written?

No