### PR TITLE
Add support for nacl renderer for encrypted data

### DIFF
--- a/salt/renderers/nacl.py
+++ b/salt/renderers/nacl.py
@@ -50,12 +50,11 @@ data like so:
 
     #!yaml|nacl
 
-    a-secret: "NACLENC[MRN3cc+fmdxyQbz6WMF+jq1hKdU5X5BBI7OjK+atvHo1ll+w1gZ7XyWtZVfq9gK9rQaMfkDxmidJKwE0Mw==]"
+    a-secret: "NACL[MRN3cc+fmdxyQbz6WMF+jq1hKdU5X5BBI7OjK+atvHo1ll+w1gZ7XyWtZVfq9gK9rQaMfkDxmidJKwE0Mw==]"
 '''
 
 
 from __future__ import absolute_import
-import os
 import re
 import logging
 
@@ -63,13 +62,12 @@ import logging
 import salt.utils
 import salt.utils.stringio
 import salt.syspaths
-from salt.exceptions import SaltRenderError
 
 # Import 3rd-party libs
 import salt.ext.six as six
 
 log = logging.getLogger(__name__)
-NACL_REGEX = '^NACLENC\[(.*)\]$'
+NACL_REGEX = r'^NACL\[(.*)\]$'
 
 
 def _decrypt_object(obj, **kwargs):
@@ -79,7 +77,7 @@ def _decrypt_object(obj, **kwargs):
     otherwise keep going until a string is found.
     '''
     if salt.utils.stringio.is_readable(obj):
-        return _decrypt_object(obj.getvalue())
+        return _decrypt_object(obj.getvalue(), **kwargs)
     if isinstance(obj, six.string_types):
         if re.search(NACL_REGEX, obj) is not None:
             return __salt__['nacl.dec_pub'](re.search(NACL_REGEX, obj).group(1), **kwargs)
@@ -87,11 +85,11 @@ def _decrypt_object(obj, **kwargs):
             return obj
     elif isinstance(obj, dict):
         for key, value in six.iteritems(obj):
-            obj[key] = _decrypt_object(value)
+            obj[key] = _decrypt_object(value, **kwargs)
         return obj
     elif isinstance(obj, list):
         for key, value in enumerate(obj):
-            obj[key] = _decrypt_object(value)
+            obj[key] = _decrypt_object(value, **kwargs)
         return obj
     else:
         return obj

--- a/salt/renderers/nacl.py
+++ b/salt/renderers/nacl.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+r'''
+Renderer that will decrypt NACL ciphers
+
+Any key in the SLS file can be an NACL cipher, and this renderer will decrypt it
+before passing it off to Salt. This allows you to safely store secrets in
+source control, in such a way that only your Salt master can decrypt them and
+distribute them only to the minions that need them.
+
+The typical use-case would be to use ciphers in your pillar data, and keep a
+secret key on your master. You can put the public key in source control so that
+developers can add new secrets quickly and easily.
+
+This renderer requires the libsodium library binary and libnacl >= 1.5.1
+python package (support for sealed boxes came in 1.5.1 version).
+
+
+Setup
+-----
+
+To set things up, first generate a keypair. On the master, run the following:
+
+.. code-block:: bash
+
+    # salt-call --local nacl.keygen keyfile=/root/.nacl
+    # salt-call --local nacl.keygen_pub keyfile_pub=/root/.nacl.pub
+
+
+Using encrypted pillar
+---------------------
+
+To encrypt secrets, copy the public key to your local machine and run:
+
+.. code-block:: bash
+
+    $ salt-call --local nacl.enc_pub datatoenc keyfile_pub=/root/.nacl.pub
+
+
+To apply the renderer on a file-by-file basis add the following line to the
+top of any pillar with nacl encrypted data in it:
+
+.. code-block:: yaml
+
+    #!yaml|nacl
+
+Now with your renderer configured, you can include your ciphers in your pillar
+data like so:
+
+.. code-block:: yaml
+
+    #!yaml|nacl
+
+    a-secret: "NACLENC[MRN3cc+fmdxyQbz6WMF+jq1hKdU5X5BBI7OjK+atvHo1ll+w1gZ7XyWtZVfq9gK9rQaMfkDxmidJKwE0Mw==]"
+'''
+
+
+from __future__ import absolute_import
+import os
+import re
+import logging
+
+# Import salt libs
+import salt.utils
+import salt.utils.stringio
+import salt.syspaths
+from salt.exceptions import SaltRenderError
+
+# Import 3rd-party libs
+import salt.ext.six as six
+
+log = logging.getLogger(__name__)
+NACL_REGEX = '^NACLENC\[(.*)\]$'
+
+
+def _decrypt_object(obj, **kwargs):
+    '''
+    Recursively try to decrypt any object. If the object is a six.string_types
+    (string or unicode), and it contains a valid NACLENC pretext, decrypt it,
+    otherwise keep going until a string is found.
+    '''
+    if salt.utils.stringio.is_readable(obj):
+        return _decrypt_object(obj.getvalue())
+    if isinstance(obj, six.string_types):
+        if re.search(NACL_REGEX, obj) is not None:
+            return __salt__['nacl.dec_pub'](re.search(NACL_REGEX, obj).group(1), **kwargs)
+        else:
+            return obj
+    elif isinstance(obj, dict):
+        for key, value in six.iteritems(obj):
+            obj[key] = _decrypt_object(value)
+        return obj
+    elif isinstance(obj, list):
+        for key, value in enumerate(obj):
+            obj[key] = _decrypt_object(value)
+        return obj
+    else:
+        return obj
+
+
+def render(nacl_data, saltenv='base', sls='', argline='', **kwargs):
+    '''
+    Decrypt the data to be rendered using the given nacl key or the one given
+    in config
+    '''
+    return _decrypt_object(nacl_data, **kwargs)

