### PR TITLE
Fix package name collisions in chocolatey state

### DIFF
--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -167,7 +167,8 @@ def uninstalled(name, version=None, uninstall_args=None, override_args=False):
            'comment': ''}
 
     # Determine if package is installed
-    if name in __salt__['cmd.run']('choco list --local-only --limit-output'):
+    packages = __salt__['cmd.run']('choco list --local-only --limit-output')
+    if name.lower() in [package.split('|')[0].lower() for package in packages.splitlines()]:
         ret['changes'] = {'name': '{0} will be removed'.format(name)}
     else:
         ret['comment'] = 'The package {0} is not installed'.format(name)

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -86,7 +86,8 @@ def installed(name, version=None, source=None, force=False, pre_versions=False,
            'comment': ''}
 
     # Determine if the package is installed
-    if name not in __salt__['cmd.run']('choco list --local-only --limit-output'):
+    packages = __salt__['cmd.run']('choco list --local-only --limit-output')
+    if name.lower() not in [package.split('|')[0].lower() for package in packages.splitlines()]:
         ret['changes'] = {'name': '{0} will be installed'.format(name)}
     elif force:
         ret['changes'] = {'name': '{0} is already installed but will reinstall'


### PR DESCRIPTION
### What does this PR do?

Allows for case-insensitive package matching and tests for the exact package name rather than using python's `in` operator

### What issues does this PR fix or reference?

#41185

### Previous Behavior

chocolatey is unable to install a package if the name is a substring of another installed package
chocolatey attempts to install a package if the name does not match the case in the salt state

### New Behavior

chocolatey state allows for case-insensitive matching to align with chocolatey behavior
chocolatey is able to install a package which is a substring of an installed package

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
