### PR TITLE
Naive attempt to fix db escaping with GRANT

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -521,8 +521,7 @@ def quote_identifier(identifier, for_grants=False):
         salt '*' mysql.quote_identifier 'foo`bar'
     '''
     if for_grants:
-        return '`' + identifier.replace('`', '``').replace('_', r'\_') \
-            .replace('%', r'\%%') + '`'
+        return '`' + identifier.replace('%', r'%%') + '`'
     else:
         return '`' + identifier.replace('`', '``').replace('%', '%%') + '`'
 
@@ -539,7 +538,6 @@ def _execute(cur, qry, args=None):
     this wrapper ensure this escape is not made if no arguments are used.
     '''
     if args is None or args == {}:
-        qry = qry.replace('%%', '%')
         log.debug('Doing query: {0}'.format(qry))
         return cur.execute(qry)
     else:


### PR DESCRIPTION
### What does this PR do?
This is a request for comment.  In attempting to diagnose https://github.com/saltstack/salt/issues/26920 I made this change to get the following state to work:

```
user3_grants:                                                                   
  mysql_grants.present:                                                         
    - grant: all privileges                                                     
    - database: projectA_%.*                                                    
    - user: user3                                                               
    - host: localhost
```

Specifically the `projectA_%.*`. It was basically impossible to get escaping to work correctly that would be acceptable to both yaml and the mysql engine. This change allows the above to work, but it quite likely removes needed escaping for other types of entries.

I'd like to get the input of others with a deeper understanding how the needed escaping here.