### PR TITLE
Fixed issue with parsing of master minion returns when batching is en…

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -300,7 +300,7 @@ def state(
             except KeyError:
                 m_state = False
             if m_state:
-                m_state = salt.utils.check_state_result(m_ret)
+                m_state = salt.utils.check_state_result(m_ret, recurse=True)
 
         if not m_state:
             if minion not in fail_minions:
@@ -309,9 +309,10 @@ def state(
             continue
         try:
             for state_item in six.itervalues(m_ret):
-                if 'changes' in state_item and state_item['changes']:
-                    changes[minion] = m_ret
-                    break
+                if isinstance(state_item, dict):
+                    if 'changes' in state_item and state_item['changes']:
+                        changes[minion] = m_ret
+                        break
             else:
                 no_change.add(minion)
         except AttributeError:


### PR DESCRIPTION
…abled.

### What does this PR do?
Addresses issue #40635 

### What issues does this PR fix or reference?
#40635 

### Previous Behavior
Batched orchestration runs give failure status even though they are successful.

### New Behavior
Batched orchestration runs return as expected.

### Tests written?

No - however, this has been tested with batch enabled and disabled, along with forced failures which behave as expected.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
