### PR TITLE
Use dump instead of dumps for json files

### DIFF
--- a/salt/returners/rawfile_json.py
+++ b/salt/returners/rawfile_json.py
@@ -72,7 +72,8 @@ def event_return(events):
     try:
         with salt.utils.flopen(opts['filename'], 'a') as logfile:
             for event in events:
-                logfile.write(str(json.dumps(event))+'\n')
+                json.dump(event, logfile)
+                logfile.write('\n')
     except:
         log.error('Could not write to rawdata_json file {0}'.format(opts['filename']))
         raise


### PR DESCRIPTION
### What does this PR do?
json offers two functions which can be used to work with file-like objects in Python: json.load and json.dump. It is therefore not necessary to store the content of some object in a json-string before calling dumps.


From  [quantifiedcode.com](https://www.quantifiedcode.com/knowledge-base/maintainability/Use%20dump%20instead%20of%20dumps%20for%20json%20files/55b5QncE)