### PR TITLE
Fix anchor to _linux-iptables

### DIFF
--- a/doc/topics/tutorials/firewall.rst
+++ b/doc/topics/tutorials/firewall.rst
@@ -91,8 +91,6 @@ firewall.
 
    yast2 firewall
 
-.. _linux-iptables:
-
 
 Windows
 =======
@@ -136,6 +134,8 @@ following command from the command line or a run prompt:
 
     netsh advfirewall firewall add rule name="Salt" dir=in action=allow protocol=TCP localport=4505-4506
 
+
+.. _linux-iptables:
 
 iptables
 ========


### PR DESCRIPTION
### What does this PR do?
I messed up the `_linux-iptabes` anchor with my PR. A community member brought it to my attention.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/pull/41744#pullrequestreview-45650206