### PR TITLE
Fix docs for puppet.plugin_sync

### DIFF
--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -337,9 +337,10 @@ def summary():
 
 def plugin_sync():
     '''
-    Runs a plugin synch between the puppet master and agent
+    Runs a plugin sync between the puppet master and agent
 
     CLI Example:
+
     .. code-block:: bash
 
         salt '*' puppet.plugin_sync


### PR DESCRIPTION
... so code-block renders properly and sync is spelled consistently.

### What does this PR do?

Causes the example code block underneath puppet.plugin_sync to render properly. Also spells 'sync' consistently (instead of 'synch').

### What issues does this PR fix or reference?

N/A

### Previous Behavior

From https://docs.saltstack.com/en/2016.3/ref/modules/all/salt.modules.puppet.html#salt.modules.puppet.plugin_sync :

![image](https://user-images.githubusercontent.com/1628311/27889812-c4e24df4-61bc-11e7-94f6-b1c93a6bd69f.png)

### New Behavior

![image](https://user-images.githubusercontent.com/1628311/27889801-b9cd90e0-61bc-11e7-8816-8b7dfd914bd2.png)

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
