### PR TITLE
[PY3] Fix test that is flaky in Python 3

### DIFF
--- a/tests/unit/templates/test_jinja.py
+++ b/tests/unit/templates/test_jinja.py
@@ -486,7 +486,7 @@ class TestCustomExtensions(TestCase):
         env = Environment(extensions=[SerializerExtension])
         if six.PY3:
             rendered = env.from_string('{{ dataset|unique }}').render(dataset=dataset).strip("'{}").split("', '")
-            self.assertEqual(rendered, list(unique))
+            self.assertEqual(sorted(rendered), sorted(list(unique)))
         else:
             rendered = env.from_string('{{ dataset|unique }}').render(dataset=dataset)
             self.assertEqual(rendered, u"{0}".format(unique))


### PR DESCRIPTION
We can't rely on lists having the same order in Python3 the same way we rely on them in Python2. If we sort them first, and then compare them, this test will be more reliable.
