### PR TITLE
Fix ImportError in boto3_sns module

### DIFF
--- a/salt/modules/boto3_sns.py
+++ b/salt/modules/boto3_sns.py
@@ -53,16 +53,11 @@ log = logging.getLogger(__name__)
 try:
     import botocore
     import boto3
+    import jmespath
     logging.getLogger('boto3').setLevel(logging.CRITICAL)
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
-
-try:
-    import jmespath
-    HAS_JMESPATH = True
-except ImportError:
-    HAS_JMESPATH = False
 #pylint: enable=unused-import
 
 def __virtual__():
@@ -71,8 +66,6 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, 'The boto3_sns module could not be loaded: boto3 libraries not found')
-    if not HAS_JMESPATH:
-        return (False, 'The boto3_sns module could not be loaded: jmespath module not found')
     __utils__['boto3.assign_funcs'](__name__, 'sns')
     return True
 

--- a/salt/modules/boto3_sns.py
+++ b/salt/modules/boto3_sns.py
@@ -45,21 +45,25 @@ Connection module for Amazon SNS
 from __future__ import absolute_import
 
 import logging
-import jmespath
 
 log = logging.getLogger(__name__)
 
 # Import third party libs
+#pylint: disable=unused-import
 try:
-    #pylint: disable=unused-import
     import botocore
     import boto3
-    #pylint: enable=unused-import
     logging.getLogger('boto3').setLevel(logging.CRITICAL)
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
 
+try:
+    import jmespath
+    HAS_JMESPATH = True
+except ImportError:
+    HAS_JMESPATH = False
+#pylint: enable=unused-import
 
 def __virtual__():
     '''
@@ -67,6 +71,8 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, 'The boto3_sns module could not be loaded: boto3 libraries not found')
+    if not HAS_JMESPATH:
+        return (False, 'The boto3_sns module could not be loaded: jmespath module not found')
     __utils__['boto3.assign_funcs'](__name__, 'sns')
     return True
 

--- a/salt/modules/boto3_sns.py
+++ b/salt/modules/boto3_sns.py
@@ -60,6 +60,7 @@ except ImportError:
     HAS_BOTO = False
 #pylint: enable=unused-import
 
+
 def __virtual__():
     '''
     Only load if boto libraries exist.


### PR DESCRIPTION
This module attempts to import jmespath which is not a dependency and is
not in the stdlib. This commit gates this behind a try/except to
prevent an ImportError from being logged.