### PR TITLE
Override proxy minion opts with pillar data

### DIFF
--- a/doc/ref/configuration/proxy.rst
+++ b/doc/ref/configuration/proxy.rst
@@ -118,3 +118,53 @@ has to be closed after every command.
 .. code-block:: yaml
 
     proxy_always_alive: False
+
+``proxy_merge_pillar_in_opts``
+------------------------------
+
+.. versionadded:: 2017.7.3
+
+Default: ``False``.
+
+Wheter the pillar data to be merged into the proxy configuration options.
+As multiple proxies can run on the same server, we may need different
+configuration options for each, while there's one single configuration file.
+The solution is merging the pillar data of each proxy minion into the opts.
+
+.. code-block:: yaml
+
+    proxy_merge_pillar_in_opts: True
+
+``proxy_deep_merge_pillar_in_opts``
+-----------------------------------
+
+.. versionadded:: 2017.7.3
+
+Default: ``False``.
+
+Deep merge of pillar data into configuration opts.
+This option is evaluated only when :conf_proxy:`proxy_merge_pillar_in_opts` is
+enabled.
+
+``proxy_merge_pillar_in_opts_strategy``
+---------------------------------------
+
+.. versionadded:: 2017.7.3
+
+Default: ``smart``.
+
+The strategy used when merging pillar configuration into opts.
+This option is evaluated only when :conf_proxy:`proxy_merge_pillar_in_opts` is
+enabled.
+
+``proxy_mines_pillar``
+----------------------
+
+.. versionadded:: 2017.7.3
+
+Default: ``True``.
+
+Allow enabling mine details using pillar data. This evaluates the mine
+configuration under the pillar, for the following regular minion options that
+are also equally available on the proxy minion: :conf_minion:`mine_interval`,
+and :conf_minion:`mine_functions`.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -583,6 +583,9 @@ VALID_OPTS = {
     # Considered only when `proxy_merge_pillar_in_opts` is True.
     'proxy_merge_pillar_in_opts_strategy': str,
 
+    # Allow enabling mine details using pillar data.
+    'proxy_mines_pillar': bool,
+
     # In some particular cases, always alive proxies are not beneficial.
     # This option can be used in those less dynamic environments:
     # the user can request the connection
@@ -1654,6 +1657,8 @@ DEFAULT_PROXY_MINION_OPTS = {
     'proxy_merge_pillar_in_opts': False,
     'proxy_deep_merge_pillar_in_opts': False,
     'proxy_merge_pillar_in_opts_strategy': 'smart',
+
+    'proxy_mines_pillar': True,
 
     # By default, proxies will preserve the connection.
     # If this option is set to False,

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -569,6 +569,20 @@ VALID_OPTS = {
     # False in 2016.3.0
     'add_proxymodule_to_opts': bool,
 
+    # Merge pillar data into configuration opts.
+    # As multiple proxies can run on the same server, we may need different
+    # configuration options for each, while there's one single configuration file.
+    # The solution is merging the pillar data of each proxy minion into the opts.
+    'proxy_merge_pillar_in_opts': bool,
+
+    # Deep merge of pillar data into configuration opts.
+    # Evaluated only when `proxy_merge_pillar_in_opts` is True.
+    'proxy_deep_merge_pillar_in_opts': bool,
+
+    # The strategy used when merging pillar into opts.
+    # Considered only when `proxy_merge_pillar_in_opts` is True.
+    'proxy_merge_pillar_in_opts_strategy': str,
+
     # In some particular cases, always alive proxies are not beneficial.
     # This option can be used in those less dynamic environments:
     # the user can request the connection
@@ -1636,6 +1650,10 @@ DEFAULT_PROXY_MINION_OPTS = {
     'extension_modules': os.path.join(salt.syspaths.CACHE_DIR, 'proxy', 'extmods'),
     'append_minionid_config_dirs': ['cachedir', 'pidfile', 'default_include', 'extension_modules'],
     'default_include': 'proxy.d/*.conf',
+
+    'proxy_merge_pillar_in_opts': False,
+    'proxy_deep_merge_pillar_in_opts': False,
+    'proxy_merge_pillar_in_opts_strategy': 'smart',
 
     # By default, proxies will preserve the connection.
     # If this option is set to False,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3118,6 +3118,9 @@ class ProxyMinion(Minion):
         if 'proxy' not in self.opts:
             self.opts['proxy'] = self.opts['pillar']['proxy']
 
+        # update opts, to override data with pillar data
+        self.opts.update(self.opts['pillar'])
+
         fq_proxyname = self.opts['proxy']['proxytype']
 
         # Need to load the modules so they get all the dunder variables

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3125,7 +3125,7 @@ class ProxyMinion(Minion):
                                                     self.opts['pillar'],
                                                     strategy=self.opts.get('proxy_merge_pillar_in_opts_strategy'),
                                                     merge_lists=self.opts.get('proxy_deep_merge_pillar_in_opts', False))
-        else:
+        elif self.opts.get('proxy_mines_pillar'):
             # Even when not required, some details such as mine configuration
             # should be merged anyway whenever possible.
             if 'mine_interval' in self.opts['pillar']:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -100,6 +100,7 @@ import salt.defaults.exitcodes
 import salt.cli.daemons
 import salt.log.setup
 
+import salt.utils.dictupdate
 from salt.config import DEFAULT_MINION_OPTS
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.executors import FUNCTION_EXECUTORS
@@ -3118,8 +3119,11 @@ class ProxyMinion(Minion):
         if 'proxy' not in self.opts:
             self.opts['proxy'] = self.opts['pillar']['proxy']
 
-        # update opts, to override data with pillar data
-        self.opts.update(self.opts['pillar'])
+        if self.opts.get('proxy_merge_pillar_in_opts'):
+            self.opts = salt.utils.dictupdate.merge(self.opts,
+                                                    self.opts['pillar'],
+                                                    strategy=self.opts.get('proxy_merge_pillar_in_opts_strategy'),
+                                                    merge_lists=self.opts.get('proxy_deep_merge_pillar_in_opts', False))
 
         fq_proxyname = self.opts['proxy']['proxytype']
 


### PR DESCRIPTION
### What does this PR do?

Overrides proxy minion opts with their pillar data.
Potential problem: it copies also everything under the `proxy` key (including sensitive data etc.) into the opts. Do you think this may be a problem?
To solve #39775 speficially, it would be enough just to transfer the values of the `mine_*` fields into the opts object. But I was thinking that there may be other interesting cases to solve by copying everything.
I am looking forward to hearing your thoughts on this. Thanks!

### What issues does this PR fix or reference?

#39775

### Previous Behavior

`mine_interval` ignored in the proxy pillar

### New Behavior

`mine_interval` and other options have the values per minion