### PR TITLE
Add mode back in for tmp file creation on Linux for ssh unit test

### DIFF
--- a/tests/unit/modules/test_ssh.py
+++ b/tests/unit/modules/test_ssh.py
@@ -91,8 +91,13 @@ class SSHAuthKeyTestCase(TestCase, LoaderModuleMockMixin):
         email = 'github.com'
         empty_line = '\n'
         comment_line = '# this is a comment \n'
+
         # Write out the authorized key to a temporary file
-        temp_file = tempfile.NamedTemporaryFile(delete=False)
+        if salt.utils.is_windows():
+            temp_file = tempfile.NamedTemporaryFile(delete=False)
+        else:
+            temp_file = tempfile.NamedTemporaryFile(delete=False, mode='w+')
+
         # Add comment
         temp_file.write(comment_line)
         # Add empty line for #41335


### PR DESCRIPTION
The mode arg was removed in PR #41966 to get this test to pass on Windows. However, this caused the same test to fail on Arch Linux when running Python 3.

Let's keep the test the way it was for non-windows boxes, and only remove the mode for windows.
