### PR TITLE
Handle a few edge/corner cases with non-string input to cmd.run

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -987,9 +987,12 @@ class State(object):
             errors.append('Missing "name" data')
         if data['name'] and not isinstance(data['name'], six.string_types):
             errors.append(
-                'ID \'{0}\' in SLS \'{1}\' is not formed as a string, but is '
-                'a {2}'.format(
-                    data['name'], data['__sls__'], type(data['name']).__name__)
+                'ID \'{0}\' {1}is not formed as a string, but is a {2}'.format(
+                    data['name'],
+                    'in SLS \'{0}\' '.format(data['__sls__'])
+                        if '__sls__' in data else '',
+                    type(data['name']).__name__
+                )
             )
         if errors:
             return errors

--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -2,6 +2,7 @@
 '''For running command line executables with a timeout'''
 from __future__ import absolute_import
 
+import shlex
 import subprocess
 import threading
 import salt.exceptions
@@ -40,13 +41,29 @@ class TimedProc(object):
         try:
             self.process = subprocess.Popen(args, **kwargs)
         except TypeError:
-            str_args = []
-            for arg in args:
-                if not isinstance(arg, six.string_types):
-                    str_args.append(str(arg))
-                else:
-                    str_args.append(arg)
-            args = str_args
+            if not kwargs.get('shell', False):
+                if not isinstance(args, list):
+                    try:
+                        args = shlex.split(args)
+                    except AttributeError:
+                        args = shlex.split(str(args))
+                str_args = []
+                for arg in args:
+                    if not isinstance(arg, six.string_types):
+                        str_args.append(str(arg))
+                    else:
+                        str_args.append(arg)
+                args = str_args
+            else:
+                if not isinstance(args, (list, six.string_types)):
+                    # Handle corner case where someone does a 'cmd.run 3'
+                    args = str(args)
+            # Ensure that environment variables are strings
+            for key, val in six.iteritems(kwargs.get('env', {})):
+                if not isinstance(val, six.string_types):
+                    kwargs['env'][key] = str(val)
+                if not isinstance(key, six.string_types):
+                    kwargs['env'][str(key)] = kwargs['env'].pop(key)
             self.process = subprocess.Popen(args, **kwargs)
         self.command = args
 

--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -42,7 +42,7 @@ class TimedProc(object):
             self.process = subprocess.Popen(args, **kwargs)
         except TypeError:
             if not kwargs.get('shell', False):
-                if not isinstance(args, list):
+                if not isinstance(args, (list, tuple)):
                     try:
                         args = shlex.split(args)
                     except AttributeError:
@@ -55,7 +55,7 @@ class TimedProc(object):
                         str_args.append(arg)
                 args = str_args
             else:
-                if not isinstance(args, (list, six.string_types)):
+                if not isinstance(args, (list, tuple, six.string_types)):
                     # Handle corner case where someone does a 'cmd.run 3'
                     args = str(args)
             # Ensure that environment variables are strings


### PR DESCRIPTION
1. Handle non-string environment variables (Resolves #41691)
2. Ensure that we pass a string to ``subprocess.Popen()`` when ``shell=True``
3. Avoid traceback in ``state.single`` when a non-string ID dec is used

The third case above is not specific to ``cmd.run``, it can happen with any call to ``state.single`` in which the ID dec (i.e. the ``name`` argument) is not a string. This is because state.single does not set the ``__sls__`` key in the chunk being called.