### PR TITLE
[PY3] Remove uses of urllib.urlencode for PY3 - use six instead

### DIFF
--- a/salt/returners/slack_returner.py
+++ b/salt/returners/slack_returner.py
@@ -82,10 +82,10 @@ from __future__ import absolute_import
 import yaml
 import pprint
 import logging
-import urllib
 
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six.moves.http_client
+from salt.ext.six.moves.urllib.parse import urlencode as _urlencode
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 # Import Salt Libs
@@ -168,7 +168,7 @@ def _post_message(channel,
                                     api_key=api_key,
                                     method='POST',
                                     header_dict={'Content-Type': 'application/x-www-form-urlencoded'},
-                                    data=urllib.urlencode(parameters))
+                                    data=_urlencode(parameters))
 
     log.debug('result {0}'.format(result))
     if result:

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -14,7 +14,6 @@ import logging
 import os.path
 import pprint
 import socket
-import urllib
 import yaml
 
 import ssl
@@ -54,6 +53,7 @@ import salt.ext.six.moves.http_cookiejar
 import salt.ext.six.moves.urllib.request as urllib_request
 from salt.ext.six.moves.urllib.error import URLError
 from salt.ext.six.moves.urllib.parse import splitquery
+from salt.ext.six.moves.urllib.parse import urlencode as _urlencode
 # pylint: enable=import-error,no-name-in-module
 
 # Don't need a try/except block, since Salt depends on tornado
@@ -448,7 +448,7 @@ def query(url,
                           'not valid: {0}'.format(cert))
 
         if isinstance(data, dict):
-            data = urllib.urlencode(data)
+            data = _urlencode(data)
 
         if verify_ssl:
             req_kwargs['ca_certs'] = ca_bundle


### PR DESCRIPTION
Similar to the changes made for the vultr driver in PR #41600, we need to be using the urlencode version from the six library instead of the urllibe.urlencode function. The urlencode function was moved in PY3.

This PR removes the remaining instances of urllib.urlencode in the salt directory.