### PR TITLE
Allowing salted annotation stamp on VMWare VM #35568

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -194,6 +194,7 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
         guestinfo.foo: bar
         guestinfo.domain: foobar.com
         guestinfo.customVariable: customValue
+      annotation: Created by Salt-Cloud
 
       deploy: True
       customization: True
@@ -450,6 +451,11 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
     describes a set of modifications to the additional options. If the key is already
     present, it will be reset with the new value provided. Otherwise, a new option is
     added. Keys with empty values will be removed.
+
+``annotation``
+    User-provided description of the virtual machine. This will store a message in the
+    vSphere interface, under the annotations section in the Summary view of the virtual
+    machine.
 
 ``deploy``
     Specifies if salt should be installed on the newly created VM. Default is ``True``

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2573,7 +2573,7 @@ def create(vm_):
             config_spec.extraConfig.append(option)
 
     if annotation:
-        config_spec.annotation = annotation
+        config_spec.annotation = str(annotation)
 
     if 'clonefrom' in vm_:
         clone_spec = handle_snapshot(

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2359,6 +2359,9 @@ def create(vm_):
     extra_config = config.get_cloud_config_value(
         'extra_config', vm_, __opts__, default=None
     )
+    annotation = config.get_cloud_config_value(
+        'annotation', vm_, __opts__, default=None
+    )
     power = config.get_cloud_config_value(
         'power_on', vm_, __opts__, default=True
     )
@@ -2568,6 +2571,9 @@ def create(vm_):
         for key, value in six.iteritems(extra_config):
             option = vim.option.OptionValue(key=key, value=value)
             config_spec.extraConfig.append(option)
+
+    if annotation:
+        config_spec.annotation = annotation
 
     if 'clonefrom' in vm_:
         clone_spec = handle_snapshot(


### PR DESCRIPTION
### What does this PR do?

Allows a user to set a message for the notes/annotation box in vmware vsphere for a newly created VM.

I could not find any documented limit on the message size.

### What issues does this PR fix or reference?
#35568 

