### PR TITLE
Fix issue with change in RSA key format in cryptodome [PENDING]

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -899,8 +899,8 @@ class AsyncAuth(object):
             with salt.utils.fopen(m_pub_fn) as fp_:
                 local_master_pub = fp_.read()
 
-            if payload['pub_key'].replace('\n', '').replace('\r', '') != \
-                    local_master_pub.replace('\n', '').replace('\r', ''):
+            if payload['pub_key'].replace('\n', '').replace('\r', '').replace('RSA ', '') != \
+                    local_master_pub.replace('\n', '').replace('\r', '').replace('RSA ', ''):
                 if not self.check_auth_deps(payload):
                     return ''
 


### PR DESCRIPTION
Basically, in pycryptodome the RSA key header changed which also changes
how we need to parse the keys.

### What does this PR do?
Strip the RSA from the key header for comparison
### What issues does this PR fix or reference?
#39599 #40889