### PR TITLE
yumpkg: fix latest_version() when showdupesfromrepos=1 set in /etc/yum.conf

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -454,10 +454,11 @@ def latest_version(*names, **kwargs):
     def _check_cur(pkg):
         if pkg.name in cur_pkgs:
             for installed_version in cur_pkgs[pkg.name]:
-                # If any installed version is greater than the one found by
-                # yum/dnf list available, then it is not an upgrade.
+                # If any installed version is greater than (or equal to) the
+                # one found by yum/dnf list available, then it is not an
+                # upgrade.
                 if salt.utils.compare_versions(ver1=installed_version,
-                                               oper='>',
+                                               oper='>=',
                                                ver2=pkg.version,
                                                cmp_func=version_cmp):
                     return False

--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -33,7 +33,7 @@ __testcontext__ = {}
 _PKG_TARGETS = {
     'Arch': ['python2-django', 'libpng'],
     'Debian': ['python-plist', 'apg'],
-    'RedHat': ['xz-devel', 'zsh-html'],
+    'RedHat': ['units', 'zsh-html'],
     'FreeBSD': ['aalib', 'pth'],
     'Suse': ['aalib', 'python-pssh'],
     'MacOS': ['libpng', 'jpeg'],


### PR DESCRIPTION
The existing logic assumes that showdupesfromrepos=0, in which a package will not be shown if it is not an upgrade. This expands the version check to include versions equal to the installed version, which will keep the _check_cur() helper from incorrectly reporting that an already-installed version is an upgrade.

Resolves #41234.