### PR TITLE
Fix regression in CLI pillar override for salt-call

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -660,8 +660,17 @@ class State(object):
                     .format(', '.join(VALID_PILLAR_ENC))
                 )
         self._pillar_enc = pillar_enc
-        self.opts['pillar'] = initial_pillar if initial_pillar is not None \
-            else self._gather_pillar()
+        if initial_pillar is not None:
+            self.opts['pillar'] = initial_pillar
+            if self._pillar_override:
+                self.opts['pillar'] = salt.utils.dictupdate.merge(
+                    self.opts['pillar'],
+                    self._pillar_override,
+                    self.opts.get('pillar_source_merging_strategy', 'smart'),
+                    self.opts.get('renderer', 'yaml'),
+                    self.opts.get('pillar_merge_lists', False))
+        else:
+            self.opts['pillar'] = self._gather_pillar()
         self.state_con = context or {}
         self.load_modules()
         self.active = set()

--- a/tests/integration/files/file/base/issue-42116-cli-pillar-override.sls
+++ b/tests/integration/files/file/base/issue-42116-cli-pillar-override.sls
@@ -1,0 +1,2 @@
+ping -c 2 {{ pillar['myhost'] }}:
+  cmd.run

--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -430,6 +430,21 @@ class CallTest(integration.ShellCase, testprogram.TestProgramCase, integration.S
             # Restore umask
             os.umask(current_umask)
 
+    @skipIf(sys.platform.startswith('win'), 'This test does not apply on Win')
+    def test_42116_cli_pillar_override(self):
+        ret = self.run_call(
+            'state.apply issue-42116-cli-pillar-override '
+            'pillar=\'{"myhost": "localhost"}\''
+        )
+        for line in ret:
+            line = line.lstrip()
+            if line == 'Comment: Command "ping -c 2 localhost" run':
+                # Successful test
+                break
+        else:
+            log.debug('salt-call output:\n\n%s', '\n'.join(ret))
+            self.fail('CLI pillar override not found in pillar data')
+
     def tearDown(self):
         '''
         Teardown method to remove installed packages


### PR DESCRIPTION
Includes integration test. Fixes #42116.