### PR TITLE
Fixes to ipc transport

### DIFF
--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -185,10 +185,9 @@ class IPCServer(object):
                 # and continue.
                 if wire_bytes:
                     log.trace('Exception occured but wire_bytes data exists, '
-                              'spurious exception: {}'.format(exc))
-                    pass
+                              'spurious exception: {0}'.format(exc))
                 else:
-                    log.error('Exception occurred while ',
+                    log.error('Exception occurred while '
                               'handling stream: {0}'.format(exc))
 
     def handle_connection(self, connection, address):

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -192,7 +192,7 @@ class IPCServer(object):
                           'handling stream: {0}'.format(exc))
 
     def handle_connection(self, connection, address):
-        log.trace('IPCServer: Handling connection ',
+        log.trace('IPCServer: Handling connection '
                   'to address: {0}'.format(address))
         try:
             stream = IOStream(

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -178,17 +178,18 @@ class IPCServer(object):
                 log.trace('Client disconnected ',
                           'from IPC {0}'.format(self.socket_path))
                 break
-            except Exception as exc:
-                # On occasion an exception will occur which results in the
-                # event not returning properly, even though the wire_bytes
-                # is correctly populated.  In this situation, we log to trace
-                # and continue.
-                if wire_bytes:
-                    log.trace('Exception occured but wire_bytes data exists, '
-                              'spurious exception: {0}'.format(exc))
+            except socket.error as e:
+                # On occasion an exception will occur with
+                # an error code of 0, it's a spurious exception.
+                if e.errno == 0:
+                    log.trace('Exception occured with error number 0, '
+                              'spurious exception: {0}'.format(e))
                 else:
                     log.error('Exception occurred while '
-                              'handling stream: {0}'.format(exc))
+                              'handling stream: {0}'.format(e))
+            except Exception as exc:
+                log.error('Exception occurred while '
+                          'handling stream: {0}'.format(exc))
 
     def handle_connection(self, connection, address):
         log.trace('IPCServer: Handling connection ',

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -175,13 +175,25 @@ class IPCServer(object):
                     body = framed_msg['body']
                     self.io_loop.spawn_callback(self.payload_handler, body, write_callback(stream, framed_msg['head']))
             except tornado.iostream.StreamClosedError:
-                log.trace('Client disconnected from IPC {0}'.format(self.socket_path))
+                log.trace('Client disconnected ',
+                          'from IPC {0}'.format(self.socket_path))
                 break
             except Exception as exc:
-                log.error('Exception occurred while handling stream: {0}'.format(exc))
+                # On occasion an exception will occur which results in the
+                # event not returning properly, even though the wire_bytes
+                # is correctly populated.  In this situation, we log to trace
+                # and continue.
+                if wire_bytes:
+                    log.trace('Exception occured but wire_bytes data exists, '
+                              'spurious exception: {}'.format(exc))
+                    pass
+                else:
+                    log.error('Exception occurred while ',
+                              'handling stream: {0}'.format(exc))
 
     def handle_connection(self, connection, address):
-        log.trace('IPCServer: Handling connection to address: {0}'.format(address))
+        log.trace('IPCServer: Handling connection ',
+                  'to address: {0}'.format(address))
         try:
             stream = IOStream(
                 connection,

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -178,15 +178,15 @@ class IPCServer(object):
                 log.trace('Client disconnected '
                           'from IPC {0}'.format(self.socket_path))
                 break
-            except socket.error as e:
+            except socket.error as exc:
                 # On occasion an exception will occur with
                 # an error code of 0, it's a spurious exception.
-                if e.errno == 0:
+                if exc.errno == 0:
                     log.trace('Exception occured with error number 0, '
-                              'spurious exception: {0}'.format(e))
+                              'spurious exception: {0}'.format(exc))
                 else:
                     log.error('Exception occurred while '
-                              'handling stream: {0}'.format(e))
+                              'handling stream: {0}'.format(exc))
             except Exception as exc:
                 log.error('Exception occurred while '
                           'handling stream: {0}'.format(exc))

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -175,7 +175,7 @@ class IPCServer(object):
                     body = framed_msg['body']
                     self.io_loop.spawn_callback(self.payload_handler, body, write_callback(stream, framed_msg['head']))
             except tornado.iostream.StreamClosedError:
-                log.trace('Client disconnected ',
+                log.trace('Client disconnected '
                           'from IPC {0}'.format(self.socket_path))
                 break
             except socket.error as e:


### PR DESCRIPTION
### What does this PR do?
On occasion an exception will occur which results in the  event not returning properly, even though the wire_bytes  is correctly populated. In this situation, we log to trace  and continue.

### What issues does this PR fix or reference?
#34460

### Previous Behavior
Previously spurious exceptions were causing logs to fill up and events to not return properly.

### New Behavior
If we detect an exception but the wire_bytes is populated, eg. the event data returned properly then continue on.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
