### PR TITLE
Bugfix: datetime should be returned always in UTC

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1803,7 +1803,7 @@ def list_downloaded():
                 'path': package_path,
                 'size': os.path.getsize(package_path),
                 'creation_date_time_t': pkg_timestamp,
-                'creation_date_time': datetime.datetime.fromtimestamp(pkg_timestamp).isoformat(),
+                'creation_date_time': datetime.datetime.utcfromtimestamp(pkg_timestamp).isoformat(),
             }
     return ret
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bug: zypper's `list_downloaded` does not returns creation time in UTC.
It also breaks the unit tests, if your environment is not in UTC :smile: 

### Tests written?

Yes