### PR TITLE
Add documentation key to systemd service files

### DIFF
--- a/pkg/salt-api.service
+++ b/pkg/salt-api.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=The Salt API
+Documentation=man:salt-api(1) file:///usr/share/doc/salt/html/contents.html https://docs.saltstack.com/en/latest/contents.html
 After=network.target
 
 [Service]

--- a/pkg/salt-master.service
+++ b/pkg/salt-master.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=The Salt Master Server
+Documentation=man:salt-master(1) file:///usr/share/doc/salt/html/contents.html https://docs.saltstack.com/en/latest/contents.html
 After=network.target
 
 [Service]

--- a/pkg/salt-minion.service
+++ b/pkg/salt-minion.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=The Salt Minion
+Documentation=man:salt-minion(1) file:///usr/share/doc/salt/html/contents.html https://docs.saltstack.com/en/latest/contents.html
 After=network.target
 
 [Service]

--- a/pkg/salt-proxy@.service
+++ b/pkg/salt-proxy@.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=salt-proxy service
+Documentation=man:salt-proxy(1) file:///usr/share/doc/salt/html/contents.html https://docs.saltstack.com/en/latest/contents.html
 After=network.target
 
 [Service]

--- a/pkg/salt-syndic.service
+++ b/pkg/salt-syndic.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=The Salt Master Server
+Documentation=man:salt-syndic(1) file:///usr/share/doc/salt/html/contents.html https://docs.saltstack.com/en/latest/contents.html
 After=network.target
 
 [Service]


### PR DESCRIPTION
Documentation for systemd service files can be automatically viewed using systemctl help servicename if this field is present. Thus add the relevant man page, the local and online documentation to the
documentation key.