### PR TITLE
update aws.rst for usage clarification

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -609,7 +609,7 @@ just instances:
 
     salt-cloud -f get_tags my_ec2 resource_id=af5467ba
     salt-cloud -f set_tags my_ec2 resource_id=af5467ba tag1=somestuff
-    salt-cloud -f del_tags my_ec2 resource_id=af5467ba tag1,tag2,tag3
+    salt-cloud -f del_tags my_ec2 resource_id=af5467ba tags=tag1,tag2,tag3
 
 
 Rename EC2 Instances


### PR DESCRIPTION
`del_tags` requires `tags=`.

### What does this PR do?
Documentation clarification

### What issues does this PR fix or reference?
Missing content for how to run the action

### Previous Behavior
A warning is shown to the user requiring `tags=`

### New Behavior
Provides the appropriate action in the documentation

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
