### PR TITLE
Removes duplicates when merging pillar lists and adds pillar.get override for pillar_merge_lists

### DIFF
--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -28,6 +28,7 @@ log = logging.getLogger(__name__)
 def get(key,
         default=KeyError,
         merge=False,
+        merge_nested_lists=None,
         delimiter=DEFAULT_TARGET_DELIM,
         saltenv=None):
     '''
@@ -51,7 +52,7 @@ def get(key,
 
         pkg:apache
 
-    merge : False
+    merge : ``False``
         If ``True``, the retrieved values will be merged into the passed
         default. When the default and the retrieved value are both
         dictionaries, the dictionaries will be recursively merged.
@@ -61,6 +62,18 @@ def get(key,
             If the default and the retrieved value are not of the same type,
             then merging will be skipped and the retrieved value will be
             returned. Earlier releases raised an error in these cases.
+
+    merge_nested_lists
+        If set to ``False``, lists nested within the retrieved pillar
+        dictionary will *overwrite* lists in ``default``. If set to ``True``,
+        nested lists will be *merged* into lists in ``default``. If unspecified
+        (the default), this option is inherited from the
+        :conf_minion:`pillar_merge_lists` minion config option.
+
+        .. note::
+            This option is ignored when ``merge`` is set to ``False``.
+
+        .. versionadded:: 2016.11.6
 
     delimiter
         Specify an alternate delimiter to use when traversing a nested dict.
@@ -95,7 +108,8 @@ def get(key,
     if not __opts__.get('pillar_raise_on_missing'):
         if default is KeyError:
             default = ''
-    opt_merge_lists = __opts__.get('pillar_merge_lists', False)
+    opt_merge_lists = __opts__.get('pillar_merge_lists', False) if \
+        merge_nested_lists is None else merge_nested_lists
     pillar_dict = __pillar__ if saltenv is None else items(saltenv=saltenv)
 
     if merge:

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -27,12 +27,13 @@ def update(dest, upd, recursive_update=True, merge_lists=False):
     on a manual merge (helpful for non-dict types like FunctionWrapper)
 
     If merge_lists=True, will aggregate list object types instead of replace.
-    This behavior is only activated when recursive_update=True. By default
-    merge_lists=False.
+    The list in ``upd`` is added to the list in ``dest``, so the resulting list
+    is ``dest[key] + upd[key]``. This behavior is only activated when
+    recursive_update=True. By default merge_lists=False.
 
     .. versionchanged: 2016.11.6
-        When merging lists, duplicate values are removed and the resulting list
-        is sorted.
+        When merging lists, duplicate values are removed. Values already
+        present in the ``dest`` list are not added from the ``upd`` list.
     '''
     if (not isinstance(dest, collections.Mapping)) \
             or (not isinstance(upd, collections.Mapping)):
@@ -54,7 +55,9 @@ def update(dest, upd, recursive_update=True, merge_lists=False):
             elif isinstance(dest_subkey, list) \
                      and isinstance(val, list):
                 if merge_lists:
-                    dest[key] = sorted((set(dest_subkey + val)))
+                    merged = copy.deepcopy(dest_subkey)
+                    merged.extend([x for x in val if x not in merged])
+                    dest[key] = merged
                 else:
                     dest[key] = upd[key]
             else:

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -29,6 +29,9 @@ def update(dest, upd, recursive_update=True, merge_lists=False):
     If merge_lists=True, will aggregate list object types instead of replace.
     This behavior is only activated when recursive_update=True. By default
     merge_lists=False.
