### PR TITLE
Split up test asserts in jinja template unit test

### DIFF
--- a/tests/unit/templates/test_jinja.py
+++ b/tests/unit/templates/test_jinja.py
@@ -543,7 +543,14 @@ class TestCustomExtensions(TestCase):
         if six.PY3:
             self.assertEqual("str value", rendered)
         else:
-            self.assertEqual("!!python/unicode str value", rendered)
+            # Due to a bug in the equality handler, this check needs to be split
+            # up into several different assertions. We need to check that the various
+            # string segments are present in the rendered value, as well as the
+            # type of the rendered variable. This should cover all use cases but also
+            # allow the test to pass of CentOS 6 running Python 2.7.
+            self.assertIn('!!python/unicode', rendered)
+            self.assertIn('str value', rendered)
+            self.assertIsInstance(rendered, unicode)
 
     def test_serialize_python(self):
         dataset = {

--- a/tests/unit/templates/test_jinja.py
+++ b/tests/unit/templates/test_jinja.py
@@ -546,11 +546,12 @@ class TestCustomExtensions(TestCase):
             # Due to a bug in the equality handler, this check needs to be split
             # up into several different assertions. We need to check that the various
             # string segments are present in the rendered value, as well as the
-            # type of the rendered variable. This should cover all use cases but also
-            # allow the test to pass on CentOS 6 running Python 2.7.
+            # type of the rendered variable (should be unicode, which is the same as
+            # six.text_type). This should cover all use cases but also allow the test
+            # to pass on CentOS 6 running Python 2.7.
             self.assertIn('!!python/unicode', rendered)
             self.assertIn('str value', rendered)
-            self.assertIsInstance(rendered, unicode)
+            self.assertIsInstance(rendered, six.text_type)
 
     def test_serialize_python(self):
         dataset = {

--- a/tests/unit/templates/test_jinja.py
+++ b/tests/unit/templates/test_jinja.py
@@ -547,7 +547,7 @@ class TestCustomExtensions(TestCase):
             # up into several different assertions. We need to check that the various
             # string segments are present in the rendered value, as well as the
             # type of the rendered variable. This should cover all use cases but also
-            # allow the test to pass of CentOS 6 running Python 2.7.
+            # allow the test to pass on CentOS 6 running Python 2.7.
             self.assertIn('!!python/unicode', rendered)
             self.assertIn('str value', rendered)
             self.assertIsInstance(rendered, unicode)


### PR DESCRIPTION
### What does this PR do?
Due to a bug in the equality handler, this test was failing on CentOS 6 running Python 2.7.13. This PR splits up the test assertions into several different pieces in order to cover all the possible use cases, but also pass on CentOS 6.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-jenkins/issues/329

### Previous Behavior
Test would fail with:
```
Traceback (most recent call last):
  File "/testing/tests/unit/templates/test_jinja.py", line 546, in test_serialize_yaml_unicode
    self.assertEqual("!!python/unicode str value", rendered)
AssertionError: '!!python/unicode str value' != u"!!python/unicode 'str value'"
```

### New Behavior
Test passes.

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
