### PR TITLE
Fix pkg.remove

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1428,7 +1428,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
                 )
 
             #Compute msiexec string
-            use_msiexec, msiexec = _get_msiexec(pkginfo[version_num].get('msiexec', False))
+            use_msiexec, msiexec = _get_msiexec(pkginfo[target].get('msiexec', False))
 
             # Uninstall the software
             # Check Use Scheduler Option


### PR DESCRIPTION
### What does this PR do?
Fixes a stacktrace that was occurring with pkg.remove in Windows. Was using `version_num`. Needs to use `target`.

### What issues does this PR fix or reference?
Found in testing. Caused by https://github.com/saltstack/salt/pull/40785

### Previous Behavior
Stacktrace:
```
    The minion function caused an exception: Traceback (most recent call last):
      File "C:\salt\bin\lib\site-packages\salt\minion.py", line 1466, in _thread_return
        return_data = executor.execute()
      File "C:\salt\bin\lib\site-packages\salt\executors\direct_call.py", line 28, in execute
        return self.func(*self.args, **self.kwargs)
      File "C:\salt\bin\lib\site-packages\salt\modules\win_pkg.py", line 1512, in remove
        use_msiexec, msiexec = _get_msiexec(pkginfo[version_num].get('msiexec', False))
    KeyError: None
```
`version_num` is not defined at that point, need to use `target` instead.

### New Behavior
Uses `target`

### Tests written?
No
