### PR TITLE
Fix #41778

### DIFF
--- a/salt/utils/async.py
+++ b/salt/utils/async.py
@@ -98,5 +98,7 @@ class SyncWrapper(object):
             # Other things should be deallocated after the io_loop closes.
             # See Issue #26889.
             del self.async
-        else:
+            del self.io_loop
+        elif hasattr(self, 'io_loop'):
             self.io_loop.close()
+            del self.io_loop


### PR DESCRIPTION
### What does this PR do?

An explanation of why this fixes #41778 (which appeared after merging
PR #41436).

The following is true both before PR #41436 was merged and after it
was merged:
- On Tornado 4.2.1, `SyncWrapper.__del__` is sometimes invoked twice.
  When this happens, `self.io_loop.close()` is also invoked twice.
- On Tornado 4.5.1, `SyncWrapper.__del__` is never invoked twice. Hence
  this issue doesn't appear when using that version of Tornado.

Why did PR #41436 cause this issue?
- What that PR essentially did was ensure that there were no pending
I/O operations left in the I/O Loop before the I/O Loop was closed.
It essentially "drained out" the pending future that came from
`self._read_until_future` which let `SaltMessageClient._stream_return()`
complete. Tornado 4.2.1 seems to allow a call to close an I/O Loop
twice if it still has pending operations, but will throw the
`ValueError` exception if you attempt to close an empty I/O Loop twice.

### What issues does this PR fix or reference?

#41778 

### Tests written?

No