### PR TITLE
cloud: update parsing of libcloud version

### DIFF
--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -17,6 +17,7 @@ from salt.ext.six.moves import zip
 # Import libcloud
 try:
     import libcloud
+    import re
     from libcloud.compute.types import Provider
     from libcloud.compute.providers import get_driver
     from libcloud.compute.deployment import (
@@ -25,7 +26,7 @@ try:
     )
     HAS_LIBCLOUD = True
     LIBCLOUD_VERSION_INFO = tuple([
-        int(part) for part in libcloud.__version__.replace('-', '.').split('.')[:3]
+        int(part) for part in re.compile(r"(\d+).(\d+).(\d+)").match(libcloud.__version__.replace('-', '.')).groups()
     ])
 
 except ImportError:


### PR DESCRIPTION
since Fedora changed the version to 2.0.0rc2 the version number cannot
be parsed. This fixes the parsing using a regex which should be more
general.