### PR TITLE
fix max RecursionError, Ellipsis

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -790,7 +790,7 @@ class Schedule(object):
                     try:
                         event.fire_event(load, '__schedule_return')
                     except Exception as exc:
-                        log.exception("Unhandled exception firing evnet: {0}".format(exc))
+                        log.exception("Unhandled exception firing event: {0}".format(exc))
 
             log.debug('schedule.handle_func: Removing {0}'.format(proc_fn))
             try:

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -716,7 +716,7 @@ class Schedule(object):
             kwargs = {}
             if 'kwargs' in data:
                 kwargs = data['kwargs']
-                ret['fun_args'].append(copy.deepcopy(data['kwargs']))
+                ret['fun_args'].append(copy.deepcopy(kwargs))
 
             if func not in self.functions:
                 ret['return'] = self.functions.missing_fun_string(func)
@@ -773,25 +773,29 @@ class Schedule(object):
             ret['success'] = False
             ret['retcode'] = 254
         finally:
-            try:
-                # Only attempt to return data to the master
-                # if the scheduled job is running on a minion.
-                if '__role' in self.opts and self.opts['__role'] == 'minion':
-                    if 'return_job' in data and not data['return_job']:
-                        pass
-                    else:
-                        # Send back to master so the job is included in the job list
-                        mret = ret.copy()
-                        mret['jid'] = 'req'
-                        event = salt.utils.event.get_event('minion', opts=self.opts, listen=False)
-                        load = {'cmd': '_return', 'id': self.opts['id']}
-                        for key, value in six.iteritems(mret):
-                            load[key] = value
-                        event.fire_event(load, '__schedule_return')
+            # Only attempt to return data to the master
+            # if the scheduled job is running on a minion.
+            if '__role' in self.opts and self.opts['__role'] == 'minion':
+                if 'return_job' in data and not data['return_job']:
+                    pass
+                else:
+                    # Send back to master so the job is included in the job list
+                    mret = ret.copy()
+                    mret['jid'] = 'req'
+                    event = salt.utils.event.get_event('minion', opts=self.opts, listen=False)
+                    load = {'cmd': '_return', 'id': self.opts['id']}
+                    for key, value in six.iteritems(mret):
+                        load[key] = value
 
-                log.debug('schedule.handle_func: Removing {0}'.format(proc_fn))
+                    try:
+                        event.fire_event(load, '__schedule_return')
+                    except Exception as exc:
+                        log.exception("Unhandled exception firing evnet: {0}".format(exc))
+
+            log.debug('schedule.handle_func: Removing {0}'.format(proc_fn))
+            try:
                 os.unlink(proc_fn)
-            except Exception as exc:
+            except OSError as exc:
                 if exc.errno == errno.EEXIST or exc.errno == errno.ENOENT:
                     # EEXIST and ENOENT are OK because the file is gone and that's what
                     # we wanted

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -280,6 +280,7 @@ from __future__ import absolute_import, with_statement
 import os
 import sys
 import time
+import copy
 import signal
 import datetime
 import itertools
@@ -715,7 +716,7 @@ class Schedule(object):
             kwargs = {}
             if 'kwargs' in data:
                 kwargs = data['kwargs']
-                ret['fun_args'].append(data['kwargs'])
+                ret['fun_args'].append(copy.deepcopy(data['kwargs']))
 
             if func not in self.functions:
                 ret['return'] = self.functions.missing_fun_string(func)

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -791,7 +791,7 @@ class Schedule(object):
 
                 log.debug('schedule.handle_func: Removing {0}'.format(proc_fn))
                 os.unlink(proc_fn)
-            except OSError as exc:
+            except Exception as exc:
                 if exc.errno == errno.EEXIST or exc.errno == errno.ENOENT:
                     # EEXIST and ENOENT are OK because the file is gone and that's what
                     # we wanted


### PR DESCRIPTION
### What does this PR do?
	When I added a schedule function with parameter "kwargs",  I never got the result but the function actually had been runned, and there was no error log at all. The working process raised an RecursionError and exited silently.

**RecursionError: maximum recursion depth exceeded while calling a Python object**
 The reason is similar to the follow example:
`
In [1]: x=[]

In [2]: x.append(x)

In [3]: x
Out[3]: [[...]]
`
"fun_args" and "kwargs" are the same object, "fun_args" was added to "kwargs" as  "__pub_fun_args" 



### Tests written?

No
