### PR TITLE
Reduce the number of days an issue is stale by 15

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,8 +1,8 @@
 # Probot Stale configuration file
 
 # Number of days of inactivity before an issue becomes stale
-# 1175 is approximately 3 years and 2 months
-daysUntilStale: 1175
+# 1160 is approximately 3 years and 2 months
+daysUntilStale: 1160
 
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7


### PR DESCRIPTION
We're still within the 3 years and 2 months range. I opted to only reduce this number by 15 instead of 25 because this change will mark 18 issues as stale rather than about 35.

We need to keep reducing this number, but we also don't want to flood this process too much.
