### PR TITLE
Document use of python methods in jinja

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -1700,6 +1700,23 @@ Will insert the following message in the minion logs:
 
 .. jinja_ref:: custom-execution-modules
 
+Python methods
+====================
+
+A power feature of jinja that is only hinted at in the official jinja
+documentation is that you can use the native python methods of the
+variable type. Here is the python documentation for `string methods`_.
+
+.. code-block:: jinja
+
+  {% set hostname,domain = grains.id.partition('.')[::2] %}{{ hostname }}
+
+.. code-block:: jinja
+
+  {% set strings = grains.id.split('-') %}{{ strings[0] }}
+
+.. _`string methods`: https://docs.python.org/2/library/stdtypes.html#string-methods
+
 Custom Execution Modules
 ========================
 

--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -1700,10 +1700,10 @@ Will insert the following message in the minion logs:
 
 .. jinja_ref:: custom-execution-modules
 
-Python methods
+Python Methods
 ====================
 
-A power feature of jinja that is only hinted at in the official jinja
+A powerful feature of jinja that is only hinted at in the official jinja
 documentation is that you can use the native python methods of the
 variable type. Here is the python documentation for `string methods`_.
 


### PR DESCRIPTION
### What does this PR do?
It adds to the Salt jinja documentation mention of a the use of python methods on variables. This is lacking in the official Jinja documentation, and is an open issue, https://github.com/pallets/jinja/issues/273 . Even the salt documentation hints at it, but doesn't call it out.