### PR TITLE
Change division from / to // for MacOSX mem_total grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -419,7 +419,7 @@ def _memdata(osdata):
                 mem = __salt__['cmd.run']('{0} -n hw.physmem'.format(sysctl))
             if osdata['kernel'] == 'NetBSD' and mem.startswith('-'):
                 mem = __salt__['cmd.run']('{0} -n hw.physmem64'.format(sysctl))
-            grains['mem_total'] = int(mem) / 1024 / 1024
+            grains['mem_total'] = int(mem) // 1024 // 1024
     elif osdata['kernel'] == 'SunOS':
         prtconf = '/usr/sbin/prtconf 2>/dev/null'
         for line in __salt__['cmd.run'](prtconf, python_shell=True).splitlines():


### PR DESCRIPTION
### What does this PR do?
Change the division from `/` to `//` to ensure the MacOSX mem_total grain keeps the int grain type. 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/408

### Previous Behavior
The test `integration.modules.test_grains.TestModulesGrains.test_get_grains_int` was failing with the error:
`2048.0 is not an instance of <class 'int'> : grain: mem_total is not an int or empty`. 

### New Behavior
Tests pass and mem_total stays as an integer type to ensure we don't change type to float for some users.

### Tests written?

Yes