### PR TITLE
Update http_json.py

### DIFF
--- a/salt/pillar/http_json.py
+++ b/salt/pillar/http_json.py
@@ -41,7 +41,7 @@ def ext_pillar(minion_id,
     '''
     # Set up logging
     log = logging.getLogger(__name__)
-
+    url = url+minion_id
     data = __salt__['http.query'](url=url, decode=True, decode_type='json')
 
     if 'dict' in data:


### PR DESCRIPTION
Updated to join url and minion_id

### What does this PR do?
This change will join the url and minion_id to retrieve pillars of the specified minion_id. Earlier the url had to be hard coded.
### What issues does this PR fix or reference?

### Previous Behavior
minion_id was to be hard-coded into the url specified in the master config

### New Behavior
minion_id does not need to be hard-coded into the url specified in the master config

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
