### PR TITLE
Remove grains cache file in case if serialization failed for whatever reason

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -752,12 +752,18 @@ def grains(opts, force_refresh=False, proxy=None):
                 try:
                     serial = salt.payload.Serial(opts)
                     serial.dump(grains_data, fp_)
-                except TypeError:
-                    # Can't serialize pydsl
-                    pass
-        except (IOError, OSError):
+                except TypeError as e:
+                    log.error('Failed to serialize grains cache: {0}'.format(e))
+                    raise  # re-throw for cleanup
+        except:
             msg = 'Unable to write to grains cache file {0}'
             log.error(msg.format(cfn))
+            # Based on the original exception, the file may or may not have been
+            # created. If it was, we will remove it now, as the exception means
+            # the serialized data is not to be trusted, no matter what the
+            # exception is.
+            if os.path.isfile(cfn):
+                os.unlink(cfn)
         os.umask(cumask)
 
     if grains_deep_merge:

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -755,9 +755,9 @@ def grains(opts, force_refresh=False, proxy=None):
                 except TypeError as e:
                     log.error('Failed to serialize grains cache: {0}'.format(e))
                     raise  # re-throw for cleanup
-        except:
-            msg = 'Unable to write to grains cache file {0}'
-            log.error(msg.format(cfn))
+        except Exception as e:
+            msg = 'Unable to write to grains cache file {0}: {1}'
+            log.error(msg.format(cfn, e))
             # Based on the original exception, the file may or may not have been
             # created. If it was, we will remove it now, as the exception means
             # the serialized data is not to be trusted, no matter what the


### PR DESCRIPTION
### What does this PR do?

Grains cache writer behavior is modified to remove the cache file in case of **any** exception being raised within the handler.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/41761

### Previous Behavior

Corrupted grains could fail to be serialized, resulting in an empty (0 bytes) cache file (that later fails to be loaded).

### New Behavior

Any exception in the write process results in cache file being removed.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
