### PR TITLE
New feature: automatic job batching

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -279,6 +279,15 @@
 # a value for you. Default is disabled.
 # ipc_write_buffer: 'dynamic'
 
+# These two batch settings, batch_safe_limit and batch_safe_size, are used to
+# automatically switch to a batch mode execution. If a command would have been
+# sent to more than <batch_safe_limit> minions, then run the command in
+# batches of <batch_safe_size>. If no batch_safe_size is specified, a default
+# of 8 will be used. If no batch_safe_limit is specified, then no automatic
+# batching will occur.
+#batch_safe_limit: 100
+#batch_safe_size: 8
+
 
 #####        Security settings       #####
 ##########################################

--- a/conf/master
+++ b/conf/master
@@ -883,7 +883,7 @@
 #pillar_cache_ttl: 3600
 
 # If and only if a master has set `pillar_cache: True`, one of several storage providers
-# can be utilized.
+# can be utililzed.
 #
 # `disk`: The default storage backend. This caches rendered pillars to the master cache.
 #         Rendered pillars are serialized and deserialized as msgpack structures for speed.

--- a/conf/master
+++ b/conf/master
@@ -883,7 +883,7 @@
 #pillar_cache_ttl: 3600
 
 # If and only if a master has set `pillar_cache: True`, one of several storage providers
-# can be utililzed.
+# can be utilized.
 #
 # `disk`: The default storage backend. This caches rendered pillars to the master cache.
 #         Rendered pillars are serialized and deserialized as msgpack structures for speed.

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -103,7 +103,7 @@ class Batch(object):
         if i:
             del wait[:i]
 
-    def run(self, safe_batch=False):
+    def run(self):
         '''
         Execute the batch run
         '''
@@ -113,8 +113,6 @@ class Batch(object):
                 self.opts['timeout'],
                 'list',
                 ]
-        if safe_batch:
-            self.opts['batch'] = str(safe_batch)
         bnum = self.get_bnum()
         # No targets to run
         if not self.minions:

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -103,7 +103,7 @@ class Batch(object):
         if i:
             del wait[:i]
 
-    def run(self):
+    def run(self, safe_batch=False):
         '''
         Execute the batch run
         '''
@@ -113,6 +113,8 @@ class Batch(object):
                 self.opts['timeout'],
                 'list',
                 ]
+        if safe_batch:
+            self.opts['batch'] = str(safe_batch)
         bnum = self.get_bnum()
         # No targets to run
         if not self.minions:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1914,6 +1914,20 @@ class SaltCMDOptionParser(six.with_metaclass(OptionParserMeta,
                   'before freeing the slot in the batch for the next one.')
         )
         self.add_option(
+            '--batch-safe-limit',
+            default=0,
+            dest='batch_safe_limit',
+            type=int,
+            help=('Execute the salt job in batch mode if the job would have '
+                  'executed on more than this many minions.')
+        )
+        self.add_option(
+            '--batch-safe-size',
+            default=8,
+            dest='batch_safe_size',
+            help=('Batch size to use for batch jobs created by batch-safe-limit.')
+        )
+        self.add_option(
             '--return',
             default='',
             metavar='RETURNER',


### PR DESCRIPTION
This commit creates a new feature that provides automatic batching of
jobs if the job would have executed on too many minions.

See comments provided in commit for additional details.
Ref: #19054 (https://github.com/saltstack/salt/issues/19054)

No tests written.