### PR TITLE
Fix fullname parameter for add function

### DIFF
--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -67,7 +67,7 @@ def __virtual__():
 
 def add(name,
         password=None,
-        fullname=False,
+        fullname=None,
         description=None,
         groups=None,
         home=None,


### PR DESCRIPTION
### What does this PR do?
Fixes default value for the `fullname` parameter.
This will fix two tests on Nitrogen when merged forward:
`integration.modules.test_useradd.UseraddModuleTestWindows.test_add_user`
`integration.modules.test_useradd.UseraddModuleTestWindows.test_add_user_to_group`

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1272

### Tests written?
NA
