### PR TITLE
Bugfix: Unable to use "127" as hostname for the Minion ID (devel)

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -99,7 +99,7 @@ def _generate_minion_id():
         Needs to work on Python 2.6, because of collections.OrderedDict only since 2.7 version.
         Override 'filter()' for custom filtering.
         '''
-        localhost_matchers = [r'localhost.*', r'ip6-.*', r'127*[.]\d', r'0\.0\.0\.0',
+        localhost_matchers = [r'localhost.*', r'ip6-.*', r'127[.]\d', r'0\.0\.0\.0',
                               r'::1.*', r'ipv6-.*', r'fe00::.*', r'fe02::.*', r'1.0.0.*.ip6.arpa']
 
         def append(self, p_object):

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -99,8 +99,8 @@ def _generate_minion_id():
         Needs to work on Python 2.6, because of collections.OrderedDict only since 2.7 version.
         Override 'filter()' for custom filtering.
         '''
-        localhost_matchers = ['localhost.*', 'ip6-.*', '127.*', r'0\.0\.0\.0',
-                              '::1.*', 'ipv6-.*', 'fe00::.*', 'fe02::.*', '1.0.0.*.ip6.arpa']
+        localhost_matchers = [r'localhost.*', r'ip6-.*', r'127*[.]\d', r'0\.0\.0\.0',
+                              r'::1.*', r'ipv6-.*', r'fe00::.*', r'fe02::.*', r'1.0.0.*.ip6.arpa']
 
         def append(self, p_object):
             if p_object and p_object not in self and not self.filter(p_object):

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -279,6 +279,20 @@ class NetworkTestCase(TestCase):
         self.assertEqual(network._generate_minion_id(),
                          ['127.domainname.blank', '127', '1.2.3.4', '5.6.7.8'])
 
+    @patch('platform.node', MagicMock(return_value='127890'))
+    @patch('socket.gethostname', MagicMock(return_value='127890'))
+    @patch('socket.getfqdn', MagicMock(return_value='127890.domainname.blank'))
+    @patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'attrname', ('127.0.1.1', 0))]))
+    @patch('salt.utils.fopen', MagicMock(return_value=False))
+    @patch('os.path.exists', MagicMock(return_value=False))
+    @patch('salt.utils.network.ip_addrs', MagicMock(return_value=['1.2.3.4', '5.6.7.8']))
+    def test_generate_minion_id_127_name_startswith(self):
+        '''
+        Test if minion IDs can be named starting from "127"
+        :return:
+        '''
+        self.assertEqual(network._generate_minion_id(),
+                         ['127890.domainname.blank', '127890', '1.2.3.4', '5.6.7.8'])
     def test_generate_minion_id_duplicate(self):
         '''
         Test if IP addresses in the minion IDs are distinct in the pool

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -264,6 +264,21 @@ class NetworkTestCase(TestCase):
             self.assertEqual(network._generate_minion_id(),
                              ['hostname.domainname.blank', 'nodename', 'hostname', '1.2.3.4', '5.6.7.8'])
 
+    @patch('platform.node', MagicMock(return_value='127'))
+    @patch('socket.gethostname', MagicMock(return_value='127'))
+    @patch('socket.getfqdn', MagicMock(return_value='127.domainname.blank'))
+    @patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'attrname', ('127.0.1.1', 0))]))
+    @patch('salt.utils.fopen', MagicMock(return_value=False))
+    @patch('os.path.exists', MagicMock(return_value=False))
+    @patch('salt.utils.network.ip_addrs', MagicMock(return_value=['1.2.3.4', '5.6.7.8']))
+    def test_generate_minion_id_127_name(self):
+        '''
+        Test if minion IDs can be named 127.foo
+        :return:
+        '''
+        self.assertEqual(network._generate_minion_id(),
+                         ['127.domainname.blank', '127', '1.2.3.4', '5.6.7.8'])
+
     def test_generate_minion_id_duplicate(self):
         '''
         Test if IP addresses in the minion IDs are distinct in the pool

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -293,6 +293,7 @@ class NetworkTestCase(TestCase):
         '''
         self.assertEqual(network._generate_minion_id(),
                          ['127890.domainname.blank', '127890', '1.2.3.4', '5.6.7.8'])
+
     def test_generate_minion_id_duplicate(self):
         '''
         Test if IP addresses in the minion IDs are distinct in the pool


### PR DESCRIPTION
### What does this PR do?

Ports https://github.com/saltstack/salt/pull/41269 from 2016.11 one-to-one.
