### PR TITLE
Read some hardware grains from sysfs on Linux if available

### DIFF
--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -185,11 +185,12 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                                 )
                                 with patch.object(core, 'linux_distribution', distro_mock):
                                     with patch.object(core, '_linux_gpu_data', empty_mock):
-                                        with patch.object(core, '_linux_cpudata', empty_mock):
-                                            with patch.object(core, '_virtual', empty_mock):
-                                                # Mock the osarch
-                                                with patch.dict(core.__salt__, {'cmd.run': osarch_mock}):
-                                                    os_grains = core.os_data()
+                                        with patch.object(core, '_hw_data', empty_mock):
+                                            with patch.object(core, '_linux_cpudata', empty_mock):
+                                                with patch.object(core, '_virtual', empty_mock):
+                                                    # Mock the osarch
+                                                    with patch.dict(core.__salt__, {'cmd.run': osarch_mock}):
+                                                        os_grains = core.os_data()
 
         self.assertEqual(os_grains.get('os_family'), 'Suse')
         self.assertEqual(os_grains.get('os'), 'SUSE')


### PR DESCRIPTION
### What does this PR do?
On some lightweight Linux setups neither smbios nor dmidecode is present.
However, we can get most of the hardware related information directly from
sysfs. This requires CONFIG_DMIID to be enabled in Linux kernel configuration,
however it is the default for x86 vanilla defconfig and present on all major
Linux distributions.

May help in #35505

### Tests written?
No
