### PR TITLE
Remove GitPython from dev requirements files

### DIFF
--- a/requirements/dev_python27.txt
+++ b/requirements/dev_python27.txt
@@ -6,7 +6,6 @@ boto>=2.32.1
 boto3>=1.2.1
 moto>=0.3.6
 SaltPyLint>=v2017.3.6
-GitPython>=0.3
 pytest
 git+https://github.com/eisensheng/pytest-catchlog.git@develop#egg=Pytest-catchlog
 git+https://github.com/saltstack/pytest-salt.git@master#egg=pytest-salt

--- a/requirements/dev_python34.txt
+++ b/requirements/dev_python34.txt
@@ -11,6 +11,5 @@ moto>=0.3.6
 # prevent it from being successfully installed (at least on Python 3.4).
 httpretty
 SaltPyLint>=v2017.2.29
-GitPython>=0.3
 pytest
 git+https://github.com/saltstack/pytest-salt.git@master#egg=pytest-salt


### PR DESCRIPTION
This was added in the past because we put git_pillar configuration in
the integration suite's master config file. However, now that git_pillar
is being tested in its own separate way and no longer requires the
git_pillar config to be in the master config file, it has been removed.
This makes GitPython unnecessary in the dev requirements file. The
reason it was there before was mainly to squelch a bunch of critical
errors that would occur every time the test suite would attempt to
compile the git_pillar items and failed if GitPython wasn't installed.
This was more for the benefit of users running the test suite on their
own than for our jenkins setup of course, since we were installing
GitPython on the Jenkins VMs.