### PR TITLE
[WP] Minion Queue Processing bsc#1039056

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -105,9 +105,7 @@ from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.utils.debug import enable_sigusr1_handler
 from salt.utils.event import tagify
 from salt.utils.odict import OrderedDict
-from salt.utils.process import (default_signals,
-                                SignalHandlingMultiprocessingProcess,
-                                ProcessManager)
+from salt.utils.process import default_signals, ProcessManager
 from salt.exceptions import (
     CommandExecutionError,
     CommandNotFoundError,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1378,7 +1378,8 @@ class Minion(MinionBase):
                     # running on windows
                     instance = None
                     process = SignalHandlingMultiprocessingProcess(target=self._target,
-                                                                   args=(instance, self.opts, data, self.connected))
+                                                                   args=(instance, self.opts,
+                                                                         data, self.connected, None))
                 else:
                     # Process pooling only on Unix at the moment
                     CallbackProcessPool().add_data(data)
@@ -1386,7 +1387,7 @@ class Minion(MinionBase):
         else:
             process = threading.Thread(
                 target=self._target,
-                args=(instance, self.opts, data, self.connected),
+                args=(instance, self.opts, data, self.connected, None),
                 name=data['jid']
             )
 
@@ -3318,7 +3319,7 @@ class ProxyMinion(Minion):
         self.ready = True
 
     @classmethod
-    def _target(cls, minion_instance, opts, data, connected):
+    def _target(cls, minion_instance, opts, data, connected, name):
         if not minion_instance:
             minion_instance = cls(opts)
             minion_instance.connected = connected

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -908,8 +908,6 @@ class MinionManager(MinionBase):
             minion.destroy()
 
 
-
-
 def _process_queue_loop(obj):
     '''
     Process queue loop, controls pool queue and finished processes

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -941,7 +941,7 @@ def _instance_spawner():
     '''
     pooler = CallbackProcessPool()
     while True:
-        section = range(pooler.registered())
+        section = list(range(pooler.registered()))
         while section:  # Fire amount of minions
             section.pop()
             minion_process = threading.Thread(target=_process_queue_loop,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -918,7 +918,7 @@ def _process_queue_loop(obj):
     :return:
     '''
     process_pool = CallbackProcessPool()  # This only points to the pool, does not create a new one
-    log.debug('{0}: Started process pool', process_pool._id)
+    log.debug('{0}: Started process pool'.format(process_pool._id))
     while True:
         process_pool.swipe()
         if not process_pool.is_full():

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -793,6 +793,20 @@ class CallbackProcessPool(object):
         '''
         self._minion_instances.append(minion)
 
+    def registered(self):
+        '''
+        Return a number of registered instances
+        :return:
+        '''
+        return len(self._minion_instances)
+
+    def get_registered(self):
+        '''
+        Get oldest registered minion and remove from tracker.
+        :return:
+        '''
+        return self._minion_instances.pop(0)
+
     def get_data(self):
         '''
         Get process data.

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -737,6 +737,7 @@ class CallbackProcessPool(object):
     _active_processes = {}
     _finished_processes = multiprocessing.Queue()
     _process_queue = queue.Queue()
+    _id = 'process pool'
 
     def __new__(cls, *args, **kwargs):
         '''
@@ -838,4 +839,4 @@ class CallbackProcessPool(object):
             ref = self._finished_processes.get_nowait()
             if self._active_processes.get(ref):
                 self._active_processes.pop(ref)
-                log.debug('process pool: Process reference {0} has been removed', ref)
+                log.debug('{0}: Process reference {1} has been removed', self._id, ref)

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -815,6 +815,13 @@ class CallbackProcessPool(object):
         '''
         return self._process_queue.get_nowait()
 
+    def is_data(self):
+        '''
+        Check for pending process data
+        :return:
+        '''
+        return self._process_queue.empty()
+
     def is_full(self):
         '''
         Check if the pool is full.

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -758,6 +758,12 @@ class CallbackProcessPool(object):
         :param limit:
         '''
         self._process_limit = limit
+        self._pcnt = 0
+
+    @property
+    def pcnt(self):
+        self._pcnt += 1
+        return str(self._pcnt)
 
     def add(self, process):
         '''

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -846,3 +846,10 @@ class CallbackProcessPool(object):
             if self._active_processes.get(ref):
                 self._active_processes.pop(ref)
                 log.debug('{0}: Process reference {1} has been removed', self._id, ref)
+
+    def generate_name(self):
+        '''
+        Generate name for the process.
+        :return:
+        '''
+        return '-'.join([self._id, self.pcnt, str(int(time.time()))])

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -859,7 +859,7 @@ class CallbackProcessPool(object):
             ref = self._finished_processes.get_nowait()
             if self._active_processes.get(ref):
                 self._active_processes.pop(ref)
-                log.debug('{0}: Process reference {1} has been removed', self._id, ref)
+                log.debug('{0}: Process reference {1} has been removed'.format(self._id, ref))
 
     def generate_name(self):
         '''


### PR DESCRIPTION
### What does this PR do?
If you do the following:
```bash
for i in {1..10}; do
    salt --async yourminion  state.some_heavy_state$i queue=true
done
```
In this case you will get 10 running processes on the minion that consumes memory, but does nothing much (queue). So this is an attempt to set the limit of `X` working processes, while other are stays in the queue and waiting for the better times.

Problems I've hit:

- The task of queuing all that in multiprocessing apparently isn't easiest, since `multiprocessing.Pool` seems do not "digesting" all required Python types and refuses to apply. 
- Child processes for yet-unknown reason are reported as "dead" immadiately (despite of that they are actually perfectly running), so it invalidates the tracking if the process is running or dead (and thus ready to be removed). And even so, such tracking won't be reliable (process still can detach).

So I decided to have an internal call-back mechanism, where the Minion (and then soon Master and other subclassed entities in a future) will report its instance finished the job/request/response and thus are ready to be wiped out from the memory.

Currently the limit is hard-coded to `2` processes.

### Tests written?

Not (yet, WP!)

(moved to `develop` from http://github.com/saltstack/salt/pull/41919)