### PR TITLE
added usermacro functions to the zabbix execution module

### DIFF
--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -1489,6 +1489,290 @@ def hostinterface_update(interfaceid, **connection_args):
         return ret
 
 
+def usermacro_get(macro=None, hostids=None, templateids=None, hostmacroids=None,
+                  globalmacroids=None, globalmacro=False, **connection_args):
+    '''
+    Retrieve user macros according to the given parameters.
+
+    Args:
+        macro:          name of the usermacro
+        hostids:        Return macros for the given hostids
+        templateids:    Return macros for the given templateids
+        hostmacroids:   Return macros with the given hostmacroids
+        globalmacroids: Return macros with the given globalmacroids (implies globalmacro=True)
+        globalmacro:    if True, returns only global macros
+
+
+        optional connection_args:
+                _connection_user: zabbix user (can also be set in opts or pillar, see module's docstring)
+                _connection_password: zabbix password (can also be set in opts or pillar, see module's docstring)
+                _connection_url: url of zabbix frontend (can also be set in opts or pillar, see module's docstring)
+
+    Returns:
+        Array with usermacro details, False if no usermacro found or on failure.
+
+    CLI Example:
+    .. code-block:: bash
+
+        salt '*' zabbix.usermacro_get macro='{$SNMP_COMMUNITY}'
+    '''
+    conn_args = _login(**connection_args)
+    ret = False
+    try:
+        if conn_args:
+            method = 'usermacro.get'
+            params = {"output": "extend", "filter": {}}
+            if macro:
+                # Python mistakenly interprets macro names starting and ending with '{' and '}' as a dict
+                if isinstance(macro, dict):
+                    macro = "{" + str(macro.keys()[0]) +"}"
+                if not macro.startswith('{') and not macro.endswith('}'):
+                    macro = "{" + macro + "}"
+                params['filter'].setdefault('macro', macro)
+            if hostids:
+                params.setdefault('hostids', hostids)
+            elif templateids:
+                params.setdefault('templateids', hostids)
+            if hostmacroids:
+                params.setdefault('hostmacroids', hostmacroids)
+            elif globalmacroids:
+                globalmacro = True
+                params.setdefault('globalmacroids', globalmacroids)
+            if globalmacro:
+                params = _params_extend(params, globalmacro=True)
+            params = _params_extend(params, **connection_args)
+            ret = _query(method, params, conn_args['url'], conn_args['auth'])
+            return ret['result'] if len(ret['result']) > 0 else False
+        else:
+            raise KeyError
+    except KeyError:
+        return ret
+
+
+def usermacro_create(macro, value, hostid, **connection_args):
+    '''
+    Create new host usermacro.
+
+    :param macro: name of the host usermacro
+    :param value: value of the host usermacro
+    :param hostid: hostid or templateid
+    :param _connection_user: Optional - zabbix user (can also be set in opts or pillar, see module's docstring)
+    :param _connection_password: Optional - zabbix password (can also be set in opts or pillar, see module's docstring)
+    :param _connection_url: Optional - url of zabbix frontend (can also be set in opts, pillar, see module's docstring)
+
+    return: ID of the created host usermacro.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zabbix.usermacro_create '{$SNMP_COMMUNITY}' 'public' 1
+    '''
+    conn_args = _login(**connection_args)
+    ret = False
+    try:
+        if conn_args:
+            params = {}
+            method = 'usermacro.create'
+            if macro:
+                # Python mistakenly interprets macro names starting and ending with '{' and '}' as a dict
+                if isinstance(macro, dict):
+                    macro = "{" + str(macro.keys()[0]) +"}"
+                if not macro.startswith('{') and not macro.endswith('}'):
+                    macro = "{" + macro + "}"
+                params['macro'] = macro
+            params['value'] = value
+            params['hostid'] = hostid
+            params = _params_extend(params, _ignore_name=True, **connection_args)
+            ret = _query(method, params, conn_args['url'], conn_args['auth'])
+            return ret['result']['hostmacroids'][0]
+        else:
+            raise KeyError
+    except KeyError:
+        return ret
+
+
+def usermacro_createglobal(macro, value, **connection_args):
+    '''
+    Create new global usermacro.
+
+    :param macro: name of the global usermacro
+    :param value: value of the global usermacro
+    :param _connection_user: Optional - zabbix user (can also be set in opts or pillar, see module's docstring)
+    :param _connection_password: Optional - zabbix password (can also be set in opts or pillar, see module's docstring)
+    :param _connection_url: Optional - url of zabbix frontend (can also be set in opts, pillar, see module's docstring)
+
+    return: ID of the created global usermacro.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zabbix.usermacro_createglobal '{$SNMP_COMMUNITY}' 'public'
+    '''
+    conn_args = _login(**connection_args)
+    ret = False
+    try:
+        if conn_args:
+            params = {}
+            method = 'usermacro.createglobal'
+            if macro:
+                # Python mistakenly interprets macro names starting and ending with '{' and '}' as a dict
+                if isinstance(macro, dict):
+                    macro = "{" + str(macro.keys()[0]) +"}"
+                if not macro.startswith('{') and not macro.endswith('}'):
+                    macro = "{" + macro + "}"
+                params['macro'] = macro
+            params['value'] = value
+            params = _params_extend(params, _ignore_name=True, **connection_args)
+            ret = _query(method, params, conn_args['url'], conn_args['auth'])
+            return ret['result']['globalmacroids'][0]
+        else:
+            raise KeyError
+    except KeyError:
+        return ret
+
+
+def usermacro_delete(macroids, **connection_args):
+    '''
+    Delete host usermacros.
+
+    :param macroids: macroids of the host usermacros
+
+    :param _connection_user: Optional - zabbix user (can also be set in opts or pillar, see module's docstring)
+    :param _connection_password: Optional - zabbix password (can also be set in opts or pillar, see module's docstring)
+    :param _connection_url: Optional - url of zabbix frontend (can also be set in opts, pillar, see module's docstring)
+
+    return: IDs of the deleted host usermacro.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zabbix.usermacro_delete 21
+    '''
+    conn_args = _login(**connection_args)
+    ret = False
+    try:
+        if conn_args:
+            method = 'usermacro.delete'
+            if isinstance(macroids, list):
+                params = macroids
+            else:
+                params = [macroids]
+            ret = _query(method, params, conn_args['url'], conn_args['auth'])
+            return ret['result']['hostmacroids']
+        else:
+            raise KeyError
+    except KeyError:
+        return ret
+
+
+def usermacro_deleteglobal(macroids, **connection_args):
+    '''
+    Delete global usermacros.
+
+    :param macroids: macroids of the global usermacros
+
+    :param _connection_user: Optional - zabbix user (can also be set in opts or pillar, see module's docstring)
+    :param _connection_password: Optional - zabbix password (can also be set in opts or pillar, see module's docstring)
+    :param _connection_url: Optional - url of zabbix frontend (can also be set in opts, pillar, see module's docstring)
+
+    return: IDs of the deleted global usermacro.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zabbix.usermacro_deleteglobal 21
+    '''
+    conn_args = _login(**connection_args)
+    ret = False
+    try:
+        if conn_args:
+            method = 'usermacro.deleteglobal'
+            if isinstance(macroids, list):
+                params = macroids
+            else:
+                params = [macroids]
+            ret = _query(method, params, conn_args['url'], conn_args['auth'])
+            return ret['result']['globalmacroids']
+        else:
+            raise KeyError
+    except KeyError:
+        return ret
+
+
+def usermacro_update(hostmacroid, value, **connection_args):
+    '''
+    Update existing host usermacro.
+
+    :param hostmacroid: id of the host usermacro
+    :param value: new value of the host usermacro
+    :param _connection_user: Optional - zabbix user (can also be set in opts or pillar, see module's docstring)
+    :param _connection_password: Optional - zabbix password (can also be set in opts or pillar, see module's docstring)
+    :param _connection_url: Optional - url of zabbix frontend (can also be set in opts, pillar, see module's docstring)
+
+    return: ID of the update host usermacro.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zabbix.usermacro_update 1 'public'
+    '''
+    conn_args = _login(**connection_args)
+    ret = False
+    try:
+        if conn_args:
+            params = {}
+            method = 'usermacro.update'
+            params['hostmacroid'] = hostmacroid
+            params['value'] = value
+            params = _params_extend(params, _ignore_name=True, **connection_args)
+            ret = _query(method, params, conn_args['url'], conn_args['auth'])
+            return ret['result']['hostmacroids'][0]
+        else:
+            raise KeyError
+    except KeyError:
+        return ret
+
+
+def usermacro_updateglobal(globalmacroid, value, **connection_args):
+    '''
+    Update existing global usermacro.
+
+    :param globalmacroid: id of the host usermacro
+    :param value: new value of the host usermacro
+    :param _connection_user: Optional - zabbix user (can also be set in opts or pillar, see module's docstring)
+    :param _connection_password: Optional - zabbix password (can also be set in opts or pillar, see module's docstring)
+    :param _connection_url: Optional - url of zabbix frontend (can also be set in opts, pillar, see module's docstring)
+
+    return: ID of the update global usermacro.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zabbix.usermacro_updateglobal 1 'public'
+    '''
+    conn_args = _login(**connection_args)
+    ret = False
+    try:
+        if conn_args:
+            params = {}
+            method = 'usermacro.updateglobal'
+            params['globalmacroid'] = globalmacroid
+            params['value'] = value
+            params = _params_extend(params, _ignore_name=True, **connection_args)
+            ret = _query(method, params, conn_args['url'], conn_args['auth'])
+            return ret['result']['globalmacroids'][0]
+        else:
+            raise KeyError
+    except KeyError:
+        return ret
+
+
 def mediatype_get(name=None, mediatypeids=None, **connection_args):
     '''
     Retrieve mediatypes according to the given parameters.

--- a/salt/states/zabbix_usermacro.py
+++ b/salt/states/zabbix_usermacro.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
 Management of Zabbix usermacros.
-
 :codeauthor: Raymond Kuiper <qix@the-wired.net>
 
 '''

