### PR TITLE
rest_cherrypy: remove sleep call

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -465,7 +465,6 @@ import json
 import os
 import signal
 import tarfile
-import time
 from multiprocessing import Process, Pipe
 
 # Import third-party libs
@@ -2326,7 +2325,6 @@ class WebsocketEndpoint(object):
                         logger.error(
                                 "Error: Salt event has non UTF-8 data:\n{0}"
                                 .format(data))
-                time.sleep(0.1)
 
         parent_pipe, child_pipe = Pipe()
         handler.pipe = parent_pipe


### PR DESCRIPTION
### What does this PR do?

It removes a delay when processing events from the `rest_cherrypy` netapi that limited the throughput to 10 events per second maximum.

### What issues does this PR fix or reference?

None known.

### Previous Behavior

If more than 10 events per second were published on the Event bus, `netapi` clients would only get up to 10 per second, and the rest would be queued.

This can be easily reproduced with the [evil-minions Salt load generator](https://github.com/moio/evil-minions).

### New Behavior

Events are processed as fast as possible.

### Tests written?

No.


This PR is more of a question rather than a code contribution (to @pass-by-value, @whiteinge or anyone with in-depth knowledge of this matter). I am not experienced enough to see why this might be needed or what would an alternative solution look like at the moment.

I did not observe negative side effects with this patch.

Thanks in advance!