### PR TITLE
salt.modules.dockermod: ensure that json.loads is fed a string

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -619,7 +619,7 @@ def _client_wrapper(attr, *args, **kwargs):
             api_events = []
             try:
                 for event in ret:
-                    api_events.append(json.loads(event))
+                    api_events.append(json.loads(salt.utils.to_str(event)))
             except Exception as exc:
                 raise CommandExecutionError(
                     'Unable to interpret API event: \'{0}\''.format(event),


### PR DESCRIPTION
json.loads can only handle bytestrings in 3.x in version 3.6 and later.

Resolves #41996.