### PR TITLE
Enhance napalm CLI execution function to use the TextFSM mod

### DIFF
--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -415,6 +415,10 @@ def cli(*commands, **kwargs):  # pylint: disable=unused-argument
 
         .. versionadded:: Oxygen
 
+        .. note::
+            This option can be also specified in the minion configuration
+            file or pillar as ``napalm_cli_textfsm_template_dict``.
+
     platform_grain_name: ``os``
         The name of the grain used to identify the platform name
         in the TextFSM index file. Default: ``os``.
@@ -563,6 +567,9 @@ def cli(*commands, **kwargs):  # pylint: disable=unused-argument
     textfsm_path = kwargs.get('textfsm_path') or __opts__.get('textfsm_path') or\
                    __pillar__.get('textfsm_path')
     log.debug('textfsm_path: {}'.format(textfsm_path))
+    textfsm_template_dict = kwargs.get('textfsm_template_dict') or __opts__.get('napalm_cli_textfsm_template_dict') or\
+                            __pillar__.get('napalm_cli_textfsm_template_dict', {})
+    log.debug('TextFSM command-template mapping: {}'.format(textfsm_template_dict))
     index_file = kwargs.get('index_file') or __opts__.get('textfsm_index_file') or\
                  __pillar__.get('textfsm_index_file')
     log.debug('index_file: {}'.format(index_file))
@@ -610,7 +617,10 @@ def cli(*commands, **kwargs):  # pylint: disable=unused-argument
                 log.debug('All good, {} has a nice output!'.format(command))
                 processed_command_output = processed_cli_output['out']
             else:
-                log.debug('Processing {} didnt fail, but didnt return anything either. Dumping raw.'.format(command))
+                comment = '''\nProcessing "{}" didn't fail, but didn't return anything either. Dumping raw.'''.format(
+                    command)
+                processed_cli_outputs['comment'] += comment
+                log.error(comment)
                 processed_command_output = command_output
         elif textfsm_template or command in textfsm_template_dict:
             if command in textfsm_template_dict:

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -370,6 +370,8 @@ def cli(*commands, **kwargs):  # pylint: disable=unused-argument
     textfsm_parse: ``False``
         Try parsing the outputs using the TextFSM templates.
 
+        .. versionadded:: Oxygen
+
         .. note::
             This option can be also specified in the minion configuration
             file or pillar as ``napalm_cli_textfsm_parse``.
@@ -381,6 +383,8 @@ def cli(*commands, **kwargs):  # pylint: disable=unused-argument
         either specified using the following URL mschemes: ``file://``,
         ``salt://``, ``http://``, ``https://``, ``ftp://``,
         ``s3://``, ``swift://``.
+
+        .. versionadded:: Oxygen
 
         .. note::
             This needs to be a directory with a flat structure, having an
@@ -402,9 +406,13 @@ def cli(*commands, **kwargs):  # pylint: disable=unused-argument
         - ``s3://``
         - ``swift://``
 
+        .. versionadded:: Oxygen
+
     platform_grain_name: ``os``
         The name of the grain used to identify the platform name
         in the TextFSM index file. Default: ``os``.
+
+        .. versionadded:: Oxygen
 
         .. note::
             This option can be also specified in the minion configuration
@@ -414,6 +422,8 @@ def cli(*commands, **kwargs):  # pylint: disable=unused-argument
         The column name used to identify the platform,
         exactly as specified in the TextFSM index file.
         Default: ``Platform``.
+
+        .. versionadded:: Oxygen
 
         .. note::
             This is field is case sensitive, make sure
@@ -427,6 +437,8 @@ def cli(*commands, **kwargs):  # pylint: disable=unused-argument
     index_file: ``index``
         The name of the TextFSM index file, under the ``textfsm_path``. Default: ``index``.
 
+        .. versionadded:: Oxygen
+
         .. note::
             This option can be also specified in the minion configuration
             file or pillar as ``textfsm_index_file``.
@@ -435,18 +447,26 @@ def cli(*commands, **kwargs):  # pylint: disable=unused-argument
         Salt fileserver envrionment from which to retrieve the file.
         Ignored if ``textfsm_path`` is not a ``salt://`` URL.
 
+        .. versionadded:: Oxygen
+
     include_empty: ``False``
         Include empty files under the ``textfsm_path``.
+
+        .. versionadded:: Oxygen
 
     include_pat
         Glob or regex to narrow down the files cached from the given path.
         If matching with a regex, the regex must be prefixed with ``E@``,
         otherwise the expression will be interpreted as a glob.
 
