### PR TITLE
Document how to specify view permissions

### DIFF
--- a/salt/states/postgres_privileges.py
+++ b/salt/states/postgres_privileges.py
@@ -110,6 +110,8 @@ def present(name,
        - group
        - function
 
+       View permissions should specify `object_type: table`.
+
     privileges
        List of privileges to grant, from the list below:
 
@@ -230,6 +232,8 @@ def absent(name,
        - database
        - group
        - function
+
+       View permissions should specify `object_type: table`.
 
     privileges
        Comma separated list of privileges to revoke, from the list below:


### PR DESCRIPTION
### What does this PR do?
It adds documentation to explain how to specify view permissions.

Example:

`pg_stat_database` is a view in `pg_catalog`.

```
datadog_grants:
  postgres_privileges.present:
    - name: datadog
    - prepend: pg_catalog
    - object_name: pg_stat_database
    - object_type: table
    - privileges:
      - SELECT
```

### What issues does this PR fix or reference?
None.

### Previous Behavior
There was no relevant documentation.

### New Behavior
There is documentation.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
