### PR TITLE
Add support for encrypted tag in yaml serializer 

### DIFF
--- a/salt/serializers/yaml.py
+++ b/salt/serializers/yaml.py
@@ -77,10 +77,25 @@ def serialize(obj, **options):
         raise SerializationError(error)
 
 
+class EncryptedString(str):
+
+    yaml_tag = u'!encrypted'
+
+    @staticmethod
+    def yaml_constructor(loader, tag, node):
+        return EncryptedString(loader.construct_scalar(node))
+
+    @staticmethod
+    def yaml_dumper(dumper, data):
+        return dumper.represent_scalar(EncryptedString.yaml_tag, data.__str__())
+
+
 class Loader(BaseLoader):  # pylint: disable=W0232
     '''Overwrites Loader as not for pollute legacy Loader'''
     pass
 
+
+Loader.add_multi_constructor(EncryptedString.yaml_tag, EncryptedString.yaml_constructor)
 Loader.add_multi_constructor('tag:yaml.org,2002:null', Loader.construct_yaml_null)
 Loader.add_multi_constructor('tag:yaml.org,2002:bool', Loader.construct_yaml_bool)
 Loader.add_multi_constructor('tag:yaml.org,2002:int', Loader.construct_yaml_int)
@@ -100,6 +115,7 @@ class Dumper(BaseDumper):  # pylint: disable=W0232
     '''Overwrites Dumper as not for pollute legacy Dumper'''
     pass
 
+Dumper.add_multi_representer(EncryptedString, EncryptedString.yaml_dumper)
 Dumper.add_multi_representer(type(None), Dumper.represent_none)
 Dumper.add_multi_representer(str, Dumper.represent_str)
 if six.PY2:

--- a/tests/unit/serializers/test_serializers.py
+++ b/tests/unit/serializers/test_serializers.py
@@ -18,6 +18,7 @@ import salt.serializers.yaml as yaml
 import salt.serializers.yamlex as yamlex
 import salt.serializers.msgpack as msgpack
 import salt.serializers.python as python
+from salt.serializers.yaml import EncryptedString
 from salt.serializers import SerializationError
 from salt.utils.odict import OrderedDict
 
@@ -43,10 +44,11 @@ class TestSerializers(TestCase):
     @skipIf(not yaml.available, SKIP_MESSAGE % 'yaml')
     def test_serialize_yaml(self):
         data = {
-            "foo": "bar"
+            "foo": "bar",
+            "encrypted_data": EncryptedString("foo")
         }
         serialized = yaml.serialize(data)
-        assert serialized == '{foo: bar}', serialized
+        assert serialized == '{encrypted_data: !encrypted foo, foo: bar}', serialized
 
         deserialized = yaml.deserialize(serialized)
         assert deserialized == data, deserialized


### PR DESCRIPTION
### What does this PR do?
This pr adds support for a custom tag in yml which allows us to mark a string as encrypted. This is the first step to support encrypted pillars with a better user experience

### What issues does this PR fix or reference?
closes https://github.com/saltstack/salt/issues/41881

### New Behavior
With this pr, we can add a tag to a node in yml which gets loaded as encryptedstring
```
encrypted_data: !encrypted |
                 data that needs to be encrypted
```

When the above code is loaded into python, the type of the object is EncryptedString as opposed to string type.

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
