### PR TITLE
ret_config and ret_kwargs in orchestration

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -66,6 +66,8 @@ def state(name,
         tgt_type='glob',
         expr_form=None,
         ret='',
+        ret_config=None,
+        ret_kwargs=None,
         highstate=None,
         sls=None,
         top=None,
@@ -105,6 +107,12 @@ def state(name,
 
     ret
         Optionally set a single or a list of returners to use
+        
+    ret_config
+        Use an alternative returner configuration
+        
+    ret_kwargs
+        Override individual returner configuration items
 
     highstate
         Defaults to None, if set to True the target systems will ignore any
@@ -198,6 +206,12 @@ def state(name,
     '''
     cmd_kw = {'arg': [], 'kwarg': {}, 'ret': ret, 'timeout': timeout}
 
+    if ret_config:
+        cmd_kw['ret_config'] = ret_config
+        
+    if ret_kwargs:
+        cmd_kw['ret_kwargs'] = ret_kwargs
+    
     state_ret = {'name': name,
                  'changes': {},
                  'comment': '',
@@ -385,6 +399,8 @@ def function(
         tgt_type='glob',
         expr_form=None,
         ret='',
+        ret_config=None,
+        ret_kwargs=None,
         expect_minions=False,
         fail_minions=None,
         fail_function=None,
@@ -417,6 +433,12 @@ def function(
 
     ret
         Optionally set a single or a list of returners to use
+
+    ret_config
+        Use an alternative returner configuration
+        
+    ret_kwargs
+        Override individual returner configuration items
 
     expect_minions
         An optional boolean for failing if some minions do not respond
@@ -474,6 +496,13 @@ def function(
     cmd_kw['ssh'] = ssh
     cmd_kw['expect_minions'] = expect_minions
     cmd_kw['_cmd_meta'] = True
+    
+    if ret_config:
+        cmd_kw['ret_config'] = ret_config
+        
+    if ret_kwargs:
+        cmd_kw['ret_kwargs'] = ret_kwargs
+    
     fun = name
     if __opts__['test'] is True:
         func_ret['comment'] = (

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -107,10 +107,10 @@ def state(name,
 
     ret
         Optionally set a single or a list of returners to use
-        
+
     ret_config
         Use an alternative returner configuration
-        
+
     ret_kwargs
         Override individual returner configuration items
 
@@ -208,10 +208,10 @@ def state(name,
 
     if ret_config:
         cmd_kw['ret_config'] = ret_config
-        
+
     if ret_kwargs:
         cmd_kw['ret_kwargs'] = ret_kwargs
-    
+
     state_ret = {'name': name,
                  'changes': {},
                  'comment': '',
@@ -436,7 +436,7 @@ def function(
 
     ret_config
         Use an alternative returner configuration
-        
+
     ret_kwargs
         Override individual returner configuration items
 
@@ -496,13 +496,13 @@ def function(
     cmd_kw['ssh'] = ssh
     cmd_kw['expect_minions'] = expect_minions
     cmd_kw['_cmd_meta'] = True
-    
+
     if ret_config:
         cmd_kw['ret_config'] = ret_config
-        
+
     if ret_kwargs:
         cmd_kw['ret_kwargs'] = ret_kwargs
-    
+
     fun = name
     if __opts__['test'] is True:
         func_ret['comment'] = (


### PR DESCRIPTION
### What does this PR do?

Add support for `ret_config` and `ret_kwargs` parameters to the `saltmod` state module, which is used in orchestration SLS files. 

### What issues does this PR fix or reference?

### Previous Behavior
Only `ret` supported

### New Behavior
Can now do this in an orchestration SLS files:

```yaml
restart-webapp:
    salt.function:
        - name: cmd.run
        - tgt: my-webapp-minion
        - arg:
              - "systemctl restart webapp"
        - ret: audit_returner
        - ret_kwargs:
              whodunnit: "{{ pillar.user }}"
```

### Tests written?

No

