### PR TITLE
gpg renderer: fix gpg_keydir always reverting to default

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -247,12 +247,18 @@ def _get_key_dir():
     gpg_keydir = None
     if 'config.get' in __salt__:
         gpg_keydir = __salt__['config.get']('gpg_keydir')
+
     if not gpg_keydir:
-        gpg_keydir = __opts__.get('gpg_keydir')
-    if not gpg_keydir and 'config_dir' in __opts__:
-        gpg_keydir = os.path.join(__opts__['config_dir'], 'gpgkeys')
-    else:
-        gpg_keydir = os.path.join(os.path.split(__opts__['conf_file'])[0], 'gpgkeys')
+        gpg_keydir = __opts__.get(
+            'gpg_keydir',
+            os.path.join(
+                __opts__.get(
+                    'config_dir',
+                    os.path.dirname(__opts__['conf_file']),
+                ),
+                'gpgkeys'
+            ))
+
     return gpg_keydir
 
 


### PR DESCRIPTION
### What does this PR do?
The gpg renderer tries to find it's config parameter `gpg_keydir` through a variety of means. Recent changes in `_get_key_dir()` introduced a logic error resulting in the setting always reverting to default.

### What issues does this PR fix or reference?
Quite likely #41135

### Previous Behavior
https://github.com/saltstack/salt/blob/develop/salt/renderers/gpg.py#L252 tests for `not gpg_keydir` *and* `config_dir in __opts__`. 
Ergo if `gpg_keydir` is already set, that results in the `else` block setting it to the location of `conf_file`

### New Behavior
Proper cascade of default values
