### PR TITLE
Add test to query results of /jobs call in api

### DIFF
--- a/tests/integration/netapi/rest_cherrypy/app_test.py
+++ b/tests/integration/netapi/rest_cherrypy/app_test.py
@@ -206,3 +206,60 @@ class TestArgKwarg(BaseRestCherryPyTest):
         self.assertEqual(resp['return'][0]['args'], [1234])
         self.assertEqual(resp['return'][0]['kwargs'],
                          {'ext_source': 'redis'})
+
+
+class TestJobs(BaseRestCherryPyTest):
+    auth_creds = (
+        ('username', 'saltdev_auto'),
+        ('password', 'saltdev'),
+        ('eauth', 'auto'))
+
+    low = (
+        ('client', 'local'),
+        ('tgt', '*'),
+        ('fun', 'test.ping'),
+    )
+
+    def _token(self):
+        '''
+        Return the token
+        '''
+        body = urlencode(self.auth_creds)
+        request, response = self.request(
+            '/login',
+            method='POST',
+            body=body,
+            headers={
+                'content-type': 'application/x-www-form-urlencoded'
+            }
+        )
+        return response.headers['X-Auth-Token']
+
+    def _add_job(self):
+        '''
+        Helper function to add a job to the job cache
+        '''
+        cmd = dict(self.low, **dict(self.auth_creds))
+        body = urlencode(cmd)
+
+        request, response = self.request('/run', method='POST', body=body,
+            headers={
+                'content-type': 'application/x-www-form-urlencoded'
+        })
+        self.assertEqual(response.status, '200 OK')
+
+    def test_all_jobs(self):
+        '''
+        test query to /jobs returns job data
+        '''
+        self._add_job()
+
+        request, response = self.request('/jobs', method='GET',
+            headers={
+                'Accept': 'application/json',
+                'X-Auth-Token': self._token(),
+        })
+
+        resp = json.loads(response.body[0])
+        self.assertIn('test.ping', str(resp['return']))
+        self.assertEqual(response.status, '200 OK')


### PR DESCRIPTION
### What does this PR do?
Add test to check the results of the query to /jobs using the salt-api.

This will help to make sure the following issues don't occur again:

https://github.com/saltstack/salt/issues/41100
https://github.com/saltstack/salt/issues/40845

NOTE: This will fail until this is merged:  https://github.com/saltstack/salt/pull/41102

### Tests written?

Yes
