### PR TITLE
Make salt.auth.rest heading consistent with all other salt.auth documentation

### DIFF
--- a/doc/ref/auth/all/salt.auth.rest.rst
+++ b/doc/ref/auth/all/salt.auth.rest.rst
@@ -1,5 +1,6 @@
-salt.auth.rest module
-=====================
+==============
+salt.auth.rest
+==============
 
 .. automodule:: salt.auth.rest
     :members:


### PR DESCRIPTION
### What does this PR do?

Updates the `salt.auth.rest` documentation to be consistent with all other documentation for salt.auth modules.

### Tests written?

No