### PR TITLE
Fixing module function to use correct rabbitmq command

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -473,8 +473,8 @@ def check_password(name, password, runas=None):
             return False
         return True
 
-    cmd = ('rabbit_auth_backend_internal:user_login_authentication'
-        '(<<"{0}">>, [{{password, <<"{1}">>}}]).').format(
+    cmd = ('rabbit_access_control:check_user_pass_login'
+        '(list_to_binary("{0}"), list_to_binary("{1}")).').format(
         name.replace('"', '\\"'),
         password.replace('"', '\\"'))
 

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -473,7 +473,7 @@ def check_password(name, password, runas=None):
             return False
         return True
 
-    cmd = ('rabbit_auth_backend_internal:check_user_login'
+    cmd = ('rabbit_auth_backend_internal:user_login_authentication'
         '(<<"{0}">>, [{{password, <<"{1}">>}}]).').format(
         name.replace('"', '\\"'),
         password.replace('"', '\\"'))


### PR DESCRIPTION
#41458

### What does this PR do?
Fixes rabbitmq module function to form correct command

### What issues does this PR fix or reference?
41458
Related to issue https://github.com/saltstack/salt/issues/41458

### Previous Behavior
rabbitmq_user.present fails with rabbitmq-servers versions below 3.5.6

### New Behavior
rabbitmq_user.present succeeds with rabbitmq-servers versions below 3.5.6

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
