### PR TITLE
Skip locale tests on MacOSX

### DIFF
--- a/tests/integration/modules/test_locale.py
+++ b/tests/integration/modules/test_locale.py
@@ -22,6 +22,7 @@ def _find_new_locale(current_locale):
 
 
 @skipIf(salt.utils.is_windows(), 'minion is windows')
+@skipIf(salt.utils.is_darwin(), 'locale method is not supported on mac')
 @requires_salt_modules('locale')
 class LocaleModuleTest(ModuleCase):
     def test_get_locale(self):


### PR DESCRIPTION
### What does this PR do?
When glancing at the locale method it seems logic for macosx was never added so skipping these tests for now until it is added.The reason these are failing now is because there was some test improvements here: https://github.com/saltstack/salt/pull/40834 that starting catching these failures. 

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-jenkins/issues/387 and https://github.com/saltstack/salt-jenkins/issues/386


### Tests written?

Yes