### PR TITLE
Do not merge master_tops and top file matches using set union

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -133,6 +133,24 @@ name) is set in the :conf_minion:`master` configuration setting.
 
     master_uri_format: ip_only
 
+.. conf_minion:: master_tops_first
+
+``master_tops_first``
+---------------------
+
+.. versionadded:: Oxygen
+
+Default: ``False``
+
+SLS targets defined using the :ref:`Master Tops <master-tops-system>` system
+are normally executed *after* any matches defined in the :ref:`Top File
+<states-top>`. Set this option to ``True`` to have the minion execute the
+:ref:`Master Tops <master-tops-system>` states first.
+
+.. code-block:: yaml
+
+    master_tops_first: True
+
 .. conf_minion:: master_type
 
 ``master_type``

--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -13,6 +13,18 @@ packages on minions which use :mod:`yum/dnf <salt.modules.yumpkg>` or :mod:`apt
 <salt.states.pkg.installed>` state and in the ``pkg.install`` remote execution
 function.
 
+:ref:`Master Tops <master-tops-system>` Changes
+-----------------------------------------------
+
+When both :ref:`Master Tops <master-tops-system>` and a :ref:`Top File
+<states-top>` produce SLS matches for a given minion, the matches were being
+merged in an unpredictable manner which did not preserve ordering. This has
+been changed. The top file matches now execute in the expected order, followed
+by any master tops matches that are not matched via a top file.
+
+To make master tops matches execute first, followed by top file matches, set
+the new :conf_minion:`master_tops_first` minion config option to ``True``.
+
 Configuration Option Deprecations
 ---------------------------------
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -723,6 +723,10 @@ VALID_OPTS = {
     # A mapping of external systems that can be used to generate topfile data.
     'master_tops': dict,
 
+    # Whether or not matches from master_tops should be executed before or
+    # after those from the top file(s).
+    'master_tops_first': bool,
+
     # A flag that should be set on a top-level master when it is ordering around subordinate masters
     # via the use of a salt syndic
     'order_masters': bool,
@@ -1283,6 +1287,7 @@ DEFAULT_MINION_OPTS = {
     'auth_timeout': 5,
     'auth_tries': 7,
     'master_tries': _MASTER_TRIES,
+    'master_tops_first': False,
     'auth_safemode': False,
     'random_master': False,
     'minion_floscript': os.path.join(FLO_DIR, 'minion.flo'),

--- a/salt/state.py
+++ b/salt/state.py
@@ -3120,11 +3120,15 @@ class BaseHighState(object):
                 _filter_matches(match, data, self.opts['nodegroups'])
         ext_matches = self._master_tops()
         for saltenv in ext_matches:
-            if saltenv in matches:
-                matches[saltenv] = list(
-                    set(ext_matches[saltenv]).union(matches[saltenv]))
+            top_file_matches = matches.get(saltenv, [])
+            if self.opts['master_tops_first']:
+                first = ext_matches[saltenv]
+                second = top_file_matches
             else:
-                matches[saltenv] = ext_matches[saltenv]
+                first = top_file_matches
+                second = ext_matches[saltenv]
+            matches[saltenv] = first + [x for x in second if x not in first]
+
         # pylint: enable=cell-var-from-loop
         return matches
 


### PR DESCRIPTION
The code which integrates `master_tops` SLS matches with top file SLS matches was using set operations to ensure there were no duplicate matches. However, the process of first converting the matches to a set, and then performing a union on the two sets, has the side effect of making the ordering unpredictable.

The set operations have been removed in favor of list comprehensions. This ensures that the ordering is predictable, and that `master_tops` matches are executed *after* top file matches.

In addition, a new minion config option called `master_tops_first` has been added to allow for the `master_tops` matches to be executed *before* top file matches.

I've created a docker container to demonstrate this. Replace `/path/to/git/checkout` below with the path to your git checkout of salt. You can use [this walkthrough](https://help.github.com/articles/checking-out-pull-requests-locally/) to check out this pull request locally for testing purposes.

```
% docker run --rm -it -v /path/to/git/checkout:/testing terminalmage/issues:37322
[root@28ccd66bae87 /]# cat /etc/salt/master
master_tops:
  mytop: True
[root@28ccd66bae87 /]# cat /srv/salt/_tops/mytop.py

import logging

log = logging.getLogger(__name__)

__virtualname__ = 'mytop'


def __virtual__():
    return __virtualname__

def top(**kwargs):
    log.debug('kwargs = %s', kwargs)
    return {'base': ['one', 'two', 'three']}
[root@28ccd66bae87 /]# salt-run saltutil.sync_tops
- tops.mytop
[root@28ccd66bae87 /]# cat /srv/salt/top.sls
base:
  '*':
    - foo
    - bar
    - baz
[root@28ccd66bae87 /]# salt-master -d; salt-minion -d
[root@28ccd66bae87 /]# salt \* state.show_top
test:
    ----------
    base:
        - foo
        - bar
        - baz
        - one
        - two
        - three
[root@28ccd66bae87 /]# pkill -f salt
[root@28ccd66bae87 /]# ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.0  11776  2920 ?        Ss   01:21   0:00 /bin/bash
root       388  0.0  0.0  47448  3264 ?        R+   01:47   0:00 ps aux
[root@28ccd66bae87 /]# echo 'master_tops_first: True' >/etc/salt/minion.d/master_tops.conf
[root@28ccd66bae87 /]# salt-master -d; salt-minion -d
[root@28ccd66bae87 /]# salt \* state.show_top
test:
    ----------
    base:
        - one
        - two
        - three
        - foo
        - bar
        - baz
[root@28ccd66bae87 /]#
```