### PR TITLE
Add the 'provider' key to salt.cloud.CloudClient.create()

### DIFF
--- a/doc/topics/cloud/config.rst
+++ b/doc/topics/cloud/config.rst
@@ -97,7 +97,7 @@ Using the example configuration above:
 
 .. note::
 
-    Salt Cloud provider configurations within ``/etc/cloud.provider.d/ should not
+    Salt Cloud provider configurations within ``/etc/cloud.provider.d/`` should not
     specify the ``providers`` starting key.
 
 It is also possible to have multiple cloud configuration blocks within the same alias block.

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -381,10 +381,9 @@ class CloudClient(object):
 
         .. code-block:: python
 
-            client.create(names=['myinstance'], provider='my-ec2-config',
-                kwargs={'image': 'ami-1624987f', 'size': 't1.micro',
-                        'ssh_username': 'ec2-user', 'securitygroup': 'default',
-                        'delvol_on_destroy': True})
+            client.create(provider='my-ec2-config', names=['myinstance'],
+                image='ami-1624987f', size='t1.micro', ssh_username='ec2-user',
+                securitygroup='default', delvol_on_destroy=True)
         '''
         mapper = salt.cloud.Map(self._opts_defaults())
         providers = self.opts['providers']
@@ -399,7 +398,16 @@ class CloudClient(object):
             vm_ = kwargs.copy()
             vm_['name'] = name
             vm_['driver'] = provider
+
+            # This function doesn't require a profile, but many cloud drivers
+            # check for profile information (which includes the provider key) to
+            # help with config file debugging and setting up instances. Setting
+            # the profile and provider defaults here avoids errors in other
+            # cloud functions relying on these keys. See SaltStack Issue #41971
+            # and PR #38166 for more information.
             vm_['profile'] = None
+            vm_['provider'] = provider
+
             ret[name] = salt.utils.simple_types_filter(
                 mapper.create(vm_))
         return ret

--- a/tests/integration/cloud/test_cloud.py
+++ b/tests/integration/cloud/test_cloud.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+'''
+Integration tests for functions located in the salt.cloud.__init__.py file.
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import os
+import random
+import string
+
+# Import Salt Testing libs
+from tests.support.case import ShellCase
+from tests.support.helpers import expensiveTest
+from tests.support.runtests import RUNTIME_VARS
+
+# Import Salt libs
+import salt.cloud
+from salt.ext.six.moves import range
+
+
+def __random_name(size=6):
+    '''
+    Generates a random cloud instance name
+    '''
+    return 'CLOUD-TEST-' + ''.join(
+        random.choice(string.ascii_uppercase + string.digits)
+        for x in range(size)
+    )
+
+# Create the cloud instance name to be used throughout the tests
+INSTANCE_NAME = __random_name()
+
+
+class CloudClientTestCase(ShellCase):
+    '''
+    Integration tests for the CloudClient class. Uses DigitalOcean as a salt-cloud provider.
+    '''
+
+    @expensiveTest
+    def setUp(self):
+        self.config_file = os.path.join(RUNTIME_VARS.TMP_CONF_CLOUD_PROVIDER_INCLUDES,
+                                        'digital_ocean.conf')
+        self.provider_name = 'digitalocean-config'
+        self.image_name = '14.04.5 x64'
+
+        # Use a --list-images salt-cloud call to see if the Digital Ocean provider is
+        # configured correctly before running any tests.
+        images = self.run_cloud('--list-images {0}'.format(self.provider_name))
+
+        if self.image_name not in [i.strip() for i in images]:
+            self.skipTest(
+                'Image \'{0}\' was not found in image search. Is the {1} provider '
+                'configured correctly for this test?'.format(
+                    self.provider_name,
+                    self.image_name
+                )
+            )
+
+    def test_cloud_client_create_and_delete(self):
+        '''
+        Tests that a VM is created successfully when calling salt.cloud.CloudClient.create(),
+        which does not require a profile configuration.
+
+        Also checks that salt.cloud.CloudClient.destroy() works correctly since this test needs
+        to remove the VM after creating it.
+
+        This test was created as a regression check against Issue #41971.
+        '''
+        cloud_client = salt.cloud.CloudClient(self.config_file)
+
+        # Create the VM using salt.cloud.CloudClient.create() instead of calling salt-cloud
+        created = cloud_client.create(
+            provider=self.provider_name,
+            names=[INSTANCE_NAME],
+            image=self.image_name,
+            location='sfo1',
+            size='512mb',
+            vm_size='512mb'
+        )
+
+        # Check that the VM was created correctly
+        self.assertIn(INSTANCE_NAME, created)
+
+        # Clean up after ourselves and delete the VM
+        deleted = cloud_client.destroy(names=[INSTANCE_NAME])
+
+        # Check that the VM was deleted correctly
+        self.assertIn(INSTANCE_NAME, deleted)


### PR DESCRIPTION
Much like how the 'profile' key exists in this function, the 'provider' key must also exist for other salt-cloud functions to work properly. Various salt-cloud functions rely on provider being available (as it is always available when using cloud profiles), and so it should be available when no profile is used as well.

Also adjusted some rst syntax in the cloud config file as well as the documentation around the create() function. Passing in kwargs as the docs originally suggested does not work.

Fixes #41971

Without this change, the cloud client stack traces:
```
>>> import salt.cloud
>>> cc = salt.cloud.CloudClient('/etc/salt/cloud.providers')
>>> cc.create(provider='do', names=['rally-test-1'], image='14.04.5 x64', location='sfo1', size='512mb', vm_size='512mb')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "salt/cloud/__init__.py", line 404, in create
    mapper.create(vm_))
  File "salt/cloud/__init__.py", line 1182, in create
    alias, driver = vm_['provider'].split(':')
KeyError: 'provider'
```

This change fixes the stack trace and allows the VM to be created successfully. I also wrote a regression test for this issue.