### PR TITLE
mount.swap state should report correctly on test=True if swap file already mounted

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -630,14 +630,6 @@ def swap(name, persist=True, config='/etc/fstab'):
 
     if persist:
         fstab_data = __salt__['mount.fstab'](config)
-        if __opts__['test']:
-            if name not in fstab_data:
-                ret['result'] = None
-                if name in on_:
-                    ret['comment'] = ('Swap {0} is set to be added to the '
-                                      'fstab and to be activated').format(name)
-            return ret
-
         if 'none' in fstab_data:
             if fstab_data['none']['device'] == name and \
                fstab_data['none']['fstype'] != 'swap':
@@ -665,6 +657,13 @@ def swap(name, persist=True, config='/etc/fstab'):
         if out == 'bad config':
             ret['result'] = False
             ret['comment'] += '. However, the fstab was not found.'
+            return ret
+        if __opts__['test']:
+            if name not in fstab_data:
+                ret['result'] = None
+                if name in on_:
+                    ret['comment'] = ('Swap {0} is set to be added to the '
+                                      'fstab and to be activated').format(name)
             return ret
     return ret
 

--- a/tests/unit/states/mount_test.py
+++ b/tests/unit/states/mount_test.py
@@ -205,9 +205,8 @@ class MountTestCase(TestCase):
                                          'mount.fstab': mock_fs,
                                          'file.is_link': mock_f}):
             with patch.dict(mount.__opts__, {'test': True}):
-                comt = ('Swap {0} is set to be added to the '
-                        'fstab and to be activated'.format(name))
-                ret.update({'comment': comt})
+                comt = ('Swap {0} already active'.format(name))
+                ret.update({'comment': comt, 'result': True})
                 self.assertDictEqual(mount.swap(name), ret)
 
             with patch.dict(mount.__opts__, {'test': False}):


### PR DESCRIPTION
### What does this PR do?
Fixes incorrect result from test=True if swap file already mounted.

### What issues does this PR fix or reference?
#41583

### Previous Behavior
Remove this section if not relevant

local:
----------
          ID: /swapfile
    Function: mount.swap
      Result: None
     Comment: Swap /swapfile is set to be added to the fstab and to be activated
     Started: 12:11:44.588313
    Duration: 6.851 ms
     Changes:   

Summary for local
------------
Succeeded: 2 (unchanged=1)
Failed:    0
------------
Total states run:     2
Total run time:  13.197 ms

### New Behavior
Remove this section if not relevant

local:

Summary for local
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2
Total run time:  12.951 ms

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
