### PR TITLE
Allow modifiable opts for http.query in module and runner.

### DIFF
--- a/salt/modules/http.py
+++ b/salt/modules/http.py
@@ -30,7 +30,7 @@ def query(url, **kwargs):
         salt '*' http.query http://somelink.com/ method=POST \
             data='<xml>somecontent</xml>'
     '''
-    opts = __opts__
+    opts = __opts__.copy()
     if 'opts' in kwargs:
         opts.update(kwargs['opts'])
         del kwargs['opts']

--- a/salt/modules/http.py
+++ b/salt/modules/http.py
@@ -30,7 +30,12 @@ def query(url, **kwargs):
         salt '*' http.query http://somelink.com/ method=POST \
             data='<xml>somecontent</xml>'
     '''
-    return salt.utils.http.query(url=url, opts=__opts__, **kwargs)
+    opts = __opts__
+    if 'opts' in kwargs:
+        opts.update(kwargs['opts'])
+        del kwargs['opts']
+
+    return salt.utils.http.query(url=url, opts=opts, **kwargs)
 
 
 def wait_for_successful_query(url, wait_for=300, **kwargs):

--- a/salt/runners/http.py
+++ b/salt/runners/http.py
@@ -35,7 +35,7 @@ def query(url, output=True, **kwargs):
         log.warning('Output option has been deprecated. Please use --quiet.')
     if 'node' not in kwargs:
         kwargs['node'] = 'master'
-    opts = __opts__
+    opts = __opts__.copy()
     if 'opts' in kwargs:
         opts.update(kwargs['opts'])
         del kwargs['opts']

--- a/salt/runners/http.py
+++ b/salt/runners/http.py
@@ -35,8 +35,12 @@ def query(url, output=True, **kwargs):
         log.warning('Output option has been deprecated. Please use --quiet.')
     if 'node' not in kwargs:
         kwargs['node'] = 'master'
+    opts = __opts__
+    if 'opts' in kwargs:
+        opts.update(kwargs['opts'])
+        del kwargs['opts']
 
-    ret = salt.utils.http.query(url=url, opts=__opts__, **kwargs)
+    ret = salt.utils.http.query(url=url, opts=opts, **kwargs)
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?
Checks if opts is present in the kwargs passed and if present, updates the __opts__ dict locally with the opts passed and removes the opts from kwargs, and if not present, just forwards the current kwargs.

### What issues does this PR fix or reference?
Faced an issue today where I had to set the opts but it failed.

### Previous Behavior
Passing on the opts as kwargs currently fails with repeated keyword argument error.

### New Behavior
Allows opts to be passed to module and runner.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
