### PR TITLE
Extend resolution of 'virtual' grain for OpenBSD on KVM.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -824,7 +824,7 @@ def _virtual(osdata):
             if 'QEMU Virtual CPU' in model:
                 grains['virtual'] = 'kvm'
     elif osdata['kernel'] == 'OpenBSD':
-        if osdata['manufacturer'] == 'QEMU':
+        if osdata['manufacturer'] in ['QEMU', 'Red Hat']:
             grains['virtual'] = 'kvm'
     elif osdata['kernel'] == 'SunOS':
         # Check if it's a "regular" zone. (i.e. Solaris 10/11 zone)


### PR DESCRIPTION
### What does this PR do?

Recognise OpenBSD when running on KVM.

### What issues does this PR fix or reference?

My KVM guest was incorrectly recognised as `virtual: physical`.

### Previous Behavior

```
openbsd.localdomain:
    ----------
    virtual:
        physical
```

### New Behavior

```
openbsd.localdomain:
    ----------
    virtual:
        kvm
```

### Tests written?

No

The coverage for OpenBSD guests is far from complete, however this would be a good start.