### PR TITLE
Add support for KDE neon

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1123,6 +1123,7 @@ _OS_NAME_MAP = {
     'slesexpand': 'RES',
     'void': 'Void',
     'linuxmint': 'Mint',
+    'neon': 'KDE neon',
 }
 
 # Map the 'os' grain to the 'os_family' grain
@@ -1183,6 +1184,7 @@ _OS_FAMILY_MAP = {
     'antiX': 'Debian',
     'NILinuxRT': 'NILinuxRT',
     'NILinuxRT-XFCE': 'NILinuxRT',
+    'KDE neon': 'Debian',
     'Void': 'Void',
 }
 


### PR DESCRIPTION
Updated _OS_MAP_NAME and  _OS_FAMILY_MAP to map 'neon' into 'KDE neon' and to associate that with the Debian. 
For details about KDE neon see neon.kde.org

### What does this PR do?
Adds support for KDE neon to salt.  KDE neon is a distribution of linux with the latest version of the KDE desktop environment built on top of the last Ubuntu LTS release.  

### What issues does this PR fix or reference?
This issue addresses the salt-users mailing list question found at: 
https://groups.google.com/forum/#!topic/salt-users/C5u525hmxLg

### Previous Behavior
The os 'neon' was not mapped to an OS family and as a result most commands (e.g. pkg.install) would fail with the `error: 'pkg' __virtual__ returned False`

### New Behavior
The os 'neon' now maps to the name KDE neon and the OS family Debian which allows salt to work as expected.  

### Tests written?
No

