### PR TITLE
Fix: zypper handling of multiple version packages

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1068,6 +1068,12 @@ def install(name=None,
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
+
+    # Handle packages which report multiple new versions
+    # (affects only kernel packages at this point)
+    for pkg in new:
+        new[pkg] = new[pkg].split(',')[-1]
+
     ret = salt.utils.compare_dicts(old, new)
 
     if errors:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1181,6 +1181,11 @@ def upgrade(refresh=True,
     __zypper__(systemd_scope=_systemd_scope()).noraise.call(*cmd_update)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
+
+    # Handle packages which report multiple new versions
+    # (affects only kernel packages at this point)
+    for pkg in new:
+        new[pkg] = new[pkg].split(',')[-1]
     ret = salt.utils.compare_dicts(old, new)
 
     if __zypper__.exit_code not in __zypper__.SUCCESS_EXIT_CODES:

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -394,11 +394,12 @@ class ZypperTestCase(TestCase):
         :return:
         '''
 
-        with patch.dict(zypper.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=(['kernel-default'], None))}):
-            with patch('salt.modules.zypper.__zypper__.noraise.call', MagicMock()):
-                with patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"kernel-default": "3.12.49-11.1"}, {"kernel-default": "3.12.49-11.1,3.12.51-60.20.2"}])):
-                    ret = zypper.install('kernel-default', '--auto-agree-with-licenses')
-                    self.assertDictEqual(ret, {"kernel-default": {"old": "3.12.49-11.1", "new": "3.12.51-60.20.2"}})
+        with patch.dict(zypper.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=(['kernel-default'], None))}), \
+             patch('salt.modules.zypper.__zypper__.noraise.call', MagicMock()), \
+             patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[
+                 {"kernel-default": "3.12.49-11.1"}, {"kernel-default": "3.12.49-11.1,3.12.51-60.20.2"}])):
+            ret = zypper.install('kernel-default', '--auto-agree-with-licenses')
+            self.assertDictEqual(ret, {"kernel-default": {"old": "3.12.49-11.1", "new": "3.12.51-60.20.2"}})
 
     @patch('salt.modules.zypper.refresh_db', MagicMock(return_value=True))
     @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -394,12 +394,12 @@ class ZypperTestCase(TestCase):
         :return:
         '''
 
-        with patch.dict(zypper.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=(['kernel-default'], None))}), \
-             patch('salt.modules.zypper.__zypper__.noraise.call', MagicMock()), \
-             patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[
-                 {"kernel-default": "3.12.49-11.1"}, {"kernel-default": "3.12.49-11.1,3.12.51-60.20.2"}])):
-            ret = zypper.install('kernel-default', '--auto-agree-with-licenses')
-            self.assertDictEqual(ret, {"kernel-default": {"old": "3.12.49-11.1", "new": "3.12.51-60.20.2"}})
+        with patch.dict(zypper.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=(['kernel-default'], None))}):
+            with patch('salt.modules.zypper.__zypper__.noraise.call', MagicMock()):
+                with patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[
+                    {"kernel-default": "3.12.49-11.1"}, {"kernel-default": "3.12.49-11.1,3.12.51-60.20.2"}])):
+                    ret = zypper.install('kernel-default', '--auto-agree-with-licenses')
+                    self.assertDictEqual(ret, {"kernel-default": {"old": "3.12.49-11.1", "new": "3.12.51-60.20.2"}})
 
     @patch('salt.modules.zypper.refresh_db', MagicMock(return_value=True))
     @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))


### PR DESCRIPTION
### What does this PR do?

For kernel packages, zypper reports multiple versions as "new" during
upgrade. Thus, a salt state requesting pkg.latest of any kernel package
would fail, even though zypper runs successfully. This commit provides
a simple fix.

### Previous Behavior
pkg.latest on SLE minions installed latest kernel version, but the state failed. 

### New Behavior
pkg.latest on SLE minions installs latest kernel version, and the state succeeds. 

### Tests written?

Yes