### PR TITLE
Patch calls to salt.client.Caller and salt.client.get_local_client in spm unit tests

### DIFF
--- a/tests/unit/test_spm.py
+++ b/tests/unit/test_spm.py
@@ -8,7 +8,7 @@ import tempfile
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase
-from tests.support.mock import patch
+from tests.support.mock import patch, MagicMock
 from tests.support.helpers import destructiveTest
 from tests.support.mixins import AdaptedConfigurationTestCaseMixin
 import salt.config
@@ -107,11 +107,15 @@ class SPMTest(TestCase, AdaptedConfigurationTestCaseMixin):
     def test_build_install(self):
         # Build package
         fdir = self._create_formula_files(_F1)
-        self.client.run(['build', fdir])
+        with patch('salt.client.Caller', MagicMock(return_value=self.minion_opts)):
+            with patch('salt.client.get_local_client', MagicMock(return_value=self.minion_opts['conf_file'])):
+                self.client.run(['build', fdir])
         pkgpath = self.ui._status[-1].split()[-1]
         assert os.path.exists(pkgpath)
         # Install package
-        self.client.run(['local', 'install', pkgpath])
+        with patch('salt.client.Caller', MagicMock(return_value=self.minion_opts)):
+            with patch('salt.client.get_local_client', MagicMock(return_value=self.minion_opts['conf_file'])):
+                self.client.run(['local', 'install', pkgpath])
         # Check filesystem
         for path, contents in _F1['contents']:
             path = os.path.join(self.minion_config['file_roots']['base'][0], _F1['definition']['name'], path)
@@ -119,7 +123,9 @@ class SPMTest(TestCase, AdaptedConfigurationTestCaseMixin):
             with salt.utils.fopen(path, 'r') as rfh:
                 assert rfh.read() == contents
         # Check database
-        self.client.run(['info', _F1['definition']['name']])
+        with patch('salt.client.Caller', MagicMock(return_value=self.minion_opts)):
+            with patch('salt.client.get_local_client', MagicMock(return_value=self.minion_opts['conf_file'])):
+                self.client.run(['info', _F1['definition']['name']])
         lines = self.ui._status[-1].split('\n')
         for key, line in (
                 ('name', 'Name: {0}'),
@@ -129,12 +135,16 @@ class SPMTest(TestCase, AdaptedConfigurationTestCaseMixin):
             assert line.format(_F1['definition'][key]) in lines
         # Reinstall with force=False, should fail
         self.ui._error = []
-        self.client.run(['local', 'install', pkgpath])
+        with patch('salt.client.Caller', MagicMock(return_value=self.minion_opts)):
+            with patch('salt.client.get_local_client', MagicMock(return_value=self.minion_opts['conf_file'])):
+                self.client.run(['local', 'install', pkgpath])
         assert len(self.ui._error) > 0
         # Reinstall with force=True, should succeed
         with patch.dict(self.minion_config, {'force': True}):
             self.ui._error = []
-            self.client.run(['local', 'install', pkgpath])
+            with patch('salt.client.Caller', MagicMock(return_value=self.minion_opts)):
+                with patch('salt.client.get_local_client', MagicMock(return_value=self.minion_opts['conf_file'])):
+                    self.client.run(['local', 'install', pkgpath])
             assert len(self.ui._error) == 0
 
     def test_failure_paths(self):
@@ -166,5 +176,7 @@ class SPMTest(TestCase, AdaptedConfigurationTestCaseMixin):
 
         for args in fail_args:
             self.ui._error = []
-            self.client.run(args)
+            with patch('salt.client.Caller', MagicMock(return_value=self.minion_opts)):
+                with patch('salt.client.get_local_client', MagicMock(return_value=self.minion_opts['conf_file'])):
+                    self.client.run(args)
             assert len(self.ui._error) > 0


### PR DESCRIPTION
### What does this PR do?
Fixes the spm unit test failures in CentOS 6. These calls to the client need to be patched so they don't interact with other unit tests.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/328

### Previous Behavior
On CentOS 6, these unit tests interact with some other unit tests (these failures only happen when running these tests with the `unit.test_state.py` tests. The unpatched calls to the client caused the following stacktrace:
```
Traceback (most recent call last):
         File "/testing/tests/unit/test_spm.py", line 114, in test_build_install
           self.client.run(['local', 'install', pkgpath])
         File "/testing/salt/spm/__init__.py", line 115, in run
           self._local(args)
         File "/testing/salt/spm/__init__.py", line 171, in _local
           self._local_install(args)
         File "/testing/salt/spm/__init__.py", line 374, in _local_install
           self._install(args)
         File "/testing/salt/spm/__init__.py", line 235, in _install
           self.caller = salt.client.Caller(mopts=caller_opts)
         File "/testing/salt/client/__init__.py", line 2031, in __init__
           self.sminion = salt.minion.SMinion(self.opts)
         File "/testing/salt/minion.py", line 657, in __init__
           opts['grains'] = salt.loader.grains(opts)
         File "/testing/salt/loader.py", line 671, in grains
           salt.config.DEFAULT_MINION_OPTS['conf_file']
         File "/testing/salt/config/__init__.py", line 1993, in load_config
           sys.exit(salt.defaults.exitcodes.EX_GENERIC)
       SystemExit: 1
```

### New Behavior
Tests pass

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
