### PR TITLE
Minor dict diff enhance in tests.

### DIFF
--- a/tests/support/unit.py
+++ b/tests/support/unit.py
@@ -177,6 +177,7 @@ class TestCase(_TestCase):
 
     def run(self, result=None):
         self._prerun_instance_attributes = dir(self)
+        self.maxDiff = None
         outcome = super(TestCase, self).run(result=result)
         for attr in dir(self):
             if attr == '_prerun_instance_attributes':

--- a/tests/unit/test_pyobjects.py
+++ b/tests/unit/test_pyobjects.py
@@ -409,16 +409,16 @@ class MapTests(RendererMixin, TestCase):
             return self.render(map_template, {'grains': grains})
 
         def assert_ret(ret, server, client, service):
-            self.assertEqual(ret, OrderedDict([
-                ('samba', {
-                    'pkg.installed': [
+            self.assertDictEqual(ret, OrderedDict([
+                ('samba', OrderedDict([
+                    ('pkg.installed', [
                         {'names': [server, client]}
-                    ],
-                    'service.running': [
+                    ]),
+                    ('service.running', [
                         {'name': service},
                         {'require': [{'pkg': 'samba'}]}
-                    ]
-                })
+                    ])
+                ]))
             ]))
 
         ret = samba_with_grains({'os_family': 'Debian', 'os': 'Debian'})


### PR DESCRIPTION
### What does this PR do?
* Don't limit the diff size for assertion pretty print if dicts are differ. This allows to understand more without reproducing.
* Expect exactly the same dict as expected to have more useful diff on fail in `map_test`

### What issues does this PR fix or reference?
Related to https://github.com/saltstack/salt-jenkins/issues/435

### Previous Behavior
The test report was looking like this:
```
AssertionError: Order[13 chars]ba', OrderedDict([('pkg.installed', [{'names':[104 chars]]))]) != Order[13 chars]ba', {'pkg.installed': [{'names': ['samba', 's[86 chars]]})])
```
Here we don't see what's the problem.

### New Behavior
Now the diff in the error case looks like this:
```
AssertionError: Order[105 chars]ng', [{'name': 'samba'}, {'require': [{'pkg': 'samba'}]}])]))]) != Order[105 chars]ng', [{'name': 'smbd'}, {'require': [{'pkg': 'samba'}]}])]))])
         OrderedDict([('samba',
                       OrderedDict([('pkg.installed',
                                     [{'names': ['samba', 'samba-client']}]),
                                    ('service.running',
       -                             [{'name': 'samba'},
       ?                                         -  ^
       
       +                             [{'name': 'smbd'},
       ?                                           ^
       
                                      {'require': [{'pkg': 'samba'}]}])]))])
```

### Tests written?
No