### PR TITLE
Reduce the number of days an issue is stale by 25

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,8 +1,8 @@
 # Probot Stale configuration file
 
 # Number of days of inactivity before an issue becomes stale
-# 1275 is approximately 3 years and 6 months
-daysUntilStale: 1275
+# 1250 is approximately 3 years and 5 months
+daysUntilStale: 1250
 
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7


### PR DESCRIPTION
Let's ease into a more reasonable `daysUntilStale` value. This updates the time an issue will be marked as stale to about 3 years and 5 months.
