### PR TITLE
Fix #41688 : fix mkfs command linux-swap support

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -380,7 +380,7 @@ def mkfs(device, fs_type):
                           'hfs', 'hfs+', 'hfsx', 'NTFS', 'ufs']):
         raise CommandExecutionError('Invalid fs_type passed to partition.mkfs')
 
-    if fs_type is 'linux-swap':
+    if fs_type == 'linux-swap':
         mkfs_cmd = 'mkswap'
     else:
         mkfs_cmd = 'mkfs.{0}'.format(fs_type)


### PR DESCRIPTION
### What does this PR do?
Fix 'linux-swap' support for mkfs command
### What issues does this PR fix or reference?
#41688 
### Previous Behavior

using linux-swap call the unexisting command mkfs.linux-swap

### New Behavior

using linux-swap call the command "mkswap"
