### PR TITLE
Fix junos grains

### DIFF
--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -131,10 +131,9 @@ def get_serialized_facts():
     # For backward compatibility. 'junos_info' is present
     # only of in newer versions of facts.
     if 'junos_info' in facts:
-        facts['junos_info']['re0']['object'] = \
-            dict(facts['junos_info']['re0']['object'])
-        facts['junos_info']['re1']['object'] = \
-            dict(facts['junos_info']['re1']['object'])
+        for re in facts['junos_info']:
+            facts['junos_info'][re]['object'] = \
+                dict(facts['junos_info'][re]['object'])
     return facts
 
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes the junos grains which weren't collected properly. Grains were incorrectly parsed,
when the junos device did not have 2 REs. Now the grains are parsed dynamically according to the number of REs present.

### What issues does this  #PR fix or reference?
https://github.com/saltstack/salt/issues/41196

### Previous Behavior
While collecting junos grains the following error occured (For junos devices having single RE):
```
[CRITICAL] Failed to load grains defined in grain file junos.facts in function <function facts at 0x7f84e2f63c80>, error:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 719, in grains
    ret = funcs[key](proxy)
  File "/usr/lib/python2.7/dist-packages/salt/grains/junos.py", line 51, in facts
    return {'junos_facts': proxy['junos.get_serialized_facts']()}
  File "/usr/lib/python2.7/dist-packages/salt/proxy/junos.py", line 137, in get_serialized_facts
    dict(facts['junos_info']['re1']['object'])
KeyError: 're1'
```

### New Behavior
The junos grains are collected just fine. This can be verified with the 'grains.items' command.

### Tests written?
No