### PR TITLE
Kill child PIDs when shutting down a testprogram daemon

### DIFF
--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -771,11 +771,11 @@ class TestDaemon(TestProgram):
         if not self._shutdown:
             try:
                 pid = self.wait_for_daemon_pid(timeout)
-                terminate_process(pid=pid)
+                terminate_process(pid=pid, kill_children=True)
             except TimeoutError:
                 pass
         if self.process:
-            terminate_process(pid=self.process.pid)
+            terminate_process(pid=self.process.pid, kill_children=True)
             self.process.wait()
             self.process = None
         self._shutdown = True


### PR DESCRIPTION
This fixes the test failures recently observed in ``integration.shell.test_master.MasterTest.test_exit_status_correct_usage``.  The test failures were not a regression, but rather a symptom of a greater problem with the ``TestProgram`` class' ``shutdown()`` func. When terminating the process using the ``terminate_process`` helper from pytest-salt, it does not pass ``kill_children``, which defaults to ``False``.  This makes the helper only kill the main PID, leaving all the other PIDs running.

This means that every time the integration suite was being run, each time the ``TestProgram`` class was used to spawn a temporary daemon, it would leave all the child PIDs running when the ``shutdown()`` is invoked.

By passing ``kill_children=True``, we ensure that the child PIDs are also killed. This should provide a significant perfomance improvement in the test suite.