### PR TITLE
Add skip filter to jinja template

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -179,6 +179,22 @@ class PrintableDict(OrderedDict):
         return '{' + ', '.join(output) + '}'
 
 
+def skip_filter(data):
+    '''
+    Suppress data output
+
+    .. code-balock:: yaml
+
+        {% my_string = "foo" %}
+
+        {{ my_string|skip }}
+
+    will be rendered as empty string,
+
+    '''
+    return ''
+
+
 def ensure_sequence_filter(data):
     '''
     Ensure sequenced data.

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -326,6 +326,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
         jinja_env = jinja2.Environment(undefined=jinja2.StrictUndefined,
                                        **env_args)
 
+    jinja_env.filters['skip'] = salt.utils.jinja.skip_filter
     jinja_env.filters['strftime'] = salt.utils.date_format
     jinja_env.filters['sequence'] = salt.utils.jinja.ensure_sequence_filter
     jinja_env.filters['http_query'] = salt.utils.http.query


### PR DESCRIPTION
Allow to update dictionary value within jinja loop

```
{% set _stash = {} %}
{% for a in b -%}
{%   if not _stash.get('key') -%}
{{     _stash.update({'key': a}) | skip -}}
{%   endif -%}
{% endfor -%}
```

### What does this PR do?

Add jinja skip filter that returns nothing

### What issues does this PR fix or reference?

#41059

### New Behavior

New skip filter for jinja templates

### Tests written?

No
