### PR TITLE
smtp state can use profile or sender

### DIFF
--- a/salt/states/smtp.py
+++ b/salt/states/smtp.py
@@ -25,7 +25,7 @@ def __virtual__():
     return 'smtp' if 'smtp.send_msg' in __salt__ else False
 
 
-def send_msg(name, recipient, subject, sender, profile, use_ssl='True'):
+def send_msg(name, recipient, subject, sender=None, profile=None, use_ssl='True'):
     '''
     Send a message via SMTP
 
@@ -47,6 +47,12 @@ def send_msg(name, recipient, subject, sender, profile, use_ssl='True'):
            'changes': {},
            'result': None,
            'comment': ''}
+
+    if profile is None and sender is None:
+        ret['result'] = False
+        ret['comment'] = 'Missing parameter sender or profile for state smtp.send_msg'
+        return ret
+
     if __opts__['test']:
         ret['comment'] = 'Need to send message to {0}: {1}'.format(
             recipient,


### PR DESCRIPTION
### What does this PR do?
</topic>

### What issues does this PR fix or reference?
Fixes #40976 

```
[root@salt salt]# cat /srv/salt/test.sls
test:
  smtp.send_msg:
    - profile: smtp
    - recipient: "daniel@localhost"
    - subject: "hello"
    - name: "hello, i'm your friendly local salt minion"
```
### Previous Behavior
```
[root@salt salt]# salt-call --local state.apply test
[ERROR   ] Missing parameter sender for state smtp.send_msg

local:
----------
          ID: test
    Function: smtp.send_msg
        Name: hello, i'm your friendly local salt minion
      Result: False
     Comment: Missing parameter sender for state smtp.send_msg
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   0.000 ms
```

### New Behavior
```
[root@salt salt]# salt-call state.apply test --local
local:
----------
          ID: test
    Function: smtp.send_msg
        Name: hello, i'm your friendly local salt minion
      Result: True
     Comment: Sent message to daniel@localhost: hello, i'm your friendly local salt minion
     Started: 17:12:27.061954
    Duration: 45.334 ms
     Changes:

Summary for local
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:  45.334 ms
```

### Tests written?

No