### PR TITLE
Update win_dns_client to use reg.read_value and set_value

### DIFF
--- a/salt/states/win_dns_client.py
+++ b/salt/states/win_dns_client.py
@@ -171,32 +171,32 @@ def primary_suffix(name,
 
     reg_data = {
             'suffix': {
-                'hkey': 'HKEY_LOCAL_MACHINE',
-                'path': r'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
-                'key':  'NV Domain',
-                'type': 'REG_SZ',
+                'hive': 'HKEY_LOCAL_MACHINE',
+                'key': r'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
+                'vname':  'NV Domain',
+                'vtype': 'REG_SZ',
                 'old':  None,
                 'new':  suffix
             },
             'updates': {
-                'hkey': 'HKEY_LOCAL_MACHINE',
-                'path': r'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
-                'key':  'SyncDomainWithMembership',
-                'type': 'REG_DWORD',
+                'hive': 'HKEY_LOCAL_MACHINE',
+                'key': r'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
+                'vname':  'SyncDomainWithMembership',
+                'vtype': 'REG_DWORD',
                 'old':  None,
                 'new':  updates
             }
     }
 
-    reg_data['suffix']['old'] = __salt__['reg.read_key'](
-            reg_data['suffix']['hkey'],
-            reg_data['suffix']['path'],
-            reg_data['suffix']['key'],)
+    reg_data['suffix']['old'] = __salt__['reg.read_value'](
+            reg_data['suffix']['hive'],
+            reg_data['suffix']['key'],
+            reg_data['suffix']['vname'],)['vdata']
 
-    reg_data['updates']['old'] = bool(__salt__['reg.read_key'](
-            reg_data['updates']['hkey'],
-            reg_data['updates']['path'],
-            reg_data['updates']['key'],))
+    reg_data['updates']['old'] = bool(__salt__['reg.read_value'](
+            reg_data['updates']['hive'],
+            reg_data['updates']['key'],
+            reg_data['updates']['vname'],)['vdata'])
 
     updates_operation = 'enabled' if reg_data['updates']['new'] else 'disabled'
 
@@ -234,19 +234,19 @@ def primary_suffix(name,
                     'new': {
                         'suffix': reg_data['suffix']['new']}}
 
-    suffix_result = __salt__['reg.set_key'](
-            reg_data['suffix']['hkey'],
-            reg_data['suffix']['path'],
+    suffix_result = __salt__['reg.set_value'](
+            reg_data['suffix']['hive'],
             reg_data['suffix']['key'],
+            reg_data['suffix']['vname'],
             reg_data['suffix']['new'],
-            reg_data['suffix']['type'])
+            reg_data['suffix']['vtype'])
 
-    updates_result = __salt__['reg.set_key'](
-            reg_data['updates']['hkey'],
-            reg_data['updates']['path'],
+    updates_result = __salt__['reg.set_value'](
+            reg_data['updates']['hive'],
             reg_data['updates']['key'],
+            reg_data['updates']['vname'],
             reg_data['updates']['new'],
-            reg_data['updates']['type'])
+            reg_data['updates']['vtype'])
 
     ret['result'] = suffix_result & updates_result
 

--- a/tests/unit/states/test_win_dns_client.py
+++ b/tests/unit/states/test_win_dns_client.py
@@ -120,13 +120,13 @@ class WinDnsClientTestCase(TestCase, LoaderModuleMockMixin):
                                                            ), ret)
 
         mock = MagicMock(side_effect=['a', False, 'b', False])
-        with patch.dict(win_dns_client.__salt__, {'reg.read_key': mock}):
+        with patch.dict(win_dns_client.__salt__, {'reg.read_value': mock}):
             ret.update({'comment': 'No changes needed', 'result': True})
             self.assertDictEqual(win_dns_client.primary_suffix('salt', 'a'),
                                  ret)
 
             mock = MagicMock(return_value=True)
-            with patch.dict(win_dns_client.__salt__, {'reg.set_key': mock}):
+            with patch.dict(win_dns_client.__salt__, {'reg.set_value': mock}):
                 ret.update({'changes': {'new': {'suffix': 'a'},
                                         'old': {'suffix': 'b'}},
                             'comment': 'Updated primary DNS suffix (a)'})

--- a/tests/unit/states/test_win_dns_client.py
+++ b/tests/unit/states/test_win_dns_client.py
@@ -119,7 +119,7 @@ class WinDnsClientTestCase(TestCase, LoaderModuleMockMixin):
         self.assertDictEqual(win_dns_client.primary_suffix('salt', updates='a'
                                                            ), ret)
 
-        mock = MagicMock(side_effect=['a', False, 'b', False])
+        mock = MagicMock(side_effect=[{'vdata': 'a'}, {'vdata': False}, {'vdata': 'b'}, {'vdata': False}])
         with patch.dict(win_dns_client.__salt__, {'reg.read_value': mock}):
             ret.update({'comment': 'No changes needed', 'result': True})
             self.assertDictEqual(win_dns_client.primary_suffix('salt', 'a'),


### PR DESCRIPTION
### What does this PR do?
updates win_dns_client state to use the correct reg function names (set_value, read_value)

### What issues does this PR fix or reference?
N/A

### Previous Behavior
primary_suffix function will not work due to use of old function names

### New Behavior
primary_suffix function works as it did previously

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
