### PR TITLE
Add documentation for PyYAML's loading of time expressions

### DIFF
--- a/doc/topics/troubleshooting/yaml_idiosyncrasies.rst
+++ b/doc/topics/troubleshooting/yaml_idiosyncrasies.rst
@@ -139,6 +139,31 @@ excellent explanation for why can be found here__.
 To keep time expressions like this from being loaded as integers, always quote
 them.
 
+.. note::
+    When using a jinja ``load_yaml`` map, items must be quoted twice. For
+    example:
+
+    .. code-block:: yaml
+
+        {% load_yaml as wsus_schedule %}
+
+        FRI_10:
+          time: '"23:00"'
+          day: 6 - Every Friday
+        SAT_10:
+          time: '"06:00"'
+          day: 7 - Every Saturday
+        SAT_20:
+          time: '"14:00"'
+          day: 7 - Every Saturday
+        SAT_30:
+          time: '"22:00"'
+          day: 7 - Every Saturday
+        SUN_10:
+          time: '"06:00"'
+          day: 1 - Every Sunday
+        {% endload %}
+
 .. __: http://stackoverflow.com/a/31007425
 
 YAML does not like "Double Short Decs"

--- a/doc/topics/troubleshooting/yaml_idiosyncrasies.rst
+++ b/doc/topics/troubleshooting/yaml_idiosyncrasies.rst
@@ -129,44 +129,17 @@ string literal:
         - source: salt://ssh_keys/chease.pub
         - config: '%h/.ssh/authorized_keys'
 
-Integers are Parsed as Integers
-===============================
+Time Expressions
+================
 
-NOTE: This has been fixed in salt 0.10.0, as of this release passing an
-integer that is preceded by a 0 will be correctly parsed
+PyYAML will load a time expression as the integer value of that, assuming
+``HH:MM``. So for example, ``12:00`` is loaded by PyYAML as ``720``. An
+excellent explanation for why can be found here__.
 
-When passing :func:`integers <python2:int>` into an SLS file, they are
-passed as integers. This means that if a state accepts a string value
-and an integer is passed, that an integer will be sent. The solution here
-is to send the integer as a string.
+To keep time expressions like this from being loaded as integers, always quote
+them.
 
-This is best explained when setting the mode for a file:
-
-.. code-block:: yaml
-
-    /etc/vimrc:
-      file:
-        - managed
-        - source: salt://edit/vimrc
-        - user: root
-        - group: root
-        - mode: 644
-
-Salt manages this well, since the mode is passed as 644, but if the mode is
-zero padded as 0644, then it is read by YAML as an integer and evaluated as
-an octal value, 0644 becomes 420. Therefore, if the file mode is
-preceded by a 0 then it needs to be passed as a string:
-
-.. code-block:: yaml
-
-    /etc/vimrc:
-      file:
-        - managed
-        - source: salt://edit/vimrc
-        - user: root
-        - group: root
-        - mode: '0644'
-
+.. __: http://stackoverflow.com/a/31007425
 
 YAML does not like "Double Short Decs"
 ======================================


### PR DESCRIPTION
Also remove the notice about the handling of integer scalars starting
with zeroes, as this was fixed in 0.10.0 which is roughly 5 years old
now.