### PR TITLE
Skip a test that doesn't apply to Python 3

### DIFF
--- a/tests/integration/states/test_pip.py
+++ b/tests/integration/states/test_pip.py
@@ -114,6 +114,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)
 
+    @skipIf(six.PY3, 'Issue is specific to carbon module, which is PY2-only')
     @requires_system_grains
     def test_pip_installed_weird_install(self, grains=None):
         # First, check to see if this is running on CentOS 5 or MacOS.


### PR DESCRIPTION
This test is checking behavior that seems to have been specific to the
carbon package from PyPI. Since this is a Python 2-only module, and has
deps that do not exist on Python 3, it should not be run on Python 3.