### PR TITLE
Allow full package names to be specified on OpenBSD

### DIFF
--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -19,6 +19,7 @@ Package support for OpenBSD
       - rsync
       - vim--no_x11
       - ruby%2.3
+      - postfix-3.3.20170218-mysql
 
 '''
 from __future__ import absolute_import
@@ -194,9 +195,13 @@ def install(name=None, pkgs=None, sources=None, **kwargs):
         # A special case for OpenBSD package "branches" is also required in
         # salt/states/pkg.py
         if pkg_type == 'repository':
-            stem, branch = (pkg.split('%') + [''])[:2]
-            base, flavor = (stem.split('--') + [''])[:2]
-            pkg = '{0}--{1}%{2}'.format(base, flavor, branch)
+            stem, branch = (pkg.split('%') + [None])[:2]
+            base, flavor = (stem.split('--') + [None])[:2]
+            pkg = base
+            if flavor:
+                pkg = '{0}--{1}'.format(pkg, flavor)
+            if branch:
+                pkg = '{0}%{1}'.format(pkg, branch)
         cmd = 'pkg_add -x -I {0}'.format(pkg)
         out = __salt__['cmd.run_all'](
             cmd,

--- a/tests/unit/modules/test_openbsdpkg.py
+++ b/tests/unit/modules/test_openbsdpkg.py
@@ -103,9 +103,9 @@ class OpenbsdpkgTestCase(TestCase, LoaderModuleMockMixin):
                 }
                 self.assertDictEqual(added, expected)
         expected_calls = [
-            call('pkg_add -x -I png--%', output_loglevel='trace', python_shell=False),
-            call('pkg_add -x -I ruby--%2.3', output_loglevel='trace', python_shell=False),
-            call('pkg_add -x -I vim--gtk2%', output_loglevel='trace', python_shell=False),
+            call('pkg_add -x -I png', output_loglevel='trace', python_shell=False),
+            call('pkg_add -x -I ruby%2.3', output_loglevel='trace', python_shell=False),
+            call('pkg_add -x -I vim--gtk2', output_loglevel='trace', python_shell=False),
         ]
         run_all_mock.assert_has_calls(expected_calls, any_order=True)
         self.assertEqual(run_all_mock.call_count, 3)


### PR DESCRIPTION
### What does this PR do?

Allows fully-qualified package names to be specified on OpenBSD

### What issues does this PR fix or reference?

#42112

### Previous Behavior

Package can be specified without qualification

    pkg.install 'bash'

Package can be specified by branch

    pkg.install 'ruby%2.4'

Package can be specified by with flavor

    pkg.install 'vim--no_x11'

### New Behavior

Full package name can also be specified on OpenBSD

    $ sudo -E salt-call --local --file-root=$PWD pkg.install 'postfix-3.3.20170218-mysql'
    local:
        ----------
        postfix--mysql:
            ----------
            new:
                3.3.20170218
            old:

### Tests written?

Modified existing test case
