### PR TITLE
Add symbolic link for salt-proxy service similar to other serivce files

### DIFF
--- a/pkg/rpm/salt-proxy@.service
+++ b/pkg/rpm/salt-proxy@.service
@@ -1,0 +1,1 @@
+../salt-proxy@.service


### PR DESCRIPTION
### What does this PR do?
Add symbolic link from directory rpm for salt-proxy@.service to be consistent with other symbolic links for service files

### What issues does this PR fix or reference?
none

### New Behavior
Remove this section if not relevant
Makes salt-proxy@.service available from the pkg/rpm file similar to other systemd service files

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
