### PR TITLE
Make result=true if Docker volume already exists

### DIFF
--- a/salt/states/dockerng.py
+++ b/salt/states/dockerng.py
@@ -2442,7 +2442,7 @@ def volume_present(name, driver=None, driver_opts=None, force=False):
                 ret['result'] = result
                 return ret
 
-    ret['result'] = None if __opts__['test'] else True
+    ret['result'] = True
     ret['comment'] = 'Volume \'{0}\' already exists.'.format(name)
     return ret
 


### PR DESCRIPTION
Fixes #42076

### What does this PR do?
Modifies the `dockerng.volume_present` state so that `result: True` is returned when applying the state and the volume is already present and `test=True` is used.  This makes the state's return values consistent with other states.

### What issues does this PR fix or reference?
#42076

### Previous Behavior
Applying the `dockerng.volume_present` state with `test=True` would result in `result: None` being returned if the volume was already present.

### New Behavior
Applying the `dockerng.volume_present` state with `test=True` results in `result: True` being returned if the volume is already present.

### Tests written?
No