### PR TITLE
Fixes problem with Version and OS Release related grains on certain versions of Python

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -984,28 +984,20 @@ def _windows_platform_data():
 
         os_release = platform.release()
         info = salt.utils.win_osinfo.get_os_version_info()
+        server = {'Vista': '2008Server',
+                  '7': '2008ServerR2',
+                  '8': '2012Server',
+                  '8.1': '2012ServerR2',
+                  '10': '2016Server'}
 
         # Starting with Python 2.7.12 and 3.5.2 the `platform.uname()` function
         # started reporting the Desktop version instead of the Server version on
         # Server versions of Windows, so we need to look those up
-        # Check for Python >=2.7.12 or >=3.5.2
-        ver = pythonversion()['pythonversion']
-        if ((six.PY2 and
-                salt.utils.compare_versions(ver, '>=', [2, 7, 12, 'final', 0]))
-            or
-            (six.PY3 and
-                salt.utils.compare_versions(ver, '>=', [3, 5, 2, 'final', 0]))):
-            # (Product Type 1 is Desktop, Everything else is Server)
-            if info['ProductType'] > 1:
-                server = {'Vista': '2008Server',
-                          '7': '2008ServerR2',
-                          '8': '2012Server',
-                          '8.1': '2012ServerR2',
-                          '10': '2016Server'}
-                os_release = server.get(os_release,
-                                        'Grain not found. Update lookup table '
-                                        'in the `_windows_platform_data` '
-                                        'function in `grains\\core.py`')
+        # So, if you find a Server Platform that's a key in the server
+        # dictionary, then lookup the actual Server Release.
+        # (Product Type 1 is Desktop, Everything else is Server)
+        if info['ProductType'] > 1 and os_release in server:
+            os_release = server[os_release]
 
         service_pack = None
         if info['ServicePackMajor'] > 0:

--- a/salt/version.py
+++ b/salt/version.py
@@ -654,18 +654,22 @@ def system_information():
     release = platform.release()
     if platform.win32_ver()[0]:
         import win32api  # pylint: disable=3rd-party-module-not-gated
-        if ((sys.version_info.major == 2 and sys.version_info >= (2, 7, 12)) or
-                (sys.version_info.major == 3 and sys.version_info >= (3, 5, 2))):
-            if win32api.GetVersionEx(1)[8] > 1:
-                server = {'Vista': '2008Server',
-                          '7': '2008ServerR2',
-                          '8': '2012Server',
-                          '8.1': '2012ServerR2',
-                          '10': '2016Server'}
-                release = server.get(platform.release(),
-                                     'UNKServer')
-                _, ver, sp, extra = platform.win32_ver()
-                version = ' '.join([release, ver, sp, extra])
+        server = {'Vista': '2008Server',
+                  '7': '2008ServerR2',
+                  '8': '2012Server',
+                  '8.1': '2012ServerR2',
+                  '10': '2016Server'}
+        # Starting with Python 2.7.12 and 3.5.2 the `platform.uname()` function
+        # started reporting the Desktop version instead of the Server version on
+        # Server versions of Windows, so we need to look those up
+        # So, if you find a Server Platform that's a key in the server
+        # dictionary, then lookup the actual Server Release.
+        # If this is a Server Platform then `GetVersionEx` will return a number
+        # greater than 1.
+        if win32api.GetVersionEx(1)[8] > 1 and release in server:
+            release = server[release]
+        _, ver, sp, extra = platform.win32_ver()
+        version = ' '.join([release, ver, sp, extra])
 
     system = [
         ('system', platform.system()),


### PR DESCRIPTION
### What does this PR do?
Starting with Python 2.7.12 and 3.5.2 the `platform.uname()` function started reporting the Desktop version instead of the Server version on Server versions of Windows, so we need to look those up

https://bugs.python.org/issue26513

This PR changes the way that issue is detected to account for future versions of Python where the issue may be fixed.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/42342

### Previous Behavior
`version.py` and `grains\core.py` were hard coded to check for certain versions of Python and lookup the correct Server release in the lookup dictionary.

### New Behavior
`version.py` and `grains\core.py` will now return the server version if it detects that it is a server and the desktop release is found in the lookup dictionary. It is not based on a specific version of Python.

### Tests written?
No