### PR TITLE
pkg.install and pkg.remove fix version number input.

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1027,7 +1027,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             #  The user user salt cmdline with version=5.3 might be interpreted
             #  as a float it must be converted to a string in order for
             #  string matching to work.
-            if not isinstance(version, six.string_types):
+            if not isinstance(version_num, six.string_types):
                 version_num = str(version_num)
 
         if not version_num:
@@ -1363,7 +1363,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             #  The user user salt cmdline with version=5.3 might be interpreted
             #  as a float it must be converted to a string in order for
             #  string matching to work.
-            if not isinstance(version, six.string_types):
+            if not isinstance(version_num, six.string_types):
                 version_num = str(version_num)
             if version_num not in pkginfo and 'latest' in pkginfo:
                 version_num = 'latest'

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1024,7 +1024,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         version_num = ''
         if options:
             version_num = options.get('version', '')
-            #  The user user salt cmdline with version=5.3 might be interpreted
+            #  Using the salt cmdline with version=5.3 might be interpreted
             #  as a float it must be converted to a string in order for
             #  string matching to work.
             if not isinstance(version_num, six.string_types) and version_num is not None:
@@ -1360,7 +1360,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             continue
 
         if version_num is not None:
-            #  The user user salt cmdline with version=5.3 might be interpreted
+            #  Using the salt cmdline with version=5.3 might be interpreted
             #  as a float it must be converted to a string in order for
             #  string matching to work.
             if not isinstance(version_num, six.string_types) and version_num is not None:

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1020,10 +1020,15 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             ret[pkg_name] = 'Unable to locate package {0}'.format(pkg_name)
             continue
 
-        # Get the version number passed or the latest available
+        # Get the version number passed or the latest available (must be a string)
         version_num = ''
         if options:
-            version_num = options.get('version', False)
+            version_num = options.get('version', '')
+            #  The user user salt cmdline with version=5.3 might be interpreted
+            #  as a float it must be converted to a string in order for
+            #  string matching to work.
+            if not isinstance(version, six.string_types):
+                version_num = str(version_num)
 
         if not version_num:
             version_num = _get_latest_pkg_version(pkginfo)
@@ -1355,6 +1360,11 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             continue
 
         if version_num is not None:
+            #  The user user salt cmdline with version=5.3 might be interpreted
+            #  as a float it must be converted to a string in order for
+            #  string matching to work.
+            if not isinstance(version, six.string_types):
+                version_num = str(version_num)
             if version_num not in pkginfo and 'latest' in pkginfo:
                 version_num = 'latest'
         elif 'latest' in pkginfo:

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1027,7 +1027,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             #  The user user salt cmdline with version=5.3 might be interpreted
             #  as a float it must be converted to a string in order for
             #  string matching to work.
-            if not isinstance(version_num, six.string_types):
+            if not isinstance(version_num, six.string_types) and version_num is not None:
                 version_num = str(version_num)
 
         if not version_num:
@@ -1363,7 +1363,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
             #  The user user salt cmdline with version=5.3 might be interpreted
             #  as a float it must be converted to a string in order for
             #  string matching to work.
-            if not isinstance(version_num, six.string_types):
+            if not isinstance(version_num, six.string_types) and version_num is not None:
                 version_num = str(version_num)
             if version_num not in pkginfo and 'latest' in pkginfo:
                 version_num = 'latest'


### PR DESCRIPTION
### What does this PR do?
    pkg.install and pkg.remove on the command line take version number e.g. 1.2 for software and
    store them within a float as its a valid float.  However version needs to be a string, to support versions
    numbers like 1.3.4

    The following for example would not work as version number would be a float, and a
    float does not match string e.g. 3.1 <> '3.1' .
    c:\salt\salt-call -l debug pkg.install name=softwarename version=3.1

### What issues does this PR fix or reference?

### Previous Behavior
The following
c:\salt\salt-call -l debug pkg.install name=softwarename version=3.1
would fail  i.e. `version_num (float) in pkginfo`  will not match against a string. All version numbers within pkginfo are strings so as to support version number like 1.2.3 which are not a valid float.

It seems difficult to pass version=3.1 as a string on the command line.

### New Behavior
If version number is not a string it is converted to a string. Which results in a successful match.

### Tests written?
No
