### PR TITLE
Fix runtests_helpers.modules_available when multiple modules passed

### DIFF
--- a/tests/integration/files/file/base/_modules/runtests_helpers.py
+++ b/tests/integration/files/file/base/_modules/runtests_helpers.py
@@ -109,13 +109,10 @@ def get_invalid_docs():
             'missing_cli_example': sorted(noexample)}
 
 
-def modules_available(names):
+def modules_available(*names):
     '''
     Returns a list of modules not available. Empty list if modules are all available
     '''
-    if isinstance(names, six.string_types):
-        names = [names]
-
     not_found = []
     for name in names:
         if '.' not in name:


### PR DESCRIPTION
tests.support.helpers passes the single-asterisk tuple of args as
individual arguments to runtest_helpers.modules_available. This breaks
tests which pass more than one argument to the requires_salt_modules
decorator.

This has been fixed by making runtests_helpers.modules_available accept
an arbitrary number of args via using a single-asterisk.