### PR TITLE
Saltify credendial verification for Windows

### DIFF
--- a/doc/topics/cloud/saltify.rst
+++ b/doc/topics/cloud/saltify.rst
@@ -135,5 +135,3 @@ Return values:
   - ``True``: Credential verification succeeded
   - ``False``: Credential verification succeeded
   - ``None``: Credential verification was not attempted.
-
-.. note:: This feature is not available for Windows targets.

--- a/salt/cloud/clouds/saltify.py
+++ b/salt/cloud/clouds/saltify.py
@@ -22,6 +22,22 @@ import salt.config as config
 # Get logging started
 log = logging.getLogger(__name__)
 
+try:
+    from impacket.smbconnection import SessionError as smbSessionError
+    from impacket.smb3 import SessionError as smb3SessionError
+    HAS_IMPACKET = True
+except ImportError:
+    HAS_IMPACKET = False
+
+try:
+    from winrm.exceptions import WinRMTransportError
+    from requests.exceptions import (
+        ConnectionError, ConnectTimeout, ReadTimeout, SSLError,
+        ProxyError, RetryError, InvalidSchema)
+    HAS_WINRM = True
+except ImportError:
+    HAS_WINRM = False
+
 
 def __virtual__():
     '''
@@ -62,7 +78,7 @@ def create(vm_):
         'deploy', vm_, __opts__, default=False)
 
     if deploy_config:
-        log.info('Provisioning existing machine {0}'.format(vm_['name']))
+        log.info('Provisioning existing machine %s', vm_['name'])
         ret = __utils__['cloud.bootstrap'](vm_, __opts__)
     else:
         ret = _verify(vm_)
@@ -85,19 +101,65 @@ def _verify(vm_):
     '''
     Verify credentials for an exsiting system
     '''
-    log.info('Testing logon credentials for {0}'.format(vm_['name']))
+    log.info('Verifying credentials for %s', vm_['name'])
 
     win_installer = config.get_cloud_config_value(
-        'win_installer', vm_, __opts__
-    )
+        'win_installer', vm_, __opts__)
 
     if win_installer:
 
-        # No support for Windows at this time
-        log.warning('Credential verification is not available for Windows targets')
-        return None
+        log.debug('Testing Windows authentication method for %s', vm_['name'])
+
+        if not HAS_IMPACKET:
+            log.error('Impacket library not found')
+            return False
+
+        # Test Windows connection
+        kwargs = {
+            'host': vm_['ssh_host'],
+            'username': config.get_cloud_config_value(
+                'win_username', vm_, __opts__, default='Administrator'),
+            'password': config.get_cloud_config_value(
+                'win_password', vm_, __opts__, default='')
+        }
+
+        # Test SMB connection
+        try:
+            log.debug('Testing SMB protocol for %s', vm_['name'])
+            if __utils__['smb.get_conn'](**kwargs) is False:
+                return False
+        except (smbSessionError, smb3SessionError) as exc:
+            log.error('Exception: %s', exc)
+            return False
+
+        # Test WinRM connection
+        use_winrm = config.get_cloud_config_value(
+            'use_winrm', vm_, __opts__, default=False)
+
+        if use_winrm:
+            log.debug('WinRM protocol requested for %s', vm_['name'])
+            if not HAS_WINRM:
+                log.error('WinRM library not found')
+                return False
+
+            kwargs['port'] = config.get_cloud_config_value(
+                'winrm_port', vm_, __opts__, default=5986)
+            kwargs['timeout'] = 10
+
+            try:
+                log.debug('Testing WinRM protocol for %s', vm_['name'])
+                return __utils__['cloud.wait_for_winrm'](**kwargs) is not None
+            except (ConnectionError, ConnectTimeout, ReadTimeout, SSLError,
+                    ProxyError, RetryError, InvalidSchema, WinRMTransportError) as exc:
+                log.error('Exception: %s', exc)
+                return False
+
+        return True
 
     else:
+
+        log.debug('Testing SSH authentication method for %s', vm_['name'])
+
         # Test SSH connection
         kwargs = {
             'host': vm_['ssh_host'],
@@ -121,4 +183,5 @@ def _verify(vm_):
             'maxtries': 1
         }
 
+        log.debug('Testing SSH protocol for %s', vm_['name'])
         return __utils__['cloud.wait_for_passwd'](**kwargs)

--- a/salt/cloud/clouds/saltify.py
+++ b/salt/cloud/clouds/saltify.py
@@ -18,6 +18,7 @@ import logging
 
 # Import salt libs
 import salt.config as config
+from salt.exceptions import SaltCloudException
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -184,4 +185,8 @@ def _verify(vm_):
         }
 
         log.debug('Testing SSH protocol for %s', vm_['name'])
-        return __utils__['cloud.wait_for_passwd'](**kwargs)
+        try:
+            return __utils__['cloud.wait_for_passwd'](**kwargs) is True
+        except SaltCloudException as exc:
+            log.error('Exception: %s', exc)
+            return False


### PR DESCRIPTION
### What does this PR do?
Extends the work in #40299 to Windows targets

### What issues does this PR fix or reference?
Verifies credentials when running the Saltify cloud provider with `deploy=False`

### Previous Behavior
Credential verification was only supported for Linux and UNIX targets.

### New Behavior
Credential verification works with Windows, Linux, and UNIX.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
