### PR TITLE
Add vmware test to check new disk on seperate datastore

### DIFF
--- a/tests/integration/cloud/providers/test_vmware.py
+++ b/tests/integration/cloud/providers/test_vmware.py
@@ -10,7 +10,8 @@ import random
 import string
 
 # Import Salt Libs
-from salt.config import cloud_providers_config
+from salt.config import cloud_providers_config, cloud_config
+
 
 # Import Salt Testing LIbs
 from tests.support.case import ShellCase
@@ -90,12 +91,24 @@ class VMWareTest(ShellCase):
         Tests creating and deleting an instance on vmware and installing salt
         '''
         # create the instance
+        profile = os.path.join(
+                FILES,
+                'conf',
+                'cloud.profiles.d',
+                PROVIDER_NAME + '.conf'
+            )
+
+        profile_config = cloud_config(profile)
+        disk_datastore = profile_config['vmware-test']['devices']['disk']['Hard disk 2']['datastore']
+
         instance = self.run_cloud('-p vmware-test {0}'.format(INSTANCE_NAME), timeout=TIMEOUT)
         ret_str = '{0}:'.format(INSTANCE_NAME)
+        disk_datastore_str = '                [{0}] {1}/Hard disk 2-flat.vmdk'.format(disk_datastore, INSTANCE_NAME)
 
         # check if instance returned with salt installed
         try:
             self.assertIn(ret_str, instance)
+            self.assertIn(disk_datastore_str, instance, msg='Hard Disk 2 did not use the Datastore {0} '.format(disk_datastore))
         except AssertionError:
             self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=TIMEOUT)
             raise

--- a/tests/integration/cloud/providers/test_vmware.py
+++ b/tests/integration/cloud/providers/test_vmware.py
@@ -12,7 +12,6 @@ import string
 # Import Salt Libs
 from salt.config import cloud_providers_config, cloud_config
 
-
 # Import Salt Testing LIbs
 from tests.support.case import ShellCase
 from tests.support.paths import FILES
@@ -108,7 +107,8 @@ class VMWareTest(ShellCase):
         # check if instance returned with salt installed
         try:
             self.assertIn(ret_str, instance)
-            self.assertIn(disk_datastore_str, instance, msg='Hard Disk 2 did not use the Datastore {0} '.format(disk_datastore))
+            self.assertIn(disk_datastore_str, instance,
+                          msg='Hard Disk 2 did not use the Datastore {0} '.format(disk_datastore))
         except AssertionError:
             self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME), timeout=TIMEOUT)
             raise

--- a/tests/integration/files/conf/cloud.profiles.d/vmware.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/vmware.conf
@@ -7,6 +7,8 @@ vmware-test:
     disk:
       Hard disk 1:
         size: 30
+      Hard disk 2:
+        size: 5
         datastore: ''
   resourcepool: ''
   datastore: ''


### PR DESCRIPTION
### What does this PR do?
Adds an extra check in the vmware test to add a separate datastore on `Hard disk 2` and checks to ensure that datastore was used. 

Test for https://github.com/saltstack/salt/pull/36457

### Tests written?

Yes