### PR TITLE
Adding keepalive optional arg for NAPALM always alive minions

### DIFF
--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -210,6 +210,8 @@ def get_device_opts(opts, salt_obj=None):
     # get driver object form NAPALM
     if 'config_lock' not in network_device['OPTIONAL_ARGS']:
         network_device['OPTIONAL_ARGS']['config_lock'] = False
+    if network_device['ALWAYS_ALIVE'] and 'keepalive' not in network_device['OPTIONAL_ARGS']:
+        network_device['OPTIONAL_ARGS']['keepalive'] = 5  # 5 seconds keepalive
     return network_device
 
 


### PR DESCRIPTION
### What does this PR do?

And default to 5 seconds when running inside a always alive proxy
minion. This prevents the SSH disconnection when the communication
with the remote network device is established through a NAT,
firewall etc. which tears down the session after a specific time.
Defaulting to 5 seconds when not explicitly set, the user does
not need to do anything else on their side.
This, in combination with the new proxy keepalive mechanism
should prevent annoying issues when the minion is not
available.
