### PR TITLE
Update deprecated version info in manage.bootstrap func for root_user

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -678,7 +678,7 @@ def bootstrap(version='develop',
 
         .. versionchanged:: 2016.11.0
 
-        .. deprecated:: 2016.11.0
+        .. deprecated:: Oxygen
 
     script_args
         Any additional arguments that you want to pass to the script.


### PR DESCRIPTION
The warnings are for this argument to be removed in Oxygen. The documentation tag should match.

Fixes #40605