### PR TITLE
Add backward-compat function for salt.utils.mkstemp()

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -33,6 +33,8 @@ import string
 import subprocess
 import getpass
 
+import salt.utils.files
+
 # Import 3rd-party libs
 from salt.ext import six
 # pylint: disable=import-error
@@ -3453,3 +3455,15 @@ def dequote(val):
     if is_quoted(val):
         return val[1:-1]
     return val
+
+
+def mkstemp(*args, **kwargs):
+    '''
+    Moved to salt.utils.files
+    '''
+    warn_until(
+        'Fluorine',
+        'salt.utils.mkstemp() has been moved to salt.utils.files.mkstemp(). '
+        'Please update references to use the new function name.'
+    )
+    return salt.utils.files.mkstemp(*args, **kwargs)

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -13,7 +13,6 @@ import tempfile
 import time
 
 # Import salt libs
-import salt.utils
 import salt.modules.selinux
 from salt.exceptions import CommandExecutionError, FileLockError, MinionError
 
@@ -83,6 +82,9 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
     Copy files from a source to a destination in an atomic way, and if
     specified cache the file.
     '''
+    # Explicit late import to avoid circular import
+    import salt.utils
+
     if not os.path.isfile(source):
         raise IOError(
             '[Errno 2] No such file or directory: {0}'.format(source)
@@ -260,6 +262,9 @@ def set_umask(mask):
     '''
     Temporarily set the umask and restore once the contextmanager exits
     '''
+    # Explicit late import to avoid circular import
+    import salt.utils
+
     if salt.utils.is_windows():
         # Don't attempt on Windows
         yield


### PR DESCRIPTION
This function has been moved as of 2017.7, but new code added to
2016.11, when merged forward, may still reference the old location. This
allows code like this to work properly once merged forward.