### PR TITLE
Fix modules.cp.get_file_str to match the documentation.

### DIFF
--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -345,9 +345,11 @@ def get_file_str(path, saltenv='base'):
     '''
     fn_ = cache_file(path, saltenv)
     if isinstance(fn_, six.string_types):
-        with salt.utils.fopen(fn_, 'r') as fp_:
-            data = fp_.read()
-        return data
+        try:
+            with salt.utils.fopen(fn_, 'r') as fp_:
+                return fp_.read()
+        except IOError:
+            return False
     return fn_
 
 


### PR DESCRIPTION
### What does this PR do?
Change modules.cpy.get_file_str to return False instead of raise an exception.

The documentation states that it will return False if the file can't be cached,
in reality it threw an IOError. This makes it return False.

### What issues does this PR fix or reference?
None

### Previous Behavior
Exception

### New Behavior
return False

### Tests written?

No