### PR TITLE
Fix docker_events field handling

### DIFF
--- a/salt/engines/docker_events.py
+++ b/salt/engines/docker_events.py
@@ -80,6 +80,13 @@ def start(docker_url='unix://var/run/docker.sock',
         events = client.events()
         for event in events:
             data = json.loads(event)
-            fire('{0}/{1}'.format(tag, data['status']), data)
+            # https://github.com/docker/cli/blob/master/cli/command/system/events.go#L109
+            # https://github.com/docker/engine-api/blob/master/types/events/events.go
+            # Each output includes the event type, actor id, name and action.
+            # status field can be ommited
+            if data['Action']:
+                fire('{0}/{1}'.format(tag, data['Action']), data)
+            else:
+                fire('{0}/{1}'.format(tag, data['status']), data)
     except Exception:
         traceback.print_exc()


### PR DESCRIPTION
```
[DEBUG   ] Sending event: tag = salt/engines/docker_events/attach; data = {'Type': 'container', 'from': 'a58442926dc0', 'Actor': {'Attributes': {'image': 'a58442926dc0', 'name': 'brave_banach'}, 'ID': '705dc8d539de400e57d970861c494f3039522198135f450a45c836d12e4edd16'}, 'id': '705dc8d539de400e57d970861c494f3039522198135f450a45c836d12e4edd16', 'time': 1493620435, 'status': 'attach', '_stamp': '2017-05-01T06:33:55.078234', 'Action': 'attach', 'timeNano': 1493620435077227350}
Traceback (most recent call last):
  File "/home/ezh/.virtualenvs/salt/lib/python3.4/site-packages/salt/engines/docker_events.py", line 83, in start
    fire('{0}/{1}'.format(tag, data['status']), data)
KeyError: 'status'
[INFO    ] Process <class 'salt.engines.Engine'> (21196) died with exit status 0, restarting...
```

### What does this PR do?

Fix docker_events engine

### What issues does this PR fix or reference?

#40981 

### Tests written?

No
