### PR TITLE
Fix merge order of options in run_wfunc (fix mine.get issues)

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -922,8 +922,8 @@ class Single(object):
                     opts_pkg['grains'][grain] = self.target['grains'][grain]
 
             popts = {}
-            popts.update(opts_pkg['__master_opts__'])
             popts.update(opts_pkg)
+            popts.update(opts_pkg['__master_opts__'])
             pillar = salt.pillar.Pillar(
                     popts,
                     opts_pkg['grains'],


### PR DESCRIPTION
### What does this PR do?
This fix issues with mine.get when using salt-ssh

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/36796


### Previous Behavior
pillar.Pillar() is called with options where master_opts options are overwritten (because of dict merge/update order).

### New Behavior
pillar.Pillar() is called with options where master_opts take precedence. This allow mine.get over salt-ssh to work properly.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
