### PR TITLE
Adding logic so that update_floatingip can dissassociate floatingip's

### DIFF
--- a/salt/modules/neutron.py
+++ b/salt/modules/neutron.py
@@ -816,7 +816,7 @@ def create_floatingip(floating_network, port=None, profile=None):
     return conn.create_floatingip(floating_network, port)
 
 
-def update_floatingip(floatingip_id, port, profile=None):
+def update_floatingip(floatingip_id, port=None, profile=None):
     '''
     Updates a floatingIP
 
@@ -827,7 +827,8 @@ def update_floatingip(floatingip_id, port, profile=None):
         salt '*' neutron.update_floatingip network-name port-name
 
     :param floatingip_id: ID of floatingIP
-    :param port: ID or name of port
+    :param port: ID or name of port, to associate floatingip to
+    `None` or do not specify to disassociate the floatingip (Optional)
     :param profile: Profile to build on (Optional)
     :return: Value of updated floating IP information
     '''

--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -539,10 +539,14 @@ class SaltNeutron(NeutronShell):
 
     def update_floatingip(self, floatingip_id, port):
         '''
-        Updates a floatingip
+        Updates a floatingip, disassociates the floating ip if
+        port is set to `None`
         '''
-        port_id = self._find_port_id(port)
-        body = {'floatingip': {'port_id': port_id}}
+        if port is None:
+            body = {'floatingip': {}}
+        else:
+            port_id = self._find_port_id(port)
+            body = {'floatingip': {'port_id': port_id}}
         return self.network_conn.update_floatingip(
             floatingip=floatingip_id, body=body)
 

--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -537,7 +537,7 @@ class SaltNeutron(NeutronShell):
 
         return self.network_conn.create_floatingip(body={'floatingip': body})
 
-    def update_floatingip(self, floatingip_id, port):
+    def update_floatingip(self, floatingip_id, port=None):
         '''
         Updates a floatingip, disassociates the floating ip if
         port is set to `None`


### PR DESCRIPTION
Previously update_floatingip would cause an error if port is set to None.

### What does this PR do?
Allows user to set "port" to None which will cause a floating IP to be disassociated when using Neutron Module

### What issues does this PR fix or reference?
Original content. Fixes ServerError when not passing a port_id to update_floatingip

### Previous Behavior
Module is unable to properly disassociate a floating ip by either omitting or passing None

### New Behavior
Now a user can specify port=None or leave the port option off to disassociate the IP
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
