### PR TITLE
slack_notify: use correct function name in docstring

### DIFF
--- a/salt/modules/slack_notify.py
+++ b/salt/modules/slack_notify.py
@@ -264,7 +264,7 @@ def call_hook(message,
 
     .. code-block:: bash
 
-        salt '*' slack.post_hook message='Hello, from SaltStack'
+        salt '*' slack.call_hook message='Hello, from SaltStack'
 
     '''
     base_url = 'https://hooks.slack.com/services/'


### PR DESCRIPTION
### What does this PR do?

The docstring of `slack_notify.call_hook` uses a different, undefined
function for the example. This PR corrects the function name.

### What issues does this PR fix or reference?
N/A

### Tests written?
No, N/A.
