### PR TITLE
Fix pkgrepo.managed always return changes for test=true

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2216,6 +2216,9 @@ def expand_repo_def(**kwargs):
                                                  dist)
 
     source_entry = sourceslist.SourceEntry(repo)
+    for list_args in ('architectures', 'comps'):
+        if list_args in kwargs:
+            kwargs[list_args] = kwargs[list_args].split(',')
     for kwarg in _MODIFY_OK:
         if kwarg in kwargs:
             setattr(source_entry, kwarg, kwargs[kwarg])

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1843,6 +1843,11 @@ def mod_repo(repo, saltenv='base', **kwargs):
 
     The following options are available to modify a repo definition:
 
+        architectures
+            a comma separated list of supported architectures, e.g. ``amd64``
+            If this option is not set, all architectures (configured in the
+            system) will be used.
+
         comps
             a comma separated list of components for the repo, e.g. ``main``
 

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -222,6 +222,11 @@ def managed(name, ppa=None, **kwargs):
         the reverse will be passed as ``disabled``. For example, passing
         ``enabled=False`` will assume ``disabled=False``.
 
+    architectures
+        On apt-based systems, architectures can restrict the available
+        architectures that the repository provides (e.g. only amd64).
+        architectures should be a comma-separated list.
+
     comps
         On apt-based systems, comps dictate the types of packages to be
         installed from the repository (e.g. main, nonfree, ...).  For


### PR DESCRIPTION
You can write a pkgrepo.managed state that contains components as comma separated list (as specified in the documentation):

```yaml
my-repository:
  pkgrepo.managed:
    - name: deb [arch=amd64] http://example.com/ stretch main non-free
    - dist: stretch
    - architectures: amd64
    - comps: main,non-free
    - file: /etc/apt/sources.list.d/example.list
    - clean_file: True
```

When running the state with `test=true`, salt will always tell that the state would change the configuration. `pkg.get_repo` returns comps as list, but `pkgrepo.managed` compares this list against the comma-separated comps from kwargs (which will always be not equal).

Thus convert the comma-separated comps to a list in `pkg.expand_repo_def` to compare two lists in pkgrepo.managed.

