### PR TITLE
[Feature] Turns a gitfs remote into a true "formula", merges specified branch into current saltenv

### DIFF
--- a/doc/topics/development/conventions/formulas.rst
+++ b/doc/topics/development/conventions/formulas.rst
@@ -37,7 +37,8 @@ Adding a Formula as a GitFS remote
 One design goal of Salt's GitFS fileserver backend was to facilitate reusable
 States. GitFS is a quick and natural way to use Formulas.
 
-1.  :ref:`Install and configure GitFS <tutorial-gitfs>`.
+1.  :ref:`Install any necessary dependencies and configure GitFS
+    <tutorial-gitfs>`.
 
 2.  Add one or more Formula repository URLs as remotes in the
     :conf_master:`gitfs_remotes` list in the Salt Master configuration file:
@@ -56,6 +57,13 @@ States. GitFS is a quick and natural way to use Formulas.
     upstream with a quick pull request!
 
 3.  Restart the Salt master.
+
+Beginning with the Oxygen release, using formulas with GitFS is now much more
+convenient for deployments which use many different fileserver environments
+(i.e. saltenvs). Using the :ref:`all_saltenvs <gitfs-global-remotes>`
+parameter, files from a single git branch/tag will appear in all environments.
+See :ref:`here <gitfs-global-remotes>` for more information on this feature.
+
 
 Adding a Formula directory manually
 -----------------------------------

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -354,6 +354,8 @@ tremendous amount of customization. Here's some example usage:
         - user: joe
         - password: mysupersecretpassword
         - insecure_auth: True
+      - http://foo.com/quux.git:
+        - all_saltenvs: master
 
 .. important::
 
@@ -365,8 +367,8 @@ tremendous amount of customization. Here's some example usage:
 
     2. Per-remote configuration parameters are named like the global versions,
        with the ``gitfs_`` removed from the beginning. The exception being the
-       ``name`` and ``saltenv`` parameters, which are only available to
-       per-remote configurations.
+       ``name``, ``saltenv``, and ``all_saltenvs`` (new in Oxygen) parameters,
+       which are only available to per-remote configurations.
 
 In the example configuration above, the following is true:
 
@@ -392,6 +394,9 @@ In the example configuration above, the following is true:
 5. The fourth remote overrides the default behavior of :ref:`not authenticating
    to insecure (non-HTTPS) remotes <gitfs-insecure-auth>`.
 
+6. The fifth remote defines itself as an `all_saltenvs` remote. This means that
+   the branch/tag ``master`` will automatically be used for merging the states
+   together no matter what the value of saltenv is.
 
 .. _gitfs-per-saltenv-config:
 
@@ -499,6 +504,33 @@ would only fetch branches and tags (the default).
           - '+refs/tags/*:refs/tags/*'
           - '+refs/pull/*/head:refs/remotes/origin/pr/*'
           - '+refs/pull/*/merge:refs/remotes/origin/merge/*'
+
+
+.. _gitfs-global-remotes:
+
+Global Remotes
+==============
+
+.. versionadded:: Oxygen
+
+Global Remotes allows you to define a remote using the per-remote-only configuration
+option ``all_saltenvs`` which instructs SaltStack to merged the defined branch/tag
+into the current ``saltenv``.
+
+This feature provides a very powerful option when it comes to working with GitFS remotes.
+
+The code example below shows a remote with ``all_saltenvs`` enabled. In the context of a
+saltformula_ this will allow you to define your formula once in a single branch, before this
+feature you would have had to clone your states to every branch or tag to match your ``saltenv``
+
+.. code-block:: yaml
+
+    gitfs_remotes:
+      - http://foo.com/quux.git:
+        - all_saltenvs: anything
+
+.. _saltformulas: https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html
+
 
 Configuration Order of Precedence
 =================================

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -367,8 +367,10 @@ tremendous amount of customization. Here's some example usage:
 
     2. Per-remote configuration parameters are named like the global versions,
        with the ``gitfs_`` removed from the beginning. The exception being the
