### PR TITLE
Fix incorrect service.running state response when enable=None and init script returns 0

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -394,6 +394,7 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
         ret['comment'] = 'Started Service {0}'.format(name)
     else:
         ret['comment'] = 'Service {0} failed to start'.format(name)
+        ret['result'] = False
 
     if enable is True:
         ret.update(_enable(name, after_toggle_status, result=after_toggle_status, **kwargs))

--- a/tests/unit/states/service_test.py
+++ b/tests/unit/states/service_test.py
@@ -60,7 +60,7 @@ class ServiceTestCase(TestCase):
                 'name': 'salt', 'result': True},
                {'changes': 'saltstack',
                 'comment': 'Service salt failed to start', 'name': 'salt',
-                'result': True}]
+                'result': False}]
 
         tmock = MagicMock(return_value=True)
         fmock = MagicMock(return_value=False)


### PR DESCRIPTION
### What does this PR do?

The `service.running` state would previously incorrectly indicate success on failure to start a service if:

* init script returns 0; and
* Salt discovered the service initialization failed; and
* the `enable` flag was set to None; 

This change ensures the Salt result indicates failure in the above scenario. While I suspect this issue was just a mental typo, it's very possible there's a reason I'm missing that this was the expected behavior.

### What issues does this PR fix or reference?

Fixes #41125

### Previous Behavior

In the above scenario, the result indicated success.

### New Behavior

In the above scenario, the result indicates failure.

### Tests written?

The unit.service `running` test was updated to reflect this behavior.