### PR TITLE
Fix regression in state orchestration

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -230,7 +230,7 @@ def state(
     if pillar:
         cmd_kw['kwarg']['pillar'] = pillar
 
-    cmd_kw['kwarg']['saltenv'] = saltenv
+    cmd_kw['kwarg']['saltenv'] = saltenv if saltenv is not None else __env__
     cmd_kw['kwarg']['queue'] = queue
 
     if isinstance(concurrent, bool):


### PR DESCRIPTION
This falls back to using the effective saltenv when no saltenv has been explicitly passed.

Resolves #41353.