### PR TITLE
doc: make examples consistent with each other

### DIFF
--- a/doc/topics/grains/index.rst
+++ b/doc/topics/grains/index.rst
@@ -95,44 +95,17 @@ the following configuration:
 
 .. code-block:: yaml
 
-    'node_type:webserver':
+    'roles:webserver':
       - match: grain
-      - webserver
+      - state0
 
-    'node_type:postgres':
+    'roles:memcache':
       - match: grain
-      - postgres
-
-    'node_type:redis':
-      - match: grain
-      - redis
-
-    'node_type:lb':
-      - match: grain
-      - lb
+      - state1
+      - state2
 
 For this example to work, you would need to have defined the grain
-``node_type`` for the minions you wish to match. This simple example is nice,
-but too much of the code is similar. To go one step further, Jinja templating
-can be used to simplify the :term:`top file`.
-
-.. code-block:: yaml
-
-    {% set the_node_type = salt['grains.get']('node_type', '') %}
-
-    {% if the_node_type %}
-      'node_type:{{ the_node_type }}':
-        - match: grain
-        - {{ the_node_type }}
-    {% endif %}
-
-Using Jinja templating, only one match entry needs to be defined.
-
-.. note::
-
-    The example above uses the :mod:`grains.get <salt.modules.grains.get>`
-    function to account for minions which do not have the ``node_type`` grain
-    set.
+``role`` for the minions you wish to match.
 
 .. _writing-grains:
 


### PR DESCRIPTION
Also, show a more complex example, which makes removing the templating necessary

### What does this PR do?
Makes it easier to understand this part of the documentation