### PR TITLE
PY3.6: Eliminate `imp` module DeprecationWarning

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -8,13 +8,13 @@ plugin interfaces used by Salt.
 # Import python libs
 from __future__ import absolute_import
 import os
-import imp
 import sys
 import time
 import logging
 import inspect
 import tempfile
 import functools
+import types
 from collections import MutableMapping
 from zipimport import zipimporter
 
@@ -33,6 +33,13 @@ from salt.utils import is_proxy
 # Import 3rd-party libs
 import salt.ext.six as six
 from salt.ext.six.moves import reload_module
+
+if six.PY3:
+    import importlib.machinery  # pylint: disable=no-name-in-module,import-error
+    import importlib.util  # pylint: disable=no-name-in-module,import-error
+else:
+    import imp
+
 try:
     import pkg_resources
     HAS_PKG_RESOURCES = True
@@ -45,16 +52,24 @@ SALT_BASE_PATH = os.path.abspath(salt.syspaths.INSTALL_DIR)
 LOADED_BASE_NAME = 'salt.loaded'
 
 if six.PY3:
-    # pylint: disable=no-member,no-name-in-module,import-error
-    import importlib.machinery
+    # pylint: disable=no-member
+    MODULE_KIND_SOURCE = 1
+    MODULE_KIND_COMPILED = 2
+    MODULE_KIND_EXTENSION = 3
+    MODULE_KIND_PKG_DIRECTORY = 5
     SUFFIXES = []
     for suffix in importlib.machinery.EXTENSION_SUFFIXES:
-        SUFFIXES.append((suffix, 'rb', 3))
+        SUFFIXES.append((suffix, 'rb', MODULE_KIND_EXTENSION))
     for suffix in importlib.machinery.BYTECODE_SUFFIXES:
-        SUFFIXES.append((suffix, 'rb', 2))
+        SUFFIXES.append((suffix, 'rb', MODULE_KIND_COMPILED))
     for suffix in importlib.machinery.SOURCE_SUFFIXES:
-        SUFFIXES.append((suffix, 'rb', 1))
-    # pylint: enable=no-member,no-name-in-module,import-error
+        SUFFIXES.append((suffix, 'rb', MODULE_KIND_SOURCE))
+    MODULE_KIND_MAP = {
+        MODULE_KIND_SOURCE: importlib.machinery.SourceFileLoader,
+        MODULE_KIND_COMPILED: importlib.machinery.SourcelessFileLoader,
+        MODULE_KIND_EXTENSION: importlib.machinery.ExtensionFileLoader
+    }
+    # pylint: enable=no-member
 else:
     SUFFIXES = imp.get_suffixes()
 
@@ -955,7 +970,7 @@ def _generate_module(name):
         return
 
     code = "'''Salt loaded {0} parent module'''".format(name.split('.')[-1])
-    module = imp.new_module(name)
+    module = types.ModuleType(name)
     exec(code, module.__dict__)
     sys.modules[name] = module
 
@@ -1172,7 +1187,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         if self.opts.get('enable_zip_modules', True) is True:
             self.suffix_map['.zip'] = tuple()
         # allow for module dirs
-        self.suffix_map[''] = ('', '', imp.PKG_DIRECTORY)
+        if six.PY3:
+            self.suffix_map[''] = ('', '', MODULE_KIND_PKG_DIRECTORY)
+        else:
+            self.suffix_map[''] = ('', '', imp.PKG_DIRECTORY)
 
         # create mapping of filename (without suffix) to (path, suffix)
         # The files are added in order of priority, so order *must* be retained.
@@ -1337,14 +1355,45 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                         self.tag,
                         name)
                 if suffix == '':
-                    mod = imp.load_module(mod_namespace, None, fpath, desc)
+                    if six.PY3:
+                        # pylint: disable=no-member
+                        # Package directory, look for __init__
+                        loader_details = [
+                            (importlib.machinery.SourceFileLoader, importlib.machinery.SOURCE_SUFFIXES),
+                            (importlib.machinery.SourcelessFileLoader, importlib.machinery.BYTECODE_SUFFIXES),
+                            (importlib.machinery.ExtensionFileLoader, importlib.machinery.EXTENSION_SUFFIXES),
+                        ]
+                        file_finder = importlib.machinery.FileFinder(fpath, *loader_details)
+                        spec = file_finder.find_spec('__init__')
+                        if spec is None:
+                            raise ImportError()
+                        mod = importlib.util.module_from_spec(spec)
+                        spec.loader.exec_module(mod)
+                        # pylint: enable=no-member
+                        sys.modules[mod_namespace] = mod
+                    else:
+                        mod = imp.load_module(mod_namespace, None, fpath, desc)
                     # reload all submodules if necessary
                     if not self.initial_load:
                         self._reload_submodules(mod)
                 else:
