### PR TITLE
Make sure runtests_engine is ASCII text

### DIFF
--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-    :copyright: © 2017 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2017 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/tests/integration/files/engines/runtests_engine.py
+++ b/tests/integration/files/engines/runtests_engine.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2015 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2015 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/tests/integration/files/log_handlers/runtests_log_handler.py
+++ b/tests/integration/files/log_handlers/runtests_log_handler.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2016 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2016 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-    :copyright: © 2013-2017 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2013-2017 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/tests/support/parser/__init__.py
+++ b/tests/support/parser/__init__.py
@@ -6,7 +6,7 @@
     Salt Tests CLI access classes
 
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2013-2017 by the SaltStack Team, see AUTHORS for more details
+    :copyright: Copyright 2013-2017 by the SaltStack Team, see AUTHORS for more details
     :license: Apache 2.0, see LICENSE for more details.
 '''
 # pylint: disable=repr-flag-used-in-string

--- a/tests/support/parser/cover.py
+++ b/tests/support/parser/cover.py
@@ -6,7 +6,7 @@
     Code coverage aware testing parser
 
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2013 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2013 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 '''
 # pylint: disable=repr-flag-used-in-string

--- a/tests/support/paths.py
+++ b/tests/support/paths.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2017 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2017 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/tests/support/processes.py
+++ b/tests/support/processes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-    :copyright: © 2017 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2017 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/tests/support/xmlunit.py
+++ b/tests/support/xmlunit.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2014 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2014 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
 
 

--- a/tests/unit/beacons/test_status.py
+++ b/tests/unit/beacons/test_status.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2017 by the SaltStack Team, see AUTHORS for more details.
+    :copyright: Copyright 2017 by the SaltStack Team, see AUTHORS for more details.
 
 
     tests.unit.beacons.test_status


### PR DESCRIPTION
### What does this PR do?
If this is has any unicode characters in it, it won't load on systems that do
not default to a unicode locale.

`find . -type f | while read line; do ret=$(file $line); if [[ $ret == *UTF-8* && $line == *.py ]]; then echo $line; fi; done`

The above will list all files that have unicode characters in it and possibly won't load
with locale set to C or POSIX

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-jenkins/issues/356 with https://github.com/saltstack/pytest-salt/pull/21