### PR TITLE
Fix dockerng.network_* name matching

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -2242,6 +2242,9 @@ def network_present(name, driver=None, containers=None):
     # map containers to container's Ids.
     containers = [__salt__['dockerng.inspect_container'](c)['Id'] for c in containers]
     networks = __salt__['dockerng.networks'](names=[name])
+    log.trace(
+        'dockerng.network_present: current networks: {0}'.format(networks)
+    )
 
     # networks will contain all Docker networks which partially match 'name'.
     # We need to loop through to find the matching network, if there is one.
@@ -2311,6 +2314,9 @@ def network_absent(name, driver=None):
            'comment': ''}
 
     networks = __salt__['dockerng.networks'](names=[name])
+    log.trace(
+        'dockerng.network_present: current networks: {0}'.format(networks)
+    )
 
     # networks will contain all Docker networks which partially match 'name'.
     # We need to loop through to find the matching network, if there is one.

--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -2242,8 +2242,17 @@ def network_present(name, driver=None, containers=None):
     # map containers to container's Ids.
     containers = [__salt__['dockerng.inspect_container'](c)['Id'] for c in containers]
     networks = __salt__['dockerng.networks'](names=[name])
+
+    # networks will contain all Docker networks which partially match 'name'.
+    # We need to loop through to find the matching network, if there is one.
+    network = None
     if networks:
-        network = networks[0]  # we expect network's name to be unique
+        for network_iter in networks:
+            if network_iter['Name'] == name:
+                network = network_iter
+                break
+
+    if network is not None:
         if all(c in network['Containers'] for c in containers):
             ret['result'] = True
             ret['comment'] = 'Network \'{0}\' already exists.'.format(name)
@@ -2302,7 +2311,17 @@ def network_absent(name, driver=None):
            'comment': ''}
 
     networks = __salt__['dockerng.networks'](names=[name])
-    if not networks:
+
+    # networks will contain all Docker networks which partially match 'name'.
+    # We need to loop through to find the matching network, if there is one.
+    network = None
+    if networks:
+        for network_iter in networks:
+            if network_iter['Name'] == name:
+                network = network_iter
+                break
+
+    if network is None:
         ret['result'] = True
         ret['comment'] = 'Network \'{0}\' already absent'.format(name)
         return ret

--- a/tests/unit/states/dockerng_test.py
+++ b/tests/unit/states/dockerng_test.py
@@ -698,10 +698,18 @@ class DockerngTestCase(TestCase):
         dockerng_create_network = Mock(return_value='created')
         dockerng_connect_container_to_network = Mock(return_value='connected')
         dockerng_inspect_container = Mock(return_value={'Id': 'abcd'})
+        # Get dockerng.networks to return a network with a name which is a superset of the name of
+        # the network which is to be created, despite this network existing we should still expect
+        # that the new network will be created.
+        # Regression test for #41982.
+        dockerng_networks = Mock(return_value=[{
+            'Name': 'network_foobar',
+            'Containers': {'container': {}}
+        }])
         __salt__ = {'dockerng.create_network': dockerng_create_network,
                     'dockerng.inspect_container': dockerng_inspect_container,
                     'dockerng.connect_container_to_network': dockerng_connect_container_to_network,
-                    'dockerng.networks': Mock(return_value=[]),
+                    'dockerng.networks': dockerng_networks,
                     }
         with patch.dict(dockerng_state.__dict__,
                         {'__salt__': __salt__}):
@@ -744,6 +752,36 @@ class DockerngTestCase(TestCase):
                                'comment': '',
                                'changes': {'disconnected': 'disconnected',
                                            'removed': 'removed'},
+                               'result': True})
+
+    def test_network_absent_with_matching_network(self):
+        '''
+        Test dockerng.network_absent when the specified network does not exist,
+        but another network with a name which is a superset of the specified
+        name does exist.  In this case we expect there to be no attempt to remove
+        any network.
+        Regression test for #41982.
+        '''
+        dockerng_remove_network = Mock(return_value='removed')
+        dockerng_disconnect_container_from_network = Mock(return_value='disconnected')
+        dockerng_networks = Mock(return_value=[{
+            'Name': 'network_foobar',
+            'Containers': {'container': {}}
+        }])
+        __salt__ = {'dockerng.remove_network': dockerng_remove_network,
+                    'dockerng.disconnect_container_from_network': dockerng_disconnect_container_from_network,
+                    'dockerng.networks': dockerng_networks,
+                    }
+        with patch.dict(dockerng_state.__dict__,
+                        {'__salt__': __salt__}):
+            ret = dockerng_state.network_absent(
+                'network_foo',
+                )
+        dockerng_disconnect_container_from_network.assert_not_called()
+        dockerng_remove_network.assert_not_called()
+        self.assertEqual(ret, {'name': 'network_foo',
+                               'comment': 'Network \'network_foo\' already absent',
+                               'changes': {},
                                'result': True})
 
     def test_volume_present(self):

