### PR TITLE
Prevent unnecessary duplicate pillar compilation

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -731,7 +731,7 @@ class RemoteFuncs(object):
                 load.get('saltenv', load.get('env')),
                 load.get('ext'),
                 self.mminion.functions,
-                pillar=load.get('pillar_override', {}))
+                pillar_override=load.get('pillar_override', {}))
         pillar_dirs = {}
         data = pillar.compile_pillar(pillar_dirs=pillar_dirs)
         if self.opts.get('minion_data_cache', False):

--- a/salt/master.py
+++ b/salt/master.py
@@ -1336,7 +1336,7 @@ class AESFuncs(object):
             load['id'],
             load.get('saltenv', load.get('env')),
             ext=load.get('ext'),
-            pillar=load.get('pillar_override', {}),
+            pillar_override=load.get('pillar_override', {}),
             pillarenv=load.get('pillarenv'))
         data = pillar.compile_pillar(pillar_dirs=pillar_dirs)
         self.fs_.update_opts()

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -211,7 +211,7 @@ def _gather_pillar(pillarenv, pillar_override):
         __grains__,
         __opts__['id'],
         __opts__['environment'],
-        pillar=pillar_override,
+        pillar_override=pillar_override,
         pillarenv=pillarenv
     )
     ret = pillar.compile_pillar()

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -48,7 +48,7 @@ def _gather_pillar(pillarenv, pillar_override):
         __grains__,
         __opts__['id'],
         __opts__['environment'],
-        pillar=pillar_override,
+        pillar_override=pillar_override,
         pillarenv=pillarenv
     )
     ret = pillar.compile_pillar()

--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -5620,7 +5620,7 @@ def _gather_pillar(pillarenv, pillar_override, **grains):
         # Not sure if these two are correct
         __opts__['id'],
         __opts__['environment'],
-        pillar=pillar_override,
+        pillar_override=pillar_override,
         pillarenv=pillarenv
     )
     ret = pillar.compile_pillar()

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -189,7 +189,7 @@ def items(*args, **kwargs):
         __opts__,
         __grains__,
         __opts__['id'],
-        pillar=kwargs.get('pillar'),
+        pillar_override=kwargs.get('pillar'),
         pillarenv=kwargs.get('pillarenv') or __opts__['pillarenv'])
 
     return pillar.compile_pillar()
@@ -397,7 +397,7 @@ def ext(external, pillar=None):
         __opts__['id'],
         __opts__['environment'],
         ext=external,
-        pillar=pillar)
+        pillar_override=pillar)
 
     ret = pillar_obj.compile_pillar()
 

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -76,7 +76,8 @@ def _get_top_file_envs():
         return __context__['saltutil._top_file_envs']
     except KeyError:
         try:
-            st_ = salt.state.HighState(__opts__)
+            st_ = salt.state.HighState(__opts__,
+                                       initial_pillar=__pillar__)
             top = st_.get_top()
             if top:
                 envs = list(st_.top_matches(top).keys()) or 'base'
@@ -186,9 +187,13 @@ def sync_beacons(saltenv=None, refresh=True):
 
     Sync beacons from ``salt://_beacons`` to the minion
 
-    saltenv : base
+    saltenv
         The fileserver environment from which to sync. To sync from more than
         one environment, pass a comma-separated list.
+
+        If not passed, then all environments configured in the :ref:`top files
+        <states-top>` will be checked for beacons to sync. If no top files are
+        found, then the ``base`` environment will be synced.
 
     refresh : True
         If ``True``, refresh the available beacons on the minion. This refresh
@@ -215,9 +220,13 @@ def sync_sdb(saltenv=None):
 
     Sync sdb modules from ``salt://_sdb`` to the minion
 
-    saltenv : base
+    saltenv
         The fileserver environment from which to sync. To sync from more than
         one environment, pass a comma-separated list.
+
+        If not passed, then all environments configured in the :ref:`top files
+        <states-top>` will be checked for sdb modules to sync. If no top files
+        are found, then the ``base`` environment will be synced.
 
     refresh : False
         This argument has no affect and is included for consistency with the
@@ -241,9 +250,13 @@ def sync_modules(saltenv=None, refresh=True):
 
     Sync execution modules from ``salt://_modules`` to the minion
 
-    saltenv : base
+    saltenv
         The fileserver environment from which to sync. To sync from more than
         one environment, pass a comma-separated list.
+
+        If not passed, then all environments configured in the :ref:`top files
+        <states-top>` will be checked for execution modules to sync. If no top
+        files are found, then the ``base`` environment will be synced.
 
     refresh : True
         If ``True``, refresh the available execution modules on the minion.
@@ -287,9 +300,13 @@ def sync_states(saltenv=None, refresh=True):
 
     Sync state modules from ``salt://_states`` to the minion
 
