### PR TITLE
boto_vpc.route_table_present: avoid exception in testing mode

### DIFF
--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -948,6 +948,8 @@ def route_table_present(name, vpc_name=None, vpc_id=None, routes=None,
         ret['result'] = _ret['result']
         if ret['result'] is False:
             return ret
+        if ret['result'] is None and __opts__['test']:
+            return ret
     _ret = _routes_present(route_table_name=name, routes=routes, tags=tags,
                            region=region, key=key, keyid=keyid, profile=profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])


### PR DESCRIPTION
### What does this PR do?

When there is an attempt to create new (non-existent) route table with boto_vpc.route_table_present and testing mode is turned on, the "list index out of range" exception is being throw in _routes_present().

This PR fixes such behavior.

Example state:

```
{% set dc = salt['pillar.get']('mydc') %}

Test Routing Table:
  boto_vpc.route_table_present:
    - name: test-routing-table
    - vpc_name: myvpc
    - profile: {{ dc.profile }}
    - routes:
      - destination_cidr_block: 10.10.10.10/24
        gateway_id: local
```

### What issues does this PR fix or reference?

None that I'm aware of.

### Previous Behavior

```
root@vagrant:~# salt-call state.apply test-rt test=true
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1746, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1704, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/states/boto_vpc.py", line 954, in route_table_present
    region=region, key=key, keyid=keyid, profile=profile)
  File "/usr/lib/python2.7/dist-packages/salt/states/boto_vpc.py", line 1032, in _routes_present
    route_table = route_table[0]
IndexError: list index out of range

local:
----------
          ID: Test Routing Table
    Function: boto_vpc.route_table_present
        Name: test-routing-table
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1746, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1704, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/boto_vpc.py", line 954, in route_table_present
                  region=region, key=key, keyid=keyid, profile=profile)
                File "/usr/lib/python2.7/dist-packages/salt/states/boto_vpc.py", line 1032, in _routes_present
                  route_table = route_table[0]
              IndexError: list index out of range
     Started: 12:01:48.276447
    Duration: 2350.085 ms
     Changes:   

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   2.350 s
```

### New Behavior

```
root@vagrant:~# salt-call state.apply test-rt test=true
local:
----------
          ID: Test Routing Table
    Function: boto_vpc.route_table_present
        Name: test-routing-table
      Result: None
     Comment: Route table test-routing-table is set to be created.
     Started: 12:02:58.368347
    Duration: 1222.924 ms
     Changes:   

Summary for local
------------
Succeeded: 1 (unchanged=1)
Failed:    0
------------
Total states run:     1
Total run time:   1.223 s
```

### Tests written?

No.