### PR TITLE
Adding test argument for runners & wheel orchestration modules

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -647,6 +647,16 @@ def runner(name, **kwargs):
             'Unable to fire args event due to missing __orchestration_jid__'
         )
         jid = None
+
+    if __opts__.get('test', False):
+        ret = {
+            'name': name,
+            'result': True,
+            'changes': {},
+            'comment': "Runner function '{0}' would be executed.".format(name)
+        }
+        return ret
+
     out = __salt__['saltutil.runner'](name,
                                       __orchestration_jid__=jid,
                                       __env__=__env__,
@@ -704,6 +714,12 @@ def wheel(name, **kwargs):
             'Unable to fire args event due to missing __orchestration_jid__'
         )
         jid = None
+
+    if __opts__.get('test', False):
+        ret['result'] = True,
+        ret['comment'] = "Wheel function '{0}' would be executed.".format(name)
+        return ret
+
     out = __salt__['saltutil.wheel'](name,
                                      __orchestration_jid__=jid,
                                      __env__=__env__,


### PR DESCRIPTION
### What does this PR do?
Adding test argument for runners & wheel orchestration modules

### What issues does this PR fix or reference?
Closes #38894 

### Previous Behavior
Previously passing test=True was ignored.

### New Behavior
If test=True is passed in as an argument then rather than the runner or wheel function being run, the result will be a message reporting what would have been done.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
