### PR TITLE
Do not automatically unmask services to start/restart/etc. them

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -70,6 +70,8 @@ from salt.exceptions import CommandExecutionError
 # Import 3rd-party libs
 import salt.ext.six as six
 
+SYSTEMD_ONLY = ('no_block', 'unmask', 'unmask_runtime')
+
 __virtualname__ = 'service'
 
 
@@ -85,6 +87,24 @@ def __virtual__():
                 'check support for service management on {0} '
                 ''.format(__grains__.get('osfinger', __grains__['os']))
                )
+
+
+# Double-asterisk deliberately not used here
+def _get_systemd_only(func, kwargs):
+    ret = {}
+    warnings = []
+    valid_args = _argspec(func).args
+    for systemd_arg in SYSTEMD_ONLY:
+        arg_val = kwargs.get(systemd_arg, False)
+        if arg_val:
+            if systemd_arg in valid_args:
+                ret[systemd_arg] = arg_val
+            else:
+                warnings.append(
+                    'The \'{0}\' argument is not supported by this '
+                    'platform/action'.format(systemd_arg)
+                )
+    return ret, warnings
 
 
 def _enabled_used_error(ret):
@@ -154,25 +174,32 @@ def _enable(name, started, result=True, **kwargs):
         ret['comment'] = 'Service {0} set to be enabled'.format(name)
         return ret
 
-    if __salt__['service.enable'](name, **kwargs):
-        # Service has been enabled
-        ret['changes'] = {}
-        after_toggle_enable_status = __salt__['service.enabled'](name, **kwargs)
-        # on upstart, certain services like apparmor will always return
-        # False, even if correctly activated
-        # do not trigger a change
-        if before_toggle_enable_status != after_toggle_enable_status:
-            ret['changes'][name] = True
-        if started is True:
-            ret['comment'] = ('Service {0} has been enabled,'
-                              ' and is running').format(name)
-        elif started is None:
-            ret['comment'] = ('Service {0} has been enabled,'
-                              ' and is in the desired state').format(name)
-        else:
-            ret['comment'] = ('Service {0} has been enabled,'
-                              ' and is dead').format(name)
-        return ret
+    try:
+        if __salt__['service.enable'](name, **kwargs):
+            # Service has been enabled
+            ret['changes'] = {}
+            after_toggle_enable_status = __salt__['service.enabled'](
+                name,
+                **kwargs)
+            # on upstart, certain services like apparmor will always return
+            # False, even if correctly activated
+            # do not trigger a change
+            if before_toggle_enable_status != after_toggle_enable_status:
+                ret['changes'][name] = True
+            if started is True:
+                ret['comment'] = ('Service {0} has been enabled,'
+                                  ' and is running').format(name)
+            elif started is None:
+                ret['comment'] = ('Service {0} has been enabled,'
+                                  ' and is in the desired state').format(name)
+            else:
+                ret['comment'] = ('Service {0} has been enabled,'
+                                  ' and is dead').format(name)
+            return ret
+    except CommandExecutionError as exc:
+        enable_error = exc.strerror
+    else:
+        enable_error = False
 
     # Service failed to be enabled
     ret['result'] = False
@@ -185,6 +212,12 @@ def _enable(name, started, result=True, **kwargs):
     else:
         ret['comment'] = ('Failed when setting service {0} to start at boot,'
                           ' and the service is dead').format(name)
+
+    if enable_error:
+        ret['comment'] += '. Additional information follows:\n\n{0}'.format(
+            enable_error
+        )
+
     return ret
 
 
@@ -299,6 +332,8 @@ def running(name,
             sig=None,
             init_delay=None,
             no_block=False,
+            unmask=False,
+            unmask_runtime=False,
             **kwargs):
     '''
     Ensure that the service is running
@@ -326,6 +361,22 @@ def running(name,
         **For systemd minions only.** Starts the service using ``--no-block``.
 
         .. versionadded:: Nitrogen
+
+    unmask : False
+        **For systemd minions only.** Set to ``True`` to remove an indefinite
+        mask before attempting to start the service.
+
+        .. versionadded:: Nitrogen
+            In previous releases, Salt would simply unmask a service before
+            making any changes. This behavior is no longer the default.
+
+    unmask_runtime : False
+        **For systemd minions only.** Set to ``True`` to remove a runtime mask
+        before attempting to start the service.
+
+        .. versionadded:: Nitrogen
+            In previous releases, Salt would simply unmask a service before
+            making any changes. This behavior is no longer the default.
 
     .. note::
         ``watch`` can be used with service.running to restart a service when
@@ -382,16 +433,18 @@ def running(name,
         if enable is True:
             ret.update(_enable(name, False, result=False, **kwargs))
 
-    start_kwargs = {}
-    if no_block:
-        if 'no_block' in _argspec(__salt__['service.start']).args:
-            start_kwargs = {'no_block': no_block}
-        else:
-            ret.setdefault('warnings', []).append(
-                'The \'no_block\' argument is not supported on this platform.'
-            )
+    # Conditionally add systemd-specific args to call to service.start
+    start_kwargs, warnings = \
+        _get_systemd_only(__salt__['service.start'], locals())
+    if warnings:
+        ret.setdefault('warnings', []).extend(warnings)
 
-    func_ret = __salt__['service.start'](name, **start_kwargs)
+    try:
+        func_ret = __salt__['service.start'](name, **start_kwargs)
+    except CommandExecutionError as exc:
+        ret['result'] = False
+        ret['comment'] = exc.strerror
+        return ret
 
     if not func_ret:
         ret['result'] = False
@@ -440,7 +493,6 @@ def dead(name,
          enable=None,
          sig=None,
          init_delay=None,
-         no_block=False,
          **kwargs):
     '''
     Ensure that the named service is dead by stopping the service if it is running
