### PR TITLE
Fix dockerng.network_* ignoring of tests=True

### DIFF
--- a/salt/states/docker_network.py
+++ b/salt/states/docker_network.py
@@ -109,6 +109,10 @@ def present(name, driver=None, containers=None):
             ret['result'] = result
 
     else:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = ('The network \'{0}\' will be created'.format(name))
+            return ret
         try:
             ret['changes']['created'] = __salt__['docker.create_network'](
                 name, driver=driver)
@@ -153,6 +157,11 @@ def absent(name, driver=None):
     if not networks:
         ret['result'] = True
         ret['comment'] = 'Network \'{0}\' already absent'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = ('The network \'{0}\' will be removed'.format(name))
         return ret
 
     for container in networks[0]['Containers']:


### PR DESCRIPTION
Fixes #41982

### What does this PR do?

This PR is a copy of #41977 but against the 2017.7 branch.  The rest of the description below is copied from there.

Adds a check of `__opts__['test']` prior to actually creating/removing the network in the `dockerng.test_present` and `dockerng.test_absent` states.

### What issues does this PR fix or reference?
#41976 

### Previous Behavior
`dockerng.network_present` would create a network even when `test=True` was set, `dockerng.network_absent` would remove a network even when `test=True` was set:
```
user@host ~ $ sudo docker network ls | grep test
user@host ~ $ sudo salt '*' state.apply docker.network.test_present test=True
host.domain:
----------
          ID: test_network_present
    Function: dockerng.network_present
        Name: test
      Result: True
     Comment: 
     Started: 14:42:06.191536
    Duration: 461.163 ms
     Changes:   
              ----------
              created:
                  ----------
                  Id:
                      1d5e94256e208f1ce4f634c4e4047b469c41922d87ec909795addce6412b8fb6
                  Warning:

Summary for host.domain
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time: 461.163 ms
user@host ~ $ sudo docker network ls | grep test
1d5e94256e20        test                bridge              local
user@host ~ $ sudo salt '*' state.apply docker.network.test_absent test=True
host.domain:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: test
      Result: True
     Comment: 
     Started: 14:42:17.596201
    Duration: 321.123 ms
     Changes:   
              ----------
              removed:
                  None

Summary for host.domain
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time: 321.123 ms
user@host ~ $ sudo docker network ls | grep test
user@host ~ $
```

### New Behavior
Setting `test=True` results in the states just printing that they would create/remove the network, rather than actually doing it:
```
user@host ~ $ sudo docker network ls | grep test
user@host ~ $ sudo salt '*' state.apply docker.network.test_present test=True
host.domain:
----------
          ID: test_network_present
    Function: dockerng.network_present
        Name: test
      Result: None
     Comment: The network 'test' will be created
     Started: 14:49:24.748032
    Duration: 21.536 ms
     Changes:   

Summary for host.domain
------------
Succeeded: 1 (unchanged=1)
Failed:    0
------------
Total states run:     1
Total run time:  21.536 ms
user@host ~ $ sudo docker network ls | grep test
user@host ~ $ sudo docker network create test
d6e5b92ad3875183709373ddd58f2774b9c1e7a3d35ea14e3c3a767e34e3bf00
user@host ~ $ sudo docker network ls | grep test
d6e5b92ad387        test                bridge              local
user@host ~ $ sudo salt '*' state.apply docker.network.test_absent test=True
host.domain:
----------
          ID: test_network_absent
    Function: dockerng.network_absent
        Name: test
      Result: None
     Comment: The network 'test' will be removed
     Started: 14:49:43.775741
    Duration: 4.83 ms
     Changes:   

Summary for host.domain
------------
Succeeded: 1 (unchanged=1)
Failed:    0
------------
Total states run:     1
Total run time:   4.830 ms
user@host ~ $ sudo docker network ls | grep test
d6e5b92ad387        test                bridge              local
```

### Tests written?
No