### PR TITLE
zypper.list_pkgs: add parameter for returned attribute selection

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -670,6 +670,8 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
         Valid attributes are: ``version``, ``arch``, ``install_date``, ``install_date_time_t``.
 
+        If ``all`` is specified, all valid attributes will be returned.
+
             .. versionadded:: Oxygen
 
     removed:
@@ -726,9 +728,10 @@ def _format_pkg_list(packages, versions_as_list, attr):
     '''
     ret = copy.deepcopy(packages)
     if attr:
-        requested_attr = (set(attr + ['version']) &
-                          set(['version', 'arch', 'install_date',
-                               'install_date_time_t']))
+        requested_attr = set(['version', 'arch', 'install_date', 'install_date_time_t'])
+
+        if attr != 'all':
+            requested_attr &= set(attr + ['version'])
 
         for name in ret:
             versions = []
@@ -1124,6 +1127,8 @@ def install(name=None,
                     'arch': '<new-arch>'}}}
 
         Valid attributes are: ``version``, ``arch``, ``install_date``, ``install_date_time_t``.
+
+        If ``all`` is specified, all valid attributes will be returned.
 
         .. versionadded:: Oxygen
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -650,7 +650,7 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
     return __salt__['lowpkg.version_cmp'](ver1, ver2, ignore_epoch=ignore_epoch)
 
 
-def list_pkgs(versions_as_list=False, attr=None, **kwargs):
+def list_pkgs(versions_as_list=False, **kwargs):
     '''
     List the packages currently installed as a dict. By default, the dict
     contains versions as a comma separated string::
@@ -691,6 +691,7 @@ def list_pkgs(versions_as_list=False, attr=None, **kwargs):
             for x in ('removed', 'purge_desired')]):
         return {}
 
+    attr = kwargs.get("attr")
     if 'pkg.list_pkgs' in __context__:
         return _format_pkg_list(__context__['pkg.list_pkgs'], versions_as_list, attr)
 
@@ -1025,7 +1026,6 @@ def install(name=None,
             skip_verify=False,
             version=None,
             ignore_repo_failure=False,
-            diff_attr=None,
             **kwargs):
     '''
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
@@ -1181,6 +1181,7 @@ def install(name=None,
     else:
         targets = pkg_params
 
+    diff_attr = kwargs.get("diff_attr")
     old = list_pkgs(attr=diff_attr) if not downloadonly else list_downloaded()
     downgrades = []
     if fromrepo:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -652,8 +652,8 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
 
 def list_pkgs(versions_as_list=False, attr=None, **kwargs):
     '''
-    List the packages currently installed as a dict with versions
-    as a comma separated string::
+    List the packages currently installed as a dict. By default, the dict
+    contains versions as a comma separated string::
 
         {'<package_name>': '<version>[,<version>...]'}
 
@@ -661,6 +661,16 @@ def list_pkgs(versions_as_list=False, attr=None, **kwargs):
         If set to true, the versions are provided as a list
 
         {'<package_name>': ['<version>', '<version>']}
+
+    attr:
+        If a list of package attributes is specified, returned value will
+        contain them in addition to version, eg.::
+
+        {'<package_name>': [{'version' : 'version', 'arch' : 'arch'}]}
+
+        Valid attributes are: ``version``, ``arch``, ``install_date``.
+
+            .. versionadded:: Oxygen
 
     removed:
         not supported
@@ -673,6 +683,7 @@ def list_pkgs(versions_as_list=False, attr=None, **kwargs):
     .. code-block:: bash
 
         salt '*' pkg.list_pkgs
+        salt '*' pkg.list_pkgs attr='["version", "arch"]'
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
     # not yet implemented or not applicable
