### PR TITLE
Fixed crash image lacks file ext

### DIFF
--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -606,7 +606,7 @@ def find_pool_and_volume(conn, path):
 
 
 def generate_new_name(orig_name):
-    if not '.' in orig_name:
+    if '.' not in orig_name:
         return '{0}-{1}'.format(orig_name, uuid.uuid1())
 
     name, ext = orig_name.rsplit('.', 1)

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -606,6 +606,9 @@ def find_pool_and_volume(conn, path):
 
 
 def generate_new_name(orig_name):
+    if not '.' in orig_name:
+        return '{0}-{1}'.format(orig_name, uuid.uuid1())
+
     name, ext = orig_name.rsplit('.', 1)
     return '{0}-{1}.{2}'.format(name, uuid.uuid1(), ext)
 


### PR DESCRIPTION
Some tools, like Packer, don't include the 'qcow2' file extension
when generating disk images. When the libvirt cloud module was
given a disk image with no extension, the function would raise a
ValueError extension.


### What does this PR do?

This PR fixes `ValueError` exceptions being raised when the
`base_domain` of the libvirt cloud profile has a disk image
without a file extension (i.e. `.qcow2`).

### What issues does this PR fix or reference?

None. I can open a new issue if necessary.

### Previous Behavior

- Libvirt cloud profile had `base_domain: debian-jessie-8` set.
- The `debian-jessie-8` domain used a disk image named `debian-jessie-8`, without the file extension.

```
salt-cloud -p debian-jessie-8 myclone
....
[ERROR   ] There was a profile error: need more than 1 value to unpack                            
Traceback (most recent call last):                                                                       
  File "/usr/lib/python2.7/dist-packages/salt/cloud/cli.py", line 284, in run                            
    self.config.get('names')                                                                            
  File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1449, in run_profile       
    ret[name] = self.create(vm_)                                                                         
  File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1279, in create                   
    output = self.clouds[func](vm_)                                                                      
  File "/usr/lib/python2.7/dist-packages/salt/cloud/clouds/libvirt.py", line 462, in create
    raise e
ValueError: need more than 1 value to unpack
```

### New Behavior

- Libvirt cloud profile had `base_domain: debian-jessie-8` set.
- The `debian-jessie-8` domain used a disk image named `debian-jessie-8`, without the file extension.

```
salt-cloud -p debian-jessie-8 myclone
```

- Creates the domain `myclone` that has a disk image named `debian-jessie-8-27400cc0-3021-11e7-8acd-eec219dc6767`.

### Tests written?

No