### PR TITLE
Salt cloud libvirt tweaks

### DIFF
--- a/doc/topics/cloud/libvirt.rst
+++ b/doc/topics/cloud/libvirt.rst
@@ -32,6 +32,8 @@ Set up the provider cloud configuration file at ``/etc/salt/cloud.providers`` or
     local-kvm:
       driver: libvirt
       url: qemu:///system
+      # work around flag for XML validation errors while cloning
+      validate_xml: no
 
 Cloud Profiles
 ==============

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -278,7 +278,9 @@ def create(vm_):
     if ip_source not in set(['ip-learning', 'qemu-agent']):
         raise SaltCloudSystemExit("'ip_source' must be one of qemu-agent or ip-learning. Got '{0}'".format(ip_source))
 
-    log.info("Cloning machine '{0}' with strategy '{1}'".format(vm_['name'], clone_strategy))
+    validate_xml = vm_.get('validate_xml') if vm_.get('validate_xml') is not None else True
+
+    log.info("Cloning machine '{0}' with strategy '{1}' validate_xml='{2}'".format(vm_['name'], clone_strategy, validate_xml))
 
     try:
         # Check for required profile parameters before sending any API calls.
@@ -412,7 +414,9 @@ def create(vm_):
             clone_xml = ElementTree.tostring(domain_xml)
             log.debug("Clone XML '{0}'".format(clone_xml))
 
-            clone_domain = conn.defineXMLFlags(clone_xml, libvirt.VIR_DOMAIN_DEFINE_VALIDATE)
+            validate_flags = libvirt.VIR_DOMAIN_DEFINE_VALIDATE if validate_xml else 0
+            clone_domain = conn.defineXMLFlags(clone_xml, validate_flags)
+
             cleanup.append({'what': 'domain', 'item': clone_domain})
             clone_domain.createWithFlags(libvirt.VIR_DOMAIN_START_FORCE_BOOT)
 

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -409,8 +409,8 @@ def create(vm_):
                 else:
                     raise SaltCloudExecutionFailure("Disk type '{0}' not supported".format(disk_type))
 
-            log.debug("Clone XML '{0}'".format(domain_xml))
             clone_xml = ElementTree.tostring(domain_xml)
+            log.debug("Clone XML '{0}'".format(clone_xml))
 
             clone_domain = conn.defineXMLFlags(clone_xml, libvirt.VIR_DOMAIN_DEFINE_VALIDATE)
             cleanup.append({'what': 'domain', 'item': clone_domain})


### PR DESCRIPTION
### What does this PR do?

* Fix a small logging issue.
* Provide a flag that disables domain XML validation while cloning a domain with salt-cloud and the libvirt driver.

### What issues does this PR fix or reference?

#41137 

### Previous Behavior

In some setups a validation error occurred while cloning. Locally modifying the driver to not pass the validation flag to the clone call worked around the issue.

### New Behavior

Allow the user to specify a `validate_xml: false` in the configuration to disable validation if it gives an issue.

### Tests written?

No.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
