### PR TITLE
Allow apt to update held packages.

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -771,7 +771,7 @@ def install(name=None,
     hold_pkgs = state.get('hold')
     to_unhold = []
     for _pkg in hold_pkgs:
-        if _pkg in all_pkgs:
+        if any(_pkg in _a_pkg for _a_pkg in all_pkgs):
             to_unhold.append(_pkg)
 
     if to_unhold:


### PR DESCRIPTION
There was an issue with unholding held packages.
`hold_pkgs `holds only the name of the package to update, while `all_pkgs `holds the name and the version as one string.
When trying to update salt-minion:
```
hold_pkgs  = ['salt-minion']
all_pkgs  = ['salt-minion=2016.11.4+ds-1']
```
In this configuration the install function will not detect that a package needs to be unhold and throw an error when trying to update.

### What does this PR do?
Allow apt to update held packages.

### Previous Behavior
Trying to update packlages that are marked as held will throw an error.

### New Behavior
pkg module will now update held packages.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
