### PR TITLE
Correct references from pkgng to pkg

### DIFF
--- a/doc/topics/installation/freebsd.rst
+++ b/doc/topics/installation/freebsd.rst
@@ -5,14 +5,14 @@ FreeBSD
 Installation
 ============
 
-Salt is available in binary package form from both the FreeBSD pkgng repository
+Salt is available in binary package form from both the FreeBSD pkg repository
 or directly from SaltStack. The instructions below outline installation via
 both methods:
 
 FreeBSD repo
 ============
 
-The FreeBSD pkgng repository is preconfigured on systems 10.x and above. No
+The FreeBSD pkg repository is preconfigured on systems 10.x and above. No
 configuration is needed to pull from these repositories.
 
 .. code-block:: shell


### PR DESCRIPTION
### What does this PR do?
pkg is now just referred to as pkg, not pkgng. So chase the name change.