### PR TITLE
add destroying and destroy cloud events to azurearm provider

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -1293,7 +1293,7 @@ def destroy(name, conn=None, call=None, kwargs=None):  # pylint: disable=unused-
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
-        args={'name': name },
+        args={'name': name},
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
     )
@@ -1395,7 +1395,7 @@ def destroy(name, conn=None, call=None, kwargs=None):  # pylint: disable=unused-
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
-        args={'name': name },
+        args={'name': name},
         sock_dir=__opts__['sock_dir'],
         transport=__opts__['transport']
     )

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -1289,6 +1289,15 @@ def destroy(name, conn=None, call=None, kwargs=None):  # pylint: disable=unused-
             '-a or --action.'
         )
 
+    __utils__['cloud.fire_event'](
+        'event',
+        'destroying instance',
+        'salt/cloud/{0}/destroying'.format(name),
+        args={'name': name },
+        sock_dir=__opts__['sock_dir'],
+        transport=__opts__['transport']
+    )
+
     global compconn  # pylint: disable=global-statement,invalid-name
     if not compconn:
         compconn = get_conn()
@@ -1381,6 +1390,15 @@ def destroy(name, conn=None, call=None, kwargs=None):  # pylint: disable=unused-
                     call='function',
                 )
             )
+
+    __utils__['cloud.fire_event'](
+        'event',
+        'destroyed instance',
+        'salt/cloud/{0}/destroyed'.format(name),
+        args={'name': name },
+        sock_dir=__opts__['sock_dir'],
+        transport=__opts__['transport']
+    )
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?
Add **destroying** and **destroyed** cloud events for the **azurearm** provider, making Salt Reactor being able to react when a VM is destroyed.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
