### PR TITLE
Fix `pkg.install` on Windows on 2016.11

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1355,8 +1355,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             if version_num not in pkginfo and 'latest' in pkginfo:
                 version_num = 'latest'
         elif 'latest' in pkginfo:
-            if 'latest' in pkginfo:
-                version_num = 'latest'
+            version_num = 'latest'
 
         # Check to see if package is installed on the system
         removal_targets = []

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1351,10 +1351,12 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             ret[pkgname] = msg
             continue
 
-        if version_num is not None \
-                and version_num not in pkginfo \
-                and 'latest' in pkginfo:
-            version_num = 'latest'
+        if version_num is not None:
+            if version_num not in pkginfo and 'latest' in pkginfo:
+                version_num = 'latest'
+        elif 'latest' in pkginfo:
+            if 'latest' in pkginfo:
+                version_num = 'latest'
 
         # Check to see if package is installed on the system
         removal_targets = []
@@ -1366,7 +1368,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             if version_num is None:
                 removal_targets.extend(old[pkgname])
             elif version_num not in old[pkgname] \
-                    and 'Not Found' not in old['pkgname'] \
+                    and 'Not Found' not in old[pkgname] \
                     and version_num != 'latest':
                 log.error('%s %s not installed', pkgname, version)
                 ret[pkgname] = {

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -842,15 +842,16 @@ def _get_msiexec(use_msiexec):
     Return if msiexec.exe will be used and the command to invoke it.
     '''
     if use_msiexec is False:
-        return (False, '')
-    if os.path.isfile(use_msiexec):
-        return (True, use_msiexec)
-    else:
-        log.warning(("msiexec path '{0}' not found. Using system registered"
-                     " msiexec instead").format(use_msiexec))
-        use_msiexec = True
+        return False, ''
+    if isinstance(use_msiexec, six.string_types):
+        if os.path.isfile(use_msiexec):
+            return True, use_msiexec
+        else:
+            log.warning(("msiexec path '{0}' not found. Using system registered"
+                         " msiexec instead").format(use_msiexec))
+            use_msiexec = True
     if use_msiexec is True:
-        return (True, 'msiexec')
+        return True, 'msiexec'
 
 
 def install(name=None, refresh=False, pkgs=None, **kwargs):


### PR DESCRIPTION
### What does this PR do?
Fixes a problem where `use_msiexec` is a bool value. This is a back port from: https://github.com/saltstack/salt/pull/41086

Fixes some other issues with software with versions of 'latest' (Chrome)

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/41129 