-       ``name``, ``saltenv``, and ``all_saltenvs`` (new in Oxygen) parameters,
-       which are only available to per-remote configurations.
+       ``name``, ``saltenv``, and ``all_saltenvs`` parameters, which are only
+       available to per-remote configurations.
+
+    The ``all_saltenvs`` parameter is new in the Oxygen release.
 
 In the example configuration above, the following is true:
 

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -396,9 +396,14 @@ In the example configuration above, the following is true:
 5. The fourth remote overrides the default behavior of :ref:`not authenticating
    to insecure (non-HTTPS) remotes <gitfs-insecure-auth>`.
 
-6. The fifth remote defines itself as an `all_saltenvs` remote. This means that
-   the branch/tag ``master`` will automatically be used for merging the states
-   together no matter what the value of saltenv is.
+6. Because ``all_saltenvs`` is configured for the fifth remote, files from the
+   branch/tag ``master`` will appear in every fileserver environment.
+
+   .. note::
+       The use of ``http://`` (instead of ``https://``) is permitted here
+       *only* because authentication is not being used. Otherwise, the
+       ``insecure_auth`` parameter must be used (as in the fourth remote) to
+       force Salt to authenticate to an ``http://`` remote.
 
 .. _gitfs-per-saltenv-config:
 
@@ -515,24 +520,25 @@ Global Remotes
 
 .. versionadded:: Oxygen
 
-Global Remotes allows you to define a remote using the per-remote-only configuration
-option ``all_saltenvs`` which instructs SaltStack to merged the defined branch/tag
-into the current ``saltenv``.
+The ``all_saltenvs`` per-remote configuration parameter overrides the logic
+Salt uses to map branches/tags to fileserver environments (i.e. saltenvs). This
+allows a single branch/tag to appear in *all* saltenvs.
 
-This feature provides a very powerful option when it comes to working with GitFS remotes.
+This is very useful in particular when working with :ref:`salt formulas
+<conventions-formula>`. Prior to the addition of this feature, it was necessary
+to push a branch/tag to the remote repo for each saltenv in which that formula
+was to be used. If the formula needed to be updated, this update would need to
+be reflected in all of the other branches/tags. This is both inconvenient and
+not scalable.
 
-The code example below shows a remote with ``all_saltenvs`` enabled. In the context of a
-saltformula_ this will allow you to define your formula once in a single branch, before this
-feature you would have had to clone your states to every branch or tag to match your ``saltenv``
+With ``all_saltenvs``, it is now possible to define your formula once, in a
+single branch.
 
 .. code-block:: yaml
 
     gitfs_remotes:
       - http://foo.com/quux.git:
         - all_saltenvs: anything
-
-.. _saltformulas: https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html
-
 
 Configuration Order of Precedence
 =================================
@@ -574,6 +580,17 @@ overrides all levels below it):
 
        gitfs_mountpoint: salt://bar
 
+.. note::
+    The one exception to the above is when :ref:`all_saltenvs
+    <gitfs-global-remotes>` is used. This value overrides all logic for mapping
+    branches/tags to fileserver environments. So, even if
+    :conf_master:`gitfs_saltenv` is used to globally override the mapping for a
+    given saltenv, :ref:`all_saltenvs <gitfs-global-remotes>` would take
+    precedence for any remote which uses it.
+
+    It's important to note however that any ``root`` and ``mountpoint`` values
+    configured in :conf_master:`gitfs_saltenv` (or :ref:`per-saltenv
+    configuration <gitfs-per-saltenv-config>`) would be unaffected by this.
 
 .. _gitfs-walkthrough-root:
 

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -50,7 +50,7 @@ import logging
 
 PER_REMOTE_OVERRIDES = ('base', 'mountpoint', 'root', 'ssl_verify',
                         'env_whitelist', 'env_blacklist', 'refspecs')
