### PR TITLE
Add batch_wait support for Python API

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -567,6 +567,8 @@ class LocalClient(object):
             opts['timeout'] = kwargs['timeout']
         if 'gather_job_timeout' in kwargs:
             opts['gather_job_timeout'] = kwargs['gather_job_timeout']
+        if 'batch_wait' in kwargs:
+            opts['batch_wait'] = int(kwargs['batch_wait'])
 
         eauth = {}
         if 'eauth' in kwargs:


### PR DESCRIPTION
### What does this PR do?
This PR allows the use of batch_wait from the salt python api.

### What issues does this PR fix or reference?
Fixes #42225

### Previous Behavior
The batch_wait argument to salt.client.LocalClient.cmd_batch was previously ignored.

### Tests written?
No