### PR TITLE
pkg.installed: pack name/version into pkgs argument

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1248,6 +1248,15 @@ def installed(
                 'result': True,
                 'comment': 'No packages to install provided'}
 
+    # If just a name (and optionally a version) is passed, just pack them into
+    # the pkgs argument.
+    if name and not any((pkgs, sources)):
+        if version:
+            pkgs = [{name: version}]
+            version = None
+        else:
+            pkgs = [name]
+
     kwargs['saltenv'] = __env__
     refresh = salt.utils.pkg.check_refresh(__opts__, refresh)
     if not isinstance(pkg_verify, list):
@@ -1414,7 +1423,7 @@ def installed(
         if salt.utils.is_freebsd():
             force = True    # Downgrades need to be forced.
         try:
-            pkg_ret = __salt__['pkg.install'](name,
+            pkg_ret = __salt__['pkg.install'](name=None,
                                               refresh=refresh,
                                               version=version,
                                               force=force,


### PR DESCRIPTION
This allows a version of `latest` to work when just a name and version is passed.

Resolves #42194