### PR TITLE
Gate and skip git state integration tests when git version is older

### DIFF
--- a/tests/integration/states/test_git.py
+++ b/tests/integration/states/test_git.py
@@ -23,7 +23,7 @@ import salt.utils
 from salt.utils.versions import LooseVersion as _LooseVersion
 
 
-def _check_git_version(git_version):
+def _check_git_version(git_version, git_opts=False):
     '''
     Check to see if the version of git running on the test machine is new enough
     for various tests and format the return message accordingly.
@@ -45,7 +45,7 @@ def _check_git_version(git_version):
         return skip, msg
 
     # The "git_opts" options needs a minimum version of 1.7.2.
-    if git_version < _LooseVersion('1.7.2'):
+    if git_opts and git_version < _LooseVersion('1.7.2'):
         msg = 'The "git_opts" parameter is only supported for git versions >= 1.7.2 ' \
               '(detected: {0}). Skipping.'.format(git_version)
     else:
@@ -252,7 +252,7 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
         made to the remote repo.
         '''
         git_version = self.run_function('git.version')
-        skip, msg = _check_git_version(git_version)
+        skip, msg = _check_git_version(git_version, git_opts=True)
         if skip:
             self.skipTest(msg)
 
@@ -317,7 +317,7 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
         is the rev used for the git.latest state.
         '''
         git_version = self.run_function('git.version')
-        skip, msg = _check_git_version(git_version)
+        skip, msg = _check_git_version(git_version, git_opts=True)
         if skip:
             self.skipTest(msg)
 
@@ -388,7 +388,7 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
         Ensure that we don't exit early when checking for a fast-forward
         '''
         git_version = self.run_function('git.version')
-        skip, msg = _check_git_version(git_version)
+        skip, msg = _check_git_version(git_version, git_opts=True)
         if skip:
             self.skipTest(msg)
 
@@ -526,7 +526,7 @@ class LocalRepoGitTest(ModuleCase, SaltReturnAssertsMixin):
         https://github.com/saltstack/salt/issues/36242
         '''
         git_version = self.run_function('git.version')
-        skip, msg = _check_git_version(git_version)
+        skip, msg = _check_git_version(git_version, git_opts=True)
         if skip:
             self.skipTest(msg)
 

--- a/tests/integration/states/test_git.py
+++ b/tests/integration/states/test_git.py
@@ -30,6 +30,7 @@ def __check_git_version(caller, min_version, skip_msg):
     '''
     if inspect.isclass(caller):
         actual_setup = getattr(caller, 'setUp', None)
+
         def setUp(self, *args, **kwargs):
             if not salt.utils.which('git'):
                 self.skipTest('git is not installed')


### PR DESCRIPTION
### What does this PR do?
This PR adds a helper function to the git state integration tests to check for minimum versions of git installed on the testing box.

A git version of 1.6.5 must be installed at a minimum for any of these tests to run.

A git version of 1.7.2 must be installed at a minimum for certain tests that use the "git_opts" option when calling out to the git execution module.

This helper function checks to see if the version of git running on the test machine is new enough to either run any of these tests, or if it's new enough to run the tests that need "git_opts". It then returns a "skip" boolean and a message string to skip the test accordingly.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-jenkins/issues/327

### Previous Behavior
Five tests were failing on CentOS 6 builds on the nitrogen branch because the version of git is 1.7.1 here instead of 1.7.2, so the tests that had function calls using `git_opts` were failing.

### New Behavior
The tests are skipped when the version of git is not new enough:
```
integration.states.test_git.LocalRepoGitTest.test_renamed_default_branch          ->  The "git_opts" parameter is only supported for git versions >= 1.7.2 (detected: 1.7.1). Skipping.
```

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
