### PR TITLE
FIX Documentation about RPM Based distros.

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
-Management of APT/YUM package repos
+Management of APT/RPM package repos
 ===================================
 
-Package repositories for APT-based and YUM-based distros can be managed with
+Package repositories for APT-based and RPM-based distros(openSUSE/SUSE, CentOS/Fedora/Redhat) can be managed with
 these states. Here is some example SLS:
 
 .. code-block:: yaml


### PR DESCRIPTION
There is no YUM based distro(even the last fedora is based on dnf), so
the correct documentation is RPM.

### What does this PR do?
Fix documentation about wrong info (yum distros)

### What issues does this PR fix or reference?
Wrong information

