### PR TITLE
Update timezone get/set_hwclock for NILinuxRT systems

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -480,12 +480,14 @@ def set_hwclock(clock):
 
         salt '*' timezone.set_hwclock UTC
     '''
-    if 'AIX' in __grains__['os_family']:
-        if clock.lower() != 'utc':
-            raise SaltInvocationError(
-                'UTC is the only permitted value'
-            )
-        return True
+    os_family = __grains__['os_family']
+    for family in ('AIX', 'NILinuxRT'):
+        if family in os_family:
+            if clock.lower() != 'utc':
+                raise SaltInvocationError(
+                    'UTC is the only permitted value'
+                )
+            return True
 
     timezone = get_zone()
 

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -389,7 +389,7 @@ def get_hwclock():
 
     else:
         os_family = __grains__['os_family']
-        for family in ('RedHat', 'Suse'):
+        for family in ('RedHat', 'Suse', 'NILinuxRT'):
             if family in os_family:
                 return _get_adjtime_timezone()
 

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -481,13 +481,12 @@ def set_hwclock(clock):
         salt '*' timezone.set_hwclock UTC
     '''
     os_family = __grains__['os_family']
-    for family in ('AIX', 'NILinuxRT'):
-        if family in os_family:
-            if clock.lower() != 'utc':
-                raise SaltInvocationError(
-                    'UTC is the only permitted value'
-                )
-            return True
+    if os_family in ('AIX', 'NILinuxRT'):
+        if clock.lower() != 'utc':
+            raise SaltInvocationError(
+                'UTC is the only permitted value'
+            )
+        return True
 
     timezone = get_zone()
 

--- a/tests/unit/modules/test_timezone.py
+++ b/tests/unit/modules/test_timezone.py
@@ -316,15 +316,16 @@ class TimezoneModuleTestCase(TestCase, LoaderModuleMockMixin):
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.unlink', MagicMock())
     @patch('os.symlink', MagicMock())
-    def test_set_hwclock_aix(self):
+    def test_set_hwclock_aix_nilinuxrt(self):
         '''
-        Test set hwclock on AIX
+        Test set hwclock on AIX and NILinuxRT
         :return:
         '''
-        with patch.dict(timezone.__grains__, {'os_family': ['AIX']}):
-            with self.assertRaises(SaltInvocationError):
-                assert timezone.set_hwclock('forty two')
-            assert timezone.set_hwclock('UTC')
+        for osfamily in ['AIX', 'NILinuxRT']:
+            with patch.dict(timezone.__grains__, {'os_family': osfamily}):
+                with self.assertRaises(SaltInvocationError):
+                    assert timezone.set_hwclock('forty two')
+                assert timezone.set_hwclock('UTC')
 
     @patch('salt.utils.which', MagicMock(return_value=False))
     @patch('os.path.exists', MagicMock(return_value=True))


### PR DESCRIPTION
### What does this PR do?

Updates timezone get_hwclock and set_hwclock to work correctly for NILinuxRT systems.
### Tests written?

Yes