### PR TITLE
Look for currently-running python's pip first

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -81,6 +81,7 @@ import os
 import re
 import shutil
 import logging
+import sys
 
 # Import salt libs
 import salt.utils
@@ -118,7 +119,10 @@ def _get_pip_bin(bin_env):
     executable itself, or from searching conventional filesystem locations
     '''
     if not bin_env:
-        which_result = __salt__['cmd.which_bin'](['pip', 'pip2', 'pip3', 'pip-python'])
+        which_result = __salt__['cmd.which_bin'](
+            ['pip{0}.{1}'.format(*sys.version_info[:2]),
+             'pip', 'pip2', 'pip3', 'pip-python']
+        )
         if which_result is None:
             raise CommandNotFoundError('Could not find a `pip` binary')
         if salt.utils.is_windows():


### PR DESCRIPTION
This improves pip detection on hosts where a ``pip`` executable exists and refers to a different Python version from the Python under which Salt is running. It does so by getting the major and minor version from ``sys.version_info`` and looking for ``pipX.Y`` before checking the rest of the potential names for pip.