### PR TITLE
Fix #38839: remove `state` from Reactor runner kwags

### DIFF
--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -278,6 +278,9 @@ class ReactWrap(object):
                 # Update called function's low data with event user to
                 # segregate events fired by reactor and avoid reaction loops
                 kwargs['__user__'] = self.event_user
+                # Replace ``state`` kwarg which comes from high data compiler.
+                # It breaks some runner functions and seems unnecessary.
+                kwargs['__state__'] = kwargs.pop('state')
 
             l_fun(*f_call.get('args', ()), **kwargs)
         except Exception:


### PR DESCRIPTION
### What does this PR do?
It replaces `state` kwarg with `__state__` for runner and wheel functions called by Reactor.

It appears that `state` is always added to kwars by high state compiler, but `salt.utils.format_call()` filters it out whenever necessary. The problem is that some functions (like `cloud.action`) accept any named args (`**kwarg`), but call another (polymorphic?) functions under the hood with strictly defined interface.
Also, any runner or wheel function which accepts `**kwarg` argument may emit undesired side-effects.

### What issues does this PR fix or reference?
#38839

### Previous Behavior
Reactions using `cloud.action` runner function (and possibly others) have been broken.

### New Behavior
The `cloud.action` runner function is executed correctly by Salt Reactor.

### Tests written?
No.
