### PR TITLE
Support apache-libcloud work-around for issue #32743 for versions older than 2.0.0

### DIFF
--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -33,14 +33,20 @@ import salt.config as config
 from salt.cloud.libcloudfuncs import *  # pylint: disable=redefined-builtin,wildcard-import,unused-wildcard-import
 from salt.utils import namespaced_function
 from salt.exceptions import SaltCloudSystemExit
+from salt.utils.versions import LooseVersion as _LooseVersion
 
 # CloudStackNetwork will be needed during creation of a new node
 # pylint: disable=import-error
 try:
     from libcloud.compute.drivers.cloudstack import CloudStackNetwork
-    # See https://github.com/saltstack/salt/issues/32743
-    import libcloud.security
-    libcloud.security.CA_CERTS_PATH.append('/etc/ssl/certs/YaST-CA.pem')
+    # This work-around for Issue #32743 is no longer needed for libcloud >= 2.0.0.
+    # However, older versions of libcloud must still be supported with this work-around.
+    # This work-around can be removed when the required minimum version of libcloud is
+    # 2.0.0 (See PR #40837 - which is implemented in Salt Oxygen).
+    if _LooseVersion(libcloud.__version__) < _LooseVersion('2.0.0'):
+        # See https://github.com/saltstack/salt/issues/32743
+        import libcloud.security
+        libcloud.security.CA_CERTS_PATH.append('/etc/ssl/certs/YaST-CA.pem')
     HAS_LIBS = True
 except ImportError:
     HAS_LIBS = False

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -33,17 +33,17 @@ import salt.config as config
 from salt.cloud.libcloudfuncs import *  # pylint: disable=redefined-builtin,wildcard-import,unused-wildcard-import
 from salt.utils import namespaced_function
 from salt.exceptions import SaltCloudSystemExit
-from salt.utils.versions import LooseVersion as _LooseVersion
+from distutils.version import LooseVersion as _LooseVersion
 
 # CloudStackNetwork will be needed during creation of a new node
 # pylint: disable=import-error
 try:
     from libcloud.compute.drivers.cloudstack import CloudStackNetwork
-    # This work-around for Issue #32743 is no longer needed for libcloud >= 2.0.0.
+    # This work-around for Issue #32743 is no longer needed for libcloud >= 1.4.0.
     # However, older versions of libcloud must still be supported with this work-around.
     # This work-around can be removed when the required minimum version of libcloud is
     # 2.0.0 (See PR #40837 - which is implemented in Salt Oxygen).
-    if _LooseVersion(libcloud.__version__) < _LooseVersion('2.0.0'):
+    if _LooseVersion(libcloud.__version__) < _LooseVersion('1.4.0'):
         # See https://github.com/saltstack/salt/issues/32743
         import libcloud.security
         libcloud.security.CA_CERTS_PATH.append('/etc/ssl/certs/YaST-CA.pem')

--- a/salt/cloud/clouds/dimensiondata.py
+++ b/salt/cloud/clouds/dimensiondata.py
@@ -25,9 +25,11 @@ from __future__ import absolute_import
 import logging
 import socket
 import pprint
+from salt.utils.versions import LooseVersion as _LooseVersion
 
 # Import libcloud
 try:
+    import libcloud
     from libcloud.compute.base import NodeState
     from libcloud.compute.base import NodeAuthPassword
     from libcloud.compute.types import Provider
@@ -35,9 +37,15 @@ try:
     from libcloud.loadbalancer.base import Member
     from libcloud.loadbalancer.types import Provider as Provider_lb
     from libcloud.loadbalancer.providers import get_driver as get_driver_lb
