### PR TITLE
Fix user.present for Windows/Mac

### DIFF
--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -144,7 +144,6 @@ def add(name,
         password = _to_unicode(password)
         fullname = _to_unicode(fullname)
         description = _to_unicode(description)
-        groups = _to_unicode(groups)
         home = _to_unicode(home)
         homedrive = _to_unicode(homedrive)
         profile = _to_unicode(profile)

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -394,14 +394,8 @@ def present(name,
 
         .. versionchanged:: 2015.8.0
     '''
-
     # First check if a password is set. If password is set, check if
     # hash_password is True, then hash it.
-
-    if __grains__['kernel'] in ('Darwin', 'Windows'):
-        # createhome not supported on Windows or Mac
-        createhome = False
-
     if password and hash_password:
         log.debug('Hashing a clear text password')
         password = __salt__['shadow.gen_password'](password)
@@ -414,6 +408,10 @@ def present(name,
         workphone = sdecode(workphone)
     if homephone is not None:
         homephone = sdecode(homephone)
+
+    # createhome not supported on Windows or Mac
+    if __grains__['kernel'] in ('Darwin', 'Windows'):
+        createhome = False
 
     ret = {'name': name,
            'changes': {},

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -398,6 +398,10 @@ def present(name,
     # First check if a password is set. If password is set, check if
     # hash_password is True, then hash it.
 
+    if __grains__['kernel'] in ('Darwin', 'Windows'):
+        # createhome not supported on Windows or Mac
+        createhome = False
+
     if password and hash_password:
         log.debug('Hashing a clear text password')
         password = __salt__['shadow.gen_password'](password)


### PR DESCRIPTION
### What does this PR do?
Disables `createhome` parameter for Windows and Mac. The docs say this is unsupported in those two operating systems.  Windows handles Home directory creation automatically.
Removes `_to_unicode` for groups in `user.add` modules, `_to_unicode` is handled by `user.chgroups` function for groups.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/41056

### Previous Behavior
Stacktrace when passing a home directory in Windows. Stacktracing when passing multiple groups in a list.

### New Behavior
User created successfully

### Tests written?
No
