### PR TITLE
Set default for consul_pillar to None

### DIFF
--- a/salt/pillar/consul_pillar.py
+++ b/salt/pillar/consul_pillar.py
@@ -189,8 +189,8 @@ def ext_pillar(minion_id,
 
     client = get_conn(__opts__, opts['profile'])
 
-    role = __salt__['grains.get']('role')
-    environment = __salt__['grains.get']('environment')
+    role = __salt__['grains.get']('role', None)
+    environment = __salt__['grains.get']('environment', None)
     # put the minion's ID in the path if necessary
     opts['root'] %= {
         'minion_id': minion_id,


### PR DESCRIPTION
### What does this PR do?
If these do not default to None, they will default to an empty string,
which could cause the pillar tree to leak to minions it should't.

Also, allow role and environment to be pulled from pillars or minion
config by using config.get

### What issues does this PR fix or reference?
Fixes #41478

### Tests written?

No