### PR TITLE
Allow failhard to work with the salt-api.  Gracefully stop iteration.

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -21,7 +21,9 @@ from salt.utils import print_cli
 import salt.ext.six as six
 from salt.ext.six.moves import range
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
+import logging
 
+log = logging.getLogger(__name__)
 
 class Batch(object):
     '''
@@ -245,8 +247,12 @@ class Batch(object):
                     if bwait:
                         wait.append(datetime.now() + timedelta(seconds=bwait))
                 # Munge retcode into return data
+                failhard = False
                 if 'retcode' in data and isinstance(data['ret'], dict) and 'retcode' not in data['ret']:
                     data['ret']['retcode'] = data['retcode']
+                    if self.opts.get('failhard') and data['ret']['retcode'] > 0:
+                        failhard = True
+
                 if self.opts.get('raw'):
                     ret[minion] = data
                     yield data
@@ -264,6 +270,9 @@ class Batch(object):
                             data,
                             out,
                             self.opts)
+                if failhard:
+                    log.error('ERROR: Minion {} returned with non-zero exit code. Batch run stopped due to failhard'.format(minion))
+                    raise StopIteration
 
             # remove inactive iterators from the iters list
             for queue in minion_tracker:

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -25,6 +25,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
+
 class Batch(object):
     '''
     Manage the execution of batch runs

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -262,14 +262,6 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                     if job_retcode > retcode:
                         # Exit with the highest retcode we find
                         retcode = job_retcode
-                    if self.options.failhard:
-                        if retcode != 0:
-                            sys.stderr.write(
-                                '{0}\nERROR: Minions returned with non-zero exit code.\n'.format(
-                                    res
-                                )
-                            )
-                            sys.exit(retcode)
             sys.exit(retcode)
 
     def _print_errors_summary(self, errors):

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -560,6 +560,7 @@ class LocalClient(object):
                 'tgt_type': tgt_type,
                 'ret': ret,
                 'batch': batch,
+                'failhard': kwargs.get('failhard', False),
                 'raw': kwargs.get('raw', False)}
 
         if 'timeout' in kwargs:


### PR DESCRIPTION
### What does this PR do?

Move the logic for failhard inside of batch.py.  This allows the salt-api to use failhard.
It also stops the iteration instead of crashing the process during a failhard event.  This allows for nicely formatted output.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/30329

### Previous Behavior

It was not possible to use failhard with the salt-api.

failhard on the salt cli looked like this (ugly):
```
[root@localhost saltstack]# salt '*' -b 1 --failhard state.apply test

Executing run on ['local-container-fedora']

{'local-container-fedora': {'test_|-always-passes_|-foo_|-fail_without_changes': {'comment': 'Failure!', 'name': 'foo', 'start_time': '09:04:48.843944', 'result': False, 'duration': 0.573, '__run_num__': 0, 'changes': {}, '__id__': 'always-passes'}, 'retcode': 2}}
ERROR: Minions returned with non-zero exit code.
```

### New Behavior

On the salt-api {"failhard": True} can now be passed. Example post arguments to salt-api: `{"expr_form": "glob", "tgt": "*", "arg": ["test"], "fun": "state.apply", "failhard": "True", "batch": "1", "client": "local_batch"}`

failhard on the salt cli now looks like this (beautiful):
```
[root@localhost saltstack]# salt '*' -b 1 --failhard state.apply test

Executing run on ['local-container-fedora']

local-container-fedora:
----------
		  ID: always-passes
	Function: test.fail_without_changes
		Name: foo
	  Result: False
	 Comment: Failure!
	 Started: 08:15:22.828206
	Duration: 0.484 ms
	 Changes:   

Summary for local-container-fedora
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   0.484 ms
jid:
	20170504081521862123
retcode:
	2
[ERROR   ] ERROR: Minion local-container-fedora returned with non-zero exit code. Batch run stopped due to failhard
```

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
