### PR TITLE
JunOS: Change os_install to use get_file instead of get_template

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1005,7 +1005,7 @@ def install_os(path=None, **kwargs):
         return ret
 
     image_cached_path = files.mkstemp()
-    __salt__['cp.get_template'](path, image_cached_path)
+    __salt__['cp.get_file'](path, image_cached_path)
 
     if not os.path.isfile(image_cached_path):
         ret['message'] = 'Invalid image path.'

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -38,8 +38,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                     'junos.conn': self.make_connect,
                     'junos.get_serialized_facts': self.get_facts
                 },
-                '__salt__': {'cp.get_template': self.mock_cp, 
-                             'cp.get_file' : self.mock_cp}
+                '__salt__': {'cp.get_template': self.mock_cp,
+                             'cp.get_file': self.mock_cp}
             }
         }
 

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -38,7 +38,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                     'junos.conn': self.make_connect,
                     'junos.get_serialized_facts': self.get_facts
                 },
-                '__salt__': {'cp.get_template': self.mock_cp}
+                '__salt__': {'cp.get_template': self.mock_cp, 
+                             'cp.get_file' : self.mock_cp}
             }
         }
 


### PR DESCRIPTION
### What does this PR do?
In the JunOS modules os_install is designed to install operating system
images to the device.  The current code uses get_template to upload the
OS image file to the device.  This does not work because get_template
attempts to load the entire file into memory so that it can process any
template directives inside the file.  The typical JunOS files are so large
that they cause a MemoryError exception in Python.

I can think of no circumstances where it would be useful to template an
OS image file.  Any changes you make to it will break the internal
checksums and cause upgrades to break.  Therefore, I have changed the
code to use get_file which does not have the problem with large files.
This code has been tested in my lab with JunOS 15.1X53-D55.5 version
upgrades on EX2300 switches.

### What issues does this PR fix or reference?

### Previous Behavior
ips-swi-lab1:
----------
          ID: /home/mcdermj/junos-arm-32-15.1X53-D55.5.tgz
    Function: junos.install_os
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/home/mcdermj/src/salt/salt/state.py", line 1822, in call
                  **cdata['kwargs'])
                File "/home/mcdermj/src/salt/salt/loader.py", line 1727, in wrapper
                  return f(*args, **kwargs)
                File "/home/mcdermj/src/salt/salt/states/junos.py", line 379, in install_os
                  ret['changes'] = __salt__['junos.install_os'](name, **kwargs)
                File "/home/mcdermj/src/salt/salt/modules/junos.py", line 1008, in install_os
                  __salt__['cp.get_template'](path, image_cached_path)
                File "/home/mcdermj/src/salt/salt/modules/cp.py", line 262, in get_template
                  **kwargs)
                File "/home/mcdermj/src/salt/salt/fileclient.py", line 715, in get_template
                  **kwargs
                File "/home/mcdermj/src/salt/salt/utils/templates.py", line 139, in render_tmpl
                  tmplstr = _tmplsrc.read()
                File "/usr/lib/python2.7/codecs.py", line 686, in read
                  return self.reader.read(size)
                File "/usr/lib/python2.7/codecs.py", line 492, in read
                  newchars, decodedbytes = self.decode(data, self.errors)
              MemoryError
     Started: 12:08:02.232216
    Duration: 1275.237 ms
     Changes:   

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
