### PR TITLE
Updating Nova/Neutron modules to support KeystoneAuth and SSLVerify

### DIFF
--- a/salt/modules/neutron.py
+++ b/salt/modules/neutron.py
@@ -84,6 +84,7 @@ def _auth(profile=None):
         auth_url = credentials['keystone.auth_url']
         region_name = credentials.get('keystone.region_name', None)
         service_type = credentials.get('keystone.service_type', 'network')
+        os_auth_system = credentials.get('keystone.os_auth_system', None)
         use_keystoneauth = credentials.get('keystone.use_keystoneauth', False)
         verify = credentials.get('keystone.verify', True)
     else:
@@ -93,6 +94,7 @@ def _auth(profile=None):
         auth_url = __salt__['config.option']('keystone.auth_url')
         region_name = __salt__['config.option']('keystone.region_name')
         service_type = __salt__['config.option']('keystone.service_type')
+        os_auth_system = __salt__['config.option']('keystone.os_auth_system')
         use_keystoneauth = __salt__['config.option']('keystone.use_keystoneauth')
         verify = __salt__['config.option']('keystone.verify')
 
@@ -107,6 +109,7 @@ def _auth(profile=None):
             'auth_url': auth_url,
             'region_name': region_name,
             'service_type': service_type,
+            'os_auth_plugin': os_auth_system,
             'use_keystoneauth': use_keystoneauth,
             'verify': verify,
             'project_domain_name': project_domain_name,
@@ -119,7 +122,8 @@ def _auth(profile=None):
             'tenant_name': tenant,
             'auth_url': auth_url,
             'region_name': region_name,
-            'service_type': service_type
+            'service_type': service_type,
+            'os_auth_plugin': os_auth_system
         }
 
     return suoneu.SaltNeutron(**kwargs)

--- a/salt/modules/neutron.py
+++ b/salt/modules/neutron.py
@@ -83,14 +83,16 @@ def _auth(profile=None):
         tenant = credentials['keystone.tenant']
         auth_url = credentials['keystone.auth_url']
         region_name = credentials.get('keystone.region_name', None)
+        service_type = credentials.get('keystone.service_type', 'network')
         use_keystoneauth = credentials.get('keystone.use_keystoneauth', False)
-        verify = credentials.get('keystone.verify', None)
+        verify = credentials.get('keystone.verify', True)
     else:
         user = __salt__['config.option']('keystone.user')
         password = __salt__['config.option']('keystone.password')
         tenant = __salt__['config.option']('keystone.tenant')
         auth_url = __salt__['config.option']('keystone.auth_url')
         region_name = __salt__['config.option']('keystone.region_name')
+        service_type = __salt__['config.option']('keystone.service_type')
         use_keystoneauth = __salt__['config.option']('keystone.use_keystoneauth')
         verify = __salt__['config.option']('keystone.verify')
 
@@ -104,6 +106,7 @@ def _auth(profile=None):
             'tenant_name': tenant,
             'auth_url': auth_url,
             'region_name': region_name,
+            'service_type': service_type,
             'use_keystoneauth': use_keystoneauth,
             'verify': verify,
             'project_domain_name': project_domain_name,
@@ -116,7 +119,7 @@ def _auth(profile=None):
             'tenant_name': tenant,
             'auth_url': auth_url,
             'region_name': region_name,
-            'verify': verify
+            'service_type': service_type
         }
 
     return suoneu.SaltNeutron(**kwargs)

--- a/salt/modules/neutron.py
+++ b/salt/modules/neutron.py
@@ -83,23 +83,39 @@ def _auth(profile=None):
         tenant = credentials['keystone.tenant']
         auth_url = credentials['keystone.auth_url']
         region_name = credentials.get('keystone.region_name', None)
