### PR TITLE
Sign_minion_messages support

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -366,6 +366,20 @@
 # will cause minion to throw an exception and drop the message.
 # sign_pub_messages: False
 
+# Signature verification on messages published from minions
+# This requires that minions cryptographically sign the messages they
+# publish to the master.  If minions are not signing, then log this information
+# at loglevel 'INFO' and drop the message without acting on it.
+# require_minion_sign_messages: False
+
+# The below will drop messages when their signatures do not validate.
+# Note that when this option is False but `require_minion_sign_messages` is True
+# minions MUST sign their messages but the validity of their signatures
+# is ignored.
+# These two config options exist so a Salt infrastructure can be moved
+# to signing minion messages gradually.
+# drop_messages_signature_fail: False
+
 #####     Salt-SSH Configuration     #####
 ##########################################
 

--- a/doc/topics/releases/2016.3.7.rst
+++ b/doc/topics/releases/2016.3.7.rst
@@ -9,3 +9,18 @@ controls whether a minion can request that the master revoke its key.  When True
 can request a key revocation and the master will comply.  If it is False, the key will not
 be revoked by the msater.
 
+New master configuration option `require_minion_sign_messages`
+This requires that minions cryptographically sign the messages they
+publish to the master.  If minions are not signing, then log this information
+at loglevel 'INFO' and drop the message without acting on it.
+
+New master configuration option `drop_messages_signature_fail`
+Drop messages from minions when their signatures do not validate.
+Note that when this option is False but `require_minion_sign_messages` is True
+minions MUST sign their messages but the validity of their signatures
+is ignored.
+
+New minion configuration option `minion_sign_messages`
+Causes the minion to cryptographically sign the payload of messages it places
+on the event bus for the master.  The payloads are signed with the minion's
+private key so the master can verify the signature with its public key.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -874,6 +874,19 @@ VALID_OPTS = {
 
     # File chunk size for salt-cp
     'salt_cp_chunk_size': int,
+
+    # Require that the minion sign messages it posts to the master on the event
+    # bus
+    'minion_sign_messages': bool,
+
+    # Have master drop messages from minions for which their signatures do
+    # not verify
+    'drop_messages_signature_fail': bool,
+
+    # Require that payloads from minions have a 'sig' entry
+    # (in other words, require that minions have 'minion_sign_messages'
+    # turned on)
+    'require_minion_sign_messages': bool,
 }
 
 # default configurations
@@ -1105,6 +1118,7 @@ DEFAULT_MINION_OPTS = {
     'ssl': None,
     'cache': 'localfs',
     'salt_cp_chunk_size': 65536,
+    'minion_sign_messages': False,
 }
 
 DEFAULT_MASTER_OPTS = {
@@ -1364,6 +1378,8 @@ DEFAULT_MASTER_OPTS = {
     'thin_extra_mods': '',
     'allow_minion_key_revoke': True,
     'salt_cp_chunk_size': 98304,
+    'require_minion_sign_messages': False,
+    'drop_messages_signature_fail': False,
 }
 
 

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -37,6 +37,7 @@ except ImportError:
 # Import salt libs
 import salt.defaults.exitcodes
 import salt.utils
+import salt.utils.decorators
 import salt.payload
 import salt.transport.client
 import salt.utils.rsax931
@@ -127,13 +128,41 @@ def gen_keys(keydir, keyname, keysize, user=None):
     return priv
 
 
+@salt.utils.decorators.memoize
+def _get_key_with_evict(path, timestamp):
+    '''
+    Load a key from disk.  `timestamp` above is intended to be the timestamp
+    of the file's last modification. This fn is memoized so if it is called with the
+    same path and timestamp (the file's last modified time) the second time
+    the result is returned from the memoiziation.  If the file gets modified
+    then the params are different and the key is loaded from disk.
+    '''
+    log.debug('salt.crypt._get_key_with_evict: Loading private key')
+    with salt.utils.fopen(path) as f:
+        key = RSA.importKey(f.read())
+    return key
+
+
+def _get_rsa_key(path):
+    '''
+    Read a key off the disk.  Poor man's simple cache in effect here,
+    we memoize the result of calling _get_rsa_with_evict.  This means
+    the first time _get_key_with_evict is called with a path and a timestamp
+    the result is cached.  If the file (the private key) does not change
+    then its timestamp will not change and the next time the result is returned
+    from the cache.  If the key DOES change the next time _get_rsa_with_evict
+    is called it is called with different parameters and the fn is run fully to
+    retrieve the key from disk.
+    '''
+    log.debug('salt.crypt._get_rsa_key: Loading private key')
+    return _get_key_with_evict(path, os.path.getmtime(path))
+
+
 def sign_message(privkey_path, message):
     '''
     Use Crypto.Signature.PKCS1_v1_5 to sign a message. Returns the signature.
     '''
-    log.debug('salt.crypt.sign_message: Loading private key')
-    with salt.utils.fopen(privkey_path) as f:
-        key = RSA.importKey(f.read())
+    key = _get_rsa_key(privkey_path)
     log.debug('salt.crypt.sign_message: Signing message.')
     signer = PKCS1_v1_5.new(key)
     return signer.sign(SHA.new(message))

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -780,6 +780,7 @@ class RemoteFuncs(object):
         # If the return data is invalid, just ignore it
         if any(key not in load for key in ('return', 'jid', 'id')):
             return False
+
         if load['jid'] == 'req':
             # The minion is returning a standalone job, request a jobid
             prep_fstr = '{0}.prep_jid'.format(self.opts['master_job_cache'])

--- a/salt/master.py
+++ b/salt/master.py
@@ -1084,8 +1084,6 @@ class AESFuncs(object):
                 )
             )
             return False
