### PR TITLE
Enhance BGP runner

### DIFF
--- a/salt/runners/bgp.py
+++ b/salt/runners/bgp.py
@@ -17,7 +17,7 @@ Configuration
     .. code-block:: yaml
 
         mine_functions:
-            bgp.neighbors: []
+          bgp.neighbors: []
 
     Which instructs Salt to cache the data returned by the ``neighbors`` function
     from the :mod:`NAPALM BGP module <salt.modules.napalm_bgp>`
@@ -33,12 +33,12 @@ Configuration
     By default the following options can be configured on the master.
     They are not necessary, but available in case the user has different requirements.
 
-    tgt: '*'
+    target: ``*``
         From what minions will collect the mine data.
-        Default: `*` (will collect mine data from all minions)
+        Default: ``*`` (collect mine data from all minions)
 
-    tgt_type: 'glob'
-        The type of ``tgt``. Default: `glob`.
+    expr_form: ``glob``
+        Minion matching expression form. Default: ``glob``.
 
     return_fields
         What fields to return in the output.
@@ -48,7 +48,7 @@ Configuration
         an output of the form ``State|#Active/Received/Accepted/Damped``, e.g.
         ``Established 398/399/399/0`` similar to the usual output
         from network devices.
-        There are also some fields that cannot be removed:
+        Some fields cannot be removed:
 
         - ``as_number``: the AS number of the neighbor
         - ``device``: the minion ID
@@ -60,27 +60,40 @@ Configuration
         - ``import_policy``: the name of the import policy
         - ``export_policy``: the name of the export policy
 
-    display: True
-        Display on the screen or return structured object? Default: `True`, will return on the CLI.
+        Special fields:
 
-    outputter: table
-        Specify the outputter name when displaying on the CLI. Default: `table`.
+        - ``interface_description``: matches the neighbor details with the
+        corresponding interface and returns its description. This will reuse
+        functionality from the :mod:`net runner <salt.runners.net>`,
+        so the user needs to enable the mines as specified in the documentation.
+
+        - ``interface_name``: matches the neighbor details with the
+        corresponding interface and returns the name.
+        Similar to ``interface_description``, this will reuse
+        functionality from the :mod:`net runner <salt.runners.net>`,
+        so the user needs to enable the mines as specified in the documentation.
+
+    display: ``True``
+        Display on the screen or return structured object? Default: ``True``, will return on the CLI.
+
+    outputter: ``table``
+        Specify the outputter name when displaying on the CLI. Default: :mod:`table <salt.output.table_out>`.
 
     Configuration example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         runners:
           bgp:
             tgt: 'edge*'
             tgt_type: 'glob'
             return_fields:
