### PR TITLE
Remove win_unicode_console dependency

### DIFF
--- a/pkg/windows/build_env_2.ps1
+++ b/pkg/windows/build_env_2.ps1
@@ -262,17 +262,6 @@ DownloadFileWithProgress $url $file
 Start_Process_and_test_exitcode  "$($ini['Settings']['Scripts2Dir'])\pip.exe" "install --no-index --find-links=$($ini['Settings']['DownloadDir']) $file " "pip install PyCrypto"
 
 #==============================================================================
-# Download sitecustomize.py
-#==============================================================================
-Write-Output " ----------------------------------------------------------------"
-Write-Output "   - $script_name :: Download sitecustomize . . ."
-Write-Output " ----------------------------------------------------------------"
-$file = "sitecustomize.py"
-$url  = "$($ini['Settings']['SaltRepo'])/$file"
-$file = "$($ini['Settings']['SitePkgs2Dir'])\$file"
-DownloadFileWithProgress $url $file
-
-#==============================================================================
 # Copy DLLs to Python Directory
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"

--- a/pkg/windows/req_2.txt
+++ b/pkg/windows/req_2.txt
@@ -2,4 +2,3 @@
 
 lxml==3.6.0
 pypiwin32==219
-win-unicode-console==0.5


### PR DESCRIPTION
### What does this PR do?
Removes `win_unicode_console` dependency. Full unicode support will only be supported in Py3.

https://github.com/saltstack/salt/pull/40870

### Previous Behavior
many pip installs in the salt environment failed because of this module

### Tests written?
No