### PR TITLE
Remove the default value for emailAddress in the tls module

### DIFF
--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -575,7 +575,7 @@ def create_ca(ca_name,
               L='Salt Lake City',
               O='SaltStack',
               OU=None,
-              emailAddress='xyz@pdq.net',
+              emailAddress=None,
               fixmode=False,
               cacert_path=None,
               ca_filename=None,
@@ -605,7 +605,7 @@ def create_ca(ca_name,
     OU
         organizational unit, default is None
     emailAddress
-        email address for the CA owner, default is 'xyz@pdq.net'
+        email address for the CA owner, default is None
     cacert_path
         absolute path to ca certificates root directory
     ca_filename
@@ -698,7 +698,8 @@ def create_ca(ca_name,
     if OU:
         ca.get_subject().OU = OU
     ca.get_subject().CN = CN
-    ca.get_subject().emailAddress = emailAddress
+    if emailAddress:
+        ca.get_subject().emailAddress = emailAddress
 
     ca.gmtime_adj_notBefore(0)
     ca.gmtime_adj_notAfter(int(days) * 24 * 60 * 60)
@@ -854,7 +855,7 @@ def create_csr(ca_name,
                L='Salt Lake City',
                O='SaltStack',
                OU=None,
-               emailAddress='xyz@pdq.net',
+               emailAddress=None,
                subjectAltName=None,
                cacert_path=None,
                ca_filename=None,
@@ -886,7 +887,7 @@ def create_csr(ca_name,
     OU
         organizational unit, default is None
     emailAddress
-        email address for the request, default is 'xyz@pdq.net'
+        email address for the request, default is None
     subjectAltName
         valid subjectAltNames in full form, e.g. to add DNS entry you would call
         this function with this value:
@@ -998,7 +999,8 @@ def create_csr(ca_name,
     if OU:
         req.get_subject().OU = OU
     req.get_subject().CN = CN
-    req.get_subject().emailAddress = emailAddress
+    if emailAddress:
+        req.get_subject().emailAddress = emailAddress
 
     try:
         extensions = get_extensions(cert_type)['csr']
@@ -1074,7 +1076,7 @@ def create_self_signed_cert(tls_dir='tls',
                             L='Salt Lake City',
                             O='SaltStack',
                             OU=None,
-                            emailAddress='xyz@pdq.net',
+                            emailAddress=None,
                             cacert_path=None,
                             cert_filename=None,
                             digest='sha256',
@@ -1100,7 +1102,7 @@ def create_self_signed_cert(tls_dir='tls',
     OU
         organizational unit, default is None
     emailAddress
-        email address for the request, default is 'xyz@pdq.net'
+        email address for the request, default is None
     cacert_path
         absolute path to ca certificates root directory
     digest
@@ -1171,7 +1173,8 @@ def create_self_signed_cert(tls_dir='tls',
     if OU:
         cert.get_subject().OU = OU
     cert.get_subject().CN = CN
-    cert.get_subject().emailAddress = emailAddress
+    if emailAddress:
+        cert.get_subject().emailAddress = emailAddress
 
     cert.set_serial_number(_new_serial(tls_dir))
     cert.set_issuer(cert.get_subject())


### PR DESCRIPTION
### What does this PR do?
This PR changes functionality in the tls module in order to allow the emailAddress field to be empty and not set a default value. The email address is an optional field and makes DNs... interesting.

### What issues does this PR fix or reference?
None

### Previous Behavior
The emailAddress parameter received a default value of 'xyz@pdq.net' if not supplied by the user.
`subject= /C=US/ST=Maryland/L=Columbia/O=DecisionLab/OU=DecisionLab/CN=dev-02.example.local/emailAddress=xyz@pdq.net`

### New Behavior
The emailAddress parameter defaults to None, and won't add the field to the OpenSSL functions if it's not explicitly set.
`subject= /C=US/ST=Maryland/L=Columbia/O=DecisionLab/OU=DecisionLab/CN=dev-02.example.local`

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
