### PR TITLE
Various Python 3 fixes for salt-cloud

### DIFF
--- a/salt/cloud/clouds/aliyun.py
+++ b/salt/cloud/clouds/aliyun.py
@@ -655,7 +655,7 @@ def create(vm_):
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
-        args=__utils__['cloud.filter_event']('requesting', kwargs, kwargs.keys()),
+        args=__utils__['cloud.filter_event']('requesting', kwargs, list(kwargs)),
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -1164,8 +1164,8 @@ def create(vm_):
     def _query_ip_address():
         data = request_instance(kwargs=vm_)
         ifaces = data['network_profile']['network_interfaces']
-        iface = ifaces.keys()[0]
-        ip_name = ifaces[iface]['ip_configurations'].keys()[0]
+        iface = list(ifaces)[0]
+        ip_name = list(ifaces[iface]['ip_configurations'])[0]
 
         if vm_.get('public_ip') is True:
             hostname = ifaces[iface]['ip_configurations'][ip_name]['public_ip_address']

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -432,7 +432,7 @@ def create(vm_):
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
-        args=__utils__['cloud.filter_event']('requesting', kwargs, kwargs.keys()),
+        args=__utils__['cloud.filter_event']('requesting', kwargs, list(keys)),
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -432,7 +432,7 @@ def create(vm_):
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
-        args=__utils__['cloud.filter_event']('requesting', kwargs, list(keys)),
+        args=__utils__['cloud.filter_event']('requesting', kwargs, list(kwargs)),
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/dimensiondata.py
+++ b/salt/cloud/clouds/dimensiondata.py
@@ -257,7 +257,7 @@ def create(vm_):
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
-        args=__utils__['cloud.filter_event']('requesting', event_data, event_data.keys()),
+        args=__utils__['cloud.filter_event']('requesting', event_data, list(event_data)),
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -112,7 +112,7 @@ def create(vm_):
         public_ips = list_public_ips()
         if len(public_ips.keys()) < 1:
             raise SaltCloudException('No more IPs available')
-        host_ip = public_ips.keys()[0]
+        host_ip = list(public_ips)[0]
 
     create_kwargs = {
         'name': vm_['name'],

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -43,7 +43,6 @@ from __future__ import absolute_import
 import pprint
 import logging
 import time
-import hashlib
 
 # Import salt cloud libs
 import salt.config as config

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -48,6 +48,7 @@ import hashlib
 # Import salt cloud libs
 import salt.config as config
 import salt.utils.cloud
+import salt.utils.hashutils
 from salt.exceptions import SaltCloudSystemExit, SaltCloudException
 
 # Get logging started
@@ -534,7 +535,7 @@ def _query(action=None,
 
     epoch = str(int(time.time()))
     hashtext = ''.join((apikey, sharedsecret, epoch))
-    args['sig'] = hashlib.md5(hashtext).hexdigest()
+    args['sig'] = salt.utils.hashutils.md5_digest(hashtext)
     args['format'] = 'json'
     args['v'] = '1.0'
     args['api_key'] = apikey

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -126,7 +126,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         args={
-            'kwargs': __utils__['cloud.filter_event']('requesting', create_kwargs, create_kwargs.keys()),
+            'kwargs': __utils__['cloud.filter_event']('requesting', create_kwargs, list(create_kwargs)),
         },
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -290,7 +290,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         args={
-            'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, kwargs.keys()),
+            'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, list(kwargs)),
         },
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -339,7 +339,7 @@ def create(vm_):
                 'requesting instance',
                 'salt/cloud/{0}/requesting'.format(name),
                 args={
-                    'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, kwargs.keys()),
+                    'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, list(kwargs)),
                 },
                 sock_dir=__opts__['sock_dir'],
                 transport=__opts__['transport']

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -538,7 +538,7 @@ def create(vm_):
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
-        args=__utils__['cloud.filter_event']('requesting', event_kwargs, event_kwargs.keys()),
+        args=__utils__['cloud.filter_event']('requesting', event_kwargs, list(event_kwargs)),
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -686,7 +686,7 @@ def request_instance(vm_=None, call=None):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         args={
-            'kwargs': __utils__['cloud.filter_event']('requesting', event_kwargs, event_kwargs.keys()),
+            'kwargs': __utils__['cloud.filter_event']('requesting', event_kwargs, list(event_kwargs)),
         },
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
@@ -1054,7 +1054,7 @@ def create(vm_):
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
-        args=__utils__['cloud.filter_event']('created', event_data, event_data.keys()),
+        args=__utils__['cloud.filter_event']('created', event_data, list(event_data)),
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -1029,7 +1029,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         args={
-            'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, kwargs.keys()),
+            'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, list(kwargs)),
         },
         sock_dir=__opts__['sock_dir'],
     )

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -556,7 +556,7 @@ def request_instance(vm_=None, call=None):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         args={
-            'kwargs': __utils__['cloud.filter_event']('requesting', event_kwargs, event_kwargs.keys()),
+            'kwargs': __utils__['cloud.filter_event']('requesting', event_kwargs, list(event_kwargs)),
         },
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -258,7 +258,7 @@ def create_node(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         args={
-            'kwargs': __utils__['cloud.filter_event']('requesting', data, data.keys()),
+            'kwargs': __utils__['cloud.filter_event']('requesting', data, list(data)),
         },
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -762,7 +762,7 @@ def create_node(vm_, newid):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         args={
-            'kwargs': __utils__['cloud.filter_event']('requesting', newnode, newnode.keys()),
+            'kwargs': __utils__['cloud.filter_event']('requesting', newnode, list(newnode)),
         },
         sock_dir=__opts__['sock_dir'],
     )

--- a/salt/cloud/clouds/qingcloud.py
+++ b/salt/cloud/clouds/qingcloud.py
@@ -694,7 +694,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         args={
-            'kwargs': __utils__['cloud.filter_event']('requesting', params, params.keys()),
+            'kwargs': __utils__['cloud.filter_event']('requesting', params, list(params)),
         },
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']

--- a/salt/cloud/clouds/scaleway.py
+++ b/salt/cloud/clouds/scaleway.py
@@ -246,7 +246,7 @@ def create(server_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(server_['name']),
         args={
-            'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, kwargs.keys()),
+            'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, list(kwargs)),
         },
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']

--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -373,7 +373,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(name),
         args={
-            'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, kwargs.keys()),
+            'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, list(kwargs)),
         },
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -326,7 +326,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(name),
         args={
-            'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, kwargs.keys()),
+            'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, list(kwargs)),
         },
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']

--- a/salt/cloud/clouds/virtualbox.py
+++ b/salt/cloud/clouds/virtualbox.py
@@ -155,7 +155,7 @@ def create(vm_info):
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_info['name']),
-        args=__utils__['cloud.filter_event']('requesting', request_kwargs, request_kwargs.keys()),
+        args=__utils__['cloud.filter_event']('requesting', request_kwargs, list(request_kwargs)),
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
     )
