### PR TITLE
Documentation fix: mine.get compound example

### DIFF
--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -270,7 +270,7 @@ def get(tgt,
 
         salt '*' mine.get '*' network.interfaces
         salt '*' mine.get 'os:Fedora' network.interfaces grain
-        salt '*' mine.get 'os:Fedora and S@192.168.5.0/24' network.ipaddrs compound
+        salt '*' mine.get 'G@os:Fedora and S@192.168.5.0/24' network.ipaddrs compound
 
     .. seealso:: Retrieving Mine data from Pillar and Orchestrate
 


### PR DESCRIPTION
The compound example is missing the G@ prefix for "os" grain.

https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.mine.html#salt.modules.mine.get