### PR TITLE
Better support for numeric saltenvs

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -257,12 +257,22 @@ def _get_opts(**kwargs):
     Return a copy of the opts for use, optionally load a local config on top
     '''
     opts = copy.deepcopy(__opts__)
+
     if 'localconfig' in kwargs:
-        opts = salt.config.minion_config(kwargs['localconfig'], defaults=opts)
-    else:
-        if 'saltenv' in kwargs:
+        return salt.config.minion_config(kwargs['localconfig'], defaults=opts)
+
+    if 'saltenv' in kwargs:
+        saltenv = kwargs['saltenv']
+        if not isinstance(saltenv, six.string_types):
+            opts['environment'] = str(kwargs['saltenv'])
+        else:
             opts['environment'] = kwargs['saltenv']
-        if 'pillarenv' in kwargs:
+
+    if 'pillarenv' in kwargs:
+        pillarenv = kwargs['pillarenv']
+        if not isinstance(pillarenv, six.string_types):
+            opts['pillarenv'] = str(kwargs['pillarenv'])
+        else:
             opts['pillarenv'] = kwargs['pillarenv']
 
     return opts


### PR DESCRIPTION
When passing the saltenv on the CLI when running states, it is passed through PyYAML. This means that a numeric saltenv (e.g. ``2017.7``) would be loaded as a float, causing an error when the fileclient runs ``salt.utils.path_join()`` and passes the numeric saltenv as one of the path components.

This commit forces CLI saltenvs to be strings.