@@ -1095,11 +1106,40 @@ def install(name=None,
         Zypper returns error code 106 if one of the repositories are not available for various reasons.
         In case to set strict check, this parameter needs to be set to True. Default: False.
 
+    diff_attr:
+        If a list of package attributes is specified, returned value will
+        contain them, eg.::
+
+            {'<package>': {
+                'old': {
+                    'version': '<old-version>',
+                    'arch': '<old-arch>'},
+
+                'new': {
+                    'version': '<new-version>',
+                    'arch': '<new-arch>'}}}
+
+        Valid attributes are: ``version``, ``arch``, ``install_date``.
+
+        .. versionadded:: Oxygen
+
 
     Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
+
+    If an attribute list is specified in ``diff_attr``, the dict will also contain
+    any specified attribute, eg.::
+
+        {'<package>': {
+            'old': {
+                'version': '<old-version>',
+                'arch': '<old-arch>'},
+
+            'new': {
+                'version': '<new-version>',
+                'arch': '<new-arch>'}}}
     '''
     if refresh:
         refresh_db()

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -668,7 +668,7 @@ def list_pkgs(versions_as_list=False, attr=None, **kwargs):
 
         {'<package_name>': [{'version' : 'version', 'arch' : 'arch'}]}
 
-        Valid attributes are: ``version``, ``arch``, ``install_date``.
+        Valid attributes are: ``version``, ``arch``, ``install_date``, ``install_date_time_t``.
 
             .. versionadded:: Oxygen
 
@@ -704,9 +704,11 @@ def list_pkgs(versions_as_list=False, attr=None, **kwargs):
             pkgver = '{0}:{1}'.format(epoch, pkgver)
         if rel:
             pkgver += '-{0}'.format(rel)
-        install_time = datetime.datetime.utcfromtimestamp(int(install_time)).isoformat() + "Z"
+        install_date = datetime.datetime.utcfromtimestamp(int(install_time)).isoformat() + "Z"
+        install_date_time_t = int(install_time)
 
-        all_attr = {'version': pkgver, 'arch': arch, 'install_date': install_time}
+        all_attr = {'version': pkgver, 'arch': arch, 'install_date': install_date,
+                    'install_date_time_t': install_date_time_t}
         __salt__['pkg_resource.add_pkg'](ret, name, all_attr)
 
     for pkgname in ret:
@@ -723,7 +725,9 @@ def _format_pkg_list(packages, versions_as_list, attr):
     '''
     ret = copy.deepcopy(packages)
     if attr:
-        requested_attr = set(attr + ['version']) & set(['version', 'arch', 'install_date'])
+        requested_attr = (set(attr + ['version']) &
+                          set(['version', 'arch', 'install_date',
+                               'install_date_time_t']))
 
         for name in ret:
             versions = []
@@ -1119,7 +1123,7 @@ def install(name=None,
                     'version': '<new-version>',
                     'arch': '<new-arch>'}}}
 
-        Valid attributes are: ``version``, ``arch``, ``install_date``.
+        Valid attributes are: ``version``, ``arch``, ``install_date``, ``install_date_time_t``.
 
         .. versionadded:: Oxygen
 

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -511,6 +511,54 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                             self.assertTrue(pkgs.get(pkg_name))
                             self.assertEqual(pkgs[pkg_name], [pkg_version])
 
