### PR TITLE
pass cachedir from kwargs in cache

### DIFF
--- a/salt/cache/__init__.py
+++ b/salt/cache/__init__.py
@@ -77,6 +77,7 @@ class Cache(object):
         self.serial = Serial(opts)
         self._modules = None
         self._kwargs = kwargs
+        self._kwargs['cachedir'] = self.cachedir
 
     def __lazy_init(self):
         self._modules = salt.loader.cache(self.opts, self.serial)


### PR DESCRIPTION
### What does this PR do?
localfs looks into the kwargs dictionary for the cachedir, but we never pass the cachedir to kwargs.

### What issues does this PR fix or reference?
Fixes #42069 
