### PR TITLE
base64 encode binary data sent using salt-cp

### DIFF
--- a/salt/cli/cp.py
+++ b/salt/cli/cp.py
@@ -9,6 +9,7 @@ Salt-cp can be used to distribute configuration files
 # Import python libs
 from __future__ import print_function
 from __future__ import absolute_import
+import base64
 import errno
 import logging
 import os
@@ -19,7 +20,7 @@ import sys
 import salt.client
 import salt.utils.gzip_util
 import salt.utils.minions
-from salt.utils import parsers
+from salt.utils import parsers, to_bytes
 from salt.utils.verify import verify_log
 import salt.output
 
@@ -150,6 +151,7 @@ class SaltCP(object):
             index = 1
             failed = {}
             for chunk in reader(fn_, chunk_size=self.opts['salt_cp_chunk_size']):
+                chunk = base64.b64encode(to_bytes(chunk))
                 append = index > 1
                 log.debug(
                     'Copying %s to %starget \'%s\' as %s%s',

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1095,7 +1095,16 @@ DEFAULT_MINION_OPTS = {
     'http_request_timeout': 1 * 60 * 60.0,  # 1 hour
     'http_max_body': 100 * 1024 * 1024 * 1024,  # 100GB
     'event_match_type': 'startswith',
-    'salt_cp_chunk_size': 98304,
+    'minion_restart_command': [],
+    'pub_ret': True,
+    'proxy_host': '',
+    'proxy_username': '',
+    'proxy_password': '',
+    'proxy_port': 0,
+    'minion_jid_queue_hwm': 100,
+    'ssl': None,
+    'cache': 'localfs',
+    'salt_cp_chunk_size': 65536,
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -5,6 +5,7 @@ Minion side functions for salt-cp
 
 # Import python libs
 from __future__ import absolute_import
+import base64
 import errno
 import os
 import logging
@@ -79,6 +80,8 @@ def recv(dest, chunk, append=False, compressed=True, mode=None):
             else:
                 return _error(exc.__str__())
         return True
+
+    chunk = base64.b64decode(chunk)
 
     open_mode = 'ab' if append else 'wb'
     try:


### PR DESCRIPTION
This fixes a problem when you make a request to salt-api using the /jobs
endpoint and request a JSON return. json.dumps() fails to serialize the
binary data entered into the job cache from salt-cp calls.