### PR TITLE
import salt.minion for EventReturn for Windows

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -59,6 +59,7 @@ import fnmatch
 import hashlib
 import logging
 import datetime
+import sys
 from collections import MutableMapping
 from multiprocessing.util import Finalize
 from salt.ext.six.moves import range
@@ -1159,6 +1160,16 @@ class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
     A dedicated process which listens to the master event bus and queues
     and forwards events to the specified returner.
     '''
+    def __new__(cls, *args, **kwargs):
+        if sys.platform.startswith('win'):
+            # This is required for Windows.  On Linux, when a process is
+            # forked, the module namespace is copied and the current process
+            # gets all of sys.modules from where the fork happens.  This is not
+            # the case for Windows.
+            import salt.minion
+        instance = super(EventReturn, cls).__new__(cls, *args, **kwargs)
+        return instance
+
     def __init__(self, opts, log_queue=None):
         '''
         Initialize the EventReturn system


### PR DESCRIPTION
### What does this PR do?
Because of the way our multiprocessing works on Windows, this module is not
available.  In Linux, the namespace is copied over, and the module is
available, so we only need the import on Windows.

### What issues does this PR fix or reference?
Fixes #41949 

### Tests written?

No