### PR TITLE
rdurations should be floats so that they can be summed when profiling

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -198,13 +198,11 @@ def _format_host(host, data):
             rcounts[ret['result']] += 1
             rduration = ret.get('duration', 0)
             try:
-                float(rduration)
-                rdurations.append(rduration)
+                rdurations.append(float(rduration))
             except ValueError:
                 rduration, _, _ = rduration.partition(' ms')
                 try:
-                    float(rduration)
-                    rdurations.append(rduration)
+                    rdurations.append(float(rduration))
                 except ValueError:
                     log.error('Cannot parse a float from duration {0}'
                               .format(ret.get('duration', 0)))


### PR DESCRIPTION
### What does this PR do?

Converts rdurations to floats so that they can be summed when profiling is activated (state_output_profile = True):
https://github.com/bbinet/salt/blob/fd48a63653560c9977f566b582c24095ef094ab9/salt/output/highstate.py#L448