### PR TITLE
Out execution module

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -298,6 +298,7 @@ execution modules
     opkg
     oracle
     osquery
+    out
     pacman
     pagerduty
     pagerduty_util

--- a/doc/ref/modules/all/salt.modules.out.rst
+++ b/doc/ref/modules/all/salt.modules.out.rst
@@ -1,0 +1,5 @@
+salt.modules.out module
+=======================
+
+.. automodule:: salt.modules.out
+    :members:

--- a/salt/modules/out.py
+++ b/salt/modules/out.py
@@ -13,9 +13,9 @@ in applications that require human readable data rather than Python objects.
 
 For example, inside a Jinja template:
 
-```jinja
-{{ salt.out.string_format(complex_object) }}
-```
+.. code-block:: jinja
+
+    {{ salt.out.string_format(complex_object, out='highstate') }}
 '''
 from __future__ import absolute_import
 

--- a/salt/modules/out.py
+++ b/salt/modules/out.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+'''
+Output Module
+=============
+
+.. versionadded:: Oxygen
+
+Execution module that processes JSON serializable data
+and returns string having the format as processed by the outputters.
+
+Although this does not bring much value on the CLI, it turns very handy
+in applications that require human readable data rather than Python objects.
+
+For example, inside a Jinja template:
+
+```jinja
+{{ salt.out.string_format(complex_object) }}
+```
+'''
+from __future__ import absolute_import
+
+# Import python libs
+import logging
+log = logging.getLogger(__name__)
+
+# Import salt modules
+import salt.output
+
+__virtualname__ = 'out'
+__proxyenabled__ = ['*']
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def out_format(data, out='nested', opts=None, **kwargs):
+    '''
+    Return the formatted outputter string for the Python object.
+
+    data
+        The JSON serializable object.
+
+    out: ``nested``
+        The name of the output to use to transform the data. Default: ``nested``.
+
+    opts
+        Dictionary of configuration options. Default: ``__opts__``.
+
+    **kwargs
+        Arguments to sent to the outputter module.
+
+    CLI Example:
+
+    ..code-block:: bash
+
+        salt '*' out.out_format "{'key': 'value'}"
+    '''
+    if not opts:
+        opts = __opts__
+    return salt.output.out_format(data, out, opts=opts, **kwargs)
+
+
+def string_format(data, out='nested', opts=None, **kwargs):
+    '''
+    Return the outputter formatted string, removing the ANSI escape sequences.
+
+    data
+        The JSON serializable object.
+
+    out: ``nested``
+        The name of the output to use to transform the data. Default: ``nested``.
+
+    opts
+        Dictionary of configuration options. Default: ``__opts__``.
+
+    **kwargs
+        Arguments to sent to the outputter module.
+
+    CLI Example:
+
+    ..code-block:: bash
+
+        salt '*' out.string_format "{'key': 'value'}" out=table
+    '''
+    if not opts:
+        opts = __opts__
+    return salt.output.string_format(data, out, opts=opts, **kwargs)
+
+
+def html_format(data, out='nested', opts=None, **kwargs):
+    '''
+    Return the formatted string as HTML.
+
+    data
+        The JSON serializable object.
+
+    out: ``nested``
+        The name of the output to use to transform the data. Default: ``nested``.
+
+    opts
+        Dictionary of configuration options. Default: ``__opts__``.
+
+    **kwargs
+        Arguments to sent to the outputter module.
+
+    CLI Example:
+
+    ..code-block:: bash
+
+        salt '*' out.html_format "{'key': 'value'}" out=yaml
+    '''
+    if not opts:
+        opts = __opts__
+    return salt.output.html_format(data, out, opts=opts, **kwargs)


### PR DESCRIPTION
### What does this PR do?

A ridiculously simple execution module whose main purpose is mostly to be used inside templates or whenever we need to transform Python objects into more human readable formats, as presented on the CLI via the `--out` option.

For example, I struggled many times identifying what's the best way to send an email with the result of `state.apply` in the same format as on the CLI, from the `highstate` outputter. This seems to do it pretty well. For example, inside a Jinja template it could be like:

```jinja
{{ salt.out.string_format(my_complex_object, out='highstate') }}
```

But I can see many other use cases.