### PR TITLE
Only deal with integer bits in win_service.py.

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -717,7 +717,7 @@ def modify(name,
     if service_type is not win32service.SERVICE_NO_CHANGE:
         flags = list()
         for bit in SERVICE_TYPE:
-            if service_type & bit:
+            if isinstance(bit, int) and service_type & bit:
                 flags.append(SERVICE_TYPE[bit])
 
         changes['ServiceType'] = flags if flags else service_type


### PR DESCRIPTION
Since SERVICE_TYPE is a dictionary that contains integer, and string
keys it is not possible to perform a bitmask on the key values in
win_service.py. This make sure that this logic only runs on integer
keys.

This should be fairly easy to see the issue. The iterated dictionary is here:
https://github.com/saltstack/salt/blob/develop/salt/modules/win_service.py#L30

Prior to this using the service module would always produce this error: `TypeError: unsupported operand type(s) for &: 'int' and 'str'` on line 720 every time its run.