### PR TITLE
2017.7.0 modules/schedule.py fix

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -128,15 +128,6 @@ def list_(show_all=False,
             continue
 
         if '_seconds' in schedule[job]:
-            # if _seconds is greater than zero
-            # then include the original back in seconds.
-            # otherwise remove seconds from the listing as the
-            # original item didn't include it.
-            if schedule[job]['_seconds'] > 0:
-                schedule[job]['seconds'] = schedule[job]['_seconds']
-            elif 'seconds' in schedule[job]:
-                del schedule[job]['seconds']
-
             # remove _seconds from the listing
             del schedule[job]['_seconds']
 


### PR DESCRIPTION
### What does this PR do?
Removing code that was previously in place to account for a situation where we backed up the value of the original seconds parameter in the event that the splay parameter was included.  Recent changes made this code no long necessary, so removing it and simply deleting the "_seconds" parameter from the schedule list output.

### What issues does this PR fix or reference?
#42127 

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
