### PR TITLE
fix setting and getting locale on SUSE systems

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -127,13 +127,14 @@ def get_locale():
         salt '*' locale.get_locale
     '''
     cmd = ''
-    if salt.utils.systemd.booted(__context__):
+    if 'Suse' in __grains__['os_family']:
+        # this block applies to all SUSE systems - also with systemd
+        cmd = 'grep "^RC_LANG" /etc/sysconfig/language'
+    elif salt.utils.systemd.booted(__context__):
         params = _parse_dbus_locale() if HAS_DBUS else _parse_localectl()
         return params.get('LANG', '')
     elif 'RedHat' in __grains__['os_family']:
         cmd = 'grep "^LANG=" /etc/sysconfig/i18n'
-    elif 'SUSE' in __grains__['os_family']:
-        cmd = 'grep "^RC_LANG" /etc/sysconfig/language'
     elif 'Debian' in __grains__['os_family']:
         # this block only applies to Debian without systemd
         cmd = 'grep "^LANG=" /etc/default/locale'
@@ -161,7 +162,17 @@ def set_locale(locale):
 
         salt '*' locale.set_locale 'en_US.UTF-8'
     '''
-    if salt.utils.systemd.booted(__context__):
+    if 'Suse' in __grains__['os_family']:
+        # this block applies to all SUSE systems - also with systemd
+        if not __salt__['file.file_exists']('/etc/sysconfig/language'):
+            __salt__['file.touch']('/etc/sysconfig/language')
+        __salt__['file.replace'](
+            '/etc/sysconfig/language',
+            '^RC_LANG=.*',
+            'RC_LANG="{0}"'.format(locale),
+            append_if_not_found=True
+        )
+    elif salt.utils.systemd.booted(__context__):
         return _localectl_set(locale)
     elif 'RedHat' in __grains__['os_family']:
         if not __salt__['file.file_exists']('/etc/sysconfig/i18n'):
@@ -170,15 +181,6 @@ def set_locale(locale):
             '/etc/sysconfig/i18n',
             '^LANG=.*',
             'LANG="{0}"'.format(locale),
-            append_if_not_found=True
-        )
-    elif 'SUSE' in __grains__['os_family']:
-        if not __salt__['file.file_exists']('/etc/sysconfig/language'):
-            __salt__['file.touch']('/etc/sysconfig/language')
-        __salt__['file.replace'](
-            '/etc/sysconfig/language',
-            '^RC_LANG=.*',
-            'RC_LANG="{0}"'.format(locale),
             append_if_not_found=True
         )
     elif 'Debian' in __grains__['os_family']:

--- a/tests/unit/modules/localemod_test.py
+++ b/tests/unit/modules/localemod_test.py
@@ -44,19 +44,20 @@ class LocalemodTestCase(TestCase):
         Test for Get the current system locale
         '''
         with patch.dict(localemod.__context__, {'salt.utils.systemd.booted': True}):
-            localemod.HAS_DBUS = True
-            with patch.object(localemod,
-                              '_parse_dbus_locale',
-                              return_value={'LANG': 'A'}):
-                self.assertEqual('A', localemod.get_locale())
-                localemod._parse_dbus_locale.assert_called_once_with()
+            with patch.dict(localemod.__grains__, {'os_family': ['Unknown']}):
+                localemod.HAS_DBUS = True
+                with patch.object(localemod,
+                                  '_parse_dbus_locale',
+                                  return_value={'LANG': 'A'}):
+                    self.assertEqual('A', localemod.get_locale())
+                    localemod._parse_dbus_locale.assert_called_once_with()
 
-            localemod.HAS_DBUS = False
-            with patch.object(localemod,
-                              '_parse_localectl',
-                              return_value={'LANG': 'A'}):
-                self.assertEqual('A', localemod.get_locale())
-                localemod._parse_localectl.assert_called_once_with()
+                localemod.HAS_DBUS = False
+                with patch.object(localemod,
+                                  '_parse_localectl',
+                                  return_value={'LANG': 'A'}):
+                    self.assertEqual('A', localemod.get_locale())
+                    localemod._parse_localectl.assert_called_once_with()
 
         with patch.dict(localemod.__context__, {'salt.utils.systemd.booted': False}):
             with patch.dict(localemod.__grains__, {'os_family': ['Gentoo']}):
@@ -82,8 +83,9 @@ class LocalemodTestCase(TestCase):
         Test for Sets the current system locale
         '''
         with patch.dict(localemod.__context__, {'salt.utils.systemd.booted': True}):
-            with patch.object(localemod, '_localectl_set', return_value=True):
-                self.assertTrue(localemod.set_locale('l'))
+            with patch.dict(localemod.__grains__, {'os_family': ['Unknown']}):
+                with patch.object(localemod, '_localectl_set', return_value=True):
+                    self.assertTrue(localemod.set_locale('l'))
 
         with patch.dict(localemod.__context__, {'salt.utils.systemd.booted': False}):
             with patch.dict(localemod.__grains__, {'os_family': ['Gentoo']}):


### PR DESCRIPTION


### What does this PR do?

fix setting the system language on SUSE systems

Also on with systems with systemd, SUSE still uses /etc/sysconfig/language
for setting the language.

### Previous Behavior
On SUSE systems with system, /etc/locale.conf was created which is nowhere used.

### New Behavior
Now it will write /etc/sysconfig/language

### Tests written?

No