### PR TITLE
minion_id_lowercase

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -451,7 +451,7 @@ FQDN (for instance, Solaris).
 .. conf_minion:: minion_id_lowercase
 
 ``minion_id_lowercase``
------------------
+-----------------------
 
 Default: ``False``
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -448,6 +448,20 @@ FQDN (for instance, Solaris).
 
     append_domain: foo.org
 
+.. conf_minion:: minion_id_lowercase
+
+``minion_id_lowercase``
+-----------------
+
+Default: ``False``
+
+Convert minion id to lowercase when it is being generated. Helpful when some hosts
+get the minion id in uppercase. Cached ids will remain the same and not converted.
+
+.. code-block:: yaml
+
+    minion_id_lowercase: True
+
 .. conf_minion:: cachedir
 
 ``cachedir``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -838,6 +838,9 @@ VALID_OPTS = {
     # Cache minion ID to file
     'minion_id_caching': bool,
 
+    # Always generate minion id in lowercase.
+    'minion_id_lowercase': bool,
+
     # If set, the master will sign all publications before they are sent out
     'sign_pub_messages': bool,
 
@@ -1259,6 +1262,7 @@ DEFAULT_MINION_OPTS = {
     'modules_max_memory': -1,
     'grains_refresh_every': 0,
     'minion_id_caching': True,
+    'minion_id_lowercase': False,
     'keysize': 2048,
     'transport': 'zeromq',
     'auth_timeout': 5,
@@ -3270,6 +3274,9 @@ def get_id(opts, cache_minion_id=False):
                   .format(os.path.join(salt.syspaths.CONFIG_DIR, 'minion')))
 
     newid = salt.utils.network.generate_minion_id()
+
+    if opts.get('minion_id_lowercase', True):
+        newid = newid.lower()
     if '__role' in opts and opts.get('__role') == 'minion':
         log.debug('Found minion id from generate_minion_id(): {0}'.format(newid))
     if cache_minion_id and opts.get('minion_id_caching', True):

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3275,8 +3275,9 @@ def get_id(opts, cache_minion_id=False):
 
     newid = salt.utils.network.generate_minion_id()
 
-    if opts.get('minion_id_lowercase', True):
+    if opts.get('minion_id_lowercase'):
         newid = newid.lower()
+        log.debug('Changed minion id {0} to lowercase.'.format(newid))
     if '__role' in opts and opts.get('__role') == 'minion':
         log.debug('Found minion id from generate_minion_id(): {0}'.format(newid))
     if cache_minion_id and opts.get('minion_id_caching', True):


### PR DESCRIPTION
### What does this PR do?
Adds option to minion config to always lowercase minion id when generated by salt.

### What issues does this PR fix or reference?
Some windows hosts have minion id in capital letters.

### Previous Behavior
minion id would be in capital.

### New Behavior
User will have the option to always have minion id in lowercase.

### Tests written?
No

