### PR TITLE
Move vault deprecation warnings from Oxygen to Fluorine

### DIFF
--- a/salt/pillar/vault.py
+++ b/salt/pillar/vault.py
@@ -76,7 +76,7 @@ def ext_pillar(minion_id,  # pylint: disable=W0613
 
     if not comps[0].startswith('path='):
         salt.utils.warn_until(
-            'Oxygen',
+            'Fluorine',
             'The \'profile\' argument has been deprecated. Any parts up until '
             'and following the first "path=" are discarded'
         )

--- a/salt/utils/vault.py
+++ b/salt/utils/vault.py
@@ -137,10 +137,11 @@ def make_request_with_profile(method, resource, profile, **args):
     details.
     '''
     salt.utils.warn_until(
-        'Oxygen',
+        'Fluorine',
         'Specifying Vault connection data within a \'profile\' has been '
         'deprecated. Please see the documentation for details on the new '
-        'configuration schema.'
+        'configuration schema. Support for this function will be removed '
+        'in Salt Fluorine.'
     )
     url = '{0}://{1}:{2}/v1/{3}'.format(
         profile.get('vault.scheme', 'https'),


### PR DESCRIPTION
This deprecation notice was just recently added to Nitrogen. The deprecation policy states that we should give two feature releases in the warning.
