### PR TITLE
Handle forward compatibility for azurearm 

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -59,6 +59,7 @@ import logging
 import pprint
 import base64
 import yaml
+import collections
 import salt.cache
 import salt.config as config
 import salt.utils
@@ -250,7 +251,9 @@ def avail_locations(conn=None, call=None):  # pylint: disable=unused-argument
 
     ret = {}
     regions = webconn.global_model.get_subscription_geo_regions()
-    for location in regions.value:  # pylint: disable=no-member
+    if hasattr(regions, 'value'):
+        regions = regions.value
+    for location in regions:  # pylint: disable=no-member
         lowername = str(location.name).lower().replace(' ', '')
         ret[lowername] = object_to_dict(location)
     return ret
@@ -1661,9 +1664,14 @@ def pages_to_list(items):
     while True:
         try:
             page = items.next()  # pylint: disable=incompatible-py3-code
-            for item in page:
-                objs.append(item)
+            if isinstance(page, collections.Iterable):
+                for item in page:
+                    objs.append(item)
+            else:
+                objs.append(page)
         except GeneratorExit:
+            break
+        except StopIteration:
             break
     return objs
 


### PR DESCRIPTION
### What does this PR do?
Fixes 2 breakages with incompatible azure api calls

1. list_storage

```
# salt-cloud -ldebug -c etc/salt -f list_storage_accounts azure_demo
[ERROR   ] There was an error running the function: 'StorageAccount' object is not iterable

Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/cloud/cli.py", line 274, in run
    self.function_provider, self.function_name, kwargs
  File "/usr/lib/python2.7/site-packages/salt/cloud/__init__.py", line 1619, in do_function
    driver: self.clouds[fun](call='function')
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/azurearm.py", line 1548, in list_storage_accounts
    for acct in pages_to_list(storconn.storage_accounts.list()):
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/azurearm.py", line 1529, in pages_to_list
    for item in page:
TypeError: 'StorageAccount' object is not iterable
```

2. avail_locations

```
[ERROR   ] Failed to get the output of 'azurearm.avail_locations()': 'GeoRegionPaged' object has no attribute 'value'
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/cloud/__init__.py", line 834, in location_list
    data[alias][driver] = self.clouds[fun]()
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/azurearm.py", line 205, in avail_locations
    for location in regions.value:  # pylint: disable=no-member
AttributeError: 'GeoRegionPaged' object has no attribute 'value'
```

### What issues does this PR fix or reference?

No reported issue 

### Previous Behavior
only works with older version of msrestazure module

### New Behavior
works with both oldversion and new versions of msrestazure

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
