### PR TITLE
Upgrade psutil to version 5.2.2

### DIFF
--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -18,7 +18,7 @@ lxml==3.6.0
 Mako==1.0.4
 MarkupSafe==0.23
 msgpack-python==0.4.8
-psutil==4.3.0
+psutil==5.2.2
 pyasn1==0.1.9
 pycparser==2.17
 pycurl==7.43.0


### PR DESCRIPTION
### What does this PR do?
Fixes to the status module (backported) require psutil version 5.2.2

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/41797

### Tests written?
No