### PR TITLE
Change docs to match what I see in the code

### DIFF
--- a/doc/topics/thorium/index.rst
+++ b/doc/topics/thorium/index.rst
@@ -57,7 +57,16 @@ Writing Thorium Formulas
 ========================
 Like some other Salt subsystems, Thorium uses its own directory structure. The
 default location for this structure is ``/srv/thorium/``, but it can be changed
-using the ``thorium_roots_dir`` setting in the ``master`` configuration file.
+using the ``thorium_roots`` setting in the ``master`` configuration file.
+
+This would explicitly set the roots to the default:
+
+.. code-block:: yaml
+
+thorium_roots:
+  base:
+    - /srv/thorium
+
 
 
 The Thorium top.sls File

--- a/doc/topics/thorium/index.rst
+++ b/doc/topics/thorium/index.rst
@@ -63,9 +63,9 @@ This would explicitly set the roots to the default:
 
 .. code-block:: yaml
 
-thorium_roots:
-  base:
-    - /srv/thorium
+    thorium_roots:
+      base:
+        - /srv/thorium
 
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes what appears to be a discrepancy between the docs description of the thorium_roots_dir being able to configure the thorium roots:

```
Like some other Salt subsystems, Thorium uses its own directory structure. The default
location for this structure is /srv/thorium/, but it can be changed using the thorium_roots_dir
 setting in the master configuration file.
```

Vs what I see in the code at https://github.com/saltstack/salt/blob/4475d1757d8e4a66e08f99fdf390fb9e09025f1d/salt/thorium/__init__.py#L44:

```python
         opts['file_roots'] = opts['thorium_roots']
```

### What issues does this PR fix or reference?

What appears to be a documentation discrepancy.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
