### PR TITLE
Pylint: remove extra line in mac_system module

### DIFF
--- a/salt/modules/mac_system.py
+++ b/salt/modules/mac_system.py
@@ -37,7 +37,6 @@ def __virtual__():
     if getpass.getuser() != 'root':
         return False, 'The mac_system module is not useful for non-root users.'
 
-
     if not _atrun_enabled():
         if not _enable_atrun():
             return False, 'atrun could not be enabled on this system'


### PR DESCRIPTION
Fixes a pylint error that got in from #41048.
