### PR TITLE
Fix changing a mysql user to unix socket authentication.

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1385,7 +1385,10 @@ def user_chpass(user,
     if salt.utils.is_true(allow_passwordless) and \
             salt.utils.is_true(unix_socket):
         if host == 'localhost':
-            qry += ' IDENTIFIED VIA unix_socket'
+            qry = ('UPDATE mysql.user SET ' + password_column + '='
+                   + password_sql + ', plugin=%(unix_socket)s' +
+                   ' WHERE User=%(user)s AND Host = %(host)s;')
+            args['unix_socket'] = 'unix_socket'
         else:
             log.error('Auth via unix_socket can be set only for host=localhost')
     try:


### PR DESCRIPTION
### What does this PR do?

This allows salt to change an existing mysql user to use unix socket authentication

### What issues does this PR fix or reference?

Previous behavior constructs a broken query:

```
UPDATE mysql.user SET password='' WHERE User='root' AND Host='localhost'; IDENTIFIED VIA unix_socket
```

The `IDENTIFIED VIA unix_socket` part was never part of the query because of the semicolon.
But even beside that, `UPDATE` doesn't support the `IDENTIFIED VIA` syntax, so we need a completely different query here.

### Tests written?

No

I have this currently based on 2016.11 since that is what I can test, but the code is broken for much longer. If I should rebase to an older version just let me know.