### PR TITLE
Change repo_ng to repo-ng

### DIFF
--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -141,7 +141,7 @@ packages:
 - 2015.8.0 and later minions: https://github.com/saltstack/salt-winrepo-ng
 - Earlier releases: https://github.com/saltstack/salt-winrepo
 
-By default, these repositories are mirrored to ``/srv/salt/win/repo_ng``
+By default, these repositories are mirrored to ``/srv/salt/win/repo-ng``
 and ``/srv/salt/win/repo``.
 
 This location can be changed in the master config file by setting the


### PR DESCRIPTION
### What does this PR do?
Changes `repo_ng` to `repo-ng` in the docs for winrepo.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/42093