### PR TITLE
Supports quoted values in /etc/sysconfig/network

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1153,7 +1153,10 @@ def mod_hostname(hostname):
         with salt.utils.fopen('/etc/sysconfig/network', 'w') as fh_:
             for net in network_c:
                 if net.startswith('HOSTNAME'):
-                    fh_.write('HOSTNAME={0}\n'.format(hostname))
+                    old_hostname = net.split('=', 1)[1].rstrip()
+                    quote_type = salt.utils.is_quoted(old_hostname)
+                    fh_.write('HOSTNAME={1}{0}{1}\n'.format(
+                        salt.utils.dequote(hostname), quote_type))
                 else:
                     fh_.write(net)
     elif __grains__['os_family'] in ('Debian', 'NILinuxRT'):

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -787,21 +787,30 @@ def _parse_network_settings(opts, current):
     retain_settings = opts.get('retain_settings', False)
     result = current if retain_settings else {}
 
+    # Default quote type is an empty string, which will not quote values
+    quote_type = ''
+
     valid = _CONFIG_TRUE + _CONFIG_FALSE
     if 'enabled' not in opts:
         try:
             opts['networking'] = current['networking']
+            # If networking option is quoted, use its quote type
+            quote_type = salt.utils.is_quoted(opts['networking'])
             _log_default_network('networking', current['networking'])
         except ValueError:
             _raise_error_network('networking', valid)
     else:
         opts['networking'] = opts['enabled']
 
-    if opts['networking'] in valid:
-        if opts['networking'] in _CONFIG_TRUE:
-            result['networking'] = 'yes'
-        elif opts['networking'] in _CONFIG_FALSE:
-            result['networking'] = 'no'
+    true_val = '{0}yes{0}'.format(quote_type)
+    false_val = '{0}no{0}'.format(quote_type)
+
+    networking = salt.utils.dequote(opts['networking'])
+    if networking in valid:
+        if networking in _CONFIG_TRUE:
+            result['networking'] = true_val
+        elif networking in _CONFIG_FALSE:
+            result['networking'] = false_val
     else:
         _raise_error_network('networking', valid)
 
@@ -813,22 +822,25 @@ def _parse_network_settings(opts, current):
             _raise_error_network('hostname', ['server1.example.com'])
 
     if opts['hostname']:
-        result['hostname'] = opts['hostname']
+        result['hostname'] = '{1}{0}{1}'.format(
+            salt.utils.dequote(opts['hostname']), quote_type)
     else:
         _raise_error_network('hostname', ['server1.example.com'])
 
     if 'nozeroconf' in opts:
-        if opts['nozeroconf'] in valid:
-            if opts['nozeroconf'] in _CONFIG_TRUE:
-                result['nozeroconf'] = 'true'
-            elif opts['nozeroconf'] in _CONFIG_FALSE:
-                result['nozeroconf'] = 'false'
+        nozeroconf = salt.utils.dequote(opts['nozerconf'])
+        if nozeroconf in valid:
+            if nozeroconf in _CONFIG_TRUE:
+                result['nozeroconf'] = true_val
+            elif nozeroconf in _CONFIG_FALSE:
+                result['nozeroconf'] = false_val
         else:
             _raise_error_network('nozeroconf', valid)
 
     for opt in opts:
         if opt not in ['networking', 'hostname', 'nozeroconf']:
-            result[opt] = opts[opt]
+            result[opt] = '{1}{0}{1}'.format(
+                salt.utils.dequote(opts[opt]), quote_type)
     return result
 
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -3210,3 +3210,26 @@ def substr_in_list(string_to_search_for, list_to_search):
     string is present in any of the strings which comprise a list
     '''
     return any(string_to_search_for in s for s in list_to_search)
+
+
+def is_quoted(val):
+    '''
+    Return a single or double quote, if a string is wrapped in extra quotes.
+    Otherwise return an empty string.
+    '''
+    ret = ''
+    if (
+        isinstance(val, six.string_types) and val[0] == val[-1] and
+        val.startswith(('\'', '"'))
+    ):
+        ret = val[0]
+    return ret
+
+
+def dequote(val):
+    '''
+    Remove extra quotes around a string.
+    '''
+    if is_quoted(val):
+        return val[1:-1]
+    return val


### PR DESCRIPTION
### What does this PR do?

Supports quoted values in /etc/sysconfig/network.

### What issues does this PR fix or reference?

Fixes #41341

### Previous Behavior

Previously, quoted values would cause a traceback. See the linked issue.

### New Behavior

Detects whether the `networking` option is quoted currently, and if so will use the same quote type when modifying options.

In support of this, two new util functions are available, `is_quoted()` and `dequote()`.

### Tests written?

No. I looked at the current tests, but what they are doing did not make sense to me and I didn't want to break them. Give me a pointer, and I'll work on tests.
