### PR TITLE
[WIP] Allow to wipe the "salt-thin" on the client when calling "salt-ssh" wrapped functions

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -946,6 +946,20 @@ class Single(object):
         self.wfuncs = salt.loader.ssh_wrapper(opts, wrapper, self.context)
         wrapper.wfuncs = self.wfuncs
 
+        # If salt-thin is set to be wiped, a 'test.ping' command is executed
+        # after running the wfunc in order to trigger the salt-thin cleanup
+        # done by SHIM on the client
+        if 'ssh_wipe' in self.opts:
+            single = Single(self.opts,
+                            "test.ping",
+                            self.target['host'],
+                            fsclient=self.fsclient,
+                            thin=self.thin,
+                            **self.target)
+            stdout, stderr, retcode = single.cmd_block()
+            if salt.defaults.exitcodes.EX_OK != retcode:
+                log.error("ERROR when trying to wipe salt-thin on client")
+
         # We're running in the mine, need to fetch the arguments from the
         # roster, pillar, master config (in that order)
         if self.mine:


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue on `salt-ssh` when using `-w` or `--wipe` argument to wipe the `salt-thin` on the ssh minion and calling any of the wrapped functions (wfuncs) defined for `salt-ssh`.

Currently, the cleanup of the deployed `salt-thin` is made by the SHIM code, but when calling `salt-ssh` wrapped functions (wfuncs), like `state.apply`, `state.show_highstate`, `pillar.get`, `grains.get`, etc, the cleanup is not performed even if `-w` or `--wipe` are passed as parameter to the `salt-ssh` call.

This is happening because few reasons:
- Not all wrapped functions are actually running SHIM on its execution. i.a. `grains.get`
- In such wrapped functions which execute SHIM, they don't pass the `wipe` option to the `Single` object so the cleanup is also not performed even if SHIM code is executed.

This PR proposes to trigger a `test.ping` job to the ssh minion just after calling a `wfunc` in cases where `-w` is set for `salt-ssh`. This `test.ping` job will execute SHIM code on the minion including the cleanup, so the deployed `salt-thin` from SHIM execution on previous stages will be wiped from the ssh minion.

What do you think about this?

### Previous Behavior
```
clisles11sp4:~ # ls -l /var/tmp/
total 0

---

suma3pg-new:~ # salt-ssh clisles11sp4 -i --roster-file=/tmp/tmp_roster grains.get uuid -w -W
clisles11sp4:
    cb2956de-5a8c-e44d-85a8-fc8d1b170412

---

clisles11sp4:~ # ls -l /var/tmp/
total 8
drwx------ 4 root root 4096 jul 10 14:46 .208736
```

### New Behavior
```
clisles11sp4:~ # ls -l /var/tmp/
total 0

---

suma3pg-new:~ # salt-ssh clisles11sp4 -i --roster-file=/tmp/tmp_roster grains.get uuid -w -W
clisles11sp4:
    cb2956de-5a8c-e44d-85a8-fc8d1b170412

---

clisles11sp4:~ # ls -l /var/tmp/
total 0
```

### Tests written?

No

/cc @isbm 