### PR TITLE
Fix `unit.fileserver.test_roots` for Windows

### DIFF
--- a/tests/unit/fileserver/test_roots.py
+++ b/tests/unit/fileserver/test_roots.py
@@ -165,8 +165,8 @@ class RootsTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModuleMockMix
         self.assertIn('empty_dir', ret)
 
     def test_symlink_list(self):
-        file_roots = self.test_symlink_list_file_roots \
-            or self.opts['file_roots']
+        if self.test_symlink_list_file_roots:
+            self.opts['file_roots'] = self.test_symlink_list_file_roots
         ret = roots.symlink_list({'saltenv': 'base'})
         self.assertDictEqual(ret, {'dest_sym': 'source_sym'})
 


### PR DESCRIPTION
### What does this PR do?
The setup for the test creates a new `file_roots` that points to the temp directory in Windows. It then creates a couple files for symlink. The `file_roots` that was pointing to the temp dir was never getting set for the symlink test.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439