### PR TITLE
Remove references in docs to pip install salt-cloud

### DIFF
--- a/doc/topics/cloud/index.rst
+++ b/doc/topics/cloud/index.rst
@@ -64,7 +64,9 @@ automatically installed salt-cloud for you. Use your distribution's package
 manager to install the ``salt-cloud`` package from the same repo that you
 used to install Salt.  These repos will automatically be setup by Salt Bootstrap.
 
-If there is no salt-cloud package, install with ``pip install salt-cloud``.
+Alternatively, the ``-L`` option can be passed to the `Salt Bootstrap`_ script when
+installing Salt. The ``-L`` option will install ``salt-cloud`` and the required
+``libcloud`` package.
 
 .. _`Salt Bootstrap`: https://github.com/saltstack/salt-bootstrap
 

--- a/doc/topics/cloud/qs.rst
+++ b/doc/topics/cloud/qs.rst
@@ -12,7 +12,9 @@ automatically installed salt-cloud for you. Use your distribution's package
 manager to install the ``salt-cloud`` package from the same repo that you
 used to install Salt.  These repos will automatically be setup by Salt Bootstrap.
 
-If there is no salt-cloud package, install with ``pip install salt-cloud``.
+Alternatively, the ``-L`` option can be passed to the `Salt Bootstrap`_ script when
+installing Salt. The ``-L`` option will install ``salt-cloud`` and the required
+``libcloud`` package.
 
 .. _`Salt Bootstrap`: https://github.com/saltstack/salt-bootstrap
 


### PR DESCRIPTION
Instead, provide the option to use "-L" with the Bootstrap script.

Fixes #41885
