### PR TITLE
DO NOT MERGE: Run expanduser on all paths

### DIFF
--- a/fix_expanduser.py
+++ b/fix_expanduser.py
@@ -194,8 +194,9 @@ def load_whitelist(whitelist_path):
 
 
 def get_modules():
+    valid_python_re = re.compile(r'^\w+\.py$')
     for filename in os.listdir('salt/states'):
-        if filename.startswith('_') or filename.endswith('.pyc'):
+        if not valid_python_re.match(filename):
             continue
         module_name = os.path.splitext(filename)[0]
         module = imp.find_module(module_name, salt.states.__path__)

--- a/fix_expanduser.py
+++ b/fix_expanduser.py
@@ -221,6 +221,10 @@ def get_function_parameter_docs(function):
     if not function.__doc__:
         return
     doc_lines = function.__doc__.split('\n')
+
+    # Search for docs like
+    # param
+    #     docs
     i = 0
     while i < len(doc_lines):
         line = doc_lines[i]
@@ -232,6 +236,13 @@ def get_function_parameter_docs(function):
                 i += 1
             yield parameter_name, ''.join(parameter_doc)
         i += 1
+
+    # Search for docs like
+    # :param param: docs
+    doc_re = re.compile(r':param (\w+):([\w\s\n.,/]+)', re.MULTILINE)
+    for parameter_name, parameter_doc in doc_re.findall(function.__doc__):
+        clean_docs = ' '.join(parameter_doc.split())
+        yield parameter_name, clean_docs
 
 
 def get_function_parameter_names(function):

--- a/fix_expanduser.py
+++ b/fix_expanduser.py
@@ -1,0 +1,251 @@
+from __future__ import print_function
+
+import os
+import re
+import argparse
+import imp
+import inspect
+
+
+import salt.states
+
+
+def main():
+    args = get_args()
+    
+    if args.load_whitelist:
+        whitelist = load_whitelist(args.load_whitelist)
+
+    modules = get_modules()
+    search_keywords = set(['file', 'directory', 'path'])
+    for module in modules:
+        # module_path = get_path_to_module(module.__name__)
+        # zookeeper, # import after __virtualname__
+
+        start_line_to_function = {}
+        for function in get_global_functions(module):
+            function_parameters = []
+            for parameter, docs in get_function_parameter_docs(function):
+                parameter_id = '%s.%s:%s' % ('.'.join(module.__name__.split('.')[2:]),
+                    function.__name__, parameter)
+                if args.load_whitelist:
+                    if parameter_id in whitelist:
+                        function_parameters.append(parameter)
+                else:
+                    doc_words = set(docs.split())
+                    # super inefficient search, whatever
+                    for search_keyword in search_keywords:
+                        if search_keyword in doc_words:
+                            print('%s \t%s' % (parameter_id, docs))
+
+            if function_parameters:
+                start_line_to_function[find_function_first_line(function)] = (function, function_parameters)
+
+        for line_number, (function, function_parameters) in sorted(start_line_to_function.items(), reverse=True):
+            add_expanduser_call(function, function_parameters, line_number)
+
+        if start_line_to_function:
+            add_import_statement(module)
+
+
+def add_import_statement(module):
+    module_path = get_path_to_module(module.__name__)
+    has_import = False
+    header_lines = []
+    # Modules should have a section, that follows python libs and is proceeded by 3rd party libs
+    # # Import salt libs
+    # import salt.utils
+
+    # Can look for anything `import salt.*` or `from salt.*`, if so add in that section
+    # If no such section, add it after the first unbroken string of `import *`, unless it's prepended with `# Import 3*`
+    header_done = False
+    body_lines = []
+    with open(module_path, 'r+') as fh:
+        for line in fh:
+            if line.startswith('def '):
+                header_done = True
+            if header_done:
+                body_lines.append(line.rstrip())
+            else:
+                header_lines.append(line.rstrip())
+
+    # Check it it's already present
+    for line in header_lines:
+        if line == 'import salt.utils':
+            return
+
+    # Check if we have a salt import section
+    salt_imports = []
+    salt_imports_location = -1
+
+    ideal_import_location = -1 # used to track in case there's no imports, should be right after the docs
+    in_docs = False
+    for line_number, line in enumerate(header_lines):
+        if line == "'''":
+            if not in_docs:
+                in_docs = True
+            else:
+                ideal_import_location = line_number + 2
+
+        if salt_imports and not line:
+            break
+        if '3rd-party' in line:
+            # Found 3rd party section, no salt imports
+            ideal_import_location = line_number
+            break
+        if line.startswith('import salt.') or line.startswith('from salt.'):
+            if salt_imports_location == -1:
+                salt_imports_location = line_number
+            salt_imports.append(line)
+
+        if line.startswith('import ') or line.startswith('from '):
+            # Assumed to be normal python stdlib import
+            ideal_import_location = line_number + 1
+
+    if salt_imports:
+        print('adding import to %s with existing salt imports' % module_path)
+        salt_imports.append('import salt.utils')
+        def line_sorter(line):
+            import_type, rest_of_import = line.split(' ', 1)
+            return (0 if import_type == 'import' else 1, rest_of_import)
+        salt_imports.sort(key=line_sorter)
+        header_lines[salt_imports_location:salt_imports_location + len(salt_imports) - 1] = salt_imports
+        # Not the exact line inserted, but the only thing that counts here is
+        # that it's in the import section at all
+        write_header_and_body(module_path, header_lines, body_lines)
+        return
+
+    header_lines.insert(ideal_import_location, '# Import Salt Libs')
+    header_lines.insert(ideal_import_location + 1, 'import salt.utils')
+    if header_lines[ideal_import_location + 2] != '':
+        # if next line after import is not blank, add a blank
+        header_lines.insert(ideal_import_location + 2, '')
+    if header_lines[ideal_import_location - 1] != '':
+        # If last line before import location is not blank, add a blank
+        header_lines.insert(ideal_import_location, '')
+
+    write_header_and_body(module_path, header_lines, body_lines)
+
+
+def write_header_and_body(module_path, header_lines, body_lines):
+    with open(module_path, 'w') as fh:
+        for line in header_lines + body_lines:
+            fh.write(line)
+            fh.write('\n')
+
+
+def get_path_to_module(module_name):
+    return os.path.join(module_name.replace('.', '/') + '.py')
+
+
+def get_args():
+    # By default we only write all the candidate parameters to stdout, to do
+    # the fix you need to filter that list for false positives, and pass a flag
+    # with the edited list
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-L', '--load-whitelist')
+    return parser.parse_args()
+
+
+def add_expanduser_call(function, parameters, line_number):
+    function_source_file = get_path_to_module(function.__module__)
+    with open(function_source_file, 'r+') as fh:
+        source_file_lines = fh.readlines()
+        source_file_lines.insert(line_number, '    {0} = salt.utils.expanduser({0})\n'.format(
+            ', '.join(parameters)))
+        fh.seek(0)
+        for line in source_file_lines:
+            fh.write(line)
+
+
+def find_function_first_line(function):
+    ''' return value is 0-indexed'''
+    sourcelines, line_number = inspect.getsourcelines(function)
+    doc_end_marker_re = re.compile(r'^    r?(?:\'\'\'|\"\"\")\n$')
+    found_doc_markers = 0
+    for line_offset, line in enumerate(sourcelines):
+        if doc_end_marker_re.match(line):
+            found_doc_markers += 1
+            if found_doc_markers == 2:
+                line_number += line_offset
+                break
+    else:
+        for line in sourcelines:
+            print(line, end='')
+        # import pdb; pdb.set_trace()
+        raise ValueError("Didn't find end marker for %s.%s" % (function.__module__,
+            function.__name__))
+    return line_number
+
+
+def load_whitelist(whitelist_path):
+    # The whitelist should hold module:parameter pairs, then optionally the documentation for the parameter
+    # We filter by a regex to enable commenting out lines, adding whitespace, etc
+    whitelist = set()
+    valid_line_re = re.compile(r'^(\w+\.\w+:\w+).*')
+    with open(whitelist_path) as fh:
+        for line in fh:
+            valid_match = valid_line_re.match(line)
+            if not valid_match:
+                continue
+            parameter_id = valid_match.group(1)
+            whitelist.add(parameter_id)
+    return whitelist
+
+
+def get_modules():
+    for filename in os.listdir('salt/states'):
+        if filename.startswith('_') or filename.endswith('.pyc'):
+            continue
+        module_name = os.path.splitext(filename)[0]
+        module = imp.find_module(module_name, salt.states.__path__)
+        yield imp.load_module('salt.states.%s' % module_name, *module)
+
+
+def get_global_functions(module):
+    for global_name in dir(module):
+        if global_name.startswith('_'):
+            continue
+        
+        function = getattr(module, global_name)
+
+        if not inspect.isfunction(function):
+            continue
+
+        yield function    
+
+
+def get_function_parameter_docs(function):
+    # TODO: Also needs to extract ':param <parameter>: \n?<docs>'
+    parameter_names = get_function_parameter_names(function)
+    if not function.__doc__:
+        return
+    doc_lines = function.__doc__.split('\n')
+    i = 0
+    while i < len(doc_lines):
+        line = doc_lines[i]
+        parameter_name = line.strip()
+        if parameter_name in parameter_names:
+            parameter_doc = []
+            while doc_lines[i+1].startswith(' '*8):
+                parameter_doc.append(doc_lines[i+1].strip())
+                i += 1
+            yield parameter_name, ''.join(parameter_doc)
+        i += 1
+
+
+def get_function_parameter_names(function):
+    argspec = inspect.getargspec(function)
+    parameter_names = set(argspec.args)
+
+    # To avoid some false positives, remove parameters with default arguments
+    # that are not None or string
+    for parameter, default in zip(reversed(argspec.args), reversed(argspec.defaults or [])):
+        if type(default) not in (type(None), type('')):
+            parameter_names.remove(parameter)
+
+    return parameter_names
+
+
+if __name__ == '__main__':
+    main()

--- a/fix_expanduser.py
+++ b/fix_expanduser.py
@@ -27,7 +27,7 @@ def main():
         for function in get_global_functions(module):
             function_parameters = []
             for parameter, docs in get_function_parameter_docs(function):
-                parameter_id = '%s.%s:%s' % ('.'.join(module.__name__.split('.')[2:]),
+                parameter_id = '%s.%s:%s' % ('.'.join(module.__name__.split('.')[1:]),
                     function.__name__, parameter)
                 if args.load_whitelist:
                     if parameter_id in whitelist:

--- a/fix_expanduser.py
+++ b/fix_expanduser.py
@@ -8,6 +8,7 @@ import inspect
 
 
 import salt.states
+import salt.modules
 
 
 def main():
@@ -201,6 +202,13 @@ def get_modules():
         module_name = os.path.splitext(filename)[0]
         module = imp.find_module(module_name, salt.states.__path__)
         yield imp.load_module('salt.states.%s' % module_name, *module)
+
+    for filename in os.listdir('salt/modules'):
+        if not valid_python_re.match(filename):
+            continue
+        module_name = os.path.splitext(filename)[0]
+        module = imp.find_module(module_name, salt.modules.__path__)
+        yield imp.load_module('salt.modules.%s' % module_name, *module)
 
 
 def get_global_functions(module):

--- a/fix_expanduser.py
+++ b/fix_expanduser.py
@@ -33,7 +33,7 @@ def main():
                     if parameter_id in whitelist:
                         function_parameters.append(parameter)
                 else:
-                    doc_words = set(docs.split())
+                    doc_words = set(word.lower() for word in docs.split())
                     # super inefficient search, whatever
                     for search_keyword in search_keywords:
                         if search_keyword in doc_words:

--- a/fix_expanduser.py
+++ b/fix_expanduser.py
@@ -41,7 +41,11 @@ def main():
                             break
 
             if function_parameters:
-                start_line_to_function[find_function_first_line(function)] = (function, function_parameters)
+                try:
+                    start_line_to_function[find_function_first_line(function)] = (function, function_parameters)
+                except IOError:
+                    print('Failed to find source code for %s.%s, probably decorated' % (
+                        function.__module__, function.__name__))
 
         for line_number, (function, function_parameters) in sorted(start_line_to_function.items(), reverse=True):
             add_expanduser_call(function, function_parameters, line_number)

--- a/fix_expanduser.py
+++ b/fix_expanduser.py
@@ -38,6 +38,7 @@ def main():
                     for search_keyword in search_keywords:
                         if search_keyword in doc_words:
                             print('%s \t%s' % (parameter_id, docs))
+                            break
 
             if function_parameters:
                 start_line_to_function[find_function_first_line(function)] = (function, function_parameters)

--- a/fix_expanduser.py
+++ b/fix_expanduser.py
@@ -184,7 +184,7 @@ def load_whitelist(whitelist_path):
     # The whitelist should hold module:parameter pairs, then optionally the documentation for the parameter
     # We filter by a regex to enable commenting out lines, adding whitespace, etc
     whitelist = set()
-    valid_line_re = re.compile(r'^(\w+\.\w+:\w+).*')
+    valid_line_re = re.compile(r'^((?:modules|states)\.\w+\.\w+:\w+).*')
     with open(whitelist_path) as fh:
         for line in fh:
             valid_match = valid_line_re.match(line)

--- a/fix_expanduser.py
+++ b/fix_expanduser.py
@@ -46,6 +46,8 @@ def main():
                 except IOError:
                     print('Failed to find source code for %s.%s, probably decorated' % (
                         function.__module__, function.__name__))
+                except ValueError as e:
+                    print(e)
 
         for line_number, (function, function_parameters) in sorted(start_line_to_function.items(), reverse=True):
             add_expanduser_call(function, function_parameters, line_number)
@@ -109,7 +111,6 @@ def add_import_statement(module):
             ideal_import_location = line_number + 1
 
     if salt_imports:
-        print('adding import to %s with existing salt imports' % module_path)
         salt_imports.append('import salt.utils')
         def line_sorter(line):
             import_type, rest_of_import = line.split(' ', 1)
@@ -176,9 +177,6 @@ def find_function_first_line(function):
                 line_number += line_offset
                 break
     else:
-        for line in sourcelines:
-            print(line, end='')
-        # import pdb; pdb.set_trace()
         raise ValueError("Didn't find end marker for %s.%s" % (function.__module__,
             function.__name__))
     return line_number

--- a/fix_expanduser.py
+++ b/fix_expanduser.py
@@ -17,7 +17,7 @@ def main():
         whitelist = load_whitelist(args.load_whitelist)
 
     modules = get_modules()
-    search_keywords = set(['file', 'directory', 'path'])
+    search_keywords = set(['file', 'directory', 'path', 'location'])
     for module in modules:
         # module_path = get_path_to_module(module.__name__)
         # zookeeper, # import after __virtualname__

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -124,6 +124,7 @@ def cert(name,
 
         salt 'gitlab.example.com' acme.cert dev.example.com "[gitlab.example.com]" test_cert=True renew=14 webroot=/opt/gitlab/embedded/service/gitlab-rails/public
     '''
+    webroot = salt.utils.expanduser(webroot)
 
     cmd = [LEA, 'certonly', '--quiet']
 

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -446,6 +446,7 @@ def config(name, config, edit=True):
 
         salt '*' apache.config /etc/httpd/conf.d/ports.conf config="[{'Listen': '22'}]"
     '''
+    name = salt.utils.expanduser(name)
 
     for entry in config:
         key = next(six.iterkeys(entry))

--- a/salt/modules/apk.py
+++ b/salt/modules/apk.py
@@ -289,6 +289,7 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
+    sources = salt.utils.expanduser(sources)
     refreshdb = salt.utils.is_true(refresh)
     pkg_to_install = []
 

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -587,6 +587,7 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
+    debconf, sources = salt.utils.expanduser(debconf, sources)
     _refresh_db = False
     if salt.utils.is_true(refresh):
         _refresh_db = True

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -440,7 +440,7 @@ def _expand_sources(sources):
         sources = [x.strip() for x in sources.split(',')]
     elif isinstance(sources, (float, six.integer_types)):
         sources = [str(sources)]
-    return [path
+    return [salt.utils.expanduser(path)
             for source in sources
             for path in _glob(source)]
 
@@ -511,6 +511,7 @@ def tar(options, tarfile, sources=None, dest=None,
         # Unpack a tarfile
         salt '*' archive.tar xf foo.tar dest=/target/directory
     '''
+    tarfile, dest, cwd = salt.utils.expanduser(tarfile, dest, cwd)
     if not options:
         # Catch instances were people pass an empty string for the "options"
         # argument. Someone would have to be really silly to do this, but we
@@ -672,6 +673,7 @@ def cmd_zip(zip_file, sources, template=None, cwd=None, runas=None):
         # Globbing for sources (2017.7.0 and later)
         salt '*' archive.cmd_zip /tmp/zipfile.zip '/tmp/sourcefile*'
     '''
+    zip_file, cwd = salt.utils.expanduser(zip_file, cwd)
     cmd = ['zip', '-r']
     cmd.append('{0}'.format(zip_file))
     cmd.extend(_expand_sources(sources))
@@ -737,6 +739,7 @@ def zip_(zip_file, sources, template=None, cwd=None, runas=None):
         # Globbing for sources (2017.7.0 and later)
         salt '*' archive.zip /tmp/zipfile.zip '/tmp/sourcefile*'
     '''
+    zip_file = salt.utils.expanduser(zip_file)
     if runas:
         euid = os.geteuid()
         egid = os.getegid()
@@ -897,6 +900,7 @@ def cmd_unzip(zip_file,
 
         salt '*' archive.cmd_unzip /tmp/zipfile.zip /home/strongbad/ excludes=file_1,file_2
     '''
+    zip_file, dest = salt.utils.expanduser(zip_file, dest)
     if isinstance(excludes, six.string_types):
         excludes = [x.strip() for x in excludes.split(',')]
     elif isinstance(excludes, (float, six.integer_types)):
@@ -1015,6 +1019,7 @@ def unzip(zip_file,
 
         salt '*' archive.unzip /tmp/zipfile.zip /home/strongbad/ password='BadPassword'
     '''
+    zip_file, dest = salt.utils.expanduser(zip_file, dest)
     if not excludes:
         excludes = []
     if runas:
@@ -1191,6 +1196,7 @@ def rar(rarfile, sources, template=None, cwd=None, runas=None):
         # Globbing for sources (2017.7.0 and later)
         salt '*' archive.rar /tmp/rarfile.rar '/tmp/sourcefile*'
     '''
+    rarfile, cwd = salt.utils.expanduser(rarfile, cwd)
     cmd = ['rar', 'a', '-idp', '{0}'.format(rarfile)]
     cmd.extend(_expand_sources(sources))
     return __salt__['cmd.run'](cmd,
@@ -1232,6 +1238,7 @@ def unrar(rarfile, dest, excludes=None, template=None, runas=None, trim_output=F
         salt '*' archive.unrar /tmp/rarfile.rar /home/strongbad/ excludes=file_1,file_2
 
     '''
+    rarfile, dest = salt.utils.expanduser(rarfile, dest)
     if isinstance(excludes, six.string_types):
         excludes = [entry.strip() for entry in excludes.split(',')]
 

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -1121,6 +1121,7 @@ def is_encrypted(name, clean=False, saltenv='base'):
             salt '*' archive.is_encrypted https://domain.tld/myfile.zip clean=True
             salt '*' archive.is_encrypted ftp://10.1.2.3/foo.zip
     '''
+    name = salt.utils.expanduser(name)
     cached = __salt__['cp.cache_file'](name, saltenv)
     if not cached:
         raise CommandExecutionError('Failed to cache {0}'.format(name))

--- a/salt/modules/artifactory.py
+++ b/salt/modules/artifactory.py
@@ -62,7 +62,7 @@ def get_latest_snapshot(artifactory_url, repository, group_id, artifact_id, pack
            Artifactory username. Optional parameter.
        password
            Artifactory password. Optional parameter.
-       '''
+    '''
     log.debug("======================== MODULE FUNCTION: artifactory.get_latest_snapshot, artifactory_url=%s, repository=%s, group_id=%s, artifact_id=%s, packaging=%s, target_dir=%s, classifier=%s)",
                     artifactory_url, repository, group_id, artifact_id, packaging, target_dir, classifier)
 
@@ -103,7 +103,7 @@ def get_snapshot(artifactory_url, repository, group_id, artifact_id, packaging, 
            Artifactory username. Optional parameter.
        password
            Artifactory password. Optional parameter.
-       '''
+    '''
     log.debug('======================== MODULE FUNCTION: artifactory.get_snapshot(artifactory_url=%s, repository=%s, group_id=%s, artifact_id=%s, packaging=%s, version=%s, target_dir=%s, classifier=%s)',
               artifactory_url, repository, group_id, artifact_id, packaging, version, target_dir, classifier)
     headers = {}
@@ -139,7 +139,7 @@ def get_latest_release(artifactory_url, repository, group_id, artifact_id, packa
            Artifactory username. Optional parameter.
        password
            Artifactory password. Optional parameter.
-       '''
+    '''
     log.debug('======================== MODULE FUNCTION: artifactory.get_latest_release(artifactory_url=%s, repository=%s, group_id=%s, artifact_id=%s, packaging=%s, target_dir=%s, classifier=%s)',
               artifactory_url, repository, group_id, artifact_id, packaging, target_dir, classifier)
     headers = {}
@@ -178,7 +178,7 @@ def get_release(artifactory_url, repository, group_id, artifact_id, packaging, v
            Artifactory username. Optional parameter.
        password
            Artifactory password. Optional parameter.
-       '''
+    '''
     log.debug('======================== MODULE FUNCTION: artifactory.get_release(artifactory_url=%s, repository=%s, group_id=%s, artifact_id=%s, packaging=%s, version=%s, target_dir=%s, classifier=%s)',
               artifactory_url, repository, group_id, artifact_id, packaging, version, target_dir, classifier)
     headers = {}

--- a/salt/modules/artifactory.py
+++ b/salt/modules/artifactory.py
@@ -63,6 +63,7 @@ def get_latest_snapshot(artifactory_url, repository, group_id, artifact_id, pack
        password
            Artifactory password. Optional parameter.
     '''
+    target_dir, target_file = salt.utils.expanduser(target_dir, target_file)
     log.debug("======================== MODULE FUNCTION: artifactory.get_latest_snapshot, artifactory_url=%s, repository=%s, group_id=%s, artifact_id=%s, packaging=%s, target_dir=%s, classifier=%s)",
                     artifactory_url, repository, group_id, artifact_id, packaging, target_dir, classifier)
 
@@ -104,6 +105,7 @@ def get_snapshot(artifactory_url, repository, group_id, artifact_id, packaging, 
        password
            Artifactory password. Optional parameter.
     '''
+    target_dir, target_file = salt.utils.expanduser(target_dir, target_file)
     log.debug('======================== MODULE FUNCTION: artifactory.get_snapshot(artifactory_url=%s, repository=%s, group_id=%s, artifact_id=%s, packaging=%s, version=%s, target_dir=%s, classifier=%s)',
               artifactory_url, repository, group_id, artifact_id, packaging, version, target_dir, classifier)
     headers = {}
@@ -140,6 +142,7 @@ def get_latest_release(artifactory_url, repository, group_id, artifact_id, packa
        password
            Artifactory password. Optional parameter.
     '''
+    target_dir, target_file = salt.utils.expanduser(target_dir, target_file)
     log.debug('======================== MODULE FUNCTION: artifactory.get_latest_release(artifactory_url=%s, repository=%s, group_id=%s, artifact_id=%s, packaging=%s, target_dir=%s, classifier=%s)',
               artifactory_url, repository, group_id, artifact_id, packaging, target_dir, classifier)
     headers = {}
@@ -179,6 +182,7 @@ def get_release(artifactory_url, repository, group_id, artifact_id, packaging, v
        password
            Artifactory password. Optional parameter.
     '''
+    target_dir, target_file = salt.utils.expanduser(target_dir, target_file)
     log.debug('======================== MODULE FUNCTION: artifactory.get_release(artifactory_url=%s, repository=%s, group_id=%s, artifact_id=%s, packaging=%s, version=%s, target_dir=%s, classifier=%s)',
               artifactory_url, repository, group_id, artifact_id, packaging, version, target_dir, classifier)
     headers = {}

--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -103,7 +103,7 @@ def _lstrip_word(word, prefix):
 def _check_load_paths(load_path):
     '''
     Checks the validity of the load_path, returns a sanitized version
-    with invalid paths removed.
+    with invalid paths removed and home directories expanded.
     '''
     if load_path is None or not isinstance(load_path, six.string_types):
         return None
@@ -119,7 +119,7 @@ def _check_load_paths(load_path):
     if len(_paths) == 0:
         return None
 
-    return ':'.join(_paths)
+    return ':'.join(salt.utils.expanduser(_paths))
 
 
 def execute(context=None, lens=None, commands=(), load_path=None):

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -45,6 +45,7 @@ import yaml
 
 # Import salt libs
 import salt.ext.six as six
+import salt.utils
 import salt.utils.compat
 import salt.utils.odict as odict
 
@@ -1548,6 +1549,7 @@ def upload_server_cert(cert_name, cert_body, private_key, cert_chain=None, path=
     :param profile: The profile that contains a dict of region, key, keyid
     :return: True / False
     '''
+    path = salt.utils.expanduser(path)
 
     exists = get_server_certificate(cert_name, region, key, keyid, profile)
     if exists:

--- a/salt/modules/bower.py
+++ b/salt/modules/bower.py
@@ -110,6 +110,7 @@ def install(pkg,
         salt '*' bower.install jquery#2.0 /path/to/project
 
     '''
+    dir = salt.utils.expanduser(dir)
     _check_valid_version()
 
     cmd = _construct_bower_command('install')
@@ -159,6 +160,7 @@ def uninstall(pkg, dir, runas=None, env=None):
         salt '*' bower.uninstall underscore /path/to/project
 
     '''
+    dir = salt.utils.expanduser(dir)
     _check_valid_version()
 
     cmd = _construct_bower_command('uninstall')
@@ -200,6 +202,7 @@ def list_(dir, runas=None, env=None):
         salt '*' bower.list /path/to/project
 
     '''
+    dir = salt.utils.expanduser(dir)
     _check_valid_version()
 
     cmd = _construct_bower_command('list')
@@ -241,6 +244,7 @@ def prune(dir, runas=None, env=None):
         salt '*' bower.prune /path/to/project
 
     '''
+    dir = salt.utils.expanduser(dir)
     _check_valid_version()
 
     cmd = _construct_bower_command('prune')

--- a/salt/modules/chef.py
+++ b/salt/modules/chef.py
@@ -123,6 +123,7 @@ def client(whyrun=False,
         Enable whyrun mode when set to True
 
     '''
+    logfile = salt.utils.expanduser(logfile)
     if logfile is None:
         logfile = _default_logfile('chef-client')
     args = ['chef-client',
@@ -192,6 +193,7 @@ def solo(whyrun=False,
     whyrun
         Enable whyrun mode when set to True
     '''
+    logfile = salt.utils.expanduser(logfile)
     if logfile is None:
         logfile = _default_logfile('chef-solo')
     args = ['chef-solo',

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2589,6 +2589,7 @@ def run_chroot(root,
 
         salt '*' cmd.run_chroot /var/lib/lxc/container_name/rootfs 'sh /tmp/bootstrap.sh'
     '''
+    root, cwd = salt.utils.expanduser(root, cwd)
     __salt__['mount.mount'](
         os.path.join(root, 'dev'),
         'udev',

--- a/salt/modules/composer.py
+++ b/salt/modules/composer.py
@@ -53,6 +53,7 @@ def did_composer_install(dir):
 
         salt '*' composer.did_composer_install /var/www/application
     '''
+    dir = salt.utils.expanduser(dir)
     lockFile = "{0}/vendor".format(dir)
     if os.path.exists(lockFile):
         return True
@@ -265,6 +266,7 @@ def install(directory,
         salt '*' composer.install /var/www/application \
             no_dev=True optimize=True
     '''
+    directory, composer, php = salt.utils.expanduser(directory, composer, php)
     result = _run_composer('install',
                            directory=directory,
                            composer=composer,
@@ -351,6 +353,7 @@ def update(directory,
         salt '*' composer.update /var/www/application \
             no_dev=True optimize=True
     '''
+    directory, composer, php = salt.utils.expanduser(directory, composer, php)
     result = _run_composer('update',
                            directory=directory,
                            extra_flags='--no-progress',
@@ -404,6 +407,7 @@ def selfupdate(composer=None,
 
         salt '*' composer.selfupdate
     '''
+    composer, php = salt.utils.expanduser(composer, php)
     result = _run_composer('selfupdate',
                            extra_flags='--no-progress',
                            composer=composer,

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -363,6 +363,7 @@ def get_url(path, dest='', saltenv='base', makedirs=False):
         salt '*' cp.get_url salt://my/file /tmp/this_file_is_mine
         salt '*' cp.get_url http://www.slashdot.org /tmp/index.html
     '''
+    dest = salt.utils.expanduser(dest)
     if isinstance(dest, six.string_types):
         result = _client().get_url(path, dest, makedirs, saltenv)
     else:

--- a/salt/modules/debbuild.py
+++ b/salt/modules/debbuild.py
@@ -564,6 +564,7 @@ def make_repo(repodir,
         salt '*' pkgbuild.make_repo /var/www/html
 
     '''
+    repodir = salt.utils.expanduser(repodir)
     res = {'retcode': 1,
             'stdout': '',
             'stderr': 'initialization value'}

--- a/salt/modules/debconfmod.py
+++ b/salt/modules/debconfmod.py
@@ -160,6 +160,7 @@ def set_template(path, template, context, defaults, saltenv='base', **kwargs):
         salt '*' debconf.set_template salt://pathto/pkg.selections.jinja jinja None None
 
     '''
+    path = salt.utils.expanduser(path)
 
     path = __salt__['cp.get_template'](
         path=path,

--- a/salt/modules/dnsmasq.py
+++ b/salt/modules/dnsmasq.py
@@ -139,6 +139,7 @@ def get_config(config_file='/etc/dnsmasq.conf'):
         salt '*' dnsmasq.get_config
         salt '*' dnsmasq.get_config config_file=/etc/dnsmasq.conf
     '''
+    config_file = salt.utils.expanduser(config_file)
     dnsopts = _parse_dnamasq(config_file)
     if 'conf-dir' in dnsopts:
         for filename in os.listdir(dnsopts['conf-dir']):

--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -286,6 +286,7 @@ def get(path):
 
         salt myminion dockercompose.get /path/where/docker-compose/stored
     '''
+    path = salt.utils.expanduser(path)
 
     salt_result = __read_docker_compose(path)
     if not salt_result['status']:
@@ -314,6 +315,7 @@ def create(path, docker_compose):
 
         salt myminion dockercompose.create /path/where/docker-compose/stored content
     '''
+    path = salt.utils.expanduser(path)
     if docker_compose:
         ret = __write_docker_compose(path, docker_compose)
         if isinstance(ret, dict):
@@ -342,6 +344,7 @@ def pull(path, service_names=None):
         salt myminion dockercompose.pull /path/where/docker-compose/stored
         salt myminion dockercompose.pull /path/where/docker-compose/stored '[janus]'
     '''
+    path = salt.utils.expanduser(path)
 
     project = __load_project(path)
     if isinstance(project, dict):
@@ -376,6 +379,7 @@ def build(path, service_names=None):
         salt myminion dockercompose.build /path/where/docker-compose/stored
         salt myminion dockercompose.build /path/where/docker-compose/stored '[janus]'
     '''
+    path = salt.utils.expanduser(path)
 
     project = __load_project(path)
     if isinstance(project, dict):
@@ -407,6 +411,7 @@ def restart(path, service_names=None):
         salt myminion dockercompose.restart /path/where/docker-compose/stored
         salt myminion dockercompose.restart /path/where/docker-compose/stored '[janus]'
     '''
+    path = salt.utils.expanduser(path)
 
     project = __load_project(path)
     debug_ret = {}
@@ -444,6 +449,7 @@ def stop(path, service_names=None):
         salt myminion dockercompose.stop /path/where/docker-compose/stored
         salt myminion dockercompose.stop  /path/where/docker-compose/stored '[janus]'
     '''
+    path = salt.utils.expanduser(path)
 
     project = __load_project(path)
     debug_ret = {}
@@ -481,6 +487,7 @@ def pause(path, service_names=None):
         salt myminion dockercompose.pause /path/where/docker-compose/stored
         salt myminion dockercompose.pause /path/where/docker-compose/stored '[janus]'
     '''
+    path = salt.utils.expanduser(path)
 
     project = __load_project(path)
     debug_ret = {}
@@ -518,6 +525,7 @@ def unpause(path, service_names=None):
         salt myminion dockercompose.pause /path/where/docker-compose/stored
         salt myminion dockercompose.pause /path/where/docker-compose/stored '[janus]'
     '''
+    path = salt.utils.expanduser(path)
 
     project = __load_project(path)
     debug_ret = {}
@@ -555,6 +563,7 @@ def start(path, service_names=None):
         salt myminion dockercompose.start /path/where/docker-compose/stored
         salt myminion dockercompose.start /path/where/docker-compose/stored '[janus]'
     '''
+    path = salt.utils.expanduser(path)
 
     project = __load_project(path)
     debug_ret = {}
@@ -592,6 +601,7 @@ def kill(path, service_names=None):
         salt myminion dockercompose.kill /path/where/docker-compose/stored
         salt myminion dockercompose.kill /path/where/docker-compose/stored '[janus]'
     '''
+    path = salt.utils.expanduser(path)
 
     project = __load_project(path)
     debug_ret = {}
@@ -629,6 +639,7 @@ def rm(path, service_names=None):
         salt myminion dockercompose.rm /path/where/docker-compose/stored
         salt myminion dockercompose.rm /path/where/docker-compose/stored '[janus]'
     '''
+    path = salt.utils.expanduser(path)
 
     project = __load_project(path)
     if isinstance(project, dict):
@@ -654,6 +665,7 @@ def ps(path):
 
         salt myminion dockercompose.ps /path/where/docker-compose/stored
     '''
+    path = salt.utils.expanduser(path)
 
     project = __load_project(path)
     result = {}
@@ -702,6 +714,7 @@ def up(path, service_names=None):
         salt myminion dockercompose.up /path/where/docker-compose/stored
         salt myminion dockercompose.up /path/where/docker-compose/stored '[janus]'
     '''
+    path = salt.utils.expanduser(path)
 
     debug_ret = {}
     project = __load_project(path)

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -3073,6 +3073,7 @@ def build(path=None,
 
         salt myminion docker.build /path/to/docker/build/dir dockerfile=Dockefile.different image=myimage:dev
     '''
+    path, dockerfile = salt.utils.expanduser(path, dockerfile)
     _prep_pull()
 
     image = ':'.join(salt.utils.docker.get_repo_tag(image))
@@ -3303,6 +3304,7 @@ def import_(source,
         salt myminion docker.import /tmp/cent7-minimal.tar.xz myuser/centos:7
         salt myminion docker.import salt://dockerimages/cent7-minimal.tar.xz myuser/centos:7
     '''
+    source = salt.utils.expanduser(source)
     repo_name, repo_tag = salt.utils.docker.get_repo_tag(image)
     path = __salt__['container_resource.cache_file'](source)
 
@@ -3392,6 +3394,7 @@ def load(path, image=None):
         salt myminion docker.load /path/to/image.tar
         salt myminion docker.load salt://path/to/docker/saved/image.tar image=myuser/myimage:mytag
     '''
+    path = salt.utils.expanduser(path)
     if image is not None:
         image = ':'.join(salt.utils.docker.get_repo_tag(image))
     local_path = __salt__['container_resource.cache_file'](path)
@@ -3806,6 +3809,7 @@ def save(name,
         salt myminion docker.save centos:7 /tmp/cent7.tar
         salt myminion docker.save 0123456789ab cdef01234567 /tmp/saved.tar
     '''
+    path = salt.utils.expanduser(path)
     err = 'Path \'{0}\' is not absolute'.format(path)
     try:
         if not os.path.isabs(path):
@@ -5023,6 +5027,7 @@ def script(name,
         salt myminion docker.script mycontainer salt://scripts/runme.sh 'arg1 arg2 "arg 3"'
         salt myminion docker.script mycontainer salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n' output_loglevel=quiet
     '''
+    source = salt.utils.expanduser(source)
     return _script(name,
                    source,
                    saltenv=saltenv,
@@ -5096,6 +5101,7 @@ def script_retcode(name,
         salt myminion docker.script_retcode mycontainer salt://scripts/runme.sh 'arg1 arg2 "arg 3"'
         salt myminion docker.script_retcode mycontainer salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n' output_loglevel=quiet
     '''
+    source = salt.utils.expanduser(source)
     return _script(name,
                    source,
                    saltenv=saltenv,

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -55,6 +55,7 @@ def bin_pkg_info(path, saltenv='base'):
         salt '*' lowpkg.bin_pkg_info /root/foo-1.2.3-1ubuntu1_all.deb
         salt '*' lowpkg.bin_pkg_info salt://foo-1.2.3-1ubuntu1_all.deb
     '''
+    path = salt.utils.expanduser(path)
     # If the path is a valid protocol, pull it down using cp.cache_file
     if __salt__['config.valid_fileproto'](path):
         newpath = __salt__['cp.cache_file'](path, saltenv)

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -569,6 +569,7 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
+    sources = salt.utils.expanduser(sources)
     log.debug('Called modules.pkg.install: {0}'.format(
         {
             'name': name,

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -230,7 +230,7 @@ def get_gid(path, follow_symlinks=True):
     .. versionchanged:: 0.16.4
         ``follow_symlinks`` option added
     '''
-    return stats(os.path.expanduser(path), follow_symlinks=follow_symlinks).get('gid', -1)
+    return stats(salt.utils.expanduser(path), follow_symlinks=follow_symlinks).get('gid', -1)
 
 
 def get_group(path, follow_symlinks=True):
@@ -252,7 +252,7 @@ def get_group(path, follow_symlinks=True):
     .. versionchanged:: 0.16.4
         ``follow_symlinks`` option added
     '''
-    return stats(os.path.expanduser(path), follow_symlinks=follow_symlinks).get('group', False)
+    return stats(salt.utils.expanduser(path), follow_symlinks=follow_symlinks).get('group', False)
 
 
 def uid_to_user(uid):
@@ -317,7 +317,7 @@ def get_uid(path, follow_symlinks=True):
     .. versionchanged:: 0.16.4
         ``follow_symlinks`` option added
     '''
-    return stats(os.path.expanduser(path), follow_symlinks=follow_symlinks).get('uid', -1)
+    return stats(salt.utils.expanduser(path), follow_symlinks=follow_symlinks).get('uid', -1)
 
 
 def get_user(path, follow_symlinks=True):
@@ -339,7 +339,7 @@ def get_user(path, follow_symlinks=True):
     .. versionchanged:: 0.16.4
         ``follow_symlinks`` option added
     '''
-    return stats(os.path.expanduser(path), follow_symlinks=follow_symlinks).get('user', False)
+    return stats(salt.utils.expanduser(path), follow_symlinks=follow_symlinks).get('user', False)
 
 
 def get_mode(path, follow_symlinks=True):
@@ -361,7 +361,7 @@ def get_mode(path, follow_symlinks=True):
     .. versionchanged:: 2014.1.0
         ``follow_symlinks`` option added
     '''
-    return stats(os.path.expanduser(path), follow_symlinks=follow_symlinks).get('mode', '')
+    return stats(salt.utils.expanduser(path), follow_symlinks=follow_symlinks).get('mode', '')
 
 
 def set_mode(path, mode):
@@ -380,7 +380,7 @@ def set_mode(path, mode):
 
         salt '*' file.set_mode /etc/passwd 0644
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     mode = str(mode).lstrip('0Oo')
     if not mode:
@@ -414,7 +414,7 @@ def lchown(path, user, group):
 
         salt '*' file.chown /etc/passwd root root
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     uid = user_to_uid(user)
     gid = group_to_gid(group)
@@ -452,7 +452,7 @@ def chown(path, user, group):
 
         salt '*' file.chown /etc/passwd root root
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     uid = user_to_uid(user)
     gid = group_to_gid(group)
@@ -495,7 +495,7 @@ def chgrp(path, group):
 
         salt '*' file.chgrp /etc/passwd root
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     user = get_user(path)
     return chown(path, user, group)
@@ -659,7 +659,7 @@ def get_sum(path, form='sha256'):
 
         salt '*' file.get_sum /etc/passwd sha512
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.isfile(path):
         return 'File not found'
@@ -691,7 +691,7 @@ def get_hash(path, form='sha256', chunk_size=65536):
 
         salt '*' file.get_hash /etc/shadow
     '''
-    return salt.utils.get_hash(os.path.expanduser(path), form, chunk_size)
+    return salt.utils.get_hash(salt.utils.expanduser(path), form, chunk_size)
 
 
 def get_source_sum(file_name='',
@@ -857,7 +857,7 @@ def check_hash(path, file_hash):
         salt '*' file.check_hash /etc/fstab e138491e9d5b97023cea823fe17bac22
         salt '*' file.check_hash /etc/fstab md5:e138491e9d5b97023cea823fe17bac22
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not isinstance(file_hash, six.string_types):
         raise SaltInvocationError('hash must be a string')
@@ -1011,7 +1011,7 @@ def find(path, *args, **kwargs):
     except ValueError as ex:
         return 'error: {0}'.format(ex)
 
-    ret = [item for i in [finder.find(p) for p in glob.glob(os.path.expanduser(path))] for item in i]
+    ret = [item for i in [finder.find(p) for p in glob.glob(salt.utils.expanduser(path))] for item in i]
     ret.sort()
     return ret
 
@@ -1083,7 +1083,7 @@ def sed(path,
     # Largely inspired by Fabric's contrib.files.sed()
     # XXX:dc: Do we really want to always force escaping?
     #
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.exists(path):
         return False
@@ -1134,7 +1134,7 @@ def sed_contains(path,
         salt '*' file.contains /etc/crontab 'mymaintenance.sh'
     '''
     # Largely inspired by Fabric's contrib.files.contains()
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.exists(path):
         return False
@@ -1220,7 +1220,7 @@ def psed(path,
     # XXX:dc: Do we really want to always force escaping?
     #
     # Mandate that before and after are strings
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     multi = bool(multi)
 
@@ -1421,7 +1421,7 @@ def comment_line(path,
                 '$' if regex.endswith('$') else '')
 
     # Load the real path to the file
-    path = os.path.realpath(os.path.expanduser(path))
+    path = os.path.realpath(salt.utils.expanduser(path))
 
     # Make sure the file exists
     if not os.path.isfile(path):
@@ -1833,7 +1833,7 @@ def line(path, content=None, match=None, mode=None, location=None,
 
             salt '*' file.line /path/to/file content="CREATEMAIL_SPOOL=no" match="CREATE_MAIL_SPOOL=yes" mode="replace"
     '''
-    path = os.path.realpath(os.path.expanduser(path))
+    path = os.path.realpath(salt.utils.expanduser(path))
     if not os.path.isfile(path):
         if not quiet:
             raise CommandExecutionError('File "{0}" does not exists or is not a file.'.format(path))
@@ -2153,9 +2153,9 @@ def replace(path,
     if is_link(path):
         symlink = True
         target_path = os.readlink(path)
-        given_path = os.path.expanduser(path)
+        given_path = salt.utils.expanduser(path)
 
-    path = os.path.realpath(os.path.expanduser(path))
+    path = os.path.realpath(salt.utils.expanduser(path))
 
     if not os.path.exists(path):
         if ignore_if_missing:
@@ -2465,7 +2465,7 @@ def blockreplace(path,
         '#-- end managed zone foobar --' $'10.0.1.1 foo.foobar\\n10.0.1.2 bar.foobar' True
 
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.exists(path):
         raise SaltInvocationError('File not found: {0}'.format(path))
@@ -2753,7 +2753,7 @@ def contains(path, text):
 
         salt '*' file.contains /etc/crontab 'mymaintenance.sh'
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.exists(path):
         return False
@@ -2786,7 +2786,7 @@ def contains_regex(path, regex, lchar=''):
 
         salt '*' file.contains_regex /etc/crontab
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.exists(path):
         return False
@@ -2816,7 +2816,7 @@ def contains_glob(path, glob_expr):
 
         salt '*' file.contains_glob /etc/foobar '*cheese*'
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.exists(path):
         return False
@@ -2864,7 +2864,7 @@ def append(path, *args, **kwargs):
             salt '*' file.append /etc/motd args="['cheese=spam','spam=cheese']"
 
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     # Largely inspired by Fabric's contrib.files.append()
 
@@ -2932,7 +2932,7 @@ def prepend(path, *args, **kwargs):
             salt '*' file.prepend /etc/motd args="['cheese=spam','spam=cheese']"
 
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if 'args' in kwargs:
         if isinstance(kwargs['args'], list):
@@ -2988,7 +2988,7 @@ def write(path, *args, **kwargs):
             salt '*' file.write /etc/motd args="['cheese=spam','spam=cheese']"
 
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if 'args' in kwargs:
         if isinstance(kwargs['args'], list):
@@ -3022,7 +3022,7 @@ def touch(name, atime=None, mtime=None):
 
         salt '*' file.touch /var/log/emptyfile
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     if atime and atime.isdigit():
         atime = int(atime)
@@ -3072,7 +3072,7 @@ def seek_read(path, size, offset):
 
         salt '*' file.seek_read /path/to/file 4096 0
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
     seek_fh = os.open(path, os.O_RDONLY)
     try:
         os.lseek(seek_fh, int(offset), 0)
@@ -3103,7 +3103,7 @@ def seek_write(path, data, offset):
 
         salt '*' file.seek_write /path/to/file 'some data' 4096
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
     seek_fh = os.open(path, os.O_WRONLY)
     try:
         os.lseek(seek_fh, int(offset), 0)
@@ -3132,7 +3132,7 @@ def truncate(path, length):
 
         salt '*' file.truncate /path/to/file 512
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
     with salt.utils.files.fopen(path, 'rb+') as seek_fh:
         seek_fh.truncate(int(length))
 
@@ -3149,7 +3149,7 @@ def link(src, path):
 
         salt '*' file.link /path/to/file /path/to/link
     '''
-    src = os.path.expanduser(src)
+    src = salt.utils.expanduser(src)
 
     if not os.path.isabs(src):
         raise SaltInvocationError('File path must be absolute.')
@@ -3177,7 +3177,7 @@ def is_link(path):
     # therefore helps API consistency by providing a single function to call for
     # both operating systems.
 
-    return os.path.islink(os.path.expanduser(path))
+    return os.path.islink(salt.utils.expanduser(path))
 
 
 def symlink(src, path):
@@ -3190,7 +3190,7 @@ def symlink(src, path):
 
         salt '*' file.symlink /path/to/file /path/to/link
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     try:
         if os.path.normpath(os.readlink(path)) == os.path.normpath(src):
@@ -3220,8 +3220,7 @@ def rename(src, dst):
 
         salt '*' file.rename /path/to/src /path/to/dst
     '''
-    src = os.path.expanduser(src)
-    dst = os.path.expanduser(dst)
+    src, dst = salt.utils.expanduser(src, dst)
 
     if not os.path.isabs(src):
         raise SaltInvocationError('File path must be absolute.')
@@ -3263,8 +3262,7 @@ def copy(src, dst, recurse=False, remove_existing=False):
         salt '*' file.copy /path/to/src_dir /path/to/dst_dir recurse=True remove_existing=True
 
     '''
-    src = os.path.expanduser(src)
-    dst = os.path.expanduser(dst)
+    src, dst = salt.utils.expanduser(src, dst)
 
     if not os.path.isabs(src):
         raise SaltInvocationError('File path must be absolute.')
@@ -3313,7 +3311,7 @@ def lstat(path):
 
         salt '*' file.lstat /path/to/file
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.isabs(path):
         raise SaltInvocationError('Path to file must be absolute.')
@@ -3347,7 +3345,7 @@ def access(path, mode):
         salt '*' file.access /path/to/file f
         salt '*' file.access /path/to/file x
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.isabs(path):
         raise SaltInvocationError('Path to link must be absolute.')
@@ -3397,7 +3395,7 @@ def readlink(path, canonicalize=False):
 
         salt '*' file.readlink /path/to/link
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.isabs(path):
         raise SaltInvocationError('Path to link must be absolute.')
@@ -3423,7 +3421,7 @@ def readdir(path):
 
         salt '*' file.readdir /path/to/dir/
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.isabs(path):
         raise SaltInvocationError('Dir path must be absolute.')
@@ -3448,7 +3446,7 @@ def statvfs(path):
 
         salt '*' file.statvfs /path/to/file
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.isabs(path):
         raise SaltInvocationError('File path must be absolute.')
@@ -3473,7 +3471,7 @@ def stats(path, hash_type=None, follow_symlinks=True):
 
         salt '*' file.stats /etc/passwd
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     ret = {}
     if not os.path.exists(path):
@@ -3532,7 +3530,7 @@ def rmdir(path):
 
         salt '*' file.rmdir /tmp/foo/
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.isabs(path):
         raise SaltInvocationError('File path must be absolute.')
@@ -3558,7 +3556,7 @@ def remove(path):
 
         salt '*' file.remove /tmp/foo
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.isabs(path):
         raise SaltInvocationError('File path must be absolute: {0}'.format(path))
@@ -3588,7 +3586,7 @@ def directory_exists(path):
         salt '*' file.directory_exists /etc
 
     '''
-    return os.path.isdir(os.path.expanduser(path))
+    return os.path.isdir(salt.utils.expanduser(path))
 
 
 def file_exists(path):
@@ -3602,7 +3600,7 @@ def file_exists(path):
         salt '*' file.file_exists /etc/passwd
 
     '''
-    return os.path.isfile(os.path.expanduser(path))
+    return os.path.isfile(salt.utils.expanduser(path))
 
 
 def path_exists_glob(path):
@@ -3620,7 +3618,7 @@ def path_exists_glob(path):
         salt '*' file.path_exists_glob /etc/pam*/pass*
 
     '''
-    return True if glob.glob(os.path.expanduser(path)) else False
+    return True if glob.glob(salt.utils.expanduser(path)) else False
 
 
 def restorecon(path, recursive=False):
@@ -4283,7 +4281,7 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
     .. versionchanged:: 2014.1.3
         ``follow_symlinks`` option added
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     if not ret:
         ret = {'name': name,
@@ -4748,7 +4746,7 @@ def get_diff(
 
         salt '*' file.get_diff /home/fred/.vimrc salt://users/fred/.vimrc
     '''
-    minionfile = os.path.expanduser(minionfile)
+    minionfile = salt.utils.expanduser(minionfile)
 
     ret = ''
 
@@ -4899,7 +4897,7 @@ def manage_file(name,
         ``follow_symlinks`` option added
 
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     if not ret:
         ret = {'name': name,
@@ -5287,7 +5285,7 @@ def mkdir(dir_path,
 
         salt '*' file.mkdir /opt/jetty/context
     '''
-    dir_path = os.path.expanduser(dir_path)
+    dir_path = salt.utils.expanduser(dir_path)
 
     directory = os.path.normpath(dir_path)
 
@@ -5321,7 +5319,7 @@ def makedirs_(path,
 
         salt '*' file.makedirs /opt/code/
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if mode:
         mode = salt.utils.normalize_mode(mode)
@@ -5380,7 +5378,7 @@ def makedirs_perms(name,
 
         salt '*' file.makedirs_perms /opt/code
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     path = os.path
     head, tail = path.split(name)
@@ -5413,7 +5411,7 @@ def get_devmm(name):
 
        salt '*' file.get_devmm /dev/chr
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     if is_chrdev(name) or is_blkdev(name):
         stat_structure = os.stat(name)
@@ -5434,7 +5432,7 @@ def is_chrdev(name):
 
        salt '*' file.is_chrdev /dev/chr
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     stat_structure = None
     try:
@@ -5465,7 +5463,7 @@ def mknod_chrdev(name,
 
        salt '*' file.mknod_chrdev /dev/chr 180 31
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name,
            'changes': {},
@@ -5509,7 +5507,7 @@ def is_blkdev(name):
 
        salt '*' file.is_blkdev /dev/blk
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     stat_structure = None
     try:
@@ -5540,7 +5538,7 @@ def mknod_blkdev(name,
 
        salt '*' file.mknod_blkdev /dev/blk 8 999
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name,
            'changes': {},
@@ -5584,7 +5582,7 @@ def is_fifo(name):
 
        salt '*' file.is_fifo /dev/fifo
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     stat_structure = None
     try:
@@ -5613,7 +5611,7 @@ def mknod_fifo(name,
 
        salt '*' file.mknod_fifo /dev/fifo
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name,
            'changes': {},
@@ -5698,7 +5696,7 @@ def list_backups(path, limit=None):
 
         salt '*' file.list_backups /foo/bar/baz.txt
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     try:
         limit = int(limit)
@@ -5769,7 +5767,7 @@ def list_backups_dir(path, limit=None):
 
         salt '*' file.list_backups_dir /foo/bar/baz/
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     try:
         limit = int(limit)
@@ -5833,7 +5831,7 @@ def restore_backup(path, backup_id):
 
         salt '*' file.restore_backup /foo/bar/baz.txt 0
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     # Note: This only supports minion backups, so this function will need to be
     # modified if/when master backups are implemented.
@@ -5895,7 +5893,7 @@ def delete_backup(path, backup_id):
 
         salt '*' file.delete_backup /var/cache/salt/minion/file_backup/home/foo/bar/baz.txt 0
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     ret = {'result': False,
            'comment': 'Invalid backup_id \'{0}\''.format(backup_id)}
@@ -5964,7 +5962,7 @@ def grep(path,
         salt '*' file.grep /etc/sysconfig/network-scripts/ifcfg-eth0 ipaddr -- -i -B2
         salt '*' file.grep "/etc/sysconfig/network-scripts/*" ipaddr -- -i -l
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     split_opts = []
     for opt in opts:
@@ -6192,8 +6190,7 @@ def move(src, dst):
 
         salt '*' file.move /path/to/src /path/to/dst
     '''
-    src = os.path.expanduser(src)
-    dst = os.path.expanduser(dst)
+    src, dst = salt.utils.expanduser(src, dst)
 
     if not os.path.isabs(src):
         raise SaltInvocationError('Source path must be absolute.')

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3149,7 +3149,7 @@ def link(src, path):
 
         salt '*' file.link /path/to/file /path/to/link
     '''
-    src = salt.utils.expanduser(src)
+    src, path = salt.utils.expanduser(src, path)
 
     if not os.path.isabs(src):
         raise SaltInvocationError('File path must be absolute.')
@@ -3190,7 +3190,7 @@ def symlink(src, path):
 
         salt '*' file.symlink /path/to/file /path/to/link
     '''
-    path = salt.utils.expanduser(path)
+    src, path = salt.utils.expanduser(src, path)
 
     try:
         if os.path.normpath(os.readlink(path)) == os.path.normpath(src):
@@ -4897,7 +4897,7 @@ def manage_file(name,
         ``follow_symlinks`` option added
 
     '''
-    name = salt.utils.expanduser(name)
+    name, sfn = salt.utils.expanduser(name, sfn)
 
     if not ret:
         ret = {'name': name,

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -740,6 +740,7 @@ def get_source_sum(file_name='',
         salt '*' file.get_source_sum /tmp/foo.tar.gz source=http://mydomain.tld/foo.tar.gz source_hash=https://mydomain.tld/hashes.md5
         salt '*' file.get_source_sum /tmp/foo.tar.gz source=http://mydomain.tld/foo.tar.gz source_hash=https://mydomain.tld/hashes.md5 source_hash_name=./dir2/foo.tar.gz
     '''
+    file_name = salt.utils.expanduser(file_name)
     def _invalid_source_hash_format():
         '''
         DRY helper for reporting invalid source_hash input
@@ -857,6 +858,8 @@ def check_hash(path, file_hash):
         salt '*' file.check_hash /etc/fstab e138491e9d5b97023cea823fe17bac22
         salt '*' file.check_hash /etc/fstab md5:e138491e9d5b97023cea823fe17bac22
     '''
+    path = salt.utils.expanduser(path)
+    path = salt.utils.expanduser(path)
     path = salt.utils.expanduser(path)
 
     if not isinstance(file_hash, six.string_types):
@@ -2466,6 +2469,7 @@ def blockreplace(path,
 
     '''
     path = salt.utils.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not os.path.exists(path):
         raise SaltInvocationError('File not found: {0}'.format(path))
@@ -2687,6 +2691,7 @@ def patch(originalfile, patchfile, options='', dry_run=False):
 
     .. code-block:: bash
 
+    originalfile, patchfile = salt.utils.expanduser(originalfile, patchfile)
         salt '*' file.patch /opt/file.txt /tmp/file.txt.patch
     '''
     patchpath = salt.utils.which('patch')
@@ -2864,6 +2869,7 @@ def append(path, *args, **kwargs):
             salt '*' file.append /etc/motd args="['cheese=spam','spam=cheese']"
 
     '''
+    path = salt.utils.expanduser(path)
     path = salt.utils.expanduser(path)
 
     # Largely inspired by Fabric's contrib.files.append()
@@ -3914,6 +3920,7 @@ def get_managed(
     CLI Example:
 
     .. code-block:: bash
+    name = salt.utils.expanduser(name)
 
         salt '*' file.get_managed /etc/httpd/conf.d/httpd.conf jinja salt://http/httpd.conf '{hash_type: 'md5', 'hsum': <md5sum>}' None root root '755' base None None
     '''
@@ -4646,9 +4653,11 @@ def check_file_meta(
     saltenv
         Salt environment used to resolve source files
 
+    name = salt.utils.expanduser(name)
     contents
         File contents
     '''
+    name, contents = salt.utils.expanduser(name, contents)
     changes = {}
     if not source_sum:
         source_sum = dict()
@@ -5958,6 +5967,7 @@ def grep(path,
     .. code-block:: bash
 
         salt '*' file.grep /etc/passwd nobody
+    path = salt.utils.expanduser(path)
         salt '*' file.grep /etc/sysconfig/network-scripts/ifcfg-eth0 ipaddr -- -i
         salt '*' file.grep /etc/sysconfig/network-scripts/ifcfg-eth0 ipaddr -- -i -B2
         salt '*' file.grep "/etc/sysconfig/network-scripts/*" ipaddr -- -i -l

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -375,6 +375,7 @@ def install(name=None,
 
         salt '*' pkg.install <package name>
     '''
+    sources = salt.utils.expanduser(sources)
     try:
         pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](
             name, pkgs, sources, **kwargs

--- a/salt/modules/genesis.py
+++ b/salt/modules/genesis.py
@@ -143,6 +143,7 @@ def bootstrap(
             flavor=wheezy static_qemu=/usr/bin/qemu-x86_64-static
 
     '''
+    root, static_qemu, mount_dir, pkg_cache = salt.utils.expanduser(root, static_qemu, mount_dir, pkg_cache)
     if img_format not in ('dir', 'sparse'):
         raise SaltInvocationError('The img_format must be "sparse" or "dir"')
 

--- a/salt/modules/gentoolkitmod.py
+++ b/salt/modules/gentoolkitmod.py
@@ -7,6 +7,9 @@ from __future__ import absolute_import
 
 import os
 
+# Import Salt Libs
+import salt.utils
+
 HAS_GENTOOLKIT = False
 
 # Import third party libs
@@ -45,6 +48,7 @@ def revdep_rebuild(lib=None):
 
         salt '*' gentoolkit.revdep_rebuild
     '''
+    lib = salt.utils.expanduser(lib)
     cmd = 'revdep-rebuild -i --quiet --no-progress'
     if lib is not None:
         cmd += ' --library={0}'.format(lib)
@@ -123,6 +127,7 @@ def eclean_dist(destructive=False, package_names=False, size_limit=0,
 
         salt '*' gentoolkit.eclean_dist destructive=True
     '''
+    exclude_file = salt.utils.expanduser(exclude_file)
     if exclude_file is None:
         exclude = None
     else:
@@ -195,6 +200,7 @@ def eclean_pkg(destructive=False, package_names=False, time_limit=0,
 
         salt '*' gentoolkit.eclean_pkg destructive=True
     '''
+    exclude_file = salt.utils.expanduser(exclude_file)
     if exclude_file is None:
         exclude = None
     else:

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -1718,6 +1718,8 @@ def diff(cwd,
             command.append(value)
 
     if paths:
+        paths = paths.split(';') if isinstance(paths, six.string_types) else paths
+        paths = salt.utils.expanduser(paths)
         command.append('--')
         command.extend(paths)
 

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -444,6 +444,7 @@ def add(cwd,
         salt myminion git.add /path/to/repo foo/bar.py
         salt myminion git.add /path/to/repo foo/bar.py opts='--dry-run'
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     if not isinstance(filename, six.string_types):
         filename = str(filename)
@@ -568,6 +569,7 @@ def archive(cwd,
 
         salt myminion git.archive /path/to/repo /path/to/archive.tar
     '''
+    cwd, output = salt.utils.expanduser(cwd, output)
     cwd = _expand_path(cwd, user)
     output = _expand_path(output, user)
     # Sanitize kwargs and make sure that no invalid ones were passed. This
@@ -680,6 +682,7 @@ def branch(cwd,
         # Rename branch (2015.8.0 and later)
         salt myminion git.branch /path/to/repo newbranch opts='-m oldbranch'
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     command = ['git'] + _format_git_opts(git_opts)
     command.append('branch')
@@ -768,6 +771,7 @@ def checkout(cwd,
         # Checking out current revision into new branch (2015.8.0 and later)
         salt myminion git.checkout /path/to/repo opts='-b newbranch'
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     command = ['git'] + _format_git_opts(git_opts)
     command.append('checkout')
@@ -903,6 +907,7 @@ def clone(cwd,
 
         salt myminion git.clone /path/to/repo_parent_dir git://github.com/saltstack/salt.git
     '''
+    cwd, identity = salt.utils.expanduser(cwd, identity)
     cwd = _expand_path(cwd, user)
 
     if not url:
@@ -1022,6 +1027,7 @@ def commit(cwd,
         salt myminion git.commit /path/to/repo 'The commit message'
         salt myminion git.commit /path/to/repo 'The commit message' filename=foo/bar.py
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     command = ['git'] + _format_git_opts(git_opts)
     command.extend(['commit', '-m', message])
@@ -1097,6 +1103,7 @@ def config_get(key,
         salt myminion git.config_get user.email global=True
         salt myminion git.config_get core.gitproxy cwd=/path/to/repo all=True
     '''
+    cwd = salt.utils.expanduser(cwd)
     # Sanitize kwargs and make sure that no invalid ones were passed. This
     # allows us to accept 'all' as an argument to this function without
     # shadowing all(), while also not allowing unwanted arguments to be passed.
@@ -1186,6 +1193,7 @@ def config_get_regexp(key,
         # Matches any key starting with 'user.'
         salt myminion git.config_get_regexp '^user\.' global=True
     '''
+    cwd = salt.utils.expanduser(cwd)
     result = _config_getter('--get-regexp',
                             key,
                             value_regex=value_regex,
@@ -1281,6 +1289,7 @@ def config_set(key,
         salt myminion git.config_set user.email me@example.com cwd=/path/to/repo
         salt myminion git.config_set user.email foo@bar.com global=True
     '''
+    cwd = salt.utils.expanduser(cwd)
     kwargs = salt.utils.clean_kwargs(**kwargs)
     add_ = kwargs.pop('add', False)
     global_ = kwargs.pop('global', False)
@@ -1408,6 +1417,7 @@ def config_unset(key,
         salt myminion git.config_unset /path/to/repo foo.bar
         salt myminion git.config_unset /path/to/repo foo.bar all=True
     '''
+    cwd = salt.utils.expanduser(cwd)
     kwargs = salt.utils.clean_kwargs(**kwargs)
     all_ = kwargs.pop('all', False)
     global_ = kwargs.pop('global', False)
@@ -1507,6 +1517,7 @@ def current_branch(cwd,
 
         salt myminion git.current_branch /path/to/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     command = ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
     return _git_run(command,
@@ -1557,6 +1568,7 @@ def describe(cwd,
         salt myminion git.describe /path/to/repo
         salt myminion git.describe /path/to/repo develop
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     if not isinstance(rev, six.string_types):
         rev = str(rev)
@@ -1670,6 +1682,7 @@ def diff(cwd,
         # Diff two files with one being outside the working tree
         salt myminion git.diff /path/to/repo no_index=True paths=path/to/file1,/absolute/path/to/file2
     '''
+    cwd, paths = salt.utils.expanduser(cwd, paths)
     if no_index and cached:
         raise CommandExecutionError(
             'The \'no_index\' and \'cached\' options cannot be used together'
@@ -1842,6 +1855,7 @@ def fetch(cwd,
         salt myminion git.fetch /path/to/repo upstream
         salt myminion git.fetch /path/to/repo identity=/root/.ssh/id_rsa
     '''
+    cwd, identity = salt.utils.expanduser(cwd, identity)
     cwd = _expand_path(cwd, user)
     command = ['git'] + _format_git_opts(git_opts)
     command.append('fetch')
@@ -1988,6 +2002,7 @@ def init(cwd,
         # Init a bare repo (2015.8.0 and later)
         salt myminion git.init /path/to/bare/repo.git bare=True
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     command = ['git'] + _format_git_opts(git_opts)
     command.append('init')
@@ -2048,6 +2063,7 @@ def is_worktree(cwd,
 
         salt myminion git.is_worktree /path/to/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     try:
         toplevel = _get_toplevel(cwd, user=user, password=password)
@@ -2123,6 +2139,7 @@ def list_branches(cwd,
         salt myminion git.list_branches /path/to/repo
         salt myminion git.list_branches /path/to/repo remote=True
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     command = ['git', 'for-each-ref', '--format', '%(refname:short)',
                'refs/{0}/'.format('heads' if not remote else 'remotes')]
@@ -2168,6 +2185,7 @@ def list_tags(cwd,
 
         salt myminion git.list_tags /path/to/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     command = ['git', 'for-each-ref', '--format', '%(refname:short)',
                'refs/tags/']
@@ -2235,6 +2253,7 @@ def list_worktrees(cwd,
         salt myminion git.list_worktrees /path/to/repo all=True
         salt myminion git.list_worktrees /path/to/repo stale=True
     '''
+    cwd = salt.utils.expanduser(cwd)
     if not _check_worktree_support(failhard=True):
         return {}
     cwd = _expand_path(cwd, user)
@@ -2591,6 +2610,7 @@ def ls_remote(cwd=None,
         salt myminion git.ls_remote /path/to/repo origin master
         salt myminion git.ls_remote remote=https://mydomain.tld/repo.git ref=mytag opts='--tags'
     '''
+    cwd, identity = salt.utils.expanduser(cwd, identity)
     if cwd is not None:
         cwd = _expand_path(cwd, user)
     try:
@@ -2695,6 +2715,7 @@ def merge(cwd,
         # .. or merge another rev
         salt myminion git.merge /path/to/repo rev=upstream/foo
     '''
+    cwd = salt.utils.expanduser(cwd)
     kwargs = salt.utils.clean_kwargs(**kwargs)
     if kwargs:
         salt.utils.invalid_kwargs(kwargs)
@@ -2826,6 +2847,7 @@ def merge_base(cwd,
         salt myminion git.merge_base /path/to/repo fork_point=upstream/master
         salt myminion git.merge_base /path/to/repo refs=mybranch fork_point=upstream/master
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     kwargs = salt.utils.clean_kwargs(**kwargs)
     all_ = kwargs.pop('all', False)
@@ -2969,6 +2991,7 @@ def merge_tree(cwd,
         salt myminion git.merge_tree /path/to/repo HEAD upstream/dev
         salt myminion git.merge_tree /path/to/repo HEAD upstream/dev base=aaf3c3d
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     command = ['git', 'merge-tree']
     if not isinstance(ref1, six.string_types):
@@ -3075,6 +3098,7 @@ def pull(cwd,
 
         salt myminion git.pull /path/to/repo opts='--rebase origin master'
     '''
+    cwd, identity = salt.utils.expanduser(cwd, identity)
     cwd = _expand_path(cwd, user)
     command = ['git'] + _format_git_opts(git_opts)
     command.append('pull')
@@ -3193,6 +3217,7 @@ def push(cwd,
         # Delete remote branch 'upstream/temp'
         salt myminion git.push /path/to/repo upstream :temp
     '''
+    cwd, identity = salt.utils.expanduser(cwd, identity)
     kwargs = salt.utils.clean_kwargs(**kwargs)
     if kwargs:
         salt.utils.invalid_kwargs(kwargs)
@@ -3276,6 +3301,7 @@ def rebase(cwd,
         salt myminion git.rebase /path/to/repo 'origin master'
         salt myminion git.rebase /path/to/repo origin/master opts='--onto newbranch'
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     opts = _format_opts(opts)
     if any(x for x in opts if x in ('-i', '--interactive')):
@@ -3344,6 +3370,7 @@ def remote_get(cwd,
         salt myminion git.remote_get /path/to/repo
         salt myminion git.remote_get /path/to/repo upstream
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     all_remotes = remotes(cwd,
                           user=user,
@@ -3436,6 +3463,7 @@ def remote_refs(url,
 
         salt myminion git.remote_refs https://github.com/saltstack/salt.git
     '''
+    identity = salt.utils.expanduser(identity)
     command = ['git', 'ls-remote']
     if heads:
         command.append('--heads')
@@ -3537,6 +3565,7 @@ def remote_set(cwd,
         salt myminion git.remote_set /path/to/repo git@github.com:user/repo.git remote=upstream
         salt myminion git.remote_set /path/to/repo https://github.com/user/repo.git remote=upstream push_url=git@github.com:user/repo.git
     '''
+    cwd = salt.utils.expanduser(cwd)
     # Check if remote exists
     if remote in remotes(cwd, user=user, password=password):
         log.debug(
@@ -3637,6 +3666,7 @@ def remotes(cwd,
 
         salt myminion git.remotes /path/to/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     command = ['git', 'remote', '--verbose']
     ret = {}
@@ -3726,6 +3756,7 @@ def reset(cwd,
         # Hard reset
         salt myminion git.reset /path/to/repo opts='--hard origin/master'
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     command = ['git'] + _format_git_opts(git_opts)
     command.append('reset')
@@ -3807,6 +3838,7 @@ def rev_parse(cwd,
         # Find out whether or not the repo at /path/to/repo is a bare repository
         salt myminion git.rev_parse /path/to/repo opts='--is-bare-repository'
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     command = ['git'] + _format_git_opts(git_opts)
     command.append('rev-parse')
@@ -3862,6 +3894,7 @@ def revision(cwd,
 
         salt myminion git.revision /path/to/repo mybranch
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     if not isinstance(rev, six.string_types):
         rev = str(rev)
@@ -3941,6 +3974,7 @@ def rm_(cwd,
         salt myminion git.rm /path/to/repo foo/bar.py opts='--dry-run'
         salt myminion git.rm /path/to/repo foo/baz opts='-r'
     '''
+    cwd, filename = salt.utils.expanduser(cwd, filename)
     cwd = _expand_path(cwd, user)
     command = ['git'] + _format_git_opts(git_opts)
     command.append('rm')
@@ -4011,6 +4045,7 @@ def stash(cwd,
         salt myminion git.stash /path/to/repo drop opts='stash@{1}'
         salt myminion git.stash /path/to/repo list
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     if not isinstance(action, six.string_types):
         # No numeric actions but this will prevent a traceback when the git
@@ -4062,6 +4097,7 @@ def status(cwd,
 
         salt myminion git.status /path/to/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     state_map = {
         'M': 'modified',
@@ -4205,6 +4241,7 @@ def submodule(cwd,
         # Unregister submodule (2015.8.0 and later)
         salt myminion git.submodule /path/to/repo/sub/repo deinit
     '''
+    cwd, identity = salt.utils.expanduser(cwd, identity)
     kwargs = salt.utils.clean_kwargs(**kwargs)
     init_ = kwargs.pop('init', False)
     if kwargs:
@@ -4302,6 +4339,7 @@ def symbolic_ref(cwd,
         # Delete symbolic ref 'FOO'
         salt myminion git.symbolic_ref /path/to/repo FOO opts='--delete'
     '''
+    cwd = salt.utils.expanduser(cwd)
     cwd = _expand_path(cwd, user)
     command = ['git'] + _format_git_opts(git_opts)
     command.append('symbolic-ref')
@@ -4469,6 +4507,7 @@ def worktree_add(cwd,
         salt myminion git.worktree_add /path/to/repo/main ../hotfix ref=origin/master
         salt myminion git.worktree_add /path/to/repo/main ../hotfix branch=hotfix21 ref=v2.1.9.3
     '''
+    cwd, worktree_path = salt.utils.expanduser(cwd, worktree_path)
     _check_worktree_support()
     kwargs = salt.utils.clean_kwargs(**kwargs)
     branch_ = kwargs.pop('branch', None)
@@ -4596,6 +4635,7 @@ def worktree_prune(cwd,
         salt myminion git.worktree_prune /path/to/repo dry_run=True
         salt myminion git.worktree_prune /path/to/repo expire=1.day.ago
     '''
+    cwd = salt.utils.expanduser(cwd)
     _check_worktree_support()
     cwd = _expand_path(cwd, user)
     command = ['git'] + _format_git_opts(git_opts)
@@ -4648,6 +4688,7 @@ def worktree_rm(cwd, user=None):
 
         salt myminion git.worktree_rm /path/to/worktree
     '''
+    cwd = salt.utils.expanduser(cwd)
     _check_worktree_support()
     cwd = _expand_path(cwd, user)
     if not os.path.exists(cwd):

--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -601,6 +601,7 @@ def set_quota_volume(name, path, size, enable_quota=False):
         salt '*' glusterfs.set_quota_volume <volume> <path> <size> enable_quota=True
 
     '''
+    path = salt.utils.expanduser(path)
     cmd = 'volume quota {0}'.format(name)
     if path:
         cmd += ' limit-usage {0}'.format(path)
@@ -628,6 +629,7 @@ def unset_quota_volume(name, path):
         salt '*' glusterfs.unset_quota_volume <volume> <path>
 
     '''
+    path = salt.utils.expanduser(path)
     cmd = 'volume quota {0}'.format(name)
     if path:
         cmd += ' remove {0}'.format(path)

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -287,6 +287,7 @@ def list_keys(user=None, gnupghome=None):
         salt '*' gpg.list_keys
 
     '''
+    gnupghome = salt.utils.expanduser(gnupghome)
     _keys = []
     for _key in _list_keys(user, gnupghome):
         tmp = {'keyid': _key['keyid'],
@@ -334,6 +335,7 @@ def list_secret_keys(user=None, gnupghome=None):
         salt '*' gpg.list_secret_keys
 
     '''
+    gnupghome = salt.utils.expanduser(gnupghome)
     _keys = []
     for _key in _list_keys(user, gnupghome, secret=True):
         tmp = {'keyid': _key['keyid'],
@@ -522,6 +524,7 @@ def delete_key(keyid=None,
         salt '*' gpg.delete_key keyid=3FAD9F1E user=username delete_secret=True
 
     '''
+    gnupghome = salt.utils.expanduser(gnupghome)
     ret = {
            'res': True,
            'message': ''
@@ -590,6 +593,7 @@ def get_key(keyid=None, fingerprint=None, user=None, gnupghome=None):
         salt '*' gpg.get_key keyid=3FAD9F1E user=username
 
     '''
+    gnupghome = salt.utils.expanduser(gnupghome)
     tmp = {}
     for _key in _list_keys(user, gnupghome):
         if (_key['fingerprint'] == fingerprint or
@@ -652,6 +656,7 @@ def get_secret_key(keyid=None, fingerprint=None, user=None, gnupghome=None):
         salt '*' gpg.get_secret_key keyid=3FAD9F1E user=username
 
     '''
+    gnupghome = salt.utils.expanduser(gnupghome)
     tmp = {}
     for _key in _list_keys(user, gnupghome, secret=True):
         if (_key['fingerprint'] == fingerprint or
@@ -793,6 +798,7 @@ def export_key(keyids=None, secret=False, user=None, gnupghome=None):
         salt '*' gpg.export_key keyids="['3FAD9F1E','3FBD8F1E']" user=username
 
     '''
+    gnupghome = salt.utils.expanduser(gnupghome)
     gpg = _create_gpg(user, gnupghome)
 
     if isinstance(keyids, six.string_types):
@@ -1003,6 +1009,7 @@ def sign(user=None,
         salt '*' gpg.sign filename='/path/to/important.file' use_passphrase=True
 
     '''
+    output, gnupghome = salt.utils.expanduser(output, gnupghome)
     gpg = _create_gpg(user, gnupghome)
     if use_passphrase:
         gpg_passphrase = __salt__['pillar.get']('gpg_passphrase')
@@ -1070,6 +1077,7 @@ def verify(text=None,
         salt '*' gpg.verify filename='/path/to/important.file' use_passphrase=True
 
     '''
+    gnupghome = salt.utils.expanduser(gnupghome)
     gpg = _create_gpg(user)
 
     if text:
@@ -1154,6 +1162,7 @@ def encrypt(user=None,
         salt '*' gpg.encrypt filename='/path/to/important.file' use_passphrase=True
 
     '''
+    output, gnupghome = salt.utils.expanduser(output, gnupghome)
     ret = {
         'res': True,
         'comment': ''
@@ -1249,6 +1258,7 @@ def decrypt(user=None,
         salt '*' gpg.decrypt filename='/path/to/important.file.gpg' use_passphrase=True
 
     '''
+    gnupghome = salt.utils.expanduser(gnupghome)
     ret = {
         'res': True,
         'comment': ''

--- a/salt/modules/hashutil.py
+++ b/salt/modules/hashutil.py
@@ -69,6 +69,7 @@ def digest_file(infile, checksum='md5'):
 
         salt '*' hashutil.digest_file /path/to/file
     '''
+    infile = salt.utils.expanduser(infile)
     if not __salt__['file.file_exists'](infile):
         raise salt.exceptions.CommandExecutionError(
                 "File path '{0}' not found.".format(infile))

--- a/salt/modules/heat.py
+++ b/salt/modules/heat.py
@@ -502,6 +502,7 @@ def create_stack(name=None, template_file=None, enviroment=None,
                  poll=5 rollback=False timeout=60 profile=openstack1
 
     '''
+    template_file, enviroment = salt.utils.expanduser(template_file, enviroment)
     h_client = _auth(profile)
     ret = {
         'result': True,
@@ -687,6 +688,7 @@ def update_stack(name=None, template_file=None, enviroment=None,
                  poll=5 rollback=False timeout=60 profile=openstack1
 
     '''
+    template_file, enviroment = salt.utils.expanduser(template_file, enviroment)
     h_client = _auth(profile)
     ret = {
         'result': True,

--- a/salt/modules/hg.py
+++ b/salt/modules/hg.py
@@ -51,6 +51,7 @@ def revision(cwd, rev='tip', short=False, user=None):
 
         salt '*' hg.revision /path/to/repo mybranch
     '''
+    cwd = salt.utils.expanduser(cwd)
     cmd = [
             'hg',
             'id',
@@ -90,6 +91,7 @@ def describe(cwd, rev='tip', user=None):
 
         salt '*' hg.describe /path/to/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     cmd = [
             'hg',
             'log',
@@ -139,6 +141,7 @@ def archive(cwd, output, rev='tip', fmt=None, prefix=None, user=None):
 
         salt '*' hg.archive /path/to/repo output=/tmp/archive.tgz fmt=tgz
     '''
+    cwd, output = salt.utils.expanduser(cwd, output)
     cmd = [
             'hg',
             'archive',
@@ -182,6 +185,7 @@ def pull(cwd, opts=None, user=None, identity=None, repository=None):
 
         salt '*' hg.pull /path/to/repo opts=-u
     '''
+    cwd = salt.utils.expanduser(cwd)
     cmd = ['hg', 'pull']
     if identity:
         cmd.extend(_ssh_flag(identity))
@@ -222,6 +226,7 @@ def update(cwd, rev, force=False, user=None):
 
         salt devserver1 hg.update /path/to/repo somebranch
     '''
+    cwd = salt.utils.expanduser(cwd)
     cmd = ['hg', 'update', '{0}'.format(rev)]
     if force:
         cmd.append('-C')
@@ -262,6 +267,7 @@ def clone(cwd, repository, opts=None, user=None, identity=None):
 
         salt '*' hg.clone /path/to/repo https://bitbucket.org/birkenfeld/sphinx
     '''
+    cwd = salt.utils.expanduser(cwd)
     cmd = ['hg', 'clone', '{0}'.format(repository), '{0}'.format(cwd)]
     if opts:
         for opt in opts.split():
@@ -297,6 +303,7 @@ def status(cwd, opts=None, user=None):
 
         salt '*' hg.status /path/to/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     def _status(cwd):
         cmd = ['hg', 'status']
         if opts:

--- a/salt/modules/htpasswd.py
+++ b/salt/modules/htpasswd.py
@@ -65,6 +65,7 @@ def useradd(pwfile, user, password, opts='', runas=None):
         salt '*' webutil.useradd /etc/httpd/htpasswd larry badpassword
         salt '*' webutil.useradd /etc/httpd/htpasswd larry badpass opts=ns
     '''
+    pwfile = salt.utils.expanduser(pwfile)
     if not os.path.exists(pwfile):
         opts += 'c'
 
@@ -94,6 +95,7 @@ def userdel(pwfile, user, runas=None, all_results=False):
 
         salt '*' webutil.userdel /etc/httpd/htpasswd larry
     '''
+    pwfile = salt.utils.expanduser(pwfile)
     if not os.path.exists(pwfile):
         return 'Error: The specified htpasswd file does not exist'
 
@@ -140,6 +142,7 @@ def verify(pwfile, user, password, opts='', runas=None):
         salt '*' webutil.verify /etc/httpd/htpasswd larry maybepassword
         salt '*' webutil.verify /etc/httpd/htpasswd larry maybepassword opts=ns
     '''
+    pwfile = salt.utils.expanduser(pwfile)
     if not os.path.exists(pwfile):
         return False
 

--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -77,6 +77,7 @@ def set_option(file_name, sections=None, separator='='):
 
         salt '*' ini.set_option /path/to/ini '{section_foo: {key: value}}'
     '''
+    file_name = salt.utils.expanduser(file_name)
     sections = sections or {}
     changes = {}
     inifile = _Ini.get_ini_file(file_name, separator=separator)

--- a/salt/modules/jenkins.py
+++ b/salt/modules/jenkins.py
@@ -253,6 +253,7 @@ def create_job(name=None,
         salt '*' jenkins.create_job jobname config_xml='salt://jenkins/config.xml'
 
     '''
+    config_xml = salt.utils.expanduser(config_xml)
     if not name:
         raise SaltInvocationError('Required parameter `name` is missing.')
 
@@ -295,6 +296,7 @@ def update_job(name=None,
         salt '*' jenkins.update_job jobname config_xml='salt://jenkins/config.xml'
 
     '''
+    config_xml = salt.utils.expanduser(config_xml)
     if not name:
         raise SaltInvocationError('Required parameter `name` is missing.')
 

--- a/salt/modules/kapacitor.py
+++ b/salt/modules/kapacitor.py
@@ -132,6 +132,7 @@ def define_task(name,
 
         salt '*' kapacitor.define_task cpu salt://kapacitor/cpu.tick database=telegraf
     '''
+    tick_script = salt.utils.expanduser(tick_script)
     if version() < '0.13':
         cmd = 'kapacitor define -name {0}'.format(name)
     else:

--- a/salt/modules/libcloud_compute.py
+++ b/salt/modules/libcloud_compute.py
@@ -37,6 +37,7 @@ import logging
 import os.path
 
 # Import salt libs
+import salt.utils
 import salt.utils.compat
 from salt.utils import clean_kwargs
 from salt.utils.versions import LooseVersion as _LooseVersion
@@ -714,6 +715,7 @@ def import_key_pair(name, key, profile, key_type=None, **libcloud_kwargs):
         salt myminion libcloud_compute.import_key_pair pair1 key_value_data123 profile1
         salt myminion libcloud_compute.import_key_pair pair1 /path/to/key profile1
     '''
+    key = salt.utils.expanduser(key)
     conn = _get_driver(profile=profile)
     libcloud_kwargs = clean_kwargs(**libcloud_kwargs)
     if os.path.exists(key) or key_type == 'FILE':

--- a/salt/modules/libcloud_storage.py
+++ b/salt/modules/libcloud_storage.py
@@ -36,6 +36,7 @@ from __future__ import absolute_import
 import logging
 
 # Import salt libs
+import salt.utils
 import salt.utils.compat
 from salt.utils import clean_kwargs
 from salt.utils.versions import LooseVersion as _LooseVersion
@@ -280,6 +281,7 @@ def download_object(container_name, object_name, destination_path, profile,
         salt myminion libcloud_storage.download_object MyFolder me.jpg /tmp/me.jpg profile1
 
     '''
+    destination_path = salt.utils.expanduser(destination_path)
     conn = _get_driver(profile=profile)
     obj = conn.get_object(container_name, object_name)
     libcloud_kwargs = clean_kwargs(**libcloud_kwargs)
@@ -327,6 +329,7 @@ def upload_object(file_path, container_name, object_name, profile, extra=None,
         salt myminion libcloud_storage.upload_object /file/to/me.jpg MyFolder me.jpg profile1
 
     '''
+    file_path = salt.utils.expanduser(file_path)
     conn = _get_driver(profile=profile)
     libcloud_kwargs = clean_kwargs(**libcloud_kwargs)
     container = conn.get_container(container_name)

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1865,6 +1865,7 @@ def create(name,
 
         .. versionadded:: 2015.8.0
     '''
+    config = salt.utils.expanduser(config)
     # Required params for 'download' template
     download_template_deps = ('dist', 'release', 'arch')
 
@@ -2123,6 +2124,7 @@ def ls_(active=None, cache=True, path=None):
         salt '*' lxc.ls
         salt '*' lxc.ls active=True
     '''
+    path = salt.utils.expanduser(path)
     contextvar = 'lxc.ls{0}'.format(path)
     if active:
         contextvar += '.active'
@@ -2172,6 +2174,7 @@ def list_(extra=False, limit=None, path=None):
         salt '*' lxc.list extra=True
         salt '*' lxc.list limit=running
     '''
+    path = salt.utils.expanduser(path)
     ctnrs = ls_(path=path)
 
     if extra:
@@ -2367,6 +2370,7 @@ def restart(name, path=None, lxc_config=None, force=False):
 
         salt myminion lxc.restart name
     '''
+    path, lxc_config = salt.utils.expanduser(path, lxc_config)
     _ensure_exists(name, path=path)
     orig_state = state(name, path=path)
     if orig_state != 'stopped':
@@ -2461,6 +2465,7 @@ def stop(name, kill=False, path=None, use_vt=None):
 
         salt myminion lxc.stop name
     '''
+    path = salt.utils.expanduser(path)
     _ensure_exists(name, path=path)
     orig_state = state(name, path=path)
     if orig_state == 'frozen' and not kill:
@@ -2546,6 +2551,7 @@ def unfreeze(name, path=None, use_vt=None):
 
         salt '*' lxc.unfreeze name
     '''
+    path = salt.utils.expanduser(path)
     _ensure_exists(name, path=path)
     if state(name, path=path) == 'stopped':
         raise CommandExecutionError(
@@ -2587,6 +2593,7 @@ def destroy(name, stop=False, path=None):
         salt '*' lxc.destroy foo
         salt '*' lxc.destroy foo stop=True
     '''
+    path = salt.utils.expanduser(path)
     _ensure_exists(name, path=path)
     if not stop and state(name, path=path) != 'stopped':
         raise CommandExecutionError(
@@ -2614,6 +2621,7 @@ def exists(name, path=None):
 
         salt '*' lxc.exists name
     '''
+    path = salt.utils.expanduser(path)
 
     _exists = name in ls_(path=path)
     # container may be just created but we did cached earlier the
@@ -2638,6 +2646,7 @@ def state(name, path=None):
 
         salt '*' lxc.state name
     '''
+    path = salt.utils.expanduser(path)
     # Don't use _ensure_exists() here, it will mess with _change_state()
 
     cachekey = 'lxc.state.{0}{1}'.format(name, path)
@@ -2684,6 +2693,7 @@ def get_parameter(name, parameter, path=None):
 
         salt '*' lxc.get_parameter container_name memory.limit_in_bytes
     '''
+    path = salt.utils.expanduser(path)
     _ensure_exists(name, path=path)
     cmd = 'lxc-cgroup'
     if path:
@@ -2713,6 +2723,7 @@ def set_parameter(name, parameter, value, path=None):
 
         salt '*' lxc.set_parameter name parameter value
     '''
+    path = salt.utils.expanduser(path)
     if not exists(name, path=path):
         return None
 
@@ -2743,6 +2754,7 @@ def info(name, path=None):
 
         salt '*' lxc.info name
     '''
+    path = salt.utils.expanduser(path)
     cachekey = 'lxc.info.{0}{1}'.format(name, path)
     try:
         return __context__[cachekey]
@@ -2909,6 +2921,7 @@ def set_password(name, users, password, encrypted=True, path=None):
         salt '*' lxc.set_pass container-name root foo encrypted=False
 
     '''
+    path = salt.utils.expanduser(path)
     def _bad_user_input():
         raise SaltInvocationError('Invalid input for \'users\' parameter')
 
@@ -2960,6 +2973,7 @@ def update_lxc_conf(name, lxc_conf, lxc_conf_unset, path=None):
                 lxc_conf_unset="['lxc.utsname']"
 
     '''
+    path = salt.utils.expanduser(path)
     _ensure_exists(name, path=path)
     cpath = get_root_path(path)
     lxc_conf_p = os.path.join(cpath, name, 'config')
@@ -3156,6 +3170,7 @@ def running_systemd(name, cache=True, path=None):
         salt '*' lxc.running_systemd ubuntu
 
     '''
+    path = salt.utils.expanduser(path)
     k = 'lxc.systemd.test.{0}{1}'.format(name, path)
     ret = __context__.get(k, None)
     if ret is None or not cache:
@@ -3234,6 +3249,7 @@ def systemd_running_state(name, path=None):
         salt myminion lxc.systemd_running_state ubuntu
 
     '''
+    path = salt.utils.expanduser(path)
     try:
         ret = run_all(name,
                       'systemctl is-system-running',
@@ -3264,6 +3280,7 @@ def test_sd_started_state(name, path=None):
         salt myminion lxc.test_sd_started_state ubuntu
 
     '''
+    path = salt.utils.expanduser(path)
     qstate = systemd_running_state(name, path=path)
     if qstate in ('initializing', 'starting'):
         return False
@@ -3292,6 +3309,7 @@ def test_bare_started_state(name, path=None):
         salt myminion lxc.test_bare_started_state ubuntu
 
     '''
+    path = salt.utils.expanduser(path)
     try:
         ret = run_all(
             name, 'ls', path=path, ignore_retcode=True
@@ -3322,6 +3340,7 @@ def wait_started(name, path=None, timeout=300):
         salt myminion lxc.wait_started ubuntu
 
     '''
+    path = salt.utils.expanduser(path)
     if not exists(name, path=path):
         raise CommandExecutionError(
             'Container {0} does does exists'.format(name))
@@ -3446,6 +3465,7 @@ def bootstrap(name,
                 [approve_key=(True|False)] [install=(True|False)]
 
     '''
+    path = salt.utils.expanduser(path)
     wait_started(name, path=path)
     if bootstrap_delay is not None:
         try:
@@ -3592,6 +3612,7 @@ def attachable(name, path=None):
 
         salt 'minion' lxc.attachable ubuntu
     '''
+    path = salt.utils.expanduser(path)
     cachekey = 'lxc.attachable{0}{1}'.format(name, path)
     try:
         return __context__[cachekey]
@@ -3757,6 +3778,7 @@ def run(name,
 
         salt myminion lxc.run mycontainer 'ifconfig -a'
     '''
+    path = salt.utils.expanduser(path)
     return _run(name,
                 cmd,
                 path=path,
@@ -3846,6 +3868,7 @@ def run_stdout(name,
 
         salt myminion lxc.run_stdout mycontainer 'ifconfig -a'
     '''
+    path = salt.utils.expanduser(path)
     return _run(name,
                 cmd,
                 path=path,
@@ -3933,6 +3956,7 @@ def run_stderr(name,
 
         salt myminion lxc.run_stderr mycontainer 'ip addr show'
     '''
+    path = salt.utils.expanduser(path)
     return _run(name,
                 cmd,
                 path=path,
@@ -4022,6 +4046,7 @@ def retcode(name,
 
         salt myminion lxc.retcode mycontainer 'ip addr show'
     '''
+    path = salt.utils.expanduser(path)
     return _run(name,
                 cmd,
                 output='retcode',
@@ -4115,6 +4140,7 @@ def run_all(name,
 
         salt myminion lxc.run_all mycontainer 'ip addr show'
     '''
+    path = salt.utils.expanduser(path)
     return _run(name,
                 cmd,
                 output='all',
@@ -4192,6 +4218,7 @@ def copy_to(name, source, dest, overwrite=False, makedirs=False, path=None):
         salt 'minion' lxc.copy_to /tmp/foo /root/foo
         salt 'minion' lxc.cp /tmp/foo /root/foo
     '''
+    source, path = salt.utils.expanduser(source, path)
     _ensure_running(name, no_start=True, path=path)
     return __salt__['container_resource.copy_to'](
         name,
@@ -4445,6 +4472,7 @@ def reboot(name, path=None):
         salt 'minion' lxc.reboot myvm
 
     '''
+    path = salt.utils.expanduser(path)
     ret = {'result': True,
            'changes': {},
            'comment': '{0} rebooted'.format(name)}
@@ -4541,6 +4569,7 @@ def reconfigure(name,
         salt-call -lall mc_lxc_fork.reconfigure foobar nic_opts="{'eth1': {'mac': '00:16:3e:dd:ee:44'}}" memory=4
 
     '''
+    path = salt.utils.expanduser(path)
     changes = {}
     cpath = get_root_path(path)
     path = os.path.join(cpath, name, 'config')
@@ -4635,6 +4664,7 @@ def apply_network_profile(name, network_profile, nic_opts=None, path=None):
         salt 'minion' lxc.apply_network_profile web1 centos \\
                 "{eth0: {disable: true}}"
     '''
+    path = salt.utils.expanduser(path)
     cpath = get_root_path(path)
     cfgpath = os.path.join(cpath, name, 'config')
 

--- a/salt/modules/mac_keychain.py
+++ b/salt/modules/mac_keychain.py
@@ -206,6 +206,7 @@ def set_default_keychain(keychain, domain="user", user=None):
 
         salt '*' keychain.set_keychain /Users/fred/Library/Keychains/login.keychain
     '''
+    keychain = salt.utils.expanduser(keychain)
     cmd = "security default-keychain -d {0} -s {1}".format(domain, keychain)
     return __salt__['cmd.run'](cmd, runas=user)
 

--- a/salt/modules/mac_sysctl.py
+++ b/salt/modules/mac_sysctl.py
@@ -148,6 +148,7 @@ def persist(name, value, config='/etc/sysctl.conf', apply_change=False):
         salt '*' sysctl.persist net.inet.icmp.icmplim 50
         salt '*' sysctl.persist coretemp_load NO config=/etc/sysctl.conf
     '''
+    config = salt.utils.expanduser(config)
     nlines = []
     edited = False
     value = str(value)

--- a/salt/modules/namecheap_ssl.py
+++ b/salt/modules/namecheap_ssl.py
@@ -561,6 +561,7 @@ def parse_csr(csr_file, certificate_type, http_dc_validation=False):
 
         salt 'my-minion' namecheap_ssl.parse_csr my-csr-file PremiumSSL
     '''
+    csr_file = salt.utils.expanduser(csr_file)
     valid_certs = set(['QuickSSL Premium',
                        'RapidSSL',
                        'RapidSSL Wildcard',

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -127,6 +127,7 @@ def install(pkg=None,
         salt '*' npm.install coffee-script@1.0.1
 
     '''
+    dir = salt.utils.expanduser(dir)
     # Protect against injection
     if pkg:
         pkgs = [_cmd_quote(pkg)]
@@ -227,6 +228,7 @@ def uninstall(pkg, dir=None, runas=None, env=None):
         salt '*' npm.uninstall coffee-script
 
     '''
+    dir = salt.utils.expanduser(dir)
     # Protect against injection
     if pkg:
         pkg = _cmd_quote(pkg)
@@ -290,6 +292,7 @@ def list_(pkg=None, dir=None, runas=None, env=None, depth=None):
         salt '*' npm.list
 
     '''
+    dir = salt.utils.expanduser(dir)
     env = env or {}
 
     if runas:

--- a/salt/modules/openstack_config.py
+++ b/salt/modules/openstack_config.py
@@ -69,7 +69,7 @@ def set_(filename, section, parameter, value):
         salt-call openstack_config.set /etc/keystone/keystone.conf sql connection foo
     '''
 
-    filename = _quote(filename)
+    filename = _quote(salt.utils.expanduser(filename))
     section = _quote(section)
     parameter = _quote(parameter)
     value = _quote(str(value))
@@ -109,7 +109,7 @@ def get(filename, section, parameter):
 
     '''
 
-    filename = _quote(filename)
+    filename = _quote(salt.utils.expanduser(filename))
     section = _quote(section)
     parameter = _quote(parameter)
 
@@ -146,8 +146,7 @@ def delete(filename, section, parameter):
 
         salt-call openstack_config.delete /etc/keystone/keystone.conf sql connection
     '''
-
-    filename = _quote(filename)
+    filename = _quote(salt.utils.expanduser(filename))
     section = _quote(section)
     parameter = _quote(parameter)
 

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -280,6 +280,7 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
+    sources = salt.utils.expanduser(sources)
     refreshdb = salt.utils.is_true(refresh)
 
     try:

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -515,6 +515,7 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
+    sources = salt.utils.expanduser(sources)
     refresh = salt.utils.is_true(refresh)
     sysupgrade = salt.utils.is_true(sysupgrade)
 

--- a/salt/modules/pcs.py
+++ b/salt/modules/pcs.py
@@ -257,6 +257,7 @@ def cib_create(cibfile, scope='configuration', extra_args=None):
         salt '*' pcs.cib_create cibfile='/tmp/VIP_apache_1.cib' \\
                                 'scope=False'
     '''
+    cibfile = salt.utils.expanduser(cibfile)
     cmd = ['pcs', 'cluster', 'cib', cibfile]
     if isinstance(scope, six.string_types):
         cmd += ['scope={0}'.format(scope)]
@@ -284,6 +285,7 @@ def cib_push(cibfile, scope='configuration', extra_args=None):
         salt '*' pcs.cib_push cibfile='/tmp/VIP_apache_1.cib' \\
                               'scope=False'
     '''
+    cibfile = salt.utils.expanduser(cibfile)
     cmd = ['pcs', 'cluster', 'cib-push', cibfile]
     if isinstance(scope, six.string_types):
         cmd += ['scope={0}'.format(scope)]
@@ -306,6 +308,7 @@ def config_show(cibfile=None):
 
         salt '*' pcs.config_show cibfile='/tmp/cib_for_galera'
     '''
+    cibfile = salt.utils.expanduser(cibfile)
     return item_show(item='config', item_id=None, extra_args=None, cibfile=cibfile)
 
 

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -530,6 +530,7 @@ def file_exists(path, saltenv=None):
 
         salt '*' pillar.file_exists foo/bar.sls
     '''
+    path = salt.utils.expanduser(path)
     pillar_roots = __opts__.get('pillar_roots')
     if not pillar_roots:
         raise CommandExecutionError('No pillar_roots found. Are you running '

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -558,6 +558,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
                 editable=git+https://github.com/worldcompany/djangoembed.git#egg=djangoembed upgrade=True no_deps=True
 
     '''
+    requirements, bin_env, log, exists_action, install_options, cwd, cert = salt.utils.expanduser(requirements, bin_env, log, exists_action, install_options, cwd, cert)
     pip_bin = _get_pip_bin(bin_env)
 
     cmd = [pip_bin, 'install']
@@ -894,6 +895,7 @@ def uninstall(pkgs=None,
         salt '*' pip.uninstall <package name> bin_env=/path/to/pip_bin
 
     '''
+    requirements, bin_env, log, cwd = salt.utils.expanduser(requirements, bin_env, log, cwd)
     pip_bin = _get_pip_bin(bin_env)
 
     cmd = [pip_bin, 'uninstall', '-y']
@@ -999,6 +1001,7 @@ def freeze(bin_env=None,
         The packages pip, wheel, setuptools, and distribute are included if the
         installed pip is new enough.
     '''
+    bin_env, cwd = salt.utils.expanduser(bin_env, cwd)
     pip_bin = _get_pip_bin(bin_env)
 
     cmd = [pip_bin, 'freeze']

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -342,6 +342,7 @@ def install(name=None, refresh=False, fromrepo=None,
 
         salt '*' pkg.install <package name>
     '''
+    sources = salt.utils.expanduser(sources)
     try:
         pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](
             name, pkgs, sources, **kwargs

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -563,6 +563,7 @@ def backup(file_name, jail=None, chroot=None, root=None):
 
             salt '*' pkg.backup /tmp/pkg chroot=/path/to/chroot
     '''
+    jail, chroot, root = salt.utils.expanduser(jail, chroot, root)
     ret = __salt__['cmd.run'](
         _pkg(jail, chroot, root) + ['backup', '-d', file_name],
         output_loglevel='trace',
@@ -610,6 +611,7 @@ def restore(file_name, jail=None, chroot=None, root=None):
 
             salt '*' pkg.restore /tmp/pkg chroot=/path/to/chroot
     '''
+    jail, chroot, root = salt.utils.expanduser(jail, chroot, root)
     return __salt__['cmd.run'](
         _pkg(jail, chroot, root) + ['backup', '-r', file_name],
         output_loglevel='trace',
@@ -1789,6 +1791,7 @@ def updating(name,
 
             salt '*' pkg.updating foo filename=/tmp/UPDATING
     '''
+    filename = salt.utils.expanduser(filename)
 
     opts = ''
     if filedate:

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -1739,7 +1739,7 @@ def updating(name,
              root=None,
              filedate=None,
              filename=None):
-    ''''
+    '''
     Displays UPDATING entries of software packages
 
     CLI Example:

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -3132,6 +3132,7 @@ def datadir_init(name,
     runas
         The system user the operation should be performed on behalf of
     '''
+    name = salt.utils.expanduser(name)
     if datadir_exists(name):
         log.info('%s already exists', name)
         return False
@@ -3162,6 +3163,7 @@ def datadir_exists(name):
     name
         Name of the directory to check
     '''
+    name = salt.utils.expanduser(name)
     _version_file = os.path.join(name, 'PG_VERSION')
     _config_file = os.path.join(name, 'postgresql.conf')
 

--- a/salt/modules/pyenv.py
+++ b/salt/modules/pyenv.py
@@ -15,6 +15,9 @@ import os
 import re
 import logging
 
+# Import salt libs
+import salt.utils
+
 try:
     from shlex import quote as _cmd_quote  # pylint: disable=E0611
 except ImportError:
@@ -74,7 +77,7 @@ def _pyenv_path(runas=None):
     else:
         path = __salt__['config.option']('pyenv.root') or '~{0}/.pyenv'.format(runas)
 
-    return os.path.expanduser(path)
+    return salt.utils.expanduser(path)
 
 
 def _install_pyenv(path, runas=None):
@@ -113,7 +116,7 @@ def install(runas=None, path=None):
         salt '*' pyenv.install
     '''
     path = path or _pyenv_path(runas)
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
     return _install_pyenv(path, runas)
 
 
@@ -128,7 +131,7 @@ def update(runas=None, path=None):
         salt '*' pyenv.update
     '''
     path = path or _pyenv_path(runas)
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     return _update_pyenv(path, runas)
 

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -85,7 +85,7 @@ def _rbenv_path(runas=None):
         path = __salt__['config.option']('rbenv.root') \
             or '~{0}/.rbenv'.format(runas)
 
-    return os.path.expanduser(path)
+    return salt.utils.expanduser(path)
 
 
 def _rbenv_exec(command, env=None, runas=None, ret=None):
@@ -164,7 +164,7 @@ def install(runas=None, path=None):
         salt '*' rbenv.install
     '''
     path = path or _rbenv_path(runas)
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
     return _install_rbenv(path, runas) and _install_ruby_build(path, runas)
 
 
@@ -183,7 +183,7 @@ def update(runas=None, path=None):
         salt '*' rbenv.update
     '''
     path = path or _rbenv_path(runas)
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     return _update_rbenv(path, runas) and _update_ruby_build(path, runas)
 

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -84,6 +84,7 @@ def bin_pkg_info(path, saltenv='base'):
         salt '*' lowpkg.bin_pkg_info /root/salt-2015.5.1-2.el7.noarch.rpm
         salt '*' lowpkg.bin_pkg_info salt://salt-2015.5.1-2.el7.noarch.rpm
     '''
+    path = salt.utils.expanduser(path)
     # If the path is a valid protocol, pull it down using cp.cache_file
     if __salt__['config.valid_fileproto'](path):
         newpath = __salt__['cp.cache_file'](path, saltenv)

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -439,6 +439,7 @@ def diff(package, path):
 
         salt '*' lowpkg.diff apache2 /etc/apache2/httpd.conf
     '''
+    path = salt.utils.expanduser(path)
 
     cmd = "rpm2cpio {0} " \
           "| cpio -i --quiet --to-stdout .{1} " \

--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -419,6 +419,7 @@ def make_repo(repodir,
         salt '*' pkgbuild.make_repo /var/www/html/
 
     '''
+    repodir = salt.utils.expanduser(repodir)
     SIGN_PROMPT_RE = re.compile(r'Enter pass phrase: ', re.M)
 
     define_gpg_name = ''

--- a/salt/modules/rsync.py
+++ b/salt/modules/rsync.py
@@ -138,6 +138,7 @@ def rsync(src,
 
         salt '*' rsync.rsync {src} {dst} {delete=True} {excludefrom=/xx.ini} additional_opts='["--partial", "--bwlimit=5000"]'
     '''
+    src, dst, passwordfile = salt.utils.expanduser(src, dst, passwordfile)
     if not src:
         src = __salt__['config.option']('rsync.src')
     if not dst:

--- a/salt/modules/runit.py
+++ b/salt/modules/runit.py
@@ -309,6 +309,7 @@ def add_svc_avail_path(path):
     path
         directory to add to AVAIL_SVR_DIRS
     '''
+    path = salt.utils.expanduser(path)
     if os.path.exists(path):
         if path not in AVAIL_SVR_DIRS:
             AVAIL_SVR_DIRS.append(path)

--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -461,6 +461,7 @@ def do(ruby, command, runas=None, cwd=None, env=None):  # pylint: disable=C0103
 
         salt '*' rvm.do 2.0.0 <command>
     '''
+    cwd = salt.utils.expanduser(cwd)
     try:
         command = salt.utils.shlex_split(command)
     except AttributeError:

--- a/salt/modules/seed.py
+++ b/salt/modules/seed.py
@@ -127,6 +127,7 @@ def apply_(path, id_=None, config=None, approve_key=True, install=True,
     prep_install
         Prepare the bootstrap script, but don't run it. Default: false
     '''
+    path = salt.utils.expanduser(path)
     stats = __salt__['file.stats'](path, follow_symlinks=True)
     if not stats:
         return '{0} does not exist'.format(path)
@@ -209,6 +210,7 @@ def mkconfig(config=None,
         salt 'minion' seed.mkconfig [config=config_data] [tmp=tmp_dir] \\
                 [id_=minion_id] [approve_key=(true|false)]
     '''
+    pub_key, priv_key = salt.utils.expanduser(pub_key, priv_key)
     if tmp is None:
         tmp = tempfile.mkdtemp()
     if config is None:

--- a/salt/modules/sensehat.py
+++ b/salt/modules/sensehat.py
@@ -21,6 +21,9 @@ Example:
 from __future__ import absolute_import
 import logging
 
+# Import Salt Libs
+import salt.utils
+
 try:
     from sense_hat import SenseHat
     _sensehat = SenseHat()
@@ -222,6 +225,7 @@ def show_image(image):
 
         salt 'raspberry' sensehat.show_image /tmp/my_image.png
     '''
+    image = salt.utils.expanduser(image)
     return _sensehat.load_image(image)
 
 

--- a/salt/modules/slsutil.py
+++ b/salt/modules/slsutil.py
@@ -116,6 +116,7 @@ def renderer(path=None, string=None, default_renderer='jinja|yaml', **kwargs):
         salt '*' slsutil.renderer string='Inline template! {{ saltenv }}'
         salt '*' slsutil.renderer string='Hello, {{ name }}.' name='world'
     '''
+    path = salt.utils.expanduser(path)
     if not path and not string:
         raise salt.exceptions.SaltInvocationError(
                 'Must pass either path or string')

--- a/salt/modules/snapper.py
+++ b/salt/modules/snapper.py
@@ -318,6 +318,7 @@ def create_config(name=None,
       salt '*' snapper.create_config name=myconfig subvolume=/foo/bar/ fstype=btrfs template="default"
       salt '*' snapper.create_config name=myconfig subvolume=/foo/bar/ fstype=btrfs extra_opts='{"NUMBER_CLEANUP": False}'
     '''
+    subvolume = salt.utils.expanduser(subvolume)
     def raise_arg_error(argname):
         raise CommandExecutionError(
             'You must provide a "{0}" for the new configuration'.format(argname)

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -1265,6 +1265,7 @@ def hash_known_hosts(user=None, config=None):
         salt '*' ssh.hash_known_hosts
 
     '''
+    config = salt.utils.expanduser(config)
     full = _get_known_hosts_file(config=config, user=user)
 
     if isinstance(full, dict):

--- a/salt/modules/supervisord.py
+++ b/salt/modules/supervisord.py
@@ -89,6 +89,7 @@ def start(name='all', user=None, conf_file=None, bin_env=None):
         salt '*' supervisord.start <service>
         salt '*' supervisord.start <group>:
     '''
+    conf_file, bin_env = salt.utils.expanduser(conf_file, bin_env)
     if name.endswith(':*'):
         name = name[:-1]
     ret = __salt__['cmd.run_all'](
@@ -119,6 +120,7 @@ def restart(name='all', user=None, conf_file=None, bin_env=None):
         salt '*' supervisord.restart <service>
         salt '*' supervisord.restart <group>:
     '''
+    conf_file, bin_env = salt.utils.expanduser(conf_file, bin_env)
     if name.endswith(':*'):
         name = name[:-1]
     ret = __salt__['cmd.run_all'](
@@ -149,6 +151,7 @@ def stop(name='all', user=None, conf_file=None, bin_env=None):
         salt '*' supervisord.stop <service>
         salt '*' supervisord.stop <group>:
     '''
+    conf_file, bin_env = salt.utils.expanduser(conf_file, bin_env)
     if name.endswith(':*'):
         name = name[:-1]
     ret = __salt__['cmd.run_all'](
@@ -177,6 +180,7 @@ def add(name, user=None, conf_file=None, bin_env=None):
 
         salt '*' supervisord.add <name>
     '''
+    conf_file, bin_env = salt.utils.expanduser(conf_file, bin_env)
     if name.endswith(':'):
         name = name[:-1]
     elif name.endswith(':*'):
@@ -207,6 +211,7 @@ def remove(name, user=None, conf_file=None, bin_env=None):
 
         salt '*' supervisord.remove <name>
     '''
+    conf_file, bin_env = salt.utils.expanduser(conf_file, bin_env)
     if name.endswith(':'):
         name = name[:-1]
     elif name.endswith(':*'):
@@ -237,6 +242,7 @@ def reread(user=None, conf_file=None, bin_env=None):
 
         salt '*' supervisord.reread
     '''
+    conf_file, bin_env = salt.utils.expanduser(conf_file, bin_env)
     ret = __salt__['cmd.run_all'](
         _ctl_cmd('reread', None, conf_file, bin_env),
         runas=user,
@@ -266,6 +272,7 @@ def update(user=None, conf_file=None, bin_env=None, name=None):
 
         salt '*' supervisord.update
     '''
+    conf_file, bin_env = salt.utils.expanduser(conf_file, bin_env)
 
     if isinstance(name, string_types):
         if name.endswith(':'):
@@ -299,6 +306,7 @@ def status(name=None, user=None, conf_file=None, bin_env=None):
 
         salt '*' supervisord.status
     '''
+    conf_file, bin_env = salt.utils.expanduser(conf_file, bin_env)
     all_process = {}
     for line in status_raw(name, user, conf_file, bin_env).splitlines():
         if len(line.split()) > 2:
@@ -327,6 +335,7 @@ def status_raw(name=None, user=None, conf_file=None, bin_env=None):
 
         salt '*' supervisord.status_raw
     '''
+    conf_file, bin_env = salt.utils.expanduser(conf_file, bin_env)
     ret = __salt__['cmd.run_all'](
         _ctl_cmd('status', name, conf_file, bin_env),
         runas=user,
@@ -353,6 +362,7 @@ def custom(command, user=None, conf_file=None, bin_env=None):
 
         salt '*' supervisord.custom "mstop '*gunicorn*'"
     '''
+    conf_file, bin_env = salt.utils.expanduser(conf_file, bin_env)
     ret = __salt__['cmd.run_all'](
         _ctl_cmd(command, None, conf_file, bin_env),
         runas=user,
@@ -402,6 +412,7 @@ def options(name, conf_file=None):
 
         salt '*' supervisord.options foo
     '''
+    conf_file = salt.utils.expanduser(conf_file)
     config = _read_config(conf_file)
     section_name = 'program:{0}'.format(name)
     if section_name not in config.sections():

--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -108,6 +108,7 @@ def info(cwd,
 
         salt '*' svn.info /path/to/svn/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     opts = list()
     if fmt == 'xml':
         opts.append('--xml')
@@ -166,6 +167,7 @@ def checkout(cwd,
 
         salt '*' svn.checkout /path/to/repo svn://remote/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     opts += (remote,)
     if target:
         opts += (target,)
@@ -205,6 +207,7 @@ def switch(cwd, remote, target=None, user=None, username=None,
 
         salt '*' svn.switch /path/to/repo svn://remote/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     opts += (remote,)
     if target:
         opts += (target,)
@@ -240,6 +243,7 @@ def update(cwd, targets=None, user=None, username=None, password=None, *opts):
 
         salt '*' svn.update /path/to/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     if targets:
         opts += tuple(salt.utils.shlex_split(targets))
     return _run_svn('update', cwd, user, username, password, opts)
@@ -274,6 +278,7 @@ def diff(cwd, targets=None, user=None, username=None, password=None, *opts):
 
         salt '*' svn.diff /path/to/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     if targets:
         opts += tuple(salt.utils.shlex_split(targets))
     return _run_svn('diff', cwd, user, username, password, opts)
@@ -317,6 +322,7 @@ def commit(cwd,
 
         salt '*' svn.commit /path/to/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     if msg:
         opts += ('-m', msg)
     if targets:
@@ -351,6 +357,7 @@ def add(cwd, targets, user=None, username=None, password=None, *opts):
 
         salt '*' svn.add /path/to/repo /path/to/new/file
     '''
+    cwd = salt.utils.expanduser(cwd)
     if targets:
         opts += tuple(salt.utils.shlex_split(targets))
     return _run_svn('add', cwd, user, username, password, opts)
@@ -392,6 +399,7 @@ def remove(cwd,
 
         salt '*' svn.remove /path/to/repo /path/to/repo/remove
     '''
+    cwd = salt.utils.expanduser(cwd)
     if msg:
         opts += ('-m', msg)
     if targets:
@@ -428,6 +436,7 @@ def status(cwd, targets=None, user=None, username=None, password=None, *opts):
 
         salt '*' svn.status /path/to/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     if targets:
         opts += tuple(salt.utils.shlex_split(targets))
     return _run_svn('status', cwd, user, username, password, opts)
@@ -471,6 +480,7 @@ def export(cwd,
 
         salt '*' svn.export /path/to/repo svn://remote/repo
     '''
+    cwd = salt.utils.expanduser(cwd)
     opts += (remote,)
     if target:
         opts += (target,)

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -181,6 +181,7 @@ def cert_base_path(cacert_path=None):
 
         salt '*' tls.cert_base_path
     '''
+    cacert_path = salt.utils.expanduser(cacert_path)
     if not cacert_path:
         cacert_path = __context__.get(
             'ca.contextual_cert_base_path',
@@ -333,6 +334,7 @@ def maybe_fix_ssl_version(ca_name, cacert_path=None, ca_filename=None):
 
         salt '*' tls.maybe_fix_ssl_version test_ca /etc/certs
     '''
+    cacert_path = salt.utils.expanduser(cacert_path)
     set_ca_path(cacert_path)
     if not ca_filename:
         ca_filename = '{0}_ca_cert'.format(ca_name)
@@ -400,6 +402,7 @@ def ca_exists(ca_name, cacert_path=None, ca_filename=None):
 
         salt '*' tls.ca_exists test_ca /etc/certs
     '''
+    cacert_path = salt.utils.expanduser(cacert_path)
     set_ca_path(cacert_path)
     if not ca_filename:
         ca_filename = '{0}_ca_cert'.format(ca_name)
@@ -437,6 +440,7 @@ def get_ca(ca_name, as_text=False, cacert_path=None):
 
         salt '*' tls.get_ca test_ca as_text=False cacert_path=/etc/certs
     '''
+    cacert_path = salt.utils.expanduser(cacert_path)
     set_ca_path(cacert_path)
     certp = '{0}/{1}/{2}_ca_cert.crt'.format(
             cert_base_path(),
@@ -479,6 +483,7 @@ def get_ca_signed_cert(ca_name,
 
         salt '*' tls.get_ca_signed_cert test_ca CN=localhost as_text=False cacert_path=/etc/certs
     '''
+    cacert_path = salt.utils.expanduser(cacert_path)
     set_ca_path(cacert_path)
     if not cert_filename:
         cert_filename = CN
@@ -528,6 +533,7 @@ def get_ca_signed_key(ca_name,
                 as_text=False \
                 cacert_path=/etc/certs
     '''
+    cacert_path = salt.utils.expanduser(cacert_path)
     set_ca_path(cacert_path)
     if not key_filename:
         key_filename = CN
@@ -644,6 +650,7 @@ def create_ca(ca_name,
 
         salt '*' tls.create_ca test_ca
     '''
+    cacert_path = salt.utils.expanduser(cacert_path)
     status = _check_onlyif_unless(onlyif, unless)
     if status is not None:
         return None
@@ -1142,6 +1149,7 @@ def create_self_signed_cert(tls_dir='tls',
 
         salt 'minion' tls.create_self_signed_cert CN='test.mysite.org'
     '''
+    cacert_path = salt.utils.expanduser(cacert_path)
     set_ca_path(cacert_path)
 
     if not os.path.exists('{0}/{1}/certs/'.format(cert_base_path(), tls_dir)):
@@ -1319,6 +1327,7 @@ def create_ca_signed_cert(ca_name,
 
         salt '*' tls.create_ca_signed_cert test localhost
     '''
+    cacert_path, cert_path = salt.utils.expanduser(cacert_path, cert_path)
     ret = {}
 
     set_ca_path(cacert_path)
@@ -1481,6 +1490,7 @@ def create_pkcs12(ca_name, CN, passphrase='', cacert_path=None, replace=False):
 
         salt '*' tls.create_pkcs12 test localhost
     '''
+    cacert_path = salt.utils.expanduser(cacert_path)
     set_ca_path(cacert_path)
     if not replace and os.path.exists(
             '{0}/{1}/certs/{2}.p12'.format(
@@ -1554,6 +1564,7 @@ def cert_info(cert_path, digest='sha256'):
 
         salt '*' tls.cert_info /dir/for/certs/cert.pem
     '''
+    cert_path = salt.utils.expanduser(cert_path)
     # format that OpenSSL returns dates in
     date_fmt = '%Y%m%d%H%M%SZ'
 
@@ -1656,6 +1667,7 @@ def create_empty_crl(
                 ca_filename='ca' \
                 crl_file='/etc/openvpn/team1/crl.pem'
     '''
+    cacert_path, crl_file = salt.utils.expanduser(cacert_path, crl_file)
 
     set_ca_path(cacert_path)
 
@@ -1744,6 +1756,7 @@ def revoke_cert(
                 crl_file='/etc/openvpn/team1/crl.pem'
 
     '''
+    cacert_path, cert_path, crl_file = salt.utils.expanduser(cacert_path, cert_path, crl_file)
 
     set_ca_path(cacert_path)
     ca_dir = '{0}/{1}'.format(cert_base_path(), ca_name)

--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -371,6 +371,7 @@ def stop(app, url='http://localhost:8080/manager', timeout=180):
         salt '*' tomcat.stop /jenkins
         salt '*' tomcat.stop /jenkins http://localhost:8080/manager
     '''
+    app = salt.utils.expanduser(app)
 
     return _simple_cmd('stop', app, url, timeout=timeout)
 
@@ -393,6 +394,7 @@ def start(app, url='http://localhost:8080/manager', timeout=180):
         salt '*' tomcat.start /jenkins
         salt '*' tomcat.start /jenkins http://localhost:8080/manager
     '''
+    app = salt.utils.expanduser(app)
 
     return _simple_cmd('start', app, url, timeout=timeout)
 
@@ -415,6 +417,7 @@ def reload_(app, url='http://localhost:8080/manager', timeout=180):
         salt '*' tomcat.reload /jenkins
         salt '*' tomcat.reload /jenkins http://localhost:8080/manager
     '''
+    app = salt.utils.expanduser(app)
 
     return _simple_cmd('reload', app, url, timeout=timeout)
 
@@ -437,6 +440,7 @@ def sessions(app, url='http://localhost:8080/manager', timeout=180):
         salt '*' tomcat.sessions /jenkins
         salt '*' tomcat.sessions /jenkins http://localhost:8080/manager
     '''
+    app = salt.utils.expanduser(app)
 
     return _simple_cmd('sessions', app, url, timeout=timeout)
 
@@ -459,6 +463,7 @@ def status_webapp(app, url='http://localhost:8080/manager', timeout=180):
         salt '*' tomcat.status_webapp /jenkins
         salt '*' tomcat.status_webapp /jenkins http://localhost:8080/manager
     '''
+    app = salt.utils.expanduser(app)
 
     webapps = ls(url, timeout=timeout)
     for i in webapps:
@@ -516,6 +521,7 @@ def undeploy(app, url='http://localhost:8080/manager', timeout=180):
         salt '*' tomcat.undeploy /jenkins
         salt '*' tomcat.undeploy /jenkins http://localhost:8080/manager
     '''
+    app = salt.utils.expanduser(app)
 
     return _simple_cmd('undeploy', app, url, timeout=timeout)
 
@@ -578,6 +584,7 @@ def deploy_war(war,
         salt '*' tomcat.deploy_war /tmp/application.war /api no
         salt '*' tomcat.deploy_war /tmp/application.war /api yes http://localhost:8080/manager
     '''
+    war, context = salt.utils.expanduser(war, context)
     # Decide the location to copy the war for the deployment
     tfile = 'salt.{0}'.format(os.path.basename(war))
     if temp_war_location is not None:

--- a/salt/modules/vbox_guest.py
+++ b/salt/modules/vbox_guest.py
@@ -13,6 +13,9 @@ import os
 import re
 import tempfile
 
+# Import Salt Libs
+import salt.utils
+
 
 log = logging.getLogger(__name__)
 __virtualname__ = 'vbox_guest'
@@ -65,6 +68,7 @@ def additions_umount(mount_point):
     :param mount_point: directory VirtualBox Guest Additions is mounted to
     :return: True or an string with error
     '''
+    mount_point = salt.utils.expanduser(mount_point)
     ret = __salt__['mount.umount'](mount_point)
     if ret:
         os.rmdir(mount_point)

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -128,6 +128,7 @@ def create(path,
 
         salt '*' virtualenv.create /path/to/new/virtualenv
     '''
+    path, venv_bin = salt.utils.expanduser(path, venv_bin)
     if venv_bin is None:
         venv_bin = __opts__.get('venv_bin') or __pillar__.get('venv_bin')
 
@@ -313,6 +314,7 @@ def get_site_packages(venv):
 
         salt '*' virtualenv.get_site_packages /path/to/my/venv
     '''
+    venv = salt.utils.expanduser(venv)
     bin_path = _verify_virtualenv(venv)
 
     ret = __salt__['cmd.exec_code_all'](
@@ -345,6 +347,7 @@ def get_distribution_path(venv, distribution):
 
         salt '*' virtualenv.get_distribution_path /path/to/my/venv my_distribution
     '''
+    venv = salt.utils.expanduser(venv)
     _verify_safe_py_code(distribution)
     bin_path = _verify_virtualenv(venv)
 
@@ -389,6 +392,7 @@ def get_resource_path(venv,
 
         salt '*' virtualenv.get_resource_path /path/to/my/venv my_package my/resource.xml
     '''
+    venv = salt.utils.expanduser(venv)
     _verify_safe_py_code(package, resource)
     bin_path = _verify_virtualenv(venv)
 
@@ -434,6 +438,7 @@ def get_resource_content(venv,
 
         salt '*' virtualenv.get_resource_content /path/to/my/venv my_package my/resource.xml
     '''
+    venv = salt.utils.expanduser(venv)
     _verify_safe_py_code(package, resource)
     bin_path = _verify_virtualenv(venv)
 

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -439,6 +439,7 @@ def esxcli_cmd(cmd_str, host=None, username=None, password=None, protocol=None, 
         salt '*' vsphere.esxcli_cmd my.vcenter.location root bad-password \
             'system coredump network get' esxi_hosts='[esxi-1.host.com, esxi-2.host.com]'
     '''
+    credstore = salt.utils.expanduser(credstore)
     ret = {}
     if esxi_hosts:
         if not isinstance(esxi_hosts, list):
@@ -511,6 +512,7 @@ def get_coredump_network_config(host, username, password, protocol=None, port=No
             esxi_hosts='[esxi-1.host.com, esxi-2.host.com]'
 
     '''
+    credstore = salt.utils.expanduser(credstore)
     cmd = 'system coredump network get'
     ret = {}
     if esxi_hosts:
@@ -586,6 +588,7 @@ def coredump_network_enable(host, username, password, enabled, protocol=None, po
         salt '*' vsphere.coredump_network_enable my.vcenter.location root bad-password True \
             esxi_hosts='[esxi-1.host.com, esxi-2.host.com]'
     '''
+    credstore = salt.utils.expanduser(credstore)
     if enabled:
         enable_it = 1
     else:
@@ -683,6 +686,7 @@ def set_coredump_network_config(host,
         salt '*' vsphere.set_coredump_network_config my.vcenter.location root bad-password 'dump_ip.host.com' \
             esxi_hosts='[esxi-1.host.com, esxi-2.host.com]'
     '''
+    credstore = salt.utils.expanduser(credstore)
     cmd = 'system coredump network set -v {0} -i {1} -o {2}'.format(host_vnic,
                                                                     dump_ip,
                                                                     dump_port)
@@ -761,6 +765,7 @@ def get_firewall_status(host, username, password, protocol=None, port=None, esxi
         salt '*' vsphere.get_firewall_status my.vcenter.location root bad-password \
             esxi_hosts='[esxi-1.host.com, esxi-2.host.com]'
     '''
+    credstore = salt.utils.expanduser(credstore)
     cmd = 'network firewall ruleset list'
 
     ret = {}
@@ -851,6 +856,7 @@ def enable_firewall_ruleset(host,
         salt '*' vsphere.enable_firewall_ruleset my.vcenter.location root bad-password True 'syslog' \
             esxi_hosts='[esxi-1.host.com, esxi-2.host.com]'
     '''
+    credstore = salt.utils.expanduser(credstore)
     cmd = 'network firewall ruleset set --enabled {0} --ruleset-id={1}'.format(
         ruleset_enable, ruleset_name
     )
@@ -918,6 +924,7 @@ def syslog_service_reload(host, username, password, protocol=None, port=None, es
         salt '*' vsphere.syslog_service_reload my.vcenter.location root bad-password \
             esxi_hosts='[esxi-1.host.com, esxi-2.host.com]'
     '''
+    credstore = salt.utils.expanduser(credstore)
     cmd = 'system syslog reload'
 
     ret = {}
@@ -1018,6 +1025,7 @@ def set_syslog_config(host,
             esxi_hosts='[esxi-1.host.com, esxi-2.host.com]'
 
     '''
+    credstore = salt.utils.expanduser(credstore)
     ret = {}
 
     # First, enable the syslog firewall ruleset, for each host, if needed.
@@ -1121,6 +1129,7 @@ def get_syslog_config(host, username, password, protocol=None, port=None, esxi_h
         salt '*' vsphere.get_syslog_config my.vcenter.location root bad-password \
             esxi_hosts='[esxi-1.host.com, esxi-2.host.com]'
     '''
+    credstore = salt.utils.expanduser(credstore)
     cmd = 'system syslog config get'
 
     ret = {}
@@ -1207,6 +1216,7 @@ def reset_syslog_config(host,
         salt '*' vsphere.reset_syslog_config my.vcenter.location root bad-password \
             syslog_config='logdir,loghost' esxi_hosts='[esxi-1.host.com, esxi-2.host.com]'
     '''
+    credstore = salt.utils.expanduser(credstore)
     if not syslog_config:
         raise CommandExecutionError('The \'reset_syslog_config\' function requires a '
                                     '\'syslog_config\' setting.')

--- a/salt/modules/win_certutil.py
+++ b/salt/modules/win_certutil.py
@@ -42,6 +42,7 @@ def get_cert_serial(cert_file):
 
         salt '*' certutil.get_cert_serial <certificate name>
     '''
+    cert_file = salt.utils.expanduser(cert_file)
     cmd = "certutil.exe -silent -verify {0}".format(cert_file)
     out = __salt__['cmd.run'](cmd)
     # match serial number by paragraph to work with multiple languages
@@ -93,6 +94,7 @@ def add_store(source, store, saltenv='base'):
 
         salt '*' certutil.add_store salt://cert.cer TrustedPublisher
     '''
+    source = salt.utils.expanduser(source)
     cert_file = __salt__['cp.cache_file'](source, saltenv)
     cmd = "certutil.exe -addstore {0} {1}".format(store, cert_file)
     return __salt__['cmd.run'](cmd)
@@ -119,6 +121,7 @@ def del_store(source, store, saltenv='base'):
 
         salt '*' certutil.del_store salt://cert.cer TrustedPublisher
     '''
+    source = salt.utils.expanduser(source)
     cert_file = __salt__['cp.cache_file'](source, saltenv)
     serial = get_cert_serial(cert_file)
     cmd = "certutil.exe -delstore {0} {1}".format(store, serial)

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1052,7 +1052,7 @@ def remove(path, force=False):
     # Symlinks. The shutil.rmtree function will remove the contents of
     # the Symlink source in windows.
 
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     # Does the file/folder exists
     if not os.path.exists(path):
@@ -1277,7 +1277,7 @@ def mkdir(path,
     if not os.path.isdir(drive):
         raise CommandExecutionError('Drive {0} is not mapped'.format(drive))
 
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
     path = os.path.expandvars(path)
 
     if not os.path.isdir(path):
@@ -1365,7 +1365,7 @@ def makedirs_(path,
         # Specify advanced attributes with a list
         salt '*' file.makedirs C:\\Temp\\ Administrators "{'jsnuffy': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder_only'}}"
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     # walk up the directory structure until we find the first existing
     # directory
@@ -1466,7 +1466,7 @@ def makedirs_perms(path,
         salt '*' file.makedirs_perms C:\\Temp\\ Administrators "{'jsnuffy': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder_files'}}"
     '''
     # Expand any environment variables
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
     path = os.path.expandvars(path)
 
     # Get parent directory (head)
@@ -1556,7 +1556,7 @@ def check_perms(path,
         # Specify advanced attributes with a list
         salt '*' file.check_perms C:\\Temp\\ Administrators "{'jsnuffy': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'files_only'}}"
     '''
-    path = os.path.expanduser(path)
+    path = salt.utils.expanduser(path)
 
     if not ret:
         ret = {'name': path,

--- a/salt/modules/xbpspkg.py
+++ b/salt/modules/xbpspkg.py
@@ -388,6 +388,7 @@ def install(name=None, refresh=False, fromrepo=None,
 
         salt '*' pkg.install <package name>
     '''
+    sources = salt.utils.expanduser(sources)
 
     # XXX sources is not yet used in this code
 
@@ -586,6 +587,7 @@ def add_repo(repo, conffile='/usr/share/xbps.d/15-saltstack.conf'):
 
         salt '*' pkg.add_repo <repo url> [conffile=/path/to/xbps/repo.conf]
     '''
+    conffile = salt.utils.expanduser(conffile)
 
     if len(_locate_repo_files(repo)) == 0:
         try:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1225,6 +1225,7 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
+    sources = salt.utils.expanduser(sources)
     repo_arg = _get_repo_options(**kwargs)
     exclude_arg = _get_excludes_option(**kwargs)
     branch_arg = _get_branch_option(**kwargs)
@@ -2983,6 +2984,7 @@ def diff(*paths):
 
         salt '*' pkg.diff /etc/apache2/httpd.conf /etc/sudoers
     '''
+    path = salt.utils.expanduser(path)
     ret = {}
 
     pkg_to_paths = {}

--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -1846,6 +1846,7 @@ def mediatype_create(name, mediatype, **connection_args):
         salt '*' zabbix.mediatype_create 'Email' 0 smtp_email='noreply@example.com'
         smtp_server='mailserver.example.com' smtp_helo='zabbix.example.com'
     '''
+    exec_path, gsm_modem = salt.utils.expanduser(exec_path, gsm_modem)
     conn_args = _login(**connection_args)
     ret = False
     try:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1150,6 +1150,7 @@ def install(name=None,
                 'version': '<new-version>',
                 'arch': '<new-arch>'}}}
     '''
+    sources = salt.utils.expanduser(sources)
     if refresh:
         refresh_db()
 
@@ -1987,6 +1988,7 @@ def diff(*paths):
 
         salt '*' pkg.diff /etc/apache2/httpd.conf /etc/sudoers
     '''
+    path = salt.utils.expanduser(path)
     ret = {}
 
     pkg_to_paths = {}

--- a/salt/states/acme.py
+++ b/salt/states/acme.py
@@ -29,6 +29,9 @@ See also the module documentation
 from __future__ import absolute_import
 import logging
 
+# Import Salt Libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 
@@ -65,6 +68,7 @@ def cert(name,
     :param group: group of private key
     :param certname: Name of the certificate to save
     '''
+    webroot = salt.utils.expanduser(webroot)
 
     if __opts__['test']:
         ret = {

--- a/salt/states/alternatives.py
+++ b/salt/states/alternatives.py
@@ -27,6 +27,9 @@ Control the alternatives system
 
 '''
 
+# Import Salt Libs
+import salt.utils
+
 # Define a function alias in order not to shadow built-in's
 __func_alias__ = {
     'set_': 'set'
@@ -61,6 +64,7 @@ def install(name, link, path, priority):
         is an integer; options with higher numbers have higher priority in
         automatic mode.
     '''
+    path = salt.utils.expanduser(path)
     ret = {'name': name,
            'link': link,
            'path': path,
@@ -113,6 +117,7 @@ def remove(name, path):
         is the location of one of the alternative target files.
         (e.g. /usr/bin/less)
     '''
+    path = salt.utils.expanduser(path)
     ret = {'name': name,
            'path': path,
            'result': True,
@@ -202,6 +207,7 @@ def set_(name, path):
         is the location of one of the alternative target files.
         (e.g. /usr/bin/less)
     '''
+    path = salt.utils.expanduser(path)
     ret = {'name': name,
            'path': path,
            'result': True,

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -618,7 +618,8 @@ def extracted(name,
                - source_hash: md5=499ae16dcae71eeb7c3a30c75ea7a1a6
                - source_hash_update: True
     '''
-    name, source_hash_name, if_missing, enforce_ownership_on = salt.utils.expanduser(name, source_hash_name, if_missing, enforce_ownership_on)
+    name, source_hash_name, if_missing, enforce_ownership_on = salt.utils.expanduser(
+        name, source_hash_name, if_missing, enforce_ownership_on)
     ret = {'name': name, 'result': False, 'changes': {}, 'comment': ''}
 
     # Remove pub kwargs as they're irrelevant here.

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -618,6 +618,7 @@ def extracted(name,
                - source_hash: md5=499ae16dcae71eeb7c3a30c75ea7a1a6
                - source_hash_update: True
     '''
+    name, source_hash_name, if_missing, enforce_ownership_on = salt.utils.expanduser(name, source_hash_name, if_missing, enforce_ownership_on)
     ret = {'name': name, 'result': False, 'changes': {}, 'comment': ''}
 
     # Remove pub kwargs as they're irrelevant here.

--- a/salt/states/artifactory.py
+++ b/salt/states/artifactory.py
@@ -8,6 +8,9 @@ This state downloads artifacts from artifactory.
 from __future__ import absolute_import
 import logging
 
+# Import Salt Libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 
@@ -77,6 +80,7 @@ def downloaded(name, artifact, target_dir='/tmp', target_file=None, use_literal_
            - target_dir: /opt/jboss7/modules/com/company/lib
 
     '''
+    target_dir, target_file = salt.utils.expanduser(target_dir, target_file)
     log.debug(" ======================== STATE: artifactory.downloaded (name: %s) ", name)
     ret = {'name': name,
            'result': True,

--- a/salt/states/augeas.py
+++ b/salt/states/augeas.py
@@ -255,6 +255,7 @@ def change(name, context=None, changes=None, lens=None,
     http://augeas.net/docs/references/lenses/files/services-aug.html#Services.record
 
     '''
+    context = salt.utils.expanduser(context)
     ret = {'name': name, 'result': False, 'comment': '', 'changes': {}}
 
     if not changes or not isinstance(changes, list):

--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -233,6 +233,7 @@ def present(name, api_name, swagger_file, stage_name, api_key_required,
 
         .. versionadded:: 2017.7.0
     '''
+    swagger_file = salt.utils.expanduser(swagger_file)
     ret = {'name': name,
            'result': True,
            'comment': '',
@@ -380,6 +381,7 @@ def absent(name, api_name, stage_name, nuke_api=False, region=None, key=None, ke
         A dict with region, key and keyid, or a pillar key (string) that
         contains a dict with region, key and keyid.
     '''
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name,
            'result': True,

--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -88,8 +88,9 @@ on the IAM role to be persistent. This functionality was added in 2015.8.0.
 '''
 from __future__ import absolute_import
 import logging
-import salt.utils.dictupdate as dictupdate
 import salt.ext.six as six
+import salt.utils
+import salt.utils.dictupdate as dictupdate
 
 log = logging.getLogger(__name__)
 
@@ -173,6 +174,7 @@ def present(
 
         .. versionadded:: 2015.8.0
     '''
+    path = salt.utils.expanduser(path)
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     # Build up _policy_document
     _policy_document = {}

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -199,6 +199,7 @@ def function_present(name, FunctionName, Runtime, Role, Handler, ZipFile=None,
         A dict with region, key and keyid, or a pillar key (string) that
         contains a dict with region, key and keyid.
     '''
+    ZipFile = salt.utils.expanduser(ZipFile)
     ret = {'name': FunctionName,
            'result': True,
            'comment': '',

--- a/salt/states/bower.py
+++ b/salt/states/bower.py
@@ -33,6 +33,7 @@ Example:
 from __future__ import absolute_import
 
 # Import salt libs
+import salt.utils
 from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
 # Import 3rd-party libs
@@ -85,6 +86,7 @@ def installed(name,
         state function.
 
     '''
+    dir = salt.utils.expanduser(dir)
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     if pkgs is not None:
@@ -201,6 +203,7 @@ def removed(name, dir, user=None):
         The user to run Bower with
 
     '''
+    dir = salt.utils.expanduser(dir)
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     try:

--- a/salt/states/cisconso.py
+++ b/salt/states/cisconso.py
@@ -8,6 +8,8 @@ For documentation on setting up the cisconso proxy minion look in the documentat
 for :mod:`salt.proxy.cisconso <salt.proxy.cisconso>`.
 '''
 
+# Import Salt Libs
+import salt.utils
 
 def __virtual__():
     return 'cisconso.set_data_value' in __salt__
@@ -46,6 +48,7 @@ def value_present(name, datastore, path, config):
                     "list-name": foobar
 
     '''
+    path, config = salt.utils.expanduser(path, config)
     ret = {'name': name,
            'result': False,
            'changes': {},

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -502,6 +502,7 @@ def wait(name,
         interactively to the console and the logs.
         This is experimental.
     '''
+    cwd, creates = salt.utils.expanduser(cwd, creates)
     # Ignoring our arguments is intentional.
     return {'name': name,
             'changes': {},
@@ -622,6 +623,7 @@ def wait_script(name,
         regardless, unless ``quiet`` is used for this value.
 
     '''
+    cwd = salt.utils.expanduser(cwd)
     # Ignoring our arguments is intentional.
     return {'name': name,
             'changes': {},
@@ -775,6 +777,7 @@ def run(name,
                 - reload_modules: True
 
     '''
+    cwd, creates = salt.utils.expanduser(cwd, creates)
     ### NOTE: The keyword arguments in **kwargs are passed directly to the
     ###       ``cmd.run_all`` function and cannot be removed from the function
     ###       definition, otherwise the use of unsupported arguments in a
@@ -993,6 +996,7 @@ def script(name,
         regardless, unless ``quiet`` is used for this value.
 
     '''
+    cwd, creates = salt.utils.expanduser(cwd, creates)
     test_name = None
     if not isinstance(stateful, list):
         stateful = stateful is True

--- a/salt/states/composer.py
+++ b/salt/states/composer.py
@@ -40,6 +40,7 @@ the location of composer in the state.
 from __future__ import absolute_import
 
 # Import salt libs
+import salt.utils
 from salt.exceptions import SaltException
 
 
@@ -112,6 +113,7 @@ def installed(name,
         default behavior.  If ``False``, only run ``composer install`` if there is no
         vendor directory present.
     '''
+    composer, php = salt.utils.expanduser(composer, php)
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     did_install = __salt__['composer.did_composer_install'](name)
@@ -234,6 +236,7 @@ def update(name,
     composer_home
         ``$COMPOSER_HOME`` environment variable
     '''
+    composer, php = salt.utils.expanduser(composer, php)
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     # Check if composer.lock exists, if so we already ran `composer install`

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -515,6 +515,7 @@ def file(name,
     backup
         Overrides the default backup mode for the user's crontab.
     '''
+    source_hash_name = salt.utils.expanduser(source_hash_name)
     # Initial set up
     mode = '0600'
 

--- a/salt/states/cryptdev.py
+++ b/salt/states/cryptdev.py
@@ -31,6 +31,10 @@ Ensure that an encrypted device is mapped with the `mapped` function:
 from __future__ import absolute_import
 
 import logging
+
+# Import Salt Libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 
@@ -79,6 +83,7 @@ def mapped(name,
         parameter. If the desired configuration requires two devices mapped to
         the same name, supply a list of parameters to match on.
     '''
+    keyfile, config = salt.utils.expanduser(keyfile, config)
     ret = {'name': name,
            'changes': {},
            'result': True,
@@ -154,6 +159,7 @@ def unmapped(name,
     immediate
         Set if the device should be unmapped immediately. Default is ``False``.
     '''
+    config = salt.utils.expanduser(config)
     ret = {'name': name,
            'changes': {},
            'result': True,

--- a/salt/states/dellchassis.py
+++ b/salt/states/dellchassis.py
@@ -161,6 +161,7 @@ import os
 
 # Import Salt lobs
 import salt.ext.six as six
+import salt.utils
 from salt.exceptions import CommandExecutionError
 
 # Get logging started
@@ -705,6 +706,7 @@ def firmware_update(hosts=None, directory=''):
                 salt://firmware.exe
             directory: /opt/firmwares
     '''
+    directory = salt.utils.expanduser(directory)
     ret = {}
     ret.changes = {}
     success = True

--- a/salt/states/docker_image.py
+++ b/salt/states/docker_image.py
@@ -39,6 +39,7 @@ from __future__ import absolute_import
 import logging
 
 # Import salt libs
+import salt.utils
 import salt.utils.docker
 
 # Enable proper logging
@@ -160,6 +161,7 @@ def present(name,
 
         .. versionadded: 2017.7.0
     '''
+    build, dockerfile = salt.utils.expanduser(build, dockerfile)
     ret = {'name': name,
            'changes': {},
            'result': False,

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -700,6 +700,7 @@ def ssh_configured(name,
             - certificate_verify: True
 
     '''
+    ssh_key_file = salt.utils.expanduser(ssh_key_file)
     ret = {'name': name,
            'result': False,
            'changes': {},

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1246,7 +1246,7 @@ def symlink(
         The default mode for new files and directories corresponds umask of salt
         process. For existing files and directories it's not enforced.
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     # Make sure that leading zeros stripped by YAML loader are added back
     mode = salt.utils.normalize_mode(mode)
@@ -1414,7 +1414,7 @@ def absent(name):
     name
         The path which should be deleted
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name,
            'changes': {},
@@ -1474,7 +1474,7 @@ def exists(name):
     name
         Absolute path which must exist
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name,
            'changes': {},
@@ -1498,7 +1498,7 @@ def missing(name):
     name
         Absolute path which must NOT exist
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name,
            'changes': {},
@@ -2078,7 +2078,7 @@ def managed(name,
             )
         kwargs.pop('env')
 
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'changes': {},
            'pchanges': {},
@@ -2761,7 +2761,7 @@ def directory(name,
                   perms: full_control
             - win_inheritance: False
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
     ret = {'name': name,
            'changes': {},
            'pchanges': {},
@@ -3211,7 +3211,7 @@ def recurse(name,
             )
         kwargs.pop('env')
 
-    name = os.path.expanduser(sdecode(name))
+    name = salt.utils.expanduser(sdecode(name))
 
     user = _test_owner(kwargs, user=user)
     if salt.utils.is_windows():
@@ -3505,7 +3505,7 @@ def retention_schedule(name, retain, strptime_format=None, timezone=None):
             - timezone: None
 
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
     ret = {'name': name,
            'changes': {'retained': [], 'deleted': [], 'ignored': []},
            'pchanges': {'retained': [], 'deleted': [], 'ignored': []},
@@ -3754,7 +3754,7 @@ def line(name, content=None, match=None, mode=None, location=None,
            - before: somekey.*?
 
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
     ret = {'name': name,
            'changes': {},
            'pchanges': {},
@@ -3929,7 +3929,7 @@ def replace(name,
        also use that syntax in the ``repl:`` part, or you might loose line
        feeds.
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name,
            'changes': {},
@@ -4161,7 +4161,7 @@ def blockreplace(
         text 4
         # END managed zone 42 --
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name,
            'changes': {},
@@ -4283,7 +4283,7 @@ def comment(name, regex, char='#', backup='.bak'):
 
     .. versionadded:: 0.9.5
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name,
            'changes': {},
@@ -4393,7 +4393,7 @@ def uncomment(name, regex, char='#', backup='.bak'):
 
     .. versionadded:: 0.9.5
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name,
            'changes': {},
@@ -4615,7 +4615,7 @@ def append(name,
     if not name:
         return _error(ret, 'Must provide name to file.append')
 
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     if sources is None:
         sources = []
@@ -4799,7 +4799,7 @@ def prepend(name,
 
     .. versionadded:: 2014.7.0
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name,
            'changes': {},
@@ -5016,7 +5016,7 @@ def patch(name,
             )
         kwargs.pop('env')
 
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
     if not name:
@@ -5106,7 +5106,7 @@ def touch(name, atime=None, mtime=None, makedirs=False):
 
     .. versionadded:: 0.9.5
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {
         'name': name,
@@ -5219,8 +5219,7 @@ def copy(
         <salt.states.file.recurse>`.
 
     '''
-    name = os.path.expanduser(name)
-    source = os.path.expanduser(source)
+    name, source = salt.utils.expanduser(name, source)
 
     ret = {
         'name': name,
@@ -5364,8 +5363,7 @@ def rename(name, source, force=False, makedirs=False):
         If the target subdirectories don't exist create them
 
     '''
-    name = os.path.expanduser(name)
-    source = os.path.expanduser(source)
+    name, source = salt.utils.expanduser(name, source)
 
     ret = {
         'name': name,
@@ -5674,7 +5672,7 @@ def serialize(name,
             )
         kwargs.pop('env')
 
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     default_serializer_opts = {'yaml.serialize': {'default_flow_style': False},
                               'json.serialize': {'indent': 2,
@@ -5877,7 +5875,7 @@ def mknod(name, ntype, major=0, minor=0, user=None, group=None, mode='0600'):
 
     .. versionadded:: 0.17.0
     '''
-    name = os.path.expanduser(name)
+    name = salt.utils.expanduser(name)
 
     ret = {'name': name,
            'changes': {},
@@ -6244,13 +6242,13 @@ def shortcut(
 
     # Normalize paths; do this after error checks to avoid invalid input
     # getting expanded, e.g. '' turning into '.'
-    name = os.path.realpath(os.path.expanduser(name))
+    name = os.path.realpath(salt.utils.expanduser(name))
     if name.endswith('.lnk'):
-        target = os.path.realpath(os.path.expanduser(target))
+        target = os.path.realpath(salt.utils.expanduser(target))
     if working_dir:
-        working_dir = os.path.realpath(os.path.expanduser(working_dir))
+        working_dir = os.path.realpath(salt.utils.expanduser(working_dir))
     if icon_location:
-        icon_location = os.path.realpath(os.path.expanduser(icon_location))
+        icon_location = os.path.realpath(salt.utils.expanduser(icon_location))
 
     if user is None:
         user = __opts__['user']

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6109,6 +6109,7 @@ def decode(name,
             - encoded_data: |
                 {{ salt.pillar.get('path:to:data') | indent(8) }}
     '''
+    name = salt.utils.expanduser(name)
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
     if not (encoded_data or contents_pillar):
@@ -6228,6 +6229,7 @@ def shortcut(
         The default mode for new files and directories corresponds umask of salt
         process. For existing files and directories it's not enforced.
     '''
+    icon_location = salt.utils.expanduser(icon_location)
     user = _test_owner(kwargs, user=user)
     ret = {'name': name,
            'changes': {},

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1246,7 +1246,7 @@ def symlink(
         The default mode for new files and directories corresponds umask of salt
         process. For existing files and directories it's not enforced.
     '''
-    name = salt.utils.expanduser(name)
+    name, target = salt.utils.expanduser(name, target)
 
     # Make sure that leading zeros stripped by YAML loader are added back
     mode = salt.utils.normalize_mode(mode)
@@ -2078,7 +2078,7 @@ def managed(name,
             )
         kwargs.pop('env')
 
-    name = salt.utils.expanduser(name)
+    name, source_hash_name = salt.utils.expanduser(name, source_hash_name)
 
     ret = {'changes': {},
            'pchanges': {},
@@ -2761,7 +2761,7 @@ def directory(name,
                   perms: full_control
             - win_inheritance: False
     '''
-    name = salt.utils.expanduser(name)
+    name, backupname = salt.utils.expanduser(name, backupname)
     ret = {'name': name,
            'changes': {},
            'pchanges': {},

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -571,6 +571,7 @@ def latest(name,
                   - pkg: git
                   - ssh_known_hosts: gitlab.example.com
     '''
+    target, identity = salt.utils.expanduser(target, identity)
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     kwargs = salt.utils.clean_kwargs(**kwargs)
@@ -1917,6 +1918,7 @@ def present(name,
     .. _`git-init(1)`: http://git-scm.com/docs/git-init
     .. _`worktree`: http://git-scm.com/docs/git-worktree
     '''
+    name = salt.utils.expanduser(name)
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     # If the named directory is a git repo return True
@@ -2104,6 +2106,7 @@ def detached(name,
         passed to the ``unless`` option returns false
 
     '''
+    target, identity = salt.utils.expanduser(target, identity)
 
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
@@ -2588,6 +2591,7 @@ def config_unset(name,
             - name: foo.bar
             - global: True
     '''
+    repo = salt.utils.expanduser(repo)
     ret = {'name': name,
            'changes': {},
            'result': True,
@@ -2833,6 +2837,7 @@ def config_set(name,
             - user: foo
             - global: True
     '''
+    repo = salt.utils.expanduser(repo)
     ret = {'name': name,
            'changes': {},
            'result': True,

--- a/salt/states/gpg.py
+++ b/salt/states/gpg.py
@@ -9,6 +9,7 @@ Management of the GPG keychains
 
 
 from __future__ import absolute_import
+import salt.utils
 from salt.ext.six import string_types
 
 import logging
@@ -64,6 +65,7 @@ def present(name,
 
 
     '''
+    gnupghome = salt.utils.expanduser(gnupghome)
 
     ret = {'name': name,
            'result': True,
@@ -157,6 +159,7 @@ def absent(name,
         Override GNUPG Home directory
 
     '''
+    gnupghome = salt.utils.expanduser(gnupghome)
 
     ret = {'name': name,
            'result': True,

--- a/salt/states/heat.py
+++ b/salt/states/heat.py
@@ -154,6 +154,7 @@ def deployed(name, template=None, enviroment=None, params=None, poll=5,
         Profile to use
 
     '''
+    template, enviroment = salt.utils.expanduser(template, enviroment)
     log.debug('Deployed with(' +
               '{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})'
               .format(name, template, enviroment, params, poll, rollback,

--- a/salt/states/hg.py
+++ b/salt/states/hg.py
@@ -86,6 +86,7 @@ def latest(name,
         .. versionadded:: 2017.7.0
 
     '''
+    target = salt.utils.expanduser(target)
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     if not target:

--- a/salt/states/htpasswd.py
+++ b/salt/states/htpasswd.py
@@ -57,6 +57,7 @@ def user_exists(name, password=None, htpasswd_file=None, options='',
         the htpasswd file (unlike force, which updates regardless)
 
     '''
+    htpasswd_file = salt.utils.expanduser(htpasswd_file)
     ret = {'name': name,
            'changes': {},
            'comment': '',
@@ -115,6 +116,7 @@ def user_absent(name, htpasswd_file=None, runas=None):
         The system user to run htpasswd command with
 
     '''
+    htpasswd_file = salt.utils.expanduser(htpasswd_file)
     ret = {'name': name,
            'changes': {},
            'comment': '',

--- a/salt/states/incron.py
+++ b/salt/states/incron.py
@@ -42,6 +42,8 @@ then a new cron job will be added to the user's crontab.
 
 '''
 
+# Import Salt Libs
+import salt.utils
 
 def _check_cron(user,
                 path,
@@ -114,6 +116,7 @@ def present(name,
         The cmd that should be executed
 
     '''
+    path = salt.utils.expanduser(path)
     mask = ',' . join(mask)
 
     ret = {'changes': {},
@@ -184,6 +187,7 @@ def absent(name,
         The cmd that should be executed
 
     '''
+    path = salt.utils.expanduser(path)
 
     mask = ',' . join(mask)
 

--- a/salt/states/kapacitor.py
+++ b/salt/states/kapacitor.py
@@ -57,6 +57,7 @@ def task_present(name,
     enable
         Whether to enable the task or not. Defaults to True.
     '''
+    tick_script = salt.utils.expanduser(tick_script)
     comments = []
     changes = []
     ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}

--- a/salt/states/libcloud_storage.py
+++ b/salt/states/libcloud_storage.py
@@ -144,6 +144,7 @@ def object_present(container, name, path, profile):
     :param profile: The profile key
     :type  profile: ``str``
     '''
+    path = salt.utils.expanduser(path)
     existing_object = __salt__['libcloud_storage.get_container_object'](container, name, profile)
     if existing_object is not None:
         return state_result(True, "Object already present", name, {})
@@ -192,5 +193,6 @@ def file_present(container, name, path, profile, overwrite_existing=False):
     :param overwrite_existing: Replace if already exists
     :type  overwrite_existing: ``bool``
     '''
+    path = salt.utils.expanduser(path)
     result = __salt__['libcloud_storage.download_object'](path, container, name, profile, overwrite_existing)
     return state_result(result, "Downloaded object", name, {})

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -149,6 +149,7 @@ def present(name,
         Name of a pool volume that will be used for thin-provisioning this
         container. Only applicable if ``backing`` is set to ``lvm``.
     '''
+    path = salt.utils.expanduser(path)
     ret = {'name': name,
            'result': True,
            'comment': 'Container \'{0}\' already exists'.format(name),
@@ -356,6 +357,7 @@ def absent(name, stop=False, path=None):
         web01:
           lxc.absent
     '''
+    path = salt.utils.expanduser(path)
     ret = {'name': name,
            'changes': {},
            'result': True,
@@ -417,6 +419,7 @@ def running(name, restart=False, path=None):
           lxc.running:
             - restart: True
     '''
+    path = salt.utils.expanduser(path)
     ret = {'name': name,
            'result': True,
            'comment': 'Container \'{0}\' is already running'.format(name),
@@ -516,6 +519,7 @@ def frozen(name, start=True, path=None):
           lxc.frozen:
             - start: False
     '''
+    path = salt.utils.expanduser(path)
     ret = {'name': name,
            'result': True,
            'comment': 'Container \'{0}\' is already frozen'.format(name),
@@ -602,6 +606,7 @@ def stopped(name, kill=False, path=None):
         web01:
           lxc.stopped
     '''
+    path = salt.utils.expanduser(path)
     ret = {'name': name,
            'result': True,
            'comment': 'Container \'{0}\' is already stopped'.format(name),

--- a/salt/states/mac_assistive.py
+++ b/salt/states/mac_assistive.py
@@ -46,6 +46,7 @@ def installed(name, enabled=True):
         Should assistive access be enabled on this application?
 
     '''
+    name = salt.utils.expanduser(name)
     ret = {'name': name,
            'result': True,
            'comment': '',

--- a/salt/states/mac_keychain.py
+++ b/salt/states/mac_keychain.py
@@ -123,6 +123,7 @@ def uninstalled(name, password, keychain="/Library/Keychains/System.keychain", k
         before running the import
 
     '''
+    name = salt.utils.expanduser(name)
     ret = {'name': name,
            'result': True,
            'comment': '',

--- a/salt/states/mac_package.py
+++ b/salt/states/mac_package.py
@@ -95,6 +95,7 @@ def installed(name, target="LocalSystem", dmg=False, store=False, app=False, mpk
             version_check: python --version_check=2.7.[0-9]
 
     '''
+    name, target, target = salt.utils.expanduser(name, target, target)
     ret = {'name': name,
            'result': True,
            'comment': '',

--- a/salt/states/mac_xattr.py
+++ b/salt/states/mac_xattr.py
@@ -19,6 +19,9 @@ from __future__ import absolute_import
 import logging
 import os
 
+# Import Salt Libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 __virtualname__ = "xattr"
 
@@ -45,6 +48,7 @@ def exists(name, attributes):
         a hex value then add 0x to the beginning of the value.
 
     '''
+    name = salt.utils.expanduser(name)
     ret = {'name': name,
            'result': True,
            'comment': '',
@@ -96,6 +100,7 @@ def delete(name, attributes):
         The attributes that should be removed from the file/directory, this is accepted as
         an array.
     '''
+    name = salt.utils.expanduser(name)
     ret = {'name': name,
            'result': True,
            'comment': '',

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -42,6 +42,7 @@ import os.path
 import re
 
 # Import salt libs
+import salt.utils
 from salt.ext.six import string_types
 
 import logging
@@ -191,6 +192,7 @@ def mounted(name,
 
         .. versionadded:: 2015.8.2
     '''
+    name, config = salt.utils.expanduser(name, config)
     ret = {'name': name,
            'changes': {},
            'result': True,
@@ -723,6 +725,7 @@ def unmounted(name,
         The user to own the mount; this defaults to the user salt is
         running as on the minion
     '''
+    name, config = salt.utils.expanduser(name, config)
     ret = {'name': name,
            'changes': {},
            'result': True,

--- a/salt/states/mysql_query.py
+++ b/salt/states/mysql_query.py
@@ -86,6 +86,7 @@ def run_file(name,
 
     .. versionadded:: 2017.7.0
     '''
+    query_file, output = salt.utils.expanduser(query_file, output)
     ret = {'name': name,
            'changes': {},
            'result': True,
@@ -237,6 +238,7 @@ def run(name,
     overwrite:
         The file or grain will be overwritten if it already exists (default)
     '''
+    output = salt.utils.expanduser(output)
     ret = {'name': name,
            'changes': {},
            'result': True,

--- a/salt/states/netconfig.py
+++ b/salt/states/netconfig.py
@@ -24,6 +24,7 @@ import logging
 log = logging.getLogger(__name__)
 
 # import NAPALM utils
+import salt.utils
 import salt.utils.napalm
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -320,6 +321,7 @@ def managed(name,
             }
         }
     '''
+    template_name = salt.utils.expanduser(template_name)
 
     ret = salt.utils.napalm.default_ret(name)
 

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -21,6 +21,7 @@ for the package which provides npm (simply ``npm`` in most cases). Example:
 
 # Import salt libs
 from __future__ import absolute_import
+import salt.utils
 from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
 # Import 3rd-party libs
@@ -91,6 +92,7 @@ def installed(name,
     force_reinstall
         Install the package even if it is already installed
     '''
+    dir = salt.utils.expanduser(dir)
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     pkg_list = pkgs if pkgs else [name]
@@ -229,6 +231,7 @@ def removed(name, dir=None, user=None):
 
         .. versionadded:: 0.17.0
     '''
+    dir = salt.utils.expanduser(dir)
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     try:

--- a/salt/states/openstack_config.py
+++ b/salt/states/openstack_config.py
@@ -13,6 +13,7 @@ Manage OpenStack configuration file settings.
 from __future__ import absolute_import
 
 # Import Salt Libs
+import salt.utils
 from salt.exceptions import CommandExecutionError
 
 
@@ -46,6 +47,7 @@ def present(name, filename, section, value, parameter=None):
         The value to set
 
     '''
+    filename = salt.utils.expanduser(filename)
 
     if parameter is None:
         parameter = name
@@ -103,6 +105,7 @@ def absent(name, filename, section, parameter=None):
         The parameter to change.  If the parameter is not supplied, the name will be used as the parameter.
 
     '''
+    filename = salt.utils.expanduser(filename)
 
     if parameter is None:
         parameter = name

--- a/salt/states/pcs.py
+++ b/salt/states/pcs.py
@@ -650,6 +650,7 @@ def cib_present(name, cibname, scope=None, extra_args=None):
                 - scope: None
                 - extra_args: None
     '''
+    cibname = salt.utils.expanduser(cibname)
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     cib_hash_form = 'sha256'
@@ -766,6 +767,7 @@ def cib_pushed(name, cibname, scope=None, extra_args=None):
                 - scope: None
                 - extra_args: None
     '''
+    cibname = salt.utils.expanduser(cibname)
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     cib_hash_form = 'sha256'

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -509,6 +509,7 @@ def installed(name,
 
     .. _`virtualenv`: http://www.virtualenv.org/en/latest/
     '''
+    requirements, log, cwd, cert = salt.utils.expanduser(requirements, log, cwd, cert)
 
     if pip_bin and not bin_env:
         bin_env = pip_bin

--- a/salt/states/pkgbuild.py
+++ b/salt/states/pkgbuild.py
@@ -49,6 +49,7 @@ import logging
 import os
 
 # Import salt libs
+import salt.utils
 from salt.ext import six
 
 log = logging.getLogger(__name__)
@@ -162,6 +163,7 @@ def built(name,
 
         .. versionadded:: 2015.8.2
     '''
+    dest_dir, spec = salt.utils.expanduser(dest_dir, spec)
     ret = {'name': name,
            'changes': {},
            'comment': '',
@@ -345,6 +347,7 @@ def repo(name,
         Timeout in seconds to wait for the prompt for inputting the passphrase.
 
     '''
+    name = salt.utils.expanduser(name)
     ret = {'name': name,
            'changes': {},
            'comment': '',

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -281,6 +281,7 @@ def managed(name, ppa=None, **kwargs):
        running of apt-get update prior to attempting to install these
        packages. Setting a require in the pkg will not work for this.
     '''
+    name, name = salt.utils.expanduser(name, name)
     ret = {'name': name,
            'changes': {},
            'result': None,

--- a/salt/states/postgres_initdb.py
+++ b/salt/states/postgres_initdb.py
@@ -23,6 +23,9 @@ data directory.
 '''
 from __future__ import absolute_import
 
+# Import Salt Libs
+import salt.utils
+
 
 def __virtual__():
     '''
@@ -64,6 +67,7 @@ def present(name,
     runas
         The system user the operation should be performed on behalf of
     '''
+    name = salt.utils.expanduser(name)
     _cmt = 'Postgres data directory {0} is already present'.format(name)
     ret = {
         'name': name,

--- a/salt/states/postgres_tablespace.py
+++ b/salt/states/postgres_tablespace.py
@@ -20,6 +20,7 @@ A module used to create and manage PostgreSQL tablespaces.
 from __future__ import absolute_import
 
 # Import salt libs
+import salt.utils
 from salt.utils import dictupdate
 
 # Import 3rd-party libs
@@ -92,6 +93,7 @@ def present(name,
     db_port
         Database port if different from config or default
     '''
+    directory = salt.utils.expanduser(directory)
     ret = {'name': name,
            'changes': {},
            'result': True,

--- a/salt/states/rsync.py
+++ b/salt/states/rsync.py
@@ -124,6 +124,7 @@ def synchronized(name, source,
 
         .. versionadded:: Oxygen
     '''
+    passwordfile, excludefrom = salt.utils.expanduser(passwordfile, excludefrom)
 
     ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
 

--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -25,6 +25,8 @@ booleans can be set.
     execution module is available.
 '''
 
+# Import Salt Libs
+import salt.utils
 
 def __virtual__():
     '''
@@ -264,6 +266,7 @@ def module_install(name):
 
     .. versionadded:: 2016.11.6
     '''
+    name = salt.utils.expanduser(name)
     ret = {'name': name,
            'result': True,
            'comment': '',

--- a/salt/states/sqlite3.py
+++ b/salt/states/sqlite3.py
@@ -97,6 +97,7 @@ from __future__ import absolute_import
 
 # Import Salt libs
 import salt.ext.six as six
+import salt.utils
 
 try:
     import sqlite3
@@ -133,6 +134,7 @@ def row_absent(name, db, table, where_sql, where_args=None):
     where_args
         The list parameters to substitute in where_sql
     """
+    db = salt.utils.expanduser(db)
     changes = {'name': name,
                'changes': {},
                'result': None,
@@ -229,6 +231,7 @@ def row_present(name,
         When False and the row exists and data does not equal
         the row data then the state will fail
     """
+    db = salt.utils.expanduser(db)
     changes = {'name': name,
                'changes': {},
                'result': None,
@@ -340,6 +343,7 @@ def table_absent(name, db):
     db
         The name of the database file
     """
+    db = salt.utils.expanduser(db)
     changes = {'name': name,
                'changes': {},
                'result': None,
@@ -397,6 +401,7 @@ def table_present(name, db, schema, force=False):
         the state will fail.  If force is set to True, the existing
         table will be replaced with the new table
     """
+    db = salt.utils.expanduser(db)
     changes = {'name': name,
                'changes': {},
                'result': None,

--- a/salt/states/supervisord.py
+++ b/salt/states/supervisord.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 # Import python libs
 import logging
 import salt.ext.six as six
+import salt.utils
 
 
 log = logging.getLogger(__name__)
@@ -81,6 +82,7 @@ def running(name,
         installed
 
     '''
+    conf_file, bin_env = salt.utils.expanduser(conf_file, bin_env)
     if name.endswith(':*'):
         name = name[:-1]
 
@@ -296,6 +298,7 @@ def dead(name,
         installed
 
     '''
+    conf_file, bin_env = salt.utils.expanduser(conf_file, bin_env)
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     if __opts__['test']:

--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -25,6 +25,7 @@ import os
 
 # Import salt libs
 from salt import exceptions
+import salt.utils
 from salt.states.git import _fail, _neutral_test
 
 log = logging.getLogger(__name__)
@@ -82,6 +83,7 @@ def latest(name,
     trust : False
         Automatically trust the remote server. SVN's --trust-server-cert
     '''
+    target = salt.utils.expanduser(target)
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     if not target:
         return _fail(ret, 'Target option is required')
@@ -220,6 +222,7 @@ def export(name,
     trust : False
         Automatically trust the remote server. SVN's --trust-server-cert
     '''
+    name, target = salt.utils.expanduser(name, target)
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     if not target:
         return _fail(ret, 'Target option is required')

--- a/salt/states/sysctl.py
+++ b/salt/states/sysctl.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 import re
 
 # Import salt libs
+import salt.utils
 from salt.exceptions import CommandExecutionError
 
 
@@ -43,6 +44,7 @@ def present(name, value, config=None):
         The location of the sysctl configuration file. If not specified, the
         proper location will be detected based on platform.
     '''
+    config = salt.utils.expanduser(config)
     ret = {'name': name,
            'result': True,
            'changes': {},

--- a/salt/states/tomcat.py
+++ b/salt/states/tomcat.py
@@ -57,6 +57,9 @@ Notes
 
 from __future__ import absolute_import
 
+# Import Salt Libs
+import salt.utils
+
 
 # Private
 def __virtual__():
@@ -127,6 +130,7 @@ def war_deployed(name,
         either specify a version yourself, or set version to ``False``.
 
     '''
+    name, war = salt.utils.expanduser(name, war)
     # Prepare
     ret = {'name': name,
            'result': True,
@@ -309,6 +313,7 @@ def undeployed(name,
             - require:
               - service: application-service
     '''
+    name = salt.utils.expanduser(name)
 
     # Prepare
     ret = {'name': name,

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -86,6 +86,7 @@ def keys(name, basepath='/etc/pki', **kwargs):
         .. versionadded:: Oxygen
 
     '''
+    basepath = salt.utils.expanduser(basepath)
     ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
 
     # Grab all kwargs to make them available as pillar values

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -127,6 +127,7 @@ def managed(name,
             - env_vars:
                 PATH_VAR: '/usr/local/bin/'
     '''
+    name = salt.utils.expanduser(name)
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     if 'virtualenv.create' not in __salt__:

--- a/salt/states/zcbuildout.py
+++ b/salt/states/zcbuildout.py
@@ -42,6 +42,7 @@ import logging
 import sys
 
 # Import salt libs
+import salt.utils
 from salt.ext.six import string_types
 
 # Define the module's virtual name
@@ -203,6 +204,7 @@ def installed(name,
     loglevel
         loglevel for buildout commands
     '''
+    name = salt.utils.expanduser(name)
     ret = {}
 
     if 'group' in kwargs:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -3517,13 +3517,23 @@ def expanduser(*paths):
     '''
     None-safe version of os.path.expanduser, that can also expand multiple
     arguments at the same time.
+
+    If one of the arguments is a list of strings, all those will be expanded
+    too.
     '''
     expanded_paths = []
     for path in paths:
         if not path:
             expanded_paths.append(path)
-        else:
+        elif isinstance(path, six.string_types):
             expanded_paths.append(os.path.expanduser(path))
+        elif isinstance(path, (list, tuple)):
+            nested_expanded = []
+            for nested_element in path:
+                nested_expanded.append(expanduser(nested_element))
+            expanded_paths.append(nested_expanded)
+        else:
+            expanded_paths.append(path)
 
     if len(expanded_paths) == 1:
         return expanded_paths[0]

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -3513,10 +3513,19 @@ def mkstemp(*args, **kwargs):
     return salt.utils.files.mkstemp(*args, **kwargs)
 
 
-def expanduser(path):
+def expanduser(*paths):
     '''
-    None-safe version of os.path.expanduser.
+    None-safe version of os.path.expanduser, that can also expand multiple
+    arguments at the same time.
     '''
-    if not path:
-        return path
-    return os.path.expanduser(path)
+    expanded_paths = []
+    for path in paths:
+        if not path:
+            expanded_paths.append(path)
+        else:
+            expanded_paths.append(os.path.expanduser(path))
+
+    if len(expanded_paths) == 1:
+        return expanded_paths[0]
+    else:
+        return tuple(expanded_paths)

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -3519,7 +3519,7 @@ def expanduser(*paths):
     arguments at the same time.
 
     If one of the arguments is a list of strings, all those will be expanded
-    too.
+    too. Values in dictionaries (potentially within lists) will also be expanded.
     '''
     expanded_paths = []
     for path in paths:
@@ -3532,6 +3532,10 @@ def expanduser(*paths):
             for nested_element in path:
                 nested_expanded.append(expanduser(nested_element))
             expanded_paths.append(nested_expanded)
+        elif isinstance(path, dict):
+            for key, value in path.items():
+                path[key] = expanduser(value)
+            expanded_paths.append(path)
         else:
             expanded_paths.append(path)
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -3511,3 +3511,12 @@ def mkstemp(*args, **kwargs):
     # Late import to avoid circular import.
     import salt.utils.files
     return salt.utils.files.mkstemp(*args, **kwargs)
+
+
+def expanduser(path):
+    '''
+    None-safe version of os.path.expanduser.
+    '''
+    if not path:
+        return path
+    return os.path.expanduser(path)

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1094,3 +1094,4 @@ class UtilsTestCase(TestCase):
         self.assertEqual(utils.expanduser(0), 0)
         with patch('os.path.expanduser', '/root/myfile'):
             self.assertEqual(utils.expanduser('~root/myfile'), '/root/myfile')
+            self.assertEqual(utils.expanduser(None, '~root/myfile'), (None, '/root/myfile'))

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1087,3 +1087,10 @@ class UtilsTestCase(TestCase):
             ut = '\xe4\xb8\xad\xe5\x9b\xbd\xe8\xaa\x9e (\xe7\xb9\x81\xe4\xbd\x93)'
             un = u'\u4e2d\u56fd\u8a9e (\u7e41\u4f53)'
             self.assertEqual(utils.to_unicode(ut, 'utf-8'), un)
+
+    def test_expanduser(self):
+        self.assertEqual(utils.expanduser(None), None)
+        self.assertEqual(utils.expanduser(''), '')
+        self.assertEqual(utils.expanduser(0), 0)
+        with patch('os.path.expanduser', '/root/myfile'):
+            self.assertEqual(utils.expanduser('~root/myfile'), '/root/myfile')

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1092,6 +1092,9 @@ class UtilsTestCase(TestCase):
         self.assertEqual(utils.expanduser(None), None)
         self.assertEqual(utils.expanduser(''), '')
         self.assertEqual(utils.expanduser(0), 0)
-        with patch('os.path.expanduser', '/root/myfile'):
+        def mock_expanduser(path):
+            return path.replace('~root', '/root')
+        with patch('os.path.expanduser', mock_expanduser):
             self.assertEqual(utils.expanduser('~root/myfile'), '/root/myfile')
             self.assertEqual(utils.expanduser(None, '~root/myfile'), (None, '/root/myfile'))
+            self.assertEqual(utils.expanduser(['file', '~root/myfile']), ['file', '/root/myfile'])

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1098,3 +1098,5 @@ class UtilsTestCase(TestCase):
             self.assertEqual(utils.expanduser('~root/myfile'), '/root/myfile')
             self.assertEqual(utils.expanduser(None, '~root/myfile'), (None, '/root/myfile'))
             self.assertEqual(utils.expanduser(['file', '~root/myfile']), ['file', '/root/myfile'])
+
+            self.assertEqual(utils.expanduser([{'key': '~root/file'}]), [{'key': '/root/file'}])

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -50,54 +50,54 @@ states.docker_image.present:build 	Path to directory on the Minion containing a 
 states.docker_image.present:dockerfile 	Allows for an alternative Dockerfile to be specified.  Path to alternativeDockefile is relative to the build path for the Docker container.
 # states.esxi.ssh_configured:ssh_key 	Public SSH key to added to the authorized_keys file on the ESXi host. You canuse ``ssh_key`` or ``ssh_key_file``, but not both.
 # states.esxi.ssh_configured:ssh_key_file 	File containing the public SSH key to be added to the authorized_keys file onthe ESXi host. You can use ``ssh_key_file`` or ``ssh_key``, but not both.
-states.file.absent:name 	The path which should be deleted
-states.file.append:name 	The location of the file to append to.
+# states.file.absent:name 	The path which should be deleted
+# states.file.append:name 	The location of the file to append to.
 # states.file.append:source 	A single source file to append. This source file can be hosted on eitherthe salt master server, or on an HTTP or FTP server. Both HTTPS andHTTP are supported as well as downloading directly from Amazon S3compatible URLs with both pre-configured and automatic IAM credentials(see s3.get state documentation). File retrieval from Openstack Swiftobject storage is supported via swift://container/object_path URLs(see swift.get documentation).
 # states.file.append:source_hash 	This can be one of the following:1. a source hash string2. the URI of a file that contains source hash strings
-states.file.blockreplace:name 	Filesystem path to the file to be edited
+# states.file.blockreplace:name 	Filesystem path to the file to be edited
 # states.file.blockreplace:source 	The source file to download to the minion, this source file can behosted on either the salt master server, or on an HTTP or FTP server.Both HTTPS and HTTP are supported as well as downloading directlyfrom Amazon S3 compatible URLs with both pre-configured and automaticIAM credentials. (see s3.get state documentation)File retrieval from Openstack Swift object storage is supported viaswift://container/object_path URLs, see swift.get documentation.For files hosted on the salt file server, if the file is located onthe master in the directory named spam, and is called eggs, the sourcestring is salt://spam/eggs. If source is left blank or None(use ~ in YAML), the file will be created as an empty file andthe content will not be managed. This is also the case when a filealready exists and the source is undefined; the contents of the filewill not be changed or managed.
 # states.file.blockreplace:source_hash 	This can be one of the following:1. a source hash string2. the URI of a file that contains source hash strings
 # states.file.blockreplace:backup 	The file extension to use for a backup of the file if any edit is made.Set this to ``False`` to skip making a backup.
-states.file.comment:name 	The full path to the file to be edited
-states.file.copy:name 	The location of the file to copy to
-states.file.copy:source 	The location of the file to copy to the location specified with name
+# states.file.comment:name 	The full path to the file to be edited
+# states.file.copy:name 	The location of the file to copy to
+# states.file.copy:source 	The location of the file to copy to the location specified with name
 states.file.decode:name 	Path of the file to be written.
 # states.file.decode:contents_pillar 	A Pillar path to the encoded file. Uses the same path syntax as:py:func:`pillar.get <salt.modules.pillar.get>`. The:py:func:`hashutil.base64_encodefile<salt.modules.hashutil.base64_encodefile>` function can load encodedcontent into Pillar. Either this option or ``encoded_data`` must bespecified.
-states.file.directory:name 	The location to create or manage a directory
+# states.file.directory:name 	The location to create or manage a directory
 # states.file.directory:recurse 	Enforce user/group ownership and mode of directory recursively. Acceptsa list of strings representing what you would like to recurse.  If``mode`` is defined, will recurse on both ``file_mode`` and ``dir_mode`` ifthey are defined.  If ``ignore_files`` or ``ignore_dirs`` is included, files ordirectories will be left unchanged respectively.Example:
-states.file.directory:backupname 	If the name of the directory exists and is not a directory, it will berenamed to the backupname. If the backupname alreadyexists and force is False, the state will fail. Otherwise, thebackupname will be removed first.
-states.file.exists:name 	Absolute path which must exist
-states.file.line:name 	Filesystem path to the file to be edited.
+# states.file.directory:backupname 	If the name of the directory exists and is not a directory, it will berenamed to the backupname. If the backupname alreadyexists and force is False, the state will fail. Otherwise, thebackupname will be removed first.
+# states.file.exists:name 	Absolute path which must exist
+# states.file.line:name 	Filesystem path to the file to be edited.
 # states.file.line:location 	Defines where to place content in the line. Note this option is onlyused when ``mode=insert`` is specified. If a location is passed in, ittakes precedence over both the ``before`` and ``after`` kwargs. Validlocations are:
-states.file.line:create 	Create an empty file if doesn
-states.file.managed:name 	The location of the file to manage
+# states.file.line:create 	Create an empty file if doesn
+# states.file.managed:name 	The location of the file to manage
 # states.file.managed:source 	The source file to download to the minion, this source file can behosted on either the salt master server (``salt://``), the salt minionlocal file system (``/``), or on an HTTP or FTP server (``http(s)://``,``ftp://``).
 # states.file.managed:source_hash 	This can be one of the following:1. a source hash string2. the URI of a file that contains source hash strings
-states.file.managed:source_hash_name 	When ``source_hash`` refers to a hash file, Salt will try to find thecorrect hash by matching the filename/URI associated with that hash. Bydefault, Salt will look for the filename being managed. When managing afile at path ``/tmp/foo.txt``, then the following line in a hash filewould match:
+# states.file.managed:source_hash_name 	When ``source_hash`` refers to a hash file, Salt will try to find thecorrect hash by matching the filename/URI associated with that hash. Bydefault, Salt will look for the filename being managed. When managing afile at path ``/tmp/foo.txt``, then the following line in a hash filewould match:
 # states.file.managed:encoding 	Encoding used for the file, e.g. ```UTF-8```, ```base64```.Default is None, which means str() will be applied to contents toensure an ascii encoded file and backwards compatibility.See https://docs.python.org/3/library/codecs.html#standard-encodingsfor available encodings.
 # states.file.managed:tmp_ext 	Suffix for temp file created by ``check_cmd``. Useful for checkersdependent on config file extension (e.g. the init-checkconf upstartconfig checker).
-states.file.missing:name 	Absolute path which must NOT exist
-states.file.mknod:name 	name of the file
-states.file.patch:name 	The file or directory to which the patch will be applied.
+# states.file.missing:name 	Absolute path which must NOT exist
+# states.file.mknod:name 	name of the file
+# states.file.patch:name 	The file or directory to which the patch will be applied.
 # states.file.patch:source 	The source patch to download to the minion, this source file must behosted on the salt master server. If the file is located in thedirectory named spam, and is called eggs, the source string issalt://spam/eggs. A source is required.
-states.file.recurse:name 	The directory to set the recursion in
+# states.file.recurse:name 	The directory to set the recursion in
 # states.file.recurse:source 	The source directory, this directory is located on the salt master fileserver and is specified with the salt:// protocol. If the directory islocated on the master in the directory named spam, and is called eggs,the source string is salt://spam/eggs
-states.file.rename:name 	The location of the file to rename to
-states.file.rename:source 	The location of the file to move to the location specified with name
-states.file.replace:name 	Filesystem path to the file to be edited. If a symlink is specified, itwill be resolved to its target.
+# states.file.rename:name 	The location of the file to rename to
+# states.file.rename:source 	The location of the file to move to the location specified with name
+# states.file.replace:name 	Filesystem path to the file to be edited. If a symlink is specified, itwill be resolved to its target.
 # states.file.replace:backup 	The file extension to use for a backup of the file before editing. Setto ``False`` to skip making a backup.
-states.file.retention_schedule:name 	The filesystem path to the directory containing backups to be managed.
-states.file.serialize:name 	The location of the file to create
+# states.file.retention_schedule:name 	The filesystem path to the directory containing backups to be managed.
+# states.file.serialize:name 	The location of the file to create
 # states.file.serialize:dataset_pillar 	Operates like ``dataset``, but draws from a value stored in pillar,using the pillar path syntax used in :mod:`pillar.get<salt.modules.pillar.get>`. This is useful when the pillar valuecontains newlines, as referencing a pillar variable using a jinja/makotemplate can result in YAML formatting issues due to the newlinescausing indentation mismatches.
-states.file.shortcut:name 	The location of the shortcut to create. Must end with either".lnk" or ".url"
-states.file.shortcut:target 	The location that the shortcut points to
-states.file.shortcut:working_dir 	Working directory in which to execute target
-states.file.symlink:name 	The location of the symlink to create
-states.file.symlink:target 	The location that the symlink points to
-states.file.touch:name 	name of the file
+# states.file.shortcut:name 	The location of the shortcut to create. Must end with either".lnk" or ".url"
+# states.file.shortcut:target 	The location that the shortcut points to
+# states.file.shortcut:working_dir 	Working directory in which to execute target
+# states.file.symlink:name 	The location of the symlink to create
+# states.file.symlink:target 	The location that the symlink points to
+# states.file.touch:name 	name of the file
 # states.file.touch:atime 	atime of the file
 # states.file.touch:mtime 	mtime of the file
-states.file.uncomment:name 	The full path to the file to be edited
+# states.file.uncomment:name 	The full path to the file to be edited
 states.git.detached:target 	Name of the target directory where repository is about to be cloned.
 states.git.detached:identity 	A path on the minion (or a SaltStack fileserver URL, e.g.``salt://path/to/identity_file``) to a private key to use for SSHauthentication.
 states.git.latest:target 	Name of the target directory where repository is about to be cloned
@@ -427,8 +427,8 @@ modules.dockermod.save:path 	Absolute path on the Minion where the image will be
 modules.dockermod.script:source 	Path to the script. Can be a local path on the Minion or a remote filefrom the Salt fileserver.
 modules.dockermod.script_retcode:source 	Path to the script. Can be a local path on the Minion or a remote filefrom the Salt fileserver.
 modules.ebuild.install:sources 	A list of tbz2 packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
-modules.file.append:path 	path to file
-modules.file.blockreplace:path 	Filesystem path to the file to be edited
+# modules.file.append:path 	path to file
+# modules.file.blockreplace:path 	Filesystem path to the file to be edited
 # modules.file.blockreplace:backup 	The file extension to use for a backup of the file if any edit is made.Set to ``False`` to skip making a backup.
 modules.file.check_file_meta:name 	Path to file destination
 # modules.file.check_file_meta:sfn 	Template-processed source file contents
@@ -436,60 +436,60 @@ modules.file.check_file_meta:name 	Path to file destination
 # modules.file.check_file_meta:user 	Destination file user owner
 # modules.file.check_file_meta:group 	Destination file group owner
 # modules.file.check_file_meta:mode 	Destination file permissions mode
-modules.file.check_hash:path 	Path to a file local to the minion.
-modules.file.chgrp:path 	path to the file or directory
-modules.file.chown:path 	path to the file or directory
-modules.file.comment:path 	The full path to the file to be edited
-modules.file.comment_line:path 	string The full path to the text file.
+# modules.file.check_hash:path 	Path to a file local to the minion.
+# modules.file.chgrp:path 	path to the file or directory
+# modules.file.chown:path 	path to the file or directory
+# modules.file.comment:path 	The full path to the file to be edited
+# modules.file.comment_line:path 	string The full path to the text file.
 # modules.file.comment_line:char 	string The character used to comment a line in the type of file you
 # modules.file.comment_line:backup 	string The file extension to give the backup file. Default is
-modules.file.delete_backup:path 	The path on the minion to check for backups
-modules.file.get_gid:path 	file or directory of which to get the gid
-modules.file.get_group:path 	file or directory of which to get the group
-modules.file.get_hash:path 	path to the file or directory
+# modules.file.delete_backup:path 	The path on the minion to check for backups
+# modules.file.get_gid:path 	file or directory of which to get the gid
+# modules.file.get_group:path 	file or directory of which to get the group
+# modules.file.get_hash:path 	path to the file or directory
 modules.file.get_managed:name 	location where the file lives on the server
 # modules.file.get_managed:source 	managed source file
 # modules.file.get_managed:source_hash 	hash of the source file
 # modules.file.get_managed:user 	Owner of file
 # modules.file.get_managed:group 	Group owner of file
 # modules.file.get_managed:mode 	Permissions of file
-modules.file.get_mode:path 	file or directory of which to get the mode
+# modules.file.get_mode:path 	file or directory of which to get the mode
 modules.file.get_source_sum:file_name 	Optional file name being managed, for matching with:py:func:`file.extract_hash <salt.modules.file.extract_hash>`.
 # modules.file.get_source_sum:source 	Source file, as used in :py:mod:`file <salt.states.file>` and otherstates. If ``source_hash`` refers to a file containing hashes, thenthis filename will be used to match a filename in that file. If the``source_hash`` is a hash expression, then this argument will beignored.
 # modules.file.get_source_sum:source_hash 	Hash file/expression, as used in :py:mod:`file <salt.states.file>` andother states. If this value refers to a remote URL or absolute path toa local file, it will be cached and :py:func:`file.extract_hash<salt.modules.file.extract_hash>` will be used to obtain a hash fromit.
 # modules.file.get_source_sum:source_hash_name 	Specific file name to look for when ``source_hash`` refers to a remotefile, used to disambiguate ambiguous matches.
-modules.file.get_sum:path 	path to the file or directory
-modules.file.get_uid:path 	file or directory of which to get the uid
-modules.file.get_user:path 	file or directory of which to get the user
-modules.file.grep:path 	Path to the file to be searched
-modules.file.lchown:path 	path to the file or directory
-modules.file.line:path 	Filesystem path to the file to be edited.
+# modules.file.get_sum:path 	path to the file or directory
+# modules.file.get_uid:path 	file or directory of which to get the uid
+# modules.file.get_user:path 	file or directory of which to get the user
+# modules.file.grep:path 	Path to the file to be searched
+# modules.file.lchown:path 	path to the file or directory
+# modules.file.line:path 	Filesystem path to the file to be edited.
 # modules.file.line:location 	Defines where to place content in the line. Note this option is onlyused when ``mode=insert`` is specified. If a location is passed in, ittakes precedence over both the ``before`` and ``after`` kwargs. Validlocations are:
-modules.file.list_backup:path 	The path on the minion to check for backups
-modules.file.list_backups:path 	The path on the minion to check for backups
-modules.file.list_backups_dir:path 	The directory on the minion to check for backups
-modules.file.manage_file:name 	location to place the file
-modules.file.manage_file:sfn 	location of cached file on the minion
+# modules.file.list_backup:path 	The path on the minion to check for backups
+# modules.file.list_backups:path 	The path on the minion to check for backups
+# modules.file.list_backups_dir:path 	The directory on the minion to check for backups
+# modules.file.manage_file:name 	location to place the file
+# modules.file.manage_file:sfn 	location of cached file on the minion
 # modules.file.manage_file:source 	file reference on the master
 modules.file.patch:originalfile 	The full path to the file or directory to be patched
 modules.file.patch:patchfile 	A patch file to apply to ``originalfile``
-modules.file.prepend:path 	path to file
-modules.file.psed:path 	The full path to the file to be edited
-modules.file.remove_backup:path 	The path on the minion to check for backups
-modules.file.replace:path 	Filesystem path to the file to be edited. If a symlink is specified, itwill be resolved to its target.
-modules.file.restore_backup:path 	The path on the minion to check for backups
-modules.file.sed:path 	The full path to the file to be edited
-modules.file.seek_read:path 	path to file
+# modules.file.prepend:path 	path to file
+# modules.file.psed:path 	The full path to the file to be edited
+# modules.file.remove_backup:path 	The path on the minion to check for backups
+# modules.file.replace:path 	Filesystem path to the file to be edited. If a symlink is specified, itwill be resolved to its target.
+# modules.file.restore_backup:path 	The path on the minion to check for backups
+# modules.file.sed:path 	The full path to the file to be edited
+# modules.file.seek_read:path 	path to file
 # modules.file.seek_read:offset 	offset to start into the file
-modules.file.seek_write:path 	path to file
+# modules.file.seek_write:path 	path to file
 # modules.file.seek_write:data 	data to write to file
 # modules.file.seek_write:offset 	position in file to start writing
-modules.file.set_mode:path 	file or directory of which to set the mode
+# modules.file.set_mode:path 	file or directory of which to set the mode
 # modules.file.set_mode:mode 	mode to set the path to
-modules.file.truncate:path 	path to file
+# modules.file.truncate:path 	path to file
 # modules.file.truncate:length 	offset into file to truncate
-modules.file.uncomment:path 	The full path to the file to be edited
-modules.file.write:path 	path to file
+# modules.file.uncomment:path 	The full path to the file to be edited
+# modules.file.write:path 	path to file
 modules.freebsdpkg.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.git.add:cwd 	The path to the git checkout
 # modules.git.add:filename 	The location of the file/directory to add, relative to ``cwd``
@@ -667,44 +667,44 @@ modules.win_file.check_file_meta:name 	Path to file destination
 # modules.win_file.check_file_meta:user 	Destination file user owner
 # modules.win_file.check_file_meta:group 	Destination file group owner
 # modules.win_file.check_file_meta:mode 	Destination file permissions mode
-modules.win_file.check_hash:path 	Path to a file local to the minion.
-modules.win_file.comment:path 	The full path to the file to be edited
-modules.win_file.comment_line:path 	string The full path to the text file.
+# modules.win_file.check_hash:path 	Path to a file local to the minion.
+# modules.win_file.comment:path 	The full path to the file to be edited
+# modules.win_file.comment_line:path 	string The full path to the text file.
 # modules.win_file.comment_line:char 	string The character used to comment a line in the type of file you
 # modules.win_file.comment_line:backup 	string The file extension to give the backup file. Default is
-modules.win_file.delete_backup:path 	The path on the minion to check for backups
-modules.win_file.get_hash:path 	path to the file or directory
-modules.win_file.get_managed:name 	location where the file lives on the server
+# modules.win_file.delete_backup:path 	The path on the minion to check for backups
+# modules.win_file.get_hash:path 	path to the file or directory
+# modules.win_file.get_managed:name 	location where the file lives on the server
 # modules.win_file.get_managed:source 	managed source file
 # modules.win_file.get_managed:source_hash 	hash of the source file
 # modules.win_file.get_managed:user 	Owner of file
 # modules.win_file.get_managed:group 	Group owner of file
 # modules.win_file.get_managed:mode 	Permissions of file
-modules.win_file.get_source_sum:file_name 	Optional file name being managed, for matching with:py:func:`file.extract_hash <salt.modules.file.extract_hash>`.
+# modules.win_file.get_source_sum:file_name 	Optional file name being managed, for matching with:py:func:`file.extract_hash <salt.modules.file.extract_hash>`.
 # modules.win_file.get_source_sum:source 	Source file, as used in :py:mod:`file <salt.states.file>` and otherstates. If ``source_hash`` refers to a file containing hashes, thenthis filename will be used to match a filename in that file. If the``source_hash`` is a hash expression, then this argument will beignored.
 # modules.win_file.get_source_sum:source_hash 	Hash file/expression, as used in :py:mod:`file <salt.states.file>` andother states. If this value refers to a remote URL or absolute path toa local file, it will be cached and :py:func:`file.extract_hash<salt.modules.file.extract_hash>` will be used to obtain a hash fromit.
 # modules.win_file.get_source_sum:source_hash_name 	Specific file name to look for when ``source_hash`` refers to a remotefile, used to disambiguate ambiguous matches.
-modules.win_file.get_sum:path 	path to the file or directory
-modules.win_file.line:path 	Filesystem path to the file to be edited.
+# modules.win_file.get_sum:path 	path to the file or directory
+# modules.win_file.line:path 	Filesystem path to the file to be edited.
 # modules.win_file.line:location 	Defines where to place content in the line. Note this option is onlyused when ``mode=insert`` is specified. If a location is passed in, ittakes precedence over both the ``before`` and ``after`` kwargs. Validlocations are:
-modules.win_file.list_backups:path 	The path on the minion to check for backups
-modules.win_file.list_backups_dir:path 	The directory on the minion to check for backups
-modules.win_file.manage_file:name 	location to place the file
+# modules.win_file.list_backups:path 	The path on the minion to check for backups
+# modules.win_file.list_backups_dir:path 	The directory on the minion to check for backups
+# modules.win_file.manage_file:name 	location to place the file
 # modules.win_file.manage_file:sfn 	location of cached file on the minion
 # modules.win_file.manage_file:source 	file reference on the master
-modules.win_file.prepend:path 	path to file
-modules.win_file.psed:path 	The full path to the file to be edited
-modules.win_file.replace:path 	Filesystem path to the file to be edited. If a symlink is specified, itwill be resolved to its target.
-modules.win_file.restore_backup:path 	The path on the minion to check for backups
-modules.win_file.seek_read:path 	path to file
+# modules.win_file.prepend:path 	path to file
+# modules.win_file.psed:path 	The full path to the file to be edited
+# modules.win_file.replace:path 	Filesystem path to the file to be edited. If a symlink is specified, itwill be resolved to its target.
+# modules.win_file.restore_backup:path 	The path on the minion to check for backups
+# modules.win_file.seek_read:path 	path to file
 # modules.win_file.seek_read:offset 	offset to start into the file
-modules.win_file.seek_write:path 	path to file
+# modules.win_file.seek_write:path 	path to file
 # modules.win_file.seek_write:data 	data to write to file
 # modules.win_file.seek_write:offset 	position in file to start writing
-modules.win_file.truncate:path 	path to file
+# modules.win_file.truncate:path 	path to file
 # modules.win_file.truncate:length 	offset into file to truncate
-modules.win_file.uncomment:path 	The full path to the file to be edited
-modules.win_file.write:path 	path to file
+# modules.win_file.uncomment:path 	The full path to the file to be edited
+# modules.win_file.write:path 	path to file
 modules.xbpspkg.add_repo:conffile 	path to xbps conf file to add this repodefault: /usr/share/xbps.d/15-saltstack.conf
 modules.xbpspkg.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.yumpkg.diff:path 	Full path to the installed file

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -267,7 +267,7 @@ modules.win_certutil.add_store:source 	The source certificate file this can be i
 modules.win_certutil.del_store:source 	The source certificate file this can be in the formsalt://path/to/file
 modules.win_certutil.get_cert_serial:cert_file 	The certificate file to find the serial for
 # modules.apk.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
-# modules.apk.install:sources 	A list of IPK packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
+modules.apk.install:sources 	A list of IPK packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
 modules.debconfmod.set_template:path 	location of the file containing the package selections
 modules.dnsmasq.get_config:config_file 	The location of the config file from which to obtain contents.Defaults to ``/etc/dnsmasq.conf``.
 modules.hg.archive:cwd 	The path to the Mercurial repository
@@ -398,7 +398,7 @@ modules.tomcat.undeploy:app 	the webapp context path
 modules.acme.cert:webroot 	True or a full path to use to use webroot. Otherwise use standalone mode
 # modules.aptpkg.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
 modules.aptpkg.install:debconf 	Provide the path to a debconf answers file, processed beforeinstallation.
-# modules.aptpkg.install:sources 	A list of DEB packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
+modules.aptpkg.install:sources 	A list of DEB packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
 modules.archive.cmd_unzip:zip_file 	Path of zip file to be unpacked
 modules.archive.cmd_unzip:dest 	The destination directory into which the file should be unpacked
 modules.archive.cmd_zip:zip_file 	Path of zip file to be created
@@ -426,7 +426,7 @@ modules.dockermod.load:path 	Path to docker tar archive. Path can be a file on t
 modules.dockermod.save:path 	Absolute path on the Minion where the image will be exported
 modules.dockermod.script:source 	Path to the script. Can be a local path on the Minion or a remote filefrom the Salt fileserver.
 modules.dockermod.script_retcode:source 	Path to the script. Can be a local path on the Minion or a remote filefrom the Salt fileserver.
-# modules.ebuild.install:sources 	A list of tbz2 packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.ebuild.install:sources 	A list of tbz2 packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.file.append:path 	path to file
 modules.file.blockreplace:path 	Filesystem path to the file to be edited
 # modules.file.blockreplace:backup 	The file extension to use for a backup of the file if any edit is made.Set to ``False`` to skip making a backup.
@@ -490,7 +490,7 @@ modules.file.truncate:path 	path to file
 # modules.file.truncate:length 	offset into file to truncate
 modules.file.uncomment:path 	The full path to the file to be edited
 modules.file.write:path 	path to file
-# modules.freebsdpkg.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.freebsdpkg.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.git.add:cwd 	The path to the git checkout
 # modules.git.add:filename 	The location of the file/directory to add, relative to ``cwd``
 modules.git.archive:cwd 	The path to be archived
@@ -601,9 +601,9 @@ modules.lxc.unfreeze:path 	path to the container parent directorydefault: /var/l
 modules.lxc.update_lxc_conf:path 	path to the container parentdefault: /var/lib/lxc (system default)
 modules.lxc.wait_started:path 	path to the container parentdefault: /var/lib/lxc (system default)
 # modules.opkg.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
-# modules.opkg.install:sources 	A list of IPK packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
+modules.opkg.install:sources 	A list of IPK packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
 # modules.pacman.install:name 	The name of the package to be installed. Note that this parameter isignored if either ``pkgs`` or ``sources`` is passed. Additionally,please note that this option can only be used to install packages froma software repository. To install a package file manually, use the``sources`` option.
-# modules.pacman.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.pacman.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.pip.freeze:bin_env 	path to pip bin or path to virtualenv. If doing an uninstall fromthe system python and want to use a specific pip bin (pip-2.7,pip-2.6, etc..) just specify the pip bin you want.If uninstalling from a virtualenv, just use the path to the virtualenv(/home/code/path/to/virtualenv/)
 modules.pip.freeze:cwd 	Current working directory to run pip from
 modules.pip.install:bin_env 	Path to pip bin or path to virtualenv. If doing a system install,and want to use a specific pip bin (pip-2.7, pip-2.6, etc..) justspecify the pip bin you want.
@@ -617,7 +617,7 @@ modules.pip.uninstall:requirements 	path to requirements.
 modules.pip.uninstall:bin_env 	path to pip bin or path to virtualenv. If doing an uninstall fromthe system python and want to use a specific pip bin (pip-2.7,pip-2.6, etc..) just specify the pip bin you want.If uninstalling from a virtualenv, just use the path to the virtualenv(/home/code/path/to/virtualenv/)
 modules.pip.uninstall:log 	Log file where a complete (maximum verbosity) record will be kept
 modules.pip.uninstall:cwd 	Current working directory to run pip from
-# modules.pkgin.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.pkgin.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.pkgng.backup:jail 	Backup packages from the specified jail. Note that this will run thecommand within the jail, and so the path to the backup file will berelative to the root of the jail
 modules.pkgng.backup:chroot 	Backup packages from the specified chroot (ignored if ``jail`` isspecified). Note that this will run the command within the chroot, andso the path to the backup file will be relative to the root of thechroot.
 modules.pkgng.backup:root 	Backup packages from the specified root (ignored if ``jail`` isspecified). Note that this will run the command within the root, andso the path to the backup file will be relative to the root of theroot.
@@ -706,10 +706,10 @@ modules.win_file.truncate:path 	path to file
 modules.win_file.uncomment:path 	The full path to the file to be edited
 modules.win_file.write:path 	path to file
 modules.xbpspkg.add_repo:conffile 	path to xbps conf file to add this repodefault: /usr/share/xbps.d/15-saltstack.conf
-# modules.xbpspkg.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.xbpspkg.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.yumpkg.diff:path 	Full path to the installed file
 # modules.yumpkg.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
-# modules.yumpkg.install:sources 	A list of RPM packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.yumpkg.install:sources 	A list of RPM packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.zabbix.mediatype_create:exec_path 	exec path
 modules.zabbix.mediatype_create:gsm_modem 	exec path
 # modules.zookeeper.create:path 	path of znode to create
@@ -722,7 +722,7 @@ modules.zabbix.mediatype_create:gsm_modem 	exec path
 # modules.zookeeper.set_acls:path 	path to znode
 modules.zypper.diff:path 	Full path to the installed file
 # modules.zypper.install:name 	The name of the package to be installed. Note that this parameter isignored if either ``pkgs`` or ``sources`` is passed. Additionally,please note that this option can only be used to install packages froma software repository. To install a package file manually, use the``sources`` option.
-# modules.zypper.install:sources 	A list of RPM packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.zypper.install:sources 	A list of RPM packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.apache.config:name 	File for the virtual host
 modules.composer.did_composer_install:dir 	Directory location of the composer.json file
 modules.composer.install:directory 	Directory location of the composer.json file.

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -2,101 +2,101 @@ states.virt.keys:basepath 	Defaults to ``/etc/pki``, this is the root location u
 states.libcloud_storage.file_present:path 	Local path to file
 states.libcloud_storage.object_present:path 	Local path to file
 states.acme.cert:webroot 	True or a full path to webroot. Otherwise use standalone mode
-states.boto3_route53.rr_present:GeoLocation 	Geo location resource record sets only.  A dict that lets you control how Route 53 respondsto DNS queries based on the geographic origin of the query.  For example, if you want allqueries from Africa to be routed to a web server with an IP address of 192.0.2.111, create aresource record set with a Type of A and a ContinentCode of AF.
-states.boto_asg.present:placement_group 	Physical location of your cluster placement group created in AmazonEC2. Once set this can not be updated (Amazon restriction).
+# states.boto3_route53.rr_present:GeoLocation 	Geo location resource record sets only.  A dict that lets you control how Route 53 respondsto DNS queries based on the geographic origin of the query.  For example, if you want allqueries from Africa to be routed to a web server with an IP address of 192.0.2.111, create aresource record set with a Type of A and a ContinentCode of AF.
+# states.boto_asg.present:placement_group 	Physical location of your cluster placement group created in AmazonEC2. Once set this can not be updated (Amazon restriction).
 states.cisconso.value_present:path 	The device path to set the value at, a list of element names in order, / separated
 states.cisconso.value_present:config 	The new value at the given path
-states.dellchassis.chassis:location 	The location of the chassis.
+# states.dellchassis.chassis:location 	The location of the chassis.
 states.sysctl.present:config 	The location of the sysctl configuration file. If not specified, theproper location will be detected based on platform.
 states.alternatives.install:path 	is the location of the new alternative target.NB: This file / directory must already exist.(e.g. /usr/bin/less)
 states.alternatives.remove:path 	is the location of one of the alternative target files.(e.g. /usr/bin/less)
 states.alternatives.set_:path 	is the location of one of the alternative target files.(e.g. /usr/bin/less)
-states.archive.extracted:source_hash 	Hash of source file, or file with list of hash-to-file mappings
+# states.archive.extracted:source_hash 	Hash of source file, or file with list of hash-to-file mappings
 states.archive.extracted:source_hash_name 	When ``source_hash`` refers to a hash file, Salt will try to find thecorrect hash by matching the filename part of the ``source`` URI. Whenmanaging a file with a ``source`` of ``salt://files/foo.tar.gz``, thenthe following line in a hash file would match:
-states.archive.extracted:list_options 	**For tar archives only.** This state uses :py:func:`archive.list<salt.modules.archive.list_>` to discover the contents of the sourcearchive so that it knows which file paths should exist on the minion ifthe archive has already been extracted. For the vast majority of tararchives, :py:func:`archive.list <salt.modules.archive.list_>` "justworks". Archives compressed using gzip, bzip2, and xz/lzma (with thehelp of the xz_ CLI command) are supported automatically. However, forarchives compressed using other compression types, CLI options must bepassed to :py:func:`archive.list <salt.modules.archive.list_>`.
+# states.archive.extracted:list_options 	**For tar archives only.** This state uses :py:func:`archive.list<salt.modules.archive.list_>` to discover the contents of the sourcearchive so that it knows which file paths should exist on the minion ifthe archive has already been extracted. For the vast majority of tararchives, :py:func:`archive.list <salt.modules.archive.list_>` "justworks". Archives compressed using gzip, bzip2, and xz/lzma (with thehelp of the xz_ CLI command) are supported automatically. However, forarchives compressed using other compression types, CLI options must bepassed to :py:func:`archive.list <salt.modules.archive.list_>`.
 states.archive.extracted:if_missing 	If specified, this path will be checked, and if it exists then thearchive will not be extracted. This path can be either a directory or afile, so this option can also be used to check for a semaphore file andconditionally skip extraction.
 states.archive.extracted:enforce_ownership_on 	When ``user`` or ``group`` is specified, Salt will default to enforcingpermissions on the file/directory paths detected by running:py:func:`archive.list <salt.modules.archive.list_>` on the sourcearchive. Use this argument to specify an alternate directory on whichownership should be enforced.
 states.artifactory.downloaded:target_file 	Target file to download artifact to. By default file name is resolved by artifactory.
 states.augeas.change:context 	A file path, prefixed by ``/files``. Should resolve to an actual file(not an arbitrary augeas path). This is used to avoid duplicating thefile name for each item in the changes list (for example, ``set bind 0.0.0.0``in the example below operates on the file specified by ``context``). If``context`` is not specified, a file path prefixed by ``/files`` should beincluded with the ``set`` command.
-states.augeas.change:load_path 	A list of directories that modules should be searched in. This is inaddition to the standard load path and the directories inAUGEAS_LENS_LIB.
+# states.augeas.change:load_path 	A list of directories that modules should be searched in. This is inaddition to the standard load path and the directories inAUGEAS_LENS_LIB.
 states.boto_apigateway.absent:name 	Name of the swagger file in YAML format
-states.boto_apigateway.absent:stage_name 	Name of the stage to be removed irrespective of the swagger file content.If the current deployment associated with the stage_name has no other stages associatedwith it, the deployment will also be removed.
+# states.boto_apigateway.absent:stage_name 	Name of the stage to be removed irrespective of the swagger file content.If the current deployment associated with the stage_name has no other stages associatedwith it, the deployment will also be removed.
 states.boto_apigateway.present:swagger_file 	Name of the location of the swagger rest api definition file in YAML format.
-states.boto_cloudtrail.present:S3KeyPrefix 	Specifies the Amazon S3 key prefix that comes after the name of thebucket you have designated for log file delivery.
-states.boto_cloudtrail.present:SnsTopicName 	Specifies the name of the Amazon SNS topic defined for notification oflog file delivery. The maximum length is 256 characters.
+# states.boto_cloudtrail.present:S3KeyPrefix 	Specifies the Amazon S3 key prefix that comes after the name of thebucket you have designated for log file delivery.
+# states.boto_cloudtrail.present:SnsTopicName 	Specifies the name of the Amazon SNS topic defined for notification oflog file delivery. The maximum length is 256 characters.
 states.boto_iam_role.present:path 	The path to the role/instance profile. (See https://boto.readthedocs.io/en/latest/ref/iam.html#boto.iam.connection.IAMConnection.create_role)
 states.boto_lambda.function_present:ZipFile 	A path to a .zip file containing your deployment package. If this isspecified, S3Bucket and S3Key must not be specified.
-states.boto_lambda.function_present:S3Bucket 	Amazon S3 bucket name where the .zip file containing your package isstored. If this is specified, S3Key must be specified and ZipFile mustNOT be specified.
+# states.boto_lambda.function_present:S3Bucket 	Amazon S3 bucket name where the .zip file containing your package isstored. If this is specified, S3Key must be specified and ZipFile mustNOT be specified.
 states.bower.installed:dir 	The target directory in which to install the package
 states.bower.removed:dir 	The target directory in which to install the package
 states.cmd.run:cwd 	The current working directory to execute the command in, defaults to/root
 states.cmd.run:creates 	Only run if the file or files specified by ``creates`` do not exist.
-states.cmd.script:source 	The location of the script to download. If the file is located on themaster in the directory named spam, and is called eggs, the sourcestring is salt://spam/eggs
+# states.cmd.script:source 	The location of the script to download. If the file is located on themaster in the directory named spam, and is called eggs, the sourcestring is salt://spam/eggs
 states.cmd.script:cwd 	The current working directory to execute the command in, defaults to/root
 states.cmd.script:creates 	Only run if the file or files specified by ``creates`` do not exist.
 states.cmd.wait:cwd 	The current working directory to execute the command in, defaults to/root
 states.cmd.wait:creates 	Only run if the file or files specified by ``creates`` do not exist.
-states.cmd.wait_script:source 	The source script being downloaded to the minion, this source script ishosted on the salt master server.  If the file is located on the masterin the directory named spam, and is called eggs, the source string issalt://spam/eggs
+# states.cmd.wait_script:source 	The source script being downloaded to the minion, this source script ishosted on the salt master server.  If the file is located on the masterin the directory named spam, and is called eggs, the source string issalt://spam/eggs
 states.cmd.wait_script:cwd 	The current working directory to execute the command in, defaults to/root
 states.cmd.watch:cwd 	The current working directory to execute the command in, defaults to/root
 states.cmd.watch:creates 	Only run if the file or files specified by ``creates`` do not exist.
-states.cron.file:name 	The source file to be used as the crontab. This source file can behosted on either the salt master server, or on an HTTP or FTP server.For files hosted on the salt file server, if the file is located onthe master in the directory named spam, and is called eggs, the sourcestring is ``salt://spam/eggs``
-states.cron.file:source_hash 	This can be either a file which contains a source hash string forthe source, or a source hash string. The source hash string is thehash algorithm followed by the hash of the file:``md5=e138491e9d5b97023cea823fe17bac22``
+# states.cron.file:name 	The source file to be used as the crontab. This source file can behosted on either the salt master server, or on an HTTP or FTP server.For files hosted on the salt file server, if the file is located onthe master in the directory named spam, and is called eggs, the sourcestring is ``salt://spam/eggs``
+# states.cron.file:source_hash 	This can be either a file which contains a source hash string forthe source, or a source hash string. The source hash string is thehash algorithm followed by the hash of the file:``md5=e138491e9d5b97023cea823fe17bac22``
 states.cron.file:source_hash_name 	When ``source_hash`` refers to a hash file, Salt will try to find thecorrect hash by matching the filename/URI associated with that hash. Bydefault, Salt will look for the filename being managed. When managing afile at path ``/tmp/foo.txt``, then the following line in a hash filewould match:
 states.cryptdev.mapped:keyfile 	Either ``None`` if the password is to be entered manually on boot, oran absolute path to a keyfile. If the password is to be askedinteractively, the mapping cannot be performed with ``immediate=True``.
 states.cryptdev.mapped:config 	Set an alternative location for the crypttab, if the map is persistent,Default is ``/etc/crypttab``
 states.cryptdev.unmapped:config 	Set an alternative location for the crypttab, if the map is persistent,Default is ``/etc/crypttab``
 states.docker_image.present:build 	Path to directory on the Minion containing a Dockerfile
 states.docker_image.present:dockerfile 	Allows for an alternative Dockerfile to be specified.  Path to alternativeDockefile is relative to the build path for the Docker container.
-states.esxi.ssh_configured:ssh_key 	Public SSH key to added to the authorized_keys file on the ESXi host. You canuse ``ssh_key`` or ``ssh_key_file``, but not both.
-states.esxi.ssh_configured:ssh_key_file 	File containing the public SSH key to be added to the authorized_keys file onthe ESXi host. You can use ``ssh_key_file`` or ``ssh_key``, but not both.
+# states.esxi.ssh_configured:ssh_key 	Public SSH key to added to the authorized_keys file on the ESXi host. You canuse ``ssh_key`` or ``ssh_key_file``, but not both.
+# states.esxi.ssh_configured:ssh_key_file 	File containing the public SSH key to be added to the authorized_keys file onthe ESXi host. You can use ``ssh_key_file`` or ``ssh_key``, but not both.
 states.file.absent:name 	The path which should be deleted
 states.file.append:name 	The location of the file to append to.
-states.file.append:source 	A single source file to append. This source file can be hosted on eitherthe salt master server, or on an HTTP or FTP server. Both HTTPS andHTTP are supported as well as downloading directly from Amazon S3compatible URLs with both pre-configured and automatic IAM credentials(see s3.get state documentation). File retrieval from Openstack Swiftobject storage is supported via swift://container/object_path URLs(see swift.get documentation).
-states.file.append:source_hash 	This can be one of the following:1. a source hash string2. the URI of a file that contains source hash strings
+# states.file.append:source 	A single source file to append. This source file can be hosted on eitherthe salt master server, or on an HTTP or FTP server. Both HTTPS andHTTP are supported as well as downloading directly from Amazon S3compatible URLs with both pre-configured and automatic IAM credentials(see s3.get state documentation). File retrieval from Openstack Swiftobject storage is supported via swift://container/object_path URLs(see swift.get documentation).
+# states.file.append:source_hash 	This can be one of the following:1. a source hash string2. the URI of a file that contains source hash strings
 states.file.blockreplace:name 	Filesystem path to the file to be edited
-states.file.blockreplace:source 	The source file to download to the minion, this source file can behosted on either the salt master server, or on an HTTP or FTP server.Both HTTPS and HTTP are supported as well as downloading directlyfrom Amazon S3 compatible URLs with both pre-configured and automaticIAM credentials. (see s3.get state documentation)File retrieval from Openstack Swift object storage is supported viaswift://container/object_path URLs, see swift.get documentation.For files hosted on the salt file server, if the file is located onthe master in the directory named spam, and is called eggs, the sourcestring is salt://spam/eggs. If source is left blank or None(use ~ in YAML), the file will be created as an empty file andthe content will not be managed. This is also the case when a filealready exists and the source is undefined; the contents of the filewill not be changed or managed.
-states.file.blockreplace:source_hash 	This can be one of the following:1. a source hash string2. the URI of a file that contains source hash strings
-states.file.blockreplace:backup 	The file extension to use for a backup of the file if any edit is made.Set this to ``False`` to skip making a backup.
+# states.file.blockreplace:source 	The source file to download to the minion, this source file can behosted on either the salt master server, or on an HTTP or FTP server.Both HTTPS and HTTP are supported as well as downloading directlyfrom Amazon S3 compatible URLs with both pre-configured and automaticIAM credentials. (see s3.get state documentation)File retrieval from Openstack Swift object storage is supported viaswift://container/object_path URLs, see swift.get documentation.For files hosted on the salt file server, if the file is located onthe master in the directory named spam, and is called eggs, the sourcestring is salt://spam/eggs. If source is left blank or None(use ~ in YAML), the file will be created as an empty file andthe content will not be managed. This is also the case when a filealready exists and the source is undefined; the contents of the filewill not be changed or managed.
+# states.file.blockreplace:source_hash 	This can be one of the following:1. a source hash string2. the URI of a file that contains source hash strings
+# states.file.blockreplace:backup 	The file extension to use for a backup of the file if any edit is made.Set this to ``False`` to skip making a backup.
 states.file.comment:name 	The full path to the file to be edited
 states.file.copy:name 	The location of the file to copy to
 states.file.copy:source 	The location of the file to copy to the location specified with name
 states.file.decode:name 	Path of the file to be written.
-states.file.decode:contents_pillar 	A Pillar path to the encoded file. Uses the same path syntax as:py:func:`pillar.get <salt.modules.pillar.get>`. The:py:func:`hashutil.base64_encodefile<salt.modules.hashutil.base64_encodefile>` function can load encodedcontent into Pillar. Either this option or ``encoded_data`` must bespecified.
+# states.file.decode:contents_pillar 	A Pillar path to the encoded file. Uses the same path syntax as:py:func:`pillar.get <salt.modules.pillar.get>`. The:py:func:`hashutil.base64_encodefile<salt.modules.hashutil.base64_encodefile>` function can load encodedcontent into Pillar. Either this option or ``encoded_data`` must bespecified.
 states.file.directory:name 	The location to create or manage a directory
-states.file.directory:recurse 	Enforce user/group ownership and mode of directory recursively. Acceptsa list of strings representing what you would like to recurse.  If``mode`` is defined, will recurse on both ``file_mode`` and ``dir_mode`` ifthey are defined.  If ``ignore_files`` or ``ignore_dirs`` is included, files ordirectories will be left unchanged respectively.Example:
+# states.file.directory:recurse 	Enforce user/group ownership and mode of directory recursively. Acceptsa list of strings representing what you would like to recurse.  If``mode`` is defined, will recurse on both ``file_mode`` and ``dir_mode`` ifthey are defined.  If ``ignore_files`` or ``ignore_dirs`` is included, files ordirectories will be left unchanged respectively.Example:
 states.file.directory:backupname 	If the name of the directory exists and is not a directory, it will berenamed to the backupname. If the backupname alreadyexists and force is False, the state will fail. Otherwise, thebackupname will be removed first.
 states.file.exists:name 	Absolute path which must exist
 states.file.line:name 	Filesystem path to the file to be edited.
-states.file.line:location 	Defines where to place content in the line. Note this option is onlyused when ``mode=insert`` is specified. If a location is passed in, ittakes precedence over both the ``before`` and ``after`` kwargs. Validlocations are:
+# states.file.line:location 	Defines where to place content in the line. Note this option is onlyused when ``mode=insert`` is specified. If a location is passed in, ittakes precedence over both the ``before`` and ``after`` kwargs. Validlocations are:
 states.file.line:create 	Create an empty file if doesn
 states.file.managed:name 	The location of the file to manage
-states.file.managed:source 	The source file to download to the minion, this source file can behosted on either the salt master server (``salt://``), the salt minionlocal file system (``/``), or on an HTTP or FTP server (``http(s)://``,``ftp://``).
-states.file.managed:source_hash 	This can be one of the following:1. a source hash string2. the URI of a file that contains source hash strings
+# states.file.managed:source 	The source file to download to the minion, this source file can behosted on either the salt master server (``salt://``), the salt minionlocal file system (``/``), or on an HTTP or FTP server (``http(s)://``,``ftp://``).
+# states.file.managed:source_hash 	This can be one of the following:1. a source hash string2. the URI of a file that contains source hash strings
 states.file.managed:source_hash_name 	When ``source_hash`` refers to a hash file, Salt will try to find thecorrect hash by matching the filename/URI associated with that hash. Bydefault, Salt will look for the filename being managed. When managing afile at path ``/tmp/foo.txt``, then the following line in a hash filewould match:
-states.file.managed:encoding 	Encoding used for the file, e.g. ```UTF-8```, ```base64```.Default is None, which means str() will be applied to contents toensure an ascii encoded file and backwards compatibility.See https://docs.python.org/3/library/codecs.html#standard-encodingsfor available encodings.
-states.file.managed:tmp_ext 	Suffix for temp file created by ``check_cmd``. Useful for checkersdependent on config file extension (e.g. the init-checkconf upstartconfig checker).
+# states.file.managed:encoding 	Encoding used for the file, e.g. ```UTF-8```, ```base64```.Default is None, which means str() will be applied to contents toensure an ascii encoded file and backwards compatibility.See https://docs.python.org/3/library/codecs.html#standard-encodingsfor available encodings.
+# states.file.managed:tmp_ext 	Suffix for temp file created by ``check_cmd``. Useful for checkersdependent on config file extension (e.g. the init-checkconf upstartconfig checker).
 states.file.missing:name 	Absolute path which must NOT exist
 states.file.mknod:name 	name of the file
 states.file.patch:name 	The file or directory to which the patch will be applied.
-states.file.patch:source 	The source patch to download to the minion, this source file must behosted on the salt master server. If the file is located in thedirectory named spam, and is called eggs, the source string issalt://spam/eggs. A source is required.
+# states.file.patch:source 	The source patch to download to the minion, this source file must behosted on the salt master server. If the file is located in thedirectory named spam, and is called eggs, the source string issalt://spam/eggs. A source is required.
 states.file.recurse:name 	The directory to set the recursion in
-states.file.recurse:source 	The source directory, this directory is located on the salt master fileserver and is specified with the salt:// protocol. If the directory islocated on the master in the directory named spam, and is called eggs,the source string is salt://spam/eggs
+# states.file.recurse:source 	The source directory, this directory is located on the salt master fileserver and is specified with the salt:// protocol. If the directory islocated on the master in the directory named spam, and is called eggs,the source string is salt://spam/eggs
 states.file.rename:name 	The location of the file to rename to
 states.file.rename:source 	The location of the file to move to the location specified with name
 states.file.replace:name 	Filesystem path to the file to be edited. If a symlink is specified, itwill be resolved to its target.
-states.file.replace:backup 	The file extension to use for a backup of the file before editing. Setto ``False`` to skip making a backup.
+# states.file.replace:backup 	The file extension to use for a backup of the file before editing. Setto ``False`` to skip making a backup.
 states.file.retention_schedule:name 	The filesystem path to the directory containing backups to be managed.
 states.file.serialize:name 	The location of the file to create
-states.file.serialize:dataset_pillar 	Operates like ``dataset``, but draws from a value stored in pillar,using the pillar path syntax used in :mod:`pillar.get<salt.modules.pillar.get>`. This is useful when the pillar valuecontains newlines, as referencing a pillar variable using a jinja/makotemplate can result in YAML formatting issues due to the newlinescausing indentation mismatches.
+# states.file.serialize:dataset_pillar 	Operates like ``dataset``, but draws from a value stored in pillar,using the pillar path syntax used in :mod:`pillar.get<salt.modules.pillar.get>`. This is useful when the pillar valuecontains newlines, as referencing a pillar variable using a jinja/makotemplate can result in YAML formatting issues due to the newlinescausing indentation mismatches.
 states.file.shortcut:name 	The location of the shortcut to create. Must end with either".lnk" or ".url"
 states.file.shortcut:target 	The location that the shortcut points to
 states.file.shortcut:working_dir 	Working directory in which to execute target
 states.file.symlink:name 	The location of the symlink to create
 states.file.symlink:target 	The location that the symlink points to
 states.file.touch:name 	name of the file
-states.file.touch:atime 	atime of the file
-states.file.touch:mtime 	mtime of the file
+# states.file.touch:atime 	atime of the file
+# states.file.touch:mtime 	mtime of the file
 states.file.uncomment:name 	The full path to the file to be edited
 states.git.detached:target 	Name of the target directory where repository is about to be cloned.
 states.git.detached:identity 	A path on the minion (or a SaltStack fileserver URL, e.g.``salt://path/to/identity_file``) to a private key to use for SSHauthentication.
@@ -107,10 +107,10 @@ states.gpg.present:gnupghome 	Override GNUPG Home directory
 states.hg.latest:target 	Target destination directory path on minion to clone into
 states.htpasswd.user_absent:htpasswd_file 	Path to the htpasswd file
 states.htpasswd.user_exists:htpasswd_file 	Path to the htpasswd file
-states.icinga2.generate_ticket:output 	grain: output in a grainother: the file to store resultsNone:  output to the result comment (default)
+# states.icinga2.generate_ticket:output 	grain: output in a grainother: the file to store resultsNone:  output to the result comment (default)
 states.incron.absent:path 	The path that should be watched
 states.incron.present:path 	The path that should be watched
-states.jenkins.present:config 	The Salt URL for the file to use forconfiguring the job.
+# states.jenkins.present:config 	The Salt URL for the file to use forconfiguring the job.
 states.lxc.absent:path 	path to the container parentdefault: /var/lib/lxc (system default)
 states.lxc.frozen:path 	path to the container parentdefault: /var/lib/lxc (system default)
 states.lxc.present:path 	path to the container parentdefault: /var/lib/lxc (system default)
@@ -138,39 +138,39 @@ states.pcs.cib_present:cibname 	name/path of the file containing the CIB
 states.pcs.cib_pushed:cibname 	name/path of the file containing the CIB
 states.pip_state.installed:requirements 	Path to a pip requirements file. If the path begins with salt://the file will be transferred from the master file server.
 states.pip_state.installed:log 	Log file where a complete (maximum verbosity) record will be kept
-states.pip_state.installed:exists_action 	Default action when a path already exists: (s)witch, (i)gnore, (w)ipe,(b)ackup
+# states.pip_state.installed:exists_action 	Default action when a path already exists: (s)witch, (i)gnore, (w)ipe,(b)ackup
 states.pip_state.installed:cwd 	Current working directory to run pip from
 states.pip_state.installed:cert 	Provide a path to an alternate CA bundle
 states.pkgbuild.built:dest_dir 	The directory on the minion to place the built package(s)
 states.pkgbuild.built:spec 	The location of the spec file (used for rpms)
-states.pkgbuild.built:template 	Run the spec file through a templating engine
+# states.pkgbuild.built:template 	Run the spec file through a templating engine
 states.pkgbuild.repo:name 	The directory to find packages that will be in the repository
 states.pkgrepo.managed:name 	This value will be used in two ways: Firstly, it will be the repo ID,as seen in the entry in square brackets (e.g. ``[foo]``) for a givenrepo. Secondly, it will be the name of the file as stored in/etc/yum.repos.d (e.g. ``/etc/yum.repos.d/foo.conf``).
 states.postgres_initdb.present:name 	The name of the directory to initialize
 states.postgres_tablespace.present:directory 	The directory where the tablespace will be located, must already exist
 states.rsync.synchronized:passwordfile 	Read daemon-access password from the file (path)
 states.rsync.synchronized:excludefrom 	Read exclude patterns from the file (path)
-states.saltmod.state:top 	Should be the name of a top file. If set state.top is called with thistop file instead of state.sls.
+# states.saltmod.state:top 	Should be the name of a top file. If set state.top is called with thistop file instead of state.sls.
 states.selinux.module_install:name 	Path to file with module to install
 states.sqlite3.row_absent:db 	The database file name
 states.sqlite3.row_present:db 	The database file name
 states.sqlite3.table_absent:db 	The name of the database file
 states.sqlite3.table_present:db 	The name of the database file
-states.ssh_auth.absent:user 	The user who owns the SSH authorized keys file to modify
-states.ssh_auth.absent:source 	The source file for the key(s). Can contain any number of public keys,in standard "authorized_keys" format. If this is set, comment, enc andoptions will be ignored.
-states.ssh_auth.absent:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/authorized_keys". Token expansion %u and%h for username and home path supported.
-states.ssh_auth.present:user 	The user who owns the SSH authorized keys file to modify
-states.ssh_auth.present:source 	The source file for the key(s). Can contain any number of public keys,in standard "authorized_keys" format. If this is set, comment and encwill be ignored.
-states.ssh_auth.present:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/authorized_keys". Token expansion %u and%h for username and home path supported.
-states.ssh_known_hosts.absent:user 	The user who owns the ssh authorized keys file to modify
-states.ssh_known_hosts.absent:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/known_hosts". If no user is specified,defaults to "/etc/ssh/ssh_known_hosts". If present, must be anabsolute path when a user is not specified.
-states.ssh_known_hosts.present:user 	The user who owns the ssh authorized keys file to modify
-states.ssh_known_hosts.present:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/known_hosts". If no user is specified,defaults to "/etc/ssh/ssh_known_hosts". If present, must be anabsolute path when a user is not specified.
-states.stormpath_account.absent:directory_id 	Optional. The ID of the directory that the account is expected to belongto. If not specified, then a list of directories will be retrieved, andeach will be scanned for the account. Specifying a directory_id willtherefore cut down on the number of requests to Stormpath, and increaseperformance of this state.
-states.supervisord.dead:name 	Service name as defined in the supervisor configuration file
+# states.ssh_auth.absent:user 	The user who owns the SSH authorized keys file to modify
+# states.ssh_auth.absent:source 	The source file for the key(s). Can contain any number of public keys,in standard "authorized_keys" format. If this is set, comment, enc andoptions will be ignored.
+# states.ssh_auth.absent:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/authorized_keys". Token expansion %u and%h for username and home path supported.
+# states.ssh_auth.present:user 	The user who owns the SSH authorized keys file to modify
+# states.ssh_auth.present:source 	The source file for the key(s). Can contain any number of public keys,in standard "authorized_keys" format. If this is set, comment and encwill be ignored.
+# states.ssh_auth.present:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/authorized_keys". Token expansion %u and%h for username and home path supported.
+# states.ssh_known_hosts.absent:user 	The user who owns the ssh authorized keys file to modify
+# states.ssh_known_hosts.absent:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/known_hosts". If no user is specified,defaults to "/etc/ssh/ssh_known_hosts". If present, must be anabsolute path when a user is not specified.
+# states.ssh_known_hosts.present:user 	The user who owns the ssh authorized keys file to modify
+# states.ssh_known_hosts.present:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/known_hosts". If no user is specified,defaults to "/etc/ssh/ssh_known_hosts". If present, must be anabsolute path when a user is not specified.
+# states.stormpath_account.absent:directory_id 	Optional. The ID of the directory that the account is expected to belongto. If not specified, then a list of directories will be retrieved, andeach will be scanned for the account. Specifying a directory_id willtherefore cut down on the number of requests to Stormpath, and increaseperformance of this state.
+# states.supervisord.dead:name 	Service name as defined in the supervisor configuration file
 states.supervisord.dead:conf_file 	path to supervisorctl config file
 states.supervisord.dead:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
-states.supervisord.running:name 	Service name as defined in the supervisor configuration file
+# states.supervisord.running:name 	Service name as defined in the supervisor configuration file
 states.supervisord.running:conf_file 	path to supervisorctl config file
 states.supervisord.running:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
 states.svn.export:name 	Address and path to the file or directory to be exported.
@@ -179,24 +179,24 @@ states.svn.latest:target 	Name of the target directory where the checkout will p
 states.tomcat.undeployed:name 	The context path to undeploy.
 states.tomcat.war_deployed:name 	The context path to deploy (incl. forward slash) the WAR to.
 states.tomcat.war_deployed:war 	Absolute path to WAR file (should be accessible by the user runningTomcat) or a path supported by the ``salt.modules.cp.get_url`` function.
-states.user.present:home 	The custom login directory of user. Uses default value of underlyingsystem if not set. Notice that this directory does not have to exist.This also the location of the home directory to create if createhome isset to True.
+# states.user.present:home 	The custom login directory of user. Uses default value of underlyingsystem if not set. Notice that this directory does not have to exist.This also the location of the home directory to create if createhome isset to True.
 states.zcbuildout.installed:name 	directory to execute in
-states.zookeeper.absent:name 	path to znode
-states.zookeeper.acls:name 	path to znode
-states.zookeeper.present:name 	path to znode
+# states.zookeeper.absent:name 	path to znode
+# states.zookeeper.acls:name 	path to znode
+# states.zookeeper.present:name 	path to znode
 modules.chef.client:logfile 	Set the log file location
 modules.chef.solo:logfile 	Set the log file location
 modules.composer.did_composer_install:dir 	Directory location of the composer.json file
 modules.composer.install:directory 	Directory location of the composer.json file.
 modules.composer.update:directory 	Directory location of the composer.json file.
 modules.genesis.bootstrap:root 	Local path to create the root of the image filesystem.
-modules.genesis.bootstrap:img_format 	Which format to create the image in. By default, just copies files intoa directory on the local filesystem (``dir``). Future support will existfor ``sparse``.
-modules.genesis.bootstrap:flavor 	Which flavor of operating system to install. This correlates to aspecific directory on the distribution repositories. For instance,``wheezy`` on Debian.
+# modules.genesis.bootstrap:img_format 	Which format to create the image in. By default, just copies files intoa directory on the local filesystem (``dir``). Future support will existfor ``sparse``.
+# modules.genesis.bootstrap:flavor 	Which flavor of operating system to install. This correlates to aspecific directory on the distribution repositories. For instance,``wheezy`` on Debian.
 modules.genesis.bootstrap:static_qemu 	Local path to the static qemu binary required for this arch.(e.x.: /usr/bin/qemu-amd64-static)
 modules.genesis.bootstrap:mount_dir 	If img_format is not ``dir``, then the image must be mounted somewhere.If the ``mount_dir`` is not specified, then it will be created at``/opt/salt-genesis.<random_uuid>``. This directory will be unmountedand removed when the process is finished.
 modules.genesis.bootstrap:pkg_cache 	This points to a directory containing a cache of package files to becopied to the image. It does not need to be specified.
 modules.gentoolkitmod.revdep_rebuild:lib 	Search for reverse dependencies for a particular library ratherthan every library on the system. It can be a full path to alibrary or basic regular expression.
-modules.jboss7.deploy:source_file 	Source file to deploy from
+# modules.jboss7.deploy:source_file 	Source file to deploy from
 modules.mac_keychain.set_default_keychain:keychain 	The location of the keychain to set as default
 modules.openstack_config.delete:filename 	The full path to the configuration file
 modules.openstack_config.get:filename 	The full path to the configuration file
@@ -238,8 +238,8 @@ modules.svn.update:cwd 	The path to the Subversion repository
 modules.win_certutil.add_store:source 	The source certificate file this can be in the formsalt://path/to/file
 modules.win_certutil.del_store:source 	The source certificate file this can be in the formsalt://path/to/file
 modules.win_certutil.get_cert_serial:cert_file 	The certificate file to find the serial for
-modules.apk.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
-modules.apk.install:sources 	A list of IPK packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
+# modules.apk.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
+# modules.apk.install:sources 	A list of IPK packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
 modules.debconfmod.set_template:path 	location of the file containing the package selections
 modules.dnsmasq.get_config:config_file 	The location of the config file from which to obtain contents.Defaults to ``/etc/dnsmasq.conf``.
 modules.hg.archive:cwd 	The path to the Mercurial repository
@@ -254,19 +254,19 @@ modules.seed.apply_:path 	Full path to the directory, device, or disk image  on 
 modules.seed.mkconfig:pub_key 	absolute path or file content of an optional preseeded salt key
 modules.seed.mkconfig:priv_key 	absolute path or file content of an optional preseeded salt key
 modules.sensehat.show_image:image 	The path to the image to display. The image must be 8 x 8 pixels in size.
-modules.sysfs.read:key 	file or path in SysFS
-modules.sysfs.target:key 	the location to resolve within SysFS
-modules.sysfs.target:full 	full path instead of basename
-modules.augeas_cfg.execute:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
-modules.augeas_cfg.get:path 	The path to get the value of
-modules.augeas_cfg.get:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
-modules.augeas_cfg.ls:path 	The path to list
-modules.augeas_cfg.ls:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
-modules.augeas_cfg.match:path 	The path to match
-modules.augeas_cfg.match:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
-modules.augeas_cfg.remove:path 	The path to remove
-modules.augeas_cfg.remove:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
-modules.augeas_cfg.tree:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
+# modules.sysfs.read:key 	file or path in SysFS
+# modules.sysfs.target:key 	the location to resolve within SysFS
+# modules.sysfs.target:full 	full path instead of basename
+# modules.augeas_cfg.execute:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
+# modules.augeas_cfg.get:path 	The path to get the value of
+# modules.augeas_cfg.get:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
+# modules.augeas_cfg.ls:path 	The path to list
+# modules.augeas_cfg.ls:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
+# modules.augeas_cfg.match:path 	The path to match
+# modules.augeas_cfg.match:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
+# modules.augeas_cfg.remove:path 	The path to remove
+# modules.augeas_cfg.remove:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
+# modules.augeas_cfg.tree:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
 modules.glusterfs.set_quota_volume:path 	Folder path for restriction in volume ("/")
 modules.glusterfs.unset_quota_volume:path 	Folder path for restriction in volume
 modules.htpasswd.useradd:pwfile 	Path to htpasswd file
@@ -274,8 +274,8 @@ modules.htpasswd.userdel:pwfile 	Path to htpasswd file
 modules.htpasswd.verify:pwfile 	Fully qualified path to htpasswd file
 modules.mac_sysctl.persist:config 	The location of the sysctl configuration file.
 modules.slsutil.renderer:path 	The path to a file on the filesystem.
-modules.slsutil.renderer:string 	An inline string to be used as the file to send through the renderer system. Note, not all renderer modules can work with strings
-modules.slsutil.renderer:default_renderer 	The renderer pipe to send the file through
+# modules.slsutil.renderer:string 	An inline string to be used as the file to send through the renderer system. Note, not all renderer modules can work with strings
+# modules.slsutil.renderer:default_renderer 	The renderer pipe to send the file through
 modules.artifactory.get_latest_release:target_dir 	Target directory to download artifact to (default: /tmp)
 modules.artifactory.get_latest_release:target_file 	Target file to download artifact to (by default it is target_dir/artifact_id-version.packaging)
 modules.artifactory.get_latest_snapshot:target_dir 	Target directory to download artifact to (default: /tmp)
@@ -284,17 +284,17 @@ modules.artifactory.get_release:target_dir 	Target directory to download artifac
 modules.artifactory.get_release:target_file 	Target file to download artifact to (by default it is target_dir/artifact_id-version.packaging)
 modules.artifactory.get_snapshot:target_dir 	Target directory to download artifact to (default: /tmp)
 modules.artifactory.get_snapshot:target_file 	Target file to download artifact to (by default it is target_dir/artifact_id-snapshot_version.packaging)
-modules.boto_efs.create_file_system:name 	(string) - The name for the new file system
-modules.boto_efs.create_file_system:performance_mode 	(string) - The PerformanceMode of the file system. Can be eithergeneralPurpose or maxIO
-modules.boto_efs.create_mount_target:filesystemid 	(string) - ID of the file system for which to create the mount target.
-modules.boto_efs.create_tags:filesystemid 	(string) - ID of the file system for whose tags will be modified.
-modules.boto_efs.create_tags:tags 	(dict) - The tags to add to the file system
-modules.boto_efs.delete_file_system:filesystemid 	(string) - ID of the file system to delete.
-modules.boto_efs.delete_tags:filesystemid 	(string) - ID of the file system for whose tags will be removed.
-modules.boto_efs.delete_tags:tags 	(list[string]) - The tag keys to delete to the file system
-modules.boto_efs.get_file_systems:filesystemid 	(string) - ID of the file system to retrieve properties
-modules.boto_efs.get_mount_targets:filesystemid 	(string) - ID of the file system whose mount targets to listMust be specified if mounttargetid is not
-modules.boto_efs.get_tags:filesystemid 	(string) - ID of the file system whose tags to list
+# modules.boto_efs.create_file_system:name 	(string) - The name for the new file system
+# modules.boto_efs.create_file_system:performance_mode 	(string) - The PerformanceMode of the file system. Can be eithergeneralPurpose or maxIO
+# modules.boto_efs.create_mount_target:filesystemid 	(string) - ID of the file system for which to create the mount target.
+# modules.boto_efs.create_tags:filesystemid 	(string) - ID of the file system for whose tags will be modified.
+# modules.boto_efs.create_tags:tags 	(dict) - The tags to add to the file system
+# modules.boto_efs.delete_file_system:filesystemid 	(string) - ID of the file system to delete.
+# modules.boto_efs.delete_tags:filesystemid 	(string) - ID of the file system for whose tags will be removed.
+# modules.boto_efs.delete_tags:tags 	(list[string]) - The tag keys to delete to the file system
+# modules.boto_efs.get_file_systems:filesystemid 	(string) - ID of the file system to retrieve properties
+# modules.boto_efs.get_mount_targets:filesystemid 	(string) - ID of the file system whose mount targets to listMust be specified if mounttargetid is not
+# modules.boto_efs.get_tags:filesystemid 	(string) - ID of the file system whose tags to list
 modules.bower.install:dir 	The target directory in which to install the package
 modules.bower.list_:dir 	The directory whose packages will be listed
 modules.bower.prune:dir 	The directory whose packages will be pruned
@@ -302,7 +302,7 @@ modules.bower.uninstall:dir 	The target directory from which to uninstall the pa
 modules.debbuild.make_repo:repodir 	The directory to find packages that will be in the repository.
 modules.dockercompose.build:path 	Path where the docker-compose file is stored on the server
 modules.dockercompose.create:path 	Path where the docker-compose file will be stored on the server
-modules.dockercompose.create:docker_compose 	docker_compose file
+# modules.dockercompose.create:docker_compose 	docker_compose file
 modules.dockercompose.get:path 	Path where the docker-compose file is stored on the server
 modules.dockercompose.kill:path 	Path where the docker-compose file is stored on the server
 modules.dockercompose.pause:path 	Path where the docker-compose file is stored on the server
@@ -315,13 +315,13 @@ modules.dockercompose.stop:path 	Path where the docker-compose file is stored on
 modules.dockercompose.unpause:path 	Path where the docker-compose file is stored on the server
 modules.dockercompose.up:path 	Path where the docker-compose file is stored on the server
 modules.dpkg.bin_pkg_info:path 	Path to the file. Can either be an absolute path to a file on theminion, or a salt fileserver URL (e.g. ``salt://path/to/file.rpm``).If a salt fileserver URL is passed, the file will be cached to theminion so that it can be examined.
-modules.dracr.set_chassis_location:location 	The name of the location to be set on the chassis.
+# modules.dracr.set_chassis_location:location 	The name of the location to be set on the chassis.
 modules.hashutil.digest_file:infile 	A file path
 modules.ini_manage.set_option:file_name 	path of ini_file
 modules.jenkins.create_job:config_xml 	The configuration file to use to create the job.
-modules.jenkins.create_job:saltenv 	The environment to look for the file in.
+# modules.jenkins.create_job:saltenv 	The environment to look for the file in.
 modules.jenkins.update_job:config_xml 	The configuration file to use to create the job.
-modules.jenkins.update_job:saltenv 	The environment to look for the file in.
+# modules.jenkins.update_job:saltenv 	The environment to look for the file in.
 modules.npm.install:dir 	The target directory in which to install the package, or None forglobal installation
 modules.npm.list_:dir 	The directory whose packages will be listed, or None for globalinstallation
 modules.npm.uninstall:dir 	The target directory from which to uninstall the package, or None forglobal installation
@@ -331,30 +331,30 @@ modules.postgres.datadir_init:name 	The name of the directory to initialize
 modules.rpm.bin_pkg_info:path 	Path to the file. Can either be an absolute path to a file on theminion, or a salt fileserver URL (e.g. ``salt://path/to/file.rpm``).If a salt fileserver URL is passed, the file will be cached to theminion so that it can be examined.
 modules.rpm.diff:path 	Full path to the installed file
 modules.rvm.do:cwd 	The directory from which to run the rvm command. Defaults to the user'shome directory.
-modules.solaris_user.chhome:home 	New home directory to set
+# modules.solaris_user.chhome:home 	New home directory to set
 modules.vbox_guest.additions_umount:mount_point 	directory VirtualBox Guest Additions is mounted to
-modules.vsphere.coredump_network_enable:host 	The location of the host.
+# modules.vsphere.coredump_network_enable:host 	The location of the host.
 modules.vsphere.coredump_network_enable:credstore 	Optionally set to path to the credential store file.
-modules.vsphere.enable_firewall_ruleset:host 	The location of the host.
+# modules.vsphere.enable_firewall_ruleset:host 	The location of the host.
 modules.vsphere.enable_firewall_ruleset:credstore 	Optionally set to path to the credential store file.
-modules.vsphere.esxcli_cmd:host 	The location of the host.
+# modules.vsphere.esxcli_cmd:host 	The location of the host.
 modules.vsphere.esxcli_cmd:credstore 	Optionally set to path to the credential store file.
-modules.vsphere.get_coredump_network_config:host 	The location of the host.
+# modules.vsphere.get_coredump_network_config:host 	The location of the host.
 modules.vsphere.get_coredump_network_config:credstore 	Optionally set to path to the credential store file.
-modules.vsphere.get_firewall_status:host 	The location of the host.
+# modules.vsphere.get_firewall_status:host 	The location of the host.
 modules.vsphere.get_firewall_status:credstore 	Optionally set to path to the credential store file.
-modules.vsphere.get_syslog_config:host 	The location of the host.
+# modules.vsphere.get_syslog_config:host 	The location of the host.
 modules.vsphere.get_syslog_config:credstore 	Optionally set to path to the credential store file.
-modules.vsphere.reset_syslog_config:host 	The location of the host.
+# modules.vsphere.reset_syslog_config:host 	The location of the host.
 modules.vsphere.reset_syslog_config:credstore 	Optionally set to path to the credential store file.
-modules.vsphere.set_coredump_network_config:host 	The location of the host.
+# modules.vsphere.set_coredump_network_config:host 	The location of the host.
 modules.vsphere.set_coredump_network_config:credstore 	Optionally set to path to the credential store file.
 modules.vsphere.set_syslog_config:credstore 	Optionally set to path to the credential store file.
-modules.vsphere.syslog_service_reload:host 	The location of the host.
+# modules.vsphere.syslog_service_reload:host 	The location of the host.
 modules.vsphere.syslog_service_reload:credstore 	Optionally set to path to the credential store file.
-modules.boto_iam.upload_server_cert:cert_name 	The name for the server certificate. Do not include the path in this value.
+# modules.boto_iam.upload_server_cert:cert_name 	The name for the server certificate. Do not include the path in this value.
 modules.boto_iam.upload_server_cert:path 	The path for the server certificate.
-modules.pw_user.chhome:home 	New home directory to set
+# modules.pw_user.chhome:home 	New home directory to set
 modules.tomcat.deploy_war:war 	absolute path to WAR file (should be accessible by the user runningtomcat) or a path supported by the salt.modules.cp.get_file function
 modules.tomcat.deploy_war:context 	the context path to deploy
 modules.tomcat.reload_:app 	the webapp context path
@@ -363,14 +363,14 @@ modules.tomcat.start:app 	the webapp context path
 modules.tomcat.status_webapp:app 	the webapp context path
 modules.tomcat.stop:app 	the webapp context path
 modules.tomcat.undeploy:app 	the webapp context path
-modules.zk_concurrency.lock:path 	The path in zookeeper where the lock is
-modules.zk_concurrency.lock_holders:path 	The path in zookeeper where the lock is
-modules.zk_concurrency.party_members:path 	The path in zookeeper where the lock is
-modules.zk_concurrency.unlock:path 	The path in zookeeper where the lock is
+# modules.zk_concurrency.lock:path 	The path in zookeeper where the lock is
+# modules.zk_concurrency.lock_holders:path 	The path in zookeeper where the lock is
+# modules.zk_concurrency.party_members:path 	The path in zookeeper where the lock is
+# modules.zk_concurrency.unlock:path 	The path in zookeeper where the lock is
 modules.acme.cert:webroot 	True or a full path to use to use webroot. Otherwise use standalone mode
-modules.aptpkg.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
+# modules.aptpkg.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
 modules.aptpkg.install:debconf 	Provide the path to a debconf answers file, processed beforeinstallation.
-modules.aptpkg.install:sources 	A list of DEB packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
+# modules.aptpkg.install:sources 	A list of DEB packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
 modules.archive.cmd_unzip:zip_file 	Path of zip file to be unpacked
 modules.archive.cmd_unzip:dest 	The destination directory into which the file should be unpacked
 modules.archive.cmd_zip:zip_file 	Path of zip file to be created
@@ -382,67 +382,67 @@ modules.archive.unrar:dest 	The destination directory into which to **unpack** t
 modules.archive.unzip:zip_file 	Path of zip file to be unpacked
 modules.archive.unzip:dest 	The destination directory into which the file should be unpacked
 modules.archive.zip_:zip_file 	Path of zip file to be created
-modules.cisconso.get_data:path 	The device path to set the value at, a list of element names in order, / separated
-modules.cisconso.set_data_value:path 	The device path to set the value at, a list of element names in order, / separated
-modules.cisconso.set_data_value:data 	The new value at the given path
+# modules.cisconso.get_data:path 	The device path to set the value at, a list of element names in order, / separated
+# modules.cisconso.set_data_value:path 	The device path to set the value at, a list of element names in order, / separated
+# modules.cisconso.set_data_value:data 	The new value at the given path
 modules.cmdmod.run_chroot:cwd 	The current working directory to execute the command in. defaults to/root
-modules.cp.get_url:path 	A URL to download a file from. Supported URL schemes are: ``salt://``,``http://``, ``https://``, ``ftp://``, ``s3://``, ``swift://`` and``file://`` (local filesystem). If no scheme was specified, this isequivalent of using ``file://``.If a ``file://`` URL is given, the function just returns absolute pathto that file on a local filesystem.The function returns ``False`` if Salt was unable to fetch a file froma ``salt://`` URL.
+# modules.cp.get_url:path 	A URL to download a file from. Supported URL schemes are: ``salt://``,``http://``, ``https://``, ``ftp://``, ``s3://``, ``swift://`` and``file://`` (local filesystem). If no scheme was specified, this isequivalent of using ``file://``.If a ``file://`` URL is given, the function just returns absolute pathto that file on a local filesystem.The function returns ``False`` if Salt was unable to fetch a file froma ``salt://`` URL.
 modules.cp.get_url:dest 	The default behaviour is to write the fetched file to the givendestination path. If this parameter is omitted or set as empty string(``''``), the function places the remote file on the local filesysteminside the Minion cache directory and returns the path to that file.
-modules.cp.push:upload_path 	Provide a different path inside the master's minion files cachedir
-modules.cp.push_dir:upload_path 	Provide a different path and directory name inside the master's minionfiles cachedir
+# modules.cp.push:upload_path 	Provide a different path inside the master's minion files cachedir
+# modules.cp.push_dir:upload_path 	Provide a different path and directory name inside the master's minionfiles cachedir
 modules.dockermod.build:path 	Path to directory on the Minion containing a Dockerfile
-modules.dockermod.build:fileobj 	Allows for a file-like object containing the contents of the Dockerfileto be passed in place of a file ``path`` argument. This argument shouldnot be used from the CLI, only from other Salt code.
-modules.dockermod.build:dockerfile 	Allows for an alternative Dockerfile to be specified.  Path to alternativeDockefile is relative to the build path for the Docker container.
+# modules.dockermod.build:fileobj 	Allows for a file-like object containing the contents of the Dockerfileto be passed in place of a file ``path`` argument. This argument shouldnot be used from the CLI, only from other Salt code.
+# modules.dockermod.build:dockerfile 	Allows for an alternative Dockerfile to be specified.  Path to alternativeDockefile is relative to the build path for the Docker container.
 modules.dockermod.import_:source 	Content to import (URL or absolute path to a tarball).  URL can be afile on the Salt fileserver (i.e.``salt://path/to/rootfs/tarball.tar.xz``. To import a file from asaltenv other than ``base`` (e.g. ``dev``), pass it at the end of theURL (ex. ``salt://path/to/rootfs/tarball.tar.xz?saltenv=dev``).
 modules.dockermod.load:path 	Path to docker tar archive. Path can be a file on the Minion, or theURL of a file on the Salt fileserver (i.e.``salt://path/to/docker/saved/image.tar``). To load a file from asaltenv other than ``base`` (e.g. ``dev``), pass it at the end of theURL (ex. ``salt://path/to/rootfs/tarball.tar.xz?saltenv=dev``).
 modules.dockermod.save:path 	Absolute path on the Minion where the image will be exported
 modules.dockermod.script:source 	Path to the script. Can be a local path on the Minion or a remote filefrom the Salt fileserver.
 modules.dockermod.script_retcode:source 	Path to the script. Can be a local path on the Minion or a remote filefrom the Salt fileserver.
-modules.ebuild.install:sources 	A list of tbz2 packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+# modules.ebuild.install:sources 	A list of tbz2 packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.file.append:path 	path to file
 modules.file.blockreplace:path 	Filesystem path to the file to be edited
-modules.file.blockreplace:backup 	The file extension to use for a backup of the file if any edit is made.Set to ``False`` to skip making a backup.
+# modules.file.blockreplace:backup 	The file extension to use for a backup of the file if any edit is made.Set to ``False`` to skip making a backup.
 modules.file.check_file_meta:name 	Path to file destination
-modules.file.check_file_meta:sfn 	Template-processed source file contents
-modules.file.check_file_meta:source 	URL to file source
-modules.file.check_file_meta:user 	Destination file user owner
-modules.file.check_file_meta:group 	Destination file group owner
-modules.file.check_file_meta:mode 	Destination file permissions mode
+# modules.file.check_file_meta:sfn 	Template-processed source file contents
+# modules.file.check_file_meta:source 	URL to file source
+# modules.file.check_file_meta:user 	Destination file user owner
+# modules.file.check_file_meta:group 	Destination file group owner
+# modules.file.check_file_meta:mode 	Destination file permissions mode
 modules.file.check_hash:path 	Path to a file local to the minion.
 modules.file.chgrp:path 	path to the file or directory
 modules.file.chown:path 	path to the file or directory
 modules.file.comment:path 	The full path to the file to be edited
 modules.file.comment_line:path 	string The full path to the text file.
-modules.file.comment_line:char 	string The character used to comment a line in the type of file you
-modules.file.comment_line:backup 	string The file extension to give the backup file. Default is
+# modules.file.comment_line:char 	string The character used to comment a line in the type of file you
+# modules.file.comment_line:backup 	string The file extension to give the backup file. Default is
 modules.file.delete_backup:path 	The path on the minion to check for backups
 modules.file.get_gid:path 	file or directory of which to get the gid
 modules.file.get_group:path 	file or directory of which to get the group
 modules.file.get_hash:path 	path to the file or directory
 modules.file.get_managed:name 	location where the file lives on the server
-modules.file.get_managed:source 	managed source file
-modules.file.get_managed:source_hash 	hash of the source file
-modules.file.get_managed:user 	Owner of file
-modules.file.get_managed:group 	Group owner of file
-modules.file.get_managed:mode 	Permissions of file
+# modules.file.get_managed:source 	managed source file
+# modules.file.get_managed:source_hash 	hash of the source file
+# modules.file.get_managed:user 	Owner of file
+# modules.file.get_managed:group 	Group owner of file
+# modules.file.get_managed:mode 	Permissions of file
 modules.file.get_mode:path 	file or directory of which to get the mode
 modules.file.get_source_sum:file_name 	Optional file name being managed, for matching with:py:func:`file.extract_hash <salt.modules.file.extract_hash>`.
-modules.file.get_source_sum:source 	Source file, as used in :py:mod:`file <salt.states.file>` and otherstates. If ``source_hash`` refers to a file containing hashes, thenthis filename will be used to match a filename in that file. If the``source_hash`` is a hash expression, then this argument will beignored.
-modules.file.get_source_sum:source_hash 	Hash file/expression, as used in :py:mod:`file <salt.states.file>` andother states. If this value refers to a remote URL or absolute path toa local file, it will be cached and :py:func:`file.extract_hash<salt.modules.file.extract_hash>` will be used to obtain a hash fromit.
-modules.file.get_source_sum:source_hash_name 	Specific file name to look for when ``source_hash`` refers to a remotefile, used to disambiguate ambiguous matches.
+# modules.file.get_source_sum:source 	Source file, as used in :py:mod:`file <salt.states.file>` and otherstates. If ``source_hash`` refers to a file containing hashes, thenthis filename will be used to match a filename in that file. If the``source_hash`` is a hash expression, then this argument will beignored.
+# modules.file.get_source_sum:source_hash 	Hash file/expression, as used in :py:mod:`file <salt.states.file>` andother states. If this value refers to a remote URL or absolute path toa local file, it will be cached and :py:func:`file.extract_hash<salt.modules.file.extract_hash>` will be used to obtain a hash fromit.
+# modules.file.get_source_sum:source_hash_name 	Specific file name to look for when ``source_hash`` refers to a remotefile, used to disambiguate ambiguous matches.
 modules.file.get_sum:path 	path to the file or directory
 modules.file.get_uid:path 	file or directory of which to get the uid
 modules.file.get_user:path 	file or directory of which to get the user
 modules.file.grep:path 	Path to the file to be searched
 modules.file.lchown:path 	path to the file or directory
 modules.file.line:path 	Filesystem path to the file to be edited.
-modules.file.line:location 	Defines where to place content in the line. Note this option is onlyused when ``mode=insert`` is specified. If a location is passed in, ittakes precedence over both the ``before`` and ``after`` kwargs. Validlocations are:
+# modules.file.line:location 	Defines where to place content in the line. Note this option is onlyused when ``mode=insert`` is specified. If a location is passed in, ittakes precedence over both the ``before`` and ``after`` kwargs. Validlocations are:
 modules.file.list_backup:path 	The path on the minion to check for backups
 modules.file.list_backups:path 	The path on the minion to check for backups
 modules.file.list_backups_dir:path 	The directory on the minion to check for backups
 modules.file.manage_file:name 	location to place the file
 modules.file.manage_file:sfn 	location of cached file on the minion
-modules.file.manage_file:source 	file reference on the master
+# modules.file.manage_file:source 	file reference on the master
 modules.file.patch:originalfile 	The full path to the file or directory to be patched
 modules.file.patch:patchfile 	A patch file to apply to ``originalfile``
 modules.file.prepend:path 	path to file
@@ -452,27 +452,27 @@ modules.file.replace:path 	Filesystem path to the file to be edited. If a symlin
 modules.file.restore_backup:path 	The path on the minion to check for backups
 modules.file.sed:path 	The full path to the file to be edited
 modules.file.seek_read:path 	path to file
-modules.file.seek_read:offset 	offset to start into the file
+# modules.file.seek_read:offset 	offset to start into the file
 modules.file.seek_write:path 	path to file
-modules.file.seek_write:data 	data to write to file
-modules.file.seek_write:offset 	position in file to start writing
+# modules.file.seek_write:data 	data to write to file
+# modules.file.seek_write:offset 	position in file to start writing
 modules.file.set_mode:path 	file or directory of which to set the mode
-modules.file.set_mode:mode 	mode to set the path to
+# modules.file.set_mode:mode 	mode to set the path to
 modules.file.truncate:path 	path to file
-modules.file.truncate:length 	offset into file to truncate
+# modules.file.truncate:length 	offset into file to truncate
 modules.file.uncomment:path 	The full path to the file to be edited
 modules.file.write:path 	path to file
-modules.freebsdpkg.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+# modules.freebsdpkg.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.git.add:cwd 	The path to the git checkout
-modules.git.add:filename 	The location of the file/directory to add, relative to ``cwd``
+# modules.git.add:filename 	The location of the file/directory to add, relative to ``cwd``
 modules.git.archive:cwd 	The path to be archived
 modules.git.archive:output 	The path of the archive to be created
-modules.git.archive:prefix 	Prepend ``<prefix>`` to every filename in the archive. If unspecified,the name of the directory at the top level of the repository will beused as the prefix (e.g. if ``cwd`` is set to ``/foo/bar/baz``, theprefix will be ``baz``, and the resulting archive will contain atop-level directory by that name).
+# modules.git.archive:prefix 	Prepend ``<prefix>`` to every filename in the archive. If unspecified,the name of the directory at the top level of the repository will beused as the prefix (e.g. if ``cwd`` is set to ``/foo/bar/baz``, theprefix will be ``baz``, and the resulting archive will contain atop-level directory by that name).
 modules.git.branch:cwd 	The path to the git checkout
 modules.git.checkout:cwd 	The path to the git checkout
-modules.git.clone:name 	Optional alternate name for the top-level directory to be created bythe clone
+# modules.git.clone:name 	Optional alternate name for the top-level directory to be created bythe clone
 modules.git.commit:cwd 	The path to the git checkout
-modules.git.commit:filename 	The location of the file/directory to commit, relative to ``cwd``.This argument is optional, and can be used to commit a file withoutfirst staging it.
+# modules.git.commit:filename 	The location of the file/directory to commit, relative to ``cwd``.This argument is optional, and can be used to commit a file withoutfirst staging it.
 modules.git.config_get:cwd 	The path to the git checkout
 modules.git.config_get_regex:cwd 	The path to the git checkout
 modules.git.config_get_regexp:cwd 	The path to the git checkout
@@ -508,7 +508,7 @@ modules.git.submodule:cwd 	The path to the submodule
 modules.git.symbolic_ref:cwd 	The path to the git checkout
 modules.git.worktree_add:cwd 	The path to the git checkout
 modules.git.worktree_prune:cwd 	The path to the main git checkout or a linked worktree
-modules.git.worktree_rm:user 	Used for path expansion when ``cwd`` is not an absolute path. Bydefault, when ``cwd`` is not absolute, the path will be assumed to berelative to the home directory of the user under which the minion isrunning. Setting this option will change the home directory from whichpath expansion is performed.
+# modules.git.worktree_rm:user 	Used for path expansion when ``cwd`` is not an absolute path. Bydefault, when ``cwd`` is not absolute, the path will be assumed to berelative to the home directory of the user under which the minion isrunning. Setting this option will change the home directory from whichpath expansion is performed.
 modules.gpg.decrypt:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
 modules.gpg.decrypt:gnupghome 	Specify the location where GPG keyring and related files are stored.
 modules.gpg.delete_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -184,6 +184,34 @@ states.zcbuildout.installed:name 	directory to execute in
 # states.zookeeper.absent:name 	path to znode
 # states.zookeeper.acls:name 	path to znode
 # states.zookeeper.present:name 	path to znode
+states.kapacitor.task_present:tick_script 	Path to the TICK script for the task. Can be a salt:// source.
+# states.boto_rds.present:domain 	The identifier of the Active Directory Domain.
+# states.boto_rds.present:domain_iam_role_name 	Specify the name of the IAM role to be used when making API calls tothe Directory Service.
+states.heat.deployed:template 	File of template
+states.heat.deployed:enviroment 	File of enviroment
+states.virtualenv_mod.manage:name 	Path to the virtualenv.
+states.virtualenv_mod.managed:name 	Path to the virtualenv.
+states.composer.installed:composer 	Location of the composer.phar file. If not set composer willjust execute "composer" as if it is installed globally.(i.e. /path/to/composer.phar)
+states.composer.installed:php 	Location of the php executable to use with composer.(i.e. /usr/bin/php)
+states.composer.update:composer 	Location of the composer.phar file. If not set composer willjust execute "composer" as if it is installed globally.(i.e. /path/to/composer.phar)
+states.composer.update:php 	Location of the php executable to use with composer.(i.e. /usr/bin/php)
+states.dellchassis.firmware_update:directory 	Directory name where firmwarefilewill be downloaded
+states.archive.extracted:name 	Directory into which the archive should be extracted
+states.artifactory.downloaded:target_dir 	Directory where the artifact should be downloaded. By default it is downloaded to /tmp directory.
+states.docker_image.present:build 	Path to directory on the Minion containing a Dockerfile
+states.docker_image.present:dockerfile 	Allows for an alternative Dockerfile to be specified.  Path to alternativeDockefile is relative to the build path for the Docker container.
+states.esxi.ssh_configured:ssh_key_file 	File containing the public SSH key to be added to the authorized_keys file onthe ESXi host. You can use ``ssh_key_file`` or ``ssh_key``, but not both.
+# states.file.append:source 	A single source file to append. This source file can be hosted on eitherthe salt master server, or on an HTTP or FTP server. Both HTTPS andHTTP are supported as well as downloading directly from Amazon S3compatible URLs with both pre-configured and automatic IAM credentials(see s3.get state documentation). File retrieval from Openstack Swiftobject storage is supported via swift://container/object_path URLs(see swift.get documentation).
+states.file.decode:name 	Path of the file to be written.
+states.file.shortcut:icon_location 	Location of shortcut's icon
+states.git.config_set:repo 	Location of the git repository for which the config value should beset. Required unless ``global`` is set to ``True``.
+states.git.config_unset:repo 	Location of the git repository for which the config value should beset. Required unless ``global`` is set to ``True``.
+states.git.latest:identity 	Path to a private key to use for ssh URLs. This can be either a singlestring, or a list of strings. For example:
+states.git.present:name 	Path to the directory
+states.htpasswd.user_absent:htpasswd_file 	Path to the htpasswd file
+states.htpasswd.user_exists:htpasswd_file 	Path to the htpasswd file
+states.pip_state.installed:requirements 	Path to a pip requirements file. If the path begins with salt://the file will be transferred from the master file server.
+states.selinux.module_install:name 	Path to file with module to install
 modules.chef.client:logfile 	Set the log file location
 modules.chef.solo:logfile 	Set the log file location
 modules.composer.did_composer_install:dir 	Directory location of the composer.json file
@@ -695,3 +723,82 @@ modules.zabbix.mediatype_create:gsm_modem 	exec path
 modules.zypper.diff:path 	Full path to the installed file
 # modules.zypper.install:name 	The name of the package to be installed. Note that this parameter isignored if either ``pkgs`` or ``sources`` is passed. Additionally,please note that this option can only be used to install packages froma software repository. To install a package file manually, use the``sources`` option.
 # modules.zypper.install:sources 	A list of RPM packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.apache.config:name 	File for the virtual host
+modules.composer.did_composer_install:dir 	Directory location of the composer.json file
+modules.composer.install:directory 	Directory location of the composer.json file.
+modules.composer.install:composer 	Location of the composer.phar file. If not set composer willjust execute "composer" as if it is installed globally.(i.e. /path/to/composer.phar)
+modules.composer.install:php 	Location of the php executable to use with composer.(i.e. /usr/bin/php)
+modules.composer.selfupdate:composer 	Location of the composer.phar file. If not set composer willjust execute "composer" as if it is installed globally.(i.e. /path/to/composer.phar)
+modules.composer.selfupdate:php 	Location of the php executable to use with composer.(i.e. /usr/bin/php)
+modules.composer.update:directory 	Directory location of the composer.json file.
+modules.composer.update:composer 	Location of the composer.phar file. If not set composer willjust execute "composer" as if it is installed globally.(i.e. /path/to/composer.phar)
+modules.composer.update:php 	Location of the php executable to use with composer.(i.e. /usr/bin/php)
+modules.gentoolkitmod.eclean_dist:exclude_file 	Path to exclusion file. Default is /etc/eclean/distfiles.excludeThis is the same default eclean-dist uses. Use None if this fileexists and you want to ignore.
+modules.gentoolkitmod.eclean_pkg:exclude_file 	Path to exclusion file. Default is /etc/eclean/packages.excludeThis is the same default eclean-pkg uses. Use None if this fileexists and you want to ignore.
+modules.kapacitor.define_task:tick_script 	Path to the TICK script for the task. Can be a salt:// source.
+modules.htpasswd.useradd:pwfile 	Path to htpasswd file
+modules.htpasswd.userdel:pwfile 	Path to htpasswd file
+modules.dockercompose.build:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.create:path 	Path where the docker-compose file will be stored on the server
+modules.dockercompose.get:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.kill:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.pause:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.ps:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.pull:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.restart:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.rm:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.start:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.stop:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.unpause:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.up:path 	Path where the docker-compose file is stored on the server
+modules.dpkg.bin_pkg_info:path 	Path to the file. Can either be an absolute path to a file on theminion, or a salt fileserver URL (e.g. ``salt://path/to/file.rpm``).If a salt fileserver URL is passed, the file will be cached to theminion so that it can be examined.
+modules.heat.create_stack:template_file 	File of template
+modules.heat.create_stack:enviroment 	File of enviroment
+modules.heat.update_stack:template_file 	File of template
+modules.heat.update_stack:enviroment 	File of enviroment
+modules.namecheap_ssl.parse_csr:csr_file 	string  Certificate Signing Request File
+modules.napalm_snmp.remove_config:location 	Location
+modules.napalm_snmp.update_config:location 	Location
+modules.rpm.bin_pkg_info:path 	Path to the file. Can either be an absolute path to a file on theminion, or a salt fileserver URL (e.g. ``salt://path/to/file.rpm``).If a salt fileserver URL is passed, the file will be cached to theminion so that it can be examined.
+modules.archive.cmd_unzip:zip_file 	Path of zip file to be unpacked
+modules.archive.cmd_zip:zip_file 	Path of zip file to be created
+modules.archive.rar:rarfile 	Path of rar file to be created
+modules.archive.unzip:zip_file 	Path of zip file to be unpacked
+modules.archive.zip_:zip_file 	Path of zip file to be created
+modules.cmdmod.run_chroot:root 	Path to the root of the jail to use.
+modules.dockermod.build:path 	Path to directory on the Minion containing a Dockerfile
+modules.dockermod.build:dockerfile 	Allows for an alternative Dockerfile to be specified.  Path to alternativeDockefile is relative to the build path for the Docker container.
+modules.dockermod.load:path 	Path to docker tar archive. Path can be a file on the Minion, or theURL of a file on the Salt fileserver (i.e.``salt://path/to/docker/saved/image.tar``). To load a file from asaltenv other than ``base`` (e.g. ``dev``), pass it at the end of theURL (ex. ``salt://path/to/rootfs/tarball.tar.xz?saltenv=dev``).
+modules.dockermod.script:source 	Path to the script. Can be a local path on the Minion or a remote filefrom the Salt fileserver.
+modules.dockermod.script_retcode:source 	Path to the script. Can be a local path on the Minion or a remote filefrom the Salt fileserver.
+modules.file.check_file_meta:name 	Path to file destination
+# modules.file.check_file_meta:source_sum 	File checksum information as a dictionary
+# modules.file.check_file_meta:contents 	File contents
+modules.file.check_hash:path 	Path to a file local to the minion.
+modules.file.grep:path 	Path to the file to be searched
+modules.git.clone:cwd 	Location of git clone
+modules.git.clone:identity 	Path to a private key to use for ssh URLs
+modules.git.diff:paths 	File paths to pass to the ``git diff`` command. Can be passed as acomma-separated list or a Python list.
+modules.git.fetch:identity 	Path to a private key to use for ssh URLs
+modules.git.ls_remote:identity 	Path to a private key to use for ssh URLs
+modules.git.pull:identity 	Path to a private key to use for ssh URLs
+modules.git.push:identity 	Path to a private key to use for ssh URLs
+modules.git.remote_refs:identity 	Path to a private key to use for ssh URLs
+modules.git.submodule:identity 	Path to a private key to use for ssh URLs
+modules.git.worktree_add:worktree_path 	Path to the new worktree. Can be either absolute, or relative to``cwd``.
+modules.git.worktree_rm:cwd 	Path to the worktree to be removed
+modules.libcloud_storage.upload_object:file_path 	Path to the object on disk.
+modules.lxc.copy_to:source 	File to be copied to the container
+modules.lxc.cp:source 	File to be copied to the container
+modules.pip.install:requirements 	Path to requirements
+modules.pip.install:bin_env 	Path to pip bin or path to virtualenv. If doing a system install,and want to use a specific pip bin (pip-2.7, pip-2.6, etc..) justspecify the pip bin you want.
+modules.snapper.create_config:subvolume 	Path to the related subvolume.
+modules.tls.revoke_cert:cert_path 	Path to the cert file.
+modules.virtualenv_mod.get_distribution_path:venv 	Path to the virtualenv.
+modules.virtualenv_mod.get_resource_content:venv 	Path to the virtualenv
+modules.virtualenv_mod.get_resource_path:venv 	Path to the virtualenv
+modules.virtualenv_mod.get_site_packages:venv 	Path to the virtualenv.
+modules.win_file.check_file_meta:name 	Path to file destination
+# modules.win_file.check_file_meta:source_sum 	File checksum information as a dictionary
+modules.win_file.check_file_meta:contents 	File contents
+modules.win_file.check_hash:path 	Path to a file local to the minion.

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -212,8 +212,8 @@ states.htpasswd.user_absent:htpasswd_file 	Path to the htpasswd file
 states.htpasswd.user_exists:htpasswd_file 	Path to the htpasswd file
 states.pip_state.installed:requirements 	Path to a pip requirements file. If the path begins with salt://the file will be transferred from the master file server.
 states.selinux.module_install:name 	Path to file with module to install
-modules.chef.client:logfile 	Set the log file location
-modules.chef.solo:logfile 	Set the log file location
+# modules.chef.client:logfile 	Set the log file location
+# modules.chef.solo:logfile 	Set the log file location
 modules.composer.did_composer_install:dir 	Directory location of the composer.json file
 modules.composer.install:directory 	Directory location of the composer.json file.
 modules.composer.update:directory 	Directory location of the composer.json file.
@@ -226,9 +226,9 @@ modules.genesis.bootstrap:pkg_cache 	This points to a directory containing a cac
 modules.gentoolkitmod.revdep_rebuild:lib 	Search for reverse dependencies for a particular library ratherthan every library on the system. It can be a full path to alibrary or basic regular expression.
 # modules.jboss7.deploy:source_file 	Source file to deploy from
 modules.mac_keychain.set_default_keychain:keychain 	The location of the keychain to set as default
-modules.openstack_config.delete:filename 	The full path to the configuration file
-modules.openstack_config.get:filename 	The full path to the configuration file
-modules.openstack_config.set_:filename 	The full path to the configuration file
+# modules.openstack_config.delete:filename 	The full path to the configuration file
+# modules.openstack_config.get:filename 	The full path to the configuration file
+# modules.openstack_config.set_:filename 	The full path to the configuration file
 modules.pcs.cib_create:cibfile 	name/path of the file containing the CIB
 modules.pcs.cib_push:cibfile 	name/path of the file containing the CIB
 modules.pcs.config_show:cibfile 	name/path of the file containing the CIB
@@ -357,7 +357,7 @@ modules.pillar.file_exists:path 	The path to the file in question. Will be treat
 modules.postgres.datadir_exists:name 	Name of the directory to check
 modules.postgres.datadir_init:name 	The name of the directory to initialize
 modules.rpm.bin_pkg_info:path 	Path to the file. Can either be an absolute path to a file on theminion, or a salt fileserver URL (e.g. ``salt://path/to/file.rpm``).If a salt fileserver URL is passed, the file will be cached to theminion so that it can be examined.
-modules.rpm.diff:path 	Full path to the installed file
+# modules.rpm.diff:path 	Full path to the installed file
 modules.rvm.do:cwd 	The directory from which to run the rvm command. Defaults to the user'shome directory.
 # modules.solaris_user.chhome:home 	New home directory to set
 modules.vbox_guest.additions_umount:mount_point 	directory VirtualBox Guest Additions is mounted to
@@ -399,17 +399,17 @@ modules.acme.cert:webroot 	True or a full path to use to use webroot. Otherwise 
 # modules.aptpkg.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
 modules.aptpkg.install:debconf 	Provide the path to a debconf answers file, processed beforeinstallation.
 modules.aptpkg.install:sources 	A list of DEB packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
-modules.archive.cmd_unzip:zip_file 	Path of zip file to be unpacked
-modules.archive.cmd_unzip:dest 	The destination directory into which the file should be unpacked
-modules.archive.cmd_zip:zip_file 	Path of zip file to be created
+# modules.archive.cmd_unzip:zip_file 	Path of zip file to be unpacked
+# modules.archive.cmd_unzip:dest 	The destination directory into which the file should be unpacked
+# modules.archive.cmd_zip:zip_file 	Path of zip file to be created
 modules.archive.is_encrypted:name 	The path / URL of the archive to check.
-modules.archive.rar:rarfile 	Path of rar file to be created
-modules.archive.tar:dest 	The destination directory into which to **unpack** the tarfile
-modules.archive.unrar:rarfile 	Name of rar file to be unpacked
-modules.archive.unrar:dest 	The destination directory into which to **unpack** the rar file
-modules.archive.unzip:zip_file 	Path of zip file to be unpacked
-modules.archive.unzip:dest 	The destination directory into which the file should be unpacked
-modules.archive.zip_:zip_file 	Path of zip file to be created
+# modules.archive.rar:rarfile 	Path of rar file to be created
+# modules.archive.tar:dest 	The destination directory into which to **unpack** the tarfile
+# modules.archive.unrar:rarfile 	Name of rar file to be unpacked
+# modules.archive.unrar:dest 	The destination directory into which to **unpack** the rar file
+# modules.archive.unzip:zip_file 	Path of zip file to be unpacked
+# modules.archive.unzip:dest 	The destination directory into which the file should be unpacked
+# modules.archive.zip_:zip_file 	Path of zip file to be created
 # modules.cisconso.get_data:path 	The device path to set the value at, a list of element names in order, / separated
 # modules.cisconso.set_data_value:path 	The device path to set the value at, a list of element names in order, / separated
 # modules.cisconso.set_data_value:data 	The new value at the given path
@@ -630,7 +630,7 @@ modules.rsync.rsync:src 	The source location where files will be rsynced from.
 modules.rsync.rsync:dst 	The destination location where files will be rsynced to.
 modules.rsync.rsync:passwordfile 	A file that contains a password for accessing anrsync daemon.  The file should contain just thepassword.
 modules.runit.add_svc_avail_path:path 	directory to add to AVAIL_SVR_DIRS
-modules.ssh.hash_known_hosts:config 	path to known hosts file: can be absolute or relative to user's homedirectory
+# modules.ssh.hash_known_hosts:config 	path to known hosts file: can be absolute or relative to user's homedirectory
 # modules.ssh.set_known_host:user 	The user who owns the ssh authorized keys file to modify
 # modules.ssh.set_known_host:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/known_hosts". If no user is specified,defaults to "/etc/ssh/ssh_known_hosts". If present, must be anabsolute path when a user is not specified.
 # modules.state.event:sock_dir 	path to the Salt master
@@ -760,11 +760,11 @@ modules.namecheap_ssl.parse_csr:csr_file 	string  Certificate Signing Request Fi
 modules.napalm_snmp.remove_config:location 	Location
 modules.napalm_snmp.update_config:location 	Location
 modules.rpm.bin_pkg_info:path 	Path to the file. Can either be an absolute path to a file on theminion, or a salt fileserver URL (e.g. ``salt://path/to/file.rpm``).If a salt fileserver URL is passed, the file will be cached to theminion so that it can be examined.
-modules.archive.cmd_unzip:zip_file 	Path of zip file to be unpacked
-modules.archive.cmd_zip:zip_file 	Path of zip file to be created
-modules.archive.rar:rarfile 	Path of rar file to be created
-modules.archive.unzip:zip_file 	Path of zip file to be unpacked
-modules.archive.zip_:zip_file 	Path of zip file to be created
+# modules.archive.cmd_unzip:zip_file 	Path of zip file to be unpacked
+# modules.archive.cmd_zip:zip_file 	Path of zip file to be created
+# modules.archive.rar:rarfile 	Path of rar file to be created
+# modules.archive.unzip:zip_file 	Path of zip file to be unpacked
+# modules.archive.zip_:zip_file 	Path of zip file to be created
 modules.cmdmod.run_chroot:root 	Path to the root of the jail to use.
 modules.dockermod.build:path 	Path to directory on the Minion containing a Dockerfile
 modules.dockermod.build:dockerfile 	Allows for an alternative Dockerfile to be specified.  Path to alternativeDockefile is relative to the build path for the Docker container.

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,0 +1,697 @@
+states.virt.keys:basepath 	Defaults to ``/etc/pki``, this is the root location used for libvirtkeys on the hypervisor
+states.libcloud_storage.file_present:path 	Local path to file
+states.libcloud_storage.object_present:path 	Local path to file
+states.acme.cert:webroot 	True or a full path to webroot. Otherwise use standalone mode
+states.boto3_route53.rr_present:GeoLocation 	Geo location resource record sets only.  A dict that lets you control how Route 53 respondsto DNS queries based on the geographic origin of the query.  For example, if you want allqueries from Africa to be routed to a web server with an IP address of 192.0.2.111, create aresource record set with a Type of A and a ContinentCode of AF.
+states.boto_asg.present:placement_group 	Physical location of your cluster placement group created in AmazonEC2. Once set this can not be updated (Amazon restriction).
+states.cisconso.value_present:path 	The device path to set the value at, a list of element names in order, / separated
+states.cisconso.value_present:config 	The new value at the given path
+states.dellchassis.chassis:location 	The location of the chassis.
+states.sysctl.present:config 	The location of the sysctl configuration file. If not specified, theproper location will be detected based on platform.
+states.alternatives.install:path 	is the location of the new alternative target.NB: This file / directory must already exist.(e.g. /usr/bin/less)
+states.alternatives.remove:path 	is the location of one of the alternative target files.(e.g. /usr/bin/less)
+states.alternatives.set_:path 	is the location of one of the alternative target files.(e.g. /usr/bin/less)
+states.archive.extracted:source_hash 	Hash of source file, or file with list of hash-to-file mappings
+states.archive.extracted:source_hash_name 	When ``source_hash`` refers to a hash file, Salt will try to find thecorrect hash by matching the filename part of the ``source`` URI. Whenmanaging a file with a ``source`` of ``salt://files/foo.tar.gz``, thenthe following line in a hash file would match:
+states.archive.extracted:list_options 	**For tar archives only.** This state uses :py:func:`archive.list<salt.modules.archive.list_>` to discover the contents of the sourcearchive so that it knows which file paths should exist on the minion ifthe archive has already been extracted. For the vast majority of tararchives, :py:func:`archive.list <salt.modules.archive.list_>` "justworks". Archives compressed using gzip, bzip2, and xz/lzma (with thehelp of the xz_ CLI command) are supported automatically. However, forarchives compressed using other compression types, CLI options must bepassed to :py:func:`archive.list <salt.modules.archive.list_>`.
+states.archive.extracted:if_missing 	If specified, this path will be checked, and if it exists then thearchive will not be extracted. This path can be either a directory or afile, so this option can also be used to check for a semaphore file andconditionally skip extraction.
+states.archive.extracted:enforce_ownership_on 	When ``user`` or ``group`` is specified, Salt will default to enforcingpermissions on the file/directory paths detected by running:py:func:`archive.list <salt.modules.archive.list_>` on the sourcearchive. Use this argument to specify an alternate directory on whichownership should be enforced.
+states.artifactory.downloaded:target_file 	Target file to download artifact to. By default file name is resolved by artifactory.
+states.augeas.change:context 	A file path, prefixed by ``/files``. Should resolve to an actual file(not an arbitrary augeas path). This is used to avoid duplicating thefile name for each item in the changes list (for example, ``set bind 0.0.0.0``in the example below operates on the file specified by ``context``). If``context`` is not specified, a file path prefixed by ``/files`` should beincluded with the ``set`` command.
+states.augeas.change:load_path 	A list of directories that modules should be searched in. This is inaddition to the standard load path and the directories inAUGEAS_LENS_LIB.
+states.boto_apigateway.absent:name 	Name of the swagger file in YAML format
+states.boto_apigateway.absent:stage_name 	Name of the stage to be removed irrespective of the swagger file content.If the current deployment associated with the stage_name has no other stages associatedwith it, the deployment will also be removed.
+states.boto_apigateway.present:swagger_file 	Name of the location of the swagger rest api definition file in YAML format.
+states.boto_cloudtrail.present:S3KeyPrefix 	Specifies the Amazon S3 key prefix that comes after the name of thebucket you have designated for log file delivery.
+states.boto_cloudtrail.present:SnsTopicName 	Specifies the name of the Amazon SNS topic defined for notification oflog file delivery. The maximum length is 256 characters.
+states.boto_iam_role.present:path 	The path to the role/instance profile. (See https://boto.readthedocs.io/en/latest/ref/iam.html#boto.iam.connection.IAMConnection.create_role)
+states.boto_lambda.function_present:ZipFile 	A path to a .zip file containing your deployment package. If this isspecified, S3Bucket and S3Key must not be specified.
+states.boto_lambda.function_present:S3Bucket 	Amazon S3 bucket name where the .zip file containing your package isstored. If this is specified, S3Key must be specified and ZipFile mustNOT be specified.
+states.bower.installed:dir 	The target directory in which to install the package
+states.bower.removed:dir 	The target directory in which to install the package
+states.cmd.run:cwd 	The current working directory to execute the command in, defaults to/root
+states.cmd.run:creates 	Only run if the file or files specified by ``creates`` do not exist.
+states.cmd.script:source 	The location of the script to download. If the file is located on themaster in the directory named spam, and is called eggs, the sourcestring is salt://spam/eggs
+states.cmd.script:cwd 	The current working directory to execute the command in, defaults to/root
+states.cmd.script:creates 	Only run if the file or files specified by ``creates`` do not exist.
+states.cmd.wait:cwd 	The current working directory to execute the command in, defaults to/root
+states.cmd.wait:creates 	Only run if the file or files specified by ``creates`` do not exist.
+states.cmd.wait_script:source 	The source script being downloaded to the minion, this source script ishosted on the salt master server.  If the file is located on the masterin the directory named spam, and is called eggs, the source string issalt://spam/eggs
+states.cmd.wait_script:cwd 	The current working directory to execute the command in, defaults to/root
+states.cmd.watch:cwd 	The current working directory to execute the command in, defaults to/root
+states.cmd.watch:creates 	Only run if the file or files specified by ``creates`` do not exist.
+states.cron.file:name 	The source file to be used as the crontab. This source file can behosted on either the salt master server, or on an HTTP or FTP server.For files hosted on the salt file server, if the file is located onthe master in the directory named spam, and is called eggs, the sourcestring is ``salt://spam/eggs``
+states.cron.file:source_hash 	This can be either a file which contains a source hash string forthe source, or a source hash string. The source hash string is thehash algorithm followed by the hash of the file:``md5=e138491e9d5b97023cea823fe17bac22``
+states.cron.file:source_hash_name 	When ``source_hash`` refers to a hash file, Salt will try to find thecorrect hash by matching the filename/URI associated with that hash. Bydefault, Salt will look for the filename being managed. When managing afile at path ``/tmp/foo.txt``, then the following line in a hash filewould match:
+states.cryptdev.mapped:keyfile 	Either ``None`` if the password is to be entered manually on boot, oran absolute path to a keyfile. If the password is to be askedinteractively, the mapping cannot be performed with ``immediate=True``.
+states.cryptdev.mapped:config 	Set an alternative location for the crypttab, if the map is persistent,Default is ``/etc/crypttab``
+states.cryptdev.unmapped:config 	Set an alternative location for the crypttab, if the map is persistent,Default is ``/etc/crypttab``
+states.docker_image.present:build 	Path to directory on the Minion containing a Dockerfile
+states.docker_image.present:dockerfile 	Allows for an alternative Dockerfile to be specified.  Path to alternativeDockefile is relative to the build path for the Docker container.
+states.esxi.ssh_configured:ssh_key 	Public SSH key to added to the authorized_keys file on the ESXi host. You canuse ``ssh_key`` or ``ssh_key_file``, but not both.
+states.esxi.ssh_configured:ssh_key_file 	File containing the public SSH key to be added to the authorized_keys file onthe ESXi host. You can use ``ssh_key_file`` or ``ssh_key``, but not both.
+states.file.absent:name 	The path which should be deleted
+states.file.append:name 	The location of the file to append to.
+states.file.append:source 	A single source file to append. This source file can be hosted on eitherthe salt master server, or on an HTTP or FTP server. Both HTTPS andHTTP are supported as well as downloading directly from Amazon S3compatible URLs with both pre-configured and automatic IAM credentials(see s3.get state documentation). File retrieval from Openstack Swiftobject storage is supported via swift://container/object_path URLs(see swift.get documentation).
+states.file.append:source_hash 	This can be one of the following:1. a source hash string2. the URI of a file that contains source hash strings
+states.file.blockreplace:name 	Filesystem path to the file to be edited
+states.file.blockreplace:source 	The source file to download to the minion, this source file can behosted on either the salt master server, or on an HTTP or FTP server.Both HTTPS and HTTP are supported as well as downloading directlyfrom Amazon S3 compatible URLs with both pre-configured and automaticIAM credentials. (see s3.get state documentation)File retrieval from Openstack Swift object storage is supported viaswift://container/object_path URLs, see swift.get documentation.For files hosted on the salt file server, if the file is located onthe master in the directory named spam, and is called eggs, the sourcestring is salt://spam/eggs. If source is left blank or None(use ~ in YAML), the file will be created as an empty file andthe content will not be managed. This is also the case when a filealready exists and the source is undefined; the contents of the filewill not be changed or managed.
+states.file.blockreplace:source_hash 	This can be one of the following:1. a source hash string2. the URI of a file that contains source hash strings
+states.file.blockreplace:backup 	The file extension to use for a backup of the file if any edit is made.Set this to ``False`` to skip making a backup.
+states.file.comment:name 	The full path to the file to be edited
+states.file.copy:name 	The location of the file to copy to
+states.file.copy:source 	The location of the file to copy to the location specified with name
+states.file.decode:name 	Path of the file to be written.
+states.file.decode:contents_pillar 	A Pillar path to the encoded file. Uses the same path syntax as:py:func:`pillar.get <salt.modules.pillar.get>`. The:py:func:`hashutil.base64_encodefile<salt.modules.hashutil.base64_encodefile>` function can load encodedcontent into Pillar. Either this option or ``encoded_data`` must bespecified.
+states.file.directory:name 	The location to create or manage a directory
+states.file.directory:recurse 	Enforce user/group ownership and mode of directory recursively. Acceptsa list of strings representing what you would like to recurse.  If``mode`` is defined, will recurse on both ``file_mode`` and ``dir_mode`` ifthey are defined.  If ``ignore_files`` or ``ignore_dirs`` is included, files ordirectories will be left unchanged respectively.Example:
+states.file.directory:backupname 	If the name of the directory exists and is not a directory, it will berenamed to the backupname. If the backupname alreadyexists and force is False, the state will fail. Otherwise, thebackupname will be removed first.
+states.file.exists:name 	Absolute path which must exist
+states.file.line:name 	Filesystem path to the file to be edited.
+states.file.line:location 	Defines where to place content in the line. Note this option is onlyused when ``mode=insert`` is specified. If a location is passed in, ittakes precedence over both the ``before`` and ``after`` kwargs. Validlocations are:
+states.file.line:create 	Create an empty file if doesn
+states.file.managed:name 	The location of the file to manage
+states.file.managed:source 	The source file to download to the minion, this source file can behosted on either the salt master server (``salt://``), the salt minionlocal file system (``/``), or on an HTTP or FTP server (``http(s)://``,``ftp://``).
+states.file.managed:source_hash 	This can be one of the following:1. a source hash string2. the URI of a file that contains source hash strings
+states.file.managed:source_hash_name 	When ``source_hash`` refers to a hash file, Salt will try to find thecorrect hash by matching the filename/URI associated with that hash. Bydefault, Salt will look for the filename being managed. When managing afile at path ``/tmp/foo.txt``, then the following line in a hash filewould match:
+states.file.managed:encoding 	Encoding used for the file, e.g. ```UTF-8```, ```base64```.Default is None, which means str() will be applied to contents toensure an ascii encoded file and backwards compatibility.See https://docs.python.org/3/library/codecs.html#standard-encodingsfor available encodings.
+states.file.managed:tmp_ext 	Suffix for temp file created by ``check_cmd``. Useful for checkersdependent on config file extension (e.g. the init-checkconf upstartconfig checker).
+states.file.missing:name 	Absolute path which must NOT exist
+states.file.mknod:name 	name of the file
+states.file.patch:name 	The file or directory to which the patch will be applied.
+states.file.patch:source 	The source patch to download to the minion, this source file must behosted on the salt master server. If the file is located in thedirectory named spam, and is called eggs, the source string issalt://spam/eggs. A source is required.
+states.file.recurse:name 	The directory to set the recursion in
+states.file.recurse:source 	The source directory, this directory is located on the salt master fileserver and is specified with the salt:// protocol. If the directory islocated on the master in the directory named spam, and is called eggs,the source string is salt://spam/eggs
+states.file.rename:name 	The location of the file to rename to
+states.file.rename:source 	The location of the file to move to the location specified with name
+states.file.replace:name 	Filesystem path to the file to be edited. If a symlink is specified, itwill be resolved to its target.
+states.file.replace:backup 	The file extension to use for a backup of the file before editing. Setto ``False`` to skip making a backup.
+states.file.retention_schedule:name 	The filesystem path to the directory containing backups to be managed.
+states.file.serialize:name 	The location of the file to create
+states.file.serialize:dataset_pillar 	Operates like ``dataset``, but draws from a value stored in pillar,using the pillar path syntax used in :mod:`pillar.get<salt.modules.pillar.get>`. This is useful when the pillar valuecontains newlines, as referencing a pillar variable using a jinja/makotemplate can result in YAML formatting issues due to the newlinescausing indentation mismatches.
+states.file.shortcut:name 	The location of the shortcut to create. Must end with either".lnk" or ".url"
+states.file.shortcut:target 	The location that the shortcut points to
+states.file.shortcut:working_dir 	Working directory in which to execute target
+states.file.symlink:name 	The location of the symlink to create
+states.file.symlink:target 	The location that the symlink points to
+states.file.touch:name 	name of the file
+states.file.touch:atime 	atime of the file
+states.file.touch:mtime 	mtime of the file
+states.file.uncomment:name 	The full path to the file to be edited
+states.git.detached:target 	Name of the target directory where repository is about to be cloned.
+states.git.detached:identity 	A path on the minion (or a SaltStack fileserver URL, e.g.``salt://path/to/identity_file``) to a private key to use for SSHauthentication.
+states.git.latest:target 	Name of the target directory where repository is about to be cloned
+states.git.present:name 	Path to the directory
+states.gpg.absent:gnupghome 	Override GNUPG Home directory
+states.gpg.present:gnupghome 	Override GNUPG Home directory
+states.hg.latest:target 	Target destination directory path on minion to clone into
+states.htpasswd.user_absent:htpasswd_file 	Path to the htpasswd file
+states.htpasswd.user_exists:htpasswd_file 	Path to the htpasswd file
+states.icinga2.generate_ticket:output 	grain: output in a grainother: the file to store resultsNone:  output to the result comment (default)
+states.incron.absent:path 	The path that should be watched
+states.incron.present:path 	The path that should be watched
+states.jenkins.present:config 	The Salt URL for the file to use forconfiguring the job.
+states.lxc.absent:path 	path to the container parentdefault: /var/lib/lxc (system default)
+states.lxc.frozen:path 	path to the container parentdefault: /var/lib/lxc (system default)
+states.lxc.present:path 	path to the container parentdefault: /var/lib/lxc (system default)
+states.lxc.running:path 	path to the container parentdefault: /var/lib/lxc (system default)
+states.lxc.stopped:path 	path to the container parentdefault: /var/lib/lxc (system default)
+states.mac_assistive.installed:name 	The bundle ID or path to command
+states.mac_keychain.uninstalled:name 	The certificate to uninstall, this can be a path for a .p12 or the friendlyname
+states.mac_package.installed:name 	The pkg or dmg file to install
+states.mac_package.installed:target 	The location in which to install the package. This can be a path or LocalSystem
+states.mac_xattr.delete:name 	The path to the file/directory
+states.mac_xattr.exists:name 	The path to the file/directory
+states.mount.mounted:name 	The path to the location where the device is to be mounted
+states.mount.mounted:config 	Set an alternative location for the fstab, Default is ``/etc/fstab``
+states.mount.unmounted:name 	The path to the location where the device is to be unmounted from
+states.mount.unmounted:config 	Set an alternative location for the fstab, Default is ``/etc/fstab``
+states.mysql_query.run:output 	grain: output in a grainother: the file to store resultsNone:  output to the result comment (default)
+states.mysql_query.run_file:query_file 	The file of mysql commands to run
+states.mysql_query.run_file:output 	grain: output in a grainother: the file to store resultsNone:  output to the result comment (default)
+states.netconfig.managed:template_name 	Identifies path to the template source. The template can be either stored on the local machine,either remotely.The recommended location is under the ``file_roots`` as specified in the master config file.For example, let's suppose the ``file_roots`` is configured as:
+states.npm.installed:dir 	The target directory in which to install the package, or None forglobal installation
+states.npm.removed:dir 	The target directory in which to install the package, or None forglobal installation
+states.openstack_config.absent:filename 	The full path to the configuration file
+states.openstack_config.present:filename 	The full path to the configuration file
+states.pcs.cib_present:cibname 	name/path of the file containing the CIB
+states.pcs.cib_pushed:cibname 	name/path of the file containing the CIB
+states.pip_state.installed:requirements 	Path to a pip requirements file. If the path begins with salt://the file will be transferred from the master file server.
+states.pip_state.installed:log 	Log file where a complete (maximum verbosity) record will be kept
+states.pip_state.installed:exists_action 	Default action when a path already exists: (s)witch, (i)gnore, (w)ipe,(b)ackup
+states.pip_state.installed:cwd 	Current working directory to run pip from
+states.pip_state.installed:cert 	Provide a path to an alternate CA bundle
+states.pkgbuild.built:dest_dir 	The directory on the minion to place the built package(s)
+states.pkgbuild.built:spec 	The location of the spec file (used for rpms)
+states.pkgbuild.built:template 	Run the spec file through a templating engine
+states.pkgbuild.repo:name 	The directory to find packages that will be in the repository
+states.pkgrepo.managed:name 	This value will be used in two ways: Firstly, it will be the repo ID,as seen in the entry in square brackets (e.g. ``[foo]``) for a givenrepo. Secondly, it will be the name of the file as stored in/etc/yum.repos.d (e.g. ``/etc/yum.repos.d/foo.conf``).
+states.postgres_initdb.present:name 	The name of the directory to initialize
+states.postgres_tablespace.present:directory 	The directory where the tablespace will be located, must already exist
+states.rsync.synchronized:passwordfile 	Read daemon-access password from the file (path)
+states.rsync.synchronized:excludefrom 	Read exclude patterns from the file (path)
+states.saltmod.state:top 	Should be the name of a top file. If set state.top is called with thistop file instead of state.sls.
+states.selinux.module_install:name 	Path to file with module to install
+states.sqlite3.row_absent:db 	The database file name
+states.sqlite3.row_present:db 	The database file name
+states.sqlite3.table_absent:db 	The name of the database file
+states.sqlite3.table_present:db 	The name of the database file
+states.ssh_auth.absent:user 	The user who owns the SSH authorized keys file to modify
+states.ssh_auth.absent:source 	The source file for the key(s). Can contain any number of public keys,in standard "authorized_keys" format. If this is set, comment, enc andoptions will be ignored.
+states.ssh_auth.absent:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/authorized_keys". Token expansion %u and%h for username and home path supported.
+states.ssh_auth.present:user 	The user who owns the SSH authorized keys file to modify
+states.ssh_auth.present:source 	The source file for the key(s). Can contain any number of public keys,in standard "authorized_keys" format. If this is set, comment and encwill be ignored.
+states.ssh_auth.present:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/authorized_keys". Token expansion %u and%h for username and home path supported.
+states.ssh_known_hosts.absent:user 	The user who owns the ssh authorized keys file to modify
+states.ssh_known_hosts.absent:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/known_hosts". If no user is specified,defaults to "/etc/ssh/ssh_known_hosts". If present, must be anabsolute path when a user is not specified.
+states.ssh_known_hosts.present:user 	The user who owns the ssh authorized keys file to modify
+states.ssh_known_hosts.present:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/known_hosts". If no user is specified,defaults to "/etc/ssh/ssh_known_hosts". If present, must be anabsolute path when a user is not specified.
+states.stormpath_account.absent:directory_id 	Optional. The ID of the directory that the account is expected to belongto. If not specified, then a list of directories will be retrieved, andeach will be scanned for the account. Specifying a directory_id willtherefore cut down on the number of requests to Stormpath, and increaseperformance of this state.
+states.supervisord.dead:name 	Service name as defined in the supervisor configuration file
+states.supervisord.dead:conf_file 	path to supervisorctl config file
+states.supervisord.dead:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
+states.supervisord.running:name 	Service name as defined in the supervisor configuration file
+states.supervisord.running:conf_file 	path to supervisorctl config file
+states.supervisord.running:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
+states.svn.export:name 	Address and path to the file or directory to be exported.
+states.svn.export:target 	Name of the target directory where the checkout will put the workingdirectory
+states.svn.latest:target 	Name of the target directory where the checkout will put the workingdirectory
+states.tomcat.undeployed:name 	The context path to undeploy.
+states.tomcat.war_deployed:name 	The context path to deploy (incl. forward slash) the WAR to.
+states.tomcat.war_deployed:war 	Absolute path to WAR file (should be accessible by the user runningTomcat) or a path supported by the ``salt.modules.cp.get_url`` function.
+states.user.present:home 	The custom login directory of user. Uses default value of underlyingsystem if not set. Notice that this directory does not have to exist.This also the location of the home directory to create if createhome isset to True.
+states.zcbuildout.installed:name 	directory to execute in
+states.zookeeper.absent:name 	path to znode
+states.zookeeper.acls:name 	path to znode
+states.zookeeper.present:name 	path to znode
+modules.chef.client:logfile 	Set the log file location
+modules.chef.solo:logfile 	Set the log file location
+modules.composer.did_composer_install:dir 	Directory location of the composer.json file
+modules.composer.install:directory 	Directory location of the composer.json file.
+modules.composer.update:directory 	Directory location of the composer.json file.
+modules.genesis.bootstrap:root 	Local path to create the root of the image filesystem.
+modules.genesis.bootstrap:img_format 	Which format to create the image in. By default, just copies files intoa directory on the local filesystem (``dir``). Future support will existfor ``sparse``.
+modules.genesis.bootstrap:flavor 	Which flavor of operating system to install. This correlates to aspecific directory on the distribution repositories. For instance,``wheezy`` on Debian.
+modules.genesis.bootstrap:static_qemu 	Local path to the static qemu binary required for this arch.(e.x.: /usr/bin/qemu-amd64-static)
+modules.genesis.bootstrap:mount_dir 	If img_format is not ``dir``, then the image must be mounted somewhere.If the ``mount_dir`` is not specified, then it will be created at``/opt/salt-genesis.<random_uuid>``. This directory will be unmountedand removed when the process is finished.
+modules.genesis.bootstrap:pkg_cache 	This points to a directory containing a cache of package files to becopied to the image. It does not need to be specified.
+modules.gentoolkitmod.revdep_rebuild:lib 	Search for reverse dependencies for a particular library ratherthan every library on the system. It can be a full path to alibrary or basic regular expression.
+modules.jboss7.deploy:source_file 	Source file to deploy from
+modules.mac_keychain.set_default_keychain:keychain 	The location of the keychain to set as default
+modules.openstack_config.delete:filename 	The full path to the configuration file
+modules.openstack_config.get:filename 	The full path to the configuration file
+modules.openstack_config.set_:filename 	The full path to the configuration file
+modules.pcs.cib_create:cibfile 	name/path of the file containing the CIB
+modules.pcs.cib_push:cibfile 	name/path of the file containing the CIB
+modules.pcs.config_show:cibfile 	name/path of the file containing the CIB
+modules.supervisord.add:conf_file 	path to supervisord config file
+modules.supervisord.add:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
+modules.supervisord.custom:conf_file 	path to supervisord config file
+modules.supervisord.custom:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
+modules.supervisord.options:conf_file 	path to supervisord config file
+modules.supervisord.remove:conf_file 	path to supervisord config file
+modules.supervisord.remove:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
+modules.supervisord.reread:conf_file 	path to supervisord config file
+modules.supervisord.reread:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
+modules.supervisord.restart:conf_file 	path to supervisord config file
+modules.supervisord.restart:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
+modules.supervisord.start:conf_file 	path to supervisord config file
+modules.supervisord.start:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
+modules.supervisord.status:conf_file 	path to supervisord config file
+modules.supervisord.status:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
+modules.supervisord.status_raw:conf_file 	path to supervisord config file
+modules.supervisord.status_raw:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
+modules.supervisord.stop:conf_file 	path to supervisord config file
+modules.supervisord.stop:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
+modules.supervisord.update:conf_file 	path to supervisord config file
+modules.supervisord.update:bin_env 	path to supervisorctl bin or path to virtualenv with supervisorinstalled
+modules.svn.add:cwd 	The path to the Subversion repository
+modules.svn.checkout:cwd 	The path to the Subversion repository
+modules.svn.commit:cwd 	The path to the Subversion repository
+modules.svn.diff:cwd 	The path to the Subversion repository
+modules.svn.export:cwd 	The path to the Subversion repository
+modules.svn.info:cwd 	The path to the Subversion repository
+modules.svn.remove:cwd 	The path to the Subversion repository
+modules.svn.status:cwd 	The path to the Subversion repository
+modules.svn.switch:cwd 	The path to the Subversion repository
+modules.svn.update:cwd 	The path to the Subversion repository
+modules.win_certutil.add_store:source 	The source certificate file this can be in the formsalt://path/to/file
+modules.win_certutil.del_store:source 	The source certificate file this can be in the formsalt://path/to/file
+modules.win_certutil.get_cert_serial:cert_file 	The certificate file to find the serial for
+modules.apk.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
+modules.apk.install:sources 	A list of IPK packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
+modules.debconfmod.set_template:path 	location of the file containing the package selections
+modules.dnsmasq.get_config:config_file 	The location of the config file from which to obtain contents.Defaults to ``/etc/dnsmasq.conf``.
+modules.hg.archive:cwd 	The path to the Mercurial repository
+modules.hg.archive:output 	The path to the archive tarball
+modules.hg.clone:cwd 	The path to the Mercurial repository
+modules.hg.describe:cwd 	The path to the Mercurial repository
+modules.hg.pull:cwd 	The path to the Mercurial repository
+modules.hg.revision:cwd 	The path to the Mercurial repository
+modules.hg.status:cwd 	The path to the Mercurial repository
+modules.hg.update:cwd 	The path to the Mercurial repository
+modules.seed.apply_:path 	Full path to the directory, device, or disk image  on the targetminion's file system.
+modules.seed.mkconfig:pub_key 	absolute path or file content of an optional preseeded salt key
+modules.seed.mkconfig:priv_key 	absolute path or file content of an optional preseeded salt key
+modules.sensehat.show_image:image 	The path to the image to display. The image must be 8 x 8 pixels in size.
+modules.sysfs.read:key 	file or path in SysFS
+modules.sysfs.target:key 	the location to resolve within SysFS
+modules.sysfs.target:full 	full path instead of basename
+modules.augeas_cfg.execute:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
+modules.augeas_cfg.get:path 	The path to get the value of
+modules.augeas_cfg.get:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
+modules.augeas_cfg.ls:path 	The path to list
+modules.augeas_cfg.ls:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
+modules.augeas_cfg.match:path 	The path to match
+modules.augeas_cfg.match:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
+modules.augeas_cfg.remove:path 	The path to remove
+modules.augeas_cfg.remove:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
+modules.augeas_cfg.tree:load_path 	A colon-spearated list of directories that modules should be searchedin. This is in addition to the standard load path and the directoriesin AUGEAS_LENS_LIB.
+modules.glusterfs.set_quota_volume:path 	Folder path for restriction in volume ("/")
+modules.glusterfs.unset_quota_volume:path 	Folder path for restriction in volume
+modules.htpasswd.useradd:pwfile 	Path to htpasswd file
+modules.htpasswd.userdel:pwfile 	Path to htpasswd file
+modules.htpasswd.verify:pwfile 	Fully qualified path to htpasswd file
+modules.mac_sysctl.persist:config 	The location of the sysctl configuration file.
+modules.slsutil.renderer:path 	The path to a file on the filesystem.
+modules.slsutil.renderer:string 	An inline string to be used as the file to send through the renderer system. Note, not all renderer modules can work with strings
+modules.slsutil.renderer:default_renderer 	The renderer pipe to send the file through
+modules.artifactory.get_latest_release:target_dir 	Target directory to download artifact to (default: /tmp)
+modules.artifactory.get_latest_release:target_file 	Target file to download artifact to (by default it is target_dir/artifact_id-version.packaging)
+modules.artifactory.get_latest_snapshot:target_dir 	Target directory to download artifact to (default: /tmp)
+modules.artifactory.get_latest_snapshot:target_file 	Target file to download artifact to (by default it is target_dir/artifact_id-snapshot_version.packaging)
+modules.artifactory.get_release:target_dir 	Target directory to download artifact to (default: /tmp)
+modules.artifactory.get_release:target_file 	Target file to download artifact to (by default it is target_dir/artifact_id-version.packaging)
+modules.artifactory.get_snapshot:target_dir 	Target directory to download artifact to (default: /tmp)
+modules.artifactory.get_snapshot:target_file 	Target file to download artifact to (by default it is target_dir/artifact_id-snapshot_version.packaging)
+modules.boto_efs.create_file_system:name 	(string) - The name for the new file system
+modules.boto_efs.create_file_system:performance_mode 	(string) - The PerformanceMode of the file system. Can be eithergeneralPurpose or maxIO
+modules.boto_efs.create_mount_target:filesystemid 	(string) - ID of the file system for which to create the mount target.
+modules.boto_efs.create_tags:filesystemid 	(string) - ID of the file system for whose tags will be modified.
+modules.boto_efs.create_tags:tags 	(dict) - The tags to add to the file system
+modules.boto_efs.delete_file_system:filesystemid 	(string) - ID of the file system to delete.
+modules.boto_efs.delete_tags:filesystemid 	(string) - ID of the file system for whose tags will be removed.
+modules.boto_efs.delete_tags:tags 	(list[string]) - The tag keys to delete to the file system
+modules.boto_efs.get_file_systems:filesystemid 	(string) - ID of the file system to retrieve properties
+modules.boto_efs.get_mount_targets:filesystemid 	(string) - ID of the file system whose mount targets to listMust be specified if mounttargetid is not
+modules.boto_efs.get_tags:filesystemid 	(string) - ID of the file system whose tags to list
+modules.bower.install:dir 	The target directory in which to install the package
+modules.bower.list_:dir 	The directory whose packages will be listed
+modules.bower.prune:dir 	The directory whose packages will be pruned
+modules.bower.uninstall:dir 	The target directory from which to uninstall the package
+modules.debbuild.make_repo:repodir 	The directory to find packages that will be in the repository.
+modules.dockercompose.build:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.create:path 	Path where the docker-compose file will be stored on the server
+modules.dockercompose.create:docker_compose 	docker_compose file
+modules.dockercompose.get:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.kill:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.pause:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.ps:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.pull:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.restart:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.rm:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.start:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.stop:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.unpause:path 	Path where the docker-compose file is stored on the server
+modules.dockercompose.up:path 	Path where the docker-compose file is stored on the server
+modules.dpkg.bin_pkg_info:path 	Path to the file. Can either be an absolute path to a file on theminion, or a salt fileserver URL (e.g. ``salt://path/to/file.rpm``).If a salt fileserver URL is passed, the file will be cached to theminion so that it can be examined.
+modules.dracr.set_chassis_location:location 	The name of the location to be set on the chassis.
+modules.hashutil.digest_file:infile 	A file path
+modules.ini_manage.set_option:file_name 	path of ini_file
+modules.jenkins.create_job:config_xml 	The configuration file to use to create the job.
+modules.jenkins.create_job:saltenv 	The environment to look for the file in.
+modules.jenkins.update_job:config_xml 	The configuration file to use to create the job.
+modules.jenkins.update_job:saltenv 	The environment to look for the file in.
+modules.npm.install:dir 	The target directory in which to install the package, or None forglobal installation
+modules.npm.list_:dir 	The directory whose packages will be listed, or None for globalinstallation
+modules.npm.uninstall:dir 	The target directory from which to uninstall the package, or None forglobal installation
+modules.pillar.file_exists:path 	The path to the file in question. Will be treated as a relative path
+modules.postgres.datadir_exists:name 	Name of the directory to check
+modules.postgres.datadir_init:name 	The name of the directory to initialize
+modules.rpm.bin_pkg_info:path 	Path to the file. Can either be an absolute path to a file on theminion, or a salt fileserver URL (e.g. ``salt://path/to/file.rpm``).If a salt fileserver URL is passed, the file will be cached to theminion so that it can be examined.
+modules.rpm.diff:path 	Full path to the installed file
+modules.rvm.do:cwd 	The directory from which to run the rvm command. Defaults to the user'shome directory.
+modules.solaris_user.chhome:home 	New home directory to set
+modules.vbox_guest.additions_umount:mount_point 	directory VirtualBox Guest Additions is mounted to
+modules.vsphere.coredump_network_enable:host 	The location of the host.
+modules.vsphere.coredump_network_enable:credstore 	Optionally set to path to the credential store file.
+modules.vsphere.enable_firewall_ruleset:host 	The location of the host.
+modules.vsphere.enable_firewall_ruleset:credstore 	Optionally set to path to the credential store file.
+modules.vsphere.esxcli_cmd:host 	The location of the host.
+modules.vsphere.esxcli_cmd:credstore 	Optionally set to path to the credential store file.
+modules.vsphere.get_coredump_network_config:host 	The location of the host.
+modules.vsphere.get_coredump_network_config:credstore 	Optionally set to path to the credential store file.
+modules.vsphere.get_firewall_status:host 	The location of the host.
+modules.vsphere.get_firewall_status:credstore 	Optionally set to path to the credential store file.
+modules.vsphere.get_syslog_config:host 	The location of the host.
+modules.vsphere.get_syslog_config:credstore 	Optionally set to path to the credential store file.
+modules.vsphere.reset_syslog_config:host 	The location of the host.
+modules.vsphere.reset_syslog_config:credstore 	Optionally set to path to the credential store file.
+modules.vsphere.set_coredump_network_config:host 	The location of the host.
+modules.vsphere.set_coredump_network_config:credstore 	Optionally set to path to the credential store file.
+modules.vsphere.set_syslog_config:credstore 	Optionally set to path to the credential store file.
+modules.vsphere.syslog_service_reload:host 	The location of the host.
+modules.vsphere.syslog_service_reload:credstore 	Optionally set to path to the credential store file.
+modules.boto_iam.upload_server_cert:cert_name 	The name for the server certificate. Do not include the path in this value.
+modules.boto_iam.upload_server_cert:path 	The path for the server certificate.
+modules.pw_user.chhome:home 	New home directory to set
+modules.tomcat.deploy_war:war 	absolute path to WAR file (should be accessible by the user runningtomcat) or a path supported by the salt.modules.cp.get_file function
+modules.tomcat.deploy_war:context 	the context path to deploy
+modules.tomcat.reload_:app 	the webapp context path
+modules.tomcat.sessions:app 	the webapp context path
+modules.tomcat.start:app 	the webapp context path
+modules.tomcat.status_webapp:app 	the webapp context path
+modules.tomcat.stop:app 	the webapp context path
+modules.tomcat.undeploy:app 	the webapp context path
+modules.zk_concurrency.lock:path 	The path in zookeeper where the lock is
+modules.zk_concurrency.lock_holders:path 	The path in zookeeper where the lock is
+modules.zk_concurrency.party_members:path 	The path in zookeeper where the lock is
+modules.zk_concurrency.unlock:path 	The path in zookeeper where the lock is
+modules.acme.cert:webroot 	True or a full path to use to use webroot. Otherwise use standalone mode
+modules.aptpkg.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
+modules.aptpkg.install:debconf 	Provide the path to a debconf answers file, processed beforeinstallation.
+modules.aptpkg.install:sources 	A list of DEB packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
+modules.archive.cmd_unzip:zip_file 	Path of zip file to be unpacked
+modules.archive.cmd_unzip:dest 	The destination directory into which the file should be unpacked
+modules.archive.cmd_zip:zip_file 	Path of zip file to be created
+modules.archive.is_encrypted:name 	The path / URL of the archive to check.
+modules.archive.rar:rarfile 	Path of rar file to be created
+modules.archive.tar:dest 	The destination directory into which to **unpack** the tarfile
+modules.archive.unrar:rarfile 	Name of rar file to be unpacked
+modules.archive.unrar:dest 	The destination directory into which to **unpack** the rar file
+modules.archive.unzip:zip_file 	Path of zip file to be unpacked
+modules.archive.unzip:dest 	The destination directory into which the file should be unpacked
+modules.archive.zip_:zip_file 	Path of zip file to be created
+modules.cisconso.get_data:path 	The device path to set the value at, a list of element names in order, / separated
+modules.cisconso.set_data_value:path 	The device path to set the value at, a list of element names in order, / separated
+modules.cisconso.set_data_value:data 	The new value at the given path
+modules.cmdmod.run_chroot:cwd 	The current working directory to execute the command in. defaults to/root
+modules.cp.get_url:path 	A URL to download a file from. Supported URL schemes are: ``salt://``,``http://``, ``https://``, ``ftp://``, ``s3://``, ``swift://`` and``file://`` (local filesystem). If no scheme was specified, this isequivalent of using ``file://``.If a ``file://`` URL is given, the function just returns absolute pathto that file on a local filesystem.The function returns ``False`` if Salt was unable to fetch a file froma ``salt://`` URL.
+modules.cp.get_url:dest 	The default behaviour is to write the fetched file to the givendestination path. If this parameter is omitted or set as empty string(``''``), the function places the remote file on the local filesysteminside the Minion cache directory and returns the path to that file.
+modules.cp.push:upload_path 	Provide a different path inside the master's minion files cachedir
+modules.cp.push_dir:upload_path 	Provide a different path and directory name inside the master's minionfiles cachedir
+modules.dockermod.build:path 	Path to directory on the Minion containing a Dockerfile
+modules.dockermod.build:fileobj 	Allows for a file-like object containing the contents of the Dockerfileto be passed in place of a file ``path`` argument. This argument shouldnot be used from the CLI, only from other Salt code.
+modules.dockermod.build:dockerfile 	Allows for an alternative Dockerfile to be specified.  Path to alternativeDockefile is relative to the build path for the Docker container.
+modules.dockermod.import_:source 	Content to import (URL or absolute path to a tarball).  URL can be afile on the Salt fileserver (i.e.``salt://path/to/rootfs/tarball.tar.xz``. To import a file from asaltenv other than ``base`` (e.g. ``dev``), pass it at the end of theURL (ex. ``salt://path/to/rootfs/tarball.tar.xz?saltenv=dev``).
+modules.dockermod.load:path 	Path to docker tar archive. Path can be a file on the Minion, or theURL of a file on the Salt fileserver (i.e.``salt://path/to/docker/saved/image.tar``). To load a file from asaltenv other than ``base`` (e.g. ``dev``), pass it at the end of theURL (ex. ``salt://path/to/rootfs/tarball.tar.xz?saltenv=dev``).
+modules.dockermod.save:path 	Absolute path on the Minion where the image will be exported
+modules.dockermod.script:source 	Path to the script. Can be a local path on the Minion or a remote filefrom the Salt fileserver.
+modules.dockermod.script_retcode:source 	Path to the script. Can be a local path on the Minion or a remote filefrom the Salt fileserver.
+modules.ebuild.install:sources 	A list of tbz2 packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.file.append:path 	path to file
+modules.file.blockreplace:path 	Filesystem path to the file to be edited
+modules.file.blockreplace:backup 	The file extension to use for a backup of the file if any edit is made.Set to ``False`` to skip making a backup.
+modules.file.check_file_meta:name 	Path to file destination
+modules.file.check_file_meta:sfn 	Template-processed source file contents
+modules.file.check_file_meta:source 	URL to file source
+modules.file.check_file_meta:user 	Destination file user owner
+modules.file.check_file_meta:group 	Destination file group owner
+modules.file.check_file_meta:mode 	Destination file permissions mode
+modules.file.check_hash:path 	Path to a file local to the minion.
+modules.file.chgrp:path 	path to the file or directory
+modules.file.chown:path 	path to the file or directory
+modules.file.comment:path 	The full path to the file to be edited
+modules.file.comment_line:path 	string The full path to the text file.
+modules.file.comment_line:char 	string The character used to comment a line in the type of file you
+modules.file.comment_line:backup 	string The file extension to give the backup file. Default is
+modules.file.delete_backup:path 	The path on the minion to check for backups
+modules.file.get_gid:path 	file or directory of which to get the gid
+modules.file.get_group:path 	file or directory of which to get the group
+modules.file.get_hash:path 	path to the file or directory
+modules.file.get_managed:name 	location where the file lives on the server
+modules.file.get_managed:source 	managed source file
+modules.file.get_managed:source_hash 	hash of the source file
+modules.file.get_managed:user 	Owner of file
+modules.file.get_managed:group 	Group owner of file
+modules.file.get_managed:mode 	Permissions of file
+modules.file.get_mode:path 	file or directory of which to get the mode
+modules.file.get_source_sum:file_name 	Optional file name being managed, for matching with:py:func:`file.extract_hash <salt.modules.file.extract_hash>`.
+modules.file.get_source_sum:source 	Source file, as used in :py:mod:`file <salt.states.file>` and otherstates. If ``source_hash`` refers to a file containing hashes, thenthis filename will be used to match a filename in that file. If the``source_hash`` is a hash expression, then this argument will beignored.
+modules.file.get_source_sum:source_hash 	Hash file/expression, as used in :py:mod:`file <salt.states.file>` andother states. If this value refers to a remote URL or absolute path toa local file, it will be cached and :py:func:`file.extract_hash<salt.modules.file.extract_hash>` will be used to obtain a hash fromit.
+modules.file.get_source_sum:source_hash_name 	Specific file name to look for when ``source_hash`` refers to a remotefile, used to disambiguate ambiguous matches.
+modules.file.get_sum:path 	path to the file or directory
+modules.file.get_uid:path 	file or directory of which to get the uid
+modules.file.get_user:path 	file or directory of which to get the user
+modules.file.grep:path 	Path to the file to be searched
+modules.file.lchown:path 	path to the file or directory
+modules.file.line:path 	Filesystem path to the file to be edited.
+modules.file.line:location 	Defines where to place content in the line. Note this option is onlyused when ``mode=insert`` is specified. If a location is passed in, ittakes precedence over both the ``before`` and ``after`` kwargs. Validlocations are:
+modules.file.list_backup:path 	The path on the minion to check for backups
+modules.file.list_backups:path 	The path on the minion to check for backups
+modules.file.list_backups_dir:path 	The directory on the minion to check for backups
+modules.file.manage_file:name 	location to place the file
+modules.file.manage_file:sfn 	location of cached file on the minion
+modules.file.manage_file:source 	file reference on the master
+modules.file.patch:originalfile 	The full path to the file or directory to be patched
+modules.file.patch:patchfile 	A patch file to apply to ``originalfile``
+modules.file.prepend:path 	path to file
+modules.file.psed:path 	The full path to the file to be edited
+modules.file.remove_backup:path 	The path on the minion to check for backups
+modules.file.replace:path 	Filesystem path to the file to be edited. If a symlink is specified, itwill be resolved to its target.
+modules.file.restore_backup:path 	The path on the minion to check for backups
+modules.file.sed:path 	The full path to the file to be edited
+modules.file.seek_read:path 	path to file
+modules.file.seek_read:offset 	offset to start into the file
+modules.file.seek_write:path 	path to file
+modules.file.seek_write:data 	data to write to file
+modules.file.seek_write:offset 	position in file to start writing
+modules.file.set_mode:path 	file or directory of which to set the mode
+modules.file.set_mode:mode 	mode to set the path to
+modules.file.truncate:path 	path to file
+modules.file.truncate:length 	offset into file to truncate
+modules.file.uncomment:path 	The full path to the file to be edited
+modules.file.write:path 	path to file
+modules.freebsdpkg.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.git.add:cwd 	The path to the git checkout
+modules.git.add:filename 	The location of the file/directory to add, relative to ``cwd``
+modules.git.archive:cwd 	The path to be archived
+modules.git.archive:output 	The path of the archive to be created
+modules.git.archive:prefix 	Prepend ``<prefix>`` to every filename in the archive. If unspecified,the name of the directory at the top level of the repository will beused as the prefix (e.g. if ``cwd`` is set to ``/foo/bar/baz``, theprefix will be ``baz``, and the resulting archive will contain atop-level directory by that name).
+modules.git.branch:cwd 	The path to the git checkout
+modules.git.checkout:cwd 	The path to the git checkout
+modules.git.clone:name 	Optional alternate name for the top-level directory to be created bythe clone
+modules.git.commit:cwd 	The path to the git checkout
+modules.git.commit:filename 	The location of the file/directory to commit, relative to ``cwd``.This argument is optional, and can be used to commit a file withoutfirst staging it.
+modules.git.config_get:cwd 	The path to the git checkout
+modules.git.config_get_regex:cwd 	The path to the git checkout
+modules.git.config_get_regexp:cwd 	The path to the git checkout
+modules.git.config_set:cwd 	The path to the git checkout. Must be an absolute path, or the word``global`` to indicate that a global key should be set.
+modules.git.config_unset:cwd 	The path to the git checkout. Must be an absolute path, or the word``global`` to indicate that a global key should be unset.
+modules.git.current_branch:cwd 	The path to the git checkout
+modules.git.describe:cwd 	The path to the git checkout
+modules.git.diff:cwd 	The path to the git checkout
+modules.git.fetch:cwd 	The path to the git checkout
+modules.git.init:cwd 	The path to the directory to be initialized
+modules.git.is_worktree:cwd 	path to the worktree to be removed
+modules.git.list_branches:cwd 	The path to the git checkout
+modules.git.list_tags:cwd 	The path to the git checkout
+modules.git.list_worktrees:cwd 	The path to the git checkout
+modules.git.ls_remote:cwd 	The path to the git checkout. Optional (and ignored if present) when``remote`` is set to a URL instead of a remote name.
+modules.git.merge:cwd 	The path to the git checkout
+modules.git.merge_base:cwd 	The path to the git checkout
+modules.git.merge_tree:cwd 	The path to the git checkout
+modules.git.pull:cwd 	The path to the git checkout
+modules.git.push:cwd 	The path to the git checkout
+modules.git.rebase:cwd 	The path to the git checkout
+modules.git.remote_get:cwd 	The path to the git checkout
+modules.git.remote_set:cwd 	The path to the git checkout
+modules.git.remotes:cwd 	The path to the git checkout
+modules.git.reset:cwd 	The path to the git checkout
+modules.git.rev_parse:cwd 	The path to the git checkout
+modules.git.revision:cwd 	The path to the git checkout
+modules.git.rm_:cwd 	The path to the git checkout
+modules.git.rm_:filename 	The location of the file/directory to remove, relative to ``cwd``
+modules.git.stash:cwd 	The path to the git checkout
+modules.git.status:cwd 	The path to the git checkout
+modules.git.submodule:cwd 	The path to the submodule
+modules.git.symbolic_ref:cwd 	The path to the git checkout
+modules.git.worktree_add:cwd 	The path to the git checkout
+modules.git.worktree_prune:cwd 	The path to the main git checkout or a linked worktree
+modules.git.worktree_rm:user 	Used for path expansion when ``cwd`` is not an absolute path. Bydefault, when ``cwd`` is not absolute, the path will be assumed to berelative to the home directory of the user under which the minion isrunning. Setting this option will change the home directory from whichpath expansion is performed.
+modules.gpg.decrypt:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+modules.gpg.decrypt:gnupghome 	Specify the location where GPG keyring and related files are stored.
+modules.gpg.delete_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+modules.gpg.delete_key:gnupghome 	Specify the location where GPG keyring and related files are stored.
+modules.gpg.encrypt:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+modules.gpg.encrypt:output 	The filename where the signed file will be written, default is standard out.
+modules.gpg.encrypt:gnupghome 	Specify the location where GPG keyring and related files are stored.
+modules.gpg.export_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+modules.gpg.export_key:gnupghome 	Specify the location where GPG keyring and related files are stored.
+modules.gpg.get_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+modules.gpg.get_key:gnupghome 	Specify the location where GPG keyring and related files are stored.
+modules.gpg.get_secret_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+modules.gpg.get_secret_key:gnupghome 	Specify the location where GPG keyring and related files are stored.
+modules.gpg.list_keys:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+modules.gpg.list_keys:gnupghome 	Specify the location where GPG keyring and related files are stored.
+modules.gpg.list_secret_keys:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+modules.gpg.list_secret_keys:gnupghome 	Specify the location where GPG keyring and related files are stored.
+modules.gpg.search_keys:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+modules.gpg.sign:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+modules.gpg.sign:output 	The filename where the signed file will be written, default is standard out.
+modules.gpg.sign:gnupghome 	Specify the location where GPG keyring and related files are stored.
+modules.gpg.trust_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+modules.gpg.verify:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+modules.gpg.verify:gnupghome 	Specify the location where GPG keyring and related files are stored.
+modules.libcloud_compute.import_key_pair:key 	Public key material, the string or a path to a file
+modules.libcloud_compute.list_images:location_id 	The location key, from list_locations
+modules.libcloud_compute.list_sizes:location_id 	The location key, from list_locations
+modules.libcloud_storage.download_object:destination_path 	Full path to a file or a directory where the incoming file will be saved.
+modules.libcloud_storage.download_object:delete_on_failure 	True to delete a partially downloaded file if the download was not successful
+modules.lxc.apply_network_profile:path 	path to the container parent
+modules.lxc.attachable:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.bootstrap:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.copy_to:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.cp:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.create:config 	The config file to use for the container. Defaults to system-wideconfig (usually in /etc/lxc/lxc.conf).
+modules.lxc.destroy:path 	path to the container parent directory (default: /var/lib/lxc)
+modules.lxc.exists:path 	path to the container parent directory (default: /var/lib/lxc)
+modules.lxc.get_parameter:path 	path to the container parent directorydefault: /var/lib/lxc (system)
+modules.lxc.info:path 	path to the container parent directorydefault: /var/lib/lxc (system)
+modules.lxc.list_:path 	path to the container parent directorydefault: /var/lib/lxc (system)
+modules.lxc.ls_:path 	path to the container parent directorydefault: /var/lib/lxc (system)
+modules.lxc.reboot:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.reconfigure:path 	path to the container parent
+modules.lxc.remove:path 	path to the container parent directory (default: /var/lib/lxc)
+modules.lxc.restart:path 	path to the container parent directorydefault: /var/lib/lxc (system)
+modules.lxc.restart:lxc_config 	path to a lxc config fileconfig file will be guessed from container name otherwise
+modules.lxc.retcode:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.run:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.run_all:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.run_stderr:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.run_stdout:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.running_systemd:path 	path to the container parent
+modules.lxc.set_parameter:path 	path to the container parent directorydefault: /var/lib/lxc (system)
+modules.lxc.set_pass:path 	path to the container parent directorydefault: /var/lib/lxc (system)
+modules.lxc.set_password:path 	path to the container parent directorydefault: /var/lib/lxc (system)
+modules.lxc.state:path 	path to the container parent directory (default: /var/lib/lxc)
+modules.lxc.stop:path 	path to the container parent directorydefault: /var/lib/lxc (system)
+modules.lxc.systemd_running_state:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.test_bare_started_state:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.test_sd_started_state:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.unfreeze:path 	path to the container parent directorydefault: /var/lib/lxc (system)
+modules.lxc.update_lxc_conf:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.lxc.wait_started:path 	path to the container parentdefault: /var/lib/lxc (system default)
+modules.opkg.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
+modules.opkg.install:sources 	A list of IPK packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
+modules.pacman.install:name 	The name of the package to be installed. Note that this parameter isignored if either ``pkgs`` or ``sources`` is passed. Additionally,please note that this option can only be used to install packages froma software repository. To install a package file manually, use the``sources`` option.
+modules.pacman.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.pip.freeze:bin_env 	path to pip bin or path to virtualenv. If doing an uninstall fromthe system python and want to use a specific pip bin (pip-2.7,pip-2.6, etc..) just specify the pip bin you want.If uninstalling from a virtualenv, just use the path to the virtualenv(/home/code/path/to/virtualenv/)
+modules.pip.freeze:cwd 	Current working directory to run pip from
+modules.pip.install:bin_env 	Path to pip bin or path to virtualenv. If doing a system install,and want to use a specific pip bin (pip-2.7, pip-2.6, etc..) justspecify the pip bin you want.
+modules.pip.install:log 	Log file where a complete (maximum verbosity) record will be kept
+modules.pip.install:exists_action 	Default action when a path already exists: (s)witch, (i)gnore, (w)ipe,(b)ackup
+modules.pip.install:install_options 	Extra arguments to be supplied to the setup.py install command (e.g.like ``--install-option='--install-scripts=/usr/local/bin'``).  Usemultiple --install-option options to pass multiple options to setup.pyinstall. If you are using an option with a directory path, be sure touse absolute path.
+modules.pip.install:cwd 	Current working directory to run pip from
+modules.pip.install:cert 	Provide a path to an alternate CA bundle
+modules.pip.install:env_vars 	Set environment variables that some builds will depend on. For example,a Python C-module may have a Makefile that needs INCLUDE_PATH set topick up a header file while compiling.  This must be in the form of adictionary or a mapping.
+modules.pip.uninstall:requirements 	path to requirements.
+modules.pip.uninstall:bin_env 	path to pip bin or path to virtualenv. If doing an uninstall fromthe system python and want to use a specific pip bin (pip-2.7,pip-2.6, etc..) just specify the pip bin you want.If uninstalling from a virtualenv, just use the path to the virtualenv(/home/code/path/to/virtualenv/)
+modules.pip.uninstall:log 	Log file where a complete (maximum verbosity) record will be kept
+modules.pip.uninstall:cwd 	Current working directory to run pip from
+modules.pkgin.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.pkgng.backup:jail 	Backup packages from the specified jail. Note that this will run thecommand within the jail, and so the path to the backup file will berelative to the root of the jail
+modules.pkgng.backup:chroot 	Backup packages from the specified chroot (ignored if ``jail`` isspecified). Note that this will run the command within the chroot, andso the path to the backup file will be relative to the root of thechroot.
+modules.pkgng.backup:root 	Backup packages from the specified root (ignored if ``jail`` isspecified). Note that this will run the command within the root, andso the path to the backup file will be relative to the root of theroot.
+modules.pkgng.restore:jail 	Restore database to the specified jail. Note that this will run thecommand within the jail, and so the path to the file from which the pkgdatabase will be restored is relative to the root of the jail.
+modules.pkgng.restore:chroot 	Restore database to the specified chroot (ignored if ``jail`` isspecified). Note that this will run the command within the chroot, andso the path to the file from which the pkg database will be restored isrelative to the root of the chroot.
+modules.pkgng.restore:root 	Restore database to the specified root (ignored if ``jail`` isspecified). Note that this will run the command within the root, andso the path to the file from which the pkg database will be restored isrelative to the root of the root.
+modules.pkgng.updating:filename 	Defines an alternative location of the UPDATING file.
+modules.rpmbuild.make_repo:repodir 	The directory to find packages that will be in the repository.
+modules.rsync.rsync:src 	The source location where files will be rsynced from.
+modules.rsync.rsync:dst 	The destination location where files will be rsynced to.
+modules.rsync.rsync:passwordfile 	A file that contains a password for accessing anrsync daemon.  The file should contain just thepassword.
+modules.runit.add_svc_avail_path:path 	directory to add to AVAIL_SVR_DIRS
+modules.ssh.hash_known_hosts:config 	path to known hosts file: can be absolute or relative to user's homedirectory
+modules.ssh.set_known_host:user 	The user who owns the ssh authorized keys file to modify
+modules.ssh.set_known_host:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/known_hosts". If no user is specified,defaults to "/etc/ssh/ssh_known_hosts". If present, must be anabsolute path when a user is not specified.
+modules.state.event:sock_dir 	path to the Salt master
+modules.state.show_low_sls:pillarenv 	Specify a Pillar environment to be used when applying states. Thiscan also be set in the minion config file using the:conf_minion:`pillarenv` option. When neither the:conf_minion:`pillarenv` minion config option nor this CLI argument isused, all Pillar environments will be merged together.
+modules.state.sls:pillarenv 	Specify a Pillar environment to be used when applying states. Thiscan also be set in the minion config file using the:conf_minion:`pillarenv` option. When neither the:conf_minion:`pillarenv` minion config option nor this CLI argument isused, all Pillar environments will be merged together.
+modules.state.sls_id:pillarenv 	Specify a Pillar environment to be used when applying states. Thiscan also be set in the minion config file using the:conf_minion:`pillarenv` option. When neither the:conf_minion:`pillarenv` minion config option nor this CLI argument isused, all Pillar environments will be merged together.
+modules.state.top:pillarenv 	Specify a Pillar environment to be used when applying states. Thiscan also be set in the minion config file using the:conf_minion:`pillarenv` option. When neither the:conf_minion:`pillarenv` minion config option nor this CLI argument isused, all Pillar environments will be merged together.
+modules.tls.ca_exists:cacert_path 	absolute path to ca certificates root directory
+modules.tls.cert_base_path:cacert_path 	absolute path to ca certificates root directory
+modules.tls.cert_info:cert_path 	path to the cert file
+modules.tls.create_ca:cacert_path 	absolute path to ca certificates root directory
+modules.tls.create_ca_signed_cert:cacert_path 	absolute path to ca certificates root directory
+modules.tls.create_ca_signed_cert:cert_path 	full path to the certificates directory
+modules.tls.create_empty_crl:cacert_path 	absolute path to ca certificates root directory
+modules.tls.create_empty_crl:crl_file 	full path to the CRL file
+modules.tls.create_pkcs12:cacert_path 	absolute path to ca certificates root directory
+modules.tls.create_self_signed_cert:tls_dir 	location appended to the ca.cert_base_path, default is 'tls'
+modules.tls.create_self_signed_cert:cacert_path 	absolute path to ca certificates root directory
+modules.tls.get_ca:cacert_path 	absolute path to ca certificates root directory
+modules.tls.get_ca_signed_cert:cacert_path 	absolute path to certificates root directory
+modules.tls.get_ca_signed_key:cacert_path 	absolute path to certificates root directory
+modules.tls.maybe_fix_ssl_version:cacert_path 	absolute path to ca certificates root directory
+modules.tls.revoke_cert:cacert_path 	Absolute path to ca certificates root directory.
+modules.tls.revoke_cert:crl_file 	Full path to the CRL file.
+modules.virtualenv_mod.create:path 	The path to the virtualenv to be created
+modules.virtualenv_mod.create:venv_bin 	The name (and optionally path) of the virtualenv command. This can alsobe set globally in the minion config file as ``virtualenv.venv_bin``.Defaults to ``virtualenv``.
+modules.virtualenv_mod.get_resource_path:resource 	Name of the resource of which the path is to be returned
+modules.win_file.append:path 	path to file
+modules.win_file.blockreplace:path 	Filesystem path to the file to be edited
+modules.win_file.blockreplace:backup 	The file extension to use for a backup of the file if any edit is made.Set to ``False`` to skip making a backup.
+modules.win_file.check_file_meta:name 	Path to file destination
+modules.win_file.check_file_meta:sfn 	Template-processed source file contents
+modules.win_file.check_file_meta:source 	URL to file source
+modules.win_file.check_file_meta:user 	Destination file user owner
+modules.win_file.check_file_meta:group 	Destination file group owner
+modules.win_file.check_file_meta:mode 	Destination file permissions mode
+modules.win_file.check_hash:path 	Path to a file local to the minion.
+modules.win_file.comment:path 	The full path to the file to be edited
+modules.win_file.comment_line:path 	string The full path to the text file.
+modules.win_file.comment_line:char 	string The character used to comment a line in the type of file you
+modules.win_file.comment_line:backup 	string The file extension to give the backup file. Default is
+modules.win_file.delete_backup:path 	The path on the minion to check for backups
+modules.win_file.get_hash:path 	path to the file or directory
+modules.win_file.get_managed:name 	location where the file lives on the server
+modules.win_file.get_managed:source 	managed source file
+modules.win_file.get_managed:source_hash 	hash of the source file
+modules.win_file.get_managed:user 	Owner of file
+modules.win_file.get_managed:group 	Group owner of file
+modules.win_file.get_managed:mode 	Permissions of file
+modules.win_file.get_source_sum:file_name 	Optional file name being managed, for matching with:py:func:`file.extract_hash <salt.modules.file.extract_hash>`.
+modules.win_file.get_source_sum:source 	Source file, as used in :py:mod:`file <salt.states.file>` and otherstates. If ``source_hash`` refers to a file containing hashes, thenthis filename will be used to match a filename in that file. If the``source_hash`` is a hash expression, then this argument will beignored.
+modules.win_file.get_source_sum:source_hash 	Hash file/expression, as used in :py:mod:`file <salt.states.file>` andother states. If this value refers to a remote URL or absolute path toa local file, it will be cached and :py:func:`file.extract_hash<salt.modules.file.extract_hash>` will be used to obtain a hash fromit.
+modules.win_file.get_source_sum:source_hash_name 	Specific file name to look for when ``source_hash`` refers to a remotefile, used to disambiguate ambiguous matches.
+modules.win_file.get_sum:path 	path to the file or directory
+modules.win_file.line:path 	Filesystem path to the file to be edited.
+modules.win_file.line:location 	Defines where to place content in the line. Note this option is onlyused when ``mode=insert`` is specified. If a location is passed in, ittakes precedence over both the ``before`` and ``after`` kwargs. Validlocations are:
+modules.win_file.list_backups:path 	The path on the minion to check for backups
+modules.win_file.list_backups_dir:path 	The directory on the minion to check for backups
+modules.win_file.manage_file:name 	location to place the file
+modules.win_file.manage_file:sfn 	location of cached file on the minion
+modules.win_file.manage_file:source 	file reference on the master
+modules.win_file.prepend:path 	path to file
+modules.win_file.psed:path 	The full path to the file to be edited
+modules.win_file.replace:path 	Filesystem path to the file to be edited. If a symlink is specified, itwill be resolved to its target.
+modules.win_file.restore_backup:path 	The path on the minion to check for backups
+modules.win_file.seek_read:path 	path to file
+modules.win_file.seek_read:offset 	offset to start into the file
+modules.win_file.seek_write:path 	path to file
+modules.win_file.seek_write:data 	data to write to file
+modules.win_file.seek_write:offset 	position in file to start writing
+modules.win_file.truncate:path 	path to file
+modules.win_file.truncate:length 	offset into file to truncate
+modules.win_file.uncomment:path 	The full path to the file to be edited
+modules.win_file.write:path 	path to file
+modules.xbpspkg.add_repo:conffile 	path to xbps conf file to add this repodefault: /usr/share/xbps.d/15-saltstack.conf
+modules.xbpspkg.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.yumpkg.diff:path 	Full path to the installed file
+modules.yumpkg.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
+modules.yumpkg.install:sources 	A list of RPM packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+modules.zabbix.mediatype_create:exec_path 	exec path
+modules.zabbix.mediatype_create:gsm_modem 	exec path
+modules.zookeeper.create:path 	path of znode to create
+modules.zookeeper.delete:path 	path to znode
+modules.zookeeper.ensure_path:path 	Parent path to create
+modules.zookeeper.exists:path 	path to check
+modules.zookeeper.get:path 	path to check
+modules.zookeeper.get_acls:path 	path to znode
+modules.zookeeper.get_children:path 	path to check
+modules.zookeeper.set_acls:path 	path to znode
+modules.zypper.diff:path 	Full path to the installed file
+modules.zypper.install:name 	The name of the package to be installed. Note that this parameter isignored if either ``pkgs`` or ``sources`` is passed. Additionally,please note that this option can only be used to install packages froma software repository. To install a package file manually, use the``sources`` option.
+modules.zypper.install:sources 	A list of RPM packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -509,35 +509,35 @@ modules.git.symbolic_ref:cwd 	The path to the git checkout
 modules.git.worktree_add:cwd 	The path to the git checkout
 modules.git.worktree_prune:cwd 	The path to the main git checkout or a linked worktree
 # modules.git.worktree_rm:user 	Used for path expansion when ``cwd`` is not an absolute path. Bydefault, when ``cwd`` is not absolute, the path will be assumed to berelative to the home directory of the user under which the minion isrunning. Setting this option will change the home directory from whichpath expansion is performed.
-modules.gpg.decrypt:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+# modules.gpg.decrypt:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
 modules.gpg.decrypt:gnupghome 	Specify the location where GPG keyring and related files are stored.
-modules.gpg.delete_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+# modules.gpg.delete_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
 modules.gpg.delete_key:gnupghome 	Specify the location where GPG keyring and related files are stored.
-modules.gpg.encrypt:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+# modules.gpg.encrypt:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
 modules.gpg.encrypt:output 	The filename where the signed file will be written, default is standard out.
 modules.gpg.encrypt:gnupghome 	Specify the location where GPG keyring and related files are stored.
-modules.gpg.export_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+# modules.gpg.export_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
 modules.gpg.export_key:gnupghome 	Specify the location where GPG keyring and related files are stored.
-modules.gpg.get_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+# modules.gpg.get_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
 modules.gpg.get_key:gnupghome 	Specify the location where GPG keyring and related files are stored.
-modules.gpg.get_secret_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+# modules.gpg.get_secret_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
 modules.gpg.get_secret_key:gnupghome 	Specify the location where GPG keyring and related files are stored.
-modules.gpg.list_keys:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+# modules.gpg.list_keys:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
 modules.gpg.list_keys:gnupghome 	Specify the location where GPG keyring and related files are stored.
-modules.gpg.list_secret_keys:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+# modules.gpg.list_secret_keys:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
 modules.gpg.list_secret_keys:gnupghome 	Specify the location where GPG keyring and related files are stored.
-modules.gpg.search_keys:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
-modules.gpg.sign:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+# modules.gpg.search_keys:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+# modules.gpg.sign:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
 modules.gpg.sign:output 	The filename where the signed file will be written, default is standard out.
 modules.gpg.sign:gnupghome 	Specify the location where GPG keyring and related files are stored.
-modules.gpg.trust_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
-modules.gpg.verify:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+# modules.gpg.trust_key:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
+# modules.gpg.verify:user 	Which user's keychain to access, defaults to user Salt is running as.Passing the user as ``salt`` will set the GnuPG home directory to the``/etc/salt/gpgkeys``.
 modules.gpg.verify:gnupghome 	Specify the location where GPG keyring and related files are stored.
 modules.libcloud_compute.import_key_pair:key 	Public key material, the string or a path to a file
-modules.libcloud_compute.list_images:location_id 	The location key, from list_locations
-modules.libcloud_compute.list_sizes:location_id 	The location key, from list_locations
+# modules.libcloud_compute.list_images:location_id 	The location key, from list_locations
+# modules.libcloud_compute.list_sizes:location_id 	The location key, from list_locations
 modules.libcloud_storage.download_object:destination_path 	Full path to a file or a directory where the incoming file will be saved.
-modules.libcloud_storage.download_object:delete_on_failure 	True to delete a partially downloaded file if the download was not successful
+# modules.libcloud_storage.download_object:delete_on_failure 	True to delete a partially downloaded file if the download was not successful
 modules.lxc.apply_network_profile:path 	path to the container parent
 modules.lxc.attachable:path 	path to the container parentdefault: /var/lib/lxc (system default)
 modules.lxc.bootstrap:path 	path to the container parentdefault: /var/lib/lxc (system default)
@@ -572,10 +572,10 @@ modules.lxc.test_sd_started_state:path 	path to the container parentdefault: /va
 modules.lxc.unfreeze:path 	path to the container parent directorydefault: /var/lib/lxc (system)
 modules.lxc.update_lxc_conf:path 	path to the container parentdefault: /var/lib/lxc (system default)
 modules.lxc.wait_started:path 	path to the container parentdefault: /var/lib/lxc (system default)
-modules.opkg.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
-modules.opkg.install:sources 	A list of IPK packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
-modules.pacman.install:name 	The name of the package to be installed. Note that this parameter isignored if either ``pkgs`` or ``sources`` is passed. Additionally,please note that this option can only be used to install packages froma software repository. To install a package file manually, use the``sources`` option.
-modules.pacman.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+# modules.opkg.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
+# modules.opkg.install:sources 	A list of IPK packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.  Dependencies are automatically resolvedand marked as auto-installed.
+# modules.pacman.install:name 	The name of the package to be installed. Note that this parameter isignored if either ``pkgs`` or ``sources`` is passed. Additionally,please note that this option can only be used to install packages froma software repository. To install a package file manually, use the``sources`` option.
+# modules.pacman.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.pip.freeze:bin_env 	path to pip bin or path to virtualenv. If doing an uninstall fromthe system python and want to use a specific pip bin (pip-2.7,pip-2.6, etc..) just specify the pip bin you want.If uninstalling from a virtualenv, just use the path to the virtualenv(/home/code/path/to/virtualenv/)
 modules.pip.freeze:cwd 	Current working directory to run pip from
 modules.pip.install:bin_env 	Path to pip bin or path to virtualenv. If doing a system install,and want to use a specific pip bin (pip-2.7, pip-2.6, etc..) justspecify the pip bin you want.
@@ -584,12 +584,12 @@ modules.pip.install:exists_action 	Default action when a path already exists: (s
 modules.pip.install:install_options 	Extra arguments to be supplied to the setup.py install command (e.g.like ``--install-option='--install-scripts=/usr/local/bin'``).  Usemultiple --install-option options to pass multiple options to setup.pyinstall. If you are using an option with a directory path, be sure touse absolute path.
 modules.pip.install:cwd 	Current working directory to run pip from
 modules.pip.install:cert 	Provide a path to an alternate CA bundle
-modules.pip.install:env_vars 	Set environment variables that some builds will depend on. For example,a Python C-module may have a Makefile that needs INCLUDE_PATH set topick up a header file while compiling.  This must be in the form of adictionary or a mapping.
+# modules.pip.install:env_vars 	Set environment variables that some builds will depend on. For example,a Python C-module may have a Makefile that needs INCLUDE_PATH set topick up a header file while compiling.  This must be in the form of adictionary or a mapping.
 modules.pip.uninstall:requirements 	path to requirements.
 modules.pip.uninstall:bin_env 	path to pip bin or path to virtualenv. If doing an uninstall fromthe system python and want to use a specific pip bin (pip-2.7,pip-2.6, etc..) just specify the pip bin you want.If uninstalling from a virtualenv, just use the path to the virtualenv(/home/code/path/to/virtualenv/)
 modules.pip.uninstall:log 	Log file where a complete (maximum verbosity) record will be kept
 modules.pip.uninstall:cwd 	Current working directory to run pip from
-modules.pkgin.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+# modules.pkgin.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.pkgng.backup:jail 	Backup packages from the specified jail. Note that this will run thecommand within the jail, and so the path to the backup file will berelative to the root of the jail
 modules.pkgng.backup:chroot 	Backup packages from the specified chroot (ignored if ``jail`` isspecified). Note that this will run the command within the chroot, andso the path to the backup file will be relative to the root of thechroot.
 modules.pkgng.backup:root 	Backup packages from the specified root (ignored if ``jail`` isspecified). Note that this will run the command within the root, andso the path to the backup file will be relative to the root of theroot.
@@ -603,13 +603,13 @@ modules.rsync.rsync:dst 	The destination location where files will be rsynced to
 modules.rsync.rsync:passwordfile 	A file that contains a password for accessing anrsync daemon.  The file should contain just thepassword.
 modules.runit.add_svc_avail_path:path 	directory to add to AVAIL_SVR_DIRS
 modules.ssh.hash_known_hosts:config 	path to known hosts file: can be absolute or relative to user's homedirectory
-modules.ssh.set_known_host:user 	The user who owns the ssh authorized keys file to modify
-modules.ssh.set_known_host:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/known_hosts". If no user is specified,defaults to "/etc/ssh/ssh_known_hosts". If present, must be anabsolute path when a user is not specified.
-modules.state.event:sock_dir 	path to the Salt master
-modules.state.show_low_sls:pillarenv 	Specify a Pillar environment to be used when applying states. Thiscan also be set in the minion config file using the:conf_minion:`pillarenv` option. When neither the:conf_minion:`pillarenv` minion config option nor this CLI argument isused, all Pillar environments will be merged together.
-modules.state.sls:pillarenv 	Specify a Pillar environment to be used when applying states. Thiscan also be set in the minion config file using the:conf_minion:`pillarenv` option. When neither the:conf_minion:`pillarenv` minion config option nor this CLI argument isused, all Pillar environments will be merged together.
-modules.state.sls_id:pillarenv 	Specify a Pillar environment to be used when applying states. Thiscan also be set in the minion config file using the:conf_minion:`pillarenv` option. When neither the:conf_minion:`pillarenv` minion config option nor this CLI argument isused, all Pillar environments will be merged together.
-modules.state.top:pillarenv 	Specify a Pillar environment to be used when applying states. Thiscan also be set in the minion config file using the:conf_minion:`pillarenv` option. When neither the:conf_minion:`pillarenv` minion config option nor this CLI argument isused, all Pillar environments will be merged together.
+# modules.ssh.set_known_host:user 	The user who owns the ssh authorized keys file to modify
+# modules.ssh.set_known_host:config 	The location of the authorized keys file relative to the user's homedirectory, defaults to ".ssh/known_hosts". If no user is specified,defaults to "/etc/ssh/ssh_known_hosts". If present, must be anabsolute path when a user is not specified.
+# modules.state.event:sock_dir 	path to the Salt master
+# modules.state.show_low_sls:pillarenv 	Specify a Pillar environment to be used when applying states. Thiscan also be set in the minion config file using the:conf_minion:`pillarenv` option. When neither the:conf_minion:`pillarenv` minion config option nor this CLI argument isused, all Pillar environments will be merged together.
+# modules.state.sls:pillarenv 	Specify a Pillar environment to be used when applying states. Thiscan also be set in the minion config file using the:conf_minion:`pillarenv` option. When neither the:conf_minion:`pillarenv` minion config option nor this CLI argument isused, all Pillar environments will be merged together.
+# modules.state.sls_id:pillarenv 	Specify a Pillar environment to be used when applying states. Thiscan also be set in the minion config file using the:conf_minion:`pillarenv` option. When neither the:conf_minion:`pillarenv` minion config option nor this CLI argument isused, all Pillar environments will be merged together.
+# modules.state.top:pillarenv 	Specify a Pillar environment to be used when applying states. Thiscan also be set in the minion config file using the:conf_minion:`pillarenv` option. When neither the:conf_minion:`pillarenv` minion config option nor this CLI argument isused, all Pillar environments will be merged together.
 modules.tls.ca_exists:cacert_path 	absolute path to ca certificates root directory
 modules.tls.cert_base_path:cacert_path 	absolute path to ca certificates root directory
 modules.tls.cert_info:cert_path 	path to the cert file
@@ -619,7 +619,7 @@ modules.tls.create_ca_signed_cert:cert_path 	full path to the certificates direc
 modules.tls.create_empty_crl:cacert_path 	absolute path to ca certificates root directory
 modules.tls.create_empty_crl:crl_file 	full path to the CRL file
 modules.tls.create_pkcs12:cacert_path 	absolute path to ca certificates root directory
-modules.tls.create_self_signed_cert:tls_dir 	location appended to the ca.cert_base_path, default is 'tls'
+# modules.tls.create_self_signed_cert:tls_dir 	location appended to the ca.cert_base_path, default is 'tls'
 modules.tls.create_self_signed_cert:cacert_path 	absolute path to ca certificates root directory
 modules.tls.get_ca:cacert_path 	absolute path to ca certificates root directory
 modules.tls.get_ca_signed_cert:cacert_path 	absolute path to certificates root directory
@@ -629,69 +629,69 @@ modules.tls.revoke_cert:cacert_path 	Absolute path to ca certificates root direc
 modules.tls.revoke_cert:crl_file 	Full path to the CRL file.
 modules.virtualenv_mod.create:path 	The path to the virtualenv to be created
 modules.virtualenv_mod.create:venv_bin 	The name (and optionally path) of the virtualenv command. This can alsobe set globally in the minion config file as ``virtualenv.venv_bin``.Defaults to ``virtualenv``.
-modules.virtualenv_mod.get_resource_path:resource 	Name of the resource of which the path is to be returned
+# modules.virtualenv_mod.get_resource_path:resource 	Name of the resource of which the path is to be returned
 modules.win_file.append:path 	path to file
 modules.win_file.blockreplace:path 	Filesystem path to the file to be edited
-modules.win_file.blockreplace:backup 	The file extension to use for a backup of the file if any edit is made.Set to ``False`` to skip making a backup.
+# modules.win_file.blockreplace:backup 	The file extension to use for a backup of the file if any edit is made.Set to ``False`` to skip making a backup.
 modules.win_file.check_file_meta:name 	Path to file destination
-modules.win_file.check_file_meta:sfn 	Template-processed source file contents
-modules.win_file.check_file_meta:source 	URL to file source
-modules.win_file.check_file_meta:user 	Destination file user owner
-modules.win_file.check_file_meta:group 	Destination file group owner
-modules.win_file.check_file_meta:mode 	Destination file permissions mode
+# modules.win_file.check_file_meta:sfn 	Template-processed source file contents
+# modules.win_file.check_file_meta:source 	URL to file source
+# modules.win_file.check_file_meta:user 	Destination file user owner
+# modules.win_file.check_file_meta:group 	Destination file group owner
+# modules.win_file.check_file_meta:mode 	Destination file permissions mode
 modules.win_file.check_hash:path 	Path to a file local to the minion.
 modules.win_file.comment:path 	The full path to the file to be edited
 modules.win_file.comment_line:path 	string The full path to the text file.
-modules.win_file.comment_line:char 	string The character used to comment a line in the type of file you
-modules.win_file.comment_line:backup 	string The file extension to give the backup file. Default is
+# modules.win_file.comment_line:char 	string The character used to comment a line in the type of file you
+# modules.win_file.comment_line:backup 	string The file extension to give the backup file. Default is
 modules.win_file.delete_backup:path 	The path on the minion to check for backups
 modules.win_file.get_hash:path 	path to the file or directory
 modules.win_file.get_managed:name 	location where the file lives on the server
-modules.win_file.get_managed:source 	managed source file
-modules.win_file.get_managed:source_hash 	hash of the source file
-modules.win_file.get_managed:user 	Owner of file
-modules.win_file.get_managed:group 	Group owner of file
-modules.win_file.get_managed:mode 	Permissions of file
+# modules.win_file.get_managed:source 	managed source file
+# modules.win_file.get_managed:source_hash 	hash of the source file
+# modules.win_file.get_managed:user 	Owner of file
+# modules.win_file.get_managed:group 	Group owner of file
+# modules.win_file.get_managed:mode 	Permissions of file
 modules.win_file.get_source_sum:file_name 	Optional file name being managed, for matching with:py:func:`file.extract_hash <salt.modules.file.extract_hash>`.
-modules.win_file.get_source_sum:source 	Source file, as used in :py:mod:`file <salt.states.file>` and otherstates. If ``source_hash`` refers to a file containing hashes, thenthis filename will be used to match a filename in that file. If the``source_hash`` is a hash expression, then this argument will beignored.
-modules.win_file.get_source_sum:source_hash 	Hash file/expression, as used in :py:mod:`file <salt.states.file>` andother states. If this value refers to a remote URL or absolute path toa local file, it will be cached and :py:func:`file.extract_hash<salt.modules.file.extract_hash>` will be used to obtain a hash fromit.
-modules.win_file.get_source_sum:source_hash_name 	Specific file name to look for when ``source_hash`` refers to a remotefile, used to disambiguate ambiguous matches.
+# modules.win_file.get_source_sum:source 	Source file, as used in :py:mod:`file <salt.states.file>` and otherstates. If ``source_hash`` refers to a file containing hashes, thenthis filename will be used to match a filename in that file. If the``source_hash`` is a hash expression, then this argument will beignored.
+# modules.win_file.get_source_sum:source_hash 	Hash file/expression, as used in :py:mod:`file <salt.states.file>` andother states. If this value refers to a remote URL or absolute path toa local file, it will be cached and :py:func:`file.extract_hash<salt.modules.file.extract_hash>` will be used to obtain a hash fromit.
+# modules.win_file.get_source_sum:source_hash_name 	Specific file name to look for when ``source_hash`` refers to a remotefile, used to disambiguate ambiguous matches.
 modules.win_file.get_sum:path 	path to the file or directory
 modules.win_file.line:path 	Filesystem path to the file to be edited.
-modules.win_file.line:location 	Defines where to place content in the line. Note this option is onlyused when ``mode=insert`` is specified. If a location is passed in, ittakes precedence over both the ``before`` and ``after`` kwargs. Validlocations are:
+# modules.win_file.line:location 	Defines where to place content in the line. Note this option is onlyused when ``mode=insert`` is specified. If a location is passed in, ittakes precedence over both the ``before`` and ``after`` kwargs. Validlocations are:
 modules.win_file.list_backups:path 	The path on the minion to check for backups
 modules.win_file.list_backups_dir:path 	The directory on the minion to check for backups
 modules.win_file.manage_file:name 	location to place the file
-modules.win_file.manage_file:sfn 	location of cached file on the minion
-modules.win_file.manage_file:source 	file reference on the master
+# modules.win_file.manage_file:sfn 	location of cached file on the minion
+# modules.win_file.manage_file:source 	file reference on the master
 modules.win_file.prepend:path 	path to file
 modules.win_file.psed:path 	The full path to the file to be edited
 modules.win_file.replace:path 	Filesystem path to the file to be edited. If a symlink is specified, itwill be resolved to its target.
 modules.win_file.restore_backup:path 	The path on the minion to check for backups
 modules.win_file.seek_read:path 	path to file
-modules.win_file.seek_read:offset 	offset to start into the file
+# modules.win_file.seek_read:offset 	offset to start into the file
 modules.win_file.seek_write:path 	path to file
-modules.win_file.seek_write:data 	data to write to file
-modules.win_file.seek_write:offset 	position in file to start writing
+# modules.win_file.seek_write:data 	data to write to file
+# modules.win_file.seek_write:offset 	position in file to start writing
 modules.win_file.truncate:path 	path to file
-modules.win_file.truncate:length 	offset into file to truncate
+# modules.win_file.truncate:length 	offset into file to truncate
 modules.win_file.uncomment:path 	The full path to the file to be edited
 modules.win_file.write:path 	path to file
 modules.xbpspkg.add_repo:conffile 	path to xbps conf file to add this repodefault: /usr/share/xbps.d/15-saltstack.conf
-modules.xbpspkg.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+# modules.xbpspkg.install:sources 	A list of packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.yumpkg.diff:path 	Full path to the installed file
-modules.yumpkg.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
-modules.yumpkg.install:sources 	A list of RPM packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+# modules.yumpkg.install:name 	The name of the package to be installed. Note that this parameter isignored if either "pkgs" or "sources" is passed. Additionally, pleasenote that this option can only be used to install packages from asoftware repository. To install a package file manually, use the"sources" option.
+# modules.yumpkg.install:sources 	A list of RPM packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
 modules.zabbix.mediatype_create:exec_path 	exec path
 modules.zabbix.mediatype_create:gsm_modem 	exec path
-modules.zookeeper.create:path 	path of znode to create
-modules.zookeeper.delete:path 	path to znode
-modules.zookeeper.ensure_path:path 	Parent path to create
-modules.zookeeper.exists:path 	path to check
-modules.zookeeper.get:path 	path to check
-modules.zookeeper.get_acls:path 	path to znode
-modules.zookeeper.get_children:path 	path to check
-modules.zookeeper.set_acls:path 	path to znode
+# modules.zookeeper.create:path 	path of znode to create
+# modules.zookeeper.delete:path 	path to znode
+# modules.zookeeper.ensure_path:path 	Parent path to create
+# modules.zookeeper.exists:path 	path to check
+# modules.zookeeper.get:path 	path to check
+# modules.zookeeper.get_acls:path 	path to znode
+# modules.zookeeper.get_children:path 	path to check
+# modules.zookeeper.set_acls:path 	path to znode
 modules.zypper.diff:path 	Full path to the installed file
-modules.zypper.install:name 	The name of the package to be installed. Note that this parameter isignored if either ``pkgs`` or ``sources`` is passed. Additionally,please note that this option can only be used to install packages froma software repository. To install a package file manually, use the``sources`` option.
-modules.zypper.install:sources 	A list of RPM packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.
+# modules.zypper.install:name 	The name of the package to be installed. Note that this parameter isignored if either ``pkgs`` or ``sources`` is passed. Additionally,please note that this option can only be used to install packages froma software repository. To install a package file manually, use the``sources`` option.
+# modules.zypper.install:sources 	A list of RPM packages to install. Must be passed as a list of dicts,with the keys being package names, and the values being the source URIor local path to the package.


### PR DESCRIPTION
### What does this PR do?
Runs `os.path.expanduser` on all file paths to make it easier to work with user-specific files.

### What issues does this PR fix or reference?
#40710

### Tests written?
Yes

This PR currently includes a lot of commits related to the sausage making process of locating and patching the states and modules, I'll remove these once we're ready to merge, just want to get a discussion going to hear if this looks good or not first.