### PR TITLE
Add unit test for PR #40905

### DIFF
--- a/tests/unit/states/test_saltmod.py
+++ b/tests/unit/states/test_saltmod.py
@@ -67,6 +67,60 @@ class SaltmodTestCase(TestCase, LoaderModuleMockMixin):
                     'comment': 'States ran successfully.'
                     }
 
+        test_batch_return = {
+            'minion1': {
+                'ret': {
+                    'test_|-notify_me_|-this is a name_|-show_notification': {
+                        'comment': 'Notify me',
+                        'name': 'this is a name',
+                        'start_time': '10:43:41.487565',
+                        'result': True,
+                        'duration': 0.35,
+                        '__run_num__': 0,
+                        '__sls__': 'demo',
+                        'changes': {},
+                        '__id__': 'notify_me'
+                    },
+                    'retcode': 0
+                },
+                'out': 'highstate'
+            },
+            'minion2': {
+                'ret': {
+                    'test_|-notify_me_|-this is a name_|-show_notification': {
+                        'comment': 'Notify me',
+                        'name': 'this is a name',
+                        'start_time': '10:43:41.487565',
+                        'result': True,
+                        'duration': 0.35,
+                        '__run_num__': 0,
+                        '__sls__': 'demo',
+                        'changes': {},
+                        '__id__': 'notify_me'
+                    },
+                    'retcode': 0
+                },
+                'out': 'highstate'
+            },
+            'minion3': {
+                'ret': {
+                    'test_|-notify_me_|-this is a name_|-show_notification': {
+                        'comment': 'Notify me',
+                        'name': 'this is a name',
+                        'start_time': '10:43:41.487565',
+                        'result': True,
+                        'duration': 0.35,
+                        '__run_num__': 0,
+                        '__sls__': 'demo',
+                        'changes': {},
+                        '__id__': 'notify_me'
+                    },
+                    'retcode': 0
+                },
+                'out': 'highstate'
+            }
+        }
+
         self.assertDictEqual(saltmod.state(name, tgt, allow_fail='a'), ret)
 
         comt = ('No highstate or sls specified, no execution made')
@@ -86,8 +140,13 @@ class SaltmodTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(saltmod.__opts__, {'test': False}):
             mock = MagicMock(return_value={'silver': {'jid': '20170406104341210934', 'retcode': 0, 'ret': {'test_|-notify_me_|-this is a name_|-show_notification': {'comment': 'Notify me', 'name': 'this is a name', 'start_time': '10:43:41.487565', 'result': True, 'duration': 0.35, '__run_num__': 0, '__sls__': 'demo', 'changes': {}, '__id__': 'notify_me'}}, 'out': 'highstate'}})
             with patch.dict(saltmod.__salt__, {'saltutil.cmd': mock}):
-                self.assertDictEqual(saltmod.state(name, tgt, highstate=True),
-                                     ret)
+                self.assertDictEqual(saltmod.state(name, tgt, highstate=True), ret)
+
+        ret.update({'comment': 'States ran successfully. No changes made to minion1, minion3, minion2.'})
+        del ret['__jid__']
+        with patch.dict(saltmod.__opts__, {'test': False}):
+            with patch.dict(saltmod.__salt__, {'saltutil.cmd': MagicMock(return_value=test_batch_return)}):
+                self.assertDictEqual(saltmod.state(name, tgt, highstate=True), ret)
 
     # 'function' function tests: 1
 


### PR DESCRIPTION
### What does this PR do?

This ensures we do not introduce a regression which breaks
the usage of the `batch` option when using states in orchestration
runners.

### What issues does this PR fix or reference?

Related to #40635 , #39169 and #40905

### New Behavior
Added tests for #40905

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
