### PR TITLE
Fix `unit.states.test_environ` for Windows

### DIFF
--- a/tests/unit/states/test_environ.py
+++ b/tests/unit/states/test_environ.py
@@ -96,11 +96,14 @@ class TestEnvironState(TestCase, LoaderModuleMockMixin):
         ret = envstate.setenv('notimportant', {'foo': 'bar'})
         self.assertEqual(ret['changes'], {'foo': 'bar'})
 
-        ret = envstate.setenv('notimportant', {'test': False, 'foo': 'baz'}, false_unsets=True)
+        with patch.dict(envstate.__salt__, {'reg.read_value': MagicMock()}):
+            ret = envstate.setenv(
+                'notimportant', {'test': False, 'foo': 'baz'}, false_unsets=True)
         self.assertEqual(ret['changes'], {'test': None, 'foo': 'baz'})
         self.assertEqual(envstate.os.environ, {'INITIAL': 'initial', 'foo': 'baz'})
 
-        ret = envstate.setenv('notimportant', {'test': False, 'foo': 'bax'})
+        with patch.dict(envstate.__salt__, {'reg.read_value': MagicMock()}):
+            ret = envstate.setenv('notimportant', {'test': False, 'foo': 'bax'})
         self.assertEqual(ret['changes'], {'test': '', 'foo': 'bax'})
         self.assertEqual(envstate.os.environ, {'INITIAL': 'initial', 'foo': 'bax', 'test': ''})
 


### PR DESCRIPTION
### What does this PR do?
Fixes unit tests for `unit.states.test_environ`. Mocks the `reg.read_value` function for Windows. Has no effect on Linux.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439