### PR TITLE
mac_system: return False for non-root user

### DIFF
--- a/salt/modules/mac_system.py
+++ b/salt/modules/mac_system.py
@@ -13,6 +13,8 @@ try:  # python 3
 except ImportError:  # python 2
     from pipes import quote as _cmd_quote
 
+import getpass
+
 # Import salt libs
 import salt.utils
 from salt.exceptions import CommandExecutionError, SaltInvocationError
@@ -27,6 +29,10 @@ def __virtual__():
     if not salt.utils.is_darwin():
         return (False, 'The mac_system module could not be loaded: '
                        'module only works on MacOS systems.')
+
+    if getpass.getuser() != 'root':
+        return False, 'The mac_system module is not useful for non-root users.'
+
 
     if not _atrun_enabled():
         if not _enable_atrun():


### PR DESCRIPTION
### What does this PR do?

Fixes error message spam at the console when running salt-call as non-root on OSX.

### What issues does this PR fix or reference?

Fixes #40835.

### Previous Behavior

An exception was raised from `mac_system.__virtual__()` and salt repeatedly tried to load the module. This spammed the console with error messages.

### New Behavior

Return False from `mac_system.__virtual__()` if the user is not 'root'.

### Tests written?

No. I'm guessing the existing mac_system integration tests cover the root user case. For the case of a non-root user, there are two ways to test:
1. Run the test as a non-root user
2. Mock `getpass.getuser()` to return 'nonroot' (or anything else other than 'root').

I don't know enough about python or salt testing to write either of those tests.
