### PR TITLE
Abolish references to `dig` in examples.

### DIFF
--- a/salt/modules/dnsutil.py
+++ b/salt/modules/dnsutil.py
@@ -232,7 +232,7 @@ def check_ip(ip_addr):
 
     .. code-block:: bash
 
-        salt ns1 dig.check_ip 127.0.0.1
+        salt ns1 dnsutil.check_ip 127.0.0.1
     '''
     if _has_dig():
         return __salt__['dig.check_ip'](ip_addr)
@@ -302,7 +302,7 @@ def NS(domain, resolve=True, nameserver=None):
 
     .. code-block:: bash
 
-        salt ns1 dig.NS google.com
+        salt ns1 dnsutil.NS google.com
 
     '''
     if _has_dig():
@@ -323,7 +323,7 @@ def SPF(domain, record='SPF', nameserver=None):
 
     .. code-block:: bash
 
-        salt ns1 dig.SPF google.com
+        salt ns1 dnsutil.SPF google.com
     '''
     if _has_dig():
         return __salt__['dig.SPF'](domain, record, nameserver)
@@ -346,7 +346,7 @@ def MX(domain, resolve=False, nameserver=None):
 
     .. code-block:: bash
 
-        salt ns1 dig.MX google.com
+        salt ns1 dnsutil.MX google.com
     '''
     if _has_dig():
         return __salt__['dig.MX'](domain, resolve, nameserver)

--- a/salt/modules/dnsutil.py
+++ b/salt/modules/dnsutil.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
-Compendium of generic DNS utilities
+Compendium of generic DNS utilities.
+
+.. note:
+    Some functions in the `dnsutil` execution module depend on `dig`.
 '''
 from __future__ import absolute_import
 


### PR DESCRIPTION
### What does this PR do?

Fix the documentation of dnsutils to not refer to the dig module.

Should there be a reference somewhere that `dig` needs to be installed for full functionality?

### What issues does this PR fix or reference?

#42232 

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
