### PR TITLE
Remove doc ref files for search runner

### DIFF
--- a/doc/ref/runners/all/index.rst
+++ b/doc/ref/runners/all/index.rst
@@ -42,7 +42,6 @@ runner modules
     saltutil
     sdb
     smartos_vmadm
-    search
     spacewalk
     ssh
     state

--- a/doc/ref/runners/all/salt.runners.search.rst
+++ b/doc/ref/runners/all/salt.runners.search.rst
@@ -1,6 +1,0 @@
-===================
-salt.runners.search
-===================
-
-.. automodule:: salt.runners.search
-    :members:


### PR DESCRIPTION
The search runner and related code was removed in #41245.
