### PR TITLE
Fix master side scheduled jobs to return events

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -888,9 +888,10 @@ class Schedule(object):
             ret['success'] = False
             ret['retcode'] = 254
         finally:
-            # Only attempt to return data to the master
-            # if the scheduled job is running on a minion.
-            if '__role' in self.opts and self.opts['__role'] == 'minion':
+            # Only attempt to return data to the master if the scheduled job is running
+            # on a master itself or a minion.
+            if '__role' in self.opts and self.opts['__role'] in ('master', 'minion'):
+                # The 'return_job' option is enabled by default even if not set
                 if 'return_job' in data and not data['return_job']:
                     pass
                 else:
@@ -918,6 +919,7 @@ class Schedule(object):
                         log.exception("Unhandled exception firing event: {0}".format(exc))
 
             log.debug('schedule.handle_func: Removing {0}'.format(proc_fn))
+
             try:
                 os.unlink(proc_fn)
             except OSError as exc:


### PR DESCRIPTION
### What does this PR do?
It enables jobs scheduled on master to return their results back to an event bus by default.

### What issues does this PR fix or reference?
This was a long standing issue #12653, which was fixed by PR #41658.
Eventually, merging forward of PR #41695 caused a regression.

### Tests written?
No. But it appears we should have them.