+
+    .. versionchanged: 2016.11.6
+        When merging lists, duplicate values are removed.
     '''
     if (not isinstance(dest, collections.Mapping)) \
             or (not isinstance(upd, collections.Mapping)):
@@ -50,7 +53,7 @@ def update(dest, upd, recursive_update=True, merge_lists=False):
             elif isinstance(dest_subkey, list) \
                      and isinstance(val, list):
                 if merge_lists:
-                    dest[key] = dest.get(key, []) + val
+                    dest[key] = list(set(dest_subkey).union(val))
                 else:
                     dest[key] = upd[key]
             else:

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -31,7 +31,8 @@ def update(dest, upd, recursive_update=True, merge_lists=False):
     merge_lists=False.
 
     .. versionchanged: 2016.11.6
-        When merging lists, duplicate values are removed.
+        When merging lists, duplicate values are removed and the resulting list
+        is sorted.
     '''
     if (not isinstance(dest, collections.Mapping)) \
             or (not isinstance(upd, collections.Mapping)):
@@ -53,7 +54,7 @@ def update(dest, upd, recursive_update=True, merge_lists=False):
             elif isinstance(dest_subkey, list) \
                      and isinstance(val, list):
                 if merge_lists:
-                    dest[key] = list(set(dest_subkey).union(val))
+                    dest[key] = sorted((set(dest_subkey + val)))
                 else:
                     dest[key] = upd[key]
             else:

--- a/tests/unit/utils/dictupdate_test.py
+++ b/tests/unit/utils/dictupdate_test.py
@@ -39,15 +39,15 @@ class UtilDictupdateTestCase(TestCase):
         mdict['A'] = [1, 2]
         res = dictupdate.update(copy.deepcopy(mdict), {'A': [3, 4]},
                                 merge_lists=True)
-        mdict['A'] = sorted([1, 2, 3, 4])
+        mdict['A'] = [1, 2, 3, 4]
         self.assertEqual(res, mdict)
 
-        # level 1 value changes (list merge, remove duplicates)
+        # level 1 value changes (list merge, remove duplicates, preserve order)
         mdict = copy.deepcopy(self.dict1)
         mdict['A'] = [1, 2]
-        res = dictupdate.update(copy.deepcopy(mdict), {'A': [1, 2, 3, 4]},
+        res = dictupdate.update(copy.deepcopy(mdict), {'A': [4, 3, 2, 1]},
                                 merge_lists=True)
-        mdict['A'] = sorted([1, 2, 3, 4])
+        mdict['A'] = [1, 2, 4, 3]
         self.assertEqual(res, mdict)
 
         # level 2 value changes
@@ -69,16 +69,16 @@ class UtilDictupdateTestCase(TestCase):
         mdict['C']['D'] = ['a', 'b']
         res = dictupdate.update(copy.deepcopy(mdict), {'C': {'D': ['c', 'd']}},
                                 merge_lists=True)
-        mdict['C']['D'] = sorted(['a', 'b', 'c', 'd'])
+        mdict['C']['D'] = ['a', 'b', 'c', 'd']
         self.assertEqual(res, mdict)
 
-        # level 2 value changes (list merge, remove duplicates)
+        # level 2 value changes (list merge, remove duplicates, preserve order)
         mdict = copy.deepcopy(self.dict1)
         mdict['C']['D'] = ['a', 'b']
         res = dictupdate.update(copy.deepcopy(mdict),
-                                {'C': {'D': ['a', 'b', 'c', 'd']}},
+                                {'C': {'D': ['d', 'c', 'b', 'a']}},
                                 merge_lists=True)
-        mdict['C']['D'] = sorted(['a', 'b', 'c', 'd'])
+        mdict['C']['D'] = ['a', 'b', 'd', 'c']
         self.assertEqual(res, mdict)
 
         # level 3 value changes
@@ -103,15 +103,15 @@ class UtilDictupdateTestCase(TestCase):
         mdict['C']['F']['G'] = ['a', 'b']
         res = dictupdate.update(copy.deepcopy(mdict),
             {'C': {'F': {'G': ['c', 'd']}}}, merge_lists=True)
-        mdict['C']['F']['G'] = sorted(['a', 'b', 'c', 'd'])
+        mdict['C']['F']['G'] = ['a', 'b', 'c', 'd']
         self.assertEqual(res, mdict)
 
-        # level 3 value changes (list merge, remove duplicates)
+        # level 3 value changes (list merge, remove duplicates, preserve order)
         mdict = copy.deepcopy(self.dict1)
         mdict['C']['F']['G'] = ['a', 'b']
         res = dictupdate.update(copy.deepcopy(mdict),
-            {'C': {'F': {'G': ['a', 'b', 'c', 'd']}}}, merge_lists=True)
-        mdict['C']['F']['G'] = sorted(['a', 'b', 'c', 'd'])
+            {'C': {'F': {'G': ['d', 'c', 'b', 'a']}}}, merge_lists=True)
+        mdict['C']['F']['G'] = ['a', 'b', 'd', 'c']
         self.assertEqual(res, mdict)
 
         # replace a sub-dictionary

