### PR TITLE
Revert "Allow docs to be built under Python 3"

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -77,7 +77,6 @@ MOCK_MODULES = [
     'yaml.nodes',
     'yaml.parser',
     'yaml.scanner',
-    'salt.utils.yamlloader',
     'zmq',
     'zmq.eventloop',
     'zmq.eventloop.ioloop',
@@ -126,7 +125,6 @@ MOCK_MODULES = [
     'ClusterShell',
     'ClusterShell.NodeSet',
     'django',
-    'docker',
     'libvirt',
     'MySQLdb',
     'MySQLdb.cursors',
@@ -171,7 +169,7 @@ MOCK_MODULES = [
 
 for mod_name in MOCK_MODULES:
     if mod_name == 'psutil':
-        mock = Mock(mapping={'total': 0, 'version_info': (0, 6,0)})  # Otherwise it will crash Sphinx
+        mock = Mock(mapping={'total': 0})  # Otherwise it will crash Sphinx
     else:
         mock = Mock()
     sys.modules[mod_name] = mock


### PR DESCRIPTION
Reverts saltstack/salt#41961 temporarily until we can fix to the Python 3 metaclass errors.