### PR TITLE
More debug logging to troubleshoot failing manage runner tests in Python 3

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -55,6 +55,7 @@ def _ping(tgt, tgt_type, timeout, gather_job_timeout):
             tgt_type,
             gather_job_timeout=gather_job_timeout):
 
+        log.debug('fn_ret: %s', fn_ret)
         if fn_ret:
             for mid, _ in six.iteritems(fn_ret):
                 log.debug('minion \'%s\' returned from ping', mid)


### PR DESCRIPTION
Either the get_cli_event_returns generator is not returning events, or
the events being yielded otherwise are evaluating as False. This line of
debugging code will help determine which is the case.