### PR TITLE
Fix index error when setting empty values

### DIFF
--- a/salt/modules/sysrc.py
+++ b/salt/modules/sysrc.py
@@ -115,8 +115,8 @@ def set_(name, value, **kwargs):
     for sysrc in sysrcs.split("\n"):
         rcfile = sysrc.split(': ')[0]
         var = sysrc.split(': ')[1]
-        oldval = sysrc.split(': ')[2].split(" -> ")[0]
-        newval = sysrc.split(': ')[2].split(" -> ")[1]
+        oldval = sysrc.split(': ')[2].strip().split("->")[0]
+        newval = sysrc.split(': ')[2].strip().split("->")[1]
         if rcfile not in ret:
             ret[rcfile] = {}
         ret[rcfile][var] = newval


### PR DESCRIPTION
When setting empty values, the string returned by sysrc would be split in a way that would make the result a list containing just the delimiter " ->". This would then produce a failure when trying to select the second entry in the list.

### What does this PR do?
Fix a index error when trying to set empty values (like `postgresql_sessions = ""`).

### What issues does this PR fix or reference?
#42294

### Tests written?

No