### PR TITLE
INFRA-5027 - fix tagging for managed instances

### DIFF
--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -1829,6 +1829,39 @@ def set_volumes_tags(tag_maps, authoritative=False, dry_run=False,
     return ret
 
 
+def get_all_tags(filters=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Describe all tags matching the filter criteria, or all tags in the account otherwise.
+
+    .. versionadded:: Nitrogen
+
+    filters
+        (dict) - Additional constraints on which volumes to return.  Note that valid filters vary
+        extensively depending on the resource type.  When in doubt, search first without a filter
+        and then use the returned data to help fine-tune your search.  You can generally garner the
+        resource type from its ID (e.g. `vol-XXXXX` is a volume, `i-XXXXX` is an instance, etc.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-call boto_ec2.get_all_tags '{"tag:Name": myInstanceNameTag, resource-type: instance}'
+
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        ret = conn.get_all_tags(filters)
+        tags = {}
+        for t in ret:
+            if t.res_id not in tags:
+                tags[t.res_id] = {}
+            tags[t.res_id][t.name] = t.value
+        return tags
+    except boto.exception.BotoServerError as e:
+        log.error(e)
+        return {}
+
+
 def create_tags(resource_ids, tags, region=None, key=None, keyid=None, profile=None):
     '''
     Create new metadata tags for the specified resource ids.

--- a/salt/states/boto_ec2.py
+++ b/salt/states/boto_ec2.py
@@ -937,7 +937,7 @@ def instance_present(name, instance_name=None, instance_id=None, image_id=None,
         current = set(curr_tags.keys())
         desired = set(tags.keys())
         remove = current - desired
-        add = dict([(t, tags[t]) for t in (desired - current)])
+        add = dict([(t, tags[t]) for t in desired - current])
         replace = dict([(t, tags[t]) for t in tags if tags.get(t) != curr_tags.get(t)])
         # Tag keys are unique despite the bizarre semantics uses which make it LOOK like they could be duplicative.
         add.update(replace)


### PR DESCRIPTION
Found that the boto_ec2 module set tags on instances at creation but does NOT manage them on instances once they exist.  Adds code to add/remove/update tags as needed to keep things current :)

A side effect adds a get_all_tags() module function which can be used to generically query tags on any ec2 resource.