--- a/tests/unit/states/dockerng_test.py
+++ b/tests/unit/states/dockerng_test.py
@@ -724,9 +724,13 @@ class DockerngTestCase(TestCase):
         '''
         dockerng_remove_network = Mock(return_value='removed')
         dockerng_disconnect_container_from_network = Mock(return_value='disconnected')
+        dockerng_networks = Mock(return_value=[{
+            'Name': 'network_foo',
+            'Containers': {'container': {}}
+        }])
         __salt__ = {'dockerng.remove_network': dockerng_remove_network,
                     'dockerng.disconnect_container_from_network': dockerng_disconnect_container_from_network,
-                    'dockerng.networks': Mock(return_value=[{'Containers': {'container': {}}}]),
+                    'dockerng.networks': dockerng_networks,
                     }
         with patch.dict(dockerng_state.__dict__,
                         {'__salt__': __salt__}):


### PR DESCRIPTION
Fixes #41982

### What does this PR do?
Updates the states so that they loop through the list of networks returned from `dockerng.networks` to check that one of the networks returned fully matches the name of the network that needs to be ensured to be present or absent.

Another option would be to add an argument to the `dockerng.networks` execution module to enable strict matching.  This would probably be preferable to repeating the logic in the states, but I didn't want to meddle too much as the execution module is currently just wrapping the docker-py library.

### What issues does this PR fix or reference?
#41982

### Previous Behavior
`dockerng.network_present` would not create a network if another network with a partially matching name already existed, `docker.network_absent` would try to remove a network which didn't exist if there was another network in existence with a partially matching name.

```
user@host ~ $ sudo docker network ls | grep cde
e982840fa7a1        abcdef              bridge              local
user@host ~ $ sudo salt '*' state.apply docker.network.test_present test=True
host.domain:
----------
          ID: test_network_present
    Function: dockerng.network_present
        Name: cde
      Result: True
     Comment: Network 'cde' already exists.
     Started: 15:14:34.886654
    Duration: 5.399 ms
     Changes:   

Summary for host.domain
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:   5.399 ms
user@host ~ $ sudo salt '*' state.apply docker.network.test_present
host.domain:
----------
          ID: test_network_present
    Function: dockerng.network_present
        Name: cde
      Result: True
     Comment: Network 'cde' already exists.
     Started: 15:14:41.984847
    Duration: 9.433 ms
     Changes:   

Summary for host.domain
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:   9.433 ms
user@host ~ $ sudo salt '*' state.apply docker.network.test_absent test=True
host.domain:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: cde
      Result: None
     Comment: The network 'cde' will be removed
     Started: 15:16:26.964736
    Duration: 4.956 ms
     Changes:   

Summary for host.domain
------------
Succeeded: 1 (unchanged=1)
Failed:    0
------------
Total states run:     1
Total run time:   4.956 ms
user@host ~ $ sudo salt '*' state.apply docker.network.test_absent
host.domain:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: cde
      Result: False
     Comment: Failed to remove network 'cde': Error 404: {"message":"network cde not found"}
     Started: 15:16:14.349035
    Duration: 9.475 ms
     Changes:   

Summary for host.domain
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   9.475 ms
ERROR: Minions returned with non-zero exit code
```

### New Behavior
The `dockerng.network_present` and `dockerng.network_absent` states correctly recognise whether a network is present or absent, even if another network with a partially matching name exists:
```
user@host ~ $ sudo docker network ls | grep cde
e982840fa7a1        abcdef              bridge              local
user@host ~ $ sudo salt '*' state.apply .docker.network.test_present test=True
host.domain.com:
----------
          ID: test_network_present
    Function: dockerng.network_present
        Name: cde
      Result: None
     Comment: The network 'cde' will be created
     Started: 16:21:02.715381
    Duration: 4.757 ms
     Changes:   

Summary for host.domain.com
------------
Succeeded: 1 (unchanged=1)
Failed:    0
------------
Total states run:     1
Total run time:   4.757 ms
user@host ~ $ sudo salt '*' state.apply .docker.network.test_present
host.domain.com:
----------
          ID: test_network_present
    Function: dockerng.network_present
        Name: cde
      Result: True
     Comment: 
     Started: 16:21:41.720032
    Duration: 501.139 ms
     Changes:   
              ----------
              created:
                  ----------
                  Id:
                      246079aa13211fe681949b2f6f5066c2b425e631645296e078a0acff4fafbf9a
                  Warning:

Summary for host.domain.com
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time: 501.139 ms
user@host ~ $ sudo docker network ls | grep cde
e982840fa7a1        abcdef              bridge              local
246079aa1321        cde                 bridge              local
user@host ~ $ sudo salt '*' state.apply .docker.network.test_absent test=True
host.domain.com:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: cde
      Result: None
     Comment: The network 'cde' will be removed
     Started: 16:21:52.552362
    Duration: 5.432 ms
     Changes:   

Summary for host.domain.com
------------
Succeeded: 1 (unchanged=1)
Failed:    0
------------
Total states run:     1
Total run time:   5.432 ms
user@host ~ $ sudo salt '*' state.apply .docker.network.test_absent
host.domain.com:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: cde
      Result: True
     Comment: 
     Started: 16:22:09.832561
    Duration: 383.447 ms
     Changes:   
              ----------
              removed:
                  None

Summary for host.domain.com
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time: 383.447 ms
user@host ~ $ sudo docker network ls | grep cde
e982840fa7a1        abcdef              bridge              local
user@host ~ $ sudo salt '*' state.apply .docker.network.test_absent test=True
host.domain.com:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: cde
      Result: True
     Comment: Network 'cde' already absent
     Started: 16:22:18.913120
    Duration: 5.008 ms
     Changes:   

Summary for host.domain.com
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:   5.008 ms
user@host ~ $ sudo salt '*' state.apply .docker.network.test_absent
host.domain.com:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: cde
      Result: True
     Comment: Network 'cde' already absent
     Started: 16:22:24.240611
    Duration: 5.547 ms
     Changes:   

Summary for host.domain.com
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:   5.547 ms
```

### Tests written?
No