### PR TITLE
Fix #41335 - list index out of range on empty line in authorized_keys

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -154,7 +154,7 @@ def _replace_auth_key(
                     lines.append(line)
                     continue
                 comps = re.findall(r'((.*)\s)?(ssh-[a-z0-9-]+|ecdsa-[a-z0-9-]+)\s([a-zA-Z0-9+/]+={0,2})(\s(.*))?', line)
-                if comps[0][3] == key:
+                if len(comps) > 0 and len(comps[0]) > 3 and comps[0][3] == key:
                     lines.append(auth_line)
                 else:
                     lines.append(line)

--- a/tests/unit/modules/ssh_test.py
+++ b/tests/unit/modules/ssh_test.py
@@ -82,9 +82,14 @@ class SSHAuthKeyTestCase(TestCase):
               '/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
         options = 'command="/usr/local/lib/ssh-helper"'
         email = 'github.com'
-
+        empty_line = '\n'
+        comment_line = '# this is a comment \n'
         # Write out the authorized key to a temporary file
         temp_file = tempfile.NamedTemporaryFile(delete=False, mode='w+')
+        # Add comment
+        temp_file.write(comment_line)
+        # Add empty line for #41335
+        temp_file.write(empty_line)
         temp_file.write('{0} {1} {2} {3}'.format(options, enc, key, email))
         temp_file.close()
 
@@ -124,6 +129,8 @@ class SSHAuthKeyTestCase(TestCase):
             self.assertIn(key, file_txt)
             self.assertIn('{0} '.format(','.join(options)), file_txt)
             self.assertIn(email, file_txt)
+            self.assertIn(empty_line, file_txt)
+            self.assertIn(comment_line, file_txt)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?

Adds a list length check to prevent out of range access.

If there is a more pythony way of doing this, please feel free ... 

### What issues does this PR fix or reference?

Fixes #41335

### Previous Behavior

On line, that is not compatible with the module, exception is thrown.

### New Behavior

Lines not compatible with the ssh module are ignored and left as they are.
btw. do we want a warning, or something?

### Tests written?

Yes, modified the original key replacement test.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
