### PR TITLE
Fix netstat and routes test

### DIFF
--- a/tests/unit/modules/network_test.py
+++ b/tests/unit/modules/network_test.py
@@ -335,12 +335,13 @@ class NetworkTestCase(TestCase):
             self.assertRaises(CommandExecutionError, network.routes, 'inet')
 
         with patch.dict(network.__grains__, {'kernel': 'Linux'}):
-            with patch.object(network, '_netstat_route_linux',
-                              side_effect=['A', [{'addr_family': 'inet'}]]):
-                self.assertEqual(network.routes(None), 'A')
+            with patch.object(salt.utils, 'which', return_value=True):
+                with patch.object(network, '_netstat_route_linux',
+                                  side_effect=['A', [{'addr_family': 'inet'}]]):
+                    self.assertEqual(network.routes(None), 'A')
 
-                self.assertListEqual(network.routes('inet'),
-                                     [{'addr_family': 'inet'}])
+                    self.assertListEqual(network.routes('inet'),
+                                         [{'addr_family': 'inet'}])
 
     def test_default_route(self):
         '''

--- a/tests/unit/modules/network_test.py
+++ b/tests/unit/modules/network_test.py
@@ -91,8 +91,9 @@ class NetworkTestCase(TestCase):
         Test for return information on open ports and states
         '''
         with patch.dict(network.__grains__, {'kernel': 'Linux'}):
-            with patch.object(network, '_netstat_linux', return_value='A'):
-                self.assertEqual(network.netstat(), 'A')
+            with patch.object(salt.utils, 'which', return_value=True):
+                with patch.object(network, '_netstat_linux', return_value='A'):
+                    self.assertEqual(network.netstat(), 'A')
 
         with patch.dict(network.__grains__, {'kernel': 'OpenBSD'}):
             with patch.object(network, '_netstat_bsd', return_value='A'):


### PR DESCRIPTION
### What does this PR do?
The commit 017fbdbc53c30b66a3e13eca306ff53dd1685e98 added a call to `salt.utils.which`. This resulted in the unit tests `unit.modules.network_test.NetworkTestCase.test_netstat` and `unit.modules.network_test.NetworkTestCase.test_routes` to fail with the following error:

```
Traceback (most recent call last):
  File "/testing/tests/unit/modules/network_test.py", line 339, in test_routes
    self.assertEqual(network.routes(None), 'A')
  File "/testing/salt/modules/network.py", line 1592, in routes
    routes_ = _ip_route_linux()
  File "/testing/salt/modules/network.py", line 492, in _ip_route_linux
    out = __salt__['cmd.run'](cmd, python_shell=True)
KeyError: 'cmd.run'
```
This PR patches `salt.utils.which` for these tests. 

### Tests written?

Yes
