### PR TITLE
opkg may return non-zero but empty stderr

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -151,8 +151,10 @@ def refresh_db():
                                    python_shell=False)
     if call['retcode'] != 0:
         comment = ''
-        if 'stderr' in call:
+        if call['stderr']:
             comment += call['stderr']
+        else:
+            comment += call['stdout']
 
         raise CommandExecutionError(
             '{0}'.format(comment)
@@ -348,8 +350,11 @@ def install(name=None,
             output_loglevel='trace',
             python_shell=False
         )
-        if out['retcode'] != 0 and out['stderr']:
-            errors.append(out['stderr'])
+        if out['retcode'] != 0:
+            if out['stderr']:
+                errors.append(out['stderr'])
+            else:
+                errors.append(out['stdout'])
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
@@ -406,8 +411,11 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
         output_loglevel='trace',
         python_shell=False
     )
-    if out['retcode'] != 0 and out['stderr']:
-        errors = [out['stderr']]
+    if out['retcode'] != 0:
+        if out['stderr']:
+            errors = [out['stderr']]
+        else:
+            errors = [out['stdout']]
     else:
         errors = []
 
@@ -885,8 +893,10 @@ def info_installed(*names, **kwargs):
                                            python_shell=False)
             if call['retcode'] != 0:
                 comment = ''
-                if 'stderr' in call:
+                if call['stderr']:
                     comment += call['stderr']
+                else:
+                    comment += call['stdout']
 
                 raise CommandExecutionError(
                     '{0}'.format(comment)
@@ -900,8 +910,10 @@ def info_installed(*names, **kwargs):
                                        python_shell=False)
         if call['retcode'] != 0:
             comment = ''
-            if 'stderr' in call:
+            if call['stderr']:
                 comment += call['stderr']
+            else:
+                comment += call['stdout']
 
             raise CommandExecutionError(
                 '{0}'.format(comment)


### PR DESCRIPTION
### What does this PR do?

`opkg` may fail with a non-zero exit code yet have nothing output to stderr. 
This is possible with any version of opkg prior to this fix:
https://bugzilla.yoctoproject.org/show_bug.cgi?id=10407

If this is the case, use stdout in the error message so that an
exception will still be raised.

### Tests written?

No