### PR TITLE
Fix docker_events TypeError

### DIFF
--- a/salt/engines/docker_events.py
+++ b/salt/engines/docker_events.py
@@ -79,7 +79,7 @@ def start(docker_url='unix://var/run/docker.sock',
     try:
         events = client.events()
         for event in events:
-            data = json.loads(event)
+            data = json.loads(event.decode(__salt_system_encoding__, errors='replace'))
             fire('{0}/{1}'.format(tag, data['status']), data)
     except Exception:
         traceback.print_exc()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/ezh/.virtualenvs/salt/lib/python3.4/site-packages/salt/engines/docker_events.py", line 82, in start
    data = json.loads(event)
  File "/usr/lib64/python3.4/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
[INFO    ] Process <class 'salt.engines.Engine'> (12581) died with exit status 0, restarting...
```

### What does this PR do?

Fix docker-events.py TypeError on Python 3

### What issues does this PR fix or reference?

#40979

### Tests written?

No
