### PR TITLE
show chanages in file.blockreplace function in testing mode.

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3672,10 +3672,11 @@ def blockreplace(
     if changes:
         ret['pchanges'] = {'diff': changes}
         if __opts__['test']:
+            ret['changes']['diff'] = ret['pchanges']['diff']
             ret['result'] = None
             ret['comment'] = 'Changes would be made'
         else:
-            ret['changes'] = {'diff': changes}
+            ret['changes']['diff'] = ret['pchanges']['diff']
             ret['result'] = True
             ret['comment'] = 'Changes were made'
     else:


### PR DESCRIPTION
### What does this PR do?

Changes (diff) will be shown while running `file.blockreplace` function in test mode.


### Previous Behavior
Changes weren't shown:

```
          ID: my_test
    Function: file.blockreplace
        Name: /tmp/test.conf
      Result: None
     Comment: Changes would be made
     Started: 17:02:12.728462
    Duration: 6.978 ms
     Changes:
```


### New Behavior
Changes are shown:

```
          ID: my_test
    Function: file.blockreplace
        Name: /tmp/test.conf
      Result: None
     Comment: Changes would be made
     Started: 17:05:55.498624
    Duration: 5.716 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -1,3 +1,3 @@
                   # START managed zone 1  -DO-NOT-EDIT-
                  -testtestststssasdasdt
                  +testtestststssasdasdasdasdt
                   # END managed zone 1 -DO-NOT-EDIT-
```

### Tests written?
No