-    saltenv : base
+    saltenv
         The fileserver environment from which to sync. To sync from more than
         one environment, pass a comma-separated list.
+
+        If not passed, then all environments configured in the :ref:`top files
+        <states-top>` will be checked for state modules to sync. If no top
+        files are found, then the ``base`` environment will be synced.
 
     refresh : True
         If ``True``, refresh the available states on the minion. This refresh
@@ -349,9 +366,13 @@ def sync_grains(saltenv=None, refresh=True):
 
     Sync grains modules from ``salt://_grains`` to the minion
 
-    saltenv : base
+    saltenv
         The fileserver environment from which to sync. To sync from more than
         one environment, pass a comma-separated list.
+
+        If not passed, then all environments configured in the :ref:`top files
+        <states-top>` will be checked for grains modules to sync. If no top
+        files are found, then the ``base`` environment will be synced.
 
     refresh : True
         If ``True``, refresh the available execution modules and recompile
@@ -380,9 +401,13 @@ def sync_renderers(saltenv=None, refresh=True):
 
     Sync renderers from ``salt://_renderers`` to the minion
 
-    saltenv : base
+    saltenv
         The fileserver environment from which to sync. To sync from more than
         one environment, pass a comma-separated list.
+
+        If not passed, then all environments configured in the :ref:`top files
+        <states-top>` will be checked for renderers to sync. If no top files
+        are found, then the ``base`` environment will be synced.
 
     refresh : True
         If ``True``, refresh the available execution modules on the minion.
@@ -410,9 +435,13 @@ def sync_returners(saltenv=None, refresh=True):
 
     Sync beacons from ``salt://_returners`` to the minion
 
-    saltenv : base
+    saltenv
         The fileserver environment from which to sync. To sync from more than
         one environment, pass a comma-separated list.
+
+        If not passed, then all environments configured in the :ref:`top files
+        <states-top>` will be checked for returners to sync. If no top files
+        are found, then the ``base`` environment will be synced.
 
     refresh : True
         If ``True``, refresh the available execution modules on the minion.
@@ -438,9 +467,13 @@ def sync_proxymodules(saltenv=None, refresh=False):
 
     Sync proxy modules from ``salt://_proxy`` to the minion
 
-    saltenv : base
+    saltenv
         The fileserver environment from which to sync. To sync from more than
         one environment, pass a comma-separated list.
+
+        If not passed, then all environments configured in the :ref:`top files
+        <states-top>` will be checked for proxy modules to sync. If no top
+        files are found, then the ``base`` environment will be synced.
 
     refresh : True
         If ``True``, refresh the available execution modules on the minion.
@@ -467,9 +500,13 @@ def sync_engines(saltenv=None, refresh=False):
 
     Sync engine modules from ``salt://_engines`` to the minion
 
-    saltenv : base
+    saltenv
         The fileserver environment from which to sync. To sync from more than
         one environment, pass a comma-separated list.
+
+        If not passed, then all environments configured in the :ref:`top files
+        <states-top>` will be checked for engines to sync. If no top files are
+        found, then the ``base`` environment will be synced.
 
     refresh : True
         If ``True``, refresh the available execution modules on the minion.
