### PR TITLE
Force file removal on Windows. Fixes #42295

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1040,7 +1040,10 @@ def absent(name):
             ret['comment'] = 'File {0} is set for removal'.format(name)
             return ret
         try:
-            __salt__['file.remove'](name)
+            if salt.utils.is_windows():
+                __salt__['file.remove'](name, force=True)
+            else:
+                __salt__['file.remove'](name)
             ret['comment'] = 'Removed file {0}'.format(name)
             ret['changes']['removed'] = name
             return ret


### PR DESCRIPTION
### What does this PR do?
Fix file.absent on Windows for files that have the "read only attribute" set

### What issues does this PR fix or reference?
#42295

### Previous Behavior
file.absent did not force file removal on Windows, it would fail on files that have the "read only" attribute set with "access denied".

### New Behavior
file.absent forces file removal on Windows.

### Tests written?

No