### PR TITLE
Tiny fix to boto_iam.policy_absent 

### DIFF
--- a/salt/states/boto_iam.py
+++ b/salt/states/boto_iam.py
@@ -1505,7 +1505,7 @@ def policy_absent(name,
                                     keyid=keyid, profile=profile)
     if versions:
         for version in versions:
-            if version.get('is_default_version', False):
+            if version.get('is_default_version', False) in ('true', True):
                 continue
             r = __salt__['boto_iam.delete_policy_version'](name,
                                     version_id=version.get('version_id'),


### PR DESCRIPTION
Code block exists to delete non-default policy versions so that versioned policies can be removed.  It appears that code never actually worked however, since it was testing for a "truthy" value, and the string `false` is a truthy value :)