--- a/salt/states/zabbix_usermacro.py
+++ b/salt/states/zabbix_usermacro.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+'''
+Management of Zabbix usermacros.
+
+:codeauthor: Raymond Kuiper <qix@the-wired.net>
+
+'''
+
+
+def __virtual__():
+    '''
+    Only make these states available if Zabbix module is available.
+    '''
+    return 'zabbix.usermacro_create' in __salt__
+
+
+def present(name, value, hostid=None, **kwargs):
+    '''
+    Creates a new usermacro.
+
+    :param name: name of the usermacro
+    :param value: value of the usermacro
+    :param hostid: id's of the hosts to apply the usermacro on, if missing a global usermacro is assumed.
+
+    :param _connection_user: Optional - zabbix user (can also be set in opts or pillar, see module's docstring)
+    :param _connection_password: Optional - zabbix password (can also be set in opts or pillar, see module's docstring)
+    :param _connection_url: Optional - url of zabbix frontend (can also be set in opts, pillar, see module's docstring)
+
+    .. code-block:: yaml
+
+        override host usermacro:
+            zabbix_usermacro.present:
+                - name: '{$SNMP_COMMUNITY}''
+                - value: 'public'
+                - hostid: 21
+
+    '''
+    connection_args = {}
+    if '_connection_user' in kwargs:
+        connection_args['_connection_user'] = kwargs['_connection_user']
+    if '_connection_password' in kwargs:
+        connection_args['_connection_password'] = kwargs['_connection_password']
+    if '_connection_url' in kwargs:
+        connection_args['_connection_url'] = kwargs['_connection_url']
+
+    ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
+
+    # Comment and change messages
+    if hostid:
+        comment_usermacro_created = 'Usermacro {0} created on hostid {1}.'.format(name, hostid)
+        comment_usermacro_updated = 'Usermacro {0} updated on hostid {1}.'.format(name, hostid)
+        comment_usermacro_notcreated = 'Unable to create usermacro: {0} on hostid {1}. '.format(name, hostid)
+        comment_usermacro_exists = 'Usermacro {0} already exists on hostid {1}.'.format(name, hostid)
+        changes_usermacro_created = {name: {'old': 'Usermacro {0} does not exist on hostid {1}.'.format(name, hostid),
+                                            'new': 'Usermacro {0} created on hostid {1}.'.format(name, hostid),
+                                            }
+                                     }
+    else:
+        comment_usermacro_created = 'Usermacro {0} created.'.format(name)
+        comment_usermacro_updated = 'Usermacro {0} updated.'.format(name)
+        comment_usermacro_notcreated = 'Unable to create usermacro: {0}. '.format(name)
+        comment_usermacro_exists = 'Usermacro {0} already exists.'.format(name)
+        changes_usermacro_created = {name: {'old': 'Usermacro {0} does not exist.'.format(name),
+                                            'new': 'Usermacro {0} created.'.format(name),
+                                            }
+                                     }
+
+    # Zabbix API expects script parameters as a string of arguments seperated by newline characters
+    if 'exec_params' in kwargs:
+        if isinstance(kwargs['exec_params'], list):
+            kwargs['exec_params'] = '\n'.join(kwargs['exec_params'])+'\n'
+        else:
+            kwargs['exec_params'] = str(kwargs['exec_params'])+'\n'
+    if hostid:
+        usermacro_exists = __salt__['zabbix.usermacro_get'](name, hostids=hostid, **connection_args)
+    else:
+        usermacro_exists = __salt__['zabbix.usermacro_get'](name, globalmacro=True, **connection_args)
+
+    if usermacro_exists:
+        usermacroobj = usermacro_exists[0]
+        if hostid:
+            usermacroid = int(usermacroobj['hostmacroid'])
+        else:
+            usermacroid = int(usermacroobj['globalmacroid'])
+        update_value = False
+
+        if str(value) != usermacroobj['value']:
+            update_value = True
+
+    # Dry run, test=true mode
+    if __opts__['test']:
+        if usermacro_exists:
+            if update_value:
+                ret['result'] = None
+                ret['comment'] = comment_usermacro_updated
+            else:
+                ret['result'] = True
+                ret['comment'] = comment_usermacro_exists
+        else:
+            ret['result'] = None
+            ret['comment'] = comment_usermacro_created
+        return ret
+
+    error = []
+
+    if usermacro_exists:
+        if update_value:
+            ret['result'] = True
+            ret['comment'] = comment_usermacro_updated
+
+            if hostid:
+                updated_value = __salt__['zabbix.usermacro_update'](usermacroid,
+                                                                    value=value,
+                                                                    **connection_args)
+            else:
+                updated_value = __salt__['zabbix.usermacro_updateglobal'](usermacroid,
+                                                                          value=value,
+                                                                          **connection_args)
+            if not isinstance(updated_value, int):
+                if 'error' in updated_value:
+                    error.append(updated_value['error'])
+                else:
+                    ret['changes']['value'] = value
+        else:
+            ret['result'] = True
+            ret['comment'] = comment_usermacro_exists
+    else:
+        if hostid:
+            usermacro_create = __salt__['zabbix.usermacro_create'](name, value, hostid, **connection_args)
+        else:
+            usermacro_create = __salt__['zabbix.usermacro_createglobal'](name, value, **connection_args)
+
+        if 'error' not in usermacro_create:
+            ret['result'] = True
+            ret['comment'] = comment_usermacro_created
+            ret['changes'] = changes_usermacro_created
+        else:
+            ret['result'] = False
+            ret['comment'] = comment_usermacro_notcreated + str(usermacro_create['error'])
+
+    # error detected
+    if error:
+        ret['changes'] = {}
+        ret['result'] = False
+        ret['comment'] = str(error)
+
+    return ret
+
+
+def absent(name, hostid=None, **kwargs):
+    '''
+    Ensures that the mediatype does not exist, eventually deletes the mediatype.
+
+    :param name: name of the usermacro
+    :param hostid: id's of the hosts to apply the usermacro on, if missing a global usermacro is assumed.
+
+    :param _connection_user: Optional - zabbix user (can also be set in opts or pillar, see module's docstring)
+    :param _connection_password: Optional - zabbix password (can also be set in opts or pillar, see module's docstring)
+    :param _connection_url: Optional - url of zabbix frontend (can also be set in opts, pillar, see module's docstring)
+
+    .. code-block:: yaml
+
+        delete_usermacro:
+            zabbix_usermacro.absent:
+                - name: '{$SNMP_COMMUNITY}'
+
+    '''
+    connection_args = {}
+    if '_connection_user' in kwargs:
+        connection_args['_connection_user'] = kwargs['_connection_user']
+    if '_connection_password' in kwargs:
+        connection_args['_connection_password'] = kwargs['_connection_password']
+    if '_connection_url' in kwargs:
+        connection_args['_connection_url'] = kwargs['_connection_url']
+
+    ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
+
+    # Comment and change messages
+    if hostid:
+        comment_usermacro_deleted = 'Usermacro {0} deleted from hostid {1}.'.format(name, hostid)
+        comment_usermacro_notdeleted = 'Unable to delete usermacro: {0} from hostid {1}.'.format(name, hostid)
+        comment_usermacro_notexists = 'Usermacro {0} does not exist on hostid {1}.'.format(name, hostid)
+        changes_usermacro_deleted = {name: {'old': 'Usermacro {0} exists on hostid {1}.'.format(name, hostid),
+                                            'new': 'Usermacro {0} deleted from {1}.'.format(name, hostid),
+                                            }
+                                     }
+    else:
+        comment_usermacro_deleted = 'Usermacro {0} deleted.'.format(name)
+        comment_usermacro_notdeleted = 'Unable to delete usermacro: {0}.'.format(name)
+        comment_usermacro_notexists = 'Usermacro {0} does not exist.'.format(name)
+        changes_usermacro_deleted = {name: {'old': 'Usermacro {0} exists.'.format(name),
+                                            'new': 'Usermacro {0} deleted.'.format(name),
+                                            }
+                                     }
+    if hostid:
+        usermacro_exists = __salt__['zabbix.usermacro_get'](name, hostids=hostid, **connection_args)
+    else:
+        usermacro_exists = __salt__['zabbix.usermacro_get'](name, globalmacro=True, **connection_args)
+
+    # Dry run, test=true mode
+    if __opts__['test']:
+        if not usermacro_exists:
+            ret['result'] = True
+            ret['comment'] = comment_usermacro_notexists
+        else:
+            ret['result'] = None
+            ret['comment'] = comment_usermacro_deleted
+        return ret
+
+    if not usermacro_exists:
+        ret['result'] = True
+        ret['comment'] = comment_usermacro_notexists
+    else:
+        try:
+            if hostid:
+                usermacroid = usermacro_exists[0]['hostmacroid']
+                usermacro_delete = __salt__['zabbix.usermacro_delete'](usermacroid, **connection_args)
+            else:
+                usermacroid = usermacro_exists[0]['globalmacroid']
+                usermacro_delete = __salt__['zabbix.usermacro_deleteglobal'](usermacroid, **connection_args)
+        except KeyError:
+            usermacro_delete = False
+
+        if usermacro_delete and 'error' not in usermacro_delete:
+            ret['result'] = True
+            ret['comment'] = comment_usermacro_deleted
+            ret['changes'] = changes_usermacro_deleted
+        else:
+            ret['result'] = False
+            ret['comment'] = comment_usermacro_notdeleted + str(usermacro_delete['error'])
+
+    return ret


### PR DESCRIPTION
### What does this PR do?
This PR adds the various functions needed to manage host and global usermacros in Zabbix to the zabbix execution module. 

### What issues does this PR fix or reference?
No current issues afaik, I needed this functionality to manage usermacros from states (still being developed).

### Previous Behavior
Usermacros could not be managed by Salt

### New Behavior
Usermacros can now be managed by salt

### Tests written?
No
