### PR TITLE
Handle libcloud objects that throw RepresenterErrors with --out=yaml

### DIFF
--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -150,7 +150,7 @@ def avail_locations(conn=None, call=None):
 
         ret[img_name] = {}
         for attr in dir(img):
-            if attr.startswith('_'):
+            if attr.startswith('_') or attr == 'driver':
                 continue
 
             attr_value = getattr(img, attr)
@@ -187,7 +187,7 @@ def avail_images(conn=None, call=None):
 
         ret[img_name] = {}
         for attr in dir(img):
-            if attr.startswith('_'):
+            if attr.startswith('_') or attr in ('driver', 'get_uuid'):
                 continue
             attr_value = getattr(img, attr)
             if isinstance(attr_value, string_types) and not six.PY3:
@@ -222,7 +222,7 @@ def avail_sizes(conn=None, call=None):
 
         ret[size_name] = {}
         for attr in dir(size):
-            if attr.startswith('_'):
+            if attr.startswith('_') or attr in ('driver', 'get_uuid'):
                 continue
 
             try:


### PR DESCRIPTION
### What does this PR do?
Instead of passing a dictionary for the `driver` and `get_uuid` keys, libcloud passes objects that throw RepresenterErrors when using the `--out=yaml` flag on salt-cloud commands. Without using the `--out=yaml` flag, salt-cloud simply ignores these keys like this:
```
# salt-cloud --list-sizes rackspace
rackspace:
    ----------
    openstack:
        ----------
        1 GB General Purpose v1:
            ----------
            bandwidth:
                None
            disk:
                20
            driver:
            ephemeral_disk:
                0
```
Since salt-cloud doesn't use this data for anything, we can just pass over processing the `driver` and the `get_uuid` keys all-together. (uuid is processed and gotten elsewhere in the libcloud functions, so we don't lose anything there either.)

### What issues does this PR fix or reference?
Fixes #42152

### Previous Behavior
```
# salt-cloud  --list-images rackspace --out=yaml
...
Traceback (most recent call last):
  File "/root/SaltStack/salt/salt/output/yaml_out.py", line 56, in output
    return yaml.dump(data, **params)
  File "/usr/local/lib/python2.7/dist-packages/yaml/__init__.py", line 202, in dump
    return dump_all([data], stream, Dumper=Dumper, **kwds)
  File "/usr/local/lib/python2.7/dist-packages/yaml/__init__.py", line 190, in dump_all
    dumper.represent(data)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 28, in represent
    node = self.represent_data(data)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 57, in represent_data
    node = self.yaml_representers[data_types[0]](self, data)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 225, in represent_dict
    return self.represent_mapping(u'tag:yaml.org,2002:map', data)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 123, in represent_mapping
    node_value = self.represent_data(item_value)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 57, in represent_data
    node = self.yaml_representers[data_types[0]](self, data)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 225, in represent_dict
    return self.represent_mapping(u'tag:yaml.org,2002:map', data)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 123, in represent_mapping
    node_value = self.represent_data(item_value)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 57, in represent_data
    node = self.yaml_representers[data_types[0]](self, data)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 225, in represent_dict
    return self.represent_mapping(u'tag:yaml.org,2002:map', data)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 123, in represent_mapping
    node_value = self.represent_data(item_value)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 57, in represent_data
    node = self.yaml_representers[data_types[0]](self, data)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 225, in represent_dict
    return self.represent_mapping(u'tag:yaml.org,2002:map', data)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 123, in represent_mapping
    node_value = self.represent_data(item_value)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 67, in represent_data
    node = self.yaml_representers[None](self, data)
  File "/usr/local/lib/python2.7/dist-packages/yaml/representer.py", line 249, in represent_undefined
    raise RepresenterError("cannot represent an object: %s" % data)
RepresenterError: cannot represent an object: <bound method NodeImage.get_uuid of <NodeImage: id=8894fcf5-0623-49bc-a0f8-04716955bded, name=10-2014, driver=OpenStack  ...>>
```

### New Behavior
```
salt-cloud  --list-images rackspace --out=yaml
rackspace:
  openstack:
    10-2014:
      extra:
        created: '2014-10-17T21:46:40Z'
        metadata:
          auto_disk_config: 'True'
          base_image_ref: e4dbdba7-b2a4-4ee5-8e8f-4595b6d694ce
          com.rackspace__1__build_core: '1'
          com.rackspace__1__build_managed: '1'
          com.rackspace__1__build_rackconnect: '1'
          com.rackspace__1__options: '0'
          com.rackspace__1__release_id: '1003'
          com.rackspace__1__source: kickstart
          com.rackspace__1__visible_core: '0'
          com.rackspace__1__visible_managed: '0'
          com.rackspace__1__visible_rackconnect: '0'
          image_type: snapshot
          instance_type_ephemeral_gb: '0'
          instance_type_flavorid: '2'
          instance_type_id: '2'
          instance_type_memory_mb: '512'
          instance_type_name: 512MB Standard Instance
          instance_type_root_gb: '20'
          instance_type_rxtx_factor: '2'
          instance_type_swap: '512'
          instance_type_vcpu_weight: '10'
          instance_type_vcpus: '1'
          instance_uuid: 8f5da007-86fa-4f03-8776-6ee3ebd4f588
          org.openstack__1__architecture: x64
          org.openstack__1__os_distro: com.ubuntu
          org.openstack__1__os_version: '12.04'
          os_distro: ubuntu
          os_type: linux
          user_id: '206265'
          xenapi_image_compression_level: '1'
        minDisk: 20
        minRam: 512
        progress: 100
        serverId: 8f5da007-86fa-4f03-8776-6ee3ebd4f588
        status: ACTIVE
        updated: '2014-10-17T22:32:22Z'
      id: 8894fcf5-0623-49bc-a0f8-04716955bded
      name: 10-2014
      uuid: c2bdf5468b3f62b2cfa8c83d44184725f9cd7952
    Arch Linux (PVHVM):
...
```
