### PR TITLE
Allows the salt.utils.slack query() to pass args

### DIFF
--- a/salt/utils/slack.py
+++ b/salt/utils/slack.py
@@ -82,7 +82,7 @@ def query(function,
     if not isinstance(args, dict):
         query_params = {}
     else:
-        query_params = dict(args.items())  # shallow copy
+        query_params = args.copy()
     query_params['token'] = api_key
 
     if header_dict is None:

--- a/salt/utils/slack.py
+++ b/salt/utils/slack.py
@@ -82,7 +82,7 @@ def query(function,
     if not isinstance(args, dict):
         query_params = {}
     else:
-        query_params = { key: val for key, val in args.items() }  # shallow copy
+        query_params = dict(args.items())  # shallow copy
     query_params['token'] = api_key
 
     if header_dict is None:

--- a/salt/utils/slack.py
+++ b/salt/utils/slack.py
@@ -45,7 +45,6 @@ def query(function,
     :param data:        The data to be sent for POST method.
     :return:            The json response from the API call or False.
     '''
-    query_params = {}
 
     ret = {'message': '',
            'res': True}
@@ -82,6 +81,8 @@ def query(function,
 
     if not isinstance(args, dict):
         query_params = {}
+    else:
+        query_params = { key: val for key, val in args.items() }  # shallow copy
     query_params['token'] = api_key
 
     if header_dict is None:
@@ -90,6 +91,8 @@ def query(function,
     if method != 'POST':
         header_dict['Accept'] = 'application/json'
 
+
+    print("params are {}".format(query_params))
     result = salt.utils.http.query(
         url,
         method,

--- a/salt/utils/slack.py
+++ b/salt/utils/slack.py
@@ -91,8 +91,6 @@ def query(function,
     if method != 'POST':
         header_dict['Accept'] = 'application/json'
 
-
-    print("params are {}".format(query_params))
     result = salt.utils.http.query(
         url,
         method,


### PR DESCRIPTION
### What does this PR do?

Fix incomplete argument passing functionality in salt.utils.slack

### What issues does this PR fix or reference?

No open PRs that I'm aware of

### Previous Behavior

Args passed into `salt.utils.slack.query()` would be ignored.

### New Behavior

Args are passed in to the slack API

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