@@ -493,9 +530,13 @@ def sync_output(saltenv=None, refresh=True):
     '''
     Sync outputters from ``salt://_output`` to the minion
 
-    saltenv : base
+    saltenv
         The fileserver environment from which to sync. To sync from more than
         one environment, pass a comma-separated list.
+
+        If not passed, then all environments configured in the :ref:`top files
+        <states-top>` will be checked for outputters to sync. If no top files
+        are found, then the ``base`` environment will be synced.
 
     refresh : True
         If ``True``, refresh the available execution modules on the minion.
@@ -524,9 +565,13 @@ def sync_utils(saltenv=None, refresh=True):
 
     Sync utility modules from ``salt://_utils`` to the minion
 
-    saltenv : base
+    saltenv
         The fileserver environment from which to sync. To sync from more than
         one environment, pass a comma-separated list.
+
+        If not passed, then all environments configured in the :ref:`top files
+        <states-top>` will be checked for utility modules to sync. If no top
+        files are found, then the ``base`` environment will be synced.
 
     refresh : True
         If ``True``, refresh the available execution modules on the minion.
@@ -553,9 +598,13 @@ def sync_log_handlers(saltenv=None, refresh=True):
 
     Sync log handlers from ``salt://_log_handlers`` to the minion
 
-    saltenv : base
+    saltenv
         The fileserver environment from which to sync. To sync from more than
         one environment, pass a comma-separated list.
+
+        If not passed, then all environments configured in the :ref:`top files
+        <states-top>` will be checked for log handlers to sync. If no top files
+        are found, then the ``base`` environment will be synced.
 
     refresh : True
         If ``True``, refresh the available execution modules on the minion.

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -252,14 +252,26 @@ def _check_queue(queue, kwargs):
             return conflict
 
 
-def _get_opts(localconfig=None):
+def _get_opts(**kwargs):
     '''
     Return a copy of the opts for use, optionally load a local config on top
     '''
     opts = copy.deepcopy(__opts__)
-    if localconfig:
-        opts = salt.config.minion_config(localconfig, defaults=opts)
+    if 'localconfig' in kwargs:
+        opts = salt.config.minion_config(kwargs['localconfig'], defaults=opts)
+    else:
+        if 'saltenv' in kwargs:
+            opts['environment'] = kwargs['saltenv']
+        if 'pillarenv' in kwargs:
+            opts['pillarenv'] = kwargs['pillarenv']
+
     return opts
+
+
+def _get_initial_pillar(opts):
+    return __pillar__ if __opts__['__cli'] == 'salt-call' \
+        and opts['pillarenv'] == __opts__['pillarenv'] \
+        else None
 
 
 def low(data, queue=False, **kwargs):
@@ -325,24 +337,32 @@ def high(data, test=None, queue=False, **kwargs):
     conflict = _check_queue(queue, kwargs)
     if conflict is not None:
         return conflict
-    opts = _get_opts(kwargs.get('localconfig'))
+    opts = _get_opts(**kwargs)
 
     opts['test'] = _get_test_value(test, **kwargs)
 
-    pillar = kwargs.get('pillar')
+    pillar_override = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
     if pillar_enc is None \
-            and pillar is not None \
-            and not isinstance(pillar, dict):
+            and pillar_override is not None \
+            and not isinstance(pillar_override, dict):
         raise SaltInvocationError(
             'Pillar data must be formatted as a dictionary, unless pillar_enc '
             'is specified.'
         )
+
     try:
-        st_ = salt.state.State(__opts__, pillar, pillar_enc=pillar_enc, proxy=__proxy__,
-                context=__context__)
+        st_ = salt.state.State(opts,
+                               pillar_override,
+                               pillar_enc=pillar_enc,
+                               proxy=__proxy__,
+                               context=__context__,
+                               initial_pillar=_get_initial_pillar(opts))
     except NameError:
-        st_ = salt.state.State(__opts__, pillar, pillar_enc=pillar_enc)
+        st_ = salt.state.State(opts,
+                               pillar_override,
+                               pillar_enc=pillar_enc,
+                               initial_pillar=_get_initial_pillar(opts))
 
     ret = st_.call_high(data)
     _set_retcode(ret)
@@ -371,15 +391,15 @@ def template(tem, queue=False, **kwargs):
             )
         kwargs.pop('env')
 
-    if 'saltenv' in kwargs:
-        saltenv = kwargs['saltenv']
-    else:
-        saltenv = ''
-
     conflict = _check_queue(queue, kwargs)
     if conflict is not None:
         return conflict
-    st_ = salt.state.HighState(__opts__, context=__context__)
+
+    opts = _get_opts(**kwargs)
+
+    st_ = salt.state.HighState(opts,
+                               context=__context__,
+                               initial_pillar=_get_initial_pillar(opts))
 
     if not _check_pillar(kwargs, st_.opts['pillar']):
         __context__['retcode'] = 5
@@ -388,7 +408,11 @@ def template(tem, queue=False, **kwargs):
 
     if not tem.endswith('.sls'):
         tem = '{sls}.sls'.format(sls=tem)
-    high_state, errors = st_.render_state(tem, saltenv, '', None, local=True)
+    high_state, errors = st_.render_state(tem,
+                                          kwargs.get('saltenv', ''),
+                                          '',
+                                          None,
+                                          local=True)
     if errors:
         __context__['retcode'] = 1
         return errors
@@ -410,10 +434,15 @@ def template_str(tem, queue=False, **kwargs):
     conflict = _check_queue(queue, kwargs)
     if conflict is not None:
         return conflict
+
+    opts = _get_opts(**kwargs)
+
     try:
-        st_ = salt.state.State(__opts__, proxy=__proxy__)
+        st_ = salt.state.State(opts,
+                               proxy=__proxy__,
+                               initial_pillar=_get_initial_pillar(opts))
     except NameError:
-        st_ = salt.state.State(__opts__)
+        st_ = salt.state.State(opts, initial_pillar=_get_initial_pillar(opts))
     ret = st_.call_template_str(tem)
     _set_retcode(ret)
     return ret
@@ -732,7 +761,7 @@ def highstate(test=None,
         states to be run with their own custom minion configuration, including
         different pillars, file_roots, etc.
 
-    mock:
+    mock
         The mock option allows for the state run to execute without actually
         calling any states. This then returns a mocked return which will show
         the requisite ordering as well as fully validate the state run.
@@ -765,7 +794,7 @@ def highstate(test=None,
         return conflict
     orig_test = __opts__.get('test', None)
 
-    opts = _get_opts(kwargs.get('localconfig'))
+    opts = _get_opts(**kwargs)
 
     opts['test'] = _get_test_value(test, **kwargs)
 
@@ -778,36 +807,32 @@ def highstate(test=None,
             )
         kwargs.pop('env')
 
-    if 'saltenv' in kwargs:
-        opts['environment'] = kwargs['saltenv']
-
-    pillar = kwargs.get('pillar')
+    pillar_override = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
     if pillar_enc is None \
-            and pillar is not None \
-            and not isinstance(pillar, dict):
+            and pillar_override is not None \
+            and not isinstance(pillar_override, dict):
         raise SaltInvocationError(
             'Pillar data must be formatted as a dictionary, unless pillar_enc '
             'is specified.'
         )
 
-    if 'pillarenv' in kwargs:
-        opts['pillarenv'] = kwargs['pillarenv']
-
     try:
         st_ = salt.state.HighState(opts,
-                                   pillar,
+                                   pillar_override,
                                    kwargs.get('__pub_jid'),
                                    pillar_enc=pillar_enc,
                                    proxy=__proxy__,
                                    context=__context__,
-                                   mocked=kwargs.get('mock', False))
+                                   mocked=kwargs.get('mock', False),
+                                   initial_pillar=_get_initial_pillar(opts))
     except NameError:
         st_ = salt.state.HighState(opts,
-                                   pillar,
+                                   pillar_override,
                                    kwargs.get('__pub_jid'),
                                    pillar_enc=pillar_enc,
-                                   mocked=kwargs.get('mock', False))
+                                   mocked=kwargs.get('mock', False),
+                                   initial_pillar=_get_initial_pillar(opts))
 
     if not _check_pillar(kwargs, st_.opts['pillar']):
         __context__['retcode'] = 5
@@ -894,7 +919,7 @@ def sls(mods,
             multiple state runs can safely be run at the same time. Do *not*
             use this flag for performance optimization.
 
-    saltenv : None
+    saltenv
         Specify a salt fileserver environment to be used when applying states
 
         .. versionchanged:: 0.17.0
@@ -946,16 +971,6 @@ def sls(mods,
             )
         kwargs.pop('env')
 
-    if saltenv is None:
-        if __opts__.get('environment', None):
-            saltenv = __opts__['environment']
-        else:
-            saltenv = 'base'
-
-    if not pillarenv:
-        if __opts__.get('pillarenv', None):
-            pillarenv = __opts__['pillarenv']
-
     # Modification to __opts__ lost after this if-else
     if queue:
         _wait(kwargs.get('__pub_jid'))
@@ -965,10 +980,6 @@ def sls(mods,
             __context__['retcode'] = 1
             return conflict
 
-    # Ensure desired environment
-    __opts__['environment'] = saltenv
-    __opts__['pillarenv'] = pillarenv
-
     if isinstance(mods, list):
         disabled = _disabled(mods)
     else:
@@ -976,20 +987,26 @@ def sls(mods,
 
     if disabled:
         for state in disabled:
-            log.debug('Salt state {0} run is disabled. To re-enable, run state.enable {0}'.format(state))
+            log.debug(
+                'Salt state %s is disabled. To re-enable, run '
+                'state.enable %s', state, state
+            )
         __context__['retcode'] = 1
         return disabled
 
     orig_test = __opts__.get('test', None)
-    opts = _get_opts(kwargs.get('localconfig'))
+    opts = _get_opts(saltenv=saltenv, pillarenv=pillarenv, **kwargs)
 
     opts['test'] = _get_test_value(test, **kwargs)
 
-    pillar = kwargs.get('pillar')
+    if opts['environment'] is None:
+        opts['environment'] = 'base'
+
+    pillar_override = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
     if pillar_enc is None \
-            and pillar is not None \
-            and not isinstance(pillar, dict):
+            and pillar_override is not None \
+            and not isinstance(pillar_override, dict):
         raise SaltInvocationError(
             'Pillar data must be formatted as a dictionary, unless pillar_enc '
             'is specified.'
@@ -1000,20 +1017,23 @@ def sls(mods,
             __opts__['cachedir'],
             '{0}.cache.p'.format(kwargs.get('cache_name', 'highstate'))
             )
+
     try:
         st_ = salt.state.HighState(opts,
-                                   pillar,
+                                   pillar_override,
                                    kwargs.get('__pub_jid'),
                                    pillar_enc=pillar_enc,
                                    proxy=__proxy__,
                                    context=__context__,
-                                   mocked=kwargs.get('mock', False))
+                                   mocked=kwargs.get('mock', False),
+                                   initial_pillar=_get_initial_pillar(opts))
     except NameError:
         st_ = salt.state.HighState(opts,
-                                   pillar,
+                                   pillar_override,
                                    kwargs.get('__pub_jid'),
                                    pillar_enc=pillar_enc,
-                                   mocked=kwargs.get('mock', False))
+                                   mocked=kwargs.get('mock', False),
+                                   initial_pillar=_get_initial_pillar(opts))
 
     if not _check_pillar(kwargs, st_.opts['pillar']):
         __context__['retcode'] = 5
@@ -1036,7 +1056,7 @@ def sls(mods,
     st_.push_active()
     ret = {}
     try:
-        high_, errors = st_.render_highstate({saltenv: mods})
+        high_, errors = st_.render_highstate({opts['environment']: mods})
 
         if errors:
             __context__['retcode'] = 1
@@ -1108,20 +1128,24 @@ def top(topfn,
     if conflict is not None:
         return conflict
     orig_test = __opts__.get('test', None)
-    opts = _get_opts(kwargs.get('localconfig'))
+    opts = _get_opts(saltenv=saltenv, **kwargs)
     opts['test'] = _get_test_value(test, **kwargs)
 
-    pillar = kwargs.get('pillar')
+    pillar_override = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
     if pillar_enc is None \
-            and pillar is not None \
-            and not isinstance(pillar, dict):
+            and pillar_override is not None \
+            and not isinstance(pillar_override, dict):
         raise SaltInvocationError(
             'Pillar data must be formatted as a dictionary, unless pillar_enc '
             'is specified.'
         )
 
-    st_ = salt.state.HighState(opts, pillar, pillar_enc=pillar_enc, context=__context__)
+    st_ = salt.state.HighState(opts,
+                               pillar_override,
+                               pillar_enc=pillar_enc,
+                               context=__context__,
+                               initial_pillar=_get_initial_pillar(opts))
     if not _check_pillar(kwargs, st_.opts['pillar']):
         __context__['retcode'] = 5
         err = ['Pillar failed to render with the following messages:']
@@ -1167,17 +1191,22 @@ def show_highstate(queue=False, **kwargs):
     conflict = _check_queue(queue, kwargs)
     if conflict is not None:
         return conflict
-    pillar = kwargs.get('pillar')
+    pillar_override = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
     if pillar_enc is None \
-            and pillar is not None \
-            and not isinstance(pillar, dict):
+            and pillar_override is not None \
+            and not isinstance(pillar_override, dict):
         raise SaltInvocationError(
             'Pillar data must be formatted as a dictionary, unless pillar_enc '
             'is specified.'
         )
 
-    st_ = salt.state.HighState(__opts__, pillar, pillar_enc=pillar_enc)
+    opts = _get_opts(**kwargs)
+
+    st_ = salt.state.HighState(opts,
+                               pillar_override,
+                               pillar_enc=pillar_enc,
+                               initial_pillar=_get_initial_pillar(opts))
 
     if not _check_pillar(kwargs, st_.opts['pillar']):
         __context__['retcode'] = 5
@@ -1207,7 +1236,11 @@ def show_lowstate(queue=False, **kwargs):
     if conflict is not None:
         assert False
         return conflict
-    st_ = salt.state.HighState(__opts__)
+
+    opts = _get_opts(**kwargs)
+
+    st_ = salt.state.HighState(opts,
+                               initial_pillar=_get_initial_pillar(opts))
 
     if not _check_pillar(kwargs, st_.opts['pillar']):
         __context__['retcode'] = 5
@@ -1246,14 +1279,16 @@ def sls_id(
     if conflict is not None:
         return conflict
     orig_test = __opts__.get('test', None)
-    opts = _get_opts(kwargs.get('localconfig'))
+    opts = _get_opts(**kwargs)
     opts['test'] = _get_test_value(test, **kwargs)
-    if 'pillarenv' in kwargs:
-        opts['pillarenv'] = kwargs['pillarenv']
+
     try:
-        st_ = salt.state.HighState(opts, proxy=__proxy__)
+        st_ = salt.state.HighState(opts,
+                                   proxy=__proxy__,
+                                   initial_pillar=_get_initial_pillar(opts))
     except NameError:
-        st_ = salt.state.HighState(opts)
+        st_ = salt.state.HighState(opts,
+                                   initial_pillar=_get_initial_pillar(opts))
 
     if not _check_pillar(kwargs, st_.opts['pillar']):
         __context__['retcode'] = 5
@@ -1318,11 +1353,10 @@ def show_low_sls(mods,
     if conflict is not None:
         return conflict
     orig_test = __opts__.get('test', None)
-    opts = _get_opts(kwargs.get('localconfig'))
+    opts = _get_opts(**kwargs)
     opts['test'] = _get_test_value(test, **kwargs)
-    if 'pillarenv' in kwargs:
-        opts['pillarenv'] = kwargs['pillarenv']
-    st_ = salt.state.HighState(opts)
+
+    st_ = salt.state.HighState(opts, initial_pillar=_get_initial_pillar(opts))
 
     if not _check_pillar(kwargs, st_.opts['pillar']):
         __context__['retcode'] = 5
@@ -1377,24 +1411,24 @@ def show_sls(mods, saltenv='base', test=None, queue=False, **kwargs):
     if conflict is not None:
         return conflict
     orig_test = __opts__.get('test', None)
-    opts = _get_opts(kwargs.get('localconfig'))
+    opts = _get_opts(**kwargs)
 
     opts['test'] = _get_test_value(test, **kwargs)
 
-    pillar = kwargs.get('pillar')
+    pillar_override = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
     if pillar_enc is None \
-            and pillar is not None \
-            and not isinstance(pillar, dict):
+            and pillar_override is not None \
+            and not isinstance(pillar_override, dict):
         raise SaltInvocationError(
             'Pillar data must be formatted as a dictionary, unless pillar_enc '
             'is specified.'
         )
 
-    if 'pillarenv' in kwargs:
-        opts['pillarenv'] = kwargs['pillarenv']
-
-    st_ = salt.state.HighState(opts, pillar, pillar_enc=pillar_enc)
+    st_ = salt.state.HighState(opts,
+                               pillar_override,
+                               pillar_enc=pillar_enc,
+                               initial_pillar=_get_initial_pillar(opts))
 
     if not _check_pillar(kwargs, st_.opts['pillar']):
         __context__['retcode'] = 5
@@ -1428,8 +1462,6 @@ def show_top(queue=False, **kwargs):
 
         salt '*' state.show_top
     '''
