### PR TITLE
Add --no-parse CLI option to salt, salt-call, salt-run, and salt-ssh

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -184,7 +184,9 @@ class BaseCaller(object):
                 sdata['metadata'] = metadata
             args, kwargs = salt.minion.load_args_and_kwargs(
                 self.minion.functions[fun],
-                salt.utils.args.parse_input(self.opts['arg']),
+                salt.utils.args.parse_input(
+                    self.opts['arg'],
+                    no_parse=self.opts.get('no_parse', [])),
                 data=sdata)
             try:
                 with salt.utils.fopen(proc_fn, 'w+b') as fp_:

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -215,7 +215,9 @@ class SyncClientMixin(object):
             raise salt.exceptions.SaltInvocationError(
                 'kwarg must be formatted as a dictionary'
             )
-        arglist = salt.utils.args.parse_input(arg)
+        arglist = salt.utils.args.parse_input(
+            arg,
+            no_parse=self.opts.get('no_parse', []))
 
         # if you were passed kwarg, add it to arglist
         if kwarg:

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -787,7 +787,10 @@ class Single(object):
         Return the function name and the arg list
         '''
         fun = self.argv[0] if self.argv else ''
-        parsed = salt.utils.args.parse_input(self.argv[1:], condition=False)
+        parsed = salt.utils.args.parse_input(
+            self.argv[1:],
+            condition=False,
+            no_parse=self.opts.get('no_parse', []))
         args = parsed[0]
         kws = parsed[1]
         return fun, args, kws

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -263,9 +263,17 @@ def main(argv):  # pylint: disable=W0613
         '--metadata',
         '--out', 'json',
         '-l', 'quiet',
-        '-c', OPTIONS.saltdir,
-        '--',
-    ] + argv_prepared
+        '-c', OPTIONS.saltdir
+    ]
+
+    try:
+        if argv_prepared[-1].startswith('--no-parse='):
+            salt_argv.append(argv_prepared.pop(-1))
+    except (IndexError, TypeError):
+        pass
+
+    salt_argv.append('--')
+    salt_argv.extend(argv_prepared)
 
     sys.stderr.write('SALT_ARGV: {0}\n'.format(salt_argv))
 

--- a/salt/daemons/flo/jobber.py
+++ b/salt/daemons/flo/jobber.py
@@ -104,7 +104,9 @@ def shell_jobber(self):
             continue
         args, kwargs = salt.minion.load_args_and_kwargs(
             func,
-            salt.utils.args.parse_input(data['arg']),
+            salt.utils.args.parse_input(
+                data['arg'],
+                no_parse=data.get('no_parse', [])),
             data)
         cmd = ['salt-call',
                '--out', 'json',
@@ -287,7 +289,9 @@ class SaltRaetNixJobber(ioflo.base.deeding.Deed):
                 func = self.modules.value[data['fun']]
                 args, kwargs = salt.minion.load_args_and_kwargs(
                     func,
-                    salt.utils.args.parse_input(data['arg']),
+                    salt.utils.args.parse_input(
+                        data['arg'],
+                        no_parse=data.get('no_parse', [])),
                     data)
                 sys.modules[func.__module__].__context__['retcode'] = 0
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -851,7 +851,9 @@ class RemoteFuncs(object):
         opts = {}
         opts.update(self.opts)
         opts.update({'fun': load['fun'],
-                'arg': salt.utils.args.parse_input(load['arg']),
+                'arg': salt.utils.args.parse_input(
+                    load['arg'],
+                    no_parse=load.get('no_parse', [])),
                 'id': load['id'],
                 'doc': False,
                 'conf_file': self.opts['conf_file']})
@@ -901,7 +903,9 @@ class RemoteFuncs(object):
         # Set up the publication payload
         pub_load = {
             'fun': load['fun'],
-            'arg': salt.utils.args.parse_input(load['arg']),
+            'arg': salt.utils.args.parse_input(
+                load['arg'],
+                no_parse=load.get('no_parse', [])),
             'tgt_type': load.get('tgt_type', 'glob'),
             'tgt': load['tgt'],
             'ret': load['ret'],
@@ -954,7 +958,9 @@ class RemoteFuncs(object):
         # Set up the publication payload
         pub_load = {
             'fun': load['fun'],
-            'arg': salt.utils.args.parse_input(load['arg']),
+            'arg': salt.utils.args.parse_input(
+                load['arg'],
+                no_parse=load.get('no_parse', [])),
             'tgt_type': load.get('tgt_type', 'glob'),
             'tgt': load['tgt'],
             'ret': load['ret'],
@@ -1327,7 +1333,9 @@ class LocalFuncs(object):
                 'tgt': load['tgt'],
                 'user': load['user'],
                 'fun': load['fun'],
-                'arg': salt.utils.args.parse_input(load['arg']),
+                'arg': salt.utils.args.parse_input(
+                    load['arg'],
+                    no_parse=load.get('no_parse', [])),
                 'minions': minions,
             }
 
@@ -1379,7 +1387,9 @@ class LocalFuncs(object):
         # way that won't have a negative impact.
         pub_load = {
             'fun': load['fun'],
-            'arg': salt.utils.args.parse_input(load['arg']),
+            'arg': salt.utils.args.parse_input(
+                load['arg'],
+                no_parse=load.get('no_parse', [])),
             'tgt': load['tgt'],
             'jid': load['jid'],
             'ret': load['ret'],

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -288,34 +288,8 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
     invalid_kwargs = []
 
     for arg in args:
-        if isinstance(arg, six.string_types):
-            string_arg, string_kwarg = salt.utils.args.parse_input([arg], condition=False)  # pylint: disable=W0632
-            if string_arg:
-                # Don't append the version that was just derived from parse_cli
-                # above, that would result in a 2nd call to
-                # salt.utils.cli.yamlify_arg(), which could mangle the input.
-                _args.append(arg)
-            elif string_kwarg:
-                salt.utils.warn_until(
-                    'Nitrogen',
-                    'The list of function args and kwargs should be parsed '
-                    'by salt.utils.args.parse_input() before calling '
-                    'salt.minion.load_args_and_kwargs().'
-                )
-                if argspec.keywords or next(six.iterkeys(string_kwarg)) in argspec.args:
-                    # Function supports **kwargs or is a positional argument to
-                    # the function.
-                    _kwargs.update(string_kwarg)
-                else:
-                    # **kwargs not in argspec and parsed argument name not in
-                    # list of positional arguments. This keyword argument is
-                    # invalid.
-                    for key, val in six.iteritems(string_kwarg):
-                        invalid_kwargs.append('{0}={1}'.format(key, val))
-                continue
-
-        # if the arg is a dict with __kwarg__ == True, then its a kwarg
-        elif isinstance(arg, dict) and arg.pop('__kwarg__', False) is True:
+        if isinstance(arg, dict) and arg.pop('__kwarg__', False) is True:
+            # if the arg is a dict with __kwarg__ == True, then its a kwarg
             for key, val in six.iteritems(arg):
                 if argspec.keywords or key in argspec.args:
                     # Function supports **kwargs or is a positional argument to
@@ -329,7 +303,18 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
             continue
 
         else:
-            _args.append(arg)
+            string_kwarg = salt.utils.args.parse_input([arg], condition=False)[1]  # pylint: disable=W0632
+            if string_kwarg:
+                log.critical(
+                    'String kwarg(s) %s passed to '
+                    'salt.minion.load_args_and_kwargs(). This is no longer '
+                    'supported, so the kwarg(s) will be ignored. Arguments '
+                    'passed to salt.minion.load_args_and_kwargs() should be '
+                    'passed to salt.utils.args.parse_input() first to load '
+                    'and condition them properly.', string_kwarg
+                )
+            else:
+                _args.append(arg)
 
     if invalid_kwargs and not ignore_invalid:
         salt.utils.invalid_kwargs(invalid_kwargs)

--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -116,7 +116,8 @@ def _publish(
             'tok': tok,
             'tmo': timeout,
             'form': form,
-            'id': __opts__['id']}
+            'id': __opts__['id'],
+            'no_parse': __opts__.get('no_parse', [])}
 
     channel = salt.transport.Channel.factory(__opts__, master_uri=master_uri)
     try:
@@ -342,7 +343,8 @@ def runner(fun, arg=None, timeout=5):
             'arg': arg,
             'tok': tok,
             'tmo': timeout,
-            'id': __opts__['id']}
+            'id': __opts__['id'],
+            'no_parse': __opts__.get('no_parse', [])}
 
     channel = salt.transport.Channel.factory(__opts__)
     try:

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -81,7 +81,9 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         # through because there is no way to send name=value strings in the low
         # dict other than by including an `arg` array.
         arg, kwarg = salt.utils.args.parse_input(
-                low.pop('arg', []), condition=False)
+            low.pop('arg', []),
+            condition=False,
+            no_parse=self.opts.get('no_parse', []))
         kwarg.update(low.pop('kwarg', {}))
 
         # If anything hasn't been pop()'ed out of low by this point it must be
@@ -176,7 +178,9 @@ class Runner(RunnerClient):
                 verify_fun(self.functions, low['fun'])
                 args, kwargs = salt.minion.load_args_and_kwargs(
                     self.functions[low['fun']],
-                    salt.utils.args.parse_input(self.opts['arg']),
+                    salt.utils.args.parse_input(
+                        self.opts['arg'],
+                        no_parse=self.opts.get('no_parse', [])),
                     self.opts,
                 )
                 low['arg'] = args

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -40,20 +40,24 @@ def condition_input(args, kwargs):
     return ret
 
 
-def parse_input(args, condition=True):
+def parse_input(args, condition=True, no_parse=None):
     '''
     Parse out the args and kwargs from a list of input values. Optionally,
     return the args and kwargs without passing them to condition_input().
 
     Don't pull args with key=val apart if it has a newline in it.
     '''
+    if no_parse is None:
+        no_parse = ()
     _args = []
     _kwargs = {}
     for arg in args:
         if isinstance(arg, six.string_types):
             arg_name, arg_value = parse_kwarg(arg)
             if arg_name:
-                _kwargs[arg_name] = yamlify_arg(arg_value)
+                _kwargs[arg_name] = yamlify_arg(arg_value) \
+                    if arg_name not in no_parse \
+                    else arg_value
             else:
                 _args.append(yamlify_arg(arg))
         elif isinstance(arg, dict):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -3029,8 +3029,9 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
 
         # Add back the --no-parse options so that shimmed/wrapped commands
         # handle the arguments correctly.
-        self.config['argv'].append(
-            '--no-parse=' + ','.join(self.options.no_parse))
+        if self.options.no_parse:
+            self.config['argv'].append(
+                '--no-parse=' + ','.join(self.options.no_parse))
 
         if self.options.ssh_askpass:
             self.options.ssh_passwd = getpass.getpass('Password: ')


### PR DESCRIPTION
# SUMMARY

This allows for these commands to bypass Salt's normal behavior of passing CLI input through PyYAML to ensure it is loaded as a proper Python data type.

**NOTE:** This only works on named CLI arguments (e.g. ``argname=value``), since ``salt.utils.args.parse_input()`` doesn't have access to the function name, nor the argspec of the function being called.

Fixes #39986.

# Testing Instructions


## Launch Docker container
Replace ``~/git/salt/issue39986`` with location of your git checkout. Use [this walkthrough](https://help.github.com/articles/checking-out-pull-requests-locally/) if you would like to checkout this PR into a local branch in your clone.

```
% docker run --rm -it -v ~/git/salt/issue39986:/testing terminalmage/issues:39986
```

## Test salt-ssh
The first command below launches sshd so you can test salt-ssh with localhost.
```
[root@83bf50621724 /]# /usr/sbin/sshd
[root@83bf50621724 /]# salt-ssh test test.arg foo='{bar: baz}' bar='{bar: baz}' abc=9 def=9 --no-parse=foo,abc --out=pprint
{'test': {'args': [],
          'kwargs': {'__pub_fun': 'test.arg',
                     '__pub_jid': '20170524214617987786',
                     '__pub_pid': 96,
                     '__pub_tgt': 'salt-call',
                     'abc': '9',
                     'bar': {'bar': 'baz'},
                     'def': 9,
                     'foo': '{bar: baz}'}}}
```

## Test masterless salt-call
```
[root@83bf50621724 /]# salt-call --local test.arg foo='{bar: baz}' bar='{bar: baz}' abc=9 def=9 --no-parse=foo,abc --out=pprint
{'local': {'args': (),
           'kwargs': {'__pub_fun': 'test.arg',
                      '__pub_jid': '20170524214653027465',
                      '__pub_pid': 143,
                      '__pub_tgt': 'salt-call',
                      'abc': '9',
                      'bar': {'bar': 'baz'},
                      'def': 9,
                      'foo': '{bar: baz}'}}}
```

## Test normal salt-call
The first command below starts the master and minion daemons.
```
[root@83bf50621724 /]# salt-master -d; salt-minion -d
[root@83bf50621724 /]# salt-call test.arg foo='{bar: baz}' bar='{bar: baz}' abc=9 def=9 --no-parse=foo,abc --out=pprint
{'local': {'args': (),
           'kwargs': {'__pub_fun': 'test.arg',
                      '__pub_jid': '20170524214740783331',
                      '__pub_pid': 700,
                      '__pub_tgt': 'salt-call',
                      'abc': '9',
                      'bar': {'bar': 'baz'},
                      'def': 9,
                      'foo': '{bar: baz}'}}}
```

## Test command published from the master
```
[root@83bf50621724 /]# salt test test.arg foo='{bar: baz}' bar='{bar: baz}' abc=9 def=9 --no-parse=foo,abc --out=pprint
{'test': {'args': [],
          'kwargs': {'__pub_arg': [{'abc': '9',
                                    'bar': {'bar': 'baz'},
                                    'def': 9,
                                    'foo': '{bar: baz}'}],
                     '__pub_fun': 'test.arg',
                     '__pub_jid': '20170524214926205767',
                     '__pub_ret': '',
                     '__pub_tgt': 'test',
                     '__pub_tgt_type': 'glob',
                     '__pub_user': 'root',
                     'abc': '9',
                     'bar': {'bar': 'baz'},
                     'def': 9,
                     'foo': '{bar: baz}'}}}
```

## Test runner
```
[root@83bf50621724 /]# salt-run test.arg foo='{bar: baz}' bar='{bar: baz}' abc=9 def=9 --no-parse=foo,abc --out=pprint
{'args': (),
 'kwargs': {'abc': '9', 'bar': {'bar': 'baz'}, 'def': 9, 'foo': '{bar: baz}'}}
[root@83bf50621724 /]# salt-call publish.publish test test.arg foo='{bar: baz}' bar='{bar: baz}' abc=9 def=9 --no-parse=foo,abc --out=pprint
The following keyword arguments are not valid: foo={bar: baz}, bar={'bar': 'baz'}, abc=9, def=9
[root@83bf50621724 /]# salt-call publish.publish test test.arg arg='["foo={bar: baz}", "bar={bar: baz}", abc=9, def=9]' --no-parse=foo,abc --out=pprint
{'local': {'test': {'args': [],
                    'kwargs': {'__pub_arg': [{'abc': '9',
                                              'bar': {'bar': 'baz'},
                                              'def': 9,
                                              'foo': '{bar: baz}'}],
                               '__pub_fun': 'test.arg',
                               '__pub_id': 'test',
                               '__pub_jid': '20170524215150058398',
                               '__pub_ret': '',
                               '__pub_tgt': 'test',
                               '__pub_tgt_type': 'glob',
                               '__pub_user': 'root',
                               'abc': '9',
                               'bar': {'bar': 'baz'},
                               'def': 9,
                               'foo': '{bar: baz}'}}}}
```

## Test peer-publishing a remote-exec func
```
[root@f8b423e56470 /]# salt-call publish.publish test test.arg arg='["foo={bar: baz}", "bar={bar: baz}", abc=9, def=9]' --no-parse=foo,abc --out=pprint
{'local': {'test': {'args': [],
                    'kwargs': {'__pub_arg': [{'abc': '9',
                                              'bar': {'bar': 'baz'},
                                              'def': 9,
                                              'foo': '{bar: baz}'}],
                               '__pub_fun': 'test.arg',
                               '__pub_id': 'test',
                               '__pub_jid': '20170524220332429444',
                               '__pub_ret': '',
                               '__pub_tgt': 'test',
                               '__pub_tgt_type': 'glob',
                               '__pub_user': 'root',
                               'abc': '9',
                               'bar': {'bar': 'baz'},
                               'def': 9,
                               'foo': '{bar: baz}'}}}}
```

## Test peer-publishing a runner func
```
[root@83bf50621724 /]# salt-call publish.runner test.arg arg='["foo={bar: baz}", "bar={bar: baz}", abc=9, def=9]' --no-parse=foo,abc --out=pprint
{'local': {'args': [],
           'kwargs': {'abc': '9',
                      'bar': {'bar': 'baz'},
                      'def': 9,
                      'foo': '{bar: baz}'}}}
```