### PR TITLE
Fixed lvm.lvcreate hanging

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -387,7 +387,7 @@ def lvcreate(lvname,
              'stripesize', 'minor', 'persistent', 'mirrors', 'noudevsync',
              'monitor', 'ignoremonitoring', 'permission', 'poolmetadatasize',
              'readahead', 'regionsize', 'type',
-             'virtualsize', 'zero')
+             'virtualsize', 'wipesignatures', 'zero')
     no_parameter = ('noudevsync', 'ignoremonitoring', 'thin', )
 
     extra_arguments = []
@@ -399,6 +399,8 @@ def lvcreate(lvname,
                 extra_arguments.extend(['--{0}'.format(k), '{0}'.format(v)])
 
     cmd = [salt.utils.which('lvcreate')]
+
+    cmd.extend(['-y'])  # https://github.com/saltstack/salt/issues/41742
 
     if thinvolume:
         cmd.extend(['--thin', '-n', lvname])


### PR DESCRIPTION
### What does this PR do?

lvcreate might call out for an user prompt in case if the beginning of the
volume has some recogniseable partition data, triggered by the lvm defaults of
'--wipesignatures y' and '--zero y'. The default allows to proceed in the
expected manner automatically.

To allow the alternative behavior, wipesignatures is accepted as a valid
optional flag, thus its behavior can be disabled.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/41742

### Previous Behavior

`lvm.lvcreate` might hang indefinitely if the newly created volume happens to have a partition header.

### New Behavior

`lvm.lvcreate` will wipe the header automatically.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
