### PR TITLE
Add cryptdev state/module for manipulating /etc/crypttab and using cryptsetup

### DIFF
--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -209,8 +209,7 @@ def set_crypttab(
         options='',
         config='/etc/crypttab',
         test=False,
-        match_on='name',
-        **kwargs):
+        match_on='name'):
     '''
     Verify that this device is represented in the crypttab, change the device to
     match the name passed, or add the name if it is not present.
@@ -298,7 +297,7 @@ def set_crypttab(
         ret = 'new'
 
     if ret != 'present':  # ret in ['new', 'change']:
-        if not salt.utils.test_mode(test=test, **kwargs):
+        if not test:
             try:
                 with salt.utils.fopen(config, 'w+') as ofile:
                     # The line was changed, commit it!

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -5,7 +5,6 @@ Salt module to manage Unix cryptsetup jobs and the crypttab file
 
 # Import python libraries
 from __future__ import absolute_import
-import json
 import logging
 import os
 import re
@@ -31,8 +30,8 @@ def __virtual__():
     '''
     if salt.utils.is_windows():
         return (False, 'The cryptdev module cannot be loaded: not a POSIX-like system')
-    else:
-        return True
+
+    return True
 
 
 class _crypttab_entry(object):
@@ -104,6 +103,7 @@ class _crypttab_entry(object):
                 return False
         return True
 
+
 def active():
     '''
     List existing device-mapper device details.
@@ -123,6 +123,7 @@ def active():
             log.warn('dmsetup output does not match expected format')
 
     return ret
+
 
 def crypttab(config='/etc/crypttab'):
     '''
