### PR TITLE
npm 5 and greater requires --force for cache clean

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -334,7 +334,7 @@ def cache_clean(path=None, runas=None, env=None, force=False):
     force
         Force cleaning of cache.  Required for npm@5 and greater
 
-        .. versionadded:: 2016.11.7
+        .. versionadded:: 2016.11.6
 
     CLI Example:
 

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -314,7 +314,7 @@ def list_(pkg=None, dir=None, runas=None, env=None):
     return json.loads(result['stdout']).get('dependencies', {})
 
 
-def cache_clean(path=None, runas=None, env=None):
+def cache_clean(path=None, runas=None, env=None, force=False):
     '''
     Clean cached NPM packages.
 
@@ -331,11 +331,16 @@ def cache_clean(path=None, runas=None, env=None):
         format as the :py:func:`cmd.run <salt.modules.cmdmod.run>` execution
         function.
 
+    force
+        Force cleaning of cache.  Required for npm@5 and greater
+
+        .. versionadded:: 2016.11.7
+
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' npm.cache_clean
+        salt '*' npm.cache_clean force=True
 
     '''
     env = env or {}
@@ -348,6 +353,8 @@ def cache_clean(path=None, runas=None, env=None):
     cmd = ['npm', 'cache', 'clean']
     if path:
         cmd.append(path)
+    if force is True:
+        cmd.append('--force')
 
     cmd = ' '.join(cmd)
     result = __salt__['cmd.run_all'](

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -309,7 +309,8 @@ def bootstrap(name, user=None, silent=True):
 
 
 def cache_cleaned(name=None,
-                  user=None):
+                  user=None,
+                  force=False):
     '''
     Ensure that the given package is not cached.
 
@@ -320,6 +321,11 @@ def cache_cleaned(name=None,
 
     user
         The user to run NPM with
+
+    force
+        Force cleaning of cache.  Required for npm@5 and greater
+
+        .. versionadded:: 2016.11.7
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
     specific_pkg = None

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -325,7 +325,7 @@ def cache_cleaned(name=None,
     force
         Force cleaning of cache.  Required for npm@5 and greater
 
-        .. versionadded:: 2016.11.7
+        .. versionadded:: 2016.11.6
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
     specific_pkg = None

--- a/tests/integration/states/npm.py
+++ b/tests/integration/states/npm.py
@@ -55,7 +55,7 @@ class NpmStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         '''
         Basic test to determine if NPM successfully cleans it's cached packages.
         '''
-        ret = self.run_state('npm.cache_cleaned', name=None)
+        ret = self.run_state('npm.cache_cleaned', name=None, force=True)
         self.assertSaltTrueReturn(ret)
 
 


### PR DESCRIPTION
### What does this PR do?
This is the error

```
npm ERR! As of npm@5, the npm cache self-heals from corruption issues and
data extracted from the cache is guaranteed to be valid. If you want to make
sure everything is consistent, use 'npm cache verify' instead.

npm ERR!
npm ERR! If you're sure you want to delete the entire cache, rerun this command
with --force.
```

### What issues does this PR fix or reference?
Fixes npm clean cache test (i don't think there is an issue)