### PR TITLE
Introduce "priority" feature for pyobjects

### DIFF
--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -223,20 +223,56 @@ different grain matches.
 
     class Samba(Map):
         merge = 'samba:lookup'
+        # NOTE: priority is new to 2017.7.0
+        priority = ('os_family', 'os')
+
+        class Ubuntu:
+            __grain__ = 'os'
+            service = 'smbd'
 
         class Debian:
             server = 'samba'
             client = 'samba-client'
             service = 'samba'
 
-        class Ubuntu:
-            __grain__ = 'os'
-            service = 'smbd'
-
-        class RedHat:
+        class RHEL:
+            __match__ = 'RedHat'
             server = 'samba'
             client = 'samba'
             service = 'smb'
+
+.. note::
+    By default, the ``os_family`` grain will be used as the target for
+    matching. This can be overridden by specifying a ``__grain__`` attribute.
+
+    If a ``__match__`` attribute is defined for a given class, then that value
+    will be matched against the targeted grain, otherwise the class name's
+    value will be be matched.
+
+    Given the above example, the following is true:
+
+    1. Minions with an ``os_family`` of **Debian** will be assigned the
+       attributes defined in the **Debian** class.
+    2. Minions with an ``os`` grain of **Ubuntu** will be assigned the
+       attributes defined in the **Ubuntu** class.
+    3. Minions with an ``os_family`` grain of **RedHat** will be assigned the
+       attributes defined in the **RHEL** class.
+
+    That said, sometimes a minion may match more than one class. For instance,
+    in the above example, Ubuntu minions will match both the **Debian** and
+    **Ubuntu** classes, since Ubuntu has an ``os_family`` grain of **Debian**
+    an an ``os`` grain of **Ubuntu**. As of the 2017.7.0 release, the order is
+    dictated by the order of declaration, with classes defined later overriding
+    earlier ones. Addtionally, 2017.7.0 adds support for explicitly defining
+    the ordering using an optional attribute called ``priority``.
+
+    Given the above example, ``os_family`` matches will be processed first,
+    with ``os`` matches processed after. This would have the effect of
+    assigning ``smbd`` as the ``service`` attribute on Ubuntu minions. If the
+    ``priority`` item was not defined, or if the order of the items in the
+    ``priority`` tuple were reversed, Ubuntu minions would have a ``service``
+    attribute of ``samba``, since ``os_family`` matches would have been
+    processed second.
 
 To use this new data you can import it into your state file and then access
 your attributes. To access the data in the map you simply access the attribute

--- a/salt/utils/pyobjects.py
+++ b/salt/utils/pyobjects.py
@@ -330,10 +330,7 @@ class MapMeta(six.with_metaclass(Prepareable, type)):
             # if so use it, otherwise use the name of the object
             # this is so that you can match complex values, which the python
             # class name syntax does not allow
-            if hasattr(filt, '__match__'):
-                match = filt.__match__
-            else:
-                match = item
+            match = getattr(filt, '__match__', item)
 
             match_attrs = {}
             for name in filt.__dict__:
@@ -341,6 +338,32 @@ class MapMeta(six.with_metaclass(Prepareable, type)):
                     match_attrs[name] = filt.__dict__[name]
 
             match_info.append((grain, match, match_attrs))
+
+        # Reorder based on priority
+        try:
+            if not hasattr(cls.priority, '__iter__'):
+                log.error('pyobjects: priority must be an iterable')
+            else:
+                new_match_info = []
+                for grain in cls.priority:
+                    # Using list() here because we will be modifying
+                    # match_info during iteration
+                    for index, item in list(enumerate(match_info)):
+                        try:
+                            if item[0] == grain:
+                                # Add item to new list
+                                new_match_info.append(item)
+                                # Clear item from old list
+                                match_info[index] = None
+                        except TypeError:
+                            # Already moved this item to new list
+                            pass
+                # Add in any remaining items not defined in priority
+                new_match_info.extend([x for x in match_info if x is not None])
+                # Save reordered list as the match_info list
+                match_info = new_match_info
+        except AttributeError:
+            pass
 
         # Check for matches and update the attrs dict accordingly
         attrs = {}

