### PR TITLE
Add generate_random_name function to tests helpers

### DIFF
--- a/tests/integration/cloud/providers/test_digital_ocean.py
+++ b/tests/integration/cloud/providers/test_digital_ocean.py
@@ -6,32 +6,17 @@ Integration tests for DigitalOcean APIv2
 # Import Python Libs
 from __future__ import absolute_import
 import os
-import random
-import string
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
 from tests.support.paths import FILES
-from tests.support.helpers import expensiveTest
+from tests.support.helpers import expensiveTest, generate_random_name
 
 # Import Salt Libs
 from salt.config import cloud_providers_config
 
-# Import 3rd-party libs
-from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
-
-
-def __random_name(size=6):
-    '''
-    Generates a random cloud instance name
-    '''
-    return 'CLOUD-TEST-' + ''.join(
-        random.choice(string.ascii_uppercase + string.digits)
-        for x in range(size)
-    )
-
 # Create the cloud instance name to be used throughout the tests
-INSTANCE_NAME = __random_name()
+INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
 PROVIDER_NAME = 'digital_ocean'
 
 

--- a/tests/integration/cloud/providers/test_ec2.py
+++ b/tests/integration/cloud/providers/test_ec2.py
@@ -6,8 +6,6 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
-import random
-import string
 
 # Import Salt Libs
 from salt.config import cloud_providers_config
@@ -15,23 +13,10 @@ from salt.config import cloud_providers_config
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
 from tests.support.paths import FILES
-from tests.support.helpers import expensiveTest
-
-# Import Third-Party Libs
-from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
-
-
-def __random_name(size=6):
-    '''
-    Generates a radom cloud instance name
-    '''
-    return 'CLOUD-TEST-' + ''.join(
-        random.choice(string.ascii_uppercase + string.digits)
-        for x in range(size)
-    )
+from tests.support.helpers import expensiveTest, generate_random_name
 
 # Create the cloud instance name to be used throughout the tests
-INSTANCE_NAME = __random_name()
+INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
 PROVIDER_NAME = 'ec2'
 
 

--- a/tests/integration/cloud/providers/test_gce.py
+++ b/tests/integration/cloud/providers/test_gce.py
@@ -7,8 +7,6 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
-import random
-import string
 
 # Import Salt Libs
 from salt.config import cloud_providers_config
@@ -16,22 +14,9 @@ from salt.config import cloud_providers_config
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
 from tests.support.paths import FILES
-from tests.support.helpers import expensiveTest
-
-# Import Third-Party Libs
-from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
+from tests.support.helpers import expensiveTest, generate_random_name
 
 TIMEOUT = 500
-
-
-def _random_name(size=6):
-    '''
-    Generates a radom cloud instance name
-    '''
-    return 'cloud-test-' + ''.join(
-        random.choice(string.ascii_lowercase + string.digits)
-        for x in range(size)
-    )
 
 
 class GCETest(ShellCase):
@@ -51,7 +36,7 @@ class GCETest(ShellCase):
         provider = 'gce'
         providers = self.run_cloud('--list-providers')
         # Create the cloud instance name to be used throughout the tests
