### PR TITLE
Use long_range function for IPv6Network hosts() function

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -1202,7 +1202,12 @@ Returns:
 
 .. versionadded:: 2017.7.0
 
-Return the list of hosts within a networks.
+Return the list of hosts within a networks. This utility works for both IPv4 and IPv6.
+
+.. note::
+
+    When running this command with a large IPv6 network, the command will
+    take a long time to gather all of the hosts.
 
 Example:
 

--- a/salt/ext/ipaddress.py
+++ b/salt/ext/ipaddress.py
@@ -28,9 +28,6 @@ bytes = bytearray
 # Python 2 does not support exception chaining.
 # s/ from None$//
 
-# Python 2 ranges need to fit in a C long
-# 'fix' hosts() for IPv6Network
-
 # When checking for instances of int, also allow Python 2's long.
 _builtin_isinstance = isinstance
 
@@ -2259,7 +2256,7 @@ class IPv6Network(_BaseV6, _BaseNetwork):
         """
         network = int(self.network_address)
         broadcast = int(self.broadcast_address)
-        for x in range(1, broadcast - network + 1):
+        for x in long_range(1, broadcast - network + 1):
             yield self._address_class(network + x)
 
     @property

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -453,6 +453,11 @@ def _network_hosts(ip_addr_entry):
 def network_hosts(value, options=None, version=None):
     '''
     Return the list of hosts within a network.
+
+    .. note::
+
+        When running this command with a large IPv6 network, the command will
+        take a long time to gather all of the hosts.
     '''
     ipaddr_filter_out = _filter_ipaddr(value, options=options, version=version)
     if not ipaddr_filter_out:


### PR DESCRIPTION
### What does this PR do?
Converts the `salt.ext.ipadress.IPv6Network.hosts()` function to use ``long_range`` instead of ``xrange``.

The previous implementation used xrange, which requires that the range fit in a C long data type. Given that an IPv6 subnet is massive, the ``salt.ext.ipadress.IPv6Network.hosts()`` function would stacktrace with an OverflowError due to the use of xrange. However, ``/64`` is a common netmask and this function should allow the function to work if the user desires.

While the function will no longer stacktrace on large IPv6 subnets, the user should be aware that the hosts on these large subnets will take a very long time to gather.

### What issues does this PR fix or reference?
Fixes #42166

### Previous Behavior
```
>>> import salt.utils.network
>>> salt.utils.network.network_hosts('2001:470:7ee7:30::/64')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/SaltStack/salt/salt/utils/network.py", line 461, in network_hosts
    return _network_hosts(ipaddr_filter_out[0])
  File "/root/SaltStack/salt/salt/utils/network.py", line 449, in _network_hosts
    for host in ipaddress.ip_network(ip_addr_entry, strict=False).hosts()
  File "/root/SaltStack/salt/salt/ext/ipaddress.py", line 2264, in hosts
    for x in range(1, broadcast - network + 1):
OverflowError: Python int too large to convert to C long
```

### New Behavior
Stack trace no longer happens and the function can get to work finding all of the hosts.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
