### PR TITLE
Look in /opt/*/lib instead of just /opt/local/lib on Illumos distros.

### DIFF
--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -38,9 +38,10 @@ def _load_libcrypto():
             # Solaris-like distribution that use pkgsrc have
             # libraries in a non standard location.
             # (SmartOS, OmniOS, OpenIndiana, ...)
-            lib = glob.glob(os.path.join(
-                '/opt/local/lib',
-                'libcrypto.so*'))
+            # This could be /opt/tools/lib (Global Zone)
+            # or /opt/local/lib (non-Global Zone), thus the
+            # two checks below
+            lib = glob.glob('/opt/local/lib/libcrypto.so*') + glob.glob('/opt/tools/lib/libcrypto.so*')
             lib = lib[0] if len(lib) > 0 else None
         if lib:
             return cdll.LoadLibrary(lib)


### PR DESCRIPTION
### What does this PR do?

Allows Salt to start on SmartOS and other Illumos-based distros that have libraries in /opt/tools
instead of /opt/local.