### PR TITLE
Git state: head_ref should be head_rev in "latest" function

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -731,7 +731,7 @@ def latest(name,
         else:
             default_branch = None
     else:
-        head_ref = None
+        head_rev = None
         default_branch = None
 
     desired_upstream = False


### PR DESCRIPTION
The "head_ref" variable is not used anywhere in the state file, and should be "head_rev" instead. Without setting "head_rev" to "None", there is a potential to hit an UnboundLocalError further down in the file.

This was caught by a test in the nitrogen branch, but the bug is present on 2016.11 as well. Here's the output from the integration test failure:
```
   -> integration.states.test_git.GitTest.test_latest_updated_remote_rev  .........................................
       Traceback (most recent call last):
         File "/testing/tests/integration/states/test_git.py", line 365, in test_latest_updated_remote_rev
           self.assertSaltTrueReturn(ret)
         File "/testing/tests/support/mixins.py", line 547, in assertSaltTrueReturn
           **(next(six.itervalues(ret)))
       AssertionError: False is not True. Salt Comment:
       An exception occurred in this state: Traceback (most recent call last):
         File "/testing/salt/state.py", line 1822, in call
           **cdata['kwargs'])
         File "/testing/salt/loader.py", line 1727, in wrapper
           return f(*args, **kwargs)
         File "/testing/salt/states/git.py", line 727, in latest
           if head_rev is not None:
       UnboundLocalError: local variable 'head_rev' referenced before assignment
```
