### PR TITLE
Fix salt.util.render_jinja_tmpl usage for when not used in an environmnet

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -288,14 +288,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
 
     if not saltenv:
         if tmplpath:
-            # i.e., the template is from a file outside the state tree
-            #
-            # XXX: FileSystemLoader is not being properly instantiated here is
-            # it? At least it ain't according to:
-            #
-            #   http://jinja.pocoo.org/docs/api/#jinja2.FileSystemLoader
-            loader = jinja2.FileSystemLoader(
-                context, os.path.dirname(tmplpath))
+            loader = jinja2.FileSystemLoader(os.path.dirname(tmplpath))
     else:
         loader = salt.utils.jinja.SaltCacheLoader(opts, saltenv, pillar_rend=context.get('_pillar_rend', False))
 


### PR DESCRIPTION
The previous code tried passing the context (variable definitions) as the
searchpath.  This is grossly wrong; in addition, it was overriding the
encoding directive with the dirpath of the template.

End result, this wasn't usable.

This pathway shouldn't be used often- in my usage, I'm triggering it purely
because I'm using salt's rendering functionality in a nonstandard way (
validation and testing), so this while previously broken, was unlikely
to have been seen by anyone else.

### What does this PR do?

Fix salt.util.templates.jinja_render_tmpl usage when invoked outside of env context.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
