### PR TITLE
backport #41301 -- properly convert packed string to decimal values

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2385,9 +2385,14 @@ def _getDataFromRegPolData(search_string, policy_data, return_value_name=False):
                 if len(pol_entry) >= 5:
                     value = pol_entry[4]
                     if vtype == 'REG_DWORD' or vtype == 'REG_QWORD':
-                        value = value.replace(chr(0), '')
                         if value:
-                            value = ord(value)
+                            vlist = list(ord(v) for v in value)
+                            if vtype == 'REG_DWORD':
+                                for v in struct.unpack('I', struct.pack('2H', *vlist)):
+                                    value = v
+                            elif vtype == 'REG_QWORD':
+                                for v in struct.unpack('I', struct.pack('4H', *vlist)):
+                                    value = v
                         else:
                             value = 0
                     elif vtype == 'REG_MULTI_SZ':


### PR DESCRIPTION
### What does this PR do?
backport #41301 to 2016.11 

### What issues does this PR fix or reference?
#41291 

### Previous Behavior
Some decimal values would cause an exception to occur when attempting to read the data out of the regpol file

### New Behavior
Decimal values are properly read out of regpol file

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
