### PR TITLE
Aliasing of salt-mine functions in salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -970,12 +970,26 @@ class Single(object):
         # roster, pillar, master config (in that order)
         if self.mine:
             mine_args = None
+            mine_fun_data = None
+            mine_fun = self.fun
+
             if self.mine_functions and self.fun in self.mine_functions:
-                mine_args = self.mine_functions[self.fun]
+                mine_fun_data = self.mine_functions[self.fun]
             elif opts['pillar'] and self.fun in opts['pillar'].get('mine_functions', {}):
-                mine_args = opts['pillar']['mine_functions'][self.fun]
+                mine_fun_data = opts['pillar']['mine_functions'][self.fun]
             elif self.fun in self.context['master_opts'].get('mine_functions', {}):
-                mine_args = self.context['master_opts']['mine_functions'][self.fun]
+                mine_fun_data = self.context['master_opts']['mine_functions'][self.fun]
+
+            if isinstance(mine_fun_data, dict):
+                mine_fun = mine_fun_data.pop('mine_function', mine_fun)
+                mine_args = mine_fun_data
+            elif isinstance(mine_fun_data, list):
+                if isinstance(mine_fun_data[0], dict) and 'mine_function' in mine_fun_data[0]:
+                    mine_fun = mine_fun_data[0]['mine_function']
+                    mine_fun_data.pop(0)
+                mine_args = mine_fun_data
+            else:
+                mine_args = mine_fun_data
 
             # If we found mine_args, replace our command's args
             if isinstance(mine_args, dict):
@@ -987,7 +1001,7 @@ class Single(object):
 
         try:
             if self.mine:
-                result = wrapper[self.fun](*self.args, **self.kwargs)
+                result = wrapper[mine_fun](*self.args, **self.kwargs)
             else:
                 result = self.wfuncs[self.fun](*self.args, **self.kwargs)
         except TypeError as exc:

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -984,9 +984,10 @@ class Single(object):
                 mine_fun = mine_fun_data.pop('mine_function', mine_fun)
                 mine_args = mine_fun_data
             elif isinstance(mine_fun_data, list):
-                if isinstance(mine_fun_data[0], dict) and 'mine_function' in mine_fun_data[0]:
-                    mine_fun = mine_fun_data[0]['mine_function']
-                    mine_fun_data.pop(0)
+                for item in mine_fun_data[:]:
+                    if isinstance(item, dict) and 'mine_function' in item:
+                        mine_fun = item['mine_function']
+                        mine_fun_data.pop(mine_fun_data.index(item))
                 mine_args = mine_fun_data
             else:
                 mine_args = mine_fun_data


### PR DESCRIPTION
### What does this PR do?
Allows a user to use salt mine aliases in salt-ssh

### What issues does this PR fix or reference?
Fixes #41377

### Previous Behavior
When executing a mine.get for an aliased value the error TypeError encountered executing say_hello: 'FunctionWrapper' object is not callable was returned

### New Behavior
If the salt mine alias is defined correctly than the value is returned from the mine

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
