### PR TITLE
Fixed typo in pkg state documentation

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -39,7 +39,7 @@ A more involved example involves pulling from a custom repository.
         - keyserver: keyserver.ubuntu.com
 
     logstash:
-      pkg.installed
+      pkg.installed:
         - fromrepo: ppa:wolfnet/logstash
 
 Multiple packages can also be installed with the use of the pkgs


### PR DESCRIPTION
A `:` is missing for the yaml to be valid. This was introduced by f4abf7f03a64c30fc179957f74d5308d1b342dda, which added sub items but missed changing this line too.
