### PR TITLE
Fix routes for vlan interfaces under debian/ubuntu

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1498,6 +1498,16 @@ def _write_file_routes(iface, data, folder, pattern):
     '''
     Writes a file to disk
     '''
+    # ifup / ifdown is executing given folder via run-parts.
+    # according to run-parts man-page, only filenames with this pattern are
+    # executed: (^[a-zA-Z0-9_-]+$)
+
+    # In order to make the routes file work for vlan interfaces
+    # (default would have been in example /etc/network/if-up.d/route-bond0.12)
+    # these dots in the iface name need to be replaced by underscores, so it
+    # can be executed by run-parts
+    iface = iface.replace('.', '_')
+
     filename = os.path.join(folder, pattern.format(iface))
     if not os.path.exists(folder):
         msg = '{0} cannot be written. {1} does not exist'


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with network.routes state, when the interface name is a vlan interface (for example bond0.1332)

### What issues does this PR fix or reference?
Whenever a file has a . in the filename (for example when adding routes for bond0.1332 interface, it would then be route-bond0.1332) the route file is skipped. By changing the dots in the iface name for underscores, it is properly executed by ifup/ifdown and routes are activated.

### Tests written?
No
