### PR TITLE
Runner arg parsing regressions

### DIFF
--- a/salt/runner.py
+++ b/salt/runner.py
@@ -72,9 +72,8 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         fun = low.pop('fun')
         verify_fun(self.functions, fun)
 
-        reserved_kwargs = dict([(i, low.pop(i)) for i in [
+        eauth_creds = dict([(i, low.pop(i)) for i in [
             'username', 'password', 'eauth', 'token', 'client', 'user', 'key',
-            '__current_eauth_groups', '__current_eauth_user',
         ] if i in low])
 
         # Separate the new-style args/kwargs.
@@ -97,7 +96,7 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
             ignore_invalid=True)
 
         return dict(fun=fun, kwarg={'kwarg': kwarg, 'arg': arg},
-                **reserved_kwargs)
+                **eauth_creds)
 
     def cmd_async(self, low):
         '''

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -77,16 +77,24 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
             '__current_eauth_groups', '__current_eauth_user',
         ] if i in low])
 
-        # Run name=value args through parse_input. We don't need to run kwargs
-        # through because there is no way to send name=value strings in the low
-        # dict other than by including an `arg` array.
-        arg, kwarg = salt.utils.args.parse_input(
-                low.pop('arg', []), condition=False)
-        kwarg.update(low.pop('kwarg', {}))
+        # Separate the new-style args/kwargs.
+        pre_arg = low.pop('arg', [])
+        pre_kwarg = low.pop('kwarg', {})
+        # Anything not pop'ed from low should hopefully be an old-style kwarg.
+        low['__kwarg__'] = True
+        pre_kwarg.update(low)
 
-        # If anything hasn't been pop()'ed out of low by this point it must be
-        # an old-style kwarg.
-        kwarg.update(low)
+        # Normalize old- & new-style args in a format suitable for
+        # load_args_and_kwargs
+        old_new_normalized_input = []
+        old_new_normalized_input.extend(pre_arg)
+        old_new_normalized_input.append(pre_kwarg)
+
+        arg, kwarg = salt.minion.load_args_and_kwargs(
+            self.functions[fun],
+            old_new_normalized_input,
+            self.opts,
+            ignore_invalid=True)
 
         return dict(fun=fun, kwarg={'kwarg': kwarg, 'arg': arg},
                 **reserved_kwargs)

--- a/salt/runners/test.py
+++ b/salt/runners/test.py
@@ -37,6 +37,18 @@ def raw_arg(*args, **kwargs):
     return ret
 
 
+def metasyntactic(locality='us'):
+    '''
+    Return common metasyntactic variables for the given locality
+    '''
+    lookup = {
+        'us': ['foo', 'bar', 'baz', 'qux', 'quux', 'quuz', 'corge', 'grault',
+            'garply', 'waldo', 'fred', 'plugh', 'xyzzy', 'thud'],
+        'uk': ['wibble', 'wobble', 'wubble', 'flob'],
+    }
+    return lookup.get(locality, None)
+
+
 def stdout_print():
     '''
     Print 'foo' and return 'bar'

--- a/tests/integration/client/runner.py
+++ b/tests/integration/client/runner.py
@@ -126,6 +126,17 @@ class RunnerModuleTest(integration.TestCase, integration.AdaptedConfigurationTes
             },
         })
 
+    def test_invalid_kwargs_are_ignored(self):
+        low = {
+            'client': 'runner',
+            'fun': 'test.metasyntactic',
+            'thiskwargisbad': 'justpretendimnothere',
+        }
+        low.update(self.eauth_creds)
+
+        ret = self.runner.cmd_sync(low)
+        self.assertEqual(ret[0], 'foo')
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?

Fixes regressions caused by #39472.

### What issues does this PR fix or reference?

#40845, #41733.

### Previous Behavior

The initial PR attempted to handle both old- and new-style Runner arg/kwarg handling and clean up redundant parsing logic. I removed the wrong redundant logic. We need to call `load_args_and_kwargs` because it introspects the function and optionally ignores invalid args -- where the regressions came from.

### New Behavior

This replaces `parse_input` with `load_args_and_kwargs` (which calls `parse_input`).

I'm pretty confident this is the right move...but I said that last time.

### Tests written?

Yes.