### PR TITLE
Fix a file.blockreplace test for Python 3

### DIFF
--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -2031,16 +2031,14 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
                 self.assertSaltTrueReturn({name: step})
             with salt.utils.fopen(testcase_filedest) as fp_:
                 contents = fp_.read().split(os.linesep)
-            self.assertEqual(
-                ['#',
-                 '#-- start managed zone PLEASE, DO NOT EDIT',
-                 'bar',
-                 '',
-                 'baz',
-                 '#-- end managed zone',
-                 ''],
-                contents
-            )
+
+            begin = contents.index(
+                '#-- start managed zone PLEASE, DO NOT EDIT') + 1
+            end = contents.index('#-- end managed zone')
+            block_contents = contents[begin:end]
+            for item in ('', 'bar', 'baz'):
+                block_contents.remove(item)
+            self.assertEqual(block_contents, [])
         finally:
             if os.path.isdir(testcase_filedest):
                 os.unlink(testcase_filedest)


### PR DESCRIPTION
This test uses ``file.accumulated`` to accumulate data, to be used in the ``file.blockreplace`` state. However, because this data is stored in a dictionary, the iteration order is different on different versions of Python. As it is very clearly stated in the ``file.accumulated`` docstring that the accumulator data structure is a dictionary, rather than modifying the ``file.accumulated`` behavior this commit just updates the test so that it searches for all values that it should find between the block markers.