### PR TITLE
salt/pillar/vault.py: Support having minion_id in vault path

### DIFF
--- a/salt/pillar/vault.py
+++ b/salt/pillar/vault.py
@@ -45,6 +45,7 @@ Multiple Vault sources may also be used:
     ext_pillar:
       - vault: path=secret/salt
       - vault: path=secret/root
+      - vault: path=secret/minions/{minion}/pass
 '''
 
 # import python libs
@@ -87,6 +88,7 @@ def ext_pillar(minion_id,  # pylint: disable=W0613
 
     try:
         path = paths[0].replace('path=', '')
+        path = path.format(**{'minion': minion_id})
         url = 'v1/{0}'.format(path)
         response = __utils__['vault.make_request']('GET', url)
         if response.status_code != 200:


### PR DESCRIPTION
### What does this PR do?
Support having minion_id in vault path

### New Behavior
path=secret/salt/minions/%(minion_id)s/pass

### Tests written?
No
