### PR TITLE
Add debug logging for grains tests

### DIFF
--- a/tests/integration/modules/test_grains.py
+++ b/tests/integration/modules/test_grains.py
@@ -5,6 +5,7 @@ Test the grains module
 
 # Import python libs
 from __future__ import absolute_import
+import logging
 import os
 import time
 
@@ -12,6 +13,8 @@ import time
 from tests.support.case import ModuleCase
 from tests.support.unit import skipIf
 from tests.support.helpers import destructiveTest
+
+log = logging.getLogger(__name__)
 
 
 class TestModulesGrains(ModuleCase):
@@ -109,11 +112,12 @@ class TestModulesGrains(ModuleCase):
         '''
         test to ensure some core grains are returned
         '''
-        grains = ['os', 'os_family', 'osmajorrelease', 'osrelease', 'osfullname', 'id']
+        grains = ('os', 'os_family', 'osmajorrelease', 'osrelease', 'osfullname', 'id')
         os = self.run_function('grains.get', ['os'])
 
         for grain in grains:
             get_grain = self.run_function('grains.get', [grain])
+            log.debug('Value of \'%s\' grain: \'%s\'', grain, get_grain)
             if os == 'Arch' and grain in ['osmajorrelease']:
                 self.assertEqual(get_grain, '')
                 continue


### PR DESCRIPTION
The assert doesn't tell us anything about the grain that is failing.
This adds some debug logging to make this easier to troubleshoot.