### PR TITLE
Use a custom dumper to ensure defaultdict and odict work

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -6,7 +6,6 @@ Return/control aspects of the grains data
 # Import python libs
 from __future__ import absolute_import, print_function
 import os
-import math
 import random
 import logging
 import operator
@@ -18,7 +17,6 @@ from functools import reduce  # pylint: disable=redefined-builtin
 import yaml
 import salt.utils.compat
 import salt.ext.six as six
-from salt.ext.six.moves import range  # pylint: disable=import-error,no-name-in-module,redefined-builtin
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -6,7 +6,6 @@ Return/control aspects of the grains data
 # Import python libs
 from __future__ import absolute_import, print_function
 import os
-import copy
 import math
 import random
 import logging
@@ -18,12 +17,12 @@ from functools import reduce  # pylint: disable=redefined-builtin
 # Import 3rd-party libs
 import yaml
 import salt.utils.compat
-from salt.utils.odict import OrderedDict
 import salt.ext.six as six
 from salt.ext.six.moves import range  # pylint: disable=import-error,no-name-in-module,redefined-builtin
 
 # Import salt libs
 import salt.utils
+import salt.utils.yamldumper
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.exceptions import SaltException
 
@@ -252,23 +251,7 @@ def setvals(grains, destructive=False):
         else:
             grains[key] = val
             __grains__[key] = val
-    # Cast defaultdict to dict; is there a more central place to put this?
-    try:
-        yaml_reps = copy.deepcopy(yaml.representer.SafeRepresenter.yaml_representers)
-        yaml_multi_reps = copy.deepcopy(yaml.representer.SafeRepresenter.yaml_multi_representers)
-    except (TypeError, NameError):
-        # This likely means we are running under Python 2.6 which cannot deepcopy
-        # bound methods. Fallback to a modification of deepcopy which can support
-        # this behavior.
-        yaml_reps = salt.utils.compat.deepcopy_bound(yaml.representer.SafeRepresenter.yaml_representers)
-        yaml_multi_reps = salt.utils.compat.deepcopy_bound(yaml.representer.SafeRepresenter.yaml_multi_representers)
-    yaml.representer.SafeRepresenter.add_representer(collections.defaultdict,
-            yaml.representer.SafeRepresenter.represent_dict)
-    yaml.representer.SafeRepresenter.add_representer(OrderedDict,
-            yaml.representer.SafeRepresenter.represent_dict)
-    cstr = yaml.safe_dump(grains, default_flow_style=False)
-    yaml.representer.SafeRepresenter.yaml_representers = yaml_reps
-    yaml.representer.SafeRepresenter.yaml_multi_representers = yaml_multi_reps
+    cstr = salt.utils.yamldumper.safe_dump(grains, default_flow_style=False)
     try:
         with salt.utils.fopen(gfn, 'w+') as fp_:
             fp_.write(cstr)

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -11,6 +11,7 @@ import logging
 import operator
 import collections
 import json
+import math
 from functools import reduce  # pylint: disable=redefined-builtin
 
 # Import 3rd-party libs
@@ -23,6 +24,7 @@ import salt.utils
 import salt.utils.yamldumper
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.exceptions import SaltException
+from salt.ext.six.moves import range
 
 __proxyenabled__ = ['*']
 

--- a/salt/utils/yamldumper.py
+++ b/salt/utils/yamldumper.py
@@ -15,6 +15,8 @@ except ImportError:
     from yaml import Dumper
     from yaml import SafeDumper
 
+import yaml
+import collections
 from salt.utils.odict import OrderedDict
 
 try:
@@ -44,6 +46,23 @@ def represent_ordereddict(dumper, data):
 OrderedDumper.add_representer(OrderedDict, represent_ordereddict)
 SafeOrderedDumper.add_representer(OrderedDict, represent_ordereddict)
 
+OrderedDumper.add_representer(
+    collections.defaultdict,
+    yaml.representer.SafeRepresenter.represent_dict
+)
+SafeOrderedDumper.add_representer(
+    collections.defaultdict,
+    yaml.representer.SafeRepresenter.represent_dict
+)
+
 if HAS_IOFLO:
     OrderedDumper.add_representer(odict, represent_ordereddict)
     SafeOrderedDumper.add_representer(odict, represent_ordereddict)
+
+
+def safe_dump(data, stream=None, **kwargs):
+    '''
+    Use a custom dumper to ensure that defaultdict and OrderedDict are
+    represented properly
+    '''
+    return yaml.dump(data, stream, Dumper=SafeOrderedDumper, **kwargs)


### PR DESCRIPTION
These types are not recognized automatically by PyYAML, so use a custom
dumper with representers added for these data types.