### PR TITLE
Extend proxy to jinja

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -559,7 +559,7 @@ def ssh_wrapper(opts, functions=None, context=None):
     )
 
 
-def render(opts, functions, states=None):
+def render(opts, functions, states=None, proxy=None):
     '''
     Returns the render modules
     '''
@@ -567,6 +567,7 @@ def render(opts, functions, states=None):
             '__grains__': opts.get('grains', {})}
     if states:
         pack['__states__'] = states
+    pack['__proxy__'] = proxy or {}
     ret = LazyLoader(
         _module_dirs(
             opts,

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -66,6 +66,7 @@ def render(template_file, saltenv='base', sls='', argline='',
                                           sls=sls,
                                           context=context,
                                           tmplpath=tmplpath,
+                                          proxy=__proxy__,
                                           **kws)
     if not tmp_data.get('result', False):
         raise SaltRenderError(

--- a/salt/state.py
+++ b/salt/state.py
@@ -895,7 +895,8 @@ class State(object):
                                 self.functions[f_key] = funcs[func]
         self.serializers = salt.loader.serializers(self.opts)
         self._load_states()
-        self.rend = salt.loader.render(self.opts, self.functions, states=self.states)
+        self.rend = salt.loader.render(self.opts, self.functions,
+                                       states=self.states, proxy=self.proxy)
 
     def module_refresh(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Provides a variable `proxy` in the jinja renderer that shadows `__proxy__` like
`salt` shadows `__salt__`.

### Tests written?

No
