### PR TITLE
add boto3_asg state and module and boto3_lc state

### DIFF
--- a/salt/modules/boto3_asg.py
+++ b/salt/modules/boto3_asg.py
@@ -1,0 +1,712 @@
+# -*- coding: utf-8 -*-
+'''
+Execution module for Amazon Autoscaling Group written against Boto 3
+
+.. versionadded:: Nitrogen
+
+:configuration: This module accepts explicit elb credentials but can also
+    utilize IAM roles assigned to the instance through Instance Profiles.
+    Dynamic credentials are then automatically obtained from AWS API and no
+    further configuration is necessary. More Information available at:
+
+    .. code-block:: yaml
+
+        http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file:
+
+    .. code-block:: yaml
+
+        asg.keyid: GKTADJGHEIQSXMKKRBJ08H
+        asg.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration:
+
+    .. code-block:: yaml
+
+        asg.region: us-east-1
+
+    It's also possible to specify key, keyid and region via a profile, either
+    as a passed in dict, or as a string to pull from pillars or minion config:
+
+    .. code-block:: yaml
+
+        myprofile:
+          keyid: GKTADJGHEIQSXMKKRBJ08H
+          key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+          region: us-east-1
+
+:depends: boto3
+'''
+
+# keep lint from choking on _get_conn and _cache_id
+#pylint: disable=E0602,W0106
+
+# Import Python libs
+from __future__ import absolute_import
+import datetime
+import logging
+import json
+
+# Import Salt libs
+import salt.utils.boto3
+import salt.utils.compat
+import salt.utils.odict as odict
+log = logging.getLogger(__name__)  # pylint: disable=W1699
+
+# Import third party libs
+import salt.ext.six as six
+try:
+    #pylint: disable=unused-import
+    import boto3
+    #pylint: enable=unused-import
+    from botocore.exceptions import ClientError
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist and if boto libraries are greater than
+    a given version.
+    '''
+    if not HAS_BOTO3:
+        return (False, 'The boto3_asg module could not be loaded: boto3 libraries not found')
+    return True
+
+
+def __init__(opts):
+    salt.utils.compat.pack_dunder(__name__)
+    if HAS_BOTO3:
+        __utils__['boto3.assign_funcs'](__name__, 'autoscaling')
+
+
+def exists(name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Check to see if an autoscale group exists.
+
+    CLI example::
+
+        salt myminion boto3_asg.exists myasg region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        _asg = conn.describe_auto_scaling_groups(AutoScalingGroupNames=[name])
+        asg = _asg['AutoScalingGroups']
+        if asg:
+            return True
+        else:
+            msg = 'The autoscale group does not exist in region {0}'.format(region)
+            log.debug(msg)
+            return False
+    except ClientError as e:
+        logging.debug(e.__dict__)
+        if e.response.get('Error', {}).get('Code') in ['Throttling']:
+            log.debug('Throttled by AWS API')
+        return False
+
+
+def get_config(name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Get the configuration for an autoscale group.
+
+    CLI example::
+
+        salt myminion boto3_asg.get_config myasg region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        _asg = conn.describe_auto_scaling_groups(AutoScalingGroupNames=[name])
+        asg = _asg['AutoScalingGroups']
+        if asg:
+            asg = asg[0]
+        else:
+            return {}
+        ret = odict.OrderedDict()
+        attrs = ['AutoScalingGroupName', 'AvailabilityZones', 'DefaultCooldown',
+                 'DesiredCapacity', 'HealthCheckGracePeriod', 'HealthCheckType',
+                 'LaunchConfigurationName', 'LoadBalancerNames', 'TargetGroupARNs',
+                 'MaxSize', 'MinSize', 'PlacementGroup', 'VPCZoneIdentifier',
+                 'Tags', 'TerminationPolicies', 'SuspendedProcesses']
+        for attr in attrs:
+            # Tags are objects, so we need to turn them into dicts.
+            if attr == 'Tags':
+                _tags = []
+                for tag in asg[attr]:
+                    _tag = odict.OrderedDict()
+                    _tag['Key'] = tag['Key']
+                    _tag['Value'] = tag['Value']
+                    _tag['PropagateAtLaunch'] = tag['PropagateAtLaunch']
+                    _tags.append(_tag)
+                ret['Tags'] = _tags
+            # Boto accepts a string or list as input for VPCZoneIdentifier,
+            # but always returns a comma separated list. We require lists in
+            # states.
+            elif attr == 'VPCZoneIdentifier':
+                ret[attr] = asg[attr].split(',')
+            # convert SuspendedProcess objects to names
+            elif attr == 'SuspendedProcesses':
+                suspended_processes = asg[attr]
+                ret[attr] = sorted([x['ProcessName'] for x in suspended_processes])
+            else:
+                #ret[attr] = getattr(asg, attr)
+                ret[attr] = asg.get(attr)
+        # scaling policies
+        policies = conn.describe_policies(AutoScalingGroupName=name)
+        ret["ScalingPolicies"] = []
+        for policy in policies['ScalingPolicies']:
+            del policy['AutoScalingGroupName']
+            ret["ScalingPolicies"].append(policy)
+        # scheduled actions
+        actions = conn.describe_scheduled_actions(AutoScalingGroupName=name)
+        ret['ScheduledUpdateGroupActions'] = {}
+        for action in actions['ScheduledUpdateGroupActions']:
+            end_time = None
+            if action['EndTime']:
+                end_time = action['EndTime'].isoformat()
+            ret['ScheduledUpdateGroupActions'][action['ScheduledActionName']] = dict([
+              ("MinSize", action['MinSize']),
+              ("MaxSize", action['MaxSize']),
+              # AWS bug
+              ("DesiredCapacity", int(action['DesiredCapacity'])),
+              ("StartTime", action['StartTime'].isoformat()),
+              ("EndTime", end_time),
+              ("Recurrence", action['Recurrence'])
+            ])
+        return ret
+    except ClientError as e:
+        logging.debug(e.__dict__)
+        if e.response.get('Error', {}).get('Code') in ['Throttling']:
+            log.debug('Throttled by AWS API')
+        return {}
+
+
+def create(AutoScalingGroupName, LaunchConfigurationName, AvailabilityZones, MinSize, MaxSize,
+           DesiredCapacity=None, LoadBalancerNames=None, TargetGroupARNs=None,
+           DefaultCooldown=None, HealthCheckType=None, HealthCheckGracePeriod=None,
+           PlacementGroup=None, VPCZoneIdentifier=None, Tags=None,
+           TerminationPolicies=None, SuspendedProcesses=None,
+           ScalingPolicies=None, ScheduledUpdateGroupActions=None, region=None,
+           NotificationARN=None, NotificationTypes=None,
+           key=None, keyid=None, profile=None):
+    '''
+    Create an autoscale group.
+
+    CLI example::
+
+        salt myminion boto3_asg.create myasg mylc '["us-east-1a", "us-east-1e"]' 1 10 LoadBalancerNames='["myelb", "myelb2"]' Tags='[{"Key": "Name", "Value": "myasg", "PropagateAtLaunch": True}]'
+    '''
+    # Need kwargs at the top to avoid extra variables and boto3 doesnt support None arguments
+    kwargs = vars()
+    for k in ['region', 'key', 'keyid', 'profile', 'NotificationARN', 'NotificationTypes', 'ScheduledUpdateGroupActions']:
+        del kwargs[k]
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if isinstance(kwargs['AvailabilityZones'], six.string_types):
+        kwargs['AvailabilityZones'] = json.loads(kwargs['AvailabilityZones'])
+    if isinstance(kwargs['LoadBalancerNames'], six.string_types):
+        kwargs['LoadBalancerNames'] = json.loads(kwargs['LoadBalancerNames'])
+    if isinstance(kwargs['TargetGroupARNs'], six.string_types):
+        kwargs['TargetGroupARNs'] = json.loads(kwargs['TargetGroupARNs'])
+    if isinstance(kwargs['VPCZoneIdentifier'], list):
+        kwargs['VPCZoneIdentifier'] = ','.join(kwargs['VPCZoneIdentifier'])
+    if isinstance(kwargs['Tags'], six.string_types):
+        kwargs['Tags'] = json.loads(kwargs['Tags'])
+    # Make a list of tag objects from the dict.
+    _tags = []
+    if kwargs['Tags']:
+        for tag in kwargs['Tags']:
+            try:
+                Key = tag.get('Key')
+            except KeyError:
+                log.error('Tag missing key.')
+                return False
+            try:
+                Value = tag.get('Value')
+            except KeyError:
+                log.error('Tag missing value.')
+                return False
+            PropagateAtLaunch = tag.get('PropagateAtLaunch', False)
+            _tag = {'ResourceId': kwargs['AutoScalingGroupName'], 'Key': Key, 'Value': Value, 'PropagateAtLaunch': PropagateAtLaunch}
+            _tags.append(_tag)
+    kwargs['Tags'] = _tags
+    if isinstance(kwargs['TerminationPolicies'], six.string_types):
+        kwargs['TerminationPolicies'] = json.loads(kwargs['TerminationPolicies'])
+    if isinstance(kwargs['SuspendedProcesses'], six.string_types):
+        kwargs['SuspendedProcesses'] = json.loads(kwargs['SuspendedProcesses'])
+    if isinstance(ScheduledUpdateGroupActions, six.string_types):
+        ScheduledUpdateGroupActions = json.loads(ScheduledUpdateGroupActions)
+    try:
+        kwargs = dict((k, v) for k, v in six.iteritems(kwargs) if v is not None)
+        conn.create_auto_scaling_group(**kwargs)
+        # create suspended process
+        _create_suspended_processes(conn, kwargs['AutoScalingGroupName'], kwargs.get('SuspendedProcesses'))
+        # create scaling policies
+        _create_scaling_policies(conn, kwargs['AutoScalingGroupName'], kwargs.get('ScalingPolicies'))
+        # create scheduled actions
+        _create_scheduled_actions(conn, kwargs['AutoScalingGroupName'], ScheduledUpdateGroupActions)
+        # create notifications
+        if NotificationARN and NotificationTypes:
+            conn.put_notification_configuration(AutoScalingGroupName=kwargs['AutoScalingGroupName'], TopicARN=NotificationARN, NotificationTypes=NotificationTypes)
+        log.info('Created ASG {0}'.format(kwargs['AutoScalingGroupName']))
+        return True
+    except ClientError as e:
+        logging.debug(e.__dict__)
+        if e.response.get('Error', {}).get('Code') in ['Throttling']:
+            log.debug('Throttled by AWS API')
+        else:
+            msg = 'Failed to create ASG {}: {}'.format(kwargs['AutoScalingGroupName'], e.response.get('Error', {}).get('Message'))
+            log.error(msg)
+        return {}
+
+
+def update(AutoScalingGroupName, LaunchConfigurationName=None, AvailabilityZones=None,
+           MinSize=None, MaxSize=None, DesiredCapacity=None, DefaultCooldown=None,
+           HealthCheckType=None, HealthCheckGracePeriod=None, PlacementGroup=None,
+           VPCZoneIdentifier=None, Tags=None, TerminationPolicies=None,
+           SuspendedProcesses=None, ScalingPolicies=None, ScheduledUpdateGroupActions=None,
+           NotificationARN=None, NotificationTypes=None,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Update an autoscale group.
+
+    CLI example::
+
+        salt myminion boto3_asg.update myasg mylc '["us-east-1a", "us-east-1e"]' 1 10 LoadBalancerNames='["myelb", "myelb2"]' Tags='[{"Key": "Name", Value="myasg", "PropagateAtLaunch": True}]'
+    '''
+
+    kwargs = vars()
+    for k in ['NotificationTypes', 'ScalingPolicies', 'ScheduledUpdateGroupActions', 'region', 'key', 'keyid', 'profile']:
+        del kwargs[k]
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if not conn:
+        return False, "failed to connect to AWS"
+    if isinstance(kwargs['AvailabilityZones'], six.string_types):
+        kwargs['AvailabilityZones'] = json.loads(kwargs['AvailabilityZones'])
+    if isinstance(kwargs['VPCZoneIdentifier'], list):
+        kwargs['VPCZoneIdentifier'] = ','.join(kwargs['VPCZoneIdentifier'])
+    if isinstance(kwargs['Tags'], six.string_types):
+        kwargs['Tags'] = json.loads(kwargs['Tags'])
+    if isinstance(kwargs['TerminationPolicies'], six.string_types):
+        kwargs['TerminationPolicies'] = json.loads(kwargs['TerminationPolicies'])
+    if isinstance(kwargs['SuspendedProcesses'], six.string_types):
+        kwargs['SuspendedProcesses'] = json.loads(kwargs['SuspendedProcesses'])
+    if isinstance(ScheduledUpdateGroupActions, six.string_types):
+        ScheduledUpdateGroupActions = json.loads(ScheduledUpdateGroupActions)
+
+    # Massage our tagset into  add / remove lists
+    # Use a boto3 call here b/c the boto2 call doeesn't implement filters
+    current_tags = conn.describe_tags(Filters=[{'Name': 'auto-scaling-group',
+                                      'Values': [kwargs['AutoScalingGroupName']]}]).get('Tags', [])
+    current_tags = [{'Key': t['Key'],
+                     'Value': t['Value'],
+                     'ResourceId': t['ResourceId'],
+                     'ResourceType': t['ResourceType'],
+                     'PropagateAtLaunch': t.get('PropagateAtLaunch', False)}
+                          for t in current_tags]
+    add_tags = []
+    desired_tags = []
+    delete_tags = []
+    if kwargs['Tags']:
+        for tag in kwargs['Tags']:
+            try:
+                Key = tag.get('Key')
+            except KeyError:
+                log.error('Tag missing key.')
+                return False
+            try:
+                Value = tag.get('Value')
+            except KeyError:
+                log.error('Tag missing value.')
+                return False
+            ResourceType = tag.get('ResourceType', 'auto-scaling-group')
+            PropagateAtLaunch = tag.get('PropagateAtLaunch', False)
+            _tag = {'ResourceId': kwargs['AutoScalingGroupName'], 'Key': Key, 'Value': Value, 'ResourceType': ResourceType, 'PropagateAtLaunch': PropagateAtLaunch}
+            if _tag not in current_tags:
+                add_tags.append(_tag)
+            desired_tags.append(_tag)
+        delete_tags = [t for t in current_tags if t not in desired_tags]
+    del kwargs['Tags']
+
+    try:
+        kwargs = dict((k, v) for k, v in six.iteritems(kwargs) if v is not None)
+        conn.update_auto_scaling_group(**kwargs)
+        if NotificationARN and NotificationTypes:
+            conn.put_notification_configuration(AutoScalingGroupName=kwargs['AutoScalingGroupName'], TopicARN=NotificationARN, NotificationTypes=NotificationTypes)
+        if add_tags:
+            log.debug('Adding/updating tags from ASG: {}'.format(add_tags))
+            conn.create_or_update_tags(Tags=add_tags)
+        if delete_tags:
+            log.debug('Deleting tags from ASG: {}'.format(delete_tags))
+            conn.delete_tags(Tags=delete_tags)
+        # update doesn't handle suspended_processes either
+        # Resume all processes
+        conn.resume_processes(AutoScalingGroupName=kwargs['AutoScalingGroupName'])
+        # suspend any that are specified.  Note that the boto default of empty
+        # list suspends all; don't do that.
+        _create_suspended_processes(conn, kwargs['AutoScalingGroupName'], kwargs.get('SuspendedProcesses'))
+        log.info('Updated ASG {0}'.format(kwargs['AutoScalingGroupName']))
+        # ### scaling policies
+        # delete all policies, then recreate them
+        policies = conn.describe_policies(AutoScalingGroupName=kwargs['AutoScalingGroupName'])
+        if policies['ScalingPolicies']:
+            for policy in policies['ScalingPolicies']:
+                conn.delete_policy(AutoScalingGroupName=kwargs['AutoScalingGroupName'], PolicyName=policy['PolicyName'])
+        _create_scaling_policies(conn, kwargs['AutoScalingGroupName'], ScalingPolicies)
+        # ### scheduled actions
+        # delete all scheduled actions, then recreate them
+        scheduled_actions = conn.describe_scheduled_actions(AutoScalingGroupName=kwargs['AutoScalingGroupName'])
+        if scheduled_actions['ScheduledUpdateGroupActions']:
+            for scheduled_action in scheduled_actions['ScheduledUpdateGroupActions']:
+                conn.delete_scheduled_action(AutoScalingGroupName=kwargs['AutoScalingGroupName'], ScheduledActionName=scheduled_action['ScheduledActionName'])
+        _create_scheduled_actions(conn, kwargs['AutoScalingGroupName'], ScheduledUpdateGroupActions)
+        return True, ''
+    except ClientError as e:
+        logging.debug(e.__dict__)
+        if e.response.get('Error', {}).get('Code') in ['Throttling']:
+            log.debug('Throttled by AWS API')
+        else:
+            msg = 'Failed to update ASG {}: {}'.format(kwargs['AutoScalingGroupName'], e.response.get('Error', {}).get('Message'))
+            log.error(msg)
+        return False, str(e)
+
+
+def _create_scaling_policies(conn, as_name, ScalingPolicies):
+    'helper function to create scaling policies'
+    if ScalingPolicies:
+        for policy in ScalingPolicies:
+            policy.update({'AutoScalingGroupName': as_name})
+            policy = dict((k, v) for k, v in six.iteritems(policy) if v is not None)
+            conn.put_scaling_policy(**policy)
+
+
+def _create_scheduled_actions(conn, as_name, ScheduledUpdateGroupActions):
+    '''
+    Helper function to create scheduled actions
+    '''
+    if ScheduledUpdateGroupActions:
+        for name, action in six.iteritems(ScheduledUpdateGroupActions):
+            if 'StartTime' in action and isinstance(action['StartTime'], six.string_types):
+                action['StartTime'] = datetime.datetime.strptime(
+                    action['StartTime'], DATE_FORMAT
+                )
+            if 'EndTime' in action and isinstance(action['EndTime'], six.string_types):
+                action['EndTime'] = datetime.datetime.strptime(
+                    action['EndTime'], DATE_FORMAT
+                )
+            conn.put_scheduled_update_group_action(
+                AutoScalingGroupName=as_name,
+                ScheduledActionName=name,
+                DesiredCapacity=action.get('DesiredCapacity'),
+                MinSize=action.get('MinSize'),
+                MaxSize=action.get('MaxSize'),
+                StartTime=action.get('StartTime'),
+                EndTime=action.get('EndTime'),
+                Recurrence=action.get('Recurrence')
+            )
+
+
+def _create_suspended_processes(conn, as_name, SuspendedProcesses):
+    'helper function to create suspended processes'
+    if SuspendedProcesses is not None and len(SuspendedProcesses) > 0:
+        conn.suspend_processes(AutoScalingGroupName=name, ScalingProcesses=ScalingProcesses)
+
+
+def delete(AutoScalingGroupName, force=False, region=None, key=None, keyid=None, profile=None):
+    '''
+    Delete an autoscale group.
+
+    CLI example::
+
+        salt myminion boto3_asg.delete myasg region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        conn.delete_auto_scaling_group(AutoScalingGroupName=AutoScalingGroupName, ForceDelete=force)
+        msg = 'Deleted autoscale group {0}.'.format(AutoScalingGroupName)
+        log.info(msg)
+        return True
+    except ClientError as e:
+        logging.debug(e.__dict__)
+        if e.response.get('Error', {}).get('Code') in ['Throttling']:
+            log.debug('Throttled by AWS API')
+        else:
+            msg = 'Failed to delete ASG {}: {}'.format(AutoScalingGroupName, e.response.get('Error', {}).get('Message'))
+            log.error(msg)
+        return False
+
+
+def launch_configuration_exists(name, region=None, key=None, keyid=None,
+                                profile=None):
+    '''
+    Check for a launch configuration's existence.
+
+    CLI example::
+
+        salt myminion boto3_asg.launch_configuration_exists mylc
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        _lc = conn.describe_launch_configurations(LaunchConfigurationNames=[name])
+        lc = _lc['LaunchConfigurations']
+        if lc:
+            return True
+        else:
+            msg = 'The launch configuration does not exist in region {0}'.format(region)
+            log.debug(msg)
+            return False
+    except ClientError as e:
+        logging.debug(e.__dict__)
+        if e.response.get('Error', {}).get('Code') in ['Throttling']:
+            log.debug('Throttled by AWS API')
+        return False
+
+
+def get_all_launch_configurations(region=None, key=None, keyid=None,
+                                  profile=None):
+    '''
+    Fetch and return all Launch Configuration with details.
+
+    CLI example::
+
+        salt myminion boto3_asg.get_all_launch_configurations
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        lc = conn.describe_launch_configurations()
+        return lc['LaunchConfigurations']
+    except ClientError as e:
+        logging.debug(e.__dict__)
+        if e.response.get('Error', {}).get('Code') in ['Throttling']:
+            log.debug('Throttled by AWS API')
+        return []
+
+
+def describe_launch_configuration(name, region=None, key=None, keyid=None,
+                                  profile=None):
+    '''
+    Dump details of a given launch configuration.
+
+    CLI example::
+
+        salt myminion boto3_asg.describe_launch_configuration mylc
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        _lc = conn.describe_launch_configurations(LaunchConfigurationNames=[name])
+        lc = _lc['LaunchConfigurations']
+        if lc:
+            return lc[0]
+        else:
+            msg = 'The launch configuration does not exist in region {0}'.format(region)
+            log.debug(msg)
+            return None
+    except ClientError as e:
+        logging.debug(e.__dict__)
+        if e.response.get('Error', {}).get('Code') in ['Throttling']:
+            log.debug('Throttled by AWS API')
+        return None
+
+
+def create_launch_configuration(LaunchConfigurationName, ImageId, KeyName=None,
+                                VpcId=None, VpcName=None,
+                                SecurityGroups=None, UserData=None,
+                                InstanceType='m1.small', KernelId=None,
+                                RamdiskId=None, BlockDeviceMappings=None,
+                                InstanceMonitoring=False, SpotPrice=None,
+                                IamInstanceProfile=None,
+                                EbsOptimized=False,
+                                AssociatePublicIpAddress=False,
+                                region=None, key=None, keyid=None,
+                                profile=None):
+    '''
+    Create a launch configuration.
+
+    CLI example::
+
+        salt myminion boto3_asg.create_launch_configuration mylc ImageId=ami-0b9c9f62 KeyName='mykey' SecurityGroups='["mygroup"]' InstanceType='c3.2xlarge'
+    '''
+    # Need kwargs at the top to avoid extra variables and boto3 doesnt support None arguments
+    kwargs = vars()
+    for k in ['region', 'key', 'keyid', 'profile']:
+        del kwargs[k]
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if isinstance(kwargs['SecurityGroups'], six.string_types):
+        kwargs['SecurityGroups'] = json.loads(kwargs['SecurityGroups'])
+    if isinstance(kwargs['BlockDeviceMappings'], six.string_types):
+        kwargs['BlockDeviceMappings'] = json.loads(kwargs['BlockDeviceMappings'])
+    if kwargs['SpotPrice']:
+        kwargs['SpotPrice'] = str(kwargs['SpotPrice'])
+    _bdms = []
+    if kwargs['BlockDeviceMappings']:
+        # Boto requires objects for the mappings and the devices.
+        for block_device_dict in kwargs['BlockDeviceMappings']:
+            for block_device, attributes in six.iteritems(block_device_dict):
+                _block_device_map = {'DeviceName': block_device, 'Ebs': {}}
+                for attribute, value in six.iteritems(attributes):
+                    _block_device_map['Ebs'][attribute] = value
+            _bdms.append(_block_device_map)
+    kwargs['BlockDeviceMappings'] = _bdms
+
+    # If a VPC is specified, then determine the secgroup id's within that VPC, not
+    # within the default VPC. If a security group id is already part of the list,
+    # convert_to_group_ids leaves that entry without attempting a lookup on it.
+    if kwargs['SecurityGroups'] and (VpcId or VpcName):
+        kwargs['SecurityGroups'] = __salt__['boto_secgroup.convert_to_group_ids'](
+                               kwargs['SecurityGroups'],
+                               vpc_id=VpcId, vpc_name=VpcName,
+                               region=region, key=key, keyid=keyid,
+                               profile=profile
+                           )
+    kwargs['InstanceMonitoring'] = {'Enabled': InstanceMonitoring}
+    try:
+        kwargs = dict((k, v) for k, v in six.iteritems(kwargs) if v is not None)
+        conn.create_launch_configuration(**kwargs)
+        log.info('Created LC {0}'.format(kwargs['LaunchConfigurationName']))
+        return True
+    except ClientError as e:
+        logging.debug(e.__dict__)
+        if e.response.get('Error', {}).get('Code') in ['Throttling']:
+            log.debug('Throttled by AWS API')
+        else:
+            msg = 'Failed to create LC {}: {}'.format(kwargs['LaunchConfigurationName'], e.response.get('Error', {}).get('Message'))
+            log.error(msg)
+        return False
+
+
+def delete_launch_configuration(name, region=None, key=None, keyid=None,
+                                profile=None):
+    '''
+    Delete a launch configuration.
+
+    CLI example::
+
+        salt myminion boto3_asg.delete_launch_configuration mylc
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        conn.delete_launch_configuration(LaunchConfigurationName=name)
+        log.info('Deleted LC {0}'.format(name))
+        return True
+    except ClientError as e:
+        logging.debug(e.__dict__)
+        if e.response.get('Error', {}).get('Code') in ['Throttling']:
+            log.debug('Throttled by AWS API')
+        else:
+            msg = 'Failed to delete LC {0}'.format(name)
+            log.error(msg)
+        return False
+
+
+def get_scaling_policy_arn(as_group, PolicyName, region=None,
+                           key=None, keyid=None, profile=None):
+    '''
+    Return the arn for a scaling policy in a specific autoscale group or None
+    if not found. Mainly used as a helper method for boto_cloudwatch_alarm, for
+    linking alarms to scaling policies.
+
+    CLI Example::
+
+        salt '*' boto3_asg.get_scaling_policy_arn mygroup mypolicy
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    policies = conn.describe_policies(AutoScalingGroupName=as_group)
+    for policy in policies['ScalingPolicies']:
+        if policy['PolicyName'] == PolicyName:
+            return policy['PolicyARN']
+    log.error('Could not convert: {0}'.format(as_group))
+    return None
+
+
+def get_all_groups(region=None, key=None, keyid=None, profile=None):
+    '''
+    Return all AutoScale Groups visible in the account
+    (as a list of boto.ec2.autoscale.group.AutoScalingGroup).
+
+    .. versionadded:: 2016.11.0
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt-call boto3_asg.get_all_groups region=us-east-1 --output yaml
+
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    try:
+        _asg = conn.describe_auto_scaling_groups()
+        return _asg['AutoScalingGroups']
+    except ClientError as e:
+        logging.debug(e.__dict__)
+        if e.response.get('Error', {}).get('Code') in ['Throttling']:
+            log.debug('Throttled by AWS API')
+        else:
+            log.error(e)
+        return []
+
+
+def list_groups(region=None, key=None, keyid=None, profile=None):
+    '''
+    Return all AutoScale Groups visible in the account
+    (as a list of names).
+
+    .. versionadded:: 2016.11.0
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt-call boto3_asg.list_groups region=us-east-1
+
+    '''
+    return [a['AutoScalingGroupName'] for a in get_all_groups(region=region, key=key, keyid=keyid, profile=profile)]
+
+
+def update_asg_load_balancers(AutoScalingGroupName, attach=None, detach=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Updates the autoscaling group classic load balancers
+    (as a list of names).
+
+    .. versionadded:: 2016.11.0
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt-call boto3_asg.update_asg_load_balancers mygroup attach='["my-load-balancer"]' region=us-east-1
+        salt-call boto3_asg.update_asg_load_balancers mygroup detach='["my-load-balancer"]' region=us-east-1
+
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if attach:
+        conn.attach_load_balancers(AutoScalingGroupName=AutoScalingGroupName, LoadBalancerNames=attach)
+    elif detach:
+        conn.detach_load_balancers(AutoScalingGroupName=AutoScalingGroupName, LoadBalancerNames=detach)
+        return True
+    return False
+
+
+def update_asg_target_groups(AutoScalingGroupName, attach=None, detach=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Updates the autoscaling group target groups
+    (as a list of names).
+
+    .. versionadded:: 2016.11.0
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt-call boto3_asg.update_asg_target_groups mygroup attach='["arn:aws:elasticloadbalancing:us-west-2:644138682826:targetgroup/learn1give1-api/414788a16b5cf163"]' region=us-east-1
+        salt-call boto3_asg.update_asg_target_groups mygroup detach='["arn:aws:elasticloadbalancing:us-west-2:644138682826:targetgroup/learn1give1-api/414788a16b5cf163"]' region=us-east-1
+
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+    if attach:
+        conn.attach_load_balancer_target_groups(AutoScalingGroupName=AutoScalingGroupName, TargetGroupARNs=attach)
+    elif detach:
+        conn.detach_load_balancer_target_groups(AutoScalingGroupName=AutoScalingGroupName, TargetGroupARNs=detach)
+        return True
+    return False

--- a/salt/states/boto3_asg.py
+++ b/salt/states/boto3_asg.py
@@ -1,0 +1,874 @@
+# -*- coding: utf-8 -*-
+'''
+Manage Autoscale Groups with Boto 3
+===================================
+
+.. versionadded:: 2014.7.0
+
+Create and destroy autoscale groups. Be aware that this interacts with Amazon's
+services, and so may incur charges.
+
+This module uses boto, which can be installed via package, or pip.
+
+This module accepts explicit autoscale credentials but can also utilize
+IAM roles assigned to the instance through Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More Information available at:
+
+.. code-block:: text
+
+    http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+If IAM roles are not used you need to specify them either in a pillar or
+in the minion's config file:
+
+.. code-block:: yaml
+
+    asg.keyid: GKTADJGHEIQSXMKKRBJ08H
+    asg.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+It's also possible to specify key, keyid and region via a profile, either
+as a passed in dict, or as a string to pull from pillars or minion config:
+
+.. code-block:: yaml
+
+    myprofile:
+        keyid: GKTADJGHEIQSXMKKRBJ08H
+        key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+        region: us-east-1
+
+.. code-block:: yaml
+
+    Ensure myasg exists:
+      boto3_asg.present:
+        - AutoScalingGroupName: myasg
+        - LaunchConfigurationName: mylc
+        - AvailabilityZones:
+          - us-east-1a
+          - us-east-1b
+        - MinSize: 1
+        - MaxSize: 1
+        - DesiredCapacity: 1
+        - LoadBalancerNames:
+          - myelb
+        - SuspendedProcesses:
+            - AddToLoadBalancer
+            - AlarmNotification
+        - ScalingPolicies
+            - AdjustmentType: ChangeInCapacity
+            - AutoScalingGroupName: api-production-iad
+            - Cooldown: 1800
+            - MinAdjustmentStep: None
+            - PolicyName: ScaleDown
+            - ScalingAdjustment: -1
+        - region: us-east-1
+        - keyid: GKTADJGHEIQSXMKKRBJ08H
+        - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    # Using a profile from pillars.
+    Ensure myasg exists:
+      boto3_asg.present:
+        - AutoScalingGroupName: myasg
+        - LaunchConfigurationName: mylc
+        - AvailabilityZones:
+          - us-east-1a
+          - us-east-1b
+        - MinSize: 1
+        - MaxSize: 1
+        - DesiredCapacity: 1
+        - LoadBalancerNames:
+          - myelb
+        - profile: myprofile
+
+    # Passing in a profile.
+    Ensure myasg exists:
+      boto3_asg.present:
+        - AutoScalingGroupName: myasg
+        - LaunchConfigurationName: mylc
+        - AvailabilityZones:
+          - us-east-1a
+          - us-east-1b
+        - MinSize: 1
+        - MaxSize: 1
+        - DesiredCapacity: 1
+        - LoadBalancerNames:
+          - myelb
+        - profile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+    # Deleting an autoscale group with running instances.
+    Ensure myasg is deleted:
+      boto3_asg.absent:
+        - name: myasg
+        # If instances exist, we must force the deletion of the asg.
+        - force: True
+
+It's possible to specify cloudwatch alarms that will be setup along with the
+ASG. Note the alarm name will be the name attribute defined, plus the ASG
+resource name.
+
+.. code-block:: yaml
+
+    Ensure myasg exists:
+      boto3_asg.present:
+        - AutoScalingGroupName: myasg
+        - LaunchConfigurationName: mylc
+        - AvailabilityZones:
+          - us-east-1a
+          - us-east-1b
+        - MinSize: 1
+        - MaxSize: 1
+        - DesiredCapacity: 1
+        - LoadBalancerNames:
+          - myelb
+        - profile: myprofile
+        - alarms:
+            CPU:
+              name: 'ASG CPU **MANAGED BY SALT**'
+              attributes:
+                metric: CPUUtilization
+                namespace: AWS/EC2
+                statistic: Average
+                comparison: '>='
+                threshold: 65.0
+                period: 60
+                evaluation_periods: 30
+                unit: null
+                description: 'ASG CPU'
+                alarm_actions: [ 'arn:aws:sns:us-east-1:12345:myalarm' ]
+                insufficient_data_actions: []
+                ok_actions: [ 'arn:aws:sns:us-east-1:12345:myalarm' ]
+
+You can also use alarms from pillars, and override values from the pillar
+alarms by setting overrides on the resource. Note that 'boto3_asg_alarms'
+will be used as a default value for all resources, if defined and can be
+used to ensure alarms are always set for an ASG resource.
+
+Setting the alarms in a pillar:
+
+.. code-block:: yaml
+
+    my_asg_alarm:
+      CPU:
+        name: 'ASG CPU **MANAGED BY SALT**'
+        attributes:
+          metric: CPUUtilization
+          namespace: AWS/EC2
+          statistic: Average
+          comparison: '>='
+          threshold: 65.0
+          period: 60
+          evaluation_periods: 30
+          unit: null
+          description: 'ASG CPU'
+          alarm_actions: [ 'arn:aws:sns:us-east-1:12345:myalarm' ]
+          insufficient_data_actions: []
+          ok_actions: [ 'arn:aws:sns:us-east-1:12345:myalarm' ]
+
+Overriding the alarm values on the resource:
+
+.. code-block:: yaml
+
+    Ensure myasg exists:
+      boto3_asg.present:
+        - AutoScalingGroupName: myasg
+        - LaunchConfigurationName: mylc
+        - AvailabilityZones:
+          - us-east-1a
+          - us-east-1b
+        - MinSize: 1
+        - MaxSize: 1
+        - DesiredCapacity: 1
+        - LoadBalancerNames:
+          - myelb
+        - profile: myprofile
+        - alarms_from_pillar: my_asg_alarm
+        # override CPU:attributes:threshold
+        - alarms:
+            CPU:
+              attributes:
+                threshold: 50.0
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+import hashlib
+import logging
+import copy
+
+# Import Salt libs
+import salt.utils.dictupdate as dictupdate
+import salt.ext.six as six
+from salt.exceptions import SaltInvocationError
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if boto is available.
+    '''
+    return 'boto3_asg' if 'boto3_asg.exists' in __salt__ else False
+
+
+def present(name,
+        LaunchConfigurationName,
+        AvailabilityZones,
+        MinSize,
+        MaxSize,
+        AutoScalingGroupName=None,
+        LaunchConfig=None,
+        DesiredCapacity=None,
+        LoadBalancerNames=None,
+        TargetGroupNames=None,
+        DefaultCooldown=None,
+        HealthCheckType=None,
+        HealthCheckGracePeriod=None,
+        PlacementGroup=None,
+        VPCZoneIdentifier=None,
+        SubnetNames=None,
+        Tags=None,
+        TerminationPolicies=None,
+        TerminationPolicies_from_pillar='boto3_asg_termination_policies',
+        SuspendedProcesses=None,
+        ScalingPolicies=None,
+        ScalingPolicies_from_pillar='boto3_asg_scaling_policies',
+        ScheduledUpdateGroupActions=None,
+        ScheduledUpdateGroupActions_from_pillar='boto3_asg_scheduled_actions',
+        alarms=None,
+        alarms_from_pillar='boto3_asg_alarms',
+        region=None,
+        key=None,
+        keyid=None,
+        profile=None,
+        NotificationARN=None,
+        NotificationARN_from_pillar='boto3_asg_notification_arn',
+        NotificationTypes=None,
+        NotificationTypes_from_pillar='boto3_asg_notification_types'):
+    '''
+    Ensure the autoscale group exists.
+
+    name
+        The name of the state definition.  This will be used as the 'CallerReference' param when
+        creating the autoscaling group to help ensure idempotency.
+
+    AutoScalingGroupName
+        Name of the autoscale group.
+
+    LaunchConfigurationName
+        Name of the launch config to use for the group.  Or, if
+        ``LaunchConfig`` is specified, this will be the launch config
+        name's prefix.  (see below)
+
+    LaunchConfig
+        A dictionary of launch config attributes.  If specified, a
+        launch config will be used or created, matching this set
+        of attributes, and the autoscale group will be set to use
+        that launch config.  The launch config name will be the
+        ``launch_config_name`` followed by a hyphen followed by a hash
+        of the ``LaunchConfig`` dict contents.
+        Example:
+
+        .. code-block:: yaml
+
+            my_asg:
+              boto3_asg.present:
+              - LaunchConfig:
+                - EbsOptimized: false
+                - IamInstanceProfile: my_iam_profile
+                - KernelId: ''
+                - RamdiskId: ''
+                - KeyName: my_ssh_key
+                - ImageName: aws2015091-hvm
+                - InstanceType: c3.xlarge
+                - InstanceMonitoring: false
+                - SecurityGroups:
+                  - my_sec_group_01
+                  - my_sec_group_02
+
+    AvailabilityZones
+        List of availability zones for the group.
+
+    MinSize
+        Minimum size of the group.
+
+    MaxSize
+        Maximum size of the group.
+
+    DesiredCapacity
+        The desired capacity of the group.
+
+    LoadBalancerNames
+        List of load balancers for the group. Once set this can not be
+        updated (Amazon restriction).
+
+    TargetGroupNames
+        List of target groups for the autoscaling group. Once set this can not
+        be updated (Amazon restriction).
+
+    DefaultCooldown
+        Number of seconds after a Scaling Activity completes before any further
+        scaling activities can start.
+
+    HealthCheckType
+        The service you want the health status from, Amazon EC2 or Elastic Load
+        Balancer (EC2 or ELB).
+
+    HealthCheckGracePeriod
+        Length of time in seconds after a new EC2 instance comes into service
+        that Auto Scaling starts checking its health.
+
+    PlacementGroup
+        Physical location of your cluster placement group created in Amazon
+        EC2. Once set this can not be updated (Amazon restriction).
+
+    VPCZoneIdentifier
+        A list of the subnet identifiers of the Virtual Private Cloud.
+
+    SubnetNames
+        For VPC, a list of subnet names (NOT subnet IDs) to deploy into.
+        Exclusive with VPCZoneIdentifier.
+
+    Tags
+        A list of tags. Example:
+
+        .. code-block:: yaml
+
+            - Key: 'Key'
+              Value: 'Value'
+              PropagateAtLaunch: true
+
+    TerminationPolicies
+        A list of termination policies. Valid values are:
+
+        * ``OldestInstance``
+        * ``NewestInstance``
+        * ``OldestLaunchConfiguration``
+        * ``ClosestToNextInstanceHour``
+        * ``Default``
+
+        If no value is specified, the ``Default`` value is used.
+
+    TerminationPolicies_from_pillar:
+        name of pillar dict that contains termination policy settings.   Termination policies
+        defined for this specific state will override those from pillar.
+
+    SuspendedProcesses
+        List of processes to be suspended. see
+        http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/US_SuspendResume.html
+
+    ScalingPolicies
+        List of scaling policies.  Each policy is a dict of key-values described by
+        https://boto.readthedocs.io/en/latest/ref/autoscale.html#boto.ec2.autoscale.policy.ScalingPolicy
+
+    ScalingPolicies_from_pillar:
+        name of pillar dict that contains scaling policy settings.   Scaling policies defined for
+        this specific state will override those from pillar.
+
+    ScheduledUpdateGroupActions:
+        a dictionary of scheduled actions. Each key is the name of scheduled action and each value
+        is dictionary of options. For example:
+
+        .. code-block:: yaml
+
+            - ScheduledUpdateGroupActions:
+                scale_up_at_10:
+                    DesiredCapacity: 4
+                    MinSize: 3
+                    MaxSize: 5
+                    Recurrence: "0 9 * * 1-5"
+                scale_down_at_7:
+                    DesiredCapacity: 1
+                    MinSize: 1
+                    MaxSize: 1
+                    Recurrence: "0 19 * * 1-5"
+
+    ScheduledUpdateGroupActions_from_pillar:
+        name of pillar dict that contains scheduled_actions settings. Scheduled actions
+        for this specific state will override those from pillar.
+
+    alarms:
+        a dictionary of name->boto_cloudwatch_alarm sections to be associated with this ASG.
+        All attributes should be specified except for dimension which will be
+        automatically set to this ASG.
+
+        See the :mod:`salt.states.boto_cloudwatch_alarm` state for information
+        about these attributes.
+
+        If any alarm actions include  ":self:" this will be replaced with the asg name.
+        For example, alarm_actions reading "['scaling_policy:self:ScaleUp']" will
+        map to the arn for this asg's scaling policy named "ScaleUp".
+        In addition, any alarms that have only scaling_policy as actions will be ignored if
+        min_size is equal to max_size for this ASG.
+
+    alarms_from_pillar:
+        name of pillar dict that contains alarm settings.   Alarms defined for this specific
+        state will override those from pillar.
+
+    region
+        The region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+
+    NotificationARN
+        The AWS arn that notifications will be sent to
+
+    NotificationARN_from_pillar
+        name of the pillar dict that contains ``NotificationARN`` settings.  A
+        ``notification_arn`` defined for this specific state will override the
+        one from pillar.
+
+    NotificationTypes
+        A list of event names that will trigger a notification.  The list of valid
+        notification types is:
+
+        * ``autoscaling:EC2_INSTANCE_LAUNCH``
+        * ``autoscaling:EC2_INSTANCE_LAUNCH_ERROR``
+        * ``autoscaling:EC2_INSTANCE_TERMINATE``
+        * ``autoscaling:EC2_INSTANCE_TERMINATE_ERROR``
+        * ``autoscaling:TEST_NOTIFICATION``
+
+    NotificationTypes_from_pillar
+        name of the pillar dict that contains ``NotificationTypes`` settings.
+        ``notification_types`` defined for this specific state will override those
+        from the pillar.
+    '''
+    AutoScalingGroupName = AutoScalingGroupName if AutoScalingGroupName else name
+    if VPCZoneIdentifier and SubnetNames:
+        raise SaltInvocationError('VPCZoneIdentifier and SubnetNames are '
+                                  'mutually exclusive options.')
+    ret = {'name': AutoScalingGroupName, 'result': True, 'comment': '', 'changes': {}}
+    if SubnetNames:
+        VPCZoneIdentifier = []
+        for i in SubnetNames:
+            r = __salt__['boto_vpc.get_resource_id']('subnet', name=i, region=region,
+                                                     key=key, keyid=keyid, profile=profile)
+            if 'error' in r:
+                ret['comment'] = 'Error looking up subnet ids: {0}'.format(r['error'])
+                ret['result'] = False
+                return ret
+            if 'id' not in r:
+                ret['comment'] = 'Subnet {0} does not exist.'.format(i)
+                ret['result'] = False
+                return ret
+            VPCZoneIdentifier.append(r['id'])
+    if VPCZoneIdentifier:
+        vpc_id = __salt__['boto_vpc.get_subnet_association'](
+            VPCZoneIdentifier,
+            region,
+            key,
+            keyid,
+            profile
+        )
+        vpc_id = vpc_id.get('vpc_id')
+        log.debug('Auto Scaling Group {0} is associated with VPC ID {1}'
+                  .format(AutoScalingGroupName, vpc_id))
+    else:
+        vpc_id = None
+        log.debug('Auto Scaling Group {0} has no VPC Association'
+                  .format(AutoScalingGroupName))
+
+    if TargetGroupNames:
+        TargetGroupARNs = []
+        for tg in TargetGroupNames:
+            _tg = __salt__['boto_elbv2.describe_target_group'](tg, region, key, keyid, profile)
+            _arn = _tg.get('TargetGroupArn')
+            if _arn:
+                TargetGroupARNs.append(_arn)
+    else:
+        TargetGroupARNs = None
+
+    # if launch_config is defined, manage the launch config first.
+    # hash the launch_config dict to create a unique name suffix and then
+    # ensure it is present
+    if LaunchConfig:
+        LaunchConfigurationName = LaunchConfigurationName + '-' + hashlib.md5(str(LaunchConfig)).hexdigest()
+        args = {
+            'name': LaunchConfigurationName,
+            'region': region,
+            'key': key,
+            'keyid': keyid,
+            'profile': profile
+        }
+
+        for index, item in enumerate(LaunchConfig):
+            if 'ImageName' in item:
+                ImageName = item['ImageName']
+                iargs = {'ami_name': ImageName, 'region': region, 'key': key,
+                         'keyid': keyid, 'profile': profile}
+                image_ids = __salt__['boto_ec2.find_images'](**iargs)
+                if len(image_ids):
+                    LaunchConfig[index]['ImageId'] = image_ids[0]
+                else:
+                    LaunchConfig[index]['ImageId'] = ImageName
+                del LaunchConfig[index]['ImageName']
+                break
+
+        if vpc_id:
+            log.debug('Auto Scaling Group {0} is a associated with a vpc')
+            # locate the security groups attribute of a launch config
+            sg_index = None
+            for index, item in enumerate(LaunchConfig):
+                if 'SecurityGroups' in item:
+                    sg_index = index
+                    break
+            # if security groups exist within LaunchConfig then convert
+            # to group ids
+            if sg_index is not None:
+                log.debug('security group associations found in launch config')
+                _group_ids = __salt__['boto_secgroup.convert_to_group_ids'](
+                    LaunchConfig[sg_index]['SecurityGroups'], vpc_id=vpc_id,
+                    region=region, key=key, keyid=keyid, profile=profile
+                )
+                LaunchConfig[sg_index]['SecurityGroups'] = _group_ids
+
+        for d in LaunchConfig:
+            args.update(d)
+        if not __opts__['test']:
+            lc_ret = __states__['boto3_lc.present'](**args)
+            if lc_ret['result'] is True and lc_ret['changes']:
+                if 'LaunchConfig' not in ret['changes']:
+                    ret['changes']['LaunchConfig'] = {}
+                ret['changes']['LaunchConfig'] = lc_ret['changes']
+
+    asg = __salt__['boto3_asg.get_config'](AutoScalingGroupName, region, key, keyid, profile)
+    TerminationPolicies = _determine_termination_policies(
+        TerminationPolicies,
+        TerminationPolicies_from_pillar
+    )
+    ScalingPolicies = _determine_scaling_policies(
+        ScalingPolicies,
+        ScalingPolicies_from_pillar
+    )
+    ScheduledUpdateGroupActions = _determine_scheduled_actions(
+        ScheduledUpdateGroupActions,
+        ScheduledUpdateGroupActions_from_pillar
+    )
+    if asg is None:
+        ret['result'] = False
+        ret['comment'] = 'Failed to check autoscale group existence.'
+    elif not asg:
+        if __opts__['test']:
+            msg = 'Autoscale group set to be created.'
+            ret['comment'] = msg
+            ret['result'] = None
+            return ret
+        NotificationARN, NotificationTypes = _determine_notification_info(
+            NotificationARN,
+            NotificationARN_from_pillar,
+            NotificationTypes,
+            NotificationTypes_from_pillar
+        )
+        created = __salt__['boto3_asg.create'](AutoScalingGroupName, LaunchConfigurationName,
+                                              AvailabilityZones, MinSize, MaxSize, DesiredCapacity,
+                                              LoadBalancerNames, TargetGroupARNs, DefaultCooldown,
+                                              HealthCheckType, HealthCheckGracePeriod,
+                                              PlacementGroup, VPCZoneIdentifier, Tags,
+                                              TerminationPolicies, SuspendedProcesses,
+                                              ScalingPolicies, ScheduledUpdateGroupActions,
+                                              NotificationARN, NotificationTypes,
+                                              region, key, keyid, profile)
+        if created:
+            ret['changes']['old'] = None
+            asg = __salt__['boto3_asg.get_config'](name, region, key, keyid,
+                                                  profile)
+            ret['changes']['new'] = asg
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to create autoscale group'
+    else:
+        need_update = False
+        # If any of these attributes can't be modified after creation
+        # time, we should remove them from the dict.
+        if ScalingPolicies:
+            for policy in ScalingPolicies:
+                if 'MinAdjustmentStep' not in policy:
+                    policy['MinAdjustmentStep'] = None
+        if ScheduledUpdateGroupActions:
+            for s_name, action in six.iteritems(ScheduledUpdateGroupActions):
+                if 'EndTime' not in action:
+                    action['EndTime'] = None
+        config = {
+            'LaunchConfigurationName': LaunchConfigurationName,
+            'AvailabilityZones': AvailabilityZones,
+            'MinSize': MinSize,
+            'MaxSize': MaxSize,
+            'DesiredCapacity': DesiredCapacity,
+            'DefaultCooldown': DefaultCooldown,
+            'HealthCheckType': HealthCheckType,
+            'HealthCheckGracePeriod': HealthCheckGracePeriod,
+            'VPCZoneIdentifier': VPCZoneIdentifier,
+            'LoadBalancerNames': LoadBalancerNames,
+            'TargetGroupARNs': TargetGroupARNs,
+            'Tags': Tags,
+            'TerminationPolicies': TerminationPolicies,
+            'SuspendedProcesses': SuspendedProcesses,
+            'ScalingPolicies': ScalingPolicies,
+            'ScheduledUpdateGroupActions': ScheduledUpdateGroupActions
+        }
+        #ensure that we reset TerminationPolicies to default if none are specified
+        if not TerminationPolicies:
+            config['TerminationPolicies'] = ['Default']
+        if LoadBalancerNames is None:
+            config['LoadBalancerNames'] = []
+        if TargetGroupARNs is None:
+            config['TargetGroupARNs'] = []
+        if SuspendedProcesses is None:
+            config['SuspendedProcesses'] = []
+        # ensure that we delete ScalingPolicies if none are specified
+        if ScalingPolicies is None:
+            config['ScalingPolicies'] = []
+        # ensure that we delete ScalingPolicies if none are specified
+        if ScheduledUpdateGroupActions is None:
+            config['ScheduledUpdateGroupActions'] = {}
+        # allow defaults on StartTime
+        for s_name, action in six.iteritems(ScheduledUpdateGroupActions):
+            if 'StartTime' not in action:
+                asg_action = asg['ScheduledUpdateGroupActions'].get(s_name, {})
+                if 'StartTime' in asg_action:
+                    del asg_action['StartTime']
+        proposed = {}
+        # note: do not loop using "key, value" - this can modify the value of
+        # the aws access key
+        for asg_property, value in six.iteritems(config):
+            # Only modify values being specified; introspection is difficult
+            # otherwise since it's hard to track default values, which will
+            # always be returned from AWS.
+            if value is None:
+                continue
+            value = _ordered(value)
+            if asg_property in asg:
+                _value = _ordered(asg[asg_property])
+                if not value == _value:
+                    log_msg = '{0} asg_property differs from {1}'
+                    log.debug(log_msg.format(value, _value))
+                    proposed.setdefault('old', {}).update({asg_property: _value})
+                    proposed.setdefault('new', {}).update({asg_property: value})
+                    need_update = True
+        if need_update:
+            if __opts__['test']:
+                msg = 'Autoscale group set to be updated.'
+                ret['comment'] = msg
+                ret['result'] = None
+                ret['changes'] = proposed
+                return ret
+            # add in alarms
+            NotificationARN, NotificationTypes = _determine_notification_info(
+                NotificationARN,
+                NotificationARN_from_pillar,
+                NotificationTypes,
+                NotificationTypes_from_pillar
+            )
+            updated, msg = __salt__['boto3_asg.update'](
+                AutoScalingGroupName,
+                LaunchConfigurationName,
+                AvailabilityZones,
+                MinSize,
+                MaxSize,
+                DesiredCapacity=DesiredCapacity,
+                DefaultCooldown=DefaultCooldown,
+                HealthCheckType=HealthCheckType,
+                HealthCheckGracePeriod=HealthCheckGracePeriod,
+                PlacementGroup=PlacementGroup,
+                VPCZoneIdentifier=VPCZoneIdentifier,
+                Tags=Tags,
+                TerminationPolicies=TerminationPolicies,
+                SuspendedProcesses=SuspendedProcesses,
+                ScalingPolicies=ScalingPolicies,
+                ScheduledUpdateGroupActions=ScheduledUpdateGroupActions,
+                NotificationARN=NotificationARN,
+                NotificationTypes=NotificationTypes,
+                region=region,
+                key=key,
+                keyid=keyid,
+                profile=profile
+            )
+            if asg['LaunchConfigurationName'] != LaunchConfigurationName:
+                # delete the old LaunchConfigurationName
+                deleted = __salt__['boto3_asg.delete_launch_configuration'](
+                    asg['LaunchConfigurationName'],
+                    region=region,
+                    key=key,
+                    keyid=keyid,
+                    profile=profile
+                )
+                if deleted:
+                    if 'LaunchConfig' not in ret['changes']:
+                        ret['changes']['LaunchConfig'] = {}
+                    ret['changes']['LaunchConfig']['deleted'] = asg['LaunchConfigurationName']
+            if asg['LoadBalancerNames'] != config['LoadBalancerNames']:
+                attach_lb = [t for t in config['LoadBalancerNames'] if t not in asg['LoadBalancerNames']]
+                detach_lb = [t for t in asg['LoadBalancerNames'] if t not in config['LoadBalancerNames']]
+                __salt__['boto3_asg.update_asg_load_balancers'](
+                    AutoScalingGroupName,
+                    attach=attach_lb,
+                    detach=detach_lb,
+                    region=region,
+                    key=key,
+                    keyid=keyid,
+                    profile=profile
+                )
+            if asg['TargetGroupARNs'] != config['TargetGroupARNs']:
+                desired_tg = config['TargetGroupARNs']
+                attach_tg = [t for t in desired_tg if t not in asg['TargetGroupARNs']]
+                detach_tg = [t for t in desired_tg if t not in config['TargetGroupARNs']]
+                __salt__['boto3_asg.update_asg_target_groups'](
+                    AutoScalingGroupName,
+                    attach=attach_tg,
+                    detach=detach_tg,
+                    region=region,
+                    key=key,
+                    keyid=keyid,
+                    profile=profile
+                )
+            if updated:
+                ret['changes']['old'] = asg
+                asg = __salt__['boto3_asg.get_config'](AutoScalingGroupName, region, key, keyid,
+                                                      profile)
+                ret['changes']['new'] = asg
+                ret['comment'] = 'Updated autoscale group.'
+            else:
+                ret['result'] = False
+                ret['comment'] = msg
+        else:
+            ret['comment'] = 'Autoscale group present.'
+    # add in alarms
+    _ret = _alarms_present(
+        AutoScalingGroupName, MinSize == MaxSize, alarms, alarms_from_pillar, region, key,
+        keyid, profile
+    )
+    ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
+    ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
+    if not _ret['result']:
+        ret['result'] = _ret['result']
+    return ret
+
+
+def _determine_termination_policies(TerminationPolicies, TerminationPolicies_from_pillar):
+    '''
+    helper method for present.  ensure that TerminationPolicies are set
+    '''
+    pillar_termination_policies = copy.deepcopy(
+        __salt__['config.option'](TerminationPolicies_from_pillar, [])
+    )
+    if not TerminationPolicies and len(pillar_termination_policies) > 0:
+        TerminationPolicies = pillar_termination_policies
+    return TerminationPolicies
+
+
+def _determine_scaling_policies(ScalingPolicies, ScalingPolicies_from_pillar):
+    '''
+    helper method for present.  ensure that ScalingPolicies are set
+    '''
+    pillar_scaling_policies = copy.deepcopy(
+        __salt__['config.option'](ScalingPolicies_from_pillar, {})
+    )
+    if not ScalingPolicies and len(pillar_scaling_policies) > 0:
+        ScalingPolicies = pillar_scaling_policies
+    return ScalingPolicies
+
+
+def _determine_scheduled_actions(ScheduledUpdateGroupActions, ScheduledUpdateGroupActions_from_pillar):
+    '''
+    helper method for present,  ensure scheduled actions are setup
+    '''
+    tmp = copy.deepcopy(
+        __salt__['config.option'](ScheduledUpdateGroupActions_from_pillar, {})
+    )
+    # merge with data from state
+    if ScheduledUpdateGroupActions:
+        tmp = dictupdate.update(tmp, ScheduledUpdateGroupActions)
+    return tmp
+
+
+def _determine_notification_info(NotificationARN,
+                                 NotificationARN_from_pillar,
+                                 NotificationTypes,
+                                 NotificationTypes_from_pillar):
+    '''
+    helper method for present.  ensure that notification_configs are set
+    '''
+    pillar_arn_list = copy.deepcopy(
+        __salt__['config.option'](NotificationARN_from_pillar, {})
+    )
+    pillar_arn = None
+    if len(pillar_arn_list) > 0:
+        pillar_arn = pillar_arn_list[0]
+    pillar_notification_types = copy.deepcopy(
+        __salt__['config.option'](NotificationTypes_from_pillar, {})
+    )
+    arn = NotificationARN if NotificationARN else pillar_arn
+    types = NotificationTypes if NotificationTypes else pillar_notification_types
+    return (arn, types)
+
+
+def _alarms_present(name, min_size_equals_max_size, alarms, alarms_from_pillar, region, key, keyid, profile):
+    '''
+    helper method for present.  ensure that cloudwatch_alarms are set
+    '''
+    # load data from alarms_from_pillar
+    tmp = copy.deepcopy(__salt__['config.option'](alarms_from_pillar, {}))
+    # merge with data from alarms
+    if alarms:
+        tmp = dictupdate.update(tmp, alarms)
+    # set alarms, using boto_cloudwatch_alarm.present
+    merged_return_value = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+    for _, info in six.iteritems(tmp):
+        # add asg to name and description
+        info['name'] = name + ' ' + info['name']
+        info['attributes']['description'] = name + ' ' + info['attributes']['description']
+        # add dimension attribute
+        if 'dimensions' not in info['attributes']:
+            info['attributes']['dimensions'] = {'AutoScalingGroupName': [name]}
+        scaling_policy_actions_only = True
+        # replace ":self:" with our name
+        for action_type in ['alarm_actions', 'insufficient_data_actions', 'ok_actions']:
+            if action_type in info['attributes']:
+                new_actions = []
+                for action in info['attributes'][action_type]:
+                    if 'scaling_policy' not in action:
+                        scaling_policy_actions_only = False
+                    if ':self:' in action:
+                        action = action.replace(':self:', ':{0}:'.format(name))
+                    new_actions.append(action)
+                info['attributes'][action_type] = new_actions
+        # skip alarms that only have actions for scaling policy, if min_size == max_size for this ASG
+        if scaling_policy_actions_only and min_size_equals_max_size:
+            continue
+        # set alarm
+        kwargs = {
+            'name': info['name'],
+            'attributes': info['attributes'],
+            'region': region,
+            'key': key,
+            'keyid': keyid,
+            'profile': profile,
+        }
+        results = __states__['boto_cloudwatch_alarm.present'](**kwargs)
+        if not results['result']:
+            merged_return_value['result'] = False
+        if results.get('changes', {}) != {}:
+            merged_return_value['changes'][info['name']] = results['changes']
+        if 'comment' in results:
+            merged_return_value['comment'] += results['comment']
+    return merged_return_value
+
+
+def _ordered(obj):
+    if isinstance(obj, (list, tuple)):
+        return sorted(_ordered(x) for x in obj)
+    elif isinstance(obj, dict):
+        return dict((six.text_type(k) if isinstance(k, six.string_types) else k, _ordered(v)) for k, v in obj.items())
+    elif isinstance(obj, six.string_types):
+        return six.text_type(obj)
+    return obj

--- a/salt/states/boto3_lc.py
+++ b/salt/states/boto3_lc.py
@@ -1,0 +1,352 @@
+# -*- coding: utf-8 -*-
+'''
+Manage Launch Configurations
+
+.. versionadded:: 2014.7.0
+
+Create and destroy Launch Configurations. Be aware that this interacts with
+Amazon's services, and so may incur charges.
+
+A limitation of this module is that you can not modify launch configurations
+once they have been created. If a launch configuration with the specified name
+exists, this module will always report success, even if the specified
+configuration doesn't match. This is due to a limitation in Amazon's launch
+configuration API, as it only allows launch configurations to be created and
+deleted.
+
+Also note that a launch configuration that's in use by an autoscale group can
+not be deleted until the autoscale group is no longer using it. This may affect
+the way in which you want to order your states.
+
+This module uses ``boto``, which can be installed via package, or pip.
+
+This module accepts explicit autoscale credentials but can also utilize
+IAM roles assigned to the instance through Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More information available `here
+<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_.
+
+If IAM roles are not used you need to specify them either in a pillar file or
+in the minion's config file:
+
+.. code-block:: yaml
+
+    asg.keyid: GKTADJGHEIQSXMKKRBJ08H
+    asg.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+It's also possible to specify ``key``, ``keyid`` and ``region`` via a profile, either
+passed in as a dict, or as a string to pull from pillars or minion config:
+
+.. code-block:: yaml
+
+    myprofile:
+        keyid: GKTADJGHEIQSXMKKRBJ08H
+        key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+        region: us-east-1
+
+Credential information is shared with autoscale groups as launch configurations
+and autoscale groups are completely dependent on each other.
+
+.. code-block:: yaml
+
+    Ensure mylc exists:
+      boto3_lc.present:
+        - LaunchConfigurationName: mylc
+        - ImageId: ami-0b9c9f62
+        - KeyName: mykey
+        - SecurityGroups:
+            - mygroup
+        - InstanceType: m1.small
+        - InstanceMonitoring: true
+        - BlockDeviceMappings:
+            - '/dev/sda1':
+                VolumeSize: 20
+                VolumeType: 'io1'
+                Iops: 220
+                DeleteOnTermination: true
+        - CloudInit:
+            boothooks:
+              'disable-master.sh': |
+                #!/bin/bash
+                echo "manual" > /etc/init/salt-master.override
+            scripts:
+              'run_salt.sh': |
+                #!/bin/bash
+
+                add-apt-repository -y ppa:saltstack/salt
+                apt-get update
+                apt-get install -y salt-minion
+                salt-call state.highstate
+        - region: us-east-1
+        - keyid: GKTADJGHEIQSXMKKRBJ08H
+        - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    # Using a profile from pillars.
+    Ensure mylc exists:
+      boto3_lc.present:
+        - LaunchConfigurationName: mylc
+        - ImageId: ami-0b9c9f62
+        - profile: myprofile
+
+    # Passing in a profile.
+    Ensure mylc exists:
+      boto3_lc.present:
+        - LaunchConfigurationName: mylc
+        - ImageId: ami-0b9c9f62
+        - profile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+'''
+from __future__ import absolute_import
+from salt.exceptions import SaltInvocationError
+
+
+def __virtual__():
+    '''
+    Only load if boto is available.
+    '''
+    return 'boto3_lc' if 'boto3_asg.exists' in __salt__ else False
+
+
+def present(name,
+        ImageId,
+        LaunchConfigurationName=None,
+        KeyName=None,
+        VpcId=None,
+        VpcName=None,
+        SecurityGroups=None,
+        UserData=None,
+        CloudInit=None,
+        InstanceType='m1.small',
+        KernelId=None,
+        RamdiskId=None,
+        BlockDeviceMappings=None,
+        InstanceMonitoring=False,
+        SpotPrice=None,
+        IamInstanceProfile=None,
+        EbsOptimized=False,
+        AssociatePublicIpAddress=False,
+        region=None,
+        key=None,
+        keyid=None,
+        profile=None):
+    '''
+    Ensure the launch configuration exists.
+
+    name
+        The name of the state definition.  This will be used as the 'CallerReference' param when
+        creating the launch configuration to help ensure idempotency.
+
+    LaunchConfigurationName
+        Name of the launch configuration.
+
+    ImageId
+        AMI to use for instances. AMI must exist or creation of the launch
+        configuration will fail.
+
+    KeyName
+        Name of the EC2 key pair to use for instances. Key must exist or
+        creation of the launch configuration will fail.
+
+    VpcId
+        The VPC id where the security groups are defined. Only necessary when
+        using named security groups that exist outside of the default VPC.
+        Mutually exclusive with VpcName.
+
+    VpcName
+        Name of the VPC where the security groups are defined. Only Necessary
+        when using named security groups that exist outside of the default VPC.
+        Mutually exclusive with VpcId.
+
+    SecurityGroups
+        List of Names or security group id’s of the security groups with which
+        to associate the EC2 instances or VPC instances, respectively. Security
+        groups must exist, or creation of the launch configuration will fail.
+
+    UserData
+        The user data available to launched EC2 instances.
+
+    CloudInit
+        A dict of CloudInit configuration. Currently supported values:
+        scripts, cloud-config. Mutually exclusive with UserData.
+
+    InstanceType
+        The instance type. ex: m1.small.
+
+    KernelId
+        The kernel id for the instance.
+
+    RamdiskId
+        The RAM disk ID for the instance.
+
+    BlockDeviceMappings
+        A dict of block device mappings that contains a dict
+        with VolumeType, DeleteOnTermination, Iops, VolumeSize, Encrypted,
+        snapshot_id.
+
+        VolumeType
+            Indicates what volume type to use. Valid values are standard, io1, gp2.
+            Default is standard.
+
+        DeleteOnTermination
+            Indicates whether to delete the volume on instance termination (true) or
+            not (false).
+
+        Iops
+            For Provisioned IOPS (SSD) volumes only. The number of I/O operations per
+            second (IOPS) to provision for the volume.
+
+        VolumeSize
+            Desired volume size (in GiB).
+
+        Encrypted
+            Indicates whether the volume should be encrypted. Encrypted EBS volumes must
+            be attached to instances that support Amazon EBS encryption. Volumes that are
+            created from encrypted snapshots are automatically encrypted. There is no way
+            to create an encrypted volume from an unencrypted snapshot or an unencrypted
+            volume from an encrypted snapshot.
+
+    InstanceMonitoring
+        Whether instances in group are launched with detailed monitoring.
+
+    SpotPrice
+        The spot price you are bidding. Only applies if you are building an
+        autoscaling group with spot instances.
+
+    IamInstanceProfile
+        The name or the Amazon Resource Name (ARN) of the instance profile
+        associated with the IAM role for the instance. Instance profile must
+        exist or the creation of the launch configuration will fail.
+
+    EbsOptimized
+        Specifies whether the instance is optimized for EBS I/O (true) or not
+        (false).
+
+    AssociatePublicIpAddress
+        Used for Auto Scaling groups that launch instances into an Amazon
+        Virtual Private Cloud. Specifies whether to assign a public IP address
+        to each instance launched in a Amazon VPC.
+
+    region
+        The region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+    '''
+    LaunchConfigurationName = LaunchConfigurationName if LaunchConfigurationName else name
+    if UserData and CloudInit:
+        raise SaltInvocationError('UserData and CloudInit are mutually'
+                                  ' exclusive options.')
+    ret = {'name': LaunchConfigurationName, 'result': True, 'comment': '', 'changes': {}}
+    exists = __salt__['boto3_asg.launch_configuration_exists'](LaunchConfigurationName,
+                                                              region=region,
+                                                              key=key,
+                                                              keyid=keyid,
+                                                              profile=profile)
+    if not exists:
+        if __opts__['test']:
+            msg = 'Launch configuration set to be created.'
+            ret['comment'] = msg
+            ret['result'] = None
+            return ret
+        if CloudInit:
+            UserData = __salt__['boto_asg.get_cloud_init_mime'](CloudInit)
+        # TODO: Ensure ImageId, KeyName, SecurityGroups and IamInstanceProfile
+        # exist, or throw an invocation error.
+        created = __salt__['boto3_asg.create_launch_configuration'](
+            LaunchConfigurationName,
+            ImageId,
+            KeyName=KeyName,
+            VpcId=VpcId,
+            VpcName=VpcName,
+            SecurityGroups=SecurityGroups,
+            UserData=UserData,
+            InstanceType=InstanceType,
+            KernelId=KernelId,
+            RamdiskId=RamdiskId,
+            BlockDeviceMappings=BlockDeviceMappings,
+            InstanceMonitoring=InstanceMonitoring,
+            SpotPrice=SpotPrice,
+            IamInstanceProfile=IamInstanceProfile,
+            EbsOptimized=EbsOptimized,
+            AssociatePublicIpAddress=AssociatePublicIpAddress,
+            region=region,
+            key=key,
+            keyid=keyid,
+            profile=profile)
+        if created:
+            ret['changes']['old'] = None
+            ret['changes']['new'] = name
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to create launch configuration.'
+    else:
+        ret['comment'] = 'Launch configuration present.'
+    return ret
+
+
+def absent(name,
+        LaunchConfigurationName=None,
+        region=None,
+        key=None,
+        keyid=None,
+        profile=None):
+    '''
+    Ensure the named launch configuration is deleted.
+
+    name
+        The name of the state definition.  This will be used as the 'CallerReference' param when
+        deleting the launch configuration to help ensure idempotency.
+
+    LaunchConfigurationName
+        Name of the launch configuration.
+
+    region
+        The region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+    '''
+    LaunchConfigurationName = LaunchConfigurationName if LaunchConfigurationName else name
+    ret = {'name': LaunchConfigurationName, 'result': True, 'comment': '', 'changes': {}}
+    exists = __salt__['boto3_asg.launch_configuration_exists'](LaunchConfigurationName,
+                                                              region=region,
+                                                              key=key,
+                                                              keyid=keyid,
+                                                              profile=profile)
+    if exists:
+        if __opts__['test']:
+            ret['comment'] = 'Launch configuration set to be deleted.'
+            ret['result'] = None
+            return ret
+        deleted = __salt__['boto3_asg.delete_launch_configuration'](
+                                                              LaunchConfigurationName,
+                                                              region=region,
+                                                              key=key,
+                                                              keyid=keyid,
+                                                              profile=profile)
+        if deleted:
+            ret['changes']['old'] = LaunchConfigurationName
+            ret['changes']['new'] = None
+            ret['comment'] = 'Deleted launch configuration.'
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to delete launch configuration.'
+    else:
+        ret['comment'] = 'Launch configuration does not exist.'
+    return ret


### PR DESCRIPTION
### What does this PR do?

This PR does
 * adds boto3 equivalent for `boto_asg` state module and execution module
* adds boto3 equivalent for `boto_lc` state module

### What issues does this PR fix or reference?

We started noticing that boto_asg was failing for some of our autoscaling groups, making the same call with boto3 works. On chatting with AWS support team, it was recommended to move to boto3 which prompted us to rewrite the state modules and execution modules in boto3

Steps to reproduce the issues
```
# ipython
In [1]: import boto.ec2.autoscale
In [2]: conn = boto.ec2.autoscale.connect_to_region()
In [3]: conn.get_all_groups()
Out[3]: 
[AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 redated,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 AutoScaleGroup<None>,
 redacted]

In [4]: import boto3
In [5]: client = boto3.client('autoscaling')
In [6]: client.describe_auto_scaling_groups()
Out[6]: works well
```

### Previous Behavior
N/A

### New Behavior
N/A

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
