### PR TITLE
Fix package name collisions in chocolatey state

### DIFF
--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -92,7 +92,7 @@ def installed(name, version=None, source=None, force=False, pre_versions=False,
 
     # Determine action
     # Package not installed
-    if name not in pre_install:
+    if name not in [package.split('|')[0].lower() for package in pre_install.splitlines()]:
         if version:
             ret['changes'] = {name: 'Version {0} will be installed'
                                     ''.format(version)}
@@ -193,7 +193,7 @@ def uninstalled(name, version=None, uninstall_args=None, override_args=False):
     pre_uninstall = __salt__['chocolatey.list'](local_only=True)
 
     # Determine if package is installed
-    if name in pre_uninstall:
+    if name in [package.split('|')[0].lower() for package in pre_uninstall.splitlines()]:
         ret['changes'] = {name: '{0} version {1} will be removed'
                                 ''.format(name, pre_uninstall[name][0])}
     else:


### PR DESCRIPTION
### What does this PR do?

Allows for case-insensitive package matching and tests for the exact package name rather than using python's `in` operator

### What issues does this PR fix or reference?

#41185

### Previous Behavior

chocolatey is unable to install a package if the name is a substring of another installed package
chocolatey attempts to install a package if the name does not match the case in the salt state

### New Behavior

chocolatey state allows for case-insensitive matching to align with chocolatey behavior
chocolatey is able to install a package which is a substring of an installed package

### Tests written?

No