### PR TITLE
Skip the test_salt_documentation_arguments_not_assumed test for Arch

### DIFF
--- a/tests/integration/shell/matcher.py
+++ b/tests/integration/shell/matcher.py
@@ -305,11 +305,6 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         '''
         Test to see if we're supporting --doc
         '''
-        os_family = self.run_call('--local grains.get os_family')[1].strip()
-        if os_family == 'Arch':
-            self.skipTest('This test is failing in Arch due to a bug in salt-testing. '
-                          'Skipping until salt-testing can be upgraded. For more information, '
-                          'see https://github.com/saltstack/salt-jenkins/issues/324.')
         data = self.run_salt('-d "*" user')
         self.assertIn('user.add:', data)
 

--- a/tests/integration/shell/matcher.py
+++ b/tests/integration/shell/matcher.py
@@ -312,6 +312,11 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         '''
         Test to see if we're not auto-adding '*' and 'sys.doc' to the call
         '''
+        os_family = self.run_call('--local grains.get os_family')[1].strip()
+        if os_family == 'Arch':
+            self.skipTest('This test is failing in Arch due to a bug in salt-testing. '
+                          'Skipping until salt-testing can be upgraded. For more information, '
+                          'see https://github.com/saltstack/salt-jenkins/issues/324.')
         data = self.run_salt('-d -t 20')
         if data:
             self.assertIn('user.add:', data)


### PR DESCRIPTION
I mixed up the test that was actually failing for Arch. I originally submitted #41074 to skip the test_salt_documentation test in the shell matcher tests. This is the wrong test to skip.

I reverted the previous commit, and applied the skipTest to the correct test that is failing on Arch, which is the `test_salt_documentation_arguments_not_assumed` test.