### PR TITLE
Remove git_pillar warning from integration suite startup

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -60,12 +60,6 @@ from salt.utils.nb_popen import NonBlockingPopen
 from salt.exceptions import SaltClientError
 
 try:
-    from salt.utils.gitfs import HAS_GITPYTHON, HAS_PYGIT2
-    HAS_GITFS = HAS_GITPYTHON or HAS_PYGIT2
-except ImportError:
-    HAS_GITFS = False
-
-try:
     import salt.master
 except ImportError:
     # Not required for raet tests
@@ -209,14 +203,6 @@ class TestDaemon(object):
 
         # Set up PATH to mockbin
         self._enter_mockbin()
-
-        if not HAS_GITFS:
-            sys.stdout.write(
-                ' * {LIGHT_RED}No suitable provider for git_pillar is installed. Install\n'
-                '   GitPython or Pygit2.{ENDC}\n'.format(
-                    **self.colors
-                )
-            )
 
         if self.parser.options.transport == 'zeromq':
             self.start_zeromq_daemons()


### PR DESCRIPTION
This is no longer needed since the git_pillar configuration has been removed from the suite's master config file now that git_pillar integration tests have been added.