### PR TITLE
Refactored grains cache loader.

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -590,6 +590,43 @@ def grain_funcs(opts, proxy=None):
     )
 
 
+def _load_cached_grains(opts, cfn):
+    '''
+    Returns the grains cached in cfn, or None if the cache is too old or is
+    corrupted.
+    '''
+    if not os.path.isfile(cfn):
+        log.debug('Grains cache file does not exist.')
+        return None
+
+    grains_cache_age = int(time.time() - os.path.getmtime(cfn))
+    if grains_cache_age > opts.get('grains_cache_expiration', 300):
+        log.debug('Grains cache last modified {0} seconds ago and '
+                  'cache expiration is set to {1}. '
+                  'Grains cache expired. Refreshing.'.format(
+                      grains_cache_age,
+                      opts.get('grains_cache_expiration', 300)
+                  ))
+        return None
+
+    if opts.get('refresh_grains_cache', False):
+        log.debug('refresh_grains_cache requested, Refreshing.')
+        return None
+
+    log.debug('Retrieving grains from cache')
+    try:
+        serial = salt.payload.Serial(opts)
+        with salt.utils.fopen(cfn, 'rb') as fp_:
+            cached_grains = serial.load(fp_)
+        if not cached_grains:
+            log.debug('Cached grains are empty, cache might be corrupted. Refreshing.')
+            return None
+
+        return cached_grains
+    except (IOError, OSError):
+        return None
+
+
 def grains(opts, force_refresh=False, proxy=None):
     '''
     Return the functions for the dynamic grains and the values for the static
@@ -616,29 +653,10 @@ def grains(opts, force_refresh=False, proxy=None):
         opts['cachedir'],
         'grains.cache.p'
     )
-    if not force_refresh:
-        if opts.get('grains_cache', False):
-            if os.path.isfile(cfn):
-                grains_cache_age = int(time.time() - os.path.getmtime(cfn))
-                if opts.get('grains_cache_expiration', 300) >= grains_cache_age and not \
-                        opts.get('refresh_grains_cache', False) and not force_refresh:
-                    log.debug('Retrieving grains from cache')
-                    try:
-                        serial = salt.payload.Serial(opts)
-                        with salt.utils.fopen(cfn, 'rb') as fp_:
-                            cached_grains = serial.load(fp_)
-                        return cached_grains
-                    except (IOError, OSError):
-                        pass
-                else:
-                    log.debug('Grains cache last modified {0} seconds ago and '
-                              'cache expiration is set to {1}. '
-                              'Grains cache expired. Refreshing.'.format(
-                                  grains_cache_age,
-                                  opts.get('grains_cache_expiration', 300)
-                              ))
-            else:
-                log.debug('Grains cache file does not exist.')
+    if not force_refresh and opts.get('grains_cache', False):
+        cached_grains = _load_cached_grains(opts, cfn)
+        if cached_grains:
+            return cached_grains
     else:
         log.debug('Grains refresh requested. Refreshing grains.')
 


### PR DESCRIPTION
### What does this PR do?

  - refresh_grains_cache opt will now give a distinct debug message
  - if the grains fail to load from cache, or if the cache is vaild but is
    empty, grains will be reloaded
  - dramatically reduced nesting by extracting loader to dedicated function and
    inverting the condition clauses.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/41761

### Previous Behavior

Salt will crash if the grains cache file is empty.

### New Behavior

Salt will ignore invalid cache file and load grains as usual.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
