### PR TITLE
Fix dockerng.network_* name matching

### DIFF
--- a/salt/states/docker_network.py
+++ b/salt/states/docker_network.py
@@ -90,8 +90,17 @@ def present(name, driver=None, containers=None):
     # map containers to container's Ids.
     containers = [__salt__['docker.inspect_container'](c)['Id'] for c in containers]
     networks = __salt__['docker.networks'](names=[name])
+
+    # networks will contain all Docker networks which partially match 'name'.
+    # We need to loop through to find the matching network, if there is one.
+    network = None
     if networks:
-        network = networks[0]  # we expect network's name to be unique
+        for network_iter in networks:
+            if network_iter['Name'] == name:
+                network = network_iter
+                break
+
+    if network is not None:
         if all(c in network['Containers'] for c in containers):
             ret['result'] = True
             ret['comment'] = 'Network \'{0}\' already exists.'.format(name)
@@ -150,7 +159,17 @@ def absent(name, driver=None):
            'comment': ''}
 
     networks = __salt__['docker.networks'](names=[name])
-    if not networks:
+
+    # networks will contain all Docker networks which partially match 'name'.
+    # We need to loop through to find the matching network, if there is one.
+    network = None
+    if networks:
+        for network_iter in networks:
+            if network_iter['Name'] == name:
+                network = network_iter
+                break
+
+    if network is None:
         ret['result'] = True
         ret['comment'] = 'Network \'{0}\' already absent'.format(name)
         return ret

--- a/salt/states/docker_network.py
+++ b/salt/states/docker_network.py
@@ -90,6 +90,9 @@ def present(name, driver=None, containers=None):
     # map containers to container's Ids.
     containers = [__salt__['docker.inspect_container'](c)['Id'] for c in containers]
     networks = __salt__['docker.networks'](names=[name])
+    log.trace(
+        'docker_network.present: current networks: {0}'.format(networks)
+    )
 
     # networks will contain all Docker networks which partially match 'name'.
     # We need to loop through to find the matching network, if there is one.
@@ -159,6 +162,9 @@ def absent(name, driver=None):
            'comment': ''}
 
     networks = __salt__['docker.networks'](names=[name])
+    log.trace(
+        'docker_network.absent: current networks: {0}'.format(networks)
+    )
 
     # networks will contain all Docker networks which partially match 'name'.
     # We need to loop through to find the matching network, if there is one.

--- a/tests/unit/states/test_docker_network.py
+++ b/tests/unit/states/test_docker_network.py
@@ -43,10 +43,18 @@ class DockerNetworkTestCase(TestCase, LoaderModuleMockMixin):
         docker_create_network = Mock(return_value='created')
         docker_connect_container_to_network = Mock(return_value='connected')
         docker_inspect_container = Mock(return_value={'Id': 'abcd'})
+        # Get docker.networks to return a network with a name which is a superset of the name of
+        # the network which is to be created, despite this network existing we should still expect
+        # that the new network will be created.
+        # Regression test for #41982.
+        docker_networks = Mock(return_value=[{
+            'Name': 'network_foobar',
+            'Containers': {'container': {}}
+        }])
         __salt__ = {'docker.create_network': docker_create_network,
                     'docker.inspect_container': docker_inspect_container,
                     'docker.connect_container_to_network': docker_connect_container_to_network,
-                    'docker.networks': Mock(return_value=[]),
+                    'docker.networks': docker_networks,
                     }
         with patch.dict(docker_state.__dict__,
                         {'__salt__': __salt__}):
@@ -89,3 +97,33 @@ class DockerNetworkTestCase(TestCase, LoaderModuleMockMixin):
                                'changes': {'disconnected': 'disconnected',
                                            'removed': 'removed'},
                                'result': True})
+
+    def test_absent_with_matching_network(self):
+        '''
+        Test docker_network.absent when the specified network does not exist,
+        but another network with a name which is a superset of the specified
+        name does exist.  In this case we expect there to be no attempt to remove
+        any network.
+        Regression test for #41982.
+        '''
+        docker_remove_network = Mock(return_value='removed')
+        docker_disconnect_container_from_network = Mock(return_value='disconnected')
+        docker_networks = Mock(return_value=[{
+            'Name': 'network_foobar',
+            'Containers': {'container': {}}
+        }])
+        __salt__ = {
+            'docker.remove_network': docker_remove_network,
+            'docker.disconnect_container_from_network': docker_disconnect_container_from_network,
+            'docker.networks': docker_networks,
+        }
+        with patch.dict(docker_state.__dict__,
+                        {'__salt__': __salt__}):
+            ret = docker_state.absent('network_foo')
+        docker_disconnect_container_from_network.assert_not_called()
+        docker_remove_network.assert_not_called()
+        self.assertEqual(ret, {'name': 'network_foo',
+                               'comment': 'Network \'network_foo\' already absent',
+                               'changes': {},
+                               'result': True})
+

--- a/tests/unit/states/test_docker_network.py
+++ b/tests/unit/states/test_docker_network.py
@@ -126,4 +126,3 @@ class DockerNetworkTestCase(TestCase, LoaderModuleMockMixin):
                                'comment': 'Network \'network_foo\' already absent',
                                'changes': {},
                                'result': True})
-

