### PR TITLE
Fix redis returner using too many connections

### DIFF
--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -100,6 +100,16 @@ def _get_options(ret=None):
     return _options
 
 
+CONN_POOL = None
+
+
+def _get_conn_pool():
+    global CONN_POOL
+    if CONN_POOL is None:
+        CONN_POOL = redis.ConnectionPool()
+    return CONN_POOL
+
+
 def _get_serv(ret=None):
     '''
     Return a redis server object
@@ -108,11 +118,13 @@ def _get_serv(ret=None):
     host = _options.get('host')
     port = _options.get('port')
     db = _options.get('db')
+    pool = _get_conn_pool()
 
     return redis.Redis(
             host=host,
             port=port,
-            db=db)
+            db=db,
+            connection_pool=pool)
 
 
 def _get_ttl():


### PR DESCRIPTION

### What does this PR do?

This patch fix redis returner using too many connections by using redis connection pool.

### What issues does this PR fix or reference?

Currently, when using redis returner (by set `master_job_cache: redis`
in salt master configuration). Each execution will create a new
connection to redis, which may use up the connection pool of redis sooner or
latter, especially in large scale deployment. We found many exception in log:

```
ConnectionError: Error 99 connecting localhost:6379. Cannot assign requested
address.
```

### Previous Behavior
Each execution creates new Redis connection.

### New Behavior
Reusing the Redis connection in connection pool, each worker has a pool.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
