### PR TITLE
Do not force effective saltenv when running states via orchestration

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -230,7 +230,7 @@ def state(
     if pillar:
         cmd_kw['kwarg']['pillar'] = pillar
 
-    cmd_kw['kwarg']['saltenv'] = __env__
+    cmd_kw['kwarg']['saltenv'] = saltenv
     cmd_kw['kwarg']['queue'] = queue
 
     if isinstance(concurrent, bool):


### PR DESCRIPTION
The saltenv argument from state orchestration was being ignored in favor of the magic ``__env__`` dunder. This affects highstates run via orchestration, which by default should process all envs in the loaded tops.

Resolves #40928.