### PR TITLE
Disable libcloud test if the module doesn't load

### DIFF
--- a/tests/integration/modules/test_libcloud_dns.py
+++ b/tests/integration/modules/test_libcloud_dns.py
@@ -1,9 +1,24 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+# import salt libs
+from salt.utils.versions import LooseVersion as _LooseVersion
+
+# Import test Helpers
 from tests.support.case import ModuleCase
+from tests.support.unit import skipIf
 
+REQUIRED_LIBCLOUD_VERSION = '0.21.0'
+try:
+    import libcloud
+    #pylint: enable=unused-import
+    if _LooseVersion(getattr(libcloud, '__version__', '0.0.0')) < _LooseVersion(REQUIRED_LIBCLOUD_VERSION):
+        raise ImportError()
+    HAS_LIBCLOUD = True
+except ImportError:
+    HAS_LIBCLOUD = False
 
+@skipIf(not HAS_LIBCLOUD, 'Requires libcloud >= {0}'.format(REQUIRED_LIBCLOUD_VERSION))
 class LibcloudDNSTest(ModuleCase):
     '''
     Validate the libcloud_dns module

--- a/tests/integration/modules/test_libcloud_dns.py
+++ b/tests/integration/modules/test_libcloud_dns.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     HAS_LIBCLOUD = False
 
+
 @skipIf(not HAS_LIBCLOUD, 'Requires libcloud >= {0}'.format(REQUIRED_LIBCLOUD_VERSION))
 class LibcloudDNSTest(ModuleCase):
     '''


### PR DESCRIPTION
### What does this PR do?
This is causing the mac tests to fail.  apache-libcloud 0.20.1 is what is being
imported, and the libcloud_dns module is not being used.

### What issues does this PR fix or reference?
Fixes saltstack/salt-jenkins#389