### PR TITLE
Update test_enable in test_win_service.py

### DIFF
--- a/tests/unit/modules/test_win_service.py
+++ b/tests/unit/modules/test_win_service.py
@@ -214,7 +214,8 @@ class WinServiceTestCase(TestCase, LoaderModuleMockMixin):
             Test to enable the named service to start at boot
         '''
         mock_modify = MagicMock(return_value=True)
-        mock_info = MagicMock(return_value={'StartType': 'Auto'})
+        mock_info = MagicMock(return_value={'StartType': 'Auto',
+                                            'StartTypeDelayed': False})
         with patch.object(win_service, 'modify', mock_modify):
             with patch.object(win_service, 'info', mock_info):
                 self.assertTrue(win_service.enable('spongebob'))


### PR DESCRIPTION
Added StartTypeDelayed to the mock_info return of test_enable for PR #42053

### What does this PR do?
Updates test to accommodate changes made to win_service.py execution module.

### What issues does this PR fix or reference?
Failing CentOS and Ubuntu tests for PR #42053
