### PR TITLE
Skip git_pillar tests on MacOSX

### DIFF
--- a/tests/integration/pillar/test_git_pillar.py
+++ b/tests/integration/pillar/test_git_pillar.py
@@ -117,6 +117,10 @@ def _rand_key_name(length):
     )
 
 
+def _windows_or_mac():
+    return salt.utils.is_windows() or salt.utils.is_darwin()
+
+
 class GitPythonMixin(object):
     '''
     GitPython doesn't support anything fancy in terms of authentication
@@ -337,7 +341,7 @@ class GitPythonMixin(object):
 
 @destructiveTest
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@skipIf(salt.utils.is_windows(), 'minion is windows')
+@skipIf(_windows_or_mac(), 'minion is windows or mac')
 @skip_if_not_root
 @skipIf(not HAS_GITPYTHON, 'GitPython >= {0} required'.format(GITPYTHON_MINVER))
 @skipIf(not HAS_SSHD, 'sshd not present')
@@ -352,7 +356,7 @@ class TestGitPythonSSH(GitPillarSSHTestBase, GitPythonMixin):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@skipIf(salt.utils.is_windows(), 'minion is windows')
+@skipIf(_windows_or_mac(), 'minion is windows or mac')
 @skip_if_not_root
 @skipIf(not HAS_GITPYTHON, 'GitPython >= {0} required'.format(GITPYTHON_MINVER))
 @skipIf(not HAS_NGINX, 'nginx not present')
@@ -365,7 +369,7 @@ class TestGitPythonHTTP(GitPillarHTTPTestBase, GitPythonMixin):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@skipIf(salt.utils.is_windows(), 'minion is windows')
+@skipIf(_windows_or_mac(), 'minion is windows or mac')
 @skip_if_not_root
 @skipIf(not HAS_GITPYTHON, 'GitPython >= {0} required'.format(GITPYTHON_MINVER))
 @skipIf(not HAS_NGINX, 'nginx not present')
@@ -396,7 +400,7 @@ class TestGitPythonAuthenticatedHTTP(TestGitPythonHTTP, GitPythonMixin):
 
 @destructiveTest
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@skipIf(salt.utils.is_windows(), 'minion is windows')
+@skipIf(_windows_or_mac(), 'minion is windows or mac')
 @skip_if_not_root
 @skipIf(not HAS_PYGIT2, 'pygit2 >= {0} required'.format(PYGIT2_MINVER))
 @skipIf(not HAS_SSHD, 'sshd not present')
@@ -1112,7 +1116,7 @@ class TestPygit2SSH(GitPillarSSHTestBase):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@skipIf(salt.utils.is_windows(), 'minion is windows')
+@skipIf(_windows_or_mac(), 'minion is windows or mac')
 @skip_if_not_root
 @skipIf(not HAS_PYGIT2, 'pygit2 >= {0} required'.format(PYGIT2_MINVER))
 @skipIf(not HAS_NGINX, 'nginx not present')
@@ -1349,7 +1353,7 @@ class TestPygit2HTTP(GitPillarHTTPTestBase):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@skipIf(salt.utils.is_windows(), 'minion is windows')
+@skipIf(_windows_or_mac(), 'minion is windows or mac')
 @skip_if_not_root
 @skipIf(not HAS_PYGIT2, 'pygit2 >= {0} required'.format(PYGIT2_MINVER))
 @skipIf(not HAS_NGINX, 'nginx not present')


### PR DESCRIPTION
### What does this PR do?
Currently the git pillar tests are failing on MacOSX because the setup was linux specific. The setup of these git pillar tests would need to be adjusted in multiple places in the user sls file: https://github.com/saltstack/salt/blob/develop/tests/integration/files/file/base/git_pillar/ssh/user/init.sls and most likely in other places. I would like to skip these tests on mac since macosx is not supported on master anyways.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/384

### Previous Behavior
Tests would not even setup the git server due to issues such as not having a root user and different directory paths on mac vs linux (for example /root/.ssh vs /var/root/.ssh)

### New Behavior
The tests are now skipped

### Tests written?

Yes
