### PR TITLE
boto_lambda.function_present state: allow Qualifier parameter in Permissions

### DIFF
--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -208,7 +208,7 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None,
         if isinstance(Permissions, six.string_types):
             Permissions = json.loads(Permissions)
         required_keys = set(('Action', 'Principal'))
-        optional_keys = set(('SourceArn', 'SourceAccount'))
+        optional_keys = set(('SourceArn', 'SourceAccount', 'Qualifier'))
         for sid, permission in six.iteritems(Permissions):
             keyset = set(permission.keys())
             if not keyset.issuperset(required_keys):


### PR DESCRIPTION
### What does this PR do?
Adds support for the Qualifier parameter to the boto_lambda.function_present state. This is already supported in the module here https://github.com/saltstack/salt/blob/develop/salt/modules/boto_lambda.py#L498, this change just exposes the functionality in the state.

### What issues does this PR fix or reference?
N/A

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
