### PR TITLE
[40966] Fix ssh client TypeError

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1080,7 +1080,7 @@ ARGS = {10}\n'''.format(self.minion_config,
         with tempfile.NamedTemporaryFile(mode='w+b',
                                          prefix='shim_',
                                          delete=False) as shim_tmp_file:
-            shim_tmp_file.write(cmd_str)
+            shim_tmp_file.write(salt.utils.to_bytes(cmd_str))
 
         # Copy shim to target system, under $HOME/.<randomized name>
         target_shim_file = '.{0}.{1}'.format(binascii.hexlify(os.urandom(6)), extension)


### PR DESCRIPTION
salt-ssh -i '*' test.ping
...
File "/home/ezh/.virtualenvs/salt/lib/python3.4/site-packages/salt/client/ssh/__init__.py", line 1129, in cmd_block
File "/home/ezh/.virtualenvs/salt/lib/python3.4/site-packages/salt/client/ssh/__init__.py", line 1084, in shim_cmd
File "/home/ezh/.virtualenvs/salt/lib64/python3.4/tempfile.py", line 417, in func_wrapper
    return func(*args, **kwargs)
TypeError: 'str' does not support the buffer interface

### What does this PR do?

Fix salt-ssh TypeError on python 3

### What issues does this PR fix or reference?

#40966

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