-        service_type = credentials['keystone.service_type']
+        use_keystoneauth = credentials['keystone.use_keystoneauth']
+        verify = credentials['keystone.verify']
     else:
         user = __salt__['config.option']('keystone.user')
         password = __salt__['config.option']('keystone.password')
         tenant = __salt__['config.option']('keystone.tenant')
         auth_url = __salt__['config.option']('keystone.auth_url')
         region_name = __salt__['config.option']('keystone.region_name')
-        service_type = __salt__['config.option']('keystone.service_type')
 
-    kwargs = {
-        'username': user,
-        'password': password,
-        'tenant_name': tenant,
-        'auth_url': auth_url,
-        'region_name': region_name,
-        'service_type': service_type
-    }
+    if use_keystoneauth is True:
+        project_domain_name = credentials['keystone.project_domain_name']
+        user_domain_name = credentials['keystone.user_domain_name']
+
+        kwargs = {
+            'username': user,
+            'password': password,
+            'tenant_name': tenant,
+            'auth_url': auth_url,
+            'region_name': region_name,
+            'use_keystoneauth': use_keystoneauth,
+            'verify': verify,
+            'project_domain_name': project_domain_name,
+            'user_domain_name': user_domain_name
+        }
+    else:
+        kwargs = {
+            'username': user,
+            'password': password,
+            'tenant_name': tenant,
+            'auth_url': auth_url,
+            'region_name': region_name,
+            'verify': verify
+        }
 
     return suoneu.SaltNeutron(**kwargs)
 

--- a/salt/modules/neutron.py
+++ b/salt/modules/neutron.py
@@ -39,6 +39,30 @@ Module for handling OpenStack Neutron calls
     For example::
 
         salt '*' neutron.network_list profile=openstack1
