### PR TITLE
LazyLoader: fix loading module from a subdir

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1365,7 +1365,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                             (importlib.machinery.SourcelessFileLoader, importlib.machinery.BYTECODE_SUFFIXES),
                             (importlib.machinery.ExtensionFileLoader, importlib.machinery.EXTENSION_SUFFIXES),
                         ]
-                        file_finder = importlib.machinery.FileFinder(fpath, *loader_details)
+                        file_finder = importlib.machinery.FileFinder(
+                            os.path.dirname(fpath),
+                            *loader_details
+                        )
                         spec = file_finder.find_spec(mod_namespace)
                         if spec is None:
                             raise ImportError()

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1366,7 +1366,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                             (importlib.machinery.ExtensionFileLoader, importlib.machinery.EXTENSION_SUFFIXES),
                         ]
                         file_finder = importlib.machinery.FileFinder(
-                            os.path.dirname(fpath),
+                            fpath_dirname,
                             *loader_details
                         )
                         spec = file_finder.find_spec(mod_namespace)


### PR DESCRIPTION
PRs #41937 and #41963 changed the LazyLoader it so that newer Python releases (>=3.5) usee importlib instead of imp to load modules. However, when importlib is in use, and the module is being loaded from a `__init__.py`, the `importlib.machinery.FileFinder` instance is created with the path to the directory containing the `__init__.py`, which makes it impossible to find a match for the desired module.

This commit passes the parent dir when instantiating the `FileFinder` so that it can properly locate the module.