### PR TITLE
Update win_pki.py

### DIFF
--- a/salt/modules/win_pki.py
+++ b/salt/modules/win_pki.py
@@ -272,9 +272,9 @@ def import_cert(name,
         return False
 
     if password:
-        cert_props = get_cert_file(name=cached_source_path, password=password)
+        cert_props = get_cert_file(name=cached_source_path, cert_format=cert_format, password=password)
     else:
-        cert_props = get_cert_file(name=cached_source_path)
+        cert_props = get_cert_file(name=cached_source_path, cert_format=cert_format)
 
     current_certs = get_certs(context=context, store=store)
 


### PR DESCRIPTION
Always pass cert_format when calling get_cert_file from import_cert

### What does this PR do?
adds passing of cert_format to get_cert_file when called from import_cert

### What issues does this PR fix or reference?
#40950 

### Previous Behavior
Not possible to import PFX-certs that have a password set

### New Behavior
Possible to import PFX-certificates that have a password set.

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
