### PR TITLE
[RFC] Fix cp tests for mac

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -486,8 +486,11 @@ class Client(object):
                     'Path \'{0}\' is not absolute'.format(url_path)
                 )
             if dest is None:
-                with salt.utils.fopen(url_path, 'r') as fp_:
+                mode = 'rb' if six.PY3 else 'r'
+                with salt.utils.fopen(url_path, mode) as fp_:
                     data = fp_.read()
+                    if six.PY3:
+                        data = data.decode()
                 return data
             return url_path
 

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -384,8 +384,11 @@ def get_file_str(path, saltenv='base'):
     '''
     fn_ = cache_file(path, saltenv)
     if isinstance(fn_, six.string_types):
-        with salt.utils.fopen(fn_, 'r') as fp_:
+        mode = 'rb' if six.PY3 else 'r'
+        with salt.utils.fopen(fn_, mode) as fp_:
             data = fp_.read()
+            if six.PY3:
+                data = data.decode()
         return data
     return fn_
 

--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -64,6 +64,7 @@ class CPModuleTest(ModuleCase):
             self.assertIn('Gromit', data)
             self.assertNotIn('bacon', data)
 
+    @skipIf(__salt_system_encoding__ == 'US-ASCII', 'Requires a unicode locale, i.e. en_US.UTF-8')
     def test_get_file_gzipped(self):
         '''
         cp.get_file
@@ -84,8 +85,11 @@ class CPModuleTest(ModuleCase):
             ],
             gzip=5
         )
-        with salt.utils.fopen(tgt, 'r') as scene:
+        mode = 'rb' if six.PY3 else 'r'
+        with salt.utils.fopen(tgt, mode) as scene:
             data = scene.read()
+            if six.PY3:
+                data = data.decode()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
             if six.PY3:
@@ -246,8 +250,11 @@ class CPModuleTest(ModuleCase):
                 'https://repo.saltstack.com/index.html',
                 tgt,
             ])
-        with salt.utils.fopen(tgt, 'r') as instructions:
+        mode = 'rb' if six.PY3 else 'r'
+        with salt.utils.fopen(tgt, mode) as instructions:
             data = instructions.read()
+            if six.PY3:
+                data = data.decode()
             self.assertIn('Bootstrap', data)
             self.assertIn('Debian', data)
             self.assertIn('Windows', data)
@@ -262,8 +269,11 @@ class CPModuleTest(ModuleCase):
             [
                 'https://repo.saltstack.com/index.html',
             ])
-        with salt.utils.fopen(ret, 'r') as instructions:
+        mode = 'rb' if six.PY3 else 'r'
+        with salt.utils.fopen(ret, mode) as instructions:
             data = instructions.read()
+            if six.PY3:
+                data = data.decode()
             self.assertIn('Bootstrap', data)
             self.assertIn('Debian', data)
             self.assertIn('Windows', data)
@@ -297,8 +307,11 @@ class CPModuleTest(ModuleCase):
                 src,
                 tgt,
             ])
-        with salt.utils.fopen(ret, 'r') as scene:
+        mode = 'rb' if six.PY3 else 'r'
+        with salt.utils.fopen(ret, mode) as scene:
             data = scene.read()
+            if six.PY3:
+                data = data.decode()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
 


### PR DESCRIPTION
### What does this PR do?
Mac does not have a locale set.  It uses C.  This allows the tests to run on
systems without a locale and python3

Is there a better way to fix these?

### What issues does this PR fix or reference?
Fixes saltstack/salt-jenkins#404
Fixes saltstack/salt-jenkins#405
Fixes saltstack/salt-jenkins#406
Fixes saltstack/salt-jenkins#407