### PR TITLE
Add host_dns grain for napalm

### DIFF
--- a/doc/topics/releases/nitrogen.rst
+++ b/doc/topics/releases/nitrogen.rst
@@ -334,6 +334,7 @@ New functions:
   (in dBm).
 
 New grains: :mod:`Host <salt.grains.napalm.host>`,
+:mod:`Host DNS<salt.grains.napalm.host_dns>`,
 :mod:`Username <salt.grains.napalm.username>` and
 :mod:`Optional args <salt.grains.napalm.optional_args>`.
 

--- a/salt/engines/napalm_syslog.py
+++ b/salt/engines/napalm_syslog.py
@@ -123,7 +123,8 @@ changes on the device(s) firing the event, one is able to
 identify the minion ID, using one of the following alternatives, but not limited to:
 
 - :mod:`Host grains <salt.grains.napalm.host>` to match the event tag
-- :mod:`Hostname grains <salt.grains.napalm.hostname>` to match the IP address in the event data
+- :mod:`Host DNS grain <salt.grains.napalm.host_dns>` to match the IP address in the event data
+- :mod:`Hostname grains <salt.grains.napalm.hostname>` to match the event tag
 - :ref:`Define static grains <static-custom-grains>`
 - :ref:`Write a grains module <writing-grains>`
 - :ref:`Targeting minions using pillar data <targeting-pillar>` -- the user

--- a/salt/grains/napalm.py
+++ b/salt/grains/napalm.py
@@ -22,6 +22,7 @@ import logging
 log = logging.getLogger(__name__)
 
 # Salt lib
+import salt.utils.dns
 import salt.utils.napalm
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -353,6 +354,60 @@ def host(proxy=None):
         # this grain is set only when running in a proxy minion
         # otherwise will use the default Salt grains
         return {'host': _get_device_grain('hostname', proxy=proxy)}
+
+
+def host_dns(proxy=None):
+    '''
+    Return the DNS information of the host.
+    This grain is a dictionary having two keys:
+
+    - ``A``
+    - ``AAAA``
+
+    .. versionadded:: Nitrogen
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'device*' grains.get host_dns
+
+    Output:
+
+    .. code-block:: yaml
+
+        device1:
+            A:
+                - 172.31.9.153
+            AAAA:
+                - fd52:188c:c068::1
+        device2:
+            A:
+                - 172.31.46.249
+            AAAA:
+                - fdca:3b17:31ab::17
+        device3:
+            A:
+                - 172.31.8.167
+            AAAA:
+                - fd0f:9fd6:5fab::1
+    '''
+    device_host = host(proxy=proxy)
+    if device_host:
+        device_host_value = device_host['host']
+        host_dns_ret = {
+            'host_dns': {
+                'A': [],
+                'AAAA': []
+            }
+        }
+        dns_a = salt.utils.dns.query(device_host_value, 'A')
+        if dns_a:
+            host_dns_ret['host_dns']['A'] = dns_a
+        dns_aaaa = salt.utils.dns.query(device_host_value, 'AAAA')
+        if dns_aaaa:
+            host_dns_ret['host_dns']['AAAA'] = dns_aaaa
+        return host_dns_ret
 
 
 def optional_args(proxy=None):

--- a/salt/grains/napalm.py
+++ b/salt/grains/napalm.py
@@ -364,6 +364,16 @@ def host_dns(proxy=None):
     - ``A``
     - ``AAAA``
 
+    .. note::
+        This grain is disabled by default, as the proxy startup may be slower
+        when the lookup fails.
+        The user can enable it using the ``napalm_host_dns_grain`` option (in
+        the pillar or proxy configuration file):
+
+        .. code-block:: yaml
+
+            napalm_host_dns_grain: true
+
     .. versionadded:: Nitrogen
 
     CLI Example:

--- a/salt/grains/napalm.py
+++ b/salt/grains/napalm.py
@@ -392,6 +392,8 @@ def host_dns(proxy=None):
             AAAA:
                 - fd0f:9fd6:5fab::1
     '''
+    if not __opts__.get('napalm_host_dns_grain', False):
+        return
     device_host = host(proxy=proxy)
     if device_host:
         device_host_value = device_host['host']


### PR DESCRIPTION
### What does this PR do?

It will be very useful in the new `napalm_syslog` engine when identifying the minion ID. The events have a tag with the hostname, as configured on the device, but also a field with the IP address of the sender. Using this grain, one can determine from the IP address of the sender what's the minion ID and trigger an action.