### PR TITLE
Update fingerprint hash type default from md5 to sha256

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -60,7 +60,6 @@ State Module Changes
   ``no_block`` argument which, when set to ``True`` on systemd minions, will
   start/stop the service using the ``--no-block`` flag in the ``systemctl``
   command. On non-systemd minions, a warning will be issued.
-
 - The :py:func:`module.run <salt.states.module.run>` state has dropped its
   previous syntax with ``m_`` prefix for reserved keywords. Additionally, it
   allows running several functions in a batch.
@@ -105,6 +104,9 @@ State Module Changes
 
       use_superseded:
         - module.run
+- The default for the ``fingerprint_hash_type`` option used in the ``present``
+  function in the :mod:`ssh <salt.states.ssh_know_hosts>` state changed from
+  ``md5`` to ``sha256``.
 
 
 Execution Module Changes
@@ -132,6 +134,9 @@ Execution Module Changes
   :py:func:`Arch Linux <salt.modules.pacman.list_repo_pkgs>`-based distros.
 - The :mod:`system <salt.modules.system>` module changed its return format
   from "HH:MM AM/PM" to "HH:MM:SS AM/PM" for `get_system_time`.
+- The default for the ``fingerprint_hash_type`` option used in the
+  :mod:`ssh <salt.modules.ssh>` execution module changed from ``md5`` to
+  ``sha256``.
 
 
 Proxy Module Changes

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -237,14 +237,10 @@ def _fingerprint(public_key, fingerprint_hash_type=None):
 
     fingerprint_hash_type
         The public key fingerprint hash type that the public key fingerprint
-        was originally hashed with. This defaults to ``md5`` if not specified.
+        was originally hashed with. This defaults to ``sha256`` if not specified.
 
         .. versionadded:: 2016.11.4
-
-        .. note::
-
-            The default value of the ``fingerprint_hash_type`` will change to
-            ``sha256`` in Salt Nitrogen.
+        .. versionchanged:: Nitrogen: default changed from ``md5`` to ``sha256``
 
     '''
     if fingerprint_hash_type:
@@ -253,7 +249,7 @@ def _fingerprint(public_key, fingerprint_hash_type=None):
         # Set fingerprint_hash_type to md5 as default
         log.warning('Public Key hashing currently defaults to "md5". This will '
                     'change to "sha256" in the Nitrogen release.')
-        hash_type = 'md5'
+        hash_type = 'sha256'
 
     try:
         hash_func = getattr(hashlib, hash_type)
@@ -829,14 +825,10 @@ def recv_known_host(hostname,
 
     fingerprint_hash_type
         The public key fingerprint hash type that the public key fingerprint
-        was originally hashed with. This defaults to ``md5`` if not specified.
+        was originally hashed with. This defaults to ``sha256`` if not specified.
 
         .. versionadded:: 2016.11.4
-
-        .. note::
-
-            The default value of the ``fingerprint_hash_type`` will change to
-            ``sha256`` in Salt Nitrogen.
+        .. versionchanged:: Nitrogen: default changed from ``md5`` to ``sha256``
 
     CLI Example:
 
@@ -1006,14 +998,10 @@ def set_known_host(user=None,
 
     fingerprint_hash_type
         The public key fingerprint hash type that the public key fingerprint
-        was originally hashed with. This defaults to ``md5`` if not specified.
+        was originally hashed with. This defaults to ``sha256`` if not specified.
 
         .. versionadded:: 2016.11.4
-
-        .. note::
-
-            The default value of the ``fingerprint_hash_type`` will change to
-            ``sha256`` in Salt Nitrogen.
+        .. versionchanged:: Nitrogen: default changed from ``md5`` to ``sha256``
 
     CLI Example:
 

--- a/salt/states/ssh_known_hosts.py
+++ b/salt/states/ssh_known_hosts.py
@@ -100,14 +100,10 @@ def present(
 
     fingerprint_hash_type
         The public key fingerprint hash type that the public key fingerprint
-        was originally hashed with. This defaults to ``md5`` if not specified.
+        was originally hashed with. This defaults to ``sha256`` if not specified.
 
         .. versionadded:: 2016.11.4
-
-        .. note::
-
-            The default value of the ``fingerprint_hash_type`` will change to
-            ``sha256`` in Salt Nitrogen.
+        .. versionchanged:: Nitrogen: default changed from ``md5`` to ``sha256``
 
     '''
     ret = {'name': name,

--- a/tests/integration/modules/test_ssh.py
+++ b/tests/integration/modules/test_ssh.py
@@ -22,7 +22,7 @@ from tornado.httpclient import HTTPClient
 SUBSALT_DIR = os.path.join(TMP, 'subsalt')
 AUTHORIZED_KEYS = os.path.join(SUBSALT_DIR, 'authorized_keys')
 KNOWN_HOSTS = os.path.join(SUBSALT_DIR, 'known_hosts')
-GITHUB_FINGERPRINT = '16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48'
+GITHUB_FINGERPRINT = '9d:38:5b:83:a9:17:52:92:56:1a:5e:c4:d4:81:8e:0a:ca:51:a2:64:f1:74:20:11:2e:f8:8a:c3:a1:39:49:8f'
 
 
 def check_status():

--- a/tests/integration/states/test_ssh.py
+++ b/tests/integration/states/test_ssh.py
@@ -23,7 +23,7 @@ from tests.support.helpers import (
 import salt.utils
 
 KNOWN_HOSTS = os.path.join(RUNTIME_VARS.TMP, 'known_hosts')
-GITHUB_FINGERPRINT = '16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48'
+GITHUB_FINGERPRINT = '9d:38:5b:83:a9:17:52:92:56:1a:5e:c4:d4:81:8e:0a:ca:51:a2:64:f1:74:20:11:2e:f8:8a:c3:a1:39:49:8f'
 GITHUB_IP = '192.30.253.113'
 
 

--- a/tests/support/gitfs.py
+++ b/tests/support/gitfs.py
@@ -513,6 +513,7 @@ class GitPillarSSHTestBase(GitPillarTestBase, SSHDMixin):
                 enc='ssh-rsa',
                 fingerprint='fd:6f:7f:5d:06:6b:f2:06:0d:26:93:9e:5a:b5:19:46',
                 hash_known_hosts=False,
+                fingerprint_hash_type='md5',
             )
             if 'error' in known_hosts_ret:
                 raise Exception(


### PR DESCRIPTION
This PR also removes the warnings that this default will change in the Nitrogen release, updates the documentation accordingly, and adjusts some of the affected tests.

This was originally submitted in #40899, but I had to revert it because once it was merged into the nitrogen branch, the test suite started hanging. However, I am unable to reproduce the behavior of the test suite hanging, so let's just try to submit this again.