### PR TITLE
change group to wheel for macosx in tests

### DIFF
--- a/tests/integration/states/test_archive.py
+++ b/tests/integration/states/test_archive.py
@@ -99,10 +99,13 @@ class ArchiveTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         test archive.extracted with user and group set to "root"
         '''
+        r_group = 'root'
+        if salt.utils.is_darwin():
+            r_group = 'wheel'
         ret = self.run_state('archive.extracted', name=ARCHIVE_DIR,
                              source=self.archive_tar_source, archive_format='tar',
                              source_hash=ARCHIVE_TAR_HASH,
-                             user='root', group='root')
+                             user='root', group=r_group)
         log.debug('ret = %s', ret)
         if 'Timeout' in ret:
             self.skipTest('Timeout talking to local tornado server.')

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -545,6 +545,9 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         Test file.managed passing a basic check_cmd kwarg. See Issue #38111.
         '''
+        r_group = 'root'
+        if salt.utils.is_darwin():
+            r_group = 'wheel'
         if not salt.utils.which('visudo'):
             self.fail('sudo is missing')
         try:
@@ -552,7 +555,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
                 'file.managed',
                 name='/tmp/sudoers',
                 user='root',
-                group='root',
+                group=r_group,
                 mode=440,
                 check_cmd='visudo -c -s -f'
             )


### PR DESCRIPTION
### What does this PR do?
changes the group to `wheel` for macosx, because it seems the root group is not enabled by default. I am seeing this error on a couple tests: `Group root does not exist`.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/390
https://github.com/saltstack/salt-jenkins/issues/391

### Previous Behavior
Tests where failing with the error that the root group did not exist. 

### New Behavior
Tests pass

### Tests written?

Yes
