### PR TITLE
Fix spurious error when glob/regex used in publisher_acl

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -253,27 +253,12 @@ def access_keys(opts):
         acl_users.add(opts['user'])
     acl_users.add(salt.utils.get_user())
     if opts['client_acl_verify'] and HAS_PWD:
-        log.profile('Beginning pwd.getpwall() call in masterarpi acess_keys function')
+        log.profile('Beginning pwd.getpwall() call in masterarpi access_keys function')
         for user in pwd.getpwall():
             users.append(user.pw_name)
-        log.profile('End pwd.getpwall() call in masterarpi acess_keys function')
+        log.profile('End pwd.getpwall() call in masterarpi access_keys function')
     for user in acl_users:
-        log.info(
-            'Preparing the {0} key for local communication'.format(
-                user
-            )
-        )
-
-        if opts['client_acl_verify'] and HAS_PWD:
-            if user not in users:
-                try:
-                    log.profile('Beginning pwd.getpnam() call in masterarpi acess_keys function')
-                    user = pwd.getpwnam(user).pw_name
-                    log.profile('Beginning pwd.getpwnam() call in masterarpi acess_keys function')
-                except KeyError:
-                    log.error('ACL user {0} is not available'.format(user))
-                    continue
-
+        log.info('Preparing the %s key for local communication', user)
         keys[user] = mk_key(opts, user)
 
     # Check other users matching ACL patterns


### PR DESCRIPTION
An error is logged if any of the publisher_acl targets is not present in
the available usernames (as derived using pwd.getpwall()). However, at
some point publisher_acl was expanded to support globs and regexes to
specify user names. When this was done, the code which checks the
publisher_acl entries against the available users was not updated. This
results in spurious errors in the log when this code tries to look for a
regex or glob expression in the list of available usernames.

However, there is no real reason for this check, as all it does is run
pwd.getpwnam() on the publisher_acl entry, and it does this only when
the entry is not in the list of available users. So there is no way for
this to do anything but raise a KeyError.

The if block which checks the entry against the list of available users
has therefore been removed.