### PR TITLE
Allow docker.call to run as non-root user

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -185,7 +185,6 @@ import copy
 import fnmatch
 import functools
 import gzip
-import io
 import json
 import logging
 import os
@@ -5184,7 +5183,7 @@ def call(name, function, *args, **kwargs):
     untar_cmd = ["python", "-c", (
                      "import tarfile; "
                      "tarfile.open(\"{0}/{1}\").extractall(path=\"{0}\")"
-                 ).format(thin_dest_path, os.path.basename(thin_path)) ]
+                 ).format(thin_dest_path, os.path.basename(thin_path))]
     ret = run_all(name, subprocess.list2cmdline(untar_cmd))
     if ret['retcode'] != 0:
         return {'result': False, 'comment': ret['stderr']}

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -5179,7 +5179,10 @@ def call(name, function, *args, **kwargs):
     ret = copy_to(name, thin_path, os.path.join(thin_dest_path, os.path.basename(thin_path)))
 
     # untar archive
-    untar_cmd = ['tar', 'xf', os.path.join(thin_dest_path, os.path.basename(thin_path)), '-C', thin_dest_path]
+    untar_cmd = ["python", "-c", (
+                     "import tarfile; "
+                     "tarfile.open(\"{0}/{1}\").extractall(path=\"{0}\")"
+                 ).format(thin_dest_path, os.path.basename(thin_path)) ]
     ret = run_all(name, subprocess.list2cmdline(untar_cmd))
     if ret['retcode'] != 0:
         return {'result': False, 'comment': ret['stderr']}

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -2627,7 +2627,7 @@ cp = salt.utils.alias_function(copy_from, 'cp')
 def copy_to(name,
             source,
             dest,
-            exec_driver='docker-exec',
+            exec_driver=None,
             overwrite=False,
             makedirs=False):
     '''
@@ -2669,6 +2669,8 @@ def copy_to(name,
 
         salt myminion docker.copy_to mycontainer /tmp/foo /root/foo
     '''