-    opts = copy.deepcopy(__opts__)
-
     if 'env' in kwargs:
         salt.utils.warn_until(
             'Oxygen',
@@ -1439,12 +1471,13 @@ def show_top(queue=False, **kwargs):
             )
         kwargs.pop('env')
 
-    if 'saltenv' in kwargs:
-        opts['environment'] = kwargs['saltenv']
     conflict = _check_queue(queue, kwargs)
     if conflict is not None:
         return conflict
-    st_ = salt.state.HighState(opts)
+
+    opts = _get_opts(**kwargs)
+
+    st_ = salt.state.HighState(opts, initial_pillar=_get_initial_pillar(opts))
 
     if not _check_pillar(kwargs, st_.opts['pillar']):
         __context__['retcode'] = 5
@@ -1490,23 +1523,30 @@ def single(fun, name, test=None, queue=False, **kwargs):
                    '__id__': name,
                    'name': name})
     orig_test = __opts__.get('test', None)
-    opts = _get_opts(kwargs.get('localconfig'))
+    opts = _get_opts(**kwargs)
     opts['test'] = _get_test_value(test, **kwargs)
 
-    pillar = kwargs.get('pillar')
+    pillar_override = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
     if pillar_enc is None \
-            and pillar is not None \
-            and not isinstance(pillar, dict):
+            and pillar_override is not None \
+            and not isinstance(pillar_override, dict):
         raise SaltInvocationError(
             'Pillar data must be formatted as a dictionary, unless pillar_enc '
             'is specified.'
         )
 
     try:
