### PR TITLE
archive.extracted: fix hash sum verification for local archives

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -376,7 +376,7 @@ def extracted(name,
 
         .. versionadded:: 2016.11.0
 
-    source_hash_update
+    source_hash_update : False
         Set this to ``True`` if archive should be extracted if source_hash has
         changed. This would extract regardless of the ``if_missing`` parameter.
 
@@ -871,10 +871,10 @@ def extracted(name,
     if source_hash:
         try:
             source_sum = __salt__['file.get_source_sum'](
-                 source=source_match,
-                 source_hash=source_hash,
-                 source_hash_name=source_hash_name,
-                 saltenv=__env__)
+                source=source_match,
+                source_hash=source_hash,
+                source_hash_name=source_hash_name,
+                saltenv=__env__)
         except CommandExecutionError as exc:
             ret['comment'] = exc.strerror
             return ret
@@ -895,7 +895,7 @@ def extracted(name,
             # Prevent a traceback from attempting to read from a directory path
             salt.utils.rm_rf(cached_source)
 
-    existing_cached_source_sum = _read_cached_checksum(cached_source) \
+    existing_cached_source_sum = _read_cached_checksum(cached_source)
 
     if source_is_local:
         # No need to download archive, it's local to the minion
@@ -962,14 +962,15 @@ def extracted(name,
                 )
                 return file_result
 
-        if source_hash:
-            _update_checksum(cached_source)
-
     else:
         log.debug(
             'Archive %s is already in cache',
             salt.utils.url.redact_http_basic_auth(source_match)
         )
+
+    if source_hash and source_hash_update and not skip_verify:
+        # Create local hash sum file if we're going to track sum update
+        _update_checksum(cached_source)
 
     if archive_format == 'zip' and not password:
         log.debug('Checking %s to see if it is password-protected',
@@ -1174,6 +1175,15 @@ def extracted(name,
     created_destdir = False
 
     if extraction_needed:
+        if source_is_local and source_hash and not skip_verify:
+            ret['result'] = __salt__['file.check_hash'](source_match, source_sum['hsum'])
+            if not ret['result']:
+                ret['comment'] = \
+                    '{0} does not match the desired source_hash {1}'.format(
+                        source_match, source_sum['hsum']
+                    )
+                return ret
+
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = \

--- a/tests/integration/states/archive.py
+++ b/tests/integration/states/archive.py
@@ -33,9 +33,12 @@ else:
     ARCHIVE_DIR = '/tmp/archive'
 
 PORT = 9999
-ARCHIVE_TAR_SOURCE = 'http://localhost:{0}/custom.tar.gz'.format(PORT)
+ARCHIVE_NAME = 'custom.tar.gz'
+ARCHIVE_TAR_SOURCE = 'http://localhost:{0}/{1}'.format(PORT, ARCHIVE_NAME)
+ARCHIVE_LOCAL_TAR_SOURCE = 'file://{0}'.format(os.path.join(STATE_DIR, ARCHIVE_NAME))
 UNTAR_FILE = os.path.join(ARCHIVE_DIR, 'custom/README')
 ARCHIVE_TAR_HASH = 'md5=7643861ac07c30fe7d2310e9f25ca514'
+ARCHIVE_TAR_BAD_HASH = 'md5=d41d8cd98f00b204e9800998ecf8427e'
 
 REDHAT7 = False
 QUERY_OS = platform.dist()
@@ -221,6 +224,55 @@ class ArchiveTest(integration.ModuleCase,
         self.assertSaltTrueReturn(ret)
 
         self._check_extracted(UNTAR_FILE)
+
+    def test_local_archive_extracted(self):
+        '''
+        test archive.extracted with local file
+        '''
+        ret = self.run_state('archive.extracted', name=ARCHIVE_DIR,
+                             source=ARCHIVE_LOCAL_TAR_SOURCE, archive_format='tar')
+        log.debug('ret = %s', ret)
+
+        self.assertSaltTrueReturn(ret)
+
+        self._check_extracted(UNTAR_FILE)
+
+    def test_local_archive_extracted_skip_verify(self):
+        '''
+        test archive.extracted with local file, bad hash and skip_verify
+        '''
+        ret = self.run_state('archive.extracted', name=ARCHIVE_DIR,
+                             source=ARCHIVE_LOCAL_TAR_SOURCE, archive_format='tar',
+                             source_hash=ARCHIVE_TAR_BAD_HASH, skip_verify=True)
+        log.debug('ret = %s', ret)
+
+        self.assertSaltTrueReturn(ret)
+
+        self._check_extracted(UNTAR_FILE)
+
+    def test_local_archive_extracted_with_source_hash(self):
+        '''
+        test archive.extracted with local file and valid hash
+        '''
+        ret = self.run_state('archive.extracted', name=ARCHIVE_DIR,
+                             source=ARCHIVE_LOCAL_TAR_SOURCE, archive_format='tar',
+                             source_hash=ARCHIVE_TAR_HASH)
+        log.debug('ret = %s', ret)
+
+        self.assertSaltTrueReturn(ret)
+
+        self._check_extracted(UNTAR_FILE)
+
+    def test_local_archive_extracted_with_bad_source_hash(self):
+        '''
+        test archive.extracted with local file and bad hash
+        '''
+        ret = self.run_state('archive.extracted', name=ARCHIVE_DIR,
+                             source=ARCHIVE_LOCAL_TAR_SOURCE, archive_format='tar',
+                             source_hash=ARCHIVE_TAR_BAD_HASH)
+        log.debug('ret = %s', ret)
+
+        self.assertSaltFalseReturn(ret)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?
It makes `archive.extracted` verify provided `source_hash` for archives located on Minion's file system (specified as `/full/path/to/archive.tar.gz` or `file:///full/path/to/archive.tar.gz`).

### What issues does this PR fix or reference?
It appears that `archive.extracted` only verify hash sum for a remote sources. I'm not completely sure is that an expected behavior or a bug, but it would be very convenient to be able to verify integrity of local archives which could be produced by other states or even created outside of Salt's control.

Good example is https://github.com/saltstack-formulas/sun-java-formula. It currently uses `curl` to download JDK tarball, because that require passing HTTP cookie in the request. But such method lacks the ability to verify file integrity in "Salty" way.

### Previous Behavior
The `archive.extracted` state completely ignores `source_hash*` parameters.

### New Behavior
The `archive.extracted` state calculates hash sum if `skip_verify` set to `False` and the archive should be extracted. If hash sum does not match the one given in `source_hash` parameter, the state would fail.

### Tests written?
Yes, added 4 integration test cases for local archives extraction.