@@ -515,14 +567,10 @@ def dead(name,
         ret['comment'] = 'Service {0} is set to be killed'.format(name)
         return ret
 
-    stop_kwargs = {}
-    if no_block:
-        if 'no_block' in _argspec(__salt__['service.stop']).args:
-            stop_kwargs = {'no_block': no_block}
-        else:
-            ret.setdefault('warnings', []).append(
-                'The \'no_block\' argument is not supported on this platform.'
-            )
+    # Conditionally add systemd-specific args to call to service.start
+    stop_kwargs, warnings = _get_systemd_only(__salt__['service.stop'], kwargs)
+    if warnings:
+        ret.setdefault('warnings', []).extend(warnings)
 
     func_ret = __salt__['service.stop'](name, **stop_kwargs)
     if not func_ret:
@@ -837,7 +885,17 @@ def mod_watch(name,
         # stop service before start
         __salt__['service.stop'](name)
 
-    result = func(name)
+    func_kwargs, warnings = _get_systemd_only(func, kwargs)
+    if warnings:
+        ret.setdefault('warnings', []).extend(warnings)
+
+    try:
+        result = func(name, **func_kwargs)
+    except CommandExecutionError as exc:
+        ret['result'] = True
+        ret['comment'] = exc.strerror
+        return ret
+
     if init_delay:
         time.sleep(init_delay)
 

--- a/tests/unit/modules/test_systemd.py
+++ b/tests/unit/modules/test_systemd.py
@@ -307,8 +307,8 @@ class SystemdScopeTestCase(TestCase, LoaderModuleMockMixin):
 
         with patch.object(systemd, '_check_for_unit_changes', self.mock_none):
             with patch.object(systemd, '_unit_file_changed', self.mock_none):
-                with patch.object(systemd, '_get_sysv_services', self.mock_empty_list):
-                    with patch.object(systemd, 'unmask', self.mock_true):
+                with patch.object(systemd, '_check_unmask', self.mock_none):
+                    with patch.object(systemd, '_get_sysv_services', self.mock_empty_list):
 
                         # Has scopes available
                         with patch.object(salt.utils.systemd, 'has_scope', self.mock_true):
@@ -317,10 +317,10 @@ class SystemdScopeTestCase(TestCase, LoaderModuleMockMixin):
                             with patch.dict(
                                     systemd.__salt__,
                                     {'config.get': self.mock_true,
-                                     'cmd.retcode': self.mock_success}):
+                                     'cmd.run_all': self.mock_run_all_success}):
                                 ret = func(self.unit_name, no_block=no_block)
                                 self.assertTrue(ret)
-                                self.mock_success.assert_called_with(
+                                self.mock_run_all_success.assert_called_with(
                                     scope_prefix + systemctl_command,
                                     **assert_kwargs)
 
@@ -328,10 +328,17 @@ class SystemdScopeTestCase(TestCase, LoaderModuleMockMixin):
                             with patch.dict(
                                     systemd.__salt__,
                                     {'config.get': self.mock_true,
-                                     'cmd.retcode': self.mock_failure}):
-                                ret = func(self.unit_name, no_block=no_block)
-                                self.assertFalse(ret)
-                                self.mock_failure.assert_called_with(
+                                     'cmd.run_all': self.mock_run_all_failure}):
+                                if action in ('stop', 'disable'):
+                                    ret = func(self.unit_name, no_block=no_block)
+                                    self.assertFalse(ret)
+                                else:
+                                    self.assertRaises(
+                                        CommandExecutionError,
+                                        func,
+                                        self.unit_name,
+                                        no_block=no_block)
+                                self.mock_run_all_failure.assert_called_with(
                                     scope_prefix + systemctl_command,
                                     **assert_kwargs)
 
