### PR TITLE
Fix the EC2 salt-cloud driver to work with Python 3

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -22,6 +22,7 @@ import salt.config
 import re
 
 # Import Salt libs
+import salt.utils.hashutils
 import salt.utils.xmlutil as xml
 from salt._compat import ElementTree as ET
 
@@ -244,7 +245,7 @@ def sig4(method, endpoint, params, prov_dict,
     # Create payload hash (hash of the request body content). For GET
     # requests, the payload is an empty string ('').
     if not payload_hash:
-        payload_hash = hashlib.sha256(data).hexdigest()
+        payload_hash = salt.utils.hashutils.sha256_digest(data)
 
     new_headers['X-Amz-date'] = amzdate
     new_headers['host'] = endpoint
@@ -280,7 +281,7 @@ def sig4(method, endpoint, params, prov_dict,
         algorithm,
         amzdate,
         credential_scope,
-        hashlib.sha256(canonical_request).hexdigest()
+        salt.utils.hashutils.sha256_digest(canonical_request)
     ))
 
     # Create the signing key using the function defined above.

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2536,7 +2536,8 @@ def cachedir_index_add(minion_id, profile, driver, provider, base=None):
     lock_file(index_file)
 
     if os.path.exists(index_file):
-        with salt.utils.fopen(index_file, 'r') as fh_:
+        mode = 'rb' if six.PY3 else 'r'
+        with salt.utils.fopen(index_file, mode) as fh_:
             index = msgpack.load(fh_)
     else:
         index = {}
@@ -2552,7 +2553,8 @@ def cachedir_index_add(minion_id, profile, driver, provider, base=None):
         }
     })
 
-    with salt.utils.fopen(index_file, 'w') as fh_:
+    mode = 'wb' if six.PY3 else 'w'
+    with salt.utils.fopen(index_file, mode) as fh_:
         msgpack.dump(index, fh_)
 
     unlock_file(index_file)
@@ -2568,7 +2570,8 @@ def cachedir_index_del(minion_id, base=None):
     lock_file(index_file)
 
     if os.path.exists(index_file):
-        with salt.utils.fopen(index_file, 'r') as fh_:
+        mode = 'rb' if six.PY3 else 'r'
+        with salt.utils.fopen(index_file, mode) as fh_:
             index = msgpack.load(fh_)
     else:
         return
@@ -2576,7 +2579,8 @@ def cachedir_index_del(minion_id, base=None):
     if minion_id in index:
         del index[minion_id]
 
-    with salt.utils.fopen(index_file, 'w') as fh_:
+    mode = 'wb' if six.PY3 else 'w'
+    with salt.utils.fopen(index_file, mode) as fh_:
         msgpack.dump(index, fh_)
 
     unlock_file(index_file)


### PR DESCRIPTION
Fixes #41410

- Use `salt.utils.hashutils` functions to handle PY2 and PY3 for hash generations
- Replace uses of `keys()` calls as this doesn't work for dict_views in Python 3
- Handle use of `values()` function on dictionary view, too.
- Use different reading and writing modes for msgpack load/dump for PY3