--- a/tests/unit/renderers/test_nacl.py
+++ b/tests/unit/renderers/test_nacl.py
@@ -15,7 +15,6 @@ from tests.support.mock import (
 
 # Import Salt libs
 import salt.renderers.nacl as nacl
-from salt.exceptions import SaltRenderError
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -31,7 +30,7 @@ class NaclTestCase(TestCase, LoaderModuleMockMixin):
         test _decrypt_object
         '''
         secret = 'Use more salt.'
-        crypted = 'NACLENC[MRN3cc+fmdxyQbz6WMF+jq1hKdU5X5BBI7OjK+atvHo1ll+w1gZ7XyWtZVfq9gK9rQaMfkDxmidJKwE0Mw==]'
+        crypted = 'NACL[MRN3cc+fmdxyQbz6WMF+jq1hKdU5X5BBI7OjK+atvHo1ll+w1gZ7XyWtZVfq9gK9rQaMfkDxmidJKwE0Mw==]'
 
         secret_map = {'secret': secret}
         crypted_map = {'secret': crypted}
@@ -39,7 +38,7 @@ class NaclTestCase(TestCase, LoaderModuleMockMixin):
         secret_list = [secret]
         crypted_list = [crypted]
 
-        with patch.dict(nacl.__salt__,{'nacl.dec_pub': MagicMock(return_value=secret)}):
+        with patch.dict(nacl.__salt__, {'nacl.dec_pub': MagicMock(return_value=secret)}):
             self.assertEqual(nacl._decrypt_object(secret), secret)
             self.assertEqual(nacl._decrypt_object(crypted), secret)
             self.assertEqual(nacl._decrypt_object(crypted_map), secret_map)
@@ -51,6 +50,6 @@ class NaclTestCase(TestCase, LoaderModuleMockMixin):
         test render
         '''
         secret = 'Use more salt.'
-        crypted = 'NACLENC[MRN3cc+fmdxyQbz6WMF+jq1hKdU5X5BBI7OjK+atvHo1ll+w1gZ7XyWtZVfq9gK9rQaMfkDxmidJKwE0Mw==]'
-        with patch.dict(nacl.__salt__,{'nacl.dec_pub': MagicMock(return_value=secret)}):
+        crypted = 'NACL[MRN3cc+fmdxyQbz6WMF+jq1hKdU5X5BBI7OjK+atvHo1ll+w1gZ7XyWtZVfq9gK9rQaMfkDxmidJKwE0Mw==]'
+        with patch.dict(nacl.__salt__, {'nacl.dec_pub': MagicMock(return_value=secret)}):
             self.assertEqual(nacl.render(crypted), secret)

--- a/tests/unit/renderers/test_nacl.py
+++ b/tests/unit/renderers/test_nacl.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch
+)
+
+# Import Salt libs
+import salt.renderers.nacl as nacl
+from salt.exceptions import SaltRenderError
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class NaclTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    unit test NaCl renderer
+    '''
+    def setup_loader_modules(self):
+        return {nacl: {}}
+
+    def test__decrypt_object(self):
+        '''
+        test _decrypt_object
+        '''
+        secret = 'Use more salt.'
+        crypted = 'NACLENC[MRN3cc+fmdxyQbz6WMF+jq1hKdU5X5BBI7OjK+atvHo1ll+w1gZ7XyWtZVfq9gK9rQaMfkDxmidJKwE0Mw==]'
+
+        secret_map = {'secret': secret}
+        crypted_map = {'secret': crypted}
+
+        secret_list = [secret]
+        crypted_list = [crypted]
+
+        with patch.dict(nacl.__salt__,{'nacl.dec_pub': MagicMock(return_value=secret)}):
+            self.assertEqual(nacl._decrypt_object(secret), secret)
+            self.assertEqual(nacl._decrypt_object(crypted), secret)
+            self.assertEqual(nacl._decrypt_object(crypted_map), secret_map)
+            self.assertEqual(nacl._decrypt_object(crypted_list), secret_list)
+            self.assertEqual(nacl._decrypt_object(None), None)
+
+    def test_render(self):
+        '''
+        test render
+        '''
+        secret = 'Use more salt.'
+        crypted = 'NACLENC[MRN3cc+fmdxyQbz6WMF+jq1hKdU5X5BBI7OjK+atvHo1ll+w1gZ7XyWtZVfq9gK9rQaMfkDxmidJKwE0Mw==]'
+        with patch.dict(nacl.__salt__,{'nacl.dec_pub': MagicMock(return_value=secret)}):
+            self.assertEqual(nacl.render(crypted), secret)


### PR DESCRIPTION
### Add support for nacl renderer with sealed boxes

### Addition
- New renderer on top of nacl sealed boxes to allow encrypted data in sls files

### Tests written?
Yes

### Requires
https://github.com/saltstack/salt/pull/41833

