### PR TITLE
gitfs: refresh env cache during update in masterless

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -16,6 +16,7 @@ import time
 import salt.loader
 import salt.utils
 import salt.utils.locales
+from salt.utils.args import get_function_argspec as _argspec
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -467,10 +468,14 @@ class Fileserver(object):
             ret = {}
         for fsb in back:
             fstr = '{0}.envs'.format(fsb)
+            kwargs = {'ignore_cache': True} \
+                if 'ignore_cache' in _argspec(self.servers[fstr]).args \
+                and self.opts['__role'] == 'minion' \
+                else {}
             if sources:
-                ret[fsb] = self.servers[fstr]()
+                ret[fsb] = self.servers[fstr](**kwargs)
             else:
-                ret.update(self.servers[fstr]())
+                ret.update(self.servers[fstr](**kwargs))
         if sources:
             return ret
         return list(ret)

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2273,10 +2273,17 @@ class GitBase(object):
         if self.fetch_remotes():
             data['changed'] = True
 
+        # A masterless minion will need a new env cache file even if no changes
+        # were fetched.
+        refresh_env_cache = self.opts['__role'] == 'minion'
+
         if data['changed'] is True or not os.path.isfile(self.env_cache):
             env_cachedir = os.path.dirname(self.env_cache)
             if not os.path.exists(env_cachedir):
                 os.makedirs(env_cachedir)
+            refresh_env_cache = True
+
+        if refresh_env_cache:
             new_envs = self.envs(ignore_cache=True)
             serial = salt.payload.Serial(self.opts)
             with salt.utils.fopen(self.env_cache, 'w+') as fp_:


### PR DESCRIPTION
This fixes an edge case where an env blacklist/whitelist was updated between masterless runs, or in later releases if an environment was added via per-saltenv configuration. In these cases, if there are no changes fetched, the env cache will remain intact, and will be returned when ``envs()`` is called. This commit forces the env cache to be refreshed on every update in masterless mode.

It also forces the env cache to be ignored when ``salt.fileserver.Fileserver.envs()`` is executed in masterless mode (such as via the ``fileserver.envs`` runner).
