### PR TITLE
Add silent action to MsgBox for Path Actions

### DIFF
--- a/doc/topics/releases/2016.11.5.rst
+++ b/doc/topics/releases/2016.11.5.rst
@@ -13,12 +13,19 @@ Extended changelog courtesy of Todd Stansell (https://github.com/tjstansell/salt
 
 Statistics:
 
-- Total Merges: **82**
-- Total Issue references: **30**
-- Total PR references: **98**
+- Total Merges: **83**
+- Total Issue references: **31**
+- Total PR references: **99**
 
 Changes:
 
+
+- **PR** `#41173`_: (*twangboy*) Add silent action to MsgBox for Path Actions
+  @ *2017-05-10T17:22:18Z*
+
+  - **ISSUE** `#41099`_: (*lomeroe*) Windows 2016.11.4 minion installer silent mode issue
+    | refs: `#41173`_
+  * 96918dc Add silent action to MsgBox for Path Actions
 
 - **PR** `#41134`_: (*twangboy*) Fix `pkg.install` on Windows on 2016.11
   @ *2017-05-09T15:10:19Z*
@@ -815,10 +822,12 @@ Changes:
 .. _`#41093`: https://github.com/saltstack/salt/pull/41093
 .. _`#41097`: https://github.com/saltstack/salt/pull/41097
 .. _`#41098`: https://github.com/saltstack/salt/pull/41098
+.. _`#41099`: https://github.com/saltstack/salt/pull/41099
 .. _`#41100`: https://github.com/saltstack/salt/issues/41100
 .. _`#41102`: https://github.com/saltstack/salt/pull/41102
 .. _`#41103`: https://github.com/saltstack/salt/pull/41103
 .. _`#41134`: https://github.com/saltstack/salt/pull/41134
+.. _`#41173`: https://github.com/saltstack/salt/pull/41173
 .. _`#5`: https://github.com/saltstack/salt/issues/5
 .. _`bp-37696`: https://github.com/saltstack/salt/pull/37696
 .. _`bp-38115`: https://github.com/saltstack/salt/pull/38115

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -539,8 +539,10 @@ Function AddToPath
 
     ; Check for Error Code 234, Path too long for the variable
     IntCmp $4 234 0 +4 +4 ; $4 == ERROR_MORE_DATA
-        DetailPrint "AddToPath: original length $2 > ${NSIS_MAX_STRLEN}"
-        MessageBox MB_OK "PATH not updated, original length $2 > ${NSIS_MAX_STRLEN}"
+        DetailPrint "AddToPath Failed: original length $2 > ${NSIS_MAX_STRLEN}"
+        MessageBox MB_OK \
+            "You may add C:\salt to the %PATH% for convenience when issuing local salt commands from the command line." \
+            /SD IDOK
         Goto done
 
     ; If no error, continue
@@ -575,7 +577,9 @@ Function AddToPath
     ; Make sure the new length isn't over the NSIS_MAX_STRLEN
     IntCmp $2 ${NSIS_MAX_STRLEN} +4 +4 0
         DetailPrint "AddToPath: new length $2 > ${NSIS_MAX_STRLEN}"
-        MessageBox MB_OK "PATH not updated, new length $2 > ${NSIS_MAX_STRLEN}."
+        MessageBox MB_OK \
+            "You may add C:\salt to the %PATH% for convenience when issuing local salt commands from the command line." \
+            /SD IDOK
         Goto done
 
     ; Append dir to PATH
@@ -637,7 +641,6 @@ Function ${un}RemoveFromPath
     ; Check for Error Code 234, Path too long for the variable
     IntCmp $4 234 0 +4 +4 ; $4 == ERROR_MORE_DATA
         DetailPrint "AddToPath: original length $2 > ${NSIS_MAX_STRLEN}"
-        MessageBox MB_OK "PATH not updated, original length $2 > ${NSIS_MAX_STRLEN}"
         Goto done
 
     ; If no error, continue


### PR DESCRIPTION
### What does this PR do?
Adds 'Silent' behavior to the `AddToPath` MessageBoxes.
Improves the Message displayed when the installer can't add the path... emphasizing that this is a convenience when working with Salt from the command line and not a requirement for Salt functionality.
Removes the MessageBox from the uninstaller. The failure to remove the path will be noted in the contents of the Progress dialog box.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/41099

### Previous Behavior
The installer attempts to add the path `C:\salt` to the path in Windows. NSIS installer variables are limited to a max length of 1024 characters. If the existing path exceeds 1024, a MessageBox is displayed saying that the current path length exceeds the Variable limit of 1024. You must click OK to dismiss the box and finish the installation.

The problem is exacerbated when the installer is launched with the Silent option `/S`. The installer reaches the point where it tries to add the path and displays a dialog box for the user to click (not silent). When launch using Salt, it appears that Salt hangs because it is waiting for user input.

Additionally, the wording of the MessageBox implies that it is a serious failure and that Salt will not function properly.

### New Behavior
The MessageBoxes now have a 'Silent' default, so when the installer is launched 'Silently', the message boxes are not displayed and the installer continues.

When the MessageBox is displayed, the fact that it is not a hard requirement is emphasized.

### Tests written?
NA
