### PR TITLE
Python 3 test fixes + better pip/virtualenv detection.

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -121,7 +121,8 @@ def _get_pip_bin(bin_env):
     if not bin_env:
         which_result = __salt__['cmd.which_bin'](
             ['pip{0}.{1}'.format(*sys.version_info[:2]),
-             'pip', 'pip2', 'pip3', 'pip-python']
+             'pip{0}'.format(sys.version_info[0]),
+             'pip', 'pip-python']
         )
         if salt.utils.is_windows() and six.PY2:
             which_result.encode('string-escape')

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -11,6 +11,7 @@ import glob
 import shutil
 import logging
 import os
+import sys
 
 # Import salt libs
 import salt.utils
@@ -19,13 +20,11 @@ import salt.utils.verify
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext.six import string_types
 
-KNOWN_BINARY_NAMES = frozenset(
-    ['virtualenv',
-     'virtualenv2',
-     'virtualenv-2.6',
-     'virtualenv-2.7'
-     ]
-)
+KNOWN_BINARY_NAMES = frozenset([
+    'virtualenv-{0}.{1}'.format(*sys.version_info[:2]),
+    'virtualenv{0}'.format(sys.version_info[0]),
+    'virtualenv',
+])
 
 log = logging.getLogger(__name__)
 

--- a/tests/integration/netapi/rest_cherrypy/test_app.py
+++ b/tests/integration/netapi/rest_cherrypy/test_app.py
@@ -253,6 +253,6 @@ class TestJobs(cptc.BaseRestCherryPyTest):
                 'X-Auth-Token': self._token(),
         })
 
-        resp = json.loads(response.body[0])
+        resp = json.loads(salt.utils.to_str(response.body[0]))
         self.assertIn('test.ping', str(resp['return']))
         self.assertEqual(response.status, '200 OK')


### PR DESCRIPTION
This PR fixes:

- https://github.com/saltstack/salt-jenkins/issues/347
- https://github.com/saltstack/salt-jenkins/issues/348

It also improves pip and virtualenv detection. #41039 made changes to pip detection which look for pipX.Y first, but Ubuntu for instance distributes a ``pip3`` executable and not a ``pip3.5``. For virtualenv detection, ``virtualenv`` was checked first, but when Python 3 is not the default Python ``virtualenv`` refers to Python 2's virtualenv executable. So, similarly to pip, the virtualenv detection logic now prefers ``virtualenv-X.Y``, then ``virtualenvX``, then ``virtualenv``, where X and Y are the major and minor versions, respectively.