### PR TITLE
Wildcards for Zypper

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -387,7 +387,7 @@ class Wildcard(object):
         if not version:
             return
 
-        exact_version = re.sub(r'[<>=]*', '', version)
+        exact_version = re.sub(r'[<>=+]*', '', version)
         self._op = version.replace(exact_version, '') or None
         if self._op and self._op not in self.Z_OP:
             raise CommandExecutionError('Zypper do not supports operator "{0}".'.format(self._op))

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -389,6 +389,8 @@ class Wildcard(object):
 
         exact_version = re.sub(r'[<>=]*', '', version)
         self._op = version.replace(exact_version, '') or None
+        if self._op and self._op not in self.Z_OP:
+            raise CommandExecutionError('Zypper do not supports operator "{0}".'.format(self._op))
         self.version = exact_version
 
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1069,7 +1069,7 @@ def install(name=None,
     if pkg_params is None or len(pkg_params) == 0:
         return {}
 
-    version_num = version
+    version_num = Wildcard(__zypper__)(name, version)
     if version_num:
         if pkgs is None and sources is None:
             # Allow "version" to work for single package target

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -21,6 +21,10 @@ import re
 import os
 import time
 import datetime
+try:
+    from distutils.version import LooseVersion
+except ImportError:
+    LooseVersion = None
 
 # Import 3rd-party libs
 # pylint: disable=import-error,redefined-builtin,no-name-in-module

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -347,11 +347,12 @@ class Wildcard(object):
         :param pkg_version: 
         :return: 
         '''
-        self.name = pkg_name
-        self.version = pkg_version
-        versions = sorted([LooseVersion and LooseVersion(vrs) or vrs
-                           for vrs in self._get_scope_versions(self._get_available_versions())])
-        return versions and versions[-1] or None
+        if pkg_version:
+            self.name = pkg_name
+            self.version = pkg_version
+            versions = sorted([LooseVersion and LooseVersion(vrs) or vrs
+                               for vrs in self._get_scope_versions(self._get_available_versions())])
+            return versions and '{0}'.format(versions[-1]) or None
 
     def _get_available_versions(self):
         '''

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -22,7 +22,7 @@ import os
 import time
 import datetime
 try:
-    from distutils.version import LooseVersion
+    from salt.utils.versions import LooseVersion
 except ImportError:
     LooseVersion = None
 
@@ -326,7 +326,7 @@ class Wildcard(object):
        '1.2.3.4*' is '1.2.3.4.whatever.is.here' and is equal to:
        '1.2.3.4 >= and < 1.2.3.5'
 
-    :param ptn: Pattern 
+    :param ptn: Pattern
     :return: Query range
     '''
 
@@ -346,9 +346,9 @@ class Wildcard(object):
         '''
         Convert a string wildcard to a zypper query.
 
-        :param pkg_name: 
-        :param pkg_version: 
-        :return: 
+        :param pkg_name:
+        :param pkg_version:
+        :return:
         '''
         if pkg_version:
             self.name = pkg_name
@@ -360,7 +360,7 @@ class Wildcard(object):
     def _get_available_versions(self):
         '''
         Get available versions of the package.
-        :return: 
+        :return:
         '''
         solvables = self.zypper.nolock.xml.call('se', '-xv', self.name).getElementsByTagName('solvable')
         if not solvables:
@@ -373,7 +373,7 @@ class Wildcard(object):
         '''
         Get available difference between next possible matches.
 
-        :return: 
+        :return:
         '''
         get_in_versions = []
         for p_version in pkg_versions:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -349,7 +349,9 @@ class Wildcard(object):
         '''
         self.name = pkg_name
         self.version = pkg_version
-        versions = self._get_available_versions()
+        versions = sorted([LooseVersion and LooseVersion(vrs) or vrs
+                           for vrs in self._get_scope_versions(self._get_available_versions())])
+        return versions and versions[-1] or None
 
     def _get_available_versions(self):
         '''
@@ -363,13 +365,17 @@ class Wildcard(object):
         return sorted(set([slv.getAttribute(self._attr_solvable_version)
                            for slv in solvables if slv.getAttribute(self._attr_solvable_version)]))
 
-    def _get_scope_versions(self):
+    def _get_scope_versions(self, pkg_versions):
         '''
         Get available difference between next possible matches.
 
         :return: 
         '''
-        self.version
+        get_in_versions = []
+        for p_version in pkg_versions:
+            if fnmatch.fnmatch(p_version, self.version):
+                get_in_versions.append(p_version)
+        return get_in_versions
 
 
 def _systemd_scope():

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -313,6 +313,61 @@ class _Zypper(object):
 __zypper__ = _Zypper()
 
 
+class Wildcard(object):
+    '''
+    .. versionadded:: Nitrogen
+
+    Converts string wildcard to a zypper query.
+    Example:
+       '1.2.3.4*' is '1.2.3.4.whatever.is.here' and is equal to:
+       '1.2.3.4 >= and < 1.2.3.5'
+
+    :param ptn: Pattern 
+    :return: Query range
+    '''
+
+    def __init__(self, zypper):
+        '''
+        :type zypper: a reference to an instance of a _Zypper class.
+        '''
+        self.name = None
+        self.version = None
+        self.zypper = zypper
+        self._attr_solvable_version = 'edition'
+
+    def __call__(self, pkg_name, pkg_version):
+        '''
+        Convert a string wildcard to a zypper query.
+
+        :param pkg_name: 
+        :param pkg_version: 
+        :return: 
+        '''
+        self.name = pkg_name
+        self.version = pkg_version
+        versions = self._get_available_versions()
+
+    def _get_available_versions(self):
+        '''
+        Get available versions of the package.
+        :return: 
+        '''
+        solvables = self.zypper.nolock.xml.call('se', '-xv', self.name).getElementsByTagName('solvable')
+        if not solvables:
+            raise CommandExecutionError('No packages found matching \'{0}\''.format(self.name))
+
+        return sorted(set([slv.getAttribute(self._attr_solvable_version)
+                           for slv in solvables if slv.getAttribute(self._attr_solvable_version)]))
+
+    def _get_scope_versions(self):
+        '''
+        Get available difference between next possible matches.
+
+        :return: 
+        '''
+        self.version
+
+
 def _systemd_scope():
     return salt.utils.systemd.has_scope(__context__) \
         and __salt__['config.get']('systemd.scope', True)

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -390,7 +390,7 @@ class Wildcard(object):
         if not version:
             return
 
-        exact_version = re.sub('[<>=]*', '', version)
+        exact_version = re.sub(r'[<>=]*', '', version)
         self._op = version.replace(exact_version, '') or None
         self.version = exact_version
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -21,10 +21,7 @@ import re
 import os
 import time
 import datetime
-try:
-    from salt.utils.versions import LooseVersion
-except ImportError:
-    LooseVersion = None
+from salt.utils.versions import LooseVersion
 
 # Import 3rd-party libs
 # pylint: disable=import-error,redefined-builtin,no-name-in-module
@@ -353,7 +350,7 @@ class Wildcard(object):
         if pkg_version:
             self.name = pkg_name
             self._set_version(pkg_version)  # Dissects possible operator
-            versions = sorted([LooseVersion and LooseVersion(vrs) or vrs
+            versions = sorted([LooseVersion(vrs)
                                for vrs in self._get_scope_versions(self._get_available_versions())])
             return versions and '{0}{1}'.format(self._op or '', versions[-1]) or None
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -330,6 +330,8 @@ class Wildcard(object):
     :return: Query range
     '''
 
+    Z_OP = ['<', '<=', '=', '>=', '>']
+
     def __init__(self, zypper):
         '''
         :type zypper: a reference to an instance of a _Zypper class.
@@ -338,6 +340,7 @@ class Wildcard(object):
         self.version = None
         self.zypper = zypper
         self._attr_solvable_version = 'edition'
+        self._op = None
 
     def __call__(self, pkg_name, pkg_version):
         '''
@@ -349,10 +352,10 @@ class Wildcard(object):
         '''
         if pkg_version:
             self.name = pkg_name
-            self.version = pkg_version
+            self._set_version(pkg_version)  # Dissects possible operator
             versions = sorted([LooseVersion and LooseVersion(vrs) or vrs
                                for vrs in self._get_scope_versions(self._get_available_versions())])
-            return versions and '{0}'.format(versions[-1]) or None
+            return versions and '{0}{1}'.format(self._op or '', versions[-1]) or None
 
     def _get_available_versions(self):
         '''
@@ -377,6 +380,19 @@ class Wildcard(object):
             if fnmatch.fnmatch(p_version, self.version):
                 get_in_versions.append(p_version)
         return get_in_versions
+
+    def _set_version(self, version):
+        '''
+        Stash operator from the version, if any.
+
+        :return:
+        '''
+        if not version:
+            return
+
+        exact_version = re.sub('[<>=]*', '', version)
+        self._op = version.replace(exact_version, '') or None
+        self.version = exact_version
 
 
 def _systemd_scope():

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -988,11 +988,11 @@ def installed(
         **WILDCARD VERSIONS**
 
         As of the Nitrogen release, this state now supports wildcards in
-        package versions for Debian/Ubuntu, RHEL/CentOS, Arch Linux, and their
-        derivatives. Using wildcards can be useful for packages where the
-        release name is built into the version in some way, such as for
-        RHEL/CentOS which typically has version numbers like ``1.2.34-5.el7``.
-        An example of the usage for this would be:
+        package versions for SUSE SLES/Leap/Tumbleweed, Debian/Ubuntu, RHEL/CentOS,
+        Arch Linux, and their derivatives. Using wildcards can be useful for
+        packages where the release name is built into the version in some way,
+        such as for RHEL/CentOS which typically has version numbers like
+        ``1.2.34-5.el7``. An example of the usage for this would be:
 
         .. code-block:: yaml
 

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -952,3 +952,20 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         _zpr = MagicMock()
         _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
         assert zypper.Wildcard(_zpr)('libzypp', '16.2.*-2*') == [u'16.2.5-25.1', u'16.2.6-27.9.1']
+
+    def test_wildcard_to_query_exact_match_at_end(self):
+        '''
+        Test wildcard to query match exact pattern at the end
+        :return:
+        '''
+        xmldoc = """<?xml version='1.0'?><stream>
+        <search-result version="0.0"><solvable-list>
+        <solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="16.2.5-25.1" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="16.2.6-27.9.1" arch="x86_64" repository="foo"/>
+        </solvable-list></search-result></stream>
+        """
+
+        _zpr = MagicMock()
+        _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
+        assert zypper.Wildcard(_zpr)('libzypp', '16.2.5*') == [u'16.2.5-25.1']

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -1032,3 +1032,21 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
         assert zypper.Wildcard(_zpr)('libzypp', None) is None
 
+    def test_wildcard_to_query_typecheck(self):
+        '''
+        Test wildcard to query typecheck.
+
+        :return:
+        '''
+        xmldoc = """<?xml version='1.0'?><stream>
+        <search-result version="0.0"><solvable-list>
+        <solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="16.2.5-25.1" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="17.2.6-27.9.1" arch="x86_64" repository="foo"/>
+        </solvable-list></search-result></stream>
+        """
+        _zpr = MagicMock()
+        _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
+
+        assert type(zypper.Wildcard(_zpr)('libzypp', '*.1')) is type('')
+

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -1050,3 +1050,26 @@ Repository 'DUMMY' not found by its alias, number, or URI.
 
         assert type(zypper.Wildcard(_zpr)('libzypp', '*.1')) is type('')
 
+    def test_wildcard_to_query_condition_preservation(self):
+        '''
+        Test wildcard to query Zypper condition preservation.
+
+        :return:
+        '''
+        xmldoc = """<?xml version='1.0'?><stream>
+        <search-result version="0.0"><solvable-list>
+        <solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="16.2.5-25.1" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="17.2.6-27.9.1" arch="x86_64" repository="foo"/>
+        </solvable-list></search-result></stream>
+        """
+        _zpr = MagicMock()
+        _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
+
+        for op in zypper.Wildcard.Z_OP:
+            assert zypper.Wildcard(_zpr)('libzypp', '{0}*.1'.format(op)) == '{0}17.2.6-27.9.1'.format(op)
+
+        # Auto-fix feature: moves operator from end to front
+        for op in zypper.Wildcard.Z_OP:
+            assert zypper.Wildcard(_zpr)('libzypp', '16*{0}'.format(op)) == '{0}16.2.5-25.1'.format(op)
+

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -969,3 +969,20 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         _zpr = MagicMock()
         _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
         assert zypper.Wildcard(_zpr)('libzypp', '16.2.5*') == [u'16.2.5-25.1']
+
+    def test_wildcard_to_query_exact_match_at_beginning(self):
+        '''
+        Test wildcard to query match exact pattern at the beginning
+        :return:
+        '''
+        xmldoc = """<?xml version='1.0'?><stream>
+        <search-result version="0.0"><solvable-list>
+        <solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="16.2.5-25.1" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="17.2.6-27.9.1" arch="x86_64" repository="foo"/>
+        </solvable-list></search-result></stream>
+        """
+
+        _zpr = MagicMock()
+        _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
+        assert zypper.Wildcard(_zpr)('libzypp', '*.1') == [u'16.2.5-25.1', u'17.2.6-27.9.1']

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -918,7 +918,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
 
     def test_wildcard_to_query_match_all(self):
         '''
-        Test wildcard to query
+        Test wildcard to query match all pattern
         :return: 
         '''
         xmldoc = """<?xml version='1.0'?><stream>

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -920,7 +920,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
     def test_wildcard_to_query_match_all(self):
         '''
         Test wildcard to query match all pattern
-        :return: 
+        :return:
         '''
         xmldoc = """<?xml version='1.0'?><stream>
         <search-result version="0.0"><solvable-list>
@@ -1047,8 +1047,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         """
         _zpr = MagicMock()
         _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
-
-        assert type(zypper.Wildcard(_zpr)('libzypp', '*.1')) is type('')
+        assert isinstance(zypper.Wildcard(_zpr)('libzypp', '*.1'), str)
 
     def test_wildcard_to_query_condition_preservation(self):
         '''
@@ -1072,4 +1071,3 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         # Auto-fix feature: moves operator from end to front
         for op in zypper.Wildcard.Z_OP:
             assert zypper.Wildcard(_zpr)('libzypp', '16*{0}'.format(op)) == '{0}16.2.5-25.1'.format(op)
-

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -6,6 +6,7 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
+from xml.dom import minidom
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -935,8 +936,19 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
         assert zypper.Wildcard(_zpr)('libzypp', '*') == [u'16.2.4-19.5', u'16.3.2-25.1', u'16.5.2-27.9.1']
 
+    def test_wildcard_to_query_multiple_asterisk(self):
+        '''
+        Test wildcard to query match multiple asterisk
+        :return:
+        '''
+        xmldoc = """<?xml version='1.0'?><stream>
+        <search-result version="0.0"><solvable-list>
+        <solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="16.2.5-25.1" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="16.2.6-27.9.1" arch="x86_64" repository="foo"/>
+        </solvable-list></search-result></stream>
         """
-        solvables = minidom.parseString(xmldoc)
+
         _zpr = MagicMock()
-        _zpr.nolock.xml.call = MagicMock(return_value=solvables)
-        wildcard = zypper.Wildcard(_zpr)
+        _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
+        assert zypper.Wildcard(_zpr)('libzypp', '16.2.*-2*') == [u'16.2.5-25.1', u'16.2.6-27.9.1']

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -1071,3 +1071,22 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         # Auto-fix feature: moves operator from end to front
         for op in zypper.Wildcard.Z_OP:
             assert zypper.Wildcard(_zpr)('libzypp', '16*{0}'.format(op)) == '{0}16.2.5-25.1'.format(op)
+
+    def test_wildcard_to_query_unsupported_operators(self):
+        '''
+        Test wildcard to query unsupported operators.
+
+        :return:
+        '''
+        xmldoc = """<?xml version='1.0'?><stream>
+        <search-result version="0.0"><solvable-list>
+        <solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="16.2.5-25.1" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="17.2.6-27.9.1" arch="x86_64" repository="foo"/>
+        </solvable-list></search-result></stream>
+        """
+        _zpr = MagicMock()
+        _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
+        with self.assertRaises(CommandExecutionError):
+            for op in ['>>', '==', '<<', '+']:
+                zypper.Wildcard(_zpr)('libzypp', '{0}*.1'.format(op))

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -922,16 +922,19 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         :return: 
         '''
         xmldoc = """<?xml version='1.0'?><stream>
-<message type="info">Loading repository data...</message>
-<message type="info">Reading installed packages...</message>
-<search-result version="0.0"><solvable-list>
-<solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="SLE-12-SP2-x86_64-Pool"/>
-<solvable status="not-installed" name="libzypp" kind="srcpackage" edition="16.3.2-25.1" arch="noarch" repository="SLE-12-SP2-x86_64-Update"/>
-<solvable status="not-installed" name="libzypp" kind="srcpackage" edition="16.5.2-27.9.1" arch="noarch" repository="SLE-12-SP2-x86_64-Update"/>
-<solvable status="other-version" name="libzypp" kind="package" edition="16.3.2-25.1" arch="x86_64" repository="SLE-12-SP2-x86_64-Update"/>
-<solvable status="other-version" name="libzypp" kind="package" edition="16.5.2-27.9.1" arch="x86_64" repository="SLE-12-SP2-x86_64-Update"/>
-<solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="(System Packages)"/>
-</solvable-list></search-result></stream>
+        <search-result version="0.0"><solvable-list>
+        <solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="SLE-12-SP2-x86_64-Pool"/>
+        <solvable status="not-installed" name="libzypp" kind="srcpackage" edition="16.3.2-25.1" arch="noarch" repository="SLE-12-SP2-x86_64-Update"/>
+        <solvable status="not-installed" name="libzypp" kind="srcpackage" edition="16.5.2-27.9.1" arch="noarch" repository="SLE-12-SP2-x86_64-Update"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="16.3.2-25.1" arch="x86_64" repository="SLE-12-SP2-x86_64-Update"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="16.5.2-27.9.1" arch="x86_64" repository="SLE-12-SP2-x86_64-Update"/>
+        <solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="(System Packages)"/>
+        </solvable-list></search-result></stream>
+                """
+        _zpr = MagicMock()
+        _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
+        assert zypper.Wildcard(_zpr)('libzypp', '*') == [u'16.2.4-19.5', u'16.3.2-25.1', u'16.5.2-27.9.1']
+
         """
         solvables = minidom.parseString(xmldoc)
         _zpr = MagicMock()

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -934,7 +934,9 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 """
         _zpr = MagicMock()
         _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
-        assert zypper.Wildcard(_zpr)('libzypp', '*') == [u'16.2.4-19.5', u'16.3.2-25.1', u'16.5.2-27.9.1']
+        wcard = zypper.Wildcard(_zpr)
+        wcard.name, wcard.version = 'libzypp', '*'
+        assert wcard._get_scope_versions(wcard._get_available_versions()) == [u'16.2.4-19.5', u'16.3.2-25.1', u'16.5.2-27.9.1']
 
     def test_wildcard_to_query_multiple_asterisk(self):
         '''
@@ -951,7 +953,9 @@ Repository 'DUMMY' not found by its alias, number, or URI.
 
         _zpr = MagicMock()
         _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
-        assert zypper.Wildcard(_zpr)('libzypp', '16.2.*-2*') == [u'16.2.5-25.1', u'16.2.6-27.9.1']
+        wcard = zypper.Wildcard(_zpr)
+        wcard.name, wcard.version = 'libzypp', '16.2.*-2*'
+        assert wcard._get_scope_versions(wcard._get_available_versions()) == [u'16.2.5-25.1', u'16.2.6-27.9.1']
 
     def test_wildcard_to_query_exact_match_at_end(self):
         '''
@@ -968,7 +972,9 @@ Repository 'DUMMY' not found by its alias, number, or URI.
 
         _zpr = MagicMock()
         _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
-        assert zypper.Wildcard(_zpr)('libzypp', '16.2.5*') == [u'16.2.5-25.1']
+        wcard = zypper.Wildcard(_zpr)
+        wcard.name, wcard.version = 'libzypp', '16.2.5*'
+        assert wcard._get_scope_versions(wcard._get_available_versions()) == [u'16.2.5-25.1']
 
     def test_wildcard_to_query_exact_match_at_beginning(self):
         '''
@@ -985,4 +991,6 @@ Repository 'DUMMY' not found by its alias, number, or URI.
 
         _zpr = MagicMock()
         _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
-        assert zypper.Wildcard(_zpr)('libzypp', '*.1') == [u'16.2.5-25.1', u'17.2.6-27.9.1']
+        wcard = zypper.Wildcard(_zpr)
+        wcard.name, wcard.version = 'libzypp', '*.1'
+        assert wcard._get_scope_versions(wcard._get_available_versions()) == [u'16.2.5-25.1', u'17.2.6-27.9.1']

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -916,7 +916,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 '--gpg-auto-import-keys', 'mr', '--refresh', name
             )
 
-    def test_wildcard_to_query(self):
+    def test_wildcard_to_query_match_all(self):
         '''
         Test wildcard to query
         :return: 

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -915,3 +915,25 @@ Repository 'DUMMY' not found by its alias, number, or URI.
             zypper.__zypper__.refreshable.xml.call.assert_called_once_with(
                 '--gpg-auto-import-keys', 'mr', '--refresh', name
             )
+
+    def test_wildcard_to_query(self):
+        '''
+        Test wildcard to query
+        :return: 
+        '''
+        xmldoc = """<?xml version='1.0'?><stream>
+<message type="info">Loading repository data...</message>
+<message type="info">Reading installed packages...</message>
+<search-result version="0.0"><solvable-list>
+<solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="SLE-12-SP2-x86_64-Pool"/>
+<solvable status="not-installed" name="libzypp" kind="srcpackage" edition="16.3.2-25.1" arch="noarch" repository="SLE-12-SP2-x86_64-Update"/>
+<solvable status="not-installed" name="libzypp" kind="srcpackage" edition="16.5.2-27.9.1" arch="noarch" repository="SLE-12-SP2-x86_64-Update"/>
+<solvable status="other-version" name="libzypp" kind="package" edition="16.3.2-25.1" arch="x86_64" repository="SLE-12-SP2-x86_64-Update"/>
+<solvable status="other-version" name="libzypp" kind="package" edition="16.5.2-27.9.1" arch="x86_64" repository="SLE-12-SP2-x86_64-Update"/>
+<solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="(System Packages)"/>
+</solvable-list></search-result></stream>
+        """
+        solvables = minidom.parseString(xmldoc)
+        _zpr = MagicMock()
+        _zpr.nolock.xml.call = MagicMock(return_value=solvables)
+        wildcard = zypper.Wildcard(_zpr)

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -1014,3 +1014,21 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         assert zypper.Wildcard(_zpr)('libzypp', '16.2*') == '16.2.5-25.1'
         assert zypper.Wildcard(_zpr)('libzypp', '*6-*') == '17.2.6-27.9.1'
         assert zypper.Wildcard(_zpr)('libzypp', '*.1') == '17.2.6-27.9.1'
+
+    def test_wildcard_to_query_noversion(self):
+        '''
+        Test wildcard to query when no version has been passed on.
+
+        :return:
+        '''
+        xmldoc = """<?xml version='1.0'?><stream>
+        <search-result version="0.0"><solvable-list>
+        <solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="16.2.5-25.1" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="17.2.6-27.9.1" arch="x86_64" repository="foo"/>
+        </solvable-list></search-result></stream>
+        """
+        _zpr = MagicMock()
+        _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
+        assert zypper.Wildcard(_zpr)('libzypp', None) is None
+

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -994,3 +994,23 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         wcard = zypper.Wildcard(_zpr)
         wcard.name, wcard.version = 'libzypp', '*.1'
         assert wcard._get_scope_versions(wcard._get_available_versions()) == [u'16.2.5-25.1', u'17.2.6-27.9.1']
+
+    def test_wildcard_to_query_usage(self):
+        '''
+        Test wildcard to query usage.
+
+        :return:
+        '''
+        xmldoc = """<?xml version='1.0'?><stream>
+        <search-result version="0.0"><solvable-list>
+        <solvable status="installed" name="libzypp" kind="package" edition="16.2.4-19.5" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="16.2.5-25.1" arch="x86_64" repository="foo"/>
+        <solvable status="other-version" name="libzypp" kind="package" edition="17.2.6-27.9.1" arch="x86_64" repository="foo"/>
+        </solvable-list></search-result></stream>
+        """
+        _zpr = MagicMock()
+        _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
+        assert zypper.Wildcard(_zpr)('libzypp', '16.2.4*') == '16.2.4-19.5'
+        assert zypper.Wildcard(_zpr)('libzypp', '16.2*') == '16.2.5-25.1'
+        assert zypper.Wildcard(_zpr)('libzypp', '*6-*') == '17.2.6-27.9.1'
+        assert zypper.Wildcard(_zpr)('libzypp', '*.1') == '17.2.6-27.9.1'


### PR DESCRIPTION
### What does this PR do?

Adds a wildcards feature, whether versions can be referenced by a wildcard `*` just like Debian/Ubuntu, RHEL/CentOS, Arch Linux does. Example:

```yaml
best_editor_ever:
  pkg.installed:
    - name: emacs
    - version: '24*'
```

But it can do even better than this, since Zypper supports operators (more, less, equal etc). So you can also do now something like:

```yaml
best_editor_ever:
  pkg.installed:
    - name: emacs
    - version: '>23*'
```
This will resolve to the version `24.3-19.2` currently available for SLES. Yes, wildcards are _also_ supported anywhere in the version, i.e. `*24*`, `*123` are also valid patterns.

:sunglasses: 

### Tests written?

Yes