-                - up
-                - connection_state
-                - previous_connection_state
-                - suppress_4byte_as
-                - holdtime
-                - flap_count
+              - up
+              - connection_state
+              - previous_connection_state
+              - suppress_4byte_as
+              - holdtime
+              - flap_count
             outputter: yaml
 '''
 from __future__ import print_function
@@ -187,13 +200,16 @@ def _compare_match(dict1, dict2):
     return True
 
 
-def _display_runner(rows, labels, title, display=_DEFAULT_DISPLAY):
+def _display_runner(rows,
+                    labels,
+                    title,
+                    display=_DEFAULT_DISPLAY,
+                    outputter=_DEFAULT_OUTPUTTER):
     '''
     Display or return the rows.
     '''
     if display:
-        bgp_runner_opts = _get_bgp_runner_opts()
-        if bgp_runner_opts.get('outputter') == 'table':
+        if outputter == 'table':
             ret = salt.output.out_format({'rows': rows, 'labels': labels},
                                          'table',
                                          __opts__,
@@ -202,7 +218,7 @@ def _display_runner(rows, labels, title, display=_DEFAULT_DISPLAY):
                                          labels_key='labels')
         else:
             ret = salt.output.out_format(rows,
-                                         bgp_runner_opts.get('outputter'),
+                                         outputter,
                                          __opts__)
         print(ret)
     else:
@@ -237,10 +253,13 @@ def neighbors(*asns, **kwargs):
     title
         Custom title.
 
-    display: True
-        Display on the screen or return structured object? Default: `True`, will return on the CLI.
+    display: ``True``
+        Display on the screen or return structured object? Default: ``True`` (return on the CLI).
 
-    In addition, any field from the output of the `neighbors` function
+    outputter: ``table``
+        Specify the outputter name when displaying on the CLI. Default: :mod:`table <salt.output.table_out>`.
+
+    In addition, any field from the output of the ``neighbors`` function
     from the :mod:`NAPALM BGP module <salt.modules.napalm_bgp>` can be used as a filter.
 
     CLI Example:
@@ -279,6 +298,7 @@ def neighbors(*asns, **kwargs):
     opts = _get_bgp_runner_opts()
     title = kwargs.pop('title', None)
     display = kwargs.pop('display', opts['display'])
+    outputter = kwargs.pop('outputter', opts['outputter'])
 
     # cleaning up the kwargs
     # __pub args not used in this runner (yet)
@@ -365,8 +385,23 @@ def neighbors(*asns, **kwargs):
                             damped=neighbor.get('suppressed_prefix_count', -1),
                         )
                         row['connection_stats'] = connection_stats
+                    if 'interface_description' in display_fields or 'interface_name' in display_fields:
+                        net_find = __salt__['net.interfaces'](device=minion,
+                                                              ipnet=neighbor.get('remote_address'),
+                                                              display=False)
+                        if net_find:
+                            if 'interface_description' in display_fields:
+                                row['interface_description'] = net_find[0]['interface_description']
+                            if 'interface_name' in display_fields:
+                                row['interface_name'] = net_find[0]['interface']
+                        else:
+                            # if unable to find anything, leave blank
+                            if 'interface_description' in display_fields:
+                                row['interface_description'] = ''
+                            if 'interface_name' in display_fields:
+                                row['interface_name'] = ''
                     for field in display_fields:
                         if field in neighbor:
                             row[field] = neighbor[field]
                     rows.append(row)
-    return _display_runner(rows, labels, title, display=display)
+    return _display_runner(rows, labels, title, display=display, outputter=outputter)

--- a/salt/runners/bgp.py
+++ b/salt/runners/bgp.py
@@ -31,7 +31,7 @@ Configuration
 - Master config
 
     By default the following options can be configured on the master.
-    They are not necessary, but available in case the user has different requirements.
+    They are not mandatory, but available in case the user has different requirements.
 
     tgt: ``*``
         From what minions will collect the mine data.
@@ -75,7 +75,7 @@ Configuration
         so the user needs to enable the mines as specified in the documentation.
 
     display: ``True``
-        Display on the screen or return structured object? Default: ``True``, will return on the CLI.
+        Display on the screen or return structured object? Default: ``True`` (return on the CLI).
 
     outputter: ``table``
         Specify the outputter name when displaying on the CLI. Default: :mod:`table <salt.output.table_out>`.

--- a/salt/runners/bgp.py
+++ b/salt/runners/bgp.py
@@ -33,11 +33,11 @@ Configuration
     By default the following options can be configured on the master.
     They are not necessary, but available in case the user has different requirements.
 
-    target: ``*``
+    tgt: ``*``
         From what minions will collect the mine data.
         Default: ``*`` (collect mine data from all minions)
 
-    expr_form: ``glob``
+    tgt_type: ``glob``
         Minion matching expression form. Default: ``glob``.
 
     return_fields

--- a/salt/runners/bgp.py
+++ b/salt/runners/bgp.py
@@ -42,12 +42,9 @@ Configuration
 
     return_fields
         What fields to return in the output.
-        At most, it can display all the fields from the ``neighbor`` function
+        It can display all the fields from the ``neighbor`` function
         from the :mod:`NAPALM BGP module <salt.modules.napalm_bgp>`.
-        There's one additional field called ``connection_stats`` returning
-        an output of the form ``State|#Active/Received/Accepted/Damped``, e.g.
-        ``Established 398/399/399/0`` similar to the usual output
-        from network devices.
+
         Some fields cannot be removed:
 
         - ``as_number``: the AS number of the neighbor
@@ -56,17 +53,21 @@ Configuration
 
         By default, the following extra fields are returned (displayed):
 
-        - ``connection_stats``: connection stats, as descibed above
+        - ``connection_stats``: connection stats, as descibed below
         - ``import_policy``: the name of the import policy
         - ``export_policy``: the name of the export policy
 
         Special fields:
 
+        - ``vrf``: return the name of the VRF.
+        - ``connection_stats``: returning an output of the form
+        ``<State> <Active>/<Received>/<Accepted>/<Damped>``, e.g.
+        ``Established 398/399/399/0`` similar to the usual output
+        from network devices.
         - ``interface_description``: matches the neighbor details with the
         corresponding interface and returns its description. This will reuse
         functionality from the :mod:`net runner <salt.runners.net>`,
         so the user needs to enable the mines as specified in the documentation.
-
         - ``interface_name``: matches the neighbor details with the
         corresponding interface and returns the name.
         Similar to ``interface_description``, this will reuse
@@ -146,7 +147,8 @@ _DEFAULT_LABELS_MAPPING = {
     'neighbor_address': 'Neighbor IP',
     'connection_stats': 'State|#Active/Received/Accepted/Damped',
     'import_policy': 'Policy IN',
-    'export_policy': 'Policy OUT'
+    'export_policy': 'Policy OUT',
+    'vrf': 'VRF'
 }
 
 # -----------------------------------------------------------------------------
@@ -376,6 +378,8 @@ def neighbors(*asns, **kwargs):
                         'neighbor_address': neighbor.get('remote_address'),
                         'as_number': asn
                     }
+                    if 'vrf' in display_fields:
+                        row['vrf'] = vrf
                     if 'connection_stats' in display_fields:
                         connection_stats = '{state} {active}/{received}/{accepted}/{damped}'.format(
                             state=neighbor.get('connection_state', -1),

--- a/salt/runners/bgp.py
+++ b/salt/runners/bgp.py
@@ -66,12 +66,12 @@ Configuration
         from network devices.
         - ``interface_description``: matches the neighbor details with the
         corresponding interface and returns its description. This will reuse
-        functionality from the :mod:`net runner <salt.runners.net>`,
+        functionality from the :mod:`net runner <salt.runners.net.interfaces>`,
         so the user needs to enable the mines as specified in the documentation.
         - ``interface_name``: matches the neighbor details with the
         corresponding interface and returns the name.
         Similar to ``interface_description``, this will reuse
-        functionality from the :mod:`net runner <salt.runners.net>`,
+        functionality from the :mod:`net runner <salt.runners.net.interfaces>`,
         so the user needs to enable the mines as specified in the documentation.
 
     display: ``True``

--- a/salt/runners/bgp.py
+++ b/salt/runners/bgp.py
@@ -20,7 +20,7 @@ Configuration
           bgp.neighbors: []
 
     Which instructs Salt to cache the data returned by the ``neighbors`` function
-    from the :mod:`NAPALM BGP module <salt.modules.napalm_bgp>`
+    from the :mod:`NAPALM BGP module <salt.modules.napalm_bgp.neighbors>`.
 
     How often the mines are refreshed, can be specified using:
 
@@ -42,8 +42,8 @@ Configuration
 
     return_fields
         What fields to return in the output.
-        It can display all the fields from the ``neighbor`` function
-        from the :mod:`NAPALM BGP module <salt.modules.napalm_bgp>`.
+        It can display all the fields from the ``neighbors`` function
+        from the :mod:`NAPALM BGP module <salt.modules.napalm_bgp.neighbors>`.
 
         Some fields cannot be removed:
 
@@ -262,7 +262,7 @@ def neighbors(*asns, **kwargs):
         Specify the outputter name when displaying on the CLI. Default: :mod:`table <salt.output.table_out>`.
 
     In addition, any field from the output of the ``neighbors`` function
-    from the :mod:`NAPALM BGP module <salt.modules.napalm_bgp>` can be used as a filter.
+    from the :mod:`NAPALM BGP module <salt.modules.napalm_bgp.neighbors>` can be used as a filter.
 
     CLI Example:
 


### PR DESCRIPTION
### What does this PR do?

Add `interface_name` and `interface_description` options.
Reuses the functionality from the net.interfaces runner
and matches the neighbor IP to determine the network interface
and return the interface description & interface name fields.
This field is not enable by default, as the users require to configure
few other mines, as documented in the net runner.
In the master configuration opts, they need to append the additional
interface_description and/or interface_name options under `return_fields`.

This pull request also addresses few documentation improvements/fixes.