@@ -308,6 +309,7 @@ def set_crypttab(
 
     return ret
 
+
 def open(name, device, keyfile):
     '''
     Open a crypt device using ``cryptsetup``. The ``keyfile`` must not be
@@ -323,9 +325,10 @@ def open(name, device, keyfile):
     if keyfile is None or keyfile == 'none' or keyfile == '-':
         raise CommandExecutionError('For immediate crypt device mapping, keyfile must not be none')
 
-    code = __salt__['cmd.retcode']('cryptsetup open --key-file {0} {1} {2}'\
-                                       .format(keyfile, device, name))
+    code = __salt__['cmd.retcode']('cryptsetup open --key-file {0} {1} {2}'
+                                   .format(keyfile, device, name))
     return code == 0
+
 
 def close(name):
     '''

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+'''
+Salt module to manage Unix cryptsetup jobs and the crypttab file
+'''
+
+# Import python libraries
+from __future__ import absolute_import
+import logging
+
+# Import salt libraries
+import salt
+
+# Set up logger
+log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'cryptdev'
+
+def __virtual__():
+    '''
+    Only load on POSIX-like systems
+    '''
+    if salt.utils.is_windows():
+        return (False, 'The cryptdev module cannot be loaded: not a POSIX-like system')
+    else:
+        return True

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -308,7 +308,7 @@ def set_crypttab(
 
     return ret
 
-def open(name, device, keyfile=None):
+def open(name, device, keyfile):
     '''
     Open a crypt device using ``cryptsetup``.
 
@@ -320,9 +320,11 @@ def open(name, device, keyfile=None):
     '''
     ret = {}
 
-    keyfile_option = ('--key-file %s' % keyfile) if keyfile else ''
-    devices = __salt__['cmd.run_stdout']('cryptsetup open {0} {1} {2}'\
-                                         .format(keyfile_option, device, name))
+    if keyfile is None or keyfile == 'none' or keyfile == '-':
+        raise CommandExecutionError('For immediate crypt device mapping, keyfile must not be none')
+
+    devices = __salt__['cmd.run_stdout']('cryptsetup open --key-file {0} {1} {2}'\
+                                         .format(keyfile, device, name))
     return ret
 
 def close(name):

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -136,7 +136,8 @@ def crypttab(config='/etc/crypttab'):
 
 def rm_crypttab(name, device, config='/etc/crypttab'):
     '''
-    Remove the device point from the crypttab
+    Remove the device point from the crypttab. If the described entry does not
+    exist, nothing is changed, but the command succeeds.
 
     CLI Example:
 

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -319,6 +319,21 @@ def open(name, device, keyfile=None):
     ret = {}
 
     keyfile_option = ('--key-file %s' % keyfile) if keyfile else ''
-    devices = __salt__['cmd.run_stdout']('cryptsetup open %s %s %s' \
-                                         % (keyfile_option, device, name))
+    devices = __salt__['cmd.run_stdout']('cryptsetup open {0} {0} {0}'\
+                                         .format(keyfile_option, device, name))
+    return ret
+
+def close(name):
+    '''
+    Close a crypt device using ``cryptsetup``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cryptdev.close foo
+    '''
+    ret = {}
+
+    devices = __salt__['cmd.run_stdout']('cryptsetup close {0}'.format(name))
     return ret

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -234,7 +234,7 @@ def set_crypttab(
     entry_args = {
         'name': name,
         'device': device,
-        'password': password,
+        'password': password if password is not None else 'none',
         'options': options,
     }
 

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -155,19 +155,20 @@ def crypttab(config='/etc/crypttab'):
     return ret
 
 
-def rm_crypttab(name, device, config='/etc/crypttab'):
+def rm_crypttab(name, config='/etc/crypttab'):
     '''
-    Remove the device point from the crypttab. If the described entry does not
-    exist, nothing is changed, but the command succeeds.
+    Remove the named mapping from the crypttab. If the described entry does not
+    exist, nothing is changed, but the command succeeds by returning
+    ``'absent'``. If a line is removed, it returns ``'change'``.
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' cryptdev.rm_crypttab foo /dev/sdg
+        salt '*' cryptdev.rm_crypttab foo
     '''
     modified = False
-    criteria = _crypttab_entry(name=name, device=device)
+    criteria = _crypttab_entry(name=name)
 
     # For each line in the config that does not match the criteria, add it to
     # the list. At the end, re-create the config from just those lines.
@@ -197,7 +198,7 @@ def rm_crypttab(name, device, config='/etc/crypttab'):
             raise CommandExecutionError(msg.format(config, str(exc)))
 
     # If we reach this point, the changes were successful
-    return True
+    return 'change' if modified else 'absent'
 
 
 def set_crypttab(

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -222,7 +222,9 @@ def set_crypttab(
     '''
 
     # Fix the options type if it is not a string
-    if isinstance(options, six.string_types):
+    if options is None:
+        options = ''
+    elif isinstance(options, six.string_types):
         pass
     elif isinstance(options, list):
         options = ','.join(options)

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -310,7 +310,9 @@ def set_crypttab(
 
 def open(name, device, keyfile):
     '''
-    Open a crypt device using ``cryptsetup``.
+    Open a crypt device using ``cryptsetup``. The ``keyfile`` must not be
+    ``None`` or ``'none'``, because ``cryptsetup`` will otherwise ask for the
+    password interactively.
 
     CLI Example:
 

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -5,10 +5,16 @@ Salt module to manage Unix cryptsetup jobs and the crypttab file
 
 # Import python libraries
 from __future__ import absolute_import
+import json
 import logging
+import os
 
 # Import salt libraries
-import salt
+import salt.utils
+
+# Import 3rd-party libs
+import salt.ext.six as six
+from salt.ext.six.moves import filter, zip  # pylint: disable=import-error,redefined-builtin
 
 # Set up logger
 log = logging.getLogger(__name__)
@@ -24,3 +30,103 @@ def __virtual__():
         return (False, 'The cryptdev module cannot be loaded: not a POSIX-like system')
     else:
         return True
+
+class _crypttab_entry(object):
+    '''
+    Utility class for manipulating crypttab entries. Primarily we're parsing,
+    formatting, and comparing lines. Parsing emits dicts expected from
+    crypttab() or raises a ValueError.
+    '''
+
+    class ParseError(ValueError):
+        '''Error raised when a line isn't parsible as a crypttab entry'''
+
+    crypttab_keys = ('name', 'device', 'password', 'options')
+    crypttab_format = '{name}\t\t{device}\t\t\t\t{password}\t\t\t{options}'
+
+    @classmethod
+    def dict_from_line(cls, line, keys=crypttab_keys):
+        if len(keys) != 4:
+            raise ValueError('Invalid key array: {0}'.format(keys))
+        if line.startswith('#'):
+            raise cls.ParseError("Comment!")
+
+        comps = line.split()
+        # If there are only three entries, then the options have been omitted.
+        if len(comps) == 3:
+            comps += ['']
+
+        if len(comps) != 4:
+            raise cls.ParseError("Invalid Entry!")
+
+        return dict(zip(keys, comps))
+
+    @classmethod
+    def from_line(cls, *args, **kwargs):
+        return cls(** cls.dict_from_line(*args, **kwargs))
+
+    @classmethod
+    def dict_to_line(cls, entry):
+        return cls.crypttab_format.format(**entry)
+
+    def __str__(self):
+        '''String value, only works for full repr'''
+        return self.dict_to_line(self.criteria)
+
+    def __repr__(self):
+        '''Always works'''
+        return str(self.criteria)
+
+    def pick(self, keys):
+        '''Returns an instance with just those keys'''
+        subset = dict([(key, self.criteria[key]) for key in keys])
+        return self.__class__(**subset)
+
+    def __init__(self, **criteria):
+        '''Store non-empty, non-null values to use as filter'''
+        self.criteria = {key: str(value) for key, value in six.iteritems(criteria)
+                         if value is not None}
+
+    @staticmethod
+    def norm_path(path):
+        '''Resolve equivalent paths equivalently'''
+        return os.path.normcase(os.path.normpath(path))
+
+    def match(self, line):
+        '''Compare potentially partial criteria against a complete line'''
+        entry = self.dict_from_line(line)
+        for key, value in six.iteritems(self.criteria):
+            if entry[key] != value:
+                return False
+        return True
+
+
+def crypttab(config='/etc/crypttab'):
+    '''
+    List the contents of the crypttab
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cryptdev.crypttab
+    '''
+    ret = {}
+    if not os.path.isfile(config):
+        return ret
+    with salt.utils.fopen(config) as ifile:
+        for line in ifile:
+            try:
+                entry = _crypttab_entry.dict_from_line(line)
+
+                entry['options'] = entry['options'].split(',')
+
+                # Handle duplicate names by appending `_`
+                while entry['name'] in ret:
+                    entry['name'] += '_'
+
+                ret[entry.pop('name')] = entry
+            except _crypttab_entry.ParseError:
+                pass
+
+    return ret

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -11,6 +11,7 @@ import os
 
 # Import salt libraries
 import salt.utils
+from salt.exceptions import CommandExecutionError
 
 # Import 3rd-party libs
 import salt.ext.six as six

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
 Salt module to manage Unix cryptsetup jobs and the crypttab file
+
+.. versionadded:: Oxygen
 '''
 
 # Import python libraries

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -321,7 +321,7 @@ def open(name, device, keyfile=None):
     ret = {}
 
     keyfile_option = ('--key-file %s' % keyfile) if keyfile else ''
-    devices = __salt__['cmd.run_stdout']('cryptsetup open {0} {0} {0}'\
+    devices = __salt__['cmd.run_stdout']('cryptsetup open {0} {1} {2}'\
                                          .format(keyfile_option, device, name))
     return ret
 

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -320,14 +320,12 @@ def open(name, device, keyfile):
 
         salt '*' cryptdev.open foo /dev/sdz1 /path/to/keyfile
     '''
-    ret = {}
-
     if keyfile is None or keyfile == 'none' or keyfile == '-':
         raise CommandExecutionError('For immediate crypt device mapping, keyfile must not be none')
 
-    devices = __salt__['cmd.run_stdout']('cryptsetup open --key-file {0} {1} {2}'\
-                                         .format(keyfile, device, name))
-    return ret
+    code = __salt__['cmd.retcode']('cryptsetup open --key-file {0} {1} {2}'\
+                                       .format(keyfile, device, name))
+    return code == 0
 
 def close(name):
     '''
@@ -339,7 +337,5 @@ def close(name):
 
         salt '*' cryptdev.close foo
     '''
-    ret = {}
-
-    devices = __salt__['cmd.run_stdout']('cryptsetup close {0}'.format(name))
-    return ret
+    code = __salt__['cmd.retcode']('cryptsetup close {0}'.format(name))
+    return code == 0

--- a/salt/states/cryptdev.py
+++ b/salt/states/cryptdev.py
@@ -44,7 +44,7 @@ def mapped(name,
            opts=None,
            config='/etc/crypttab',
            persist=True,
-           delay_mapping=True,
+           immediate=False,
            match_on='name'):
     '''
     Verify that a device is mapped
@@ -71,9 +71,10 @@ def mapped(name,
     persist
         Set if the map should be saved in the crypttab, Default is ``True``
 
-    delay_mapping
-        Set if the device mapping should not be executed until the next boot.
-        Default is ``True``.
+    immediate
+        Set if the device mapping should be executed immediately. Note that
+        options cannot be passed through on the initial mapping.
+        Default is ``False``.
 
     match_on
         A name or list of crypttab properties on which this state should be applied.
@@ -86,7 +87,7 @@ def mapped(name,
            'result': True,
            'comment': ''}
 
-    if not delay_mapping:
+    if immediate:
         # Get the active crypt mounts. If ours is listed already, no action is necessary.
         active = __salt__['cryptdev.active']()
         if name not in active.keys():

--- a/salt/states/cryptdev.py
+++ b/salt/states/cryptdev.py
@@ -25,6 +25,8 @@ Ensure that an encrypted device is mapped with the `mapped` function:
         - device: UUID=066e0200-2867-4ebe-b9e6-f30026ca2314
         - keyfile: /etc/keyfile.key
         - config: /etc/alternate-crypttab
+
+.. versionadded:: Oxygen
 '''
 from __future__ import absolute_import
 

--- a/salt/states/cryptdev.py
+++ b/salt/states/cryptdev.py
@@ -87,6 +87,13 @@ def mapped(name,
            'changes': {},
            'result': True,
            'comment': ''}
+
+    # If neither option is set, we've been asked to do nothing.
+    if not immediate and not persist:
+        ret['result'] = False
+        ret['comment'] = 'Either persist or immediate must be set, otherwise this state does nothing'
+        return ret
+
     if immediate and (keyfile is None or keyfile == 'none' or keyfile == '-'):
         ret['result'] = False
         ret['changes']['cryptsetup'] = 'Device cannot be mapped immediately without a keyfile'

--- a/salt/states/cryptdev.py
+++ b/salt/states/cryptdev.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+'''
+Opening of Encrypted Devices
+=======================
+
+Ensure that an encrypted device is mapped with the `mapped` function:
+
+.. code-block:: yaml
+
+    mappedname:
+      cryptdev.mapped:
+        - device: /dev/sdb1
+        - password: /etc/keyfile.key
+        - opts:
+          - size=256
+
+    swap:
+      crypted.mapped:
+        - device: /dev/sdx4
+        - password: /dev/urandom
+        - opts: swap,cipher=aes-cbc-essiv:sha256,size=256
+
+    mappedbyuuid:
+      crypted.mapped:
+        - device: UUID=066e0200-2867-4ebe-b9e6-f30026ca2314
+        - password: /etc/keyfile.key
+        - config: /etc/alternate-crypttab
+'''
+from __future__ import absolute_import
+
+# Import python libs
+import os.path
+
+# Import salt libs
+from salt.ext.six import string_types
+
+import logging
+import salt.ext.six as six
+log = logging.getLogger(__name__)
+
+def mapped(name,
+           device,
+           password=None,
+           opts=None,
+           config='/etc/crypttab',
+           persist=True,
+           delay_mapping=True,
+           match_on='name'):
+    '''
+    Verify that a device is mapped
+
+    name
+        The name under which the device is to be mapped
+
+    device
+        The device name, typically the device node, such as ``/dev/sdb1``
+        or ``UUID=066e0200-2867-4ebe-b9e6-f30026ca2314``.
+
+    password
+        Either ``None`` if the password is to be entered manually on boot, or
+        an absolute path to a key file. If it must be entered manually, it
+        cannot be mapped immediately.
+
+    opts
+        A list object of options or a comma delimited list
+
+    config
+        Set an alternative location for the crypttab, if the map is persistent,
+        Default is ``/etc/crypttab``
+
+    persist
+        Set if the map should be saved in the crypttab, Default is ``True``
+
+    delay_mapping
+        Set if the device mapping should not be executed until the next boot.
+        Default is ``True``.
+
+    match_on
+        A name or list of crypttab properties on which this state should be applied.
+        Default is ``name``, meaning that the line is matched only by the name
+        parameter. If the desired configuration requires two devices mapped to
+        the same name, supply a list of parameters to match on.
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    if not delay_mapping:
+        # Get the active crypt mounts. If ours is listed already, no action is necessary.
+        active = __salt__['cryptdev.active']()
+        if name not in active.keys():
+            # Open the map using cryptsetup. This does not pass any options.
+            if opts:
+                log.warn('passed cryptdev options are ignored when mapping immediately')
+
+            if __opts__['test']:
+                ret['result'] = None
+                ret['commment'] = 'Device would be mapped immediately'
+            else:
+                cryptsetup_result = __salt__['cryptdev.open'](name, device, password)
+                if cryptsetup_result:
+                    ret['changes']['cryptsetup'] = 'Device mapped using cryptsetup'
+                else:
+                    ret['changes']['cryptsetup'] = 'Device failed to map using cryptsetup'
+                    ret['result'] = False
+
+    if persist and not __opts__['test']:
+        crypttab_result = __salt__['cryptdev.set_crypttab'](name,
+                                                            device,
+                                                            password=password,
+                                                            options=opts,
+                                                            config=config,
+                                                            match_on=match_on)
+        if crypttab_result:
+            if crypttab_result == 'new':
+                ret['changes']['crypttab'] = 'Entry added in {0}'.format(config)
+
+            if crypttab_result == 'change':
+                ret['changes']['crypttab'] = 'Existing entry in {0} changed'.format(config)
+        
+        else:
+            ret['changes']['crypttab'] = 'Unable to set entry in {0}'.format(config)
+            ret['result'] = False
+
+    return ret

--- a/salt/states/cryptdev.py
+++ b/salt/states/cryptdev.py
@@ -28,15 +28,9 @@ Ensure that an encrypted device is mapped with the `mapped` function:
 '''
 from __future__ import absolute_import
 
-# Import python libs
-import os.path
-
-# Import salt libs
-from salt.ext.six import string_types
-
 import logging
-import salt.ext.six as six
 log = logging.getLogger(__name__)
+
 
 def mapped(name,
            device,
@@ -117,7 +111,6 @@ def mapped(name,
                     ret['changes']['cryptsetup'] = 'Device failed to map using cryptsetup'
                     ret['result'] = False
 
-
     if persist and not __opts__['test']:
         crypttab_result = __salt__['cryptdev.set_crypttab'](name,
                                                             device,
@@ -131,12 +124,13 @@ def mapped(name,
 
             if crypttab_result == 'change':
                 ret['changes']['crypttab'] = 'Existing entry in {0} changed'.format(config)
-        
+
         else:
             ret['changes']['crypttab'] = 'Unable to set entry in {0}'.format(config)
             ret['result'] = False
 
     return ret
+
 
 def unmapped(name,
              config='/etc/crypttab',


### PR DESCRIPTION
### What does this PR do?

Adds a `cryptdev` states and module for manipulating the `/etc/crypttab` file and issuing certain `cryptsetup `commands.

### What issues does this PR fix or reference?

This addresses the feature request #35816, for such a state to manipulate `/etc/crypttab`.

### Tests written?

No

### Issues to address

- [x] <del>I was not able to run the linter on my system -- I have some dependency problems that I need to look further into.</del> Fixed the linting issues
- [ ] I was not able to successfully build the HTML documentation, for the same reason
- [x] <del>I have *not* included a `versionadded` in the documentation</del> Included in c66ce0f18cb6cf07bb9de2ccf592f754087770f6