+    if exec_driver is None:
+        exec_driver = _get_exec_driver()
     return __salt__['container_resource.copy_to'](
         name,
         __salt__['container_resource.cache_file'](source),

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -2627,7 +2627,7 @@ cp = salt.utils.alias_function(copy_from, 'cp')
 def copy_to(name,
             source,
             dest,
-            exec_driver=None,
+            exec_driver='docker-exec',
             overwrite=False,
             makedirs=False):
     '''
@@ -5164,7 +5164,7 @@ def call(name, function, *args, **kwargs):
     thin_dest_path = _generate_tmp_path()
     mkdirp_thin_argv = ['mkdir', '-p', thin_dest_path]
 
-    # put_archive reqires the path to exist
+    # make thin_dest_path in the container
     ret = run_all(name, subprocess.list2cmdline(mkdirp_thin_argv))
     if ret['retcode'] != 0:
         return {'result': False, 'comment': ret['stderr']}
@@ -5176,14 +5176,22 @@ def call(name, function, *args, **kwargs):
     thin_path = salt.utils.thin.gen_thin(__opts__['cachedir'],
                                          extra_mods=__salt__['config.option']("thin_extra_mods", ''),
                                          so_mods=__salt__['config.option']("thin_so_mods", ''))
-    with io.open(thin_path, 'rb') as file:
-        _client_wrapper('put_archive', name, thin_dest_path, file)
+    ret = copy_to(name, thin_path, os.path.join(thin_dest_path, os.path.basename(thin_path)))
+
+    # untar archive
+    untar_cmd = ['tar', 'xf', os.path.join(thin_dest_path, os.path.basename(thin_path)), '-C', thin_dest_path]
+    ret = run_all(name, subprocess.list2cmdline(untar_cmd))
+    if ret['retcode'] != 0:
+        return {'result': False, 'comment': ret['stderr']}
+
     try:
         salt_argv = [
             'python',
             os.path.join(thin_dest_path, 'salt-call'),
             '--metadata',
             '--local',
+            '--log-file', os.path.join(thin_dest_path, 'log'),
+            '--cachedir', os.path.join(thin_dest_path, 'cache'),
             '--out', 'json',
             '-l', 'quiet',
             '--',

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1214,6 +1214,18 @@ class ProxyIdMixIn(six.with_metaclass(MixInMeta, object)):
         )
 
 
+class CacheDirMixIn(six.with_metaclass(MixInMeta, object)):
+    _mixin_prio = 40
+
+    def _mixin_setup(self):
+        self.add_option(
+            '--cachedir',
+            default='/var/cache/salt/',
+            dest='cachedir',
+            help=('Cache Directory')
+        )
+
+
 class OutputOptionsMixIn(six.with_metaclass(MixInMeta, object)):
 
     _mixin_prio_ = 40
@@ -2453,7 +2465,8 @@ class SaltCallOptionParser(six.with_metaclass(OptionParserMeta,
                                               HardCrashMixin,
                                               SaltfileMixIn,
                                               ArgsStdinMixIn,
-                                              ProfilingPMixIn)):
+                                              ProfilingPMixIn,
+                                              CacheDirMixIn)):
 
     description = (
         'salt-call is used to execute module functions locally on a Salt Minion'
@@ -2571,6 +2584,12 @@ class SaltCallOptionParser(six.with_metaclass(OptionParserMeta,
             default=False,
             action='store_true',
             help=('Force a refresh of the grains cache.')
+        )
+        self.add_option(
+            '--cachedir',
+            default='/var/cache/salt/',
+            dest='cachedir',
+            help=('Cache Directory')
         )
         self.add_option(
             '-t', '--timeout',

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2586,12 +2586,6 @@ class SaltCallOptionParser(six.with_metaclass(OptionParserMeta,
             help=('Force a refresh of the grains cache.')
         )
         self.add_option(
-            '--cachedir',
-            default='/var/cache/salt/',
-            dest='cachedir',
-            help=('Cache Directory')
-        )
-        self.add_option(
             '-t', '--timeout',
             default=60,
             dest='auth_timeout',

--- a/tests/integration/files/file/base/docker_non_root/Dockerfile
+++ b/tests/integration/files/file/base/docker_non_root/Dockerfile
@@ -1,0 +1,6 @@
+FROM opensuse/python:latest
+
+RUN useradd -m daniel
+USER daniel
+
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/tests/integration/modules/test_dockermod.py
+++ b/tests/integration/modules/test_dockermod.py
@@ -13,12 +13,15 @@ import tempfile
 # Import Salt Testing Libs
 from tests.support.unit import skipIf
 from tests.support.case import ModuleCase
-from tests.support.paths import FILES, TMP
+from tests.support.paths import TMP
 from tests.support.helpers import destructiveTest
 from tests.support.mixins import SaltReturnAssertsMixin
 
 # Import Salt Libs
 import salt.utils
+
+# Import 3rd-party libs
+from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
 
 def _random_name(prefix=''):
@@ -48,10 +51,11 @@ class DockerCallTestCase(ModuleCase, SaltReturnAssertsMixin):
     @with_random_name
     def setUp(self, name):
         '''
+        setup docker.call tests
         '''
         # Create temp dir
         self.random_name = name
-        self.tmp_build_dir= tempfile.mkdtemp(dir=TMP)
+        self.tmp_build_dir = tempfile.mkdtemp(dir=TMP)
 
         self.run_state('file.managed',
                        source='salt://docker_non_root/Dockerfile',
@@ -64,6 +68,9 @@ class DockerCallTestCase(ModuleCase, SaltReturnAssertsMixin):
                        image=self.random_name)
 
     def tearDown(self):
+        '''
+        teardown docker.call tests
+        '''
         self.run_state('file.absent',
                        name=self.tmp_build_dir)
         self.run_state('docker_container.absent',
@@ -74,5 +81,8 @@ class DockerCallTestCase(ModuleCase, SaltReturnAssertsMixin):
                        force=True)
 
     def test_docker_call(self):
+        '''
+        check that docker.call works, and works with a container not running as root
+        '''
         ret = self.run_function('docker.call', [self.random_name, 'test.ping'])
         self.assertTrue(ret)

--- a/tests/integration/modules/test_dockermod.py
+++ b/tests/integration/modules/test_dockermod.py
@@ -51,20 +51,27 @@ class DockerCallTestCase(ModuleCase, SaltReturnAssertsMixin):
         '''
         # Create temp dir
         self.random_name = name
-        tmp_build_dir= tempfile.mkdtemp(dir=TMP)
+        self.tmp_build_dir= tempfile.mkdtemp(dir=TMP)
 
         self.run_state('file.managed',
                        source='salt://docker_non_root/Dockerfile',
-                       name='{0}/Dockerfile'.format(tmp_build_dir))
+                       name='{0}/Dockerfile'.format(self.tmp_build_dir))
         self.run_state('docker_image.present',
-                       build=tmp_build_dir,
+                       build=self.tmp_build_dir,
                        name=self.random_name)
         self.run_state('docker_container.running',
                        name=self.random_name,
                        image=self.random_name)
 
     def tearDown(self):