@@ -181,7 +181,7 @@ def create(vm_info):
         'event',
         'created machine',
         'salt/cloud/{0}/created'.format(vm_info['name']),
-        args=__utils__['cloud.filter_event']('created', vm_result, vm_result.keys()),
+        args=__utils__['cloud.filter_event']('created', vm_result, list(vm_result)),
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2648,7 +2648,7 @@ def create(vm_):
             'event',
             'requesting instance',
             'salt/cloud/{0}/requesting'.format(vm_['name']),
-            args=__utils__['cloud.filter_event']('requesting', event_kwargs, event_kwargs.keys()),
+            args=__utils__['cloud.filter_event']('requesting', event_kwargs, list(event_kwargs)),
             sock_dir=__opts__['sock_dir'],
             transport=__opts__['transport']
         )

--- a/salt/cloud/clouds/vultrpy.py
+++ b/salt/cloud/clouds/vultrpy.py
@@ -284,7 +284,7 @@ def create(vm_):
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         args={
-            'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, kwargs.keys()),
+            'kwargs': __utils__['cloud.filter_event']('requesting', kwargs, list(kwargs)),
         },
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport'],

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1756,6 +1756,12 @@ def filter_event(tag, data, defaults):
     if use_defaults is False:
         defaults = []
 
+    # For PY3, if something like ".keys()" or ".values()" is used on a dictionary,
+    # it returns a dict_view and not a list like in PY2. "defaults" should be passed
+    # in with the correct data type, but don't stack-trace in case it wasn't.
+    if not isinstance(defaults, list):
+        defaults = list(defaults)
+
     defaults = list(set(defaults + keys))
 
     for key in defaults:


### PR DESCRIPTION
- Pass in a list as final arg to cloud.filter_event utils call: The third argument that is passed to the salt.utils.cloud.filter_event function is supposed to be a list. Most of the places calling this function were using `foo.keys()`, which returns a list in PY2. But, in PY3, this is a dictionary view. We need to handle this both from the function call passing the arg, and in the function itself if the type is incorrect.
- Fix some more places where .keys() is being used improperly for PY3: The .keys() function itself is fine, it's just what we do after calling it that matters. Anywhere we try to index the dictionary view will stacktrace in PY3.
- Use `salt.utils.hashutils` function to handle PY2 and PY3 for hash generations in the gogrid driver.

These fixes are similar to the ones found in #41514, but those fixes were largely just for the ec2 driver.

Should likely fix all of the following, but I might need to circle back around to these once cloud tests run:
- https://github.com/saltstack/salt-jenkins/issues/395
- https://github.com/saltstack/salt-jenkins/issues/396
- https://github.com/saltstack/salt-jenkins/issues/397
- https://github.com/saltstack/salt-jenkins/issues/399
- https://github.com/saltstack/salt-jenkins/issues/400
- https://github.com/saltstack/salt-jenkins/issues/401