### PR TITLE
Fix win_firewall execution and state modules

### DIFF
--- a/salt/modules/win_firewall.py
+++ b/salt/modules/win_firewall.py
@@ -1,35 +1,39 @@
 # -*- coding: utf-8 -*-
 '''
-Module for configuring Windows Firewall
+Module for configuring Windows Firewall using ``netsh``
 '''
 from __future__ import absolute_import
 
 # Import python libs
 import re
-import logging
 
 # Import salt libs
 import salt.utils
-from salt.ext import six
+from salt.exceptions import CommandExecutionError
 
 # Define the module's virtual name
 __virtualname__ = 'firewall'
-
-log = logging.getLogger(__name__)
 
 
 def __virtual__():
     '''
     Only works on Windows systems
     '''
-    if salt.utils.is_windows():
-        return __virtualname__
-    return (False, "Module win_firewall: module only works on Windows systems")
+    if not salt.utils.is_windows():
+        return False, "Module win_firewall: module only available on Windows"
+
+    return __virtualname__
 
 
 def get_config():
     '''
     Get the status of all the firewall profiles
+
+    Returns:
+        dict: A dictionary of all profiles on the system
+
+    Raises:
+        CommandExecutionError: If the command fails
 
     CLI Example:
 
@@ -41,7 +45,14 @@ def get_config():
     curr = None
 
     cmd = ['netsh', 'advfirewall', 'show', 'allprofiles']
-    for line in __salt__['cmd.run'](cmd, python_shell=False).splitlines():
+    ret = __salt__['cmd.run_all'](cmd, python_shell=False, ignore_retcode=True)
+    if ret['retcode'] != 0:
+        raise CommandExecutionError(ret['stdout'])
+
+    # There may be some problems with this depending on how `netsh` is localized
+    # It's looking for lines that contain `Profile Settings` or start with
+    # `State` which may be different in different localizations
+    for line in ret['stdout'].splitlines():
         if not curr:
             tmp = re.search('(.*) Profile Settings:', line)
             if tmp:
@@ -55,7 +66,22 @@ def get_config():
 
 def disable(profile='allprofiles'):
     '''
-    Disable firewall profile :param profile: (default: allprofiles)
+    Disable firewall profile
+
+    Args:
+        profile (Optional[str]): The name of the profile to disable. Default is
+            ``allprofiles``. Valid options are:
+
+            - allprofiles
+            - domainprofile
+            - privateprofile
+            - publicprofile
+
+    Returns:
+        bool: True if successful
+
+    Raises:
+        CommandExecutionError: If the command fails
 
     CLI Example:
 
@@ -64,14 +90,33 @@ def disable(profile='allprofiles'):
         salt '*' firewall.disable
     '''
     cmd = ['netsh', 'advfirewall', 'set', profile, 'state', 'off']
-    return __salt__['cmd.run'](cmd, python_shell=False) == 'Ok.'
+    ret = __salt__['cmd.run_all'](cmd, python_shell=False, ignore_retcode=True)
+    if ret['retcode'] != 0:
+        raise CommandExecutionError(ret['stdout'])
+
+    return True
 
 
 def enable(profile='allprofiles'):
     '''
-    Enable firewall profile :param profile: (default: allprofiles)
-
     .. versionadded:: 2015.5.0
+
+    Enable firewall profile
+
+    Args:
+        profile (Optional[str]): The name of the profile to enable. Default is
+            ``allprofiles``. Valid options are:
+
+            - allprofiles
+            - domainprofile
+            - privateprofile
+            - publicprofile
+
+    Returns:
+        bool: True if successful
+
+    Raises:
+        CommandExecutionError: If the command fails
 
     CLI Example:
 
@@ -80,14 +125,28 @@ def enable(profile='allprofiles'):
         salt '*' firewall.enable
     '''
     cmd = ['netsh', 'advfirewall', 'set', profile, 'state', 'on']
-    return __salt__['cmd.run'](cmd, python_shell=False) == 'Ok.'
+    ret = __salt__['cmd.run_all'](cmd, python_shell=False, ignore_retcode=True)
+    if ret['retcode'] != 0:
+        raise CommandExecutionError(ret['stdout'])
+
+    return True
 
 
 def get_rule(name='all'):
     '''
     .. versionadded:: 2015.5.0
 
-    Get firewall rule(s) info
+    Display all matching rules as specified by name
+
+    Args:
+        name (Optional[str]): The full name of the rule. ``all`` will return all
+            rules. Default is ``all``
+
+    Returns:
+        dict: A dictionary of all rules or rules that match the name exactly
+
+    Raises:
+        CommandExecutionError: If the command fails
 
     CLI Example:
 
