### PR TITLE
Fix issue #34245 with ini.options_present reporting changes

### DIFF
--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -86,8 +86,9 @@ def options_present(name, sections=None, separator='=', strict=False):
                         changes[section_name].update({key_to_remove: ''})
                         changes[section_name].update({key_to_remove: {'before': orig_value,
                                                                       'after': None}})
-                changes[section_name].update(
-                    __salt__['ini.set_option'](name, {section_name: section_body}, separator)[section_name])
+                options_updated = __salt__['ini.set_option'](name, {section_name: section_body}, separator)
+                if options_updated:
+                    changes[section_name].update(options_updated[section_name])
         else:
             changes = __salt__['ini.set_option'](name, sections, separator)
     except IOError as err:
@@ -99,8 +100,12 @@ def options_present(name, sections=None, separator='=', strict=False):
         ret['comment'] = 'Errors encountered. {0}'.format(changes['error'])
         ret['changes'] = {}
     else:
-        ret['comment'] = 'Changes take effect'
-        ret['changes'] = changes
+        if all(value == {} for value in changes.values()):
+            ret['changes'] = {}
+            ret['comment'] = 'No changes take effect'
+        else:
+            ret['changes'] = changes
+            ret['comment'] = 'Changes take effect'
     return ret
 
 

--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -89,6 +89,8 @@ def options_present(name, sections=None, separator='=', strict=False):
                 options_updated = __salt__['ini.set_option'](name, {section_name: section_body}, separator)
                 if options_updated:
                     changes[section_name].update(options_updated[section_name])
+                if not changes[section_name]:
+                    del changes[section_name]
         else:
             changes = __salt__['ini.set_option'](name, sections, separator)
     except IOError as err:
@@ -100,12 +102,12 @@ def options_present(name, sections=None, separator='=', strict=False):
         ret['comment'] = 'Errors encountered. {0}'.format(changes['error'])
         ret['changes'] = {}
     else:
-        if all(value == {} for value in changes.values()):
-            ret['changes'] = {}
-            ret['comment'] = 'No changes take effect'
-        else:
+        if changes:
             ret['changes'] = changes
             ret['comment'] = 'Changes take effect'
+        else:
+            ret['changes'] = {}
+            ret['comment'] = 'No changes take effect'
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?

  - Fixes issue where `ini.options_present` reported changes when there were no changes.
  - Fixes unreported issue in develop that causes `KeyError` when no changes were to be applied.

### What issues does this PR fix or reference?

#34245

### Previous Behavior

  - `ini.options_present` would always report changes, even when there were none.
  - Attempt to reference key when `ini.set_option` returned an empty dict in `ini.options_present`, causing a `KeyError`.

### New Behavior

  - `ini.options_present` no longer reports changes when there are none to apply.
  - `ini.options_present` no longer returns `KeyError` when no changes are to be applied.

### Tests written?

No
