### PR TITLE
added Void linux family to iptables _conf function

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -107,6 +107,11 @@ def _conf(family='ipv4'):
     elif __grains__['os_family'] == 'SUSE':
         # SuSE does not seem to use separate files for IPv4 and IPv6
         return '/etc/sysconfig/scripts/SuSEfirewall2-custom'
+    elif __grains__['os_family'] == 'Void':
+        if family == 'ipv6':
+            return '/etc/iptables/iptables.rules'
+        else:
+            return '/etc/iptables/ip6tables.rules'
     elif __grains__['os'] == 'Alpine':
         if family == 'ipv6':
             return '/etc/iptables/rules6-save'


### PR DESCRIPTION
### What does this PR do?

Fix iptables rules for Void Linux in `salt/modules/iptables.py`.

### What issues does this PR fix or reference?

None.

### Previous Behavior

A simple rule

```
drop incoming ipv6:
  iptables.set_policy:
    - family: ipv6
    - chain: INPUT
    - policy: DROP
    - require:
      - pkg: iptables
    - save: True
```
would result in an exception:

```
          ID: drop incoming ipv6
    Function: iptables.set_policy
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/site-packages/salt/state.py", line 1746, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1704, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/site-packages/salt/states/iptables.py", line 715, in set_policy
                  family) == kwargs['policy']:
                File "/usr/lib/python2.7/site-packages/salt/modules/iptables.py", line 523, in get_policy
                  rules = _parse_conf(in_mem=True, family=family)
                File "/usr/lib/python2.7/site-packages/salt/modules/iptables.py", line 878, in _parse_conf
                  if _conf() and not conf_file and not in_mem:
                File "/usr/lib/python2.7/site-packages/salt/modules/iptables.py", line 89, in _conf
                  ' Please file an issue with SaltStack')
              SaltException: Saving iptables to file is not supported on Void. Please file an issue with SaltStack
     Started: 16:37:57.859667
    Duration: 1.511 ms
     Changes:
```

### New Behavior

It works now.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
