### PR TITLE
Unicode support to cp.push dir

### DIFF
--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -8,6 +8,9 @@ from __future__ import absolute_import
 import os
 import logging
 import fnmatch
+import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
 
 # Import salt libs
 import salt.minion

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -900,7 +900,7 @@ def push_dir(path, glob=None, upload_path=None):
         return push(path, upload_path=upload_path)
     else:
         filelist = []
-        for root, _, files in os.walk(path):
+        for root, _, files in os.walk(ur''.join(path)):
             filelist += [os.path.join(root, tmpfile) for tmpfile in files]
         if glob is not None:
             filelist = [fi for fi in filelist if fnmatch.fnmatch(os.path.basename(fi), glob)]

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -818,8 +818,14 @@ def _client_wrapper(attr, *args, **kwargs):
     '''
     catch_api_errors = kwargs.pop('catch_api_errors', True)
     func = getattr(__context__['docker.client'], attr, None)
-    if func is None:
+    if func is None or not hasattr(func, '__call__'):
         raise SaltInvocationError('Invalid client action \'{0}\''.format(attr))
+    if attr in ('push', 'pull'):
+        try:
+            # Refresh auth config from config.json
+            __context__['docker.client'].reload_config()
+        except AttributeError:
+            pass
     err = ''
     try:
         log.debug(


### PR DESCRIPTION
### What does this PR do?
Unicode named Files and directories pushed successfully

### What issues does this PR fix?

#41018

### Previous Behavior
cp.push_dir returned False while read unicode filenames and directories.

### New Behavior
Unicode file names get successfully pushed to master 

### Tests written?

No
