### PR TITLE
Revert "Updated ssh fingerprint hash-type default to sah256 for Nitrogen and remove md5 warnings"

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -106,10 +106,6 @@ State Module Changes
       use_superseded:
         - module.run
 
-- The default for the ``fingerprint_hash_type`` option used in the ``present``
-  function in the :mod:`ssh <salt.states.ssh_know_hosts>` state changed from
-  ``md5`` to ``sha256``.
-
 
 Execution Module Changes
 ========================
@@ -136,9 +132,6 @@ Execution Module Changes
   :py:func:`Arch Linux <salt.modules.pacman.list_repo_pkgs>`-based distros.
 - The :mod:`system <salt.modules.system>` module changed its return format
   from "HH:MM AM/PM" to "HH:MM:SS AM/PM" for `get_system_time`.
-- The default for the ``fingerprint_hash_type`` option used in the
-  :mod:`ssh <salt.modules.ssh>` execution module changed from ``md5`` to
-  ``sha256``.
 
 
 Proxy Module Changes

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -237,16 +237,23 @@ def _fingerprint(public_key, fingerprint_hash_type=None):
 
     fingerprint_hash_type
         The public key fingerprint hash type that the public key fingerprint
-        was originally hashed with. This defaults to ``sha256`` if not specified.
+        was originally hashed with. This defaults to ``md5`` if not specified.
 
         .. versionadded:: 2016.11.4
-        .. versionchanged:: Nitrogen: default changed from ``md5`` to ``sha256``
+
+        .. note::
+
+            The default value of the ``fingerprint_hash_type`` will change to
+            ``sha256`` in Salt Nitrogen.
 
     '''
     if fingerprint_hash_type:
         hash_type = fingerprint_hash_type.lower()
     else:
-        hash_type = 'sha256'
+        # Set fingerprint_hash_type to md5 as default
+        log.warning('Public Key hashing currently defaults to "md5". This will '
+                    'change to "sha256" in the Nitrogen release.')
+        hash_type = 'md5'
 
     try:
         hash_func = getattr(hashlib, hash_type)
@@ -822,10 +829,14 @@ def recv_known_host(hostname,
 
     fingerprint_hash_type
         The public key fingerprint hash type that the public key fingerprint
-        was originally hashed with. This defaults to ``sha256`` if not specified.
+        was originally hashed with. This defaults to ``md5`` if not specified.
 
         .. versionadded:: 2016.11.4
-        .. versionchanged:: Nitrogen: default changed from ``md5`` to ``sha256``
+
+        .. note::
+
+            The default value of the ``fingerprint_hash_type`` will change to
+            ``sha256`` in Salt Nitrogen.
 
     CLI Example:
 
@@ -995,10 +1006,14 @@ def set_known_host(user=None,
 
     fingerprint_hash_type
         The public key fingerprint hash type that the public key fingerprint
-        was originally hashed with. This defaults to ``sha256`` if not specified.
+        was originally hashed with. This defaults to ``md5`` if not specified.
 
         .. versionadded:: 2016.11.4
-        .. versionchanged:: Nitrogen: default changed from ``md5`` to ``sha256``
+
+        .. note::
+
+            The default value of the ``fingerprint_hash_type`` will change to
+            ``sha256`` in Salt Nitrogen.
 
     CLI Example:
 

--- a/salt/states/ssh_known_hosts.py
+++ b/salt/states/ssh_known_hosts.py
@@ -100,9 +100,14 @@ def present(
 
     fingerprint_hash_type
         The public key fingerprint hash type that the public key fingerprint
-        was originally hashed with. This defaults to ``sha256`` if not specified.
+        was originally hashed with. This defaults to ``md5`` if not specified.
 
         .. versionadded:: 2016.11.4
+
+        .. note::
+
+            The default value of the ``fingerprint_hash_type`` will change to
+            ``sha256`` in Salt Nitrogen.
 
     '''
     ret = {'name': name,

--- a/tests/integration/modules/test_ssh.py
+++ b/tests/integration/modules/test_ssh.py
@@ -22,7 +22,7 @@ from tornado.httpclient import HTTPClient
 SUBSALT_DIR = os.path.join(TMP, 'subsalt')
 AUTHORIZED_KEYS = os.path.join(SUBSALT_DIR, 'authorized_keys')
 KNOWN_HOSTS = os.path.join(SUBSALT_DIR, 'known_hosts')
-GITHUB_FINGERPRINT = '9d:38:5b:83:a9:17:52:92:56:1a:5e:c4:d4:81:8e:0a:ca:51:a2:64:f1:74:20:11:2e:f8:8a:c3:a1:39:49:8f'
+GITHUB_FINGERPRINT = '16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48'
 
 
 def check_status():

--- a/tests/integration/states/test_ssh.py
+++ b/tests/integration/states/test_ssh.py
@@ -23,7 +23,7 @@ from tests.support.helpers import (
 import salt.utils
 
 KNOWN_HOSTS = os.path.join(RUNTIME_VARS.TMP, 'known_hosts')
-GITHUB_FINGERPRINT = '9d:38:5b:83:a9:17:52:92:56:1a:5e:c4:d4:81:8e:0a:ca:51:a2:64:f1:74:20:11:2e:f8:8a:c3:a1:39:49:8f'
+GITHUB_FINGERPRINT = '16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48'
 GITHUB_IP = '192.30.253.113'
 
 


### PR DESCRIPTION
Reverts saltstack/salt#40899