### PR TITLE
Add a note to the ssh_known_hosts State doc.

### DIFF
--- a/salt/states/ssh_known_hosts.py
+++ b/salt/states/ssh_known_hosts.py
@@ -61,6 +61,9 @@ def present(
 
     name
         The name of the remote host (e.g. "github.com")
+        Note that only a single hostname is supported, if foo.example.com and
+        bar.example.com have the same host you will need two separate Salt
+        States to represent them.
 
     user
         The user who owns the ssh authorized keys file to modify
@@ -197,6 +200,9 @@ def absent(name, user=None, config=None):
 
     name
         The host name
+        Note that only single host names are supported.  If foo.example.com
+        and bar.example.com are the same machine and you need to exclude both,
+        you will need one Salt state for each.
 
     user
         The user who owns the ssh authorized keys file to modify


### PR DESCRIPTION
I tried to use this state with multiple
hostname aliases in a single entry, and
discovered it did not work.  Hopefully this
documentation tweak will help future users.

### What does this PR do?
Update the documentation for the ssh_known_hosts Salt State.

### What issues does this PR fix or reference?
It makes it clearer to the user that they can't do, for example, name: foo.example.com,10.1.2.3 with that state as-is.

### Previous Behavior

### New Behavior

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