-        self.INSTANCE_NAME = _random_name()
+        self.INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
 
         if profile_str not in providers:
             self.skipTest(

--- a/tests/integration/cloud/providers/test_gogrid.py
+++ b/tests/integration/cloud/providers/test_gogrid.py
@@ -6,31 +6,18 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
-import random
-import string
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
 from tests.support.paths import FILES
-from tests.support.helpers import expensiveTest
+from tests.support.helpers import expensiveTest, generate_random_name
 from tests.support.unit import skipIf
 
 # Import Salt Libs
 from salt.config import cloud_providers_config
-from salt.ext.six.moves import range
-
-
-def __random_name(size=6):
-    '''
-    Generates a random cloud instance name
-    '''
-    return 'CLOUD-TEST-' + ''.join(
-        random.choice(string.ascii_uppercase + string.digits)
-        for x in range(size)
-    )
 
 # Create the cloud instance name to be used throughout the tests
-INSTANCE_NAME = __random_name()
+INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
 PROVIDER_NAME = 'gogrid'
 
 

--- a/tests/integration/cloud/providers/test_joyent.py
+++ b/tests/integration/cloud/providers/test_joyent.py
@@ -6,30 +6,18 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
-import random
-import string
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
 from tests.support.paths import FILES
-from tests.support.helpers import expensiveTest
+from tests.support.helpers import expensiveTest, generate_random_name
 
 # Import Salt Libs
 from salt.config import cloud_providers_config
-from salt.ext.six.moves import range  # pylint: disable=redefined-builtin
 
-
-def __random_name(size=6):
-    '''
-    Generates a random cloud instance name
-    '''
-    return 'CLOUD-TEST-' + ''.join(
-        random.choice(string.ascii_uppercase + string.digits)
-        for x in range(size)
-    )
 
 # Create the cloud instance name to be used throughout the tests
-INSTANCE_NAME = __random_name()
+INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
 PROVIDER_NAME = 'joyent'
 
 

--- a/tests/integration/cloud/providers/test_linode.py
+++ b/tests/integration/cloud/providers/test_linode.py
@@ -6,30 +6,17 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
-import random
-import string
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
 from tests.support.paths import FILES
-from tests.support.helpers import expensiveTest
+from tests.support.helpers import expensiveTest, generate_random_name
 
 # Import Salt Libs
 from salt.config import cloud_providers_config
-from salt.ext.six.moves import range
-
-
-def __random_name(size=6):
-    '''
-    Generates a random cloud instance name
-    '''
-    return 'CLOUD-TEST-' + ''.join(
-        random.choice(string.ascii_uppercase + string.digits)
-        for x in range(size)
-    )
 
 # Create the cloud instance name to be used throughout the tests
-INSTANCE_NAME = __random_name()
+INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
 PROVIDER_NAME = 'linode'
 
 

--- a/tests/integration/cloud/providers/test_msazure.py
+++ b/tests/integration/cloud/providers/test_msazure.py
@@ -6,21 +6,16 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
-import random
-import string
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
 from tests.support.paths import FILES
 from tests.support.unit import skipIf
-from tests.support.helpers import expensiveTest
+from tests.support.helpers import expensiveTest, generate_random_name
 
 # Import Salt Libs
 from salt.config import cloud_providers_config
 from salt.utils.versions import LooseVersion
-
-# Import Third-Party Libs
-from salt.ext.six.moves import range
 
 TIMEOUT = 500
 
@@ -33,18 +28,8 @@ except ImportError:
 if HAS_AZURE and not hasattr(azure, '__version__'):
     import azure.common
 
-
-def __random_name(size=6):
-    '''
-    Generates a random cloud instance name
-    '''
-    return 'CLOUD-TEST-' + ''.join(
-        random.choice(string.ascii_uppercase + string.digits)
-        for x in range(size)
-    )
-
 # Create the cloud instance name to be used throughout the tests
-INSTANCE_NAME = __random_name()
+INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
 PROVIDER_NAME = 'azure'
 PROFILE_NAME = 'azure-test'
 REQUIRED_AZURE = '0.11.1'

--- a/tests/integration/cloud/providers/test_profitbricks.py
+++ b/tests/integration/cloud/providers/test_profitbricks.py
@@ -6,18 +6,15 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
-import random
-import string
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
 from tests.support.paths import FILES
 from tests.support.unit import skipIf
-from tests.support.helpers import expensiveTest
+from tests.support.helpers import expensiveTest, generate_random_name
 
 # Import Salt Libs
 from salt.config import cloud_providers_config
-from salt.ext.six.moves import range
 
 # Import Third-Party Libs
 try:
@@ -26,18 +23,8 @@ try:
 except ImportError:
     HAS_PROFITBRICKS = False
 
-
-def __random_name(size=6):
-    '''
-    Generates a random cloud instance name
-    '''
-    return 'CLOUD-TEST-' + ''.join(
-        random.choice(string.ascii_uppercase + string.digits)
-        for x in range(size)
-    )
-
 # Create the cloud instance name to be used throughout the tests
-INSTANCE_NAME = __random_name()
+INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
 PROVIDER_NAME = 'profitbricks'
 DRIVER_NAME = 'profitbricks'
 

--- a/tests/integration/cloud/providers/test_rackspace.py
+++ b/tests/integration/cloud/providers/test_rackspace.py
@@ -6,18 +6,15 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
-import random
-import string
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
 from tests.support.paths import FILES
 from tests.support.unit import skipIf
-from tests.support.helpers import expensiveTest
+from tests.support.helpers import expensiveTest, generate_random_name
 
 # Import Salt Libs
 from salt.config import cloud_providers_config
-from salt.ext.six.moves import range
 
 # Import Third-Party Libs
 try:
@@ -26,18 +23,8 @@ try:
 except ImportError:
     HAS_LIBCLOUD = False
 
-
-def __random_name(size=6):
-    '''
-    Generates a random cloud instance name
-    '''
-    return 'CLOUD-TEST-' + ''.join(
-        random.choice(string.ascii_uppercase + string.digits)
-        for x in range(size)
-    )
-
 # Create the cloud instance name to be used throughout the tests
-INSTANCE_NAME = __random_name()
+INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
 PROVIDER_NAME = 'rackspace'
 DRIVER_NAME = 'openstack'
 

--- a/tests/integration/cloud/providers/test_vmware.py
+++ b/tests/integration/cloud/providers/test_vmware.py
@@ -6,8 +6,6 @@
 # Import Python Libs
 from __future__ import absolute_import
 import os
-import random
-import string
 
 # Import Salt Libs
 from salt.config import cloud_providers_config, cloud_config
@@ -15,21 +13,10 @@ from salt.config import cloud_providers_config, cloud_config
 # Import Salt Testing LIbs
 from tests.support.case import ShellCase
 from tests.support.paths import FILES
-from tests.support.helpers import expensiveTest
-from salt.ext.six.moves import range
-
-
-def __random_name(size=6):
-    '''
-    Generates a radom cloud instance name
-    '''
-    return 'CLOUD-TEST-' + ''.join(
-        random.choice(string.ascii_uppercase + string.digits)
-        for x in range(size)
-    )
+from tests.support.helpers import expensiveTest, generate_random_name
 
 # Create the cloud instance name to be used throughout the tests
-INSTANCE_NAME = __random_name()
+INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
 PROVIDER_NAME = 'vmware'
 TIMEOUT = 500
 

--- a/tests/integration/cloud/providers/test_vultr.py
+++ b/tests/integration/cloud/providers/test_vultr.py
@@ -6,33 +6,18 @@ Integration tests for Vultr
 # Import Python Libs
 from __future__ import absolute_import
 import os
-import random
-import string
 import time
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
 from tests.support.paths import FILES
-from tests.support.helpers import expensiveTest
+from tests.support.helpers import expensiveTest, generate_random_name
 
 # Import Salt Libs
 from salt.config import cloud_providers_config
 
-# Import 3rd-party libs
-from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
-
-
-def __random_name(size=6):
-    '''
-    Generates a random cloud instance name
-    '''
-    return 'CLOUD-TEST-' + ''.join(
-        random.choice(string.ascii_uppercase + string.digits)
-        for x in range(size)
-    )
-
 # Create the cloud instance name to be used throughout the tests
-INSTANCE_NAME = __random_name()
+INSTANCE_NAME = generate_random_name('CLOUD-TEST-')
 PROVIDER_NAME = 'vultr'
 
 

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -19,8 +19,10 @@ import functools
 import inspect
 import logging
 import os
+import random
 import signal
 import socket
+import string
 import sys
 import threading
 import time
@@ -1329,6 +1331,25 @@ def http_basic_auth(login_cb=lambda username, password: False):
         handler_class._execute = wrap_execute(handler_class._execute)
         return handler_class
     return wrapper
+
+
+def generate_random_name(prefix, size=6):
+    '''
+    Generates a random name by combining the provided prefix with a randomly generated
+    ascii string.
+
+    .. versionadded:: Oxygen
+
+    prefix
+        The string to prefix onto the randomly generated ascii string.
+
+    size
+        The number of characters to generate. Default: 6.
+    '''
+    return prefix + ''.join(
+        random.choice(string.ascii_uppercase + string.digits)
+        for x in range(size)
+    )
 
 
 class Webserver(object):


### PR DESCRIPTION
### What does this PR do?
Adds a new function, `generate_random_name`, to the test helpers. A function similar to this is being used in nearly all of the salt-cloud provider tests, and they're all identical. Instead of repeating this in all of these test files, we should make this more DRY.

It might be useful to other tests in the future, too.
