### PR TITLE
Fix: Reactor emits critical error

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -577,6 +577,8 @@ class Compiler(object):
                 if '__env__' in body:
                     chunk['__env__'] = body['__env__']
                 chunk['__id__'] = name
+                chunk['arg'] = []
+                chunk['kwarg'] = {}
                 for arg in run:
                     if isinstance(arg, six.string_types):
                         funcs.add(arg)
@@ -589,7 +591,7 @@ class Compiler(object):
                                         names.append(_name)
                                 continue
                             else:
-                                chunk.update(arg)
+                                chunk['kwarg'].update(arg)
                 if names:
                     name_order = 1
                     for entry in names:


### PR DESCRIPTION
### What does this PR do?

Under normal usage, the reactor will emit this critical error:

```
[CRITICAL] kwargs must be passed inside the low data within the 'kwarg'
key. See usage of salt.utils.args.parse_input() and
salt.minion.load_args_and_kwargs() elsewhere in the codebase.
 ```

It seems like only `salt.utils.reactor.Reactor` uses `salt.state.Compiler`.
Due to this, it appears safe to customize `Compiler.compile_high_data`
for usage only by the reactor. Since reactor arguments are always named,
we ensure that each 'chunk' has an `arg` field that is an empty list
and a `kwarg` field that contains all the named arguments for use
with the given function call. This conforms to the format expected by
`salt.client.mixins.SyncClientMixin._low`.

### Tests written?

No

Fixes #42400