### PR TITLE
fix to ssh/wrapper/state.sls

### DIFF
--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -48,6 +48,7 @@ def _thin_dir():
     Get the thin_dir from the master_opts if not in __opts__
     '''
     thin_dir = __opts__.get('thin_dir', __opts__['__master_opts__']['thin_dir'])
+    return thin_dir
 
 
 def sls(mods, saltenv='base', test=None, exclude=None, **kwargs):


### PR DESCRIPTION
### What does this PR do?
When building up the remote file location nothing was being returned via _thin_dir so the remote path was starting with None.  This change updates _thin_dir to return a value for `format` to use.

### What issues does this PR fix or reference?
#42070 

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
