### PR TITLE
Correct doc to actually blacklist a module

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -975,7 +975,8 @@ This is completely disabled by default.
         - root
         - '^(?!sudo_).*$'   #  all non sudo users
       modules:
-        - cmd
+        - cmd.*
+        - test.echo
 
 .. conf_master:: external_auth
 


### PR DESCRIPTION
### What does this PR do?
Fixes incorrect documentation

The config below would not actually block access to the `test` execution module.

```
publisher_acl_blacklist:
  modules:
    - test
```

By my testing the following will actually block access to the `test` execution module:

```
publisher_acl_blacklist:
  modules:
    - test.*
```