### PR TITLE
Fix #41299 list nodes in active provider only

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -372,7 +372,7 @@ def avail_sizes(call=None):  # pylint: disable=unused-argument
 
 def list_nodes(conn=None, call=None):  # pylint: disable=unused-argument
     '''
-    List VMs on this Azure account
+    List VMs on this Azure Active Provider
     '''
     if call == 'action':
         raise SaltCloudSystemExit(
@@ -385,7 +385,17 @@ def list_nodes(conn=None, call=None):  # pylint: disable=unused-argument
         compconn = get_conn()
 
     nodes = list_nodes_full(compconn, call)
+
+    active_resource_group = None
+    try:
+        provider, driver = __active_provider_name__.split(':')
+        active_resource_group = __opts__['providers'][provider][driver]['resource_group']
+    except:
+        pass
+
     for node in nodes:
+        if not nodes[node]['resource_group'] == active_resource_group:
+            continue
         ret[node] = {'name': node}
         for prop in ('id', 'image', 'size', 'state', 'private_ips', 'public_ips'):
             ret[node][prop] = nodes[node].get(prop)


### PR DESCRIPTION
### What does this PR do?
Modify function **list_nodes** to return only the nodes of the active salt provider (resource_group of the provider)

This function is called by salt function **map_providers_parallel** for each providers configured. So it was called for example 3 times, each times the function returned all the nodes of all the resource_groups.

### What issues does this PR fix or reference?
#41299 

### Previous Behavior
Returned all the nodes of the Azure account

### New Behavior
Return only the nodes of the resource_group linked to the active provider

### Tests written?
No
