### PR TITLE
Disable home dir check for mac in test_user

### DIFF
--- a/tests/integration/states/test_user.py
+++ b/tests/integration/states/test_user.py
@@ -104,7 +104,8 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_state('user.present', name=self.user_name,
                              home=self.user_home)
         self.assertSaltTrueReturn(ret)
-        self.assertTrue(os.path.isdir(self.user_home))
+        if not salt.utils.is_darwin():
+            self.assertTrue(os.path.isdir(self.user_home))
 
     @requires_system_grains
     def test_user_present_gid_from_name_default(self, grains=None):

--- a/tests/integration/states/test_user.py
+++ b/tests/integration/states/test_user.py
@@ -128,7 +128,8 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertReturnNonEmptySaltType(ret)
         group_name = grp.getgrgid(ret['gid']).gr_name
 
-        self.assertTrue(os.path.isdir(self.user_home))
+        if not salt.utils.is_darwin():
+            self.assertTrue(os.path.isdir(self.user_home))
         if grains['os_family'] in ('Suse',):
             self.assertEqual(group_name, 'users')
         elif grains['os_family'] == 'MacOS':
@@ -152,7 +153,8 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertReturnNonEmptySaltType(ret)
         group_name = grp.getgrgid(ret['gid']).gr_name
 
-        self.assertTrue(os.path.isdir(self.user_home))
+        if not salt.utils.is_darwin():
+            self.assertTrue(os.path.isdir(self.user_home))
         self.assertEqual(group_name, self.user_name)
         ret = self.run_state('user.absent', name=self.user_name)
         self.assertSaltTrueReturn(ret)


### PR DESCRIPTION
### What does this PR do?
Disables the home dir check in the `test_user_present_nondefault` test. `createhome` is automatically set to False for both windows and mac so the home directory never gets created. We also mention in the `user.present` docs that createhome is not supported on mac so I believe this is expected behavior and the correct approach.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/383


### Tests written?

Yes