### PR TITLE
remove unicode from engines loading in test suite

### DIFF
--- a/salt/engines/ircbot.py
+++ b/salt/engines/ircbot.py
@@ -42,12 +42,12 @@ Example of usage
 
 .. code:: txt
 
-    08:33:57 @gtmanfred » !ping
-    08:33:57   gtmanbot » gtmanfred: pong
-    08:34:02 @gtmanfred » !echo ping
-    08:34:02   gtmanbot » ping
-    08:34:17 @gtmanfred » !event test/tag/ircbot irc is usefull
-    08:34:17   gtmanbot » gtmanfred: TaDa!
+    08:33:57 @gtmanfred > !ping
+    08:33:57   gtmanbot > gtmanfred: pong
+    08:34:02 @gtmanfred > !echo ping
+    08:34:02   gtmanbot > ping
+    08:34:17 @gtmanfred > !event test/tag/ircbot irc is usefull
+    08:34:17   gtmanbot > gtmanfred: TaDa!
 
 .. code:: txt
 

--- a/salt/engines/junos_syslog.py
+++ b/salt/engines/junos_syslog.py
@@ -28,7 +28,7 @@ of the following fields:
 10.   raw (the raw event data forwarded from the device)
 
 The topic title can consist of any of the combination of above fields,
-but the topic has to start with ‘jnpr/syslog’.
+but the topic has to start with 'jnpr/syslog'.
 So, we can have different combinations:
  - jnpr/syslog/hostip/daemon/event
  - jnpr/syslog/daemon/severity
@@ -37,7 +37,7 @@ The corresponding dynamic topic sent on salt event bus would look something like
 
  - jnpr/syslog/1.1.1.1/mgd/UI_COMMIT_COMPLETED
  - jnpr/syslog/sshd/7
-The default topic title is ‘jnpr/syslog/hostname/event’.
+The default topic title is 'jnpr/syslog/hostname/event'.
 
 The user can choose the type of data he/she wants of the event bus.
 Like, if one wants only events pertaining to a particular daemon, he/she can


### PR DESCRIPTION
### What does this PR do?
This removes the unicode that is causing the stack traces in the test suite if locale is set to C or POSIX.