### PR TITLE
Use os.access in grains.core to check a file for usage

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1209,6 +1209,10 @@ def _linux_bin_exists(binary):
         return False
 
 
+def _file_readable(fpath):
+    return os.access(fpath, os.R_OK)
+
+
 def _get_interfaces():
     '''
     Provide a dict of the connected interfaces and their ip addresses
@@ -1329,7 +1333,7 @@ def os_data():
             os.stat('/run/systemd/system')
             grains['init'] = 'systemd'
         except (OSError, IOError):
-            if os.path.exists('/proc/1/cmdline'):
+            if _file_readable('/proc/1/cmdline'):
                 with salt.utils.fopen('/proc/1/cmdline') as fhr:
                     init_cmdline = fhr.read().replace('\x00', ' ').split()
                     init_bin = salt.utils.which(init_cmdline[0])
@@ -1920,7 +1924,7 @@ def get_machine_id():
     # Provides:
     #   machine-id
     locations = ['/etc/machine-id', '/var/lib/dbus/machine-id']
-    existing_locations = [loc for loc in locations if os.path.exists(loc)]
+    existing_locations = [loc for loc in locations if _file_readable(loc)]
     if not existing_locations:
         return {}
     else:
@@ -2041,7 +2045,7 @@ def _hw_data(osdata):
         }
         for key, fw_file in sysfs_firmware_info.items():
             contents_file = os.path.join('/sys/class/dmi/id', fw_file)
-            if os.path.exists(contents_file):
+            if _file_readable(contents_file):
                 with salt.utils.fopen(contents_file, 'r') as ifile:
                     grains[key] = ifile.read()
                     if key == 'uuid':


### PR DESCRIPTION
The os.path.exists(path) just checks for the existence of a file. The
os.access(path, os.R_OK) for the existence _and_ readability. The latter
is preferred in cases where that functionality is wanted.

Fixes a bug in 74508eb12555e462b5be8f7b36eea6fa56beb40a

See https://github.com/saltstack/salt/commit/74508eb12555e462b5be8f7b36eea6fa56beb40a#diff-6e894b39b67c4bab67796752744ea9d5R2044

### What does this PR do?
Fixes a bug for linux containers, where files exist, but are not readable for root.

### What issues does this PR fix or reference?

See https://github.com/saltstack/salt/commit/74508eb12555e462b5be8f7b36eea6fa56beb40a#diff-6e894b39b67c4bab67796752744ea9d5R2044

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
