### PR TITLE
Add kwargs argument to reactor caller

### DIFF
--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -348,10 +348,11 @@ class ReactWrap(object):
         '''
         log.debug("in caller with fun {0} args {1} kwargs {2}".format(fun, args, kwargs))
         args = kwargs.get('args', [])
+        kwargs = kwargs.get('kwargs', {})
         if 'caller' not in self.client_cache:
             self.client_cache['caller'] = salt.client.Caller(self.opts['conf_file'])
         try:
-            self.client_cache['caller'].function(fun, *args)
+            self.client_cache['caller'].cmd(fun, *args, **kwargs)
         except SystemExit:
             log.warning('Attempt to exit reactor. Ignored.')
         except Exception as exc:


### PR DESCRIPTION
```
local_salt_call:
  caller.cmd.run:
    - args:
      - "mkdir test"
    - kwargs:
        cwd: /tmp
```

### What does this PR do?

Add `kwargs` option to reactor caller

### What issues does this PR fix or reference?

#40984 

### New Behavior

`kwarg` option for sls definition

### Tests written?

No
