### PR TITLE
Multiple documentation fixes

### DIFF
--- a/salt/engines/docker_events.py
+++ b/salt/engines/docker_events.py
@@ -50,8 +50,8 @@ def start(docker_url='unix://var/run/docker.sock',
     .. code-block:: yaml
 
         engines:
-          docker_events:
-            docker_url: unix://var/run/docker.sock
+          - docker_events:
+              docker_url: unix://var/run/docker.sock
 
     The config above sets up engines to listen
     for events from the Docker daemon and publish

--- a/salt/engines/hipchat.py
+++ b/salt/engines/hipchat.py
@@ -14,22 +14,22 @@ keys make the engine interactive.
     .. code-block:: yaml
 
         engines:
-            hipchat:
-               token: 'XXXXXX'
-               room: 'salt'
-               control: True
-               valid_users:
-                   - SomeUser
-               valid_commands:
-                   - test.ping
-                   - cmd.run
-                   - list_jobs
-                   - list_commands
-               aliases:
-                   list_jobs:
-                       cmd: jobs.list_jobs
-                   list_commands:
-                       cmd: pillar.get salt:engines:hipchat:valid_commands target=saltmaster
+            - hipchat:
+                token: 'XXXXXX'
+                room: 'salt'
+                control: True
+                valid_users:
+                    - SomeUser
+                valid_commands:
+                    - test.ping
+                    - cmd.run
+                    - list_jobs
+                    - list_commands
+                aliases:
+                    list_jobs:
+                        cmd: jobs.list_jobs
+                    list_commands:
+                        cmd: pillar.get salt:engines:hipchat:valid_commands target=saltmaster
 '''
 
 from __future__ import absolute_import

--- a/salt/engines/http_logstash.py
+++ b/salt/engines/http_logstash.py
@@ -12,13 +12,13 @@ them onto a logstash endpoint via HTTP requests.
 
         engines:
           - http_logstash:
-                url: http://blabla.com/salt-stuff
-                tags:
-                    - salt/job/*/new
-                    - salt/job/*/ret/*
-                funs:
-                    - probes.results
-                    - bgp.config
+              url: http://blabla.com/salt-stuff
+              tags:
+                  - salt/job/*/new
+                  - salt/job/*/ret/*
+              funs:
+                  - probes.results
+                  - bgp.config
 '''
 
 from __future__ import absolute_import

--- a/salt/engines/logentries.py
+++ b/salt/engines/logentries.py
@@ -24,6 +24,9 @@ master config.
 :configuration:
 
     Example configuration
+
+    .. code-block:: yaml
+
         engines:
           - logentries:
             endpoint: data.logentries.com

--- a/salt/engines/logstash.py
+++ b/salt/engines/logstash.py
@@ -8,6 +8,9 @@ them onto a logstash endpoint.
 :configuration:
 
     Example configuration
+
+    .. code-block:: yaml
+
         engines:
           - logstash:
             host: log.my_network.com

--- a/salt/engines/reactor.py
+++ b/salt/engines/reactor.py
@@ -7,10 +7,10 @@ Example Config in Master or Minion config
 .. code-block:: yaml
 
     engines:
-      reactor:
-        refresh_interval: 60
-        worker_threads: 10
-        worker_hwm: 10000
+      - reactor:
+          refresh_interval: 60
+          worker_threads: 10
+          worker_hwm: 10000
 
     reactor:
       - 'salt/cloud/*/destroyed':

--- a/salt/engines/redis_sentinel.py
+++ b/salt/engines/redis_sentinel.py
@@ -8,6 +8,9 @@ events based on the channels they are subscribed to.
 :configuration:
 
     Example configuration
+
+    .. code-block:: yaml
+
         engines:
           - redis_sentinel:
               hosts:

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -12,21 +12,21 @@ prefaced with a ``!``.
     .. code-block:: yaml
 
         engines:
-            slack:
-               token: 'xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx'
-               control: True
-               valid_users:
-                   - garethgreenaway
-               valid_commands:
-                   - test.ping
-                   - cmd.run
-                   - list_jobs
-                   - list_commands
-               aliases:
-                   list_jobs:
-                       cmd: jobs.list_jobs
-                   list_commands:
-                       cmd: pillar.get salt:engines:slack:valid_commands target=saltmaster
+            - slack:
+                token: 'xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx'
+                control: True
+                valid_users:
+                    - garethgreenaway
+                valid_commands:
+                    - test.ping
+                    - cmd.run
+                    - list_jobs
+                    - list_commands
+                aliases:
+                    list_jobs:
+                        cmd: jobs.list_jobs
+                    list_commands:
+                        cmd: pillar.get salt:engines:slack:valid_commands target=saltmaster
 
 :depends: slackclient
 '''


### PR DESCRIPTION
### What does this PR do?
The master config 'engines' option takes a list of engines
but will accept a single engine instead of the list but adds
a warning that it requires a list. The documentation for some
of the engine modules pass a single engine instead of a list
of engines. This commit fixes the documentation of these engine
modules to give correct usage of the 'engines' option.

Additionally, A few of the documentation pages were missing
code-blocks where they were needed to ensure proper formatting.
This commit adds the code blocks where they were missing in the
engine modules documentation.

### What issues does this PR fix or reference?
Fixes #42333

### Tests written?

No