+        .. versionadded:: Oxygen
+
     exclude_pat
         Glob or regex to exclude certain files from being cached from the given path.
         If matching with a regex, the regex must be prefixed with ``E@``,
         otherwise the expression will be interpreted as a glob.
+
+        .. versionadded:: Oxygen
 
         .. note::
             If used with ``include_pat``, files matching this pattern will be

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -361,18 +361,108 @@ def environment(**kwargs):  # pylint: disable=unused-argument
 
 @proxy_napalm_wrap
 def cli(*commands, **kwargs):  # pylint: disable=unused-argument
-
     '''
     Returns a dictionary with the raw output of all commands passed as arguments.
 
-    :param commands: list of commands to be executed on the device
-    :return: a dictionary with the mapping between each command and its raw output
+    commands
+        List of commands to be executed on the device.
+
+    textfsm_parse: ``False``
+        Try parsing the outputs using the TextFSM templates.
+
+        .. note::
+            This option can be also specified in the minion configuration
+            file or pillar as ``napalm_cli_textfsm_parse``.
+
+    textfsm_path
+        The path where the TextFSM templates can be found. This option implies
+        the usage of the TextFSM index file.
+        ``textfsm_path`` can be either absolute path on the server,
+        either specified using the following URL mschemes: ``file://``,
+        ``salt://``, ``http://``, ``https://``, ``ftp://``,
+        ``s3://``, ``swift://``.
+
+        .. note::
+            This needs to be a directory with a flat structure, having an
+            index file (whose name can be specified using the ``index_file`` option)
+            and a number of TextFSM templates.
+
+        .. note::
+            This option can be also specified in the minion configuration
+            file or pillar as ``textfsm_path``.
+
+    textfsm_template
+        The path to a certain the TextFSM template.
+        This can be specified using the absolute path
+        to the file, or using one of the following URL schemes:
+
+        - ``salt://``, to fetch the template from the Salt fileserver.
+        - ``http://`` or ``https://``
+        - ``ftp://``
+        - ``s3://``
+        - ``swift://``
+
+    platform_grain_name: ``os``
+        The name of the grain used to identify the platform name
+        in the TextFSM index file. Default: ``os``.
+
+        .. note::
+            This option can be also specified in the minion configuration
+            file or pillar as ``textfsm_platform_grain``.
+
+    platform_column_name: ``Platform``
+        The column name used to identify the platform,
+        exactly as specified in the TextFSM index file.
+        Default: ``Platform``.
+
+        .. note::
+            This is field is case sensitive, make sure
+            to assign the correct value to this option,
+            exactly as defined in the index file.
+
+        .. note::
+            This option can be also specified in the minion configuration
+            file or pillar as ``textfsm_platform_column_name``.
+
+    index_file: ``index``
+        The name of the TextFSM index file, under the ``textfsm_path``. Default: ``index``.
+
+        .. note::
+            This option can be also specified in the minion configuration
+            file or pillar as ``textfsm_index_file``.
+
+    saltenv: ``base``
+        Salt fileserver envrionment from which to retrieve the file.
+        Ignored if ``textfsm_path`` is not a ``salt://`` URL.
+
+    include_empty: ``False``
+        Include empty files under the ``textfsm_path``.
+
+    include_pat
+        Glob or regex to narrow down the files cached from the given path.
+        If matching with a regex, the regex must be prefixed with ``E@``,
+        otherwise the expression will be interpreted as a glob.
+
+    exclude_pat
+        Glob or regex to exclude certain files from being cached from the given path.
+        If matching with a regex, the regex must be prefixed with ``E@``,
+        otherwise the expression will be interpreted as a glob.
+
+        .. note::
+            If used with ``include_pat``, files matching this pattern will be
+            excluded from the subset of files defined by ``include_pat``.
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' net.cli "show version" "show chassis fan"
+
+    CLI Example with TextFSM template:
+
+    .. code-block::
+
+        salt '*' net.cli textfsm_parse=True textfsm_path=salt://textfsm/
 
     Example output:
 
@@ -395,9 +485,31 @@ def cli(*commands, **kwargs):  # pylint: disable=unused-argument
                                       Bottom Front Fan          OK       3840    Spinning at intermediate-speed
                                      '
         }
-    '''
 
