### PR TITLE
linux_sysctl.default_config() no longer creates files and directories

### DIFF
--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -35,20 +35,6 @@ def __virtual__():
     return __virtualname__
 
 
-def _check_systemd_salt_config():
-    conf = '/etc/sysctl.d/99-salt.conf'
-    if not os.path.exists(conf):
-        sysctl_dir = os.path.split(conf)[0]
-        if not os.path.exists(sysctl_dir):
-            os.makedirs(sysctl_dir)
-        try:
-            salt.utils.fopen(conf, 'w').close()
-        except (IOError, OSError):
-            msg = 'Could not create file: {0}'
-            raise CommandExecutionError(msg.format(conf))
-    return conf
-
-
 def default_config():
     '''
     Linux hosts using systemd 207 or later ignore ``/etc/sysctl.conf`` and only
@@ -64,7 +50,7 @@ def default_config():
     '''
     if salt.utils.systemd.booted(__context__) \
             and salt.utils.systemd.version(__context__) >= 207:
-        return _check_systemd_salt_config()
+        return '/etc/sysctl.d/99-salt.conf'
     return '/etc/sysctl.conf'
 
 


### PR DESCRIPTION
### What does this PR do?
linux_sysctl.default_config() no longer creates files and directories

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/41153

### Previous Behavior
linux_sysctl.default_config() , which would naturally be expected to be read-only,
created the file /etc/sysctl.d/99-salt.conf, even though it was called by the state
sysctl.present even if test=True.

### New Behavior
linux_sysctl.default_config() now merely returns the appropriate path. 
linux_sysctl.persist() already created the needed file and parent directories when needed,
so this shouldn't cause a regression.

### Tests written?

No