### PR TITLE
Allow vmware to query deploy arg from opts

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2366,7 +2366,7 @@ def create(vm_):
         'private_key', vm_, __opts__, search_global=False, default=None
     )
     deploy = config.get_cloud_config_value(
-        'deploy', vm_, __opts__, search_global=False, default=True
+        'deploy', vm_, __opts__, search_global=True, default=True
     )
     wait_for_ip_timeout = config.get_cloud_config_value(
         'wait_for_ip_timeout', vm_, __opts__, default=20 * 60


### PR DESCRIPTION
### What does this PR do?
Allows the argument deploy to be queried from opts instead of just the cloud profile and provider configs. This now allows a user to use the argument `--no-deploy` to ensure salt is not installed or add `deploy: False` in the cloud config. 

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/40439

### Previous Behavior

Returns this stack trace:

```
[ERROR   ] Failed to create VM CLOUD-TEST-RNDTWU. Configuration value 'deploy_kwargs' needs to be set
Traceback (most recent call last):
  File "/home/ch3ll/git/salt/salt/cloud/__init__.py", line 1274, in create
    output = self.clouds[func](vm_)
  File "/home/ch3ll/git/salt/salt/cloud/clouds/vmware.py", line 2725, in create
    data['deploy_kwargs'] = out['deploy_kwargs']
KeyError: 'deploy_kwargs'
```


### New Behavior
Can create a VM in vmware with `--no-deploy` argument. 

### Tests written?

Yes - the tests are currently failing, they pass with this fix