-    return salt.utils.napalm.call(
+    Example output with TextFSM parsing:
+
+    .. code-block:: json
+
+        {
+          "comment": "",
+          "result": true,
+          "out": {
+            "sh ver": [
+              {
+                "kernel": "9.1S3.5",
+                "documentation": "9.1S3.5",
+                "boot": "9.1S3.5",
+                "crypto": "9.1S3.5",
+                "chassis": "",
+                "routing": "9.1S3.5",
+                "base": "9.1S3.5",
+                "model": "mx960"
+              }
+            ]
+          }
+        }
+    '''
+    raw_cli_outputs = salt.utils.napalm.call(
         napalm_device,  # pylint: disable=undefined-variable
         'cli',
         **{
@@ -406,6 +518,70 @@ def cli(*commands, **kwargs):  # pylint: disable=unused-argument
     )
     # thus we can display the output as is
     # in case of errors, they'll be catched in the proxy
+    if not raw_cli_outputs['result']:
+        # Error -> dispaly the output as-is.
+        return raw_cli_outputs
+    textfsm_parse = kwargs.get('textfsm_parse') or __opts__.get('napalm_cli_textfsm_parse') or\
+                    __pillar__.get('napalm_cli_textfsm_parse', False)
+    if not textfsm_parse:
+        # No TextFSM parsing required, return raw commands.
+        return raw_cli_outputs
+    if 'textfsm.extract' not in __salt__ or 'textfsm.index' not in __salt__:
+        raw_cli_outputs['comment'] += 'Unable to process: is TextFSM installed?'
+        return raw_cli_outputs
+    textfsm_template = kwargs.get('textfsm_template')
+    textfsm_path = kwargs.get('textfsm_path') or __opts__.get('textfsm_path') or\
+                   __pillar__.get('textfsm_path')
+    index_file = kwargs.get('index_file') or __opts__.get('textfsm_index_file') or\
+                 __pillar__.get('textfsm_index_file')
+    platform_grain_name = kwargs.get('platform_grain_name') or __opts__.get('textfsm_platform_grain') or\
+                          __pillar__.get('textfsm_platform_grain')
+    platform_column_name = kwargs.get('platform_column_name') or __opts__.get('textfsm_platform_column_name') or\
+                           __pillar__.get('textfsm_platform_column_name')
+    saltenv = kwargs.get('saltenv', 'base')
+    include_empty = kwargs.get('include_empty', False)
+    include_pat = kwargs.get('include_pat')
+    exclude_pat = kwargs.get('exclude_pat')
+    processed_cli_outputs = {
+        'comment': raw_cli_outputs.get('comment', ''),
+        'result': raw_cli_outputs['result'],
+        'out': {}
+    }
+    for command in list(commands):
+        command_output = raw_cli_outputs['out'][command]
+        processed_command_output = None
+        if textfsm_path:
+            processed_cli_output = __salt__['textfsm.index'](command,
+                                                             platform_grain_name=platform_grain_name,
+                                                             platform_column_name=platform_column_name,
+                                                             output=command_output.strip(),
+                                                             textfsm_path=textfsm_path,
+                                                             saltenv=saltenv,
+                                                             include_empty=include_empty,
+                                                             include_pat=include_pat,
+                                                             exclude_pat=exclude_pat)
+            if not processed_cli_output['result']:
+                processed_command_output = command_output
+                processed_cli_outputs['comment'] += '\nUnable to process the output from {0}: {1}.'.format(command,
+                    processed_cli_output['comment'])
+            else:
+                processed_command_output = processed_cli_output['out']
+        elif textfsm_template:
+            processed_cli_output = __salt__['textfsm.extract'](textfsm_template,
+                                                               raw_text=command_output,
+                                                               saltenv=saltenv)
+            if not processed_cli_output['result']:
+                processed_command_output = command_output
+                processed_cli_outputs['comment'] += '\nUnable to process the output from {0}: {1}'.format(command,
+                    processed_cli_output['comment'])
+            else:
+                processed_command_output = processed_cli_output['out']
+        else:
+            processed_command_output = command_output
+            processed_cli_outputs['comment'] += '\nUnable to process the output from {}.'.format(command)
+        processed_cli_outputs['out'][command] = processed_command_output
+    processed_cli_outputs['comment'] = processed_cli_outputs['comment'].strip()
+    return processed_cli_outputs
 
 
 @proxy_napalm_wrap


### PR DESCRIPTION
### What does this PR do?

These enhancements are based on the TextFSM module defined in https://github.com/saltstack/salt/pull/42336.
The `net.cli` function is now able to parse raw CLI commands using the templates defined under a specific path. They can be equally defined through opts for easier usage, so, if configured properly, the user only needs to add the corresponding opts and the raw text provided by the device is parsed whenever possible.