### PR TITLE
Add debug logging for manage.up/down

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -41,6 +41,11 @@ def _ping(tgt, tgt_type, timeout, gather_job_timeout):
     if not pub_data:
         return pub_data
 
+    log.debug(
+        'manage runner will ping the following minion(s): %s',
+        ', '.join(sorted(pub_data['minions']))
+    )
+
     returned = set()
     for fn_ret in client.get_cli_event_returns(
             pub_data['jid'],
@@ -52,11 +57,13 @@ def _ping(tgt, tgt_type, timeout, gather_job_timeout):
 
         if fn_ret:
             for mid, _ in six.iteritems(fn_ret):
+                log.debug('minion \'%s\' returned from ping', mid)
                 returned.add(mid)
 
-    not_returned = set(pub_data['minions']) - returned
+    not_returned = sorted(set(pub_data['minions']) - returned)
+    returned = sorted(returned)
 
-    return list(returned), list(not_returned)
+    return returned, not_returned
 
 
 def status(output=True, tgt='*', tgt_type='glob', expr_form=None, timeout=None, gather_job_timeout=None):


### PR DESCRIPTION
This adds some debug logging which we can hopefully use to troubleshoot https://github.com/saltstack/salt-jenkins/issues/341.

Also, this ensures that the lists of up/down minions are always sorted. This will make future testing more reliable.