### PR TITLE
Remove ex_subnetwork requirement for GCE

### DIFF
--- a/doc/topics/cloud/gce.rst
+++ b/doc/topics/cloud/gce.rst
@@ -224,7 +224,7 @@ subnetwork
 
 Use this setting to define the subnetwork an instance will be created in.
 This requires that the network your instance is created under has a mode of 'custom' or 'auto'.
-Additionally, the subnetwork your instance is created under is associated with the location you provide. Required.
+Additionally, the subnetwork your instance is created under is associated with the location you provide.
 
 .. versionadded:: Nitrogen
 

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -460,7 +460,7 @@ def __get_subnetwork(vm_):
     '''
     ex_subnetwork = config.get_cloud_config_value(
         'subnetwork', vm_, __opts__,
-        default='default', search_global=False)
+        search_global=False)
 
     return ex_subnetwork
 


### PR DESCRIPTION
### What does this PR do?
Removes the requirement for ex_subnetwork. Currently it defaults to default, but in our gce cloud for example we do not have this default subnetwork. I believe this is due to using an old vpc network configuration and not having any subnetworks configured so I don't think we should add this as a requirement. Although I am not very familiar with GCE so any other input would be useful. I think @erjohnso has spent some time here. 

### What issues does this PR fix or reference?
Our cloud tests are currently failing. Here is the issue: https://github.com/saltstack/salt-jenkins/issues/321

### Previous Behavior
Could not create a VM in gce because it stated the subnetwork default did not exist.

### New Behavior
I can now create a VM in gce

### Tests written?

Yes