### PR TITLE
fix ntfs case problem in parted module #41668

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -377,8 +377,11 @@ def mkfs(device, fs_type):
     _validate_device(device)
 
     if fs_type not in set(['ext2', 'fat32', 'fat16', 'linux-swap', 'reiserfs',
-                          'hfs', 'hfs+', 'hfsx', 'NTFS', 'ufs']):
+                          'hfs', 'hfs+', 'hfsx', 'NTFS', 'ntfs', 'ufs']):
         raise CommandExecutionError('Invalid fs_type passed to partition.mkfs')
+
+    if fs_type is 'NTFS':
+        fs_type = 'ntfs'
 
     if fs_type is 'linux-swap':
         mkfs_cmd = 'mkswap'
@@ -386,7 +389,7 @@ def mkfs(device, fs_type):
         mkfs_cmd = 'mkfs.{0}'.format(fs_type)
 
     if not salt.utils.which(mkfs_cmd):
-        return 'Error: {0} is unavailable.'
+        return 'Error: {0} is unavailable.'.format(mkfs_cmd)
     cmd = '{0} {1}'.format(mkfs_cmd, device)
     out = __salt__['cmd.run'](cmd).splitlines()
     return out


### PR DESCRIPTION
### What does this PR do?
fixes #41668 
This PR fixes the naming issues when using the parted module to format (mkfs) a partition using NTFS. 
### What issues does this PR fix or reference?
Currently, the authorized fs_type for NTFS is set in capital letter while mkfs uses small letters. Parted uses NTFS in capital letters. 
The PR maintain backward compatibility and consistency of the API by allowing both capital and small letters for mkfs.
### Previous Behavior
salt 'minion' partition.mkfs /dev/sda1 NTFS
minion:
    Error: {0} is unavailable

salt 'minion' partition.mkfs /dev/sda1 ntfs
minion:
    ERROR: Invalid fs_type passed to partition.mkfs

Note : the first output format is also fixed by this PR

### New Behavior
Both the command will result in launching mkfs -t ntfs

