### PR TITLE
Make sure "version" exists before looking for pkg key

### DIFF
--- a/tests/integration/modules/test_pkg.py
+++ b/tests/integration/modules/test_pkg.py
@@ -150,7 +150,7 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
             remove_ret = self.run_function('pkg.remove', [pkg])
             self.assertIn(pkg, remove_ret)
 
-        if isinstance(version, dict):
+        if version and isinstance(version, dict):
             version = version[pkg]
 
         if version:


### PR DESCRIPTION
Fixes the test failure happening on the SUSE Leap build in the nitrogen branch.

Version can be an empty dictionary and pass the check, but then we hit a key error on the next line. Let's avoid that.

Fixes https://github.com/saltstack/salt-jenkins/issues/332
