### PR TITLE
Remove --hard option from salt-clould

### DIFF
--- a/doc/ref/cli/salt-cloud.rst
+++ b/doc/ref/cli/salt-cloud.rst
@@ -61,14 +61,6 @@ Execution Options
     will ensure that all of the mapped VMs are created. If the named VM already
     exists then it will be skipped.
 
-.. option:: -H, --hard
-
-    When specifying a map file, the default behavior is to ensure that all of
-    the VMs specified in the map file are created. If the --hard option is
-    set, then any VMs that exist on configured cloud providers that are
-    not specified in the map file will be destroyed. Be advised that this can
-    be a destructive operation and should be used with care.
-
 .. option:: -d, --destroy
 
     Pass in the name(s) of VMs to destroy, salt-cloud will search the

--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -48,22 +48,6 @@ to create the virtual machines in parallel:
     with the GoGrid driver. Map files will work with GoGrid, but the ``-P``
     argument should not be used on maps referencing GoGrid instances.
 
-A map file can also be enforced to represent the total state of a cloud
-deployment by using the ``--hard`` option. When using the hard option any vms
-that exist but are not specified in the map file will be destroyed:
-
-.. code-block:: bash
-
-    $ salt-cloud -m /path/to/mapfile -P -H
-
-Be careful with this argument, it is very dangerous! In fact, it is so
-dangerous that in order to use it, you must explicitly enable it in the main
-configuration file.
-
-.. code-block:: yaml
-
-    enable_hard_maps: True
-
 A map file can include grains and minion configuration options:
 
 .. code-block:: yaml

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -2014,17 +2014,6 @@ class Map(Cloud):
                             ret['existing'] = {}
                         ret['existing'][name] = ret['create'].pop(name)
 
-        if 'hard' in self.opts and self.opts['hard']:
-            if self.opts['enable_hard_maps'] is False:
-                raise SaltCloudSystemExit(
-                    'The --hard map can be extremely dangerous to use, '
-                    'and therefore must explicitly be enabled in the main '
-                    'configuration file, by setting \'enable_hard_maps\' '
-                    'to True'
-                )
-
-            # Hard maps are enabled, Look for the items to delete.
-            ret['destroy'] = exist.difference(defined)
         return ret
 
     def run_map(self, dmap):

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1652,7 +1652,6 @@ DEFAULT_CLOUD_OPTS = {
     'os': '',
     'script': 'bootstrap-salt',
     'start_action': None,
-    'enable_hard_maps': False,
     'delete_sshkeys': False,
     # Custom deploy scripts
     'deploy_scripts_search_path': 'cloud.deploy.d',

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1417,14 +1417,6 @@ class ExecutionOptionsMixIn(six.with_metaclass(MixInMeta, object)):
                  'The map can also be filtered by a list of VM names.'
         )
         group.add_option(
-            '-H', '--hard',
-            default=False,
-            action='store_true',
-            help='Delete all VMs that are not defined in the map file. '
-                 'CAUTION!!! This operation can irrevocably destroy VMs! It '
-                 'must be explicitly enabled in the cloud config file.'
-        )
-        group.add_option(
             '-d', '--destroy',
             default=False,
             action='store_true',


### PR DESCRIPTION
### What does this PR do?

This is a suggestion to remove  the `-H`/`--hard` option from `salt-cloud`. This sort of special-purpose behavior can and should be implemented by those who need it and understand their own environment.

### Discussion

To me this is a distracting part of the command help output and documentation:

"CAUTION!!!"
"any VMs that exist on configured cloud providers"
"Be advised"
"can be destructive"
"very dangerous!"
"should be used with care"
"in fact, it is so dangerous"

These warnings not only detract from the basic brilliant design of the `salt-cloud` tool, but they do not add safety. Consider this sequence

1. *Person A* uses `-H` to "clean" their AWS account before running system tests
2. *Person B* adds a new provider to ensure their code works on another platform
3. *Person A* runs the same command again with surprising results

The problem in this case is that *Person A* did not mean to wipe all accounts--he probably meant to clean one account. *Person B* does not encounter the alarming warnings because he was performing an unrelated task.