### PR TITLE
open and write in byte mode using fileserver

### DIFF
--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -314,7 +314,7 @@ def init():
     if new_remote:
         remote_map = os.path.join(__opts__['cachedir'], 'hgfs/remote_map.txt')
         try:
-            with salt.utils.fopen(remote_map, 'wb+') as fp_:
+            with salt.utils.fopen(remote_map, 'w+') as fp_:
                 timestamp = datetime.now().strftime('%d %b %Y %H:%M:%S.%f')
                 fp_.write('# hgfs_remote map as of {0}\n'.format(timestamp))
                 for repo in repos:

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -314,7 +314,7 @@ def init():
     if new_remote:
         remote_map = os.path.join(__opts__['cachedir'], 'hgfs/remote_map.txt')
         try:
-            with salt.utils.fopen(remote_map, 'w+') as fp_:
+            with salt.utils.fopen(remote_map, 'wb+') as fp_:
                 timestamp = datetime.now().strftime('%d %b %Y %H:%M:%S.%f')
                 fp_.write('# hgfs_remote map as of {0}\n'.format(timestamp))
                 for repo in repos:
@@ -538,7 +538,7 @@ def update():
             os.makedirs(env_cachedir)
         new_envs = envs(ignore_cache=True)
         serial = salt.payload.Serial(__opts__)
-        with salt.utils.fopen(env_cache, 'w+') as fp_:
+        with salt.utils.fopen(env_cache, 'wb+') as fp_:
             fp_.write(serial.dumps(new_envs))
             log.trace('Wrote env cache data to {0}'.format(env_cache))
 

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -453,7 +453,7 @@ def update():
             os.makedirs(env_cachedir)
         new_envs = envs(ignore_cache=True)
         serial = salt.payload.Serial(__opts__)
-        with salt.utils.fopen(env_cache, 'w+') as fp_:
+        with salt.utils.fopen(env_cache, 'wb+') as fp_:
             fp_.write(serial.dumps(new_envs))
             log.trace('Wrote env cache data to {0}'.format(env_cache))
 

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2177,8 +2177,7 @@ class GitBase(object):
         if refresh_env_cache:
             new_envs = self.envs(ignore_cache=True)
             serial = salt.payload.Serial(self.opts)
-            mode = 'wb+' if six.PY3 else 'w+'
-            with salt.utils.fopen(self.env_cache, mode) as fp_:
+            with salt.utils.fopen(self.env_cache, 'wb+') as fp_:
                 fp_.write(serial.dumps(new_envs))
                 log.trace('Wrote env cache data to {0}'.format(self.env_cache))
 


### PR DESCRIPTION
### What does this PR do?
This switches to byte mode explicitely in the last few places I could find that
are using the fileserver payload to store files.

We should only ever be reading in the file, and then passing it to the minion,
the unicode locale on the master should not matter.  Then we want to make sure
to write the information in bytes to the filesystem.