### PR TITLE
AWS specific metadata string prefix tuple match added

### DIFF
--- a/salt/grains/metadata.py
+++ b/salt/grains/metadata.py
@@ -50,6 +50,8 @@ def _search(prefix="latest/"):
     for line in http.query(os.path.join(HOST, prefix))['body'].split('\n'):
         if line.endswith('/'):
             ret[line[:-1]] = _search(prefix=os.path.join(prefix, line))
+        elif line.endswith(('dynamic', 'meta-data')):
+            ret[line] = _search(prefix=os.path.join(prefix, line))
         elif '=' in line:
             key, value = line.split('=')
             ret[value] = _search(prefix=os.path.join(prefix, key))


### PR DESCRIPTION
Prefix path ending with `latest/dynamic` and `latest/meta-data` should be handled differently as it only returns body content for those paths. Also due to the `/` path handling returns last element in the array, secondary conditional is added.

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
