### PR TITLE
Root dir prepend fix gh

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2053,23 +2053,24 @@ def prepend_root_dir(opts, path_options):
     Prepends the options that represent filesystem paths with value of the
     'root_dir' option.
     '''
-    root_dir = os.path.abspath(opts['root_dir'])
-    root_opt = opts['root_dir'].rstrip(os.sep)
-    def_root_dir = salt.syspaths.ROOT_DIR.rstrip(os.sep)
+    root_dir = opts['root_dir']
+    root_opt_val = opts['root_dir']
+    if not os.path.isabs(root_dir):
+        # default root dir is always absolute and it needs to prefix the
+        # relative root_dir which is relative
+        def_root_dir = salt.syspaths.ROOT_DIR.rstrip(os.sep)
+        root_dir = salt.utils.path_join(def_root_dir, root_dir)
+
     for path_option in path_options:
         if path_option in opts:
             path = opts[path_option]
-            # When running testsuite, salt.syspaths.ROOT_DIR is often empty
-            if def_root_dir != '' and (path == def_root_dir or path.startswith(def_root_dir + os.sep)):
-                # Remove the default root dir so we can add the override
-                path = path[len(def_root_dir):]
-            elif path == root_opt or path.startswith(root_opt + os.sep):
+            if os.path.isabs(path):
+                # Absolute path - no prepending required
+                continue
+            elif path == root_opt_val or \
+                    path.startswith(root_opt_val + os.sep):
                 # Remove relative root dir so we can add the absolute root dir
                 path = path[len(root_opt):]
-            elif os.path.isabs(path_option):
-                # Absolute path (not default or overriden root_dir)
-                # No prepending required
-                continue
             # Prepending the root dir
             opts[path_option] = salt.utils.path_join(root_dir, path)
     logging.getLogger(__name__).trace('log_file = {}'.format(opts.get(

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2073,8 +2073,6 @@ def prepend_root_dir(opts, path_options):
                 path = path[len(root_opt_val):]
             # Prepending the root dir
             opts[path_option] = salt.utils.path_join(root_dir, path)
-    logging.getLogger(__name__).trace('log_file = {}'.format(opts.get(
-        'log_file')))
 
 
 def insert_system_path(opts, paths):

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2053,8 +2053,11 @@ def prepend_root_dir(opts, path_options):
     Prepends the options that represent filesystem paths with value of the
     'root_dir' option.
     '''
-    root_dir = opts['root_dir'].rstrip(os.sep)
     root_opt_val = opts['root_dir']
+    if root_opt_val != os.sep:
+        root_opt_val = root_opt_val.rstrip(os.sep)
+
+    root_dir = root_opt_val
     if not os.path.isabs(root_dir):
         # default root dir is always absolute and it needs to prefix the
         # relative root_dir which is relative

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2072,6 +2072,8 @@ def prepend_root_dir(opts, path_options):
                 continue
             # Prepending the root dir
             opts[path_option] = salt.utils.path_join(root_dir, path)
+    logging.getLogger(__name__).trace('log_file = {}'.format(opts.get(
+        'log_file')))
 
 
 def insert_system_path(opts, paths):
@@ -3272,6 +3274,24 @@ def _update_ssl_config(opts):
         opts['ssl'][key] = getattr(ssl, val)
 
 