-        st_ = salt.state.State(opts, pillar, pillar_enc=pillar_enc, proxy=__proxy__)
+        st_ = salt.state.State(opts,
+                               pillar_override,
+                               pillar_enc=pillar_enc,
+                               proxy=__proxy__,
+                               initial_pillar=_get_initial_pillar(opts))
     except NameError:
-        st_ = salt.state.State(opts, pillar, pillar_enc=pillar_enc)
+        st_ = salt.state.State(opts,
+                               pillar_override,
+                               pillar_enc=pillar_enc,
+                               initial_pillar=_get_initial_pillar(opts))
     err = st_.verify_data(kwargs)
     if err:
         __context__['retcode'] = 1
@@ -1587,10 +1627,10 @@ def pkg(pkg_path, pkg_sum, hash_type, test=None, **kwargs):
     pillar_json = os.path.join(root, 'pillar.json')
     if os.path.isfile(pillar_json):
         with salt.utils.fopen(pillar_json, 'r') as fp_:
-            pillar = json.load(fp_)
+            pillar_override = json.load(fp_)
     else:
-        pillar = None
-    popts = _get_opts(kwargs.get('localconfig'))
+        pillar_override = None
+    popts = _get_opts(**kwargs)
     popts['fileclient'] = 'local'
     popts['file_roots'] = {}
     popts['test'] = _get_test_value(test, **kwargs)
