### PR TITLE
Use clean_kwargs from salt.utils in cloud runner

### DIFF
--- a/salt/runners/cloud.py
+++ b/salt/runners/cloud.py
@@ -14,7 +14,7 @@ import os
 
 # Import Salt libs
 import salt.cloud
-import salt.utils
+import salt.utils.args
 from salt.exceptions import SaltCloudConfigError
 
 # Get logging started
@@ -111,7 +111,7 @@ def profile(prof=None, instances=None, opts=None, **kwargs):
     client = _get_client()
     if isinstance(opts, dict):
         client.opts.update(opts)
-    info = client.profile(prof, instances, **salt.utils.clean_kwargs(**kwargs))
+    info = client.profile(prof, instances, **salt.utils.args.clean_kwargs(**kwargs))
     return info
 
 
@@ -120,7 +120,7 @@ def map_run(path=None, **kwargs):
     Execute a salt cloud map file
     '''
     client = _get_client()
-    info = client.map_run(path, **salt.utils.clean_kwargs(**kwargs))
+    info = client.map_run(path, **salt.utils.args.clean_kwargs(**kwargs))
     return info
 
 
@@ -157,7 +157,7 @@ def action(func=None,
             instances,
             provider,
             instance,
-            **salt.utils.clean_kwargs(**kwargs)
+            **salt.utils.args.clean_kwargs(**kwargs)
         )
     except SaltCloudConfigError as err:
         log.error(err)
@@ -179,5 +179,5 @@ def create(provider, instances, opts=None, **kwargs):
     client = _get_client()
     if isinstance(opts, dict):
         client.opts.update(opts)
-    info = client.create(provider, instances, **salt.utils.clean_kwargs(**kwargs))
+    info = client.create(provider, instances, **salt.utils.args.clean_kwargs(**kwargs))
     return info

--- a/salt/runners/cloud.py
+++ b/salt/runners/cloud.py
@@ -14,14 +14,11 @@ import os
 
 # Import Salt libs
 import salt.cloud
+import salt.utils
 from salt.exceptions import SaltCloudConfigError
 
 # Get logging started
 log = logging.getLogger(__name__)
-
-
-def _filter_kwargs(k):
-    return dict((x, k[x]) for x in k if not x.startswith('__'))
 
 
 def _get_client():
@@ -114,7 +111,7 @@ def profile(prof=None, instances=None, opts=None, **kwargs):
     client = _get_client()
     if isinstance(opts, dict):
         client.opts.update(opts)
-    info = client.profile(prof, instances, **_filter_kwargs(kwargs))
+    info = client.profile(prof, instances, **salt.utils.clean_kwargs(**kwargs))
     return info
 
 
@@ -123,7 +120,7 @@ def map_run(path=None, **kwargs):
     Execute a salt cloud map file
     '''
     client = _get_client()
-    info = client.map_run(path, **_filter_kwargs(kwargs))
+    info = client.map_run(path, **salt.utils.clean_kwargs(**kwargs))
     return info
 
 
@@ -154,7 +151,14 @@ def action(func=None,
     info = {}
     client = _get_client()
     try:
-        info = client.action(func, cloudmap, instances, provider, instance, **_filter_kwargs(kwargs))
+        info = client.action(
+            func,
+            cloudmap,
+            instances,
+            provider,
+            instance,
+            **salt.utils.clean_kwargs(**kwargs)
+        )
     except SaltCloudConfigError as err:
         log.error(err)
     return info
@@ -172,12 +176,8 @@ def create(provider, instances, opts=None, **kwargs):
             image=ami-1624987f size='t1.micro' ssh_username=ec2-user \
             securitygroup=default delvol_on_destroy=True
     '''
-    create_kwargs = {}
-    for kwarg in kwargs:
-        if not kwarg.startswith('__'):
-            create_kwargs[kwarg] = kwargs[kwarg]
     client = _get_client()
     if isinstance(opts, dict):
         client.opts.update(opts)
-    info = client.create(provider, instances, **create_kwargs)
+    info = client.create(provider, instances, **salt.utils.clean_kwargs(**kwargs))
     return info


### PR DESCRIPTION
There are two different ways in this file that we're looking for keys that start with "__" and removing them from kwargs. Let's just use salt.utils.clean_kwargs.
