### PR TITLE
saltutil module sync_* should default to base saltenv

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -68,34 +68,12 @@ __proxyenabled__ = ['*']
 log = logging.getLogger(__name__)
 
 
-def _get_top_file_envs():
-    '''
-    Get all environments from the top file
-    '''
-    try:
-        return __context__['saltutil._top_file_envs']
-    except KeyError:
-        try:
-            st_ = salt.state.HighState(__opts__)
-            top = st_.get_top()
-            if top:
-                envs = list(st_.top_matches(top).keys()) or 'base'
-            else:
-                envs = 'base'
-        except SaltRenderError as exc:
-            raise CommandExecutionError(
-                'Unable to render top file(s): {0}'.format(exc)
-            )
-        __context__['saltutil._top_file_envs'] = envs
-        return envs
-
-
 def _sync(form, saltenv=None):
     '''
     Sync the given directory in the given environment
     '''
     if saltenv is None:
-        saltenv = _get_top_file_envs()
+        saltenv = ['base']
     if isinstance(saltenv, six.string_types):
         saltenv = saltenv.split(',')
     ret, touched = salt.utils.extmods.sync(__opts__, form, saltenv=saltenv)
@@ -585,6 +563,10 @@ def sync_pillar(saltenv=None, refresh=True):
     environment to grab the contents of the ``_pillar`` directory from that
     environment. The default environment, if none is specified,  is ``base``.
 
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
     refresh : True
         Also refresh the execution modules available to the minion, and refresh
         pillar data.
@@ -620,6 +602,10 @@ def sync_all(saltenv=None, refresh=True):
     Sync down all of the dynamic modules from the file server for a specific
     environment. This function synchronizes custom modules, states, beacons,
     grains, returners, output modules, renderers, and utils.
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
 
     refresh : True
         Also refresh the execution modules and recompile pillar data available

--- a/tests/unit/modules/saltutil_test.py
+++ b/tests/unit/modules/saltutil_test.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+'''
+unit tests for the saltutil module
+'''
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import skipIf, TestCase
+from salttesting.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    call,
+    patch)
+
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.modules import saltutil
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.utils.extmods.sync')
+class SaltutilTestCase(TestCase):
+
+    def setUp(self):
+        saltutil.__opts__ = {}
+
+    @patch('salt.modules.saltutil.refresh_pillar', return_value=True)
+    @patch('salt.modules.saltutil.refresh_modules', return_value=True)
+    def test_sync_all_local_refresh(self, mock_ref_modules,
+                                    mock_ref_pillar, mock_extmods_sync):
+        '''
+        Test to ensure sync_all uses base and refreshes modules and
+        pillar only once
+        '''
+        with patch.dict(saltutil.__opts__, {'file_client': 'local'}):
+            mock_extmods_sync.return_value = True, False
+            # Refresh modules and pillar
+            ret = saltutil.sync_all(None, True)
+            calls = []
+            for r in ret:
+                # Rename due to mod not mapping to mod function name
+                if r == 'proxymodules':
+                    r = 'proxy'
+                calls.append(call(saltutil.__opts__,
+                                  r,
+                                  saltenv=['base']))
+            mock_extmods_sync.assert_has_calls(calls, any_order=True)
+            mock_ref_modules.assert_called_once()
+            mock_ref_pillar.assert_called_once()
+
+    @patch('salt.modules.saltutil.refresh_pillar', return_value=None)
+    @patch('salt.modules.saltutil.refresh_modules', return_value=None)
+    def test_sync_all_local_no_refresh(self, mock_ref_modules,
+                                       mock_ref_pillar, mock_extmods_sync):
+        '''
+        test to ensure that sync_all doesnt call refreshes more than
+        once
+        '''
+        with patch.dict(saltutil.__opts__, {'file_client': 'local'}):
+            mock_extmods_sync.return_value = True, False
+            # skip all refresh of modules and pillar
+            ret = saltutil.sync_all(None, False)
+            calls = []
+            for r in ret:
+                # rename due to mod not mapping to mod function name
+                if r == 'proxymodules':
+                    r = 'proxy'
+                calls.append(call(saltutil.__opts__,
+                                  r,
+                                  saltenv=['base']))
+            mock_extmods_sync.assert_has_calls(calls, any_order=True)
+            mock_ref_modules.assert_not_called()
+            mock_ref_pillar.assert_not_called()
+
+    def test_sync_all_master_no_pillar(self, mock_extmods_sync):
+        '''
+        test to ensure that pillar is skipped during sync_all on master
+        '''
+        with patch.dict(saltutil.__opts__, {'file_client': 'remote'}):
+            mock_extmods_sync.return_value = True, False
+            # skip all refresh of modules and pillar
+            saltutil.sync_all(None, False)
+            # pillar sync shouldnt happen on remote
+            pillar_call = call(saltutil.__opts__, 'pillar', saltenv=['base'])
+            assert pillar_call not in mock_extmods_sync.call_args_list


### PR DESCRIPTION
### What does this PR do?
The `saltutil` module now defaults to `saltenv=['base']` for salt version 2016.11

### What issues does this PR fix or reference?
I"m currently using an external pillar that make me sensitive to additional pillar compile calls. The `saltutil` module should be defaulting to `saltenv=['base']` instead of trying to infer the environment via the top file which leads to the compiling of pillar due to https://github.com/saltstack/salt/blob/develop/salt/modules/saltutil.py#L79. This PR makes the documentation consistent as well. 

### Previous Behavior
Infer environment via the top file if `saltenv=None`

### Tests written?

Yes. It looks like there's been some effort to rework the tests on the `develop` branch. I figured Id include some that were similar to how tests were laid out on `2016.11`. Let me know if there's anything I can do to make the tests easier to port over for the future.

Output of tests:
```bash
$ python tests/runtests.py -n unit.modules.saltutil_test.SaltutilTestCase
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Transplanting configuration files to '/tmp/salt-tests-tmpdir/config'
 * Current Directory: /home/rherna/workspace/salt
 * Test suite is running under PID 8343
 * Logging tests on /tmp/salt-runtests.log
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Starting unit.modules.saltutil_test.SaltutilTestCase Tests
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
...
----------------------------------------------------------------------
Ran 3 tests in 0.003s

OK

===============================================  Overall Tests Report  ================================================
***  No Problems Found While Running Tests  ***************************************************************************
=======================================================================================================================
OK (total=3, skipped=0, passed=3, failures=0, errors=0)
===============================================  Overall Tests Report  ================================================
```

Salt Version:
           Salt: 2016.3.0-2162-g0bb68fd

Dependency Versions:
           cffi: 1.10.0
       cherrypy: Not Installed
       dateutil: 2.6.0
      docker-py: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.9.6
        libgit2: Not Installed
        libnacl: Not Installed
       M2Crypto: Not Installed
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.4.8
   mysql-python: Not Installed
      pycparser: 2.17
       pycrypto: 2.6.1
   pycryptodome: Not Installed
         pygit2: Not Installed
         Python: 2.7.9 (default, Jun 29 2016, 13:08:31)
   python-gnupg: Not Installed
         PyYAML: 3.12
          PyZMQ: 16.0.2
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.5.1
            ZMQ: 4.1.6

System Versions:
           dist: debian 8.7
        machine: x86_64
        release: 3.16.0-4-amd64
         system: Linux
        version: debian 8.7
