### PR TITLE
Change typo default_passwoord by default_password

### DIFF
--- a/salt/states/postgres_user.py
+++ b/salt/states/postgres_user.py
@@ -95,7 +95,7 @@ def present(name,
         encrypted to the previous
         format if it is not already done.
 
-    default_passwoord
+    default_password
         The password used only when creating the user, unless password is set.
 
         .. versionadded:: 2016.3.0


### PR DESCRIPTION
### What does this PR do?

change typo on doc string state/postgres_user.sls 