### PR TITLE
properly pack/unpack the verison numbers into a number

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -4029,8 +4029,7 @@ def _write_regpol_data(data_to_write,
                         version_nums = (version_nums[0], version_nums[1] + 1)
                     elif gpt_extension.lower() == 'gPCUserExtensionNames'.lower():
                         version_nums = (version_nums[0] + 1, version_nums[1])
-                    version_num = int("{0}{1}".format(str(version_nums[0]).zfill(4),
-                                                      str(version_nums[1]).zfill(4)), 16)
+                    version_num = struct.unpack('>I', struct.pack('>2H', *version_nums))[0]
                     gpt_ini_data = "{0}{1}={2}\r\n{3}".format(
                             gpt_ini_data[0:version_loc.start()],
                             'Version', version_num,


### PR DESCRIPTION
### What does this PR do?
correctly convert the GPO number into gpt.ini

### What issues does this PR fix or reference?
Fixes #41306 

### Previous Behavior
Method used to convert the User/Machine policy number would improperly convert the numbers if a policies version number was greater than 16384

### New Behavior
Group policy version number is properly converted

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
