### PR TITLE
Bugfix: Jobs scheduled to run at a future time stay pending for Salt minions (bsc#1036125)

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -333,6 +333,7 @@ import logging
 import errno
 import random
 import yaml
+import copy
 
 # Import Salt libs
 import salt.config
@@ -844,7 +845,7 @@ class Schedule(object):
             if argspec.keywords:
                 # this function accepts **kwargs, pack in the publish data
                 for key, val in six.iteritems(ret):
-                    kwargs['__pub_{0}'.format(key)] = val
+                    kwargs['__pub_{0}'.format(key)] = copy.deepcopy(val)
 
             ret['return'] = self.functions[func](*args, **kwargs)
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where data is unable to be deserialised on the minion side and crashes on infinite recursion.

### Tests written?

[Not exactly here](https://github.com/opensuse/salt-toaster) as they need an integration...
