### PR TITLE
Updated remove Redhat 5 and MD5, utilize SHA256 building Redhat

### DIFF
--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -79,6 +79,8 @@ def _create_rpmmacros():
     with salt.utils.fopen(rpmmacros, 'w') as afile:
         afile.write('%_topdir {0}\n'.format(rpmbuilddir))
         afile.write('%signature gpg\n')
+        afile.write('%_source_filedigest_algorithm 8\n')
+        afile.write('%_binary_filedigest_algorithm 8\n')
         afile.write('%_gpg_name packaging@saltstack.com\n')
 
 
@@ -128,7 +130,7 @@ def _get_distset(tgt):
     tgtattrs = tgt.split('-')
     if tgtattrs[0] == 'amzn':
         distset = '--define "dist .{0}1"'.format(tgtattrs[0])
-    elif tgtattrs[1] in ['5', '6', '7']:
+    elif tgtattrs[1] in ['6', '7']:
         distset = '--define "dist .el{0}"'.format(tgtattrs[1])
     else:
         distset = ''
@@ -173,6 +175,13 @@ def make_src_pkg(dest_dir, spec, sources, env=None, template=None, saltenv='base
 
     This example command should build the libnacl SOURCE package and place it in
     /var/www/html/ on the minion
+
+    .. versionchanged:: Nitrogen
+
+    .. note::
+
+        using SHA256 as digest and minimum level dist el6
+
     '''
     _create_rpmmacros()
     tree_base = _mk_tree()
@@ -182,8 +191,8 @@ def make_src_pkg(dest_dir, spec, sources, env=None, template=None, saltenv='base
     for src in sources:
         _get_src(tree_base, src, saltenv)
 
-    # make source rpms for dist el5, usable with mock on other dists
-    cmd = 'rpmbuild --define "_topdir {0}" -bs --define "_source_filedigest_algorithm md5" --define "_binary_filedigest_algorithm md5" --define "dist .el5" {1}'.format(tree_base, spec_path)
+    # make source rpms for dist el6 with SHA256, usable with mock on other dists
+    cmd = 'rpmbuild --verbose --define "_topdir {0}" -bs --define "dist .el6" {1}'.format(tree_base, spec_path)
     __salt__['cmd.run'](cmd)
     srpms = os.path.join(tree_base, 'SRPMS')
     ret = []


### PR DESCRIPTION
### What does this PR do?
Removes building rpm on Redhat with MD5 and support for Redhat 5 which is end-of-life'd

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-pack/issues/319

### Previous Behavior
Used to build rpms with MD5 signature digests

### New Behavior
Rpms will now be build with SHA256 signature digests and support for Redhat 5 is removed

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
