### PR TITLE
Remove build and dist directories before install

### DIFF
--- a/pkg/windows/build.bat
+++ b/pkg/windows/build.bat
@@ -110,6 +110,12 @@ if not %errorLevel%==0 (
 )
 @echo.
 
+:: Remove build and dist directories
+@echo %0 :: Remove build and dist directories...
+@echo ---------------------------------------------------------------------
+rd /s /q "%SrcDir%\build"
+rd /s /q "%SrcDir%\dist"
+
 :: Install Current Version of salt
 @echo %0 :: Install Current Version of salt...
 @echo ---------------------------------------------------------------------

--- a/pkg/windows/build.bat
+++ b/pkg/windows/build.bat
@@ -115,6 +115,7 @@ if not %errorLevel%==0 (
 @echo ---------------------------------------------------------------------
 rd /s /q "%SrcDir%\build"
 rd /s /q "%SrcDir%\dist"
+@echo.
 
 :: Install Current Version of salt
 @echo %0 :: Install Current Version of salt...


### PR DESCRIPTION
### What does this PR do?
Removes the `salt\build` and `salt\dist` directories before running `setup.py install` when building Salt Windows packages.

### Previous Behavior
Some stale files were being copied over to the install.