@@ -95,14 +154,13 @@ def get_rule(name='all'):
 
         salt '*' firewall.get_rule 'MyAppPort'
     '''
-    ret = {}
-    cmd = ['netsh', 'advfirewall', 'firewall', 'show', 'rule', 'name={0}'.format(name)]
-    ret[name] = __salt__['cmd.run'](cmd, python_shell=False)
+    cmd = ['netsh', 'advfirewall', 'firewall', 'show', 'rule',
+           'name="{0}"'.format(name)]
+    ret = __salt__['cmd.run_all'](cmd, python_shell=False, ignore_retcode=True)
+    if ret['retcode'] != 0:
+        raise CommandExecutionError(ret['stdout'])
 
-    if ret[name].strip() == 'No rules match the specified criteria.':
-        ret = False
-
-    return ret
+    return {name: ret['stdout']}
 
 
 def add_rule(name, localport, protocol='tcp', action='allow', dir='in',
@@ -110,7 +168,56 @@ def add_rule(name, localport, protocol='tcp', action='allow', dir='in',
     '''
     .. versionadded:: 2015.5.0
 
-    Add a new firewall rule
+    Add a new inbound or outbound rule to the firewall policy
+
+    Args:
+
+        name (str): The name of the rule. Must be unique and cannot be "all".
+            Required.
+
+        localport (int): The port the rule applies to. Must be a number between
+            0 and 65535. Can be a range. Can specify multiple ports separated by
+            commas. Required.
+
+        protocol (Optional[str]): The protocol. Can be any of the following:
+
+            - A number between 0 and 255
+            - icmpv4
+            - icmpv6
+            - tcp
+            - udp
+            - any
+
+        action (Optional[str]): The action the rule performs. Can be any of the
+            following:
+
+            - allow
+            - block
+            - bypass
+
+        dir (Optional[str]): The direction. Can be ``in`` or ``out``.
+
+        remoteip (Optional [str]): The remote IP. Can be any of the following:
+
+            - any
+            - localsubnet
+            - dns
+            - dhcp
+            - wins
+            - defaultgateway
+            - Any valid IPv4 address (192.168.0.12)
+            - Any valid IPv6 address (2002:9b3b:1a31:4:208:74ff:fe39:6c43)
+            - Any valid subnet (192.168.1.0/24)
+            - Any valid range of IP addresses (192.168.0.1-192.168.0.12)
+            - A list of valid IP addresses
+
+            Can be combinations of the above separated by commas.
+
+    Returns:
+        bool: True if successful
+
+    Raises:
+        CommandExecutionError: If the command fails
 
     CLI Example:
 
