### PR TITLE
Sadly, you can't have '.'s and '$'s in dict keys in a mongodb doc.

### DIFF
--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -199,17 +199,53 @@ def returner(ret):
     else:
         mdb.saltReturns.insert(sdata.copy())
 
+def _safe_copy(dat):
+    ''' mongodb doesn't allow '.' in keys, but does allow unicode equivs.
+        Apparently the docs suggest using escaped unicode full-width
+        encodings.  *sigh*
+
+            \\  -->  \\\\
+            $  -->  \\\\u0024
+            .  -->  \\\\u002e
+
+        Personally, I prefer URL encodings,
+
+        \\  -->  %5c
+        $  -->  %24
+        .  -->  %2e
+
+
+        Which means also escaping '%':
+
+        % -> %25
+    '''
+
+    if isinstance(dat,dict):
+        ret = {}
+        for k in dat:
+            r = k.replace('%', '%25').replace('\\', '%5c').replace('$', '%24').replace('.', '%2e')
+            if r != k:
+                log.debug(u'converting dict key from {} to {} for mongodb'.format(k,r))
+            ret[r] = _safe_copy(dat[k])
+        return ret
+
+    if isinstance(dat, (list,tuple)):
+        return [ _safe_copy(i) for i in dat ]
+
+    return dat
 
 def save_load(jid, load, minions=None):
     '''
     Save the load for a given job id
     '''
     conn, mdb = _get_conn(ret=None)
+    to_save = _safe_copy( load )
+
     if float(version) > 2.3:
         #using .copy() to ensure original data for load is unchanged
-        mdb.jobs.insert_one(load.copy())
+        mdb.jobs.insert_one(to_save)
     else:
-        mdb.jobs.insert(load.copy())
+        mdb.jobs.insert(to_save)
 
 
 def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
