### PR TITLE
Properly handle strings/bytestrings in Zookeeper/Docker

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -342,7 +342,8 @@ def _get_client(timeout=NOTSET, **kwargs):
             ['docker-machine', 'inspect', docker_machine],
             python_shell=False)
         try:
-            docker_machine_json = json.loads(docker_machine_json)
+            docker_machine_json = \
+                json.loads(salt.utils.to_str(docker_machine_json))
             docker_machine_tls = \
                 docker_machine_json['HostOptions']['AuthOptions']
             docker_machine_ip = docker_machine_json['Driver']['IPAddress']
@@ -618,7 +619,7 @@ def _client_wrapper(attr, *args, **kwargs):
             api_events = []
             try:
                 for event in ret:
-                    api_events.append(json.loads(event))
+                    api_events.append(json.loads(salt.utils.to_str(event)))
             except Exception as exc:
                 raise CommandExecutionError(
                     'Unable to interpret API event: \'{0}\''.format(event),
@@ -3058,7 +3059,9 @@ def build(path=None,
 
     stream_data = []
     for line in response:
-        stream_data.extend(json.loads(line, cls=DockerJSONDecoder))
+        stream_data.extend(
+            json.loads(salt.utils.to_str(line), cls=DockerJSONDecoder)
+        )
     errors = []
     # Iterate through API response and collect information
     for item in stream_data:

--- a/salt/modules/zookeeper.py
+++ b/salt/modules/zookeeper.py
@@ -74,6 +74,7 @@ except ImportError:
     HAS_KAZOO = False
 
 # Import Salt libraries
+import salt.utils
 
 __virtualname__ = 'zookeeper'
 
@@ -182,7 +183,7 @@ def create(path, value='', acls=None, ephemeral=False, sequence=False, makepath=
     acls = [make_digest_acl(**acl) for acl in acls]
     conn = _get_zk_conn(profile=profile, hosts=hosts, scheme=scheme,
                         username=username, password=password, default_acl=default_acl)
-    return conn.create(path, value, acls, ephemeral, sequence, makepath)
+    return conn.create(path, salt.utils.to_bytes(value), acls, ephemeral, sequence, makepath)
 
 
 def ensure_path(path, acls=None, profile=None, hosts=None, scheme=None,
@@ -301,7 +302,7 @@ def get(path, profile=None, hosts=None, scheme=None, username=None, password=Non
     conn = _get_zk_conn(profile=profile, hosts=hosts, scheme=scheme,
                         username=username, password=password, default_acl=default_acl)
     ret, _ = conn.get(path)
-    return ret
+    return salt.utils.to_str(ret)
 
 
 def get_children(path, profile=None, hosts=None, scheme=None, username=None, password=None, default_acl=None):
@@ -383,7 +384,7 @@ def set(path, value, version=-1, profile=None, hosts=None, scheme=None,
     '''
     conn = _get_zk_conn(profile=profile, hosts=hosts, scheme=scheme,
                         username=username, password=password, default_acl=default_acl)
-    return conn.set(path, value, version=version)
+    return conn.set(path, salt.utils.to_bytes(value), version=version)
 
 
 def get_acls(path, profile=None, hosts=None, scheme=None, username=None, password=None, default_acl=None):


### PR DESCRIPTION
This both fixes the tests in https://github.com/saltstack/salt-jenkins/issues/354 and also fixes the handling of streamed events from docker-py, which are returned as bytestrings and must be decoded to be used.