### PR TITLE
Temporary POC: disable runtests log handler for Py3 tests.

### DIFF
--- a/tests/integration/files/log_handlers/runtests_log_handler.py
+++ b/tests/integration/files/log_handlers/runtests_log_handler.py
@@ -23,6 +23,7 @@ from multiprocessing import Queue
 import msgpack
 
 # Import Salt libs
+import salt.ext.six as six
 import salt.log.setup
 
 log = logging.getLogger(__name__)
@@ -33,6 +34,8 @@ __virtualname__ = 'runtests_log_handler'
 def __virtual__():
     if 'runtests_log_port' not in __opts__:
         return False, "'runtests_log_port' not in options"
+    if six.PY3:
+        return False, "runtests external logging handler is temporarily disabled for Python 3 tests"
     return True
 
 


### PR DESCRIPTION
### What does this PR do?
Disable runtests log handler for Py3 tests.
This is done to run tests on Jenkins and proof this would resolve the tests memory consumption issue.
This would be reverted after tests run.
The complete fix is under development.

### What issues does this PR fix or reference?
Related to saltstack/salt-jenkins#333