### PR TITLE
Update notrim check, netstat takes minutes if large number connections

### DIFF
--- a/pkg/rpm/salt-minion
+++ b/pkg/rpm/salt-minion
@@ -246,7 +246,7 @@ main() {
     fi
 
     # Check to see if --notrim is a valid netstat option
-    if netstat --notrim -n 2>&1 >/dev/null | grep -q 'unrecognized'; then
+    if ! ( netstat --help 2>&1 | grep -wq '\-\-notrim') ; then
         NS_NOTRIM=''
     fi
 


### PR DESCRIPTION
### What does this PR do?
Checks for notrim option by examining netstat's help text for the parameter
if there are a large number of connections (~260K) then netstat can take minutes to return

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/41450

### Previous Behavior
Previously on a system with a large number of connections, the check for whether notrim was supported (netstat --notrim -n) and look for unrecognized parameter could take minutes ( 5 ~ 11 minutes), causing startup failures.

### New Behavior
Checks for notrim option supported by examining netstat command help output for the option. No checking of connections occurs, thus returning information less than a second.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
