### PR TITLE
Don't run coverage if not admin

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -448,7 +448,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
 
         if self.options.coverage and any((
                     self.options.name,
-                    is_admin,
+                    not is_admin,
                     not self.options.run_destructive)) \
                 and self._check_enabled_suites(include_unit=True):
             self.error(


### PR DESCRIPTION
### What does this PR do?
Fixes the logic where it checks if the shell is Not admin.

### What issues does this PR fix or reference?
Part of getting tests to work in Windows.

### Previous Behavior
Previous iterations of this function used the command `os.geteuid != 0`. Later, the `is_admin` variable was defined that added the ability to detect admin/root on Windows as well. On Linux this was set to `is_admin = os.geteuid == 0`, but the if statement below was not updated to reflect the new logic. Instead of `os.geteuid != 0` it was simply `is_admin`.

### New Behavior
The code has been changed to `not is_admin`.

### Tests written?
NA
