### PR TITLE
get config from __salt__

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -133,7 +133,7 @@ def _get_user_gnupghome(user):
     Return default GnuPG home directory path for a user
     '''
     if user == 'salt':
-        gnupghome = os.path.join(salt.syspaths.CONFIG_DIR, 'gpgkeys')
+        gnupghome = os.path.join(__salt__['config.get']('config_dir'), 'gpgkeys')
     else:
         gnupghome = os.path.join(_get_user_info(user)['home'], '.gnupg')
 

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -22,7 +22,6 @@ import time
 
 # Import salt libs
 import salt.utils
-import salt.syspaths
 from salt.exceptions import SaltInvocationError
 from salt.utils.versions import LooseVersion as _LooseVersion
 
@@ -929,7 +928,7 @@ def trust_key(keyid=None,
     _user = user
 
     if user == 'salt':
-        homeDir = os.path.join(salt.syspaths.CONFIG_DIR, 'gpgkeys')
+        homeDir = os.path.join(__salt__['config.get']('config_dir'), 'gpgkeys')
         cmd.extend([' --homedir', homeDir])
         _user = 'root'
     res = __salt__['cmd.run_all'](cmd,


### PR DESCRIPTION
### What does this PR do?
get config from __salt__ instead of statically defined variable
