### PR TITLE
Disable new part of test_exit_status_correct_usage test for now

### DIFF
--- a/tests/integration/shell/test_master.py
+++ b/tests/integration/shell/test_master.py
@@ -165,17 +165,21 @@ class MasterTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
             master.shutdown(wait_for_orphans=3)
 
         # Do the test again to check does master shut down correctly
-        stdout, stderr, status = master.run(
-            args=['-d'],
-            catch_stderr=True,
-            with_retcode=True,
-        )
-        try:
-            self.assert_exit_status(
-                status, 'EX_OK',
-                message='correct usage',
-                stdout=stdout,
-                stderr=tests.integration.utils.decode_byte_list(stderr)
-            )
-        finally:
-            master.shutdown(wait_for_orphans=3)
+        # **Due to some underlying subprocessing issues with Minion._thread_return, this
+        # part of the test has been commented out. Once these underlying issues have
+        # been addressed, this part of the test should be uncommented. Work for this
+        # issue is being tracked in https://github.com/saltstack/salt-jenkins/issues/378
+        # stdout, stderr, status = master.run(
+        #     args=['-d'],
+        #     catch_stderr=True,
+        #     with_retcode=True,
+        # )
+        # try:
+        #     self.assert_exit_status(
+        #         status, 'EX_OK',
+        #         message='correct usage',
+        #         stdout=stdout,
+        #         stderr=tests.integration.utils.decode_byte_list(stderr)
+        #     )
+        # finally:
+        #     master.shutdown(wait_for_orphans=3)


### PR DESCRIPTION
This new part of the test_exit_status_correct_usage test was added in PR #41382. This test, along with some memory leakage for the test running in Python 3, has exposed an underlying issue with
Minion._thread_return subprocessing in the test suite. Due to this issue, this test is extremely flaky.

Per @DmitryKuzmenko's recomendation in https://github.com/saltstack/salt-jenkins/issues/378, this test should be commented out for the time being. He is planning on coming back to this issue to uncomment the test once the underlying problem has been resolved.