-PER_REMOTE_ONLY = ('formula', 'name', 'saltenv')
+PER_REMOTE_ONLY = ('all_saltenvs', 'name', 'saltenv')
 
 # Auth support (auth params can be global or per-remote, too)
 AUTH_PROVIDERS = ('pygit2',)

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -50,7 +50,7 @@ import logging
 
 PER_REMOTE_OVERRIDES = ('base', 'mountpoint', 'root', 'ssl_verify',
                         'env_whitelist', 'env_blacklist', 'refspecs')
-PER_REMOTE_ONLY = ('name', 'saltenv')
+PER_REMOTE_ONLY = ('formula', 'name', 'saltenv')
 
 # Auth support (auth params can be global or per-remote, too)
 AUTH_PROVIDERS = ('pygit2',)

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -411,6 +411,12 @@ class GitProvider(object):
             # Get saltenv-specific configuration
             saltenv_conf = self.saltenv.get(tgt_env, {})
             if name == 'ref':
+                # Return formula if remote is a formula
+                try:
+                    return self.formula
+                except AttributeError as e:
+                    pass
+
                 if tgt_env == 'base':
                     return self.base
                 else:

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -411,9 +411,8 @@ class GitProvider(object):
             # Get saltenv-specific configuration
             saltenv_conf = self.saltenv.get(tgt_env, {})
             if name == 'ref':
-                # Return formula if remote is a formula
                 try:
-                    return self.formula
+                    return self.all_saltenvs
                 except AttributeError as e:
                     pass
 

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -424,7 +424,7 @@ class GitProvider(object):
                 try:
                     all_saltenvs_ref = self.all_saltenvs
                     per_saltenv_ref = _get_per_saltenv(tgt_env)
-                    if all_saltenvs_ref != per_saltenv_ref:
+                    if per_saltenv_ref and all_saltenvs_ref != per_saltenv_ref:
                         log.debug(
                             'The per-saltenv configuration has mapped the '
                             '\'%s\' branch/tag to saltenv \'%s\' for %s '

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -413,7 +413,7 @@ class GitProvider(object):
             if name == 'ref':
                 try:
                     return self.all_saltenvs
-                except AttributeError as e:
+                except AttributeError:
                     pass
 
                 if tgt_env == 'base':


### PR DESCRIPTION
Thank you to @terminalmage for taking the time to give me basically everything I needed to implement this in a comment on the original issue. Very much appreciated.

**Note:** (added after @terminalmage initial review comment) -- we originally discussed naming the variable `global` but that seems to be reserved and causes python syntax errors when being referenced on `self` (ie `return self.global`). I used `formula` for the initial PR, but I agree it's not the best name as this feature has many more uses. 

### What does this PR do?
It enables a gitfs remote to be a true formula, or a global one, when set, all states from the referenced branch are merged into whichever saltenv is actually being referenced by the minion in which the states are being resolved for.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40527

### How to use and test this feature.
Add the following to your salt-minion (for a masterless test) config.

```yaml
environment: testing
fileserver_backend:
  - git
gitfs_remotes:
  - https://github.com/ekristen/salt-states-testing.git
  - https://github.com/ekristen/salt-formula-testing.git
```

If you inspect `https://github.com/ekristen/salt-states-testing.git` you'll find a testing branch and if you inspect `https://github.com/ekristen/salt-formula-testing.git` you will NOT find a testing branch. Given this setup, if you run the following command `salt-call --local state.sls testing` it will succeed (as it is from the first repo), however if you run `salt-call --local state.sls formula` it will fail as there is no `testing` branch on the second repository.

Modify the config so it looks like this.

```yaml
environment: testing
fileserver_backend:
  - git
gitfs_remotes:
  - https://github.com/ekristen/salt-states-testing.git
  - https://github.com/ekristen/salt-formula-testing.git:
    - formula: master
```

Then rerun the commands, first `salt-call --local state.sls testing` it will still resolve and run, and now `salt-call --local state.sls formula` this time it will resolve and run appropriately. 

### Tests written?
No - I looked at the gitfs tests and there did not seem to be an appropriate way or place to test this new feature within the current test suite for gitfs.