### PR TITLE
Fix test_full_returns integration test on Windows

### DIFF
--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -7,7 +7,7 @@ ret_port: 64506
 worker_threads: 3
 pidfile: master.pid
 sock_dir: master_sock
-timeout: 3
+timeout: 12
 open_mode: True
 fileserver_list_cache_time: 0
 file_buffer_size: 8192

--- a/tests/integration/files/conf/syndic_master
+++ b/tests/integration/files/conf/syndic_master
@@ -7,7 +7,7 @@ ret_port: 54506
 worker_threads: 3
 pidfile: syndic_master.pid
 sock_dir: syndic_master_sock
-timeout: 1
+timeout: 10
 open_mode: True
 fileserver_list_cache_time: 0
 pillar_opts: True

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -566,7 +566,7 @@ class ModuleCase(TestCase, SaltClientTestCaseMixin):
         '''
         return self.run_function(_function, args, **kw)
 
-    def run_function(self, function, arg=(), minion_tgt='minion', timeout=25, **kwargs):
+    def run_function(self, function, arg=(), minion_tgt='minion', timeout=90, **kwargs):
         '''
         Run a single salt function and condition the return down to match the
         behavior of the raw function call


### PR DESCRIPTION
### What does this PR do?
Increases the timeout for the Master and the Syndic Master. Some tests were failing because the master wasn't waiting long enough for the minion to return. Though a targeted fix for a single test, this may fix the random test failures as well.
Increases the timeout for the `run_function` as well.
I don't think these values actually increase the amount of time it takes for individual tests to run, unless there really is a problem and the minion/function is not returning.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40941
https://github.com/saltstack/zh/issues/1272

### Tests written?
No
