### PR TITLE
Allow Nova cloud module to set a specific floating ip address

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -712,16 +712,16 @@ def request_instance(vm_=None, call=None):
         floating_ip = None
         if floating_ip_conf.get('ip_address', None) is not None:
             ip_address = floating_ip_conf.get('ip_address', None)
-            ## DEBUG ONLY
+            # DEBUG ONLY
             for fl_ip, opts in six.iteritems(conn.floating_ip_list()):
                 if opts['fixed_ip'] is None and opts['pool'] == 'External-net':
                     floating_ip = fl_ip
                     log.debug("Default:")
                     log.debug(floating_ip)
-            ## END DEBUG
+            # END DEBUG
             try:
-                fl_ip = conn.floating_ip_show(ip_address)
-                floating_ip = str(fl_ip.ip)
+                fl_ip_dict = conn.floating_ip_show(ip_address)
+                floating_ip = str(fl_ip_dict['ip'])
                 log.debug("New:")
                 log.debug(floating_ip)
             except Exception as err:

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -773,7 +773,7 @@ def request_instance(vm_=None, call=None):
             raise SaltCloudSystemExit(
                 'Error assigning floating_ip for {0} on Nova\n\n'
                 'The following exception was thrown by libcloud when trying to '
-                'assing a floating ip: {1}\n'.format(
+                'assign a floating ip: {1}\n'.format(
                     vm_['name'], exc
                 )
             )

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -712,8 +712,17 @@ def request_instance(vm_=None, call=None):
         floating_ip = None
         if floating_ip_conf.get('ip_address', None) is not None:
             ip_address = floating_ip_conf.get('ip_address', None)
+            ## DEBUG ONLY
+            for fl_ip, opts in six.iteritems(conn.floating_ip_list()):
+                if opts['fixed_ip'] is None and opts['pool'] == 'External-net':
+                    floating_ip = fl_ip
+                    log.debug("Default:")
+                    log.debug(floating_ip)
+            ## END DEBUG
             try:
                 floating_ip = conn.floating_ip_show(ip_address)
+                log.debug("New:")
+                log.debug(floating_ip)
             except Exception as err:
                 log.error('Specified Fixed Floating IP does not exist or is not yet allocated')
                 # Trigger a failure in the wait for IP function
@@ -724,6 +733,7 @@ def request_instance(vm_=None, call=None):
             for fl_ip, opts in six.iteritems(conn.floating_ip_list()):
                 if opts['fixed_ip'] is None and opts['pool'] == pool:
                     floating_ip = fl_ip
+                    log.debug
                     break
             if floating_ip is None:
                 floating_ip = conn.floating_ip_create(pool)['ip']

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -713,7 +713,10 @@ def request_instance(vm_=None, call=None):
         if floating_ip_conf.get('ip_address', None) is not None:
             ip_address = floating_ip_conf.get('ip_address', None)
             # DEBUG ONLY
-            for fl_ip, opts in six.iteritems(conn.floating_ip_list()):
+            floating_ips_list = conn.floating_ip_list()
+            log.debug("Default List:")
+            log.debug(floating_ips_list)
+            for fl_ip, opts in six.iteritems(floating_ips_list):
                 if opts['fixed_ip'] is None and opts['pool'] == 'External-net':
                     floating_ip = fl_ip
                     log.debug("Default:")
@@ -725,9 +728,13 @@ def request_instance(vm_=None, call=None):
                 log.debug("New:")
                 log.debug(floating_ip)
             except Exception as err:
-                log.error('Specified Fixed Floating IP does not exist or is not yet allocated')
-                # Trigger a failure in the wait for IP function
-                return False
+                raise SaltCloudSystemExit(
+                    'Error assigning floating_ip for {0} on Nova\n\n'
+                    'The following exception was thrown by libcloud when trying to '
+                    'assign a floating ip: {1}\n'.format(
+                        vm_['name'], exc
+                    )
+                )
 
         else:
             pool = floating_ip_conf.get('pool', 'public')
@@ -788,7 +795,7 @@ def request_instance(vm_=None, call=None):
                     vm_['name'], exc
                 )
             )
-        
+
     if not vm_.get('password', None):
         vm_['password'] = data.extra.get('password', '')
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -732,7 +732,7 @@ def request_instance(vm_=None, call=None):
                     'Error assigning floating_ip for {0} on Nova\n\n'
                     'The following exception was thrown by libcloud when trying to '
                     'assign a floating ip: {1}\n'.format(
-                        vm_['name'], exc
+                        vm_['name'], err
                     )
                 )
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -720,7 +720,8 @@ def request_instance(vm_=None, call=None):
                     log.debug(floating_ip)
             ## END DEBUG
             try:
-                floating_ip = conn.floating_ip_show(ip_address)
+                fl_ip = conn.floating_ip_show(ip_address)
+                floating_ip = str(fl_ip.ip)
                 log.debug("New:")
                 log.debug(floating_ip)
             except Exception as err:

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -709,14 +709,24 @@ def request_instance(vm_=None, call=None):
                                                      search_global=False,
                                                      default={})
     if floating_ip_conf.get('auto_assign', False):
-        pool = floating_ip_conf.get('pool', 'public')
         floating_ip = None
