### PR TITLE
Fix `unit.modules.test_reg_win` for Windows

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -150,7 +150,9 @@ class Registry(object):  # pylint: disable=R0903
             _winreg.REG_DWORD:     'REG_DWORD',
             _winreg.REG_EXPAND_SZ: 'REG_EXPAND_SZ',
             _winreg.REG_MULTI_SZ:  'REG_MULTI_SZ',
-            _winreg.REG_SZ:        'REG_SZ'
+            _winreg.REG_SZ:        'REG_SZ',
+            # REG_QWORD isn't in the winreg library
+            11:                    'REG_QWORD'
         }
         self.opttype_reverse = {
             _winreg.REG_OPTION_NON_VOLATILE: 'REG_OPTION_NON_VOLATILE',

--- a/tests/unit/modules/test_reg_win.py
+++ b/tests/unit/modules/test_reg_win.py
@@ -27,7 +27,7 @@ except ImportError:
 PY2 = sys.version_info[0] == 2
 # The following used to make sure we are not
 # testing already existing data
-# Note strftime retunrns a str, so we need to make it unicode
+# Note strftime returns a str, so we need to make it unicode
 TIMEINT = int(time.time())
 
 if PY2:


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with `reg.list_values` for `REG_QWORD` types. Not handled by winreg.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439