### PR TITLE
Use proposed docker-py reload_config() function

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -818,8 +818,14 @@ def _client_wrapper(attr, *args, **kwargs):
     '''
     catch_api_errors = kwargs.pop('catch_api_errors', True)
     func = getattr(__context__['docker.client'], attr, None)
-    if func is None:
+    if func is None or not hasattr(func, '__call__'):
         raise SaltInvocationError('Invalid client action \'{0}\''.format(attr))
+    if attr in ('push', 'pull'):
+        try:
+            # Refresh auth config from config.json
+            __context__['docker.client'].reload_config()
+        except AttributeError:
+            pass
     err = ''
     try:
         log.debug(


### PR DESCRIPTION
See https://github.com/docker/docker-py/pull/1586

Refs: https://github.com/saltstack/salt/issues/40884#issuecomment-298670975

This allows an existing client instance to disregard its cached auth config and use the most up-to-date login info from the config.json.

~~**NOTE: This should not be merged until the upstream PR is accepted.**~~ (Upstream PR is now merged)