--- a/tests/unit/test_pyobjects.py
+++ b/tests/unit/test_pyobjects.py
@@ -2,9 +2,12 @@
 
 # Import Pytohn libs
 from __future__ import absolute_import
+import jinja2
+import logging
 import os
 import shutil
 import tempfile
+import textwrap
 import uuid
 
 # Import Salt Testing libs
@@ -19,6 +22,9 @@ from salt.template import compile_template
 from salt.utils.odict import OrderedDict
 from salt.utils.pyobjects import (StateFactory, State, Registry,
                                   SaltObject, InvalidFunction, DuplicateState)
+
+log = logging.getLogger(__name__)
+
 File = StateFactory('file')
 Service = StateFactory('service')
 
@@ -58,32 +64,34 @@ Service = StateFactory('service')
 Service.running(extend('apache'), watch=[{'file': '/etc/file'}])
 '''
 
-map_template = '''#!pyobjects
+map_prefix = '''\
+#!pyobjects
 from salt.utils.pyobjects import StateFactory
 Service = StateFactory('service')
 
 
 class Samba(Map):
-    priority = ('os_family', 'os')
+'''
 
-    class Debian:
-        server = 'samba'
-        client = 'samba-client'
-        service = 'samba'
-
-    class RougeChapeau:
-        __match__ = 'RedHat'
-        server = 'samba'
-        client = 'samba'
-        service = 'smb'
-
-    class Ubuntu:
-        __grain__ = 'os'
-        service = 'smbd'
-
+map_suffix = '''
 with Pkg.installed("samba", names=[Samba.server, Samba.client]):
     Service.running("samba", name=Samba.service)
 '''
+
+map_data = {
+    'debian': "    class Debian:\n"
+              "        server = 'samba'\n"
+              "        client = 'samba-client'\n"
+              "        service = 'samba'\n",
+    'centos': "    class RougeChapeau:\n"
+              "        __match__ = 'RedHat'\n"
+              "        server = 'samba'\n"
+              "        client = 'samba'\n"
+              "        service = 'smb'\n",
+    'ubuntu': "    class Ubuntu:\n"
+              "        __grain__ = 'os'\n"
+              "        service = 'smbd'\n"
+}
 
 import_template = '''#!pyobjects
 import salt://map.sls
@@ -138,6 +146,24 @@ Service = StateFactory('service')
 with Pkg.installed("pkg"):
     Service.running("service", watch=File("file"), require=Cmd("cmd"))
 '''
+
+
+class MapBuilder(object):
+    def build_map(self, template=None):
+        '''
+        Build from a specific template or just use a default if no template
+        is passed to this function.
+        '''
+        if template is None:
+            template = textwrap.dedent('''\
+                {{ ubuntu }}
+                {{ centos }}
+                {{ debian }}
+                ''')
+        full_template = map_prefix + template + map_suffix
+        ret = jinja2.Template(full_template).render(**map_data)
+        log.debug('built map: \n%s', ret)
+        return ret
 
 
 class StateTests(TestCase):
@@ -292,7 +318,7 @@ class RendererMixin(object):
                                 state.opts['renderer_whitelist'])
 
 
-class RendererTests(RendererMixin, StateTests):
+class RendererTests(RendererMixin, StateTests, MapBuilder):
     def test_basic(self):
         ret = self.render(basic_template)
         self.assertEqual(ret, OrderedDict([
@@ -350,7 +376,7 @@ class RendererTests(RendererMixin, StateTests):
                 })
             ]))
 
-        self.write_template_file("map.sls", map_template)
+        self.write_template_file("map.sls", self.build_map())
         render_and_assert(import_template)
         render_and_assert(from_import_template)
         render_and_assert(import_as_template)
@@ -359,7 +385,7 @@ class RendererTests(RendererMixin, StateTests):
         render_and_assert(recursive_import_template)
 
     def test_import_scope(self):
-        self.write_template_file("map.sls", map_template)
+        self.write_template_file("map.sls", self.build_map())
         self.write_template_file("recursive_map.sls", recursive_map_template)
 
         def do_render():
@@ -401,34 +427,73 @@ class RendererTests(RendererMixin, StateTests):
         ]))
 
 
-class MapTests(RendererMixin, TestCase):
+class MapTests(RendererMixin, TestCase, MapBuilder):
     maxDiff = None
 
