### PR TITLE
fixes to state.py for names parameter

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -547,7 +547,7 @@ class Compiler(object):
                 continue
             for state, run in six.iteritems(body):
                 funcs = set()
-                names = set()
+                names = []
                 if state.startswith('__'):
                     continue
                 chunk = {'state': state,
@@ -564,7 +564,9 @@ class Compiler(object):
                     if isinstance(arg, dict):
                         for key, val in six.iteritems(arg):
                             if key == 'names':
-                                names.update(val)
+                                for _name in val:
+                                    if _name not in names:
+                                        names.append(_name)
                                 continue
                             else:
                                 chunk.update(arg)
@@ -1287,7 +1289,7 @@ class State(object):
                 continue
             for state, run in six.iteritems(body):
                 funcs = set()
-                names = set()
+                names = []
                 if state.startswith('__'):
                     continue
                 chunk = {'state': state,
@@ -1306,7 +1308,9 @@ class State(object):
                     if isinstance(arg, dict):
                         for key, val in six.iteritems(arg):
                             if key == 'names':
-                                names.update(val)
+                                for _name in val:
+                                    if _name not in names:
+                                        names.append(_name)
                             elif key == 'state':
                                 # Don't pass down a state override
                                 continue

--- a/tests/integration/files/file/base/issue-7649-handle-iorder.sls
+++ b/tests/integration/files/file/base/issue-7649-handle-iorder.sls
@@ -1,9 +1,9 @@
 handle-iorder:
   cmd:
-      - cwd: /tmp/ruby-1.9.2-p320
-      - names:
-        - ./configure
-        - make
-        - make install
-      - run
+    - cwd: /tmp/ruby-1.9.2-p320
+    - names:
+      - ./configure
+      - make
+      - make install
+    - run
 

--- a/tests/integration/states/handle_iorder.py
+++ b/tests/integration/states/handle_iorder.py
@@ -24,11 +24,10 @@ class HandleOrderTest(integration.ModuleCase):
         '''
         ret = self.run_function('state.show_low_sls', mods='issue-7649-handle-iorder')
 
-        sorted_chunks = sorted(ret, key=lambda c: c.get('order'))
+        sorted_chunks = [chunk['name'] for chunk in sorted(ret, key=lambda c: c.get('order'))]
 
-        self.assertEqual(sorted_chunks[0]['name'], './configure')
-        self.assertEqual(sorted_chunks[1]['name'], 'make')
-        self.assertEqual(sorted_chunks[2]['name'], 'make install')
+        expected = ['./configure', 'make', 'make install']
+        self.assertEqual(expected, sorted_chunks)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What does this PR do?
Back porting the fix for 2017.7 that ensures the order of the names parameter.

### What issues does this PR fix or reference?
#42137 

### Previous Behavior
Order of the names parameter was not guaranteed.

### New Behavior
Swaps out using the names parameter was a set to preserve it as a list so the order is preserved.

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