@@ -1600,7 +1640,7 @@ def pkg(pkg_path, pkg_sum, hash_type, test=None, **kwargs):
         if not os.path.isdir(full):
             continue
         popts['file_roots'][fn_] = [full]
-    st_ = salt.state.State(popts, pillar=pillar)
+    st_ = salt.state.State(popts, pillar_override=pillar_override)
     snapper_pre = _snapper_pre(popts, kwargs.get('__pub_jid', 'called localy'))
     ret = st_.call_chunks(lowstate)
     try:

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -57,10 +57,10 @@ def orchestrate(mods,
     minion = salt.minion.MasterMinion(__opts__)
     running = minion.functions['state.sls'](
             mods,
-            saltenv,
             test,
             exclude,
             pillar=pillar,
+            saltenv=saltenv,
             pillarenv=pillarenv,
             orchestration_jid=orchestration_jid)
     ret = {'data': {minion.opts['id']: running}, 'outputter': 'highstate'}

--- a/salt/state.py
+++ b/salt/state.py
@@ -635,19 +635,20 @@ class State(object):
     def __init__(
             self,
             opts,
-            pillar=None,
+            pillar_override=None,
             jid=None,
             pillar_enc=None,
             proxy=None,
             context=None,
             mocked=False,
-            loader='states'):
+            loader='states',
+            initial_pillar=None):
         self.states_loader = loader
         if 'grains' not in opts:
             opts['grains'] = salt.loader.grains(opts)
         self.opts = opts
         self.proxy = proxy
