### PR TITLE
Make the Hipchat engine more user friendly

### DIFF
--- a/salt/engines/hipchat.py
+++ b/salt/engines/hipchat.py
@@ -219,6 +219,8 @@ def start(token,
     api_url: ``https://api.hipchat.com``
         The URL to the HipChat API.
 
+        .. versionadded:: Nitrogen
+
     max_rooms: ``1000``
         Maximum number of rooms allowed to fetch. If set to 0,
         it is able to retrieve the entire list of rooms.
@@ -235,9 +237,13 @@ def start(token,
 
         This can be overriden when executing a command, using the ``--out-type`` argument.
 
+        .. versionadded:: Nitrogen
+
     outputter: ``nested``
         The format to display the data, using the outputters available on the CLI.
         This argument can also be overriden when executing a command, using the ``--out`` option.
+
+        .. versionadded:: Nitrogen
 
     HipChat Example:
 

--- a/salt/engines/hipchat.py
+++ b/salt/engines/hipchat.py
@@ -189,7 +189,64 @@ def start(token,
           output_type='file',
           outputter='nested'):
     '''
-    Listen to Hipchat messages and forward them to Salt
+    Listen to Hipchat messages and forward them to Salt.
+
+    token
+        The HipChat API key. It requires a key for global usgae,
+        assigned per user, rather than room.
+
+    room
+        The HipChat room name.
+
+    aliases
+        Define custom aliases.
+
+    valid_users
+        Restrict access only to certain users.
+
+    valid_commands
+        Restrict the execution to a limited set of commands.
+
+    control
+        Send commands to the master.
+
+    trigger: ``!``
+        Special character that triggers the execution of salt commands.
+
+    tag: ``salt/engines/hipchat/incoming``
+        The event tag on the Salt bus.
+
+    api_url: ``https://api.hipchat.com``
+        The URL to the HipChat API.
+
+    max_rooms: ``1000``
+        Maximum number of rooms allowed to fetch. If set to 0,
+        it is able to retrieve the entire list of rooms.
+
+    wait_time: ``5``
+        Maximum wait time, in seconds.
+
+    output_type: ``file``
+        The type of the output. Choose bewteen:
+
+            - ``file``: save the output into a temporary file and upload
+            - ``html``: send the output as HTML
+            - ``code``: send the output as code
+
+        This can be overriden when executing a command, using the ``--out-type`` argument.
+
+    outputter: ``nested``
+        The format to display the data, using the outputters available on the CLI.
+        This argument can also be overriden when executing a command, using the ``--out`` option.
+
+    HipChat Example:
+
+    .. code-block:: text
+
+        ! test.ping
+        ! test.ping target=minion1
+        ! test.ping --out=nested
+        ! test.ping --out-type=code --out=table
     '''
     target_room = None
 

--- a/salt/engines/hipchat.py
+++ b/salt/engines/hipchat.py
@@ -14,25 +14,25 @@ keys make the engine interactive.
     .. code-block:: yaml
 
         engines:
-            hipchat:
-               api_url: http://api.hipchat.myteam.com
-               token: 'XXXXXX'
-               room: 'salt'
-               control: True
-               valid_users:
-                   - SomeUser
-               valid_commands:
-                   - test.ping
-                   - cmd.run
-                   - list_jobs
-                   - list_commands
-               aliases:
-                   list_jobs:
-                       cmd: jobs.list_jobs
-                   list_commands:
-                       cmd: pillar.get salt:engines:hipchat:valid_commands target=saltmaster tgt_type=list
-                max_rooms: 0
-                wait_time: 1
+          - hipchat:
+              api_url: http://api.hipchat.myteam.com
+              token: 'XXXXXX'
+              room: 'salt'
+              control: True
+              valid_users:
+                 - SomeUser
+              valid_commands:
+                 - test.ping
+                 - cmd.run
+                 - list_jobs
+                 - list_commands
+              aliases:
+                 list_jobs:
+                     cmd: jobs.list_jobs
+                 list_commands:
+                     cmd: pillar.get salt:engines:hipchat:valid_commands target=saltmaster tgt_type=list
+              max_rooms: 0
+              wait_time: 1
 '''
 
 from __future__ import absolute_import

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -7,6 +7,7 @@ for managing outputters.
 # Import python libs
 from __future__ import print_function
 from __future__ import absolute_import
+import re
 import os
 import sys
 import errno
@@ -183,6 +184,23 @@ def out_format(data, out, opts=None, **kwargs):
     Return the formatted outputter string for the passed data
     '''
     return try_printout(data, out, opts, **kwargs)
+
+
+def string_format(data, out, opts=None, **kwargs):
+    '''
+    Return the formatted outputter string, removing the ANSI escape sequences.
+    '''
+    raw_output = try_printout(data, out, opts, **kwargs)
+    ansi_escape = re.compile(r'\x1b[^m]*m')
+    return ansi_escape.sub('', raw_output)
+
+
+def html_format(data, out, opts=None, **kwargs):
+    '''
+    Return the formatted string as HTML.
+    '''
+    ansi_escaped_string = string_format(data, out, opts, **kwargs)
+    return ansi_escaped_string.replace(' ', '&nbsp;').replace('\n', '<br />')
 
 
 def strip_esc_sequence(txt):


### PR DESCRIPTION
### What does this PR do?

I have been playing with this engine yesterday and one of the things that strike me is the way the data is returned from the minions:

<img width="545" alt="screen shot 2017-05-25 at 15 03 58" src="https://cloud.githubusercontent.com/assets/16694679/26453390/6ea38c36-415b-11e7-8601-559ecc9167c4.png">

Returns a file -> click -> download -> open and select text editor, as it does not have any extension -> view the output. Not only that it's a bit annoying, but also very user unfriendly.

So I'm adding two new options that can return the output directly in the chat:

<img width="1083" alt="screen shot 2017-05-25 at 15 08 36" src="https://cloud.githubusercontent.com/assets/16694679/26453556/117756ea-415c-11e7-94b9-d176cf3fbe32.png">

This PR also addresses the representation under "Results for [...]":

<img width="532" alt="screen shot 2017-05-25 at 15 12 40" src="https://cloud.githubusercontent.com/assets/16694679/26453738/aab397a6-415c-11e7-969c-84d72bf93c65.png">

(yeah, I used my username as bot).

By default, the engine will continue to send the data back as files.

On the longer term, we may need to consider another outputter for chats, maybe we can get this into Oxygen.