### PR TITLE
fix #42315, add option to disable the use of security groups

### DIFF
--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -178,6 +178,7 @@ def get_security_groups(conn, vm_):
     else:
         return False
 
+
 def get_password(vm_):
     '''
     Return the password to use

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -168,9 +168,15 @@ def get_security_groups(conn, vm_):
     '''
     Return a list of security groups to use, defaulting to ['default']
     '''
-    return config.get_cloud_config_value('securitygroup', vm_, __opts__,
-                                         default=['default'])
-
+    securitygroup_enabled = config.get_cloud_config_value(
+        'securitygroup_enabled', vm_, __opts__, default=True
+    )
+    if securitygroup_enabled:
+        return config.get_cloud_config_value(
+            'securitygroup', vm_, __opts__, default=['default']
+        )
+    else:
+        return False
 
 def get_password(vm_):
     '''
@@ -281,8 +287,10 @@ def create(vm_):
         'image': get_image(conn, vm_),
         'size': get_size(conn, vm_),
         'location': get_location(conn, vm_),
-        'ex_security_groups': get_security_groups(conn, vm_)
     }
+
+    if get_security_groups(conn, vm_) is not False:
+        kwargs['ex_security_groups'] = get_security_groups(conn, vm_)
 
     if get_keypair(vm_) is not False:
         kwargs['ex_keyname'] = get_keypair(vm_)

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -290,8 +290,9 @@ def create(vm_):
         'location': get_location(conn, vm_),
     }
 
-    if get_security_groups(conn, vm_) is not False:
-        kwargs['ex_security_groups'] = get_security_groups(conn, vm_)
+    sg = get_security_groups(conn, vm_)
+    if sg is not False:
+        kwargs['ex_security_groups'] = sg
 
     if get_keypair(vm_) is not False:
         kwargs['ex_keyname'] = get_keypair(vm_)


### PR DESCRIPTION
### What does this PR do?
With salt-cloud and cloudstack provider:
In advanced zones, security groups are supported only on the KVM hypervisor.
With hypervisor other than KVM, we need a way to disable the use of SGs

ref: https://svn.apache.org/repos/asf/cloudstack/docsite/html/docs/en-US/Apache_CloudStack/4.1.0/html/Admin_Guide/security-groups.html

### What issues does this PR fix or reference?
#42315 
