### PR TITLE
backport #41307 to 2016.11, properly pack version numbers into single

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -4036,8 +4036,7 @@ def _write_regpol_data(data_to_write,
                         version_nums = (version_nums[0], version_nums[1] + 1)
                     elif gpt_extension.lower() == 'gPCUserExtensionNames'.lower():
                         version_nums = (version_nums[0] + 1, version_nums[1])
-                    version_num = int("{0}{1}".format(str(version_nums[0]).zfill(4),
-                                                      str(version_nums[1]).zfill(4)), 16)
+                    version_num = struct.unpack('>I', struct.pack('>2H', *version_nums))[0]
                     gpt_ini_data = "{0}{1}={2}\r\n{3}".format(
                             gpt_ini_data[0:version_loc.start()],
                             'Version', version_num,


### PR DESCRIPTION
number

### What does this PR do?
backport #41307 

### What issues does this PR fix or reference?
#41306 

### Previous Behavior
Version numbers over 16384 weren't properly packed into the version number

### New Behavior
Verion numbers packed properly

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
