### PR TITLE
Add probot-stale config file for the salt repo

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,33 @@
+# Probot Stale configuration file
+
+# Number of days of inactivity before an issue becomes stale
+# 1275 is approximately 3 years and 6 months
+daysUntilStale: 1275
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+
+# Issues with these labels will never be considered stale
+#exemptLabels:
+#  - pinned
+#  - security
+
+# Label to use when marking an issue as stale
+staleLabel: stale
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: |
+  This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.
+
+  If this issue is closed prematurely, please leave a comment and we will gladly reopen the issue.
+
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: |
+  Thank you for updating this issue. It is no longer marked as stale.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+
+# Limit to only `issues` or `pulls`
+only: issues
+


### PR DESCRIPTION
This config file enables the [probot-stale](https://github.com/probot/stale/) bot to comment on stale issues. We're starting off with issues that have become stale after approximately 3 years and 6 months. This value is configured in the `daysUntilStale` setting.
