### PR TITLE
Add basic auth for SPM

### DIFF
--- a/doc/topics/spm/master.rst
+++ b/doc/topics/spm/master.rst
@@ -26,6 +26,16 @@ the name of the repository, and the link to the repository:
     my_repo:
       url: https://spm.example.com/
 
+For HTTP/HTTPS Basic authorization you can define credentials:
+
+.. code-block:: yaml
+    my_repo:
+      url: https://spm.example.com/
+      username: user
+      password: pass
+
+Beware of unauthorized access to this file, please set at least 0640 permissions for this configuration file:
+
 The URL can use ``http``, ``https``, ``ftp``, or ``file``.
 
 .. code-block:: yaml

--- a/salt/spm/__init__.py
+++ b/salt/spm/__init__.py
@@ -228,9 +228,8 @@ class SPMClient(object):
                             dl_path = dl_path.replace('file://', '')
                             shutil.copyfile(dl_path, out_file)
                         else:
-                            response = http.query(dl_path, text=True)
                             with salt.utils.fopen(out_file, 'w') as outf:
-                                outf.write(response.get("text"))
+                                outf.write(self._query_http(dl_path, repo_info['info']))
 
                         # Kick off the install
                         self._install_indv_pkg(package, out_file)
@@ -463,6 +462,45 @@ class SPMClient(object):
                         continue
                     callback(repo, repo_data[repo])
 