-                    with salt.utils.fopen(fpath, desc[1]) as fn_:
-                        mod = imp.load_module(mod_namespace, fn_, fpath, desc)
-
+                    if six.PY3:
+                        # pylint: disable=no-member
+                        loader_details = (
+                            MODULE_KIND_MAP[desc[2]],
+                            [desc[0]]
+                        )
+                        file_finder = importlib.machinery.FileFinder(fpath_dirname, loader_details)
+                        spec = file_finder.find_spec(name)
+                        if spec is None:
+                            raise ImportError()
+                        mod = importlib.util.module_from_spec(spec)
+                        spec.loader.exec_module(mod)
+                        # pylint: enable=no-member
+                        sys.modules[mod_namespace] = mod
+                    else:
+                        with salt.utils.fopen(fpath, desc[1]) as fn_:
+                            mod = imp.load_module(mod_namespace, fn_, fpath, desc)
         except IOError:
             raise
         except ImportError as exc:

--- a/salt/renderers/pydsl.py
+++ b/salt/renderers/pydsl.py
@@ -338,7 +338,7 @@ from __future__ import absolute_import
 
 import types
 from salt.ext.six import exec_
-from salt.utils import pydsl
+from salt.utils import pydsl, to_str
 from salt.utils.pydsl import PyDslError
 from salt.exceptions import SaltRenderError
 
@@ -346,6 +346,7 @@ __all__ = ['render']
 
 
 def render(template, saltenv='base', sls='', tmplpath=None, rendered_sls=None, **kws):
+    sls = to_str(sls)
     mod = types.ModuleType(sls)
     # Note: mod object is transient. It's existence only lasts as long as
     #       the lowstate data structure that the highstate in the sls file

--- a/salt/renderers/pydsl.py
+++ b/salt/renderers/pydsl.py
@@ -336,7 +336,7 @@ For example:
 '''
 from __future__ import absolute_import
 
-import imp
+import types
 from salt.ext.six import exec_
 from salt.utils import pydsl
 from salt.utils.pydsl import PyDslError
@@ -346,7 +346,7 @@ __all__ = ['render']
 
 
 def render(template, saltenv='base', sls='', tmplpath=None, rendered_sls=None, **kws):
-    mod = imp.new_module(sls)
+    mod = types.ModuleType(sls)
     # Note: mod object is transient. It's existence only lasts as long as
     #       the lowstate data structure that the highstate in the sls file
     #       is compiled to.

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -30,8 +30,8 @@ try:
     # installation time.
     import salt._syspaths as __generated_syspaths  # pylint: disable=no-name-in-module
 except ImportError:
-    import imp
-    __generated_syspaths = imp.new_module('salt._syspaths')
+    import types
+    __generated_syspaths = types.ModuleType('salt._syspaths')
     for key in ('ROOT_DIR', 'CONFIG_DIR', 'CACHE_DIR', 'SOCK_DIR',
                 'SRV_ROOT_DIR', 'BASE_FILE_ROOTS_DIR',
                 'BASE_PILLAR_ROOTS_DIR', 'BASE_THORIUM_ROOTS_DIR',

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -12,7 +12,6 @@ import datetime
 import errno
 import fnmatch
 import hashlib
-import imp
 import json
 import logging
 import numbers
@@ -44,6 +43,10 @@ from salt.ext.six.moves import zip
 from stat import S_IMODE
 # pylint: enable=import-error,redefined-builtin
 
+if six.PY3:
+    import importlib.util  # pylint: disable=no-name-in-module,import-error
+else:
+    import imp
 
 try:
     import cProfile
@@ -837,7 +840,11 @@ def required_module_list(docstring=None):
     modules = parse_docstring(docstring).get('deps', [])
     for mod in modules:
         try:
-            imp.find_module(mod)
+            if six.PY3:
+                if importlib.util.find_spec(mod) is None:  # pylint: disable=no-member
+                    ret.append(mod)
+            else:
+                imp.find_module(mod)
         except ImportError:
             ret.append(mod)
     return ret


### PR DESCRIPTION
### What does this PR do?

This warning keeps recurring:

```
DeprecationWarning: the imp module is deprecated in favour of
importlib; see the module's documentation for alternative uses
```

The `imp` module is deprecated in Python 3.6 and will likely be
removed altogether in a future version of Python.

### Tests written?

No