### PR TITLE
Update napalm_syslog engine to use auth class

### DIFF
--- a/salt/engines/napalm_syslog.py
+++ b/salt/engines/napalm_syslog.py
@@ -312,9 +312,10 @@ def start(transport='zmq',
         if not certificate:
             log.critical('Please use a certificate, or disable the security.')
             return
-        priv_key, verify_key = napalm_logs.utils.authenticate(certificate,
-                                                              address=auth_address,
-                                                              port=auth_port)
+        auth = napalm_logs.utils.ClientAuth(certificate,
+                                            address=auth_address,
+                                            port=auth_port)
+
     transport_recv_fun = _get_transport_recv(name=transport,
                                              address=address,
                                              port=port)
@@ -330,7 +331,7 @@ def start(transport='zmq',
         log.debug('Received from napalm-logs:')
         log.debug(raw_object)
         if not disable_security:
-            dict_object = napalm_logs.utils.decrypt(raw_object, verify_key, priv_key)
+            dict_object = auth.decrypt(raw_object)
         else:
             dict_object = napalm_logs.utils.unserialize(raw_object)
         try:


### PR DESCRIPTION
### What does this PR do?

Changes napalm_syslog engine to use the new client auth method in napalm-logs

### What issues does this PR fix or reference?
None

### Previous Behavior
Authenticate and get a key to decrypt data when starting the engine. Then if the server were to restart new keys would be generated by the server, so the client could no longer decrypt. 

### New Behavior
Add a keep alive to make sure the server is alive, and if not try to reconnect and re-authenticate

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
