### PR TITLE
Fix `unit.modules.test_cmdmod` on Windows

### DIFF
--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -263,6 +263,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
             with patch('salt.utils.fopen', mock_open(read_data=MOCK_SHELL_FILE)):
                 self.assertFalse(cmdmod._is_valid_shell('foo'))
 
+    @skipIf(salt.utils.is_windows(), 'Do not run on Windows')
     def test_os_environment_remains_intact(self):
         '''
         Make sure the OS environment is not tainted after running a command


### PR DESCRIPTION
### What does this PR do?
Skips test that uses `pwd`. `pwd` is not available on Windows.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439