### PR TITLE
[PY3] Make test_saltmod unit tests less flaky for Python 3

### DIFF
--- a/tests/unit/states/test_saltmod.py
+++ b/tests/unit/states/test_saltmod.py
@@ -146,7 +146,17 @@ class SaltmodTestCase(TestCase, LoaderModuleMockMixin):
         del ret['__jid__']
         with patch.dict(saltmod.__opts__, {'test': False}):
             with patch.dict(saltmod.__salt__, {'saltutil.cmd': MagicMock(return_value=test_batch_return)}):
-                self.assertDictEqual(saltmod.state(name, tgt, highstate=True), ret)
+                state_run = saltmod.state(name, tgt, highstate=True)
+
+                # Test return without checking the comment contents. Comments are tested later.
+                comment = state_run.pop('comment')
+                ret.pop('comment')
+                self.assertDictEqual(state_run, ret)
+
+                # Check the comment contents in a non-order specific way (ordering fails sometimes on PY3)
+                self.assertIn('States ran successfully. No changes made to', comment)
+                for minion in ['minion1', 'minion2', 'minion3']:
+                    self.assertIn(minion, comment)
 
     # 'function' function tests: 1
 


### PR DESCRIPTION
Separates out the comment from the rest of the state return to make this test more stable on Python 3. This state run in PY3 adds the minion names to the comment in a random order, so we can't rely on asserting against this order in the test.

This PR updates the test so that we are still checking for all of the elements in the comment, but not relying on the order the minions are added the comment list.

Without this change, the test failure looks like this on Python 3:
```
Traceback (most recent call last):
  File "/testing/tests/unit/states/test_saltmod.py", line 149, in test_state
    self.assertDictEqual(saltmod.state(name, tgt, highstate=True), ret)
AssertionError: {'result': True, 'changes': {}, 'comment': 'States ran succ[69 chars]ate'} != {'result': True, 'name': 'state', 'comment': 'States ran su[69 chars]: {}}
  {'changes': {},
-  'comment': 'States ran successfully. No changes made to minion3, minion2, '
?                                                                   ---------

+  'comment': 'States ran successfully. No changes made to minion1, minion3, '
?                                                         +++++++++

-             'minion1.',
?                    ^

+             'minion2.',
?                    ^

   'name': 'state',
   'result': True}
```

With this change, the test passes every time.
