### PR TITLE
Root dir prepend fix gh #2

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2067,7 +2067,9 @@ def prepend_root_dir(opts, path_options):
     'root_dir' option.
     '''
     root_dir = os.path.abspath(opts['root_dir'])
-    def_root_dir = salt.syspaths.ROOT_DIR.rstrip(os.sep)
+    def_root_dir = salt.syspaths.ROOT_DIR.rstrip(os.sep) \
+            if salt.syspaths.ROOT_DIR != os.sep else os.sep
+
     for path_option in path_options:
         if path_option in opts:
             path = opts[path_option]
@@ -2098,7 +2100,7 @@ def prepend_root_dir(opts, path_options):
                     path = tmp_path_root_dir
                 else:
                     path = tmp_path_def_root_dir
-            if os.path.isabs(path):
+            elif os.path.isabs(path):
                 # Absolute path (not default or overriden root_dir)
                 # No prepending required
                 continue

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2082,7 +2082,7 @@ def prepend_root_dir(opts, path_options):
                 # Remove the default root dir prefix
                 tmp_path_def_root_dir = path[len(def_root_dir):]
             if root_dir and (path == root_dir or
-                             path.startswith(root_dir + os.sep)) :
+                             path.startswith(root_dir + os.sep)):
                 # Remove the root dir prefix
                 tmp_path_root_dir = path[len(root_dir):]
             if tmp_path_def_root_dir and not tmp_path_root_dir:

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2067,18 +2067,14 @@ def prepend_root_dir(opts, path_options):
     'root_dir' option.
     '''
     root_dir = os.path.abspath(opts['root_dir'])
-    def_root_dir = salt.syspaths.ROOT_DIR.rstrip(os.sep) \
-            if salt.syspaths.ROOT_DIR != os.sep else os.sep
-
+    def_root_dir = salt.syspaths.ROOT_DIR.rstrip(os.sep)
     for path_option in path_options:
         if path_option in opts:
             path = opts[path_option]
             tmp_path_def_root_dir = None
             tmp_path_root_dir = None
             # When running testsuite, salt.syspaths.ROOT_DIR is often empty
-            if def_root_dir != '' and (path == def_root_dir or
-                                       path.startswith(def_root_dir + os.sep)):
-
+            if path == def_root_dir or path.startswith(def_root_dir + os.sep):
                 # Remove the default root dir prefix
                 tmp_path_def_root_dir = path[len(def_root_dir):]
             if root_dir and (path == root_dir or

--- a/tests/unit/config/test_api.py
+++ b/tests/unit/config/test_api.py
@@ -31,6 +31,13 @@ class APIConfigTestCase(TestCase):
     '''
     TestCase for the api_config function in salt.config.__init__.py
     '''
+    def setUp(self):
+        # Copy DEFAULT_API_OPTS to restore after the test
+        self.default_api_opts = salt.config.DEFAULT_API_OPTS.copy()
+
+    def tearDown(self):
+        # Reset DEFAULT_API_OPTS settings as to not interfere with other unit tests
+        salt.config.DEFAULT_API_OPTS = self.default_api_opts
 
     def test_api_config_log_file_values(self):
         '''
@@ -59,9 +66,6 @@ class APIConfigTestCase(TestCase):
         various default dict updates that should be overridden by settings in
         the user's master config file.
         '''
-        # Copy DEFAULT_API_OPTS to restore after the test
-        default_api_opts = salt.config.DEFAULT_API_OPTS.copy()
-
         foo_dir = '/foo/bar/baz'
         hello_dir = '/hello/world'
         mock_master_config = {
@@ -80,9 +84,6 @@ class APIConfigTestCase(TestCase):
             self.assertEqual(ret['api_logfile'], hello_dir)
             self.assertEqual(ret['log_file'], hello_dir)
 
-        # Reset DEFAULT_API_OPTS settings as to not interfere with other unit tests
-        salt.config.DEFAULT_API_OPTS = default_api_opts
-
     @destructiveTest
     def test_api_config_prepend_root_dirs_return(self):
         '''
@@ -91,9 +92,6 @@ class APIConfigTestCase(TestCase):
         values is present in the list of opts keys that should have the root_dir
         prepended when the api_config function returns the opts dictionary.
         '''
-        # Copy DEFAULT_API_OPTS to restore after the test
-        default_api_opts = salt.config.DEFAULT_API_OPTS.copy()
-
         mock_log = '/mock/root/var/log/salt/api'
         mock_pid = '/mock/root/var/run/salt-api.pid'
 
@@ -107,6 +105,3 @@ class APIConfigTestCase(TestCase):
             self.assertEqual(ret['log_file'], mock_log)
             self.assertEqual(ret['api_pidfile'], mock_pid)
             self.assertEqual(ret['pidfile'], mock_pid)
-
-        # Reset DEFAULT_API_OPTS settings as to not interfere with other unit tests
-        salt.config.DEFAULT_API_OPTS = default_api_opts

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -138,6 +138,25 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             if os.path.isdir(tempdir):
                 shutil.rmtree(tempdir)
 
+    def test_default_root_dir_included_in_config_root_dir(self):
+        os.makedirs(os.path.join(TMP, 'tmp2'))
+        tempdir = tempfile.mkdtemp(dir=os.path.join(TMP, 'tmp2'))
+        try:
+            root_dir = os.path.join(tempdir, 'foo', 'bar')
+            os.makedirs(root_dir)
+            fpath = os.path.join(root_dir, 'config')
+            with salt.utils.fopen(fpath, 'w') as fp_:
+                fp_.write(
+                    'root_dir: {0}\n'
+                    'log_file: {1}\n'.format(root_dir, fpath)
+                )
+            with patch('salt.syspaths.ROOT_DIR', TMP):
+                config = sconfig.master_config(fpath)
+            self.assertEqual(config['log_file'], fpath)
+        finally:
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)
+
     def test_load_master_config_from_environ_var(self):
         original_environ = os.environ.copy()
 


### PR DESCRIPTION
### What issues does this PR fix or reference?
The PR fixes how the root_dir is prependend to relative paths. Also it fixes how the log_file path is derived when the log_dir override is set in the config file.

### Previous Behavior
The previous logic of prepending the root_dir to relative paths doesn't take into consideration if the default root_dir (set in the code in `_syspaths.py`) is included in the overriden root dir (set in the config file). The logic strips out just a segment of the root_dir (the default root_dir) so the prepend doesn't work correctly. 

Also, the default path assigned to the default log_file won't be overriden if the log_dir override is specified in the config file.

### New Behavior
The prepend and log_file bugs are fixed. The default log_file path is adjusted if the log_dir override is specified. The logic to prepend the root_dir (either the default one in code or the override in the config) is fixed.


### Tests written?

Yes

- test

 added to check that the prepend logic works correctly when the default root_dir is included in the override root_dir.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
