### PR TITLE
Add exeptions to path safety check

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -637,16 +637,37 @@ def _get_repo_details(saltenv):
 
         # Do some safety checks on the repo_path as its contents can be removed,
         # this includes check for bad coding
-        paths = (
-            r'[a-z]\:\\$',
-            r'\\$',
-            re.escape(os.environ.get('SystemRoot', r'C:\Windows'))
+        system_root = os.environ.get('SystemRoot', r'C:\Windows')
+        deny_paths = (
+            r'[a-z]\:\\$',  # C:\, D:\, etc
+            r'\\$',  # \
+            re.escape(system_root)  # C:\Windows
         )
-        for path in paths:
-            if re.match(path, local_dest, flags=re.IGNORECASE) is not None:
-                raise CommandExecutionError(
-                    'Local cache dir {0} is not a good location'.format(local_dest)
-                )
+
+        # Since the above checks anything in C:\Windows, there are some
+        # directories we may want to make exceptions for
+        allow_paths = (
+            re.escape('\\'.join([system_root, 'TEMP']))  # C:\Windows\TEMP
+        )
+
+        # Check the local_dest to make sure it's not one of the bad paths
+        good_path = True
+        for d_path in deny_paths:
+            if re.match(d_path, local_dest, flags=re.IGNORECASE) is not None:
+                # Found deny path
+                good_path = False
+
+        # If local_dest is one of the bad paths, check for exceptions
+        if not good_path:
+            for a_path in allow_paths:
+                if re.match(a_path, local_dest, flags=re.IGNORECASE) is not None:
+                    # Found exception
+                    good_path = True
+
+        if not good_path:
+            raise CommandExecutionError(
+                'Local cache dir {0} is not a good location'.format(local_dest)
+            )
 
         __context__[contextkey] = (winrepo_source_dir, local_dest, winrepo_file)
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -647,7 +647,7 @@ def _get_repo_details(saltenv):
         # Since the above checks anything in C:\Windows, there are some
         # directories we may want to make exceptions for
         allow_paths = (
-            re.escape('\\'.join([system_root, 'TEMP']))  # C:\Windows\TEMP
+            re.escape('\\'.join([system_root, 'TEMP'])),  # C:\Windows\TEMP
         )
 
         # Check the local_dest to make sure it's not one of the bad paths

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -666,7 +666,8 @@ def _get_repo_details(saltenv):
 
         if not good_path:
             raise CommandExecutionError(
-                'Local cache dir {0} is not a good location'.format(local_dest)
+                'Attempting to delete files from a possibly unsafe location: '
+                '{0}'.format(local_dest)
             )
 
         __context__[contextkey] = (winrepo_source_dir, local_dest, winrepo_file)


### PR DESCRIPTION
### What does this PR do?
Adds an exception to the path safety check in the `_get_repo_details` function in `win_pkg`. The exception is `C:\Windows\TEMP`

History:
The `pkg.refresh_db` function deletes the contents of the winrepo directory to avoid having stale files left there that no longer exist on the master. This directory, by default, is `C:\salt\var\cache\salt\minion\files\base\win\repo-ng`. It is feasible, though unlikely, that someone could change the `winrepo_dir` config option to `C:\Windows` in which case `pkg.refresh_db` would begin to delete the contents of `C:\Windows`. The path safety check was added to check for dangerous paths such as `C:\`, `\` and anything in `C:\Windows`.

The Problem:
The test suite places a bunch of files used for testing in the TEMP directory. The test suite is launched from the Jenkins slave using `winexe`. Even though it authenticates as a user on the system, the user profile and environment variables are not loaded. When a user is logged in normally, the temp directory is `C:\Users\<username>\AppData\Local\Temp\`. When logged in via winexe, however, the temp directory is `C:\Windows\TEMP`. This was creating a problem when the `integration.modules.test_pkg` tests tried to run `pkg.refresh_db`, the path to the winrepo, being located in `c:\windows\temp\salt-tests-tmpdir\rootdir\cache\files\base\win\repo-ng`, was failing the safety check because `TEMP` is a folder in `C:\Windows`.

The Fix:
This PR adds an exception for the `C:\Windows\TEMP` directory. This should allow the `pkg.refresh_db` function to complete successfully and the tests to pass.

_NOTE: I tried passing `winexe` the `--profile` switch which is supposed to load the profile, but this had no affect on the `%TEMP%` system variable._

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1272