+
+    To use keystoneauth1 instead of keystoneclient, include the `use_keystoneauth`
+    option in the pillar or minion config.
+
+    .. note:: this is required to use keystone v3 as for authentication.
+
+    .. code-block:: yaml
+
+        keystone.user: admin
+        keystone.password: verybadpass
+        keystone.tenant: admin
+        keystone.auth_url: 'http://127.0.0.1:5000/v3/'
+        keystone.region_name: 'RegionOne'
+        keystone.service_type: 'network'
+        keystone.use_keystoneauth: true
+        keystone.verify: '/path/to/custom/certs/ca-bundle.crt'
+
+
+    Note: by default the neutron module will attempt to verify its connection
+    utilizing the system certificates. If you need to verify against another bundle
+    of CA certificates or want to skip verification altogether you will need to
+    specify the `verify` option. You can specify True or False to verify (or not)
+    against system certificates, a path to a bundle or CA certs to check against, or
+    None to allow keystoneauth to search for the certificates on its own.(defaults to True)
 '''
 
 # Import python libs

--- a/salt/modules/neutron.py
+++ b/salt/modules/neutron.py
@@ -83,14 +83,16 @@ def _auth(profile=None):
         tenant = credentials['keystone.tenant']
         auth_url = credentials['keystone.auth_url']
         region_name = credentials.get('keystone.region_name', None)
-        use_keystoneauth = credentials['keystone.use_keystoneauth']
-        verify = credentials['keystone.verify']
+        use_keystoneauth = credentials.get('keystone.use_keystoneauth', False)
+        verify = credentials.get('keystone.verify', None)
     else:
         user = __salt__['config.option']('keystone.user')
         password = __salt__['config.option']('keystone.password')
         tenant = __salt__['config.option']('keystone.tenant')
         auth_url = __salt__['config.option']('keystone.auth_url')
         region_name = __salt__['config.option']('keystone.region_name')
+        use_keystoneauth = __salt__['config.option']('keystone.use_keystoneauth')
+        verify = __salt__['config.option']('keystone.verify')
 
     if use_keystoneauth is True:
         project_domain_name = credentials['keystone.project_domain_name']

--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -84,6 +84,8 @@ def _auth(profile=None):
         region_name = credentials.get('keystone.region_name', None)
         api_key = credentials.get('keystone.api_key', None)
         os_auth_system = credentials.get('keystone.os_auth_system', None)
+        use_keystoneauth = credentials.get('keystone.use_keystoneauth', False)
+        verify = credentials.get('keystone.verify', None)
     else:
         user = __salt__['config.option']('keystone.user')
         password = __salt__['config.option']('keystone.password')
@@ -92,15 +94,34 @@ def _auth(profile=None):
         region_name = __salt__['config.option']('keystone.region_name')
         api_key = __salt__['config.option']('keystone.api_key')
         os_auth_system = __salt__['config.option']('keystone.os_auth_system')
-    kwargs = {
-        'username': user,
-        'password': password,
-        'api_key': api_key,
-        'project_id': tenant,
-        'auth_url': auth_url,
-        'region_name': region_name,
-        'os_auth_plugin': os_auth_system
-    }
+        use_keystoneauth = __salt__['config.option']('keystone.use_keystoneauth')
+        verify = __salt__['config.option']('keystone.verify')
+
+    if use_keystoneauth is True:
+        project_domain_name = credentials['keystone.project_domain_name']
+        user_domain_name = credentials['keystone.user_domain_name']
+
+        kwargs = {
+            'username': user,
+            'password': password,
+            'project_id': tenant,
+            'auth_url': auth_url,
+            'region_name': region_name,
+            'use_keystoneauth': use_keystoneauth,
+            'verify': verify,
+            'project_domain_name': project_domain_name,
+            'user_domain_name': user_domain_name
+        }
+    else:
+        kwargs = {
+            'username': user,
+            'password': password,
+            'api_key': api_key,
+            'project_id': tenant,
+            'auth_url': auth_url,
+            'region_name': region_name,
+            'os_auth_plugin': os_auth_system
+        }
 
     return suon.SaltNova(**kwargs)
 

--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -17,7 +17,7 @@ Module for handling OpenStack Nova calls
     If configuration for multiple OpenStack accounts is required, they can be
     set up as different configuration profiles:
     For example::
-
+    
         openstack1:
           keystone.user: admin
           keystone.password: verybadpass
@@ -35,6 +35,28 @@ Module for handling OpenStack Nova calls
     For example::
 
         salt '*' nova.flavor_list profile=openstack1
+
+    To use keystoneauth1 instead of keystoneclient, include the `use_keystoneauth`
+    option in the pillar or minion config.
+
+    .. note:: this is required to use keystone v3 as for authentication.
+
+    .. code-block:: yaml
+
+        keystone.user: admin
+        keystone.password: verybadpass
+        keystone.tenant: admin
+        keystone.auth_url: 'http://127.0.0.1:5000/v3/'
+        keystone.use_keystoneauth: true
+        keystone.verify: '/path/to/custom/certs/ca-bundle.crt'
+
+
+    Note: by default the nova module will attempt to verify its connection
+    utilizing the system certificates. If you need to verify against another bundle
+    of CA certificates or want to skip verification altogether you will need to
+    specify the `verify` option. You can specify True or False to verify (or not)
+    against system certificates, a path to a bundle or CA certs to check against, or
+    None to allow keystoneauth to search for the certificates on its own.(defaults to True)
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -17,7 +17,7 @@ Module for handling OpenStack Nova calls
     If configuration for multiple OpenStack accounts is required, they can be
     set up as different configuration profiles:
     For example::
-    
+
         openstack1:
           keystone.user: admin
           keystone.password: verybadpass
@@ -63,9 +63,6 @@ from __future__ import absolute_import
 # Import python libs
 import logging
 
-# Import salt libs
-import salt.utils.openstack.nova as suon
-
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -75,8 +72,11 @@ __func_alias__ = {
     'list_': 'list'
 }
 
-# Define the module's virtual name
-__virtualname__ = 'nova'
+try:
+    import salt.utils.openstack.nova as suon
+    HAS_NOVA = True
+except NameError as exc:
+    HAS_NOVA = False
 
 
 def __virtual__():
@@ -84,10 +84,7 @@ def __virtual__():
     Only load this module if nova
     is installed on this minion.
     '''
