### PR TITLE
Fix `unit.modules.test_useradd` for Windows

### DIFF
--- a/tests/unit/modules/test_useradd.py
+++ b/tests/unit/modules/test_useradd.py
@@ -72,6 +72,7 @@ class UserAddTestCase(TestCase, LoaderModuleMockMixin):
 
     # 'getent' function tests: 2
 
+    @skipIf(HAS_PWD is False, 'The pwd module is not available')
     def test_getent(self):
         '''
         Test if user.getent already have a value
@@ -359,6 +360,7 @@ class UserAddTestCase(TestCase, LoaderModuleMockMixin):
 
     # 'list_users' function tests: 1
 
+    @skipIf(HAS_PWD is False, 'The pwd module is not available')
     def test_list_users(self):
         '''
         Test if it returns a list of all users


### PR DESCRIPTION
### What does this PR do?
Fixes more tests that require `pwd`. `pwd` is not available in Windows and causes the mock to fail.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439