+def _adjust_log_file_override(overrides, default_log_file):
+    '''
+    Adjusts the log_file based on the log_dir override
+    '''
+    if overrides.get('log_dir'):
+        # Adjust log_file if a log_dir override is introduced
+        if overrides.get('log_file'):
+            if not os.path.abspath(overrides['log_file']):
+                # Prepend log_dir if log_file is relative
+                overrides['log_file'] = os.path.join(overrides['log_dir'],
+                                                     overrides['log_file'])
+        else:
+            # Create the log_file override
+            overrides['log_file'] = \
+                os.path.join(overrides['log_dir'],
+                             os.path.basename(default_log_file))
+
+
 def apply_minion_config(overrides=None,
                         defaults=None,
                         cache_minion_id=False,
@@ -3284,6 +3304,7 @@ def apply_minion_config(overrides=None,
 
     opts = defaults.copy()
     opts['__role'] = 'minion'
+    _adjust_log_file_override(overrides, defaults['log_file'])
     if overrides:
         opts.update(overrides)
 
@@ -3435,6 +3456,7 @@ def apply_master_config(overrides=None, defaults=None):
 
     opts = defaults.copy()
     opts['__role'] = 'master'
+    _adjust_log_file_override(overrides, defaults['log_file'])
     if overrides:
         opts.update(overrides)
 
@@ -3678,6 +3700,7 @@ def apply_spm_config(overrides, defaults):
     .. versionadded:: 2015.8.1
     '''
     opts = defaults.copy()
+    _adjust_log_file_override(overrides, defaults['log_file'])
     if overrides:
         opts.update(overrides)
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2070,7 +2070,7 @@ def prepend_root_dir(opts, path_options):
             elif path == root_opt_val or \
                     path.startswith(root_opt_val + os.sep):
                 # Remove relative root dir so we can add the absolute root dir
-                path = path[len(root_opt):]
+                path = path[len(root_opt_val):]
             # Prepending the root dir
             opts[path_option] = salt.utils.path_join(root_dir, path)
     logging.getLogger(__name__).trace('log_file = {}'.format(opts.get(

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2053,7 +2053,7 @@ def prepend_root_dir(opts, path_options):
     Prepends the options that represent filesystem paths with value of the
     'root_dir' option.
     '''
-    root_dir = opts['root_dir']
+    root_dir = opts['root_dir'].rstrip(os.sep)
     root_opt_val = opts['root_dir']
     if not os.path.isabs(root_dir):
         # default root dir is always absolute and it needs to prefix the

--- a/tests/unit/config/test_api.py
+++ b/tests/unit/config/test_api.py
@@ -40,7 +40,9 @@ class APIConfigTestCase(TestCase):
         '''
         with patch('salt.config.client_config', MagicMock(return_value=MOCK_MASTER_DEFAULT_OPTS)):
             ret = salt.config.api_config('/some/fake/path')
-            self.assertEqual(ret['log_file'], '/var/log/salt/api')
+            self.assertEqual(ret['log_file'],
+                             '{0}/var/log/salt/api'.format(
+                                 salt.syspaths.ROOT_DIR))
 
     def test_api_config_pidfile_values(self):
         '''
@@ -50,7 +52,9 @@ class APIConfigTestCase(TestCase):
         '''
         with patch('salt.config.client_config', MagicMock(return_value=MOCK_MASTER_DEFAULT_OPTS)):
             ret = salt.config.api_config('/some/fake/path')
-            self.assertEqual(ret['pidfile'], '/var/run/salt-api.pid')
+            self.assertEqual(ret['pidfile'],
+                             '{0}/var/run/salt-api.pid'
+                             ''.format(salt.syspaths.ROOT_DIR))
 
     @destructiveTest
     def test_master_config_file_overrides_defaults(self):

--- a/tests/unit/config/test_api.py
+++ b/tests/unit/config/test_api.py
@@ -5,6 +5,7 @@ tests.unit.api_config_test
 
 # Import Python libs
 from __future__ import absolute_import
+import os
 
 # Import Salt Testing libs
 from tests.support.unit import skipIf, TestCase
@@ -42,7 +43,7 @@ class APIConfigTestCase(TestCase):
             ret = salt.config.api_config('/some/fake/path')
             self.assertEqual(ret['log_file'],
                              '{0}/var/log/salt/api'.format(
-                                 salt.syspaths.ROOT_DIR))
+                                 salt.syspaths.ROOT_DIR.rstrip(os.sep)))
 
     def test_api_config_pidfile_values(self):
         '''
@@ -54,7 +55,7 @@ class APIConfigTestCase(TestCase):
             ret = salt.config.api_config('/some/fake/path')
             self.assertEqual(ret['pidfile'],
                              '{0}/var/run/salt-api.pid'
-                             ''.format(salt.syspaths.ROOT_DIR))
+                             ''.format(salt.syspaths.ROOT_DIR.rstrip(os.sep)))
 
     @destructiveTest
     def test_master_config_file_overrides_defaults(self):

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -138,6 +138,25 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             if os.path.isdir(tempdir):
                 shutil.rmtree(tempdir)
 
+    def test_default_root_dir_included_in_config_root_dir(self):
+        os.makedirs(os.path.join(TMP, 'tmp2'))
+        tempdir = tempfile.mkdtemp(dir=os.path.join(TMP, 'tmp2'))
+        try:
+            root_dir = os.path.join(tempdir, 'foo', 'bar')
+            os.makedirs(root_dir)
+            fpath = os.path.join(root_dir, 'config')
+            with salt.utils.fopen(fpath, 'w') as fp_:
+                fp_.write(
+                    'root_dir: {0}\n'
+                    'log_file: {1}\n'.format(root_dir, fpath)
+                )
+            with patch('salt.syspaths.ROOT_DIR', TMP):
+                config = sconfig.master_config(fpath)
+            self.assertEqual(config['log_file'], fpath)
+        finally:
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)
+
     def test_load_master_config_from_environ_var(self):
         original_environ = os.environ.copy()
 


### PR DESCRIPTION
### What issues does this PR fix or reference?

The PR fixes how the root_dir is prependend to relative paths. Also it fixes how the log_file path is derived when the log_dir override is set in the config file.

### Previous Behavior
The previous logic of prepending the root_dir to relative locations has a bug in which if the default root_dir (set in the code) is included in the overriden file locations (specified in the config file), the default root_dir segment is replaced by the the override root_dir, even if those paths should be skipped. Also the prepend logic is faulty when the default root_dir is included in the overriden root_dir.

Also, the default path assigned to the default log_file won't be overriden if the log_dir override is specified in the config file.

### New Behavior
The prepend and log_file bugs are fixed. The default log_file path is adjusted if the log_dir override is specified. The logic to prepend the root_dir (either the default one in code or the override in the config) is fixed. 

### Tests written?

Yes 

- test added to check that the prepend logic works correctly when the default root_dir is included in the override root_dir.
- fixed tests that didn't take into account the existence of the default root_dir override (in test_api)


Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
