### PR TITLE
Backport #41081 to 2016.11

### DIFF
--- a/salt/states/win_dns_client.py
+++ b/salt/states/win_dns_client.py
@@ -171,32 +171,32 @@ def primary_suffix(name,
 
     reg_data = {
             'suffix': {
-                'hkey': 'HKEY_LOCAL_MACHINE',
-                'path': r'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
-                'key':  'NV Domain',
-                'type': 'REG_SZ',
+                'hive': 'HKEY_LOCAL_MACHINE',
+                'key': r'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
+                'vname':  'NV Domain',
+                'vtype': 'REG_SZ',
                 'old':  None,
                 'new':  suffix
             },
             'updates': {
-                'hkey': 'HKEY_LOCAL_MACHINE',
-                'path': r'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
-                'key':  'SyncDomainWithMembership',
-                'type': 'REG_DWORD',
+                'hive': 'HKEY_LOCAL_MACHINE',
+                'key': r'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
+                'vname':  'SyncDomainWithMembership',
+                'vtype': 'REG_DWORD',
                 'old':  None,
                 'new':  updates
             }
     }
 
-    reg_data['suffix']['old'] = __salt__['reg.read_key'](
-            reg_data['suffix']['hkey'],
-            reg_data['suffix']['path'],
-            reg_data['suffix']['key'],)
+    reg_data['suffix']['old'] = __salt__['reg.read_value'](
+            reg_data['suffix']['hive'],
+            reg_data['suffix']['key'],
+            reg_data['suffix']['vname'],)['vdata']
 
-    reg_data['updates']['old'] = bool(__salt__['reg.read_key'](
-            reg_data['updates']['hkey'],
-            reg_data['updates']['path'],
-            reg_data['updates']['key'],))
+    reg_data['updates']['old'] = bool(__salt__['reg.read_value'](
+            reg_data['updates']['hive'],
+            reg_data['updates']['key'],
+            reg_data['updates']['vname'],)['vdata'])
 
     updates_operation = 'enabled' if reg_data['updates']['new'] else 'disabled'
 
@@ -234,19 +234,19 @@ def primary_suffix(name,
                     'new': {
                         'suffix': reg_data['suffix']['new']}}
 
-    suffix_result = __salt__['reg.set_key'](
-            reg_data['suffix']['hkey'],
-            reg_data['suffix']['path'],
+    suffix_result = __salt__['reg.set_value'](
+            reg_data['suffix']['hive'],
             reg_data['suffix']['key'],
+            reg_data['suffix']['vname'],
             reg_data['suffix']['new'],
-            reg_data['suffix']['type'])
+            reg_data['suffix']['vtype'])
 
-    updates_result = __salt__['reg.set_key'](
-            reg_data['updates']['hkey'],
-            reg_data['updates']['path'],
+    updates_result = __salt__['reg.set_value'](
+            reg_data['updates']['hive'],
             reg_data['updates']['key'],
+            reg_data['updates']['vname'],
             reg_data['updates']['new'],
-            reg_data['updates']['type'])
+            reg_data['updates']['vtype'])
 
     ret['result'] = suffix_result & updates_result
 

--- a/tests/unit/states/win_dns_client_test.py
+++ b/tests/unit/states/win_dns_client_test.py
@@ -122,7 +122,7 @@ class WinDnsClientTestCase(TestCase):
         self.assertDictEqual(win_dns_client.primary_suffix('salt', updates='a'
                                                            ), ret)
 
-        mock = MagicMock(side_effect=['a', False, 'b', False])
+        mock = MagicMock(side_effect=[{'vdata': 'a'}, {'vdata': False}, {'vdata': 'b'}, {'vdata': False}])
         with patch.dict(win_dns_client.__salt__, {'reg.read_value': mock}):
             ret.update({'comment': 'No changes needed', 'result': True})
             self.assertDictEqual(win_dns_client.primary_suffix('salt', 'a'),

--- a/tests/unit/states/win_dns_client_test.py
+++ b/tests/unit/states/win_dns_client_test.py
@@ -123,13 +123,13 @@ class WinDnsClientTestCase(TestCase):
                                                            ), ret)
 
         mock = MagicMock(side_effect=['a', False, 'b', False])
-        with patch.dict(win_dns_client.__salt__, {'reg.read_key': mock}):
+        with patch.dict(win_dns_client.__salt__, {'reg.read_value': mock}):
             ret.update({'comment': 'No changes needed', 'result': True})
             self.assertDictEqual(win_dns_client.primary_suffix('salt', 'a'),
                                  ret)
 
             mock = MagicMock(return_value=True)
-            with patch.dict(win_dns_client.__salt__, {'reg.set_key': mock}):
+            with patch.dict(win_dns_client.__salt__, {'reg.set_value': mock}):
                 ret.update({'changes': {'new': {'suffix': 'a'},
                                         'old': {'suffix': 'b'}},
                             'comment': 'Updated primary DNS suffix (a)'})


### PR DESCRIPTION
### What does this PR do?
Backport #41081 to 2016.11

### What issues does this PR fix or reference?
None

### Previous Behavior
win_dns_client state used deprecated/removed functions

### New Behavior
win_dns_client uses proper functions

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
