### PR TITLE
Update __init__.py

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3182,7 +3182,7 @@ def is_profile_configured(opts, provider, profile_name, vm_=None):
     alias, driver = provider.split(':')
 
     # Most drivers need an image to be specified, but some do not.
-    non_image_drivers = ['nova', 'virtualbox', 'libvirt']
+    non_image_drivers = ['nova', 'virtualbox', 'libvirt', 'softlayer']
 
     # Most drivers need a size, but some do not.
     non_size_drivers = ['opennebula', 'parallels', 'proxmox', 'scaleway',


### PR DESCRIPTION
Fix for #35481

### What does this PR do?
Fixes issue with softlayer VM creation via API

### What issues does this PR fix or reference?
#35481
### Previous Behavior
image attribute is required even though global identifier is used.  This should not be the case.

### New Behavior
Enables creation of VM using the global identifier without the image configuration.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
