### PR TITLE
Fix "latest" keyword for version specification when used with aggregation

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -369,6 +369,7 @@ def refresh_db(cache_valid_time=0):
 
         salt '*' pkg.refresh_db
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     APT_LISTS_PATH = "/var/lib/apt/lists"
     ret = {}

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -38,6 +38,7 @@ import salt.config
 import salt.syspaths
 from salt.modules.cmdmod import _parse_env
 import salt.utils
+import salt.utils.pkg
 import salt.utils.pkg.deb
 import salt.utils.systemd
 from salt.exceptions import (
@@ -368,6 +369,7 @@ def refresh_db(cache_valid_time=0):
 
         salt '*' pkg.refresh_db
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     APT_LISTS_PATH = "/var/lib/apt/lists"
     ret = {}
     if cache_valid_time:

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -22,6 +22,7 @@ import re
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 import salt.utils.systemd
 from salt.exceptions import CommandExecutionError, MinionError
 import salt.ext.six as six
@@ -412,6 +413,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     if 'eix.sync' in __salt__:
         return __salt__['eix.sync']()
 

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -413,6 +413,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     if 'eix.sync' in __salt__:
         return __salt__['eix.sync']()

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -81,6 +81,7 @@ import re
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 from salt.exceptions import CommandExecutionError, MinionError
 import salt.ext.six as six
 
@@ -246,6 +247,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     return True
 
 

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -247,6 +247,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     return True
 

--- a/salt/modules/mac_brew.py
+++ b/salt/modules/mac_brew.py
@@ -257,6 +257,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     cmd = 'brew update'
     if _call_brew(cmd)['retcode']:

--- a/salt/modules/mac_brew.py
+++ b/salt/modules/mac_brew.py
@@ -17,6 +17,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 from salt.exceptions import CommandExecutionError, MinionError
 import salt.ext.six as six
 from salt.ext.six.moves import zip
@@ -256,6 +257,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     cmd = 'brew update'
     if _call_brew(cmd)['retcode']:
         log.error('Failed to update')

--- a/salt/modules/mac_ports.py
+++ b/salt/modules/mac_ports.py
@@ -390,6 +390,7 @@ def refresh_db():
         salt mac pkg.refresh_db
 
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     cmd = ['port', 'selfupdate']
     return salt.utils.mac_utils.execute_return_success(cmd)

--- a/salt/modules/mac_ports.py
+++ b/salt/modules/mac_ports.py
@@ -38,6 +38,7 @@ import re
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 import salt.utils.mac_utils
 from salt.exceptions import CommandExecutionError
 
@@ -389,6 +390,7 @@ def refresh_db():
         salt mac pkg.refresh_db
 
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     cmd = ['port', 'selfupdate']
     return salt.utils.mac_utils.execute_return_success(cmd)
 

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -31,6 +31,7 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 import salt.utils.itertools
 from salt.utils.decorators import which as _which
 
@@ -140,6 +141,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     ret = {}
     cmd = ['opkg', 'update']
     call = __salt__['cmd.run_all'](cmd,

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -141,6 +141,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     ret = {}
     cmd = ['opkg', 'update']

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -398,6 +398,7 @@ def refresh_db(root=None):
 
         salt '*' pkg.refresh_db
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     cmd = ['pacman', '-Sy']
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -19,6 +19,7 @@ import os.path
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 import salt.utils.itertools
 import salt.utils.systemd
 from salt.exceptions import CommandExecutionError, MinionError
@@ -397,6 +398,7 @@ def refresh_db(root=None):
 
         salt '*' pkg.refresh_db
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     cmd = ['pacman', '-Sy']
 
     if root is not None:

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -222,6 +222,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     pkgin = _check_pkgin()
 

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -18,6 +18,7 @@ import re
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 import salt.utils.decorators as decorators
 from salt.exceptions import CommandExecutionError, MinionError
 
@@ -221,7 +222,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
-
+    salt.utils.pkg.clear_rtag(__opts__)
     pkgin = _check_pkgin()
 
     if pkgin:

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -252,6 +252,7 @@ def refresh_db(jail=None, chroot=None, root=None, force=False):
 
             salt '*' pkg.refresh_db force=True
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     cmd = _pkg(jail, chroot, root)
     cmd.append('update')

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -45,6 +45,7 @@ import os
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 from salt.exceptions import CommandExecutionError, MinionError
 import salt.ext.six as six
 
@@ -251,6 +252,7 @@ def refresh_db(jail=None, chroot=None, root=None, force=False):
 
             salt '*' pkg.refresh_db force=True
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     cmd = _pkg(jail, chroot, root)
     cmd.append('update')
     if force:

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -43,6 +43,7 @@ def refresh_db():
 
         salt '*' pkgutil.refresh_db
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     return __salt__['cmd.retcode']('/opt/csw/bin/pkgutil -U') == 0
 

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -15,6 +15,7 @@ import copy
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 from salt.exceptions import CommandExecutionError, MinionError
 import salt.ext.six as six
 
@@ -42,6 +43,7 @@ def refresh_db():
 
         salt '*' pkgutil.refresh_db
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     return __salt__['cmd.retcode']('/opt/csw/bin/pkgutil -U') == 0
 
 

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -119,6 +119,7 @@ def refresh_db(full=False):
         salt '*' pkg.refresh_db
         salt '*' pkg.refresh_db full=True
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     if full:
         return __salt__['cmd.retcode']('/bin/pkg refresh --full') == 0

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -44,6 +44,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 from salt.exceptions import CommandExecutionError
 
 # Define the module's virtual name
@@ -118,6 +119,7 @@ def refresh_db(full=False):
         salt '*' pkg.refresh_db
         salt '*' pkg.refresh_db full=True
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     if full:
         return __salt__['cmd.retcode']('/bin/pkg refresh --full') == 0
     else:

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -511,6 +511,7 @@ def refresh_db(**kwargs):
         salt '*' pkg.refresh_db
         salt '*' pkg.refresh_db saltenv=base
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     saltenv = kwargs.pop('saltenv', 'base')
     verbose = salt.utils.is_true(kwargs.pop('verbose', False))

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -57,6 +57,7 @@ from salt.exceptions import (CommandExecutionError,
                              SaltInvocationError,
                              SaltRenderError)
 import salt.utils
+import salt.utils.pkg
 import salt.syspaths
 from salt.exceptions import MinionError
 
@@ -510,6 +511,7 @@ def refresh_db(**kwargs):
         salt '*' pkg.refresh_db
         salt '*' pkg.refresh_db saltenv=base
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     saltenv = kwargs.pop('saltenv', 'base')
     verbose = salt.utils.is_true(kwargs.pop('verbose', False))
     failhard = salt.utils.is_true(kwargs.pop('failhard', True))

--- a/salt/modules/xbpspkg.py
+++ b/salt/modules/xbpspkg.py
@@ -262,6 +262,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     cmd = 'xbps-install -Sy'
     call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')

--- a/salt/modules/xbpspkg.py
+++ b/salt/modules/xbpspkg.py
@@ -17,6 +17,7 @@ import glob
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 import salt.utils.decorators as decorators
 from salt.exceptions import CommandExecutionError, MinionError
 
@@ -261,6 +262,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     cmd = 'xbps-install -Sy'
     call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
     if call['retcode'] != 0:
@@ -270,7 +272,7 @@ def refresh_db():
 
         raise CommandExecutionError('{0}'.format(comment))
 
-    return {}
+    return True
 
 
 def version(*names, **kwargs):

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -865,6 +865,7 @@ def refresh_db(**kwargs):
 
         salt '*' pkg.refresh_db
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     retcodes = {
         100: True,

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -41,6 +41,7 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 import salt.utils.itertools
 import salt.utils.systemd
 import salt.utils.decorators as decorators
@@ -864,6 +865,7 @@ def refresh_db(**kwargs):
 
         salt '*' pkg.refresh_db
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     retcodes = {
         100: True,
         0: None,

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -875,6 +875,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    # Remove rtag file to keep multiple refreshes from happening in pkg states
     salt.utils.pkg.clear_rtag(__opts__)
     ret = {}
     out = __zypper__.refreshable.call('refresh', '--force')

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -35,6 +35,7 @@ from xml.parsers.expat import ExpatError
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 import salt.utils.systemd
 from salt.exceptions import (
     CommandExecutionError, MinionError)
@@ -874,6 +875,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    salt.utils.pkg.clear_rtag(__opts__)
     ret = {}
     out = __zypper__.refreshable.call('refresh', '--force')
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -75,13 +75,13 @@ state module
 
 # Import python libs
 from __future__ import absolute_import
-import errno
 import logging
 import os
 import re
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 from salt.output import nested
 from salt.utils import namespaced_function as _namespaced_function
 from salt.utils.odict import OrderedDict as _OrderedDict
@@ -149,13 +149,6 @@ def __virtual__():
     assigned for this minion
     '''
     return 'pkg.install' in __salt__
-
-
-def __gen_rtag():
-    '''
-    Return the location of the refresh tag
-    '''
-    return os.path.join(__opts__['cachedir'], 'pkg_refresh')
 
 
 def _get_comparison_spec(pkgver):
@@ -307,11 +300,14 @@ def _find_install_targets(name=None,
                           normalize=True,
                           ignore_epoch=False,
                           reinstall=False,
+                          refresh=False,
                           **kwargs):
     '''
     Inspect the arguments to pkg.installed and discover what packages need to
     be installed. Return a dict of desired packages
     '''
+    was_refreshed = False
+
     if all((pkgs, sources)):
         return {'name': name,
                 'changes': {},
@@ -347,6 +343,11 @@ def _find_install_targets(name=None,
     if __grains__['os'] == 'FreeBSD':
         kwargs['with_origin'] = True
 
+    if salt.utils.is_windows():
+        # Windows requires a refresh to establish a pkg db if refresh=True, so
+        # add it to the kwargs.
+        kwargs['refresh'] = refresh
+
     try:
         cur_pkgs = __salt__['pkg.list_pkgs'](versions_as_list=True, **kwargs)
     except CommandExecutionError as exc:
@@ -354,6 +355,11 @@ def _find_install_targets(name=None,
                 'changes': {},
                 'result': False,
                 'comment': exc.strerror}
+
+    if salt.utils.is_windows() and kwargs.pop('refresh', False):
+        # We already refreshed when we called pkg.list_pkgs
+        was_refreshed = True
+        refresh = False
 
     if any((pkgs, sources)):
         if pkgs:
@@ -465,6 +471,35 @@ def _find_install_targets(name=None,
                                 'changes': {},
                                 'result': False,
                                 'comment': '. '.join(comments).rstrip()}
+
+    # Resolve the latest package version for any packages with "latest" in the
+    # package version
+    wants_latest = [] \
+        if sources \
+        else [x for x, y in six.iteritems(desired) if y == 'latest']
+    if wants_latest:
+        resolved_latest = __salt__['pkg.latest_version'](*wants_latest,
+                                                         refresh=refresh,
+                                                         **kwargs)
+        if len(wants_latest) == 1:
+            resolved_latest = {wants_latest[0]: resolved_latest}
+        if refresh:
+            was_refreshed = True
+            refresh = False
+
+        # pkg.latest_version returns an empty string when the package is
+        # up-to-date. So check the currently-installed packages. If found, the
+        # resolved latest version will be the currently installed one from
+        # cur_pkgs. If not found, then the package doesn't exist and the
+        # resolved latest version will be None.
+        for key in resolved_latest:
+            if not resolved_latest[key]:
+                if key in cur_pkgs:
+                    resolved_latest[key] = cur_pkgs[key][-1]
+                else:
+                    resolved_latest[key] = None
+        # Update the desired versions with the ones we resolved
+        desired.update(resolved_latest)
 
     # Find out which packages will be targeted in the call to pkg.install
     targets = {}
@@ -584,7 +619,8 @@ def _find_install_targets(name=None,
                 'result': True,
                 'comment': msg}
 
-    return desired, targets, to_unpurge, to_reinstall, altered_files, warnings
+    return (desired, targets, to_unpurge, to_reinstall, altered_files,
+            warnings, was_refreshed)
 
 
 def _verify_install(desired, new_pkgs, ignore_epoch=False):
@@ -1213,11 +1249,7 @@ def installed(
                 'comment': 'No packages to install provided'}
 
     kwargs['saltenv'] = __env__
-    rtag = __gen_rtag()
-    refresh = bool(
-        salt.utils.is_true(refresh) or
-        (os.path.isfile(rtag) and refresh is not False)
-    )
+    refresh = salt.utils.pkg.check_refresh(__opts__, refresh)
     if not isinstance(pkg_verify, list):
         pkg_verify = pkg_verify is True
     if (pkg_verify or isinstance(pkg_verify, list)) \
@@ -1230,42 +1262,7 @@ def installed(
     if not isinstance(version, six.string_types) and version is not None:
         version = str(version)
 
-    was_refreshed = False
-
-    if version is not None and version == 'latest':
-        try:
-            version = __salt__['pkg.latest_version'](name,
-                                                     fromrepo=fromrepo,
-                                                     refresh=refresh)
-        except CommandExecutionError as exc:
-            return {'name': name,
-                    'changes': {},
-                    'result': False,
-                    'comment': 'An error was encountered while checking the '
-                               'newest available version of package(s): {0}'
-                               .format(exc)}
-
-        was_refreshed = refresh
-        refresh = False
-
-        # If version is empty, it means the latest version is installed
-        # so we grab that version to avoid passing an empty string
-        if not version:
-            try:
-                version = __salt__['pkg.version'](name)
-            except CommandExecutionError as exc:
-                return {'name': name,
-                        'changes': {},
-                        'result': False,
-                        'comment': exc.strerror}
-
     kwargs['allow_updates'] = allow_updates
-
-    # if windows and a refresh
-    # is required, we will have to do a refresh when _find_install_targets
-    # calls pkg.list_pkgs
-    if salt.utils.is_windows():
-        kwargs['refresh'] = refresh
 
     result = _find_install_targets(name, version, pkgs, sources,
                                    fromrepo=fromrepo,
@@ -1274,25 +1271,14 @@ def installed(
                                    normalize=normalize,
                                    ignore_epoch=ignore_epoch,
                                    reinstall=reinstall,
+                                   refresh=refresh,
                                    **kwargs)
 
-    if salt.utils.is_windows():
-        was_refreshed = was_refreshed or refresh
-        if was_refreshed:
-            try:
-                os.remove(rtag)
-            except OSError as exc:
-                if exc.errno != errno.ENOENT:
-                    log.error(
-                        'Failed to remove refresh tag %s: %s',
-                        rtag, exc.__str__()
-                    )
-        kwargs.pop('refresh')
-        refresh = False
-
     try:
-        (desired, targets, to_unpurge,
-         to_reinstall, altered_files, warnings) = result
+        (desired, targets, to_unpurge, to_reinstall,
+         altered_files, warnings, was_refreshed) = result
+        if was_refreshed:
+            refresh = False
     except ValueError:
         # _find_install_targets() found no targets or encountered an error
 
@@ -1454,7 +1440,8 @@ def installed(
                 ret['comment'] += '\n\n' + '. '.join(warnings) + '.'
             return ret
 
-        was_refreshed = was_refreshed or refresh
+        if refresh:
+            refresh = False
 
         if isinstance(pkg_ret, dict):
             changes['installed'].update(pkg_ret)
@@ -1506,16 +1493,6 @@ def installed(
                                              and hold_ret[x]['result']]
                         failed_hold = [hold_ret[x] for x in hold_ret
                                        if not hold_ret[x]['result']]
-
-    if os.path.isfile(rtag) and was_refreshed:
-        try:
-            os.remove(rtag)
-        except OSError as exc:
-            if exc.errno != errno.ENOENT:
-                log.error(
-                    'Failed to remove refresh tag %s: %s',
-                    rtag, exc.__str__()
-                )
 
     if to_unpurge:
         changes['purge_desired'] = __salt__['lowpkg.unpurge'](*to_unpurge)
@@ -1839,11 +1816,7 @@ def latest(
                - report_reboot_exit_codes: False
 
     '''
-    rtag = __gen_rtag()
-    refresh = bool(
-        salt.utils.is_true(refresh) or
-        (os.path.isfile(rtag) and refresh is not False)
-    )
+    refresh = salt.utils.pkg.check_refresh(__opts__, refresh)
 
     if kwargs.get('sources'):
         return {'name': name,
@@ -1892,11 +1865,6 @@ def latest(
                 'changes': {},
                 'result': False,
                 'comment': exc.strerror}
-
-    # Remove the rtag if it exists, ensuring only one refresh per salt run
-    # (unless overridden with refresh=True)
-    if os.path.isfile(rtag) and refresh:
-        os.remove(rtag)
 
     # Repack the cur/avail data if only a single package is being checked
     if isinstance(cur, six.string_types):
@@ -2622,10 +2590,7 @@ def mod_init(low):
         ret = __salt__['pkg.ex_mod_init'](low)
 
     if low['fun'] == 'installed' or low['fun'] == 'latest':
-        rtag = __gen_rtag()
-        if not os.path.exists(rtag):
-            with salt.utils.fopen(rtag, 'w+'):
-                pass
+        salt.utils.pkg.write_rtag(__opts__)
         return ret
     return False
 

--- a/salt/utils/pkg/__init__.py
+++ b/salt/utils/pkg/__init__.py
@@ -1,4 +1,64 @@
 # -*- coding: utf-8 -*-
 '''
-Helper modules used by lowpkg modules
+Common functions for managing package refreshes during states
 '''
+# Import python libs
+from __future__ import absolute_import
+import errno
+import logging
+import os
+
+# Import Salt libs
+import salt.utils
+
+log = logging.getLogger(__name__)
+
+
+def rtag(opts):
+    '''
+    Return the rtag file location. This file is used to ensure that we don't
+    refresh more than once (unless explicitly configured to do so).
+    '''
+    return os.path.join(opts['cachedir'], 'pkg_refresh')
+
+
+def clear_rtag(opts):
+    '''
+    Remove the rtag file
+    '''
+    try:
+        os.remove(rtag(opts))
+    except OSError as exc:
+        if exc.errno != errno.ENOENT:
+            # Using __str__() here to get the fully-formatted error message
+            # (error number, error message, path)
+            log.warning('Encountered error removing rtag: %s', exc.__str__())
+
+
+def write_rtag(opts):
+    '''
+    Write the rtag file
+    '''
+    rtag_file = rtag(opts)
+    if not os.path.exists(rtag_file):
+        try:
+            with salt.utils.fopen(rtag_file, 'w+'):
+                pass
+        except OSError as exc:
+            log.warning('Encountered error writing rtag: %s', exc.__str__())
+
+
+def check_refresh(opts, refresh=None):
+    '''
+    Check whether or not a refresh is necessary
+
+    Returns:
+
+    - True if refresh evaluates as True
+    - False if refresh is False
+    - A boolean if refresh is not False and the rtag file exists
+    '''
+    return bool(
+        salt.utils.is_true(refresh) or
+        (os.path.isfile(rtag(opts)) and refresh is not False)
+    )

--- a/tests/integration/modules/pkg.py
+++ b/tests/integration/modules/pkg.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
+# Import Python libs
 from __future__ import absolute_import
+import os
 
 # Import Salt Testing libs
 from salttesting.helpers import (
@@ -13,6 +15,7 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
+import salt.utils.pkg
 
 
 class PkgModuleTest(integration.ModuleCase,
@@ -196,6 +199,10 @@ class PkgModuleTest(integration.ModuleCase,
         func = 'pkg.refresh_db'
         os_family = self.run_function('grains.item', ['os_family'])['os_family']
 
+        rtag = salt.utils.pkg.rtag(self.minion_opts)
+        salt.utils.pkg.write_rtag(self.minion_opts)
+        self.assertTrue(os.path.isfile(rtag))
+
         if os_family == 'RedHat':
             ret = self.run_function(func)
             self.assertIn(ret, (True, None))
@@ -216,6 +223,8 @@ class PkgModuleTest(integration.ModuleCase,
         else:
             os_grain = self.run_function('grains.item', ['os'])['os']
             self.skipTest('{0} is unavailable on {1}'.format(func, os_grain))
+
+        self.assertFalse(os.path.isfile(rtag))
 
     @requires_salt_modules('pkg.info_installed')
     def test_pkg_info(self):

--- a/tests/unit/modules/mac_brew_test.py
+++ b/tests/unit/modules/mac_brew_test.py
@@ -12,8 +12,9 @@ from salt.exceptions import CommandExecutionError
 
 # Import Salt Testing Libs
 from salttesting import skipIf, TestCase
-from salttesting.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON
+from salttesting.mock import Mock, MagicMock, patch, NO_MOCK, NO_MOCK_REASON
 from salttesting.helpers import ensure_in_syspath
+import salt.utils.pkg
 
 ensure_in_syspath('../../')
 
@@ -156,7 +157,8 @@ class BrewTestCase(TestCase):
                                                'retcode': 1})
         with patch.dict(mac_brew.__salt__, {'file.get_user': mock_user,
                                         'cmd.run_all': mock_failure}):
-            self.assertRaises(CommandExecutionError, mac_brew.refresh_db)
+            with patch.object(salt.utils.pkg, 'clear_rtag', Mock()):
+                self.assertRaises(CommandExecutionError, mac_brew.refresh_db)
 
     @patch('salt.modules.mac_brew._homebrew_bin',
            MagicMock(return_value=HOMEBREW_BIN))
@@ -168,7 +170,8 @@ class BrewTestCase(TestCase):
         mock_success = MagicMock(return_value={'retcode': 0})
         with patch.dict(mac_brew.__salt__, {'file.get_user': mock_user,
                                         'cmd.run_all': mock_success}):
-            self.assertTrue(mac_brew.refresh_db())
+            with patch.object(salt.utils.pkg, 'clear_rtag', Mock()):
+                self.assertTrue(mac_brew.refresh_db())
 
     # 'install' function tests: 1
     # Only tested a few basics

--- a/tests/unit/modules/pkgutil_test.py
+++ b/tests/unit/modules/pkgutil_test.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
 from salttesting.mock import (
+    Mock,
     MagicMock,
     patch,
     NO_MOCK,
@@ -22,10 +23,12 @@ ensure_in_syspath('../../')
 # Import Salt Libs
 from salt.modules import pkgutil
 from salt.exceptions import CommandExecutionError, MinionError
+import salt.utils.pkg
 
 # Globals
 pkgutil.__salt__ = {}
 pkgutil.__context__ = {}
+pkgutil.__opts__ = {}
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -41,7 +44,8 @@ class PkgutilTestCase(TestCase):
         '''
         mock = MagicMock(return_value=0)
         with patch.dict(pkgutil.__salt__, {'cmd.retcode': mock}):
-            self.assertTrue(pkgutil.refresh_db())
+            with patch.object(salt.utils.pkg, 'clear_rtag', Mock()):
+                self.assertTrue(pkgutil.refresh_db())
 
     # 'upgrade_available' function tests: 1
 
@@ -69,7 +73,8 @@ class PkgutilTestCase(TestCase):
         mock_ret = MagicMock(return_value=0)
         with patch.dict(pkgutil.__salt__, {'cmd.run_stdout': mock_run,
                                            'cmd.retcode': mock_ret}):
-            self.assertDictEqual(pkgutil.list_upgrades(), {'A': ' B'})
+            with patch.object(salt.utils.pkg, 'clear_rtag', Mock()):
+                self.assertDictEqual(pkgutil.list_upgrades(), {'A': ' B'})
 
     # 'upgrade' function tests: 1
 
@@ -87,7 +92,8 @@ class PkgutilTestCase(TestCase):
                          'pkg_resource.sort_pkglist': mock_pkg,
                          'cmd.run_all': mock_ret, 'cmd.run': mock_run}):
             with patch.dict(pkgutil.__context__, {'pkg.list_pkgs': mock_ret}):
-                self.assertDictEqual(pkgutil.upgrade(), {})
+                with patch.object(salt.utils.pkg, 'clear_rtag', Mock()):
+                    self.assertDictEqual(pkgutil.upgrade(), {})
 
     # 'list_pkgs' function tests: 1
 
@@ -146,10 +152,11 @@ class PkgutilTestCase(TestCase):
                          'pkg_resource.stringify': mock_pkg,
                          'pkg_resource.sort_pkglist': mock_pkg,
                          'cmd.run_all': mock_run, 'cmd.run': mock_run_all}):
-            self.assertEqual(pkgutil.latest_version('CSWpython'), '')
+            with patch.object(salt.utils.pkg, 'clear_rtag', Mock()):
+                self.assertEqual(pkgutil.latest_version('CSWpython'), '')
 
-            self.assertDictEqual(pkgutil.latest_version('CSWpython', 'Python'),
-                                 {'Python': '', 'CSWpython': ''})
+                self.assertDictEqual(pkgutil.latest_version('CSWpython', 'Python'),
+                                     {'Python': '', 'CSWpython': ''})
 
     # 'install' function tests: 1
 

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -25,6 +25,7 @@ ensure_in_syspath('../../')
 from salt.exceptions import CommandExecutionError
 from salt.ext.six.moves import configparser
 import salt.ext.six as six
+import salt.utils.pkg
 
 
 class ZyppCallMock(object):
@@ -52,6 +53,7 @@ from salt.modules import zypper
 zypper.__salt__ = dict()
 zypper.__grains__ = dict()
 zypper.__context__ = dict()
+zypper.__opts__ = dict()
 zypper.rpm = None
 
 
@@ -249,10 +251,11 @@ class ZypperTestCase(TestCase):
         }
 
         with patch.dict(zypper.__salt__, {'cmd.run_all': MagicMock(return_value=run_out)}):
-            result = zypper.refresh_db()
-            self.assertEqual(result.get("openSUSE-Leap-42.1-LATEST"), False)
-            self.assertEqual(result.get("openSUSE-Leap-42.1-Update"), False)
-            self.assertEqual(result.get("openSUSE-Leap-42.1-Update-Non-Oss"), True)
+            with patch.object(salt.utils.pkg, 'clear_rtag', Mock()):
+                result = zypper.refresh_db()
+                self.assertEqual(result.get("openSUSE-Leap-42.1-LATEST"), False)
+                self.assertEqual(result.get("openSUSE-Leap-42.1-Update"), False)
+                self.assertEqual(result.get("openSUSE-Leap-42.1-Update-Non-Oss"), True)
 
     def test_info_installed(self):
         '''


### PR DESCRIPTION
The ``latest`` keyword was only implemented when both ``name`` and ``version`` were used, and not for ``pkgs``. But ``mod_aggregate`` puts all packages into a single low chunk, under the ``pkgs`` argument. This means that using aggregation in conjuntion with the ``latest`` keyword no longer resolves the latest version and thus breaks these states.

This fixes the problem by moving the logic for resolving the ``latest`` keyword into ``_find_install_targets()``. It also makes some improvements to the logic we use to ensure only one package DB refresh is performed per Salt run, by making the ``pkg.refresh_db`` functions handle removing the rtag file, instead of requiring a call to a helper function everywhere in the pkg state where we might be calling a function that refreshes the package DB.

Resolves #40940.