### PR TITLE
[WP] Minion Queue Processing bsc#1039056

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -923,8 +923,6 @@ class MinionManager(MinionBase):
             minion.destroy()
 
 
-
-
 def _process_queue_loop(obj):
     '''
     Process queue loop, controls pool queue and finished processes

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -956,7 +956,7 @@ def _instance_spawner():
     '''
     pooler = CallbackProcessPool()
     while True:
-        section = range(pooler.registered())
+        section = list(range(pooler.registered()))
         while section:  # Fire amount of minions
             section.pop()
             minion_process = threading.Thread(target=_process_queue_loop,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -106,7 +106,8 @@ from salt.executors import FUNCTION_EXECUTORS
 from salt.utils.debug import enable_sigusr1_handler
 from salt.utils.event import tagify
 from salt.utils.odict import OrderedDict
-from salt.utils.process import default_signals, ProcessManager, CallbackProcessPool
+from salt.utils.process import (default_signals, ProcessManager,
+                                CallbackProcessPool, SignalHandlingMultiprocessingProcess)
 from salt.exceptions import (
     CommandExecutionError,
     CommandNotFoundError,
@@ -937,7 +938,7 @@ def _process_queue_loop(obj):
     while True:
         process_pool.swipe()
         if not process_pool.is_full():
-            if not process_pool._process_queue.empty():
+            if not process_pool.is_data():
                 data = process_pool.get_data()
                 name = process_pool.generate_name()
                 process = multiprocessing.Process(target=obj._target, name=name,
@@ -1388,16 +1389,17 @@ class Minion(MinionBase):
         instance = self
         multiprocessing_enabled = self.opts.get('multiprocessing', True)
         if multiprocessing_enabled:
-            if sys.platform.startswith('win'):
-                # let python reconstruct the minion on the other side if we're
-                # running on windows
-                instance = None
             with default_signals(signal.SIGINT, signal.SIGTERM):
-                CallbackProcessPool().add_data(data)
-                #process = SignalHandlingMultiprocessingProcess(
-                #    target=self._target, args=(instance, self.opts, data, self.connected)
-                #)
-                process = None
+                if sys.platform.startswith('win'):
+                    # let python reconstruct the minion on the other side if we're
+                    # running on windows
+                    instance = None
+                    process = SignalHandlingMultiprocessingProcess(target=self._target,
+                                                                   args=(instance, self.opts, data, self.connected))
+                else:
+                    # Process pooling only on Unix at the moment
+                    CallbackProcessPool().add_data(data)
+                    process = None
         else:
             process = threading.Thread(
                 target=self._target,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -933,7 +933,7 @@ def _process_queue_loop(obj):
     :return:
     '''
     process_pool = CallbackProcessPool()  # This only points to the pool, does not create a new one
-    log.debug('{0}: Started process pool', process_pool._id)
+    log.debug('{0}: Started process pool'.format(process_pool._id))
     while True:
         process_pool.swipe()
         if not process_pool.is_full():

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -106,7 +106,7 @@ from salt.executors import FUNCTION_EXECUTORS
 from salt.utils.debug import enable_sigusr1_handler
 from salt.utils.event import tagify
 from salt.utils.odict import OrderedDict
-from salt.utils.process import default_signals, ProcessManager
+from salt.utils.process import default_signals, ProcessManager, CallbackProcessPool
 from salt.exceptions import (
     CommandExecutionError,
     CommandNotFoundError,
@@ -922,6 +922,55 @@ class MinionManager(MinionBase):
             minion.destroy()
 
 
+
+
+def _process_queue_loop(obj):
+    '''
+    Process queue loop, controls pool queue and finished processes
+    of the current minion instance.
+
+    :param obj:
+    :return:
+    '''
+    process_pool = CallbackProcessPool()  # This only points to the pool, does not create a new one
+    log.debug('{0}: Started process pool', process_pool._id)
+    while True:
+        process_pool.swipe()
+        if not process_pool.is_full():
+            if not process_pool._process_queue.empty():
+                data = process_pool.get_data()
+                name = process_pool.generate_name()
+                process = multiprocessing.Process(target=obj._target, name=name,
+                                                  args=(obj, obj.opts, data, obj.connected, name))
+                process.start()
+                process.join()
+                process_pool.add(process)
+
+        time.sleep(0.1)  # This is needed to stop CPU consumption
+
+
+def _instance_spawner():
+    '''
+    Instance spawner that activates all registered minion instances
+    :return:
+    '''
+    pooler = CallbackProcessPool()
+    while True:
+        section = range(pooler.registered())
+        while section:  # Fire amount of minions
+            section.pop()
+            minion_process = threading.Thread(target=_process_queue_loop,
+                                              args=(pooler.get_registered(),))
+            minion_process.setDaemon(True)
+            minion_process.start()
+        time.sleep(0.1)
+
+# Start poller
+single_event_catcher = threading.Thread(target=_instance_spawner)
+single_event_catcher.setDaemon(True)
+single_event_catcher.start()
+
+
 class Minion(MinionBase):
     '''
     This class instantiates a minion, runs connections for a minion,
@@ -1002,6 +1051,9 @@ class Minion(MinionBase):
         if signal.getsignal(signal.SIGTERM) is signal.SIG_DFL:
             # No custom signal handling was added, install our own
             signal.signal(signal.SIGTERM, self._handle_signals)
+
+        self._target_name = None
+        CallbackProcessPool().register(self)
 
     def _handle_signals(self, signum, sigframe):  # pylint: disable=unused-argument
         self._running = False
@@ -1341,9 +1393,11 @@ class Minion(MinionBase):
                 # running on windows
                 instance = None
             with default_signals(signal.SIGINT, signal.SIGTERM):
-                process = SignalHandlingMultiprocessingProcess(
-                    target=self._target, args=(instance, self.opts, data, self.connected)
-                )
+                CallbackProcessPool().add_data(data)
+                #process = SignalHandlingMultiprocessingProcess(
+                #    target=self._target, args=(instance, self.opts, data, self.connected)
+                #)
+                process = None
         else:
             process = threading.Thread(
                 target=self._target,
@@ -1351,20 +1405,21 @@ class Minion(MinionBase):
                 name=data['jid']
             )
 
-        if multiprocessing_enabled:
-            with default_signals(signal.SIGINT, signal.SIGTERM):
-                # Reset current signals before starting the process in
-                # order not to inherit the current signal handlers
+        if process is not None:
+            if multiprocessing_enabled:
+                with default_signals(signal.SIGINT, signal.SIGTERM):
+                    # Reset current signals before starting the process in
+                    # order not to inherit the current signal handlers
+                    process.start()
+            else:
                 process.start()
-        else:
-            process.start()
 
-        # TODO: remove the windows specific check?
-        if multiprocessing_enabled and not salt.utils.is_windows():
-            # we only want to join() immediately if we are daemonizing a process
-            process.join()
-        else:
-            self.win_proc.append(process)
+            # TODO: remove the windows specific check?
+            if multiprocessing_enabled and not salt.utils.is_windows():
+                # we only want to join() immediately if we are daemonizing a process
+                process.join()
+            else:
+                self.win_proc.append(process)
 
     def ctx(self):
         '''Return a single context manager for the minion's data
@@ -1383,7 +1438,7 @@ class Minion(MinionBase):
             return exitstack
 
     @classmethod
-    def _target(cls, minion_instance, opts, data, connected):
+    def _target(cls, minion_instance, opts, data, connected, name):
         if not minion_instance:
             minion_instance = cls(opts)
             minion_instance.connected = connected
@@ -1403,6 +1458,7 @@ class Minion(MinionBase):
                     get_proc_dir(opts['cachedir'], uid=uid)
                     )
 
+        minion_instance._target_name = name
         with tornado.stack_context.StackContext(minion_instance.ctx):
             if isinstance(data['fun'], tuple) or isinstance(data['fun'], list):
                 Minion._thread_multi_return(minion_instance, opts, data)
@@ -1476,6 +1532,7 @@ class Minion(MinionBase):
                 for executor_name in reversed(executors):
                     executor = get_executor(executor_name)(opts, data, executor)
                 return_data = executor.execute()
+                CallbackProcessPool().finish(minion_instance._target_name)
 
                 if isinstance(return_data, types.GeneratorType):
                     ind = 0

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -106,9 +106,7 @@ from salt.executors import FUNCTION_EXECUTORS
 from salt.utils.debug import enable_sigusr1_handler
 from salt.utils.event import tagify
 from salt.utils.odict import OrderedDict
-from salt.utils.process import (default_signals,
-                                SignalHandlingMultiprocessingProcess,
-                                ProcessManager)
+from salt.utils.process import default_signals, ProcessManager
 from salt.exceptions import (
     CommandExecutionError,
     CommandNotFoundError,

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -787,6 +787,20 @@ class CallbackProcessPool(object):
         '''
         self._minion_instances.append(minion)
 
+    def registered(self):
+        '''
+        Return a number of registered instances
+        :return:
+        '''
+        return len(self._minion_instances)
+
+    def get_registered(self):
+        '''
+        Get oldest registered minion and remove from tracker.
+        :return:
+        '''
+        return self._minion_instances.pop(0)
+
     def get_data(self):
         '''
         Get process data.

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -752,6 +752,12 @@ class CallbackProcessPool(object):
         :param limit:
         '''
         self._process_limit = limit
+        self._pcnt = 0
+
+    @property
+    def pcnt(self):
+        self._pcnt += 1
+        return str(self._pcnt)
 
     def add(self, process):
         '''

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -809,6 +809,13 @@ class CallbackProcessPool(object):
         '''
         return self._process_queue.get_nowait()
 
+    def is_data(self):
+        '''
+        Check for pending process data
+        :return:
+        '''
+        return self._process_queue.empty()
+
     def is_full(self):
         '''
         Check if the pool is full.

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -840,3 +840,10 @@ class CallbackProcessPool(object):
             if self._active_processes.get(ref):
                 self._active_processes.pop(ref)
                 log.debug('{0}: Process reference {1} has been removed', self._id, ref)
+
+    def generate_name(self):
+        '''
+        Generate name for the process.
+        :return:
+        '''
+        return '-'.join([self._id, self.pcnt, str(int(time.time()))])

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -853,7 +853,7 @@ class CallbackProcessPool(object):
             ref = self._finished_processes.get_nowait()
             if self._active_processes.get(ref):
                 self._active_processes.pop(ref)
-                log.debug('{0}: Process reference {1} has been removed', self._id, ref)
+                log.debug('{0}: Process reference {1} has been removed'.format(self._id, ref))
 
     def generate_name(self):
         '''

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -731,6 +731,7 @@ class CallbackProcessPool(object):
     _active_processes = {}
     _finished_processes = multiprocessing.Queue()
     _process_queue = queue.Queue()
+    _id = 'process pool'
 
     def __new__(cls, *args, **kwargs):
         '''
@@ -832,4 +833,4 @@ class CallbackProcessPool(object):
             ref = self._finished_processes.get_nowait()
             if self._active_processes.get(ref):
                 self._active_processes.pop(ref)
-                log.debug('process pool: Process reference {0} has been removed', ref)
+                log.debug('{0}: Process reference {1} has been removed', self._id, ref)

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -719,3 +719,50 @@ def default_signals(*signals):
         signal.signal(signum, old_signals[signum])
 
     del old_signals
+
+
+class CallbackProcessPool(object):
+    _instance = None
+    _minion_instances = []
+    _active_processes = {}
+    _finished_processes = multiprocessing.Queue()
+    _process_queue = queue.Queue()
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super(CallbackProcessPool, cls).__new__(cls, *args, **kwargs)
+        return cls._instance
+
+    def __init__(self, limit=2):
+        self._process_limit = limit
+
+    def add(self, process):
+        self._active_processes[process.name] = process
+
+    def add_data(self, data):
+        self._process_queue.put(data)
+
+    def register(self, minion):
+        self._minion_instances.append(minion)
+
+    def get_data(self):
+        return self._process_queue.get_nowait()
+
+    def is_full(self):
+        return len(self._active_processes) >= self._process_limit
+
+    def finish(self, name):
+        self._finished_processes.put(name)
+
+    def finished(self):
+        return self._finished_processes.qsize()
+
+    def ids(self):
+        return id(self), id(self._finished_processes)
+
+    def swipe(self):
+        while not self._finished_processes.empty():
+            ref = self._finished_processes.get_nowait()
+            if self._active_processes.get(ref):
+                self._active_processes.pop(ref)
+                log.debug('process pool: Process reference {0} has been removed', ref)

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -722,6 +722,10 @@ def default_signals(*signals):
 
 
 class CallbackProcessPool(object):
+    '''
+    Callback process pool is based on entity callbacks it is polling of.
+    The multiprocessing.Pool doesn't like many objects to be serialized.
+    '''
     _instance = None
     _minion_instances = []
     _active_processes = {}
@@ -729,38 +733,101 @@ class CallbackProcessPool(object):
     _process_queue = queue.Queue()
 
     def __new__(cls, *args, **kwargs):
+        '''
+        CallbackProcessPool is a singleton object.
+
+        :param args:
+        :param kwargs:
+        :return:
+        '''
         if not cls._instance:
             cls._instance = super(CallbackProcessPool, cls).__new__(cls, *args, **kwargs)
         return cls._instance
 
     def __init__(self, limit=2):
+        '''
+        Constructor.
+
+        :param limit:
+        '''
         self._process_limit = limit
 
     def add(self, process):
+        '''
+        Add a process to the Pool.
+
+        :param process:
+        :return:
+        '''
         self._active_processes[process.name] = process
 
     def add_data(self, data):
+        '''
+        Add process data.
+
+        :param data:
+        :return:
+        '''
         self._process_queue.put(data)
 
     def register(self, minion):
+        '''
+        Register minion process.
+        TODO: Master? Syndic? Proxy?
+
+        :param minion:
+        :return:
+        '''
         self._minion_instances.append(minion)
 
     def get_data(self):
+        '''
+        Get process data.
+
+        :return:
+        '''
         return self._process_queue.get_nowait()
 
     def is_full(self):
+        '''
+        Check if the pool is full.
+
+        :return:
+        '''
         return len(self._active_processes) >= self._process_limit
 
     def finish(self, name):
+        '''
+        Mark process as finished.
+
+        :param name:
+        :return:
+        '''
         self._finished_processes.put(name)
 
     def finished(self):
+        '''
+        Check if pool has finished its limit.
+
+        :return:
+        '''
         return self._finished_processes.qsize()
 
     def ids(self):
+        '''
+        Return finished process IDs.
+        This method is for debugging purposes.
+
+        :return:
+        '''
         return id(self), id(self._finished_processes)
 
     def swipe(self):
+        '''
+        Cleanup finished procsses from the registry.
+
+        :return:
+        '''
         while not self._finished_processes.empty():
             ref = self._finished_processes.get_nowait()
             if self._active_processes.get(ref):


### PR DESCRIPTION
### What does this PR do?
If you do the following:
```bash
for i in {1..10}; do
    salt --async yourminion  state.some_heavy_state$i queue=true
done
```
In this case you will get 10 running processes on the minion that consumes memory, but does nothing much (queue). So this is an attempt to set the limit of `X` working processes, while other are stays in the queue and waiting for the better times.

The task queuing all that isn't easiest, since `multiprocessing.Pool` seems do not digesting all required Python types. And on top of that, child processes for yet-unknown reason (seems top-level `_current_process` variable is clashing) are reported as "dead" (despite of that they are actually perfectly running). So I decided to have a call-back mechanism, where Minion (and then soon Master in a future) will report its instance finished the job/request/response and is ready to be wiped out from the memory.

Currently the limit is hard-coded to `2` processes.

### Tests written?

Not (yet, WP!)
