### PR TITLE
Fix azure tests to query provider

### DIFF
--- a/tests/integration/cloud/providers/test_msazure.py
+++ b/tests/integration/cloud/providers/test_msazure.py
@@ -111,17 +111,9 @@ class AzureTest(ShellCase):
 
         # check if ssh_username, ssh_password, and media_link are present
         # in the azure configuration file
-        profile_config = cloud_providers_config(
-            os.path.join(
-                FILES,
-                'conf',
-                'cloud.profiles.d',
-                PROVIDER_NAME + '.conf'
-            )
-        )
-        ssh_user = profile_config[PROFILE_NAME][provider_str]['ssh_username']
-        ssh_pass = profile_config[PROFILE_NAME][provider_str]['ssh_password']
-        media_link = profile_config[PROFILE_NAME][provider_str]['media_link']
+        ssh_user = provider_config[provider_str][PROVIDER_NAME]['ssh_username']
+        ssh_pass = provider_config[provider_str][PROVIDER_NAME]['ssh_password']
+        media_link = provider_config[provider_str][PROVIDER_NAME]['media_link']
 
         if ssh_user == '' or ssh_pass == '' or media_link == '':
             self.skipTest(


### PR DESCRIPTION
### What does this PR do?
Currently the azure tests are failing in the nitrogen branch. The reason for this is due to this commit: 88936c2c84ba08b041c5b9f31a03944bf22bf1f4 which deprecated `provider` for `driver`, so now you cannot query profile information with the `cloud_providers_config` since the profile configuration uses `provider` instead of `driver`. So i moved the `ssh_*` and medialink settings into the provider config on the testing slaves.

### New Behavior
Tests pass

### Tests written?

Yes