--- a/tests/unit/utils/dictupdate_test.py
+++ b/tests/unit/utils/dictupdate_test.py
@@ -39,7 +39,15 @@ class UtilDictupdateTestCase(TestCase):
         mdict['A'] = [1, 2]
         res = dictupdate.update(copy.deepcopy(mdict), {'A': [3, 4]},
                                 merge_lists=True)
-        mdict['A'] = [1, 2, 3, 4]
+        mdict['A'] = sorted([1, 2, 3, 4])
+        self.assertEqual(res, mdict)
+
+        # level 1 value changes (list merge, remove duplicates)
+        mdict = copy.deepcopy(self.dict1)
+        mdict['A'] = [1, 2]
+        res = dictupdate.update(copy.deepcopy(mdict), {'A': [1, 2, 3, 4]},
+                                merge_lists=True)
+        mdict['A'] = sorted([1, 2, 3, 4])
         self.assertEqual(res, mdict)
 
         # level 2 value changes
@@ -61,7 +69,16 @@ class UtilDictupdateTestCase(TestCase):
         mdict['C']['D'] = ['a', 'b']
         res = dictupdate.update(copy.deepcopy(mdict), {'C': {'D': ['c', 'd']}},
                                 merge_lists=True)
-        mdict['C']['D'] = ['a', 'b', 'c', 'd']
+        mdict['C']['D'] = sorted(['a', 'b', 'c', 'd'])
+        self.assertEqual(res, mdict)
+
+        # level 2 value changes (list merge, remove duplicates)
+        mdict = copy.deepcopy(self.dict1)
+        mdict['C']['D'] = ['a', 'b']
+        res = dictupdate.update(copy.deepcopy(mdict),
+                                {'C': {'D': ['a', 'b', 'c', 'd']}},
+                                merge_lists=True)
+        mdict['C']['D'] = sorted(['a', 'b', 'c', 'd'])
         self.assertEqual(res, mdict)
 
         # level 3 value changes
@@ -86,7 +103,15 @@ class UtilDictupdateTestCase(TestCase):
         mdict['C']['F']['G'] = ['a', 'b']
         res = dictupdate.update(copy.deepcopy(mdict),
             {'C': {'F': {'G': ['c', 'd']}}}, merge_lists=True)
-        mdict['C']['F']['G'] = ['a', 'b', 'c', 'd']
+        mdict['C']['F']['G'] = sorted(['a', 'b', 'c', 'd'])
+        self.assertEqual(res, mdict)
+
+        # level 3 value changes (list merge, remove duplicates)
+        mdict = copy.deepcopy(self.dict1)
+        mdict['C']['F']['G'] = ['a', 'b']
+        res = dictupdate.update(copy.deepcopy(mdict),
+            {'C': {'F': {'G': ['a', 'b', 'c', 'd']}}}, merge_lists=True)
+        mdict['C']['F']['G'] = sorted(['a', 'b', 'c', 'd'])
         self.assertEqual(res, mdict)
 
         # replace a sub-dictionary


### PR DESCRIPTION
### What does this PR do?

Two things:

* Removes duplicate values when deep merging lists
* Adds a param to `pillar.get` that allows a user to override the `pillar_merge_lists` opt

### What issues does this PR fix or reference?

Fixes #39918?