### PR TITLE
Fix usage of assert_called_once in Python 3 < 3.6

### DIFF
--- a/tests/support/unit.py
+++ b/tests/support/unit.py
@@ -306,6 +306,16 @@ class TestCase(_TestCase):
         )
         # return _TestCase.failIfAlmostEqual(self, *args, **kwargs)
 
+    @staticmethod
+    def assert_called_once(mock):
+        '''
+        mock.assert_called_once only exists in PY3 in 3.6 and newer
+        '''
+        try:
+            mock.assert_called_once()
+        except AttributeError:
+            log.warning('assert_called_once invoked, but not available')
+
     if six.PY2:
         def assertRegexpMatches(self, *args, **kwds):
             raise DeprecationWarning(

--- a/tests/unit/cloud/clouds/test_gce.py
+++ b/tests/unit/cloud/clouds/test_gce.py
@@ -105,7 +105,7 @@ class GCETestCase(TestCase, LoaderModuleMockMixin):
             get_deps = gce.get_dependencies()
             self.assertEqual(get_deps, True)
             if LooseVersion(mock_version) >= LooseVersion('2.0.0'):
-                p.assert_called_once()
+                self.assert_called_once(p)
 
     def test_provider_matches(self):
         """

--- a/tests/unit/modules/test_disk.py
+++ b/tests/unit/modules/test_disk.py
@@ -127,7 +127,7 @@ class DiskTestCase(TestCase, LoaderModuleMockMixin):
                 kwargs = {'read-ahead': 512, 'filesystem-read-ahead': 1024}
                 disk.tune('/dev/sda', **kwargs)
 
-                mock.assert_called_once()
+                self.assert_called_once(mock)
 
                 args, kwargs = mock.call_args
 

--- a/tests/unit/modules/test_mdadm.py
+++ b/tests/unit/modules/test_mdadm.py
@@ -38,9 +38,8 @@ class MdadmTestCase(TestCase, LoaderModuleMockMixin):
             )
             self.assertEqual('salt', ret)
 
-            # Only available in 3.6 and above on py3
-            if hasattr(mock, 'assert_called_once'):
-                mock.assert_called_once()
+            self.assert_called_once(mock)
+
             args, kwargs = mock.call_args
             # expected cmd is
             # mdadm -C /dev/md0 -R -v --chunk 256 --force -l 5 -e default -n 3 /dev/sdb1 /dev/sdc1 /dev/sdd1


### PR DESCRIPTION
This is a more complete fix which builds upon 41c65b0 and covers all
refs to assert_called_once in the suite.