### PR TITLE
Fix 41562

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -252,7 +252,7 @@ def uninstall(pkg, dir=None, runas=None, env=None):
     return True
 
 
-def list_(pkg=None, dir=None, runas=None, env=None):
+def list_(pkg=None, dir=None, runas=None, env=None, depth=None):
     '''
     List installed NPM packages.
 
@@ -278,6 +278,11 @@ def list_(pkg=None, dir=None, runas=None, env=None):
 
         .. versionadded:: 2014.7.0
 
+    depth
+        Limit the depth of the packages listed
+
+        .. versionadded:: tbd
+
     CLI Example:
 
     .. code-block:: bash
@@ -296,6 +301,11 @@ def list_(pkg=None, dir=None, runas=None, env=None):
 
     if not dir:
         cmd.append('--global')
+
+    if depth is not None:
+        if not isinstance(depth, (int, float)):
+            raise salt.exceptions.SaltInvocationError('Error: depth {} must be a number'.format(depth))
+        cmd.append('--depth={}'.format(int(depth)))
 
     if pkg:
         # Protect against injection

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -96,7 +96,7 @@ def installed(name,
     pkg_list = pkgs if pkgs else [name]
 
     try:
-        installed_pkgs = __salt__['npm.list'](dir=dir, runas=user, env=env)
+        installed_pkgs = __salt__['npm.list'](dir=dir, runas=user, env=env, depth=0)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
         ret['comment'] = 'Error looking up \'{0}\': {1}'.format(name, err)
@@ -232,7 +232,7 @@ def removed(name, dir=None, user=None):
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     try:
-        installed_pkgs = __salt__['npm.list'](dir=dir)
+        installed_pkgs = __salt__['npm.list'](dir=dir, depth=0)
     except (CommandExecutionError, CommandNotFoundError) as err:
         ret['result'] = False
         ret['comment'] = 'Error uninstalling \'{0}\': {1}'.format(name, err)


### PR DESCRIPTION
### What does this PR do?
Limits scope of `npm list` to only return top level modules by default

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/41562

### Previous Behavior
All NPM modules and their dependencies would be listed which caused an issue when using `subprocess.communicate` as the stdout buffer would fill up and trim stdout.

### New Behavior
By limiting the npm list scope to only top level modules the buffer does not fill up. This behavior should have no impact on it's usage in other npm modules as the dependency information was not being used.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
