### PR TITLE
Add missing doc info for pressrelease

### DIFF
--- a/doc/topics/releases/2017.7.0.rst
+++ b/doc/topics/releases/2017.7.0.rst
@@ -191,6 +191,7 @@ Wildcard Versions in :py:func:`pkg.installed <salt.states.pkg.installed>` States
 - The :py:func:`pkg.installed <salt.states.pkg.installed>` state now supports
   wildcards in package versions, for the following platforms:
 
+  - SUSE/openSUSE Leap/Thumbleweed
   - Debian/Ubuntu
   - RHEL/CentOS
   - Arch Linux


### PR DESCRIPTION
### What does this PR do?

Adds a press-release correction: SUSE supports wildcards on pkg version.