### PR TITLE
consul: fix put-release

### DIFF
--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -309,7 +309,7 @@ def put(consul_url=None, key=None, value=None, **kwargs):
                     return ret
 
             else:
-                ret['message'] = '{0} is not a valid session.'.format(kwargs['acquire'])
+                ret['message'] = '{0} is not a valid session.'.format(kwargs['release'])
                 ret['res'] = False
         else:
             log.error('Key {0} does not exist. Skipping release.')


### PR DESCRIPTION
### What does this PR do?
Makes it so that `consul.put` operations that intend to release a lock but are using an expired session don't result in:
```python
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/state.py", line 1744, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1702, in wrapper
    return f(*args, **kwargs)
  File "/var/cache/salt/minion/extmods/states/tumbler.py", line 57, in release
    name=fqdn)
  File "/usr/lib/python2.7/site-packages/salt/modules/consul.py", line 306, in put
    ret['message'] = '{0} is not a valid session.'.format(kwargs['acquire'])
KeyError: 'acquire'
```

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