-    # See https://github.com/saltstack/salt/issues/32743
-    import libcloud.security
-    libcloud.security.CA_CERTS_PATH.append('/etc/ssl/certs/YaST-CA.pem')
+
+    # This work-around for Issue #32743 is no longer needed for libcloud >= 2.0.0.
+    # However, older versions of libcloud must still be supported with this work-around.
+    # This work-around can be removed when the required minimum version of libcloud is
+    # 2.0.0 (See PR #40837 - which is implemented in Salt Oxygen).
+    if _LooseVersion(libcloud.__version__) < _LooseVersion('2.0.0'):
+        # See https://github.com/saltstack/salt/issues/32743
+        import libcloud.security
+        libcloud.security.CA_CERTS_PATH.append('/etc/ssl/certs/YaST-CA.pem')
     HAS_LIBCLOUD = True
 except ImportError:
     HAS_LIBCLOUD = False

--- a/salt/cloud/clouds/dimensiondata.py
+++ b/salt/cloud/clouds/dimensiondata.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import
 import logging
 import socket
 import pprint
-from salt.utils.versions import LooseVersion as _LooseVersion
+from distutils.version import LooseVersion as _LooseVersion
 
 # Import libcloud
 try:
@@ -38,11 +38,11 @@ try:
     from libcloud.loadbalancer.types import Provider as Provider_lb
     from libcloud.loadbalancer.providers import get_driver as get_driver_lb
 
-    # This work-around for Issue #32743 is no longer needed for libcloud >= 2.0.0.
+    # This work-around for Issue #32743 is no longer needed for libcloud >= 1.4.0.
     # However, older versions of libcloud must still be supported with this work-around.
     # This work-around can be removed when the required minimum version of libcloud is
     # 2.0.0 (See PR #40837 - which is implemented in Salt Oxygen).
-    if _LooseVersion(libcloud.__version__) < _LooseVersion('2.0.0'):
+    if _LooseVersion(libcloud.__version__) < _LooseVersion('1.4.0'):
         # See https://github.com/saltstack/salt/issues/32743
         import libcloud.security
         libcloud.security.CA_CERTS_PATH.append('/etc/ssl/certs/YaST-CA.pem')

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -53,7 +53,7 @@ import pprint
 import logging
 import msgpack
 from ast import literal_eval
-from salt.utils.versions import LooseVersion as _LooseVersion
+from distutils.version import LooseVersion as _LooseVersion
 
 # Import 3rd-party libs
 # pylint: disable=import-error
@@ -67,11 +67,11 @@ try:
         ResourceInUseError,
         ResourceNotFoundError,
         )
-    # This work-around for Issue #32743 is no longer needed for libcloud >= 2.0.0.
+    # This work-around for Issue #32743 is no longer needed for libcloud >= 1.4.0.
     # However, older versions of libcloud must still be supported with this work-around.
     # This work-around can be removed when the required minimum version of libcloud is
     # 2.0.0 (See PR #40837 - which is implemented in Salt Oxygen).
-    if _LooseVersion(libcloud.__version__) < _LooseVersion('2.0.0'):
+    if _LooseVersion(libcloud.__version__) < _LooseVersion('1.4.0'):
         # See https://github.com/saltstack/salt/issues/32743
         import libcloud.security
         libcloud.security.CA_CERTS_PATH.append('/etc/ssl/certs/YaST-CA.pem')

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -53,10 +53,12 @@ import pprint
 import logging
 import msgpack
 from ast import literal_eval
+from salt.utils.versions import LooseVersion as _LooseVersion
 
 # Import 3rd-party libs
 # pylint: disable=import-error
 try:
+    import libcloud
     from libcloud.compute.types import Provider
     from libcloud.compute.providers import get_driver
     from libcloud.loadbalancer.types import Provider as Provider_lb
@@ -65,9 +67,14 @@ try:
         ResourceInUseError,
         ResourceNotFoundError,
         )
