### PR TITLE
Accept a list for state_aggregate global setting

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -766,7 +766,7 @@ class State(object):
             agg_opt = low['aggregate']
         if agg_opt is True:
             agg_opt = [low['state']]
-        else:
+        elif not isinstance(agg_opt, list):
             return low
         if low['state'] in agg_opt and not low.get('__agg__'):
             agg_fun = '{0}.mod_aggregate'.format(low['state'])


### PR DESCRIPTION
### What does this PR do?

According to the documentation we can provide a module list to the global setting `state_aggregate` but if we do so it is ignored.

### What issues does this PR fix or reference?

This addresses #18659

### Previous Behavior
Using, for example the following setting in the master global config, the state aggregation is not triggered.
```
state_aggregate:
  - pkg
```
### New Behavior
The aggregation is now triggered for the provided modules (if they support aggregation of course).

### Tests written?

No
