### PR TITLE
force glibc to re-read resolv.conf for fix unexpected error dns parsing

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -763,6 +763,14 @@ def ip_bracket(addr):
     return addr
 
 
+def refresh_dns():
+    '''
+    issue #21397: force glibc to re-read resolv.conf
+    '''
+    if HAS_RESINIT:
+        res_init()
+
+
 @jinja_filter('dns_check')
 def dns_check(addr, port, safe=False, ipv6=None):
     '''
@@ -775,9 +783,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
     lookup = addr
     seen_ipv6 = False
     try:
-        # issue #21397: force glibc to re-read resolv.conf
-        if HAS_RESINIT:
-            res_init()
+        refresh_dns()
         hostnames = socket.getaddrinfo(
             addr, None, socket.AF_UNSPEC, socket.SOCK_STREAM
         )

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -15,6 +15,7 @@ import os.path
 import pprint
 import socket
 import yaml
+import re
 
 import ssl
 try:
@@ -156,6 +157,10 @@ def query(url,
 
     if not backend:
         backend = opts.get('backend', 'tornado')
+
+    match = re.match(r'https?://((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?)($|/)', url)
+    if not match:
+        salt.utils.refresh_dns()
 
     if backend == 'requests':
         if HAS_REQUESTS is False:


### PR DESCRIPTION
In my case, we use CDN to speed up the distribution of files, such as the source (using http(s)://) param of salt.states.file.managed.
Unfortunately, sometimes like salt-minion start before the network is ready, the salt-minion will cache the NS record because of glibc, so the task will continued to fail even the network is normal.


### What does this PR do?
- move the task of re-reading resolv.conf to a function for quickly calling
- call the function of re-reading resolv.conf when the http server use domain name

### What issues does this PR fix or reference?
same as issue #21397

### Previous Behavior
Willnot force glibc re-read resolv.conf even the http server use domain name

### New Behavior
Will force glibc re-read resolv.conf when the http server use domain name

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