-    # See https://github.com/saltstack/salt/issues/32743
-    import libcloud.security
-    libcloud.security.CA_CERTS_PATH.append('/etc/ssl/certs/YaST-CA.pem')
+    # This work-around for Issue #32743 is no longer needed for libcloud >= 2.0.0.
+    # However, older versions of libcloud must still be supported with this work-around.
+    # This work-around can be removed when the required minimum version of libcloud is
+    # 2.0.0 (See PR #40837 - which is implemented in Salt Oxygen).
+    if _LooseVersion(libcloud.__version__) < _LooseVersion('2.0.0'):
+        # See https://github.com/saltstack/salt/issues/32743
+        import libcloud.security
+        libcloud.security.CA_CERTS_PATH.append('/etc/ssl/certs/YaST-CA.pem')
     HAS_LIBCLOUD = True
 except ImportError:
     HAS_LIBCLOUD = False

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -143,9 +143,11 @@ import os
 import logging
 import socket
 import pprint
+from salt.utils.versions import LooseVersion as _LooseVersion
 
 # Import libcloud
 try:
+    import libcloud
     from libcloud.compute.base import NodeState
     HAS_LIBCLOUD = True
 except ImportError:
@@ -156,9 +158,14 @@ HAS014 = False
 try:
     from libcloud.compute.drivers.openstack import OpenStackNetwork
     from libcloud.compute.drivers.openstack import OpenStack_1_1_FloatingIpPool
-    # See https://github.com/saltstack/salt/issues/32743
-    import libcloud.security
-    libcloud.security.CA_CERTS_PATH.append('/etc/ssl/certs/YaST-CA.pem')
+    # This work-around for Issue #32743 is no longer needed for libcloud >= 2.0.0.
+    # However, older versions of libcloud must still be supported with this work-around.
+    # This work-around can be removed when the required minimum version of libcloud is
+    # 2.0.0 (See PR #40837 - which is implemented in Salt Oxygen).
+    if _LooseVersion(libcloud.__version__) < _LooseVersion('2.0.0'):
+        # See https://github.com/saltstack/salt/issues/32743
+        import libcloud.security
+        libcloud.security.CA_CERTS_PATH.append('/etc/ssl/certs/YaST-CA.pem')
     HAS014 = True
 except Exception:
     pass

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -143,7 +143,7 @@ import os
 import logging
 import socket
 import pprint
-from salt.utils.versions import LooseVersion as _LooseVersion
+from distutils.version import LooseVersion as _LooseVersion
 
 # Import libcloud
 try:
@@ -158,11 +158,11 @@ HAS014 = False
 try:
     from libcloud.compute.drivers.openstack import OpenStackNetwork
     from libcloud.compute.drivers.openstack import OpenStack_1_1_FloatingIpPool
-    # This work-around for Issue #32743 is no longer needed for libcloud >= 2.0.0.
+    # This work-around for Issue #32743 is no longer needed for libcloud >= 1.4.0.
     # However, older versions of libcloud must still be supported with this work-around.
     # This work-around can be removed when the required minimum version of libcloud is
     # 2.0.0 (See PR #40837 - which is implemented in Salt Oxygen).
-    if _LooseVersion(libcloud.__version__) < _LooseVersion('2.0.0'):
+    if _LooseVersion(libcloud.__version__) < _LooseVersion('1.4.0'):
         # See https://github.com/saltstack/salt/issues/32743
         import libcloud.security
         libcloud.security.CA_CERTS_PATH.append('/etc/ssl/certs/YaST-CA.pem')

--- a/tests/unit/cloud/clouds/dimensiondata_test.py
+++ b/tests/unit/cloud/clouds/dimensiondata_test.py
@@ -48,11 +48,11 @@ VM_NAME = 'winterfell'
 # Use certifi if installed
 try:
     if HAS_LIBCLOUD:
-        # This work-around for Issue #32743 is no longer needed for libcloud >= 2.0.0.
+        # This work-around for Issue #32743 is no longer needed for libcloud >= 1.4.0.
         # However, older versions of libcloud must still be supported with this work-around.
         # This work-around can be removed when the required minimum version of libcloud is
         # 2.0.0 (See PR #40837 - which is implemented in Salt Oxygen).
