### PR TITLE
TCP transport: Fix occasional errors when using salt command

### DIFF
--- a/tests/unit/transport/tcp_test.py
+++ b/tests/unit/transport/tcp_test.py
@@ -95,6 +95,9 @@ class ClearReqTestCases(BaseTCPReqCase, ReqChannelMixin):
     def setUp(self):
         self.channel = salt.transport.client.ReqChannel.factory(self.minion_opts, crypt='clear')
 
+    def tearDown(self):
+        del self.channel
+
     @classmethod
     @tornado.gen.coroutine
     def _handle_payload(cls, payload):
@@ -108,6 +111,9 @@ class ClearReqTestCases(BaseTCPReqCase, ReqChannelMixin):
 class AESReqTestCases(BaseTCPReqCase, ReqChannelMixin):
     def setUp(self):
         self.channel = salt.transport.client.ReqChannel.factory(self.minion_opts)
+
+    def tearDown(self):
+        del self.channel
 
     @classmethod
     @tornado.gen.coroutine


### PR DESCRIPTION
### What does this PR do?

When using the `salt` command, errors would occasionally appear that
look like:

```
File "...\salt\transport\tcp.py", line 883, in _stream_return
AttributeError: 'NoneType' object has no attribute 'StreamClosedError'
```

Upon investigation, it was discovered that in this case,
`SaltMessageClient._stream_return()` was completed after all the modules
such as the one containing `tornado.iostream.StreamClosedError` were
unloaded, so at that time, that symbol evaluated to `None` instead of a
valid exception class.

Instead, we would expect `_stream_return` to be completed at the time
that `SaltMessageClient.close()` is invoked. It was noted that
`_stream_return` was not completed when using the `SyncWrapper`, since
that object turns off the IO Loop immediately when its own future
completes, so that the IO Loop is not running when
`SaltMessageClient.close()` is invoked which doesn't give `_stream_return`
a chance to complete. Even when the IO Loop is closed in
`SyncWrapper.__del__()`, `_stream_return` is not completed. In this case,
it only seems to complete when the Python application shuts down which
is when the error appears.

Fix this issue by allowing the IO Loop to run again until the completion
of a specially created future that completes when `_stream_return` is
exiting.

### Tests written?

No