@@ -339,10 +346,10 @@ class SystemdScopeTestCase(TestCase, LoaderModuleMockMixin):
                             with patch.dict(
                                     systemd.__salt__,
                                     {'config.get': self.mock_false,
-                                     'cmd.retcode': self.mock_success}):
+                                     'cmd.run_all': self.mock_run_all_success}):
                                 ret = func(self.unit_name, no_block=no_block)
                                 self.assertTrue(ret)
-                                self.mock_success.assert_called_with(
+                                self.mock_run_all_success.assert_called_with(
                                     systemctl_command,
                                     **assert_kwargs)
 
@@ -350,10 +357,17 @@ class SystemdScopeTestCase(TestCase, LoaderModuleMockMixin):
                             with patch.dict(
                                     systemd.__salt__,
                                     {'config.get': self.mock_false,
-                                     'cmd.retcode': self.mock_failure}):
-                                ret = func(self.unit_name, no_block=no_block)
-                                self.assertFalse(ret)
-                                self.mock_failure.assert_called_with(
+                                     'cmd.run_all': self.mock_run_all_failure}):
+                                if action in ('stop', 'disable'):
+                                    ret = func(self.unit_name, no_block=no_block)
+                                    self.assertFalse(ret)
+                                else:
+                                    self.assertRaises(
+                                        CommandExecutionError,
+                                        func,
+                                        self.unit_name,
+                                        no_block=no_block)
+                                self.mock_run_all_failure.assert_called_with(
                                     systemctl_command,
                                     **assert_kwargs)
 
@@ -370,10 +384,10 @@ class SystemdScopeTestCase(TestCase, LoaderModuleMockMixin):
                                 with patch.dict(
                                         systemd.__salt__,
                                         {'config.get': scope_mock,
-                                         'cmd.retcode': self.mock_success}):
+                                         'cmd.run_all': self.mock_run_all_success}):
                                     ret = func(self.unit_name, no_block=no_block)
                                     self.assertTrue(ret)
-                                    self.mock_success.assert_called_with(
+                                    self.mock_run_all_success.assert_called_with(
                                         systemctl_command,
                                         **assert_kwargs)
 
@@ -381,10 +395,18 @@ class SystemdScopeTestCase(TestCase, LoaderModuleMockMixin):
                                 with patch.dict(
                                         systemd.__salt__,
                                         {'config.get': scope_mock,
-                                         'cmd.retcode': self.mock_failure}):
-                                    ret = func(self.unit_name, no_block=no_block)
-                                    self.assertFalse(ret)
-                                    self.mock_failure.assert_called_with(
+                                         'cmd.run_all': self.mock_run_all_failure}):
+                                    if action in ('stop', 'disable'):
+                                        ret = func(self.unit_name,
+                                                   no_block=no_block)
+                                        self.assertFalse(ret)
+                                    else:
+                                        self.assertRaises(
+                                            CommandExecutionError,
+                                            func,
+                                            self.unit_name,
+                                            no_block=no_block)
+                                    self.mock_run_all_failure.assert_called_with(
                                         systemctl_command,
                                         **assert_kwargs)
 
@@ -396,6 +418,8 @@ class SystemdScopeTestCase(TestCase, LoaderModuleMockMixin):
         # systemd execution module, so don't provide a fallback value for the
         # call to getattr() here.
         func = getattr(systemd, action)
+        # Remove trailing _ in "unmask_"
+        action = action.rstrip('_').replace('_', '-')
         systemctl_command = ['systemctl', action]
         if runtime:
             systemctl_command.append('--runtime')
@@ -415,7 +439,7 @@ class SystemdScopeTestCase(TestCase, LoaderModuleMockMixin):
                 with patch.dict(systemd.__salt__, {'cmd.run_all': mock_not_run}):
                     with patch.object(systemd, 'masked', self.mock_false):
                         # Test not masked (should take no action and return True)
-                        self.assertTrue(systemd.unmask(self.unit_name))
+                        self.assertTrue(systemd.unmask_(self.unit_name))
                         # Also should not have called cmd.run_all
                         self.assertTrue(mock_not_run.call_count == 0)
 
@@ -543,7 +567,7 @@ class SystemdScopeTestCase(TestCase, LoaderModuleMockMixin):
         self._mask_unmask('mask', True)
 
     def test_unmask(self):
-        self._mask_unmask('unmask', False)
+        self._mask_unmask('unmask_', False)
 
     def test_unmask_runtime(self):
-        self._mask_unmask('unmask', True)
+        self._mask_unmask('unmask_', True)


### PR DESCRIPTION
Refs: #40946

NOTE: this was opened against nitrogen because the A) the behavior should be considered incorrect, and B) we have added states for managing masks in nitrogen, so there is a higher likelihood that someone will have a masked service that they may then inadvertently unmask using a state.