### PR TITLE
Fix some test instability caused by the testprogram class

### DIFF
--- a/tests/integration/shell/test_master.py
+++ b/tests/integration/shell/test_master.py
@@ -95,16 +95,18 @@ class MasterTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
             catch_stderr=True,
             with_retcode=True,
         )
-        self.assert_exit_status(
-            status, 'EX_NOUSER',
-            message='unknown user not on system',
-            stdout=stdout,
-            stderr=tests.integration.utils.decode_byte_list(stderr)
-        )
-        # Although the start-up should fail, call shutdown() to set the internal
-        # _shutdown flag and avoid the registered atexit calls to cause timeout
-        # exeptions and respective traceback
-        master.shutdown()
+        try:
+            self.assert_exit_status(
+                status, 'EX_NOUSER',
+                message='unknown user not on system',
+                stdout=stdout,
+                stderr=tests.integration.utils.decode_byte_list(stderr)
+            )
+        finally:
+            # Although the start-up should fail, call shutdown() to set the
+            # internal _shutdown flag and avoid the registered atexit calls to
+            # cause timeout exeptions and respective traceback
+            master.shutdown()
 
     # pylint: disable=invalid-name
     def test_exit_status_unknown_argument(self):
@@ -123,16 +125,18 @@ class MasterTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
             catch_stderr=True,
             with_retcode=True,
         )
-        self.assert_exit_status(
-            status, 'EX_USAGE',
-            message='unknown argument',
-            stdout=stdout,
-            stderr=tests.integration.utils.decode_byte_list(stderr)
-        )
-        # Although the start-up should fail, call shutdown() to set the internal
-        # _shutdown flag and avoid the registered atexit calls to cause timeout
-        # exeptions and respective traceback
-        master.shutdown()
+        try:
+            self.assert_exit_status(
+                status, 'EX_USAGE',
+                message='unknown argument',
+                stdout=stdout,
+                stderr=tests.integration.utils.decode_byte_list(stderr)
+            )
+        finally:
+            # Although the start-up should fail, call shutdown() to set the
+            # internal _shutdown flag and avoid the registered atexit calls to
+            # cause timeout exeptions and respective traceback
+            master.shutdown()
 
     def test_exit_status_correct_usage(self):
         '''
@@ -150,23 +154,28 @@ class MasterTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
             catch_stderr=True,
             with_retcode=True,
         )
-        self.assert_exit_status(
-            status, 'EX_OK',
-            message='correct usage',
-            stdout=stdout,
-            stderr=tests.integration.utils.decode_byte_list(stderr)
-        )
-        master.shutdown()
+        try:
+            self.assert_exit_status(
+                status, 'EX_OK',
+                message='correct usage',
+                stdout=stdout,
+                stderr=tests.integration.utils.decode_byte_list(stderr)
+            )
+        finally:
+            master.shutdown(wait_for_orphans=3)
+
         # Do the test again to check does master shut down correctly
         stdout, stderr, status = master.run(
             args=['-d'],
             catch_stderr=True,
             with_retcode=True,
         )
-        self.assert_exit_status(
-            status, 'EX_OK',
-            message='correct usage',
-            stdout=stdout,
-            stderr=tests.integration.utils.decode_byte_list(stderr)
-        )
-        master.shutdown()
+        try:
+            self.assert_exit_status(
+                status, 'EX_OK',
+                message='correct usage',
+                stdout=stdout,
+                stderr=tests.integration.utils.decode_byte_list(stderr)
+            )
+        finally:
+            master.shutdown(wait_for_orphans=3)

--- a/tests/integration/shell/test_minion.py
+++ b/tests/integration/shell/test_minion.py
@@ -292,16 +292,18 @@ class MinionTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
             catch_stderr=True,
             with_retcode=True,
         )
-        self.assert_exit_status(
-            status, 'EX_NOUSER',
-            message='unknown user not on system',
-            stdout=stdout,
-            stderr=tests.integration.utils.decode_byte_list(stderr)
-        )
-        # Although the start-up should fail, call shutdown() to set the internal
-        # _shutdown flag and avoid the registered atexit calls to cause timeout
-        # exeptions and respective traceback
-        minion.shutdown()
+        try:
+            self.assert_exit_status(
+                status, 'EX_NOUSER',
+                message='unknown user not on system',
+                stdout=stdout,
+                stderr=tests.integration.utils.decode_byte_list(stderr)
+            )
+        finally:
+            # Although the start-up should fail, call shutdown() to set the
+            # internal _shutdown flag and avoid the registered atexit calls to
+            # cause timeout exeptions and respective traceback
+            minion.shutdown()
 
     # pylint: disable=invalid-name
     def test_exit_status_unknown_argument(self):
@@ -320,16 +322,18 @@ class MinionTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
             catch_stderr=True,
             with_retcode=True,
         )
-        self.assert_exit_status(
-            status, 'EX_USAGE',
-            message='unknown argument',
-            stdout=stdout,
-            stderr=tests.integration.utils.decode_byte_list(stderr)
-        )
-        # Although the start-up should fail, call shutdown() to set the internal
-        # _shutdown flag and avoid the registered atexit calls to cause timeout
-        # exeptions and respective traceback
-        minion.shutdown()
+        try:
+            self.assert_exit_status(
+                status, 'EX_USAGE',
+                message='unknown argument',
+                stdout=stdout,
+                stderr=tests.integration.utils.decode_byte_list(stderr)
+            )
+        finally:
+            # Although the start-up should fail, call shutdown() to set the
+            # internal _shutdown flag and avoid the registered atexit calls to
+            # cause timeout exeptions and respective traceback
+            minion.shutdown()
 
     def test_exit_status_correct_usage(self):
         '''
