### PR TITLE
JunOS:  Add alive function to proxy

### DIFF
--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -116,6 +116,15 @@ def conn():
     return thisproxy['conn']
 
 
+def alive(opts):
+    '''
+    Return the connection status with the remote device.
+
+    .. versionadded:: Oxygen
+    '''
+    return thisproxy['conn'].connected
+
+
 def proxytype():
     '''
     Returns the name of this proxy


### PR DESCRIPTION
### What does this PR do?
New in Nitrogen is a proxy_keep_alive option to poll the connection
periodicaly to keep it alive.  This is predicated on having an alive function
in the proxy code to see if the connection still exists.  This code
implements the alive function so that the proxy_keep_alive can work.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
