### PR TITLE
Sadly, you can't have '.'s and '$'s in dict keys in a mongodb doc.

### DIFF
--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -199,6 +199,7 @@ def returner(ret):
     else:
         mdb.saltReturns.insert(sdata.copy())
 
+
 def _safe_copy(dat):
     ''' mongodb doesn't allow '.' in keys, but does allow unicode equivs.
         Apparently the docs suggest using escaped unicode full-width

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -230,7 +230,7 @@ def _safe_copy(dat):
         return ret
 
     if isinstance(dat, (list, tuple)):
-        return [ _safe_copy(i) for i in dat ]
+        return [_safe_copy(i) for i in dat]
 
     return dat
 

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -199,17 +199,53 @@ def returner(ret):
     else:
         mdb.saltReturns.insert(sdata.copy())
 
+def _safe_copy(dat):
+    ''' mongodb doesn't allow '.' in keys, but does allow unicode equivs.
+        Apparently the docs suggest using escaped unicode full-width
+        encodings.  *sigh*
+
+            \\  -->  \\\\
+            $  -->  \\\\u0024
+            .  -->  \\\\u002e
+
+        Personally, I prefer URL encodings,
+
+        \\  -->  %5c
+        $  -->  %24
+        .  -->  %2e
+
+
+        Which means also escaping '%':
+
+        % -> %25
+    '''
+
+    if isinstance(dat,dict):
+        ret = {}
+        for k in dat:
+            r = k.replace('%', '%25').replace('\\', '%5c').replace('$', '%24').replace('.', '%2e')
+            if r != k:
+                log.debug(u'converting dict key from {} to {} for mongodb'.format(k,r))
+            ret[r] = _safe_copy(dat[k])
+        return ret
+
+    if isinstance(dat, (list,tuple)):
+        return [ _safe_copy(i) for i in dat ]
+
+    return dat
 
 def save_load(jid, load, minions=None):
     '''
     Save the load for a given job id
     '''
     conn, mdb = _get_conn(ret=None)
+    to_save = _safe_copy( load )
+
     if float(version) > 2.3:
         #using .copy() to ensure original data for load is unchanged
-        mdb.jobs.insert_one(load.copy())
+        mdb.jobs.insert_one(to_save)
     else:
-        mdb.jobs.insert(load.copy())
+        mdb.jobs.insert(to_save)
 
 
 def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -220,26 +220,27 @@ def _safe_copy(dat):
         % -> %25
     '''
 
-    if isinstance(dat,dict):
+    if isinstance(dat, dict):
         ret = {}
         for k in dat:
             r = k.replace('%', '%25').replace('\\', '%5c').replace('$', '%24').replace('.', '%2e')
             if r != k:
-                log.debug(u'converting dict key from {} to {} for mongodb'.format(k,r))
+                log.debug('converting dict key from {0} to {1} for mongodb'.format(k, r))
             ret[r] = _safe_copy(dat[k])
         return ret
 
-    if isinstance(dat, (list,tuple)):
+    if isinstance(dat, (list, tuple)):
         return [ _safe_copy(i) for i in dat ]
 
     return dat
+
 
 def save_load(jid, load, minions=None):
     '''
     Save the load for a given job id
     '''
     conn, mdb = _get_conn(ret=None)
-    to_save = _safe_copy( load )
+    to_save = _safe_copy(load)
 
     if float(version) > 2.3:
         #using .copy() to ensure original data for load is unchanged


### PR DESCRIPTION
### What does this PR do?
I've been trying for a while to use mongodb for my job cache. I can't say why, but I'm determined to make it work. There's been many problems along the way, but the latest is that:

Mongodb can't handle having '.' and '$' and things in dictionary keys.

State return IDs usually contain '.' characters. 

### Previous Behavior

The return stack crashes with a stack trace in the error log.

### New Behavior

I've replaced load.copy() (before insert) with a _safe_copy() that does a string replace on dictionary keys, recursively.