-        self._pillar_override = pillar
+        self._pillar_override = pillar_override
         if pillar_enc is not None:
             try:
                 pillar_enc = pillar_enc.lower()
@@ -659,7 +660,8 @@ class State(object):
                     .format(', '.join(VALID_PILLAR_ENC))
                 )
         self._pillar_enc = pillar_enc
-        self.opts['pillar'] = self._gather_pillar()
+        self.opts['pillar'] = initial_pillar if initial_pillar is not None \
+            else self._gather_pillar()
         self.state_con = context or {}
         self.load_modules()
         self.active = set()
@@ -698,7 +700,7 @@ class State(object):
                 self.opts['grains'],
                 self.opts['id'],
                 self.opts['environment'],
-                pillar=self._pillar_override,
+                pillar_override=self._pillar_override,
                 pillarenv=self.opts.get('pillarenv')
                 )
         ret = pillar.compile_pillar()
@@ -3508,25 +3510,26 @@ class HighState(BaseHighState):
     def __init__(
             self,
             opts,
-            pillar=None,
+            pillar_override=None,
             jid=None,
             pillar_enc=None,
             proxy=None,
             context=None,
             mocked=False,
-            loader='states'):
+            loader='states',
+            initial_pillar=None):
         self.opts = opts
         self.client = salt.fileclient.get_file_client(self.opts)
         BaseHighState.__init__(self, opts)
-        self.state = State(
-                           self.opts,
-                           pillar,
+        self.state = State(self.opts,
+                           pillar_override,
                            jid,
                            pillar_enc,
                            proxy=proxy,
                            context=context,
                            mocked=mocked,
-                           loader=loader)
+                           loader=loader,
+                           initial_pillar=initial_pillar)
         self.matcher = salt.minion.Matcher(self.opts)
         self.proxy = proxy
 

--- a/tests/unit/modules/state_test.py
+++ b/tests/unit/modules/state_test.py
@@ -28,7 +28,9 @@ from salt.modules import state
 # Globals
 state.__salt__ = {}
 state.__context__ = {}
-state.__opts__ = {'cachedir': '/D'}
+state.__opts__ = {'cachedir': '/D',
+                  'environment': None,
+                  '__cli': 'salt'}
 state.__pillar__ = {}
 
 
@@ -45,7 +47,11 @@ class MockState(object):
         '''
         flag = None
 
-        def __init__(self, opts, pillar=False, pillar_enc=None):
+        def __init__(self,
+                     opts,
+                     pillar_override=False,
+                     pillar_enc=None,
+                     initial_pillar=None):
             pass
 
         def verify_data(self, data):
@@ -134,9 +140,9 @@ class MockState(object):
         opts = {'state_top': '',
                 'pillar': {}}
 
-        def __init__(self, opts, pillar=None, *args, **kwargs):
+        def __init__(self, opts, pillar_override=None, *args, **kwargs):
             self.state = MockState.State(opts,
-                                         pillar=pillar)
+                                         pillar_override=pillar_override)
 
         def render_state(self, sls, saltenv, mods, matches, local=False):
             '''
@@ -819,7 +825,8 @@ class StateTestCase(TestCase):
                                                            True), ret)
 
                     with patch.dict(state.__opts__, {"test": None}):
