### PR TITLE
Recognize LVM2 pv with empty vg as orphan

### DIFF
--- a/salt/states/lvm.py
+++ b/salt/states/lvm.py
@@ -135,7 +135,7 @@ def vg_present(name, devices=None, **kwargs):
                     ret['comment'] = '{0}\n{1}'.format(
                         ret['comment'],
                         '{0} is part of Volume Group'.format(device))
-                elif pvs[realdev]['Volume Group Name'] == '#orphans_lvm2':
+                elif pvs[realdev]['Volume Group Name'] in ['', '#orphans_lvm2']:
                     __salt__['lvm.vgextend'](name, device)
                     pvs = __salt__['lvm.pvdisplay'](realdev, real=True)
                     if pvs[realdev]['Volume Group Name'] == name:


### PR DESCRIPTION
### What does this PR do?

Some LVM2 versions set an empty volume group for orphans physical volumes instead of `#orphans_lvm2`. In that case, the salt state fails and cannot do anything with the physical volume. This PR fixes this.

### What issues does this PR fix or reference?
#35699

### Tests written?

No
