### PR TITLE
win_certutil: workaround for reading serial numbers with non-English languages

### DIFF
--- a/salt/modules/win_certutil.py
+++ b/salt/modules/win_certutil.py
@@ -42,10 +42,10 @@ def get_cert_serial(cert_file):
 
         salt '*' certutil.get_cert_serial <certificate name>
     '''
-    cmd = "certutil.exe -verify {0}".format(cert_file)
+    cmd = "certutil.exe -silent -verify {0}".format(cert_file)
     out = __salt__['cmd.run'](cmd)
     # match serial number by paragraph to work with multiple languages
-    matches = re.search(r":\w*(.*)\r\n\r\n", out)
+    matches = re.search(r":\s*(\w*)\r\n\r\n", out)
     if matches is not None:
         return matches.groups()[0].strip()
     else:

--- a/salt/modules/win_certutil.py
+++ b/salt/modules/win_certutil.py
@@ -44,7 +44,8 @@ def get_cert_serial(cert_file):
     '''
     cmd = "certutil.exe -verify {0}".format(cert_file)
     out = __salt__['cmd.run'](cmd)
-    matches = re.search(r"Serial: (.*)", out)
+    # match serial number by paragraph to work with multiple languages
+    matches = re.search(r":\w*(.*)\r\n\r\n", out)
     if matches is not None:
         return matches.groups()[0].strip()
     else:
