### PR TITLE
Update win_service.py

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -844,7 +844,7 @@ def enable(name, start_type='auto', start_delayed=False, **kwargs):
 
     modify(name, start_type=start_type, start_delayed=start_delayed)
     svcstat = info(name)
-    if start_type == 'auto':
+    if start_type.lower() == 'auto':
         return svcstat['StartType'].lower() == start_type.lower() and svcstat['StartTypeDelayed'] == start_delayed
     else:
         return svcstat['StartType'].lower() == start_type.lower()

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -817,7 +817,7 @@ def enable(name, start_type='auto', start_delayed=False, **kwargs):
 
     Args:
         name (str): The name of the service to enable.
-		
+
         start_type (str): Specifies the service start type. Valid options are as
             follows:
 
@@ -845,7 +845,7 @@ def enable(name, start_type='auto', start_delayed=False, **kwargs):
     modify(name, start_type=start_type, start_delayed=start_delayed)
     svcstat = info(name)
     if start_type == 'auto':
-	    return svcstat['StartType'].lower() == start_type.lower() and svcstat['StartTypeDelayed'] == start_delayed
+        return svcstat['StartType'].lower() == start_type.lower() and svcstat['StartTypeDelayed'] == start_delayed
     else:
         return svcstat['StartType'].lower() == start_type.lower()
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -817,6 +817,7 @@ def enable(name, **kwargs):
 
     Args:
         name (str): The name of the service to enable.
+        **kwargs supports StartType
 
     Returns:
         bool: ``True`` if successful, ``False`` otherwise
@@ -827,8 +828,20 @@ def enable(name, **kwargs):
 
         salt '*' service.enable <service name>
     '''
-    modify(name, start_type='Auto')
-    return info(name)['StartType'] == 'Auto'
+    if kwargs is not None:
+        for key, value in kwargs.iteritems():
+            if key == 'StartType' and value == 'Manual':
+                modify(name, start_type='Manual')
+                return info(name)['StartType'] == 'Manual'
+            elif key == 'StartType' and value == 'Delayed':
+                modify(name, start_type='Auto', start_delayed=True)
+                return info(name)['StartTypeDelayed']
+            else:
+                log.error('Invalid argument for win_service.enable!')
+                return False
+    else:
+        modify(name, start_type='Auto')
+        return info(name)['StartType'] == 'Auto'
 
 
 def disable(name, **kwargs):

--- a/tests/unit/modules/test_win_service.py
+++ b/tests/unit/modules/test_win_service.py
@@ -214,7 +214,8 @@ class WinServiceTestCase(TestCase, LoaderModuleMockMixin):
             Test to enable the named service to start at boot
         '''
         mock_modify = MagicMock(return_value=True)
-        mock_info = MagicMock(return_value={'StartType': 'Auto'})
+        mock_info = MagicMock(return_value={'StartType': 'Auto',
+                                            'StartTypeDelayed': False})
         with patch.object(win_service, 'modify', mock_modify):
             with patch.object(win_service, 'info', mock_info):
                 self.assertTrue(win_service.enable('spongebob'))


### PR DESCRIPTION
### What does this PR do?
Added named variables `start_type` and `start_delayed` in win_service.enable.  This allows for setting Manual and Auto (Delayed) start types from states.service.running and states.service.dead.

Example state.sls:
```
"Patch Agent":
  service.running:
    - enable: True
    - start_type: manual
```
Or
```
"Patch Agent":
  service.dead:
    - enable: True
    - start_delayed: True
```
### What issues does this PR fix or reference?
Set StartType for Windows Service from states.service module #42052

### Tests written?
Yes, and I found if the service is running, then changing from Auto to Auto(Delayed) or vice versa doesn't work due to the before_toggle_enable_status check in states.service.running:
```
before_toggle_status = __salt__['service.status'](name, sig)
    if 'service.enabled' in __salt__:
        before_toggle_enable_status = __salt__['service.enabled'](name)
    else:
        before_toggle_enable_status = True

    # See if the service is already running
    if before_toggle_status:
        ret['comment'] = 'The service {0} is already running'.format(name)
        if enable is True and not before_toggle_enable_status:
            ret.update(_enable(name, None, **kwargs))
        elif enable is False and before_toggle_enable_status:
            ret.update(_disable(name, None, **kwargs))
        return ret
```
Also found the same to be true with states.service.dead if the service is already stopped.