--- a/tests/unit/states/test_docker_network.py
+++ b/tests/unit/states/test_docker_network.py
@@ -69,10 +69,14 @@ class DockerNetworkTestCase(TestCase, LoaderModuleMockMixin):
         '''
         docker_remove_network = Mock(return_value='removed')
         docker_disconnect_container_from_network = Mock(return_value='disconnected')
+        docker_networks = Mock(return_value=[{
+            'Name': 'network_foo',
+            'Containers': {'container': {}}
+        }])
         __salt__ = {
             'docker.remove_network': docker_remove_network,
             'docker.disconnect_container_from_network': docker_disconnect_container_from_network,
-            'docker.networks': Mock(return_value=[{'Containers': {'container': {}}}]),
+            'docker.networks': docker_networks,
         }
         with patch.dict(docker_state.__dict__,
                         {'__salt__': __salt__}):


### PR DESCRIPTION
Fixes #41982

### What does this PR do?

This PR is a copy of #41988 but against the 2017.7 branch.  The rest of the description below is copied from there.

Updates the states so that they loop through the list of networks returned from `dockerng.networks` to check that one of the networks returned fully matches the name of the network that needs to be ensured to be present or absent.

Another option would be to add an argument to the `dockerng.networks` execution module to enable strict matching.  This would probably be preferable to repeating the logic in the states, but I didn't want to meddle too much as the execution module is currently just wrapping the docker-py library.

### What issues does this PR fix or reference?
#41982

### Previous Behavior
`dockerng.network_present` would not create a network if another network with a partially matching name already existed, `docker.network_absent` would try to remove a network which didn't exist if there was another network in existence with a partially matching name.

```
user@host ~ $ sudo docker network ls | grep cde
e982840fa7a1        abcdef              bridge              local
user@host ~ $ sudo salt '*' state.apply docker.network.test_present test=True
host.domain:
----------
          ID: test_network_present
    Function: dockerng.network_present
        Name: cde
      Result: True
     Comment: Network 'cde' already exists.
     Started: 15:14:34.886654
    Duration: 5.399 ms
     Changes:   

Summary for host.domain
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:   5.399 ms
user@host ~ $ sudo salt '*' state.apply docker.network.test_present
host.domain:
----------
          ID: test_network_present
    Function: dockerng.network_present
        Name: cde
      Result: True
     Comment: Network 'cde' already exists.
     Started: 15:14:41.984847
    Duration: 9.433 ms
     Changes:   

Summary for host.domain
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:   9.433 ms
user@host ~ $ sudo salt '*' state.apply docker.network.test_absent test=True
host.domain:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: cde
      Result: None
     Comment: The network 'cde' will be removed
     Started: 15:16:26.964736
    Duration: 4.956 ms
     Changes:   

Summary for host.domain
------------
Succeeded: 1 (unchanged=1)
Failed:    0
------------
Total states run:     1
Total run time:   4.956 ms
user@host ~ $ sudo salt '*' state.apply docker.network.test_absent
host.domain:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: cde
      Result: False
     Comment: Failed to remove network 'cde': Error 404: {"message":"network cde not found"}
     Started: 15:16:14.349035
    Duration: 9.475 ms
     Changes:   

Summary for host.domain
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   9.475 ms
ERROR: Minions returned with non-zero exit code
```

### New Behavior
The `dockerng.network_present` and `dockerng.network_absent` states correctly recognise whether a network is present or absent, even if another network with a partially matching name exists:
```
user@host ~ $ sudo docker network ls | grep cde
e982840fa7a1        abcdef              bridge              local
user@host ~ $ sudo salt '*' state.apply .docker.network.test_present test=True
host.domain.com:
----------
          ID: test_network_present
    Function: dockerng.network_present
        Name: cde
      Result: None
     Comment: The network 'cde' will be created
     Started: 16:21:02.715381
    Duration: 4.757 ms
     Changes:   

Summary for host.domain.com
------------
Succeeded: 1 (unchanged=1)
Failed:    0
------------
Total states run:     1
Total run time:   4.757 ms
user@host ~ $ sudo salt '*' state.apply .docker.network.test_present
host.domain.com:
----------
          ID: test_network_present
    Function: dockerng.network_present
        Name: cde
      Result: True
     Comment: 
     Started: 16:21:41.720032
    Duration: 501.139 ms
     Changes:   
              ----------
              created:
                  ----------
                  Id:
                      246079aa13211fe681949b2f6f5066c2b425e631645296e078a0acff4fafbf9a
                  Warning:

Summary for host.domain.com
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time: 501.139 ms
user@host ~ $ sudo docker network ls | grep cde
e982840fa7a1        abcdef              bridge              local
246079aa1321        cde                 bridge              local
user@host ~ $ sudo salt '*' state.apply .docker.network.test_absent test=True
host.domain.com:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: cde
      Result: None
     Comment: The network 'cde' will be removed
     Started: 16:21:52.552362
    Duration: 5.432 ms
     Changes:   

Summary for host.domain.com
------------
Succeeded: 1 (unchanged=1)
Failed:    0
------------
Total states run:     1
Total run time:   5.432 ms
user@host ~ $ sudo salt '*' state.apply .docker.network.test_absent
host.domain.com:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: cde
      Result: True
     Comment: 
     Started: 16:22:09.832561
    Duration: 383.447 ms
     Changes:   
              ----------
              removed:
                  None

Summary for host.domain.com
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time: 383.447 ms
user@host ~ $ sudo docker network ls | grep cde
e982840fa7a1        abcdef              bridge              local
user@host ~ $ sudo salt '*' state.apply .docker.network.test_absent test=True
host.domain.com:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: cde
      Result: True
     Comment: Network 'cde' already absent
     Started: 16:22:18.913120
    Duration: 5.008 ms
     Changes:   

Summary for host.domain.com
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:   5.008 ms
user@host ~ $ sudo salt '*' state.apply .docker.network.test_absent
host.domain.com:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: cde
      Result: True
     Comment: Network 'cde' already absent
     Started: 16:22:24.240611
    Duration: 5.547 ms
     Changes:   

Summary for host.domain.com
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
Total run time:   5.547 ms
```

### Tests written?
No