### PR TITLE
Choco: Add support for the --no-progress option

### DIFF
--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -70,6 +70,22 @@ def _yes(context):
     return answer
 
 
+def _no_progress(context):
+    '''
+    Returns ['--no-progress'] if on v0.10.4 or later, otherwise returns an
+    empty list
+    '''
+    if 'chocolatey._no_progress' in __context__:
+        return context['chocolatey._no_progress']
+    if _LooseVersion(chocolatey_version()) >= _LooseVersion('0.10.4'):
+        answer = ['--no-progress']
+    else:
+        log.warning('--no-progress unsupported in choco < 0.10.4')
+        answer = []
+    context['chocolatey._no_progress'] = answer
+    return answer
+
+
 def _find_chocolatey(context, salt):
     '''
     Returns the full path to chocolatey.bat on the host.
@@ -351,7 +367,8 @@ def install(name,
             override_args=False,
             force_x86=False,
             package_args=None,
-            allow_multiple=False):
+            allow_multiple=False,
+            no_progress=False):
     '''
     Instructs Chocolatey to install a package.
 
@@ -407,6 +424,9 @@ def install(name,
 
             .. versionadded:: Nitrogen
 
+        no_progress
+            Do not show download progress percentages. Defaults to False.
+
     Returns:
         str: The output of the ``chocolatey`` command
 
@@ -445,6 +465,8 @@ def install(name,
         cmd.extend(['--packageparameters', package_args])
     if allow_multiple:
         cmd.append('--allow-multiple')
+    if no_progress:
+        cmd.append(_no_progress(__context__))
     cmd.extend(_yes(__context__))
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 
@@ -715,7 +737,8 @@ def upgrade(name,
             install_args=None,
             override_args=False,
             force_x86=False,
-            package_args=None):
+            package_args=None,
+            no_progress=False):
     '''
     .. versionadded:: 2016.3.4
 
@@ -758,6 +781,9 @@ def upgrade(name,
         package_args
             A list of arguments you want to pass to the package
 
+        no_progress
+            Do not show download progress percentages. Defaults to False.
+
     Returns:
         str: Results of the ``chocolatey`` command
 
@@ -787,6 +813,9 @@ def upgrade(name,
         cmd.append('--forcex86')
     if package_args:
         cmd.extend(['--packageparameters', package_args])
+    if no_progress:
+        cmd.append(_no_progress(__context__))
+
     cmd.extend(_yes(__context__))
 
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
@@ -798,7 +827,7 @@ def upgrade(name,
     return result['stdout']
 
 
-def update(name, source=None, pre_versions=False):
+def update(name, source=None, pre_versions=False, no_progress=False):
     '''
     Instructs Chocolatey to update packages on the system.
 
@@ -812,6 +841,9 @@ def update(name, source=None, pre_versions=False):
 
     pre_versions
         Include pre-release packages in comparison. Defaults to False.
+
+    no_progress
+        Do not show download progress percentages. Defaults to False.
 
     CLI Example:
 
@@ -831,6 +863,8 @@ def update(name, source=None, pre_versions=False):
         cmd.extend(['--source', source])
     if salt.utils.is_true(pre_versions):
         cmd.append('--prerelease')
+    if no_progress:
+        cmd.append(_no_progress(__context__))
     cmd.extend(_yes(__context__))
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
 


### PR DESCRIPTION
### What does this PR do?

Chocolatey added support for the --no-progress option in 0.10.4. This option is super useful when calling chocolatey from automation tools like Salt - as it can dramatically reduce the amount of output when running certain commands (install, upgrade etc.). This is particularly noticable when running commands which target a large number of packages, for example when upgrading all the packages on a system.

Because this feature was only added in chocolatey 0.10.4 - we guard against execution on previous versions of Chocolatey using the same pattern as the `--yes` flag.

### What issues does this PR fix or reference?

#38331 talks about adding a generic `choco_args` parameter to remove the need to add support for the myriad of Chocolatey parameters individually. I chose the latter option in this case, since I like being able to fail gracefully if the installed version of Chocolatey doesn't support this flag - but I'd be happy to code the alternative if people think it's worthwhile.

### Tests written?

No test currently exist for Chocolatey ☹️ 