### PR TITLE
Add missing config to example

### DIFF
--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -495,6 +495,7 @@ def container_setting(name, container, settings=None):
                     processModel.maxProcesses: 1
                     processModel.userName: TestUser
                     processModel.password: TestPassword
+                    processModel.identityType: SpecificUser
 
     Example of usage for the ``Sites`` container:
 


### PR DESCRIPTION
### What does this PR do?
Fixes an issue in the documentation example for the `win_iis_container_setting` state. The example state wouldn't actually change the user as expected.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/42196