-        pass
+        self.run_state('file.absent',
+                       name=self.tmp_build_dir)
+        self.run_state('docker_container.absent',
+                       name=self.random_name,
+                       force=True)
+        self.run_state('docker_image.absent',
+                       name=self.random_name,
+                       force=True)
 
     def test_docker_call(self):
         ret = self.run_function('docker.call', [self.random_name, 'test.ping'])

--- a/tests/integration/modules/test_dockermod.py
+++ b/tests/integration/modules/test_dockermod.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+'''
+Integration tests for the docker_container states
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import functools
+import random
+import tempfile
+
+# Import Salt Testing Libs
+from tests.support.unit import skipIf
+from tests.support.case import ModuleCase
+from tests.support.paths import FILES, TMP
+from tests.support.helpers import destructiveTest
+from tests.support.mixins import SaltReturnAssertsMixin
+
+
+def _random_name(prefix=''):
+    ret = prefix
+    for _ in range(8):
+        ret += random.choice(string.ascii_lowercase)
+    return ret
+
+
+def with_random_name(func):
+    '''
+    generate a randomized name for a container
+    '''
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        name = _random_name(prefix='salt_')
+        return func(self, _random_name(prefix='salt_test_'), *args, **kwargs)
+    return wrapper
+
+
+@destructiveTest
+@skipIf(not salt.utils.which('dockerd'), 'Docker not installed')
+class DockerCallTestCase(ModuleCase, SaltReturnAssertsMixin):
+    '''
+    Test docker_container states
+    '''
+    @with_random_name
+    def setUp(self, name):
+        '''
+        '''
+        # Create temp dir
+        self.random_name = name
+        tmp_build_dir= tempfile.mkdtemp(dir=TMP)
+
+        self.run_state('file.managed',
+                       source='salt://docker_non_root/Dockerfile'
+                       name='{0}/Dockerfile'.format(tmp_build_dir))
+        self.run_state('docker_image.present',
+                       build=tmp_build_dir,
+                       name=self.random_name)
+        self.run_state('docker_container.running',
+                       name=self.random_name,
+                       image=self.random_name)
+
+    def tearDown(self):
+        pass
+
+    def test_docker_call(self):
+        ret = self.run_function('docker.call', [self.random_name, 'test.ping'])
+        self.assertTrue(ret)

--- a/tests/integration/modules/test_dockermod.py
+++ b/tests/integration/modules/test_dockermod.py
@@ -7,6 +7,7 @@ Integration tests for the docker_container states
 from __future__ import absolute_import
 import functools
 import random
+import string
 import tempfile
 
 # Import Salt Testing Libs
@@ -15,6 +16,9 @@ from tests.support.case import ModuleCase
 from tests.support.paths import FILES, TMP
 from tests.support.helpers import destructiveTest
 from tests.support.mixins import SaltReturnAssertsMixin
+
+# Import Salt Libs
+import salt.utils
 
 
 def _random_name(prefix=''):
@@ -50,7 +54,7 @@ class DockerCallTestCase(ModuleCase, SaltReturnAssertsMixin):
         tmp_build_dir= tempfile.mkdtemp(dir=TMP)
 
         self.run_state('file.managed',
-                       source='salt://docker_non_root/Dockerfile'
+                       source='salt://docker_non_root/Dockerfile',
                        name='{0}/Dockerfile'.format(tmp_build_dir))
         self.run_state('docker_image.present',
                        build=tmp_build_dir,

--- a/tests/integration/modules/test_dockermod.py
+++ b/tests/integration/modules/test_dockermod.py
@@ -70,7 +70,7 @@ class DockerCallTestCase(ModuleCase, SaltReturnAssertsMixin):
                        name=self.random_name,
                        force=True)
         self.run_state('docker_image.absent',
-                       name=self.random_name,
+                       images=[self.random_name, 'docker.io/opensuse/python:latest'],
                        force=True)
 
     def test_docker_call(self):

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -664,21 +664,28 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
 
         # Check that the directory is different each time
         # [ call(name, [args]), ...
+        self.maxDiff = None
         self.assertIn('mkdir', docker_run_all_mock.mock_calls[0][1][1])
-        self.assertIn('mkdir', docker_run_all_mock.mock_calls[3][1][1])
+        self.assertIn('mkdir', docker_run_all_mock.mock_calls[4][1][1])
         self.assertNotEqual(docker_run_all_mock.mock_calls[0][1][1],
-                            docker_run_all_mock.mock_calls[3][1][1])
-
-        self.assertIn('salt-call', docker_run_all_mock.mock_calls[1][1][1])
-        self.assertIn('salt-call', docker_run_all_mock.mock_calls[4][1][1])
-        self.assertNotEqual(docker_run_all_mock.mock_calls[1][1][1],
                             docker_run_all_mock.mock_calls[4][1][1])
 
-        # check directory cleanup
-        self.assertIn('rm -rf', docker_run_all_mock.mock_calls[2][1][1])
-        self.assertIn('rm -rf', docker_run_all_mock.mock_calls[5][1][1])
+        self.assertIn('salt-call', docker_run_all_mock.mock_calls[2][1][1])
+        self.assertIn('salt-call', docker_run_all_mock.mock_calls[6][1][1])
         self.assertNotEqual(docker_run_all_mock.mock_calls[2][1][1],
+                            docker_run_all_mock.mock_calls[6][1][1])
+
+        # check thin untar
+        self.assertIn('tarfile', docker_run_all_mock.mock_calls[1][1][1])
+        self.assertIn('tarfile', docker_run_all_mock.mock_calls[5][1][1])
+        self.assertNotEqual(docker_run_all_mock.mock_calls[1][1][1],
                             docker_run_all_mock.mock_calls[5][1][1])
+
+        # check directory cleanup
+        self.assertIn('rm -rf', docker_run_all_mock.mock_calls[3][1][1])
+        self.assertIn('rm -rf', docker_run_all_mock.mock_calls[7][1][1])
+        self.assertNotEqual(docker_run_all_mock.mock_calls[3][1][1],
+                            docker_run_all_mock.mock_calls[7][1][1])
 
         self.assertEqual({"retcode": 0, "comment": "container cmd"}, ret)
 


### PR DESCRIPTION
### What does this PR do?
This PR allows for docker.call to be used against containers that are not running with root as the main user.

Instead of using put_archive, which extracts the archive when it is put into the docker container, this change uses the salt module function `copy_to` to cat the archive into the container.  And then since python is required anyway, it uses python's tarfile to extract the tarball.

This does not support zips thin archives, but docker's put_archive also only supports tarballs.

### What issues does this PR fix or reference?
Fixes saltstack/zh#1132

### Tests written?

Not yet