### PR TITLE
Only pass a saltenv in orchestration if one was explicitly passed (2017.7)

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -245,14 +245,12 @@ def state(name,
     if pillar:
         cmd_kw['kwarg']['pillar'] = pillar
 
-    # If pillarenv is directly defined, use it
-    if pillarenv:
+    if pillarenv is not None:
         cmd_kw['kwarg']['pillarenv'] = pillarenv
-    # Use pillarenv if it's passed from __opts__ (via state.orchestrate for example)
-    elif __opts__.get('pillarenv'):
-        cmd_kw['kwarg']['pillarenv'] = __opts__['pillarenv']
 
-    cmd_kw['kwarg']['saltenv'] = saltenv if saltenv is not None else __env__
+    if saltenv is not None:
+        cmd_kw['kwarg']['saltenv'] = saltenv
+
     cmd_kw['kwarg']['queue'] = queue
 
     if isinstance(concurrent, bool):


### PR DESCRIPTION
Also, only pass pillarenv if explicitly passed. _get_opts() in the state
module will apply the correct saltenv (if applicable) when no explicit
saltenv/pillarenv is passed.