-                        mock = MagicMock(return_value={"test": ""})
+                        mock = MagicMock(return_value={"test": "",
+                                                       "environment": None})
                         with patch.object(state, '_get_opts', mock):
                             mock = MagicMock(return_value=True)
                             with patch.object(salt.utils,

--- a/tests/unit/modules/state_test.py
+++ b/tests/unit/modules/state_test.py
@@ -582,7 +582,10 @@ class StateTestCase(TestCase):
             self.assertEqual(state.sls_id("apache", "http"), "A")
 
             with patch.dict(state.__opts__, {"test": "A"}):
-                mock = MagicMock(return_value={'test': True})
+                mock = MagicMock(
+                    return_value={'test': True,
+                                  'environment': None}
+                )
                 with patch.object(state, '_get_opts', mock):
                     mock = MagicMock(return_value=True)
                     with patch.object(salt.utils, 'test_mode', mock):
@@ -606,7 +609,10 @@ class StateTestCase(TestCase):
             self.assertEqual(state.show_low_sls("foo"), "A")
 
             with patch.dict(state.__opts__, {"test": "A"}):
-                mock = MagicMock(return_value={'test': True})
+                mock = MagicMock(
+                    return_value={'test': True,
+                                  'environment': None}
+                )
                 with patch.object(state, '_get_opts', mock):
                     MockState.State.flag = True
                     MockState.HighState.flag = True
@@ -625,7 +631,10 @@ class StateTestCase(TestCase):
             self.assertEqual(state.show_sls("foo"), "A")
 
             with patch.dict(state.__opts__, {"test": "A"}):
-                mock = MagicMock(return_value={'test': True})
+                mock = MagicMock(
+                    return_value={'test': True,
+                                  'environment': None}
+                )
                 with patch.object(state, '_get_opts', mock):
                     mock = MagicMock(return_value=True)
                     with patch.object(salt.utils, 'test_mode', mock):
@@ -806,7 +815,6 @@ class StateTestCase(TestCase):
                                      state.sls("core,edit.vim dev",
                                                None,
                                                None,
-                                               None,
                                                True),
                                      ["A"])
 
@@ -819,7 +827,6 @@ class StateTestCase(TestCase):
                     with patch.dict(state.__context__, {"retcode": 5}):
                         with patch.dict(state.__pillar__, {"_errors": "E1"}):
                             self.assertListEqual(state.sls("core,edit.vim dev",
-                                                           None,
                                                            None,
                                                            None,
                                                            True), ret)
@@ -836,7 +843,6 @@ class StateTestCase(TestCase):
                                                   SaltInvocationError,
                                                   state.sls,
                                                   "core,edit.vim dev",
-                                                  None,
                                                   None,
                                                   None,
                                                   True,
@@ -857,7 +863,6 @@ class StateTestCase(TestCase):
                                                             state.sls(arg,
                                                                       None,
                                                                       None,
-                                                                      None,
                                                                       True,
                                                                       cache
                                                                       =True
@@ -867,7 +872,6 @@ class StateTestCase(TestCase):
                                     MockState.HighState.flag = True
                                     self.assertTrue(state.sls("core,edit"
                                                               ".vim dev",
-                                                              None,
                                                               None,
                                                               None,
                                                               True)
@@ -904,7 +908,6 @@ class StateTestCase(TestCase):
                                 with patch('salt.utils.fopen', mock_open()):
                                     self.assertTrue(state.sls("core,edit"
                                                               ".vim dev",
-                                                              None,
                                                               None,
                                                               None,
                                                               True))


### PR DESCRIPTION
The ``salt.state.HighState`` class' dunder init spawns a ``salt.state.State`` instance, which in its own dunder init will compile fresh pillar data. However, there are two cases in particular where this results in unnecessary duplicate pillar compilation:

1. When states are run using ``salt-call``
2. When custom types are synced using ``saltutil.sync_*``

To prevent this duplicate pillar generation, the ``salt.state.State`` and ``salt.state.HighState`` classes have been modified to accept a new ``initial_pillar`` argument (the latter only to pass through to the ``salt.state.State`` instance). If ``initial_pillar`` is set to a non-``None`` value, then the ``salt.state.State`` instance will skip compiling pillar data and use the value passed instead.

The ``state`` and ``saltutil`` execution modules now use this ``initial_pillar`` argument where applicable. There were actually a few functions in the ``state`` execution module which did not support saltenv/pillarenv, and the usage of these values has now been normalized. (*Note to @rallytime for merge-forwards: ``_get_opts()`` now accepts double-asterisk kwargs instead of having the kwargs dict passed to it.*)

In addition, to differentiate initial pillar data from CLI pillar override data, I have changed references to the ``pillar`` argument in pillar compilation (and all calls to ``salt.pillar.get_pillar``) to ``pillar_override``. This makes instantiating ``salt.states.State`` instances make more sense, as it is confusing when you are passing ``pillar`` and ``initial_pillar`` arguments. Passing ``pillar_override`` and ``initial_pillar`` is more explicit, and also paves the way for the planned eventual changes to pillar compilation which will allow the Pillar classes/subclasses to be seeded with initial data.