### PR TITLE
Fix bug in github.absent state which can cause some users to not be removed from an organization.

### DIFF
--- a/salt/states/github.py
+++ b/salt/states/github.py
@@ -123,29 +123,30 @@ def absent(name, profile="github", **kwargs):
 
     target = __salt__['github.get_user'](name, profile=profile, **kwargs)
 
-    if not target:
+    if target:
+        if isinstance(target, bool) or target.get('in_org', False):
+            if __opts__['test']:
+                ret['comment'] = "User {0} will be deleted".format(name)
+                ret['result'] = None
+                return ret
+
+            result = __salt__['github.remove_user'](name, profile=profile, **kwargs)
+
+            if result:
+                ret['comment'] = 'Deleted user {0}'.format(name)
+                ret['changes'].setdefault('old', 'User {0} exists'.format(name))
+                ret['changes'].setdefault('new', 'User {0} deleted'.format(name))
+                ret['result'] = True
+            else:
+                ret['comment'] = 'Failed to delete {0}'.format(name)
+                ret['result'] = False
+        else:
+            ret['comment'] = "User {0} has already been deleted!".format(name)
+            ret['result'] = True
+    else:
         ret['comment'] = 'User {0} does not exist'.format(name)
         ret['result'] = True
         return ret
-    elif isinstance(target, bool) and target:
-        if __opts__['test']:
-            ret['comment'] = "User {0} will be deleted".format(name)
-            ret['result'] = None
-            return ret
-
-        result = __salt__['github.remove_user'](name, profile=profile, **kwargs)
-
-        if result:
-            ret['comment'] = 'Deleted user {0}'.format(name)
-            ret['changes'].setdefault('old', 'User {0} exists'.format(name))
-            ret['changes'].setdefault('new', 'User {0} deleted'.format(name))
-            ret['result'] = True
-        else:
-            ret['comment'] = 'Failed to delete {0}'.format(name)
-            ret['result'] = False
-    else:
-        ret['comment'] = "User {0} has already been deleted!".format(name)
-        ret['result'] = True
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in the `github.absent` state.

### What issues does this PR fix or reference?
None.

### Previous Behavior
If `github.get_user` returned a dictionary, `github.absent` would assume that the user had already been removed from the organization and return successfully without taking any action.

### New Behavior
If `github.get_user` returns a dictionary, `github.absent` checks the values of the dictionary and if the user is still present in the organization it will remove them before returning successfully.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
