### PR TITLE
Bump removal version from Oxygen to Flourine for module.run state

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -214,7 +214,7 @@ def wait(name, **kwargs):
 watch = salt.utils.alias_function(wait, 'watch')
 
 
-@with_deprecated(globals(), "Oxygen", policy=with_deprecated.OPT_IN)
+@with_deprecated(globals(), "Fluorine", policy=with_deprecated.OPT_IN)
 def run(**kwargs):
     '''
     Run a single module function or a range of module functions in a batch.


### PR DESCRIPTION
This deprecation code was only recently put in for the `nitrogen` release. The policy is to give at least 2 feature releases before the deprecated code is removed. See the [Deprecating Code](https://docs.saltstack.com/en/latest/topics/development/deprecations.html) docs for more information.

This PR bumps the warn_until/removal version from `Oxygen` to `Fluorine` to give people more time to adjust their state modules with 2 feature releases.

Refs #39891