@@ -66,7 +67,8 @@ def get_stored_cert_serials(store):
     '''
     cmd = "certutil.exe -store {0}".format(store)
     out = __salt__['cmd.run'](cmd)
-    matches = re.findall(r"Serial Number: (.*)\r", out)
+    # match serial numbers by header position to work with multiple languages
+    matches = re.findall(r"={16}\r\n.*:\s*(\w*)\r\n", out)
     return matches
 
 

--- a/tests/unit/modules/win_certutil_test.py
+++ b/tests/unit/modules/win_certutil_test.py
@@ -25,34 +25,54 @@ class CertUtilTestCase(TestCase):
         '''
             Test getting the serial number from a certificate
         '''
-        expected = 'XYZABC'
-        mock = MagicMock(return_value='CertInfo\r\nSerial: XYZABC\r\nOtherStuff')
+        expected = '180720d39cd2db3244ba037417241e90'
+        mock = MagicMock(return_value=(
+            'CertInfo\r\n'
+            '================ Certificate 0 ================\r\n'
+            'Serial Number: 180720d39cd2db3244ba037417241e90\r\n'
+            'OtherStuff'))
         with patch.dict(certutil.__salt__, {'cmd.run': mock}):
             out = certutil.get_cert_serial('/path/to/cert.cer')
-            mock.assert_called_once_with('certutil.exe -verify /path/to/cert.cer')
+            mock.assert_called_once_with(
+                'certutil.exe -silent -verify /path/to/cert.cer')
             self.assertEqual(expected, out)
 
     def test_get_serials(self):
         '''
             Test getting the all the serial numbers from a store
         '''
-        expected = ['XYZABC', '123456']
-        mock = MagicMock(return_value='CertInfo\r\nSerial Number: XYZABC\r\nSerial Number: 123456\r\n')
+        expected = ['180720d39cd2db3244ba037417241e90',
+                    '1768ac4e5b72bf1d0df0df118b34b959']
+        mock = MagicMock(return_value=(
+            'CertInfo\r\n'
+            '================ Certificate 0 ================\r\n'
+            'Serial Number: 180720d39cd2db3244ba037417241e90\r\n'
+            'OtherStuff\r\n'
+            '\r\n'
+            '================ Certificate 1 ================\r\n'
+            'Serial Number: 1768ac4e5b72bf1d0df0df118b34b959\r\n'
+            'OtherStuff'))
         with patch.dict(certutil.__salt__, {'cmd.run': mock}):
             out = certutil.get_stored_cert_serials('TrustedPublisher')
-            mock.assert_called_once_with('certutil.exe -store TrustedPublisher')
+            mock.assert_called_once_with(
+                'certutil.exe -store TrustedPublisher')
             self.assertEqual(expected, out)
 
     def test_add_store(self):
         '''
             Test adding a certificate to a specific store
         '''
-        cmd_mock = MagicMock(return_value='CertInfo\r\nSerial: XYZABC\r\nOtherStuff')
+        cmd_mock = MagicMock(return_value=(
+            'CertInfo\r\n'
+            '================ Certificate 0 ================\r\n'
+            'Serial Number: 180720d39cd2db3244ba037417241e90\r\n'
+            'OtherStuff'))
         cache_mock = MagicMock(return_value='/tmp/cert.cer')
         with patch.dict(certutil.__salt__, {'cmd.run': cmd_mock,
                                             'cp.cache_file': cache_mock}):
             certutil.add_store('salt://path/to/file', 'TrustedPublisher')
-            cmd_mock.assert_called_once_with('certutil.exe -addstore TrustedPublisher /tmp/cert.cer')
+            cmd_mock.assert_called_once_with(
+                'certutil.exe -addstore TrustedPublisher /tmp/cert.cer')
             cache_mock.assert_called_once_with('salt://path/to/file', 'base')
 
     @patch('salt.modules.win_certutil.get_cert_serial')
@@ -60,13 +80,18 @@ class CertUtilTestCase(TestCase):
         '''
             Test removing a certificate to a specific store
         '''
-        cmd_mock = MagicMock(return_value='CertInfo\r\nSerial: XYZABC\r\nOtherStuff')
+        cmd_mock = MagicMock(return_value=(
+            'CertInfo\r\n'
+            '================ Certificate 0 ================\r\n'
+            'Serial Number: 180720d39cd2db3244ba037417241e90\r\n'
+            'OtherStuff'))
         cache_mock = MagicMock(return_value='/tmp/cert.cer')
-        cert_serial_mock.return_value = "ABCDEF"
+        cert_serial_mock.return_value = 'ABCDEF'
         with patch.dict(certutil.__salt__, {'cmd.run': cmd_mock,
                                             'cp.cache_file': cache_mock}):
             certutil.del_store('salt://path/to/file', 'TrustedPublisher')
-            cmd_mock.assert_called_once_with('certutil.exe -delstore TrustedPublisher ABCDEF')
+            cmd_mock.assert_called_once_with(
+                'certutil.exe -delstore TrustedPublisher ABCDEF')
             cache_mock.assert_called_once_with('salt://path/to/file', 'base')
 
 

--- a/tests/unit/modules/win_certutil_test.py
+++ b/tests/unit/modules/win_certutil_test.py
@@ -28,8 +28,8 @@ class CertUtilTestCase(TestCase):
         expected = '180720d39cd2db3244ba037417241e90'
         mock = MagicMock(return_value=(
             'CertInfo\r\n'
-            '================ Certificate 0 ================\r\n'
-            'Serial Number: 180720d39cd2db3244ba037417241e90\r\n'
+            'Cert Serial Number: 180720d39cd2db3244ba037417241e90\r\n'
+            '\r\n'
             'OtherStuff'))
         with patch.dict(certutil.__salt__, {'cmd.run': mock}):
             out = certutil.get_cert_serial('/path/to/cert.cer')
@@ -39,7 +39,7 @@ class CertUtilTestCase(TestCase):
 
     def test_get_serials(self):
         '''
-            Test getting the all the serial numbers from a store
+            Test getting all the serial numbers from a store
         '''
         expected = ['180720d39cd2db3244ba037417241e90',
                     '1768ac4e5b72bf1d0df0df118b34b959']


### PR DESCRIPTION
### What does this PR do?
I think there are probably multiple issues with this module (parsing localised text and using serial numbers as a unique values) but in the short term this should get it working for non-English languages. Feel free to reject the PR if there is better solution for the stable branch, I think to fix this properly the majority of the module would have to be re-written.

Edit: Just noticed that the win_pki modules are effectively a rewrite of this using Powershell instead of parsing the output of certutil.exe.

### What issues does this PR fix or reference?
#41367

### Previous Behavior
Regex matching uses English words and fixed colon positions.

### New Behavior
Regex matching based on the header and paragraph positions, with a bit more flexibility on where the colon is. I've tested on Windows 7 and 10, with languages set to English, French (changed certutil language), and Arabic (command prompt language seemed to fallback to a previous choice, so I'm guessing only a subset of languages are supported by command line tools).

### Tests written?
No