### PR TITLE
INFRA-4795 - fix logic for volume tagging in EC2

### DIFF
--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -1229,13 +1229,17 @@ def volumes_tagged(name, tag_maps, authoritative=False, region=None, key=None,
     if __opts__['test']:
         args['dry_run'] = True
         r = __salt__['boto_ec2.set_volumes_tags'](**args)
-        if r.get('changes'):
-            ret['comment'] = 'Tags would be updated.'
-            ret['changes'] = r['changes']
-        ret['result'] = None if r['success'] else False
+        if r['success']:
+            if r.get('changes'):
+                ret['comment'] = 'Tags would be updated.'
+                ret['changes'] = r['changes']
+                ret['result'] = None
+        else:
+            ret['comment'] = 'Error validating requested volume tags.'
+            ret['result'] = False
         return ret
     r = __salt__['boto_ec2.set_volumes_tags'](**args)
-    if r['success'] is True:
+    if r['success']:
         if r.get('changes'):
             ret['comment'] = 'Tags applied.'
             ret['changes'] = r['changes']

--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -1230,12 +1230,15 @@ def volumes_tagged(name, tag_maps, authoritative=False, region=None, key=None,
         args['dry_run'] = True
         r = __salt__['boto_ec2.set_volumes_tags'](**args)
         if r.get('changes'):
-            ret['comment'] = 'The following changes would be applied: {0}'.format(r)
+            ret['comment'] = 'Tags would be updated.'
+            ret['changes'] = r['changes']
+        ret['result'] = None if r['success'] else False
         return ret
     r = __salt__['boto_ec2.set_volumes_tags'](**args)
     if r['success'] is True:
-        ret['comment'] = 'Tags applied.'
-        ret['changes'] = r['changes']
+        if r.get('changes'):
+            ret['comment'] = 'Tags applied.'
+            ret['changes'] = r['changes']
     else:
         ret['comment'] = 'Error updating requested volume tags.'
         ret['result'] = False


### PR DESCRIPTION
The previous logic (which I wrote, so ... bleh) was basically only applying the LAST set of tags to a volume when multiple filter criteria matched it in different ways.

The new logic calculates ALL tags for each volume up front, and then uses a second loop over the volumes themselves to ensure all relevant tags for each are applied as a single changeset; thus dropping no tags on the floor...

Also updated the state code to, 1) correctly return None on a successful test=True run, and 2) for a test=True run, return much better detail on what would be changed.