@@ -352,4 +356,4 @@ class MinionTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
             message='correct usage',
             stdout=stdout, stderr=stderr
         )
-        minion.shutdown()
+        minion.shutdown(wait_for_orphans=3)

--- a/tests/integration/shell/test_proxy.py
+++ b/tests/integration/shell/test_proxy.py
@@ -45,13 +45,18 @@ class ProxyTest(testprogram.TestProgramCase):
             # without daemonizing - protect that with a timeout.
             timeout=60,
         )
-        self.assert_exit_status(
-            status, 'EX_USAGE',
-            message='no --proxyid specified',
-            stdout=stdout,
-            stderr=tests.integration.utils.decode_byte_list(stderr)
-        )
-        # proxy.shutdown() should be unnecessary since the start-up should fail
+        try:
+            self.assert_exit_status(
+                status, 'EX_USAGE',
+                message='no --proxyid specified',
+                stdout=stdout,
+                stderr=tests.integration.utils.decode_byte_list(stderr)
+            )
+        finally:
+            # Although the start-up should fail, call shutdown() to set the
+            # internal _shutdown flag and avoid the registered atexit calls to
+            # cause timeout exeptions and respective traceback
+            proxy.shutdown()
 
     def test_exit_status_unknown_user(self):
         '''
@@ -70,13 +75,18 @@ class ProxyTest(testprogram.TestProgramCase):
             catch_stderr=True,
             with_retcode=True,
         )
-        self.assert_exit_status(
-            status, 'EX_NOUSER',
-            message='unknown user not on system',
-            stdout=stdout,
-            stderr=tests.integration.utils.decode_byte_list(stderr)
-        )
-        # proxy.shutdown() should be unnecessary since the start-up should fail
+        try:
+            self.assert_exit_status(
+                status, 'EX_NOUSER',
+                message='unknown user not on system',
+                stdout=stdout,
+                stderr=tests.integration.utils.decode_byte_list(stderr)
+            )
+        finally:
+            # Although the start-up should fail, call shutdown() to set the
+            # internal _shutdown flag and avoid the registered atexit calls to
+            # cause timeout exeptions and respective traceback
+            proxy.shutdown()
 
     # pylint: disable=invalid-name
     def test_exit_status_unknown_argument(self):
@@ -95,12 +105,17 @@ class ProxyTest(testprogram.TestProgramCase):
             catch_stderr=True,
             with_retcode=True,
         )
-        self.assert_exit_status(
-            status, 'EX_USAGE',
-            message='unknown argument',
-            stdout=stdout, stderr=stderr
-        )
-        # proxy.shutdown() should be unnecessary since the start-up should fail
+        try:
+            self.assert_exit_status(
+                status, 'EX_USAGE',
+                message='unknown argument',
+                stdout=stdout, stderr=stderr
+            )
+        finally:
+            # Although the start-up should fail, call shutdown() to set the
+            # internal _shutdown flag and avoid the registered atexit calls to
+            # cause timeout exeptions and respective traceback
+            proxy.shutdown()
 
     def test_exit_status_correct_usage(self):
         '''
@@ -118,10 +133,12 @@ class ProxyTest(testprogram.TestProgramCase):
             catch_stderr=True,
             with_retcode=True,
         )
