### PR TITLE
Fix Composer state's `name` docs; formatting

### DIFF
--- a/salt/states/composer.py
+++ b/salt/states/composer.py
@@ -66,17 +66,17 @@ def installed(name,
     '''
     Verify that the correct versions of composer dependencies are present.
 
-    dir
-        Directory location of the composer.json file.
+    name
+        Directory location of the ``composer.json`` file.
 
     composer
-        Location of the composer.phar file. If not set composer will
-        just execute "composer" as if it is installed globally.
-        (i.e. /path/to/composer.phar)
+        Location of the ``composer.phar`` file. If not set composer will
+        just execute ``composer`` as if it is installed globally.
+        (i.e. ``/path/to/composer.phar``)
 
     php
         Location of the php executable to use with composer.
-        (i.e. /usr/bin/php)
+        (i.e. ``/usr/bin/php``)
 
     user
         Which system user to run composer as.
@@ -84,32 +84,32 @@ def installed(name,
         .. versionadded:: 2014.1.4
 
     prefer_source
-        --prefer-source option of composer.
+        ``--prefer-source`` option of composer.
 
     prefer_dist
-        --prefer-dist option of composer.
+        ``--prefer-dist`` option of composer.
 
     no_scripts
-        --no-scripts option of composer.
+        ``--no-scripts`` option of composer.
 
     no_plugins
-        --no-plugins option of composer.
+        ``--no-plugins`` option of composer.
 
     optimize
-        --optimize-autoloader option of composer. Recommended for production.
+        ``--optimize-autoloader`` option of composer. Recommended for production.
 
     no_dev
-        --no-dev option for composer. Recommended for production.
+        ``--no-dev`` option for composer. Recommended for production.
 
     quiet
-        --quiet option for composer. Whether or not to return output from composer.
+        ``--quiet`` option for composer. Whether or not to return output from composer.
 
     composer_home
-        $COMPOSER_HOME environment variable
+        ``$COMPOSER_HOME`` environment variable
 
     always_check
-        If True, _always_ run `composer install` in the directory.  This is the
-        default behavior.  If False, only run `composer install` if there is no
+        If ``True``, *always* run ``composer install`` in the directory.  This is the
+        default behavior.  If ``False``, only run ``composer install`` if there is no
         vendor directory present.
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
@@ -193,17 +193,17 @@ def update(name,
     Composer update the directory to ensure we have the latest versions
     of all project dependencies.
 
-    dir
-        Directory location of the composer.json file.
+    name
+        Directory location of the ``composer.json`` file.
 
     composer
-        Location of the composer.phar file. If not set composer will
-        just execute "composer" as if it is installed globally.
+        Location of the ``composer.phar`` file. If not set composer will
+        just execute ``composer`` as if it is installed globally.
         (i.e. /path/to/composer.phar)
 
     php
         Location of the php executable to use with composer.
-        (i.e. /usr/bin/php)
+        (i.e. ``/usr/bin/php``)
 
     user
         Which system user to run composer as.
@@ -211,28 +211,28 @@ def update(name,
         .. versionadded:: 2014.1.4
 
     prefer_source
-        --prefer-source option of composer.
+        ``--prefer-source`` option of composer.
 
     prefer_dist
-        --prefer-dist option of composer.
+        ``--prefer-dist`` option of composer.
 
     no_scripts
-        --no-scripts option of composer.
+        ``--no-scripts`` option of composer.
 
     no_plugins
-        --no-plugins option of composer.
+        ``--no-plugins`` option of composer.
 
     optimize
-        --optimize-autoloader option of composer. Recommended for production.
+        ``--optimize-autoloader`` option of composer. Recommended for production.
 
     no_dev
-        --no-dev option for composer. Recommended for production.
+        ``--no-dev`` option for composer. Recommended for production.
 
     quiet
-        --quiet option for composer. Whether or not to return output from composer.
+        ``--quiet`` option for composer. Whether or not to return output from composer.
 
     composer_home
-        $COMPOSER_HOME environment variable
+        ``$COMPOSER_HOME`` environment variable
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 


### PR DESCRIPTION
Reopening against `2016.11` from #41933.

### What does this PR do?

Ensures the docs mention the `name` argument rather than `dir` (which comes from the module).  This also adds some formatting to improve clarity/readability in doc output when rendered to HTML.  Some of the original formatting was specified in a non-RST format.

### What issues does this PR fix or reference?

None.

### Tests written?

No, not needed

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.