-        if 'tok' in load:
-            load.pop('tok')
 
         if 'sig' in load:
             log.trace('Verifying signed event publish from minion')
@@ -1094,6 +1092,9 @@ class AESFuncs(object):
             serialized_load = salt.serializers.msgpack.serialize(load)
             if not salt.crypt.verify_signature(this_minion_pubkey, serialized_load, sig):
                 log.info('Signature for signed event from minion published on bus did not verify')
+
+        if 'tok' in load:
+            load.pop('tok')
 
         return load
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -1085,14 +1085,6 @@ class AESFuncs(object):
             )
             return False
 
-        if 'sig' in load:
-            log.trace('Verifying signed event publish from minion')
-            sig = load.pop('sig')
-            this_minion_pubkey = os.path.join(self.opts['pki_dir'], 'minions/{0}'.format(load['id']))
-            serialized_load = salt.serializers.msgpack.serialize(load)
-            if not salt.crypt.verify_signature(this_minion_pubkey, serialized_load, sig):
-                log.info('Signature for signed event from minion published on bus did not verify')
-
         if 'tok' in load:
             load.pop('tok')
 
@@ -1385,6 +1377,24 @@ class AESFuncs(object):
 
         :param dict load: The minion payload
         '''
+        if self.opts['require_minion_sign_messages'] and 'sig' not in load:
+            log.critical('_return: Master is requiring minions to sign their messages, but there is no signature in this payload from {0}.'.format(load['id']))
+            return False
+
+        if 'sig' in load:
+            log.trace('Verifying signed event publish from minion')
+            sig = load.pop('sig')
+            this_minion_pubkey = os.path.join(self.opts['pki_dir'], 'minions/{0}'.format(load['id']))
+            serialized_load = salt.serializers.msgpack.serialize(load)
+            if not salt.crypt.verify_signature(this_minion_pubkey, serialized_load, sig):
+                log.info('Failed to verify event signature from minion {0}.'.format(load['id']))
+                if self.opts['drop_messages_signature_fail']:
+                    log.critical('Drop_messages_signature_fail is enabled, dropping message from {0}'.format(load['id']))
+                    return False
+                else:
+                    log.info('But \'drop_message_signature_fail\' is disabled, so message is still accepted.')
+            load['sig'] = sig
+
         try:
             salt.utils.job.store_job(
                 self.opts, load, event=self.event, mminion=self.mminion)
@@ -1428,6 +1438,9 @@ class AESFuncs(object):
                 ret['fun_args'] = load['arg']
             if 'out' in load:
                 ret['out'] = load['out']
+            if 'sig' in load:
+                ret['sig'] = load['sig']
+
             self._return(ret)
 
     def minion_runner(self, clear_load):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1644,7 +1644,6 @@ class Minion(MinionBase):
             log.warning(msg)
             return True
 
-
         if sync:
             try:
                 ret_val = self._send_req_sync(load, timeout=timeout)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1390,7 +1390,7 @@ class Minion(MinionBase):
                                 iret = []
                             iret.append(single)
                         tag = tagify([data['jid'], 'prog', opts['id'], str(ind)], 'job')
-
+                        event_data = {'return': single}
                         minion_instance._fire_master(event_data, tag)
                         ind += 1
                     ret['return'] = iret

--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -3,6 +3,7 @@
 # Import Python libs
 from __future__ import absolute_import
 import logging
+import os
 
 # Import Salt libs
 import salt.minion

--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -3,7 +3,6 @@
 # Import Python libs
 from __future__ import absolute_import
 import logging
-import os
 
 # Import Salt libs
 import salt.minion

--- a/tests/unit/crypt_test.py
+++ b/tests/unit/crypt_test.py
@@ -101,8 +101,9 @@ class CryptTestCase(TestCase):
                     salt.utils.fopen.assert_has_calls([open_priv_wb, open_pub_wb], any_order=True)
 
     def test_sign_message(self):
-        with patch('salt.utils.fopen', mock_open(read_data=PRIVKEY_DATA)):
-            self.assertEqual(SIG, crypt.sign_message('/keydir/keyname.pem', MSG))
+        key = Crypto.PublicKey.RSA.importKey(PRIVKEY_DATA)
+        with patch('salt.crypt._get_rsa_key', return_value=key):
+            self.assertEqual(SIG, salt.crypt.sign_message('/keydir/keyname.pem', MSG))
 
     def test_verify_signature(self):
         with patch('salt.utils.fopen', mock_open(read_data=PUBKEY_DATA)):


### PR DESCRIPTION
### What does this PR do?

Add support for signing messages that minions `_fire_master` onto the bus.  Master will verify the signature using its copy of the minion's public key.

@cachedout , @thatch45 need your review please.
