### PR TITLE
Implement copy/deepcopy for ContextDict

### DIFF
--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -125,6 +125,22 @@ class ContextDict(collections.MutableMapping):
         else:
             return iter(self.global_data)
 
+    def __copy__(self):
+        new_obj = type(self)(threadsafe=self._threadsafe)
+        if self.active:
+            new_obj.global_data = copy.copy(self._state.data)
+        else:
+            new_obj.global_data = copy.copy(self.global_data)
+        return new_obj
+
+    def __deepcopy__(self, memo):
+        new_obj = type(self)(threadsafe=self._threadsafe)
+        if self.active:
+            new_obj.global_data = copy.deepcopy(self._state.data, memo)
+        else:
+            new_obj.global_data = copy.deepcopy(self.global_data, memo)
+        return new_obj
+
 
 class ChildContextDict(collections.MutableMapping):
     '''An overrideable child of ContextDict


### PR DESCRIPTION
### What does this PR do?

There is a use case that causes this error:

```
[WARNING ] The minion function caused an exception: can't pickle
_thread._local objects
```

It happens when `salt.modules.state._get_opts` is invoked and it is
running this line of code:

```
opts = copy.deepcopy(__opts__)
```

It occurs because the `grains` in `__opts__` happens to be a
`NamespacedDictWrapper` with the internal `self.__dict` happening
to be a `ContextDict`. Implementing deepcopy for `ContextDict` fixes
this error.

### Tests written?

No