-        if LooseVersion(libcloud.__version__) < LooseVersion('2.0.0'):
+        if LooseVersion(libcloud.__version__) < LooseVersion('1.4.0'):
             import certifi
             libcloud.security.CA_CERTS_PATH.append(certifi.where())
 except (ImportError, NameError):

--- a/tests/unit/cloud/clouds/dimensiondata_test.py
+++ b/tests/unit/cloud/clouds/dimensiondata_test.py
@@ -47,8 +47,14 @@ VM_NAME = 'winterfell'
 
 # Use certifi if installed
 try:
-    import certifi
-    libcloud.security.CA_CERTS_PATH.append(certifi.where())
+    if HAS_LIBCLOUD:
+        # This work-around for Issue #32743 is no longer needed for libcloud >= 2.0.0.
+        # However, older versions of libcloud must still be supported with this work-around.
+        # This work-around can be removed when the required minimum version of libcloud is
+        # 2.0.0 (See PR #40837 - which is implemented in Salt Oxygen).
+        if LooseVersion(libcloud.__version__) < LooseVersion('2.0.0'):
+            import certifi
+            libcloud.security.CA_CERTS_PATH.append(certifi.where())
 except (ImportError, NameError):
     pass
 

--- a/tests/unit/cloud/clouds/gce_test.py
+++ b/tests/unit/cloud/clouds/gce_test.py
@@ -54,11 +54,11 @@ DUMMY_TOKEN = {
 # Use certifi if installed
 try:
     if HAS_LIBCLOUD:
-        # This work-around for Issue #32743 is no longer needed for libcloud >= 2.0.0.
+        # This work-around for Issue #32743 is no longer needed for libcloud >= 1.4.0.
         # However, older versions of libcloud must still be supported with this work-around.
         # This work-around can be removed when the required minimum version of libcloud is
         # 2.0.0 (See PR #40837 - which is implemented in Salt Oxygen).
-        if LooseVersion(libcloud.__version__) < LooseVersion('2.0.0'):
+        if LooseVersion(libcloud.__version__) < LooseVersion('1.4.0'):
             import certifi
             libcloud.security.CA_CERTS_PATH.append(certifi.where())
 except ImportError:

--- a/tests/unit/cloud/clouds/gce_test.py
+++ b/tests/unit/cloud/clouds/gce_test.py
@@ -53,8 +53,14 @@ DUMMY_TOKEN = {
 
 # Use certifi if installed
 try:
-    import certifi
-    libcloud.security.CA_CERTS_PATH.append(certifi.where())
+    if HAS_LIBCLOUD:
+        # This work-around for Issue #32743 is no longer needed for libcloud >= 2.0.0.
+        # However, older versions of libcloud must still be supported with this work-around.
+        # This work-around can be removed when the required minimum version of libcloud is
+        # 2.0.0 (See PR #40837 - which is implemented in Salt Oxygen).
+        if LooseVersion(libcloud.__version__) < LooseVersion('2.0.0'):
+            import certifi
+            libcloud.security.CA_CERTS_PATH.append(certifi.where())
 except ImportError:
     pass
 


### PR DESCRIPTION
If apache-libcloud 2.0.0 is installed, the workaround outlined in issue #32743 no longer applies and should be avoided. However, we still need to support older versions of apache-libcloud that need this work-around.

The minimum version required of apache-libcloud has been updated to 2.0.0 in pull request #40837, which will be released in Oxygen. #40837 has removed all of the work-arounds needed for issue #32743 for 2.0.0. Until Oxygen is released, however, we need to support both the work-around for older versions of apache-libcloud as well as 2.0.0.

@tonybaloney If this gets merged in and makes it's way to develop before your PR is merged in, it will cause some conflicts. My apologies in advance.

cc: @techhat, @gtmanfred, and @cachedout 
