### PR TITLE
fix integration wheel test_gen test

### DIFF
--- a/tests/integration/wheel/key.py
+++ b/tests/integration/wheel/key.py
@@ -22,8 +22,13 @@ class KeyWheelModuleTest(integration.TestCase, integration.AdaptedConfigurationT
 
         self.assertIn('pub', ret)
         self.assertIn('priv', ret)
-        self.assertTrue(
-            ret.get('pub', '').startswith('-----BEGIN PUBLIC KEY-----'))
+        try:
+            self.assertTrue(
+                ret.get('pub', '').startswith('-----BEGIN PUBLIC KEY-----'))
+        except AssertionError:
+            self.assertTrue(
+                ret.get('pub', '').startswith('-----BEGIN RSA PUBLIC KEY-----'))
+
         self.assertTrue(
             ret.get('priv', '').startswith('-----BEGIN RSA PRIVATE KEY-----'))
 


### PR DESCRIPTION
### What does this PR do?
Currently the integration test `integration.wheel.key.KeyWheelModuleTest.test_gen` is failing on Centos6 with the following error:

```
Traceback (most recent call last):
  File "/testing/tests/integration/wheel/key.py", line 26, in test_gen
    ret.get('pub', '').startswith('-----BEGIN PUBLIC KEY-----'))
AssertionError: False is not true
```

Git bisect showed commit 31c6a10d1b9ce854bb857ca6b0287650093d2f8b which led me to see that in that commit it tries to do `from Cryptodome.PublicKey import RSA` and then `from Crypto.PublicKey import RSA` if that import fails.

If I run this script on a centos6 box:

```
from Crypto.PublicKey import RSA
gen = RSA.generate(bits=2048, e=65537)
print(gen.publickey().exportKey('PEM'))

from Cryptodome.PublicKey import RSA
gen = RSA.generate(bits=2048, e=65537)
print(gen.publickey().exportKey('PEM'))
```

I see that the first and second print out two seperate key headers:

```
[root@22e366039951 tests]# python ~/test.py
-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2mfZ5Nuhk9SKzyQuQ96y
oe21Q4L4EdUnngfq306HCp9Ur2ydYofrhWSord+9pfeIVPTmOh448J5rYqqtThjK
iEtZtVucy17NYdLChZ/89ZY6krf6MXTT1SA5FRvIhJQEBNQithJHnahnuDKs82eb
7WGAt2pFY9k1AS6lTLWyb8Bw5CU1FEFUK7krp0DGrgduIyw2x+fOzHAS01l9jyuX
loz0cjbOwhimQhqiDH3Cp1SqrYDH8VxY6Pd7FbxdeFw64QAcMBai+Ninp2EBTnos
0pmy9NQmOawwDfGteduFnHRmp2jvTKvhJQ7WOaF4VcF8whY6DoD2zFhRKA7wU9fM
LQIDAQAB
-----END PUBLIC KEY-----
-----BEGIN RSA PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr2llVSlahrPWVCSDGmNt
a5w1hvlk4dE7uivTRspH0LiWAv+LZEhqMsxDlLmPvgXehlmjC2DCmGZlIGcxeHDX
xlzCaEQVLVlTN1KfM3KWY9LyfP9amOE2z+ef4wnt/FDok5F8a39GY98S+Kj8N6t4
YfUR+CPJ/9yiDHIh158h+uvq75m1/Q2INuuFlnrOvv1C/I0y7x5wOXAN4drsJ9Sb
O8NJUaEYbdO4nrTwjRpkFCuFN6VH244X+/+hcflfrd2CLn8U42zfmGbLjjchrVZh
QGljYrfHr26BNC6YEMf41lxm9lP+hwVM3U+agfXCUSmf8CqqFf1LezMsKE79yj6c
qwIDAQAB
-----END RSA PUBLIC KEY-----
```

Notice `BEGIN PUBLIC KEY` vs `BEGIN RSA PUBLIC KEY`

Fixes a test

I'm pretty sure we are okay with this change in the test, but I want to make sure @thatch45 is okay with this change. I don't quiet understand the other aspects of salt that this might impact. In fact it seems this PR https://github.com/saltstack/salt/pull/40898 is trying to fix the same sort of problem.

So to sum it up what i found is pycryptodome vs pycrypto generate different key headers, and I can simply change this in the test to accept both headers but i'm not certain if this affects anythwere else in salt.


### Tests written?

Yes
