### PR TITLE
Fix keep_jobs keyerror in redis returner

### DIFF
--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -113,7 +113,7 @@ def _get_serv(ret=None):
 
 
 def _get_ttl():
-    return __opts__['keep_jobs'] * 3600
+    return __opts__.get('keep_jobs', 24) * 3600
 
 
 def returner(ret):


### PR DESCRIPTION
### What does this PR do?
Ensures keep_jobs  sets default if does not exist so the call to _get_ttl() can be successful when run on a minion. By default a minion does not have `keep_jobs` in opts and does not have access to master opts by default so this errors out. 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/41447

### Previous Behavior
```
  File "/usr/lib/python2.7/dist-packages/salt/minion.py", line 1575, in _thread_return
    minion_instance.returners[returner_str](ret)
  File "/usr/lib/python2.7/dist-packages/salt/returners/redis_return.py", line 131, in returner
    pipeline.expire('ret:{0}'.format(jid), _get_ttl())
  File "/usr/lib/python2.7/dist-packages/salt/returners/redis_return.py", line 120, in _get_ttl
    return __opts__['keep_jobs'] * 3600
KeyError: 'keep_jobs'
```

### New Behavior
Can now run `salt '*' test.ping --return redis` and the job is added to redis:

```
127.0.0.1:6379> KEYS *
 1) "ret:20170526191541920459"
 2) "33d180ec5e2b:test.version"
 3) "ret:20170526191537170396"
 4) "33d180ec5e2b:test.echo"
 5) "ret:20170526190257082894"
 6) "ret:20170526191431863089"
 7) "ret:20170526190523380498"
 8) "33d180ec5e2b:test.args"
 9) "ret:20170526191527061398"
10) "33d180ec5e2b:test.arg"
11) "ret:20170526190350079104"
12) "ret:20170526191232553266"
13) "ret:20170526190012846487"
14) "ret:20170526190358313028"
15) "ret:20170526191414725682"
16) "33d180ec5e2b:test.ping"
````

### Tests written?

Yes
