### PR TITLE
utils/minions.py: Fixed case where data is an empty dict resulting in…

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -82,8 +82,8 @@ def get_minion_data(minion, opts):
         else:
             data = cache.fetch('minions/{0}'.format(minion), 'data')
         if data is not None:
-            grains = data['grains']
-            pillar = data['pillar']
+            grains = data.get('grains', None)
+            pillar = data.get('pillar', None)
     return minion if minion else None, grains, pillar
 
 


### PR DESCRIPTION
… errors.

### What does this PR do?
This PR fixes a KeyError when a non-existing minion's pillar is retrieved.

### What issues does this PR fix or reference?
When trying to get a "future" pillar for a minion that does not (yet) exist, using
salt-run pillar.show_pillar minion=id <kwargs>
Salt errors out.

### Previous Behavior
Exception occurred in runner pillar.show_pillar: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/client/mixins.py", line 395, in _low
    data['return'] = self.functions[fun](*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/runners/pillar.py", line 78, in show_pillar
    id_, grains, _ = salt.utils.minions.get_minion_data(minion, __opts__)
  File "/usr/lib/python2.7/site-packages/salt/utils/minions.py", line 85, in get_minion_data
    grains = data['grains']
KeyError: 'grains'

### New Behavior
No error, shows pillar based on kwargs that get copied as grains (runners/pillar.py)

### Tests written?
No