### PR TITLE
Add TLS connection options for pgjsonb returner

### DIFF
--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -35,9 +35,13 @@ either exclude these options or set them to None.
 
 .. code-block:: yaml
 
-    returner.pgjsonb.ssl_ca: None
-    returner.pgjsonb.ssl_cert: None
-    returner.pgjsonb.ssl_key: None
+    returner.pgjsonb.sslmode: None
+    returner.pgjsonb.sslcert: None
+    returner.pgjsonb.sslkey: None
+    returner.pgjsonb.sslrootcert: None
+    returner.pgjsonb.sslcrl: None
+
+.. versionadded:: 2017.5.0
 
 Alternative configuration values can be used by prefacing the configuration
 with `alternative.`. Any values not found in the alternative configuration will
@@ -154,6 +158,7 @@ import logging
 import salt.returners
 import salt.utils.jid
 import salt.exceptions
+from salt.ext import six
 
 # Import third party libs
 try:
@@ -179,17 +184,26 @@ def _get_options(ret=None):
     '''
     Returns options used for the MySQL connection.
     '''
-    defaults = {'host': 'localhost',
-                'user': 'salt',
-                'pass': 'salt',
-                'db': 'salt',
-                'port': 5432}
+    defaults = {
+        'host': 'localhost',
+        'user': 'salt',
+        'pass': 'salt',
+        'db': 'salt',
+        'port': 5432
+    }
 
-    attrs = {'host': 'host',
-             'user': 'user',
-             'pass': 'pass',
-             'db': 'db',
-             'port': 'port'}
+    attrs = {
+        'host': 'host',
+        'user': 'user',
+        'pass': 'pass',
+        'db': 'db',
+        'port': 'port',
+        'sslmode': 'sslmode',
+        'sslcert': 'sslcert',
+        'sslkey': 'sslkey',
+        'sslrootcert': 'sslrootcert',
+        'sslcrl': 'sslcrl',
+    }
 
     _options = salt.returners.get_returner_options('returner.{0}'.format(__virtualname__),
                                                    ret,
@@ -212,19 +226,18 @@ def _get_serv(ret=None, commit=False):
     try:
         # An empty ssl_options dictionary passed to MySQLdb.connect will
         # effectively connect w/o SSL.
-        ssl_options = {}
-        if _options.get('ssl_ca'):
-            ssl_options['ca'] = _options.get('ssl_ca')
-        if _options.get('ssl_cert'):
-            ssl_options['cert'] = _options.get('ssl_cert')
-        if _options.get('ssl_key'):
-            ssl_options['key'] = _options.get('ssl_key')
-        conn = psycopg2.connect(host=_options.get('host'),
-                                user=_options.get('user'),
-                                password=_options.get('pass'),
-                                database=_options.get('db'),
-                                port=_options.get('port'))
-#                                ssl=ssl_options)
+        ssl_options = {
+            k: v for k, v in six.iteritems(_options)
+            if k in ['sslmode', 'sslcert', 'sslkey', 'sslrootcert', 'sslcrl']
+        }
+        conn = psycopg2.connect(
+            host=_options.get('host'),
+            port=_options.get('port'),
+            dbname=_options.get('db'),
+            user=_options.get('user'),
+            password=_options.get('pass'),
+            **ssl_options
+        )
     except psycopg2.OperationalError as exc:
         raise salt.exceptions.SaltMasterError('pgjsonb returner could not connect to database: {exc}'.format(exc=exc))
 


### PR DESCRIPTION
Previously, any TLS options in the configuration were silently ignored,
and would not have worked regardless
because they were copied from the MySQL returner.

### What does this PR do?

Allow using TLS connections in the pgjsonb returner.

### What issues does this PR fix or reference?

#23508 (original implementation by @cro)

### Previous Behavior

TLS options for the pgjsonb returner were silently ignored.

### New Behavior

The pgjsonb returner can make TLS connections to Postgres.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.