### PR TITLE
Re-add msgpack to mocked imports

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -72,6 +72,7 @@ MOCK_MODULES = [
     'Crypto.Signature',
     'Crypto.Signature.PKCS1_v1_5',
     'M2Crypto',
+    'msgpack',
     'yaml',
     'yaml.constructor',
     'yaml.nodes',


### PR DESCRIPTION
Git fail. This commit was somehow missing from #42028.