### PR TITLE
Small documentation improvements for the NAPALM proxy

### DIFF
--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -53,6 +53,10 @@ Example:
 
     - :mod:`NAPALM grains: select network devices based on their characteristics <salt.grains.napalm>`
     - :mod:`NET module: network basic features <salt.modules.napalm_network>`
+    - :mod:`Network config state: Manage the configuration using arbitrary templates <salt.states.netconfig>`
+    - :mod:`NAPALM YANG state: Manage the configuration according to the YANG models (OpenConfig/IETF) <salt.states.netyang>`
+    - :mod:`Network ACL module: Generate and load ACL (firewall) configuration <salt.modules.napalm_acl>`
+    - :mod:`Network ACL state: Manage the firewall configuration <salt.states.netacl>`
     - :mod:`NTP operational and configuration management module <salt.modules.napalm_ntp>`
     - :mod:`BGP operational and configuration management module <salt.modules.napalm_bgp>`
     - :mod:`Routes details <salt.modules.napalm_route>`

--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -35,6 +35,12 @@ please refer to the `NAPALM Read the Docs page`_.
 .. _`NAPALM Read the Docs page`: https://napalm.readthedocs.io/en/latest/#supported-network-operating-systems
 .. _`optional arguments`: http://napalm.readthedocs.io/en/latest/support/index.html#list-of-supported-optional-arguments
 
+.. versionadded:: Nitrogen
+
+* always_alive: in certain less dynamic environments, maintaining the remote connection permanently
+    open with the network device is not always beneficial. In that case, the user can
+    select to initialize the connection only when needed, by specifying this fied to ``false``.
+    Default: ``true`` (maintains the connection with the remote network device).
 
 Example:
 

--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -39,7 +39,7 @@ please refer to the `NAPALM Read the Docs page`_.
 
 * always_alive: in certain less dynamic environments, maintaining the remote connection permanently
     open with the network device is not always beneficial. In that case, the user can
-    select to initialize the connection only when needed, by specifying this fied to ``false``.
+    select to initialize the connection only when needed, by specifying this field to ``false``.
     Default: ``true`` (maintains the connection with the remote network device).
 
 Example:

--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -48,7 +48,6 @@ Example:
         passwd: my_password
         optional_args:
             port: 12201
-            config_format: set
 
 .. seealso::
 

--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -252,7 +252,7 @@ def call(method, *args, **kwargs):
         on the `correct driver repo`_ and make sure to read the FAQ_
 
     .. _`correct driver repo`: https://github.com/napalm-automation/napalm/issues/new
-    .. FAQ_: https://github.com/napalm-automation/napalm#faq
+    .. _FAQ: https://github.com/napalm-automation/napalm#faq
 
     Example:
 


### PR DESCRIPTION
### What does this PR do?

- 	Remove config_format opt arg example
-	Add more cross references for Nitrogen modules
- 	Correct faq ref
- 	Document the new always_alive field