### PR TITLE
Allow to check whether a function is available on the AliasesLoader wrapper

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -82,6 +82,13 @@ class AliasedLoader(object):
         else:
             return getattr(self.wrapped, name)
 
+    def __contains__(self, name):
+        if name in ALIASES:
+            salt.utils.warn_until('Nitrogen', ALIAS_WARN)
+            return ALIASES[name] in self.wrapped
+        else:
+            return name in self.wrapped
+
 
 class AliasedModule(object):
     '''

--- a/tests/integration/files/file/base/jinja_salt_contains_function.sls
+++ b/tests/integration/files/file/base/jinja_salt_contains_function.sls
@@ -1,0 +1,10 @@
+{% set salt_foo_bar_exist = 'foo.bar' in salt %}
+{% set salt_test_ping_exist = 'test.ping' in salt %}
+
+test-ping-exist:
+  test.succeed_without_changes:
+    - name: salt_test_ping_exist_{{ salt_test_ping_exist }}
+
+foo-bar-not-exist:
+  test.succeed_without_changes:
+    - name: salt_foo_bar_exist_{{ salt_foo_bar_exist }}

--- a/tests/integration/states/renderers.py
+++ b/tests/integration/states/renderers.py
@@ -26,6 +26,14 @@ class TestJinjaRenderer(integration.ModuleCase):
         for state_ret in ret.values():
             self.assertTrue(state_ret['result'])
 
+    def test_salt_contains_function(self):
+        '''
+        Test if we are able to check if a function exists inside the "salt"
+        wrapper (AliasLoader) which is available on Jinja templates.
+        '''
+        ret = self.run_function('state.sls', ['jinja_salt_contains_function'])
+        for state_ret in ret.values():
+            self.assertTrue(state_ret['result'])
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?
This PR adds `__contains__` magic python method to the `AliasesLoader` class in order to allow checking if a given Salt function is available inside the wrapped object.

Currently we cannot check whether a Salt function is actually existing or not when we're checking it from within a SLS file. With this PR we would get more flexibility writing SLS files.

Given a SLS file containing something like this:

```
{% if 'foo.bar' in salt %}
  ...
{% else %}
  ...
{% endif %}
```

### Previous Behavior
Without this PR, we get the following error, as the `AliasesWrapper` class doesn't know how to check for it inside the wrapped object:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/templates.py", line 375, in render_jinja_tmpl
    output = template.render(**decoded_context)
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 969, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 742, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 2, in top-level template code
  File "/usr/lib/python2.7/site-packages/salt/utils/templates.py", line 76, in __getitem__
    return self.wrapped[name]
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1087, in __getitem__
    func = super(LazyLoader, self).__getitem__(item)
  File "/usr/lib/python2.7/site-packages/salt/utils/lazy.py", line 96, in __getitem__
    if self._load(key):
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1494, in _load
    raise KeyError
KeyError
```
### New Behavior
With this PR, the same SLS file would render and execute as expected:

```
local:
----------
          ID: test-ping-exist
    Function: test.succeed_without_changes
        Name: salt_test_ping_exist_True
      Result: True
     Comment: Success!
     Started: 13:54:08.240483
    Duration: 0.295 ms
     Changes:   
----------
          ID: foo-bar-not-exist
    Function: test.succeed_without_changes
        Name: salt_foo_bar_exist_False
      Result: True
     Comment: Success!
     Started: 13:54:08.240857
    Duration: 0.209 ms
     Changes:   

Summary for local
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2
Total run time:   0.504 ms
```

### Tests written?
Yes

/cc @isbm 