### PR TITLE
Fix bash completion

### DIFF
--- a/pkg/salt.bash
+++ b/pkg/salt.bash
@@ -35,8 +35,8 @@ _salt_get_keys(){
 }
 
 _salt(){
-    local _salt_cache_functions=${SALT_COMP_CACHE_FUNCTIONS:='~/.cache/salt-comp-cache_functions'}
-    local _salt_cache_timeout=${SALT_COMP_CACHE_TIMEOUT:='last hour'}
+    local _salt_cache_functions=${SALT_COMP_CACHE_FUNCTIONS:-"$HOME/.cache/salt-comp-cache_functions"}
+    local _salt_cache_timeout=${SALT_COMP_CACHE_TIMEOUT:-"last hour"}
 
     if [ ! -d "$(dirname ${_salt_cache_functions})" ]; then
         mkdir -p "$(dirname ${_salt_cache_functions})"

--- a/pkg/salt.bash
+++ b/pkg/salt.bash
@@ -47,10 +47,10 @@ _salt(){
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     if [ ${COMP_CWORD} -gt 2 ]; then
-	pprev="${COMP_WORDS[COMP_CWORD-2]}"
+        pprev="${COMP_WORDS[COMP_CWORD-2]}"
     fi
     if [ ${COMP_CWORD} -gt 3 ]; then
-	ppprev="${COMP_WORDS[COMP_CWORD-3]}"
+        ppprev="${COMP_WORDS[COMP_CWORD-3]}"
     fi
 
     opts="-h --help -d --doc --documentation --version --versions-report -c \
@@ -70,7 +70,7 @@ _salt(){
     case "${pprev}" in
     -G|--grain|--grain-pcre)
     if [ "${cur}" = ":" ]; then
-        COMPREPLY=($(compgen -W "`_salt_get_grain_values ${prev}`"  ))	
+        COMPREPLY=($(compgen -W "`_salt_get_grain_values ${prev}`"))
         return 0
     fi
     ;;
@@ -108,7 +108,7 @@ _salt(){
      -G|--grain|--grain-pcre)
         COMPREPLY=($(compgen -W "$(_salt_get_grains)" -- ${cur}))
         return 0
-	;;
+        ;;
      -C|--compound)
         COMPREPLY=() # TODO: finish this one? how?
         return 0
@@ -122,7 +122,7 @@ _salt(){
         return 0
         ;;
      -N|--nodegroup)
-	    MASTER_CONFIG='/etc/salt/master'
+        MASTER_CONFIG='/etc/salt/master'
         COMPREPLY=($(compgen -W "`awk -F ':'  'BEGIN {print_line = 0};  /^nodegroups/ {print_line = 1;getline } print_line && /^  */ {print $1} /^[^ ]/ {print_line = 0}' <${MASTER_CONFIG}`" -- ${cur}))
         return 0
      ;;
@@ -221,7 +221,7 @@ _saltkey(){
         return 0
      ;;
      --accept-all)
-	return 0
+        return 0
      ;;
     esac
     COMPREPLY=($(compgen -W "${opts} " -- ${cur}))
@@ -260,19 +260,19 @@ _saltcall(){
     case ${prev} in
         -m|--module-dirs)
                 COMPREPLY=( $(compgen -d ${cur} ))
-		return 0
- 	 	;;
-	-l|--log-level)
-		COMPREPLY=( $(compgen -W "info none garbage trace warning error debug" -- ${cur}))
-		return 0
-		;;
-	-g|grains)
                 return 0
-		;;
-	salt-call)
+                ;;
+        -l|--log-level)
+                COMPREPLY=( $(compgen -W "info none garbage trace warning error debug" -- ${cur}))
+                return 0
+                ;;
+        -g|grains)
+                return 0
+                ;;
+        salt-call)
                 COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
-	        return 0
-		;;
+                return 0
+                ;;
     esac
 
     _salt_coms="$(salt-call --out=txt -- sys.list_functions|sed 's/^.*\[//' | tr -d ",']"  )"
@@ -307,46 +307,45 @@ _saltcp(){
     fi
 
     case ${prev} in
- 	salt-cp)
-	    COMPREPLY=($(compgen -W "${opts} $(_salt_get_keys acc)" -- ${cur}))
-	    return 0
-	;;
+        salt-cp)
+            COMPREPLY=($(compgen -W "${opts} $(_salt_get_keys acc)" -- ${cur}))
+            return 0
+            ;;
         -t|--timeout)
-	    # those numbers are just a hint
+            # those numbers are just a hint
             COMPREPLY=($(compgen -W "2 3 4 8 10 15 20 25 30 40 60 90 120 180 240 300" -- ${cur} ))
-	    return 0
-        ;;
-	-E|--pcre)
+            return 0
+            ;;
+    -E|--pcre)
             COMPREPLY=($(compgen -W "$(_salt_get_keys acc)" -- ${cur}))
             return 0
-	;;
-	-L|--list)
-	    # IMPROVEMENTS ARE WELCOME
-	    prefpart="${cur%,*},"
-	    postpart=${cur##*,}
-	    filt="^\($(echo ${cur}| sed 's:,:\\|:g')\)$"
+            ;;
+    -L|--list)
+            # IMPROVEMENTS ARE WELCOME
+            prefpart="${cur%,*},"
+            postpart=${cur##*,}
+            filt="^\($(echo ${cur}| sed 's:,:\\|:g')\)$"
             helper=($(_salt_get_keys acc | grep -v "${filt}" | sed "s/^/${prefpart}/"))
-	    COMPREPLY=($(compgen -W "${helper[*]}" -- ${cur}))
-
-	    return 0
-	;;
-	-G|--grain|--grain-pcre)
+            COMPREPLY=($(compgen -W "${helper[*]}" -- ${cur}))
+            return 0
+            ;;
+    -G|--grain|--grain-pcre)
             COMPREPLY=($(compgen -W "$(_salt_get_grains)" -- ${cur}))
             return 0
-	    ;;
-	    # FIXME
-	-R|--range)
-	    # FIXME ??
-	    return 0
-	;;
-	-C|--compound)
-	    # FIXME ??
-	    return 0
-	;;
-	-c|--config)
-	    COMPREPLY=($(compgen -f -- ${cur}))
-	    return 0
-	;;
+            ;;
+    # FIXME
+    -R|--range)
+            # FIXME ??
+            return 0
+            ;;
+    -C|--compound)
+            # FIXME ??
+            return 0
+            ;;
+    -c|--config)
+            COMPREPLY=($(compgen -f -- ${cur}))
+            return 0
+            ;;
     esac
 
    # default is using opts:


### PR DESCRIPTION
### What does this PR do?

Bash completion adds in the current working directory the cache-file while it should have been under `$HOME/.cache....`. The problem's root is the missing tilde expansion. (around line 38)

In my second commit, I converted the tabs/spaces indentation mess to spaces only.

### What issues does this PR fix or reference?

#41302 

cc: @gtmanfred 