### PR TITLE
udpated docker_container doc for selinux

### DIFF
--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -283,9 +283,11 @@ def running(name,
 
     binds
         Files/directories to bind mount. Each bind mount should be passed in
-        the format ``<host_path>:<container_path>:<read_only>``, where
-        ``<read_only>`` is one of ``rw`` (for read-write access) or ``ro`` (for
-        read-only access). Can be expressed as a comma-separated list or a YAML
+        the format ``<host_path>:<container_path>:<read_only>,<selinux_context>``, where
+        ``<read_only>`` is one of ``rw`` (for read-write access), ``ro`` (for
+        read-only access) and ``selinux_context``, which is optional and only needed when running
+        on a selinux-enabled host can be ``z`` if the volumne is shared between multiple containers
+        or ``Z`` if the volume should be private. Can be expressed as a comma-separated list or a YAML
         list. The below two examples are equivalent:
 
         .. code-block:: yaml
@@ -303,6 +305,14 @@ def running(name,
                 - binds:
                   - /srv/www:/var/www:ro
                   - /home/myuser/conf/foo.conf:/etc/foo.conf:rw
+
+        .. code-block:: yaml
+
+            foo:
+              docker_container.running:
+                - image: bar/baz:latest
+                - binds:
+                  - /etc/baz.conf:/etc/baz.conf:ro,Z
 
         Optionally, the read-only information can be left off the end and the
         bind mount will be assumed to be read-write. The example below is

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -314,8 +314,8 @@ def running(name,
               docker_container.running:
                 - image: bar/baz:latest
                 - binds:
-                  - /srv/www:/var/www:ro:Z
-                  - /home/myuser/conf/foo.conf:/etc/foo.conf:rw:Z
+                  - /srv/www:/var/www:ro,Z
+                  - /home/myuser/conf/foo.conf:/etc/foo.conf:rw,Z
 
         Optionally, the read-only information can be left off the end and the
         bind mount will be assumed to be read-write. The example below is
@@ -338,7 +338,7 @@ def running(name,
               docker_container.running:
                 - image: bar/baz:latest
                 - binds:
-                  - /srv/www:/var/www:ro:Z
+                  - /srv/www:/var/www:ro,Z
                   - /home/myuser/conf/foo.conf:/etc/foo.conf:Z
 
     blkio_weight

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -283,10 +283,10 @@ def running(name,
 
     binds
         Files/directories to bind mount. Each bind mount should be passed in
-        the format ``<host_path>:<container_path>:<read_only>,<selinux_context>``, where
-        ``<read_only>`` is one of ``rw`` (for read-write access), ``ro`` (for
-        read-only access) and ``selinux_context``, which is optional and only needed when running
-        on a selinux-enabled host can be ``z`` if the volumne is shared between multiple containers
+        the format ``<host_path>:<container_path>:<read_only>,<selinux_context>``.
+        ``<read_only>`` can be one of ``rw`` (for read-write access), ``ro`` (for
+        read-only access). ``selinux_context`` is optional and only needed when running
+        on a selinux-enabled host can be ``z`` if the volume is shared between multiple containers
         or ``Z`` if the volume should be private. Can be expressed as a comma-separated list or a YAML
         list. The below two examples are equivalent:
 
@@ -306,13 +306,16 @@ def running(name,
                   - /srv/www:/var/www:ro
                   - /home/myuser/conf/foo.conf:/etc/foo.conf:rw
 
+        For selinux, you would have :
+
         .. code-block:: yaml
 
             foo:
               docker_container.running:
                 - image: bar/baz:latest
                 - binds:
-                  - /etc/baz.conf:/etc/baz.conf:ro,Z
+                  - /srv/www:/var/www:ro:Z
+                  - /home/myuser/conf/foo.conf:/etc/foo.conf:rw:Z
 
         Optionally, the read-only information can be left off the end and the
         bind mount will be assumed to be read-write. The example below is
@@ -326,6 +329,17 @@ def running(name,
                 - binds:
                   - /srv/www:/var/www:ro
                   - /home/myuser/conf/foo.conf:/etc/foo.conf
+
+        This is also true when using Selinux, the above example would become :
+
+        .. code-block:: yaml
+
+            foo:
+              docker_container.running:
+                - image: bar/baz:latest
+                - binds:
+                  - /srv/www:/var/www:ro:Z
+                  - /home/myuser/conf/foo.conf:/etc/foo.conf:Z
 
     blkio_weight
         Block IO weight (relative weight), accepts a weight value between 10


### PR DESCRIPTION
The selinux flags for volumes where missing in the docker_container state.

### What does this PR do?

This PR fixes a missing documentation on the docker_container state.

### What issues does this PR fix or reference?

It also fix #38368 which is not relevant anymore with the new docker module.

### Tests written?
No
