### PR TITLE
Add boto and boto3 version dependencies to boto_vpc state docs

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -4,6 +4,11 @@ Connection module for Amazon VPC
 
 .. versionadded:: 2014.7.0
 
+:depends:
+
+- boto >= 2.8.0
+- boto3 >= 1.2.6
+
 :configuration: This module accepts explicit VPC credentials but can also
     utilize IAM roles assigned to the instance through Instance Profiles.
     Dynamic credentials are then automatically obtained from AWS API and no
@@ -68,8 +73,6 @@ Connection module for Amazon VPC
 
         error:
           message: error message
-
-:depends: boto
 
 .. versionadded:: 2016.11.0
 

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -5,10 +5,13 @@ Manage VPCs
 
 .. versionadded:: 2015.8.0
 
+:depends:
+
+- boto >= 2.8.0
+- boto3 >= 1.2.6
+
 Create and destroy VPCs. Be aware that this interacts with Amazon's services,
 and so may incur charges.
-
-This module uses ``boto``, which can be installed via package, or pip.
 
 This module accepts explicit vpc credentials but can also utilize
 IAM roles assigned to the instance through Instance Profiles. Dynamic
@@ -147,6 +150,8 @@ import logging
 import salt.ext.six as six
 import salt.utils.dictupdate as dictupdate
 
+__virtualname__ = 'boto_vpc'
+
 log = logging.getLogger(__name__)
 
 
@@ -154,7 +159,14 @@ def __virtual__():
     '''
     Only load if boto is available.
     '''
-    return 'boto_vpc' if 'boto_vpc.exists' in __salt__ else False
+    boto_version = '2.8.0'
+    boto3_version = '1.2.6'
+    if 'boto_vpc.exists' in __salt__:
+        return __virtualname__
+    else:
+        return False, 'The following libraries are required to run the boto_vpc state module: ' \
+                      'boto >= {0} and boto3 >= {1}.'.format(boto_version,
+                                                             boto3_version)
 
 
 def present(name, cidr_block, instance_tenancy=None, dns_support=None,


### PR DESCRIPTION
Also update __virtual__() to provide a more helpful error message if the dependencies are not met and the boto_vpc execution module cannot be loaded.

Fixes #40155