+    def test_list_pkgs_with_attr(self):
+        '''
+        Test packages listing with the attr parameter
+
+        :return:
+        '''
+        def _add_data(data, key, value):
+            data.setdefault(key, []).append(value)
+
+        rpm_out = [
+            'protobuf-java_|-2.6.1_|-3.1.develHead_|-noarch_|-_|-1499257756',
+            'yast2-ftp-server_|-3.1.8_|-8.1_|-x86_64_|-_|-1499257798',
+            'jose4j_|-0.4.4_|-2.1.develHead_|-noarch_|-_|-1499257756',
+            'apache-commons-cli_|-1.2_|-1.233_|-noarch_|-_|-1498636510',
+            'jakarta-commons-discovery_|-0.4_|-129.686_|-noarch_|-_|-1498636511',
+            'susemanager-build-keys-web_|-12.0_|-5.1.develHead_|-noarch_|-_|-1498636510',
+        ]
+        with patch.dict(zypper.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}):
+            with patch.dict(zypper.__salt__, {'pkg_resource.add_pkg': _add_data}):
+                pkgs = zypper.list_pkgs(attr=['arch'])
+                for pkg_name, pkg_attr in {
+                    'jakarta-commons-discovery': {
+                        'version': '0.4-129.686',
+                        'arch': 'noarch',
+                    },
+                    'yast2-ftp-server': {
+                        'version': '3.1.8-8.1',
+                        'arch': 'x86_64',
+                    },
+                    'protobuf-java': {
+                        'version': '2.6.1-3.1.develHead',
+                        'arch': 'noarch',
+                    },
+                    'susemanager-build-keys-web': {
+                        'version': '12.0-5.1.develHead',
+                        'arch': 'noarch',
+                    },
+                    'apache-commons-cli': {
+                        'version': '1.2-1.233',
+                        'arch': 'noarch',
+                    },
+                    'jose4j': {
+                        'version': '0.4.4-2.1.develHead',
+                        'arch': 'noarch',
+                    }}.items():
+                    self.assertTrue(pkgs.get(pkg_name))
+                    self.assertEqual(pkgs[pkg_name], [pkg_attr])
+
     def test_list_patches(self):
         '''
         Test advisory patches listing.

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -530,31 +530,37 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         ]
         with patch.dict(zypper.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}):
             with patch.dict(zypper.__salt__, {'pkg_resource.add_pkg': _add_data}):
-                pkgs = zypper.list_pkgs(attr=['arch'])
+                pkgs = zypper.list_pkgs(attr=['arch', 'install_date_time_t'])
                 for pkg_name, pkg_attr in {
                     'jakarta-commons-discovery': {
                         'version': '0.4-129.686',
                         'arch': 'noarch',
+                        'install_date_time_t': 1498636511,
                     },
                     'yast2-ftp-server': {
                         'version': '3.1.8-8.1',
                         'arch': 'x86_64',
+                        'install_date_time_t': 1499257798,
                     },
                     'protobuf-java': {
                         'version': '2.6.1-3.1.develHead',
                         'arch': 'noarch',
+                        'install_date_time_t': 1499257756,
                     },
                     'susemanager-build-keys-web': {
                         'version': '12.0-5.1.develHead',
                         'arch': 'noarch',
+                        'install_date_time_t': 1498636510,
                     },
                     'apache-commons-cli': {
                         'version': '1.2-1.233',
                         'arch': 'noarch',
+                        'install_date_time_t': 1498636510,
                     },
                     'jose4j': {
                         'version': '0.4.4-2.1.develHead',
                         'arch': 'noarch',
+                        'install_date_time_t': 1499257756,
                     }}.items():
                     self.assertTrue(pkgs.get(pkg_name))
                     self.assertEqual(pkgs[pkg_name], [pkg_attr])

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -489,12 +489,12 @@ Repository 'DUMMY' not found by its alias, number, or URI.
             data.setdefault(key, []).append(value)
 
         rpm_out = [
-            'protobuf-java_|-2.6.1_|-3.1.develHead_|-',
-            'yast2-ftp-server_|-3.1.8_|-8.1_|-',
-            'jose4j_|-0.4.4_|-2.1.develHead_|-',
-            'apache-commons-cli_|-1.2_|-1.233_|-',
-            'jakarta-commons-discovery_|-0.4_|-129.686_|-',
-            'susemanager-build-keys-web_|-12.0_|-5.1.develHead_|-',
+            'protobuf-java_|-2.6.1_|-3.1.develHead_|-noarch_|-_|-1499257756',
+            'yast2-ftp-server_|-3.1.8_|-8.1_|-x86_64_|-_|-1499257798',
+            'jose4j_|-0.4.4_|-2.1.develHead_|-noarch_|-_|-1499257756',
+            'apache-commons-cli_|-1.2_|-1.233_|-noarch_|-_|-1498636510',
+            'jakarta-commons-discovery_|-0.4_|-129.686_|-noarch_|-_|-1498636511',
+            'susemanager-build-keys-web_|-12.0_|-5.1.develHead_|-noarch_|-_|-1498636510',
         ]
         with patch.dict(zypper.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}):
             with patch.dict(zypper.__salt__, {'pkg_resource.add_pkg': _add_data}):

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -486,7 +486,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         :return:
         '''
         def _add_data(data, key, value):
-            data[key] = value
+            data.setdefault(key, []).append(value)
 
         rpm_out = [
             'protobuf-java_|-2.6.1_|-3.1.develHead_|-',
@@ -509,7 +509,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                             'apache-commons-cli': '1.2-1.233',
                             'jose4j': '0.4.4-2.1.develHead'}.items():
                             self.assertTrue(pkgs.get(pkg_name))
-                            self.assertEqual(pkgs[pkg_name], pkg_version)
+                            self.assertEqual(pkgs[pkg_name], [pkg_version])
 
     def test_list_patches(self):
         '''


### PR DESCRIPTION
### What does this PR do?

It adds a new optional parameter to `list_pkg` in the `zypper` module to return more data than the version (original reason is that for SUSE Manager integration we also need `arch` and `install_date`). Format is the same of existing method `info_installed`.

### What issues does this PR fix or reference?

None known.

### New Behavior

If the new parameter `attr` is specified, more package attributes are returned.

### Tests written?

Yes - existing tests have been adapted and a new one has been added.

### Other notes

If this PR is accepted we will likely open others to get more attributes, add the same capabilities to the `yumpkg` module and backport this code at least to 2016.11.

This is my first core contribution so please be patient if quality is not yet at the correct level!

@meaksh, @dincamihai can you take a look please?