### PR TITLE
Prevent creating cron for user when cron.absent or cron.rm_job is called

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -604,10 +604,10 @@ def rm_job(user,
     if rm_ is not None:
         lst['crons'].pop(rm_)
         ret = 'removed'
-    comdat = _write_cron_lines(user, _render_tab(lst))
-    if comdat['retcode']:
-        # Failed to commit, return the error
-        return comdat['stderr']
+        comdat = _write_cron_lines(user, _render_tab(lst))
+        if comdat['retcode']:
+            # Failed to commit, return the error
+            return comdat['stderr']
     return ret
 
 rm = salt.utils.alias_function(rm_job, 'rm')


### PR DESCRIPTION
### What does this PR do?
Prevents creating a crontab for a user if none is present when cron.absent or cron.rm_job is called.

### What issues does this PR fix or reference?
#41063

### Previous Behavior
When cron.absent or cron.rm_job was called if a crontab did not exist for a user a new one was created with the value of 'TAG' from cron.py

### New Behavior
When cron.absent or cron.rm_job is called if a crontab does not exist for a given user then a new one is not created

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
