### PR TITLE
Increase timeout for Windows

### DIFF
--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -13,7 +13,6 @@ import salt.crypt
 import salt.payload
 import salt.transport
 import salt.utils.args
-import salt.utils
 from salt.exceptions import SaltReqTimeoutError, SaltInvocationError
 
 log = logging.getLogger(__name__)
@@ -68,9 +67,6 @@ def _publish(
 
         salt system.example.com publish.publish '*' cmd.run 'ls -la /tmp'
     '''
-    # Increase the timeout for Windows so that tests will pass
-    if salt.utils.is_windows():
-        timeout = timeout * 10
     if 'master_uri' not in __opts__:
         log.error('Cannot run publish commands without a connection to a salt master. No command sent.')
         return {}

--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -13,6 +13,7 @@ import salt.crypt
 import salt.payload
 import salt.transport
 import salt.utils.args
+import salt.utils
 from salt.exceptions import SaltReqTimeoutError, SaltInvocationError
 
 log = logging.getLogger(__name__)
@@ -67,6 +68,9 @@ def _publish(
 
         salt system.example.com publish.publish '*' cmd.run 'ls -la /tmp'
     '''
+    # Increase the timeout for Windows so that tests will pass
+    if salt.utils.is_windows():
+        timeout = timeout * 10
     if 'master_uri' not in __opts__:
         log.error('Cannot run publish commands without a connection to a salt master. No command sent.')
         return {}

--- a/tests/integration/modules/test_publish.py
+++ b/tests/integration/modules/test_publish.py
@@ -16,13 +16,18 @@ class PublishModuleTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         publish.publish
         '''
-        ret = self.run_function('publish.publish', ['minion', 'test.ping'])
+        ret = self.run_function(
+            'publish.publish',
+            ['minion', 'test.ping'],
+            f_timeout=50
+        )
         self.assertEqual(ret, {'minion': True})
 
         ret = self.run_function(
             'publish.publish',
             ['minion', 'test.kwarg'],
-            f_arg='cheese=spam'
+            f_arg='cheese=spam',
+            f_timeout=50
         )
         ret = ret['minion']
 
@@ -50,14 +55,19 @@ class PublishModuleTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         test publish.publish yaml args formatting
         '''
-        ret = self.run_function('publish.publish', ['minion', 'test.ping'])
+        ret = self.run_function(
+            'publish.publish',
+            ['minion', 'test.ping'],
+            f_timeout=50
+        )
         self.assertEqual(ret, {'minion': True})
 
         test_args_list = ['saltines, si', 'crackers, nein', 'cheese, indeed']
         test_args = '["{args[0]}", "{args[1]}", "{args[2]}"]'.format(args=test_args_list)
         ret = self.run_function(
             'publish.publish',
-            ['minion', 'test.arg', test_args]
+            ['minion', 'test.arg', test_args],
+            f_timeout=50
         )
         ret = ret['minion']
 
@@ -85,7 +95,8 @@ class PublishModuleTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         ret = self.run_function(
             'publish.full_data',
-            ['minion', 'test.fib', 20]
+            ['minion', 'test.fib', 20],
+            f_timeout=50
         )
         self.assertTrue(ret)
         self.assertEqual(ret['minion']['ret'][0], 6765)
@@ -97,7 +108,8 @@ class PublishModuleTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_function(
             'publish.full_data',
             ['minion', 'test.kwarg'],
-            f_arg='cheese=spam'
+            f_arg='cheese=spam',
+            f_timeout=50
         )
         ret = ret['minion']['ret']
 
@@ -124,7 +136,8 @@ class PublishModuleTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_function(
             'publish.full_data',
             ['minion', 'test.kwarg'],
-            cheese='spam'
+            cheese='spam',
+            f_timeout=50
         )
         self.assertIn(
             'The following keyword arguments are not valid', ret
@@ -136,6 +149,7 @@ class PublishModuleTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         ret = self.run_function(
             'publish.publish',
-            ['minion', 'cmd.run', ['echo foo']]
+            ['minion', 'cmd.run', ['echo foo']],
+            f_timeout=50
         )
         self.assertEqual(ret, {})


### PR DESCRIPTION
### What does this PR do?
Fixes `integration.modules.test_publish` tests for Windows. The timeout was set too low.

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1273

### Tests written?
NA
