### PR TITLE
When the minion key is denied by the master then exit status 77 (permission denied)

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -596,7 +596,7 @@ class AsyncAuth(object):
                             'minion.\nOr restart the Salt Master in open mode to '
                             'clean out the keys. The Salt Minion will now exit.'
                         )
-                        sys.exit(salt.defaults.exitcodes.EX_OK)
+                        sys.exit(salt.defaults.exitcodes.EX_NOPERM)
                 # has the master returned that its maxed out with minions?
                 elif payload['load']['ret'] == 'full':
                     raise tornado.gen.Return('full')
@@ -1138,7 +1138,7 @@ class SAuth(AsyncAuth):
                             'minion.\nOr restart the Salt Master in open mode to '
                             'clean out the keys. The Salt Minion will now exit.'
                         )
-                        sys.exit(salt.defaults.exitcodes.EX_OK)
+                        sys.exit(salt.defaults.exitcodes.EX_NOPERM)
                 # has the master returned that its maxed out with minions?
                 elif payload['load']['ret'] == 'full':
                     return 'full'

--- a/salt/defaults/exitcodes.py
+++ b/salt/defaults/exitcodes.py
@@ -32,6 +32,7 @@ EX_UNAVAILABLE = 69       # service unavailable
 EX_SOFTWARE = 70          # internal software error
 EX_CANTCREAT = 73         # can't create (user) output file
 EX_TEMPFAIL = 75          # temp failure; user is invited to retry
+EX_NOPERM = 77            # permission denied
 
 # The Salt specific exit codes are defined below:
 


### PR DESCRIPTION
### What does this PR do?

Returns a non-zero exit status for salt-call when a minion key is denied.

### What issues does this PR fix or reference?

A failure connecting to a salt master should be reflected by a reasonable failure code so that it can be detected when scripting.

### Previous Behavior

A minion key being denied would return a zero exit status for salt-call indicating "success" - which is not the case when the minion key is rejected.

### New Behavior

A denied minion key will return a non-zero exit status (77: EX_NOPERM) from salt-call

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
