### PR TITLE
Don't invoke lspci if enable_lspci is False

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -501,7 +501,7 @@ def _virtual(osdata):
                 '\'virtual\' grain.'
             )
     # Check if enable_lspci is True or False
-    if __opts__.get('enable_lspci', True) is False:
+    if __opts__.get('enable_lspci', True) is True:
         # /proc/bus/pci does not exists, lspci will fail
         if os.path.exists('/proc/bus/pci'):
             _cmds += ['lspci']


### PR DESCRIPTION
### What does this PR do?

Don't invoke `lspci` if `enable_lspci` is False. Fixes what appears to be a typo in the code.

### Tests written?

No
