### PR TITLE
Reopen PR #41929 against 2017.7

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -1867,19 +1867,49 @@ def create(image,
 
     binds
         Files/directories to bind mount. Each bind mount should be passed in
-        the format ``<host_path>:<container_path>:<read_only>``, where
-        ``<read_only>`` is one of ``rw`` (for read-write access) or ``ro`` (for
-        read-only access).  Optionally, the read-only information can be left
-        off the end and the bind mount will be assumed to be read-write.
+        one of the following formats:
+
+        - ``<host_path>:<container_path>`` - ``host_path`` is mounted within
+          the container as ``container_path`` with read-write access.
+        - ``<host_path>:<container_path>:<selinux_context>`` - ``host_path`` is
+          mounted within the container as ``container_path`` with read-write
+          access. Additionally, the specified selinux context will be set
+          within the container.
+        - ``<host_path>:<container_path>:<read_only>`` - ``host_path`` is
+          mounted within the container as ``container_path``, with the
+          read-only or read-write setting explicitly defined.
+        - ``<host_path>:<container_path>:<read_only>,<selinux_context>`` -
+          ``host_path`` is mounted within the container as ``container_path``,
+          with the read-only or read-write setting explicitly defined.
+          Additionally, the specified selinux context will be set within the
+          container.
+
+        ``<read_only>`` can be either ``ro`` for read-write access, or ``ro``
+        for read-only access. When omitted, it is assumed to be read-write.
+
+        ``<selinux_context>`` can be ``z`` if the volume is shared between
+        multiple containers, or ``Z`` if the volume should be private.
+
+        .. note::
+            When both ``<read_only>`` and ``<selinux_context>`` are specified,
+            there must be a comma before ``<selinux_context>``.
+
+        Binds can be expressed as a comma-separated list or a Python list,
+        however in cases where both ro/rw and an selinux context are specified,
+        the binds *must* be specified as a Python list.
 
         Examples:
 
         - ``binds=/srv/www:/var/www:ro``
         - ``binds=/srv/www:/var/www:rw``
         - ``binds=/srv/www:/var/www``
+        - ``binds="['/srv/www:/var/www:ro,Z']"``
+        - ``binds="['/srv/www:/var/www:rw,Z']"``
+        - ``binds=/srv/www:/var/www:Z``
 
         .. note::
-            The second and third examples above are equivalent.
+            The second and third examples above are equivalent to each other,
+            as are the last two examples.
 
     blkio_weight
         Block IO weight (relative weight), accepts a weight value between 10

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -1928,15 +1928,20 @@ def create(image,
         comma-separated list or a Python list. Requires Docker 1.2.0 or
         newer.
 
-        Example: ``cap_add=SYS_ADMIN,MKNOD``, ``cap_add="[SYS_ADMIN, MKNOD]"``
+        Examples:
+
+        - ``cap_add=SYS_ADMIN,MKNOD``
+        - ``cap_add="[SYS_ADMIN, MKNOD]"``
 
     cap_drop
         List of capabilities to drop within the container. Can be passed as a
         comma-separated string or a Python list. Requires Docker 1.2.0 or
         newer.
 
-        Example: ``cap_drop=SYS_ADMIN,MKNOD``,
-        ``cap_drop="[SYS_ADMIN, MKNOD]"``
+        Examples:
+
+        - ``cap_drop=SYS_ADMIN,MKNOD``,
+        - ``cap_drop="[SYS_ADMIN, MKNOD]"``
 
     command (or *cmd*)
         Command to run in the container
@@ -2060,8 +2065,10 @@ def create(image,
         List of DNS search domains. Can be passed as a comma-separated list
         or a Python list.
 
-        Example: ``dns_search=foo1.domain.tld,foo2.domain.tld`` or
-        ``dns_search="[foo1.domain.tld, foo2.domain.tld]"``
+        Examples:
+
+        - ``dns_search=foo1.domain.tld,foo2.domain.tld``
+        - ``dns_search="[foo1.domain.tld, foo2.domain.tld]"``
 
     domainname
         Set custom DNS search domains

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -283,9 +283,11 @@ def running(name,
 
     binds
         Files/directories to bind mount. Each bind mount should be passed in
-        the format ``<host_path>:<container_path>:<read_only>``, where
-        ``<read_only>`` is one of ``rw`` (for read-write access) or ``ro`` (for
-        read-only access). Can be expressed as a comma-separated list or a YAML
+        the format ``<host_path>:<container_path>:<read_only>,<selinux_context>``, where
+        ``<read_only>`` is one of ``rw`` (for read-write access), ``ro`` (for
+        read-only access) and ``selinux_context``, which is optional and only needed when running
+        on a selinux-enabled host can be ``z`` if the volumne is shared between multiple containers
+        or ``Z`` if the volume should be private. Can be expressed as a comma-separated list or a YAML
         list. The below two examples are equivalent:
 
         .. code-block:: yaml
@@ -303,6 +305,14 @@ def running(name,
                 - binds:
                   - /srv/www:/var/www:ro
                   - /home/myuser/conf/foo.conf:/etc/foo.conf:rw
+
+        .. code-block:: yaml
+
+            foo:
+              docker_container.running:
+                - image: bar/baz:latest
+                - binds:
+                  - /etc/baz.conf:/etc/baz.conf:ro,Z
 
         Optionally, the read-only information can be left off the end and the
         bind mount will be assumed to be read-write. The example below is

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -314,8 +314,8 @@ def running(name,
               docker_container.running:
                 - image: bar/baz:latest
                 - binds:
-                  - /srv/www:/var/www:ro:Z
-                  - /home/myuser/conf/foo.conf:/etc/foo.conf:rw:Z
+                  - /srv/www:/var/www:ro,Z
+                  - /home/myuser/conf/foo.conf:/etc/foo.conf:rw,Z
 
         Optionally, the read-only information can be left off the end and the
         bind mount will be assumed to be read-write. The example below is
@@ -338,7 +338,7 @@ def running(name,
               docker_container.running:
                 - image: bar/baz:latest
                 - binds:
-                  - /srv/www:/var/www:ro:Z
+                  - /srv/www:/var/www:ro,Z
                   - /home/myuser/conf/foo.conf:/etc/foo.conf:Z
 
     blkio_weight

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -283,10 +283,10 @@ def running(name,
 
     binds
         Files/directories to bind mount. Each bind mount should be passed in
-        the format ``<host_path>:<container_path>:<read_only>,<selinux_context>``, where
-        ``<read_only>`` is one of ``rw`` (for read-write access), ``ro`` (for
-        read-only access) and ``selinux_context``, which is optional and only needed when running
-        on a selinux-enabled host can be ``z`` if the volumne is shared between multiple containers
+        the format ``<host_path>:<container_path>:<read_only>,<selinux_context>``.
+        ``<read_only>`` can be one of ``rw`` (for read-write access), ``ro`` (for
+        read-only access). ``selinux_context`` is optional and only needed when running
+        on a selinux-enabled host can be ``z`` if the volume is shared between multiple containers
         or ``Z`` if the volume should be private. Can be expressed as a comma-separated list or a YAML
         list. The below two examples are equivalent:
 
@@ -306,13 +306,16 @@ def running(name,
                   - /srv/www:/var/www:ro
                   - /home/myuser/conf/foo.conf:/etc/foo.conf:rw
 
+        For selinux, you would have :
+
         .. code-block:: yaml
 
             foo:
               docker_container.running:
                 - image: bar/baz:latest
                 - binds:
-                  - /etc/baz.conf:/etc/baz.conf:ro,Z
+                  - /srv/www:/var/www:ro:Z
+                  - /home/myuser/conf/foo.conf:/etc/foo.conf:rw:Z
 
         Optionally, the read-only information can be left off the end and the
         bind mount will be assumed to be read-write. The example below is
@@ -326,6 +329,17 @@ def running(name,
                 - binds:
                   - /srv/www:/var/www:ro
                   - /home/myuser/conf/foo.conf:/etc/foo.conf
+
+        This is also true when using Selinux, the above example would become :
+
+        .. code-block:: yaml
+
+            foo:
+              docker_container.running:
+                - image: bar/baz:latest
+                - binds:
+                  - /srv/www:/var/www:ro:Z
+                  - /home/myuser/conf/foo.conf:/etc/foo.conf:Z
 
     blkio_weight
         Block IO weight (relative weight), accepts a weight value between 10

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -283,12 +283,35 @@ def running(name,
 
     binds
         Files/directories to bind mount. Each bind mount should be passed in
-        the format ``<host_path>:<container_path>:<read_only>,<selinux_context>``.
-        ``<read_only>`` can be one of ``rw`` (for read-write access), ``ro`` (for
-        read-only access). ``selinux_context`` is optional and only needed when running
-        on a selinux-enabled host can be ``z`` if the volume is shared between multiple containers
-        or ``Z`` if the volume should be private. Can be expressed as a comma-separated list or a YAML
-        list. The below two examples are equivalent:
+        one of the following formats:
+
+        - ``<host_path>:<container_path>`` - ``host_path`` is mounted within
+          the container as ``container_path`` with read-write access.
+        - ``<host_path>:<container_path>:<selinux_context>`` - ``host_path`` is
+          mounted within the container as ``container_path`` with read-write
+          access. Additionally, the specified selinux context will be set
+          within the container.
+        - ``<host_path>:<container_path>:<read_only>`` - ``host_path`` is
+          mounted within the container as ``container_path``, with the
+          read-only or read-write setting explicitly defined.
+        - ``<host_path>:<container_path>:<read_only>,<selinux_context>`` -
+          ``host_path`` is mounted within the container as ``container_path``,
+          with the read-only or read-write setting explicitly defined.
+          Additionally, the specified selinux context will be set within the
+          container.
+
+        ``<read_only>`` can be either ``ro`` for read-write access, or ``ro``
+        for read-only access. When omitted, it is assumed to be read-write.
+
+        ``<selinux_context>`` can be ``z`` if the volume is shared between
+        multiple containers, or ``Z`` if the volume should be private.
+
+        .. note::
+            When both ``<read_only>`` and ``<selinux_context>`` are specified,
+            there must be a comma before ``<selinux_context>``.
+
+        Binds can be expressed as a comma-separated list or a YAML list. The
+        below two examples are equivalent:
 
         .. code-block:: yaml
 
@@ -306,7 +329,8 @@ def running(name,
                   - /srv/www:/var/www:ro
                   - /home/myuser/conf/foo.conf:/etc/foo.conf:rw
 
-        For selinux, you would have :
+        However, in cases where both ro/rw and an selinux context are combined,
+        the only option is to use a YAML list, like so:
 
         .. code-block:: yaml
 
@@ -317,20 +341,8 @@ def running(name,
                   - /srv/www:/var/www:ro,Z
                   - /home/myuser/conf/foo.conf:/etc/foo.conf:rw,Z
 
-        Optionally, the read-only information can be left off the end and the
-        bind mount will be assumed to be read-write. The example below is
-        equivalent to the one above:
-
-        .. code-block:: yaml
-
-            foo:
-              docker_container.running:
-                - image: bar/baz:latest
-                - binds:
-                  - /srv/www:/var/www:ro
-                  - /home/myuser/conf/foo.conf:/etc/foo.conf
-
-        This is also true when using Selinux, the above example would become :
+        Since the second bind in the previous example is mounted read-write,
+        the ``rw`` and comma can be dropped. For example:
 
         .. code-block:: yaml
 


### PR DESCRIPTION
Also, make some clarifications to how selinux context is specified, and clean up some of the read-only/read-write documentation.

Finally, make a couple changes in dockermod.py to express multiple examples as an RST list to conform with other examples elsewhere in that docstring.