-    def test_map(self):
-        def samba_with_grains(grains):
-            return self.render(map_template, {'grains': grains})
+    debian_grains = {'os_family': 'Debian', 'os': 'Debian'}
+    ubuntu_grains = {'os_family': 'Debian', 'os': 'Ubuntu'}
+    centos_grains = {'os_family': 'RedHat', 'os': 'CentOS'}
 
-        def assert_ret(ret, server, client, service):
-            self.assertDictEqual(ret, OrderedDict([
-                ('samba', OrderedDict([
-                    ('pkg.installed', [
-                        {'names': [server, client]}
-                    ]),
-                    ('service.running', [
-                        {'name': service},
-                        {'require': [{'pkg': 'samba'}]}
-                    ])
-                ]))
+    debian_attrs = ('samba', 'samba-client', 'samba')
+    ubuntu_attrs = ('samba', 'samba-client', 'smbd')
+    centos_attrs = ('samba', 'samba', 'smb')
+
+    def samba_with_grains(self, template, grains):
+        return self.render(template, {'grains': grains})
+
+    def assert_equal(self, ret, server, client, service):
+        self.assertDictEqual(ret, OrderedDict([
+            ('samba', OrderedDict([
+                ('pkg.installed', [
+                    {'names': [server, client]}
+                ]),
+                ('service.running', [
+                    {'name': service},
+                    {'require': [{'pkg': 'samba'}]}
+                ])
             ]))
+        ]))
 
-        ret = samba_with_grains({'os_family': 'Debian', 'os': 'Debian'})
-        assert_ret(ret, 'samba', 'samba-client', 'samba')
+    def assert_not_equal(self, ret, server, client, service):
+        try:
+            self.assert_equal(ret, server, client, service)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError('both dicts are equal')
 
-        ret = samba_with_grains({'os_family': 'Debian', 'os': 'Ubuntu'})
-        assert_ret(ret, 'samba', 'samba-client', 'smbd')
+    def test_map(self):
 
-        ret = samba_with_grains({'os_family': 'RedHat', 'os': 'CentOS'})
-        assert_ret(ret, 'samba', 'samba', 'smb')
+        # With declarative ordering, the ubuntu-specfic service name should
+        # override the one inherited from debian.
+        template = self.build_map(textwrap.dedent('''\
+            {{ debian }}
+            {{ centos }}
+            {{ ubuntu }}
+            '''))
+
+        ret = self.samba_with_grains(template, self.debian_grains)
+        self.assert_equal(ret, *self.debian_attrs)
+
+        ret = self.samba_with_grains(template, self.ubuntu_grains)
+        self.assert_equal(ret, *self.ubuntu_attrs)
+
+        ret = self.samba_with_grains(template, self.centos_grains)
+        self.assert_equal(ret, *self.centos_attrs)
+
+        # Switching the order, debian should still work fine but ubuntu should
+        # no longer match, since the debian service name should override the
+        # ubuntu one.
+        template = self.build_map(textwrap.dedent('''\
+            {{ ubuntu }}
+            {{ debian }}
+            '''))
+
+        ret = self.samba_with_grains(template, self.debian_grains)
+        self.assert_equal(ret, *self.debian_attrs)
+
+        ret = self.samba_with_grains(template, self.ubuntu_grains)
+        self.assert_not_equal(ret, *self.ubuntu_attrs)
 
 
 class SaltObjectTests(TestCase):

--- a/tests/unit/test_pyobjects.py
+++ b/tests/unit/test_pyobjects.py
@@ -64,7 +64,7 @@ Service = StateFactory('service')
 
 
 class Samba(Map):
-    __merge__ = 'samba:lookup'
+    priority = ('os_family', 'os')
 
     class Debian:
         server = 'samba'


### PR DESCRIPTION
When there are multiple matches (such as when both an `os_family` and `os` grain both match the minion), the order in which they are processed is determined by the iteration order of the class' `__dict__` attribute. Since this would be different in different versions of Python, behavior would be inconsistent depending on which version of Python is being used.

This adds a `priority` attribute to the `Map` subclass which, if present, will re-order the match groups such that the results will be predictable irrespective of Python version.