@@ -119,7 +226,6 @@ def add_rule(name, localport, protocol='tcp', action='allow', dir='in',
         salt '*' firewall.add_rule 'test' '8080' 'tcp'
         salt '*' firewall.add_rule 'test' '1' 'icmpv4'
         salt '*' firewall.add_rule 'test_remote_ip' '8000' 'tcp' 'allow' 'in' '192.168.0.1'
-
     '''
     cmd = ['netsh', 'advfirewall', 'firewall', 'add', 'rule',
            'name={0}'.format(name),
@@ -128,42 +234,107 @@ def add_rule(name, localport, protocol='tcp', action='allow', dir='in',
            'action={0}'.format(action),
            'remoteip={0}'.format(remoteip)]
 
-    if 'icmpv4' not in protocol and 'icmpv6' not in protocol:
+    if protocol is None \
+            or ('icmpv4' not in protocol and 'icmpv6' not in protocol):
         cmd.append('localport={0}'.format(localport))
 
-    ret = __salt__['cmd.run'](cmd, python_shell=False)
-    if isinstance(ret, six.string_types):
-        return ret.strip() == 'Ok.'
-    else:
-        log.error('firewall.add_rule failed: {0}'.format(ret))
-        return False
+    ret = __salt__['cmd.run_all'](cmd, python_shell=False, ignore_retcode=True)
+    if ret['retcode'] != 0:
+        raise CommandExecutionError(ret['stdout'])
+
+    return True
 
 
-def delete_rule(name, localport, protocol='tcp', dir='in', remoteip='any'):
+def delete_rule(name,
+                localport=None,
+                protocol=None,
+                dir=None,
+                remoteip=None):
     '''
     .. versionadded:: 2015.8.0
 
-    Delete an existing firewall rule
+    Delete an existing firewall rule identified by name and optionally by ports,
+    protocols, direction, and remote IP.
+
+    Args:
+
+        name (str): The name of the rule to delete. If the name ``all`` is used
+            you must specify additional parameters.
+
+        localport (Optional[str]): The port of the rule. Must specify a
+            protocol.
+
+        protocol (Optional[str]): The protocol of the rule.
+
+        dir (Optional[str]): The direction of the rule.
+
+        remoteip (Optional[str]): The remote IP of the rule.
+
+    Returns:
+        bool: True if successful
+
+    Raises:
+        CommandExecutionError: If the command fails
 
     CLI Example:
 
     .. code-block:: bash
 
+        # Delete incoming tcp port 8080 in the rule named 'test'
         salt '*' firewall.delete_rule 'test' '8080' 'tcp' 'in'
+
+        # Delete the incoming tcp port 8000 from 192.168.0.1 in the rule named
+        # 'test_remote_ip`
         salt '*' firewall.delete_rule 'test_remote_ip' '8000' 'tcp' 'in' '192.168.0.1'
+
+        # Delete all rules for local port 80:
+        salt '*' firewall.delete_rule all 80 tcp
+
+        # Delete a rule called 'allow80':
+        salt '*' firewall.delete_rule allow80
     '''
     cmd = ['netsh', 'advfirewall', 'firewall', 'delete', 'rule',
-           'name={0}'.format(name),
-           'protocol={0}'.format(protocol),
-           'dir={0}'.format(dir),
-           'remoteip={0}'.format(remoteip)]
+           'name={0}'.format(name)]
+    if protocol:
+        cmd.append('protocol={0}'.format(protocol))
+    if dir:
+        cmd.append('dir={0}'.format(dir))
+    if remoteip:
+        cmd.append('remoteip={0}'.format(remoteip))
 
-    if 'icmpv4' not in protocol and 'icmpv6' not in protocol:
-        cmd.append('localport={0}'.format(localport))
+    if protocol is None \
+            or ('icmpv4' not in protocol and 'icmpv6' not in protocol):
+        if localport:
+            cmd.append('localport={0}'.format(localport))
 
-    ret = __salt__['cmd.run'](cmd, python_shell=False)
-    if isinstance(ret, six.string_types):
-        return ret.endswith('Ok.')
-    else:
-        log.error('firewall.delete_rule failed: {0}'.format(ret))
+    ret = __salt__['cmd.run_all'](cmd, python_shell=False, ignore_retcode=True)
+    if ret['retcode'] != 0:
+        raise CommandExecutionError(ret['stdout'])
+
+    return True
+
+
+def rule_exists(name):
+    '''
+    .. versionadded:: 2016.11.6
+
+    Checks if a firewall rule exists in the firewall policy
+
+    Args:
+        name (str): The name of the rule
+
+    Returns:
+        bool: True if exists, otherwise False
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        # Is there a rule named RemoteDesktop
+        salt '*' firewall.rule_exists RemoteDesktop
+    '''
+    try:
+        get_rule(name)
+        return True
+    except CommandExecutionError:
         return False

--- a/salt/states/win_firewall.py
+++ b/salt/states/win_firewall.py
@@ -3,6 +3,9 @@
 State for configuring Windows Firewall
 '''
 
+# Import Salt libs
+from salt.exceptions import CommandExecutionError, SaltInvocationError
+
 
 def __virtual__():
     '''
@@ -14,59 +17,143 @@ def __virtual__():
 def disabled(name='allprofiles'):
     '''
     Disable all the firewall profiles (Windows only)
+
+    Args:
+        profile (Optional[str]): The name of the profile to disable. Default is
+            ``allprofiles``. Valid options are:
+
+            - allprofiles
+            - domainprofile
+            - privateprofile
+            - publicprofile
+
+    Example:
+
+    .. code-block:: yaml
+
+        # To disable the domain profile
+        disable_domain:
+          win_firewall.disabled:
+            - name: domainprofile
+
+        # To disable all profiles
+        disable_all:
+          win_firewall.disabled:
+            - name: allprofiles
     '''
     ret = {'name': name,
            'result': True,
            'changes': {},
            'comment': ''}
 
-    # Determine what to do
-    action = False
-    check_name = None
-    if name != 'allprofiles':
-        check_name = True
+    profile_map = {'domainprofile': 'Domain',
+                   'privateprofile': 'Private',
+                   'publicprofile': 'Public',
+                   'allprofiles': 'All'}
+
+    # Make sure the profile name is valid
+    if name not in profile_map:
+        raise SaltInvocationError('Invalid profile name: {0}'.format(name))
 
     current_config = __salt__['firewall.get_config']()
-    if check_name and name not in current_config:
+    if name != 'allprofiles' and profile_map[name] not in current_config:
         ret['result'] = False
-        ret['comment'] = 'Profile {0} does not exist in firewall.get_config'.format(name)
+        ret['comment'] = 'Profile {0} does not exist in firewall.get_config' \
+                         ''.format(name)
         return ret
 
     for key in current_config:
         if current_config[key]:
-            if check_name and key != name:
-                continue
-            action = True
-            ret['changes'] = {'fw': 'disabled'}
-            break
+            if name == 'allprofiles' or key == profile_map[name]:
+                ret['changes'][key] = 'disabled'
 
     if __opts__['test']:
-        ret['result'] = not action or None
+        ret['result'] = not ret['changes'] or None
+        ret['comment'] = ret['changes']
+        ret['changes'] = {}
         return ret
 
     # Disable it
-    if action:
-        ret['result'] = __salt__['firewall.disable'](name)
-        if not ret['result']:
-            ret['comment'] = 'Could not disable the FW'
-            if check_name:
-                msg = 'Firewall profile {0} could not be disabled'.format(name)
-            else:
-                msg = 'Could not disable the FW'
-            ret['comment'] = msg
+    if ret['changes']:
+        try:
+            ret['result'] = __salt__['firewall.disable'](name)
+        except CommandExecutionError:
+            ret['comment'] = 'Firewall Profile {0} could not be disabled' \
+                             ''.format(profile_map[name])
     else:
-        if check_name:
-            msg = 'Firewall profile {0} is disabled'.format(name)
-        else:
+        if name == 'allprofiles':
             msg = 'All the firewall profiles are disabled'
+        else:
+            msg = 'Firewall profile {0} is disabled'.format(name)
         ret['comment'] = msg
 
     return ret
 
 
-def add_rule(name, localport, protocol="tcp", action="allow", dir="in"):
+def add_rule(name,
+             localport,
+             protocol='tcp',
+             action='allow',
+             dir='in',
+             remoteip='any'):
     '''
-    Add a new firewall rule (Windows only)
+    Add a new inbound or outbound rule to the firewall policy
+
+    Args:
+
+        name (str): The name of the rule. Must be unique and cannot be "all".
+            Required.
+
+        localport (int): The port the rule applies to. Must be a number between
+            0 and 65535. Can be a range. Can specify multiple ports separated by
+            commas. Required.
+
+        protocol (Optional[str]): The protocol. Can be any of the following:
+
+            - A number between 0 and 255
+            - icmpv4
+            - icmpv6
+            - tcp
+            - udp
+            - any
+
+        action (Optional[str]): The action the rule performs. Can be any of the
+            following:
+
+            - allow
+            - block
+            - bypass
+
+        dir (Optional[str]): The direction. Can be ``in`` or ``out``.
+
+        remoteip (Optional [str]): The remote IP. Can be any of the following:
+
+            - any
+            - localsubnet
+            - dns
+            - dhcp
+            - wins
+            - defaultgateway
+            - Any valid IPv4 address (192.168.0.12)
+            - Any valid IPv6 address (2002:9b3b:1a31:4:208:74ff:fe39:6c43)
+            - Any valid subnet (192.168.1.0/24)
+            - Any valid range of IP addresses (192.168.0.1-192.168.0.12)
+            - A list of valid IP addresses
+
+            Can be combinations of the above separated by commas.
+
+            .. versionadded:: 2016.11.6
+
+    Example:
+
+    .. code-block:: yaml
+
+        open_smb_port:
+          win_firewall.add_rule:
+            - name: SMB (445)
+            - localport: 445
+            - protocol: tcp
+            - action: allow
     '''
     ret = {'name': name,
            'result': True,
@@ -74,23 +161,24 @@ def add_rule(name, localport, protocol="tcp", action="allow", dir="in"):
            'comment': ''}
 
     # Check if rule exists
-    commit = False
-    current_rules = __salt__['firewall.get_rule'](name)
-    if not current_rules:
-        commit = True
+    if not __salt__['firewall.rule_exists'](name):
         ret['changes'] = {'new rule': name}
+    else:
+        ret['comment'] = 'A rule with that name already exists'
+        return ret
 
     if __opts__['test']:
-        ret['result'] = not commit or None
+        ret['result'] = not ret['changes'] or None
+        ret['comment'] = ret['changes']
+        ret['changes'] = {}
         return ret
 
     # Add rule
-    if commit:
-        ret['result'] = __salt__['firewall.add_rule'](name, localport, protocol, action, dir)
-        if not ret['result']:
-            ret['comment'] = 'Could not add rule'
-    else:
-        ret['comment'] = 'A rule with that name already exists'
+    try:
+        __salt__['firewall.add_rule'](
+            name, localport, protocol, action, dir, remoteip)
+    except CommandExecutionError:
+        ret['comment'] = 'Could not add rule'
 
     return ret
 
@@ -98,50 +186,74 @@ def add_rule(name, localport, protocol="tcp", action="allow", dir="in"):
 def enabled(name='allprofiles'):
     '''
     Enable all the firewall profiles (Windows only)
+
+    Args:
+        profile (Optional[str]): The name of the profile to enable. Default is
+            ``allprofiles``. Valid options are:
+
+            - allprofiles
+            - domainprofile
+            - privateprofile
+            - publicprofile
+
+    Example:
+
+    .. code-block:: yaml
+
+        # To enable the domain profile
+        enable_domain:
+          win_firewall.enabled:
+            - name: domainprofile
+
+        # To enable all profiles
+        enable_all:
+          win_firewall.enabled:
+            - name: allprofiles
     '''
     ret = {'name': name,
            'result': True,
            'changes': {},
            'comment': ''}
 
-    # Determine what to do
-    action = False
-    check_name = None
-    if name != 'allprofiles':
-        check_name = True
+    profile_map = {'domainprofile': 'Domain',
+                   'privateprofile': 'Private',
+                   'publicprofile': 'Public',
+                   'allprofiles': 'All'}
+
+    # Make sure the profile name is valid
+    if name not in profile_map:
+        raise SaltInvocationError('Invalid profile name: {0}'.format(name))
 
     current_config = __salt__['firewall.get_config']()
-    if check_name and name not in current_config:
+    if name != 'allprofiles' and profile_map[name] not in current_config:
         ret['result'] = False
-        ret['comment'] = 'Profile {0} does not exist in firewall.get_config'.format(name)
+        ret['comment'] = 'Profile {0} does not exist in firewall.get_config' \
+                         ''.format(name)
         return ret
 
     for key in current_config:
         if not current_config[key]:
-            if check_name and key != name:
-                continue
-            action = True
-            ret['changes'] = {'fw': 'enabled'}
-            break
+            if name == 'allprofiles' or key == profile_map[name]:
+                ret['changes'][key] = 'enabled'
 
     if __opts__['test']:
-        ret['result'] = not action or None
+        ret['result'] = not ret['changes'] or None
+        ret['comment'] = ret['changes']
+        ret['changes'] = {}
         return ret
 
-    # Disable it
-    if action:
-        ret['result'] = __salt__['firewall.enable'](name)
-        if not ret['result']:
-            if check_name:
-                msg = 'Firewall profile {0} could not be enabled'.format(name)
-            else:
-                msg = 'Could not enable the FW'
-            ret['comment'] = msg
+    # Enable it
+    if ret['changes']:
+        try:
+            ret['result'] = __salt__['firewall.enable'](name)
+        except CommandExecutionError:
+            ret['comment'] = 'Firewall Profile {0} could not be enabled' \
+                             ''.format(profile_map[name])
     else:
-        if check_name:
-            msg = 'Firewall profile {0} is enabled'.format(name)
-        else:
+        if name == 'allprofiles':
             msg = 'All the firewall profiles are enabled'
+        else:
+            msg = 'Firewall profile {0} is enabled'.format(name)
         ret['comment'] = msg
 
     return ret

--- a/salt/states/win_firewall.py
+++ b/salt/states/win_firewall.py
@@ -2,6 +2,7 @@
 '''
 State for configuring Windows Firewall
 '''
+from __future__ import absolute_import
 
 # Import Salt libs
 from salt.exceptions import CommandExecutionError, SaltInvocationError


### PR DESCRIPTION
### What does this PR do?
- Vastly improves documentation
- Raises CommandExecutionError on command failure
- Checks retcode instead of checking for 'Ok.' in the return
- Fix problem with errors showing up in the log by passing `ignore_retcode` to `cmd.run_all`
- Created rule_exists function for use by the state module

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/31435

### Tests written?
No
