### PR TITLE
vmadm always returns mac as lowercase

### DIFF
--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -171,6 +171,9 @@ def _parse_vmconfig(config, instances):
                 for instance in config[prop]:
                     instance_config = config[prop][instance]
                     instance_config[instances[prop]] = instance
+                    ## some property are lowercase
+                    if 'mac' in instance_config:
+                        instance_config['mac'] = instance_config['mac'].lower()
                     vmconfig[prop].append(instance_config)
     else:
         log.error('smartos.vm_present::parse_vmconfig - failed to parse')
@@ -188,7 +191,7 @@ def _get_instance_changes(current, state):
 
     # compare configs
     changed = salt.utils.compare_dicts(current, state)
-    for change in changed:
+    for change in salt.utils.compare_dicts(current, state):
         if change in changed and changed[change]['old'] == "":
             del changed[change]
         if change in changed and changed[change]['new'] == "":


### PR DESCRIPTION
### What does this PR do?
If a mac contains upper case letters our compare fails,
resulting in an attempt to add a new nic. This fails because
a nic with the same mac already exists.

We force the mac to lowercase to avoid this.

### What issues does this PR fix or reference?
N/a

### Previous Behavior
A new nic would be added, which would fail and result in a state failure.

### New Behavior
We now detect both macs as being the same so no new nic is added.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
