### PR TITLE
Fix `unit.pillar.test_git` for Windows

### DIFF
--- a/tests/unit/pillar/test_git.py
+++ b/tests/unit/pillar/test_git.py
@@ -16,6 +16,7 @@ import tempfile
 import shutil
 import subprocess
 import yaml
+import stat
 
 # Import Salt Testing libs
 from tests.integration import AdaptedConfigurationTestCaseMixin
@@ -72,8 +73,12 @@ class GitPillarTestCase(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModul
         git_pillar._update('master', 'file://{0}'.format(self.repo_path))
 
     def tearDown(self):
-        shutil.rmtree(self.tmpdir)
+        shutil.rmtree(self.tmpdir, onerror=self._rmtree_error)
         super(GitPillarTestCase, self).tearDown()
+
+    def _rmtree_error(self, func, path, excinfo):
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
 
     def _create_repo(self):
         'create source Git repo in temp directory'


### PR DESCRIPTION
### What does this PR do?
Fixes an issue in Windows trying to delete the tempdir. Adds an `onerror` function to the `shutil.rmtree` function.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439