### PR TITLE
Rename ext_nodes to master_tops in codebase

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -78,7 +78,7 @@ class SSHHighState(salt.state.BaseHighState):
         '''
         return
 
-    def _ext_nodes(self):
+    def _master_tops(self):
         '''
         Evaluate master_tops locally
         '''

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -536,10 +536,9 @@ class RemoteFuncs(object):
         mopts['jinja_trim_blocks'] = self.opts['jinja_trim_blocks']
         return mopts
 
-    def _ext_nodes(self, load, skip_verify=False):
+    def _master_tops(self, load, skip_verify=False):
         '''
-        Return the results from an external node classifier if one is
-        specified
+        Return the results from master_tops if configured
         '''
         if not skip_verify:
             if 'id' not in load:

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -988,7 +988,7 @@ class LocalClient(Client):
             ret.append(saltenv)
         return ret
 
-    def ext_nodes(self):
+    def master_tops(self):
         '''
         Originally returned information via the external_nodes subsystem.
         External_nodes was deprecated and removed in
@@ -1306,12 +1306,11 @@ class RemoteClient(Client):
         load = {'cmd': '_master_opts'}
         return self.channel.send(load)
 
-    def ext_nodes(self):
+    def master_tops(self):
         '''
-        Return the metadata derived from the external nodes system on the
-        master.
+        Return the metadata derived from the master_tops system
         '''
-        load = {'cmd': '_ext_nodes',
+        load = {'cmd': '_master_tops',
                 'id': self.opts['id'],
                 'opts': self.opts}
         if self.auth:

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -876,7 +876,7 @@ class FSChan(object):
                 self.opts['__fs_update'] = True
         else:
             self.fs.update()
-        self.cmd_stub = {'ext_nodes': {}}
+        self.cmd_stub = {'master_tops': {}}
 
     def send(self, load, tries=None, timeout=None, raw=False):  # pylint: disable=unused-argument
         '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -1113,7 +1113,7 @@ class AESFuncs(object):
             load.pop('tok')
         return load
 
-    def _ext_nodes(self, load):
+    def _master_tops(self, load):
         '''
         Return the results from an external node classifier if one is
         specified
@@ -1124,7 +1124,7 @@ class AESFuncs(object):
         load = self.__verify_load(load, ('id', 'tok'))
         if load is False:
             return {}
-        return self.masterapi._ext_nodes(load, skip_verify=True)
+        return self.masterapi._master_tops(load, skip_verify=True)
 
     def _master_opts(self, load):
         '''

--- a/salt/state.py
+++ b/salt/state.py
@@ -3118,7 +3118,7 @@ class BaseHighState(object):
                                     matches[env_key] = []
                                 matches[env_key].append(inc_sls)
                 _filter_matches(match, data, self.opts['nodegroups'])
-        ext_matches = self._ext_nodes()
+        ext_matches = self._master_tops()
         for saltenv in ext_matches:
             if saltenv in matches:
                 matches[saltenv] = list(
@@ -3128,13 +3128,12 @@ class BaseHighState(object):
         # pylint: enable=cell-var-from-loop
         return matches
 
-    def _ext_nodes(self):
+    def _master_tops(self):
         '''
-        Get results from an external node classifier.
-        Override it if the execution of the external node clasifier
-        needs customization.
+        Get results from the master_tops system. Override this function if the
+        execution of the master_tops needs customization.
         '''
-        return self.client.ext_nodes()
+        return self.client.master_tops()
 
     def load_dynamic(self, matches):
         '''


### PR DESCRIPTION
ext_nodes was replaced in favor of the master_tops system a few years
ago, this changes references in the codebase to refer to master_tops to
make the code more maintainable in the future.