### PR TITLE
salt-proxy:  Fix systemd unit file to handle more proxy names

### DIFF
--- a/pkg/salt-proxy@.service
+++ b/pkg/salt-proxy@.service
@@ -1,9 +1,9 @@
 [Unit]
-Description=salt-proxy service
+Description=salt-proxy service for %I
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/salt-proxy --proxyid=%I
+ExecStart=/usr/bin/salt-proxy --proxyid=%i
 Type=simple
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
### What does this PR do?
The current systemd unit file uses %I which gives the unescaped argument
to the script.  This breaks if there are special characters in the proxy
name such as '-'.  Using %i escapes the name when it's handed to the command
line allowing the use of those characters.

This change also adds the argument to the template to the unit name so that
it's a bit easier to see in systemctl.

### Tests written?
No

Tested on Ubuntu 16.04 LTS