-    if suon.check_nova():
-        return __virtualname__
-    return (False, 'The nova execution module failed to load: '
-            'only available if nova is installed.')
+    return HAS_NOVA
 
 
 __opts__ = {}

--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -80,7 +80,10 @@ class SaltNeutron(NeutronShell):
         '''
         Set up neutron credentials
         '''
-        if all([use_keystoneauth, HAS_KEYSTONEAUTH]):
+        if not HAS_NEUTRON:
+            return None
+
+        elif all([use_keystoneauth, HAS_KEYSTONEAUTH]):
             self._new_init(username=username,
                            project_name=tenant_name,
                            auth_url=auth_url,

--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -19,6 +19,14 @@ try:
     HAS_NEUTRON = True
 except ImportError:
     pass
+
+HAS_KEYSTONEAUTH = False
+try:
+    import keystoneauth1.loading
+    import keystoneauth1.session
+    HAS_KEYSTONEAUTH = True
+except ImportError:
+    pass
 # pylint: enable=import-error
 
 # Import salt libs
@@ -32,11 +40,15 @@ def check_neutron():
     return HAS_NEUTRON
 
 
+def check_keystone():
+    return HAS_KEYSTONEAUTH
+
+
 def sanitize_neutronclient(kwargs):
     variables = (
         'username', 'user_id', 'password', 'token', 'tenant_name',
         'tenant_id', 'auth_url', 'service_type', 'endpoint_type',
-        'region_name', 'endpoint_url', 'timeout', 'insecure',
+        'region_name', 'verify', 'endpoint_url', 'timeout', 'insecure',
         'ca_cert', 'retries', 'raise_error', 'session', 'auth'
     )
     ret = {}
@@ -53,22 +65,73 @@ class SaltNeutron(NeutronShell):
     Class for all neutronclient functions
     '''
 
-    def __init__(self, username, tenant_name, auth_url, password=None,
-                 region_name=None, service_type=None, **kwargs):
+    def __init__(
+        self,
+        username,
+        tenant_name,
+        auth_url,
+        password=None,
+        region_name=None,
+        os_auth_plugin=None,
+        use_keystoneauth=False,
+        **kwargs
+    ):
+
         '''
         Set up neutron credentials
         '''
-        if not HAS_NEUTRON:
-            return None
+        if all([use_keystoneauth, HAS_KEYSTONEAUTH]):
+            self._new_init(username=username,
+                           project_name=tenant_name,
+                           auth_url=auth_url,
+                           region_name=region_name,
+                           os_auth_plugin=os_auth_plugin,
+                           password=password,
+                           **kwargs)
+        else:
+            self._old_init(username=username,
+                           tenant_name=tenant_name,
+                           auth_url=auth_url,
+                           region_name=region_name,
+                           os_auth_plugin=os_auth_plugin,
+                           password=password,
+                           **kwargs)
 
+    def _new_init(self, username, project_name, auth_url, region_name, password, os_auth_plugin, auth=None, verify=True, **kwargs):
+        if auth is None:
+            auth = {}
+
+        loader = keystoneauth1.loading.get_plugin_loader(os_auth_plugin or 'password')
+
+        self.client_kwargs = kwargs.copy()
+        self.kwargs = auth.copy()
+
+        self.kwargs['username'] = username
+        self.kwargs['project_name'] = project_name
+        self.kwargs['auth_url'] = auth_url
+        self.kwargs['password'] = password
+        if auth_url.endswith('3'):
+            self.kwargs['user_domain_name'] = kwargs.get('user_domain_name', 'default')
+            self.kwargs['project_domain_name'] = kwargs.get('project_domain_name', 'default')
+
+        self.client_kwargs['region_name'] = region_name
+        self.client_kwargs['service_type'] = 'network'
+
+        self.client_kwargs = sanitize_neutronclient(self.client_kwargs)
+        options = loader.load_from_options(**self.kwargs)
+        self.session = keystoneauth1.session.Session(auth=options, verify=verify)
+        self.network_conn = client.Client(session=self.session, **self.client_kwargs)
+
+    def _old_init(self, username, tenant_name, auth_url, region_name, password, os_auth_plugin, auth=None, verify=True, **kwargs):
         self.kwargs = kwargs.copy()
 
         self.kwargs['username'] = username
         self.kwargs['tenant_name'] = tenant_name
         self.kwargs['auth_url'] = auth_url
-        self.kwargs['service_type'] = service_type
+        self.kwargs['service_type'] = 'network'
         self.kwargs['password'] = password
         self.kwargs['region_name'] = region_name
+        self.kwargs['verify'] = verify
 
         self.kwargs = sanitize_neutronclient(self.kwargs)
 

--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -72,6 +72,7 @@ class SaltNeutron(NeutronShell):
         auth_url,
         password=None,
         region_name=None,
+        service_type='network',
         os_auth_plugin=None,
         use_keystoneauth=False,
         **kwargs
@@ -88,6 +89,7 @@ class SaltNeutron(NeutronShell):
                            project_name=tenant_name,
                            auth_url=auth_url,
                            region_name=region_name,
+                           service_type=service_type,
                            os_auth_plugin=os_auth_plugin,
                            password=password,
                            **kwargs)
@@ -96,11 +98,12 @@ class SaltNeutron(NeutronShell):
                            tenant_name=tenant_name,
                            auth_url=auth_url,
                            region_name=region_name,
+                           service_type=service_type,
                            os_auth_plugin=os_auth_plugin,
                            password=password,
                            **kwargs)
 
-    def _new_init(self, username, project_name, auth_url, region_name, password, os_auth_plugin, auth=None, verify=True, **kwargs):
+    def _new_init(self, username, project_name, auth_url, region_name, service_type, password, os_auth_plugin, auth=None, verify=True, **kwargs):
         if auth is None:
             auth = {}
 
@@ -118,20 +121,20 @@ class SaltNeutron(NeutronShell):
             self.kwargs['project_domain_name'] = kwargs.get('project_domain_name', 'default')
 
         self.client_kwargs['region_name'] = region_name
-        self.client_kwargs['service_type'] = 'network'
+        self.client_kwargs['service_type'] = service_type
 
         self.client_kwargs = sanitize_neutronclient(self.client_kwargs)
         options = loader.load_from_options(**self.kwargs)
         self.session = keystoneauth1.session.Session(auth=options, verify=verify)
         self.network_conn = client.Client(session=self.session, **self.client_kwargs)
 
-    def _old_init(self, username, tenant_name, auth_url, region_name, password, os_auth_plugin, auth=None, verify=True, **kwargs):
+    def _old_init(self, username, tenant_name, auth_url, region_name, service_type, password, os_auth_plugin, auth=None, verify=True, **kwargs):
         self.kwargs = kwargs.copy()
 
         self.kwargs['username'] = username
         self.kwargs['tenant_name'] = tenant_name
         self.kwargs['auth_url'] = auth_url
-        self.kwargs['service_type'] = 'network'
+        self.kwargs['service_type'] = service_type
         self.kwargs['password'] = password
         self.kwargs['region_name'] = region_name
         self.kwargs['verify'] = verify


### PR DESCRIPTION
### What does this PR do?
Modifies the existing Neutron Client to support Keystone Auth

### What issues does this PR fix or reference?
This is the Neutron version of issue #37824 which relates to the Nova Salt-Cloud driver
This issue liberates code from the nova implementation merged here:
@gtmanfred  #38647
and my own addition of SSL verification merged here:
@Enquier #40752

### Previous Behavior
Neutron client unable to use v3 of Openstack identity api due to ssl verification error.

### New Behavior
Neutron client now able to use KeystoneAuth similar to Recent additions in Nova Cloud Module

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
