### PR TITLE
Fix for #41762

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -501,7 +501,7 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
 
     rule += after_jump
 
-    if full in ['True', 'true']:
+    if full is True:
         if not table:
             return 'Error: Table needs to be specified'
         if not chain:

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -501,7 +501,7 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
 
     rule += after_jump
 
-    if full is True:
+    if full:
         if not table:
             return 'Error: Table needs to be specified'
         if not chain:


### PR DESCRIPTION

### What does this PR do?
Changes how the full=True is checked in IPtables execution module.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/41762

### Previous Behavior
```
[root@cent01 srv]# salt 'cent01' iptables.build_rule chain=INPUT command=I full=True match=state connstate=RELATED,ESTABLISHED  jump=ACCEPT
cent01:
    -m state --state RELATED,ESTABLISHED --jump ACCEPT
```

### New Behavior
```
[root@cent01 srv]# salt 'cent01' iptables.build_rule chain=INPUT command=I full=True match=state connstate=RELATED,ESTABLISHED  jump=ACCEPT
cent01:
    /sbin/iptables  -t filter -I INPUT  -m state --state RELATED,ESTABLISHED --jump ACCEPT
```

### Tests written?
No
