### PR TITLE
Fix two issues with pip.install

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -87,7 +87,7 @@ import salt.utils
 import tempfile
 import salt.utils.locales
 import salt.utils.url
-from salt.ext.six import string_types, iteritems
+from salt.ext import six
 from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
 
@@ -213,7 +213,7 @@ def _resolve_requirements_chain(requirements):
 
     chain = []
 
-    if isinstance(requirements, string_types):
+    if isinstance(requirements, six.string_types):
         requirements = [requirements]
 
     for req_file in requirements:
@@ -230,7 +230,7 @@ def _process_requirements(requirements, cmd, cwd, saltenv, user):
     cleanup_requirements = []
 
     if requirements is not None:
-        if isinstance(requirements, string_types):
+        if isinstance(requirements, six.string_types):
             requirements = [r.strip() for r in requirements.split(',')]
         elif not isinstance(requirements, list):
             raise TypeError('requirements must be a string or list')
@@ -580,7 +580,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             'that virtualenv before using pip to install packages in it.'
         )
 
-    if isinstance(__env__, string_types):
+    if isinstance(__env__, six.string_types):
         salt.utils.warn_until(
             'Carbon',
             'Passing a salt environment should be done using \'saltenv\' '
@@ -658,7 +658,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         cmd.extend(['--timeout', timeout])
 
     if find_links:
-        if isinstance(find_links, string_types):
+        if isinstance(find_links, six.string_types):
             find_links = [l.strip() for l in find_links.split(',')]
 
         for link in find_links:
@@ -700,7 +700,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
                     ' use index_url and/or extra_index_url instead'
             )
 
-        if isinstance(mirrors, string_types):
+        if isinstance(mirrors, six.string_types):
             mirrors = [m.strip() for m in mirrors.split(',')]
 
         cmd.append('--use-mirrors')
@@ -764,21 +764,21 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         cmd.extend(['--cert', cert])
 
     if global_options:
-        if isinstance(global_options, string_types):
+        if isinstance(global_options, six.string_types):
             global_options = [go.strip() for go in global_options.split(',')]
 
         for opt in global_options:
             cmd.extend(['--global-option', opt])
 
     if install_options:
-        if isinstance(install_options, string_types):
+        if isinstance(install_options, six.string_types):
             install_options = [io.strip() for io in install_options.split(',')]
 
         for opt in install_options:
             cmd.extend(['--install-option', opt])
 
     if pkgs:
-        if isinstance(pkgs, string_types):
+        if isinstance(pkgs, six.string_types):
             pkgs = [p.strip() for p in pkgs.split(',')]
 
         # It's possible we replaced version-range commas with semicolons so
@@ -789,7 +789,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if editable:
         egg_match = re.compile(r'(?:#|#.*?&)egg=([^&]*)')
-        if isinstance(editable, string_types):
+        if isinstance(editable, six.string_types):
             editable = [e.strip() for e in editable.split(',')]
 
         for entry in editable:
@@ -808,14 +808,14 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         cmd.append('--allow-all-external')
 
     if allow_external:
-        if isinstance(allow_external, string_types):
+        if isinstance(allow_external, six.string_types):
             allow_external = [p.strip() for p in allow_external.split(',')]
 
         for pkg in allow_external:
             cmd.extend(['--allow-external', pkg])
 
     if allow_unverified:
-        if isinstance(allow_unverified, string_types):
+        if isinstance(allow_unverified, six.string_types):
             allow_unverified = \
                 [p.strip() for p in allow_unverified.split(',')]
 
@@ -825,27 +825,27 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
     if process_dependency_links:
         cmd.append('--process-dependency-links')
 
+    if trusted_host:
+        cmd.extend(['--trusted-host', trusted_host])
+
+    cmd_kwargs = dict(saltenv=saltenv, use_vt=use_vt, runas=user)
+
     if env_vars:
         if isinstance(env_vars, dict):
-            for k, v in iteritems(env_vars):
-                if not isinstance(v, string_types):
-                    env_vars[k] = str(v)
-            os.environ.update(env_vars)
+            for key, val in six.iteritems(env_vars):
+                if not isinstance(val, six.string_types):
+                    val = str(val)
+                cmd_kwargs.setdefault('env', {})[key] = val
         else:
             raise CommandExecutionError(
                 'env_vars {0} is not a dictionary'.format(env_vars))
 
-    if trusted_host:
-        cmd.extend(['--trusted-host', trusted_host])
-
     try:
-        cmd_kwargs = dict(saltenv=saltenv, use_vt=use_vt, runas=user)
-
         if cwd:
             cmd_kwargs['cwd'] = cwd
 
         if bin_env and os.path.isdir(bin_env):
-            cmd_kwargs['env'] = {'VIRTUAL_ENV': bin_env}
+            cmd_kwargs.setdefault('env', {})['VIRTUAL_ENV'] = bin_env
 
         logger.debug(
             'TRY BLOCK: end of pip.install -- cmd: %s, cmd_kwargs: %s',
@@ -926,7 +926,7 @@ def uninstall(pkgs=None,
 
     cmd = [pip_bin, 'uninstall', '-y']
 
-    if isinstance(__env__, string_types):
+    if isinstance(__env__, six.string_types):
         salt.utils.warn_until(
             'Carbon',
             'Passing a salt environment should be done using \'saltenv\' '
@@ -971,7 +971,7 @@ def uninstall(pkgs=None,
         cmd.extend(['--timeout', timeout])
 
     if pkgs:
-        if isinstance(pkgs, string_types):
+        if isinstance(pkgs, six.string_types):
             pkgs = [p.strip() for p in pkgs.split(',')]
         if requirements:
             for requirement in requirements:


### PR DESCRIPTION
- The ``iteritems`` func from six was being imported directly into the module, which means that the loader picks it up and we end up with a ``pip.iteritems`` in the ``__salt__`` dunder. This makes the following delightful silliness possible:

```
# salt-call --local sys.doc pip.iteritems
local:
    ----------
    pip.iteritems:
        Return an iterator over the (key, value) pairs of a dictionary.
```

- When ``env_vars`` is passed, it permanently modifies ``os.environ``, when it should just be passing the values in the ``env`` argument to ``cmd.run_all``.

This fixes both of these issues.

@cachedout It looks like you tried to make a similar change a while back in #36706 to keep ``iteritems`` out of the loader's hands by using the full path to refer to the items within six (e.g. ``salt.ext.six.string_types``, ``salt.ext.six.iteritems``), but then immediately reverted it. I don't see how something like that was the wrong fix, though. The only thing you and I did differently is that I import ``six`` using ``from salt.ext import six``, which is the convention which we've established (it probably wasn't well-established at the time #36706 was opened). I tested and saw no problems nor errors, so this looks like a good fix.

With my change to ``env_vars`` handling, we now actually see the passed environment variables in the debug logging (it was their absence that led me down the rabbit hole of investigating all of this in the first place):

```
00:02:47,807 [salt.loaded.int.module.pip][ 852][DEBUG   ][24331] TRY BLOCK: end of pip.install -- cmd: ['/tmp/uwsgi/bin/pip', 'install'], cmd_kwargs: {'runas': None, 'use_vt': False, 'saltenv': 'base', 'env': {'UWSGI_PROFILE': 'cgi', 'VIRTUAL_ENV': '/tmp/uwsgi'}}
```