### PR TITLE
[Py3] Use functools.cmp_to_key with sorted instead of cmp kwarg

### DIFF
--- a/salt/modules/kernelpkg_linux_apt.py
+++ b/salt/modules/kernelpkg_linux_apt.py
@@ -3,10 +3,13 @@
 Manage Linux kernel packages on APT-based systems
 '''
 from __future__ import absolute_import
+import functools
 import logging
 import re
 
-# Import 3rd-party libs
+# Import Salt libs
+import salt.ext.six as six
+
 try:
     from salt.utils.versions import LooseVersion as _LooseVersion
     from salt.ext.six.moves import filter  # pylint: disable=import-error,redefined-builtin
@@ -73,7 +76,11 @@ def list_installed():
         return []
 
     prefix_len = len(_package_prefix()) + 1
-    return sorted([pkg[prefix_len:] for pkg in result], cmp=_cmp_version)
+
+    if six.PY2:
+        return sorted([pkg[prefix_len:] for pkg in result], cmp=_cmp_version)
+    else:
+        return sorted([pkg[prefix_len:] for pkg in result], key=functools.cmp_to_key(_cmp_version))
 
 
 def latest_available():

--- a/salt/modules/kernelpkg_linux_yum.py
+++ b/salt/modules/kernelpkg_linux_yum.py
@@ -3,9 +3,12 @@
 Manage Linux kernel packages on YUM-based systems
 '''
 from __future__ import absolute_import
+import functools
 import logging
 
-# Import 3rd-party libs
+# Import Salt libs
+import salt.ext.six as six
+
 try:
     from salt.utils.versions import LooseVersion as _LooseVersion
     HAS_REQUIRED_LIBS = True
@@ -65,7 +68,10 @@ def list_installed():
     if result is None:
         return []
 
-    return sorted(result, cmp=_cmp_version)
+    if six.PY2:
+        return sorted(result, cmp=_cmp_version)
+    else:
+        return sorted(result, key=functools.cmp_to_key(_cmp_version))
 
 
 def latest_available():


### PR DESCRIPTION
In Python3, using the ``cmp=x`` functionality with sorted is no longer supported. This older-style comparison function can be replaced in Python 3, however, with `functools.cmp_to_key` as a key argument instead.