### PR TITLE
Fix `unit.modules.test_environ` for Windows

### DIFF
--- a/tests/unit/modules/test_environ.py
+++ b/tests/unit/modules/test_environ.py
@@ -70,7 +70,7 @@ class EnvironTestCase(TestCase, LoaderModuleMockMixin):
         Set multiple salt process environment variables from a dict.
         Returns a dict.
         '''
-        mock_environ = {'key': 'value'}
+        mock_environ = {'KEY': 'value'}
         with patch.dict(os.environ, mock_environ):
             self.assertFalse(environ.setenv('environ'))
 

--- a/tests/unit/modules/test_environ.py
+++ b/tests/unit/modules/test_environ.py
@@ -83,7 +83,7 @@ class EnvironTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(os.environ, mock_environ):
             mock_setval = MagicMock(return_value=None)
             with patch.object(environ, 'setval', mock_setval):
-                self.assertEqual(environ.setenv({}, False, True, False)['key'],
+                self.assertEqual(environ.setenv({}, False, True, False)['KEY'],
                                  None)
 
     def test_get(self):


### PR DESCRIPTION
### What does this PR do?
Uses an uppercase `KEY` in the dictionary in the assert statement. `os.environ` always returns UPPERCASE keys in Windows and OSX because environment variables are case sensitive in those operating systems. Apparently, environment variable names can be mixed case in other OSs.

See:
https://stackoverflow.com/questions/19023238/why-python-uppercases-all-environment-variables-in-windows

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439