### PR TITLE
Add newline after cron comment

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -129,10 +129,10 @@ def _render_tab(lst):
         if cron['comment'] is not None or cron['identifier'] is not None:
             comment = '#'
             if cron['comment']:
-                comment += ' {0}'.format(
+                comment += ' {0}\n'.format(
                     cron['comment'].rstrip().replace('\n', '\n# '))
             if cron['identifier']:
-                comment += ' {0}:{1}'.format(SALT_CRON_IDENTIFIER,
+                comment += '# {0}:{1}'.format(SALT_CRON_IDENTIFIER,
                                              cron['identifier'])
 
             comment += '\n'

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -129,10 +129,10 @@ def _render_tab(lst):
         if cron['comment'] is not None or cron['identifier'] is not None:
             comment = '#'
             if cron['comment']:
-                comment += ' {0}\n'.format(
-                    cron['comment'].rstrip().replace('\n', '\n# '))
+                comment += ' {0}'.format(
+                    cron['comment'].replace('\n', '\n# '))
             if cron['identifier']:
-                comment += '# {0}:{1}'.format(SALT_CRON_IDENTIFIER,
+                comment += ' {0}:{1}'.format(SALT_CRON_IDENTIFIER,
                                              cron['identifier'])
 
             comment += '\n'

--- a/tests/unit/states/test_cron.py
+++ b/tests/unit/states/test_cron.py
@@ -260,10 +260,12 @@ class CronTestCase(TestCase, LoaderModuleMockMixin):
             get_crontab(),
             '# Lines below here are managed by Salt, do not edit\n'
             '# First crontab\n'
-            '# second multi-line comment SALT_CRON_IDENTIFIER:1\n'
+            '# second multi-line comment\n'
+            '#  SALT_CRON_IDENTIFIER:1\n'
             '* 1 * * * foo\n'
             '# Second crontab\n'
-            '# multi-line comment SALT_CRON_IDENTIFIER:2\n'
+            '# multi-line comment\n'
+            '#  SALT_CRON_IDENTIFIER:2\n'
             '* 1 * * * foo')
 
     def test_existing_unmanaged_jobs_are_made_managed(self):


### PR DESCRIPTION
### What does this PR do?
Adds a newline character to the end of a cron comment

### What issues does this PR fix or reference?
Fixes #41508

### Previous Behavior
A newline was not placed after a comment if provided
```
# Lines below here are managed by Salt, do not edit
# This is line 1 of my comment
# This is line 2 of my comment
# . SALT_CRON_IDENTIFIER:test-01
2 1 * * * COMMAND_GOES_HERE >/dev/null 2>&1
```
### New Behavior
A newline is placed after the comment
```
# Lines below here are managed by Salt, do not edit
# This is line 1 of my comment
# This is line 2 of my comment
# .
# SALT_CRON_IDENTIFIER:test-01
2 1 * * * COMMAND_GOES_HERE >/dev/null 2>&1
```
### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