-        self.assert_exit_status(
-            status, 'EX_OK',
-            message='correct usage',
-            stdout=stdout,
-            stderr=tests.integration.utils.decode_byte_list(stderr)
-        )
-        proxy.shutdown()
+        try:
+            self.assert_exit_status(
+                status, 'EX_OK',
+                message='correct usage',
+                stdout=stdout,
+                stderr=tests.integration.utils.decode_byte_list(stderr)
+            )
+        finally:
+            proxy.shutdown(wait_for_orphans=3)

--- a/tests/integration/shell/test_syndic.py
+++ b/tests/integration/shell/test_syndic.py
@@ -102,15 +102,17 @@ class SyndicTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
             catch_stderr=True,
             with_retcode=True,
         )
-        self.assert_exit_status(
-            status, 'EX_NOUSER',
-            message='unknown user not on system',
-            stdout=stdout, stderr=stderr
-        )
-        # Although the start-up should fail, call shutdown() to set the internal
-        # _shutdown flag and avoid the registered atexit calls to cause timeout
-        # exeptions and respective traceback
-        syndic.shutdown()
+        try:
+            self.assert_exit_status(
+                status, 'EX_NOUSER',
+                message='unknown user not on system',
+                stdout=stdout, stderr=stderr
+            )
+        finally:
+            # Although the start-up should fail, call shutdown() to set the
+            # internal _shutdown flag and avoid the registered atexit calls to
+            # cause timeout exeptions and respective traceback
+            syndic.shutdown()
 
     # pylint: disable=invalid-name
     def test_exit_status_unknown_argument(self):
@@ -129,15 +131,17 @@ class SyndicTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
             catch_stderr=True,
             with_retcode=True,
         )
-        self.assert_exit_status(
-            status, 'EX_USAGE',
-            message='unknown argument',
-            stdout=stdout, stderr=stderr
-        )
-        # Although the start-up should fail, call shutdown() to set the internal
-        # _shutdown flag and avoid the registered atexit calls to cause timeout
-        # exeptions and respective traceback
-        syndic.shutdown()
+        try:
+            self.assert_exit_status(
+                status, 'EX_USAGE',
+                message='unknown argument',
+                stdout=stdout, stderr=stderr
+            )
+        finally:
+            # Although the start-up should fail, call shutdown() to set the
+            # internal _shutdown flag and avoid the registered atexit calls to
+            # cause timeout exeptions and respective traceback
+            syndic.shutdown()
 
     def test_exit_status_correct_usage(self):
         '''
@@ -155,9 +159,11 @@ class SyndicTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
             catch_stderr=True,
             with_retcode=True,
         )
-        self.assert_exit_status(
-            status, 'EX_OK',
-            message='correct usage',
-            stdout=stdout, stderr=stderr
-        )
-        syndic.shutdown()
+        try:
+            self.assert_exit_status(
+                status, 'EX_OK',
+                message='correct usage',
+                stdout=stdout, stderr=stderr
+            )
+        finally:
+            syndic.shutdown(wait_for_orphans=3)

--- a/tests/support/processes.py
+++ b/tests/support/processes.py
@@ -16,7 +16,7 @@ import logging
 
 # Import pytest-salt libs
 from pytestsalt.utils import SaltRunEventListener as PytestSaltRunEventListener
-from pytestsalt.utils import collect_child_processes, terminate_process  # pylint: disable=unused-import
+from pytestsalt.utils import collect_child_processes, terminate_process, terminate_process_list  # pylint: disable=unused-import
 from pytestsalt.fixtures.daemons import Salt as PytestSalt
 from pytestsalt.fixtures.daemons import SaltKey as PytestSaltKey
 from pytestsalt.fixtures.daemons import SaltRun as PytestSaltRun


### PR DESCRIPTION
In several tests, we are launching a daemon and very quickly (<1 sec) attempting to shut down that daemon. This can lead to race conditions when the daemon (which is still in the process of starting up) spawns new processes after the ``terminate_process`` helper from pytest-salt compiles a list of processes it needs to terminate. These processes that are spawned in the interim are orphaned but continue to run, and may even remain bound to any ports on which they were listening.

To resolve this, an optional ``wait_for_orphans`` argument has been added to the testprogram ``shutdown`` func. If this is set to a nonzero integer, then the function will find and terminate any orphaned processes with the same cmdline, and will only stop looking for orphans when none have been found before the number of seconds specified by ``wait_for_orphans`` has elapsed.

There is one caveat here that may require further changes before this is merged, and that is the method for finding the orphaned processes. This will likely not work properly if run on Windows or Mac.