### PR TITLE
Reduce the number of days an issue is stale by 25

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,8 +1,8 @@
 # Probot Stale configuration file
 
 # Number of days of inactivity before an issue becomes stale
-# 1225 is approximately 3 years and 4 months
-daysUntilStale: 1225
+# 1200 is approximately 3 years and 3 months
+daysUntilStale: 1200
 
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7


### PR DESCRIPTION
This reduces the amount of time an issue is stale to approximately 3 years, 3 months, and some change.

At the time of this submission, there were 15 more issues that would be marked as stale from this update. This number may change depending on when this PR is merged.