### PR TITLE
Fix get_hwclock_aix test on MacOSX

### DIFF
--- a/tests/unit/modules/test_timezone.py
+++ b/tests/unit/modules/test_timezone.py
@@ -309,8 +309,11 @@ class TimezoneModuleTestCase(TestCase, LoaderModuleMockMixin):
         :return:
         '''
         # Incomplete
+        hwclock = 'localtime'
+        if not os.path.isfile('/etc/environment'):
+            hwclock = 'UTC'
         with patch.dict(timezone.__grains__, {'os_family': ['AIX']}):
-            assert timezone.get_hwclock() == 'localtime'
+            assert timezone.get_hwclock() == hwclock
 
     @patch('salt.utils.which', MagicMock(return_value=False))
     @patch('os.path.exists', MagicMock(return_value=True))


### PR DESCRIPTION
### What does this PR do?
Currently the test: `unit.modules.test_timezone.TimezoneModuleTestCase.test_get_hwclock_aix` is failing on macosx because the file `/etc/environment` does not exist which means the code will return UTC instead of localtime. Adding logic around operating systems that do not have this file.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/392


### Tests written?

Yes
