### PR TITLE
Fix problems with get_rule and delete_rule

### DIFF
--- a/salt/modules/win_firewall.py
+++ b/salt/modules/win_firewall.py
@@ -155,7 +155,7 @@ def get_rule(name='all'):
         salt '*' firewall.get_rule 'MyAppPort'
     '''
     cmd = ['netsh', 'advfirewall', 'firewall', 'show', 'rule',
-           'name="{0}"'.format(name)]
+           'name={0}'.format(name)]
     ret = __salt__['cmd.run_all'](cmd, python_shell=False, ignore_retcode=True)
     if ret['retcode'] != 0:
         raise CommandExecutionError(ret['stdout'])
@@ -245,7 +245,7 @@ def add_rule(name, localport, protocol='tcp', action='allow', dir='in',
     return True
 
 
-def delete_rule(name,
+def delete_rule(name=None,
                 localport=None,
                 protocol=None,
                 dir=None,
@@ -261,10 +261,11 @@ def delete_rule(name,
         name (str): The name of the rule to delete. If the name ``all`` is used
             you must specify additional parameters.
 
-        localport (Optional[str]): The port of the rule. Must specify a
-            protocol.
+        localport (Optional[str]): The port of the rule. If protocol is not
+            specified, protocol will be set to ``tcp``
 
-        protocol (Optional[str]): The protocol of the rule.
+        protocol (Optional[str]): The protocol of the rule. Default is ``tcp``
+            when ``localport`` is specified
 
         dir (Optional[str]): The direction of the rule.
 
@@ -293,8 +294,9 @@ def delete_rule(name,
         # Delete a rule called 'allow80':
         salt '*' firewall.delete_rule allow80
     '''
-    cmd = ['netsh', 'advfirewall', 'firewall', 'delete', 'rule',
-           'name={0}'.format(name)]
+    cmd = ['netsh', 'advfirewall', 'firewall', 'delete', 'rule']
+    if name:
+        cmd.append('name={0}'.format(name))
     if protocol:
         cmd.append('protocol={0}'.format(protocol))
     if dir:
@@ -305,6 +307,8 @@ def delete_rule(name,
     if protocol is None \
             or ('icmpv4' not in protocol and 'icmpv6' not in protocol):
         if localport:
+            if not protocol:
+                cmd.append('protocol=tcp')
             cmd.append('localport={0}'.format(localport))
 
     ret = __salt__['cmd.run_all'](cmd, python_shell=False, ignore_retcode=True)


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the firewall module that was found during testing of the RC.
``get_rule`` and ``delete_rule`` were throwing errors under certain conditions.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/41860

### Previous Behavior
`get_rule` would fail
`delete_rule` would fail if you specified a port but not the protocol

### New Behavior
`get_rule` now works
`delete_rule` sets the protocol to `TCP` if you pass a port but not the protocol

### Tests written?
No