### PR TITLE
Fix trying to use a directory as a file.

### DIFF
--- a/salt/thorium/file.py
+++ b/salt/thorium/file.py
@@ -53,6 +53,9 @@ def save(name, filter=False):
     Save the register to <salt cachedir>/thorium/saves/<name>, or to an
     absolute path.
 
+    If an absolute path is specified, then the directory will be created
+    non-recursively if it doesn't exist.
+
     USAGE:
 
     .. code-block:: yaml
@@ -68,10 +71,11 @@ def save(name, filter=False):
            'comment': '',
            'result': True}
     if name.startswith('/'):
-        tgt_dir = name
+        tgt_dir = os.path.dirname(name)
+        fn_ = name
     else:
         tgt_dir = os.path.join(__opts__['cachedir'], 'thorium', 'saves')
-    fn_ = os.path.join(tgt_dir, name)
+        fn_ = os.path.join(tgt_dir, name)
     if not os.path.isdir(tgt_dir):
         os.makedirs(tgt_dir)
     with salt.utils.fopen(fn_, 'w+') as fp_:


### PR DESCRIPTION
### What does this PR do?

This fixes the thorium file runner.\

### What issues does this PR fix or reference?

No open issues are referenced that I'm aware of

### Previous Behavior
tgt_dir was getting set to the absolute path, and subsequently an
attempt was made to write to the absolute path (aka the just-created
directory).

This would always fail.

### New Behavior
When  an absolute path is specified, use the `os.path.dirname()` of the path as the `tgt_dir` and see if that needs to be created (and it still does this non-recursively).

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
