### PR TITLE
Sysrc on FreeBSD, YAML overeager to coerce to bool and int

### DIFF
--- a/salt/modules/sysrc.py
+++ b/salt/modules/sysrc.py
@@ -93,6 +93,20 @@ def set_(name, value, **kwargs):
     if 'jail' in kwargs:
         cmd += ' -j '+kwargs['jail']
 
+    # This is here because the YAML parser likes to convert the string literals
+    # YES, NO, Yes, No, True, False, etc. to boolean types.  However, in this case,
+    # we will check to see if that happened and replace it with "YES" or "NO" because
+    # those items are accepted in sysrc.
+    if type(value) == bool:
+        if value:
+            value = "YES"
+        else:
+            value = "NO"
+
+    # This is here for the same reason, except for numbers
+    if type(value) == int:
+        value = str(value)
+
     cmd += ' '+name+"=\""+value+"\""
 
     sysrcs = __salt__['cmd.run'](cmd)
@@ -105,9 +119,6 @@ def set_(name, value, **kwargs):
         newval = sysrc.split(': ')[2].split(" -> ")[1]
         if rcfile not in ret:
             ret[rcfile] = {}
-        #ret[rcfile][var] = {}
-        #ret[rcfile][var]['old'] = oldval
-        #ret[rcfile][var]['new'] = newval
         ret[rcfile][var] = newval
     return ret
 

--- a/tests/integration/modules/sysrc.py
+++ b/tests/integration/modules/sysrc.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import
+import sys
+
+# Import Salt Testing libs
+from salttesting import skipIf
+from salttesting.helpers import ensure_in_syspath, destructiveTest
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+
+
+class SysrcModuleTest(integration.ModuleCase):
+    def setUp(self):
+        super(SysrcModuleTest, self).setUp()
+        ret = self.run_function('cmd.has_exec', ['sysrc'])
+        if not ret:
+            self.skipTest('sysrc not found')
+
+    @skipIf(not sys.platform.startswith('freebsd'), 'FreeBSD specific')
+    def test_show(self):
+        ret = self.run_function('sysrc.get')
+        self.assertIsInstance(ret, dict, 'sysrc.get returned wrong type, expecting dictionary')
+        self.assertIn('/etc/rc.conf', ret, 'sysrc.get should have an rc.conf key in it.')
+
+    @skipIf(not sys.platform.startswith('freebsd'), 'FreeBSD specific')
+    @destructiveTest
+    def test_set(self):
+        ret = self.run_function('sysrc.set', ['test_var', '1'])
+        self.assertIsInstance(ret, dict, 'sysrc.get returned wrong type, expecting dictionary')
+        self.assertIn('/etc/rc.conf', ret, 'sysrc.set should have an rc.conf key in it.')
+        self.assertIn('1', ret['/etc/rc.conf']['test_var'], 'sysrc.set should return the value it set.')
+        ret = self.run_function('sysrc.remove', ['test_var'])
+        self.assertEqual('test_var removed', ret)
+
+    @skipIf(not sys.platform.startswith('freebsd'), 'FreeBSD specific')
+    @destructiveTest
+    def test_set_bool(self):
+        ret = self.run_function('sysrc.set', ['test_var', True])
+        self.assertIsInstance(ret, dict, 'sysrc.get returned wrong type, expecting dictionary')
+        self.assertIn('/etc/rc.conf', ret, 'sysrc.set should have an rc.conf key in it.')
+        self.assertIn('YES', ret['/etc/rc.conf']['test_var'], 'sysrc.set should return the value it set.')
+        ret = self.run_function('sysrc.remove', ['test_var'])
+        self.assertEqual('test_var removed', ret)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(SysrcModuleTest)


### PR DESCRIPTION
The YAML parser likes to coerce things that look like booleans and integers to their
actual types.  In the case of sysrc, that is not a good idea.

### What does this PR do?

If the YAML parser creates a bool, change it to "YES" or "NO" (permitted in /etc/rc.conf).
If the parser creates an int, just change it back to a string.

### What issues does this PR fix or reference?

I could not find an open issue.  I'm surprised, as this pretty much left the sysrc module broken on FreeBSD

### Previous Behavior

Calling the sysrc module in a state or on the CLI with something like

```
salt fbsd sysrc.set name=salt_minion_enable value=YES
```

would stacktrace saying we could not add a string and a bool.  Same thing with integers.

### New Behavior

Sysrc module no longer stacktraces.

### Tests written?

Yes!!!
