### PR TITLE
Fix serialize error when requesting a node

### DIFF
--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -152,7 +152,7 @@ def node(name, **kwargs):
 
     for k8s_node in api_response.items:
         if k8s_node.metadata.name == name:
-            return k8s_node
+            return k8s_node.to_dict()
 
     return None
 


### PR DESCRIPTION
### What does this PR do?

Fix a serialize error when requesting info for a node

### Previous Behavior

    salt '<id>' kubernetes.node name=<name>

did not return. In the minion log you found:

````
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/process.py", line 647, in _run
    return self._original_run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python2.7/site-packages/salt/minion.py", line 1377, in _target
    Minion._thread_return(minion_instance, opts, data)
  File "/usr/lib/python2.7/site-packages/salt/minion.py", line 1533, in _thread_return
    timeout=minion_instance._return_retry_timer()
  File "/usr/lib/python2.7/site-packages/salt/minion.py", line 1708, in _return_pub
    ret_val = self._send_req_sync(load, timeout=timeout)
  File "/usr/lib/python2.7/site-packages/salt/minion.py", line 1223, in _send_req_sync
    return channel.send(load, timeout=timeout)
  File "/usr/lib/python2.7/site-packages/salt/utils/async.py", line 75, in wrap
    ret = self._block_future(ret)
  File "/usr/lib/python2.7/site-packages/salt/utils/async.py", line 85, in _block_future
    return future.result()
  File "/usr/lib64/python2.7/site-packages/tornado/concurrent.py", line 214, in result
    raise_exc_info(self._exc_info)
  File "/usr/lib64/python2.7/site-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/lib/python2.7/site-packages/salt/transport/zeromq.py", line 280, in send
    ret = yield self._crypted_transfer(load, tries=tries, timeout=timeout, raw=raw)
  File "/usr/lib64/python2.7/site-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/lib64/python2.7/site-packages/tornado/concurrent.py", line 214, in result
    raise_exc_info(self._exc_info)
  File "/usr/lib64/python2.7/site-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/lib/python2.7/site-packages/salt/transport/zeromq.py", line 248, in _crypted_transfer
    ret = yield _do_transfer()
  File "/usr/lib64/python2.7/site-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/lib64/python2.7/site-packages/tornado/concurrent.py", line 214, in result
    raise_exc_info(self._exc_info)
  File "/usr/lib64/python2.7/site-packages/tornado/gen.py", line 230, in wrapper
    yielded = next(result)
  File "/usr/lib/python2.7/site-packages/salt/transport/zeromq.py", line 230, in _do_transfer
    self._package_load(self.auth.crypticle.dumps(load)),
  File "/usr/lib/python2.7/site-packages/salt/crypt.py", line 1267, in dumps
    return self.encrypt(self.PICKLE_PAD + self.serial.dumps(obj))
  File "/usr/lib/python2.7/site-packages/salt/payload.py", line 250, in dumps
    return msgpack.dumps(datetime_encoder(msg), use_bin_type=use_bin_type)
  File "/usr/lib64/python2.7/site-packages/msgpack/__init__.py", line 47, in packb
    return Packer(**kwargs).pack(o)
  File "msgpack/_packer.pyx", line 223, in msgpack._packer.Packer.pack (msgpack/_packer.cpp:223)
  File "msgpack/_packer.pyx", line 225, in msgpack._packer.Packer.pack (msgpack/_packer.cpp:225)
  File "msgpack/_packer.pyx", line 184, in msgpack._packer.Packer._pack (msgpack/_packer.cpp:184)
  File "msgpack/_packer.pyx", line 220, in msgpack._packer.Packer._pack (msgpack/_packer.cpp:220)
TypeError: can't serialize 
```

### New Behavior

We get the result

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
