### PR TITLE
Update str.split call in boto_apigateway module

### DIFF
--- a/salt/modules/boto_apigateway.py
+++ b/salt/modules/boto_apigateway.py
@@ -354,7 +354,7 @@ def create_api_resources(restApiId, path,
         salt myminion boto_apigateway.create_api_resources myapi_id resource_path
 
     '''
-    path_parts = str.split(path, '/')
+    path_parts = path.split('/')
     created = []
     current_path = ''
     try:


### PR DESCRIPTION
The previous way of calling `str.split(path, '/')` was causing a TypeError in the test runs of the boto_apigateway state and module unit tests. Switching this to `path.split('/')` instead avoids this type of error.

```
Traceback (most recent call last):
  File "/testing/tests/unit/states/test_boto_apigateway.py", line 584, in test_present_when_stage_is_to_associate_to_new_deployment
    **conn_parameters)
  File "/testing/salt/states/boto_apigateway.py", line 310, in present
    authorization_type=authorization_type)
  File "/testing/salt/states/boto_apigateway.py", line 1660, in deploy_resources
    **self._common_aws_args)
  File "/testing/salt/modules/boto_apigateway.py", line 358, in create_api_resources
    path_parts = str.split(path, '/')
TypeError: descriptor 'split' requires a 'str' object but received a 'unicode'
```
 I found this issue when debugging the test failures reported in https://github.com/saltstack/salt-jenkins/issues/326.
