### PR TITLE
Fix `unit.modules.test_ssh` for Windows

### DIFF
--- a/tests/unit/modules/test_ssh.py
+++ b/tests/unit/modules/test_ssh.py
@@ -92,7 +92,7 @@ class SSHAuthKeyTestCase(TestCase, LoaderModuleMockMixin):
         empty_line = '\n'
         comment_line = '# this is a comment \n'
         # Write out the authorized key to a temporary file
-        temp_file = tempfile.NamedTemporaryFile(delete=False, mode='w+')
+        temp_file = tempfile.NamedTemporaryFile(delete=False)
         # Add comment
         temp_file.write(comment_line)
         # Add empty line for #41335


### PR DESCRIPTION
### What does this PR do?
Fixes problematic line endings in Windows by opening the file in binary mode (default for `tempfile.NamedTemporaryFile` function).

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Previous Behavior
test would fail because line endings were being converted.

### New Behavior
temp file opens in binary, no line ending conversion