### PR TITLE
Fix `unit.states.test_winrepo` for Windows

### DIFF
--- a/tests/unit/states/test_winrepo.py
+++ b/tests/unit/states/test_winrepo.py
@@ -67,9 +67,8 @@ class WinrepoTestCase(TestCase, LoaderModuleMockMixin):
                'changes': {},
                'result': False,
                'comment': ''}
-        ret.update({'comment':
-                    '{file_roots}/win/repo is '
-                    'missing'.format(file_roots=BASE_FILE_ROOTS_DIR)})
+        ret.update({'comment': '{0} is missing'.format(
+            os.sep.join([BASE_FILE_ROOTS_DIR, 'win', 'repo']))})
         self.assertDictEqual(winrepo.genrepo('salt'), ret)
 
         mock = MagicMock(return_value={'winrepo_dir': 'salt',


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with path separators.


### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439