### PR TITLE
Removes whitespace around yum repo options

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2537,7 +2537,7 @@ def _parse_repo_file(filename):
             if '=' in line:
                 try:
                     comps = line.strip().split('=')
-                    repos[repo][comps[0].strip()] = '='.join(comps[1:])
+                    repos[repo][comps[0].strip()] = '='.join(comps[1:]).strip()
                 except KeyError:
                     log.error(
                         'Failed to parse line in %s, offending line was '


### PR DESCRIPTION
## What does this PR do?

Removes whitespace around yum repo options

### What issues does this PR fix or reference?

Fixes #42041

### Previous Behavior

Leading whitespace around a yum repo option, i.e. `enabled = 1`, would result in the value being stored with the leading whitespace, `" 1"`, causing problems when matching the value.

### New Behavior

The whitespace is stripped, so the value stored would be `"1"`.

### Tests written?

No? I couldn't find any for this module?