+    def _query_http(self, dl_path, repo_info):
+        '''
+        Download files via http
+        '''
+        query = None
+        response = None
+
+        try:
+            if 'username' in repo_info:
+                try:
+                    if 'password' in repo_info:
+                        query = http.query(
+                            dl_path, text=True,
+                            username=repo_info['username'],
+                            password=repo_info['password']
+                        )
+                    else:
+                        raise SPMException('Auth defined, but password is not set for username: \'{0}\''
+                                           .format(repo_info['username']))
+                except SPMException as exc:
+                    self.ui.error(str(exc))
+            else:
+                query = http.query(dl_path, text=True)
+        except SPMException as exc:
+            self.ui.error(str(exc))
+
+        try:
+            if query:
+                if 'SPM-METADATA' in dl_path:
+                    response = yaml.safe_load(query.get('text', '{}'))
+                else:
+                    response = query.get('text')
+            else:
+                raise SPMException('Response is empty, please check for Errors above.')
+        except SPMException as exc:
+            self.ui.error(str(exc))
+
+        return response
+
     def _download_repo_metadata(self, args):
         '''
         Connect to all repos and download metadata
@@ -474,8 +512,8 @@ class SPMClient(object):
                 with salt.utils.fopen(dl_path, 'r') as rpm:
                     metadata = yaml.safe_load(rpm)
             else:
-                response = http.query(dl_path, text=True)
-                metadata = yaml.safe_load(response.get('text', '{}'))
+                metadata = self._query_http(dl_path, repo_info)
+
             cache_path = '{0}/{1}.p'.format(
                 self.opts['spm_cache_dir'],
                 repo


### PR DESCRIPTION
### What does this PR do?
Add basic auth for HTTP/HTTPS

### What issues does this PR fix or reference?

### Previous Behavior
```
spm -l debug update_repo
[DEBUG   ] Reading configuration from /etc/salt/spm
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: minion_id
[DEBUG   ] Reading configuration from /etc/salt/spm
[DEBUG   ] Including configuration from '/etc/salt/master.d/auth.conf'
[DEBUG   ] Reading configuration from /etc/salt/master.d/auth.conf
[DEBUG   ] Including configuration from '/etc/salt/master.d/reactor.conf'
[DEBUG   ] Reading configuration from /etc/salt/master.d/reactor.conf
[DEBUG   ] Missing configuration file: /root/.saltrc
[DEBUG   ] Configuration file path: /etc/salt/spm
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
[DEBUG   ] Reading configuration from /etc/salt/minion
[DEBUG   ] Including configuration from '/etc/salt/minion.d/_schedule.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/_schedule.conf
[DEBUG   ] Including configuration from '/etc/salt/minion.d/master.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/master.conf
[DEBUG   ] Including configuration from '/etc/salt/minion.d/mine.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/mine.conf
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: minion_id
[DEBUG   ] Requesting URL https://nexus.local/content/sites/salt.formulas/SPM-METADATA using GET method
```
```
spm -l debug install confluence
[DEBUG   ] Reading configuration from /etc/salt/spm
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: minion_id
[DEBUG   ] Reading configuration from /etc/salt/spm
[DEBUG   ] Including configuration from '/etc/salt/master.d/auth.conf'
[DEBUG   ] Reading configuration from /etc/salt/master.d/auth.conf
[DEBUG   ] Including configuration from '/etc/salt/master.d/reactor.conf'
[DEBUG   ] Reading configuration from /etc/salt/master.d/reactor.conf
[DEBUG   ] Missing configuration file: /root/.saltrc
[DEBUG   ] Configuration file path: /etc/salt/spm
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
Unable to read formula for confluence
```

### New Behavior
```
# spm -l debug update_repo
[DEBUG   ] Reading configuration from /etc/salt/spm
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: minion_id
[DEBUG   ] Reading configuration from /etc/salt/spm
[DEBUG   ] Including configuration from '/etc/salt/master.d/auth.conf'
[DEBUG   ] Reading configuration from /etc/salt/master.d/auth.conf
[DEBUG   ] Including configuration from '/etc/salt/master.d/reactor.conf'
[DEBUG   ] Reading configuration from /etc/salt/master.d/reactor.conf
[DEBUG   ] Missing configuration file: /root/.saltrc
[DEBUG   ] Configuration file path: /etc/salt/spm
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
[DEBUG   ] Reading configuration from /etc/salt/minion
[DEBUG   ] Including configuration from '/etc/salt/minion.d/_schedule.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/_schedule.conf
[DEBUG   ] Including configuration from '/etc/salt/minion.d/master.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/master.conf
[DEBUG   ] Including configuration from '/etc/salt/minion.d/mine.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/mine.conf
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: minion_id
[DEBUG   ] Requesting URL https://nexus.local/content/sites/salt.formulas/SPM-METADATA using GET method
[DEBUG   ] Response Status Code: 200
```
```
# spm -l debug install confluence
[DEBUG   ] Reading configuration from /etc/salt/spm
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: minion_id
[DEBUG   ] Reading configuration from /etc/salt/spm
[DEBUG   ] Including configuration from '/etc/salt/master.d/auth.conf'
[DEBUG   ] Reading configuration from /etc/salt/master.d/auth.conf
[DEBUG   ] Including configuration from '/etc/salt/master.d/reactor.conf'
[DEBUG   ] Reading configuration from /etc/salt/master.d/reactor.conf
[DEBUG   ] Missing configuration file: /root/.saltrc
[DEBUG   ] Configuration file path: /etc/salt/spm
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
The following dependencies are optional:
	

The following dependencies are recommended:
	

Installing packages:
	confluence

Proceed? [N/y] y
[DEBUG   ] Reading configuration from /etc/salt/minion
[DEBUG   ] Including configuration from '/etc/salt/minion.d/_schedule.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/_schedule.conf
[DEBUG   ] Including configuration from '/etc/salt/minion.d/master.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/master.conf
[DEBUG   ] Including configuration from '/etc/salt/minion.d/mine.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/mine.conf
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: minion_id
[DEBUG   ] Requesting URL https://nexus.local/content/sites/salt.formulas/confluence-0.0.1-1.spm using GET method
[DEBUG   ] Response Status Code: 200
... installing confluence
[DEBUG   ] test not in top level directory, not installing
[DEBUG   ] test/integration not in top level directory, not installing
[DEBUG   ] test/integration/helpers not in top level directory, not installing
[DEBUG   ] test/integration/helpers/serverspec not in top level directory, not installing
[DEBUG   ] test/integration/helpers/serverspec/confluence_shared_spec.rb not in top level directory, not installing
[DEBUG   ] test/integration/confluence not in top level directory, not installing
[DEBUG   ] test/integration/confluence/serverspec not in top level directory, not installing
[DEBUG   ] test/integration/confluence/serverspec/confluence_spec.rb not in top level directory, not installing
[DEBUG   ] README.md not in top level directory, not installing
[DEBUG   ] Installing package file confluence.sls.orig to /opt/salt/pillar
[DEBUG   ] FORMULA not in top level directory, not installing
[DEBUG   ] .editorconfig not in top level directory, not installing
[DEBUG   ] Installing package file confluence to /opt/salt/formulas
[DEBUG   ] Installing package file confluence/nginx.sls to /opt/salt/formulas
[DEBUG   ] Installing package file confluence/init.sls to /opt/salt/formulas
[DEBUG   ] Installing package file confluence/templates to /opt/salt/formulas
[DEBUG   ] Installing package file confluence/templates/server.xml to /opt/salt/formulas
[DEBUG   ] Installing package file confluence/templates/confluence.service to /opt/salt/formulas
[DEBUG   ] Installing package file confluence/templates/setenv.sh to /opt/salt/formulas
[DEBUG   ] Installing package file confluence/templates/confluence-init.properties to /opt/salt/formulas
[DEBUG   ] Installing package file confluence/templates/confluence.nginx to /opt/salt/formulas
[DEBUG   ] Installing package file confluence/settings.jinja to /opt/salt/formulas
```

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
