### PR TITLE
napalm_syslog engine: Add check for IPv6 address for zmq socket

### DIFF
--- a/salt/engines/napalm_syslog.py
+++ b/salt/engines/napalm_syslog.py
@@ -129,6 +129,7 @@ except ImportError:
     HAS_NAPALM_LOGS = False
 
 # Import salt libs
+import salt.utils.network
 from salt.utils import event
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -156,6 +157,8 @@ def __virtual__():
 def _zmq(address, port):
     context = zmq.Context()
     socket = context.socket(zmq.SUB)
+    if salt.utils.network.is_ipv6(address):
+        socket.ipv6 = True
     socket.connect('tcp://{addr}:{port}'.format(
         addr=address,
         port=port)


### PR DESCRIPTION
### What does this PR do?
Adds a check for an IPv6 address when creating a ZMQ socket. If the address is IPv6 then we enable IPv6 on the socket.

### Previous Behavior
ZMQ would open a IPv4 socket

### New Behavior
ZMQ will enable IPv6 on the socket 

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
