### PR TITLE
postgres_schema: Add support for __opts__['test'] to present and absent states.

### DIFF
--- a/salt/states/postgres_schema.py
+++ b/salt/states/postgres_schema.py
@@ -149,7 +149,7 @@ def absent(dbname, name,
             ret['comment'] = 'Schema {0} is set to be removed' \
                              ' from database {1}'.format(name, dbname)
             return ret
-        elif __salt__['postgres.schema_remove'](dbname, name, cascade=cascade, **db_args):
+        elif __salt__['postgres.schema_remove'](dbname, name, **db_args):
             ret['comment'] = 'Schema {0} has been removed' \
                              ' from database {1}'.format(name, dbname)
             ret['changes'][name] = 'Absent'

--- a/salt/states/postgres_schema.py
+++ b/salt/states/postgres_schema.py
@@ -77,6 +77,11 @@ def present(dbname, name,
 
     # The schema is not present, make it!
     if schema_attr is None:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Schema {0} is set to be created' \
+                             ' in database {1}.'.format(name, dbname)
+            return ret
         cret = __salt__['postgres.schema_create'](dbname,
                                                   name,
                                                   owner=owner,
@@ -139,7 +144,12 @@ def absent(dbname, name,
 
     # check if schema exists and remove it
     if __salt__['postgres.schema_exists'](dbname, name, **db_args):
-        if __salt__['postgres.schema_remove'](dbname, name, **db_args):
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Schema {0} is set to be removed' \
+                             ' from database {1}'.format(name, dbname)
+            return ret
+        elif __salt__['postgres.schema_remove'](dbname, name, cascade=cascade, **db_args):
             ret['comment'] = 'Schema {0} has been removed' \
                              ' from database {1}'.format(name, dbname)
             ret['changes'][name] = 'Absent'

--- a/tests/unit/states/test_postgres_schema.py
+++ b/tests/unit/states/test_postgres_schema.py
@@ -45,10 +45,11 @@ class PostgresSchemaTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value=name)
         with patch.dict(postgres_schema.__salt__,
                         {'postgres.schema_get': mock}):
-            comt = ('Schema {0} already exists in database {1}'.format(name,
-                                                                       dbname))
-            ret.update({'comment': comt})
-            self.assertDictEqual(postgres_schema.present(dbname, name), ret)
+            with patch.dict(postgres_schema.__opts__, {'test': False}):
+                comt = ('Schema {0} already exists in database {1}'.format(name,
+                                                                           dbname))
+                ret.update({'comment': comt})
+                self.assertDictEqual(postgres_schema.present(dbname, name), ret)
 
     # 'absent' function tests: 1
 
@@ -66,19 +67,26 @@ class PostgresSchemaTestCase(TestCase, LoaderModuleMockMixin):
                'comment': ''}
 
         mock_t = MagicMock(side_effect=[True, False])
-        mock = MagicMock(side_effect=[True, True, False])
+        mock = MagicMock(side_effect=[True, True, False, False])
         with patch.dict(postgres_schema.__salt__,
                         {'postgres.schema_exists': mock,
                          'postgres.schema_remove': mock_t}):
-            comt = ('Schema {0} has been removed from database {1}'.
-                    format(name, dbname))
-            ret.update({'comment': comt, 'result': True,
-                        'changes': {name: 'Absent'}})
-            self.assertDictEqual(postgres_schema.absent(dbname, name), ret)
+            with patch.dict(postgres_schema.__opts__, {'test': True}):
+                comt = ('Schema {0} is set to be removed from database {1}'.
+                        format(name, dbname))
+                ret.update({'comment': comt, 'result': None})
+                self.assertDictEqual(postgres_schema.absent(name), ret)
 
-            comt = ('Schema {0} failed to be removed'.format(name))
-            ret.update({'comment': comt, 'result': False, 'changes': {}})
-            self.assertDictEqual(postgres_schema.absent(dbname, name), ret)
+            with patch.dict(postgres_schema.__opts__, {'test': False}):
+                comt = ('Schema {0} has been removed from database {1}'.
+                        format(name, dbname))
+                ret.update({'comment': comt, 'result': True,
+                            'changes': {name: 'Absent'}})
+                self.assertDictEqual(postgres_schema.absent(dbname, name), ret)
+
+                comt = ('Schema {0} failed to be removed'.format(name))
+                ret.update({'comment': comt, 'result': False, 'changes': {}})
+                self.assertDictEqual(postgres_schema.absent(dbname, name), ret)
 
             comt = ('Schema {0} is not present in database {1},'
                     ' so it cannot be removed'.format(name, dbname))

--- a/tests/unit/states/test_postgres_schema.py
+++ b/tests/unit/states/test_postgres_schema.py
@@ -67,7 +67,7 @@ class PostgresSchemaTestCase(TestCase, LoaderModuleMockMixin):
                'comment': ''}
 
         mock_t = MagicMock(side_effect=[True, False])
-        mock = MagicMock(side_effect=[True, True, False, False])
+        mock = MagicMock(side_effect=[True, True, True, False])
         with patch.dict(postgres_schema.__salt__,
                         {'postgres.schema_exists': mock,
                          'postgres.schema_remove': mock_t}):
@@ -75,7 +75,7 @@ class PostgresSchemaTestCase(TestCase, LoaderModuleMockMixin):
                 comt = ('Schema {0} is set to be removed from database {1}'.
                         format(name, dbname))
                 ret.update({'comment': comt, 'result': None})
-                self.assertDictEqual(postgres_schema.absent(name), ret)
+                self.assertDictEqual(postgres_schema.absent(dbname, name), ret)
 
             with patch.dict(postgres_schema.__opts__, {'test': False}):
                 comt = ('Schema {0} has been removed from database {1}'.


### PR DESCRIPTION
### What does this PR do?
Adds support for `__opts__['test']` to the `postgres_schema.present` and `postgres_schema.absent` states.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
`postgres_schema.present` and `postgres_schema.absent` would add/remove schemas to/from a postgres DB regardless of the value of `__opts__['test']`.

### New Behavior
If `__opts__['test']` is `True`, `postgres_schema.present` and `postgres_schema.absent` will return a message but will not make any changes to the postgres DB.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
