### PR TITLE
test.get_opts runner function, similar to the exec fun

### DIFF
--- a/salt/runners/test.py
+++ b/salt/runners/test.py
@@ -75,3 +75,18 @@ def stream():
         __jid_event__.fire_event({'message': 'Runner is {0}% done'.format(i)}, 'progress')
         time.sleep(0.1)
     return ret
+
+
+def get_opts():
+    '''
+    .. versionadded:: Oxygen
+
+    Return the configuration options of the master.
+
+    CLI Example:
+
+    .. code-block::
+
+        salt-run test.get_opts
+    '''
+    return __opts__


### PR DESCRIPTION
### What does this PR do?

A new runner function, that provides the configuration options on the master, similar to the `test.get_opts` [execution function](https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.test.html#salt.modules.test.get_opts). I sometimes need it for debugging purposes mostly.