### PR TITLE
[PY3] Fix haproxyconn unit tests that are failing

### DIFF
--- a/tests/unit/modules/test_haproxyconn.py
+++ b/tests/unit/modules/test_haproxyconn.py
@@ -161,7 +161,10 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test listing all frontends
         '''
-        self.assertItemsEqual(haproxyconn.list_frontends(), ['frontend-alpha', 'frontend-beta', 'frontend-gamma'])
+        self.assertEqual(
+            sorted(haproxyconn.list_frontends()),
+            sorted(['frontend-alpha', 'frontend-beta', 'frontend-gamma'])
+        )
 
     # 'show_backends' function tests: 1
 
@@ -175,7 +178,10 @@ class HaproxyConnTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test listing of all backends
         '''
-        self.assertItemsEqual(haproxyconn.list_backends(), ['backend-alpha', 'backend-beta', 'backend-gamma'])
+        self.assertEqual(
+            sorted(haproxyconn.list_backends()),
+            sorted(['backend-alpha', 'backend-beta', 'backend-gamma'])
+        )
 
     def test_get_backend(self):
         '''


### PR DESCRIPTION
``assertItemsEqual`` was removed in Python 3.3. Since ``assertItemsEqual(a, b)`` is the same thing as asserting that ``sorted(a) == sorted(b)``, we can just update the test in this manner to work in both Python 2 and 3.
