### PR TITLE
Add keystone V3 API support for keystone.endpoint_present|absent

### DIFF
--- a/salt/states/keystone.py
+++ b/salt/states/keystone.py
@@ -656,6 +656,7 @@ def endpoint_present(name,
 
     endpoint = __salt__['keystone.endpoint_get'](name, region,
                                                  profile=profile,
+                                                 interface=interface,
                                                  **connection_args)
 
     def _changes(desc):
@@ -746,7 +747,7 @@ def endpoint_present(name,
                 ret['changes']['internalurl'] = internalurl
 
         if ret['comment']:  # changed
-            __salt__['keystone.endpoint_delete'](name, region, profile=profile, **connection_args)
+            __salt__['keystone.endpoint_delete'](name, region, profile=profile, interface=interface, **connection_args)
             _createEndpoint()
             ret['comment'] += 'Endpoint for service "{0}" has been updated'.format(name)
 
@@ -761,28 +762,36 @@ def endpoint_present(name,
         ret['comment'] = 'Endpoint for service "{0}" has been added'.format(name)
 
     if ret['comment'] == '':  # => no changes
-        ret['result'] = None
         ret['comment'] = 'Endpoint for service "{0}" already exists'.format(name)
     return ret
 
 
-def endpoint_absent(name, region=None, profile=None, **connection_args):
+def endpoint_absent(name, region=None, profile=None, interface=None, **connection_args):
     '''
     Ensure that the endpoint for a service doesn't exist in Keystone catalog
 
     name
         The name of the service whose endpoints should not exist
+
+    region (optional)
+        The region of the endpoint.  Defaults to ``RegionOne``.
+
+    interface
+        The interface type, which describes the visibility
+        of the endpoint. (for V3 API)
     '''
     ret = {'name': name,
            'changes': {},
            'result': True,
-           'comment': 'Endpoint for service "{0}" is already absent'.format(name)}
+           'comment': 'Endpoint for service "{0}"{1} is already absent'.format(name,
+                      ', interface "{0}",'.format(interface) if interface is not None else '')}
 
     # Check if service is present
     endpoint = __salt__['keystone.endpoint_get'](name, region,
                                                  profile=profile,
+                                                 interface=interface,
                                                  **connection_args)
-    if not endpoint:
+    if not endpoint or 'Error' in endpoint:
         return ret
     else:
         if __opts__.get('test'):
@@ -792,7 +801,9 @@ def endpoint_absent(name, region=None, profile=None, **connection_args):
         # Delete service
         __salt__['keystone.endpoint_delete'](name, region,
                                              profile=profile,
+                                             interface=interface,
                                              **connection_args)
-        ret['comment'] = 'Endpoint for service "{0}" has been deleted'.format(name)
+        ret['comment'] = 'Endpoint for service "{0}"{1} has been deleted'.format(name,
+                         ', interface "{0}",'.format(interface) if interface is not None else '')
         ret['changes']['endpoint'] = 'Deleted'
     return ret

--- a/salt/states/keystone.py
+++ b/salt/states/keystone.py
@@ -791,7 +791,7 @@ def endpoint_absent(name, region=None, profile=None, interface=None, **connectio
                                                  profile=profile,
                                                  interface=interface,
                                                  **connection_args)
-    if not endpoint or 'Error' in endpoint:
+    if not endpoint:
         return ret
     else:
         if __opts__.get('test'):

--- a/tests/unit/states/keystone_test.py
+++ b/tests/unit/states/keystone_test.py
@@ -317,7 +317,7 @@ class KeystoneTestCase(TestCase):
                                             'keystone.endpoint_create': mock}):
 
             comt = ('Endpoint for service "{0}" already exists'.format(name))
-            ret.update({'comment': comt, 'result': None, 'changes': {}})
+            ret.update({'comment': comt, 'result': True, 'changes': {}})
             self.assertDictEqual(keystone.endpoint_present(name), ret)
 
             with patch.dict(keystone.__opts__, {'test': True}):
@@ -326,7 +326,7 @@ class KeystoneTestCase(TestCase):
                 self.assertDictEqual(keystone.endpoint_present(name), ret)
 
                 comt = ('Endpoint for service "{0}" already exists'.format(name))
-                ret.update({'comment': comt, 'result': None, 'changes': {}})
+                ret.update({'comment': comt, 'result': True, 'changes': {}})
                 self.assertDictEqual(keystone.endpoint_present(name), ret)
 
             with patch.dict(keystone.__opts__, {'test': False}):


### PR DESCRIPTION
### What does this PR do?
Add keystone V3 API support for keystone.endpoint_present|get, endpoint_absent|delete.
    
Passing interface to endpoint_present, or absent, will ensure only the given interface
for the specified region, is acted upon.
    
### What issues does this PR fix or reference?
Fixes #41435

### Previous Behavior
keystone.endpoint_present, or absent, would return an array of dictionaries containing 3 elements, unlike one with V2, when getting the endpoint list.  As a result, when creating the admin, internal, and public interfaces, each subsequent endpoint_present call for the same service and region would overwrite the previous interface, leaving you with just a single interface.

Also, endpoint absent would either delete just a single endpoint for a service using V3 API, or delete none, and still state that changes were made.


### New Behavior
endpoint_present and absent now pass the interface to endpoint_get to return information about just the chosen region, service name, and interface, and then acts upon that, much like would be the case with V2.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
