### PR TITLE
Quick fix for beacons in 2017.7

### DIFF
--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -54,9 +54,7 @@ class Beacon(object):
                 current_beacon_config = {}
                 list(map(current_beacon_config.update, config[mod]))
             elif isinstance(config[mod], dict):
-                raise CommandExecutionError(
-                    'Beacon configuration should be a list instead of a dictionary.'
-                )
+                current_beacon_config = config[mod]
 
             if 'enabled' in current_beacon_config:
                 if not current_beacon_config['enabled']:


### PR DESCRIPTION
### What does this PR do?
This PR reverts a change in 2017.7 that caused an exception when a beacon configuration using a dictionary is found.  Several beacons rely on dictionary based configurations so they become non-functional.

### What issues does this PR fix or reference?
N/A

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
