### PR TITLE
Fix Augeas state documentation example

### DIFF
--- a/salt/states/augeas.py
+++ b/salt/states/augeas.py
@@ -200,7 +200,7 @@ def change(name, context=None, changes=None, lens=None,
 
         redis-conf:
           augeas.change:
-            - lens: redis
+            - lens: redis.lns
             - context: /files/etc/redis/redis.conf
             - changes:
               - set bind 0.0.0.0
@@ -224,21 +224,34 @@ def change(name, context=None, changes=None, lens=None,
 
         zabbix-service:
           augeas.change:
-            - lens: services
+            - lens: services.lns
             - context: /files/etc/services
             - changes:
               - ins service-name after service-name[last()]
-              - set service-name[last()] zabbix-agent
-              - set service-name[. = 'zabbix-agent']/#comment "Zabbix Agent service"
-              - set service-name[. = 'zabbix-agent']/port 10050
-              - set service-name[. = 'zabbix-agent']/protocol tcp
-              - rm service-name[. = 'im-obsolete']
+              - set service-name[last()] "zabbix-agent"
+              - set "service-name[. = 'zabbix-agent']/port" 10050
+              - set "service-name[. = 'zabbix-agent']/protocol" tcp
+              - set "service-name[. = 'zabbix-agent']/#comment" "Zabbix Agent service"
+              - rm "service-name[. = 'im-obsolete']"
             - unless: grep "zabbix-agent" /etc/services
 
     .. warning::
 
-        Don't forget the ``unless`` here, otherwise a new entry will be added
-        every time this state is run.
+        Don't forget the ``unless`` here, otherwise it will fail on next runs
+        because the service is already defined. Additionally you have to quote
+        lines containing ``service-name[. = 'zabbix-agent']`` otherwise
+        :mod:`augeas_cfg <salt.modules.augeas_cfg>` execute will fail because
+        it will receive more parameters than expected.
+
+    .. note::
+
+        Order is important when defining a service with Augeas, in this case
+        it's ``port``, ``protocol`` and ``#comment``. For more info about
+        the lens check `services lens documentation`_.
+
+    .. _services lens documentation:
+
+    http://augeas.net/docs/references/lenses/files/services-aug.html#Services.record
 
     '''
     ret = {'name': name, 'result': False, 'comment': '', 'changes': {}}


### PR DESCRIPTION
### What does this PR do?
It fixes the Augeas state documentation example

### What issues does this PR fix or reference?

#34918
#16383
#[38115](https://github.com/saltstack/salt/pull/38115#commitcomment-21935180)

### Description

- The doc says `.lns` suffix is needed in `- lens` but the examples lack of it and Zabbix doesn't work because of this.
- Order of `set` attributes are wrong according to [Augeas Services lens documentation](http://augeas.net/docs/references/lenses/files/services-aug.html#Services.record).
- Lines like `service-name[. = 'zabbix-agent']` needs to be quoted otherwise `augeas_cfg.execute` will fail because it's expecting 2 arguments and more than 2 are provided. The cause is described in [38115](https://github.com/saltstack/salt/pull/38115#commitcomment-21935180).
