### PR TITLE
Add support for load balancers with AzureARM provider

### DIFF
--- a/doc/topics/cloud/azurearm.rst
+++ b/doc/topics/cloud/azurearm.rst
@@ -223,6 +223,16 @@ subnet
 Optional. The subnet inside the virtual network that the VM will be spun up in.
 Default is ``default``.
 
+load_balancer
+-------------
+Optional. The load-balancer for the VM's network interface to join. If
+specified the backend_pool option need to be set.
+
+backend_pool
+------------
+Optional. Required if the load_balancer option is set. The load-balancer's
+Backend Pool the VM's network interface will join.
+
 iface_name
 ----------
 Optional. The name to apply to the VM's network interface. If not supplied, the

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -70,6 +70,7 @@ from salt.exceptions import (
     SaltCloudExecutionFailure,
     SaltCloudExecutionTimeout,
 )
+from salt.ext.six.moves import filter
 
 # Import 3rd-party libs
 HAS_LIBS = False
@@ -830,10 +831,10 @@ def create_interface(call=None, kwargs=None):  # pylint: disable=unused-argument
             resource_group_name=kwargs['network_resource_group'],
             load_balancer_name=kwargs['load_balancer'],
         )
-        backend_pools = filter(
+        backend_pools = list(filter(
             lambda backend: backend.name == kwargs['backend_pool'],
             load_balancer_obj.backend_address_pools,
-        )
+        ))
 
     subnet_obj = netconn.subnets.get(
         resource_group_name=kwargs['network_resource_group'],

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -824,6 +824,17 @@ def create_interface(call=None, kwargs=None):  # pylint: disable=unused-argument
     if kwargs.get('iface_name') is None:
         kwargs['iface_name'] = '{0}-iface0'.format(vm_['name'])
 
+    backend_pools = None
+    if kwargs.get('load_balancer') and kwargs.get('backend_pool'):
+        load_balancer_obj = netconn.load_balancers.get(
+            resource_group_name=kwargs['network_resource_group'],
+            load_balancer_name=kwargs['load_balancer'],
+        )
+        backend_pools = filter(
+            lambda backend: backend.name == kwargs['backend_pool'],
+            load_balancer_obj.backend_address_pools,
+        )
+
     subnet_obj = netconn.subnets.get(
         resource_group_name=kwargs['network_resource_group'],
         virtual_network_name=kwargs['network'],
@@ -864,6 +875,7 @@ def create_interface(call=None, kwargs=None):  # pylint: disable=unused-argument
                     ip_configurations = [
                         NetworkInterfaceIPConfiguration(
                             name='{0}-ip'.format(kwargs['iface_name']),
+                            load_balancer_backend_address_pools=backend_pools,
                             subnet=subnet_obj,
                             **ip_kwargs
                         )
@@ -880,6 +892,7 @@ def create_interface(call=None, kwargs=None):  # pylint: disable=unused-argument
         ip_configurations = [
             NetworkInterfaceIPConfiguration(
                 name='{0}-ip'.format(kwargs['iface_name']),
+                load_balancer_backend_address_pools=backend_pools,
                 subnet=subnet_obj,
                 **ip_kwargs
             )


### PR DESCRIPTION
### What does this PR do?
Add the possibility to attach a VM to an existing load balancer backend pool

new attributes: **load_balancer** and **backend_pool** for profiles

```
azure-profile:
  provider: azurearm
  load_balancer: WorkersLB
  backend_pool: WorkersLBBAPool
  ...
```

### What issues does this PR fix or reference?
New feature

### Tests written?
No
