### PR TITLE
Py3 mdadm test

### DIFF
--- a/tests/unit/modules/test_mdadm.py
+++ b/tests/unit/modules/test_mdadm.py
@@ -18,9 +18,6 @@ from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 # Import salt libs
 import salt.modules.mdadm as mdadm
 
-# Import 3rd-party libs
-import salt.ext.six as six
-
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class MdadmTestCase(TestCase, LoaderModuleMockMixin):

--- a/tests/unit/modules/test_mdadm.py
+++ b/tests/unit/modules/test_mdadm.py
@@ -40,32 +40,26 @@ class MdadmTestCase(TestCase, LoaderModuleMockMixin):
                     chunk=256
             )
             self.assertEqual('salt', ret)
-            if six.PY2:
-                expected_args = [
-                    'mdadm',
-                    '-C', '/dev/md0',
-                    '-R',
-                    '-v',
-                    '--chunk', '256',
-                    '--force',
-                     '-l', '5',
-                     '-e', 'default',
-                     '-n', '3',
-                     '/dev/sdb1', '/dev/sdc1', '/dev/sdd1']
-            else:
-                expected_args = [
-                    'mdadm',
-                    '-C', '/dev/md0',
-                    '-R',
-                    '-v',
-                    '--force',
-                    '--chunk', '256',
-                    '-l', '5',
-                    '-e', 'default',
-                    '-n', '3',
-                    '/dev/sdb1', '/dev/sdc1', '/dev/sdd1'
-                ]
-            mock.assert_called_once_with(expected_args, python_shell=False)
+            mock.assert_called_once()
+            args, kwargs = mock.call_args
+            # expected cmd is
+            # mdadm -C /dev/md0 -R -v --chunk 256 --force -l 5 -e default -n 3 /dev/sdb1 /dev/sdc1 /dev/sdd1
+            # where args between -v and -l could be in any order
+            self.assertEqual(len(args), 1)
+            self.assertEqual(len(args[0]), 17)
+            self.assertEqual(args[0][:5], [
+                'mdadm',
+                '-C', '/dev/md0',
+                '-R',
+                '-v'])
+            self.assertEqual(args[0][8:], [
+                 '-l', '5',
+                 '-e', 'default',
+                 '-n', '3',
+                 '/dev/sdb1', '/dev/sdc1', '/dev/sdd1'])
+            self.assertEqual(sorted(args[0][5:8]), sorted(['--chunk', '256', '--force']))
+            self.assertIn('--chunk 256', ' '.join(args[0][5:8]))
+            self.assertEqual(kwargs, {'python_shell': False})
 
     def test_create_test_mode(self):
         mock = MagicMock()


### PR DESCRIPTION
### What does this PR do?
Fixes unit.modules.tests_mdadm.MdadmTestCase.test_create.

### What issues does this PR fix or reference?
Fixes saltstack/salt-jenkins#436
Related to saltstack/salt-jenkins#333

### Previous Behavior
The test passes kwargs to the function and expects the function will iterate them in the same order. Since kwargs is a dict the iteration order is undefined.

### New Behavior
Check the result in the order independent way.