### PR TITLE
Fix `unit.modules.test_disk` for Windows

### DIFF
--- a/tests/unit/modules/test_disk.py
+++ b/tests/unit/modules/test_disk.py
@@ -152,6 +152,8 @@ class DiskTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(disk.__salt__, {'cmd.retcode': mock}):
             self.assertEqual(disk.format_(device), True)
 
+    @skipIf(not salt.utils.which('lsblk') or not salt.utils.which('df'),
+            'lsblk or df not found')
     def test_fstype(self):
         '''
         unit tests for disk.fstype


### PR DESCRIPTION
### What does this PR do?
Skip test if `lsblk` or `df` not found.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439