### PR TITLE
importlib: Use load_module() instead of exec_module() to initialize loaded mods

### DIFF
--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -43,14 +43,6 @@ def _merge_extra_filerefs(*args):
     return ','.join(ret)
 
 
-def _thin_dir():
-    '''
-    Get the thin_dir from the master_opts if not in __opts__
-    '''
-    thin_dir = __opts__.get('thin_dir', __opts__['__master_opts__']['thin_dir'])
-    return thin_dir
-
-
 def sls(mods, saltenv='base', test=None, exclude=None, **kwargs):
     '''
     Create the seed file for a state.sls run
@@ -103,7 +95,7 @@ def sls(mods, saltenv='base', test=None, exclude=None, **kwargs):
             st_kwargs['id_'])
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg {0}/salt_state.tgz test={1} pkg_sum={2} hash_type={3}'.format(
-            _thin_dir(),
+            __opts__['thin_dir'],
             test,
             trans_tar_sum,
             __opts__['hash_type'])
@@ -115,7 +107,7 @@ def sls(mods, saltenv='base', test=None, exclude=None, **kwargs):
             **st_kwargs)
     single.shell.send(
             trans_tar,
-            '{0}/salt_state.tgz'.format(_thin_dir()))
+            '{0}/salt_state.tgz'.format(__opts__['thin_dir']))
     stdout, stderr, _ = single.cmd_block()
 
     # Clean up our tar
@@ -176,7 +168,7 @@ def low(data, **kwargs):
             st_kwargs['id_'])
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg {0}/salt_state.tgz pkg_sum={1} hash_type={2}'.format(
-            _thin_dir(),
+            __opts__['thin_dir'],
             trans_tar_sum,
             __opts__['hash_type'])
     single = salt.client.ssh.Single(
@@ -187,7 +179,7 @@ def low(data, **kwargs):
             **st_kwargs)
     single.shell.send(
             trans_tar,
-            '{0}/salt_state.tgz'.format(_thin_dir()))
+            '{0}/salt_state.tgz'.format(__opts__['thin_dir']))
     stdout, stderr, _ = single.cmd_block()
 
     # Clean up our tar
@@ -244,7 +236,7 @@ def high(data, **kwargs):
             st_kwargs['id_'])
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg {0}/salt_state.tgz pkg_sum={1} hash_type={2}'.format(
-            _thin_dir(),
+            __opts__['thin_dir'],
             trans_tar_sum,
             __opts__['hash_type'])
     single = salt.client.ssh.Single(
@@ -255,7 +247,7 @@ def high(data, **kwargs):
             **st_kwargs)
     single.shell.send(
             trans_tar,
-            '{0}/salt_state.tgz'.format(_thin_dir()))
+            '{0}/salt_state.tgz'.format(__opts__['thin_dir']))
     stdout, stderr, _ = single.cmd_block()
 
     # Clean up our tar
@@ -341,7 +333,7 @@ def highstate(test=None, **kwargs):
             st_kwargs['id_'])
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg {0}/salt_state.tgz test={1} pkg_sum={2} hash_type={3}'.format(
-            _thin_dir(),
+            __opts__['thin_dir'],
             test,
             trans_tar_sum,
             __opts__['hash_type'])
@@ -353,7 +345,7 @@ def highstate(test=None, **kwargs):
             **st_kwargs)
     single.shell.send(
             trans_tar,
-            '{0}/salt_state.tgz'.format(_thin_dir()))
+            '{0}/salt_state.tgz'.format(__opts__['thin_dir']))
     stdout, stderr, _ = single.cmd_block()
 
     # Clean up our tar
@@ -416,7 +408,7 @@ def top(topfn, test=None, **kwargs):
             st_kwargs['id_'])
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg {0}/salt_state.tgz test={1} pkg_sum={2} hash_type={3}'.format(
-            _thin_dir(),
+            __opts__['thin_dir'],
             test,
             trans_tar_sum,
             __opts__['hash_type'])
@@ -428,7 +420,7 @@ def top(topfn, test=None, **kwargs):
             **st_kwargs)
     single.shell.send(
             trans_tar,
-            '{0}/salt_state.tgz'.format(_thin_dir()))
+            '{0}/salt_state.tgz'.format(__opts__['thin_dir']))
     stdout, stderr, _ = single.cmd_block()
 
     # Clean up our tar
@@ -676,7 +668,7 @@ def single(fun, name, test=None, **kwargs):
 
     # We use state.pkg to execute the "state package"
     cmd = 'state.pkg {0}/salt_state.tgz test={1} pkg_sum={2} hash_type={3}'.format(
-            _thin_dir(),
+            __opts__['thin_dir'],
             test,
             trans_tar_sum,
             __opts__['hash_type'])
@@ -692,7 +684,7 @@ def single(fun, name, test=None, **kwargs):
     # Copy the tar down
     single.shell.send(
             trans_tar,
-            '{0}/salt_state.tgz'.format(_thin_dir()))
+            '{0}/salt_state.tgz'.format(__opts__['thin_dir']))
 
     # Run the state.pkg command on the target
     stdout, stderr, _ = single.cmd_block()

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1372,8 +1372,14 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                         spec = file_finder.find_spec(mod_namespace)
                         if spec is None:
                             raise ImportError()
-                        mod = importlib.util.module_from_spec(spec)
-                        spec.loader.exec_module(mod)
+                        # TODO: Get rid of load_module in favor of
+                        # exec_module below. load_module is deprecated, but
+                        # loading using exec_module has been causing odd things
+                        # with the magic dunders we pack into the loaded
+                        # modules, most notably with salt-ssh's __opts__.
+                        mod = spec.loader.load_module()
+                        # mod = importlib.util.module_from_spec(spec)
+                        # spec.loader.exec_module(mod)
                         # pylint: enable=no-member
                         sys.modules[mod_namespace] = mod
                     else:
@@ -1390,8 +1396,14 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                         )
                         if spec is None:
                             raise ImportError()
-                        mod = importlib.util.module_from_spec(spec)
-                        spec.loader.exec_module(mod)
+                        # TODO: Get rid of load_module in favor of
+                        # exec_module below. load_module is deprecated, but
+                        # loading using exec_module has been causing odd things
+                        # with the magic dunders we pack into the loaded
+                        # modules, most notably with salt-ssh's __opts__.
+                        mod = spec.loader.load_module()
+                        #mod = importlib.util.module_from_spec(spec)
+                        #spec.loader.exec_module(mod)
                         # pylint: enable=no-member
                         sys.modules[mod_namespace] = mod
                     else:


### PR DESCRIPTION
Using `exec_module()` results in some unexpected behavior in the LazyLoader, so more investigation will need to be done before we can use it. In the meantime, this commit uses `load_module()` instead. It also gets rid of the now-unnecessary workarounds we had recently instituted in salt-ssh to work around issues with the `__opts__` dunder.