### PR TITLE
Fix loader to point to custom loader as opposed to base loader

### DIFF
--- a/salt/serializers/yaml.py
+++ b/salt/serializers/yaml.py
@@ -42,7 +42,7 @@ def deserialize(stream_or_string, **options):
     :param options: options given to lower yaml module.
     '''
 
-    options.setdefault('Loader', BaseLoader)
+    options.setdefault('Loader', Loader)
     try:
         return yaml.load(stream_or_string, **options)
     except ScannerError as error:


### PR DESCRIPTION
### What does this PR do?
Currently yaml loader by default points to base loader but it should really be pointing to our custom loader

### Previous Behavior
Use base loader from py yaml library

### New Behavior
Use inherited loader from py yaml so we can extend functionality. Should not affect any interface

### Tests written?

No (not needed)

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
