### PR TITLE
add custom dns support for azurearm provider

### DIFF
--- a/doc/topics/cloud/azurearm.rst
+++ b/doc/topics/cloud/azurearm.rst
@@ -238,6 +238,20 @@ iface_name
 Optional. The name to apply to the VM's network interface. If not supplied, the
 value will be set to ``<VM name>-iface0``.
 
+dns_servers
+-----------
+Optional. A **list** of the DNS servers to configure for the network interface
+(will be set on the VM by the DHCP of the VNET).
+
+.. code-block:: yaml
+
+    my-azurearm-profile:
+      provider: azurearm-provider
+      network: mynetwork
+      dns_servers:
+        - 10.1.1.4
+        - 10.1.1.5
+
 availability_set
 ----------------
 Optional. If set, the VM will be added to the specified availability set.

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -914,7 +914,7 @@ def create_interface(call=None, kwargs=None):  # pylint: disable=unused-argument
 
     dns_settings = None
     if kwargs.get('dns_servers') is not None:
-        if type(kwargs['dns_servers']) == list:
+        if isinstance(kwargs['dns_servers'], list):
             dns_settings = NetworkInterfaceDnsSettings(
                 dns_servers=kwargs['dns_servers'],
                 applied_dns_servers=kwargs['dns_servers'],

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -916,11 +916,11 @@ def create_interface(call=None, kwargs=None):  # pylint: disable=unused-argument
     if kwargs.get('dns_servers') is not None:
         if type(kwargs['dns_servers']) == list:
             dns_settings = NetworkInterfaceDnsSettings(
-                dns_servers = kwargs['dns_servers'],
-                applied_dns_servers = kwargs['dns_servers'],
-                internal_dns_name_label = None,
-                internal_fqdn = None,
-                internal_domain_name_suffix = None,
+                dns_servers=kwargs['dns_servers'],
+                applied_dns_servers=kwargs['dns_servers'],
+                internal_dns_name_label=None,
+                internal_fqdn=None,
+                internal_domain_name_suffix=None,
             )
 
     network_security_group = None

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -103,6 +103,7 @@ try:
     from azure.mgmt.network.models import (
         IPAllocationMethod,
         NetworkInterface,
+        NetworkInterfaceDnsSettings,
         NetworkInterfaceIPConfiguration,
         NetworkSecurityGroup,
         PublicIPAddress,
@@ -911,6 +912,17 @@ def create_interface(call=None, kwargs=None):  # pylint: disable=unused-argument
             )
         ]
 
+    dns_settings = None
+    if kwargs.get('dns_servers') is not None:
+        if type(kwargs['dns_servers']) == list:
+            dns_settings = NetworkInterfaceDnsSettings(
+                dns_servers = kwargs['dns_servers'],
+                applied_dns_servers = kwargs['dns_servers'],
+                internal_dns_name_label = None,
+                internal_fqdn = None,
+                internal_domain_name_suffix = None,
+            )
+
     network_security_group = None
     if kwargs.get('security_group') is not None:
         network_security_group = netconn.network_security_groups.get(
@@ -922,6 +934,7 @@ def create_interface(call=None, kwargs=None):  # pylint: disable=unused-argument
         location=kwargs['location'],
         network_security_group=network_security_group,
         ip_configurations=ip_configurations,
+        dns_settings=dns_settings,
     )
 
     poller = netconn.network_interfaces.create_or_update(


### PR DESCRIPTION
### What does this PR do?
Add support for custom DNS servers for VMs provided by the azurearm provider.

In profile configuration file, use : 
```
my_profile:
  dns_servers:
    - 10.0.0.1
```