-        for fl_ip, opts in six.iteritems(conn.floating_ip_list()):
-            if opts['fixed_ip'] is None and opts['pool'] == pool:
-                floating_ip = fl_ip
-                break
-        if floating_ip is None:
-            floating_ip = conn.floating_ip_create(pool)['ip']
+        if floating_ip_conf.get('ip_address', None) is not None:
+            ip_address = floating_ip_conf.get('ip_address', None)
+            try:
+                floating_ip = conn.floating_ip_show(ip_address)
+            except Exception as err:
+                log.error('Specified Fixed Floating IP does not exist or is not yet allocated')
+                # Trigger a failure in the wait for IP function
+                return False
+
+        else:
+            pool = floating_ip_conf.get('pool', 'public')
+            for fl_ip, opts in six.iteritems(conn.floating_ip_list()):
+                if opts['fixed_ip'] is None and opts['pool'] == pool:
+                    floating_ip = fl_ip
+                    break
+            if floating_ip is None:
+                floating_ip = conn.floating_ip_create(pool)['ip']
 
         def __query_node_data(vm_):
             try:
@@ -767,7 +777,7 @@ def request_instance(vm_=None, call=None):
                     vm_['name'], exc
                 )
             )
-
+        
     if not vm_.get('password', None):
         vm_['password'] = data.extra.get('password', '')
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -712,21 +712,9 @@ def request_instance(vm_=None, call=None):
         floating_ip = None
         if floating_ip_conf.get('ip_address', None) is not None:
             ip_address = floating_ip_conf.get('ip_address', None)
-            # DEBUG ONLY
-            floating_ips_list = conn.floating_ip_list()
-            log.debug("Default List:")
-            log.debug(floating_ips_list)
-            for fl_ip, opts in six.iteritems(floating_ips_list):
-                if opts['fixed_ip'] is None and opts['pool'] == 'External-net':
-                    floating_ip = fl_ip
-                    log.debug("Default:")
-                    log.debug(floating_ip)
-            # END DEBUG
             try:
                 fl_ip_dict = conn.floating_ip_show(ip_address)
                 floating_ip = fl_ip_dict['ip']
-                log.debug("New:")
-                log.debug(floating_ip)
             except Exception as err:
                 raise SaltCloudSystemExit(
                     'Error assigning floating_ip for {0} on Nova\n\n'

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -729,7 +729,6 @@ def request_instance(vm_=None, call=None):
             for fl_ip, opts in six.iteritems(conn.floating_ip_list()):
                 if opts['fixed_ip'] is None and opts['pool'] == pool:
                     floating_ip = fl_ip
-                    log.debug
                     break
             if floating_ip is None:
                 floating_ip = conn.floating_ip_create(pool)['ip']

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -721,7 +721,7 @@ def request_instance(vm_=None, call=None):
             # END DEBUG
             try:
                 fl_ip_dict = conn.floating_ip_show(ip_address)
-                floating_ip = str(fl_ip_dict['ip'])
+                floating_ip = fl_ip_dict['ip']
                 log.debug("New:")
                 log.debug(floating_ip)
             except Exception as err:

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -1145,7 +1145,14 @@ class SaltNova(object):
         floating_ips = nt_ks.floating_ips.list()
         for floating_ip in floating_ips:
             if floating_ip.ip == ip:
-                return floating_ip
+                response = {
+                    'ip': floating_ip.ip,
+                    'fixed_ip': floating_ip.fixed_ip,
+                    'id': floating_ip.id,
+                    'instance_id': floating_ip.instance_id,
+                    'pool': floating_ip.pool
+                }
+                return response
         return {}
 
     def floating_ip_create(self, pool=None):

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -45,6 +45,7 @@ log = logging.getLogger(__name__)
 
 # Version added to novaclient.client.Client function
 NOVACLIENT_MINVER = '2.6.1'
+NOVACLIENT_MAXVER = '6.0.1'
 
 # dict for block_device_mapping_v2
 CLIENT_BDM2_KEYS = {
@@ -65,8 +66,12 @@ def check_nova():
     if HAS_NOVA:
         novaclient_ver = LooseVersion(novaclient.__version__)
         min_ver = LooseVersion(NOVACLIENT_MINVER)
-        if novaclient_ver >= min_ver:
+        max_ver = LooseVersion(NOVACLIENT_MAXVER)
+        if novaclient_ver >= min_ver and novaclient_ver <= max_ver:
             return HAS_NOVA
+        elif novaclient_ver > max_ver:
+            log.debug('Older novaclient version required. Maximum: {0}'.format(NOVACLIENT_MAXVER))
+            return False
         log.debug('Newer novaclient version required.  Minimum: {0}'.format(NOVACLIENT_MINVER))
     return False
 


### PR DESCRIPTION
### What does this PR do?
Add ability of users to specify an floating ip address in the floatingip block in lieu of specifying a pool name

### What issues does this PR fix or reference?
This fixes two things:
1. Allows users to specify a floating ip address in their config files (desirable for machines whose ip might be registered in DNS).
2. Adds a max nova version, recent updates to nova have removed functionality that nova cloud requires. At this time I have tested up to version 6.0.1 for functionality in python-novaclient and added an error for versions greater than that. #41654

### Previous Behavior
1. You could not specify an ip address when assigning a floating ip automatically in the nova cloud module
2. Installing a version of nova newer than 6.0.1 would cause unspecific nova cloud errors

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
