### PR TITLE
PY3: Fix importlib usage to use fullname

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1364,7 +1364,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                             (importlib.machinery.ExtensionFileLoader, importlib.machinery.EXTENSION_SUFFIXES),
                         ]
                         file_finder = importlib.machinery.FileFinder(fpath, *loader_details)
-                        spec = file_finder.find_spec('__init__')
+                        spec = file_finder.find_spec(mod_namespace)
                         if spec is None:
                             raise ImportError()
                         mod = importlib.util.module_from_spec(spec)
@@ -1379,12 +1379,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 else:
                     if six.PY3:
                         # pylint: disable=no-member
-                        loader_details = (
-                            MODULE_KIND_MAP[desc[2]],
-                            [desc[0]]
+                        loader = MODULE_KIND_MAP[desc[2]](mod_namespace, fpath)
+                        spec = importlib.util.spec_from_file_location(
+                            mod_namespace, fpath, loader=loader
                         )
-                        file_finder = importlib.machinery.FileFinder(fpath_dirname, loader_details)
-                        spec = file_finder.find_spec(name)
                         if spec is None:
                             raise ImportError()
                         mod = importlib.util.module_from_spec(spec)

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -560,14 +560,8 @@ def py(sfn, string=False, **kwargs):  # pylint: disable=C0103
 
     if six.PY3:
         # pylint: disable=no-member
-        if '.' in base_fname:
-            fname_ext = '.' + base_fname.split('.')[-1]
-        else:
-            fname_ext = ''
-        fpath_dirname = os.path.dirname(sfn)
-        loader_details = (importlib.machinery.SourceFileLoader, [fname_ext])
-        file_finder = importlib.machinery.FileFinder(fpath_dirname, loader_details)
-        spec = file_finder.find_spec(name)
+        loader = importlib.machinery.SourceFileLoader(name, sfn)
+        spec = importlib.util.spec_from_file_location(name, sfn, loader=loader)
         if spec is None:
             raise ImportError()
         mod = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
### What does this PR do?

When a module wasn't loaded using fullname, it wouldn't be able to
find the module by function since `<funcname>.__module__` wouldn't
match what is in `syspaths.modules`. Due to this, calling module functions
on the command line wouldn't work. Fixed this issue. Also optimized usage
of importlib by switching to the `importlib.util.spec_from_file_location`
API.

### Tests written?

No