### PR TITLE
Reduce the number of days an issue is stale by 25

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,8 +1,8 @@
 # Probot Stale configuration file
 
 # Number of days of inactivity before an issue becomes stale
-# 1250 is approximately 3 years and 5 months
-daysUntilStale: 1250
+# 1225 is approximately 3 years and 4 months
+daysUntilStale: 1225
 
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7


### PR DESCRIPTION
As we ease into a more reasonable `daysUntilStale` value, this updates the time an issue will be marked as stale to about 3 years and 4 months.
