### PR TITLE
fix(docker): allow log_driver or log_opt

### DIFF
--- a/salt/utils/docker/__init__.py
+++ b/salt/utils/docker/__init__.py
@@ -225,7 +225,7 @@ def translate_input(**kwargs):
         # format {'Type': log_driver, 'Config': log_opt}. So, we need to
         # construct this argument to be passed to the API from those two
         # arguments.
-        if log_driver is not NOTSET and log_opt is not NOTSET:
+        if log_driver is not NOTSET or log_opt is not NOTSET:
             kwargs['log_config'] = {
                 'Type': log_driver if log_driver is not NOTSET else 'none',
                 'Config': log_opt if log_opt is not NOTSET else {}

--- a/tests/unit/utils/test_docker.py
+++ b/tests/unit/utils/test_docker.py
@@ -984,6 +984,28 @@ class TranslateInputTestCase(TestCase):
             expected
         )
 
+        # Ensure passing either `log_driver` or `log_opt` works
+        self.assertEqual(
+            docker_utils.translate_input(
+                log_driver='foo'
+            ),
+            (
+                {'log_config': {'Type': 'foo',
+                                'Config': {}}},
+                {}, []
+            )
+        )
+        self.assertEqual(
+            docker_utils.translate_input(
+                log_opt={'foo': 'bar', 'baz': 'qux'}
+            ),
+            (
+                {'log_config': {'Type': 'none',
+                                'Config': {'foo': 'bar', 'baz': 'qux'}}},
+                {}, []
+            )
+        )
+
     @assert_key_equals_value
     def test_lxc_conf(self):
         '''


### PR DESCRIPTION
Docker allows either option without the other and the docks make no mention of both options being required.

### What does this PR do?
Fixes docker module to allow `log_driver` or `log_opt` instead of requiring both when docker does not require both.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/28122 may be related but not the exact problem. I didn't not make a specific issue for this. I just ran into it while attempting to use a `log_driver` without options.

### Previous Behavior
Salt would only pass in `log_driver` if you also set `log_opt`. This is not documented and not expected.

### New Behavior
Salt will pass in `log_driver` or `log_opt` without the other. I assume most users would just pass in `log_driver` if they only use one option since the default driver(none) has no options.

### Tests written?

Yes

I couldn't get the test to run on the latest develop with a fresh clone on macOS. I was recieiving this error but the test cases seemed pretty straight forward functionality wise. Please let me know if there is anything you'd recommend changing(this is my first python test).

I also received the same error when running without my changes or new test cases.
```
./setup.py test
2017.7.0-272-ga8affc6
running test
running build
running build_py
copying salt/utils/docker/__init__.py -> build/lib/salt/utils/docker
running build_scripts
running test
Traceback (most recent call last):
  File "$HOME/projects/salt/tests/runtests.py", line 59, in <module>
    from tests.integration import TestDaemon  # pylint: disable=W0403
  File "$HOME/projects/salt/tests/integration/__init__.py", line 35, in <module>
    from tests.support.processes import *  # pylint: disable=wildcard-import
  File "$HOME/projects/salt/tests/support/processes.py", line 18, in <module>
    from pytestsalt.utils import SaltRunEventListener as PytestSaltRunEventListener
ImportError: No module named pytestsalt.utils
```

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
