### PR TITLE
Remove sock_dir deprecation warning from salt.utils.cloud.fire_event

### DIFF
--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -124,3 +124,11 @@ For ``smartos`` some grains have been deprecated. These grains will be removed i
 
 - The ``hypervisor_uuid`` has been replaced with ``mdata:sdc:server_uuid`` grain.
 - The ``datacenter`` has been replaced with ``mdata:sdc:datacenter_name`` grain.
+
+Utils Deprecations
+------------------
+
+The ``salt.utils.cloud.py`` file had the following change:
+
+- The ``fire_event`` function now requires a ``sock_dir`` argument. It was previously
+  optional.

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -270,6 +270,7 @@ def create(vm_):
         'event',
         'starting create',
         'salt/cloud/{0}/creating'.format(vm_['name']),
+        sock_dir=__opts__['sock_dir'],
         args=__utils__['cloud.filter_event']('creating', vm_, ['name', 'profile', 'provider', 'driver']),
         transport=__opts__['transport']
     )
@@ -306,6 +307,7 @@ def create(vm_):
         'event',
         'requesting instance',
         'salt/cloud/{0}/requesting'.format(vm_['name']),
+        sock_dir=__opts__['sock_dir'],
         args={
             'kwargs': __utils__['cloud.filter_event'](
                 'requesting',
@@ -329,12 +331,13 @@ def create(vm_):
             if 'VirtualName' not in ex_blockdevicemapping:
                 ex_blockdevicemapping['VirtualName'] = '{0}-{1}'.format(vm_['name'], len(volumes))
             __utils__['cloud.fire_event'](
-              'event',
-              'requesting volume',
-              'salt/cloud/{0}/requesting'.format(ex_blockdevicemapping['VirtualName']),
-              {'kwargs': {'name': ex_blockdevicemapping['VirtualName'],
-                          'device': ex_blockdevicemapping['DeviceName'],
-                          'size': ex_blockdevicemapping['VolumeSize']}},
+                'event',
+                'requesting volume',
+                'salt/cloud/{0}/requesting'.format(ex_blockdevicemapping['VirtualName']),
+                sock_dir=__opts__['sock_dir'],
+                args={'kwargs': {'name': ex_blockdevicemapping['VirtualName'],
+                                 'device': ex_blockdevicemapping['DeviceName'],
+                                 'size': ex_blockdevicemapping['VolumeSize']}},
             )
             try:
                 volumes[ex_blockdevicemapping['DeviceName']] = conn.create_volume(
@@ -408,6 +411,7 @@ def create(vm_):
         'event',
         'created instance',
         'salt/cloud/{0}/created'.format(vm_['name']),
+        sock_dir=__opts__['sock_dir'],
         args=__utils__['cloud.filter_event']('created', vm_, ['name', 'profile', 'provider', 'driver']),
         transport=__opts__['transport']
     )
@@ -429,7 +433,8 @@ def destroy(name, conn=None, call=None):
         'event',
         'destroying instance',
         'salt/cloud/{0}/destroying'.format(name),
-        {'name': name},
+        sock_dir=__opts__['sock_dir'],
+        args={'name': name},
     )
 
     if not conn:
@@ -453,7 +458,8 @@ def destroy(name, conn=None, call=None):
             'event',
             'detaching volume',
             'salt/cloud/{0}/detaching'.format(volume.name),
-            {'name': volume.name},
+            sock_dir=__opts__['sock_dir'],
+            args={'name': volume.name},
         )
         if not conn.detach_volume(volume):
             log.error('Failed to Detach volume: {0}'.format(volume.name))
@@ -463,7 +469,8 @@ def destroy(name, conn=None, call=None):
             'event',
             'detached volume',
             'salt/cloud/{0}/detached'.format(volume.name),
-            {'name': volume.name},
+            sock_dir=__opts__['sock_dir'],
+            args={'name': volume.name},
         )
 
         log.info('Destroying volume: {0}'.format(volume.name))
@@ -471,7 +478,8 @@ def destroy(name, conn=None, call=None):
             'event',
             'destroying volume',
             'salt/cloud/{0}/destroying'.format(volume.name),
-            {'name': volume.name},
+            sock_dir=__opts__['sock_dir'],
+            args={'name': volume.name},
         )
         if not conn.destroy_volume(volume):
             log.error('Failed to Destroy volume: {0}'.format(volume.name))
@@ -481,7 +489,8 @@ def destroy(name, conn=None, call=None):
             'event',
             'destroyed volume',
             'salt/cloud/{0}/destroyed'.format(volume.name),
-            {'name': volume.name},
+            sock_dir=__opts__['sock_dir'],
+            args={'name': volume.name},
         )
     log.info('Destroying VM: {0}'.format(name))
     ret = conn.destroy_node(node)
@@ -495,7 +504,8 @@ def destroy(name, conn=None, call=None):
         'event',
         'destroyed instance',
         'salt/cloud/{0}/destroyed'.format(name),
-        {'name': name},
+        sock_dir=__opts__['sock_dir'],
+        args={'name': name},
     )
     if __opts__['delete_sshkeys'] is True:
         salt.utils.cloud.remove_sshkey(node.public_ips[0])

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -524,6 +524,7 @@ def create(vm_):
         'event',
         'waiting for ssh',
         'salt/cloud/{0}/waiting_for_ssh'.format(name),
+        sock_dir=__opts__['sock_dir'],
         args={'ip_address': vm_['ssh_host']},
         transport=__opts__['transport']
     )

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1782,18 +1782,10 @@ def filter_event(tag, data, defaults):
     return ret
 
 
-def fire_event(key, msg, tag, args=None, sock_dir=None, transport='zeromq'):
+def fire_event(key, msg, tag, sock_dir, args=None, transport='zeromq'):
     '''
     Fire deploy action
     '''
-    if sock_dir is None:
-        salt.utils.warn_until(
-            'Oxygen',
-            '`salt.utils.cloud.fire_event` requires that the `sock_dir`'
-            'parameter be passed in when calling the function.'
-        )
-        sock_dir = __opts__['sock_dir']
-
     event = salt.utils.event.get_event(
         'master',
         sock_dir,


### PR DESCRIPTION
`sock_dir` was changed from an optional kwarg to a required arg, the warning was removed, and all instances of `cloud.fire_event` were examined to make sure there were no missing `sock_dir` args. I found a couple of references where `sock_dir` was missing, so I added it in those places.
