### PR TITLE
fix a bug in boto_lambda state where if VpcConfig is None or absent, …

### DIFF
--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -321,7 +321,10 @@ def _resolve_vpcconfig(conf, region=None, key=None, keyid=None, profile=None):
     if isinstance(conf, six.string_types):
         conf = json.loads(conf)
     if not conf:
-        return None
+        # if the conf is None, we should explicitly set the VpcConfig to
+        # {'SubnetIds': [], 'SecurityGroupIds': []} to take the lambda out of
+        # the VPC it was in
+        return {'SubnetIds': [], 'SecurityGroupIds': []}
     if not isinstance(conf, dict):
         raise SaltInvocationError('VpcConfig must be a dict.')
     sns = [__salt__['boto_vpc.get_resource_id']('subnet', s, region=region, key=key,
@@ -360,7 +363,7 @@ def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
     fixed_VpcConfig = _resolve_vpcconfig(VpcConfig, region, key, keyid, profile)
     if __utils__['boto3.ordered'](oldval) != __utils__['boto3.ordered'](fixed_VpcConfig):
         need_update = True
-        ret['changes'].setdefault('new', {})['VpcConfig'] = VpcConfig
+        ret['changes'].setdefault('new', {})['VpcConfig'] = fixed_VpcConfig
         ret['changes'].setdefault(
             'old', {})['VpcConfig'] = func.get('VpcConfig')
 
@@ -382,7 +385,7 @@ def _function_config_present(FunctionName, Role, Handler, Description, Timeout,
         _r = __salt__['boto_lambda.update_function_config'](
             FunctionName=FunctionName, Role=Role, Handler=Handler,
             Description=Description, Timeout=Timeout, MemorySize=MemorySize,
-            VpcConfig=VpcConfig, Environment=Environment, region=region,
+            VpcConfig=fixed_VpcConfig, Environment=Environment, region=region,
             key=key, keyid=keyid, profile=profile, WaitForRole=True,
             RoleRetries=RoleRetries)
         if not _r.get('updated'):

--- a/tests/unit/states/test_boto_lambda.py
+++ b/tests/unit/states/test_boto_lambda.py
@@ -63,7 +63,8 @@ function_ret = dict(FunctionName='testfunction',
                     CodeSha256='abcdef',
                     CodeSize=199,
                     FunctionArn='arn:lambda:us-east-1:1234:Something',
-                    LastModified='yes')
+                    LastModified='yes',
+                    VpcConfig={'SubnetIds': [], 'SecurityGroupIds': []})
 alias_ret = dict(AliasArn='arn:lambda:us-east-1:1234:Something',
                  Name='testalias',
                  FunctionVersion='3',


### PR DESCRIPTION
…the previous VpcConfig is not getting cleared away.

### What does this PR do?
when VpcConfig is not specified in the lambda state, we need to clear away the previous VpcConfig explicitly.
### What issues does this PR fix or reference?
same as title.
### Previous Behavior
the previously specified VpcConfig will remain, which causes errors if the lambda role itself is referring to a role that don't have access to ec2 interfaces.

### New Behavior
always explicitly set VpcConfig to empty configs if not specified.

### Tests written?
No, tested manually against AWS.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
