### PR TITLE
Create presence.p directly in cachedir

### DIFF
--- a/salt/engines/stalekey.py
+++ b/salt/engines/stalekey.py
@@ -51,7 +51,7 @@ def _get_keys():
 
 def start(interval=3600, expire=604800):
     ck = salt.utils.minions.CkMinions(__opts__)
-    presence_file = '{0}/minions/presence.p'.format(__opts__['cachedir'])
+    presence_file = '{0}/presence.p'.format(__opts__['cachedir'])
     wheel = salt.wheel.WheelClient(__opts__)
 
     while True:


### PR DESCRIPTION
salt-key  was stacktracing when finding the presence.p file
in /var/cache/salt/master/minions

### What does this PR do?
Moves the presence.p file to the root of the cachedir


### What issues does this PR fix or reference?
ZD 1402
### Previous Behavior
Remove this section if not relevant
The stalekey.py engine would create the presence.p file in `__opts__['cachedir']/minions/` which would cause salt-key to stacktrace because it expects all items in `__opts__['cachedir']/minions/` to be directories named after minions.
 
### New Behavior
Put presence.p directly in `__opts__['cachedir']` per Tom's suggestion.
