### PR TITLE
Move file-related utilities out of init file and into salt.utils.files.py

### DIFF
--- a/doc/topics/development/tests/integration.rst
+++ b/doc/topics/development/tests/integration.rst
@@ -371,6 +371,7 @@ on a minion event bus.
 .. code-block:: python
 
     import tests.integration as integration
+    import salt.utils.event
 
     class TestEvent(integration.SaltEventAssertsMixin):
         '''
@@ -443,7 +444,7 @@ to test states:
     from tests.support.mixins import SaltReturnAssertsMixin
 
     # Import salt libs
-    import salt.utils
+    import salt.utils.files
 
     HFILE = os.path.join(TMP, 'hosts')
 
@@ -470,7 +471,7 @@ to test states:
             ip = '10.10.10.10'
             ret = self.run_state('host.present', name=name, ip=ip)
             self.assertSaltTrueReturn(ret)
-            with salt.utils.fopen(HFILE) as fp_:
+            with salt.utils.files.fopen(HFILE) as fp_:
                 output = fp_.read()
                 self.assertIn('{0}\t\t{1}'.format(ip, name), output)
 

--- a/doc/topics/spm/dev.rst
+++ b/doc/topics/spm/dev.rst
@@ -256,7 +256,7 @@ This function will not generally be more complex than:
 .. code-block:: python
 
     def hash_file(path, hashobj, conn=None):
-        with salt.utils.fopen(path, 'r') as f:
+        with salt.utils.files.fopen(path, 'r') as f:
             hashobj.update(f.read())
             return hashobj.hexdigest()
 

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -229,7 +229,7 @@ class LoadAuth(object):
 
         try:
             with salt.utils.files.set_umask(0o177):
-                with salt.utils.fopen(t_path, 'w+b') as fp_:
+                with salt.utils.files.fopen(t_path, 'w+b') as fp_:
                     fp_.write(self.serial.dumps(tdata))
         except (IOError, OSError):
             log.warning('Authentication failure: can not write token file "{0}".'.format(t_path))
@@ -245,7 +245,7 @@ class LoadAuth(object):
         if not os.path.isfile(t_path):
             return {}
         try:
-            with salt.utils.fopen(t_path, 'rb') as fp_:
+            with salt.utils.files.fopen(t_path, 'rb') as fp_:
                 tdata = self.serial.loads(fp_.read())
         except (IOError, OSError):
             log.warning('Authentication failure: can not read token file "{0}".'.format(t_path))
@@ -670,7 +670,7 @@ class Resolver(object):
             return tdata
         try:
             with salt.utils.files.set_umask(0o177):
-                with salt.utils.fopen(self.opts['token_file'], 'w+') as fp_:
+                with salt.utils.files.fopen(self.opts['token_file'], 'w+') as fp_:
                     fp_.write(tdata['token'])
         except (IOError, OSError):
             pass

--- a/salt/auth/file.py
+++ b/salt/auth/file.py
@@ -102,6 +102,7 @@ import os
 
 # Import salt utils
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -158,7 +159,7 @@ def _text(username, password, **kwargs):
     username_field = kwargs['username_field']-1
     password_field = kwargs['password_field']-1
 
-    with salt.utils.fopen(filename, 'r') as pwfile:
+    with salt.utils.files.fopen(filename, 'r') as pwfile:
         for line in pwfile.readlines():
             fields = line.strip().split(field_separator)
 

--- a/salt/auth/pki.py
+++ b/salt/auth/pki.py
@@ -33,7 +33,7 @@ except ImportError:
 # pylint: enable=import-error
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -74,7 +74,7 @@ def auth(username, password, **kwargs):
     cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, pem)
 
     cacert_file = __salt__['config.get']('external_auth:pki:ca_file')
-    with salt.utils.fopen(cacert_file) as f:
+    with salt.utils.files.fopen(cacert_file) as f:
         cacert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, f.read())
 
     log.debug('Attempting to authenticate via pki.')

--- a/salt/beacons/btmp.py
+++ b/salt/beacons/btmp.py
@@ -14,7 +14,7 @@ import os
 import struct
 
 # Import Salt Libs
-import salt.utils
+import salt.utils.files
 
 __virtualname__ = 'btmp'
 BTMP = '/var/log/btmp'
@@ -71,7 +71,7 @@ def beacon(config):
           btmp: {}
     '''
     ret = []
-    with salt.utils.fopen(BTMP, 'rb') as fp_:
+    with salt.utils.files.fopen(BTMP, 'rb') as fp_:
         loc = __context__.get(LOC_KEY, 0)
         if loc == 0:
             fp_.seek(0, 2)

--- a/salt/beacons/log.py
+++ b/salt/beacons/log.py
@@ -12,6 +12,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 
 try:
@@ -79,7 +80,7 @@ def beacon(config):
         ret.append(event)
         return ret
 
-    with salt.utils.fopen(config['file'], 'r') as fp_:
+    with salt.utils.files.fopen(config['file'], 'r') as fp_:
         loc = __context__.get(LOC_KEY, 0)
         if loc == 0:
             fp_.seek(0, 2)

--- a/salt/beacons/wtmp.py
+++ b/salt/beacons/wtmp.py
@@ -14,7 +14,7 @@ import os
 import struct
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 __virtualname__ = 'wtmp'
 WTMP = '/var/log/wtmp'
@@ -73,7 +73,7 @@ def beacon(config):
           wtmp: {}
     '''
     ret = []
-    with salt.utils.fopen(WTMP, 'rb') as fp_:
+    with salt.utils.files.fopen(WTMP, 'rb') as fp_:
         loc = __context__.get(LOC_KEY, 0)
         if loc == 0:
             fp_.seek(0, 2)

--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -20,6 +20,7 @@ import tempfile
 from salt.exceptions import SaltCacheError
 import salt.utils
 import salt.utils.atomicfile
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ def store(bank, key, data, cachedir):
     tmpfh, tmpfname = tempfile.mkstemp(dir=base)
     os.close(tmpfh)
     try:
-        with salt.utils.fopen(tmpfname, 'w+b') as fh_:
+        with salt.utils.files.fopen(tmpfname, 'w+b') as fh_:
             fh_.write(__context__['serial'].dumps(data))
         # On Windows, os.rename will fail if the destination file exists.
         salt.utils.atomicfile.atomic_rename(tmpfname, outfile)
@@ -85,7 +86,7 @@ def fetch(bank, key, cachedir):
         log.debug('Cache file "%s" does not exist', key_file)
         return {}
     try:
-        with salt.utils.fopen(key_file, 'rb') as fh_:
+        with salt.utils.files.fopen(key_file, 'rb') as fh_:
             if inkey:
                 return __context__['serial'].load(fh_)[key]
             else:

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -21,6 +21,7 @@ import salt.output
 import salt.payload
 import salt.transport
 import salt.utils.args
+import salt.utils.files
 import salt.utils.jid
 import salt.utils.minion
 import salt.defaults.exitcodes
@@ -189,7 +190,7 @@ class BaseCaller(object):
                     no_parse=self.opts.get('no_parse', [])),
                 data=sdata)
             try:
-                with salt.utils.fopen(proc_fn, 'w+b') as fp_:
+                with salt.utils.files.fopen(proc_fn, 'w+b') as fp_:
                     fp_.write(self.serial.dumps(sdata))
             except NameError:
                 # Don't require msgpack with local

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -75,8 +75,9 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             'show_jid': self.options.show_jid}
 
         if 'token' in self.config:
+            import salt.utils.files
             try:
-                with salt.utils.fopen(os.path.join(self.config['cachedir'], '.root_key'), 'r') as fp_:
+                with salt.utils.files.fopen(os.path.join(self.config['cachedir'], '.root_key'), 'r') as fp_:
                     kwargs['key'] = fp_.readline()
             except IOError:
                 kwargs['token'] = self.config['token']

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -35,6 +35,7 @@ import salt.loader
 import salt.utils
 import salt.utils.args
 import salt.utils.event
+import salt.utils.files
 import salt.utils.minions
 import salt.utils.verify
 import salt.utils.jid
@@ -193,7 +194,7 @@ class LocalClient(object):
                                                self.skip_perm_errors)
 
         try:
-            with salt.utils.fopen(keyfile, 'r') as key:
+            with salt.utils.files.fopen(keyfile, 'r') as key:
                 return key.read()
         except (OSError, IOError):
             # Fall back to eauth

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -39,12 +39,13 @@ import salt.serializers.yaml
 import salt.state
 import salt.utils
 import salt.utils.args
-import salt.utils.event
 import salt.utils.atomicfile
+import salt.utils.event
+import salt.utils.files
+import salt.utils.network
 import salt.utils.thin
 import salt.utils.url
 import salt.utils.verify
-import salt.utils.network
 from salt.utils import is_windows
 from salt.utils.process import MultiprocessingProcess
 
@@ -195,7 +196,7 @@ if not is_windows():
     if not os.path.exists(shim_file):
         # On esky builds we only have the .pyc file
         shim_file += "c"
-    with salt.utils.fopen(shim_file) as ssh_py_shim:
+    with salt.utils.files.fopen(shim_file) as ssh_py_shim:
         SSH_PY_SHIM = ssh_py_shim.read()
 
 log = logging.getLogger(__name__)
@@ -337,7 +338,7 @@ class SSH(object):
                         )
                     )
         pub = '{0}.pub'.format(priv)
-        with salt.utils.fopen(pub, 'r') as fp_:
+        with salt.utils.files.fopen(pub, 'r') as fp_:
             return '{0} rsa root@master'.format(fp_.read().split()[1])
 
     def key_deploy(self, host, ret):
@@ -941,12 +942,12 @@ class Single(object):
                     'grains': opts_pkg['grains'],
                     'pillar': pillar_data}
             if data_cache:
-                with salt.utils.fopen(datap, 'w+b') as fp_:
+                with salt.utils.files.fopen(datap, 'w+b') as fp_:
                     fp_.write(
                             self.serial.dumps(data)
                             )
         if not data and data_cache:
-            with salt.utils.fopen(datap, 'rb') as fp_:
+            with salt.utils.files.fopen(datap, 'rb') as fp_:
                 data = self.serial.load(fp_)
         opts = data.get('opts', {})
         opts['grains'] = data.get('grains')
@@ -1412,7 +1413,7 @@ def mod_data(fsclient):
         return mods
     tfp = tarfile.open(ext_tar_path, 'w:gz')
     verfile = os.path.join(fsclient.opts['cachedir'], 'ext_mods.ver')
-    with salt.utils.fopen(verfile, 'w+') as fp_:
+    with salt.utils.files.fopen(verfile, 'w+') as fp_:
         fp_.write(ver)
     tfp.add(verfile, 'ext_version')
     for ref in ret:

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -15,10 +15,10 @@ from contextlib import closing
 # Import salt libs
 import salt.client.ssh.shell
 import salt.client.ssh
-import salt.utils
 import salt.utils.files
 import salt.utils.thin
 import salt.utils.url
+import salt.utils.verify
 import salt.roster
 import salt.state
 import salt.loader
@@ -177,13 +177,13 @@ def prep_trans_tar(opts, file_client, chunks, file_refs, pillar=None, id_=None, 
             [salt.utils.url.create('_output')],
             [salt.utils.url.create('_utils')],
             ]
-    with salt.utils.fopen(lowfn, 'w+') as fp_:
+    with salt.utils.files.fopen(lowfn, 'w+') as fp_:
         fp_.write(json.dumps(chunks))
     if pillar:
-        with salt.utils.fopen(pillarfn, 'w+') as fp_:
+        with salt.utils.files.fopen(pillarfn, 'w+') as fp_:
             fp_.write(json.dumps(pillar))
     if roster_grains:
-        with salt.utils.fopen(roster_grainsfn, 'w+') as fp_:
+        with salt.utils.files.fopen(roster_grainsfn, 'w+') as fp_:
             fp_.write(json.dumps(roster_grains))
 
     if id_ is None:

--- a/salt/client/ssh/wrapper/cp.py
+++ b/salt/client/ssh/wrapper/cp.py
@@ -2,13 +2,15 @@
 '''
 Wrap the cp module allowing for managed ssh file transfers
 '''
+# Import Python libs
 from __future__ import absolute_import
+import logging
+import os
 
 # Import salt libs
 import salt.client.ssh
 import salt.utils.files
-import logging
-import os
+import salt.utils.templates
 from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
@@ -138,14 +140,14 @@ def _render_filenames(path, dest, saltenv, template):
         '''
         # write out path to temp file
         tmp_path_fn = salt.utils.files.mkstemp()
-        with salt.utils.fopen(tmp_path_fn, 'w+') as fp_:
+        with salt.utils.files.fopen(tmp_path_fn, 'w+') as fp_:
             fp_.write(contents)
         data = salt.utils.templates.TEMPLATE_REGISTRY[template](
             tmp_path_fn,
             to_str=True,
             **kwargs
         )
-        salt.utils.safe_rm(tmp_path_fn)
+        salt.utils.files.safe_rm(tmp_path_fn)
         if not data['result']:
             # Failed to render the template
             raise CommandExecutionError(

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1396,7 +1396,7 @@ class Cloud(object):
             vm_overrides = {}
 
         try:
-            with salt.utils.fopen(self.opts['conf_file'], 'r') as mcc:
+            with salt.utils.files.fopen(self.opts['conf_file'], 'r') as mcc:
                 main_cloud_config = yaml.safe_load(mcc)
             if not main_cloud_config:
                 main_cloud_config = {}
@@ -2106,7 +2106,7 @@ class Map(Cloud):
             # Generate the fingerprint of the master pubkey in order to
             # mitigate man-in-the-middle attacks
             master_temp_pub = salt.utils.files.mkstemp()
-            with salt.utils.fopen(master_temp_pub, 'w') as mtp:
+            with salt.utils.files.fopen(master_temp_pub, 'w') as mtp:
                 mtp.write(pub)
             master_finger = salt.utils.pem_finger(master_temp_pub, sum_type=self.opts['hash_type'])
             os.unlink(master_temp_pub)

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -64,6 +64,7 @@ import salt.cache
 import salt.config as config
 import salt.utils
 import salt.utils.cloud
+import salt.utils.files
 import salt.ext.six as six
 import salt.version
 from salt.exceptions import (
@@ -1002,7 +1003,7 @@ def request_instance(call=None, kwargs=None):  # pylint: disable=unused-argument
         )
     else:
         if os.path.exists(userdata_file):
-            with salt.utils.fopen(userdata_file, 'r') as fh_:
+            with salt.utils.files.fopen(userdata_file, 'r') as fh_:
                 userdata = fh_.read()
 
     userdata = salt.utils.cloud.userdata_template(__opts__, vm_, userdata)

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -36,6 +36,7 @@ import decimal
 
 # Import Salt Libs
 import salt.utils.cloud
+import salt.utils.files
 import salt.config as config
 from salt.exceptions import (
     SaltCloudConfigError,
@@ -383,7 +384,7 @@ def create(vm_):
     )
     if userdata_file is not None:
         try:
-            with salt.utils.fopen(userdata_file, 'r') as fp_:
+            with salt.utils.files.fopen(userdata_file, 'r') as fp_:
                 kwargs['user_data'] = salt.utils.cloud.userdata_template(
                     __opts__, vm_, fp_.read()
                 )
@@ -713,7 +714,7 @@ def import_keypair(kwargs=None, call=None):
         file(mandatory): public key file-name
         keyname(mandatory): public key name in the provider
     '''
-    with salt.utils.fopen(kwargs['file'], 'r') as public_key_filename:
+    with salt.utils.files.fopen(kwargs['file'], 'r') as public_key_filename:
         public_key_content = public_key_filename.read()
 
     digital_ocean_kwargs = {

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -89,14 +89,12 @@ import re
 import decimal
 
 # Import Salt Libs
-import salt.utils
+import salt.utils.cloud
+import salt.utils.files
 import salt.utils.hashutils
 from salt._compat import ElementTree as ET
 import salt.utils.http as http
 import salt.utils.aws as aws
-
-# Import salt.cloud libs
-import salt.utils.cloud
 import salt.config as config
 from salt.exceptions import (
     SaltCloudException,
@@ -1787,7 +1785,7 @@ def request_instance(vm_=None, call=None):
     else:
         log.trace('userdata_file: {0}'.format(userdata_file))
         if os.path.exists(userdata_file):
-            with salt.utils.fopen(userdata_file, 'r') as fh_:
+            with salt.utils.files.fopen(userdata_file, 'r') as fh_:
                 userdata = fh_.read()
 
     userdata = salt.utils.cloud.userdata_template(__opts__, vm_, userdata)
@@ -2444,7 +2442,7 @@ def wait_for_instance(
                     continue
                 keys += '\n{0} {1}'.format(ip_address, line)
 
-            with salt.utils.fopen(known_hosts_file, 'a') as fp_:
+            with salt.utils.files.fopen(known_hosts_file, 'a') as fp_:
                 fp_.write(keys)
             fp_.close()
 
@@ -4389,7 +4387,7 @@ def import_keypair(kwargs=None, call=None):
     public_key_file = kwargs['file']
 
     if os.path.exists(public_key_file):
-        with salt.utils.fopen(public_key_file, 'r') as fh_:
+        with salt.utils.files.fopen(public_key_file, 'r') as fh_:
             public_key = fh_.read()
 
     if public_key is not None:
@@ -4778,7 +4776,7 @@ def get_password_data(
 
     if 'key' not in kwargs:
         if 'key_file' in kwargs:
-            with salt.utils.fopen(kwargs['key_file'], 'r') as kf_:
+            with salt.utils.files.fopen(kwargs['key_file'], 'r') as kf_:
                 kwargs['key'] = kf_.read()
 
     if 'key' in kwargs:
@@ -4878,7 +4876,7 @@ def _parse_pricing(url, name):
     outfile = os.path.join(
         __opts__['cachedir'], 'ec2-pricing-{0}.p'.format(name)
     )
-    with salt.utils.fopen(outfile, 'w') as fho:
+    with salt.utils.files.fopen(outfile, 'w') as fho:
         msgpack.dump(regions, fho)
 
     return True
@@ -4946,7 +4944,7 @@ def show_pricing(kwargs=None, call=None):
     if not os.path.isfile(pricefile):
         update_pricing({'type': name}, 'function')
 
-    with salt.utils.fopen(pricefile, 'r') as fhi:
+    with salt.utils.files.fopen(pricefile, 'r') as fhi:
         ec2_price = msgpack.load(fhi)
 
     region = get_location(profile)

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -85,6 +85,7 @@ except ImportError:
 from salt.utils import namespaced_function
 import salt.ext.six as six
 import salt.utils.cloud
+import salt.utils.files
 import salt.config as config
 from salt.utils import http
 from salt.cloud.libcloudfuncs import *  # pylint: disable=redefined-builtin,wildcard-import,unused-wildcard-import
@@ -2619,7 +2620,7 @@ def update_pricing(kwargs=None, call=None):
     outfile = os.path.join(
         __opts__['cachedir'], 'gce-pricing.p'
     )
-    with salt.utils.fopen(outfile, 'w') as fho:
+    with salt.utils.files.fopen(outfile, 'w') as fho:
         msgpack.dump(price_json['dict'], fho)
 
     return True
@@ -2658,7 +2659,7 @@ def show_pricing(kwargs=None, call=None):
     if not os.path.exists(pricefile):
         update_pricing()
 
-    with salt.utils.fopen(pricefile, 'r') as fho:
+    with salt.utils.files.fopen(pricefile, 'r') as fho:
         sizes = msgpack.load(fho)
 
     per_hour = float(sizes['gcp_price_list'][size][region])

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -67,10 +67,10 @@ from Crypto.Signature import PKCS1_v1_5
 # Import salt libs
 import salt.ext.six as six
 from salt.ext.six.moves import http_client  # pylint: disable=import-error,no-name-in-module
-import salt.utils.http
 import salt.utils.cloud
+import salt.utils.files
+import salt.utils.http
 import salt.config as config
-from salt.utils.cloud import is_public_ip
 from salt.cloud.libcloudfuncs import node_state
 from salt.exceptions import (
     SaltCloudSystemExit,
@@ -693,7 +693,7 @@ def reformat_node(item=None, full=False):
     item['public_ips'] = []
     if 'ips' in item:
         for ip in item['ips']:
-            if is_public_ip(ip):
+            if salt.utils.cloud.is_public_ip(ip):
                 item['public_ips'].append(ip)
             else:
                 item['private_ips'].append(ip)
@@ -951,7 +951,7 @@ def import_key(kwargs=None, call=None):
         ))
         return False
 
-    with salt.utils.fopen(kwargs['keyfile'], 'r') as fp_:
+    with salt.utils.files.fopen(kwargs['keyfile'], 'r') as fp_:
         kwargs['key'] = fp_.read()
 
     send_data = {'name': kwargs['keyname'], 'key': kwargs['key']}
@@ -1070,7 +1070,7 @@ def query(action=None,
 
     timenow = datetime.datetime.utcnow()
     timestamp = timenow.strftime('%a, %d %b %Y %H:%M:%S %Z').strip()
-    with salt.utils.fopen(ssh_keyfile, 'r') as kh_:
+    with salt.utils.files.fopen(ssh_keyfile, 'r') as kh_:
         rsa_key = RSA.importKey(kh_)
     rsa_ = PKCS1_v1_5.new(rsa_key)
     hash_ = SHA256.new()

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -210,7 +210,9 @@ import yaml
 
 # Import Salt Libs
 import salt.ext.six as six
-import salt.utils
+import salt.utils.cloud
+import salt.utils.files
+import salt.utils.pycrypto
 import salt.client
 from salt.utils.openstack import nova
 try:
@@ -220,8 +222,6 @@ except ImportError as exc:
 
 # Import Salt Cloud Libs
 from salt.cloud.libcloudfuncs import *  # pylint: disable=W0614,W0401
-import salt.utils.cloud
-import salt.utils.pycrypto as sup
 import salt.config as config
 from salt.utils import namespaced_function
 from salt.exceptions import (
@@ -651,7 +651,7 @@ def request_instance(vm_=None, call=None):
         kwargs['files'] = {}
         for src_path in files:
             if os.path.exists(files[src_path]):
-                with salt.utils.fopen(files[src_path], 'r') as fp_:
+                with salt.utils.files.fopen(files[src_path], 'r') as fp_:
                     kwargs['files'][src_path] = fp_.read()
             else:
                 kwargs['files'][src_path] = files[src_path]
@@ -661,7 +661,7 @@ def request_instance(vm_=None, call=None):
     )
     if userdata_file is not None:
         try:
-            with salt.utils.fopen(userdata_file, 'r') as fp_:
+            with salt.utils.files.fopen(userdata_file, 'r') as fp_:
                 kwargs['userdata'] = salt.utils.cloud.userdata_template(
                     __opts__, vm_, fp_.read()
                 )
@@ -981,7 +981,7 @@ def create(vm_):
             )
         data = conn.server_show_libcloud(vm_['instance_id'])
         if vm_['key_filename'] is None and 'change_password' in __opts__ and __opts__['change_password'] is True:
-            vm_['password'] = sup.secure_password()
+            vm_['password'] = salt.utils.pycrypto.secure_password()
             conn.root_password(vm_['instance_id'], vm_['password'])
     else:
         # Put together all of the information required to request the instance,

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -77,6 +77,7 @@ from salt.exceptions import (
     SaltCloudSystemExit
 )
 import salt.utils
+import salt.utils.files
 
 # Import Third Party Libs
 try:
@@ -1310,7 +1311,7 @@ def image_allocate(call=None, kwargs=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -1876,7 +1877,7 @@ def image_update(call=None, kwargs=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -1969,7 +1970,7 @@ def secgroup_allocate(call=None, kwargs=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -2269,7 +2270,7 @@ def secgroup_update(call=None, kwargs=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -2335,7 +2336,7 @@ def template_allocate(call=None, kwargs=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -2650,7 +2651,7 @@ def template_update(call=None, kwargs=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -2783,7 +2784,7 @@ def vm_allocate(call=None, kwargs=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -2849,7 +2850,7 @@ def vm_attach(name, kwargs=None, call=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -2916,7 +2917,7 @@ def vm_attach_nic(name, kwargs=None, call=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -3603,7 +3604,7 @@ def vm_resize(name, kwargs=None, call=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -3831,7 +3832,7 @@ def vm_update(name, kwargs=None, call=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -3919,7 +3920,7 @@ def vn_add_ar(call=None, kwargs=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -3992,7 +3993,7 @@ def vn_allocate(call=None, kwargs=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -4217,7 +4218,7 @@ def vn_hold(call=None, kwargs=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -4362,7 +4363,7 @@ def vn_release(call=None, kwargs=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(
@@ -4449,7 +4450,7 @@ def vn_reserve(call=None, kwargs=None):
                 '\'data\' will take precedence.'
             )
     elif path:
-        with salt.utils.fopen(path, mode='r') as rfh:
+        with salt.utils.files.fopen(path, mode='r') as rfh:
             data = rfh.read()
     else:
         raise SaltCloudSystemExit(

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -175,10 +175,9 @@ from salt.cloud.libcloudfuncs import *   # pylint: disable=W0614,W0401
 
 # Import salt libs
 import salt.utils
-
-# Import salt.cloud libs
 import salt.utils.cloud
-import salt.utils.pycrypto as sup
+import salt.utils.files
+import salt.utils.pycrypto
 import salt.config as config
 from salt.utils import namespaced_function
 from salt.exceptions import (
@@ -529,7 +528,7 @@ def request_instance(vm_=None, call=None):
     if files:
         kwargs['ex_files'] = {}
         for src_path in files:
-            with salt.utils.fopen(files[src_path], 'r') as fp_:
+            with salt.utils.files.fopen(files[src_path], 'r') as fp_:
                 kwargs['ex_files'][src_path] = fp_.read()
 
     userdata_file = config.get_cloud_config_value(
@@ -537,7 +536,7 @@ def request_instance(vm_=None, call=None):
     )
     if userdata_file is not None:
         try:
-            with salt.utils.fopen(userdata_file, 'r') as fp_:
+            with salt.utils.files.fopen(userdata_file, 'r') as fp_:
                 kwargs['ex_userdata'] = salt.utils.cloud.userdata_template(
                     __opts__, vm_, fp_.read()
                 )
@@ -761,7 +760,7 @@ def create(vm_):
             )
         data = conn.ex_get_node_details(vm_['instance_id'])
         if vm_['key_filename'] is None and 'change_password' in __opts__ and __opts__['change_password'] is True:
-            vm_['password'] = sup.secure_password()
+            vm_['password'] = salt.utils.pycrypto.secure_password()
             conn.ex_set_password(data, vm_['password'])
         networks(vm_)
     else:

--- a/salt/cloud/clouds/profitbricks.py
+++ b/salt/cloud/clouds/profitbricks.py
@@ -98,7 +98,8 @@ import pprint
 import time
 
 # Import salt libs
-import salt.utils
+import salt.utils.cloud
+import salt.utils.files
 import salt.config as config
 from salt.exceptions import (
     SaltCloudConfigError,
@@ -107,9 +108,6 @@ from salt.exceptions import (
     SaltCloudExecutionTimeout,
     SaltCloudSystemExit
 )
-
-# Import salt.cloud libs
-import salt.utils.cloud
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -642,7 +640,7 @@ def get_public_keys(vm_):
                 )
             )
         ssh_keys = []
-        with salt.utils.fopen(key_filename) as rfh:
+        with salt.utils.files.fopen(key_filename) as rfh:
             for key in rfh.readlines():
                 ssh_keys.append(key)
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -33,6 +33,7 @@ from salt.ext.six.moves.urllib.parse import urlparse
 # Import salt libs
 import salt.utils
 import salt.utils.dictupdate
+import salt.utils.files
 import salt.utils.network
 import salt.syspaths
 import salt.utils.validate.path
@@ -1932,7 +1933,7 @@ def _read_conf_file(path):
     Read in a config file from a given path and process it into a dictionary
     '''
     log.debug('Reading configuration from {0}'.format(path))
-    with salt.utils.fopen(path, 'r') as conf_file:
+    with salt.utils.files.fopen(path, 'r') as conf_file:
         try:
             conf_opts = yaml.safe_load(conf_file.read()) or {}
         except yaml.YAMLError as err:
@@ -2024,8 +2025,8 @@ def load_config(path, env_var, default_path=None, exit_on_config_errors=True):
         template = '{0}.template'.format(path)
         if os.path.isfile(template):
             log.debug('Writing {0} based on {1}'.format(path, template))
-            with salt.utils.fopen(path, 'w') as out:
-                with salt.utils.fopen(template, 'r') as ifile:
+            with salt.utils.files.fopen(path, 'w') as out:
+                with salt.utils.files.fopen(template, 'r') as ifile:
                     ifile.readline()  # skip first line
                     out.write(ifile.read())
 
@@ -3313,7 +3314,7 @@ def _cache_id(minion_id, cache_file):
     Helper function, writes minion id to a cache file.
     '''
     try:
-        with salt.utils.fopen(cache_file, 'w') as idf:
+        with salt.utils.files.fopen(cache_file, 'w') as idf:
             idf.write(minion_id)
     except (IOError, OSError) as exc:
         log.error('Could not cache minion ID: {0}'.format(exc))
@@ -3346,7 +3347,7 @@ def get_id(opts, cache_minion_id=False):
 
     if opts.get('minion_id_caching', True):
         try:
-            with salt.utils.fopen(id_cache) as idf:
+            with salt.utils.files.fopen(id_cache) as idf:
                 name = idf.readline().strip()
                 bname = salt.utils.to_bytes(name)
                 if bname.startswith(codecs.BOM):  # Remove BOM if exists
@@ -3748,7 +3749,7 @@ def client_config(path, env_var='SALT_CLIENT_CONFIG', defaults=None):
         # Make sure token is still valid
         expire = opts.get('token_expire', 43200)
         if os.stat(opts['token_file']).st_mtime + expire > time.mktime(time.localtime()):
-            with salt.utils.fopen(opts['token_file']) as fp_:
+            with salt.utils.files.fopen(opts['token_file']) as fp_:
                 opts['token'] = fp_.read().strip()
     # On some platforms, like OpenBSD, 0.0.0.0 won't catch a master running on localhost
     if opts['interface'] == '0.0.0.0':

--- a/salt/daemons/flo/jobber.py
+++ b/salt/daemons/flo/jobber.py
@@ -19,8 +19,9 @@ import json
 # Import salt libs
 import salt.ext.six as six
 import salt.daemons.masterapi
-import salt.utils.args
 import salt.utils
+import salt.utils.args
+import salt.utils.files
 import salt.transport
 from raet import raeting, nacling
 from raet.lane.stacking import LaneStack
@@ -279,7 +280,7 @@ class SaltRaetNixJobber(ioflo.base.deeding.Deed):
 
         sdata = {'pid': os.getpid()}
         sdata.update(data)
-        with salt.utils.fopen(fn_, 'w+b') as fp_:
+        with salt.utils.files.fopen(fn_, 'w+b') as fp_:
             fp_.write(self.serial.dumps(sdata))
         ret = {'success': False}
         function_name = data['fun']

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -31,10 +31,11 @@ import salt.fileserver
 import salt.utils.args
 import salt.utils.atomicfile
 import salt.utils.event
-import salt.utils.verify
-import salt.utils.minions
+import salt.utils.files
 import salt.utils.gzip_util
 import salt.utils.jid
+import salt.utils.minions
+import salt.utils.verify
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.pillar import git_pillar
 from salt.utils.event import tagify
@@ -154,7 +155,7 @@ def clean_expired_tokens(opts):
     for (dirpath, dirnames, filenames) in os.walk(opts['token_dir']):
         for token in filenames:
             token_path = os.path.join(dirpath, token)
-            with salt.utils.fopen(token_path, 'rb') as token_file:
+            with salt.utils.files.fopen(token_path, 'rb') as token_file:
                 try:
                     token_data = serializer.loads(token_file.read())
                 except msgpack.UnpackValueError:
@@ -223,7 +224,7 @@ def mk_key(opts, user):
 
     key = salt.crypt.Crypticle.generate_key_string()
     cumask = os.umask(191)
-    with salt.utils.fopen(keyfile, 'w+') as fp_:
+    with salt.utils.files.fopen(keyfile, 'w+') as fp_:
         fp_.write(key)
     os.umask(cumask)
     # 600 octal: Read and write access to the owner only.
@@ -360,7 +361,7 @@ class AutoKey(object):
             log.warning(message.format(signing_file))
             return False
 
-        with salt.utils.fopen(signing_file, 'r') as fp_:
+        with salt.utils.files.fopen(signing_file, 'r') as fp_:
             for line in fp_:
                 line = line.strip()
                 if line.startswith('#'):
@@ -693,7 +694,7 @@ class RemoteFuncs(object):
             mode = 'ab'
         else:
             mode = 'wb'
-        with salt.utils.fopen(cpath, mode) as fp_:
+        with salt.utils.files.fopen(cpath, mode) as fp_:
             if load['loc']:
                 fp_.seek(load['loc'])
             fp_.write(load['data'])
@@ -858,7 +859,7 @@ class RemoteFuncs(object):
             if not os.path.isdir(auth_cache):
                 os.makedirs(auth_cache)
             jid_fn = os.path.join(auth_cache, load['jid'])
-            with salt.utils.fopen(jid_fn, 'r') as fp_:
+            with salt.utils.files.fopen(jid_fn, 'r') as fp_:
                 if not load['id'] == fp_.read():
                     return {}
 
@@ -915,7 +916,7 @@ class RemoteFuncs(object):
         if not os.path.isdir(auth_cache):
             os.makedirs(auth_cache)
         jid_fn = os.path.join(auth_cache, str(ret['jid']))
-        with salt.utils.fopen(jid_fn, 'w+') as fp_:
+        with salt.utils.files.fopen(jid_fn, 'w+') as fp_:
             fp_.write(load['id'])
         return ret
 

--- a/salt/engines/hipchat.py
+++ b/salt/engines/hipchat.py
@@ -49,7 +49,9 @@ except ImportError:
     HAS_HYPCHAT = False
 
 import salt.utils
+import salt.utils.event
 import salt.utils.files
+import salt.utils.http
 import salt.runner
 import salt.client
 import salt.loader
@@ -93,7 +95,7 @@ def _publish_file(token, room, filepath, message='', outputter=None, api_url=Non
     headers['Authorization'] = "Bearer " + token
     msg = json.dumps({'message': message})
 
-    with salt.utils.fopen(filepath, 'rb') as rfh:
+    with salt.utils.files.fopen(filepath, 'rb') as rfh:
         payload = """\
 --boundary123456
 Content-Type: application/json; charset=UTF-8
@@ -411,8 +413,8 @@ def start(token,
                 _publish_code_message(token, room, ret, message=message_string, outputter=outputter, api_url=api_url)
             else:
                 tmp_path_fn = salt.utils.files.mkstemp()
-                with salt.utils.fopen(tmp_path_fn, 'w+') as fp_:
+                with salt.utils.files.fopen(tmp_path_fn, 'w+') as fp_:
                     fp_.write(json.dumps(ret, sort_keys=True, indent=4))
                 _publish_file(token, room, tmp_path_fn, message=message_string, api_url=api_url)
-                salt.utils.safe_rm(tmp_path_fn)
+                salt.utils.files.safe_rm(tmp_path_fn)
         time.sleep(wait_time or _DEFAULT_SLEEP)

--- a/salt/engines/stalekey.py
+++ b/salt/engines/stalekey.py
@@ -24,11 +24,11 @@ import time
 import logging
 
 # Import salt libs
-import salt.utils.minions
 import salt.config
 import salt.key
+import salt.utils.files
+import salt.utils.minions
 import salt.wheel
-import salt.utils
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -59,7 +59,7 @@ def start(interval=3600, expire=604800):
         minions = {}
         if os.path.exists(presence_file):
             try:
-                with salt.utils.fopen(presence_file, 'r') as f:
+                with salt.utils.files.fopen(presence_file, 'r') as f:
                     minions = msgpack.load(f)
             except IOError as e:
                 log.error('Could not open presence file {0}: {1}'.format(presence_file, e))
@@ -94,7 +94,7 @@ def start(interval=3600, expire=604800):
             del minions[k]
 
         try:
-            with salt.utils.fopen(presence_file, 'w') as f:
+            with salt.utils.files.fopen(presence_file, 'w') as f:
                 msgpack.dump(minions, f)
         except IOError as e:
             log.error('Could not write to presence file {0}: {1}'.format(presence_file, e))

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -499,7 +499,7 @@ class Client(object):
                     'Path \'{0}\' is not absolute'.format(url_path)
                 )
             if dest is None:
-                with salt.utils.fopen(url_path, 'r') as fp_:
+                with salt.utils.files.fopen(url_path, 'r') as fp_:
                     data = fp_.read()
                 return data
             return url_path
@@ -507,7 +507,7 @@ class Client(object):
         if url_scheme == 'salt':
             result = self.get_file(url, dest, makedirs, saltenv, cachedir=cachedir)
             if result and dest is None:
-                with salt.utils.fopen(result, 'r') as fp_:
+                with salt.utils.files.fopen(result, 'r') as fp_:
                     data = fp_.read()
                 return data
             return result
@@ -558,7 +558,7 @@ class Client(object):
                 ftp = ftplib.FTP()
                 ftp.connect(url_data.hostname, url_data.port)
                 ftp.login(url_data.username, url_data.password)
-                with salt.utils.fopen(dest, 'wb') as fp_:
+                with salt.utils.files.fopen(dest, 'wb') as fp_:
                     ftp.retrbinary('RETR {0}'.format(url_data.path), fp_.write)
                 ftp.quit()
                 return dest
@@ -680,7 +680,7 @@ class Client(object):
                 dest_tmp = "{0}.part".format(dest)
                 # We need an open filehandle to use in the on_chunk callback,
                 # that's why we're not using a with clause here.
-                destfp = salt.utils.fopen(dest_tmp, 'wb')  # pylint: disable=resource-leakage
+                destfp = salt.utils.files.fopen(dest_tmp, 'wb')  # pylint: disable=resource-leakage
 
                 def on_chunk(chunk):
                     if write_body[0]:
@@ -772,7 +772,7 @@ class Client(object):
             if makedirs:
                 os.makedirs(destdir)
             else:
-                salt.utils.safe_rm(data['data'])
+                salt.utils.files.safe_rm(data['data'])
                 return ''
         shutil.move(data['data'], dest)
         return dest
@@ -1138,7 +1138,7 @@ class RemoteClient(Client):
                     return False
             # We need an open filehandle here, that's why we're not using a
             # with clause:
-            fn_ = salt.utils.fopen(dest, 'wb+')  # pylint: disable=resource-leakage
+            fn_ = salt.utils.files.fopen(dest, 'wb+')  # pylint: disable=resource-leakage
         else:
             log.debug('No dest file found')
 
@@ -1164,7 +1164,7 @@ class RemoteClient(Client):
                                 saltenv,
                                 cachedir=cachedir) as cache_dest:
                             dest = cache_dest
-                            with salt.utils.fopen(cache_dest, 'wb+') as ofile:
+                            with salt.utils.files.fopen(cache_dest, 'wb+') as ofile:
                                 ofile.write(data['data'])
                     if 'hsum' in data and d_tries < 3:
                         # Master has prompted a file verification, if the
@@ -1188,7 +1188,7 @@ class RemoteClient(Client):
                         # remove it to avoid a traceback trying to write the file
                         if os.path.isdir(dest):
                             salt.utils.rm_rf(dest)
-                        fn_ = salt.utils.fopen(dest, 'wb+')
+                        fn_ = salt.utils.files.fopen(dest, 'wb+')
                 if data.get('gzip', None):
                     data = salt.utils.gzip_util.uncompress(data['data'])
                 else:

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1187,7 +1187,7 @@ class RemoteClient(Client):
                         # If a directory was formerly cached at this path, then
                         # remove it to avoid a traceback trying to write the file
                         if os.path.isdir(dest):
-                            salt.utils.rm_rf(dest)
+                            salt.utils.files.rm_rf(dest)
                         fn_ = salt.utils.files.fopen(dest, 'wb+')
                 if data.get('gzip', None):
                     data = salt.utils.gzip_util.uncompress(data['data'])

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -16,7 +16,9 @@ import time
 # Import salt libs
 import salt.loader
 import salt.utils
+import salt.utils.files
 import salt.utils.locales
+import salt.utils.url
 from salt.utils.args import get_function_argspec as _argspec
 
 # Import 3rd-party libs
@@ -126,7 +128,7 @@ def check_file_list_cache(opts, form, list_cache, w_lock):
                     age = opts.get('fileserver_list_cache_time', 20) + 1
                 if age < opts.get('fileserver_list_cache_time', 20):
                     # Young enough! Load this sucker up!
-                    with salt.utils.fopen(list_cache, 'rb') as fp_:
+                    with salt.utils.files.fopen(list_cache, 'rb') as fp_:
                         log.trace('Returning file_lists cache data from '
                                   '{0}'.format(list_cache))
                         return serial.load(fp_).get(form, []), False, False
@@ -151,7 +153,7 @@ def write_file_list_cache(opts, data, list_cache, w_lock):
     backend to determine if the cache needs to be refreshed/written).
     '''
     serial = salt.payload.Serial(opts)
-    with salt.utils.fopen(list_cache, 'w+b') as fp_:
+    with salt.utils.files.fopen(list_cache, 'w+b') as fp_:
         fp_.write(serial.dumps(data))
         _unlock_cache(w_lock)
         log.trace('Lockfile {0} removed'.format(w_lock))
@@ -164,7 +166,7 @@ def check_env_cache(opts, env_cache):
     if not os.path.isfile(env_cache):
         return None
     try:
-        with salt.utils.fopen(env_cache, 'rb') as fp_:
+        with salt.utils.files.fopen(env_cache, 'rb') as fp_:
             log.trace('Returning env cache data from {0}'.format(env_cache))
             serial = salt.payload.Serial(opts)
             return serial.load(fp_)

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -60,6 +60,8 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
+import salt.utils.gzip_util
 import salt.utils.url
 import salt.fileserver
 from salt.utils.event import tagify
@@ -295,7 +297,7 @@ def init():
         if not refs:
             # Write an hgrc defining the remote URL
             hgconfpath = os.path.join(rp_, '.hg', 'hgrc')
-            with salt.utils.fopen(hgconfpath, 'w+') as hgconfig:
+            with salt.utils.files.fopen(hgconfpath, 'w+') as hgconfig:
                 hgconfig.write('[paths]\n')
                 hgconfig.write('default = {0}\n'.format(repo_url))
 
@@ -314,7 +316,7 @@ def init():
     if new_remote:
         remote_map = os.path.join(__opts__['cachedir'], 'hgfs/remote_map.txt')
         try:
-            with salt.utils.fopen(remote_map, 'w+') as fp_:
+            with salt.utils.files.fopen(remote_map, 'w+') as fp_:
                 timestamp = datetime.now().strftime('%d %b %Y %H:%M:%S.%f')
                 fp_.write('# hgfs_remote map as of {0}\n'.format(timestamp))
                 for repo in repos:
@@ -453,7 +455,7 @@ def lock(remote=None):
         failed = []
         if not os.path.exists(repo['lockfile']):
             try:
-                with salt.utils.fopen(repo['lockfile'], 'w+') as fp_:
+                with salt.utils.files.fopen(repo['lockfile'], 'w+') as fp_:
                     fp_.write('')
             except (IOError, OSError) as exc:
                 msg = ('Unable to set update lock for {0} ({1}): {2} '
@@ -538,7 +540,7 @@ def update():
             os.makedirs(env_cachedir)
         new_envs = envs(ignore_cache=True)
         serial = salt.payload.Serial(__opts__)
-        with salt.utils.fopen(env_cache, 'wb+') as fp_:
+        with salt.utils.files.fopen(env_cache, 'wb+') as fp_:
             fp_.write(serial.dumps(new_envs))
             log.trace('Wrote env cache data to {0}'.format(env_cache))
 
@@ -678,7 +680,7 @@ def find_file(path, tgt_env='base', **kwargs):  # pylint: disable=W0613
             continue
         salt.fileserver.wait_lock(lk_fn, dest)
         if os.path.isfile(blobshadest) and os.path.isfile(dest):
-            with salt.utils.fopen(blobshadest, 'r') as fp_:
+            with salt.utils.files.fopen(blobshadest, 'r') as fp_:
                 sha = fp_.read()
                 if sha == ref[2]:
                     fnd['rel'] = path
@@ -692,14 +694,14 @@ def find_file(path, tgt_env='base', **kwargs):  # pylint: disable=W0613
         except hglib.error.CommandError:
             repo['repo'].close()
             continue
-        with salt.utils.fopen(lk_fn, 'w+') as fp_:
+        with salt.utils.files.fopen(lk_fn, 'w+') as fp_:
             fp_.write('')
         for filename in glob.glob(hashes_glob):
             try:
                 os.remove(filename)
             except Exception:
                 pass
-        with salt.utils.fopen(blobshadest, 'w+') as fp_:
+        with salt.utils.files.fopen(blobshadest, 'w+') as fp_:
             fp_.write(ref[2])
         try:
             os.remove(lk_fn)
@@ -750,7 +752,7 @@ def serve_file(load, fnd):
     ret['dest'] = fnd['rel']
     gzip = load.get('gzip', None)
     fpath = os.path.normpath(fnd['path'])
-    with salt.utils.fopen(fpath, 'rb') as fp_:
+    with salt.utils.files.fopen(fpath, 'rb') as fp_:
         fp_.seek(load['loc'])
         data = fp_.read(__opts__['file_buffer_size'])
         if data and six.PY3 and not salt.utils.is_bin_file(fpath):
@@ -787,11 +789,11 @@ def file_hash(load, fnd):
                                                   __opts__['hash_type']))
     if not os.path.isfile(hashdest):
         ret['hsum'] = salt.utils.get_hash(path, __opts__['hash_type'])
-        with salt.utils.fopen(hashdest, 'w+') as fp_:
+        with salt.utils.files.fopen(hashdest, 'w+') as fp_:
             fp_.write(ret['hsum'])
         return ret
     else:
-        with salt.utils.fopen(hashdest, 'rb') as fp_:
+        with salt.utils.files.fopen(hashdest, 'rb') as fp_:
             ret['hsum'] = fp_.read()
         return ret
 

--- a/salt/fileserver/minionfs.py
+++ b/salt/fileserver/minionfs.py
@@ -32,6 +32,8 @@ import logging
 # Import salt libs
 import salt.fileserver
 import salt.utils
+import salt.utils.files
+import salt.utils.gzip_util
 import salt.utils.url
 
 # Import third party libs
@@ -129,7 +131,7 @@ def serve_file(load, fnd):
     # AP
     # May I sleep here to slow down serving of big files?
     # How many threads are serving files?
-    with salt.utils.fopen(fpath, 'rb') as fp_:
+    with salt.utils.files.fopen(fpath, 'rb') as fp_:
         fp_.seek(load['loc'])
         data = fp_.read(__opts__['file_buffer_size'])
         if data and six.PY3 and not salt.utils.is_bin_file(fpath):
@@ -191,7 +193,7 @@ def file_hash(load, fnd):
     # if we have a cache, serve that if the mtime hasn't changed
     if os.path.exists(cache_path):
         try:
-            with salt.utils.fopen(cache_path, 'rb') as fp_:
+            with salt.utils.files.fopen(cache_path, 'rb') as fp_:
                 try:
                     hsum, mtime = fp_.read().split(':')
                 except ValueError:
@@ -222,7 +224,7 @@ def file_hash(load, fnd):
         os.makedirs(cache_dir)
     # save the cache object "hash:mtime"
     cache_object = '{0}:{1}'.format(ret['hsum'], os.path.getmtime(path))
-    with salt.utils.flopen(cache_path, 'w') as fp_:
+    with salt.utils.files.flopen(cache_path, 'w') as fp_:
         fp_.write(cache_object)
     return ret
 

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -69,6 +69,8 @@ import logging
 import salt.fileserver as fs
 import salt.modules
 import salt.utils
+import salt.utils.files
+import salt.utils.gzip_util
 
 # Import 3rd-party libs
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
@@ -225,7 +227,7 @@ def serve_file(load, fnd):
 
     ret['dest'] = _trim_env_off_path([fnd['path']], load['saltenv'])[0]
 
-    with salt.utils.fopen(cached_file_path, 'rb') as fp_:
+    with salt.utils.files.fopen(cached_file_path, 'rb') as fp_:
         fp_.seek(load['loc'])
         data = fp_.read(__opts__['file_buffer_size'])
         if data and six.PY3 and not salt.utils.is_bin_file(cached_file_path):
@@ -535,7 +537,7 @@ def _refresh_buckets_cache_file(cache_file):
 
     log.debug('Writing buckets cache file')
 
-    with salt.utils.fopen(cache_file, 'w') as fp_:
+    with salt.utils.files.fopen(cache_file, 'w') as fp_:
         pickle.dump(metadata, fp_)
 
     return metadata
@@ -548,7 +550,7 @@ def _read_buckets_cache_file(cache_file):
 
     log.debug('Reading buckets cache file')
 
-    with salt.utils.fopen(cache_file, 'rb') as fp_:
+    with salt.utils.files.fopen(cache_file, 'rb') as fp_:
         try:
             data = pickle.load(fp_)
         except (pickle.UnpicklingError, AttributeError, EOFError, ImportError,

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -55,6 +55,8 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
+import salt.utils.gzip_util
 import salt.utils.url
 import salt.fileserver
 from salt.utils.event import tagify
@@ -224,7 +226,7 @@ def init():
     if new_remote:
         remote_map = os.path.join(__opts__['cachedir'], 'svnfs/remote_map.txt')
         try:
-            with salt.utils.fopen(remote_map, 'w+') as fp_:
+            with salt.utils.files.fopen(remote_map, 'w+') as fp_:
                 timestamp = datetime.now().strftime('%d %b %Y %H:%M:%S.%f')
                 fp_.write('# svnfs_remote map as of {0}\n'.format(timestamp))
                 for repo_conf in repos:
@@ -367,7 +369,7 @@ def lock(remote=None):
         failed = []
         if not os.path.exists(repo['lockfile']):
             try:
-                with salt.utils.fopen(repo['lockfile'], 'w+') as fp_:
+                with salt.utils.files.fopen(repo['lockfile'], 'w+') as fp_:
                     fp_.write('')
             except (IOError, OSError) as exc:
                 msg = ('Unable to set update lock for {0} ({1}): {2} '
@@ -453,7 +455,7 @@ def update():
             os.makedirs(env_cachedir)
         new_envs = envs(ignore_cache=True)
         serial = salt.payload.Serial(__opts__)
-        with salt.utils.fopen(env_cache, 'wb+') as fp_:
+        with salt.utils.files.fopen(env_cache, 'wb+') as fp_:
             fp_.write(serial.dumps(new_envs))
             log.trace('Wrote env cache data to {0}'.format(env_cache))
 
@@ -645,7 +647,7 @@ def serve_file(load, fnd):
     ret['dest'] = fnd['rel']
     gzip = load.get('gzip', None)
     fpath = os.path.normpath(fnd['path'])
-    with salt.utils.fopen(fpath, 'rb') as fp_:
+    with salt.utils.files.fopen(fpath, 'rb') as fp_:
         fp_.seek(load['loc'])
         data = fp_.read(__opts__['file_buffer_size'])
         if data and six.PY3 and not salt.utils.is_bin_file(fpath):
@@ -695,7 +697,7 @@ def file_hash(load, fnd):
                                                     __opts__['hash_type']))
     # If we have a cache, serve that if the mtime hasn't changed
     if os.path.exists(cache_path):
-        with salt.utils.fopen(cache_path, 'rb') as fp_:
+        with salt.utils.files.fopen(cache_path, 'rb') as fp_:
             hsum, mtime = fp_.read().split(':')
             if os.path.getmtime(path) == mtime:
                 # check if mtime changed
@@ -709,7 +711,7 @@ def file_hash(load, fnd):
     if not os.path.exists(cache_dir):
         os.makedirs(cache_dir)
     # save the cache object "hash:mtime"
-    with salt.utils.fopen(cache_path, 'w') as fp_:
+    with salt.utils.files.fopen(cache_path, 'w') as fp_:
         fp_.write('{0}:{1}'.format(ret['hsum'], os.path.getmtime(path)))
 
     return ret

--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -11,6 +11,7 @@ import re
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
@@ -127,7 +128,7 @@ def _linux_disks():
     ret = {'disks': [], 'SSDs': []}
 
     for entry in glob.glob('/sys/block/*/queue/rotational'):
-        with salt.utils.fopen(entry) as entry_fp:
+        with salt.utils.files.fopen(entry) as entry_fp:
             device = entry.split('/')[3]
             flag = entry_fp.read(1)
             if flag == '0':

--- a/salt/grains/extra.py
+++ b/salt/grains/extra.py
@@ -10,7 +10,7 @@ import yaml
 import logging
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ def config():
                 'grains'
                 )
     if os.path.isfile(gfn):
-        with salt.utils.fopen(gfn, 'rb') as fp_:
+        with salt.utils.files.fopen(gfn, 'rb') as fp_:
             try:
                 return yaml.safe_load(fp_.read())
             except Exception:

--- a/salt/grains/mdadm.py
+++ b/salt/grains/mdadm.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 import logging
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ def mdadm():
     '''
     devices = set()
     try:
-        with salt.utils.fopen('/proc/mdstat', 'r') as mdstat:
+        with salt.utils.files.fopen('/proc/mdstat', 'r') as mdstat:
             for line in mdstat:
                 if line.startswith('Personalities : '):
                     continue

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -22,6 +22,7 @@ from zipimport import zipimporter
 import salt.config
 import salt.syspaths
 import salt.utils.context
+import salt.utils.files
 import salt.utils.lazy
 import salt.utils.event
 import salt.utils.odict
@@ -634,7 +635,7 @@ def _load_cached_grains(opts, cfn):
     log.debug('Retrieving grains from cache')
     try:
         serial = salt.payload.Serial(opts)
-        with salt.utils.fopen(cfn, 'rb') as fp_:
+        with salt.utils.files.fopen(cfn, 'rb') as fp_:
             cached_grains = serial.load(fp_)
         if not cached_grains:
             log.debug('Cached grains are empty, cache might be corrupted. Refreshing.')
@@ -784,7 +785,7 @@ def grains(opts, force_refresh=False, proxy=None):
                 import salt.modules.cmdmod
                 # Make sure cache file isn't read-only
                 salt.modules.cmdmod._run_quiet('attrib -R "{0}"'.format(cfn))
-            with salt.utils.fopen(cfn, 'w+b') as fp_:
+            with salt.utils.files.fopen(cfn, 'w+b') as fp_:
                 try:
                     serial = salt.payload.Serial(opts)
                     serial.dump(grains_data, fp_)
@@ -1412,7 +1413,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                         # pylint: enable=no-member
                         sys.modules[mod_namespace] = mod
                     else:
-                        with salt.utils.fopen(fpath, desc[1]) as fn_:
+                        with salt.utils.files.fopen(fpath, desc[1]) as fn_:
                             mod = imp.load_module(mod_namespace, fn_, fpath, desc)
         except IOError:
             raise

--- a/salt/master.py
+++ b/salt/master.py
@@ -67,6 +67,8 @@ import salt.log.setup
 import salt.utils.args
 import salt.utils.atomicfile
 import salt.utils.event
+import salt.utils.files
+import salt.utils.gitfs
 import salt.utils.job
 import salt.utils.verify
 import salt.utils.minions
@@ -988,7 +990,7 @@ class AESFuncs(object):
         pub_path = os.path.join(self.opts['pki_dir'], 'minions', id_)
 
         try:
-            with salt.utils.fopen(pub_path, 'r') as fp_:
+            with salt.utils.files.fopen(pub_path, 'r') as fp_:
                 minion_pub = fp_.read()
                 pub = RSA.importKey(minion_pub)
         except (IOError, OSError):
@@ -1300,7 +1302,7 @@ class AESFuncs(object):
             mode = 'ab'
         else:
             mode = 'wb'
-        with salt.utils.fopen(cpath, mode) as fp_:
+        with salt.utils.files.fopen(cpath, mode) as fp_:
             if load['loc']:
                 fp_.seek(load['loc'])
             if six.PY3:
@@ -1444,7 +1446,7 @@ class AESFuncs(object):
             path_name = os.path.split(syndic_cache_path)[0]
             if not os.path.exists(path_name):
                 os.makedirs(path_name)
-            with salt.utils.fopen(syndic_cache_path, 'w') as wfh:
+            with salt.utils.files.fopen(syndic_cache_path, 'w') as wfh:
                 wfh.write('')
 
         # Format individual return loads
@@ -1500,7 +1502,7 @@ class AESFuncs(object):
         if not os.path.isdir(auth_cache):
             os.makedirs(auth_cache)
         jid_fn = os.path.join(auth_cache, str(load['jid']))
-        with salt.utils.fopen(jid_fn, 'r') as fp_:
+        with salt.utils.files.fopen(jid_fn, 'r') as fp_:
             if not load['id'] == fp_.read():
                 return {}
         # Grab the latest and return

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -86,6 +86,7 @@ import salt.payload
 import salt.syspaths
 import salt.utils
 import salt.utils.context
+import salt.utils.files
 import salt.utils.jid
 import salt.pillar
 import salt.utils.args
@@ -667,7 +668,7 @@ class SMinion(MinionBase):
             else:
                 penv = 'base'
             cache_top = {penv: {self.opts['id']: ['cache']}}
-            with salt.utils.fopen(ptop, 'wb') as fp_:
+            with salt.utils.files.fopen(ptop, 'wb') as fp_:
                 fp_.write(
                     yaml.dump(
                         cache_top,
@@ -676,7 +677,7 @@ class SMinion(MinionBase):
                 )
                 os.chmod(ptop, 0o600)
             cache_sls = os.path.join(pdir, 'cache.sls')
-            with salt.utils.fopen(cache_sls, 'wb') as fp_:
+            with salt.utils.files.fopen(cache_sls, 'wb') as fp_:
                 fp_.write(
                     yaml.dump(
                         self.opts['pillar'],
@@ -1418,7 +1419,7 @@ class Minion(MinionBase):
         sdata = {'pid': os.getpid()}
         sdata.update(data)
         log.info('Starting a new job with PID {0}'.format(sdata['pid']))
-        with salt.utils.fopen(fn_, 'w+b') as fp_:
+        with salt.utils.files.fopen(fn_, 'w+b') as fp_:
             fp_.write(minion_instance.serial.dumps(sdata))
         ret = {'success': False}
         function_name = data['fun']

--- a/salt/modules/aliases.py
+++ b/salt/modules/aliases.py
@@ -11,7 +11,7 @@ import stat
 import tempfile
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 from salt.utils import which as _which
 from salt.exceptions import SaltInvocationError
 
@@ -49,7 +49,7 @@ def __parse_aliases():
     ret = []
     if not os.path.isfile(afn):
         return ret
-    with salt.utils.fopen(afn, 'r') as ifile:
+    with salt.utils.files.fopen(afn, 'r') as ifile:
         for line in ifile:
             match = __ALIAS_RE.match(line)
             if match:

--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -11,7 +11,7 @@ import os
 import logging
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -89,7 +89,7 @@ def show_link(name):
     path += 'alternatives/{0}'.format(name)
 
     try:
-        with salt.utils.fopen(path, 'rb') as r_file:
+        with salt.utils.files.fopen(path, 'rb') as r_file:
             contents = r_file.read()
             if six.PY3:
                 contents = contents.decode(__salt_system_encoding__)

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -30,6 +30,7 @@ from salt.ext.six.moves.urllib.request import (
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -450,7 +451,7 @@ def config(name, config, edit=True):
         key = next(six.iterkeys(entry))
         configs = _parse_config(entry[key], key)
         if edit:
-            with salt.utils.fopen(name, 'w') as configfile:
+            with salt.utils.files.fopen(name, 'w') as configfile:
                 configfile.write('# This file is managed by Salt.\n')
                 configfile.write(configs)
     return configs

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -39,6 +39,7 @@ import salt.config
 import salt.syspaths
 from salt.modules.cmdmod import _parse_env
 import salt.utils
+import salt.utils.files
 import salt.utils.itertools
 import salt.utils.pkg
 import salt.utils.pkg.deb
@@ -2662,7 +2663,7 @@ def set_selections(path=None, selection=None, clear=False, saltenv='base'):
 
     if path:
         path = __salt__['cp.cache_file'](path, saltenv)
-        with salt.utils.fopen(path, 'r') as ifile:
+        with salt.utils.files.fopen(path, 'r') as ifile:
             content = ifile.readlines()
         selection = _parse_selections(content)
 

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -1279,14 +1279,14 @@ def _render_filenames(filenames, zip_file, saltenv, template):
         '''
         # write out path to temp file
         tmp_path_fn = salt.utils.files.mkstemp()
-        with salt.utils.fopen(tmp_path_fn, 'w+') as fp_:
+        with salt.utils.files.fopen(tmp_path_fn, 'w+') as fp_:
             fp_.write(contents)
         data = salt.utils.templates.TEMPLATE_REGISTRY[template](
             tmp_path_fn,
             to_str=True,
             **kwargs
         )
-        salt.utils.safe_rm(tmp_path_fn)
+        salt.utils.files.safe_rm(tmp_path_fn)
         if not data['result']:
             # Failed to render the template
             raise CommandExecutionError(

--- a/salt/modules/artifactory.py
+++ b/salt/modules/artifactory.py
@@ -10,7 +10,7 @@ import base64
 import logging
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 import salt.ext.six.moves.http_client  # pylint: disable=import-error,redefined-builtin,no-name-in-module
 from salt.ext.six.moves import urllib  # pylint: disable=no-name-in-module
 from salt.ext.six.moves.urllib.error import HTTPError, URLError  # pylint: disable=no-name-in-module
@@ -465,7 +465,7 @@ def __save_artifact(artifact_url, target_file, headers):
     try:
         request = urllib.request.Request(artifact_url, None, headers)
         f = urllib.request.urlopen(request)
-        with salt.utils.fopen(target_file, "wb") as local_file:
+        with salt.utils.files.fopen(target_file, "wb") as local_file:
             local_file.write(f.read())
         result['status'] = True
         result['comment'] = __append_comment(('Artifact downloaded from URL: {0}'.format(artifact_url)), result['comment'])

--- a/salt/modules/at_solaris.py
+++ b/salt/modules/at_solaris.py
@@ -26,6 +26,7 @@ from salt.ext.six.moves import map
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 __virtualname__ = 'at'
@@ -100,7 +101,7 @@ def atq(tag=None):
             job=job
         )
         if __salt__['file.file_exists'](atjob_file):
-            with salt.utils.fopen(atjob_file, 'r') as atjob:
+            with salt.utils.files.fopen(atjob_file, 'r') as atjob:
                 for line in atjob:
                     tmp = job_kw_regex.match(line)
                     if tmp:
@@ -224,7 +225,7 @@ def atc(jobid):
         job=jobid
     )
     if __salt__['file.file_exists'](atjob_file):
-        with salt.utils.fopen(atjob_file, 'r') as rfh:
+        with salt.utils.files.fopen(atjob_file, 'r') as rfh:
             return "".join(rfh.readlines())
     else:
         return {'error': 'invalid job id \'{0}\''.format(jobid)}

--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -14,8 +14,8 @@ import os
 import yaml
 
 # Import Salt libs
-import salt.utils
 import salt.utils.event
+import salt.utils.files
 from salt.ext.six.moves import map
 
 # Get logging started
@@ -291,7 +291,7 @@ def save():
         yaml_out = ''
 
     try:
-        with salt.utils.fopen(sfn, 'w+') as fp_:
+        with salt.utils.files.fopen(sfn, 'w+') as fp_:
             fp_.write(yaml_out)
         ret['comment'] = 'Beacons saved to {0}.'.format(sfn)
     except (IOError, OSError):

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -89,7 +89,7 @@ import random
 # Import Salt libs
 import salt.ext.six as six
 import salt.utils.compat
-import salt.utils
+import salt.utils.files
 from salt.utils.versions import LooseVersion as _LooseVersion
 from salt.exceptions import SaltInvocationError
 from salt.ext.six.moves import range  # pylint: disable=import-error
@@ -201,7 +201,7 @@ def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
 
 
 def _filedata(infile):
-    with salt.utils.fopen(infile, 'rb') as f:
+    with salt.utils.files.fopen(infile, 'rb') as f:
         return f.read()
 
 

--- a/salt/modules/bsd_shadow.py
+++ b/salt/modules/bsd_shadow.py
@@ -18,7 +18,7 @@ except ImportError:
 
 # Import salt libs
 import salt.ext.six as six
-import salt.utils
+import salt.utils.files
 from salt.exceptions import SaltInvocationError
 
 # Define the module's virtual name
@@ -76,7 +76,7 @@ def info(name):
             python_shell=False).split(':')[5:7]
     elif __grains__['kernel'] in ('NetBSD', 'OpenBSD'):
         try:
-            with salt.utils.fopen('/etc/master.passwd', 'r') as fp_:
+            with salt.utils.files.fopen('/etc/master.passwd', 'r') as fp_:
                 for line in fp_:
                     if line.startswith('{0}:'.format(name)):
                         key = line.split(':')

--- a/salt/modules/capirca_acl.py
+++ b/salt/modules/capirca_acl.py
@@ -39,7 +39,7 @@ except ImportError:
     HAS_CAPIRCA = False
 
 # Import Salt modules
-import salt.utils
+import salt.utils.files
 from salt.ext import six
 
 # ------------------------------------------------------------------------------
@@ -213,7 +213,7 @@ def _get_services_mapping():
         return _SERVICES
     services_txt = ''
     try:
-        with salt.utils.fopen('/etc/services', 'r') as srv_f:
+        with salt.utils.files.fopen('/etc/services', 'r') as srv_f:
             services_txt = srv_f.read()
     except IOError as ioe:
         log.error('Unable to read from /etc/services:')

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -142,14 +142,14 @@ def _render_cmd(cmd, cwd, template, saltenv='base', pillarenv=None, pillar_overr
     def _render(contents):
         # write out path to temp file
         tmp_path_fn = salt.utils.files.mkstemp()
-        with salt.utils.fopen(tmp_path_fn, 'w+') as fp_:
+        with salt.utils.files.fopen(tmp_path_fn, 'w+') as fp_:
             fp_.write(contents)
         data = salt.utils.templates.TEMPLATE_REGISTRY[template](
             tmp_path_fn,
             to_str=True,
             **kwargs
         )
-        salt.utils.safe_rm(tmp_path_fn)
+        salt.utils.files.safe_rm(tmp_path_fn)
         if not data['result']:
             # Failed to render the template
             raise CommandExecutionError(
@@ -2419,7 +2419,7 @@ def exec_code_all(lang, code, cwd=None):
     else:
         codefile = salt.utils.files.mkstemp()
 
-    with salt.utils.fopen(codefile, 'w+t', binary=False) as fp_:
+    with salt.utils.files.fopen(codefile, 'w+t', binary=False) as fp_:
         fp_.write(code)
 
     if powershell:
@@ -2450,7 +2450,7 @@ def tty(device, echo=''):
     else:
         return {'Error': 'The specified device is not a valid TTY'}
     try:
-        with salt.utils.fopen(teletype, 'wb') as tty_device:
+        with salt.utils.files.fopen(teletype, 'wb') as tty_device:
             tty_device.write(salt.utils.to_bytes(echo))
         return {
             'Success': 'Message was successfully echoed to {0}'.format(teletype)
@@ -2662,7 +2662,7 @@ def _is_valid_shell(shell):
     available_shells = []
     if os.path.exists(shells):
         try:
-            with salt.utils.fopen(shells, 'r') as shell_fp:
+            with salt.utils.files.fopen(shells, 'r') as shell_fp:
                 lines = shell_fp.read().splitlines()
             for line in lines:
                 if line.startswith('#'):
@@ -2694,7 +2694,7 @@ def shells():
     ret = []
     if os.path.exists(shells_fn):
         try:
-            with salt.utils.fopen(shells_fn, 'r') as shell_fp:
+            with salt.utils.files.fopen(shells_fn, 'r') as shell_fp:
                 lines = shell_fp.read().splitlines()
             for line in lines:
                 line = line.strip()

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -777,7 +777,7 @@ def push(path, keep_symlinks=False, upload_path=None, remove_source=False):
             if not load['data'] and init_send:
                 if remove_source:
                     try:
-                        salt.utils.rm_rf(path)
+                        salt.utils.files.rm_rf(path)
                         log.debug('Removing source file \'{0}\''.format(path))
                     except IOError:
                         log.error('cp.push failed to remove file \

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -17,6 +17,7 @@ import salt.fileclient
 import salt.utils
 import salt.utils.files
 import salt.utils.gzip_util
+import salt.utils.templates
 import salt.utils.url
 import salt.crypt
 import salt.transport
@@ -86,7 +87,7 @@ def recv(dest, chunk, append=False, compressed=True, mode=None):
 
     open_mode = 'ab' if append else 'wb'
     try:
-        fh_ = salt.utils.fopen(dest, open_mode)  # pylint: disable=W8470
+        fh_ = salt.utils.files.fopen(dest, open_mode)  # pylint: disable=W8470
     except (IOError, OSError) as exc:
         if exc.errno != errno.ENOENT:
             # Parent dir does not exist, we need to create it
@@ -96,7 +97,7 @@ def recv(dest, chunk, append=False, compressed=True, mode=None):
         except (IOError, OSError) as makedirs_exc:
             # Failed to make directory
             return _error(makedirs_exc.__str__())
-        fh_ = salt.utils.fopen(dest, open_mode)  # pylint: disable=W8470
+        fh_ = salt.utils.files.fopen(dest, open_mode)  # pylint: disable=W8470
 
     try:
         # Write the chunk to disk
@@ -178,14 +179,14 @@ def _render_filenames(path, dest, saltenv, template, **kw):
         '''
         # write out path to temp file
         tmp_path_fn = salt.utils.files.mkstemp()
-        with salt.utils.fopen(tmp_path_fn, 'w+') as fp_:
+        with salt.utils.files.fopen(tmp_path_fn, 'w+') as fp_:
             fp_.write(contents)
         data = salt.utils.templates.TEMPLATE_REGISTRY[template](
             tmp_path_fn,
             to_str=True,
             **kwargs
         )
-        salt.utils.safe_rm(tmp_path_fn)
+        salt.utils.files.safe_rm(tmp_path_fn)
         if not data['result']:
             # Failed to render the template
             raise CommandExecutionError(
@@ -391,7 +392,7 @@ def get_file_str(path, saltenv='base'):
     fn_ = cache_file(path, saltenv)
     if isinstance(fn_, six.string_types):
         try:
-            with salt.utils.fopen(fn_, 'r') as fp_:
+            with salt.utils.files.fopen(fn_, 'r') as fp_:
                 return fp_.read()
         except IOError:
             return False
@@ -768,7 +769,7 @@ def push(path, keep_symlinks=False, upload_path=None, remove_source=False):
             'path': load_path_list,
             'tok': auth.gen_token('salt')}
     channel = salt.transport.Channel.factory(__opts__)
-    with salt.utils.fopen(path, 'rb') as fp_:
+    with salt.utils.files.fopen(path, 'rb') as fp_:
         init_send = False
         while True:
             load['loc'] = fp_.tell()

--- a/salt/modules/cpan.py
+++ b/salt/modules/cpan.py
@@ -13,6 +13,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -107,7 +108,7 @@ def remove(module, details=False):
         if 'MANIFEST' not in contents:
             continue
         mfile = os.path.join(build_dir, 'MANIFEST')
-        with salt.utils.fopen(mfile, 'r') as fh_:
+        with salt.utils.files.fopen(mfile, 'r') as fh_:
             for line in fh_.readlines():
                 if line.startswith('lib/'):
                     files.append(line.replace('lib/', ins_path).strip())

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -227,13 +227,13 @@ def _write_cron_lines(user, lines):
     path = salt.utils.files.mkstemp()
     if _check_instance_uid_match(user) or __grains__.get('os_family') in ('Solaris', 'AIX'):
         # In some cases crontab command should be executed as user rather than root
-        with salt.utils.fpopen(path, 'w+', uid=__salt__['file.user_to_uid'](user), mode=0o600) as fp_:
+        with salt.utils.files.fpopen(path, 'w+', uid=__salt__['file.user_to_uid'](user), mode=0o600) as fp_:
             fp_.writelines(lines)
         ret = __salt__['cmd.run_all'](_get_cron_cmdstr(path),
                                       runas=user,
                                       python_shell=False)
     else:
-        with salt.utils.fpopen(path, 'w+', mode=0o600) as fp_:
+        with salt.utils.files.fpopen(path, 'w+', mode=0o600) as fp_:
             fp_.writelines(lines)
         ret = __salt__['cmd.run_all'](_get_cron_cmdstr(path, user),
                                       python_shell=False)

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -13,6 +13,7 @@ import re
 
 # Import salt libraries
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 # Import 3rd-party libs
@@ -140,7 +141,7 @@ def crypttab(config='/etc/crypttab'):
     ret = {}
     if not os.path.isfile(config):
         return ret
-    with salt.utils.fopen(config) as ifile:
+    with salt.utils.files.fopen(config) as ifile:
         for line in ifile:
             try:
                 entry = _crypttab_entry.dict_from_line(line)
@@ -177,7 +178,7 @@ def rm_crypttab(name, config='/etc/crypttab'):
     # the list. At the end, re-create the config from just those lines.
     lines = []
     try:
-        with salt.utils.fopen(config, 'r') as ifile:
+        with salt.utils.files.fopen(config, 'r') as ifile:
             for line in ifile:
                 try:
                     if criteria.match(line):
@@ -194,7 +195,7 @@ def rm_crypttab(name, config='/etc/crypttab'):
 
     if modified:
         try:
-            with salt.utils.fopen(config, 'w+') as ofile:
+            with salt.utils.files.fopen(config, 'w+') as ofile:
                 ofile.writelines(lines)
         except (IOError, OSError) as exc:
             msg = "Couldn't write to {0}: {1}"
@@ -271,7 +272,7 @@ def set_crypttab(
         raise CommandExecutionError('Bad config file "{0}"'.format(config))
 
     try:
-        with salt.utils.fopen(config, 'r') as ifile:
+        with salt.utils.files.fopen(config, 'r') as ifile:
             for line in ifile:
                 try:
                     if criteria.match(line):
@@ -301,7 +302,7 @@ def set_crypttab(
     if ret != 'present':  # ret in ['new', 'change']:
         if not test:
             try:
-                with salt.utils.fopen(config, 'w+') as ofile:
+                with salt.utils.files.fopen(config, 'w+') as ofile:
                     # The line was changed, commit it!
                     ofile.writelines(lines)
             except (IOError, OSError):

--- a/salt/modules/cyg.py
+++ b/salt/modules/cyg.py
@@ -17,6 +17,7 @@ from salt.ext.six.moves.urllib.request import urlopen as _urlopen  # pylint: dis
 
 # Import Salt libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import SaltInvocationError
 
 
@@ -146,7 +147,7 @@ def _run_silent_cygwin(cyg_arch='x86_64',
         os.remove(cyg_setup_path)
 
     file_data = _urlopen(cyg_setup_source)
-    with salt.utils.fopen(cyg_setup_path, "wb") as fhw:
+    with salt.utils.files.fopen(cyg_setup_path, "wb") as fhw:
         fhw.write(file_data.read())
 
     setup_command = cyg_setup_path

--- a/salt/modules/data.py
+++ b/salt/modules/data.py
@@ -11,7 +11,7 @@ import ast
 import logging
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 import salt.payload
 
 # Import 3rd-party lib
@@ -52,7 +52,7 @@ def load():
 
     try:
         datastore_path = os.path.join(__opts__['cachedir'], 'datastore')
-        with salt.utils.fopen(datastore_path, 'rb') as rfh:
+        with salt.utils.files.fopen(datastore_path, 'rb') as rfh:
             return serial.loads(rfh.read())
     except (IOError, OSError, NameError):
         return {}
@@ -76,7 +76,7 @@ def dump(new_data):
 
     try:
         datastore_path = os.path.join(__opts__['cachedir'], 'datastore')
-        with salt.utils.fopen(datastore_path, 'w+b') as fn_:
+        with salt.utils.files.fopen(datastore_path, 'w+b') as fn_:
             serial = salt.payload.Serial(__opts__)
             serial.dump(new_data, fn_)
 

--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -39,7 +39,7 @@ try:
 except ImportError as e:
     dns_support = False
 
-import salt.utils
+import salt.utils.files
 
 
 def __virtual__():
@@ -70,7 +70,7 @@ def _config(name, key=None, **kwargs):
 def _get_keyring(keyfile):
     keyring = None
     if keyfile:
-        with salt.utils.fopen(keyfile) as _f:
+        with salt.utils.files.fopen(keyfile) as _f:
             keyring = dns.tsigkeyring.from_text(json.load(_f))
     return keyring
 

--- a/salt/modules/debbuild.py
+++ b/salt/modules/debbuild.py
@@ -25,6 +25,8 @@ import traceback
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=no-name-in-module,import-error
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 import salt.utils
+import salt.utils.files
+import salt.utils.vt
 
 HAS_LIBS = False
 
@@ -252,7 +254,7 @@ def _create_pbuilders(env):
 
     env_overrides = _get_build_env(env)
     if env_overrides and not env_overrides.isspace():
-        with salt.utils.fopen(pbuilderrc, 'a') as fow:
+        with salt.utils.files.fopen(pbuilderrc, 'a') as fow:
             fow.write('{0}'.format(env_overrides))
 
 
@@ -575,12 +577,12 @@ def make_repo(repodir,
 
     codename, repocfg_dists = _get_repo_dists_env(env)
     repoconfdist = os.path.join(repoconf, 'distributions')
-    with salt.utils.fopen(repoconfdist, 'w') as fow:
+    with salt.utils.files.fopen(repoconfdist, 'w') as fow:
         fow.write('{0}'.format(repocfg_dists))
 
     repocfg_opts = _get_repo_options_env(env)
     repoconfopts = os.path.join(repoconf, 'options')
-    with salt.utils.fopen(repoconfopts, 'w') as fow:
+    with salt.utils.files.fopen(repoconfopts, 'w') as fow:
         fow.write('{0}'.format(repocfg_opts))
 
     local_keygrip_to_use = None
@@ -597,7 +599,7 @@ def make_repo(repodir,
     older_gnupg = __salt__['file.file_exists'](gpg_info_file)
 
     if keyid is not None:
-        with salt.utils.fopen(repoconfdist, 'a') as fow:
+        with salt.utils.files.fopen(repoconfdist, 'a') as fow:
             fow.write('SignWith: {0}\n'.format(keyid))
 
         # import_keys
@@ -657,7 +659,7 @@ def make_repo(repodir,
         _check_repo_sign_utils_support('debsign')
 
         if older_gnupg:
-            with salt.utils.fopen(gpg_info_file, 'r') as fow:
+            with salt.utils.files.fopen(gpg_info_file, 'r') as fow:
                 gpg_raw_info = fow.readlines()
 
             for gpg_info_line in gpg_raw_info:
@@ -666,7 +668,7 @@ def make_repo(repodir,
                 __salt__['environ.setenv'](gpg_info_dict)
                 break
         else:
-            with salt.utils.fopen(gpg_tty_info_file, 'r') as fow:
+            with salt.utils.files.fopen(gpg_tty_info_file, 'r') as fow:
                 gpg_raw_info = fow.readlines()
 
             for gpg_tty_info_line in gpg_raw_info:

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -24,9 +24,10 @@ from salt.ext.six.moves import StringIO  # pylint: disable=import-error,no-name-
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
+import salt.utils.odict
 import salt.utils.templates
 import salt.utils.validate.net
-import salt.utils.odict
 
 
 # Set up logging
@@ -219,7 +220,7 @@ def _read_file(path):
     Reads and returns the contents of a text file
     '''
     try:
-        with salt.utils.flopen(path, 'rb') as contents:
+        with salt.utils.files.flopen(path, 'rb') as contents:
             return [salt.utils.to_str(line) for line in contents.readlines()]
     except (OSError, IOError):
         return ''
@@ -280,7 +281,7 @@ def _parse_current_network_settings():
     opts['networking'] = ''
 
     if os.path.isfile(_DEB_NETWORKING_FILE):
-        with salt.utils.fopen(_DEB_NETWORKING_FILE) as contents:
+        with salt.utils.files.fopen(_DEB_NETWORKING_FILE) as contents:
             for line in contents:
                 if line.startswith('#'):
                     continue
@@ -574,7 +575,7 @@ def _parse_interfaces(interface_files=None):
     method = -1
 
     for interface_file in interface_files:
-        with salt.utils.fopen(interface_file) as interfaces:
+        with salt.utils.files.fopen(interface_file) as interfaces:
             # This ensures iface_dict exists, but does not ensure we're not reading a new interface.
             iface_dict = {}
             for line in interfaces:
@@ -1489,7 +1490,7 @@ def _write_file(iface, data, folder, pattern):
         msg = msg.format(filename, folder)
         log.error(msg)
         raise AttributeError(msg)
-    with salt.utils.flopen(filename, 'w') as fout:
+    with salt.utils.files.flopen(filename, 'w') as fout:
         fout.write(data)
     return filename
 
@@ -1514,7 +1515,7 @@ def _write_file_routes(iface, data, folder, pattern):
         msg = msg.format(filename, folder)
         log.error(msg)
         raise AttributeError(msg)
-    with salt.utils.flopen(filename, 'w') as fout:
+    with salt.utils.files.flopen(filename, 'w') as fout:
         fout.write(data)
 
     __salt__['file.set_mode'](filename, '0755')
@@ -1533,7 +1534,7 @@ def _write_file_network(data, filename, create=False):
         msg = msg.format(filename)
         log.error(msg)
         raise AttributeError(msg)
-    with salt.utils.flopen(filename, 'w') as fout:
+    with salt.utils.files.flopen(filename, 'w') as fout:
         fout.write(data)
 
 
@@ -1609,7 +1610,7 @@ def _write_file_ifaces(iface, data, **settings):
         msg = msg.format(os.path.dirname(filename))
         log.error(msg)
         raise AttributeError(msg)
-    with salt.utils.flopen(filename, 'w') as fout:
+    with salt.utils.files.flopen(filename, 'w') as fout:
         if _SEPARATE_FILE:
             fout.write(saved_ifcfg)
         else:
@@ -1642,7 +1643,7 @@ def _write_file_ppp_ifaces(iface, data):
         msg = msg.format(os.path.dirname(filename))
         log.error(msg)
         raise AttributeError(msg)
-    with salt.utils.fopen(filename, 'w') as fout:
+    with salt.utils.files.fopen(filename, 'w') as fout:
         fout.write(ifcfg)
 
     # Return as a array so the difflib works

--- a/salt/modules/defaults.py
+++ b/salt/modules/defaults.py
@@ -7,6 +7,7 @@ import yaml
 
 import salt.fileclient
 import salt.utils
+import salt.utils.files
 import salt.utils.url
 
 from salt.utils import dictupdate
@@ -60,7 +61,7 @@ def _load(formula):
 
         if os.path.exists(file_):
             log.debug("Reading defaults from %r", file_)
-            with salt.utils.fopen(file_) as fhr:
+            with salt.utils.files.fopen(file_) as fhr:
                 defaults = loader.load(fhr)
                 log.debug("Read defaults %r", defaults)
 

--- a/salt/modules/dnsmasq.py
+++ b/salt/modules/dnsmasq.py
@@ -10,6 +10,7 @@ import os
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
@@ -163,7 +164,7 @@ def _parse_dnamasq(filename):
             'Error: No such file \'{0}\''.format(filename)
         )
 
-    with salt.utils.fopen(filename, 'r') as fp_:
+    with salt.utils.files.fopen(filename, 'r') as fp_:
         for line in fp_:
             if not line.strip():
                 continue

--- a/salt/modules/dnsutil.py
+++ b/salt/modules/dnsutil.py
@@ -2,15 +2,14 @@
 '''
 Compendium of generic DNS utilities
 '''
+# Import python libs
 from __future__ import absolute_import
+import logging
+import time
 
 # Import salt libs
 import salt.utils
-import socket
-
-# Import python libs
-import logging
-import time
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +34,7 @@ def parse_hosts(hostsfile='/etc/hosts', hosts=None):
     '''
     if not hosts:
         try:
-            with salt.utils.fopen(hostsfile, 'r') as fp_:
+            with salt.utils.files.fopen(hostsfile, 'r') as fp_:
                 hosts = fp_.read()
         except Exception:
             return 'Error: hosts data was not found'
@@ -75,7 +74,7 @@ def hosts_append(hostsfile='/etc/hosts', ip_addr=None, entries=None):
         return 'No additional hosts were added to {0}'.format(hostsfile)
 
     append_line = '\n{0} {1}'.format(ip_addr, ' '.join(host_list))
-    with salt.utils.fopen(hostsfile, 'a') as fp_:
+    with salt.utils.files.fopen(hostsfile, 'a') as fp_:
         fp_.write(append_line)
 
     return 'The following line was added to {0}:{1}'.format(hostsfile,
@@ -95,11 +94,11 @@ def hosts_remove(hostsfile='/etc/hosts', entries=None):
         salt '*' dnsutil.hosts_remove /etc/hosts ad1.yuk.co
         salt '*' dnsutil.hosts_remove /etc/hosts ad2.yuk.co,ad1.yuk.co
     '''
-    with salt.utils.fopen(hostsfile, 'r') as fp_:
+    with salt.utils.files.fopen(hostsfile, 'r') as fp_:
         hosts = fp_.read()
 
     host_list = entries.split(',')
-    with salt.utils.fopen(hostsfile, 'w') as out_file:
+    with salt.utils.files.fopen(hostsfile, 'w') as out_file:
         for line in hosts.splitlines():
             if not line or line.strip().startswith('#'):
                 out_file.write('{0}\n'.format(line))
@@ -125,7 +124,7 @@ def parse_zone(zonefile=None, zone=None):
     '''
     if zonefile:
         try:
-            with salt.utils.fopen(zonefile, 'r') as fp_:
+            with salt.utils.files.fopen(zonefile, 'r') as fp_:
                 zone = fp_.read()
         except Exception:
             pass

--- a/salt/modules/dnsutil.py
+++ b/salt/modules/dnsutil.py
@@ -5,6 +5,7 @@ Compendium of generic DNS utilities
 # Import python libs
 from __future__ import absolute_import
 import logging
+import socket
 import time
 
 # Import salt libs

--- a/salt/modules/dockercompose.py
+++ b/salt/modules/dockercompose.py
@@ -106,7 +106,7 @@ import inspect
 import logging
 import os
 import re
-import salt.utils
+import salt.utils.files
 
 from operator import attrgetter
 try:
@@ -179,7 +179,7 @@ def __read_docker_compose(path):
         return __standardize_result(False,
                                     'Path does not exist or docker-compose.yml is not present',
                                     None, None)
-    f = salt.utils.fopen(os.path.join(path, dc_filename), 'r')  # pylint: disable=resource-leakage
+    f = salt.utils.files.fopen(os.path.join(path, dc_filename), 'r')  # pylint: disable=resource-leakage
     result = {'docker-compose.yml': ''}
     if f:
         for line in f:
@@ -207,7 +207,7 @@ def __write_docker_compose(path, docker_compose):
 
     if os.path.isdir(path) is False:
         os.mkdir(path)
-    f = salt.utils.fopen(os.path.join(path, dc_filename), 'w')  # pylint: disable=resource-leakage
+    f = salt.utils.files.fopen(os.path.join(path, dc_filename), 'w')  # pylint: disable=resource-leakage
     if f:
         f.write(docker_compose)
         f.close()

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -2862,7 +2862,7 @@ def export(name,
             # open the filehandle. If not using gzip, we need to open the
             # filehandle here. We make sure to close it in the "finally" block
             # below.
-            out = salt.utils.fopen(path, 'wb')  # pylint: disable=resource-leakage
+            out = salt.utils.files.fopen(path, 'wb')  # pylint: disable=resource-leakage
         response = _client_wrapper('export', name)
         buf = None
         while buf != '':
@@ -3874,12 +3874,12 @@ def save(name,
             compressor = lzma.LZMACompressor()
 
         try:
-            with salt.utils.fopen(saved_path, 'rb') as uncompressed:
+            with salt.utils.files.fopen(saved_path, 'rb') as uncompressed:
                 if compression != 'gzip':
                     # gzip doesn't use a Compressor object, it uses a .open()
                     # method to open the filehandle. If not using gzip, we need
                     # to open the filehandle here.
-                    out = salt.utils.fopen(path, 'wb')
+                    out = salt.utils.files.fopen(path, 'wb')
                 buf = None
                 while buf != '':
                     buf = uncompressed.read(4096)

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -12,6 +12,7 @@ import datetime
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 log = logging.getLogger(__name__)
@@ -323,7 +324,7 @@ def _get_pkg_license(pkg):
     licenses = set()
     cpr = "/usr/share/doc/{0}/copyright".format(pkg)
     if os.path.exists(cpr):
-        with salt.utils.fopen(cpr) as fp_:
+        with salt.utils.files.fopen(cpr) as fp_:
             for line in fp_.read().split(os.linesep):
                 if line.startswith("License:"):
                     licenses.add(line.split(":", 1)[1].strip())
@@ -361,7 +362,7 @@ def _get_pkg_ds_avail():
     ret = dict()
     pkg_mrk = "Package:"
     pkg_name = "package"
-    with salt.utils.fopen(avail) as fp_:
+    with salt.utils.files.fopen(avail) as fp_:
         for pkg_info in fp_.read().split(pkg_mrk):
             nfo = dict()
             for line in (pkg_mrk + pkg_info).split(os.linesep):

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1233,8 +1233,8 @@ def psed(path,
 
     shutil.copy2(path, '{0}{1}'.format(path, backup))
 
-    with salt.utils.fopen(path, 'w') as ofile:
-        with salt.utils.fopen('{0}{1}'.format(path, backup), 'r') as ifile:
+    with salt.utils.files.fopen(path, 'w') as ofile:
+        with salt.utils.files.fopen('{0}{1}'.format(path, backup), 'r') as ifile:
             if multi is True:
                 for line in ifile.readline():
                     ofile.write(_psed(line, before, after, limit, flags))
@@ -1442,7 +1442,7 @@ def comment_line(path,
     bufsize = os.path.getsize(path)
     try:
         # Use a read-only handle to open the file
-        with salt.utils.fopen(path,
+        with salt.utils.files.fopen(path,
                               mode='rb',
                               buffering=bufsize) as r_file:
             # Loop through each line of the file and look for a match
@@ -1481,12 +1481,12 @@ def comment_line(path,
 
     try:
         # Open the file in write mode
-        with salt.utils.fopen(path,
+        with salt.utils.files.fopen(path,
                               mode='wb',
                               buffering=bufsize) as w_file:
             try:
                 # Open the temp file in read mode
-                with salt.utils.fopen(temp_file,
+                with salt.utils.files.fopen(temp_file,
                                       mode='rb',
                                       buffering=bufsize) as r_file:
                     # Loop through each line of the file and look for a match
@@ -1857,7 +1857,7 @@ def line(path, content=None, match=None, mode=None, location=None,
     if before is None and after is None and not match:
         match = content
 
-    with salt.utils.fopen(path, mode='r') as fp_:
+    with salt.utils.files.fopen(path, mode='r') as fp_:
         body = fp_.read()
     body_before = hashlib.sha256(salt.utils.to_bytes(body)).hexdigest()
     after = _regex_to_static(body, after)
@@ -2000,7 +2000,7 @@ def line(path, content=None, match=None, mode=None, location=None,
 
     if changed:
         if show_changes:
-            with salt.utils.fopen(path, 'r') as fp_:
+            with salt.utils.files.fopen(path, 'r') as fp_:
                 path_content = _splitlines_preserving_trailing_newline(
                     fp_.read())
             changes_diff = ''.join(difflib.unified_diff(
@@ -2212,7 +2212,7 @@ def replace(path,
         # Searching first avoids modifying the time stamp if there are no changes
         r_data = None
         # Use a read-only handle to open the file
-        with salt.utils.fopen(path,
+        with salt.utils.files.fopen(path,
                               mode='rb',
                               buffering=bufsize) as r_file:
             try:
@@ -2271,12 +2271,12 @@ def replace(path,
         r_data = None
         try:
             # Open the file in write mode
-            with salt.utils.fopen(path,
+            with salt.utils.files.fopen(path,
                         mode='w',
                         buffering=bufsize) as w_file:
                 try:
                     # Open the temp file in read mode
-                    with salt.utils.fopen(temp_file,
+                    with salt.utils.files.fopen(temp_file,
                                           mode='r',
                                           buffering=bufsize) as r_file:
                         r_data = mmap.mmap(r_file.fileno(),
@@ -2792,7 +2792,7 @@ def contains_regex(path, regex, lchar=''):
         return False
 
     try:
-        with salt.utils.fopen(path, 'r') as target:
+        with salt.utils.files.fopen(path, 'r') as target:
             for line in target:
                 if lchar:
                     line = line.lstrip(lchar)
@@ -2876,7 +2876,7 @@ def append(path, *args, **kwargs):
 
     # Make sure we have a newline at the end of the file. Do this in binary
     # mode so SEEK_END with nonzero offset will work.
-    with salt.utils.fopen(path, 'rb+') as ofile:
+    with salt.utils.files.fopen(path, 'rb+') as ofile:
         linesep = salt.utils.to_bytes(os.linesep)
         try:
             ofile.seek(-len(linesep), os.SEEK_END)
@@ -2892,7 +2892,7 @@ def append(path, *args, **kwargs):
                 ofile.write(linesep)
 
     # Append lines in text mode
-    with salt.utils.fopen(path, 'a') as ofile:
+    with salt.utils.files.fopen(path, 'a') as ofile:
         for new_line in args:
             ofile.write('{0}{1}'.format(new_line, os.linesep))
 
@@ -2941,7 +2941,7 @@ def prepend(path, *args, **kwargs):
             args = [kwargs['args']]
 
     try:
-        with salt.utils.fopen(path) as fhr:
+        with salt.utils.files.fopen(path) as fhr:
             contents = fhr.readlines()
     except IOError:
         contents = []
@@ -2950,7 +2950,7 @@ def prepend(path, *args, **kwargs):
     for line in args:
         preface.append('{0}\n'.format(line))
 
-    with salt.utils.fopen(path, "w") as ofile:
+    with salt.utils.files.fopen(path, "w") as ofile:
         contents = preface + contents
         ofile.write(''.join(contents))
     return 'Prepended {0} lines to "{1}"'.format(len(args), path)
@@ -2999,7 +2999,7 @@ def write(path, *args, **kwargs):
     contents = []
     for line in args:
         contents.append('{0}\n'.format(line))
-    with salt.utils.fopen(path, "w") as ofile:
+    with salt.utils.files.fopen(path, "w") as ofile:
         ofile.write(''.join(contents))
     return 'Wrote {0} lines to "{1}"'.format(len(contents), path)
 
@@ -3030,7 +3030,7 @@ def touch(name, atime=None, mtime=None):
         mtime = int(mtime)
     try:
         if not os.path.exists(name):
-            with salt.utils.fopen(name, 'a') as fhw:
+            with salt.utils.files.fopen(name, 'a') as fhw:
                 fhw.write('')
 
         if not atime and not mtime:
@@ -3133,7 +3133,7 @@ def truncate(path, length):
         salt '*' file.truncate /path/to/file 512
     '''
     path = os.path.expanduser(path)
-    with salt.utils.fopen(path, 'rb+') as seek_fh:
+    with salt.utils.files.fopen(path, 'rb+') as seek_fh:
         seek_fh.truncate(int(length))
 
 
@@ -3380,7 +3380,7 @@ def read(path, binary=False):
     access_mode = 'r'
     if binary is True:
         access_mode += 'b'
-    with salt.utils.fopen(path, access_mode) as file_obj:
+    with salt.utils.files.fopen(path, access_mode) as file_obj:
         return file_obj.read()
 
 
@@ -4145,7 +4145,7 @@ def extract_hash(hash_fn,
     partial = None
     found = {}
 
-    with salt.utils.fopen(hash_fn, 'r') as fp_:
+    with salt.utils.files.fopen(hash_fn, 'r') as fp_:
         for line in fp_:
             line = line.strip()
             hash_re = r'(?i)(?<![a-z0-9])([a-f0-9]{' + hash_len_expr + '})(?![a-z0-9])'
@@ -4671,9 +4671,9 @@ def check_file_meta(
                     if bdiff:
                         changes['diff'] = bdiff
                     else:
-                        with salt.utils.fopen(sfn, 'r') as src:
+                        with salt.utils.files.fopen(sfn, 'r') as src:
                             slines = src.readlines()
-                        with salt.utils.fopen(name, 'r') as name_:
+                        with salt.utils.files.fopen(name, 'r') as name_:
                             nlines = name_.readlines()
                         changes['diff'] = \
                             ''.join(difflib.unified_diff(nlines, slines))
@@ -4687,12 +4687,12 @@ def check_file_meta(
         if salt.utils.is_windows():
             contents = os.linesep.join(
                 _splitlines_preserving_trailing_newline(contents))
-        with salt.utils.fopen(tmp, 'w') as tmp_:
+        with salt.utils.files.fopen(tmp, 'w') as tmp_:
             tmp_.write(str(contents))
         # Compare the static contents with the named file
-        with salt.utils.fopen(tmp, 'r') as src:
+        with salt.utils.files.fopen(tmp, 'r') as src:
             slines = src.readlines()
-        with salt.utils.fopen(name, 'r') as name_:
+        with salt.utils.files.fopen(name, 'r') as name_:
             nlines = name_.readlines()
         __clean_tmp(tmp)
         if ''.join(nlines) != ''.join(slines):
@@ -4758,9 +4758,9 @@ def get_diff(
 
     sfn = __salt__['cp.cache_file'](masterfile, saltenv)
     if sfn:
-        with salt.utils.fopen(sfn, 'r') as src:
+        with salt.utils.files.fopen(sfn, 'r') as src:
             slines = src.readlines()
-        with salt.utils.fopen(minionfile, 'r') as name_:
+        with salt.utils.files.fopen(minionfile, 'r') as name_:
             nlines = name_.readlines()
         if ''.join(nlines) != ''.join(slines):
             bdiff = _binary_replace(minionfile, sfn)
@@ -4983,9 +4983,9 @@ def manage_file(name,
                 if bdiff:
                     ret['changes']['diff'] = bdiff
                 else:
-                    with salt.utils.fopen(sfn, 'r') as src:
+                    with salt.utils.files.fopen(sfn, 'r') as src:
                         slines = src.readlines()
-                    with salt.utils.fopen(real_name, 'r') as name_:
+                    with salt.utils.files.fopen(real_name, 'r') as name_:
                         nlines = name_.readlines()
 
                     sndiff = ''.join(difflib.unified_diff(nlines, slines))
@@ -5010,7 +5010,7 @@ def manage_file(name,
             if salt.utils.is_windows():
                 contents = os.linesep.join(
                     _splitlines_preserving_trailing_newline(contents))
-            with salt.utils.fopen(tmp, 'w') as tmp_:
+            with salt.utils.files.fopen(tmp, 'w') as tmp_:
                 if encoding:
                     log.debug('File will be encoded with {0}'.format(encoding))
                     tmp_.write(contents.encode(encoding=encoding, errors=encoding_errors))
@@ -5018,9 +5018,9 @@ def manage_file(name,
                     tmp_.write(str(contents))
 
             # Compare contents of files to know if we need to replace
-            with salt.utils.fopen(tmp, 'r') as src:
+            with salt.utils.files.fopen(tmp, 'r') as src:
                 slines = src.readlines()
-            with salt.utils.fopen(real_name, 'r') as name_:
+            with salt.utils.files.fopen(real_name, 'r') as name_:
                 nlines = name_.readlines()
                 different = ''.join(slines) != ''.join(nlines)
 
@@ -5220,7 +5220,7 @@ def manage_file(name,
             if salt.utils.is_windows():
                 contents = os.linesep.join(
                     _splitlines_preserving_trailing_newline(contents))
-            with salt.utils.fopen(tmp, 'w') as tmp_:
+            with salt.utils.files.fopen(tmp, 'w') as tmp_:
                 if encoding:
                     log.debug('File will be encoded with {0}'.format(encoding))
                     tmp_.write(contents.encode(encoding=encoding, errors=encoding_errors))

--- a/salt/modules/freebsd_sysctl.py
+++ b/salt/modules/freebsd_sysctl.py
@@ -8,11 +8,8 @@ from __future__ import absolute_import
 import logging
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
-
-import logging
-log = logging.getLogger(__name__)
 
 # Define the module's virtual name
 __virtualname__ = 'sysctl'
@@ -69,7 +66,7 @@ def show(config_file=False):
 
     if config_file:
         try:
-            with salt.utils.fopen(config_file, 'r') as f:
+            with salt.utils.files.fopen(config_file, 'r') as f:
                 for line in f.readlines():
                     l = line.strip()
                     if l != "" and not l.startswith("#"):
@@ -144,7 +141,7 @@ def persist(name, value, config='/etc/sysctl.conf'):
     edited = False
     value = str(value)
 
-    with salt.utils.fopen(config, 'r') as ifile:
+    with salt.utils.files.fopen(config, 'r') as ifile:
         for line in ifile:
             if not line.startswith('{0}='.format(name)):
                 nlines.append(line)
@@ -165,7 +162,7 @@ def persist(name, value, config='/etc/sysctl.conf'):
                 edited = True
     if not edited:
         nlines.append("{0}\n".format(_formatfor(name, value, config)))
-    with salt.utils.fopen(config, 'w+') as ofile:
+    with salt.utils.files.fopen(config, 'w+') as ofile:
         ofile.writelines(nlines)
     if config != '/boot/loader.conf':
         assign(name, value)

--- a/salt/modules/freebsdjail.py
+++ b/salt/modules/freebsdjail.py
@@ -11,6 +11,7 @@ import subprocess
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 # Define the module's virtual name
 __virtualname__ = 'jail'
@@ -99,7 +100,7 @@ def get_enabled():
     ret = []
     for rconf in ('/etc/rc.conf', '/etc/rc.conf.local'):
         if os.access(rconf, os.R_OK):
-            with salt.utils.fopen(rconf, 'r') as _fp:
+            with salt.utils.files.fopen(rconf, 'r') as _fp:
                 for line in _fp:
                     if not line.strip():
                         continue
@@ -135,7 +136,7 @@ def show_config(jail):
     else:
         for rconf in ('/etc/rc.conf', '/etc/rc.conf.local'):
             if os.access(rconf, os.R_OK):
-                with salt.utils.fopen(rconf, 'r') as _fp:
+                with salt.utils.files.fopen(rconf, 'r') as _fp:
                     for line in _fp:
                         if not line.strip():
                             continue
@@ -145,7 +146,7 @@ def show_config(jail):
                         ret[key.split('_', 2)[2]] = value.split('"')[1]
         for jconf in ('/etc/jail.conf', '/usr/local/etc/jail.conf'):
             if os.access(jconf, os.R_OK):
-                with salt.utils.fopen(jconf, 'r') as _fp:
+                with salt.utils.files.fopen(jconf, 'r') as _fp:
                     for line in _fp:
                         line = line.partition('#')[0].strip()
                         if line:
@@ -186,7 +187,7 @@ def fstab(jail):
         c_fstab = config['mount.fstab']
     if 'fstab' in config or 'mount.fstab' in config:
         if os.access(c_fstab, os.R_OK):
-            with salt.utils.fopen(c_fstab, 'r') as _fp:
+            with salt.utils.files.fopen(c_fstab, 'r') as _fp:
                 for line in _fp:
                     line = line.strip()
                     if not line:

--- a/salt/modules/freebsdkmod.py
+++ b/salt/modules/freebsdkmod.py
@@ -9,7 +9,7 @@ import os
 import re
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 # Define the module's virtual name
 __virtualname__ = 'kmod'
@@ -70,7 +70,7 @@ def _get_persistent_modules():
     Returns a list of modules in loader.conf that load on boot.
     '''
     mods = set()
-    with salt.utils.fopen(_LOADER_CONF, 'r') as loader_conf:
+    with salt.utils.files.fopen(_LOADER_CONF, 'r') as loader_conf:
         for line in loader_conf:
             line = line.strip()
             mod_name = _get_module_name(line)

--- a/salt/modules/freebsdports.py
+++ b/salt/modules/freebsdports.py
@@ -24,6 +24,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.ext.six import string_types
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 import salt.ext.six as six
@@ -114,7 +115,7 @@ def _write_options(name, configuration):
                 'Unable to make {0}: {1}'.format(dirname, exc)
             )
 
-    with salt.utils.fopen(os.path.join(dirname, 'options'), 'w') as fp_:
+    with salt.utils.files.fopen(os.path.join(dirname, 'options'), 'w') as fp_:
         sorted_options = list(conf_ptr.keys())
         sorted_options.sort()
         fp_.write(

--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -19,6 +19,7 @@ import re
 # Import salt libs
 import salt.utils
 import salt.utils.decorators as decorators
+import salt.utils.files
 from salt.exceptions import CommandNotFoundError
 
 __func_alias__ = {
@@ -222,7 +223,7 @@ def _switch(name,                   # pylint: disable=C0103
         val = 'NO'
 
     if os.path.exists(config):
-        with salt.utils.fopen(config, 'r') as ifile:
+        with salt.utils.files.fopen(config, 'r') as ifile:
             for line in ifile:
                 if not line.startswith('{0}='.format(rcvar)):
                     nlines.append(line)
@@ -236,7 +237,7 @@ def _switch(name,                   # pylint: disable=C0103
             nlines[-1] = '{0}\n'.format(nlines[-1])
         nlines.append('{0}="{1}"\n'.format(rcvar, val))
 
-    with salt.utils.fopen(config, 'w') as ofile:
+    with salt.utils.files.fopen(config, 'w') as ofile:
         ofile.writelines(nlines)
 
     return True

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -4639,7 +4639,7 @@ def worktree_rm(cwd, user=None):
     elif not is_worktree(cwd):
         raise CommandExecutionError(cwd + ' is not a git worktree')
     try:
-        salt.utils.rm_rf(cwd)
+        salt.utils.files.rm_rf(cwd)
     except Exception as exc:
         raise CommandExecutionError(
             'Unable to remove {0}: {1}'.format(cwd, exc)

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -2039,7 +2039,7 @@ def is_worktree(cwd,
         return False
     gitdir = os.path.join(toplevel, '.git')
     try:
-        with salt.utils.fopen(gitdir, 'r') as fp_:
+        with salt.utils.files.fopen(gitdir, 'r') as fp_:
             for line in fp_:
                 try:
                     label, path = line.split(None, 1)
@@ -2381,7 +2381,7 @@ def list_worktrees(cwd,
             Return contents of a single line file with EOF newline stripped
             '''
             try:
-                with salt.utils.fopen(path, 'r') as fp_:
+                with salt.utils.files.fopen(path, 'r') as fp_:
                     for line in fp_:
                         ret = line.strip()
                         # Ignore other lines, if they exist (which they

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -22,6 +22,7 @@ import time
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import SaltInvocationError
 from salt.utils.versions import LooseVersion as _LooseVersion
 
@@ -726,7 +727,7 @@ def import_key(text=None,
 
     if filename:
         try:
-            with salt.utils.flopen(filename, 'rb') as _fp:
+            with salt.utils.files.flopen(filename, 'rb') as _fp:
                 lines = _fp.readlines()
                 text = ''.join(lines)
         except IOError:
@@ -1019,13 +1020,13 @@ def sign(user=None,
         else:
             signed_data = gpg.sign(text, keyid=keyid, passphrase=gpg_passphrase)
     elif filename:
-        with salt.utils.flopen(filename, 'rb') as _fp:
+        with salt.utils.files.flopen(filename, 'rb') as _fp:
             if gnupg_version >= '1.3.1':
                 signed_data = gpg.sign(text, default_key=keyid, passphrase=gpg_passphrase)
             else:
                 signed_data = gpg.sign_file(_fp, keyid=keyid, passphrase=gpg_passphrase)
         if output:
-            with salt.utils.flopen(output, 'w') as fout:
+            with salt.utils.files.flopen(output, 'w') as fout:
                 fout.write(signed_data.data)
     else:
         raise SaltInvocationError('filename or text must be passed.')
@@ -1077,10 +1078,10 @@ def verify(text=None,
         if signature:
             # need to call with fopen instead of flopen due to:
             # https://bitbucket.org/vinay.sajip/python-gnupg/issues/76/verify_file-closes-passed-file-handle
-            with salt.utils.fopen(signature, 'rb') as _fp:
+            with salt.utils.files.fopen(signature, 'rb') as _fp:
                 verified = gpg.verify_file(_fp, filename)
         else:
-            with salt.utils.flopen(filename, 'rb') as _fp:
+            with salt.utils.files.flopen(filename, 'rb') as _fp:
                 verified = gpg.verify_file(_fp)
     else:
         raise SaltInvocationError('filename or text must be passed.')
@@ -1173,12 +1174,12 @@ def encrypt(user=None,
         if GPG_1_3_1:
             # This version does not allow us to encrypt using the
             # file stream # have to read in the contents and encrypt.
-            with salt.utils.flopen(filename, 'rb') as _fp:
+            with salt.utils.files.flopen(filename, 'rb') as _fp:
                 _contents = _fp.read()
             result = gpg.encrypt(_contents, recipients, passphrase=gpg_passphrase, output=output)
         else:
             # This version allows encrypting the file stream
-            with salt.utils.flopen(filename, 'rb') as _fp:
+            with salt.utils.files.flopen(filename, 'rb') as _fp:
                 if output:
                     result = gpg.encrypt_file(_fp, recipients, passphrase=gpg_passphrase, output=output, sign=sign)
                 else:
@@ -1264,7 +1265,7 @@ def decrypt(user=None,
     if text:
         result = gpg.decrypt(text, passphrase=gpg_passphrase)
     elif filename:
-        with salt.utils.flopen(filename, 'rb') as _fp:
+        with salt.utils.files.flopen(filename, 'rb') as _fp:
             if output:
                 result = gpg.decrypt_file(_fp, passphrase=gpg_passphrase, output=output)
             else:

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -12,15 +12,14 @@ import operator
 import collections
 import json
 import math
+import yaml
 from functools import reduce  # pylint: disable=redefined-builtin
 
-# Import 3rd-party libs
-import yaml
-import salt.utils.compat
+# Import Salt libs
 import salt.ext.six as six
-
-# Import salt libs
 import salt.utils
+import salt.utils.compat
+import salt.utils.files
 import salt.utils.yamldumper
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.exceptions import SaltException
@@ -235,7 +234,7 @@ def setvals(grains, destructive=False):
         )
 
     if os.path.isfile(gfn):
-        with salt.utils.fopen(gfn, 'rb') as fp_:
+        with salt.utils.files.fopen(gfn, 'rb') as fp_:
             try:
                 grains = yaml.safe_load(fp_.read())
             except yaml.YAMLError as exc:
@@ -253,14 +252,14 @@ def setvals(grains, destructive=False):
             __grains__[key] = val
     cstr = salt.utils.yamldumper.safe_dump(grains, default_flow_style=False)
     try:
-        with salt.utils.fopen(gfn, 'w+') as fp_:
+        with salt.utils.files.fopen(gfn, 'w+') as fp_:
             fp_.write(cstr)
     except (IOError, OSError):
         msg = 'Unable to write to grains file at {0}. Check permissions.'
         log.error(msg.format(gfn))
     fn_ = os.path.join(__opts__['cachedir'], 'module_refresh')
     try:
-        with salt.utils.flopen(fn_, 'w+') as fp_:
+        with salt.utils.files.flopen(fn_, 'w+') as fp_:
             fp_.write('')
     except (IOError, OSError):
         msg = 'Unable to write to cache file {0}. Check permissions.'

--- a/salt/modules/grub_legacy.py
+++ b/salt/modules/grub_legacy.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 import os
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 import salt.utils.decorators as decorators
 from salt.exceptions import CommandExecutionError
 
@@ -68,7 +68,7 @@ def conf():
     ret = {}
     pos = 0
     try:
-        with salt.utils.fopen(_detect_conf(), 'r') as _fp:
+        with salt.utils.files.fopen(_detect_conf(), 'r') as _fp:
             for line in _fp:
                 if line.startswith('#'):
                     continue

--- a/salt/modules/hashutil.py
+++ b/salt/modules/hashutil.py
@@ -13,6 +13,7 @@ import hmac
 import salt.exceptions
 import salt.ext.six as six
 import salt.utils
+import salt.utils.files
 import salt.utils.hashutils
 
 if six.PY2:
@@ -72,7 +73,7 @@ def digest_file(infile, checksum='md5'):
         raise salt.exceptions.CommandExecutionError(
                 "File path '{0}' not found.".format(infile))
 
-    with salt.utils.fopen(infile, 'rb') as f:
+    with salt.utils.files.fopen(infile, 'rb') as f:
         file_hash = __salt__['hashutil.digest'](f.read(), checksum)
 
     return file_hash
@@ -156,7 +157,7 @@ def base64_encodefile(fname):
     '''
     encoded_f = StringIO.StringIO()
 
-    with salt.utils.fopen(fname, 'rb') as f:
+    with salt.utils.files.fopen(fname, 'rb') as f:
         base64.encode(f, encoded_f)
 
     encoded_f.seek(0)
@@ -193,7 +194,7 @@ def base64_decodefile(instr, outfile):
     '''
     encoded_f = StringIO.StringIO(instr)
 
-    with salt.utils.fopen(outfile, 'wb') as f:
+    with salt.utils.files.fopen(outfile, 'wb') as f:
         base64.decode(encoded_f, f)
 
     return True

--- a/salt/modules/heat.py
+++ b/salt/modules/heat.py
@@ -45,11 +45,10 @@ from __future__ import absolute_import
 import time
 import json
 import logging
-# Import third party libs
 import yaml
-# Import salt libs
+
+# Import Salt libs
 import salt.ext.six as six
-import salt.utils
 import salt.utils.files
 from salt.exceptions import SaltInvocationError
 
@@ -543,9 +542,9 @@ def create_stack(name=None, template_file=None, enviroment=None,
             contents=None,
             dir_mode=None)
         if template_manage_result['result']:
-            with salt.utils.fopen(template_tmp_file, 'r') as tfp_:
+            with salt.utils.files.fopen(template_tmp_file, 'r') as tfp_:
                 tpl = tfp_.read()
-                salt.utils.safe_rm(template_tmp_file)
+                salt.utils.files.safe_rm(template_tmp_file)
                 try:
                     if isinstance(tpl, six.binary_type):
                         tpl = tpl.decode('utf-8')
@@ -605,9 +604,9 @@ def create_stack(name=None, template_file=None, enviroment=None,
             contents=None,
             dir_mode=None)
         if enviroment_manage_result['result']:
-            with salt.utils.fopen(enviroment_tmp_file, 'r') as efp_:
+            with salt.utils.files.fopen(enviroment_tmp_file, 'r') as efp_:
                 env_str = efp_.read()
-                salt.utils.safe_rm(enviroment_tmp_file)
+                salt.utils.files.safe_rm(enviroment_tmp_file)
                 try:
                     env = _parse_enviroment(env_str)
                 except ValueError as ex:
@@ -732,9 +731,9 @@ def update_stack(name=None, template_file=None, enviroment=None,
             contents=None,
             dir_mode=None)
         if template_manage_result['result']:
-            with salt.utils.fopen(template_tmp_file, 'r') as tfp_:
+            with salt.utils.files.fopen(template_tmp_file, 'r') as tfp_:
                 tpl = tfp_.read()
-                salt.utils.safe_rm(template_tmp_file)
+                salt.utils.files.safe_rm(template_tmp_file)
                 try:
                     if isinstance(tpl, six.binary_type):
                         tpl = tpl.decode('utf-8')
@@ -794,9 +793,9 @@ def update_stack(name=None, template_file=None, enviroment=None,
             contents=None,
             dir_mode=None)
         if enviroment_manage_result['result']:
-            with salt.utils.fopen(enviroment_tmp_file, 'r') as efp_:
+            with salt.utils.files.fopen(enviroment_tmp_file, 'r') as efp_:
                 env_str = efp_.read()
-                salt.utils.safe_rm(enviroment_tmp_file)
+                salt.utils.files.safe_rm(enviroment_tmp_file)
                 try:
                     env = _parse_enviroment(env_str)
                 except ValueError as ex:

--- a/salt/modules/highstate_doc.py
+++ b/salt/modules/highstate_doc.py
@@ -221,7 +221,7 @@ import re
 import yaml
 import logging
 
-import salt.utils
+import salt.utils.files
 import salt.utils.templates as tpl
 from salt.utils.yamldumper import OrderedDumper
 
@@ -412,7 +412,7 @@ def read_file(name):
     '''
     out = ''
     try:
-        with salt.utils.fopen(name, 'r') as f:
+        with salt.utils.files.fopen(name, 'r') as f:
             out = f.read()
     except Exception as ex:
         log.error(ex)
@@ -550,7 +550,7 @@ def _format_markdown_system_file(filename, config):
         if is_binary:
             file_data = '[[skipped binary data]]'
         else:
-            with salt.utils.fopen(filename, 'r') as f:
+            with salt.utils.files.fopen(filename, 'r') as f:
                 file_data = f.read()
         #file_data = __salt__['cmd.shell']('\\file -i \'{0}\' | \\grep -q \'charset=binary\' && echo [[binary data]] || cat \'{0}\''.format(filename))
         file_data = _md_fix(file_data)

--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 import os
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 import salt.utils.odict as odict
 
 # Import 3rd-party libs
@@ -33,7 +33,7 @@ def _get_or_create_hostfile():
     if hfn is None:
         hfn = ''
     if not os.path.exists(hfn):
-        with salt.utils.fopen(hfn, 'w'):
+        with salt.utils.files.fopen(hfn, 'w'):
             pass
     return hfn
 
@@ -47,7 +47,7 @@ def _list_hosts():
     ret = odict.OrderedDict()
     if not os.path.isfile(hfn):
         return ret
-    with salt.utils.fopen(hfn) as ifile:
+    with salt.utils.files.fopen(hfn) as ifile:
         for line in ifile:
             line = line.strip()
             if not line:
@@ -161,7 +161,7 @@ def set_host(ip, alias):
     if not alias.strip():
         line_to_add = ''
 
-    with salt.utils.fopen(hfn) as fp_:
+    with salt.utils.files.fopen(hfn) as fp_:
         lines = fp_.readlines()
     for ind, line in enumerate(lines):
         tmpline = line.strip()
@@ -182,7 +182,7 @@ def set_host(ip, alias):
             lines[-1] += os.linesep
         line = line_to_add
         lines.append(line)
-    with salt.utils.fopen(hfn, 'w+') as ofile:
+    with salt.utils.files.fopen(hfn, 'w+') as ofile:
         ofile.writelines(lines)
     return True
 
@@ -200,7 +200,7 @@ def rm_host(ip, alias):
     if not has_pair(ip, alias):
         return True
     hfn = _get_or_create_hostfile()
-    with salt.utils.fopen(hfn) as fp_:
+    with salt.utils.files.fopen(hfn) as fp_:
         lines = fp_.readlines()
     for ind in range(len(lines)):
         tmpline = lines[ind].strip()
@@ -221,7 +221,7 @@ def rm_host(ip, alias):
             else:
                 # Only an alias was removed
                 lines[ind] = newline + os.linesep
-    with salt.utils.fopen(hfn, 'w+') as ofile:
+    with salt.utils.files.fopen(hfn, 'w+') as ofile:
         ofile.writelines(lines)
     return True
 
@@ -271,7 +271,7 @@ def _write_hosts(hosts):
         lines.append(line)
 
     hfn = _get_or_create_hostfile()
-    with salt.utils.fopen(hfn, 'w+') as ofile:
+    with salt.utils.files.fopen(hfn, 'w+') as ofile:
         for line in lines:
             if line.strip():
                 # /etc/hosts needs to end with EOL so that some utils that read

--- a/salt/modules/incron.py
+++ b/salt/modules/incron.py
@@ -102,7 +102,7 @@ def _write_incron_lines(user, lines):
         return ret
     else:
         path = salt.utils.files.mkstemp()
-        with salt.utils.fopen(path, 'w+') as fp_:
+        with salt.utils.files.fopen(path, 'w+') as fp_:
             fp_.writelines(lines)
         if __grains__['os_family'] == 'Solaris' and user != "root":
             __salt__['cmd.run']('chown {0} {1}'.format(user, path), python_shell=False)
@@ -121,7 +121,7 @@ def _write_file(folder, filename, data):
         msg = msg.format(filename, folder)
         log.error(msg)
         raise AttributeError(msg)
-    with salt.utils.fopen(path, 'w') as fp_:
+    with salt.utils.files.fopen(path, 'w') as fp_:
         fp_.write(data)
 
     return 0
@@ -133,7 +133,7 @@ def _read_file(folder, filename):
     '''
     path = os.path.join(folder, filename)
     try:
-        with salt.utils.fopen(path, 'rb') as contents:
+        with salt.utils.files.fopen(path, 'rb') as contents:
             return contents.readlines()
     except (OSError, IOError):
         return ''

--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -21,7 +21,7 @@ import json
 
 # Import Salt libs
 import salt.ext.six as six
-import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 from salt.utils.odict import OrderedDict
 
@@ -369,7 +369,7 @@ class _Ini(_Section):
     def refresh(self, inicontents=None):
         if inicontents is None:
             try:
-                with salt.utils.fopen(self.name) as rfh:
+                with salt.utils.files.fopen(self.name) as rfh:
                     inicontents = rfh.read()
             except (OSError, IOError) as exc:
                 raise CommandExecutionError(
@@ -395,7 +395,7 @@ class _Ini(_Section):
 
     def flush(self):
         try:
-            with salt.utils.fopen(self.name, 'w') as outfile:
+            with salt.utils.files.fopen(self.name, 'w') as outfile:
                 ini_gen = self.gen_ini()
                 next(ini_gen)
                 outfile.writelines(ini_gen)

--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -29,6 +29,7 @@ from salt.modules.inspectlib.entities import (AllowedDir, IgnoredDir, Package,
                                               PayloadFile, PackageCfgFile)
 
 import salt.utils
+import salt.utils.files
 from salt.utils import fsutils
 from salt.utils import reinit_crypto
 from salt.exceptions import CommandExecutionError
@@ -475,7 +476,7 @@ def is_alive(pidfile):
     Check if PID is still alive.
     '''
     try:
-        with salt.utils.fopen(pidfile) as fp_:
+        with salt.utils.files.fopen(pidfile) as fp_:
             os.kill(int(fp_.read().strip()), 0)
         return True
     except Exception as ex:
@@ -517,7 +518,7 @@ if __name__ == '__main__':
         pid = os.fork()
         if pid > 0:
             reinit_crypto()
-            with salt.utils.fopen(os.path.join(pidfile, EnvLoader.PID_FILE), 'w') as fp_:
+            with salt.utils.files.fopen(os.path.join(pidfile, EnvLoader.PID_FILE), 'w') as fp_:
                 fp_.write('{0}\n'.format(pid))
             sys.exit(0)
     except OSError as ex:

--- a/salt/modules/inspectlib/kiwiproc.py
+++ b/salt/modules/inspectlib/kiwiproc.py
@@ -24,7 +24,7 @@ import platform
 import socket
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 from salt.modules.inspectlib.exceptions import InspectorKiwiProcessorException
 
 # Import third party libs
@@ -145,14 +145,14 @@ class KiwiExporter(object):
         '''
         # Get real local users with the local passwords
         shadow = {}
-        with salt.utils.fopen('/etc/shadow') as rfh:
+        with salt.utils.files.fopen('/etc/shadow') as rfh:
             for sh_line in rfh.read().split(os.linesep):
                 if sh_line.strip():
                     login, pwd = sh_line.split(":")[:2]
                     if pwd and pwd[0] not in '!*':
                         shadow[login] = {'p': pwd}
 
-        with salt.utils.fopen('/etc/passwd') as rfh:
+        with salt.utils.files.fopen('/etc/passwd') as rfh:
             for ps_line in rfh.read().split(os.linesep):
                 if ps_line.strip():
                     ps_line = ps_line.strip().split(':')

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -21,6 +21,8 @@ import time
 import logging
 
 # Import Salt Libs
+import salt.utils.files
+import salt.utils.fsutils
 import salt.utils.network
 from salt.modules.inspectlib.exceptions import (InspectorQueryException, SIException)
 from salt.modules.inspectlib import EnvLoader
@@ -214,7 +216,7 @@ class Query(EnvLoader):
         '''
         users = dict()
         path = '/etc/passwd'
-        with salt.utils.fopen(path, 'r') as fp_:
+        with salt.utils.files.fopen(path, 'r') as fp_:
             for line in fp_:
                 line = line.strip()
                 if ':' not in line:
@@ -239,7 +241,7 @@ class Query(EnvLoader):
         '''
         groups = dict()
         path = '/etc/group'
-        with salt.utils.fopen(path, 'r') as fp_:
+        with salt.utils.files.fopen(path, 'r') as fp_:
             for line in fp_:
                 line = line.strip()
                 if ':' not in line:

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -37,6 +37,7 @@ import string
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 from salt.exceptions import SaltException
 from salt.ext import six
@@ -970,7 +971,7 @@ def _parse_conf(conf_file=None, in_mem=False, family='ipv4'):
 
     rules = ''
     if conf_file:
-        with salt.utils.fopen(conf_file, 'r') as ifile:
+        with salt.utils.files.fopen(conf_file, 'r') as ifile:
             rules = ifile.read()
     elif in_mem:
         cmd = '{0}-save' . format(_iptables_cmd(family))

--- a/salt/modules/jenkins.py
+++ b/salt/modules/jenkins.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     HAS_JENKINS = False
 
-import salt.utils
+import salt.utils.files
 
 # Import 3rd-party libs
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
@@ -264,7 +264,7 @@ def create_job(name=None,
     else:
         config_xml_file = __salt__['cp.cache_file'](config_xml, saltenv)
 
-        with salt.utils.fopen(config_xml_file) as _fp:
+        with salt.utils.files.fopen(config_xml_file) as _fp:
             config_xml = _fp.read()
 
     server = _connect()
@@ -303,7 +303,7 @@ def update_job(name=None,
     else:
         config_xml_file = __salt__['cp.cache_file'](config_xml, saltenv)
 
-        with salt.utils.fopen(config_xml_file) as _fp:
+        with salt.utils.files.fopen(config_xml_file) as _fp:
             config_xml = _fp.read()
 
     server = _connect()

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -25,6 +25,9 @@ try:
 except ImportError:
     from salt._compat import ElementTree as etree
 
+# Import Salt libs
+import salt.utils.files
+
 # Juniper interface libraries
 # https://github.com/Juniper/py-junos-eznc
 try:
@@ -40,11 +43,6 @@ try:
     HAS_JUNOS = True
 except ImportError:
     HAS_JUNOS = False
-
-# Import salt libraries
-from salt.utils import fopen
-from salt.utils import files
-from salt.utils import safe_rm
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -234,7 +232,7 @@ def rpc(cmd=None, dest=None, format='xml', **kwargs):
             write_response = json.dumps(reply, indent=1)
         else:
             write_response = etree.tostring(reply)
-        with fopen(dest, 'w') as fp:
+        with salt.utils.files.fopen(dest, 'w') as fp:
             fp.write(write_response)
     return ret
 
@@ -460,7 +458,7 @@ def rollback(id=0, **kwargs):
     if 'diffs_file' in op and op['diffs_file'] is not None:
         diff = conn.cu.diff()
         if diff is not None:
-            with fopen(op['diffs_file'], 'w') as fp:
+            with salt.utils.files.fopen(op['diffs_file'], 'w') as fp:
                 fp.write(diff)
         else:
             log.info(
@@ -655,7 +653,7 @@ def cli(command=None, format='text', **kwargs):
         ret['message'] = jxmlease.parse(result)
 
     if 'dest' in op and op['dest'] is not None:
-        with fopen(op['dest'], 'w') as fp:
+        with salt.utils.files.fopen(op['dest'], 'w') as fp:
             fp.write(result)
 
     ret['out'] = True
@@ -833,7 +831,7 @@ def install_config(path=None, **kwargs):
     if "template_vars" in op:
         template_vars = op["template_vars"]
 
-    template_cached_path = files.mkstemp()
+    template_cached_path = salt.utils.files.mkstemp()
     __salt__['cp.get_template'](
         path,
         template_cached_path,
@@ -888,7 +886,7 @@ def install_config(path=None, **kwargs):
             return ret
 
         finally:
-            safe_rm(template_cached_path)
+            salt.utils.files.safe_rm(template_cached_path)
 
         config_diff = cu.diff()
         if config_diff is None:
@@ -929,7 +927,7 @@ def install_config(path=None, **kwargs):
 
         try:
             if write_diff and config_diff is not None:
-                with fopen(write_diff, 'w') as fp:
+                with salt.utils.files.fopen(write_diff, 'w') as fp:
                     fp.write(config_diff)
         except Exception as exception:
             ret['message'] = 'Could not write into diffs_file due to: "{0}"'.format(
@@ -1004,7 +1002,7 @@ def install_os(path=None, **kwargs):
         ret['out'] = False
         return ret
 
-    image_cached_path = files.mkstemp()
+    image_cached_path = salt.utils.files.mkstemp()
     __salt__['cp.get_file'](path, image_cached_path)
 
     if not os.path.isfile(image_cached_path):
@@ -1034,7 +1032,7 @@ def install_os(path=None, **kwargs):
         ret['out'] = False
         return ret
     finally:
-        safe_rm(image_cached_path)
+        salt.utils.files.safe_rm(image_cached_path)
 
     if 'reboot' in op and op['reboot'] is True:
         try:
@@ -1231,7 +1229,7 @@ def load(path=None, **kwargs):
     if "template_vars" in op:
         template_vars = op["template_vars"]
 
-    template_cached_path = files.mkstemp()
+    template_cached_path = salt.utils.files.mkstemp()
     __salt__['cp.get_template'](
         path,
         template_cached_path,
@@ -1278,7 +1276,7 @@ def load(path=None, **kwargs):
         ret['out'] = False
         return ret
     finally:
-        safe_rm(template_cached_path)
+        salt.utils.files.safe_rm(template_cached_path)
 
     return ret
 

--- a/salt/modules/k8s.py
+++ b/salt/modules/k8s.py
@@ -26,7 +26,7 @@ from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: dis
 
 # TODO Remove requests dependency
 
-import salt.utils
+import salt.utils.files
 import salt.utils.http as http
 
 __virtualname__ = 'k8s'
@@ -55,7 +55,7 @@ def _guess_apiserver(apiserver_url=None):
         config = __salt__['config.get']('k8s:config', default_config)
         kubeapi_regex = re.compile("""KUBE_MASTER=['"]--master=(.*)['"]""",
                                    re.MULTILINE)
-        with salt.utils.fopen(config) as fh_k8s:
+        with salt.utils.files.fopen(config) as fh_k8s:
             for line in fh_k8s.readlines():
                 match_line = kubeapi_regex.match(line)
             if match_line:
@@ -541,7 +541,7 @@ def _is_valid_secret_file(filename):
 
 def _file_encode(filename):
     log.trace("Encoding secret file: {0}".format(filename))
-    with salt.utils.fopen(filename, "rb") as f:
+    with salt.utils.files.fopen(filename, "rb") as f:
         data = f.read()
         return base64.b64encode(data)
 

--- a/salt/modules/kmod.py
+++ b/salt/modules/kmod.py
@@ -10,7 +10,7 @@ import re
 import logging
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -201,7 +201,7 @@ def mod_list(only_persist=False):
         conf = _get_modules_conf()
         if os.path.exists(conf):
             try:
-                with salt.utils.fopen(conf, 'r') as modules_file:
+                with salt.utils.files.fopen(conf, 'r') as modules_file:
                     for line in modules_file:
                         line = line.strip()
                         mod_name = _strip_module_name(line)

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -26,7 +26,7 @@ import yaml
 
 from salt.exceptions import CommandExecutionError
 from salt.ext.six import iteritems
-import salt.utils
+import salt.utils.files
 import salt.utils.templates
 
 try:
@@ -1220,7 +1220,7 @@ def __read_and_render_yaml_file(source,
         raise CommandExecutionError(
             'Source file \'{0}\' not found'.format(source))
 
-    with salt.utils.fopen(sfn, 'r') as src:
+    with salt.utils.files.fopen(sfn, 'r') as src:
         contents = src.read()
 
         if template:

--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -22,6 +22,7 @@ import re
 # Import salt libs
 import salt.utils
 import salt.utils.decorators as decorators
+import salt.utils.files
 from salt.utils.versions import LooseVersion as _LooseVersion
 import salt.ext.six as six
 
@@ -88,7 +89,7 @@ def _available_services():
                 try:
                     # This assumes most of the plist files
                     # will be already in XML format
-                    with salt.utils.fopen(file_path):
+                    with salt.utils.files.fopen(file_path):
                         plist = plistlib.readPlist(true_path)
 
                 except Exception:

--- a/salt/modules/linux_ip.py
+++ b/salt/modules/linux_ip.py
@@ -4,6 +4,7 @@ The networking module for Non-RH/Deb Linux distros
 '''
 from __future__ import absolute_import
 import salt.utils
+import salt.utils.files
 from salt.ext.six.moves import zip
 
 __virtualname__ = 'ip'
@@ -133,7 +134,7 @@ def _parse_routes():
     '''
     Parse the contents of ``/proc/net/route``
     '''
-    with salt.utils.fopen('/proc/net/route', 'r') as fp_:
+    with salt.utils.files.fopen('/proc/net/route', 'r') as fp_:
         out = fp_.read()
 
     ret = {}

--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -11,7 +11,7 @@ import re
 
 # Import salt libs
 import salt.ext.six as six
-import salt.utils
+import salt.utils.files
 from salt.ext.six import string_types
 from salt.exceptions import CommandExecutionError
 import salt.utils.systemd
@@ -70,7 +70,7 @@ def show(config_file=False):
     ret = {}
     if config_file:
         try:
-            with salt.utils.fopen(config_file) as fp_:
+            with salt.utils.files.fopen(config_file) as fp_:
                 for line in fp_:
                     if not line.startswith('#') and '=' in line:
                         # search if we have some '=' instead of ' = ' separators
@@ -169,7 +169,7 @@ def persist(name, value, config=None):
         if not os.path.exists(sysctl_dir):
             os.makedirs(sysctl_dir)
         try:
-            with salt.utils.fopen(config, 'w+') as _fh:
+            with salt.utils.files.fopen(config, 'w+') as _fh:
                 _fh.write('#\n# Kernel sysctl configuration\n#\n')
         except (IOError, OSError):
             msg = 'Could not write to file: {0}'
@@ -178,7 +178,7 @@ def persist(name, value, config=None):
     # Read the existing sysctl.conf
     nlines = []
     try:
-        with salt.utils.fopen(config, 'r') as _fh:
+        with salt.utils.files.fopen(config, 'r') as _fh:
             # Use readlines because this should be a small file
             # and it seems unnecessary to indent the below for
             # loop since it is a fairly large block of code.
@@ -230,7 +230,7 @@ def persist(name, value, config=None):
     if not edited:
         nlines.append('{0} = {1}\n'.format(name, value))
     try:
-        with salt.utils.fopen(config, 'w+') as _fh:
+        with salt.utils.files.fopen(config, 'w+') as _fh:
             _fh.writelines(nlines)
     except (IOError, OSError):
         msg = 'Could not write to file: {0}'

--- a/salt/modules/logadm.py
+++ b/salt/modules/logadm.py
@@ -15,6 +15,7 @@ except ImportError:
 # Import salt libs
 import salt.utils
 import salt.utils.decorators as decorators
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 default_conf = '/etc/logadm.conf'
@@ -69,7 +70,7 @@ def _parse_conf(conf_file=default_conf):
     Parse a logadm configuration file.
     '''
     ret = {}
-    with salt.utils.fopen(conf_file, 'r') as ifile:
+    with salt.utils.files.fopen(conf_file, 'r') as ifile:
         for line in ifile:
             line = line.strip()
             if not line:

--- a/salt/modules/logrotate.py
+++ b/salt/modules/logrotate.py
@@ -11,6 +11,7 @@ import logging
 # Import salt libs
 from salt.exceptions import SaltInvocationError
 import salt.utils
+import salt.utils.files
 
 _LOG = logging.getLogger(__name__)
 _DEFAULT_CONF = '/etc/logrotate.conf'
@@ -62,7 +63,7 @@ def _parse_conf(conf_file=_DEFAULT_CONF):
     multi = {}
     prev_comps = None
 
-    with salt.utils.fopen(conf_file, 'r') as ifile:
+    with salt.utils.files.fopen(conf_file, 'r') as ifile:
         for line in ifile:
             line = line.strip()
             if not line:

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -29,6 +29,7 @@ import salt
 import salt.utils.odict
 import salt.utils
 import salt.utils.dictupdate
+import salt.utils.files
 import salt.utils.network
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 import salt.utils.cloud
@@ -994,7 +995,7 @@ class _LXCConfig(object):
         if self.name:
             self.path = os.path.join(path, self.name, 'config')
             if os.path.isfile(self.path):
-                with salt.utils.fopen(self.path) as fhr:
+                with salt.utils.files.fopen(self.path) as fhr:
                     for line in fhr.readlines():
                         match = self.pattern.findall((line.strip()))
                         if match:
@@ -1034,7 +1035,7 @@ class _LXCConfig(object):
             content = self.as_string()
             # 2 step rendering to be sure not to open/wipe the config
             # before as_string succeeds.
-            with salt.utils.fopen(self.path, 'w') as fic:
+            with salt.utils.files.fopen(self.path, 'w') as fic:
                 fic.write(content)
                 fic.flush()
 
@@ -2760,7 +2761,7 @@ def info(name, path=None):
 
         ret = {}
         config = []
-        with salt.utils.fopen(conf_file) as fp_:
+        with salt.utils.files.fopen(conf_file) as fp_:
             for line in fp_:
                 comps = [x.strip() for x in
                          line.split('#', 1)[0].strip().split('=', 1)]
@@ -2970,8 +2971,8 @@ def update_lxc_conf(name, lxc_conf, lxc_conf_unset, path=None):
     changes = {'edited': [], 'added': [], 'removed': []}
     ret = {'changes': changes, 'result': True, 'comment': ''}
 
-    # do not use salt.utils.fopen !
-    with salt.utils.fopen(lxc_conf_p, 'r') as fic:
+    # do not use salt.utils.files.fopen !
+    with salt.utils.files.fopen(lxc_conf_p, 'r') as fic:
         filtered_lxc_conf = []
         for row in lxc_conf:
             if not row:
@@ -3028,11 +3029,11 @@ def update_lxc_conf(name, lxc_conf, lxc_conf_unset, path=None):
         conf_changed = conf != orig_config
         chrono = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
         if conf_changed:
-            # DO NOT USE salt.utils.fopen here, i got (kiorky)
+            # DO NOT USE salt.utils.files.fopen here, i got (kiorky)
             # problems with lxc configs which were wiped !
-            with salt.utils.fopen('{0}.{1}'.format(lxc_conf_p, chrono), 'w') as wfic:
+            with salt.utils.files.fopen('{0}.{1}'.format(lxc_conf_p, chrono), 'w') as wfic:
                 wfic.write(conf)
-            with salt.utils.fopen(lxc_conf_p, 'w') as wfic:
+            with salt.utils.files.fopen(lxc_conf_p, 'w') as wfic:
                 wfic.write(conf)
             ret['comment'] = 'Updated'
             ret['result'] = True
@@ -4224,7 +4225,7 @@ def read_conf(conf_file, out_format='simple'):
     '''
     ret_commented = []
     ret_simple = {}
-    with salt.utils.fopen(conf_file, 'r') as fp_:
+    with salt.utils.files.fopen(conf_file, 'r') as fp_:
         for line in fp_.readlines():
             if '=' not in line:
                 ret_commented.append(line)
@@ -4308,7 +4309,7 @@ def write_conf(conf_file, conf):
                 if out_line:
                     content += out_line
                     content += '\n'
-    with salt.utils.fopen(conf_file, 'w') as fp_:
+    with salt.utils.files.fopen(conf_file, 'w') as fp_:
         fp_.write(content)
     return {}
 
@@ -4638,7 +4639,7 @@ def apply_network_profile(name, network_profile, nic_opts=None, path=None):
     cfgpath = os.path.join(cpath, name, 'config')
 
     before = []
-    with salt.utils.fopen(cfgpath, 'r') as fp_:
+    with salt.utils.files.fopen(cfgpath, 'r') as fp_:
         for line in fp_:
             before.append(line)
 
@@ -4655,7 +4656,7 @@ def apply_network_profile(name, network_profile, nic_opts=None, path=None):
         edit_conf(cfgpath, out_format='commented', **network_params)
 
     after = []
-    with salt.utils.fopen(cfgpath, 'r') as fp_:
+    with salt.utils.files.fopen(cfgpath, 'r') as fp_:
         for line in fp_:
             after.append(line)
 

--- a/salt/modules/mac_service.py
+++ b/salt/modules/mac_service.py
@@ -13,6 +13,7 @@ import plistlib
 # Import salt libs
 import salt.utils
 import salt.utils.decorators as decorators
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 from salt.utils.versions import LooseVersion as _LooseVersion
 
@@ -87,7 +88,7 @@ def _available_services():
                 try:
                     # This assumes most of the plist files
                     # will be already in XML format
-                    with salt.utils.fopen(file_path):
+                    with salt.utils.files.fopen(file_path):
                         plist = plistlib.readPlist(true_path)
 
                 except Exception:

--- a/salt/modules/mac_softwareupdate.py
+++ b/salt/modules/mac_softwareupdate.py
@@ -11,6 +11,7 @@ import os
 
 # import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.mac_utils
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
@@ -340,7 +341,7 @@ def list_downloads():
     ret = []
     for update in _get_available():
         for f in dist_files:
-            with salt.utils.fopen(f) as fhr:
+            with salt.utils.files.fopen(f) as fhr:
                 if update.rsplit('-', 1)[0] in fhr.read():
                     ret.append(update)
 

--- a/salt/modules/mac_sysctl.py
+++ b/salt/modules/mac_sysctl.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 import os
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 # Define the module's virtual name
@@ -155,13 +155,13 @@ def persist(name, value, config='/etc/sysctl.conf', apply_change=False):
     # If the sysctl.conf is not present, add it
     if not os.path.isfile(config):
         try:
-            with salt.utils.fopen(config, 'w+') as _fh:
+            with salt.utils.files.fopen(config, 'w+') as _fh:
                 _fh.write('#\n# Kernel sysctl configuration\n#\n')
         except (IOError, OSError):
             msg = 'Could not write to file: {0}'
             raise CommandExecutionError(msg.format(config))
 
-    with salt.utils.fopen(config, 'r') as ifile:
+    with salt.utils.files.fopen(config, 'r') as ifile:
         for line in ifile:
             if not line.startswith('{0}='.format(name)):
                 nlines.append(line)
@@ -184,7 +184,7 @@ def persist(name, value, config='/etc/sysctl.conf', apply_change=False):
     if not edited:
         nlines.append('{0}={1}'.format(name, value))
         nlines.append('\n')
-    with salt.utils.fopen(config, 'w+') as ofile:
+    with salt.utils.files.fopen(config, 'w+') as ofile:
         ofile.writelines(nlines)
     # If apply_change=True, apply edits to system
     if apply_change is True:

--- a/salt/modules/makeconf.py
+++ b/salt/modules/makeconf.py
@@ -7,7 +7,7 @@ Support for modifying make.conf under Gentoo
 from __future__ import absolute_import, print_function
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 
 
 def __virtual__():
@@ -184,7 +184,7 @@ def get_var(var):
     '''
     makeconf = _get_makeconf()
     # Open makeconf
-    with salt.utils.fopen(makeconf) as fn_:
+    with salt.utils.files.fopen(makeconf) as fn_:
         conf_file = fn_.readlines()
     for line in conf_file:
         if line.startswith(var):

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -11,6 +11,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.utils import which as _which
 from salt.exceptions import CommandNotFoundError, CommandExecutionError
 
@@ -58,7 +59,7 @@ def _active_mountinfo(ret):
 
     blkid_info = __salt__['disk.blkid']()
 
-    with salt.utils.fopen(filename) as ifile:
+    with salt.utils.files.fopen(filename) as ifile:
         for line in ifile:
             comps = line.split()
             device = comps[2].split(':')
@@ -100,7 +101,7 @@ def _active_mounts(ret):
         msg = 'File not readable {0}'
         raise CommandExecutionError(msg.format(filename))
 
-    with salt.utils.fopen(filename) as ifile:
+    with salt.utils.files.fopen(filename) as ifile:
         for line in ifile:
             comps = line.split()
             ret[comps[1]] = {'device': comps[0],
@@ -403,7 +404,7 @@ def fstab(config='/etc/fstab'):
     ret = {}
     if not os.path.isfile(config):
         return ret
-    with salt.utils.fopen(config) as ifile:
+    with salt.utils.files.fopen(config) as ifile:
         for line in ifile:
             try:
                 if __grains__['kernel'] == 'SunOS':
@@ -465,7 +466,7 @@ def rm_fstab(name, device, config='/etc/fstab'):
 
     lines = []
     try:
-        with salt.utils.fopen(config, 'r') as ifile:
+        with salt.utils.files.fopen(config, 'r') as ifile:
             for line in ifile:
                 try:
                     if criteria.match(line):
@@ -484,7 +485,7 @@ def rm_fstab(name, device, config='/etc/fstab'):
 
     if modified:
         try:
-            with salt.utils.fopen(config, 'w+') as ofile:
+            with salt.utils.files.fopen(config, 'w+') as ofile:
                 ofile.writelines(lines)
         except (IOError, OSError) as exc:
             msg = "Couldn't write to {0}: {1}"
@@ -594,7 +595,7 @@ def set_fstab(
         raise CommandExecutionError('Bad config file "{0}"'.format(config))
 
     try:
-        with salt.utils.fopen(config, 'r') as ifile:
+        with salt.utils.files.fopen(config, 'r') as ifile:
             for line in ifile:
                 try:
                     if criteria.match(line):
@@ -624,7 +625,7 @@ def set_fstab(
     if ret != 'present':  # ret in ['new', 'change']:
         if not salt.utils.test_mode(test=test, **kwargs):
             try:
-                with salt.utils.fopen(config, 'w+') as ofile:
+                with salt.utils.files.fopen(config, 'w+') as ofile:
                     # The line was changed, commit it!
                     ofile.writelines(lines)
             except (IOError, OSError):
@@ -722,7 +723,7 @@ def set_vfstab(
         raise CommandExecutionError('Bad config file "{0}"'.format(config))
 
     try:
-        with salt.utils.fopen(config, 'r') as ifile:
+        with salt.utils.files.fopen(config, 'r') as ifile:
             for line in ifile:
                 try:
                     if criteria.match(line):
@@ -752,7 +753,7 @@ def set_vfstab(
     if ret != 'present':  # ret in ['new', 'change']:
         if not salt.utils.test_mode(test=test, **kwargs):
             try:
-                with salt.utils.fopen(config, 'w+') as ofile:
+                with salt.utils.files.fopen(config, 'w+') as ofile:
                     # The line was changed, commit it!
                     ofile.writelines(lines)
             except (IOError, OSError):
@@ -778,7 +779,7 @@ def rm_automaster(name, device, config='/etc/auto_salt'):
     # The entry is present, get rid of it
     lines = []
     try:
-        with salt.utils.fopen(config, 'r') as ifile:
+        with salt.utils.files.fopen(config, 'r') as ifile:
             for line in ifile:
                 if line.startswith('#'):
                     # Commented
@@ -811,7 +812,7 @@ def rm_automaster(name, device, config='/etc/auto_salt'):
         raise CommandExecutionError(msg.format(config, str(exc)))
 
     try:
-        with salt.utils.fopen(config, 'w+') as ofile:
+        with salt.utils.files.fopen(config, 'w+') as ofile:
             ofile.writelines(lines)
     except (IOError, OSError) as exc:
         msg = "Couldn't write to {0}: {1}"
@@ -860,7 +861,7 @@ def set_automaster(
         device_fmt = device_fmt.replace(fstype, "")
 
     try:
-        with salt.utils.fopen(config, 'r') as ifile:
+        with salt.utils.files.fopen(config, 'r') as ifile:
             for line in ifile:
                 if line.startswith('#'):
                     # Commented
@@ -907,7 +908,7 @@ def set_automaster(
     if change:
         if not salt.utils.test_mode(test=test, **kwargs):
             try:
-                with salt.utils.fopen(config, 'w+') as ofile:
+                with salt.utils.files.fopen(config, 'w+') as ofile:
                     # The line was changed, commit it!
                     ofile.writelines(lines)
             except (IOError, OSError):
@@ -929,7 +930,7 @@ def set_automaster(
                )
                 lines.append(newline)
                 try:
-                    with salt.utils.fopen(config, 'w+') as ofile:
+                    with salt.utils.files.fopen(config, 'w+') as ofile:
                         # The line was changed, commit it!
                         ofile.writelines(lines)
                 except (IOError, OSError):
@@ -954,7 +955,7 @@ def automaster(config='/etc/auto_salt'):
     ret = {}
     if not os.path.isfile(config):
         return ret
-    with salt.utils.fopen(config) as ifile:
+    with salt.utils.files.fopen(config) as ifile:
         for line in ifile:
             if line.startswith('#'):
                 # Commented
@@ -1149,7 +1150,7 @@ def swaps():
                              'used': (int(comps[3]) - int(comps[4])),
                              'priority': '-'}
     elif __grains__['os'] != 'OpenBSD':
-        with salt.utils.fopen('/proc/swaps') as fp_:
+        with salt.utils.files.fopen('/proc/swaps') as fp_:
             for line in fp_:
                 if line.startswith('Filename'):
                     continue

--- a/salt/modules/munin.py
+++ b/salt/modules/munin.py
@@ -9,7 +9,7 @@ import os
 import stat
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 from salt.ext.six import string_types
 
 PLUGINDIR = '/etc/munin/plugins/'
@@ -25,7 +25,7 @@ def __virtual__():
 
 
 def _get_conf(fname='/etc/munin/munin-node.cfg'):
-    with salt.utils.fopen(fname, 'r') as fp_:
+    with salt.utils.files.fopen(fname, 'r') as fp_:
         return fp_.read()
 
 

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -44,6 +44,7 @@ import os
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 # Import third party libs
 import salt.ext.six as six
@@ -701,7 +702,7 @@ def file_query(database, file_name, **connection_args):
 
     '''
     if os.path.exists(file_name):
-        with salt.utils.fopen(file_name, 'r') as ifile:
+        with salt.utils.files.fopen(file_name, 'r') as ifile:
             contents = ifile.read()
     else:
         log.error('File "{0}" does not exist'.format(file_name))

--- a/salt/modules/nacl.py
+++ b/salt/modules/nacl.py
@@ -108,7 +108,7 @@ The '{{-' will tell jinja to strip the whitespace from the beginning of each of 
 from __future__ import absolute_import
 import base64
 import os
-import salt.utils
+import salt.utils.files
 import salt.syspaths
 
 
@@ -150,7 +150,7 @@ def _get_key(rstrip_newline=True, **kwargs):
     if not key and keyfile:
         if not os.path.isfile(keyfile):
             raise Exception('file not found: {0}'.format(keyfile))
-        with salt.utils.fopen(keyfile, 'rb') as keyf:
+        with salt.utils.files.fopen(keyfile, 'rb') as keyf:
             key = keyf.read()
     if key is None:
         raise Exception('no key found')
@@ -178,7 +178,7 @@ def keygen(keyfile=None):
     if keyfile:
         if os.path.isfile(keyfile):
             raise Exception('file already found: {0}'.format(keyfile))
-        with salt.utils.fopen(keyfile, 'w') as keyf:
+        with salt.utils.files.fopen(keyfile, 'w') as keyf:
             keyf.write(key)
             return 'saved: {0}'.format(keyfile)
     return key

--- a/salt/modules/namecheap_ssl.py
+++ b/salt/modules/namecheap_ssl.py
@@ -44,7 +44,7 @@
 from __future__ import absolute_import
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 try:
     import salt.utils.namecheap
     CAN_USE_NAMECHEAP = True
@@ -224,7 +224,7 @@ def __get_certificates(command,
 
     opts = salt.utils.namecheap.get_opts(command)
 
-    with salt.utils.fopen(csr_file, 'rb') as csr_handle:
+    with salt.utils.files.fopen(csr_file, 'rb') as csr_handle:
         opts['csr'] = csr_handle.read()
 
     opts['CertificateID'] = certificate_id
@@ -597,7 +597,7 @@ def parse_csr(csr_file, certificate_type, http_dc_validation=False):
 
     opts = salt.utils.namecheap.get_opts('namecheap.ssl.parseCSR')
 
-    with salt.utils.fopen(csr_file, 'rb') as csr_handle:
+    with salt.utils.files.fopen(csr_file, 'rb') as csr_handle:
         opts['csr'] = csr_handle.read()
 
     opts['CertificateType'] = certificate_type

--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -27,6 +27,7 @@ log = logging.getLogger(__name__)
 
 # salt libs
 from salt.ext import six
+import salt.utils.files
 import salt.utils.templates
 import salt.utils.napalm
 from salt.utils.napalm import proxy_napalm_wrap
@@ -1016,7 +1017,7 @@ def load_config(filename=None,
     loaded_config = None
     if debug:
         if filename:
-            with salt.utils.fopen(filename) as rfh:
+            with salt.utils.files.fopen(filename) as rfh:
                 loaded_config = rfh.read()
         else:
             loaded_config = text
@@ -1361,7 +1362,7 @@ def load_template(template_name,
                     _loaded['result'] = False
                     _loaded['comment'] = 'Error while rendering the template.'
                     return _loaded
-                with salt.utils.fopen(_temp_tpl_file) as rfh:
+                with salt.utils.files.fopen(_temp_tpl_file) as rfh:
                     _rendered = rfh.read()
                 __salt__['file.remove'](_temp_tpl_file)
             else:

--- a/salt/modules/netbsd_sysctl.py
+++ b/salt/modules/netbsd_sysctl.py
@@ -7,7 +7,7 @@ import os
 import re
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 # Define the module's virtual name
@@ -117,13 +117,13 @@ def persist(name, value, config='/etc/sysctl.conf'):
     # create /etc/sysctl.conf if not present
     if not os.path.isfile(config):
         try:
-            with salt.utils.fopen(config, 'w+'):
+            with salt.utils.files.fopen(config, 'w+'):
                 pass
         except (IOError, OSError):
             msg = 'Could not create {0}'
             raise CommandExecutionError(msg.format(config))
 
-    with salt.utils.fopen(config, 'r') as ifile:
+    with salt.utils.files.fopen(config, 'r') as ifile:
         for line in ifile:
             m = re.match(r'{0}(\??=)'.format(name), line)
             if not m:
@@ -148,7 +148,7 @@ def persist(name, value, config='/etc/sysctl.conf'):
         newline = '{0}={1}'.format(name, value)
         nlines.append("{0}\n".format(newline))
 
-    with salt.utils.fopen(config, 'w+') as ofile:
+    with salt.utils.files.fopen(config, 'w+') as ofile:
         ofile.writelines(nlines)
 
     assign(name, value)

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -15,6 +15,7 @@ import socket
 # Import salt libs
 import salt.utils
 import salt.utils.decorators as decorators
+import salt.utils.files
 import salt.utils.network
 import salt.utils.validate.net
 from salt.exceptions import CommandExecutionError
@@ -1296,10 +1297,10 @@ def mod_hostname(hostname):
 
     # Modify the /etc/hosts file to replace the old hostname with the
     # new hostname
-    with salt.utils.fopen('/etc/hosts', 'r') as fp_:
+    with salt.utils.files.fopen('/etc/hosts', 'r') as fp_:
         host_c = fp_.readlines()
 
-    with salt.utils.fopen('/etc/hosts', 'w') as fh_:
+    with salt.utils.files.fopen('/etc/hosts', 'w') as fh_:
         for host in host_c:
             host = host.split()
 
@@ -1316,10 +1317,10 @@ def mod_hostname(hostname):
     # Modify the /etc/sysconfig/network configuration file to set the
     # new hostname
     if __grains__['os_family'] == 'RedHat':
-        with salt.utils.fopen('/etc/sysconfig/network', 'r') as fp_:
+        with salt.utils.files.fopen('/etc/sysconfig/network', 'r') as fp_:
             network_c = fp_.readlines()
 
-        with salt.utils.fopen('/etc/sysconfig/network', 'w') as fh_:
+        with salt.utils.files.fopen('/etc/sysconfig/network', 'w') as fh_:
             for net in network_c:
                 if net.startswith('HOSTNAME'):
                     old_hostname = net.split('=', 1)[1].rstrip()
@@ -1329,17 +1330,17 @@ def mod_hostname(hostname):
                 else:
                     fh_.write(net)
     elif __grains__['os_family'] in ('Debian', 'NILinuxRT'):
-        with salt.utils.fopen('/etc/hostname', 'w') as fh_:
+        with salt.utils.files.fopen('/etc/hostname', 'w') as fh_:
             fh_.write(hostname + '\n')
     elif __grains__['os_family'] == 'OpenBSD':
-        with salt.utils.fopen('/etc/myname', 'w') as fh_:
+        with salt.utils.files.fopen('/etc/myname', 'w') as fh_:
             fh_.write(hostname + '\n')
 
     # Update /etc/nodename and /etc/defaultdomain on SunOS
     if salt.utils.is_sunos():
-        with salt.utils.fopen('/etc/nodename', 'w') as fh_:
+        with salt.utils.files.fopen('/etc/nodename', 'w') as fh_:
             fh_.write(hostname.split('.')[0] + '\n')
-        with salt.utils.fopen('/etc/defaultdomain', 'w') as fh_:
+        with salt.utils.files.fopen('/etc/defaultdomain', 'w') as fh_:
             fh_.write(".".join(hostname.split('.')[1:]) + '\n')
 
     return True

--- a/salt/modules/nfs3.py
+++ b/salt/modules/nfs3.py
@@ -9,6 +9,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ def list_exports(exports='/etc/exports'):
         salt '*' nfs.list_exports
     '''
     ret = {}
-    with salt.utils.fopen(exports, 'r') as efl:
+    with salt.utils.files.fopen(exports, 'r') as efl:
         for line in efl.read().splitlines():
             if not line:
                 continue
@@ -85,7 +86,7 @@ def _write_exports(exports, edict):
         /media/storage *(ro,sync,no_subtree_check)
         /media/data *(ro,sync,no_subtree_check)
     '''
-    with salt.utils.fopen(exports, 'w') as efh:
+    with salt.utils.files.fopen(exports, 'w') as efh:
         for export in edict:
             line = export
             for perms in edict[export]:

--- a/salt/modules/nftables.py
+++ b/salt/modules/nftables.py
@@ -10,6 +10,7 @@ import re
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 from salt.exceptions import (
     CommandExecutionError
@@ -260,7 +261,7 @@ def get_saved_rules(conf_file=None, family='ipv4'):
     if _conf() and not conf_file:
         conf_file = _conf()
 
-    with salt.utils.fopen(conf_file) as fp_:
+    with salt.utils.files.fopen(conf_file) as fp_:
         lines = fp_.readlines()
     rules = []
     for line in lines:
@@ -327,7 +328,7 @@ def save(filename=None, family='ipv4'):
     rules = rules + '\n'
 
     try:
-        with salt.utils.fopen(filename, 'w+') as _fh:
+        with salt.utils.files.fopen(filename, 'w+') as _fh:
             # Write out any changes
             _fh.writelines(rules)
     except (IOError, OSError) as exc:

--- a/salt/modules/openbsd_sysctl.py
+++ b/salt/modules/openbsd_sysctl.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 import os
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 # Define the module's virtual name
@@ -98,13 +98,13 @@ def persist(name, value, config='/etc/sysctl.conf'):
     # create /etc/sysctl.conf if not present
     if not os.path.isfile(config):
         try:
-            with salt.utils.fopen(config, 'w+'):
+            with salt.utils.files.fopen(config, 'w+'):
                 pass
         except (IOError, OSError):
             msg = 'Could not create {0}'
             raise CommandExecutionError(msg.format(config))
 
-    with salt.utils.fopen(config, 'r') as ifile:
+    with salt.utils.files.fopen(config, 'r') as ifile:
         for line in ifile:
             if not line.startswith('{0}='.format(name)):
                 nlines.append(line)
@@ -125,7 +125,7 @@ def persist(name, value, config='/etc/sysctl.conf'):
                 edited = True
     if not edited:
         nlines.append('{0}={1}\n'.format(name, value))
-    with salt.utils.fopen(config, 'w+') as ofile:
+    with salt.utils.files.fopen(config, 'w+') as ofile:
         ofile.writelines(nlines)
 
     assign(name, value)

--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -12,7 +12,6 @@ The service module for OpenBSD
 # Import python libs
 from __future__ import absolute_import
 import os
-import re
 import fnmatch
 import logging
 
@@ -21,7 +20,7 @@ import salt.ext.six as six
 from salt.ext.six.moves import map  # pylint: disable=import-error,redefined-builtin
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -169,7 +168,7 @@ def _get_rc():
     try:
         # now read the system startup script /etc/rc
         # to know what are the system enabled daemons
-        with salt.utils.fopen('/etc/rc', 'r') as handle:
+        with salt.utils.files.fopen('/etc/rc', 'r') as handle:
             lines = handle.readlines()
     except IOError:
         log.error('Unable to read /etc/rc')

--- a/salt/modules/openstack_mng.py
+++ b/salt/modules/openstack_mng.py
@@ -13,7 +13,7 @@ import logging
 import os.path
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ def restart_service(service_name, minimum_running_time=None):
         services = __salt__['cmd.run'](['/usr/bin/openstack-service', 'list', service_name]).split('\n')
         for service in services:
             service_info = __salt__['service.show'](service)
-            with salt.utils.fopen('/proc/uptime') as rfh:
+            with salt.utils.files.fopen('/proc/uptime') as rfh:
                 boot_time = float(rfh.read().split(' ')[0])
 
             expr_time = int(service_info.get('ExecMainStartTimestampMonotonic', 0)) / 1000000 < boot_time - minimum_running_time

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -25,6 +25,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.pkg
 import salt.utils.itertools
 from salt.utils.versions import LooseVersion as _LooseVersion
@@ -1048,7 +1049,7 @@ def list_repos():
     regex = re.compile(REPO_REGEXP)
     for filename in os.listdir(OPKG_CONFDIR):
         if filename.endswith(".conf"):
-            with salt.utils.fopen(os.path.join(OPKG_CONFDIR, filename)) as conf_file:
+            with salt.utils.files.fopen(os.path.join(OPKG_CONFDIR, filename)) as conf_file:
                 for line in conf_file:
                     if regex.search(line):
                         repo = {}
@@ -1095,7 +1096,7 @@ def _del_repo_from_file(alias, filepath):
     '''
     Remove a repo from filepath
     '''
-    with salt.utils.fopen(filepath) as fhandle:
+    with salt.utils.files.fopen(filepath) as fhandle:
         output = []
         regex = re.compile(REPO_REGEXP)
         for line in fhandle:
@@ -1105,7 +1106,7 @@ def _del_repo_from_file(alias, filepath):
                 cols = salt.utils.shlex_split(line.strip())
                 if alias != cols[1]:
                     output.append(line)
-    with salt.utils.fopen(filepath, 'w') as fhandle:
+    with salt.utils.files.fopen(filepath, 'w') as fhandle:
         fhandle.writelines(output)
 
 
@@ -1122,7 +1123,7 @@ def _add_new_repo(alias, uri, compressed, enabled=True):
     repostr += uri + '\n'
     conffile = os.path.join(OPKG_CONFDIR, alias + '.conf')
 
-    with salt.utils.fopen(conffile, 'a') as fhandle:
+    with salt.utils.files.fopen(conffile, 'a') as fhandle:
         fhandle.write(repostr)
 
 
@@ -1130,7 +1131,7 @@ def _mod_repo_in_file(alias, repostr, filepath):
     '''
     Replace a repo entry in filepath with repostr
     '''
-    with salt.utils.fopen(filepath) as fhandle:
+    with salt.utils.files.fopen(filepath) as fhandle:
         output = []
         for line in fhandle:
             cols = salt.utils.shlex_split(line.strip())
@@ -1138,7 +1139,7 @@ def _mod_repo_in_file(alias, repostr, filepath):
                 output.append(line)
             else:
                 output.append(repostr + '\n')
-    with salt.utils.fopen(filepath, 'w') as fhandle:
+    with salt.utils.files.fopen(filepath, 'w') as fhandle:
         fhandle.writelines(output)
 
 

--- a/salt/modules/pam.py
+++ b/salt/modules/pam.py
@@ -9,7 +9,7 @@ import os
 import logging
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def _parse(contents=None, file_name=None):
     if contents:
         pass
     elif file_name and os.path.exists(file_name):
-        with salt.utils.fopen(file_name, 'r') as ifile:
+        with salt.utils.files.fopen(file_name, 'r') as ifile:
             contents = ifile.read()
     else:
         log.error('File "{0}" does not exist'.format(file_name))

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -85,6 +85,7 @@ import sys
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import tempfile
 import salt.utils.locales
 import salt.utils.url
@@ -204,7 +205,7 @@ def _find_req(link):
 
     logger.info('_find_req -- link = %s', str(link))
 
-    with salt.utils.fopen(link) as fh_link:
+    with salt.utils.files.fopen(link) as fh_link:
         child_links = rex_pip_chain_read.findall(fh_link.read())
 
     base_path = os.path.dirname(link)
@@ -936,7 +937,7 @@ def uninstall(pkgs=None,
             pkgs = [p.strip() for p in pkgs.split(',')]
         if requirements:
             for requirement in requirements:
-                with salt.utils.fopen(requirement) as rq_:
+                with salt.utils.files.fopen(requirement) as rq_:
                     for req in rq_:
                         try:
                             req_pkg, _ = req.split('==')

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -45,6 +45,8 @@ import os
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
+import salt.utils.itertools
 import salt.utils.pkg
 from salt.exceptions import CommandExecutionError, MinionError
 import salt.ext.six as six
@@ -151,7 +153,7 @@ def parse_config(file_name='/usr/local/etc/pkg.conf'):
     if not os.path.isfile(file_name):
         return 'Unable to find {0} on file system'.format(file_name)
 
-    with salt.utils.fopen(file_name) as ifile:
+    with salt.utils.files.fopen(file_name) as ifile:
         for line in ifile:
             if line.startswith('#') or line.startswith('\n'):
                 pass

--- a/salt/modules/portage_config.py
+++ b/salt/modules/portage_config.py
@@ -10,7 +10,7 @@ import os
 import shutil
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 # Import third party libs
 import salt.ext.six as six
@@ -160,7 +160,7 @@ def _unify_keywords():
             for triplet in os.walk(old_path):
                 for file_name in triplet[2]:
                     file_path = '{0}/{1}'.format(triplet[0], file_name)
-                    with salt.utils.fopen(file_path) as fh_:
+                    with salt.utils.files.fopen(file_path) as fh_:
                         for line in fh_:
                             line = line.strip()
                             if line and not line.startswith('#'):
@@ -168,7 +168,7 @@ def _unify_keywords():
                                     'accept_keywords', string=line)
             shutil.rmtree(old_path)
         else:
-            with salt.utils.fopen(old_path) as fh_:
+            with salt.utils.files.fopen(old_path) as fh_:
                 for line in fh_:
                     line = line.strip()
                     if line and not line.startswith('#'):
@@ -188,7 +188,7 @@ def _package_conf_file_to_dir(file_name):
             else:
                 os.rename(path, path + '.tmpbak')
                 os.mkdir(path, 0o755)
-                with salt.utils.fopen(path + '.tmpbak') as fh_:
+                with salt.utils.files.fopen(path + '.tmpbak') as fh_:
                     for line in fh_:
                         line = line.strip()
                         if line and not line.startswith('#'):
@@ -219,12 +219,12 @@ def _package_conf_ordering(conf, clean=True, keep_backup=False):
                 backup_files.append(file_path + '.bak')
 
                 if cp[0] == '/' or cp.split('/') > 2:
-                    with salt.utils.fopen(file_path) as fp_:
+                    with salt.utils.files.fopen(file_path) as fp_:
                         rearrange.extend(fp_.readlines())
                     os.remove(file_path)
                 else:
                     new_contents = ''
-                    with salt.utils.fopen(file_path, 'r+') as file_handler:
+                    with salt.utils.files.fopen(file_path, 'r+') as file_handler:
                         for line in file_handler:
                             try:
                                 atom = line.strip().split()[0]
@@ -362,9 +362,9 @@ def append_to_package_conf(conf, atom='', flags=None, string='', overwrite=False
             pass
 
         try:
-            file_handler = salt.utils.fopen(complete_file_path, 'r+')  # pylint: disable=resource-leakage
+            file_handler = salt.utils.files.fopen(complete_file_path, 'r+')  # pylint: disable=resource-leakage
         except IOError:
-            file_handler = salt.utils.fopen(complete_file_path, 'w+')  # pylint: disable=resource-leakage
+            file_handler = salt.utils.files.fopen(complete_file_path, 'w+')  # pylint: disable=resource-leakage
 
         new_contents = ''
         added = False
@@ -465,7 +465,7 @@ def get_flags_from_package_conf(conf, atom):
 
         flags = []
         try:
-            with salt.utils.fopen(package_file) as fp_:
+            with salt.utils.files.fopen(package_file) as fp_:
                 for line in fp_:
                     line = line.strip()
                     line_package = line.split()[0]
@@ -563,7 +563,7 @@ def is_present(conf, atom):
             match_list = set(_porttree().dbapi.xmatch("match-all", atom))
 
         try:
-            with salt.utils.fopen(package_file) as fp_:
+            with salt.utils.files.fopen(package_file) as fp_:
                 for line in fp_:
                     line = line.strip()
                     line_package = line.split()[0]

--- a/salt/modules/postfix.py
+++ b/salt/modules/postfix.py
@@ -19,6 +19,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 SWWS = re.compile(r'^\s')
 
@@ -50,7 +51,7 @@ def _parse_master(path=MASTER_CF):
     Returns a dict of the active config lines, and a list of the entire file,
     in order. These compliment each other.
     '''
-    with salt.utils.fopen(path, 'r') as fh_:
+    with salt.utils.files.fopen(path, 'r') as fh_:
         full_conf = fh_.read()
 
     # Condense the file based on line continuations, but keep order, comments
@@ -223,7 +224,7 @@ def _parse_main(path=MAIN_CF):
     * Keys defined in the file may be referred to as variables further down in
         the file.
     '''
-    with salt.utils.fopen(path, 'r') as fh_:
+    with salt.utils.files.fopen(path, 'r') as fh_:
         full_conf = fh_.read()
 
     # Condense the file based on line continuations, but keep order, comments
@@ -306,7 +307,7 @@ def _write_conf(conf, path=MAIN_CF):
     '''
     Write out configuration file.
     '''
-    with salt.utils.fopen(path, 'w') as fh_:
+    with salt.utils.files.fopen(path, 'w') as fh_:
         for line in conf:
             if isinstance(line, dict):
                 fh_.write(' '.join(line))

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -50,6 +50,7 @@ except ImportError:
 import salt.utils
 import salt.utils.files
 import salt.utils.itertools
+import salt.utils.odict
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.utils.versions import LooseVersion as _LooseVersion
 
@@ -171,7 +172,7 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None):
         password = __salt__['config.option']('postgres.pass')
     if password is not None:
         pgpassfile = salt.utils.files.mkstemp(text=True)
-        with salt.utils.fopen(pgpassfile, 'w') as fp_:
+        with salt.utils.files.fopen(pgpassfile, 'w') as fp_:
             fp_.write('{0}:{1}:*:{2}:{3}'.format(
                 'localhost' if not host or host.startswith('/') else host,
                 port if port else '*',
@@ -227,7 +228,7 @@ def _run_initdb(name,
 
     if password is not None:
         pgpassfile = salt.utils.files.mkstemp(text=True)
-        with salt.utils.fopen(pgpassfile, 'w') as fp_:
+        with salt.utils.files.fopen(pgpassfile, 'w') as fp_:
             fp_.write('{0}'.format(password))
             __salt__['file.chown'](pgpassfile, runas, '')
         cmd.extend([

--- a/salt/modules/poudriere.py
+++ b/salt/modules/poudriere.py
@@ -10,6 +10,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -115,7 +116,7 @@ def parse_config(config_file=None):
         config_file = _config_file()
     ret = {}
     if _check_config_exists(config_file):
-        with salt.utils.fopen(config_file) as ifile:
+        with salt.utils.files.fopen(config_file) as ifile:
             for line in ifile:
                 key, val = line.split('=')
                 ret[key] = val

--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -12,6 +12,7 @@ import datetime
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 # Import 3rd-party libs
@@ -243,7 +244,7 @@ def disable(message=None):
     if os.path.isfile(puppet.disabled_lockfile):
         return False
     else:
-        with salt.utils.fopen(puppet.disabled_lockfile, 'w') as lockfile:
+        with salt.utils.files.fopen(puppet.disabled_lockfile, 'w') as lockfile:
             try:
                 # Puppet chokes when no valid json is found
                 str = '{{"disabled_message":"{0}"}}'.format(message) if message is not None else '{}'
@@ -275,7 +276,7 @@ def status():
 
     if os.path.isfile(puppet.run_lockfile):
         try:
-            with salt.utils.fopen(puppet.run_lockfile, 'r') as fp_:
+            with salt.utils.files.fopen(puppet.run_lockfile, 'r') as fp_:
                 pid = int(fp_.read())
                 os.kill(pid, 0)  # raise an OSError if process doesn't exist
         except (OSError, ValueError):
@@ -285,7 +286,7 @@ def status():
 
     if os.path.isfile(puppet.agent_pidfile):
         try:
-            with salt.utils.fopen(puppet.agent_pidfile, 'r') as fp_:
+            with salt.utils.files.fopen(puppet.agent_pidfile, 'r') as fp_:
                 pid = int(fp_.read())
                 os.kill(pid, 0)  # raise an OSError if process doesn't exist
         except (OSError, ValueError):
@@ -312,7 +313,7 @@ def summary():
     puppet = _Puppet()
 
     try:
-        with salt.utils.fopen(puppet.lastrunfile, 'r') as fp_:
+        with salt.utils.files.fopen(puppet.lastrunfile, 'r') as fp_:
             report = yaml.safe_load(fp_.read())
         result = {}
 

--- a/salt/modules/rbac_solaris.py
+++ b/salt/modules/rbac_solaris.py
@@ -9,6 +9,7 @@ import logging
 
 # Import Salt libs
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -47,14 +48,14 @@ def profile_list(default_only=False):
     default_profiles = ['All']
 
     ## lookup default profile(s)
-    with salt.utils.fopen('/etc/security/policy.conf', 'r') as policy_conf:
+    with salt.utils.files.fopen('/etc/security/policy.conf', 'r') as policy_conf:
         for policy in policy_conf:
             policy = policy.split('=')
             if policy[0].strip() == 'PROFS_GRANTED':
                 default_profiles.extend(policy[1].strip().split(','))
 
     ## read prof_attr file (profname:res1:res2:desc:attr)
-    with salt.utils.fopen('/etc/security/prof_attr', 'r') as prof_attr:
+    with salt.utils.files.fopen('/etc/security/prof_attr', 'r') as prof_attr:
         for profile in prof_attr:
             profile = profile.split(':')
 
@@ -92,7 +93,7 @@ def profile_get(user, default_hidden=True):
     user_profiles = []
 
     ## read user_attr file (user:qualifier:res1:res2:attr)
-    with salt.utils.fopen('/etc/user_attr', 'r') as user_attr:
+    with salt.utils.files.fopen('/etc/user_attr', 'r') as user_attr:
         for profile in user_attr:
             profile = profile.strip().split(':')
 
@@ -249,7 +250,7 @@ def role_list():
     roles = {}
 
     ## read user_attr file (user:qualifier:res1:res2:attr)
-    with salt.utils.fopen('/etc/user_attr', 'r') as user_attr:
+    with salt.utils.files.fopen('/etc/user_attr', 'r') as user_attr:
         for role in user_attr:
             role = role.split(':')
 
@@ -291,7 +292,7 @@ def role_get(user):
     user_roles = []
 
     ## read user_attr file (user:qualifier:res1:res2:attr)
-    with salt.utils.fopen('/etc/user_attr', 'r') as user_attr:
+    with salt.utils.files.fopen('/etc/user_attr', 'r') as user_attr:
         for role in user_attr:
             role = role.strip().strip().split(':')
 
@@ -442,7 +443,7 @@ def auth_list():
     auths = {}
 
     ## read auth_attr file (name:res1:res2:short_desc:long_desc:attr)
-    with salt.utils.fopen('/etc/security/auth_attr', 'r') as auth_attr:
+    with salt.utils.files.fopen('/etc/security/auth_attr', 'r') as auth_attr:
         for auth in auth_attr:
             auth = auth.split(':')
 
@@ -476,7 +477,7 @@ def auth_get(user, computed=True):
     user_auths = []
 
     ## read user_attr file (user:qualifier:res1:res2:attr)
-    with salt.utils.fopen('/etc/user_attr', 'r') as user_attr:
+    with salt.utils.files.fopen('/etc/user_attr', 'r') as user_attr:
         for auth in user_attr:
             auth = auth.strip().split(':')
 

--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 HAS_PSUTIL = False
 try:
@@ -126,7 +126,7 @@ def _deleted_files():
         try:
             pinfo = proc.as_dict(attrs=['pid', 'name'])
             try:
-                maps = salt.utils.fopen('/proc/{0}/maps'.format(pinfo['pid']))  # pylint: disable=resource-leakage
+                maps = salt.utils.files.fopen('/proc/{0}/maps'.format(pinfo['pid']))  # pylint: disable=resource-leakage
                 dirpath = '/proc/' + str(pinfo['pid']) + '/fd/'
                 listdir = os.listdir(dirpath)
             except (OSError, IOError):
@@ -408,7 +408,7 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, verbose=True)
                pth.find('.wants') == -1:
                 is_oneshot = False
                 try:
-                    servicefile = salt.utils.fopen(pth)  # pylint: disable=resource-leakage
+                    servicefile = salt.utils.files.fopen(pth)  # pylint: disable=resource-leakage
                 except IOError:
                     continue
                 sysfold_len = len(systemd_folder)

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -15,6 +15,7 @@ import jinja2.exceptions
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.templates
 import salt.utils.validate.net
 import salt.ext.six as six
@@ -904,7 +905,7 @@ def _read_file(path):
     Reads and returns the contents of a file
     '''
     try:
-        with salt.utils.fopen(path, 'rb') as rfh:
+        with salt.utils.files.fopen(path, 'rb') as rfh:
             contents = rfh.read()
             if six.PY3:
                 contents = contents.encode(__salt_system_encoding__)
@@ -929,7 +930,7 @@ def _write_file_iface(iface, data, folder, pattern):
         msg = msg.format(filename, folder)
         log.error(msg)
         raise AttributeError(msg)
-    with salt.utils.fopen(filename, 'w') as fp_:
+    with salt.utils.files.fopen(filename, 'w') as fp_:
         fp_.write(data)
 
 
@@ -937,7 +938,7 @@ def _write_file_network(data, filename):
     '''
     Writes a file to disk
     '''
-    with salt.utils.fopen(filename, 'w') as fp_:
+    with salt.utils.files.fopen(filename, 'w') as fp_:
         fp_.write(data)
 
 

--- a/salt/modules/rpmbuild.py
+++ b/salt/modules/rpmbuild.py
@@ -26,6 +26,8 @@ import functools
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=no-name-in-module,import-error
 from salt.exceptions import SaltInvocationError
 import salt.utils
+import salt.utils.files
+import salt.utils.vt
 
 HAS_LIBS = False
 
@@ -76,7 +78,7 @@ def _create_rpmmacros():
         os.makedirs(mockdir)
 
     rpmmacros = os.path.join(home, '.rpmmacros')
-    with salt.utils.fopen(rpmmacros, 'w') as afile:
+    with salt.utils.files.fopen(rpmmacros, 'w') as afile:
         afile.write('%_topdir {0}\n'.format(rpmbuilddir))
         afile.write('%signature gpg\n')
         afile.write('%_source_filedigest_algorithm 8\n')

--- a/salt/modules/rsync.py
+++ b/salt/modules/rsync.py
@@ -15,6 +15,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 log = logging.getLogger(__name__)
@@ -221,7 +222,7 @@ def config(conf_path='/etc/rsyncd.conf'):
     '''
     ret = ''
     try:
-        with salt.utils.fopen(conf_path, 'r') as fp_:
+        with salt.utils.files.fopen(conf_path, 'r') as fp_:
             for line in fp_:
                 ret += line
     except IOError as exc:

--- a/salt/modules/runit.py
+++ b/salt/modules/runit.py
@@ -57,7 +57,7 @@ log = logging.getLogger(__name__)
 
 # Import salt libs
 from salt.exceptions import CommandExecutionError
-import salt.utils
+import salt.utils.files
 
 # Function alias to not shadow built-ins.
 __func_alias__ = {
@@ -600,7 +600,7 @@ def enable(name, start=False, **kwargs):
         log.trace('need a temporary file {0}'.format(down_file))
         if not os.path.exists(down_file):
             try:
-                salt.utils.fopen(down_file, "w").close()  # pylint: disable=resource-leakage
+                salt.utils.files.fopen(down_file, "w").close()  # pylint: disable=resource-leakage
             except IOError:
                 log.error('Unable to create file {0}'.format(down_file))
                 return False
@@ -675,7 +675,7 @@ def disable(name, stop=False, **kwargs):
 
     if not os.path.exists(down_file):
         try:
-            salt.utils.fopen(down_file, "w").close()  # pylint: disable=resource-leakage
+            salt.utils.files.fopen(down_file, "w").close()  # pylint: disable=resource-leakage
         except IOError:
             log.error('Unable to create file {0}'.format(down_file))
             return False

--- a/salt/modules/salt_proxy.py
+++ b/salt/modules/salt_proxy.py
@@ -14,7 +14,7 @@ import salt.ext.six.moves
 import os
 import logging
 
-import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ def _write_proxy_conf(proxyfile):
 
     if proxyfile:
         log.debug('Writing proxy conf file')
-        with salt.utils.fopen(proxyfile, 'w') as proxy_conf:
+        with salt.utils.files.fopen(proxyfile, 'w') as proxy_conf:
             proxy_conf.write('master = {0}'
                              .format(__grains__['master']))
         msg = 'Wrote proxy file {0}'.format(proxyfile)

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -50,6 +50,7 @@ import salt.utils
 import salt.utils.args
 import salt.utils.event
 import salt.utils.extmods
+import salt.utils.files
 import salt.utils.minion
 import salt.utils.process
 import salt.utils.url
@@ -106,7 +107,7 @@ def _sync(form, saltenv=None, extmod_whitelist=None, extmod_blacklist=None):
     # Dest mod_dir is touched? trigger reload if requested
     if touched:
         mod_file = os.path.join(__opts__['cachedir'], 'module_refresh')
-        with salt.utils.fopen(mod_file, 'a+') as ofile:
+        with salt.utils.files.fopen(mod_file, 'a+') as ofile:
             ofile.write('')
     if form == 'grains' and \
        __opts__.get('grains_cache') and \
@@ -1099,7 +1100,7 @@ def find_cached_job(jid):
         else:
             return 'Local jobs cache directory {0} not found'.format(job_dir)
     path = os.path.join(job_dir, 'return.p')
-    with salt.utils.fopen(path, 'rb') as fp_:
+    with salt.utils.files.fopen(path, 'rb') as fp_:
         buf = fp_.read()
         fp_.close()
         if buf:

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -14,7 +14,8 @@ import os
 import yaml
 
 # Import salt libs
-import salt.utils
+import salt.utils.event
+import salt.utils.files
 import salt.utils.odict
 
 # Import 3rd-party libs
@@ -800,7 +801,7 @@ def reload_():
     # move this file into an configurable opt
     sfn = '{0}/{1}/schedule.conf'.format(__opts__['config_dir'], os.path.dirname(__opts__['default_include']))
     if os.path.isfile(sfn):
-        with salt.utils.fopen(sfn, 'rb') as fp_:
+        with salt.utils.files.fopen(sfn, 'rb') as fp_:
             try:
                 schedule = yaml.safe_load(fp_.read())
             except yaml.YAMLError as exc:

--- a/salt/modules/seed.py
+++ b/salt/modules/seed.py
@@ -13,8 +13,8 @@ import tempfile
 
 # Import salt libs
 import salt.crypt
-import salt.utils
 import salt.utils.cloud
+import salt.utils.files
 import salt.config
 import salt.syspaths
 import uuid
@@ -31,7 +31,7 @@ __func_alias__ = {
 
 def _file_or_content(file_):
     if os.path.exists(file_):
-        with salt.utils.fopen(file_) as fic:
+        with salt.utils.files.fopen(file_) as fic:
             return fic.read()
     return file_
 
@@ -220,7 +220,7 @@ def mkconfig(config=None,
 
     # Write the new minion's config to a tmp file
     tmp_config = os.path.join(tmp, 'minion')
-    with salt.utils.fopen(tmp_config, 'w+') as fp_:
+    with salt.utils.files.fopen(tmp_config, 'w+') as fp_:
         fp_.write(salt.utils.cloud.salt_config_to_yaml(config))
 
     # Generate keys for the minion
@@ -230,16 +230,16 @@ def mkconfig(config=None,
     if preseeded:
         log.debug('Writing minion.pub to {0}'.format(pubkeyfn))
         log.debug('Writing minion.pem to {0}'.format(privkeyfn))
-        with salt.utils.fopen(pubkeyfn, 'w') as fic:
+        with salt.utils.files.fopen(pubkeyfn, 'w') as fic:
             fic.write(_file_or_content(pub_key))
-        with salt.utils.fopen(privkeyfn, 'w') as fic:
+        with salt.utils.files.fopen(privkeyfn, 'w') as fic:
             fic.write(_file_or_content(priv_key))
         os.chmod(pubkeyfn, 0o600)
         os.chmod(privkeyfn, 0o600)
     else:
         salt.crypt.gen_keys(tmp, 'minion', 2048)
     if approve_key and not preseeded:
-        with salt.utils.fopen(pubkeyfn) as fp_:
+        with salt.utils.files.fopen(pubkeyfn) as fp_:
             pubkey = fp_.read()
             __salt__['pillar.ext']({'virtkey': [id_, pubkey]})
 
@@ -274,7 +274,7 @@ def _check_resolv(mpt):
     if not os.path.isfile(resolv):
         replace = True
     if not replace:
-        with salt.utils.fopen(resolv, 'rb') as fp_:
+        with salt.utils.files.fopen(resolv, 'rb') as fp_:
             conts = fp_.read()
             if 'nameserver' not in conts:
                 replace = True

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -18,6 +18,7 @@ import re
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.decorators as decorators
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
@@ -94,7 +95,7 @@ def getenforce():
         return 'Disabled'
     try:
         enforce = os.path.join(_selinux_fs_path, 'enforce')
-        with salt.utils.fopen(enforce, 'r') as _fp:
+        with salt.utils.files.fopen(enforce, 'r') as _fp:
             if _fp.readline().strip() == '0':
                 return 'Permissive'
             else:
@@ -115,7 +116,7 @@ def getconfig():
     '''
     try:
         config = '/etc/selinux/config'
-        with salt.utils.fopen(config, 'r') as _fp:
+        with salt.utils.files.fopen(config, 'r') as _fp:
             for line in _fp:
                 if line.strip().startswith('SELINUX='):
                     return line.split('=')[1].capitalize().strip()
@@ -158,7 +159,7 @@ def setenforce(mode):
     if getenforce() != 'Disabled':
         enforce = os.path.join(selinux_fs_path(), 'enforce')
         try:
-            with salt.utils.fopen(enforce, 'w') as _fp:
+            with salt.utils.files.fopen(enforce, 'w') as _fp:
                 _fp.write(mode)
         except (IOError, OSError) as exc:
             msg = 'Could not write SELinux enforce file: {0}'
@@ -166,10 +167,10 @@ def setenforce(mode):
 
     config = '/etc/selinux/config'
     try:
-        with salt.utils.fopen(config, 'r') as _cf:
+        with salt.utils.files.fopen(config, 'r') as _cf:
             conf = _cf.read()
         try:
-            with salt.utils.fopen(config, 'w') as _cf:
+            with salt.utils.files.fopen(config, 'w') as _cf:
                 conf = re.sub(r"\nSELINUX=.*\n", "\nSELINUX=" + modestring + "\n", conf)
                 _cf.write(conf)
         except (IOError, OSError) as exc:

--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -20,6 +20,7 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 try:
     import salt.utils.pycrypto
@@ -288,7 +289,7 @@ def set_password(name, password, use_usermod=False):
         if not os.path.isfile(s_file):
             return ret
         lines = []
-        with salt.utils.fopen(s_file, 'rb') as fp_:
+        with salt.utils.files.fopen(s_file, 'rb') as fp_:
             for line in fp_:
                 line = salt.utils.to_str(line)
                 comps = line.strip().split(':')
@@ -300,7 +301,7 @@ def set_password(name, password, use_usermod=False):
                 comps[2] = str(changed_date.days)
                 line = ':'.join(comps)
                 lines.append('{0}\n'.format(line))
-        with salt.utils.fopen(s_file, 'w+') as fp_:
+        with salt.utils.files.fopen(s_file, 'w+') as fp_:
             fp_.writelines(lines)
         uinfo = info(name)
         return uinfo['passwd'] == password

--- a/salt/modules/smartos_vmadm.py
+++ b/salt/modules/smartos_vmadm.py
@@ -17,6 +17,7 @@ except ImportError:
 import salt.ext.six as six
 import salt.utils
 import salt.utils.decorators as decorators
+import salt.utils.files
 from salt.utils.odict import OrderedDict
 
 log = logging.getLogger(__name__)
@@ -127,7 +128,7 @@ def _create_update_from_cfg(mode='create', uuid=None, vmcfg=None):
 
     # write json file
     vmadm_json_file = __salt__['temp.file'](prefix='vmadm-')
-    with salt.utils.fopen(vmadm_json_file, 'w') as vmadm_json:
+    with salt.utils.files.fopen(vmadm_json_file, 'w') as vmadm_json:
         vmadm_json.write(json.dumps(vmcfg))
 
     # vmadm validate create|update [-f <filename>]
@@ -166,7 +167,7 @@ def _create_update_from_cfg(mode='create', uuid=None, vmcfg=None):
         return ret
     else:
         # cleanup json file (only when succesful to help troubleshooting)
-        salt.utils.safe_rm(vmadm_json_file)
+        salt.utils.files.safe_rm(vmadm_json_file)
 
         # return uuid
         if res['stderr'].startswith('Successfully created VM'):

--- a/salt/modules/snapper.py
+++ b/salt/modules/snapper.py
@@ -26,7 +26,7 @@ except ImportError:
     HAS_PWD = False
 
 from salt.exceptions import CommandExecutionError
-import salt.utils
+import salt.utils.files
 
 
 try:
@@ -796,7 +796,7 @@ def diff(config='root', filename=None, num_pre=None, num_post=None):
 
             if os.path.isfile(pre_file):
                 pre_file_exists = True
-                with salt.utils.fopen(pre_file) as rfh:
+                with salt.utils.files.fopen(pre_file) as rfh:
                     pre_file_content = rfh.readlines()
             else:
                 pre_file_content = []
@@ -804,7 +804,7 @@ def diff(config='root', filename=None, num_pre=None, num_post=None):
 
             if os.path.isfile(post_file):
                 post_file_exists = True
-                with salt.utils.fopen(post_file) as rfh:
+                with salt.utils.files.fopen(post_file) as rfh:
                     post_file_content = rfh.readlines()
             else:
                 post_file_content = []

--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -24,7 +24,7 @@ except ImportError:
         pass  # We're most likely on a Windows machine.
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 try:
     import salt.utils.pycrypto
@@ -117,7 +117,7 @@ def info(name):
     s_file = '/etc/shadow'
     if not os.path.isfile(s_file):
         return ret
-    with salt.utils.fopen(s_file, 'rb') as ifile:
+    with salt.utils.files.fopen(s_file, 'rb') as ifile:
         for line in ifile:
             comps = line.strip().split(':')
             if comps[0] == name:
@@ -280,7 +280,7 @@ def set_password(name, password):
     if not os.path.isfile(s_file):
         return ret
     lines = []
-    with salt.utils.fopen(s_file, 'rb') as ifile:
+    with salt.utils.files.fopen(s_file, 'rb') as ifile:
         for line in ifile:
             comps = line.strip().split(':')
             if comps[0] != name:
@@ -289,7 +289,7 @@ def set_password(name, password):
             comps[1] = password
             line = ':'.join(comps)
             lines.append('{0}\n'.format(line))
-    with salt.utils.fopen(s_file, 'w+') as ofile:
+    with salt.utils.files.fopen(s_file, 'w+') as ofile:
         ofile.writelines(lines)
     uinfo = info(name)
     return uinfo['passwd'] == password

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -149,7 +149,7 @@ def _replace_auth_key(
 
     try:
         # open the file for both reading AND writing
-        with salt.utils.fopen(full, 'r') as _fh:
+        with salt.utils.files.fopen(full, 'r') as _fh:
             for line in _fh:
                 if line.startswith('#'):
                     # Commented Line
@@ -162,7 +162,7 @@ def _replace_auth_key(
                     lines.append(line)
             _fh.close()
             # Re-open the file writable after properly closing it
-            with salt.utils.fopen(full, 'w') as _fh:
+            with salt.utils.files.fopen(full, 'w') as _fh:
                 # Write out any changes
                 _fh.writelines(lines)
     except (IOError, OSError) as exc:
@@ -179,7 +179,7 @@ def _validate_keys(key_file, fingerprint_hash_type):
     linere = re.compile(r'^(.*?)\s?((?:ssh\-|ecds)[\w-]+\s.+)$')
 
     try:
-        with salt.utils.fopen(key_file, 'r') as _fh:
+        with salt.utils.files.fopen(key_file, 'r') as _fh:
             for line in _fh:
                 if line.startswith('#'):
                     # Commented Line
@@ -338,7 +338,7 @@ def host_keys(keydir=None, private=True, certs=True):
             if m.group('pub'):
                 kname += m.group('pub')
             try:
-                with salt.utils.fopen(os.path.join(keydir, fn_), 'r') as _fh:
+                with salt.utils.files.fopen(os.path.join(keydir, fn_), 'r') as _fh:
                     # As of RFC 4716 "a key file is a text file, containing a
                     # sequence of lines", although some SSH implementations
                     # (e.g. OpenSSH) manage their own format(s).  Please see
@@ -568,7 +568,7 @@ def rm_auth_key(user,
         try:
             # Read every line in the file to find the right ssh key
             # and then write out the correct one. Open the file once
-            with salt.utils.fopen(full, 'r') as _fh:
+            with salt.utils.files.fopen(full, 'r') as _fh:
                 for line in _fh:
                     if line.startswith('#'):
                         # Commented Line
@@ -599,7 +599,7 @@ def rm_auth_key(user,
 
             # Let the context manager do the right thing here and then
             # re-open the file in write mode to save the changes out.
-            with salt.utils.fopen(full, 'w') as _fh:
+            with salt.utils.files.fopen(full, 'w') as _fh:
                 _fh.writelines(lines)
         except (IOError, OSError) as exc:
             log.warning('Could not read/write key file: {0}'.format(str(exc)))
@@ -745,7 +745,7 @@ def set_auth_key(
             new_file = False
 
         try:
-            with salt.utils.fopen(fconfig, 'ab+') as _fh:
+            with salt.utils.files.fopen(fconfig, 'ab+') as _fh:
                 if new_file is False:
                     # Let's make sure we have a new line at the end of the file
                     _fh.seek(1024, 2)
@@ -1142,7 +1142,7 @@ def set_known_host(user=None,
 
     # write line to known_hosts file
     try:
-        with salt.utils.fopen(full, 'a') as ofile:
+        with salt.utils.files.fopen(full, 'a') as ofile:
             ofile.write(line)
     except (IOError, OSError) as exception:
         raise CommandExecutionError(
@@ -1230,7 +1230,7 @@ def user_keys(user=None, pubfile=None, prvfile=None):
 
             if os.path.exists(fn_):
                 try:
-                    with salt.utils.fopen(fn_, 'r') as _fh:
+                    with salt.utils.files.fopen(fn_, 'r') as _fh:
                         keys[u][keyname] = ''.join(_fh.readlines()).strip()
                 except (IOError, OSError):
                     pass
@@ -1308,7 +1308,7 @@ def key_is_encrypted(key):
         salt '*' ssh.key_is_encrypted /root/id_rsa
     '''
     try:
-        with salt.utils.fopen(key, 'r') as fp_:
+        with salt.utils.files.fopen(key, 'r') as fp_:
             key_data = fp_.read()
     except (IOError, OSError) as exc:
         # Raise a CommandExecutionError

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -29,6 +29,7 @@ import salt.config
 import salt.payload
 import salt.state
 import salt.utils
+import salt.utils.files
 import salt.utils.jid
 import salt.utils.url
 from salt.exceptions import CommandExecutionError, SaltInvocationError
@@ -631,7 +632,7 @@ def request(mods=None,
         if salt.utils.is_windows():
             # Make sure cache file isn't read-only
             __salt__['cmd.run']('attrib -R "{0}"'.format(notify_path))
-        with salt.utils.fopen(notify_path, 'w+b') as fp_:
+        with salt.utils.files.fopen(notify_path, 'w+b') as fp_:
             serial.dump(req, fp_)
     except (IOError, OSError):
         msg = 'Unable to write state request file {0}. Check permission.'
@@ -655,7 +656,7 @@ def check_request(name=None):
     notify_path = os.path.join(__opts__['cachedir'], 'req_state.p')
     serial = salt.payload.Serial(__opts__)
     if os.path.isfile(notify_path):
-        with salt.utils.fopen(notify_path, 'rb') as fp_:
+        with salt.utils.files.fopen(notify_path, 'rb') as fp_:
             req = serial.load(fp_)
         if name:
             return req[name]
@@ -695,7 +696,7 @@ def clear_request(name=None):
             if salt.utils.is_windows():
                 # Make sure cache file isn't read-only
                 __salt__['cmd.run']('attrib -R "{0}"'.format(notify_path))
-            with salt.utils.fopen(notify_path, 'w+b') as fp_:
+            with salt.utils.files.fopen(notify_path, 'w+b') as fp_:
                 serial.dump(req, fp_)
         except (IOError, OSError):
             msg = 'Unable to write state request file {0}. Check permission.'
@@ -1086,7 +1087,7 @@ def sls(mods, test=None, exclude=None, queue=False, **kwargs):
     umask = os.umask(0o77)
     if kwargs.get('cache'):
         if os.path.isfile(cfn):
-            with salt.utils.fopen(cfn, 'rb') as fp_:
+            with salt.utils.files.fopen(cfn, 'rb') as fp_:
                 high_ = serial.load(fp_)
                 return st_.state.call_high(high_, orchestration_jid)
     os.umask(umask)
@@ -1122,7 +1123,7 @@ def sls(mods, test=None, exclude=None, queue=False, **kwargs):
         if salt.utils.is_windows():
             # Make sure cache file isn't read-only
             __salt__['cmd.run'](['attrib', '-R', cache_file], python_shell=False)
-        with salt.utils.fopen(cache_file, 'w+b') as fp_:
+        with salt.utils.files.fopen(cache_file, 'w+b') as fp_:
             serial.dump(ret, fp_)
     except (IOError, OSError):
         msg = 'Unable to write to SLS cache file {0}. Check permission.'
@@ -1133,7 +1134,7 @@ def sls(mods, test=None, exclude=None, queue=False, **kwargs):
     __opts__['test'] = orig_test
 
     try:
-        with salt.utils.fopen(cfn, 'w+b') as fp_:
+        with salt.utils.files.fopen(cfn, 'w+b') as fp_:
             try:
                 serial.dump(high_, fp_)
             except TypeError:
@@ -1790,7 +1791,7 @@ def pkg(pkg_path,
     s_pkg.extractall(root)
     s_pkg.close()
     lowstate_json = os.path.join(root, 'lowstate.json')
-    with salt.utils.fopen(lowstate_json, 'r') as fp_:
+    with salt.utils.files.fopen(lowstate_json, 'r') as fp_:
         lowstate = json.load(fp_, object_hook=salt.utils.decode_dict)
     # Check for errors in the lowstate
     for chunk in lowstate:
@@ -1798,14 +1799,14 @@ def pkg(pkg_path,
             return lowstate
     pillar_json = os.path.join(root, 'pillar.json')
     if os.path.isfile(pillar_json):
-        with salt.utils.fopen(pillar_json, 'r') as fp_:
+        with salt.utils.files.fopen(pillar_json, 'r') as fp_:
             pillar_override = json.load(fp_)
     else:
         pillar_override = None
 
     roster_grains_json = os.path.join(root, 'roster_grains.json')
     if os.path.isfile(roster_grains_json):
-        with salt.utils.fopen(roster_grains_json, 'r') as fp_:
+        with salt.utils.files.fopen(roster_grains_json, 'r') as fp_:
             roster_grains = json.load(fp_, object_hook=salt.utils.decode_dict)
 
     popts = _get_opts(**kwargs)

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -25,6 +25,7 @@ import salt.config
 import salt.minion
 import salt.utils
 import salt.utils.event
+import salt.utils.files
 from salt.utils.network import host_to_ips as _host_to_ips
 from salt.utils.network import remote_port_tcp as _remote_port_tcp
 from salt.ext.six.moves import zip
@@ -215,7 +216,7 @@ def uptime():
         ut_path = "/proc/uptime"
         if not os.path.exists(ut_path):
             raise CommandExecutionError("File {ut_path} was not found.".format(ut_path=ut_path))
-        with salt.utils.fopen(ut_path) as rfh:
+        with salt.utils.files.fopen(ut_path) as rfh:
             seconds = int(float(rfh.read().split()[0]))
     elif salt.utils.is_sunos():
         # note: some flavors/vesions report the host uptime inside a zone
@@ -310,7 +311,7 @@ def cpustats():
         '''
         ret = {}
         try:
-            with salt.utils.fopen('/proc/stat', 'r') as fp_:
+            with salt.utils.files.fopen('/proc/stat', 'r') as fp_:
                 stats = fp_.read()
         except IOError:
             pass
@@ -437,7 +438,7 @@ def meminfo():
         '''
         ret = {}
         try:
-            with salt.utils.fopen('/proc/meminfo', 'r') as fp_:
+            with salt.utils.files.fopen('/proc/meminfo', 'r') as fp_:
                 stats = fp_.read()
         except IOError:
             pass
@@ -583,7 +584,7 @@ def cpuinfo():
         '''
         ret = {}
         try:
-            with salt.utils.fopen('/proc/cpuinfo', 'r') as fp_:
+            with salt.utils.files.fopen('/proc/cpuinfo', 'r') as fp_:
                 stats = fp_.read()
         except IOError:
             pass
@@ -782,7 +783,7 @@ def diskstats():
         '''
         ret = {}
         try:
-            with salt.utils.fopen('/proc/diskstats', 'r') as fp_:
+            with salt.utils.files.fopen('/proc/diskstats', 'r') as fp_:
                 stats = fp_.read()
         except IOError:
             pass
@@ -932,7 +933,7 @@ def diskusage(*args):
         # ifile source of data varies with OS, otherwise all the same
         if __grains__['kernel'] == 'Linux':
             try:
-                with salt.utils.fopen('/proc/mounts', 'r') as fp_:
+                with salt.utils.files.fopen('/proc/mounts', 'r') as fp_:
                     ifile = fp_.read().splitlines()
             except OSError:
                 return {}
@@ -987,7 +988,7 @@ def vmstats():
         '''
         ret = {}
         try:
-            with salt.utils.fopen('/proc/vmstat', 'r') as fp_:
+            with salt.utils.files.fopen('/proc/vmstat', 'r') as fp_:
                 stats = fp_.read()
         except IOError:
             pass
@@ -1065,7 +1066,7 @@ def netstats():
         '''
         ret = {}
         try:
-            with salt.utils.fopen('/proc/net/netstat', 'r') as fp_:
+            with salt.utils.files.fopen('/proc/net/netstat', 'r') as fp_:
                 stats = fp_.read()
         except IOError:
             pass
@@ -1187,7 +1188,7 @@ def netdev():
         '''
         ret = {}
         try:
-            with salt.utils.fopen('/proc/net/dev', 'r') as fp_:
+            with salt.utils.files.fopen('/proc/net/dev', 'r') as fp_:
                 stats = fp_.read()
         except IOError:
             pass
@@ -1448,7 +1449,7 @@ def version():
         linux specific implementation of version
         '''
         try:
-            with salt.utils.fopen('/proc/version', 'r') as fp_:
+            with salt.utils.files.fopen('/proc/version', 'r') as fp_:
                 return fp_.read().strip()
         except IOError:
             return {}

--- a/salt/modules/sysfs.py
+++ b/salt/modules/sysfs.py
@@ -16,6 +16,7 @@ import salt.ext.six as six
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -63,7 +64,7 @@ def write(key, value):
     try:
         key = target(key)
         log.trace('Writing {0} to {1}'.format(value, key))
-        with salt.utils.fopen(key, 'w') as twriter:
+        with salt.utils.files.fopen(key, 'w') as twriter:
             twriter.write('{0}\n'.format(value))
             return True
     except:  # pylint: disable=bare-except

--- a/salt/modules/syslog_ng.py
+++ b/salt/modules/syslog_ng.py
@@ -35,6 +35,7 @@ import os.path
 
 # Import Salt libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 # Import 3rd-party libs
@@ -1174,7 +1175,7 @@ def _write_config(config, newlines=2):
         text = config[key]
 
     try:
-        with salt.utils.fopen(__SYSLOG_NG_CONFIG_FILE, 'a') as fha:
+        with salt.utils.files.fopen(__SYSLOG_NG_CONFIG_FILE, 'a') as fha:
             fha.write(text)
 
             for _ in range(0, newlines):

--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -21,6 +21,7 @@ import os.path
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.ext.six as six
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
@@ -513,7 +514,7 @@ def get_computer_desc():
     else:
         pattern = re.compile(r'^\s*PRETTY_HOSTNAME=(.*)$')
         try:
-            with salt.utils.fopen('/etc/machine-info', 'r') as mach_info:
+            with salt.utils.files.fopen('/etc/machine-info', 'r') as mach_info:
                 for line in mach_info.readlines():
                     match = pattern.match(line)
                     if match:
@@ -557,14 +558,14 @@ def set_computer_desc(desc):
         return True if result == 0 else False
 
     if not os.path.isfile('/etc/machine-info'):
-        with salt.utils.fopen('/etc/machine-info', 'w'):
+        with salt.utils.files.fopen('/etc/machine-info', 'w'):
             pass
 
     is_pretty_hostname_found = False
     pattern = re.compile(r'^\s*PRETTY_HOSTNAME=(.*)$')
     new_line = 'PRETTY_HOSTNAME="{0}"'.format(desc)
     try:
-        with salt.utils.fopen('/etc/machine-info', 'r+') as mach_info:
+        with salt.utils.files.fopen('/etc/machine-info', 'r+') as mach_info:
             lines = mach_info.readlines()
             for i, line in enumerate(lines):
                 if pattern.match(line):

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -20,7 +20,8 @@ import fnmatch
 import re
 import shlex
 
-# Import 3rd-party libs
+import salt.utils
+import salt.utils.files
 import salt.utils.itertools
 import salt.utils.systemd
 from salt.exceptions import CommandExecutionError
@@ -152,7 +153,7 @@ def _default_runlevel():
     # Try to get the "main" default.  If this fails, throw up our
     # hands and just guess "2", because things are horribly broken
     try:
-        with salt.utils.fopen('/etc/init/rc-sysinit.conf') as fp_:
+        with salt.utils.files.fopen('/etc/init/rc-sysinit.conf') as fp_:
             for line in fp_:
                 if line.startswith('env DEFAULT_RUNLEVEL'):
                     runlevel = line.split('=')[-1].strip()
@@ -161,7 +162,7 @@ def _default_runlevel():
 
     # Look for an optional "legacy" override in /etc/inittab
     try:
-        with salt.utils.fopen('/etc/inittab') as fp_:
+        with salt.utils.files.fopen('/etc/inittab') as fp_:
             for line in fp_:
                 if not line.startswith('#') and 'initdefault' in line:
                     runlevel = line.split(':')[1]
@@ -173,7 +174,7 @@ def _default_runlevel():
     try:
         valid_strings = set(
             ('0', '1', '2', '3', '4', '5', '6', 's', 'S', '-s', 'single'))
-        with salt.utils.fopen('/proc/cmdline') as fp_:
+        with salt.utils.files.fopen('/proc/cmdline') as fp_:
             for line in fp_:
                 for arg in line.strip().split():
                     if arg in valid_strings:

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -14,6 +14,7 @@ import string
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.itertools
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 
@@ -54,7 +55,7 @@ def _timedatectl():
 
 def _get_zone_solaris():
     tzfile = '/etc/TIMEZONE'
-    with salt.utils.fopen(tzfile, 'r') as fp_:
+    with salt.utils.files.fopen(tzfile, 'r') as fp_:
         for line in fp_:
             if 'TZ=' in line:
                 zonepart = line.rstrip('\n').split('=')[-1]
@@ -81,7 +82,7 @@ def _get_adjtime_timezone():
 
 def _get_zone_sysconfig():
     tzfile = '/etc/sysconfig/clock'
-    with salt.utils.fopen(tzfile, 'r') as fp_:
+    with salt.utils.files.fopen(tzfile, 'r') as fp_:
         for line in fp_:
             if re.match(r'^\s*#', line):
                 continue
@@ -132,7 +133,7 @@ def _get_zone_etc_localtime():
 def _get_zone_etc_timezone():
     tzfile = '/etc/timezone'
     try:
-        with salt.utils.fopen(tzfile, 'r') as fp_:
+        with salt.utils.files.fopen(tzfile, 'r') as fp_:
             return fp_.read().strip()
     except IOError as exc:
         raise CommandExecutionError(
@@ -143,7 +144,7 @@ def _get_zone_etc_timezone():
 
 def _get_zone_aix():
     tzfile = '/etc/environment'
-    with salt.utils.fopen(tzfile, 'r') as fp_:
+    with salt.utils.files.fopen(tzfile, 'r') as fp_:
         for line in fp_:
             if 'TZ=' in line:
                 zonepart = line.rstrip('\n').split('=')[-1]
@@ -302,7 +303,7 @@ def set_zone(timezone):
         __salt__['file.sed'](
             '/etc/sysconfig/clock', '^TIMEZONE=.*', 'TIMEZONE="{0}"'.format(timezone))
     elif 'Debian' in __grains__['os_family'] or 'Gentoo' in __grains__['os_family']:
-        with salt.utils.fopen('/etc/timezone', 'w') as ofh:
+        with salt.utils.files.fopen('/etc/timezone', 'w') as ofh:
             ofh.write(timezone.strip())
             ofh.write('\n')
 
@@ -396,7 +397,7 @@ def get_hwclock():
         if 'Debian' in __grains__['os_family']:
             # Original way to look up hwclock on Debian-based systems
             try:
-                with salt.utils.fopen('/etc/default/rcS', 'r') as fp_:
+                with salt.utils.files.fopen('/etc/default/rcS', 'r') as fp_:
                     for line in fp_:
                         if re.match(r'^\s*#', line):
                             continue
@@ -415,7 +416,7 @@ def get_hwclock():
             if not os.path.exists('/etc/adjtime'):
                 offset_file = '/etc/conf.d/hwclock'
                 try:
-                    with salt.utils.fopen(offset_file, 'r') as fp_:
+                    with salt.utils.files.fopen(offset_file, 'r') as fp_:
                         for line in fp_:
                             if line.startswith('clock='):
                                 line = line.rstrip('\n')
@@ -438,7 +439,7 @@ def get_hwclock():
         if 'Solaris' in __grains__['os_family']:
             offset_file = '/etc/rtc_config'
             try:
-                with salt.utils.fopen(offset_file, 'r') as fp_:
+                with salt.utils.files.fopen(offset_file, 'r') as fp_:
                     for line in fp_:
                         if line.startswith('zone_info=GMT'):
                             return 'UTC'
@@ -455,7 +456,7 @@ def get_hwclock():
         if 'AIX' in __grains__['os_family']:
             offset_file = '/etc/environment'
             try:
-                with salt.utils.fopen(offset_file, 'r') as fp_:
+                with salt.utils.files.fopen(offset_file, 'r') as fp_:
                     for line in fp_:
                         if line.startswith('TZ=UTC'):
                             return 'UTC'

--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -55,6 +55,7 @@ import fnmatch
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.modules.cmdmod
 import salt.utils.systemd
 
@@ -109,7 +110,7 @@ def _default_runlevel():
     # Try to get the "main" default.  If this fails, throw up our
     # hands and just guess "2", because things are horribly broken
     try:
-        with salt.utils.fopen('/etc/init/rc-sysinit.conf') as fp_:
+        with salt.utils.files.fopen('/etc/init/rc-sysinit.conf') as fp_:
             for line in fp_:
                 if line.startswith('env DEFAULT_RUNLEVEL'):
                     runlevel = line.split('=')[-1].strip()
@@ -118,7 +119,7 @@ def _default_runlevel():
 
     # Look for an optional "legacy" override in /etc/inittab
     try:
-        with salt.utils.fopen('/etc/inittab') as fp_:
+        with salt.utils.files.fopen('/etc/inittab') as fp_:
             for line in fp_:
                 if not line.startswith('#') and 'initdefault' in line:
                     runlevel = line.split(':')[1]
@@ -130,7 +131,7 @@ def _default_runlevel():
     try:
         valid_strings = set(
             ('0', '1', '2', '3', '4', '5', '6', 's', 'S', '-s', 'single'))
-        with salt.utils.fopen('/proc/cmdline') as fp_:
+        with salt.utils.files.fopen('/proc/cmdline') as fp_:
             for line in fp_:
                 for arg in line.strip().split():
                     if arg in valid_strings:
@@ -182,7 +183,7 @@ def _upstart_is_disabled(name):
     '''
     files = ['/etc/init/{0}.conf'.format(name), '/etc/init/{0}.override'.format(name)]
     for file_name in itertools.ifilter(os.path.isfile, files):
-        with salt.utils.fopen(file_name) as fp_:
+        with salt.utils.files.fopen(file_name) as fp_:
             if re.search(r'^\s*manual', fp_.read(), re.MULTILINE):
                 return True
     return False
@@ -492,7 +493,7 @@ def _upstart_disable(name):
     if _upstart_is_disabled(name):
         return _upstart_is_disabled(name)
     override = '/etc/init/{0}.override'.format(name)
-    with salt.utils.fopen(override, 'a') as ofile:
+    with salt.utils.files.fopen(override, 'a') as ofile:
         ofile.write('manual\n')
     return _upstart_is_disabled(name)
 
@@ -506,7 +507,7 @@ def _upstart_enable(name):
     override = '/etc/init/{0}.override'.format(name)
     files = ['/etc/init/{0}.conf'.format(name), override]
     for file_name in itertools.ifilter(os.path.isfile, files):
-        with salt.utils.fopen(file_name, 'r+') as fp_:
+        with salt.utils.files.fopen(file_name, 'r+') as fp_:
             new_text = re.sub(r'^\s*manual\n?', '', fp_.read(), 0, re.MULTILINE)
             fp_.seek(0)
             fp_.write(new_text)

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -20,6 +20,7 @@ import copy
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.decorators as decorators
 from salt.ext import six
 from salt.exceptions import CommandExecutionError
@@ -138,7 +139,7 @@ def add(name,
         defs_file = '/etc/login.defs'
         if __grains__['kernel'] != 'OpenBSD':
             try:
-                with salt.utils.fopen(defs_file) as fp_:
+                with salt.utils.files.fopen(defs_file) as fp_:
                     for line in fp_:
                         if 'USERGROUPS_ENAB' not in line[:15]:
                             continue
@@ -158,7 +159,7 @@ def add(name,
         else:
             usermgmt_file = '/etc/usermgmt.conf'
             try:
-                with salt.utils.fopen(usermgmt_file) as fp_:
+                with salt.utils.files.fopen(usermgmt_file) as fp_:
                     for line in fp_:
                         if 'group' not in line[:5]:
                             continue

--- a/salt/modules/vboxmanage.py
+++ b/salt/modules/vboxmanage.py
@@ -23,6 +23,7 @@ import logging
 
 # pylint: disable=import-error,no-name-in-module
 import salt.utils
+import salt.utils.files
 from salt.ext.six import string_types
 from salt.exceptions import CommandExecutionError
 # pylint: enable=import-error,no-name-in-module
@@ -457,7 +458,7 @@ def clonemedium(medium,
         params += ' ' + uuid_out
     elif file_out:
         try:
-            salt.utils.fopen(file_out, 'w').close()  # pylint: disable=resource-leakage
+            salt.utils.files.fopen(file_out, 'w').close()  # pylint: disable=resource-leakage
             os.unlink(file_out)
             params += ' ' + file_out
         except OSError:

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1439,7 +1439,7 @@ def create_xml_path(path):
         salt '*' virt.create_xml_path <path to XML file on the node>
     '''
     try:
-        with salt.utils.fopen(path, 'r') as fp_:
+        with salt.utils.files.fopen(path, 'r') as fp_:
             return create_xml_str(fp_.read())
     except (OSError, IOError):
         return False
@@ -1471,7 +1471,7 @@ def define_xml_path(path):
 
     '''
     try:
-        with salt.utils.fopen(path, 'r') as fp_:
+        with salt.utils.files.fopen(path, 'r') as fp_:
             return define_xml_str(fp_.read())
     except (OSError, IOError):
         return False
@@ -1505,7 +1505,7 @@ def define_vol_xml_path(path):
 
     '''
     try:
-        with salt.utils.fopen(path, 'r') as fp_:
+        with salt.utils.files.fopen(path, 'r') as fp_:
             return define_vol_xml_str(fp_.read())
     except (OSError, IOError):
         return False
@@ -1698,7 +1698,7 @@ def is_kvm_hyper():
         salt '*' virt.is_kvm_hyper
     '''
     try:
-        with salt.utils.fopen('/proc/modules') as fp_:
+        with salt.utils.files.fopen('/proc/modules') as fp_:
             if 'kvm_' not in fp_.read():
                 return False
     except IOError:
@@ -1724,7 +1724,7 @@ def is_xen_hyper():
         # virtual_subtype isn't set everywhere.
         return False
     try:
-        with salt.utils.fopen('/proc/modules') as fp_:
+        with salt.utils.files.fopen('/proc/modules') as fp_:
             if 'xen_' not in fp_.read():
                 return False
     except (OSError, IOError):
@@ -2158,7 +2158,7 @@ def cpu_baseline(full=False, migratable=False, out='libvirt'):
     if full and not getattr(libvirt, 'VIR_CONNECT_BASELINE_CPU_EXPAND_FEATURES', False):
         # Try do it by ourselves
         # Find the models in cpu_map.xml and iterate over them for as long as entries have submodels
-        with salt.utils.fopen('/usr/share/libvirt/cpu_map.xml', 'r') as cpu_map:
+        with salt.utils.files.fopen('/usr/share/libvirt/cpu_map.xml', 'r') as cpu_map:
             cpu_map = minidom.parse(cpu_map)
 
         cpu_model = cpu.getElementsByTagName('model')[0].childNodes[0].nodeValue

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -47,6 +47,7 @@ import re
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltInvocationError
 import salt.utils.dictupdate as dictupdate
@@ -2696,7 +2697,7 @@ def _remove_unicode_encoding(xml_file):
     as lxml does not support that on a windows node currently
     see issue #38100
     '''
-    with salt.utils.fopen(xml_file, 'rb') as f:
+    with salt.utils.files.fopen(xml_file, 'rb') as f:
         xml_content = f.read()
     modified_xml = re.sub(r' encoding=[\'"]+unicode[\'"]+', '', xml_content.decode('utf-16'), count=1)
     xmltree = lxml.etree.parse(six.StringIO(modified_xml))
@@ -3938,7 +3939,7 @@ def _read_regpol_file(reg_pol_path):
     '''
     returndata = None
     if os.path.exists(reg_pol_path):
-        with salt.utils.fopen(reg_pol_path, 'rb') as pol_file:
+        with salt.utils.files.fopen(reg_pol_path, 'rb') as pol_file:
             returndata = pol_file.read()
         returndata = returndata.decode('utf-16-le')
     return returndata
@@ -3986,14 +3987,14 @@ def _write_regpol_data(data_to_write,
             reg_pol_header = u'\u5250\u6765\x01\x00'
             if not os.path.exists(policy_file_path):
                 ret = __salt__['file.makedirs'](policy_file_path)
-            with salt.utils.fopen(policy_file_path, 'wb') as pol_file:
+            with salt.utils.files.fopen(policy_file_path, 'wb') as pol_file:
                 if not data_to_write.startswith(reg_pol_header):
                     pol_file.write(reg_pol_header.encode('utf-16-le'))
                 pol_file.write(data_to_write.encode('utf-16-le'))
             try:
                 gpt_ini_data = ''
                 if os.path.exists(gpt_ini_path):
-                    with salt.utils.fopen(gpt_ini_path, 'rb') as gpt_file:
+                    with salt.utils.files.fopen(gpt_ini_path, 'rb') as gpt_file:
                         gpt_ini_data = gpt_file.read()
                 if not _regexSearchRegPolData(r'\[General\]\r\n', gpt_ini_data):
                     gpt_ini_data = '[General]\r\n' + gpt_ini_data
@@ -4048,7 +4049,7 @@ def _write_regpol_data(data_to_write,
                             int("{0}{1}".format(str(version_nums[0]).zfill(4), str(version_nums[1]).zfill(4)), 16),
                             gpt_ini_data[general_location.end():])
                 if gpt_ini_data:
-                    with salt.utils.fopen(gpt_ini_path, 'wb') as gpt_file:
+                    with salt.utils.files.fopen(gpt_ini_path, 'wb') as gpt_file:
                         gpt_file.write(gpt_ini_data)
             except Exception as e:
                 msg = 'An error occurred attempting to write to {0}, the exception was {1}'.format(

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -51,6 +51,7 @@ from salt.exceptions import (CommandExecutionError,
                              SaltInvocationError,
                              SaltRenderError)
 import salt.utils
+import salt.utils.files
 import salt.utils.pkg
 import salt.syspaths
 import salt.payload
@@ -762,7 +763,7 @@ def genrepo(**kwargs):
                     )
     serial = salt.payload.Serial(__opts__)
     mode = 'w+' if six.PY2 else 'wb+'
-    with salt.utils.fopen(repo_details.winrepo_file, mode) as repo_cache:
+    with salt.utils.files.fopen(repo_details.winrepo_file, mode) as repo_cache:
         repo_cache.write(serial.dumps(ret))
     # save reading it back again. ! this breaks due to utf8 issues
     #__context__['winrepo.data'] = ret
@@ -1684,7 +1685,7 @@ def get_repo_data(saltenv='base'):
 
     try:
         serial = salt.payload.Serial(__opts__)
-        with salt.utils.fopen(repo_details.winrepo_file, 'rb') as repofile:
+        with salt.utils.files.fopen(repo_details.winrepo_file, 'rb') as repofile:
             try:
                 repodata = serial.loads(repofile.read()) or {}
                 __context__['winrepo.data'] = repodata

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -24,6 +24,7 @@ import ast
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.exceptions
 import salt.ext.six as six
 from salt.utils.odict import OrderedDict
@@ -315,7 +316,7 @@ def _text_or_file(input_):
     content to be parsed.
     '''
     if os.path.isfile(input_):
-        with salt.utils.fopen(input_) as fp_:
+        with salt.utils.files.fopen(input_) as fp_:
             return fp_.read()
     else:
         return input_
@@ -768,7 +769,7 @@ def write_pem(text, path, overwrite=True, pem_type=None):
             _private_key = get_pem_entry(_filecontents, '(?:RSA )?PRIVATE KEY')
         except salt.exceptions.SaltInvocationError:
             pass
-    with salt.utils.fopen(path, 'w') as _fp:
+    with salt.utils.files.fopen(path, 'w') as _fp:
         if pem_type and pem_type == 'CERTIFICATE' and _private_key:
             _fp.write(_private_key)
         _fp.write(text)

--- a/salt/modules/xapi.py
+++ b/salt/modules/xapi.py
@@ -35,6 +35,7 @@ except ImportError:
 # Import salt libs
 from salt.exceptions import CommandExecutionError
 import salt.utils
+import salt.utils.files
 import salt.modules.cmdmod
 
 # Define the module's virtual name
@@ -773,7 +774,7 @@ def is_hyper():
         # virtual_subtype isn't set everywhere.
         return False
     try:
-        with salt.utils.fopen('/proc/modules') as fp_:
+        with salt.utils.files.fopen('/proc/modules') as fp_:
             if 'xen_' not in fp_.read():
                 return False
     except (OSError, IOError):

--- a/salt/modules/xbpspkg.py
+++ b/salt/modules/xbpspkg.py
@@ -17,6 +17,7 @@ import glob
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.pkg
 import salt.utils.decorators as decorators
 from salt.exceptions import CommandExecutionError, MinionError
@@ -552,7 +553,7 @@ def _locate_repo_files(repo, rewrite=False):
 
     for filename in files:
         write_buff = []
-        with salt.utils.fopen(filename, 'r') as cur_file:
+        with salt.utils.files.fopen(filename, 'r') as cur_file:
             for line in cur_file:
                 if regex.match(line):
                     ret_val.append(filename)
@@ -560,7 +561,7 @@ def _locate_repo_files(repo, rewrite=False):
                     write_buff.append(line)
         if rewrite and filename in ret_val:
             if len(write_buff) > 0:
-                with salt.utils.fopen(filename, 'w') as rewrite_file:
+                with salt.utils.files.fopen(filename, 'w') as rewrite_file:
                     rewrite_file.write("".join(write_buff))
             else:  # Prune empty files
                 os.remove(filename)
@@ -588,7 +589,7 @@ def add_repo(repo, conffile='/usr/share/xbps.d/15-saltstack.conf'):
 
     if len(_locate_repo_files(repo)) == 0:
         try:
-            with salt.utils.fopen(conffile, 'a+') as conf_file:
+            with salt.utils.files.fopen(conffile, 'a+') as conf_file:
                 conf_file.write('repository='+repo+'\n')
         except IOError:
             return False

--- a/salt/modules/xfs.py
+++ b/salt/modules/xfs.py
@@ -34,6 +34,7 @@ import logging
 
 # Import Salt libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 # Import 3rd-party libs
@@ -507,7 +508,7 @@ def _get_mounts():
     List mounted filesystems.
     '''
     mounts = {}
-    with salt.utils.fopen("/proc/mounts") as fhr:
+    with salt.utils.files.fopen("/proc/mounts") as fhr:
         for line in fhr.readlines():
             device, mntpnt, fstype, options, fs_freq, fs_passno = line.strip().split(" ")
             if fstype != 'xfs':

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -41,6 +41,7 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.pkg
 import salt.ext.six as six
 import salt.utils.itertools
@@ -2581,7 +2582,7 @@ def del_repo(repo, basedir=None, **kwargs):  # pylint: disable=W0613
             content += '\n{0}={1}'.format(line, filerepos[stanza][line])
         content += '\n{0}\n'.format(comments)
 
-    with salt.utils.fopen(repofile, 'w') as fileout:
+    with salt.utils.files.fopen(repofile, 'w') as fileout:
         fileout.write(content)
 
     return 'Repo {0} has been removed from {1}'.format(repo, repofile)
@@ -2722,7 +2723,7 @@ def mod_repo(repo, basedir=None, **kwargs):
             )
         content += '\n{0}\n'.format(comments)
 
-    with salt.utils.fopen(repofile, 'w') as fileout:
+    with salt.utils.files.fopen(repofile, 'w') as fileout:
         fileout.write(content)
 
     return {repofile: filerepos}
@@ -2735,7 +2736,7 @@ def _parse_repo_file(filename):
     repos = {}
     header = ''
     repo = ''
-    with salt.utils.fopen(filename, 'r') as rfile:
+    with salt.utils.files.fopen(filename, 'r') as rfile:
         for line in rfile:
             if line.startswith('['):
                 repo = line.strip().replace('[', '').replace(']', '')

--- a/salt/modules/zcbuildout.py
+++ b/salt/modules/zcbuildout.py
@@ -41,7 +41,7 @@ from salt.ext.six.moves.urllib.request import urlopen as _urlopen
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 
@@ -391,7 +391,7 @@ def _get_bootstrap_content(directory='.'):
     Get the current bootstrap.py script content
     '''
     try:
-        with salt.utils.fopen(os.path.join(
+        with salt.utils.files.fopen(os.path.join(
                                 os.path.abspath(directory),
                                 'bootstrap.py')) as fic:
             oldcontent = fic.read()
@@ -416,7 +416,7 @@ def _get_buildout_ver(directory='.'):
     try:
         files = _find_cfgs(directory)
         for f in files:
-            with salt.utils.fopen(f) as fic:
+            with salt.utils.files.fopen(f) as fic:
                 buildout1re = re.compile(r'^zc\.buildout\s*=\s*1', RE_F)
                 dfic = fic.read()
                 if (
@@ -518,7 +518,7 @@ def upgrade_bootstrap(directory='.',
                 if not os.path.isdir(dbuild):
                     os.makedirs(dbuild)
                 # only try to download once per buildout checkout
-                with salt.utils.fopen(os.path.join(
+                with salt.utils.files.fopen(os.path.join(
                         dbuild,
                         '{0}.updated_bootstrap'.format(buildout_ver))):
                     pass
@@ -534,16 +534,16 @@ def upgrade_bootstrap(directory='.',
             data = '\n'.join(ldata)
         if updated:
             comment = 'Bootstrap updated'
-            with salt.utils.fopen(b_py, 'w') as fic:
+            with salt.utils.files.fopen(b_py, 'w') as fic:
                 fic.write(data)
         if dled:
-            with salt.utils.fopen(os.path.join(dbuild,
+            with salt.utils.files.fopen(os.path.join(dbuild,
                                                '{0}.updated_bootstrap'.format(
                                                    buildout_ver)), 'w') as afic:
                 afic.write('foo')
     except (OSError, IOError):
         if oldcontent:
-            with salt.utils.fopen(b_py, 'w') as fic:
+            with salt.utils.files.fopen(b_py, 'w') as fic:
                 fic.write(oldcontent)
 
     return {'comment': comment}
@@ -734,7 +734,7 @@ def bootstrap(directory='.',
                       buildout_ver=buildout_ver)
     # be sure which buildout bootstrap we have
     b_py = os.path.join(directory, 'bootstrap.py')
-    with salt.utils.fopen(b_py) as fic:
+    with salt.utils.files.fopen(b_py) as fic:
         content = fic.read()
     if (
         (test_release is not False)

--- a/salt/modules/zonecfg.py
+++ b/salt/modules/zonecfg.py
@@ -97,7 +97,7 @@ def __virtual__():
     We are available if we are have zonecfg and are the global zone on
     Solaris 10, OmniOS, OpenIndiana, OpenSolaris, or Smartos.
     '''
-    ## note: we depend on PR#37472 to distinguish between Solaris and Oracle Solaris
+    # note: we depend on PR#37472 to distinguish between Solaris and Oracle Solaris
     if _is_globalzone() and salt.utils.which('zonecfg'):
         if __grains__['os'] in ['Solaris', 'OpenSolaris', 'SmartOS', 'OmniOS', 'OpenIndiana']:
             return __virtualname__
@@ -190,14 +190,14 @@ def _sanitize_value(value):
         new_value.append(')')
         return "".join(str(v) for v in new_value).replace(',)', ')')
     else:
-        ## note: we can't use shelx or pipes quote here because it makes zonecfg barf
+        # note: we can't use shelx or pipes quote here because it makes zonecfg barf
         return '"{0}"'.format(value) if ' ' in value else value
 
 
 def _dump_cfg(cfg_file):
     '''Internal helper for debugging cfg files'''
     if __salt__['file.file_exists'](cfg_file):
-        with salt.utils.fopen(cfg_file, 'r') as fp_:
+        with salt.utils.files.fopen(cfg_file, 'r') as fp_:
             log.debug("zonecfg - configuration file:\n{0}".format("".join(fp_.readlines())))
 
 
@@ -222,14 +222,14 @@ def create(zone, brand, zonepath, force=False):
     '''
     ret = {'status': True}
 
-    ## write config
+    # write config
     cfg_file = salt.utils.files.mkstemp()
-    with salt.utils.fpopen(cfg_file, 'w+', mode=0o600) as fp_:
+    with salt.utils.files.fpopen(cfg_file, 'w+', mode=0o600) as fp_:
         fp_.write("create -b -F\n" if force else "create -b\n")
         fp_.write("set brand={0}\n".format(_sanitize_value(brand)))
         fp_.write("set zonepath={0}\n".format(_sanitize_value(zonepath)))
 
-    ## create
+    # create
     if not __salt__['file.directory_exists'](zonepath):
         __salt__['file.makedirs_perms'](zonepath if zonepath[-1] == '/' else '{0}/'.format(zonepath), mode='0700')
 
@@ -245,7 +245,7 @@ def create(zone, brand, zonepath, force=False):
     else:
         ret['message'] = _clean_message(ret['message'])
 
-    ## cleanup config file
+    # cleanup config file
     if __salt__['file.file_exists'](cfg_file):
         __salt__['file.remove'](cfg_file)
 
@@ -272,7 +272,7 @@ def create_from_template(zone, template):
     '''
     ret = {'status': True}
 
-    ## create from template
+    # create from template
     _dump_cfg(template)
     res = __salt__['cmd.run_all']('zonecfg -z {zone} create -t {tmpl} -F'.format(
         zone=zone,
@@ -303,7 +303,7 @@ def delete(zone):
     '''
     ret = {'status': True}
 
-    ## delete zone
+    # delete zone
     res = __salt__['cmd.run_all']('zonecfg -z {zone} delete -F'.format(
         zone=zone,
     ))
@@ -335,7 +335,7 @@ def export(zone, path=None):
     '''
     ret = {'status': True}
 
-    ## export zone
+    # export zone
     res = __salt__['cmd.run_all']('zonecfg -z {zone} export{path}'.format(
         zone=zone,
         path=' -f {0}'.format(path) if path else '',
@@ -367,7 +367,7 @@ def import_(zone, path):
     '''
     ret = {'status': True}
 
-    ## create from file
+    # create from file
     _dump_cfg(path)
     res = __salt__['cmd.run_all']('zonecfg -z {zone} -f {path}'.format(
         zone=zone,
@@ -406,7 +406,7 @@ def _property(methode, zone, key, value):
         ret['message'] = 'unkown methode {0}!'.format(methode)
     else:
         cfg_file = salt.utils.files.mkstemp()
-        with salt.utils.fpopen(cfg_file, 'w+', mode=0o600) as fp_:
+        with salt.utils.files.fpopen(cfg_file, 'w+', mode=0o600) as fp_:
             if methode == 'set':
                 if isinstance(value, dict) or isinstance(value, list):
                     value = _sanitize_value(value)
@@ -415,7 +415,7 @@ def _property(methode, zone, key, value):
             elif methode == 'clear':
                 fp_.write("{0} {1}\n".format(methode, key))
 
-    ## update property
+    # update property
     if cfg_file:
         _dump_cfg(cfg_file)
         res = __salt__['cmd.run_all']('zonecfg -z {zone} -f {path}'.format(
@@ -429,7 +429,7 @@ def _property(methode, zone, key, value):
         else:
             ret['message'] = _clean_message(ret['message'])
 
-        ## cleanup config file
+        # cleanup config file
         if __salt__['file.file_exists'](cfg_file):
             __salt__['file.remove'](cfg_file)
 
@@ -518,7 +518,7 @@ def _resource(methode, zone, resource_type, resource_selector, **kwargs):
 
     # generate update script
     cfg_file = salt.utils.files.mkstemp()
-    with salt.utils.fpopen(cfg_file, 'w+', mode=0o600) as fp_:
+    with salt.utils.files.fpopen(cfg_file, 'w+', mode=0o600) as fp_:
         if methode in ['add']:
             fp_.write("add {0}\n".format(resource_type))
         elif methode in ['update']:
@@ -542,7 +542,7 @@ def _resource(methode, zone, resource_type, resource_selector, **kwargs):
                 fp_.write("add {0} {1}\n".format(k, _sanitize_value(value)))
         fp_.write("end\n")
 
-    ## update property
+    # update property
     if cfg_file:
         _dump_cfg(cfg_file)
         res = __salt__['cmd.run_all']('zonecfg -z {zone} -f {path}'.format(
@@ -556,7 +556,7 @@ def _resource(methode, zone, resource_type, resource_selector, **kwargs):
         else:
             ret['message'] = _clean_message(ret['message'])
 
-        ## cleanup config file
+        # cleanup config file
         if __salt__['file.file_exists'](cfg_file):
             __salt__['file.remove'](cfg_file)
 
@@ -634,13 +634,13 @@ def remove_resource(zone, resource_type, resource_key, resource_value):
 
     # generate update script
     cfg_file = salt.utils.files.mkstemp()
-    with salt.utils.fpopen(cfg_file, 'w+', mode=0o600) as fp_:
+    with salt.utils.files.fpopen(cfg_file, 'w+', mode=0o600) as fp_:
         if resource_key:
             fp_.write("remove {0} {1}={2}\n".format(resource_type, resource_key, _sanitize_value(resource_value)))
         else:
             fp_.write("remove {0}\n".format(resource_type))
 
-    ## update property
+    # update property
     if cfg_file:
         _dump_cfg(cfg_file)
         res = __salt__['cmd.run_all']('zonecfg -z {zone} -f {path}'.format(
@@ -654,7 +654,7 @@ def remove_resource(zone, resource_type, resource_key, resource_value):
         else:
             ret['message'] = _clean_message(ret['message'])
 
-        ## cleanup config file
+        # cleanup config file
         if __salt__['file.file_exists'](cfg_file):
             __salt__['file.remove'](cfg_file)
 
@@ -678,7 +678,7 @@ def info(zone, show_all=False):
     '''
     ret = {}
 
-    ## dump zone
+    # dump zone
     res = __salt__['cmd.run_all']('zonecfg -z {zone} info'.format(
         zone=zone,
     ))

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -37,6 +37,7 @@ from xml.parsers.expat import ExpatError
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.pkg
 import salt.utils.systemd
 from salt.exceptions import (
@@ -276,7 +277,7 @@ class _Zypper(object):
 
             if os.path.exists(self.ZYPPER_LOCK):
                 try:
-                    with salt.utils.fopen(self.ZYPPER_LOCK) as rfh:
+                    with salt.utils.files.fopen(self.ZYPPER_LOCK) as rfh:
                         data = __salt__['ps.proc_info'](int(rfh.readline()),
                                                         attrs=['pid', 'name', 'cmdline', 'create_time'])
                         data['cmdline'] = ' '.join(data['cmdline'])
@@ -1432,7 +1433,7 @@ def list_locks():
     '''
     locks = {}
     if os.path.exists(LOCKS):
-        with salt.utils.fopen(LOCKS) as fhr:
+        with salt.utils.files.fopen(LOCKS) as fhr:
             for meta in [item.split('\n') for item in fhr.read().split('\n\n')]:
                 lock = {}
                 for element in [el for el in meta if el]:
@@ -1808,7 +1809,7 @@ def list_products(all=False, refresh=False):
         if 'productline' in p_nfo and p_nfo['productline']:
             oem_file = os.path.join(OEM_PATH, p_nfo['productline'])
             if os.path.isfile(oem_file):
-                with salt.utils.fopen(oem_file, 'r') as rfile:
+                with salt.utils.files.fopen(oem_file, 'r') as rfile:
                     oem_release = rfile.readline().strip()
                     if oem_release:
                         p_nfo['release'] = oem_release

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -17,6 +17,7 @@ import traceback
 # Import salt libs
 import salt.loader
 import salt.utils
+import salt.utils.files
 import salt.ext.six as six
 from salt.utils import print_cli
 
@@ -97,7 +98,7 @@ def display_output(data, out=None, opts=None, **kwargs):
         # output filename can be either '' or None
         if output_filename:
             if not hasattr(output_filename, 'write'):
-                ofh = salt.utils.fopen(output_filename, 'a')  # pylint: disable=resource-leakage
+                ofh = salt.utils.files.fopen(output_filename, 'a')  # pylint: disable=resource-leakage
                 fh_opened = True
             else:
                 # Filehandle/file-like object

--- a/salt/pillar/csvpillar.py
+++ b/salt/pillar/csvpillar.py
@@ -48,7 +48,7 @@ Will produce the following Pillar values for a minion named "jerry":
 from __future__ import absolute_import
 import csv
 
-import salt.utils
+import salt.utils.files
 
 __virtualname__ = 'csv'
 
@@ -76,7 +76,7 @@ def ext_pillar(
     :param list fieldnames: (Optional) if the first row of the CSV is not
         column names they may be specified here instead.
     '''
-    with salt.utils.fopen(path, 'rb') as f:
+    with salt.utils.files.fopen(path, 'rb') as f:
         sheet = csv.DictReader(f, fieldnames,
                 restkey=restkey, restval=restval, dialect=dialect)
 

--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -180,8 +180,8 @@ import os
 
 # Import salt libs
 import salt.loader
-import salt.utils
 import salt.utils.dictupdate
+import salt.utils.files
 import salt.utils.minions
 import salt.utils.stringio
 import salt.template
@@ -261,7 +261,7 @@ def _construct_pillar(top_dir,
 
             contents = ''
             try:
-                with salt.utils.fopen(file_path, 'rb') as fhr:
+                with salt.utils.files.fopen(file_path, 'rb') as fhr:
                     buf = fhr.read(__opts__['file_buffer_size'])
                     while buf:
                         contents += buf

--- a/salt/pillar/libvirt.py
+++ b/salt/pillar/libvirt.py
@@ -16,6 +16,7 @@ import subprocess
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 
 def __virtual__():
@@ -50,9 +51,9 @@ def ext_pillar(minion_id,
         if not key.endswith('.pem'):
             continue
         fn_ = os.path.join(key_dir, key)
-        with salt.utils.fopen(fn_, 'r') as fp_:
+        with salt.utils.files.fopen(fn_, 'r') as fp_:
             ret['libvirt.{0}'.format(key)] = fp_.read()
-    with salt.utils.fopen(cacert, 'r') as fp_:
+    with salt.utils.files.fopen(cacert, 'r') as fp_:
         ret['libvirt.cacert.pem'] = fp_.read()
     return ret
 
@@ -76,7 +77,7 @@ def gen_hyper_keys(minion_id,
     cacert = os.path.join(key_dir, 'cacert.pem')
     cainfo = os.path.join(key_dir, 'ca.info')
     if not os.path.isfile(cainfo):
-        with salt.utils.fopen(cainfo, 'w+') as fp_:
+        with salt.utils.files.fopen(cainfo, 'w+') as fp_:
             fp_.write('cn = salted\nca\ncert_signing_key')
     if not os.path.isfile(cakey):
         subprocess.call(
@@ -96,7 +97,7 @@ def gen_hyper_keys(minion_id,
     ccert = os.path.join(sub_dir, 'clientcert.pem')
     clientinfo = os.path.join(sub_dir, 'client.info')
     if not os.path.isfile(srvinfo):
-        with salt.utils.fopen(srvinfo, 'w+') as fp_:
+        with salt.utils.files.fopen(srvinfo, 'w+') as fp_:
             infodat = ('organization = salted\ncn = {0}\ntls_www_server'
                        '\nencryption_key\nsigning_key'
                        '\ndigitalSignature\nexpiration_days = {1}'
@@ -114,7 +115,7 @@ def gen_hyper_keys(minion_id,
                ).format(priv, cacert, cakey, srvinfo, cert)
         subprocess.call(cmd, shell=True)
     if not os.path.isfile(clientinfo):
-        with salt.utils.fopen(clientinfo, 'w+') as fp_:
+        with salt.utils.files.fopen(clientinfo, 'w+') as fp_:
             infodat = ('country = {0}\nstate = {1}\nlocality = '
                        '{2}\norganization = {3}\ncn = {4}\n'
                        'tls_www_client\nencryption_key\nsigning_key\n'

--- a/salt/pillar/pepa.py
+++ b/salt/pillar/pepa.py
@@ -282,7 +282,7 @@ from os.path import isfile, join
 # Import Salt libs
 import salt.ext.six as six
 from salt.ext.six.moves import input  # pylint: disable=import-error,redefined-builtin
-import salt.utils
+import salt.utils.files
 from salt.utils.yamlloader import SaltYamlSafeLoader
 
 # Import 3rd-party libs
@@ -428,7 +428,7 @@ def ext_pillar(minion_id, pillar, resource, sequence, subkey=False, subkey_only=
             fn = join(templdir, re.sub(r'\W', '_', entry.lower()) + '.yaml')
             if isfile(fn):
                 log.info("Loading template: {0}".format(fn))
-                with salt.utils.fopen(fn) as fhr:
+                with salt.utils.files.fopen(fn) as fhr:
                     template = jinja2.Template(fhr.read())
                 output['pepa_templates'].append(fn)
 
@@ -528,7 +528,7 @@ def validate(output, resource):
     pepa_schemas = []
     for fn in glob.glob(valdir + '/*.yaml'):
         log.info("Loading schema: {0}".format(fn))
-        with salt.utils.fopen(fn) as fhr:
+        with salt.utils.files.fopen(fn) as fhr:
             template = jinja2.Template(fhr.read())
         data = output
         data['grains'] = __grains__.copy()
@@ -557,7 +557,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     # Get configuration
-    with salt.utils.fopen(args.config) as fh_:
+    with salt.utils.files.fopen(args.config) as fh_:
         __opts__.update(
             yaml.load(
                 fh_.read(),

--- a/salt/pillar/s3.py
+++ b/salt/pillar/s3.py
@@ -106,6 +106,7 @@ from salt.ext.six.moves.urllib.parse import quote as _quote
 # Import salt libs
 from salt.pillar import Pillar
 import salt.utils
+import salt.utils.files
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -337,7 +338,7 @@ def _refresh_buckets_cache_file(creds, cache_file, multiple_env, environment, pr
 
     log.debug('Writing S3 buckets pillar cache file')
 
-    with salt.utils.fopen(cache_file, 'w') as fp_:
+    with salt.utils.files.fopen(cache_file, 'w') as fp_:
         pickle.dump(metadata, fp_)
 
     return metadata
@@ -350,7 +351,7 @@ def _read_buckets_cache_file(cache_file):
 
     log.debug('Reading buckets cache file')
 
-    with salt.utils.fopen(cache_file, 'rb') as fp_:
+    with salt.utils.files.fopen(cache_file, 'rb') as fp_:
         data = pickle.load(fp_)
 
     return data

--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -302,7 +302,7 @@ import re
 
 # Import Salt Libs
 from salt.ext.six import exec_
-import salt.utils
+import salt.utils.files
 import salt.loader
 from salt.fileclient import get_file_client
 from salt.utils.pyobjects import Registry, StateFactory, SaltObject, Map
@@ -457,7 +457,7 @@ def render(template, saltenv='base', sls='', salt_data=True, **kwargs):
                         'Could not find the file \'{0}\''.format(import_file)
                     )
 
-                with salt.utils.fopen(state_file) as state_fh:
+                with salt.utils.files.fopen(state_file) as state_fh:
                     state_contents, state_globals = process_template(state_fh)
                 exec_(state_contents, state_globals)
 

--- a/salt/renderers/stateconf.py
+++ b/salt/renderers/stateconf.py
@@ -35,7 +35,7 @@ import copy
 from os import path as ospath
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 from salt.exceptions import SaltRenderError
 
 # Import 3rd-party libs
@@ -206,7 +206,7 @@ def render(input, saltenv='base', sls='', argline='', **kws):
             raise INVALID_USAGE_ERROR
 
         if isinstance(input, six.string_types):
-            with salt.utils.fopen(input, 'r') as ifile:
+            with salt.utils.files.fopen(input, 'r') as ifile:
                 sls_templ = ifile.read()
         else:  # assume file-like
             sls_templ = input.read()

--- a/salt/returners/highstate_return.py
+++ b/salt/returners/highstate_return.py
@@ -89,7 +89,7 @@ import yaml
 from salt.ext.six.moves import range
 from salt.ext.six.moves import StringIO
 
-import salt.utils
+import salt.utils.files
 import salt.returners
 
 log = logging.getLogger(__name__)
@@ -440,7 +440,7 @@ def _produce_output(report, failed, setup):
 
     if report_delivery == 'file':
         output_file = _sprinkle(setup.get('file_output', '/tmp/test.rpt'))
-        with salt.utils.fopen(output_file, 'w') as out:
+        with salt.utils.files.fopen(output_file, 'w') as out:
             out.write(report_text)
     else:
         msg = MIMEText(report_text, report_format)
@@ -490,7 +490,7 @@ def __test_html():
         report_delivery: file
         file_output: '/srv/salt/_returners/test.rpt'
     '''
-    with salt.utils.fopen('test.rpt', 'r') as input_file:
+    with salt.utils.files.fopen('test.rpt', 'r') as input_file:
         data_text = input_file.read()
     data = yaml.safe_load(data_text)
 
@@ -499,7 +499,7 @@ def __test_html():
     string_file.seek(0)
     result = string_file.read()
 
-    with salt.utils.fopen('test.html', 'w') as output:
+    with salt.utils.files.fopen('test.html', 'w') as output:
         output.write(result)
 
 

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -16,9 +16,10 @@ import bisect
 
 # Import salt libs
 import salt.payload
-import salt.utils
+import salt.utils.atomicfile
 import salt.utils.files
 import salt.utils.jid
+import salt.utils.minions
 import salt.exceptions
 
 # Import 3rd-party libs
@@ -69,7 +70,7 @@ def _walk_through(job_dir):
             if not os.path.isfile(load_path):
                 continue
 
-            with salt.utils.fopen(load_path, 'rb') as rfh:
+            with salt.utils.files.fopen(load_path, 'rb') as rfh:
                 job = serial.load(rfh)
                 jid = job['jid']
                 yield jid, job, t_path, final
@@ -106,13 +107,13 @@ def prep_jid(nocache=False, passed_jid=None, recurse_count=0):
                 return prep_jid(nocache=nocache, recurse_count=recurse_count+1)
 
     try:
-        with salt.utils.fopen(os.path.join(jid_dir, 'jid'), 'wb+') as fn_:
+        with salt.utils.files.fopen(os.path.join(jid_dir, 'jid'), 'wb+') as fn_:
             if six.PY2:
                 fn_.write(jid)
             else:
                 fn_.write(bytes(jid, 'utf-8'))
         if nocache:
-            with salt.utils.fopen(os.path.join(jid_dir, 'nocache'), 'wb+') as fn_:
+            with salt.utils.files.fopen(os.path.join(jid_dir, 'nocache'), 'wb+') as fn_:
                 fn_.write(b'')
     except IOError:
         log.warning('Could not write out jid file for job {0}. Retrying.'.format(jid))
@@ -209,7 +210,7 @@ def save_load(jid, clear_load, minions=None, recurse_count=0):
         else:
             raise
     try:
-        with salt.utils.fopen(os.path.join(jid_dir, LOAD_P), 'w+b') as wfh:
+        with salt.utils.files.fopen(os.path.join(jid_dir, LOAD_P), 'w+b') as wfh:
             serial.dump(clear_load, wfh)
     except IOError as exc:
         log.warning(
@@ -274,7 +275,7 @@ def save_minions(jid, minions, syndic_id=None):
                 os.makedirs(jid_dir)
             except OSError:
                 pass
-        with salt.utils.fopen(minions_path, 'w+b') as wfh:
+        with salt.utils.files.fopen(minions_path, 'w+b') as wfh:
             serial.dump(minions, wfh)
     except IOError as exc:
         log.error(
@@ -292,7 +293,7 @@ def get_load(jid):
     if not os.path.exists(jid_dir) or not os.path.exists(load_fn):
         return {}
     serial = salt.payload.Serial(__opts__)
-    with salt.utils.fopen(os.path.join(jid_dir, LOAD_P), 'rb') as rfh:
+    with salt.utils.files.fopen(os.path.join(jid_dir, LOAD_P), 'rb') as rfh:
         ret = serial.load(rfh)
 
     minions_cache = [os.path.join(jid_dir, MINIONS_P)]
@@ -303,7 +304,7 @@ def get_load(jid):
     for minions_path in minions_cache:
         log.debug('Reading minion list from %s', minions_path)
         try:
-            with salt.utils.fopen(minions_path, 'rb') as rfh:
+            with salt.utils.files.fopen(minions_path, 'rb') as rfh:
                 all_minions.update(serial.load(rfh))
         except IOError as exc:
             salt.utils.files.process_read_exception(exc, minions_path)
@@ -335,7 +336,7 @@ def get_jid(jid):
                 continue
             while fn_ not in ret:
                 try:
-                    with salt.utils.fopen(retp, 'rb') as rfh:
+                    with salt.utils.files.fopen(retp, 'rb') as rfh:
                         ret_data = serial.load(rfh)
                     if not isinstance(ret_data, dict) or 'return' not in ret_data:
                         # Convert the old format in which return.p contains the only return data to
@@ -344,7 +345,7 @@ def get_jid(jid):
                         ret_data = {'return': ret_data}
                     ret[fn_] = ret_data
                     if os.path.isfile(outp):
-                        with salt.utils.fopen(outp, 'rb') as rfh:
+                        with salt.utils.files.fopen(outp, 'rb') as rfh:
                             ret[fn_]['out'] = serial.load(rfh)
                 except Exception as exc:
                     if 'Permission denied:' in str(exc):
@@ -455,7 +456,7 @@ def update_endtime(jid, time):
     try:
         if not os.path.exists(jid_dir):
             os.makedirs(jid_dir)
-        with salt.utils.fopen(os.path.join(jid_dir, ENDTIME), 'w') as etfile:
+        with salt.utils.files.fopen(os.path.join(jid_dir, ENDTIME), 'w') as etfile:
             etfile.write(time)
     except IOError as exc:
         log.warning('Could not write job invocation cache file: {0}'.format(exc))
@@ -471,7 +472,7 @@ def get_endtime(jid):
     etpath = os.path.join(jid_dir, ENDTIME)
     if not os.path.exists(etpath):
         return False
-    with salt.utils.fopen(etpath, 'r') as etfile:
+    with salt.utils.files.fopen(etpath, 'r') as etfile:
         endtime = etfile.read().strip('\n')
     return endtime
 
@@ -498,7 +499,7 @@ def save_reg(data):
         else:
             raise
     try:
-        with salt.utils.fopen(regfile, 'a') as fh_:
+        with salt.utils.files.fopen(regfile, 'a') as fh_:
             msgpack.dump(data, fh_)
     except:
         log.error('Could not write to msgpack file {0}'.format(__opts__['outdir']))
@@ -512,7 +513,7 @@ def load_reg():
     reg_dir = _reg_dir()
     regfile = os.path.join(reg_dir, 'register')
     try:
-        with salt.utils.fopen(regfile, 'r') as fh_:
+        with salt.utils.files.fopen(regfile, 'r') as fh_:
             return msgpack.load(fh_)
     except:
         log.error('Could not write to msgpack file {0}'.format(__opts__['outdir']))

--- a/salt/returners/rawfile_json.py
+++ b/salt/returners/rawfile_json.py
@@ -24,6 +24,7 @@ import json
 
 import salt.returners
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ def returner(ret):
     '''
     opts = _get_options({})  # Pass in empty ret, since this is a list of events
     try:
-        with salt.utils.flopen(opts['filename'], 'a') as logfile:
+        with salt.utils.files.flopen(opts['filename'], 'a') as logfile:
             logfile.write(json.dumps(ret)+'\n')
     except:
         log.error('Could not write to rawdata_json file {0}'.format(opts['filename']))
@@ -74,7 +75,7 @@ def event_return(events):
         return
     opts = _get_options({})  # Pass in empty ret, since this is a list of events
     try:
-        with salt.utils.flopen(opts['filename'], 'a') as logfile:
+        with salt.utils.files.flopen(opts['filename'], 'a') as logfile:
             for event in events:
                 json.dump(event, logfile)
                 logfile.write('\n')

--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -97,6 +97,7 @@ import subprocess
 
 # Import Salt libs
 import salt.utils
+import salt.utils.files
 from salt.roster import get_roster_file
 
 # Import 3rd-party libs
@@ -183,7 +184,7 @@ class Inventory(Target):
         blocks = re.compile(r'^\[.*\]$')
         hostvar = re.compile(r'^\[([^:]+):vars\]$')
         parents = re.compile(r'^\[([^:]+):children\]$')
-        with salt.utils.fopen(inventory_file) as config:
+        with salt.utils.files.fopen(inventory_file) as config:
             for line in config.read().split('\n'):
                 if not line or line.startswith('#'):
                     continue

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -15,6 +15,7 @@ import salt.minion
 import salt.utils
 import salt.utils.args
 import salt.utils.event
+import salt.utils.files
 from salt.client import mixins
 from salt.output import display_output
 from salt.utils.lazy import verify_fun
@@ -204,7 +205,7 @@ class Runner(RunnerClient):
                 if self.opts.get('eauth'):
                     if 'token' in self.opts:
                         try:
-                            with salt.utils.fopen(os.path.join(self.opts['cachedir'], '.root_key'), 'r') as fp_:
+                            with salt.utils.files.fopen(os.path.join(self.opts['cachedir'], '.root_key'), 'r') as fp_:
                                 low['key'] = fp_.readline()
                         except IOError:
                             low['token'] = self.opts['token']

--- a/salt/runners/ddns.py
+++ b/salt/runners/ddns.py
@@ -28,7 +28,7 @@ except ImportError:
     HAS_LIBS = False
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ def __virtual__():
 def _get_keyring(keyfile):
     keyring = None
     if keyfile and os.path.isfile(os.path.expanduser(keyfile)):
-        with salt.utils.fopen(keyfile) as _f:
+        with salt.utils.files.fopen(keyfile) as _f:
             keyring = dns.tsigkeyring.from_text(json.load(_f))
 
     return keyring

--- a/salt/runners/digicertapi.py
+++ b/salt/runners/digicertapi.py
@@ -45,7 +45,7 @@ import json
 import re
 import salt.syspaths as syspaths
 import salt.cache
-import salt.utils
+import salt.utils.files
 import salt.utils.http
 import salt.ext.six as six
 from salt.ext.six.moves import range
@@ -568,7 +568,7 @@ def gen_csr(
 
     tmppriv = '{0}/priv'.format(tmpdir)
     tmpcsr = '{0}/csr'.format(tmpdir)
-    with salt.utils.fopen(tmppriv, 'w') as if_:
+    with salt.utils.files.fopen(tmppriv, 'w') as if_:
         if_.write(data['private_key'])
 
     subject = '/C={0}/ST={1}/L={2}/O={3}'.format(
@@ -596,7 +596,7 @@ def gen_csr(
             'have a valid Organization established inside CertCentral'
         )
 
-    with salt.utils.fopen(tmpcsr, 'r') as of_:
+    with salt.utils.files.fopen(tmpcsr, 'r') as of_:
         csr = of_.read()
 
     data['minion_id'] = minion_id

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -13,6 +13,7 @@ import os
 import salt.client
 import salt.payload
 import salt.utils
+import salt.utils.files
 import salt.utils.jid
 import salt.minion
 import salt.returners
@@ -577,13 +578,13 @@ def _walk_through(job_dir, display_progress=False):
 
         for final in os.listdir(t_path):
             load_path = os.path.join(t_path, final, '.load.p')
-            with salt.utils.fopen(load_path, 'rb') as rfh:
+            with salt.utils.files.fopen(load_path, 'rb') as rfh:
                 job = serial.load(rfh)
 
             if not os.path.isfile(load_path):
                 continue
 
-            with salt.utils.fopen(load_path, 'rb') as rfh:
+            with salt.utils.files.fopen(load_path, 'rb') as rfh:
                 job = serial.load(rfh)
             jid = job['jid']
             if display_progress:

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -15,6 +15,7 @@ import logging
 # Import Salt libs
 import salt.client
 import salt.utils
+import salt.utils.files
 import salt.utils.virt
 import salt.utils.cloud
 import salt.key
@@ -372,10 +373,10 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
         if explicit_auth:
             fcontent = ''
             if os.path.exists(key):
-                with salt.utils.fopen(key) as fic:
+                with salt.utils.files.fopen(key) as fic:
                     fcontent = fic.read().strip()
             if pub_key.strip() != fcontent:
-                with salt.utils.fopen(key, 'w') as fic:
+                with salt.utils.files.fopen(key, 'w') as fic:
                     fic.write(pub_key)
                     fic.flush()
         mid = j_ret.get('mid', None)

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -22,6 +22,7 @@ from salt.ext.six.moves.urllib.request import urlopen as _urlopen  # pylint: dis
 # Import salt libs
 import salt.key
 import salt.utils
+import salt.utils.files
 import salt.utils.minions
 import salt.client
 import salt.client.ssh
@@ -966,7 +967,7 @@ objShell.Exec("{1}{2}")'''
                  '  >>' + x + '.vbs\ncscript.exe /NoLogo ' + x + '.vbs'
 
     batch_path = tempfile.mkstemp(suffix='.bat')[1]
-    with salt.utils.fopen(batch_path, 'wb') as batch_file:
+    with salt.utils.files.fopen(batch_path, 'wb') as batch_file:
         batch_file.write(batch)
 
     for host in hosts.split(","):

--- a/salt/runners/nacl.py
+++ b/salt/runners/nacl.py
@@ -28,7 +28,7 @@ Now with the config in the master you can use the runner nacl like:
 from __future__ import absolute_import
 import base64
 import os
-import salt.utils
+import salt.utils.files
 import salt.syspaths
 
 
@@ -70,7 +70,7 @@ def _get_key(rstrip_newline=True, **kwargs):
     if not key and keyfile:
         if not os.path.isfile(keyfile):
             raise Exception('file not found: {0}'.format(keyfile))
-        with salt.utils.fopen(keyfile, 'rb') as keyf:
+        with salt.utils.files.fopen(keyfile, 'rb') as keyf:
             key = keyf.read()
     if key is None:
         raise Exception('no key found')
@@ -98,7 +98,7 @@ def keygen(keyfile=None):
     if keyfile:
         if os.path.isfile(keyfile):
             raise Exception('file already found: {0}'.format(keyfile))
-        with salt.utils.fopen(keyfile, 'w') as keyf:
+        with salt.utils.files.fopen(keyfile, 'w') as keyf:
             keyf.write(key)
             return 'saved: {0}'.format(keyfile)
     return key

--- a/salt/runners/network.py
+++ b/salt/runners/network.py
@@ -11,6 +11,7 @@ import socket
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ def wollist(maclist, bcast='255.255.255.255', destport=9):
     '''
     ret = []
     try:
-        with salt.utils.fopen(maclist, 'r') as ifile:
+        with salt.utils.files.fopen(maclist, 'r') as ifile:
             for mac in ifile:
                 wol(mac.strip(), bcast, destport)
                 print('Waking up {0}'.format(mac.strip()))

--- a/salt/runners/venafiapi.py
+++ b/salt/runners/venafiapi.py
@@ -37,7 +37,7 @@ from Crypto.PublicKey import RSA
 import json
 import salt.syspaths as syspaths
 import salt.cache
-import salt.utils
+import salt.utils.files
 import salt.ext.six as six
 from salt.exceptions import CommandExecutionError
 
@@ -188,7 +188,7 @@ def gen_csr(
 
     tmppriv = '{0}/priv'.format(tmpdir)
     tmpcsr = '{0}/csr'.format(tmpdir)
-    with salt.utils.fopen(tmppriv, 'w') as if_:
+    with salt.utils.files.fopen(tmppriv, 'w') as if_:
         if_.write(data['private_key'])
 
     if country is None:
@@ -232,7 +232,7 @@ def gen_csr(
             'country, state, loc, org, org_unit'
         )
 
-    with salt.utils.fopen(tmpcsr, 'r') as of_:
+    with salt.utils.files.fopen(tmpcsr, 'r') as of_:
         csr = of_.read()
 
     data['minion_id'] = minion_id

--- a/salt/runners/virt.py
+++ b/salt/runners/virt.py
@@ -10,7 +10,7 @@ import logging
 
 # Import Salt libs
 import salt.client
-import salt.utils.virt
+import salt.utils.files
 import salt.utils.cloud
 import salt.key
 from salt.exceptions import SaltClientError
@@ -245,7 +245,7 @@ def init(
         __jid_event__.fire_event({'message': 'Minion will be preseeded'}, 'progress')
         priv_key, pub_key = salt.utils.cloud.gen_keys()
         accepted_key = os.path.join(__opts__['pki_dir'], 'minions', name)
-        with salt.utils.fopen(accepted_key, 'w') as fp_:
+        with salt.utils.files.fopen(accepted_key, 'w') as fp_:
             fp_.write(pub_key)
 
     client = salt.client.get_local_client(__opts__['conf_file'])

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -19,7 +19,7 @@ except ImportError:
 
 # Import salt libs
 from salt.exceptions import CommandExecutionError, SaltRenderError
-import salt.utils
+import salt.utils.files
 import salt.utils.gitfs
 import logging
 import salt.minion
@@ -119,7 +119,7 @@ def genrepo(opts=None, fire_event=True):
                             revmap[repodata['full_name']] = pkgname
                     ret.setdefault('repo', {}).update(config)
                     ret.setdefault('name_map', {}).update(revmap)
-    with salt.utils.fopen(
+    with salt.utils.files.fopen(
             os.path.join(winrepo_dir, winrepo_cachefile), 'w+b') as repo:
         repo.write(msgpack.dumps(ret))
     return ret

--- a/salt/sdb/yaml.py
+++ b/salt/sdb/yaml.py
@@ -42,6 +42,7 @@ import logging
 import salt.exceptions
 import salt.loader
 import salt.utils
+import salt.utils.files
 import salt.utils.dictupdate
 
 log = logging.getLogger(__name__)
@@ -76,7 +77,7 @@ def _get_values(profile=None):
     ret = {}
     for fname in profile.get('files', []):
         try:
-            with salt.utils.flopen(fname) as f:
+            with salt.utils.files.flopen(fname) as f:
                 contents = serializers.yaml.deserialize(f)
                 ret = salt.utils.dictupdate.merge(ret, contents,
                         **profile.get('merge', {}))

--- a/salt/spm/__init__.py
+++ b/salt/spm/__init__.py
@@ -11,7 +11,6 @@ import os
 import yaml
 import tarfile
 import shutil
-import msgpack
 import hashlib
 import logging
 import pwd
@@ -23,7 +22,7 @@ import salt.client
 import salt.config
 import salt.loader
 import salt.cache
-import salt.utils
+import salt.utils.files
 import salt.utils.http as http
 import salt.syspaths as syspaths
 import salt.ext.six as six
@@ -354,7 +353,7 @@ class SPMClient(object):
                 dl_url = dl_url.replace('file://', '')
                 shutil.copyfile(dl_url, out_file)
             else:
-                with salt.utils.fopen(out_file, 'w') as outf:
+                with salt.utils.files.fopen(out_file, 'w') as outf:
                     outf.write(self._query_http(dl_url, repo_info['info']))
 
         # First we download everything, then we install
@@ -612,7 +611,7 @@ class SPMClient(object):
 
         for repo_file in repo_files:
             repo_path = '{0}.d/{1}'.format(self.opts['spm_repos_config'], repo_file)
-            with salt.utils.fopen(repo_path) as rph:
+            with salt.utils.files.fopen(repo_path) as rph:
                 repo_data = yaml.safe_load(rph)
                 for repo in repo_data:
                     if repo_data[repo].get('enabled', True) is False:
@@ -670,7 +669,7 @@ class SPMClient(object):
             dl_path = '{0}/SPM-METADATA'.format(repo_info['url'])
             if dl_path.startswith('file://'):
                 dl_path = dl_path.replace('file://', '')
-                with salt.utils.fopen(dl_path, 'r') as rpm:
+                with salt.utils.files.fopen(dl_path, 'r') as rpm:
                     metadata = yaml.safe_load(rpm)
             else:
                 metadata = self._query_http(dl_path, repo_info)
@@ -781,7 +780,7 @@ class SPMClient(object):
                     repo_metadata[spm_name]['filename'] = spm_file
 
         metadata_filename = '{0}/SPM-METADATA'.format(repo_path)
-        with salt.utils.fopen(metadata_filename, 'w') as mfh:
+        with salt.utils.files.fopen(metadata_filename, 'w') as mfh:
             yaml.dump(
                 repo_metadata,
                 mfh,
@@ -1016,7 +1015,7 @@ class SPMClient(object):
         formula_path = '{0}/FORMULA'.format(self.abspath)
         if not os.path.exists(formula_path):
             raise SPMPackageError('Formula file {0} not found'.format(formula_path))
-        with salt.utils.fopen(formula_path) as fp_:
+        with salt.utils.files.fopen(formula_path) as fp_:
             formula_conf = yaml.safe_load(fp_)
 
         for field in ('name', 'version', 'release', 'summary', 'description'):

--- a/salt/spm/pkgfiles/local.py
+++ b/salt/spm/pkgfiles/local.py
@@ -14,6 +14,7 @@ import logging
 # Import Salt libs
 import salt.syspaths
 import salt.utils
+import salt.utils.files
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -183,7 +184,7 @@ def hash_file(path, hashobj, conn=None):
     if os.path.isdir(path):
         return ''
 
-    with salt.utils.fopen(path, 'r') as f:
+    with salt.utils.files.fopen(path, 'r') as f:
         hashobj.update(salt.utils.to_bytes(f.read()))
         return hashobj.hexdigest()
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -32,9 +32,11 @@ import salt.loader
 import salt.minion
 import salt.pillar
 import salt.fileclient
+import salt.utils.args
 import salt.utils.crypt
 import salt.utils.dictupdate
 import salt.utils.event
+import salt.utils.files
 import salt.utils.url
 import salt.utils.process
 import salt.syspaths as syspaths
@@ -1702,7 +1704,7 @@ class State(object):
                 # Looks like the directory was created between the check
                 # and the attempt, we are safe to pass
                 pass
-        with salt.utils.fopen(tfile, 'wb+') as fp_:
+        with salt.utils.files.fopen(tfile, 'wb+') as fp_:
             fp_.write(msgpack.dumps(ret))
 
     def call_parallel(self, cdata, low):
@@ -2045,7 +2047,7 @@ class State(object):
                                'name': running[tag]['name'],
                                'changes': {}}
                     try:
-                        with salt.utils.fopen(ret_cache, 'rb') as fp_:
+                        with salt.utils.files.fopen(ret_cache, 'rb') as fp_:
                             ret = msgpack.loads(fp_.read())
                     except (OSError, IOError):
                         ret = {'result': False,
@@ -3623,7 +3625,7 @@ class BaseHighState(object):
 
         if cache:
             if os.path.isfile(cfn):
-                with salt.utils.fopen(cfn, 'rb') as fp_:
+                with salt.utils.files.fopen(cfn, 'rb') as fp_:
                     high = self.serial.load(fp_)
                     return self.state.call_high(high, orchestration_jid)
         # File exists so continue
@@ -3668,7 +3670,7 @@ class BaseHighState(object):
             if salt.utils.is_windows():
                 # Make sure cache file isn't read-only
                 self.state.functions['cmd.run']('attrib -R "{0}"'.format(cfn), output_loglevel='quiet')
-            with salt.utils.fopen(cfn, 'w+b') as fp_:
+            with salt.utils.files.fopen(cfn, 'w+b') as fp_:
                 try:
                     self.serial.dump(high, fp_)
                 except TypeError:

--- a/salt/states/apache.py
+++ b/salt/states/apache.py
@@ -45,7 +45,7 @@ from __future__ import absolute_import
 import os.path
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 
 
 def __virtual__():
@@ -61,7 +61,7 @@ def configfile(name, config):
     configs = __salt__['apache.config'](name, config, edit=False)
     current_configs = ''
     if os.path.exists(name):
-        with salt.utils.fopen(name) as config_file:
+        with salt.utils.files.fopen(name) as config_file:
             current_configs = config_file.read()
 
     if configs == current_configs.strip():
@@ -78,7 +78,7 @@ def configfile(name, config):
         return ret
 
     try:
-        with salt.utils.fopen(name, 'w') as config_file:
+        with salt.utils.files.fopen(name, 'w') as config_file:
             print(configs, file=config_file)
         ret['changes'] = {
             'old': current_configs,

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -866,7 +866,7 @@ def extracted(name,
 
         if os.path.isdir(cached_source):
             # Prevent a traceback from attempting to read from a directory path
-            salt.utils.rm_rf(cached_source)
+            salt.utils.files.rm_rf(cached_source)
 
     existing_cached_source_sum = _read_cached_checksum(cached_source)
 
@@ -1117,7 +1117,7 @@ def extracted(name,
                         for path in incorrect_type:
                             full_path = os.path.join(name, path)
                             try:
-                                salt.utils.rm_rf(full_path.rstrip(os.sep))
+                                salt.utils.files.rm_rf(full_path.rstrip(os.sep))
                                 ret['changes'].setdefault(
                                     'removed', []).append(full_path)
                                 extraction_needed = True
@@ -1176,7 +1176,7 @@ def extracted(name,
                 full_path = os.path.join(name, path)
                 try:
                     log.debug('Removing %s', full_path)
-                    salt.utils.rm_rf(full_path.rstrip(os.sep))
+                    salt.utils.files.rm_rf(full_path.rstrip(os.sep))
                     ret['changes'].setdefault(
                         'removed', []).append(full_path)
                 except OSError as exc:

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -70,7 +70,7 @@ def _update_checksum(cached_source):
         lines = []
         try:
             try:
-                with salt.utils.fopen(cached_source_sum, 'r') as fp_:
+                with salt.utils.files.fopen(cached_source_sum, 'r') as fp_:
                     for line in fp_:
                         try:
                             lines.append(line.rstrip('\n').split(':', 1))
@@ -80,7 +80,7 @@ def _update_checksum(cached_source):
                 if exc.errno != errno.ENOENT:
                     raise
 
-            with salt.utils.fopen(cached_source_sum, 'w') as fp_:
+            with salt.utils.files.fopen(cached_source_sum, 'w') as fp_:
                 for line in lines:
                     if line[0] == hash_type:
                         line[1] = hsum
@@ -99,7 +99,7 @@ def _read_cached_checksum(cached_source, form=None):
         form = __opts__['hash_type']
     path = '.'.join((cached_source, 'hash'))
     try:
-        with salt.utils.fopen(path, 'r') as fp_:
+        with salt.utils.files.fopen(path, 'r') as fp_:
             for line in fp_:
                 # Should only be one line in this file but just in case it
                 # isn't, read only a single line to avoid overuse of memory.

--- a/salt/states/augeas.py
+++ b/salt/states/augeas.py
@@ -37,6 +37,7 @@ import difflib
 
 # Import Salt libs
 import salt.utils
+import salt.utils.files
 
 from salt.modules.augeas_cfg import METHOD_MAP
 
@@ -275,7 +276,7 @@ def change(name, context=None, changes=None, lens=None,
     old_file = []
     if filename is not None:
         if os.path.isfile(filename):
-            with salt.utils.fopen(filename, 'r') as file_:
+            with salt.utils.files.fopen(filename, 'r') as file_:
                 old_file = file_.readlines()
 
     result = __salt__['augeas.execute'](
@@ -288,7 +289,7 @@ def change(name, context=None, changes=None, lens=None,
         return ret
 
     if old_file:
-        with salt.utils.fopen(filename, 'r') as file_:
+        with salt.utils.files.fopen(filename, 'r') as file_:
             diff = ''.join(
                 difflib.unified_diff(old_file, file_.readlines(), n=0))
 

--- a/salt/states/boto_apigateway.py
+++ b/salt/states/boto_apigateway.py
@@ -57,7 +57,7 @@ import json
 import yaml
 # Import Salt Libs
 import salt.ext.six as six
-import salt.utils
+import salt.utils.files
 from salt.utils.yamlloader import SaltYamlSafeLoader
 
 log = logging.getLogger(__name__)
@@ -432,7 +432,7 @@ def _gen_md5_filehash(fname, *args):
     and participates in the hash calculation
     '''
     _hash = hashlib.md5()
-    with salt.utils.fopen(fname, 'rb') as f:
+    with salt.utils.files.fopen(fname, 'rb') as f:
         for chunk in iter(lambda: f.read(4096), b''):
             _hash.update(chunk)
 
@@ -713,7 +713,7 @@ class _Swagger(object):
                 self._md5_filehash = _gen_md5_filehash(self._swagger_file,
                                                        error_response_template,
                                                        response_template)
-                with salt.utils.fopen(self._swagger_file, 'rb') as sf:
+                with salt.utils.files.fopen(self._swagger_file, 'rb') as sf:
                     self._cfg = yaml.load(
                         sf,
                         Loader=SaltYamlSafeLoader

--- a/salt/states/boto_iam.py
+++ b/salt/states/boto_iam.py
@@ -139,6 +139,7 @@ import os
 
 # Import Salt Libs
 import salt.utils
+import salt.utils.files
 import salt.utils.odict as odict
 import salt.utils.dictupdate as dictupdate
 import salt.ext.six as six
@@ -380,7 +381,7 @@ def keys_present(name, number, save_dir, region=None, key=None, keyid=None, prof
         new_keys[str(i)]['key_id'] = created[response][result]['access_key']['access_key_id']
         new_keys[str(i)]['secret_key'] = created[response][result]['access_key']['secret_access_key']
     try:
-        with salt.utils.fopen('{0}/{1}'.format(save_dir, name), 'a') as _wrf:
+        with salt.utils.files.fopen('{0}/{1}'.format(save_dir, name), 'a') as _wrf:
             for key_num, key in new_keys.items():
                 key_id = key['key_id']
                 secret_key = key['secret_key']

--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -72,6 +72,7 @@ import json
 import salt.ext.six as six
 import salt.utils.dictupdate as dictupdate
 import salt.utils
+import salt.utils.files
 from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
@@ -407,7 +408,7 @@ def _function_code_present(FunctionName, ZipFile, S3Bucket, S3Key,
         size = os.path.getsize(ZipFile)
         if size == func['CodeSize']:
             sha = hashlib.sha256()
-            with salt.utils.fopen(ZipFile, 'rb') as f:
+            with salt.utils.files.fopen(ZipFile, 'rb') as f:
                 sha.update(f.read())
             hashed = sha.digest().encode('base64').strip()
             if hashed != func['CodeSha256']:

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -143,7 +143,6 @@ from __future__ import absolute_import
 import os
 
 # Import salt libs
-import salt.utils
 import salt.utils.files
 from salt.modules.cron import (
     _needs_change,
@@ -529,7 +528,7 @@ def file(name,
         return ret
 
     cron_path = salt.utils.files.mkstemp()
-    with salt.utils.fopen(cron_path, 'w+') as fp_:
+    with salt.utils.files.fopen(cron_path, 'w+') as fp_:
         raw_cron = __salt__['cron.raw_cron'](user)
         if not raw_cron.endswith('\n'):
             raw_cron = "{0}\n".format(raw_cron)

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -98,7 +98,7 @@ import logging
 
 # Import Salt Libs
 import salt.ext.six as six
-import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 # Get Logging Started
@@ -757,7 +757,7 @@ def ssh_configured(name,
             if not ssh_key:
                 ssh_key = ''
                 # Open ssh key file and read in contents to create one key string
-                with salt.utils.fopen(ssh_key_file, 'r') as key_file:
+                with salt.utils.files.fopen(ssh_key_file, 'r') as key_file:
                     for line in key_file:
                         if line.startswith('#'):
                             # Commented line

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -320,7 +320,7 @@ def _load_accumulators():
         serial = salt.payload.Serial(__opts__)
         ret = {'accumulators': {}, 'accumulators_deps': {}}
         try:
-            with salt.utils.fopen(path, 'rb') as f:
+            with salt.utils.files.fopen(path, 'rb') as f:
                 loaded = serial.load(f)
                 return loaded if loaded else ret
         except (IOError, NameError):
@@ -338,7 +338,7 @@ def _persist_accummulators(accumulators, accumulators_deps):
 
     serial = salt.payload.Serial(__opts__)
     try:
-        with salt.utils.fopen(_get_accumulator_filepath(), 'w+b') as f:
+        with salt.utils.files.fopen(_get_accumulator_filepath(), 'w+b') as f:
             serial.dump(accumm_data, f)
     except NameError:
         # msgpack error from salt-ssh
@@ -1065,7 +1065,7 @@ def _get_template_texts(source_list=None,
         log.debug(msg.format(rndrd_templ_fn, source))
         if rndrd_templ_fn:
             tmplines = None
-            with salt.utils.fopen(rndrd_templ_fn, 'rb') as fp_:
+            with salt.utils.files.fopen(rndrd_templ_fn, 'rb') as fp_:
                 tmplines = fp_.read()
                 if six.PY3:
                     tmplines = tmplines.decode(__salt_system_encoding__)
@@ -4314,7 +4314,7 @@ def comment(name, regex, char='#', backup='.bak'):
         ret['comment'] = 'File {0} is set to be updated'.format(name)
         ret['result'] = None
         return ret
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
@@ -4323,7 +4323,7 @@ def comment(name, regex, char='#', backup='.bak'):
     # Perform the edit
     __salt__['file.comment_line'](name, regex, char, True, backup)
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
@@ -4422,7 +4422,7 @@ def uncomment(name, regex, char='#', backup='.bak'):
         ret['result'] = None
         return ret
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
@@ -4431,7 +4431,7 @@ def uncomment(name, regex, char='#', backup='.bak'):
     # Perform the edit
     __salt__['file.comment_line'](name, regex, char, False, backup)
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
@@ -4655,7 +4655,7 @@ def append(name,
 
     text = _validate_str_list(text)
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
@@ -4706,7 +4706,7 @@ def append(name,
     else:
         ret['comment'] = 'File {0} is in correct state'.format(name)
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
@@ -4847,7 +4847,7 @@ def prepend(name,
 
     text = _validate_str_list(text)
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
@@ -4896,7 +4896,7 @@ def prepend(name,
 
     # if header kwarg is True, use verbatim compare
     if header:
-        with salt.utils.fopen(name, 'rb') as fp_:
+        with salt.utils.files.fopen(name, 'rb') as fp_:
             # read as many lines of target file as length of user input
             contents = fp_.read()
             if six.PY3:
@@ -4917,7 +4917,7 @@ def prepend(name,
     else:
         __salt__['file.prepend'](name, *preface)
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
@@ -5732,7 +5732,7 @@ def serialize(name,
                         'name': name,
                         'result': False}
 
-            with salt.utils.fopen(name, 'r') as fhr:
+            with salt.utils.files.fopen(name, 'r') as fhr:
                 existing_data = __serializers__[deserializer_name](fhr)
 
             if existing_data is not None:

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -22,6 +22,7 @@ import string
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.url
 from salt.exceptions import CommandExecutionError
 from salt.utils.versions import LooseVersion as _LooseVersion
@@ -1597,7 +1598,7 @@ def latest(name,
                 for target_object in target_contents:
                     target_path = os.path.join(target, target_object)
                     try:
-                        salt.utils.rm_rf(target_path)
+                        salt.utils.files.rm_rf(target_path)
                     except OSError as exc:
                         if exc.errno != errno.ENOENT:
                             removal_errors[target_path] = exc
@@ -1950,7 +1951,7 @@ def present(name,
                 if os.path.islink(name):
                     os.unlink(name)
                 else:
-                    salt.utils.rm_rf(name)
+                    salt.utils.files.rm_rf(name)
             except OSError as exc:
                 return _fail(
                     ret,
@@ -2299,7 +2300,7 @@ def detached(name,
                     if os.path.islink(target):
                         os.unlink(target)
                     else:
-                        salt.utils.rm_rf(target)
+                        salt.utils.files.rm_rf(target)
                 except OSError as exc:
                     return _fail(
                         ret,

--- a/salt/states/heat.py
+++ b/salt/states/heat.py
@@ -40,7 +40,6 @@ import logging
 
 # Import third party libs
 import salt.ext.six as six
-import salt.utils
 import salt.utils.files
 import salt.exceptions
 import yaml
@@ -212,9 +211,9 @@ def deployed(name, template=None, enviroment=None, params=None, poll=5,
 
             if (template_manage_result['result']) or \
                     ((__opts__['test']) and (template_manage_result['result'] is not False)):
-                with salt.utils.fopen(template_tmp_file, 'r') as tfp_:
+                with salt.utils.files.fopen(template_tmp_file, 'r') as tfp_:
                     tpl = tfp_.read()
-                    salt.utils.safe_rm(template_tmp_file)
+                    salt.utils.files.safe_rm(template_tmp_file)
                     try:
                         if isinstance(tpl, six.binary_type):
                             tpl = tpl.decode('utf-8')
@@ -223,7 +222,7 @@ def deployed(name, template=None, enviroment=None, params=None, poll=5,
                             template_new = yaml.dump(template_parse, Dumper=YamlDumper)
                         else:
                             template_new = jsonutils.dumps(template_parse, indent=2, ensure_ascii=False)
-                        salt.utils.safe_rm(template_tmp_file)
+                        salt.utils.files.safe_rm(template_tmp_file)
                     except ValueError as ex:
                         ret['result'] = False
                         ret['comment'] = 'Error parsing template {0}'.format(ex)

--- a/salt/states/icinga2.py
+++ b/salt/states/icinga2.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import os.path
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 
 
 def __virtual__():
@@ -119,7 +119,7 @@ def generate_ticket(name, output=None, grain=None, key=None, overwrite=True):
             ret['changes']['ticket'] = "Executed. Output into grain: {0}:{1}".format(grain, key)
     elif output:
         ret['changes']['ticket'] = "Executed. Output into {0}".format(output)
-        with salt.utils.fopen(output, 'w') as output_file:
+        with salt.utils.files.fopen(output, 'w') as output_file:
             output_file.write(str(ticket))
     else:
         ret['changes']['ticket'] = "Executed"

--- a/salt/states/jenkins.py
+++ b/salt/states/jenkins.py
@@ -15,7 +15,7 @@ import logging
 # Import Salt libs
 import salt.ext.six as six
 from salt.ext.six.moves import zip
-import salt.utils
+import salt.utils.files
 
 # Import XML parser
 import xml.etree.ElementTree as ET
@@ -62,7 +62,7 @@ def present(name,
         oldXML = ET.fromstring(buf.read())
 
         cached_source_path = __salt__['cp.cache_file'](config, __env__)
-        with salt.utils.fopen(cached_source_path) as _fp:
+        with salt.utils.files.fopen(cached_source_path) as _fp:
             newXML = ET.fromstring(_fp.read())
         if not _elements_equal(oldXML, newXML):
             diff = difflib.unified_diff(
@@ -74,7 +74,7 @@ def present(name,
 
     else:
         cached_source_path = __salt__['cp.cache_file'](config, __env__)
-        with salt.utils.fopen(cached_source_path) as _fp:
+        with salt.utils.files.fopen(cached_source_path) as _fp:
             new_config_xml = _fp.read()
 
         __salt__['jenkins.create_job'](name, config, __env__)

--- a/salt/states/kapacitor.py
+++ b/salt/states/kapacitor.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 import difflib
 import logging
 
-import salt.utils
+import salt.utils.files
 
 LOG = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ def task_present(name,
     else:
         script_path = tick_script
 
-    with salt.utils.fopen(script_path, 'r') as file:
+    with salt.utils.files.fopen(script_path, 'r') as file:
         new_script = file.read().replace('\t', '    ')
 
     is_up_to_date = task and (

--- a/salt/states/mysql_query.py
+++ b/salt/states/mysql_query.py
@@ -26,7 +26,7 @@ import sys
 import os.path
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -189,7 +189,7 @@ def run_file(name,
                                     + grain + ":" + key
     elif output is not None:
         ret['changes']['query'] = "Executed. Output into " + output
-        with salt.utils.fopen(output, 'w') as output_file:
+        with salt.utils.files.fopen(output, 'w') as output_file:
             if 'results' in query_result:
                 for res in query_result['results']:
                     for col, val in six.iteritems(res):
@@ -329,7 +329,7 @@ def run(name,
                                     + grain + ":" + key
     elif output is not None:
         ret['changes']['query'] = "Executed. Output into " + output
-        with salt.utils.fopen(output, 'w') as output_file:
+        with salt.utils.files.fopen(output, 'w') as output_file:
             if 'results' in query_result:
                 for res in query_result['results']:
                     for col, val in six.iteritems(res):

--- a/salt/states/pcs.py
+++ b/salt/states/pcs.py
@@ -170,6 +170,7 @@ import os
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.ext.six as six
 
 log = logging.getLogger(__name__)
@@ -190,7 +191,7 @@ def _file_read(path):
     '''
     content = False
     if os.path.exists(path):
-        with salt.utils.fopen(path, 'r+') as fp_:
+        with salt.utils.files.fopen(path, 'r+') as fp_:
             content = fp_.read()
         fp_.close()
     return content
@@ -200,7 +201,7 @@ def _file_write(path, content):
     '''
     Write content to a file
     '''
-    with salt.utils.fopen(path, 'w+') as fp_:
+    with salt.utils.files.fopen(path, 'w+') as fp_:
         fp_.write(content)
     fp_.close()
 

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -95,6 +95,7 @@ from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.modules.aptpkg import _strip_uri
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 import salt.utils
+import salt.utils.files
 import salt.utils.pkg.deb
 import salt.utils.pkg.rpm
 
@@ -438,7 +439,7 @@ def managed(name, ppa=None, **kwargs):
 
     # empty file before configure
     if kwargs.get('clean_file', False):
-        with salt.utils.fopen(kwargs['file'], 'w'):
+        with salt.utils.files.fopen(kwargs['file'], 'w'):
             pass
 
     try:

--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -122,7 +122,7 @@ def _load_config():
     config = {}
 
     if os.path.isfile('/usbkey/config'):
-        with salt.utils.fopen('/usbkey/config', 'r') as config_file:
+        with salt.utils.files.fopen('/usbkey/config', 'r') as config_file:
             for optval in config_file:
                 if optval[0] == '#':
                     continue

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -26,6 +26,7 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 __virtualname__ = 'virt'
@@ -114,7 +115,7 @@ def keys(name, basepath='/etc/pki', **kwargs):
         if not os.path.exists(os.path.dirname(paths[key])):
             os.makedirs(os.path.dirname(paths[key]))
         if os.path.isfile(paths[key]):
-            with salt.utils.fopen(paths[key], 'r') as fp_:
+            with salt.utils.files.fopen(paths[key], 'r') as fp_:
                 if fp_.read() != pillar[p_key]:
                     ret['changes'][key] = 'update'
         else:
@@ -128,7 +129,7 @@ def keys(name, basepath='/etc/pki', **kwargs):
         ret['changes'] = {}
     else:
         for key in ret['changes']:
-            with salt.utils.fopen(paths[key], 'w+') as fp_:
+            with salt.utils.files.fopen(paths[key], 'w+') as fp_:
                 fp_.write(pillar['libvirt.{0}.pem'.format(key)])
 
         ret['comment'] = 'Updated libvirt certs and keys'

--- a/salt/template.py
+++ b/salt/template.py
@@ -66,7 +66,7 @@ def compile_template(template,
             log.error('Template does not exist: {0}'.format(template))
             return ret
         # Template is an empty file
-        if salt.utils.is_empty(template):
+        if salt.utils.files.is_empty(template):
             log.debug('Template is an empty file: {0}'.format(template))
             return ret
 
@@ -140,7 +140,7 @@ def compile_template_str(template, renderers, default, blacklist, whitelist):
     derived from the template.
     '''
     fn_ = salt.utils.files.mkstemp()
-    with salt.utils.fopen(fn_, 'wb') as ofile:
+    with salt.utils.files.fopen(fn_, 'wb') as ofile:
         ofile.write(SLS_ENCODER(template)[0])
     return compile_template(fn_, renderers, default, blacklist, whitelist)
 
@@ -168,7 +168,7 @@ def template_shebang(template, renderers, default, blacklist, whitelist, input_d
     if template == ':string:':
         line = input_data.split()[0]
     else:
-        with salt.utils.fopen(template, 'r') as ifile:
+        with salt.utils.files.fopen(template, 'r') as ifile:
             line = ifile.readline()
 
     # Check if it starts with a shebang and not a path

--- a/salt/thorium/file.py
+++ b/salt/thorium/file.py
@@ -45,7 +45,7 @@ import json
 
 # Import salt libs
 import salt.utils
-from salt.utils import simple_types_filter
+import salt.utils.files
 
 
 def save(name, filter=False):
@@ -78,9 +78,11 @@ def save(name, filter=False):
         fn_ = os.path.join(tgt_dir, name)
     if not os.path.isdir(tgt_dir):
         os.makedirs(tgt_dir)
-    with salt.utils.fopen(fn_, 'w+') as fp_:
+    with salt.utils.files.fopen(fn_, 'w+') as fp_:
         if filter is True:
-            fp_.write(json.dumps(simple_types_filter(__reg__)))
+            fp_.write(json.dumps(
+                salt.utils.simple_types_filter(__reg__))
+            )
         else:
             fp_.write(json.dumps(__reg__))
     return ret

--- a/salt/transport/local.py
+++ b/salt/transport/local.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function
 import logging
 
 # Import Salt Libs
-import salt.utils
+import salt.utils.files
 from salt.transport.client import ReqChannel
 
 log = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ class LocalChannel(ReqChannel):
             #data = json.loads(load)
             #{'path': 'apt-cacher-ng/map.jinja', 'saltenv': 'base', 'cmd': '_serve_file', 'loc': 0}
             #f = open(data['path'])
-            with salt.utils.fopen(load['path']) as f:
+            with salt.utils.files.fopen(load['path']) as f:
                 ret = {
                     'data': ''.join(f.readlines()),
                     'dest': load['path'],

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -16,6 +16,7 @@ import salt.payload
 import salt.master
 import salt.transport.frame
 import salt.utils.event
+import salt.utils.files
 import salt.ext.six as six
 from salt.utils.cache import CacheCli
 
@@ -111,7 +112,7 @@ class AESReqServerMixin(object):
             self.opts,
             key)
         try:
-            with salt.utils.fopen(pubfn) as f:
+            with salt.utils.files.fopen(pubfn) as f:
                 pub = RSA.importKey(f.read())
         except (ValueError, IndexError, TypeError):
             return self.crypticle.dumps({})
@@ -238,7 +239,7 @@ class AESReqServerMixin(object):
 
         elif os.path.isfile(pubfn):
             # The key has been accepted, check it
-            with salt.utils.fopen(pubfn, 'r') as pubfn_handle:
+            with salt.utils.files.fopen(pubfn, 'r') as pubfn_handle:
                 if pubfn_handle.read().strip() != load['pub'].strip():
                     log.error(
                         'Authentication attempt from {id} failed, the public '
@@ -246,7 +247,7 @@ class AESReqServerMixin(object):
                         'the Salt cluster.'.format(**load)
                     )
                     # put denied minion key into minions_denied
-                    with salt.utils.fopen(pubfn_denied, 'w+') as fp_:
+                    with salt.utils.files.fopen(pubfn_denied, 'w+') as fp_:
                         fp_.write(load['pub'])
                     eload = {'result': False,
                              'id': load['id'],
@@ -289,7 +290,7 @@ class AESReqServerMixin(object):
 
             if key_path is not None:
                 # Write the key to the appropriate location
-                with salt.utils.fopen(key_path, 'w+') as fp_:
+                with salt.utils.files.fopen(key_path, 'w+') as fp_:
                     fp_.write(load['pub'])
                 ret = {'enc': 'clear',
                        'load': {'ret': key_result}}
@@ -326,7 +327,7 @@ class AESReqServerMixin(object):
                 # Check if the keys are the same and error out if this is the
                 # case. Otherwise log the fact that the minion is still
                 # pending.
-                with salt.utils.fopen(pubfn_pend, 'r') as pubfn_handle:
+                with salt.utils.files.fopen(pubfn_pend, 'r') as pubfn_handle:
                     if pubfn_handle.read() != load['pub']:
                         log.error(
                             'Authentication attempt from {id} failed, the public '
@@ -335,7 +336,7 @@ class AESReqServerMixin(object):
                             .format(**load)
                         )
                         # put denied minion key into minions_denied
-                        with salt.utils.fopen(pubfn_denied, 'w+') as fp_:
+                        with salt.utils.files.fopen(pubfn_denied, 'w+') as fp_:
                             fp_.write(load['pub'])
                         eload = {'result': False,
                                  'id': load['id'],
@@ -362,7 +363,7 @@ class AESReqServerMixin(object):
                 # auto-signed. Check to see if it is the same key, and if
                 # so, pass on doing anything here, and let it get automatically
                 # accepted below.
-                with salt.utils.fopen(pubfn_pend, 'r') as pubfn_handle:
+                with salt.utils.files.fopen(pubfn_pend, 'r') as pubfn_handle:
                     if pubfn_handle.read() != load['pub']:
                         log.error(
                             'Authentication attempt from {id} failed, the public '
@@ -371,7 +372,7 @@ class AESReqServerMixin(object):
                             .format(**load)
                         )
                         # put denied minion key into minions_denied
-                        with salt.utils.fopen(pubfn_denied, 'w+') as fp_:
+                        with salt.utils.files.fopen(pubfn_denied, 'w+') as fp_:
                             fp_.write(load['pub'])
                         eload = {'result': False,
                                  'id': load['id'],
@@ -396,16 +397,16 @@ class AESReqServerMixin(object):
         # only write to disk if you are adding the file, and in open mode,
         # which implies we accept any key from a minion.
         if not os.path.isfile(pubfn) and not self.opts['open_mode']:
-            with salt.utils.fopen(pubfn, 'w+') as fp_:
+            with salt.utils.files.fopen(pubfn, 'w+') as fp_:
                 fp_.write(load['pub'])
         elif self.opts['open_mode']:
             disk_key = ''
             if os.path.isfile(pubfn):
-                with salt.utils.fopen(pubfn, 'r') as fp_:
+                with salt.utils.files.fopen(pubfn, 'r') as fp_:
                     disk_key = fp_.read()
             if load['pub'] and load['pub'] != disk_key:
                 log.debug('Host key change detected in open mode.')
-                with salt.utils.fopen(pubfn, 'w+') as fp_:
+                with salt.utils.files.fopen(pubfn, 'w+') as fp_:
                     fp_.write(load['pub'])
 
         pub = None
@@ -417,7 +418,7 @@ class AESReqServerMixin(object):
         # The key payload may sometimes be corrupt when using auto-accept
         # and an empty request comes in
         try:
-            with salt.utils.fopen(pubfn) as f:
+            with salt.utils.files.fopen(pubfn) as f:
                 pub = RSA.importKey(f.read())
         except (ValueError, IndexError, TypeError) as err:
             log.error('Corrupt public key "{0}": {1}'.format(pubfn, err))

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -5,6 +5,7 @@ Some of the utils used by salt
 
 # Import python libs
 from __future__ import absolute_import, division, print_function
+import contextlib
 import copy
 import collections
 import datetime
@@ -21,7 +22,6 @@ import re
 import shlex
 import shutil
 import socket
-import stat
 import sys
 import pstats
 import tempfile
@@ -145,6 +145,41 @@ def is_hex(value):
         return True
     except (TypeError, ValueError):
         return False
+
+
+def safe_rm(tgt):
+    '''
+    Safely remove a file
+
+    .. deprecated:: Oxygen
+    '''
+    warn_until(
+        'Neon',
+        'Use of \'salt.utils.safe_rm\' detected. This function has been moved to '
+        '\'salt.utils.files.safe_rm\' as of Salt Oxygen. This warning will be '
+        'removed in Salt Neon.'
+    )
+    # Late import to avoid circular import.
+    import salt.utils.files
+    return salt.utils.files.safe_rm(tgt)
+
+
+@jinja_filter('is_empty')
+def is_empty(filename):
+    '''
+    Is a file empty?
+
+    .. deprecated:: Oxygen
+    '''
+    warn_until(
+        'Neon',
+        'Use of \'salt.utils.is_empty\' detected. This function has been moved to '
+        '\'salt.utils.files.is_empty\' as of Salt Oxygen. This warning will be '
+        'removed in Salt Neon.'
+    )
+    # Late import to avoid circular import.
+    import salt.utils.files
+    return salt.utils.files.is_empty(filename)
 
 
 def get_color_theme(theme):
@@ -1297,6 +1332,81 @@ def str_to_num(text):
             return text
 
 
+def fopen(*args, **kwargs):
+    '''
+    Wrapper around open() built-in to set CLOEXEC on the fd.
+
+    This flag specifies that the file descriptor should be closed when an exec
+    function is invoked;
+    When a file descriptor is allocated (as with open or dup), this bit is
+    initially cleared on the new file descriptor, meaning that descriptor will
+    survive into the new program after exec.
+
+    NB! We still have small race condition between open and fcntl.
+
+    .. deprecated:: Oxygen
+    '''
+    warn_until(
+        'Neon',
+        'Use of \'salt.utils.fopen\' detected. This function has been moved to '
+        '\'salt.utils.files.fopen\' as of Salt Oxygen. This warning will be '
+        'removed in Salt Neon.'
+    )
+    # Late import to avoid circular import.
+    import salt.utils.files
+    return salt.utils.files.fopen(*args, **kwargs)
+
+
+@contextlib.contextmanager
+def flopen(*args, **kwargs):
+    '''
+    Shortcut for fopen with lock and context manager
+
+    .. deprecated:: Oxygen
+    '''
+    warn_until(
+        'Neon',
+        'Use of \'salt.utils.flopen\' detected. This function has been moved to '
+        '\'salt.utils.files.flopen\' as of Salt Oxygen. This warning will be '
+        'removed in Salt Neon.'
+    )
+    # Late import to avoid circular import.
+    import salt.utils.files
+    return salt.utils.files.flopen(*args, **kwargs)
+
+
+@contextlib.contextmanager
+def fpopen(*args, **kwargs):
+    '''
+    Shortcut for fopen with extra uid, gid and mode options.
+
+    Supported optional Keyword Arguments:
+
+      mode: explicit mode to set. Mode is anything os.chmod
+            would accept as input for mode. Works only on unix/unix
+            like systems.
+
+      uid: the uid to set, if not set, or it is None or -1 no changes are
+           made. Same applies if the path is already owned by this
+           uid. Must be int. Works only on unix/unix like systems.
+
+      gid: the gid to set, if not set, or it is None or -1 no changes are
+           made. Same applies if the path is already owned by this
+           gid. Must be int. Works only on unix/unix like systems.
+
+    .. deprecated:: Oxygen
+    '''
+    warn_until(
+        'Neon',
+        'Use of \'salt.utils.fpopen\' detected. This function has been moved to '
+        '\'salt.utils.files.fpopen\' as of Salt Oxygen. This warning will be '
+        'removed in Salt Neon.'
+    )
+    # Late import to avoid circular import.
+    import salt.utils.files
+    return salt.utils.files.fpopen(*args, **kwargs)
+
+
 def expr_match(line, expr):
     '''
     Evaluate a line of text against an expression. First try a full-string
@@ -1690,6 +1800,25 @@ def is_aix():
     return sys.platform.startswith('aix')
 
 
+def is_fcntl_available(check_sunos=False):
+    '''
+    Simple function to check if the `fcntl` module is available or not.
+    If `check_sunos` is passed as `True` an additional check to see if host is
+    SunOS is also made. For additional information see: http://goo.gl/159FF8
+
+    .. deprecated:: Oxygen
+    '''
+    warn_until(
+        'Neon',
+        'Use of \'salt.utils.is_fcntl_available\' detected. This function has been moved to '
+        '\'salt.utils.files.is_fcntl_available\' as of Salt Oxygen. This warning will be '
+        'removed in Salt Neon.'
+    )
+    # Late import to avoid circular import.
+    import salt.utils.files
+    return salt.utils.files.is_fcntl_available(check_sunos)
+
+
 def check_include_exclude(path_str, include_pat=None, exclude_pat=None):
     '''
     Check for glob or regexp patterns for include_pat and exclude_pat in the
@@ -1986,6 +2115,7 @@ def rm_rf(path):
         '\'salt.utils.files.rm_rf\' as of Salt Oxygen. This warning will be '
         'removed in Salt Neon.'
     )
+    # Late import to avoid circular import.
     import salt.utils.files
     return salt.utils.files.rm_rf(path)
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -118,7 +118,6 @@ from salt.defaults import DEFAULT_TARGET_DELIM
 import salt.defaults.exitcodes
 import salt.log
 import salt.utils.dictupdate
-import salt.utils.files
 import salt.version
 from salt.utils.decorators import jinja_filter
 from salt.utils.decorators import memoize as real_memoize
@@ -190,6 +189,9 @@ def get_color_theme(theme):
     import yaml
     if not os.path.isfile(theme):
         log.warning('The named theme {0} if not available'.format(theme))
+
+    # Late import to avoid circular import.
+    import salt.utils.files
     try:
         with salt.utils.files.fopen(theme, 'rb') as fp_:
             colors = yaml.safe_load(fp_.read())
@@ -430,6 +432,10 @@ def get_specific_user():
 
 
 def get_master_key(key_user, opts, skip_perm_errors=False):
+    # Late import to avoid circular import.
+    import salt.utils.files
+    import salt.utils.verify
+
     if key_user == 'root':
         if opts.get('user', 'root') != 'root':
             key_user = opts.get('user', 'root')
@@ -472,6 +478,9 @@ def daemonize(redirect_out=True):
     '''
     Daemonize a process
     '''
+    # Late import to avoid circular import.
+    import salt.utils.files
+
     try:
         pid = os.fork()
         if pid > 0:
@@ -652,6 +661,9 @@ def activate_profile(test=True):
 
 
 def output_profile(pr, stats_path='/tmp/stats', stop=False, id_=None):
+    # Late import to avoid circular import.
+    import salt.utils.files
+
     if pr is not None and HAS_CPROFILE:
         try:
             pr.disable()
@@ -1005,6 +1017,9 @@ def pem_finger(path=None, key=None, sum_type='sha256'):
 
     If neither a key nor a path are passed in, a blank string will be returned.
     '''
+    # Late import to avoid circular import.
+    import salt.utils.files
+
     if not key:
         if not os.path.isfile(path):
             return ''
@@ -1232,6 +1247,9 @@ def istextfile(fp_, blocksize=512):
     If more than 30% of the chars in the block are non-text, or there
     are NUL ('\x00') bytes in the block, assume this is a binary file.
     '''
+    # Late import to avoid circular import.
+    import salt.utils.files
+
     int2byte = (lambda x: bytes((x,))) if six.PY3 else chr
     text_characters = (
         b''.join(int2byte(i) for i in range(32, 127)) +
@@ -2267,6 +2285,9 @@ def get_hash(path, form='sha256', chunk_size=65536):
             ``get_sum`` cannot really be trusted since it is vulnerable to
             collisions: ``get_sum(..., 'xyz') == 'Hash xyz not supported'``
     '''
+    # Late import to avoid circular import.
+    import salt.utils.files
+
     hash_type = hasattr(hashlib, form) and getattr(hashlib, form) or None
     if hash_type is None:
         raise ValueError('Invalid hash type: {0}'.format(form))
@@ -2772,6 +2793,9 @@ def is_bin_file(path):
     Detects if the file is a binary, returns bool. Returns True if the file is
     a bin, False if the file is not and None if the file is not available.
     '''
+    # Late import to avoid circular import.
+    import salt.utils.files
+
     if not os.path.isfile(path):
         return False
     try:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1372,7 +1372,7 @@ def fopen(*args, **kwargs):
     )
     # Late import to avoid circular import.
     import salt.utils.files
-    return salt.utils.files.fopen(*args, **kwargs)
+    return salt.utils.files.fopen(*args, **kwargs)  # pylint: disable=W8470
 
 
 @contextlib.contextmanager

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1977,28 +1977,17 @@ def rm_rf(path):
     '''
     Platform-independent recursive delete. Includes code from
     http://stackoverflow.com/a/2656405
+
+    .. deprecated:: Oxygen
     '''
-    def _onerror(func, path, exc_info):
-        '''
-        Error handler for `shutil.rmtree`.
-
-        If the error is due to an access error (read only file)
-        it attempts to add write permission and then retries.
-
-        If the error is for another reason it re-raises the error.
-
-        Usage : `shutil.rmtree(path, onerror=onerror)`
-        '''
-        if is_windows() and not os.access(path, os.W_OK):
-            # Is the error an access error ?
-            os.chmod(path, stat.S_IWUSR)
-            func(path)
-        else:
-            raise  # pylint: disable=E0704
-    if os.path.islink(path) or not os.path.isdir(path):
-        os.remove(path)
-    else:
-        shutil.rmtree(path, onerror=_onerror)
+    warn_until(
+        'Neon',
+        'Use of \'salt.utils.rm_rf\' detected. This function has been moved to '
+        '\'salt.utils.files.rm_rf\' as of Salt Oxygen. This warning will be '
+        'removed in Salt Neon.'
+    )
+    import salt.utils.files
+    return salt.utils.files.rm_rf(path)
 
 
 def option(value, default='', opts=None, pillar=None):

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -15,6 +15,7 @@ except ImportError:
 import salt.config
 import salt.payload
 import salt.utils.dictupdate
+import salt.utils.files
 
 # Import third party libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
@@ -137,7 +138,7 @@ class CacheDisk(CacheDict):
         '''
         if not HAS_MSGPACK or not os.path.exists(self._path):
             return
-        with salt.utils.fopen(self._path, 'rb') as fp_:
+        with salt.utils.files.fopen(self._path, 'rb') as fp_:
             cache = msgpack.load(fp_, encoding=__salt_system_encoding__)
         if "CacheDisk_cachetime" in cache:  # new format
             self._dict = cache["CacheDisk_data"]
@@ -158,7 +159,7 @@ class CacheDisk(CacheDict):
             return
         # TODO Add check into preflight to ensure dir exists
         # TODO Dir hashing?
-        with salt.utils.fopen(self._path, 'wb+') as fp_:
+        with salt.utils.files.fopen(self._path, 'wb+') as fp_:
             cache = {
                 "CacheDisk_data": self._dict,
                 "CacheDisk_cachetime": self._key_cache_time
@@ -283,14 +284,14 @@ class ContextCache(object):
         '''
         if not os.path.isdir(os.path.dirname(self.cache_path)):
             os.mkdir(os.path.dirname(self.cache_path))
-        with salt.utils.fopen(self.cache_path, 'w+b') as cache:
+        with salt.utils.files.fopen(self.cache_path, 'w+b') as cache:
             self.serial.dump(context, cache)
 
     def get_cache_context(self):
         '''
         Retrieve a context cache from disk
         '''
-        with salt.utils.fopen(self.cache_path, 'rb') as cache:
+        with salt.utils.files.fopen(self.cache_path, 'rb') as cache:
             return self.serial.load(cache)
 
 

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -59,6 +59,7 @@ import salt.loader
 import salt.template
 import salt.utils
 import salt.utils.event
+import salt.utils.files
 from salt.utils import vt
 from salt.utils.nb_popen import NonBlockingPopen
 from salt.utils.yamldumper import SafeOrderedDumper
@@ -109,12 +110,12 @@ def __render_script(path, vm_=None, opts=None, minion=''):
     '''
     log.info('Rendering deploy script: {0}'.format(path))
     try:
-        with salt.utils.fopen(path, 'r') as fp_:
+        with salt.utils.files.fopen(path, 'r') as fp_:
             template = Template(fp_.read())
             return str(template.render(opts=opts, vm=vm_, minion=minion))
     except AttributeError:
         # Specified renderer was not found
-        with salt.utils.fopen(path, 'r') as fp_:
+        with salt.utils.files.fopen(path, 'r') as fp_:
             return fp_.read()
 
 
@@ -161,9 +162,9 @@ def gen_keys(keysize=2048):
     salt.crypt.gen_keys(tdir, 'minion', keysize)
     priv_path = os.path.join(tdir, 'minion.pem')
     pub_path = os.path.join(tdir, 'minion.pub')
-    with salt.utils.fopen(priv_path) as fp_:
+    with salt.utils.files.fopen(priv_path) as fp_:
         priv = fp_.read()
-    with salt.utils.fopen(pub_path) as fp_:
+    with salt.utils.files.fopen(pub_path) as fp_:
         pub = fp_.read()
     shutil.rmtree(tdir)
     return priv, pub
@@ -181,12 +182,12 @@ def accept_key(pki_dir, pub, id_):
             os.makedirs(key_path)
 
     key = os.path.join(pki_dir, 'minions', id_)
-    with salt.utils.fopen(key, 'w+') as fp_:
+    with salt.utils.files.fopen(key, 'w+') as fp_:
         fp_.write(pub)
 
     oldkey = os.path.join(pki_dir, 'minions_pre', id_)
     if os.path.isfile(oldkey):
-        with salt.utils.fopen(oldkey) as fp_:
+        with salt.utils.files.fopen(oldkey) as fp_:
             if fp_.read() == pub:
                 os.remove(oldkey)
 
@@ -1076,7 +1077,7 @@ def deploy_windows(host,
             # Read master-sign.pub file
             log.debug("Copying master_sign.pub file from {0} to minion".format(master_sign_pub_file))
             try:
-                with salt.utils.fopen(master_sign_pub_file, 'rb') as master_sign_fh:
+                with salt.utils.files.fopen(master_sign_pub_file, 'rb') as master_sign_fh:
                     smb_conn.putFile('C$', 'salt\\conf\\pki\\minion\\master_sign.pub', master_sign_fh.read)
             except Exception as e:
                 log.debug("Exception copying master_sign.pub file {0} to minion".format(master_sign_pub_file))
@@ -1088,7 +1089,7 @@ def deploy_windows(host,
         comps = win_installer.split('/')
         local_path = '/'.join(comps[:-1])
         installer = comps[-1]
-        with salt.utils.fopen(win_installer, 'rb') as inst_fh:
+        with salt.utils.files.fopen(win_installer, 'rb') as inst_fh:
             smb_conn.putFile('C$', 'salttemp/{0}'.format(installer), inst_fh.read)
 
         if use_winrm:
@@ -2506,7 +2507,7 @@ def lock_file(filename, interval=.5, timeout=15):
         else:
             break
 
-    with salt.utils.fopen(lock, 'a'):
+    with salt.utils.files.fopen(lock, 'a'):
         pass
 
 
@@ -2546,7 +2547,7 @@ def cachedir_index_add(minion_id, profile, driver, provider, base=None):
 
     if os.path.exists(index_file):
         mode = 'rb' if six.PY3 else 'r'
-        with salt.utils.fopen(index_file, mode) as fh_:
+        with salt.utils.files.fopen(index_file, mode) as fh_:
             index = msgpack.load(fh_)
     else:
         index = {}
@@ -2563,7 +2564,7 @@ def cachedir_index_add(minion_id, profile, driver, provider, base=None):
     })
 
     mode = 'wb' if six.PY3 else 'w'
-    with salt.utils.fopen(index_file, mode) as fh_:
+    with salt.utils.files.fopen(index_file, mode) as fh_:
         msgpack.dump(index, fh_)
 
     unlock_file(index_file)
@@ -2580,7 +2581,7 @@ def cachedir_index_del(minion_id, base=None):
 
     if os.path.exists(index_file):
         mode = 'rb' if six.PY3 else 'r'
-        with salt.utils.fopen(index_file, mode) as fh_:
+        with salt.utils.files.fopen(index_file, mode) as fh_:
             index = msgpack.load(fh_)
     else:
         return
@@ -2589,7 +2590,7 @@ def cachedir_index_del(minion_id, base=None):
         del index[minion_id]
 
     mode = 'wb' if six.PY3 else 'w'
-    with salt.utils.fopen(index_file, mode) as fh_:
+    with salt.utils.files.fopen(index_file, mode) as fh_:
         msgpack.dump(index, fh_)
 
     unlock_file(index_file)
@@ -2646,7 +2647,7 @@ def request_minion_cachedir(
 
     fname = '{0}.p'.format(minion_id)
     path = os.path.join(base, 'requested', fname)
-    with salt.utils.fopen(path, 'w') as fh_:
+    with salt.utils.files.fopen(path, 'w') as fh_:
         msgpack.dump(data, fh_)
 
 
@@ -2678,12 +2679,12 @@ def change_minion_cachedir(
     fname = '{0}.p'.format(minion_id)
     path = os.path.join(base, cachedir, fname)
 
-    with salt.utils.fopen(path, 'r') as fh_:
+    with salt.utils.files.fopen(path, 'r') as fh_:
         cache_data = msgpack.load(fh_)
 
     cache_data.update(data)
 
-    with salt.utils.fopen(path, 'w') as fh_:
+    with salt.utils.files.fopen(path, 'w') as fh_:
         msgpack.dump(cache_data, fh_)
 
 
@@ -2756,7 +2757,7 @@ def list_cache_nodes_full(opts=None, provider=None, base=None):
                 # Finally, get a list of full minion data
                 fpath = os.path.join(min_dir, fname)
                 minion_id = fname[:-2]  # strip '.p' from end of msgpack filename
-                with salt.utils.fopen(fpath, 'r') as fh_:
+                with salt.utils.files.fopen(fpath, 'r') as fh_:
                     minions[driver][prov][minion_id] = msgpack.load(fh_)
 
     return minions
@@ -2813,7 +2814,7 @@ def update_bootstrap(config, url=None):
         else:
             script_name = os.path.basename(url)
     elif os.path.exists(url):
-        with salt.utils.fopen(url) as fic:
+        with salt.utils.files.fopen(url) as fic:
             script_content = fic.read()
         script_name = os.path.basename(url)
     # in last case, assuming we got a script content
@@ -2902,7 +2903,7 @@ def update_bootstrap(config, url=None):
         deploy_path = os.path.join(entry, script_name)
         try:
             finished_full.append(deploy_path)
-            with salt.utils.fopen(deploy_path, 'w') as fp_:
+            with salt.utils.files.fopen(deploy_path, 'w') as fp_:
                 fp_.write(script_content)
         except (OSError, IOError) as err:
             log.debug(
@@ -2935,7 +2936,7 @@ def cache_node_list(nodes, provider, opts):
     for node in nodes:
         diff_node_cache(prov_dir, node, nodes[node], opts)
         path = os.path.join(prov_dir, '{0}.p'.format(node))
-        with salt.utils.fopen(path, 'w') as fh_:
+        with salt.utils.files.fopen(path, 'w') as fh_:
             msgpack.dump(nodes[node], fh_)
 
 
@@ -2960,7 +2961,7 @@ def cache_node(node, provider, opts):
     if not os.path.exists(prov_dir):
         os.makedirs(prov_dir)
     path = os.path.join(prov_dir, '{0}.p'.format(node['name']))
-    with salt.utils.fopen(path, 'w') as fh_:
+    with salt.utils.files.fopen(path, 'w') as fh_:
         msgpack.dump(node, fh_)
 
 
@@ -3034,7 +3035,7 @@ def diff_node_cache(prov_dir, node, new_data, opts):
         )
         return
 
-    with salt.utils.fopen(path, 'r') as fh_:
+    with salt.utils.files.fopen(path, 'r') as fh_:
         try:
             cache_data = msgpack.load(fh_)
         except ValueError:

--- a/salt/utils/debug.py
+++ b/salt/utils/debug.py
@@ -14,7 +14,7 @@ import traceback
 import inspect
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 
 def _makepretty(printout, stack):
@@ -39,7 +39,7 @@ def _handle_sigusr1(sig, stack):
     else:
         filename = 'salt-debug-{0}.log'.format(int(time.time()))
         destfile = os.path.join(tempfile.gettempdir(), filename)
-        with salt.utils.fopen(destfile, 'w') as output:
+        with salt.utils.files.fopen(destfile, 'w') as output:
             _makepretty(output, stack)
 
 

--- a/salt/utils/dns.py
+++ b/salt/utils/dns.py
@@ -28,6 +28,8 @@ from salt.utils.odict import OrderedDict
 # Salt
 import salt.modules.cmdmod
 import salt.utils
+import salt.utils.files
+import salt.utils.network
 
 # Debug & Logging
 import logging
@@ -948,7 +950,7 @@ def services(services_file='/etc/services'):
     }
     '''
     res = {}
-    with salt.utils.fopen(services_file, 'r') as svc_defs:
+    with salt.utils.files.fopen(services_file, 'r') as svc_defs:
         for svc_def in svc_defs.readlines():
             svc_def = svc_def.strip()
             if not len(svc_def) or svc_def.startswith('#'):
@@ -1011,7 +1013,7 @@ def parse_resolv(src='/etc/resolv.conf'):
     options = []
 
     try:
-        with salt.utils.fopen(src) as src_file:
+        with salt.utils.files.fopen(src) as src_file:
             # pylint: disable=too-many-nested-blocks
             for line in src_file:
                 line = line.strip().split()

--- a/salt/utils/extend.py
+++ b/salt/utils/extend.py
@@ -29,7 +29,7 @@ from jinja2 import Template
 from salt.serializers.yaml import deserialize
 from salt.ext.six.moves import zip
 from salt.utils.odict import OrderedDict
-import salt.utils
+import salt.utils.files
 import salt.version
 
 log = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ def _get_template(path, option_key):
     :returns: Details about the template
     :rtype: ``tuple``
     '''
-    with salt.utils.fopen(path, "r") as template_f:
+    with salt.utils.files.fopen(path, 'r') as template_f:
         template = deserialize(template_f)
         info = (option_key, template.get('description', ''), template)
     return info
@@ -138,10 +138,10 @@ def _mergetreejinja(src, dst, context):
             if item != TEMPLATE_FILE_NAME:
                 d = Template(d).render(context)
                 log.info("Copying file {0} to {1}".format(s, d))
-                with salt.utils.fopen(s, 'r') as source_file:
+                with salt.utils.files.fopen(s, 'r') as source_file:
                     src_contents = source_file.read()
                     dest_contents = Template(src_contents).render(context)
-                with salt.utils.fopen(d, 'w') as dest_file:
+                with salt.utils.files.fopen(d, 'w') as dest_file:
                     dest_file.write(dest_contents)
 
 

--- a/salt/utils/filebuffer.py
+++ b/salt/utils/filebuffer.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 
 # Import salt libs
 import salt.ext.six as six
-import salt.utils
+import salt.utils.files
 from salt.exceptions import SaltException
 
 
@@ -57,7 +57,7 @@ class BufferedReader(object):
         if 'a' in mode or 'w' in mode:
             raise InvalidFileMode("Cannot open file in write or append mode")
         self.__path = path
-        self.__file = salt.utils.fopen(self.__path, mode)  # pylint: disable=resource-leakage
+        self.__file = salt.utils.files.fopen(self.__path, mode)  # pylint: disable=resource-leakage
         self.__max_in_mem = max_in_mem
         self.__chunk_size = chunk_size
         self.__buffered = None

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -123,7 +123,7 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
         except (ImportError, CommandExecutionError):
             pass
         if policy == 'Enforcing':
-            with salt.utils.fopen(os.devnull, 'w') as dev_null:
+            with fopen(os.devnull, 'w') as dev_null:
                 cmd = [rcon, dest]
                 subprocess.call(cmd, stdout=dev_null, stderr=dev_null)
     if os.path.isfile(tgt):

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -11,13 +11,22 @@ import shutil
 import subprocess
 import time
 
-# Import salt libs
+# Import Salt libs
 import salt.utils
 import salt.modules.selinux
+import salt.ext.six as six
 from salt.exceptions import CommandExecutionError, FileLockError, MinionError
+from salt.utils.decorators import jinja_filter
 
 # Import 3rd-party libs
-from salt.ext import six
+from stat import S_IMODE
+
+try:
+    import fcntl
+    HAS_FCNTL = True
+except ImportError:
+    # fcntl is not available on windows
+    HAS_FCNTL = False
 
 log = logging.getLogger(__name__)
 
@@ -258,3 +267,156 @@ def set_umask(mask):
             yield
         finally:
             os.umask(orig_mask)
+
+
+def fopen(*args, **kwargs):
+    '''
+    Wrapper around open() built-in to set CLOEXEC on the fd.
+
+    This flag specifies that the file descriptor should be closed when an exec
+    function is invoked;
+
+    When a file descriptor is allocated (as with open or dup), this bit is
+    initially cleared on the new file descriptor, meaning that descriptor will
+    survive into the new program after exec.
+
+    NB! We still have small race condition between open and fcntl.
+    '''
+    binary = None
+    # ensure 'binary' mode is always used on Windows in Python 2
+    if ((six.PY2 and salt.utils.is_windows() and 'binary' not in kwargs) or
+            kwargs.pop('binary', False)):
+        if len(args) > 1:
+            args = list(args)
+            if 'b' not in args[1]:
+                args[1] += 'b'
+        elif kwargs.get('mode', None):
+            if 'b' not in kwargs['mode']:
+                kwargs['mode'] += 'b'
+        else:
+            # the default is to read
+            kwargs['mode'] = 'rb'
+    elif six.PY3 and 'encoding' not in kwargs:
+        # In Python 3, if text mode is used and the encoding
+        # is not specified, set the encoding to 'utf-8'.
+        binary = False
+        if len(args) > 1:
+            args = list(args)
+            if 'b' in args[1]:
+                binary = True
+        if kwargs.get('mode', None):
+            if 'b' in kwargs['mode']:
+                binary = True
+        if not binary:
+            kwargs['encoding'] = __salt_system_encoding__
+
+    if six.PY3 and not binary and not kwargs.get('newline', None):
+        kwargs['newline'] = ''
+
+    f_handle = open(*args, **kwargs)  # pylint: disable=resource-leakage
+
+    if is_fcntl_available():
+        # modify the file descriptor on systems with fcntl
+        # unix and unix-like systems only
+        try:
+            FD_CLOEXEC = fcntl.FD_CLOEXEC   # pylint: disable=C0103
+        except AttributeError:
+            FD_CLOEXEC = 1                  # pylint: disable=C0103
+        old_flags = fcntl.fcntl(f_handle.fileno(), fcntl.F_GETFD)
+        fcntl.fcntl(f_handle.fileno(), fcntl.F_SETFD, old_flags | FD_CLOEXEC)
+
+    return f_handle
+
+
+@contextlib.contextmanager
+def flopen(*args, **kwargs):
+    '''
+    Shortcut for fopen with lock and context manager.
+    '''
+    with fopen(*args, **kwargs) as f_handle:
+        try:
+            if is_fcntl_available(check_sunos=True):
+                fcntl.flock(f_handle.fileno(), fcntl.LOCK_SH)
+            yield f_handle
+        finally:
+            if is_fcntl_available(check_sunos=True):
+                fcntl.flock(f_handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextlib.contextmanager
+def fpopen(*args, **kwargs):
+    '''
+    Shortcut for fopen with extra uid, gid, and mode options.
+
+    Supported optional Keyword Arguments:
+
+    mode
+        Explicit mode to set. Mode is anything os.chmod would accept
+        as input for mode. Works only on unix/unix-like systems.
+
+    uid
+        The uid to set, if not set, or it is None or -1 no changes are
+        made. Same applies if the path is already owned by this uid.
+        Must be int. Works only on unix/unix-like systems.
+
+    gid
+        The gid to set, if not set, or it is None or -1 no changes are
+        made. Same applies if the path is already owned by this gid.
+        Must be int. Works only on unix/unix-like systems.
+
+    '''
+    # Remove uid, gid and mode from kwargs if present
+    uid = kwargs.pop('uid', -1)  # -1 means no change to current uid
+    gid = kwargs.pop('gid', -1)  # -1 means no change to current gid
+    mode = kwargs.pop('mode', None)
+    with fopen(*args, **kwargs) as f_handle:
+        path = args[0]
+        d_stat = os.stat(path)
+
+        if hasattr(os, 'chown'):
+            # if uid and gid are both -1 then go ahead with
+            # no changes at all
+            if (d_stat.st_uid != uid or d_stat.st_gid != gid) and \
+                    [i for i in (uid, gid) if i != -1]:
+                os.chown(path, uid, gid)
+
+        if mode is not None:
+            mode_part = S_IMODE(d_stat.st_mode)
+            if mode_part != mode:
+                os.chmod(path, (d_stat.st_mode ^ mode_part) | mode)
+
+        yield f_handle
+
+
+def safe_rm(tgt):
+    '''
+    Safely remove a file
+    '''
+    try:
+        os.remove(tgt)
+    except (IOError, OSError):
+        pass
+
+
+@jinja_filter('is_empty')
+def is_empty(filename):
+    '''
+    Is a file empty?
+    '''
+    try:
+        return os.stat(filename).st_size == 0
+    except OSError:
+        # Non-existent file or permission denied to the parent dir
+        return False
+
+
+def is_fcntl_available(check_sunos=False):
+    '''
+    Simple function to check if the ``fcntl`` module is available or not.
+
+    If ``check_sunos`` is passed as ``True`` an additional check to see if host is
+    SunOS is also made. For additional information see: http://goo.gl/159FF8
+    '''
+    if check_sunos and salt.utils.is_sunos():
+        return False
+    return HAS_FCNTL

--- a/salt/utils/fsutils.py
+++ b/salt/utils/fsutils.py
@@ -13,7 +13,7 @@ import os
 import logging
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 # Import 3rd-party libs
@@ -41,7 +41,7 @@ def _get_mounts(fs_type=None):
     List mounted filesystems.
     '''
     mounts = {}
-    with salt.utils.fopen("/proc/mounts") as fhr:
+    with salt.utils.files.fopen('/proc/mounts') as fhr:
         for line in fhr.readlines():
             device, mntpnt, fstype, options, fs_freq, fs_passno = line.strip().split(" ")
             if fs_type and fstype != fs_type:

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -376,7 +376,7 @@ class GitProvider(object):
                                             self.cachedir_basename)
         try:
             # Remove linkdir if it exists
-            salt.utils.rm_rf(self.linkdir)
+            salt.utils.files.rm_rf(self.linkdir)
         except OSError:
             pass
 
@@ -2865,7 +2865,7 @@ class GitPillar(GitBase):
                     # A file or dir already exists at this path, remove it and
                     # then re-attempt to create the symlink
                     try:
-                        salt.utils.rm_rf(lcachelink)
+                        salt.utils.files.rm_rf(lcachelink)
                     except OSError as exc:
                         log.error(
                             'Failed to remove file/dir at path %s: %s',

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -21,6 +21,7 @@ from datetime import datetime
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.itertools
 import salt.utils.url
 import salt.fileserver
@@ -678,7 +679,7 @@ class GitProvider(object):
                 os.write(fh_, six.b(str(os.getpid())))
         except (OSError, IOError) as exc:
             if exc.errno == errno.EEXIST:
-                with salt.utils.fopen(self._get_lock_file(lock_type), 'r') as fd_:
+                with salt.utils.files.fopen(self._get_lock_file(lock_type), 'r') as fd_:
                     try:
                         pid = int(fd_.readline().rstrip())
                     except ValueError:
@@ -1250,7 +1251,7 @@ class GitPython(GitProvider):
         '''
         Using the blob object, write the file to the destination path
         '''
-        with salt.utils.fopen(dest, 'wb+') as fp_:
+        with salt.utils.files.fopen(dest, 'wb+') as fp_:
             blob.stream_data(fp_)
 
 
@@ -1943,7 +1944,7 @@ class Pygit2(GitProvider):
         '''
         Using the blob object, write the file to the destination path
         '''
-        with salt.utils.fopen(dest, 'wb+') as fp_:
+        with salt.utils.files.fopen(dest, 'wb+') as fp_:
             fp_.write(blob.data)
 
 
@@ -2247,7 +2248,7 @@ class GitBase(object):
         if refresh_env_cache:
             new_envs = self.envs(ignore_cache=True)
             serial = salt.payload.Serial(self.opts)
-            with salt.utils.fopen(self.env_cache, 'wb+') as fp_:
+            with salt.utils.files.fopen(self.env_cache, 'wb+') as fp_:
                 fp_.write(serial.dumps(new_envs))
                 log.trace('Wrote env cache data to {0}'.format(self.env_cache))
 
@@ -2436,7 +2437,7 @@ class GitBase(object):
         '''
         remote_map = salt.utils.path_join(self.cache_root, 'remote_map.txt')
         try:
-            with salt.utils.fopen(remote_map, 'w+') as fp_:
+            with salt.utils.files.fopen(remote_map, 'w+') as fp_:
                 timestamp = \
                     datetime.now().strftime('%d %b %Y %H:%M:%S.%f')
                 fp_.write(
@@ -2597,13 +2598,13 @@ class GitFS(GitBase):
 
             salt.fileserver.wait_lock(lk_fn, dest)
             if os.path.isfile(blobshadest) and os.path.isfile(dest):
-                with salt.utils.fopen(blobshadest, 'r') as fp_:
+                with salt.utils.files.fopen(blobshadest, 'r') as fp_:
                     sha = fp_.read()
                     if sha == blob_hexsha:
                         fnd['rel'] = path
                         fnd['path'] = dest
                         return _add_file_stat(fnd, blob_mode)
-            with salt.utils.fopen(lk_fn, 'w+') as fp_:
+            with salt.utils.files.fopen(lk_fn, 'w+') as fp_:
                 fp_.write('')
             for filename in glob.glob(hashes_glob):
                 try:
@@ -2612,7 +2613,7 @@ class GitFS(GitBase):
                     pass
             # Write contents of file to their destination in the FS cache
             repo.write_file(blob, dest)
-            with salt.utils.fopen(blobshadest, 'w+') as fp_:
+            with salt.utils.files.fopen(blobshadest, 'w+') as fp_:
                 fp_.write(blob_hexsha)
             try:
                 os.remove(lk_fn)
@@ -2655,7 +2656,7 @@ class GitFS(GitBase):
         ret['dest'] = fnd['rel']
         gzip = load.get('gzip', None)
         fpath = os.path.normpath(fnd['path'])
-        with salt.utils.fopen(fpath, 'rb') as fp_:
+        with salt.utils.files.fopen(fpath, 'rb') as fp_:
             fp_.seek(load['loc'])
             data = fp_.read(self.opts['file_buffer_size'])
             if data and six.PY3 and not salt.utils.is_bin_file(fpath):
@@ -2692,11 +2693,11 @@ class GitFS(GitBase):
             if not os.path.exists(os.path.dirname(hashdest)):
                 os.makedirs(os.path.dirname(hashdest))
             ret['hsum'] = salt.utils.get_hash(path, self.opts['hash_type'])
-            with salt.utils.fopen(hashdest, 'w+') as fp_:
+            with salt.utils.files.fopen(hashdest, 'w+') as fp_:
                 fp_.write(ret['hsum'])
             return ret
         else:
-            with salt.utils.fopen(hashdest, 'rb') as fp_:
+            with salt.utils.files.fopen(hashdest, 'rb') as fp_:
                 ret['hsum'] = fp_.read()
             return ret
 

--- a/salt/utils/gzip_util.py
+++ b/salt/utils/gzip_util.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import gzip
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -96,7 +96,7 @@ def compress_file(fh_, compresslevel=9, chunk_size=1048576):
                     bytes_read = ogz.write(fh_.read(chunk_size))
                 except AttributeError:
                     # Open the file and re-attempt the read
-                    fh_ = salt.utils.fopen(fh_, 'rb')
+                    fh_ = salt.utils.files.fopen(fh_, 'rb')
                     bytes_read = ogz.write(fh_.read(chunk_size))
             yield buf.getvalue()
     finally:

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -39,6 +39,7 @@ except ImportError:
 import salt.utils
 import salt.utils.xmlutil as xml
 import salt.utils.args
+import salt.utils.files
 import salt.loader
 import salt.config
 import salt.version
@@ -233,12 +234,12 @@ def query(url,
         # proper cookie jar. Unfortunately, since session cookies do not
         # contain expirations, they can't be stored in a proper cookie jar.
         if os.path.isfile(session_cookie_jar):
-            with salt.utils.fopen(session_cookie_jar, 'rb') as fh_:
+            with salt.utils.files.fopen(session_cookie_jar, 'rb') as fh_:
                 session_cookies = msgpack.load(fh_)
             if isinstance(session_cookies, dict):
                 header_dict.update(session_cookies)
         else:
-            with salt.utils.fopen(session_cookie_jar, 'wb') as fh_:
+            with salt.utils.files.fopen(session_cookie_jar, 'wb') as fh_:
                 msgpack.dump('', fh_)
 
     for header in header_list:
@@ -549,11 +550,11 @@ def query(url,
                   'incompatibilities between requests and logging.').format(exc))
 
     if text_out is not None:
-        with salt.utils.fopen(text_out, 'w') as tof:
+        with salt.utils.files.fopen(text_out, 'w') as tof:
             tof.write(result_text)
 
     if headers_out is not None and os.path.exists(headers_out):
-        with salt.utils.fopen(headers_out, 'w') as hof:
+        with salt.utils.files.fopen(headers_out, 'w') as hof:
             hof.write(result_headers)
 
     if cookies is not None:
@@ -562,7 +563,7 @@ def query(url,
     if persist_session is True and HAS_MSGPACK:
         # TODO: See persist_session above
         if 'set-cookie' in result_headers:
-            with salt.utils.fopen(session_cookie_jar, 'wb') as fh_:
+            with salt.utils.files.fopen(session_cookie_jar, 'wb') as fh_:
                 session_cookies = result_headers.get('set-cookie', None)
                 if session_cookies is not None:
                     msgpack.dump({'Cookie': session_cookies}, fh_)
@@ -613,7 +614,7 @@ def query(url,
             text = True
 
         if decode_out:
-            with salt.utils.fopen(decode_out, 'w') as dof:
+            with salt.utils.files.fopen(decode_out, 'w') as dof:
                 dof.write(result_text)
 
     if text is True:
@@ -738,7 +739,7 @@ def update_ca_bundle(
                     )
                 )
                 try:
-                    with salt.utils.fopen(cert_file, 'r') as fcf:
+                    with salt.utils.files.fopen(cert_file, 'r') as fcf:
                         merge_content = '\n'.join((merge_content, fcf.read()))
                 except IOError as exc:
                     log.error(
@@ -750,7 +751,7 @@ def update_ca_bundle(
         if merge_content:
             log.debug('Appending merge_files to {0}'.format(target))
             try:
-                with salt.utils.fopen(target, 'a') as tfp:
+                with salt.utils.files.fopen(target, 'a') as tfp:
                     tfp.write('\n')
                     tfp.write(merge_content)
             except IOError as exc:
@@ -778,7 +779,7 @@ def _render(template, render, renderer, template_dict, opts):
         if str(ret).startswith('#!') and not str(ret).startswith('#!/'):
             ret = str(ret).split('\n', 1)[1]
         return ret
-    with salt.utils.fopen(template, 'r') as fh_:
+    with salt.utils.files.fopen(template, 'r') as fh_:
         return fh_.read()
 
 

--- a/salt/utils/itertools.py
+++ b/salt/utils/itertools.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 import re
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 
 
 def split(orig, sep=None):
@@ -53,7 +53,7 @@ def read_file(fh_, chunk_size=1048576):
                 chunk = fh_.read(chunk_size)
             except AttributeError:
                 # Open the file and re-attempt the read
-                fh_ = salt.utils.fopen(fh_, 'rb')  # pylint: disable=W8470
+                fh_ = salt.utils.files.fopen(fh_, 'rb')  # pylint: disable=W8470
                 chunk = fh_.read(chunk_size)
             if not chunk:
                 break

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -29,7 +29,7 @@ from jinja2.ext import Extension
 # Import salt libs
 import salt
 import salt.fileclient
-import salt.utils
+import salt.utils.files
 import salt.utils.url
 from salt.utils.decorators import jinja_filter, jinja_test
 from salt.utils.odict import OrderedDict
@@ -129,7 +129,7 @@ class SaltCacheLoader(BaseLoader):
         for spath in self.searchpath:
             filepath = path.join(spath, template)
             try:
-                with salt.utils.fopen(filepath, 'rb') as ifile:
+                with salt.utils.files.fopen(filepath, 'rb') as ifile:
                     contents = ifile.read().decode(self.encoding)
                     mtime = path.getmtime(filepath)
 

--- a/salt/utils/kickstart.py
+++ b/salt/utils/kickstart.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 import yaml
 import shlex
 import argparse  # pylint: disable=minimum-python-version
-import salt.utils
+import salt.utils.files
 from salt.ext.six.moves import range
 
 
@@ -898,7 +898,7 @@ def mksls(src, dst=None):
     mode = 'command'
     sls = {}
     ks_opts = {}
-    with salt.utils.fopen(src, 'r') as fh_:
+    with salt.utils.files.fopen(src, 'r') as fh_:
         for line in fh_:
             if line.startswith('#'):
                 continue
@@ -1175,7 +1175,7 @@ def mksls(src, dst=None):
             sls[package] = {'pkg': ['absent']}
 
     if dst:
-        with salt.utils.fopen(dst, 'w') as fp_:
+        with salt.utils.files.fopen(dst, 'w') as fp_:
             fp_.write(yaml.safe_dump(sls, default_flow_style=False))
     else:
         return yaml.safe_dump(sls, default_flow_style=False)

--- a/salt/utils/minion.py
+++ b/salt/utils/minion.py
@@ -11,6 +11,8 @@ import threading
 
 # Import Salt Libs
 import salt.utils
+import salt.utils.files
+import salt.utils.process
 import salt.payload
 
 # Import 3rd-party libs
@@ -53,7 +55,7 @@ def cache_jobs(opts, jid, ret):
     jdir = os.path.dirname(fn_)
     if not os.path.isdir(jdir):
         os.makedirs(jdir)
-    with salt.utils.fopen(fn_, 'w+b') as fp_:
+    with salt.utils.files.fopen(fn_, 'w+b') as fp_:
         fp_.write(serial.dumps(ret))
 
 
@@ -64,7 +66,7 @@ def _read_proc_file(path, opts):
     serial = salt.payload.Serial(opts)
     current_thread = threading.currentThread().name
     pid = os.getpid()
-    with salt.utils.fopen(path, 'rb') as fp_:
+    with salt.utils.files.fopen(path, 'rb') as fp_:
         buf = fp_.read()
         fp_.close()
         if buf:
@@ -140,7 +142,7 @@ def _check_cmdline(data):
     if not os.path.isfile(path):
         return False
     try:
-        with salt.utils.fopen(path, 'rb') as fp_:
+        with salt.utils.files.fopen(path, 'rb') as fp_:
             if six.b('salt') in fp_.read():
                 return True
     except (OSError, IOError):

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -14,6 +14,8 @@ import logging
 # Import salt libs
 import salt.payload
 import salt.utils
+import salt.utils.files
+import salt.utils.network
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.exceptions import CommandExecutionError, SaltCacheError
 import salt.auth.ldap
@@ -21,7 +23,6 @@ import salt.cache
 import salt.ext.six as six
 
 # Import 3rd-party libs
-import salt.ext.six as six
 if six.PY3:
     import ipaddress
 else:
@@ -227,7 +228,7 @@ class CkMinions(object):
         try:
             if self.opts['key_cache'] and os.path.exists(pki_cache_fn):
                 log.debug('Returning cached minion list')
-                with salt.utils.fopen(pki_cache_fn) as fn_:
+                with salt.utils.files.fopen(pki_cache_fn) as fn_:
                     return self.serial.load(fn_)
             else:
                 for fn_ in salt.utils.isorted(os.listdir(os.path.join(self.opts['pki_dir'], self.acc))):

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -27,6 +27,7 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt._compat import ipaddress
 from salt.utils.decorators import jinja_filter
 
@@ -137,7 +138,7 @@ def _generate_minion_id():
                    r'{win}\system32\drivers\etc\hosts'.format(win=os.getenv('WINDIR'))]:
         if not os.path.exists(f_name):
             continue
-        with salt.utils.fopen(f_name) as f_hdl:
+        with salt.utils.files.fopen(f_name) as f_hdl:
             for hst in (line.strip().split('#')[0].strip().split() or None for line in f_hdl.read().split(os.linesep)):
                 if hst and (hst[0][:4] in ['127.', '::1'] or len(hst) == 1):
                     hosts.extend(hst)
@@ -1206,7 +1207,7 @@ def active_tcp():
     ret = {}
     for statf in ['/proc/net/tcp', '/proc/net/tcp6']:
         if os.path.isfile(statf):
-            with salt.utils.fopen(statf, 'rb') as fp_:
+            with salt.utils.files.fopen(statf, 'rb') as fp_:
                 for line in fp_:
                     if line.strip().startswith('sl'):
                         continue
@@ -1241,7 +1242,7 @@ def _remotes_on(port, which_end):
     for statf in ['/proc/net/tcp', '/proc/net/tcp6']:
         if os.path.isfile(statf):
             proc_available = True
-            with salt.utils.fopen(statf, 'r') as fp_:
+            with salt.utils.files.fopen(statf, 'r') as fp_:
                 for line in fp_:
                     if line.strip().startswith('sl'):
                         continue

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -36,7 +36,8 @@ except ImportError:
 # pylint: enable=import-error
 
 # Import salt libs
-import salt.utils
+import salt.utils.cloud
+import salt.utils.files
 from salt.exceptions import SaltCloudSystemExit
 from salt.utils.versions import LooseVersion as _LooseVersion
 
@@ -763,7 +764,7 @@ class SaltNova(object):
         '''
         nt_ks = self.compute_conn
         if pubfile:
-            with salt.utils.fopen(pubfile, 'r') as fp_:
+            with salt.utils.files.fopen(pubfile, 'r') as fp_:
                 pubkey = fp_.read()
         if not pubkey:
             return False

--- a/salt/utils/openstack/swift.py
+++ b/salt/utils/openstack/swift.py
@@ -14,7 +14,7 @@ from os.path import dirname, isdir
 from errno import EEXIST
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -177,7 +177,7 @@ class SaltSwift(object):
                 dirpath = dirname(local_file)
                 if dirpath and not isdir(dirpath):
                     mkdirs(dirpath)
-                fp = salt.utils.fopen(local_file, 'wb')  # pylint: disable=resource-leakage
+                fp = salt.utils.files.fopen(local_file, 'wb')  # pylint: disable=resource-leakage
 
             read_length = 0
             for chunk in body:
@@ -200,7 +200,7 @@ class SaltSwift(object):
         Upload a file to Swift
         '''
         try:
-            with salt.utils.fopen(local_file, 'rb') as fp_:
+            with salt.utils.files.fopen(local_file, 'rb') as fp_:
                 self.conn.put_object(cont, obj, fp_)
             return True
         except Exception as exc:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -32,6 +32,7 @@ import salt.syspaths as syspaths
 import salt.version as version
 import salt.utils
 import salt.utils.args
+import salt.utils.files
 import salt.utils.xdg
 import salt.utils.jid
 from salt.utils import kinds
@@ -1339,7 +1340,7 @@ class OutputOptionsMixIn(six.with_metaclass(MixInMeta, object)):
         if self.options.output_file is not None and self.options.output_file_append is False:
             if os.path.isfile(self.options.output_file):
                 try:
-                    with salt.utils.fopen(self.options.output_file, 'w') as ofh:
+                    with salt.utils.files.fopen(self.options.output_file, 'w') as ofh:
                         # Make this a zero length filename instead of removing
                         # it. This way we keep the file permissions.
                         ofh.write('')

--- a/salt/utils/pkg/__init__.py
+++ b/salt/utils/pkg/__init__.py
@@ -11,6 +11,7 @@ import re
 
 # Import Salt libs
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ def write_rtag(opts):
     rtag_file = rtag(opts)
     if not os.path.exists(rtag_file):
         try:
-            with salt.utils.fopen(rtag_file, 'w+'):
+            with salt.utils.files.fopen(rtag_file, 'w+'):
                 pass
         except OSError as exc:
             log.warning('Encountered error writing rtag: %s', exc.__str__())

--- a/salt/utils/preseed.py
+++ b/salt/utils/preseed.py
@@ -7,7 +7,7 @@ Utilities for managing Debian preseed
 from __future__ import absolute_import
 import yaml
 import shlex
-import salt.utils
+import salt.utils.files
 
 
 def mksls(src, dst=None):
@@ -15,7 +15,7 @@ def mksls(src, dst=None):
     Convert a preseed file to an SLS file
     '''
     ps_opts = {}
-    with salt.utils.fopen(src, 'r') as fh_:
+    with salt.utils.files.fopen(src, 'r') as fh_:
         for line in fh_:
             if line.startswith('#'):
                 continue
@@ -72,7 +72,7 @@ def mksls(src, dst=None):
         sls[iface]['nameservers'] = ps_opts['d-i']['netcfg']['get_nameservers']['argument']
 
     if dst is not None:
-        with salt.utils.fopen(dst, 'w') as fh_:
+        with salt.utils.files.fopen(dst, 'w') as fh_:
             fh_.write(yaml.safe_dump(sls, default_flow_style=False))
     else:
         return yaml.safe_dump(sls, default_flow_style=False)

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -20,6 +20,7 @@ import multiprocessing.util
 # Import salt libs
 import salt.defaults.exitcodes
 import salt.utils
+import salt.utils.files
 import salt.log.setup
 import salt.defaults.exitcodes
 from salt.log.mixins import NewStyleClassMixIn
@@ -74,7 +75,7 @@ def set_pidfile(pidfile, user):
     if not os.path.isdir(pdir) and pdir:
         os.makedirs(pdir)
     try:
-        with salt.utils.fopen(pidfile, 'w+') as ofile:
+        with salt.utils.files.fopen(pidfile, 'w+') as ofile:
             ofile.write(str(os.getpid()))
     except IOError:
         pass
@@ -128,7 +129,7 @@ def get_pidfile(pidfile):
     '''
     Return the pid from a pidfile as an integer
     '''
-    with salt.utils.fopen(pidfile) as pdf:
+    with salt.utils.files.fopen(pidfile) as pdf:
         pid = pdf.read()
 
     return int(pid)
@@ -446,7 +447,7 @@ class ProcessManager(object):
                 # call 'taskkill', it will leave a 'taskkill' zombie process.
                 # We want to avoid this.
                 return
-            with salt.utils.fopen(os.devnull, 'wb') as devnull:
+            with salt.utils.files.fopen(os.devnull, 'wb') as devnull:
                 for pid, p_map in six.iteritems(self._process_map):
                     # On Windows, we need to explicitly terminate sub-processes
                     # because the processes don't have a sigterm handler.

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -12,6 +12,7 @@ import salt.state
 import salt.utils
 import salt.utils.cache
 import salt.utils.event
+import salt.utils.files
 import salt.utils.process
 import salt.defaults.exitcodes
 
@@ -89,7 +90,7 @@ class Reactor(salt.utils.process.SignalHandlingMultiprocessingProcess, salt.stat
         reactors = []
         if isinstance(self.opts['reactor'], six.string_types):
             try:
-                with salt.utils.fopen(self.opts['reactor']) as fp_:
+                with salt.utils.files.fopen(self.opts['reactor']) as fp_:
                     react_map = yaml.safe_load(fp_.read())
             except (OSError, IOError):
                 log.error(
@@ -126,7 +127,7 @@ class Reactor(salt.utils.process.SignalHandlingMultiprocessingProcess, salt.stat
         if isinstance(self.minion.opts['reactor'], six.string_types):
             log.debug('Reading reactors from yaml {0}'.format(self.opts['reactor']))
             try:
-                with salt.utils.fopen(self.opts['reactor']) as fp_:
+                with salt.utils.files.fopen(self.opts['reactor']) as fp_:
                     react_map = yaml.safe_load(fp_.read())
             except (OSError, IOError):
                 log.error(

--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -19,6 +19,7 @@ except ImportError:
 # Import Salt libs
 import salt.utils
 import salt.utils.aws
+import salt.utils.files
 import salt.utils.xmlutil as xml
 from salt._compat import ElementTree as ET
 from salt.exceptions import CommandExecutionError
@@ -150,7 +151,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
     try:
         if method == 'PUT':
             if local_file:
-                data = salt.utils.fopen(local_file, 'r')  # pylint: disable=resource-leakage
+                data = salt.utils.files.fopen(local_file, 'r')  # pylint: disable=resource-leakage
             result = requests.request(method,
                                       requesturl,
                                       headers=headers,
@@ -233,7 +234,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
                 'Failed to get file. {0}: {1}'.format(err_code, err_msg))
 
         log.debug('Saving to local file: {0}'.format(local_file))
-        with salt.utils.fopen(local_file, 'wb') as out:
+        with salt.utils.files.fopen(local_file, 'wb') as out:
             for chunk in result.iter_content(chunk_size=chunk_size):
                 out.write(chunk)
         return 'Saved to local file: {0}'.format(local_file)

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -337,6 +337,9 @@ import yaml
 # Import Salt libs
 import salt.config
 import salt.utils
+import salt.utils.error
+import salt.utils.event
+import salt.utils.files
 import salt.utils.jid
 import salt.utils.process
 import salt.utils.args
@@ -472,7 +475,7 @@ class Schedule(object):
         schedule_conf = os.path.join(minion_d_dir, '_schedule.conf')
         log.debug('Persisting schedule')
         try:
-            with salt.utils.fopen(schedule_conf, 'wb+') as fp_:
+            with salt.utils.files.fopen(schedule_conf, 'wb+') as fp_:
                 fp_.write(
                     salt.utils.to_bytes(
                         yaml.dump(
@@ -817,7 +820,7 @@ class Schedule(object):
                 log.debug('schedule.handle_func: adding this job to the jobcache '
                           'with data {0}'.format(ret))
                 # write this to /var/cache/salt/minion/proc
-                with salt.utils.fopen(proc_fn, 'w+b') as fp_:
+                with salt.utils.files.fopen(proc_fn, 'w+b') as fp_:
                     fp_.write(salt.payload.Serial(self.opts).dumps(ret))
 
             args = tuple()
@@ -1368,7 +1371,7 @@ def clean_proc_dir(opts):
 
     for basefilename in os.listdir(salt.minion.get_proc_dir(opts['cachedir'])):
         fn_ = os.path.join(salt.minion.get_proc_dir(opts['cachedir']), basefilename)
-        with salt.utils.fopen(fn_, 'rb') as fp_:
+        with salt.utils.files.fopen(fn_, 'rb') as fp_:
             job = None
             try:
                 job = salt.payload.Serial(opts).load(fp_)

--- a/salt/utils/smb.py
+++ b/salt/utils/smb.py
@@ -8,7 +8,7 @@ Utility functions for SMB connections
 from __future__ import absolute_import
 
 # Import python libs
-import salt.utils
+import salt.utils.files
 import logging
 
 log = logging.getLogger(__name__)
@@ -116,5 +116,5 @@ def put_file(local_path, path, share='C$', conn=None, host=None, username=None, 
     if conn is False:
         return False
 
-    with salt.utils.fopen(local_path, 'rb') as fh_:
+    with salt.utils.files.fopen(local_path, 'rb') as fh_:
         conn.putFile(share, path, fh_.read)

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -269,7 +269,7 @@ def _get_jinja_error(trace, context=None):
     if add_log:
         if template_path:
             out = '\n{0}\n'.format(msg.splitlines()[0])
-            with salt.utils.fopen(template_path) as fp_:
+            with salt.utils.files.fopen(template_path) as fp_:
                 template_contents = fp_.read()
             out += salt.utils.get_context(
                 template_contents,
@@ -523,7 +523,7 @@ def py(sfn, string=False, **kwargs):  # pylint: disable=C0103
             return {'result': True,
                     'data': data}
         tgt = salt.utils.files.mkstemp()
-        with salt.utils.fopen(tgt, 'w+') as target:
+        with salt.utils.files.fopen(tgt, 'w+') as target:
             target.write(data)
         return {'result': True,
                 'data': tgt}

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -71,6 +71,7 @@ except ImportError:
 # Import salt libs
 import salt
 import salt.utils
+import salt.utils.files
 import salt.exceptions
 
 SALTCALL = '''
@@ -181,15 +182,15 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
     thinver = os.path.join(thindir, 'version')
     pythinver = os.path.join(thindir, '.thin-gen-py-version')
     salt_call = os.path.join(thindir, 'salt-call')
-    with salt.utils.fopen(salt_call, 'w+') as fp_:
+    with salt.utils.files.fopen(salt_call, 'w+') as fp_:
         fp_.write(SALTCALL)
     if os.path.isfile(thintar):
         if not overwrite:
             if os.path.isfile(thinver):
-                with salt.utils.fopen(thinver) as fh_:
+                with salt.utils.files.fopen(thinver) as fh_:
                     overwrite = fh_.read() != salt.version.__version__
                 if overwrite is False and os.path.isfile(pythinver):
-                    with salt.utils.fopen(pythinver) as fh_:
+                    with salt.utils.files.fopen(pythinver) as fh_:
                         overwrite = fh_.read() != str(sys.version_info[0])
             else:
                 overwrite = True
@@ -318,9 +319,9 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
         tfp.add('salt-call')
     elif compress == 'zip':
         tfp.write('salt-call')
-    with salt.utils.fopen(thinver, 'w+') as fp_:
+    with salt.utils.files.fopen(thinver, 'w+') as fp_:
         fp_.write(salt.version.__version__)
-    with salt.utils.fopen(pythinver, 'w+') as fp_:
+    with salt.utils.files.fopen(pythinver, 'w+') as fp_:
         fp_.write(str(sys.version_info[0]))
     os.chdir(os.path.dirname(thinver))
     if compress == 'gzip':
@@ -366,15 +367,15 @@ def gen_min(cachedir, extra_mods='', overwrite=False, so_mods='',
     minver = os.path.join(mindir, 'version')
     pyminver = os.path.join(mindir, '.min-gen-py-version')
     salt_call = os.path.join(mindir, 'salt-call')
-    with salt.utils.fopen(salt_call, 'w+') as fp_:
+    with salt.utils.files.fopen(salt_call, 'w+') as fp_:
         fp_.write(SALTCALL)
     if os.path.isfile(mintar):
         if not overwrite:
             if os.path.isfile(minver):
-                with salt.utils.fopen(minver) as fh_:
+                with salt.utils.files.fopen(minver) as fh_:
                     overwrite = fh_.read() != salt.version.__version__
                 if overwrite is False and os.path.isfile(pyminver):
-                    with salt.utils.fopen(pyminver) as fh_:
+                    with salt.utils.files.fopen(pyminver) as fh_:
                         overwrite = fh_.read() != str(sys.version_info[0])
             else:
                 overwrite = True
@@ -606,9 +607,9 @@ def gen_min(cachedir, extra_mods='', overwrite=False, so_mods='',
 
     os.chdir(mindir)
     tfp.add('salt-call')
-    with salt.utils.fopen(minver, 'w+') as fp_:
+    with salt.utils.files.fopen(minver, 'w+') as fp_:
         fp_.write(salt.version.__version__)
-    with salt.utils.fopen(pyminver, 'w+') as fp_:
+    with salt.utils.files.fopen(pyminver, 'w+') as fp_:
         fp_.write(str(sys.version_info[0]))
     os.chdir(os.path.dirname(minver))
     tfp.add('version')

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -28,6 +28,7 @@ from salt.exceptions import SaltClientError, SaltSystemExit, \
     CommandExecutionError
 import salt.defaults.exitcodes
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -167,7 +168,7 @@ def verify_files(files, user):
                     if err.errno != errno.EEXIST:
                         raise
             if not os.path.isfile(fn_):
-                with salt.utils.fopen(fn_, 'w+') as fp_:
+                with salt.utils.files.fopen(fn_, 'w+') as fp_:
                     fp_.write('')
 
         except IOError as err:

--- a/salt/utils/virt.py
+++ b/salt/utils/virt.py
@@ -10,7 +10,7 @@ import time
 import logging
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 
 log = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ class VirtKey(object):
         Accept the provided key
         '''
         try:
-            with salt.utils.fopen(self.path, 'r') as fp_:
+            with salt.utils.files.fopen(self.path, 'r') as fp_:
                 expiry = int(fp_.read())
         except (OSError, IOError):
             log.error(
@@ -56,7 +56,7 @@ class VirtKey(object):
         pubfn = os.path.join(self.opts['pki_dir'],
                 'minions',
                 self.id)
-        with salt.utils.fopen(pubfn, 'w+') as fp_:
+        with salt.utils.files.fopen(pubfn, 'w+') as fp_:
             fp_.write(pub)
         self.void()
         return True
@@ -65,7 +65,7 @@ class VirtKey(object):
         '''
         Prepare the master to expect a signing request
         '''
-        with salt.utils.fopen(self.path, 'w+') as fp_:
+        with salt.utils.files.fopen(self.path, 'w+') as fp_:
             fp_.write(str(int(time.time())))
         return True
 

--- a/salt/utils/yast.py
+++ b/salt/utils/yast.py
@@ -7,7 +7,7 @@ Utilities for managing YAST
 from __future__ import absolute_import
 from salt._compat import ElementTree as ET
 import salt.utils.xmlutil as xml
-import salt.utils
+import salt.utils.files
 import yaml
 
 
@@ -15,11 +15,11 @@ def mksls(src, dst=None):
     '''
     Convert an AutoYAST file to an SLS file
     '''
-    with salt.utils.fopen(src, 'r') as fh_:
+    with salt.utils.files.fopen(src, 'r') as fh_:
         ps_opts = xml.to_dict(ET.fromstring(fh_.read()))
 
     if dst is not None:
-        with salt.utils.fopen(dst, 'w') as fh_:
+        with salt.utils.files.fopen(dst, 'w') as fh_:
             fh_.write(yaml.safe_dump(ps_opts, default_flow_style=False))
     else:
         return yaml.safe_dump(ps_opts, default_flow_style=False)

--- a/salt/wheel/config.py
+++ b/salt/wheel/config.py
@@ -13,6 +13,7 @@ import yaml
 
 # Import salt libs
 import salt.config
+import salt.utils.files
 from salt.utils.yamldumper import SafeOrderedDumper
 
 log = logging.getLogger(__name__)
@@ -39,7 +40,7 @@ def apply(key, value):
         path = os.path.join(path, 'master')
     data = values()
     data[key] = value
-    with salt.utils.fopen(path, 'w+') as fp_:
+    with salt.utils.files.fopen(path, 'w+') as fp_:
         fp_.write(
             yaml.dump(
                 data,
@@ -87,7 +88,7 @@ def update_config(file_name, yaml_contents):
             os.makedirs(dir_path, 0o755)
 
         file_path = os.path.join(dir_path, file_name)
-        with salt.utils.fopen(file_path, 'w') as fp_:
+        with salt.utils.files.fopen(file_path, 'w') as fp_:
             fp_.write(yaml_out)
 
         return 'Wrote {0}'.format(file_name)

--- a/salt/wheel/file_roots.py
+++ b/salt/wheel/file_roots.py
@@ -9,6 +9,7 @@ import os
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -26,7 +27,7 @@ def find(path, saltenv='base'):
         full = os.path.join(root, path)
         if os.path.isfile(full):
             # Add it to the dict
-            with salt.utils.fopen(full, 'rb') as fp_:
+            with salt.utils.files.fopen(full, 'rb') as fp_:
                 if salt.utils.istextfile(fp_):
                     ret.append({full: 'txt'})
                 else:
@@ -86,7 +87,7 @@ def read(path, saltenv='base'):
         full = next(six.iterkeys(fn_))
         form = fn_[full]
         if form == 'txt':
-            with salt.utils.fopen(full, 'rb') as fp_:
+            with salt.utils.files.fopen(full, 'rb') as fp_:
                 ret.append({full: fp_.read()})
     return ret
 
@@ -108,6 +109,6 @@ def write(data, path, saltenv='base', index=0):
     dest_dir = os.path.dirname(dest)
     if not os.path.isdir(dest_dir):
         os.makedirs(dest_dir)
-    with salt.utils.fopen(dest, 'w+') as fp_:
+    with salt.utils.files.fopen(dest, 'w+') as fp_:
         fp_.write(data)
     return 'Wrote data to file {0}'.format(dest)

--- a/salt/wheel/key.py
+++ b/salt/wheel/key.py
@@ -37,6 +37,7 @@ import logging
 from salt.key import get_key
 import salt.crypt
 import salt.utils
+import salt.utils.files
 from salt.utils.sanitizers import clean
 
 
@@ -353,9 +354,9 @@ def gen(id_=None, keysize=2048):
            'pub': ''}
     priv = salt.crypt.gen_keys(__opts__['pki_dir'], id_, keysize)
     pub = '{0}.pub'.format(priv[:priv.rindex('.')])
-    with salt.utils.fopen(priv) as fp_:
+    with salt.utils.files.fopen(priv) as fp_:
         ret['priv'] = fp_.read()
-    with salt.utils.fopen(pub) as fp_:
+    with salt.utils.files.fopen(pub) as fp_:
         ret['pub'] = fp_.read()
 
     # The priv key is given the Read-Only attribute. The causes `os.remove` to
@@ -413,7 +414,7 @@ def gen_accept(id_, keysize=2048, force=False):
     acc_path = os.path.join(__opts__['pki_dir'], 'minions', id_)
     if os.path.isfile(acc_path) and not force:
         return {}
-    with salt.utils.fopen(acc_path, 'w+') as fp_:
+    with salt.utils.files.fopen(acc_path, 'w+') as fp_:
         fp_.write(ret['pub'])
     return ret
 

--- a/salt/wheel/pillar_roots.py
+++ b/salt/wheel/pillar_roots.py
@@ -10,6 +10,7 @@ import os
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -27,7 +28,7 @@ def find(path, saltenv='base'):
         full = os.path.join(root, path)
         if os.path.isfile(full):
             # Add it to the dict
-            with salt.utils.fopen(full, 'rb') as fp_:
+            with salt.utils.files.fopen(full, 'rb') as fp_:
                 if salt.utils.istextfile(fp_):
                     ret.append({full: 'txt'})
                 else:
@@ -87,7 +88,7 @@ def read(path, saltenv='base'):
         full = next(six.iterkeys(fn_))
         form = fn_[full]
         if form == 'txt':
-            with salt.utils.fopen(full, 'rb') as fp_:
+            with salt.utils.files.fopen(full, 'rb') as fp_:
                 ret.append({full: fp_.read()})
     return ret
 
@@ -109,6 +110,6 @@ def write(data, path, saltenv='base', index=0):
     dest_dir = os.path.dirname(dest)
     if not os.path.isdir(dest_dir):
         os.makedirs(dest_dir)
-    with salt.utils.fopen(dest, 'w+') as fp_:
+    with salt.utils.files.fopen(dest, 'w+') as fp_:
         fp_.write(data)
     return 'Wrote data to file {0}'.format(dest)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ import salt.ext.six as six
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.log.setup
 from salt.utils.odict import OrderedDict
 
@@ -592,7 +593,7 @@ def cli_bin_dir(tempdir,
         if not os.path.isfile(script_path):
             log.info('Generating {0}'.format(script_path))
 
-            with salt.utils.fopen(script_path, 'w') as sfh:
+            with salt.utils.files.fopen(script_path, 'w') as sfh:
                 script_template = script_templates.get(original_script_name, None)
                 if script_template is None:
                     script_template = script_templates.get('common', None)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -50,6 +50,7 @@ import salt.runner
 import salt.output
 import salt.version
 import salt.utils
+import salt.utils.files
 import salt.utils.process
 import salt.log.setup as salt_log_setup
 from salt.ext import six
@@ -646,7 +647,7 @@ class TestDaemon(object):
         if keygen_ed25519_err:
             print('ssh-keygen had errors: {0}'.format(salt.utils.to_str(keygen_ed25519_err)))
 
-        with salt.utils.fopen(os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'sshd_config'), 'a') as ssh_config:
+        with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'sshd_config'), 'a') as ssh_config:
             ssh_config.write('AuthorizedKeysFile {0}\n'.format(auth_key_file))
             if not keygen_dsa_err:
                 ssh_config.write('HostKey {0}\n'.format(server_dsa_priv_key_file))
@@ -670,7 +671,7 @@ class TestDaemon(object):
             os.environ['SSH_DAEMON_RUNNING'] = 'True'
         roster_path = os.path.join(FILES, 'conf/_ssh/roster')
         shutil.copy(roster_path, RUNTIME_VARS.TMP_CONF_DIR)
-        with salt.utils.fopen(os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'roster'), 'a') as roster:
+        with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'roster'), 'a') as roster:
             roster.write('  user: {0}\n'.format(RUNTIME_VARS.RUNNING_TESTS_USER))
             roster.write('  priv: {0}/{1}'.format(RUNTIME_VARS.TMP_CONF_DIR, 'key_test'))
         sys.stdout.write(
@@ -724,7 +725,7 @@ class TestDaemon(object):
         os.makedirs(RUNTIME_VARS.TMP_SYNDIC_MINION_CONF_DIR)
         print(' * Transplanting configuration files to \'{0}\''.format(RUNTIME_VARS.TMP_CONF_DIR))
         tests_known_hosts_file = os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'salt_ssh_known_hosts')
-        with salt.utils.fopen(tests_known_hosts_file, 'w') as known_hosts:
+        with salt.utils.files.fopen(tests_known_hosts_file, 'w') as known_hosts:
             known_hosts.write('')
 
         # This master connects to syndic_master via a syndic
@@ -898,22 +899,22 @@ class TestDaemon(object):
 
         for entry in ('master', 'minion', 'sub_minion', 'syndic', 'syndic_master', 'proxy'):
             computed_config = copy.deepcopy(locals()['{0}_opts'.format(entry)])
-            with salt.utils.fopen(os.path.join(RUNTIME_VARS.TMP_CONF_DIR, entry), 'w') as fp_:
+            with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.TMP_CONF_DIR, entry), 'w') as fp_:
                 fp_.write(yaml.dump(computed_config, default_flow_style=False))
         sub_minion_computed_config = copy.deepcopy(sub_minion_opts)
-        with salt.utils.fopen(os.path.join(RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR, 'minion'), 'w') as wfh:
+        with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR, 'minion'), 'w') as wfh:
             wfh.write(
                 yaml.dump(sub_minion_computed_config, default_flow_style=False)
             )
         shutil.copyfile(os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'master'), os.path.join(RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR, 'master'))
 
         syndic_master_computed_config = copy.deepcopy(syndic_master_opts)
-        with salt.utils.fopen(os.path.join(RUNTIME_VARS.TMP_SYNDIC_MASTER_CONF_DIR, 'master'), 'w') as wfh:
+        with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.TMP_SYNDIC_MASTER_CONF_DIR, 'master'), 'w') as wfh:
             wfh.write(
                 yaml.dump(syndic_master_computed_config, default_flow_style=False)
             )
         syndic_computed_config = copy.deepcopy(syndic_opts)
-        with salt.utils.fopen(os.path.join(RUNTIME_VARS.TMP_SYNDIC_MINION_CONF_DIR, 'minion'), 'w') as wfh:
+        with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.TMP_SYNDIC_MINION_CONF_DIR, 'minion'), 'w') as wfh:
             wfh.write(
                 yaml.dump(syndic_computed_config, default_flow_style=False)
             )
@@ -1061,7 +1062,7 @@ class TestDaemon(object):
             except OSError as exc:
                 if exc.errno != 3:
                     raise
-            with salt.utils.fopen(self.sshd_pidfile) as fhr:
+            with salt.utils.files.fopen(self.sshd_pidfile) as fhr:
                 try:
                     os.kill(int(fhr.read()), signal.SIGKILL)
                 except OSError as exc:

--- a/tests/integration/cli/test_grains.py
+++ b/tests/integration/cli/test_grains.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 import os
 
 # Import Salt Libs
-import salt.utils
+import salt.utils.files
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase, SSHCase
@@ -61,7 +61,7 @@ class GrainsTargetingTest(ShellCase):
         # Create a minion key, but do not start the "fake" minion. This mimics a
         # disconnected minion.
         key_file = os.path.join(self.master_opts['pki_dir'], 'minions', 'disconnected')
-        with salt.utils.fopen(key_file, 'a'):
+        with salt.utils.files.fopen(key_file, 'a'):
             pass
 
         # ping disconnected minion and ensure it times out and returns with correct message

--- a/tests/integration/client/test_standard.py
+++ b/tests/integration/client/test_standard.py
@@ -8,7 +8,7 @@ import os
 from tests.support.case import ModuleCase
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 
 class StdTest(ModuleCase):
@@ -43,7 +43,7 @@ class StdTest(ModuleCase):
         # create fake minion
         key_file = os.path.join(self.master_opts['pki_dir'], 'minions', 'footest')
         # touch the file
-        with salt.utils.fopen(key_file, 'a'):
+        with salt.utils.files.fopen(key_file, 'a'):
             pass
         # ping that minion and ensure it times out
         try:
@@ -126,7 +126,7 @@ class StdTest(ModuleCase):
         # Create a minion key, but do not start the "fake" minion. This mimics
         # a disconnected minion.
         key_file = os.path.join(self.master_opts['pki_dir'], 'minions', 'disconnected')
-        with salt.utils.fopen(key_file, 'a'):
+        with salt.utils.files.fopen(key_file, 'a'):
             pass
 
         # ping disconnected minion and ensure it times out and returns with correct message

--- a/tests/integration/minion/test_blackout.py
+++ b/tests/integration/minion/test_blackout.py
@@ -15,7 +15,7 @@ from tests.support.paths import PILLAR_DIR
 from tests.support.helpers import destructiveTest
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 
 
 BLACKOUT_PILLAR = os.path.join(PILLAR_DIR, 'base', 'blackout.sls')
@@ -30,7 +30,7 @@ class MinionBlackoutTestCase(ModuleCase):
         '''
         setup minion blackout mode
         '''
-        with salt.utils.fopen(BLACKOUT_PILLAR, 'w') as wfh:
+        with salt.utils.files.fopen(BLACKOUT_PILLAR, 'w') as wfh:
             wfh.write(blackout_data)
         self.run_function('saltutil.refresh_pillar')
         sleep(5)  # wait for minion to enter blackout mode
@@ -39,7 +39,7 @@ class MinionBlackoutTestCase(ModuleCase):
         '''
         takedown minion blackout mode
         '''
-        with salt.utils.fopen(BLACKOUT_PILLAR, 'w') as blackout_pillar:
+        with salt.utils.files.fopen(BLACKOUT_PILLAR, 'w') as blackout_pillar:
             blackout_pillar.write(textwrap.dedent('''\
                 minion_blackout: False
                 '''))

--- a/tests/integration/minion/test_pillar.py
+++ b/tests/integration/minion/test_pillar.py
@@ -25,6 +25,7 @@ import salt.ext.six as six
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.pillar as pillar
 
 log = logging.getLogger(__name__)
@@ -226,13 +227,13 @@ class DecryptGPGPillarTest(ModuleCase):
             log.debug('Result:\n%s', output)
 
             os.makedirs(PILLAR_BASE)
-            with salt.utils.fopen(TOP_SLS, 'w') as fp_:
+            with salt.utils.files.fopen(TOP_SLS, 'w') as fp_:
                 fp_.write(textwrap.dedent('''\
                 base:
                   '*':
                     - gpg
                 '''))
-            with salt.utils.fopen(GPG_SLS, 'w') as fp_:
+            with salt.utils.files.fopen(GPG_SLS, 'w') as fp_:
                 fp_.write(GPG_PILLAR_YAML)
 
     @classmethod

--- a/tests/integration/modules/test_archive.py
+++ b/tests/integration/modules/test_archive.py
@@ -16,6 +16,7 @@ from tests.support.helpers import destructiveTest
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 # Import 3rd party libs
 try:
@@ -59,7 +60,7 @@ class ArchiveTest(ModuleCase):
 
         # Create source
         os.makedirs(self.src)
-        with salt.utils.fopen(os.path.join(self.src, 'file'), 'w') as theorem:
+        with salt.utils.files.fopen(os.path.join(self.src, 'file'), 'w') as theorem:
             theorem.write(textwrap.dedent(r'''\
                 Compression theorem of computational complexity theory:
 

--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 import os
 import uuid
-import shutil
 import hashlib
 import logging
 import psutil
@@ -22,6 +21,7 @@ import tests.support.paths as paths
 # Import salt libs
 import salt.ext.six as six
 import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class CPModuleTest(ModuleCase):
                     'salt://grail/scene33',
                     tgt,
                 ])
-        with salt.utils.fopen(tgt, 'r') as scene:
+        with salt.utils.files.fopen(tgt, 'r') as scene:
             data = scene.read()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
@@ -57,7 +57,7 @@ class CPModuleTest(ModuleCase):
                     'salt://grail/scene33',
                     tgt,
                 ])
-        with salt.utils.fopen(tgt + 'scene33', 'r') as scene:
+        with salt.utils.files.fopen(tgt + 'scene33', 'r') as scene:
             data = scene.read()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
@@ -75,7 +75,7 @@ class CPModuleTest(ModuleCase):
             ],
             template='jinja'
         )
-        with salt.utils.fopen(tgt, 'r') as cheese:
+        with salt.utils.files.fopen(tgt, 'r') as cheese:
             data = cheese.read()
             self.assertIn('Gromit', data)
             self.assertNotIn('bacon', data)
@@ -86,7 +86,7 @@ class CPModuleTest(ModuleCase):
         '''
         tgt = os.path.join(paths.TMP, 'file.big')
         src = os.path.join(paths.FILES, 'file', 'base', 'file.big')
-        with salt.utils.fopen(src, 'r') as fp_:
+        with salt.utils.files.fopen(src, 'r') as fp_:
             data = fp_.read()
             if six.PY3:
                 data = salt.utils.to_bytes(data)
@@ -100,7 +100,7 @@ class CPModuleTest(ModuleCase):
             ],
             gzip=5
         )
-        with salt.utils.fopen(tgt, 'r') as scene:
+        with salt.utils.files.fopen(tgt, 'r') as scene:
             data = scene.read()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
@@ -122,7 +122,7 @@ class CPModuleTest(ModuleCase):
             makedirs=True
         )
         self.addCleanup(shutil.rmtree, os.path.join(paths.TMP, 'make'), ignore_errors=True)
-        with salt.utils.fopen(tgt, 'r') as scene:
+        with salt.utils.files.fopen(tgt, 'r') as scene:
             data = scene.read()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
@@ -136,7 +136,7 @@ class CPModuleTest(ModuleCase):
                 'cp.get_template',
                 ['salt://grail/scene33', tgt],
                 spam='bacon')
-        with salt.utils.fopen(tgt, 'r') as scene:
+        with salt.utils.files.fopen(tgt, 'r') as scene:
             data = scene.read()
             self.assertIn('bacon', data)
             self.assertNotIn('spam', data)
@@ -187,7 +187,7 @@ class CPModuleTest(ModuleCase):
                 'salt://grail/scene33',
                 tgt,
             ])
-        with salt.utils.fopen(tgt, 'r') as scene:
+        with salt.utils.files.fopen(tgt, 'r') as scene:
             data = scene.read()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
@@ -206,7 +206,7 @@ class CPModuleTest(ModuleCase):
                 makedirs=True
             )
         self.addCleanup(shutil.rmtree, os.path.join(paths.TMP, 'make'), ignore_errors=True)
-        with salt.utils.fopen(tgt, 'r') as scene:
+        with salt.utils.files.fopen(tgt, 'r') as scene:
             data = scene.read()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
@@ -220,7 +220,7 @@ class CPModuleTest(ModuleCase):
             [
                 'salt://grail/scene33',
             ])
-        with salt.utils.fopen(ret, 'r') as scene:
+        with salt.utils.files.fopen(ret, 'r') as scene:
             data = scene.read()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
@@ -262,7 +262,7 @@ class CPModuleTest(ModuleCase):
                     'salt://grail/scene33',
                     tgt,
                 ])
-        with salt.utils.fopen(tgt + 'scene33', 'r') as scene:
+        with salt.utils.files.fopen(tgt + 'scene33', 'r') as scene:
             data = scene.read()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
@@ -278,7 +278,7 @@ class CPModuleTest(ModuleCase):
                 'https://repo.saltstack.com/index.html',
                 tgt,
             ])
-        with salt.utils.fopen(tgt, 'r') as instructions:
+        with salt.utils.files.fopen(tgt, 'r') as instructions:
             data = instructions.read()
             self.assertIn('Bootstrap', data)
             self.assertIn('Debian', data)
@@ -294,7 +294,7 @@ class CPModuleTest(ModuleCase):
             [
                 'https://repo.saltstack.com/index.html',
             ])
-        with salt.utils.fopen(ret, 'r') as instructions:
+        with salt.utils.files.fopen(ret, 'r') as instructions:
             data = instructions.read()
             self.assertIn('Bootstrap', data)
             self.assertIn('Debian', data)
@@ -329,7 +329,7 @@ class CPModuleTest(ModuleCase):
                 src,
                 tgt,
             ])
-        with salt.utils.fopen(ret, 'r') as scene:
+        with salt.utils.files.fopen(ret, 'r') as scene:
             data = scene.read()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
@@ -414,7 +414,7 @@ class CPModuleTest(ModuleCase):
                 [
                     'salt://grail/scene33',
                 ])
-        with salt.utils.fopen(ret, 'r') as scene:
+        with salt.utils.files.fopen(ret, 'r') as scene:
             data = scene.read()
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
@@ -429,7 +429,7 @@ class CPModuleTest(ModuleCase):
                     ['salt://grail/scene33', 'salt://grail/36/scene'],
                 ])
         for path in ret:
-            with salt.utils.fopen(path, 'r') as scene:
+            with salt.utils.files.fopen(path, 'r') as scene:
                 data = scene.read()
                 self.assertIn('ARTHUR:', data)
                 self.assertNotIn('bacon', data)
@@ -449,12 +449,12 @@ class CPModuleTest(ModuleCase):
         cp.cache_local_file
         '''
         src = os.path.join(paths.TMP, 'random')
-        with salt.utils.fopen(src, 'w+') as fn_:
+        with salt.utils.files.fopen(src, 'w+') as fn_:
             fn_.write('foo')
         ret = self.run_function(
                 'cp.cache_local_file',
                 [src])
-        with salt.utils.fopen(ret, 'r') as cp_:
+        with salt.utils.files.fopen(ret, 'r') as cp_:
             self.assertEqual(cp_.read(), 'foo')
 
     @skipIf(not salt.utils.which('nginx'), 'nginx not installed')
@@ -477,11 +477,11 @@ class CPModuleTest(ModuleCase):
             os.mkdir(dirname)
 
         # Write the temp file
-        with salt.utils.fopen(os.path.join(nginx_root_dir, 'actual_file'), 'w') as fp_:
+        with salt.utils.files.fopen(os.path.join(nginx_root_dir, 'actual_file'), 'w') as fp_:
             fp_.write(file_contents)
 
         # Write the nginx config
-        with salt.utils.fopen(nginx_conf, 'w') as fp_:
+        with salt.utils.files.fopen(nginx_conf, 'w') as fp_:
             fp_.write(textwrap.dedent(
                 '''\
                 user root;
@@ -521,7 +521,7 @@ class CPModuleTest(ModuleCase):
             [['nginx', '-c', nginx_conf]],
             python_shell=False
         )
-        with salt.utils.fopen(nginx_pidfile) as fp_:
+        with salt.utils.files.fopen(nginx_pidfile) as fp_:
             nginx_pid = int(fp_.read().strip())
             nginx_proc = psutil.Process(pid=nginx_pid)
             self.addCleanup(nginx_proc.send_signal, signal.SIGQUIT)
@@ -530,7 +530,7 @@ class CPModuleTest(ModuleCase):
             url = url_prefix + (code or 'actual_file')
             log.debug('attempting to cache %s', url)
             ret = self.run_function('cp.cache_file', [url])
-            with salt.utils.fopen(ret) as fp_:
+            with salt.utils.files.fopen(ret) as fp_:
                 cached_contents = fp_.read()
                 self.assertEqual(cached_contents, file_contents)
 
@@ -600,7 +600,7 @@ class CPModuleTest(ModuleCase):
                 [
                     'salt://grail/scene33',
                 ])
-        with salt.utils.fopen(path, 'r') as fn_:
+        with salt.utils.files.fopen(path, 'r') as fn_:
             data = fn_.read()
             if six.PY3:
                 data = salt.utils.to_bytes(data)
@@ -614,7 +614,7 @@ class CPModuleTest(ModuleCase):
         tgt = os.path.join(paths.TMP, 'cheese')
         try:
             self.run_function('cp.get_file', ['salt://cheese', tgt])
-            with salt.utils.fopen(tgt, 'r') as cheese:
+            with salt.utils.files.fopen(tgt, 'r') as cheese:
                 data = cheese.read()
                 self.assertIn('Gromit', data)
                 self.assertNotIn('Comte', data)
@@ -625,7 +625,7 @@ class CPModuleTest(ModuleCase):
         tgt = os.path.join(paths.TMP, 'cheese')
         try:
             self.run_function('cp.get_file', ['salt://cheese?saltenv=prod', tgt])
-            with salt.utils.fopen(tgt, 'r') as cheese:
+            with salt.utils.files.fopen(tgt, 'r') as cheese:
                 data = cheese.read()
                 self.assertIn('Gromit', data)
                 self.assertIn('Comte', data)

--- a/tests/integration/modules/test_darwin_sysctl.py
+++ b/tests/integration/modules/test_darwin_sysctl.py
@@ -9,7 +9,6 @@ import os
 import random
 
 # Import Salt Libs
-import salt.utils
 import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
@@ -142,8 +141,8 @@ class DarwinSysctlModuleTest(ModuleCase):
         '''
         # Create new temporary file path and open needed files
         temp_path = salt.utils.files.mkstemp()
-        with salt.utils.fopen(CONFIG, 'r') as org_conf:
-            with salt.utils.fopen(temp_path, 'w') as temp_sysconf:
+        with salt.utils.files.fopen(CONFIG, 'r') as org_conf:
+            with salt.utils.files.fopen(temp_path, 'w') as temp_sysconf:
                 # write sysctl lines to temp file
                 for line in org_conf:
                     temp_sysconf.write(line)
@@ -158,8 +157,8 @@ class DarwinSysctlModuleTest(ModuleCase):
             os.remove(CONFIG)
 
         # write temp lines to sysctl file to restore
-        with salt.utils.fopen(self.conf, 'r') as temp_sysctl:
-            with salt.utils.fopen(CONFIG, 'w') as sysctl:
+        with salt.utils.files.fopen(self.conf, 'r') as temp_sysctl:
+            with salt.utils.files.fopen(CONFIG, 'w') as sysctl:
                 for line in temp_sysctl:
                     sysctl.write(line)
 
@@ -170,7 +169,7 @@ class DarwinSysctlModuleTest(ModuleCase):
         '''
         Returns True if given line is present in file
         '''
-        with salt.utils.fopen(conf_file, 'r') as f_in:
+        with salt.utils.files.fopen(conf_file, 'r') as f_in:
             for line in f_in:
                 if to_find in line:
                     return True

--- a/tests/integration/modules/test_file.py
+++ b/tests/integration/modules/test_file.py
@@ -16,6 +16,7 @@ from tests.support.paths import FILES, TMP
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 
 class FileModuleTest(ModuleCase):
@@ -24,7 +25,7 @@ class FileModuleTest(ModuleCase):
     '''
     def setUp(self):
         self.myfile = os.path.join(TMP, 'myfile')
-        with salt.utils.fopen(self.myfile, 'w+') as fp:
+        with salt.utils.files.fopen(self.myfile, 'w+') as fp:
             fp.write('Hello\n')
         self.mydir = os.path.join(TMP, 'mydir/isawesome')
         if not os.path.isdir(self.mydir):
@@ -123,18 +124,18 @@ class FileModuleTest(ModuleCase):
         src_patch = os.path.join(
             FILES, 'file', 'base', 'hello.patch')
         src_file = os.path.join(TMP, 'src.txt')
-        with salt.utils.fopen(src_file, 'w+') as fp:
+        with salt.utils.files.fopen(src_file, 'w+') as fp:
             fp.write('Hello\n')
 
         # dry-run should not modify src_file
         ret = self.minion_run('file.patch', src_file, src_patch, dry_run=True)
         assert ret['retcode'] == 0, repr(ret)
-        with salt.utils.fopen(src_file) as fp:
+        with salt.utils.files.fopen(src_file) as fp:
             self.assertEqual(fp.read(), 'Hello\n')
 
         ret = self.minion_run('file.patch', src_file, src_patch)
         assert ret['retcode'] == 0, repr(ret)
-        with salt.utils.fopen(src_file) as fp:
+        with salt.utils.files.fopen(src_file) as fp:
             self.assertEqual(fp.read(), 'Hello world\n')
 
     def test_remove_file(self):

--- a/tests/integration/modules/test_git.py
+++ b/tests/integration/modules/test_git.py
@@ -27,6 +27,7 @@ from tests.support.helpers import skip_if_binaries_missing
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.utils.versions import LooseVersion
 
 # Import 3rd-party libs
@@ -91,7 +92,7 @@ class GitModuleTest(ModuleCase):
             dir_path = os.path.join(self.repo, dirname)
             _makedirs(dir_path)
             for filename in self.files:
-                with salt.utils.fopen(os.path.join(dir_path, filename), 'w') as fp_:
+                with salt.utils.files.fopen(os.path.join(dir_path, filename), 'w') as fp_:
                     fp_.write('This is a test file named ' + filename + '.')
         # Navigate to the root of the repo to init, stage, and commit
         os.chdir(self.repo)
@@ -124,7 +125,7 @@ class GitModuleTest(ModuleCase):
             ['git', 'checkout', '--quiet', '-b', self.branches[1]]
         )
         # Add a line to the file
-        with salt.utils.fopen(self.files[0], 'a') as fp_:
+        with salt.utils.files.fopen(self.files[0], 'a') as fp_:
             fp_.write('Added a line\n')
         # Commit the updated file
         subprocess.check_call(
@@ -152,7 +153,7 @@ class GitModuleTest(ModuleCase):
         files = [os.path.join(newdir_path, x) for x in self.files]
         files_relpath = [os.path.join(newdir, x) for x in self.files]
         for path in files:
-            with salt.utils.fopen(path, 'w') as fp_:
+            with salt.utils.files.fopen(path, 'w') as fp_:
                 fp_.write(
                     'This is a test file with relative path {0}.\n'
                     .format(path)
@@ -169,7 +170,7 @@ class GitModuleTest(ModuleCase):
         '''
         filename = 'quux'
         file_path = os.path.join(self.repo, filename)
-        with salt.utils.fopen(file_path, 'w') as fp_:
+        with salt.utils.files.fopen(file_path, 'w') as fp_:
             fp_.write('This is a test file named ' + filename + '.\n')
         ret = self.run_function('git.add', [self.repo, filename])
         self.assertEqual(ret, 'add \'{0}\''.format(filename))
@@ -310,7 +311,7 @@ class GitModuleTest(ModuleCase):
         filename = 'foo'
         commit_re_prefix = r'^\[master [0-9a-f]+\] '
         # Add a line
-        with salt.utils.fopen(os.path.join(self.repo, filename), 'a') as fp_:
+        with salt.utils.files.fopen(os.path.join(self.repo, filename), 'a') as fp_:
             fp_.write('Added a line\n')
         # Stage the file
         self.run_function('git.add', [self.repo, filename])
@@ -320,7 +321,7 @@ class GitModuleTest(ModuleCase):
         # Make sure the expected line is in the output
         self.assertTrue(bool(re.search(commit_re_prefix + commit_msg, ret)))
         # Add another line
-        with salt.utils.fopen(os.path.join(self.repo, filename), 'a') as fp_:
+        with salt.utils.files.fopen(os.path.join(self.repo, filename), 'a') as fp_:
             fp_.write('Added another line\n')
         # Commit the second file without staging
         commit_msg = 'Add another line to ' + filename
@@ -345,7 +346,7 @@ class GitModuleTest(ModuleCase):
                 ['git', 'config', '--global', '--remove-section', 'foo']
             )
             for cmd in cmds:
-                with salt.utils.fopen(os.devnull, 'w') as devnull:
+                with salt.utils.files.fopen(os.devnull, 'w') as devnull:
                     try:
                         subprocess.check_call(cmd, stderr=devnull)
                     except subprocess.CalledProcessError:
@@ -704,7 +705,7 @@ class GitModuleTest(ModuleCase):
         '''
         # Make a change to a different file than the one modifed in setUp
         file_path = os.path.join(self.repo, self.files[1])
-        with salt.utils.fopen(file_path, 'a') as fp_:
+        with salt.utils.files.fopen(file_path, 'a') as fp_:
             fp_.write('Added a line\n')
         # Commit the change
         self.assertTrue(
@@ -848,7 +849,7 @@ class GitModuleTest(ModuleCase):
         # TODO: test more stash actions
         '''
         file_path = os.path.join(self.repo, self.files[0])
-        with salt.utils.fopen(file_path, 'a') as fp_:
+        with salt.utils.files.fopen(file_path, 'a') as fp_:
             fp_.write('Temp change to be stashed')
         self.assertTrue(
             'ERROR' not in self.run_function('git.stash', [self.repo])
@@ -887,10 +888,10 @@ class GitModuleTest(ModuleCase):
             'untracked': ['thisisalsoanewfile']
         }
         for filename in changes['modified']:
-            with salt.utils.fopen(os.path.join(self.repo, filename), 'a') as fp_:
+            with salt.utils.files.fopen(os.path.join(self.repo, filename), 'a') as fp_:
                 fp_.write('Added a line\n')
         for filename in changes['new']:
-            with salt.utils.fopen(os.path.join(self.repo, filename), 'w') as fp_:
+            with salt.utils.files.fopen(os.path.join(self.repo, filename), 'w') as fp_:
                 fp_.write('This is a new file named ' + filename + '.')
             # Stage the new file so it shows up as a 'new' file
             self.assertTrue(
@@ -902,7 +903,7 @@ class GitModuleTest(ModuleCase):
         for filename in changes['deleted']:
             self.run_function('git.rm', [self.repo, filename])
         for filename in changes['untracked']:
-            with salt.utils.fopen(os.path.join(self.repo, filename), 'w') as fp_:
+            with salt.utils.files.fopen(os.path.join(self.repo, filename), 'w') as fp_:
                 fp_.write('This is a new file named ' + filename + '.')
         self.assertEqual(
             self.run_function('git.status', [self.repo]),

--- a/tests/integration/modules/test_hosts.py
+++ b/tests/integration/modules/test_hosts.py
@@ -12,7 +12,7 @@ from tests.support.case import ModuleCase
 from tests.support.paths import FILES, TMP
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 HFN = os.path.join(TMP, 'hosts')
 
@@ -167,7 +167,7 @@ class HostsModuleTest(ModuleCase):
         # use an empty one so we can prove the syntax of the entries
         # being added by the hosts module
         self.__clear_hosts()
-        with salt.utils.fopen(HFN, 'w'):
+        with salt.utils.files.fopen(HFN, 'w'):
             pass
 
         self.assertTrue(
@@ -206,7 +206,7 @@ class HostsModuleTest(ModuleCase):
         )
 
         # now read the lines and ensure they're formatted correctly
-        with salt.utils.fopen(HFN, 'r') as fp_:
+        with salt.utils.files.fopen(HFN, 'r') as fp_:
             lines = fp_.read().splitlines()
         self.assertEqual(lines, [
             '192.168.1.3\t\thost3.fqdn.com',

--- a/tests/integration/modules/test_linux_acl.py
+++ b/tests/integration/modules/test_linux_acl.py
@@ -13,6 +13,7 @@ from tests.support.helpers import skip_if_binaries_missing
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 # from salt.modules import linux_acl as acl
 
 
@@ -28,7 +29,7 @@ class LinuxAclModuleTest(ModuleCase, AdaptedConfigurationTestCaseMixin):
     def setUp(self):
         # Blindly copied from tests.integration.modules.file; Refactoring?
         self.myfile = os.path.join(TMP, 'myfile')
-        with salt.utils.fopen(self.myfile, 'w+') as fp:
+        with salt.utils.files.fopen(self.myfile, 'w+') as fp:
             fp.write('Hello\n')
         self.mydir = os.path.join(TMP, 'mydir/isawesome')
         if not os.path.isdir(self.mydir):

--- a/tests/integration/modules/test_pip.py
+++ b/tests/integration/modules/test_pip.py
@@ -22,6 +22,7 @@ from tests.support.helpers import skip_if_not_root
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES
 
 
@@ -99,13 +100,13 @@ class PipModuleTest(ModuleCase):
         req2_filename = os.path.join(self.venv_dir, 'requirements2.txt')
         req2b_filename = os.path.join(self.venv_dir, 'requirements2b.txt')
 
-        with salt.utils.fopen(req1_filename, 'w') as f:
+        with salt.utils.files.fopen(req1_filename, 'w') as f:
             f.write('-r requirements1b.txt\n')
-        with salt.utils.fopen(req1b_filename, 'w') as f:
+        with salt.utils.files.fopen(req1b_filename, 'w') as f:
             f.write('flake8\n')
-        with salt.utils.fopen(req2_filename, 'w') as f:
+        with salt.utils.files.fopen(req2_filename, 'w') as f:
             f.write('-r requirements2b.txt\n')
-        with salt.utils.fopen(req2b_filename, 'w') as f:
+        with salt.utils.files.fopen(req2b_filename, 'w') as f:
             f.write('pep8\n')
 
         this_user = pwd.getpwuid(os.getuid())[0]
@@ -137,13 +138,13 @@ class PipModuleTest(ModuleCase):
         req2_filename = os.path.join(self.venv_dir, 'requirements2.txt')
         req2b_filename = os.path.join(self.venv_dir, 'requirements2b.txt')
 
-        with salt.utils.fopen(req1_filename, 'w') as f:
+        with salt.utils.files.fopen(req1_filename, 'w') as f:
             f.write('-r requirements1b.txt\n')
-        with salt.utils.fopen(req1b_filename, 'w') as f:
+        with salt.utils.files.fopen(req1b_filename, 'w') as f:
             f.write('flake8\n')
-        with salt.utils.fopen(req2_filename, 'w') as f:
+        with salt.utils.files.fopen(req2_filename, 'w') as f:
             f.write('-r requirements2b.txt\n')
-        with salt.utils.fopen(req2b_filename, 'w') as f:
+        with salt.utils.files.fopen(req2b_filename, 'w') as f:
             f.write('pep8\n')
 
         this_user = pwd.getpwuid(os.getuid())[0]
@@ -172,9 +173,9 @@ class PipModuleTest(ModuleCase):
         req1_filename = os.path.join(self.venv_dir, 'requirements.txt')
         req2_filename = os.path.join(self.venv_dir, 'requirements2.txt')
 
-        with salt.utils.fopen(req1_filename, 'w') as f:
+        with salt.utils.files.fopen(req1_filename, 'w') as f:
             f.write('flake8\n')
-        with salt.utils.fopen(req2_filename, 'w') as f:
+        with salt.utils.files.fopen(req2_filename, 'w') as f:
             f.write('pep8\n')
 
         this_user = pwd.getpwuid(os.getuid())[0]
@@ -209,9 +210,9 @@ class PipModuleTest(ModuleCase):
         req1_filepath = os.path.join(req_cwd, req1_filename)
         req2_filepath = os.path.join(req_cwd, req2_filename)
 
-        with salt.utils.fopen(req1_filepath, 'w') as f:
+        with salt.utils.files.fopen(req1_filepath, 'w') as f:
             f.write('flake8\n')
-        with salt.utils.fopen(req2_filepath, 'w') as f:
+        with salt.utils.files.fopen(req2_filepath, 'w') as f:
             f.write('pep8\n')
 
         this_user = pwd.getpwuid(os.getuid())[0]
@@ -241,9 +242,9 @@ class PipModuleTest(ModuleCase):
         req1_filename = os.path.join(self.venv_dir, 'requirements.txt')
         req2_filename = os.path.join(self.venv_dir, 'requirements2.txt')
 
-        with salt.utils.fopen(req1_filename, 'w') as f:
+        with salt.utils.files.fopen(req1_filename, 'w') as f:
             f.write('-r requirements2.txt')
-        with salt.utils.fopen(req2_filename, 'w') as f:
+        with salt.utils.files.fopen(req2_filename, 'w') as f:
             f.write('pep8')
 
         this_user = pwd.getpwuid(os.getuid())[0]
@@ -272,9 +273,9 @@ class PipModuleTest(ModuleCase):
         req1_file = os.path.join(self.venv_dir, req1_filename)
         req2_file = os.path.join(self.venv_dir, req2_filename)
 
-        with salt.utils.fopen(req1_file, 'w') as f:
+        with salt.utils.files.fopen(req1_file, 'w') as f:
             f.write('-r requirements2.txt')
-        with salt.utils.fopen(req2_file, 'w') as f:
+        with salt.utils.files.fopen(req2_file, 'w') as f:
             f.write('pep8')
 
         this_user = pwd.getpwuid(os.getuid())[0]
@@ -297,9 +298,9 @@ class PipModuleTest(ModuleCase):
         # Create a requirements file that depends on another one.
         req1_filename = os.path.join(self.venv_dir, 'requirements.txt')
         req2_filename = os.path.join(self.venv_dir, 'requirements2.txt')
-        with salt.utils.fopen(req1_filename, 'w') as f:
+        with salt.utils.files.fopen(req1_filename, 'w') as f:
             f.write('-r requirements2.txt')
-        with salt.utils.fopen(req2_filename, 'w') as f:
+        with salt.utils.files.fopen(req2_filename, 'w') as f:
             f.write('pep8')
 
         this_user = pwd.getpwuid(os.getuid())[0]

--- a/tests/integration/modules/test_shadow.py
+++ b/tests/integration/modules/test_shadow.py
@@ -16,6 +16,7 @@ from tests.support.helpers import destructiveTest, skip_if_not_root
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.ext.six.moves import range
 
 
@@ -217,7 +218,7 @@ class ShadowModuleTest(ModuleCase):
         #saving shadow file
         if not os.access("/etc/shadow", os.R_OK | os.W_OK):
             self.skipTest('Could not save initial state of /etc/shadow')
-        with salt.utils.fopen('/etc/shadow', 'r') as sFile:
+        with salt.utils.files.fopen('/etc/shadow', 'r') as sFile:
             shadow = sFile.read()
         #set root password
         self.assertTrue(self.run_function('shadow.set_password', ['root', self._password]))
@@ -228,5 +229,5 @@ class ShadowModuleTest(ModuleCase):
         self.assertEqual(
             self.run_function('shadow.info', ['root'])['passwd'], '')
         #restore shadow file
-        with salt.utils.fopen('/etc/shadow', 'w') as sFile:
+        with salt.utils.files.fopen('/etc/shadow', 'w') as sFile:
             sFile.write(shadow)

--- a/tests/integration/modules/test_ssh.py
+++ b/tests/integration/modules/test_ssh.py
@@ -14,7 +14,7 @@ from tests.support.paths import FILES, TMP
 from tests.support.helpers import skip_if_binaries_missing
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 # Import 3rd-party libs
 from tornado.httpclient import HTTPClient
@@ -51,7 +51,7 @@ class SSHModuleTest(ModuleCase):
             os.makedirs(SUBSALT_DIR)
 
         ssh_raw_path = os.path.join(FILES, 'ssh', 'raw')
-        with salt.utils.fopen(ssh_raw_path) as fd:
+        with salt.utils.files.fopen(ssh_raw_path) as fd:
             self.key = fd.read().strip()
 
     def tearDown(self):

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -16,6 +16,7 @@ from tests.support.mixins import SaltReturnAssertsMixin
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES
 
 # Import 3rd-party libs
@@ -197,7 +198,7 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_function('state.sls', mods='testappend.step-2')
         self.assertSaltTrueReturn(ret)
 
-        with salt.utils.fopen(testfile, 'r') as fp_:
+        with salt.utils.files.fopen(testfile, 'r') as fp_:
             testfile_contents = fp_.read()
 
         contents = textwrap.dedent('''\
@@ -232,7 +233,7 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_function('state.sls', mods='testappend.step-1')
         self.assertSaltTrueReturn(ret)
 
-        with salt.utils.fopen(testfile, 'r') as fp_:
+        with salt.utils.files.fopen(testfile, 'r') as fp_:
             testfile_contents = fp_.read()
 
         self.assertMultiLineEqual(contents, testfile_contents)
@@ -299,7 +300,7 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
 
         # Does it match?
         try:
-            with salt.utils.fopen(testfile, 'r') as fp_:
+            with salt.utils.files.fopen(testfile, 'r') as fp_:
                 contents = fp_.read()
             self.assertMultiLineEqual(expected, contents)
             # Make sure we don't re-append existing text
@@ -313,7 +314,7 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
             )
             self.assertSaltTrueReturn(ret)
 
-            with salt.utils.fopen(testfile, 'r') as fp_:
+            with salt.utils.files.fopen(testfile, 'r') as fp_:
                 contents = fp_.read()
             self.assertMultiLineEqual(expected, contents)
         except Exception:
@@ -387,7 +388,7 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
             'files', 'file', 'base', 'issue-2068-template-str-no-dot.sls'
         )
 
-        with salt.utils.fopen(template_path, 'r') as fp_:
+        with salt.utils.files.fopen(template_path, 'r') as fp_:
             template = fp_.read()
             ret = self.run_function(
                 'state.template_str', [template], timeout=120
@@ -413,7 +414,7 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
             'files', 'file', 'base', 'issue-2068-template-str.sls'
         )
 
-        with salt.utils.fopen(template_path, 'r') as fp_:
+        with salt.utils.files.fopen(template_path, 'r') as fp_:
             template = fp_.read()
         ret = self.run_function(
             'state.template_str', [template], timeout=120
@@ -939,7 +940,7 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
             )
             self.assertSaltTrueReturn(ret)
             self.assertTrue(os.path.isfile(tgt))
-            with salt.utils.fopen(tgt, 'r') as cheese:
+            with salt.utils.files.fopen(tgt, 'r') as cheese:
                 data = cheese.read()
                 self.assertIn('Gromit', data)
                 self.assertIn('Comte', data)

--- a/tests/integration/modules/test_system.py
+++ b/tests/integration/modules/test_system.py
@@ -15,6 +15,7 @@ from tests.support.helpers import destructiveTest, skip_if_not_root
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.states.file
 from salt.ext.six.moves import range
 
@@ -108,7 +109,7 @@ class SystemModuleTest(ModuleCase):
                 log.debug('Comparing hwclock to sys clock')
                 with os.fdopen(rpipeFd, "r") as rpipe:
                     with os.fdopen(wpipeFd, "w") as wpipe:
-                        with salt.utils.fopen(os.devnull, "r") as nulFd:
+                        with salt.utils.files.fopen(os.devnull, "r") as nulFd:
                             p = subprocess.Popen(args=['hwclock', '--compare'],
                                 stdin=nulFd, stdout=wpipeFd, stderr=subprocess.PIPE)
                             p.communicate()
@@ -140,14 +141,14 @@ class SystemModuleTest(ModuleCase):
 
     def _save_machine_info(self):
         if os.path.isfile('/etc/machine-info'):
-            with salt.utils.fopen('/etc/machine-info', 'r') as mach_info:
+            with salt.utils.files.fopen('/etc/machine-info', 'r') as mach_info:
                 self._machine_info = mach_info.read()
         else:
             self._machine_info = False
 
     def _restore_machine_info(self):
         if self._machine_info is not False:
-            with salt.utils.fopen('/etc/machine-info', 'w') as mach_info:
+            with salt.utils.files.fopen('/etc/machine-info', 'w') as mach_info:
                 mach_info.write(self._machine_info)
         else:
             self.run_function('file.remove', ['/etc/machine-info'])
@@ -307,7 +308,7 @@ class SystemModuleTest(ModuleCase):
             if not os.path.isfile('/etc/machine-info'):
                 self.assertFalse(res)
             else:
-                with salt.utils.fopen('/etc/machine-info', 'r') as mach_info:
+                with salt.utils.files.fopen('/etc/machine-info', 'r') as mach_info:
                     data = mach_info.read()
                     self.assertIn(res, data.decode('string_escape'))
 

--- a/tests/integration/renderers/test_pydsl.py
+++ b/tests/integration/renderers/test_pydsl.py
@@ -10,6 +10,7 @@ from tests.support.case import ModuleCase
 
 # Import Salt libs
 import salt.utils
+import salt.utils.files
 
 
 class PyDSLRendererIncludeTestCase(ModuleCase):
@@ -47,7 +48,7 @@ class PyDSLRendererIncludeTestCase(ModuleCase):
                        'hello green 2 \r\n' \
                        'hello blue 3 \r\n'
 
-        with salt.utils.fopen('/tmp/output', 'r') as f:
+        with salt.utils.files.fopen('/tmp/output', 'r') as f:
             ret = f.read()
 
         os.remove('/tmp/output')

--- a/tests/integration/runners/test_runner_returns.py
+++ b/tests/integration/runners/test_runner_returns.py
@@ -16,6 +16,7 @@ from tests.support.runtests import RUNTIME_VARS
 # Import salt libs
 import salt.payload
 import salt.utils
+import salt.utils.files
 import salt.utils.jid
 
 
@@ -118,7 +119,7 @@ class RunnerReturnsTest(ShellCase):
             'return.p',
         )
         serial = salt.payload.Serial(self.master_opts)
-        with salt.utils.fopen(serialized_return, 'rb') as fp_:
+        with salt.utils.files.fopen(serialized_return, 'rb') as fp_:
             deserialized = serial.loads(fp_.read())
 
         self.clean_return(deserialized['return'])

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -23,6 +23,7 @@ from tests.support.paths import TMP
 # Import Salt Libs
 import salt.utils
 import salt.utils.event
+import salt.utils.files
 
 
 class StateRunnerTest(ShellCase):
@@ -153,14 +154,14 @@ class OrchEventTest(ShellCase):
         })
 
         state_sls = os.path.join(self.base_env, 'test_state.sls')
-        with salt.utils.fopen(state_sls, 'w') as fp_:
+        with salt.utils.files.fopen(state_sls, 'w') as fp_:
             fp_.write(textwrap.dedent('''
                 date:
                   cmd.run
             '''))
 
         orch_sls = os.path.join(self.base_env, 'test_orch.sls')
-        with salt.utils.fopen(orch_sls, 'w') as fp_:
+        with salt.utils.files.fopen(orch_sls, 'w') as fp_:
             fp_.write(textwrap.dedent('''
                 date_cmd:
                   salt.state:

--- a/tests/integration/sdb/test_env.py
+++ b/tests/integration/sdb/test_env.py
@@ -12,7 +12,7 @@ from tests.support.paths import FILES
 from tests.support.mixins import SaltReturnAssertsMixin
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 STATE_DIR = os.path.join(FILES, 'file', 'base')
 
@@ -23,7 +23,7 @@ class EnvTestCase(ModuleCase, SaltReturnAssertsMixin):
         self.state_name = 'test_sdb_env'
         self.state_file_name = self.state_name + '.sls'
         self.state_file_set_var = os.path.join(STATE_DIR, self.state_file_name)
-        with salt.utils.fopen(self.state_file_set_var, 'w') as wfh:
+        with salt.utils.files.fopen(self.state_file_set_var, 'w') as wfh:
             wfh.write(textwrap.dedent('''\
                 set some env var:
                   cmd.run:

--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -29,7 +29,7 @@ from tests.support.helpers import destructiveTest
 from tests.integration.utils import testprogram
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 import salt.ext.six as six
 
 log = logging.getLogger(__name__)
@@ -174,7 +174,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
         if not os.path.isdir(config_dir):
             os.makedirs(config_dir)
 
-        with salt.utils.fopen(self.get_config_file_path('master')) as fhr:
+        with salt.utils.files.fopen(self.get_config_file_path('master')) as fhr:
             master_config = yaml.load(fhr.read())
 
         master_root_dir = master_config['root_dir']
@@ -204,7 +204,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
             start = datetime.now()
             # Let's first test with a master running
 
-            with salt.utils.fopen(minion_config_file, 'w') as fh_:
+            with salt.utils.files.fopen(minion_config_file, 'w') as fh_:
                 fh_.write(
                     yaml.dump(minion_config, default_flow_style=False)
                 )
@@ -234,7 +234,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
             # Now let's remove the master configuration
             minion_config.pop('master')
             minion_config.pop('master_port')
-            with salt.utils.fopen(minion_config_file, 'w') as fh_:
+            with salt.utils.files.fopen(minion_config_file, 'w') as fh_:
                 fh_.write(
                     yaml.dump(minion_config, default_flow_style=False)
                 )
@@ -282,7 +282,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
 
             # Should work with local file client
             minion_config['file_client'] = 'local'
-            with salt.utils.fopen(minion_config_file, 'w') as fh_:
+            with salt.utils.files.fopen(minion_config_file, 'w') as fh_:
                 fh_.write(
                     yaml.dump(minion_config, default_flow_style=False)
                 )
@@ -309,10 +309,10 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
 
         os.chdir(config_dir)
 
-        with salt.utils.fopen(self.get_config_file_path('minion'), 'r') as fh_:
+        with salt.utils.files.fopen(self.get_config_file_path('minion'), 'r') as fh_:
             minion_config = yaml.load(fh_.read())
             minion_config['log_file'] = 'file:///dev/log/LOG_LOCAL3'
-            with salt.utils.fopen(os.path.join(config_dir, 'minion'), 'w') as fh_:
+            with salt.utils.files.fopen(os.path.join(config_dir, 'minion'), 'w') as fh_:
                 fh_.write(
                     yaml.dump(minion_config, default_flow_style=False)
                 )
@@ -353,7 +353,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
                 with_retcode=True
             )
 
-            with salt.utils.fopen(output_file_append) as ofa:
+            with salt.utils.files.fopen(output_file_append) as ofa:
                 output = ofa.read()
 
             self.run_script(
@@ -365,7 +365,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
                 catch_stderr=True,
                 with_retcode=True
             )
-            with salt.utils.fopen(output_file_append) as ofa:
+            with salt.utils.files.fopen(output_file_append) as ofa:
                 self.assertEqual(ofa.read(), output + output)
         finally:
             if os.path.exists(output_file_append):

--- a/tests/integration/shell/test_cp.py
+++ b/tests/integration/shell/test_cp.py
@@ -24,7 +24,7 @@ from tests.support.paths import TMP
 from tests.support.mixins import ShellCaseCommonTestsMixin
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -53,7 +53,7 @@ class CopyTest(ShellCase, ShellCaseCommonTestsMixin):
                 'files', 'file', 'base', 'testfile'
             )
         )
-        with salt.utils.fopen(testfile, 'r') as fh_:
+        with salt.utils.files.fopen(testfile, 'r') as fh_:
             testfile_contents = fh_.read()
 
         for idx, minion in enumerate(minions):
@@ -125,10 +125,10 @@ class CopyTest(ShellCase, ShellCaseCommonTestsMixin):
                 raise
 
         config_file_name = 'master'
-        with salt.utils.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
+        with salt.utils.files.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
             config = yaml.load(fhr.read())
             config['log_file'] = 'file:///dev/log/LOG_LOCAL3'
-            with salt.utils.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
+            with salt.utils.files.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
                 fhw.write(
                     yaml.dump(config, default_flow_style=False)
                 )
@@ -137,7 +137,7 @@ class CopyTest(ShellCase, ShellCaseCommonTestsMixin):
             fd_, fn_ = tempfile.mkstemp()
             os.close(fd_)
 
-            with salt.utils.fopen(fn_, 'w') as fp_:
+            with salt.utils.files.fopen(fn_, 'w') as fp_:
                 fp_.write('Hello world!\n')
 
             ret = self.run_script(

--- a/tests/integration/shell/test_enabled.py
+++ b/tests/integration/shell/test_enabled.py
@@ -10,7 +10,7 @@ from tests.support.case import ModuleCase
 from tests.support.paths import FILES
 
 # Import Salt Libs
-import salt.utils
+import salt.utils.files
 
 
 STATE_DIR = os.path.join(FILES, 'file', 'base')
@@ -58,7 +58,7 @@ class EnabledTest(ModuleCase):
         ret_key = 'test_|-shell_enabled_|-{0}_|-configurable_test_state'.format(enabled_ret)
 
         try:
-            with salt.utils.fopen(state_file, 'w') as fp_:
+            with salt.utils.files.fopen(state_file, 'w') as fp_:
                 fp_.write(textwrap.dedent('''\
                 {{% set shell_enabled = salt['cmd.shell']("{0}").strip() %}}
 
@@ -87,7 +87,7 @@ class EnabledTest(ModuleCase):
         ret_key = 'test_|-shell_enabled_|-{0}_|-configurable_test_state'.format(disabled_ret)
 
         try:
-            with salt.utils.fopen(state_file, 'w') as fp_:
+            with salt.utils.files.fopen(state_file, 'w') as fp_:
                 fp_.write(textwrap.dedent('''\
                 {{% set shell_disabled = salt['cmd.run']("{0}") %}}
 

--- a/tests/integration/shell/test_key.py
+++ b/tests/integration/shell/test_key.py
@@ -16,6 +16,7 @@ import yaml
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 USERA = 'saltdev'
 USERA_PWD = 'saltdev'
@@ -255,10 +256,10 @@ class KeyTest(ShellCase, ShellCaseCommonTestsMixin):
         os.chdir(config_dir)
 
         config_file_name = 'master'
-        with salt.utils.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
+        with salt.utils.files.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
             config = yaml.load(fhr.read())
             config['log_file'] = 'file:///dev/log/LOG_LOCAL3'
-            with salt.utils.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
+            with salt.utils.files.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
                 fhw.write(
                     yaml.dump(config, default_flow_style=False)
                 )

--- a/tests/integration/shell/test_master.py
+++ b/tests/integration/shell/test_master.py
@@ -17,7 +17,7 @@ import shutil
 import yaml
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 # Import salt test libs
 import tests.integration.utils
@@ -41,14 +41,14 @@ class MasterTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
 
         config_file_name = 'master'
         pid_path = os.path.join(config_dir, '{0}.pid'.format(config_file_name))
-        with salt.utils.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
+        with salt.utils.files.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
             config = yaml.load(fhr.read())
             config['root_dir'] = config_dir
             config['log_file'] = 'file:///tmp/log/LOG_LOCAL3'
             config['ret_port'] = config['ret_port'] + 10
             config['publish_port'] = config['publish_port'] + 10
 
-            with salt.utils.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
+            with salt.utils.files.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
                 fhw.write(
                     yaml.dump(config, default_flow_style=False)
                 )
@@ -66,7 +66,7 @@ class MasterTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
 
         # Now kill it if still running
         if os.path.exists(pid_path):
-            with salt.utils.fopen(pid_path) as fhr:
+            with salt.utils.files.fopen(pid_path) as fhr:
                 try:
                     os.kill(int(fhr.read()), signal.SIGKILL)
                 except OSError:

--- a/tests/integration/shell/test_matcher.py
+++ b/tests/integration/shell/test_matcher.py
@@ -15,7 +15,7 @@ from tests.support.paths import TMP
 from tests.support.mixins import ShellCaseCommonTestsMixin
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 
 def minion_in_returns(minion, lines):
@@ -348,12 +348,12 @@ class MatchTest(ShellCase, ShellCaseCommonTestsMixin):
         os.chdir(config_dir)
 
         config_file_name = 'master'
-        with salt.utils.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
+        with salt.utils.files.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
             config = yaml.load(
                 fhr.read()
             )
             config['log_file'] = 'file:///dev/log/LOG_LOCAL3'
-            with salt.utils.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
+            with salt.utils.files.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
                 fhw.write(
                     yaml.dump(config, default_flow_style=False)
             )

--- a/tests/integration/shell/test_minion.py
+++ b/tests/integration/shell/test_minion.py
@@ -32,7 +32,7 @@ from tests.integration.utils import testprogram
 import salt.ext.six as six
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -60,11 +60,11 @@ class MinionTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
 
         config_file_name = 'minion'
         pid_path = os.path.join(config_dir, '{0}.pid'.format(config_file_name))
-        with salt.utils.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
+        with salt.utils.files.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
             config = yaml.load(fhr.read())
             config['log_file'] = 'file:///tmp/log/LOG_LOCAL3'
 
-            with salt.utils.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
+            with salt.utils.files.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
                 fhw.write(
                     yaml.dump(config, default_flow_style=False)
                 )
@@ -82,7 +82,7 @@ class MinionTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
 
         # Now kill it if still running
         if os.path.exists(pid_path):
-            with salt.utils.fopen(pid_path) as fhr:
+            with salt.utils.files.fopen(pid_path) as fhr:
                 try:
                     os.kill(int(fhr.read()), signal.SIGKILL)
                 except OSError:
@@ -204,7 +204,7 @@ class MinionTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
         default_dir = os.path.join(sysconf_dir, 'default')
         if not os.path.exists(default_dir):
             os.makedirs(default_dir)
-        with salt.utils.fopen(os.path.join(default_dir, 'salt'), 'w') as defaults:
+        with salt.utils.files.fopen(os.path.join(default_dir, 'salt'), 'w') as defaults:
             # Test suites is quite slow - extend the timeout
             defaults.write(
                 'TIMEOUT=60\n'

--- a/tests/integration/shell/test_runner.py
+++ b/tests/integration/shell/test_runner.py
@@ -21,6 +21,7 @@ import yaml
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 USERA = 'saltdev'
 USERA_PWD = 'saltdev'
@@ -100,10 +101,10 @@ class RunTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin)
         os.chdir(config_dir)
 
         config_file_name = 'master'
-        with salt.utils.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
+        with salt.utils.files.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
             config = yaml.load(fhr.read())
             config['log_file'] = 'file:///dev/log/LOG_LOCAL3'
-            with salt.utils.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
+            with salt.utils.files.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
                 fhw.write(
                     yaml.dump(config, default_flow_style=False)
                 )

--- a/tests/integration/shell/test_syndic.py
+++ b/tests/integration/shell/test_syndic.py
@@ -24,7 +24,7 @@ from tests.support.mixins import ShellCaseCommonTestsMixin
 from tests.integration.utils import testprogram
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 
 log = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ class SyndicTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
 
         for fname in ('master', 'minion'):
             pid_path = os.path.join(config_dir, '{0}.pid'.format(fname))
-            with salt.utils.fopen(self.get_config_file_path(fname), 'r') as fhr:
+            with salt.utils.files.fopen(self.get_config_file_path(fname), 'r') as fhr:
                 config = yaml.load(fhr.read())
                 config['log_file'] = config['syndic_log_file'] = 'file:///tmp/log/LOG_LOCAL3'
                 config['root_dir'] = config_dir
@@ -55,7 +55,7 @@ class SyndicTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
                     config['ret_port'] = int(config['ret_port']) + 10
                     config['publish_port'] = int(config['publish_port']) + 10
 
-                with salt.utils.fopen(os.path.join(config_dir, fname), 'w') as fhw:
+                with salt.utils.files.fopen(os.path.join(config_dir, fname), 'w') as fhw:
                     fhw.write(
                         yaml.dump(config, default_flow_style=False)
                     )
@@ -73,7 +73,7 @@ class SyndicTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
 
         # Now kill it if still running
         if os.path.exists(pid_path):
-            with salt.utils.fopen(pid_path) as fhr:
+            with salt.utils.files.fopen(pid_path) as fhr:
                 try:
                     os.kill(int(fhr.read()), signal.SIGKILL)
                 except OSError:

--- a/tests/integration/states/test_archive.py
+++ b/tests/integration/states/test_archive.py
@@ -16,6 +16,7 @@ from tests.support.paths import FILES
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 # Setup logging
 log = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ class ArchiveTest(ModuleCase, SaltReturnAssertsMixin):
     @staticmethod
     def _clear_archive_dir():
         try:
-            salt.utils.rm_rf(ARCHIVE_DIR)
+            salt.utils.files.rm_rf(ARCHIVE_DIR)
         except OSError as exc:
             if exc.errno != errno.ENOENT:
                 raise

--- a/tests/integration/states/test_cmd.py
+++ b/tests/integration/states/test_cmd.py
@@ -16,6 +16,7 @@ from tests.support.mixins import SaltReturnAssertsMixin
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 IS_WINDOWS = salt.utils.is_windows()
 
@@ -84,7 +85,7 @@ class CMDRunRedirectTest(ModuleCase, SaltReturnAssertsMixin):
         test cmd.run unless
         '''
         state_key = 'cmd_|-{0}_|-{0}_|-run'.format(self.test_tmp_path)
-        with salt.utils.fopen(self.state_file, 'w') as fb_:
+        with salt.utils.files.fopen(self.state_file, 'w') as fb_:
             fb_.write(textwrap.dedent('''
                 {0}:
                   cmd.run:
@@ -115,7 +116,7 @@ class CMDRunRedirectTest(ModuleCase, SaltReturnAssertsMixin):
         test cmd.run creates already there
         '''
         state_key = 'cmd_|-echo >> {0}_|-echo >> {0}_|-run'.format(self.test_file)
-        with salt.utils.fopen(self.state_file, 'w') as fb_:
+        with salt.utils.files.fopen(self.state_file, 'w') as fb_:
             fb_.write(textwrap.dedent('''
                 echo >> {0}:
                   cmd.run:
@@ -132,7 +133,7 @@ class CMDRunRedirectTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         os.remove(self.test_file)
         state_key = 'cmd_|-echo >> {0}_|-echo >> {0}_|-run'.format(self.test_file)
-        with salt.utils.fopen(self.state_file, 'w') as fb_:
+        with salt.utils.files.fopen(self.state_file, 'w') as fb_:
             fb_.write(textwrap.dedent('''
                 echo >> {0}:
                   cmd.run:
@@ -148,7 +149,7 @@ class CMDRunRedirectTest(ModuleCase, SaltReturnAssertsMixin):
         test cmd.run with shell redirect
         '''
         state_key = 'cmd_|-echo test > {0}_|-echo test > {0}_|-run'.format(self.test_file)
-        with salt.utils.fopen(self.state_file, 'w') as fb_:
+        with salt.utils.files.fopen(self.state_file, 'w') as fb_:
             fb_.write(textwrap.dedent('''
                 echo test > {0}:
                   cmd.run
@@ -179,7 +180,7 @@ class CMDRunWatchTest(ModuleCase, SaltReturnAssertsMixin):
         saltines_key = 'cmd_|-saltines_|-echo changed=true_|-run'
         biscuits_key = 'cmd_|-biscuits_|-echo biscuits_|-wait'
 
-        with salt.utils.fopen(self.state_file, 'w') as fb_:
+        with salt.utils.files.fopen(self.state_file, 'w') as fb_:
             fb_.write(textwrap.dedent('''
                 saltines:
                   cmd.run:

--- a/tests/integration/states/test_docker_container.py
+++ b/tests/integration/states/test_docker_container.py
@@ -23,6 +23,7 @@ from tests.support.mixins import SaltReturnAssertsMixin
 
 # Import Salt Libs
 import salt.utils
+import salt.utils.files
 
 # Import 3rd-party libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
@@ -80,7 +81,7 @@ class DockerContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
             raise Exception('Failed to build image')
 
         try:
-            salt.utils.rm_rf(cls.image_build_rootdir)
+            salt.utils.files.rm_rf(cls.image_build_rootdir)
         except OSError as exc:
             if exc.errno != errno.ENOENT:
                 raise
@@ -124,7 +125,7 @@ class DockerContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
             if name in self.run_function('docker.list_containers', all=True):
                 self.run_function('docker.rm', [name], force=True)
             try:
-                salt.utils.rm_rf(bind_dir_host)
+                salt.utils.files.rm_rf(bind_dir_host)
             except OSError as exc:
                 if exc.errno != errno.ENOENT:
                     raise

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -33,6 +33,7 @@ from tests.support.mixins import SaltReturnAssertsMixin
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 
 HAS_PWD = True
 try:
@@ -166,7 +167,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         file.absent
         '''
         name = os.path.join(TMP, 'file_to_kill')
-        with salt.utils.fopen(name, 'w+') as fp_:
+        with salt.utils.files.fopen(name, 'w+') as fp_:
             fp_.write('killme')
         ret = self.run_state('file.absent', name=name)
         self.assertSaltTrueReturn(ret)
@@ -212,7 +213,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         file.absent test interface
         '''
         name = os.path.join(TMP, 'file_to_kill')
-        with salt.utils.fopen(name, 'w+') as fp_:
+        with salt.utils.files.fopen(name, 'w+') as fp_:
             fp_.write('killme')
         ret = self.run_state('file.absent', test=True, name=name)
         try:
@@ -232,9 +233,9 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         src = os.path.join(
             FILES, 'file', 'base', 'grail', 'scene33'
         )
-        with salt.utils.fopen(src, 'r') as fp_:
+        with salt.utils.files.fopen(src, 'r') as fp_:
             master_data = fp_.read()
-        with salt.utils.fopen(name, 'r') as fp_:
+        with salt.utils.files.fopen(name, 'r') as fp_:
             minion_data = fp_.read()
         self.assertEqual(master_data, minion_data)
         self.assertSaltTrueReturn(ret)
@@ -344,7 +345,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         self.run_function('state.sls', [state_file])
         self.assertTrue(os.path.exists(grain_path))
 
-        with salt.utils.fopen(grain_path, 'r') as fp_:
+        with salt.utils.files.fopen(grain_path, 'r') as fp_:
             file_contents = fp_.readlines()
 
         self.assertTrue(re.match('^minion$', file_contents[0]))
@@ -426,7 +427,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         file.managed test interface
         '''
         name = os.path.join(TMP, 'grail_not_scene33')
-        with salt.utils.fopen(name, 'wb') as fp_:
+        with salt.utils.files.fopen(name, 'wb') as fp_:
             fp_.write(six.b('test_managed_show_changes_false\n'))
 
         ret = self.run_state(
@@ -453,9 +454,9 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         state_key = 'file_|-{0}_|-{0}_|-managed'.format(funny_file)
 
         try:
-            with salt.utils.fopen(funny_url_path, 'w'):
+            with salt.utils.files.fopen(funny_url_path, 'w'):
                 pass
-            with salt.utils.fopen(state_file, 'w') as fp_:
+            with salt.utils.files.fopen(state_file, 'w') as fp_:
                 fp_.write(textwrap.dedent('''\
                 {0}:
                   file.managed:
@@ -494,7 +495,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
 
             state_keys[typ] = 'file_|-{0} file_|-{1}_|-managed'.format(typ, managed_files[typ])
         try:
-            with salt.utils.fopen(state_file, 'w') as fd_:
+            with salt.utils.files.fopen(state_file, 'w') as fd_:
                 fd_.write(textwrap.dedent('''\
                     bool file:
                       file.managed:
@@ -660,14 +661,14 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             os.makedirs(name)
 
         strayfile = os.path.join(name, 'strayfile')
-        with salt.utils.fopen(strayfile, 'w'):
+        with salt.utils.files.fopen(strayfile, 'w'):
             pass
 
         straydir = os.path.join(name, 'straydir')
         if not os.path.isdir(straydir):
             os.makedirs(straydir)
 
-        with salt.utils.fopen(os.path.join(straydir, 'strayfile2'), 'w'):
+        with salt.utils.files.fopen(os.path.join(straydir, 'strayfile2'), 'w'):
             pass
 
         ret = self.run_state('file.directory', name=name, clean=True)
@@ -688,7 +689,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             os.makedirs(name)
 
         strayfile = os.path.join(name, 'strayfile')
-        with salt.utils.fopen(strayfile, 'w'):
+        with salt.utils.files.fopen(strayfile, 'w'):
             pass
 
         straydir = os.path.join(name, 'straydir')
@@ -696,11 +697,11 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             os.makedirs(straydir)
 
         strayfile2 = os.path.join(straydir, 'strayfile2')
-        with salt.utils.fopen(strayfile2, 'w'):
+        with salt.utils.files.fopen(strayfile2, 'w'):
             pass
 
         keepfile = os.path.join(straydir, 'keepfile')
-        with salt.utils.fopen(keepfile, 'w'):
+        with salt.utils.files.fopen(keepfile, 'w'):
             pass
 
         exclude_pat = 'E@^straydir(|/keepfile)$'
@@ -729,7 +730,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             os.makedirs(name)
 
         strayfile = os.path.join(name, 'strayfile')
-        with salt.utils.fopen(strayfile, 'w'):
+        with salt.utils.files.fopen(strayfile, 'w'):
             pass
 
         straydir = os.path.join(name, 'straydir')
@@ -737,11 +738,11 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             os.makedirs(straydir)
 
         strayfile2 = os.path.join(straydir, 'strayfile2')
-        with salt.utils.fopen(strayfile2, 'w'):
+        with salt.utils.files.fopen(strayfile2, 'w'):
             pass
 
         keepfile = os.path.join(straydir, 'keepfile')
-        with salt.utils.fopen(keepfile, 'w'):
+        with salt.utils.files.fopen(keepfile, 'w'):
             pass
 
         exclude_pat = 'E@^straydir(|/keepfile)$'
@@ -780,11 +781,11 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         self.addCleanup(lambda: shutil.rmtree(directory))
 
         wrong_file = os.path.join(directory, "wrong")
-        with salt.utils.fopen(wrong_file, "w") as fp:
+        with salt.utils.files.fopen(wrong_file, "w") as fp:
             fp.write("foo")
         good_file = os.path.join(directory, "bar")
 
-        with salt.utils.fopen(state_file, 'w') as fp:
+        with salt.utils.files.fopen(state_file, 'w') as fp:
             self.addCleanup(lambda: os.remove(state_file))
             fp.write(textwrap.dedent('''\
                 some_dir:
@@ -815,11 +816,11 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         self.addCleanup(lambda: shutil.rmtree(directory))
 
         wrong_file = os.path.join(directory, "wrong")
-        with salt.utils.fopen(wrong_file, "w") as fp:
+        with salt.utils.files.fopen(wrong_file, "w") as fp:
             fp.write("foo")
         good_file = os.path.join(directory, "bar")
 
-        with salt.utils.fopen(state_file, 'w') as fp:
+        with salt.utils.files.fopen(state_file, 'w') as fp:
             self.addCleanup(lambda: os.remove(state_file))
             fp.write(textwrap.dedent('''\
                 some_dir:
@@ -851,11 +852,11 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         self.addCleanup(lambda: shutil.rmtree(directory))
 
         wrong_file = os.path.join(directory, "wrong")
-        with salt.utils.fopen(wrong_file, "w") as fp:
+        with salt.utils.files.fopen(wrong_file, "w") as fp:
             fp.write("foo")
         good_file = os.path.join(directory, "bar")
 
-        with salt.utils.fopen(state_file, 'w') as fp:
+        with salt.utils.files.fopen(state_file, 'w') as fp:
             self.addCleanup(lambda: os.remove(state_file))
             fp.write(textwrap.dedent('''\
                 some_dir:
@@ -992,7 +993,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             template='jinja', defaults={'spam': _ts})
         try:
             self.assertSaltTrueReturn(ret)
-            with salt.utils.fopen(os.path.join(name, 'scene33'), 'r') as fp_:
+            with salt.utils.files.fopen(os.path.join(name, 'scene33'), 'r') as fp_:
                 contents = fp_.read()
             self.assertIn(_ts, contents)
         finally:
@@ -1006,11 +1007,11 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         if not os.path.isdir(name):
             os.makedirs(name)
         strayfile = os.path.join(name, 'strayfile')
-        with salt.utils.fopen(strayfile, 'w'):
+        with salt.utils.files.fopen(strayfile, 'w'):
             pass
 
         # Corner cases: replacing file with a directory and vice versa
-        with salt.utils.fopen(os.path.join(name, '36'), 'w'):
+        with salt.utils.files.fopen(os.path.join(name, '36'), 'w'):
             pass
         os.makedirs(os.path.join(name, 'scene33'))
         ret = self.run_state(
@@ -1031,11 +1032,11 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         if not os.path.isdir(name):
             os.makedirs(name)
         strayfile = os.path.join(name, 'strayfile')
-        with salt.utils.fopen(strayfile, 'w'):
+        with salt.utils.files.fopen(strayfile, 'w'):
             pass
 
         # Corner cases: replacing file with a directory and vice versa
-        with salt.utils.fopen(os.path.join(name, '32'), 'w'):
+        with salt.utils.files.fopen(os.path.join(name, '32'), 'w'):
             pass
         os.makedirs(os.path.join(name, 'scene34'))
         ret = self.run_state('file.recurse',
@@ -1086,14 +1087,14 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         file.replace
         '''
         name = os.path.join(TMP, 'replace_test')
-        with salt.utils.fopen(name, 'w+') as fp_:
+        with salt.utils.files.fopen(name, 'w+') as fp_:
             fp_.write('change_me')
 
         ret = self.run_state('file.replace',
                 name=name, pattern='change', repl='salt', backup=False)
 
         try:
-            with salt.utils.fopen(name, 'r') as fp_:
+            with salt.utils.files.fopen(name, 'r') as fp_:
                 self.assertIn('salt', fp_.read())
 
             self.assertSaltTrueReturn(ret)
@@ -1116,7 +1117,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         test_name = 'test_replace_issue_18612'
         path_test = os.path.join(TMP, test_name)
 
-        with salt.utils.fopen(path_test, 'w+') as fp_test_:
+        with salt.utils.files.fopen(path_test, 'w+') as fp_test_:
             fp_test_.write('# en_US.UTF-8')
 
         ret = []
@@ -1126,11 +1127,11 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
 
         try:
             # ensure, the number of lines didn't change, even after invoking 'file.replace' 3 times
-            with salt.utils.fopen(path_test, 'r') as fp_test_:
+            with salt.utils.files.fopen(path_test, 'r') as fp_test_:
                 self.assertTrue((sum(1 for _ in fp_test_) == 1))
 
             # ensure, the replacement succeeded
-            with salt.utils.fopen(path_test, 'r') as fp_test_:
+            with salt.utils.files.fopen(path_test, 'r') as fp_test_:
                 self.assertTrue(fp_test_.read().startswith('en_US.UTF-8'))
 
             # ensure, all runs of 'file.replace' reported success
@@ -1392,7 +1393,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
                     'finally': 'the last item'},
                 formatter='json')
 
-        with salt.utils.fopen(path_test, 'r') as fp_:
+        with salt.utils.files.fopen(path_test, 'r') as fp_:
             serialized_file = fp_.read()
 
         expected_file = '''{
@@ -1473,7 +1474,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         name = os.path.join(TMP, 'comment_test')
         try:
             # write a line to file
-            with salt.utils.fopen(name, 'w+') as fp_:
+            with salt.utils.files.fopen(name, 'w+') as fp_:
                 fp_.write('comment_me')
 
             # Look for changes with test=True: return should be "None" at the first run
@@ -1485,7 +1486,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             # result is positive
             self.assertSaltTrueReturn(ret)
             # line is commented
-            with salt.utils.fopen(name, 'r') as fp_:
+            with salt.utils.files.fopen(name, 'r') as fp_:
                 self.assertTrue(fp_.read().startswith('#comment'))
 
             # comment twice
@@ -1494,7 +1495,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             # result is still positive
             self.assertSaltTrueReturn(ret)
             # line is still commented
-            with salt.utils.fopen(name, 'r') as fp_:
+            with salt.utils.files.fopen(name, 'r') as fp_:
                 self.assertTrue(fp_.read().startswith('#comment'))
 
             # Test previously commented file returns "True" now and not "None" with test=True
@@ -1510,12 +1511,12 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         name = os.path.join(TMP, 'comment_test_test')
         try:
-            with salt.utils.fopen(name, 'w+') as fp_:
+            with salt.utils.files.fopen(name, 'w+') as fp_:
                 fp_.write('comment_me')
             ret = self.run_state(
                 'file.comment', test=True, name=name, regex='.*comment.*',
             )
-            with salt.utils.fopen(name, 'r') as fp_:
+            with salt.utils.files.fopen(name, 'r') as fp_:
                 self.assertNotIn('#comment', fp_.read())
             self.assertSaltNoneReturn(ret)
         finally:
@@ -1527,10 +1528,10 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         name = os.path.join(TMP, 'uncomment_test')
         try:
-            with salt.utils.fopen(name, 'w+') as fp_:
+            with salt.utils.files.fopen(name, 'w+') as fp_:
                 fp_.write('#comment_me')
             ret = self.run_state('file.uncomment', name=name, regex='^comment')
-            with salt.utils.fopen(name, 'r') as fp_:
+            with salt.utils.files.fopen(name, 'r') as fp_:
                 self.assertNotIn('#comment', fp_.read())
             self.assertSaltTrueReturn(ret)
         finally:
@@ -1542,12 +1543,12 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         name = os.path.join(TMP, 'uncomment_test_test')
         try:
-            with salt.utils.fopen(name, 'w+') as fp_:
+            with salt.utils.files.fopen(name, 'w+') as fp_:
                 fp_.write('#comment_me')
             ret = self.run_state(
                 'file.uncomment', test=True, name=name, regex='^comment.*'
             )
-            with salt.utils.fopen(name, 'r') as fp_:
+            with salt.utils.files.fopen(name, 'r') as fp_:
                 self.assertIn('#comment', fp_.read())
             self.assertSaltNoneReturn(ret)
         finally:
@@ -1559,10 +1560,10 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         name = os.path.join(TMP, 'append_test')
         try:
-            with salt.utils.fopen(name, 'w+') as fp_:
+            with salt.utils.files.fopen(name, 'w+') as fp_:
                 fp_.write('#salty!')
             ret = self.run_state('file.append', name=name, text='cheese')
-            with salt.utils.fopen(name, 'r') as fp_:
+            with salt.utils.files.fopen(name, 'r') as fp_:
                 self.assertIn('cheese', fp_.read())
             self.assertSaltTrueReturn(ret)
         finally:
@@ -1574,12 +1575,12 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         name = os.path.join(TMP, 'append_test_test')
         try:
-            with salt.utils.fopen(name, 'w+') as fp_:
+            with salt.utils.files.fopen(name, 'w+') as fp_:
                 fp_.write('#salty!')
             ret = self.run_state(
                 'file.append', test=True, name=name, text='cheese'
             )
-            with salt.utils.fopen(name, 'r') as fp_:
+            with salt.utils.files.fopen(name, 'r') as fp_:
                 self.assertNotIn('cheese', fp_.read())
             self.assertSaltNoneReturn(ret)
         finally:
@@ -1743,7 +1744,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
                 'state.sls', mods='testappend.issue-2227'
             )
             self.assertSaltTrueReturn(ret)
-            with salt.utils.fopen(tmp_file_append, 'r') as fp_:
+            with salt.utils.files.fopen(tmp_file_append, 'r') as fp_:
                 contents_pre = fp_.read()
 
             # It should not append text again
@@ -1752,7 +1753,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             )
             self.assertSaltTrueReturn(ret)
 
-            with salt.utils.fopen(tmp_file_append, 'r') as fp_:
+            with salt.utils.files.fopen(tmp_file_append, 'r') as fp_:
                 contents_post = fp_.read()
 
             self.assertEqual(contents_pre, contents_post)
@@ -1768,7 +1769,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         if not self.run_function('cmd.has_exec', ['patch']):
             self.skipTest('patch is not installed')
         src_file = os.path.join(TMP, 'src.txt')
-        with salt.utils.fopen(src_file, 'w+') as fp:
+        with salt.utils.files.fopen(src_file, 'w+') as fp:
             fp.write(src)
         ret = self.run_state(
             'file.patch',
@@ -1781,7 +1782,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
     def test_patch(self):
         src_file, ret = self.do_patch()
         self.assertSaltTrueReturn(ret)
-        with salt.utils.fopen(src_file) as fp:
+        with salt.utils.files.fopen(src_file) as fp:
             self.assertEqual(fp.read(), 'Hello world\n')
 
     def test_patch_hash_mismatch(self):
@@ -1801,7 +1802,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         # Get a path to the temporary file
         tmp_file = os.path.join(TMP, 'issue-2041-comment.txt')
         # Write some data to it
-        with salt.utils.fopen(tmp_file, 'w') as fp_:
+        with salt.utils.files.fopen(tmp_file, 'w') as fp_:
             fp_.write('hello\nworld\n')
         # create the sls template
         template_lines = [
@@ -1836,7 +1837,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         # Get a path to the temporary file
         tmp_file = os.path.join(TMP, 'issue-2379-file-append.txt')
         # Write some data to it
-        with salt.utils.fopen(tmp_file, 'w') as fp_:
+        with salt.utils.files.fopen(tmp_file, 'w') as fp_:
             fp_.write(
                 'hello\nworld\n'           # Some junk
                 '#PermitRootLogin yes\n'   # Commented text
@@ -1958,7 +1959,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             "    - backup: '.bak2'",
             '    - show_changes: True',
             '']
-        with salt.utils.fopen(template_path, 'w') as fp_:
+        with salt.utils.files.fopen(template_path, 'w') as fp_:
             fp_.write(
                 os.linesep.join(sls_template).format(testcase_filedest))
 
@@ -1966,7 +1967,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             ret = self.run_function('state.sls', mods='issue-8343')
             for name, step in six.iteritems(ret):
                 self.assertSaltTrueReturn({name: step})
-            with salt.utils.fopen(testcase_filedest) as fp_:
+            with salt.utils.files.fopen(testcase_filedest) as fp_:
                 contents = fp_.read().split(os.linesep)
             self.assertEqual(
                 ['#-- start salt managed zonestart -- PLEASE, DO NOT EDIT',
@@ -2025,14 +2026,14 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             '    - show_changes: True'
         ]
 
-        with salt.utils.fopen(template_path, 'w') as fp_:
+        with salt.utils.files.fopen(template_path, 'w') as fp_:
             fp_.write(os.linesep.join(sls_template).format(testcase_filedest))
 
         try:
             ret = self.run_function('state.sls', mods='issue-11003')
             for name, step in six.iteritems(ret):
                 self.assertSaltTrueReturn({name: step})
-            with salt.utils.fopen(testcase_filedest) as fp_:
+            with salt.utils.files.fopen(testcase_filedest) as fp_:
                 contents = fp_.read().split(os.linesep)
 
             begin = contents.index(
@@ -2115,7 +2116,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             '    - require:',
             '      - cmd: some-utf8-file-content-remove',
         ]
-        with salt.utils.fopen(template_path, 'w') as fp_:
+        with salt.utils.files.fopen(template_path, 'w') as fp_:
             fp_.write(os.linesep.join(template_lines))
         try:
             ret = self.run_function('state.sls', mods='issue-8947')
@@ -2318,7 +2319,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             if exc.errno != errno.EBADF:
                 raise exc
 
-        with salt.utils.fopen(source, 'w') as fp_:
+        with salt.utils.files.fopen(source, 'w') as fp_:
             fp_.write('{{ foo }}\n')
 
         try:
@@ -2347,7 +2348,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             if exc.errno != errno.EBADF:
                 raise exc
 
-        with salt.utils.fopen(source, 'w') as fp_:
+        with salt.utils.files.fopen(source, 'w') as fp_:
             fp_.write('{{ foo }}\n')
 
         try:

--- a/tests/integration/states/test_git.py
+++ b/tests/integration/states/test_git.py
@@ -21,6 +21,7 @@ from tests.support.mixins import SaltReturnAssertsMixin
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.utils.versions import LooseVersion as _LooseVersion
 
 
@@ -227,7 +228,7 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
             self.assertTrue(os.path.isdir(os.path.join(name, '.git')))
 
             # Make change to LICENSE file.
-            with salt.utils.fopen(os.path.join(name, 'LICENSE'), 'a') as fp_:
+            with salt.utils.files.fopen(os.path.join(name, 'LICENSE'), 'a') as fp_:
                 fp_.write('Lorem ipsum dolor blah blah blah....\n')
 
             # Make sure that we now have uncommitted changes
@@ -295,7 +296,7 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
             # Make a change to the repo by editing the file in the admin copy
             # of the repo and committing.
             head_pre = _head(admin_dir)
-            with salt.utils.fopen(os.path.join(admin_dir, 'LICENSE'), 'a') as fp_:
+            with salt.utils.files.fopen(os.path.join(admin_dir, 'LICENSE'), 'a') as fp_:
                 fp_.write('Hello world!')
             self.run_function(
                 'git.commit', [admin_dir, 'added a line'],
@@ -342,7 +343,7 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
             # Check out a new branch in the clone and make a commit, to ensure
             # that when we re-run the state, it is not a fast-forward change
             self.run_function('git.checkout', [name, 'new_branch'], opts='-b')
-            with salt.utils.fopen(os.path.join(name, 'foo'), 'w'):
+            with salt.utils.files.fopen(os.path.join(name, 'foo'), 'w'):
                 pass
             self.run_function('git.add', [name, '.'])
             self.run_function(
@@ -405,7 +406,7 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
 
         try:
             # Add and commit a file
-            with salt.utils.fopen(os.path.join(name, 'foo.txt'), 'w') as fp_:
+            with salt.utils.files.fopen(os.path.join(name, 'foo.txt'), 'w') as fp_:
                 fp_.write('Hello world\n')
             self.run_function('git.add', [name, '.'])
             self.run_function(
@@ -422,7 +423,7 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
             self.assertSaltTrueReturn(ret)
 
             # Add another commit
-            with salt.utils.fopen(os.path.join(name, 'foo.txt'), 'w') as fp_:
+            with salt.utils.files.fopen(os.path.join(name, 'foo.txt'), 'w') as fp_:
                 fp_.write('Added a line\n')
             self.run_function(
                 'git.commit', [name, 'added a line'],
@@ -472,7 +473,7 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
         try:
             fname = os.path.join(name, 'stoptheprocess')
 
-            with salt.utils.fopen(fname, 'a') as fh_:
+            with salt.utils.files.fopen(fname, 'a') as fh_:
                 fh_.write('')
 
             ret = self.run_state(
@@ -542,7 +543,7 @@ class LocalRepoGitTest(ModuleCase, SaltReturnAssertsMixin):
         # Clone bare repo
         self.run_function('git.clone', [admin], url=repo)
         # Create, add, commit, and push file
-        with salt.utils.fopen(os.path.join(admin, 'foo'), 'w'):
+        with salt.utils.files.fopen(os.path.join(admin, 'foo'), 'w'):
             pass
         self.run_function('git.add', [admin, '.'])
         self.run_function(

--- a/tests/integration/states/test_host.py
+++ b/tests/integration/states/test_host.py
@@ -14,7 +14,7 @@ from tests.support.paths import FILES, TMP
 from tests.support.mixins import SaltReturnAssertsMixin
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 HFILE = os.path.join(TMP, 'hosts')
 
@@ -41,6 +41,6 @@ class HostTest(ModuleCase, SaltReturnAssertsMixin):
         ip = '10.10.10.10'
         ret = self.run_state('host.present', name=name, ip=ip)
         self.assertSaltTrueReturn(ret)
-        with salt.utils.fopen(HFILE) as fp_:
+        with salt.utils.files.fopen(HFILE) as fp_:
             output = fp_.read()
             self.assertIn('{0}\t\t{1}'.format(ip, name), output)

--- a/tests/integration/states/test_match.py
+++ b/tests/integration/states/test_match.py
@@ -17,7 +17,7 @@ from tests.support.paths import FILES
 from tests.support.helpers import skip_if_not_root
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 STATE_DIR = os.path.join(FILES, 'file', 'base')
 
@@ -34,7 +34,7 @@ class StateMatchTest(ModuleCase):
         top_filename = 'issue-2167-ipcidr-match.sls'
         top_file = os.path.join(STATE_DIR, top_filename)
         try:
-            with salt.utils.fopen(top_file, 'w') as fp_:
+            with salt.utils.files.fopen(top_file, 'w') as fp_:
                 fp_.write(
                     'base:\n'
                     '  {0}:\n'

--- a/tests/integration/states/test_pip.py
+++ b/tests/integration/states/test_pip.py
@@ -28,6 +28,7 @@ from tests.support.helpers import (
 # Import salt libs
 from tests.support.case import ModuleCase
 import salt.utils
+import salt.utils.files
 from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES
 from salt.exceptions import CommandExecutionError
 
@@ -293,7 +294,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         req_filename = os.path.join(
             RUNTIME_VARS.TMP_STATE_TREE, 'issue-6912-requirements.txt'
         )
-        with salt.utils.fopen(req_filename, 'wb') as reqf:
+        with salt.utils.files.fopen(req_filename, 'wb') as reqf:
             reqf.write(six.b('pep8'))
 
         try:
@@ -360,7 +361,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         req_filename = os.path.join(
             RUNTIME_VARS.TMP_STATE_TREE, 'issue-6912-requirements.txt'
         )
-        with salt.utils.fopen(req_filename, 'wb') as reqf:
+        with salt.utils.files.fopen(req_filename, 'wb') as reqf:
             reqf.write(six.b('pep8'))
 
         try:
@@ -455,7 +456,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         requirements_file = os.path.join(
             RUNTIME_VARS.TMP_PRODENV_STATE_TREE, 'prod-env-requirements.txt'
         )
-        with salt.utils.fopen(requirements_file, 'wb') as reqf:
+        with salt.utils.files.fopen(requirements_file, 'wb') as reqf:
             reqf.write(six.b('pep8\n'))
 
         try:

--- a/tests/integration/states/test_ssh.py
+++ b/tests/integration/states/test_ssh.py
@@ -20,7 +20,7 @@ from tests.support.helpers import (
 )
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 
 KNOWN_HOSTS = os.path.join(RUNTIME_VARS.TMP, 'known_hosts')
 GITHUB_FINGERPRINT = '9d:38:5b:83:a9:17:52:92:56:1a:5e:c4:d4:81:8e:0a:ca:51:a2:64:f1:74:20:11:2e:f8:8a:c3:a1:39:49:8f'
@@ -188,7 +188,7 @@ class SSHAuthStateTests(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltStateChangesEqual(
             ret, {'AAAAB3NzaC1kcQ9J5bYTEyZ==': 'New'}
         )
-        with salt.utils.fopen(authorized_keys_file, 'r') as fhr:
+        with salt.utils.files.fopen(authorized_keys_file, 'r') as fhr:
             self.assertEqual(
                 fhr.read(),
                 'ssh-rsa AAAAB3NzaC1kc3MAAACBAL0sQ9fJ5bYTEyY== root\n'
@@ -206,13 +206,13 @@ class SSHAuthStateTests(ModuleCase, SaltReturnAssertsMixin):
         key_fname = 'issue_10198.id_rsa.pub'
 
         # Create the keyfile that we expect to get back on the state call
-        with salt.utils.fopen(os.path.join(RUNTIME_VARS.TMP_PRODENV_STATE_TREE, key_fname), 'w') as kfh:
+        with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.TMP_PRODENV_STATE_TREE, key_fname), 'w') as kfh:
             kfh.write(
                 'ssh-rsa AAAAB3NzaC1kcQ9J5bYTEyZ== {0}\n'.format(username)
             )
 
         # Create a bogus key file on base environment
-        with salt.utils.fopen(os.path.join(RUNTIME_VARS.TMP_STATE_TREE, key_fname), 'w') as kfh:
+        with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.TMP_STATE_TREE, key_fname), 'w') as kfh:
             kfh.write(
                 'ssh-rsa BAAAB3NzaC1kcQ9J5bYTEyZ== {0}\n'.format(username)
             )
@@ -226,7 +226,7 @@ class SSHAuthStateTests(ModuleCase, SaltReturnAssertsMixin):
             comment=username
         )
         self.assertSaltTrueReturn(ret)
-        with salt.utils.fopen(authorized_keys_file, 'r') as fhr:
+        with salt.utils.files.fopen(authorized_keys_file, 'r') as fhr:
             self.assertEqual(
                 fhr.read(),
                 'ssh-rsa AAAAB3NzaC1kcQ9J5bYTEyZ== {0}\n'.format(username)
@@ -244,7 +244,7 @@ class SSHAuthStateTests(ModuleCase, SaltReturnAssertsMixin):
             saltenv='prod'
         )
         self.assertSaltTrueReturn(ret)
-        with salt.utils.fopen(authorized_keys_file, 'r') as fhr:
+        with salt.utils.files.fopen(authorized_keys_file, 'r') as fhr:
             self.assertEqual(
                 fhr.read(),
                 'ssh-rsa AAAAB3NzaC1kcQ9J5bYTEyZ== {0}\n'.format(username)

--- a/tests/integration/states/test_virtualenv.py
+++ b/tests/integration/states/test_virtualenv.py
@@ -21,6 +21,7 @@ from tests.support.runtests import RUNTIME_VARS
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES
 
 
@@ -78,7 +79,7 @@ class VirtualenvTest(ModuleCase, SaltReturnAssertsMixin):
         ]
 
         # Let's populate the requirements file, just pep-8 for now
-        with salt.utils.fopen(requirements_file_path, 'a') as fhw:
+        with salt.utils.files.fopen(requirements_file_path, 'a') as fhw:
             fhw.write('pep8==1.3.3\n')
 
         # Let's run our state!!!
@@ -106,7 +107,7 @@ class VirtualenvTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertNotIn('zope.interface==4.0.1', ret)
 
         # Now let's update the requirements file, which is now cached.
-        with salt.utils.fopen(requirements_file_path, 'w') as fhw:
+        with salt.utils.files.fopen(requirements_file_path, 'w') as fhw:
             fhw.write('zope.interface==4.0.1\n')
 
         # Let's run our state!!!

--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -21,7 +21,7 @@ import time
 
 import yaml
 
-import salt.utils
+import salt.utils.files
 import salt.utils.process
 import salt.utils.psutil_compat as psutils
 import salt.defaults.exitcodes as exitcodes
@@ -210,7 +210,7 @@ class TestProgram(six.with_metaclass(TestProgramMeta, object)):
         if not config:
             return
         cpath = self.abs_path(self.config_file_get(config))
-        with salt.utils.fopen(cpath, 'w') as cfo:
+        with salt.utils.files.fopen(cpath, 'w') as cfo:
             cfg = self.config_stringify(config)
             log.debug('Writing configuration for {0} to {1}:\n{2}'.format(self.name, cpath, cfg))
             cfo.write(cfg)
@@ -660,7 +660,7 @@ class TestSaltProgram(six.with_metaclass(TestSaltProgramMeta, TestProgram)):
         '''Generate the script file that calls python objects and libraries.'''
         lines = []
         script_source = os.path.join(CODE_DIR, 'scripts', self.script)
-        with salt.utils.fopen(script_source, 'r') as sso:
+        with salt.utils.files.fopen(script_source, 'r') as sso:
             lines.extend(sso.readlines())
         if lines[0].startswith('#!'):
             lines.pop(0)
@@ -668,7 +668,7 @@ class TestSaltProgram(six.with_metaclass(TestSaltProgramMeta, TestProgram)):
 
         script_path = self.abs_path(os.path.join(self.script_dir, self.script))
         log.debug('Installing "{0}" to "{1}"'.format(script_source, script_path))
-        with salt.utils.fopen(script_path, 'w') as sdo:
+        with salt.utils.files.fopen(script_path, 'w') as sdo:
             sdo.write(''.join(lines))
             sdo.flush()
 

--- a/tests/jenkins.py
+++ b/tests/jenkins.py
@@ -22,6 +22,7 @@ import random
 
 # Import Salt libs
 import salt.utils
+import salt.utils.files
 try:
     from salt.utils.nb_popen import NonBlockingPopen
 except ImportError:
@@ -154,7 +155,7 @@ def echo_parseable_environment(options, parser):
             '.github_token'
         )
         if os.path.isfile(github_access_token_path):
-            with salt.utils.fopen(github_access_token_path) as rfh:
+            with salt.utils.files.fopen(github_access_token_path) as rfh:
                 headers = {
                     'Authorization': 'token {0}'.format(rfh.read().strip())
                 }

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -83,9 +83,9 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             log.debug('Generating {0}'.format(script_path))
 
             # Late import
-            import salt.utils
+            import salt.utils.files
 
-            with salt.utils.fopen(script_path, 'w') as sfh:
+            with salt.utils.files.fopen(script_path, 'w') as sfh:
                 script_template = SCRIPT_TEMPLATES.get(script_name, None)
                 if script_template is None:
                     script_template = SCRIPT_TEMPLATES.get('common', None)

--- a/tests/support/gitfs.py
+++ b/tests/support/gitfs.py
@@ -19,6 +19,7 @@ import yaml
 
 # Import Salt libs
 import salt.utils
+import salt.utils.files
 from salt.fileserver import gitfs
 from salt.pillar import git_pillar
 from salt.ext.six.moves import range  # pylint: disable=redefined-builtin
@@ -384,14 +385,14 @@ class GitPillarTestBase(GitTestBase, LoaderModuleMockMixin):
                 user=user,
             )
 
-        with salt.utils.fopen(
+        with salt.utils.files.fopen(
                 os.path.join(self.admin_repo, 'top.sls'), 'w') as fp_:
             fp_.write(textwrap.dedent('''\
             base:
               '*':
                 - foo
             '''))
-        with salt.utils.fopen(
+        with salt.utils.files.fopen(
                 os.path.join(self.admin_repo, 'foo.sls'), 'w') as fp_:
             fp_.write(textwrap.dedent('''\
             branch: master
@@ -405,7 +406,7 @@ class GitPillarTestBase(GitTestBase, LoaderModuleMockMixin):
                 master: True
             '''))
         # Add another file to be referenced using git_pillar_includes
-        with salt.utils.fopen(
+        with salt.utils.files.fopen(
                 os.path.join(self.admin_repo, 'bar.sls'), 'w') as fp_:
             fp_.write('included_pillar: True\n')
         _push('master', 'initial commit')
@@ -421,14 +422,14 @@ class GitPillarTestBase(GitTestBase, LoaderModuleMockMixin):
             'git.rm',
             [self.admin_repo, 'bar.sls'],
             user=user)
-        with salt.utils.fopen(
+        with salt.utils.files.fopen(
                 os.path.join(self.admin_repo, 'top.sls'), 'w') as fp_:
             fp_.write(textwrap.dedent('''\
             dev:
               '*':
                 - foo
             '''))
-        with salt.utils.fopen(
+        with salt.utils.files.fopen(
                 os.path.join(self.admin_repo, 'foo.sls'), 'w') as fp_:
             fp_.write(textwrap.dedent('''\
             branch: dev
@@ -455,7 +456,7 @@ class GitPillarTestBase(GitTestBase, LoaderModuleMockMixin):
             'git.rm',
             [self.admin_repo, 'foo.sls'],
             user=user)
-        with salt.utils.fopen(
+        with salt.utils.files.fopen(
                 os.path.join(self.admin_repo, 'top.sls'), 'w') as fp_:
             fp_.write(textwrap.dedent('''\
             base:

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -218,11 +218,11 @@ class RedirectStdStreams(object):
 
     def __init__(self, stdout=None, stderr=None):
         # Late import
-        import salt.utils
+        import salt.utils.files
         if stdout is None:
-            stdout = salt.utils.fopen(os.devnull, 'w')  # pylint: disable=resource-leakage
+            stdout = salt.utils.files.fopen(os.devnull, 'w')  # pylint: disable=resource-leakage
         if stderr is None:
-            stderr = salt.utils.fopen(os.devnull, 'w')  # pylint: disable=resource-leakage
+            stderr = salt.utils.files.fopen(os.devnull, 'w')  # pylint: disable=resource-leakage
 
         self.__stdout = stdout
         self.__stderr = stderr

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -32,6 +32,7 @@ from tests.support.paths import CODE_DIR
 # Import salt libs
 #import salt.config
 import salt.utils
+import salt.utils.files
 import salt.version
 import salt.exceptions
 from salt.utils.verify import verify_env
@@ -111,7 +112,7 @@ class AdaptedConfigurationTestCaseMixin(object):
 
         rdict['config_dir'] = conf_dir
         rdict['conf_file'] = os.path.join(conf_dir, config_for)
-        with salt.utils.fopen(rdict['conf_file'], 'w') as wfh:
+        with salt.utils.files.fopen(rdict['conf_file'], 'w') as wfh:
             wfh.write(yaml.dump(rdict, default_flow_style=False))
         return rdict
 

--- a/tests/support/paths.py
+++ b/tests/support/paths.py
@@ -110,9 +110,9 @@ class ScriptPathMixin(object):
             log.info('Generating {0}'.format(script_path))
 
             # Late import
-            import salt.utils
+            import salt.utils.files
 
-            with salt.utils.fopen(script_path, 'w') as sfh:
+            with salt.utils.files.fopen(script_path, 'w') as sfh:
                 script_template = SCRIPT_TEMPLATES.get(script_name, None)
                 if script_template is None:
                     script_template = SCRIPT_TEMPLATES.get('common', None)

--- a/tests/unit/beacons/test_inotify_beacon.py
+++ b/tests/unit/beacons/test_inotify_beacon.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 
 # Salt libs
-import salt.utils
+import salt.utils.files
 from salt.beacons import inotify
 
 # Salt testing libs
@@ -47,7 +47,7 @@ class INotifyBeaconTestCase(TestCase, LoaderModuleMockMixin):
         ret = inotify.beacon(config)
         self.assertEqual(ret, [])
 
-        with salt.utils.fopen(path, 'r') as f:
+        with salt.utils.files.fopen(path, 'r') as f:
             pass
         ret = inotify.beacon(config)
         self.assertEqual(len(ret), 1)
@@ -59,13 +59,13 @@ class INotifyBeaconTestCase(TestCase, LoaderModuleMockMixin):
         ret = inotify.beacon(config)
         self.assertEqual(ret, [])
         fp = os.path.join(self.tmpdir, 'tmpfile')
-        with salt.utils.fopen(fp, 'w') as f:
+        with salt.utils.files.fopen(fp, 'w') as f:
             pass
         ret = inotify.beacon(config)
         self.assertEqual(len(ret), 1)
         self.assertEqual(ret[0]['path'], fp)
         self.assertEqual(ret[0]['change'], 'IN_CREATE')
-        with salt.utils.fopen(fp, 'r') as f:
+        with salt.utils.files.fopen(fp, 'r') as f:
             pass
         ret = inotify.beacon(config)
         self.assertEqual(ret, [])
@@ -75,7 +75,7 @@ class INotifyBeaconTestCase(TestCase, LoaderModuleMockMixin):
         ret = inotify.beacon(config)
         self.assertEqual(ret, [])
         fp = os.path.join(self.tmpdir, 'tmpfile')
-        with salt.utils.fopen(fp, 'w') as f:
+        with salt.utils.files.fopen(fp, 'w') as f:
             pass
         ret = inotify.beacon(config)
         self.assertEqual(len(ret), 2)
@@ -83,7 +83,7 @@ class INotifyBeaconTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(ret[0]['change'], 'IN_CREATE')
         self.assertEqual(ret[1]['path'], fp)
         self.assertEqual(ret[1]['change'], 'IN_OPEN')
-        with salt.utils.fopen(fp, 'r') as f:
+        with salt.utils.files.fopen(fp, 'r') as f:
             pass
         ret = inotify.beacon(config)
         self.assertEqual(len(ret), 1)
@@ -96,12 +96,12 @@ class INotifyBeaconTestCase(TestCase, LoaderModuleMockMixin):
         dp2 = os.path.join(dp1, 'subdir2')
         os.mkdir(dp2)
         fp = os.path.join(dp2, 'tmpfile')
-        with salt.utils.fopen(fp, 'w') as f:
+        with salt.utils.files.fopen(fp, 'w') as f:
             pass
         config = {self.tmpdir: {'mask': ['open'], 'recurse': True}}
         ret = inotify.beacon(config)
         self.assertEqual(ret, [])
-        with salt.utils.fopen(fp) as f:
+        with salt.utils.files.fopen(fp) as f:
             pass
         ret = inotify.beacon(config)
         self.assertEqual(len(ret), 3)
@@ -127,7 +127,7 @@ class INotifyBeaconTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(ret[0]['path'], dp2)
         self.assertEqual(ret[0]['change'], 'IN_CREATE|IN_ISDIR')
         fp = os.path.join(dp2, 'tmpfile')
-        with salt.utils.fopen(fp, 'w') as f:
+        with salt.utils.files.fopen(fp, 'w') as f:
             pass
         ret = inotify.beacon(config)
         self.assertEqual(len(ret), 1)

--- a/tests/unit/cache/test_localfs.py
+++ b/tests/unit/cache/test_localfs.py
@@ -21,7 +21,7 @@ from tests.support.mock import (
 
 # Import Salt libs
 import salt.payload
-import salt.utils
+import salt.utils.files
 import salt.cache.localfs as localfs
 from salt.exceptions import SaltCacheError
 
@@ -62,7 +62,7 @@ class LocalFSTest(TestCase, LoaderModuleMockMixin):
     def test_store_close_mkstemp_file_handle(self):
         '''
         Tests that the file descriptor that is opened by os.open during the mkstemp call
-        in localfs.store is closed before calling salt.utils.fopen on the filename.
+        in localfs.store is closed before calling salt.utils.files.fopen on the filename.
 
         This test mocks the call to mkstemp, but forces an OSError to be raised when the
         close() function is called on a file descriptor that doesn't exist.
@@ -79,7 +79,7 @@ class LocalFSTest(TestCase, LoaderModuleMockMixin):
         with patch('os.path.isdir', MagicMock(return_value=True)):
             with patch('tempfile.mkstemp', MagicMock(return_value=('one', 'two'))):
                 with patch('os.close', MagicMock(return_value=None)):
-                    with patch('salt.utils.fopen', MagicMock(side_effect=IOError)):
+                    with patch('salt.utils.files.fopen', MagicMock(side_effect=IOError)):
                         self.assertRaises(SaltCacheError, localfs.store, bank='', key='', data='', cachedir='')
 
     def test_store_success(self):
@@ -93,7 +93,7 @@ class LocalFSTest(TestCase, LoaderModuleMockMixin):
         self._create_tmp_cache_file(tmp_dir, salt.payload.Serial(self))
 
         # Read in the contents of the key.p file and assert "payload data" was written
-        with salt.utils.fopen(tmp_dir + '/bank/key.p', 'rb') as fh_:
+        with salt.utils.files.fopen(tmp_dir + '/bank/key.p', 'rb') as fh_:
             for line in fh_:
                 self.assertIn(six.b('payload data'), line)
 
@@ -113,7 +113,7 @@ class LocalFSTest(TestCase, LoaderModuleMockMixin):
         file.
         '''
         with patch('os.path.isfile', MagicMock(return_value=True)):
-            with patch('salt.utils.fopen', MagicMock(side_effect=IOError)):
+            with patch('salt.utils.files.fopen', MagicMock(side_effect=IOError)):
                 self.assertRaises(SaltCacheError, localfs.fetch, bank='', key='', cachedir='')
 
     def test_fetch_success(self):

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -23,6 +23,7 @@ from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 # Import Salt libs
 import salt.minion
 import salt.utils
+import salt.utils.files
 import salt.utils.network
 from salt.syspaths import CONFIG_DIR
 from salt import config as sconfig
@@ -62,7 +63,7 @@ DEFAULT = {'default_include': PATH}
 
 def _unhandled_mock_read(filename):
     '''
-    Raise an error because we should not be calling salt.utils.fopen()
+    Raise an error because we should not be calling salt.utils.files.fopen()
     '''
     raise CommandExecutionError('Unhandled mock read for {0}'.format(filename))
 
@@ -79,7 +80,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     def test_sha256_is_default_for_master(self):
         fpath = tempfile.mktemp()
         try:
-            with salt.utils.fopen(fpath, 'w') as wfh:
+            with salt.utils.files.fopen(fpath, 'w') as wfh:
                 wfh.write(
                     "root_dir: /\n"
                     "key_logfile: key\n"
@@ -93,7 +94,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     def test_sha256_is_default_for_minion(self):
         fpath = tempfile.mktemp()
         try:
-            with salt.utils.fopen(fpath, 'w') as wfh:
+            with salt.utils.files.fopen(fpath, 'w') as wfh:
                 wfh.write(
                     "root_dir: /\n"
                     "key_logfile: key\n"
@@ -112,7 +113,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             temp_config = 'root_dir: c:\\\n'\
                           'key_logfile: key\n'
         try:
-            with salt.utils.fopen(fpath, 'w') as fp_:
+            with salt.utils.files.fopen(fpath, 'w') as fp_:
                 fp_.write(temp_config)
 
             config = sconfig.master_config(fpath)
@@ -136,7 +137,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             root_dir = os.path.join(tempdir, 'foo', 'bar')
             os.makedirs(root_dir)
             fpath = os.path.join(root_dir, 'config')
-            with salt.utils.fopen(fpath, 'w') as fp_:
+            with salt.utils.files.fopen(fpath, 'w') as fp_:
                 fp_.write(
                     'root_dir: {0}\n'
                     'log_file: {1}\n'.format(root_dir, fpath)
@@ -154,7 +155,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             root_dir = os.path.join(tempdir, 'foo', 'bar')
             os.makedirs(root_dir)
             fpath = os.path.join(root_dir, 'config')
-            with salt.utils.fopen(fpath, 'w') as fp_:
+            with salt.utils.files.fopen(fpath, 'w') as fp_:
                 fp_.write(
                     'root_dir: {0}\n'
                     'log_file: {1}\n'.format(root_dir, fpath)
@@ -178,7 +179,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             os.makedirs(env_root_dir)
             env_fpath = os.path.join(env_root_dir, 'config-env')
 
-            with salt.utils.fopen(env_fpath, 'w') as fp_:
+            with salt.utils.files.fopen(env_fpath, 'w') as fp_:
                 fp_.write(
                     'root_dir: {0}\n'
                     'log_file: {1}\n'.format(env_root_dir, env_fpath)
@@ -194,7 +195,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             root_dir = os.path.join(tempdir, 'foo', 'bar')
             os.makedirs(root_dir)
             fpath = os.path.join(root_dir, 'config')
-            with salt.utils.fopen(fpath, 'w') as fp_:
+            with salt.utils.files.fopen(fpath, 'w') as fp_:
                 fp_.write(
                     'root_dir: {0}\n'
                     'log_file: {1}\n'.format(root_dir, fpath)
@@ -225,7 +226,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             os.makedirs(env_root_dir)
             env_fpath = os.path.join(env_root_dir, 'config-env')
 
-            with salt.utils.fopen(env_fpath, 'w') as fp_:
+            with salt.utils.files.fopen(env_fpath, 'w') as fp_:
                 fp_.write(
                     'root_dir: {0}\n'
                     'log_file: {1}\n'.format(env_root_dir, env_fpath)
@@ -241,7 +242,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             root_dir = os.path.join(tempdir, 'foo', 'bar')
             os.makedirs(root_dir)
             fpath = os.path.join(root_dir, 'config')
-            with salt.utils.fopen(fpath, 'w') as fp_:
+            with salt.utils.files.fopen(fpath, 'w') as fp_:
                 fp_.write(
                     'root_dir: {0}\n'
                     'log_file: {1}\n'.format(root_dir, fpath)
@@ -271,7 +272,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             # configuration settings using the provided client configuration
             # file
             master_config = os.path.join(env_root_dir, 'master')
-            with salt.utils.fopen(master_config, 'w') as fp_:
+            with salt.utils.files.fopen(master_config, 'w') as fp_:
                 fp_.write(
                     'blah: true\n'
                     'root_dir: {0}\n'
@@ -281,7 +282,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
             # Now the client configuration file
             env_fpath = os.path.join(env_root_dir, 'config-env')
-            with salt.utils.fopen(env_fpath, 'w') as fp_:
+            with salt.utils.files.fopen(env_fpath, 'w') as fp_:
                 fp_.write(
                     'root_dir: {0}\n'
                     'log_file: {1}\n'.format(env_root_dir, env_fpath)
@@ -298,7 +299,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             root_dir = os.path.join(tempdir, 'foo', 'bar')
             os.makedirs(root_dir)
             fpath = os.path.join(root_dir, 'config')
-            with salt.utils.fopen(fpath, 'w') as fp_:
+            with salt.utils.files.fopen(fpath, 'w') as fp_:
                 fp_.write(
                     'root_dir: {0}\n'
                     'log_file: {1}\n'.format(root_dir, fpath)
@@ -326,7 +327,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
             # Let's populate a minion configuration file with some basic
             # settings
-            with salt.utils.fopen(minion_config, 'w') as fp_:
+            with salt.utils.files.fopen(minion_config, 'w') as fp_:
                 fp_.write(
                     'blah: false\n'
                     'root_dir: {0}\n'
@@ -339,7 +340,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             # file so overrides can happen, the final value of blah should be
             # True.
             extra_config = os.path.join(minion_confd, 'extra.conf')
-            with salt.utils.fopen(extra_config, 'w') as fp_:
+            with salt.utils.files.fopen(extra_config, 'w') as fp_:
                 fp_.write('blah: true\n')
 
             # Let's load the configuration
@@ -361,7 +362,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
             # Let's populate a master configuration file with some basic
             # settings
-            with salt.utils.fopen(master_config, 'w') as fp_:
+            with salt.utils.files.fopen(master_config, 'w') as fp_:
                 fp_.write(
                     'blah: false\n'
                     'root_dir: {0}\n'
@@ -374,7 +375,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             # file so overrides can happen, the final value of blah should be
             # True.
             extra_config = os.path.join(master_confd, 'extra.conf')
-            with salt.utils.fopen(extra_config, 'w') as fp_:
+            with salt.utils.files.fopen(extra_config, 'w') as fp_:
                 fp_.write('blah: true\n')
 
             # Let's load the configuration
@@ -395,10 +396,10 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             # Create some kown files.
             for f in 'abc':
                 fpath = os.path.join(tempdir, f)
-                with salt.utils.fopen(fpath, 'w') as wfh:
+                with salt.utils.files.fopen(fpath, 'w') as wfh:
                     wfh.write(f)
 
-            with salt.utils.fopen(fpath, 'w') as wfh:
+            with salt.utils.files.fopen(fpath, 'w') as wfh:
                 wfh.write(
                     'file_roots:\n'
                     '  base:\n'
@@ -425,10 +426,10 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             # Create some kown files.
             for f in 'abc':
                 fpath = os.path.join(tempdir, f)
-                with salt.utils.fopen(fpath, 'w') as wfh:
+                with salt.utils.files.fopen(fpath, 'w') as wfh:
                     wfh.write(f)
 
-            with salt.utils.fopen(fpath, 'w') as wfh:
+            with salt.utils.files.fopen(fpath, 'w') as wfh:
                 wfh.write(
                     'pillar_roots:\n'
                     '  base:\n'
@@ -455,10 +456,10 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             # Create some kown files.
             for f in 'abc':
                 fpath = os.path.join(tempdir, f)
-                with salt.utils.fopen(fpath, 'w') as wfh:
+                with salt.utils.files.fopen(fpath, 'w') as wfh:
                     wfh.write(f)
 
-            with salt.utils.fopen(fpath, 'w') as wfh:
+            with salt.utils.files.fopen(fpath, 'w') as wfh:
                 wfh.write(
                     'file_roots:\n'
                     '  base:\n'
@@ -485,10 +486,10 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             # Create some kown files.
             for f in 'abc':
                 fpath = os.path.join(tempdir, f)
-                with salt.utils.fopen(fpath, 'w') as wfh:
+                with salt.utils.files.fopen(fpath, 'w') as wfh:
                     wfh.write(f)
 
-            with salt.utils.fopen(fpath, 'w') as wfh:
+            with salt.utils.files.fopen(fpath, 'w') as wfh:
                 wfh.write(
                     'pillar_roots:\n'
                     '  base:\n'
@@ -1037,7 +1038,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             os.makedirs(env_root_dir)
             env_fpath = os.path.join(env_root_dir, 'config-env')
 
-            with salt.utils.fopen(env_fpath, 'w') as fp_:
+            with salt.utils.files.fopen(env_fpath, 'w') as fp_:
                 fp_.write(
                     'root_dir: {0}\n'
                     'log_file: {1}\n'.format(env_root_dir, env_fpath)
@@ -1053,7 +1054,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             root_dir = os.path.join(tempdir, 'foo', 'bar')
             os.makedirs(root_dir)
             fpath = os.path.join(root_dir, 'config')
-            with salt.utils.fopen(fpath, 'w') as fp_:
+            with salt.utils.files.fopen(fpath, 'w') as fp_:
                 fp_.write(
                     'root_dir: {0}\n'
                     'log_file: {1}\n'.format(root_dir, fpath)
@@ -1084,7 +1085,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
             default_config = sconfig.cloud_config(config_file_path)
             default_config['deploy_scripts_search_path'] = deploy_dir_path
-            with salt.utils.fopen(config_file_path, 'w') as cfd:
+            with salt.utils.files.fopen(config_file_path, 'w') as cfd:
                 cfd.write(yaml.dump(default_config))
 
             default_config = sconfig.cloud_config(config_file_path)

--- a/tests/unit/fileserver/test_fileclient.py
+++ b/tests/unit/fileserver/test_fileclient.py
@@ -17,7 +17,7 @@ from tests.support.unit import TestCase, skipIf
 from tests.support.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 from salt import fileclient
 import salt.ext.six as six
 
@@ -118,7 +118,7 @@ class FileclientCacheTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderMod
             _new_dir(saltenv_root)
 
             path = os.path.join(saltenv_root, 'foo.txt')
-            with salt.utils.fopen(path, 'w') as fp_:
+            with salt.utils.files.fopen(path, 'w') as fp_:
                 fp_.write(
                     'This is a test file in the \'{0}\' saltenv.\n'
                     .format(saltenv)
@@ -128,7 +128,7 @@ class FileclientCacheTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderMod
             os.makedirs(subdir_abspath)
             for subdir_file in SUBDIR_FILES:
                 path = os.path.join(subdir_abspath, subdir_file)
-                with salt.utils.fopen(path, 'w') as fp_:
+                with salt.utils.files.fopen(path, 'w') as fp_:
                     fp_.write(
                         'This is file \'{0}\' in subdir \'{1} from saltenv '
                         '\'{2}\''.format(subdir_file, SUBDIR, saltenv)
@@ -174,7 +174,7 @@ class FileclientCacheTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderMod
                     # sufficient here. If opening the file raises an exception,
                     # this is a problem, so we are not catching the exception
                     # and letting it be raised so that the test fails.
-                    with salt.utils.fopen(cache_loc) as fp_:
+                    with salt.utils.files.fopen(cache_loc) as fp_:
                         content = fp_.read()
                     log.debug('cache_loc = %s', cache_loc)
                     log.debug('content = %s', content)
@@ -214,7 +214,7 @@ class FileclientCacheTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderMod
                     # sufficient here. If opening the file raises an exception,
                     # this is a problem, so we are not catching the exception
                     # and letting it be raised so that the test fails.
-                    with salt.utils.fopen(cache_loc) as fp_:
+                    with salt.utils.files.fopen(cache_loc) as fp_:
                         content = fp_.read()
                     log.debug('cache_loc = %s', cache_loc)
                     log.debug('content = %s', content)
@@ -255,7 +255,7 @@ class FileclientCacheTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderMod
                     # sufficient here. If opening the file raises an exception,
                     # this is a problem, so we are not catching the exception
                     # and letting it be raised so that the test fails.
-                    with salt.utils.fopen(cache_loc) as fp_:
+                    with salt.utils.files.fopen(cache_loc) as fp_:
                         content = fp_.read()
                     log.debug('cache_loc = %s', cache_loc)
                     log.debug('content = %s', content)
@@ -285,7 +285,7 @@ class FileclientCacheTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderMod
                 # opening the file raises an exception, this is a problem, so
                 # we are not catching the exception and letting it be raised so
                 # that the test fails.
-                with salt.utils.fopen(cache_loc) as fp_:
+                with salt.utils.files.fopen(cache_loc) as fp_:
                     content = fp_.read()
                 log.debug('cache_loc = %s', cache_loc)
                 log.debug('content = %s', content)
@@ -319,7 +319,7 @@ class FileclientCacheTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderMod
                 # opening the file raises an exception, this is a problem, so
                 # we are not catching the exception and letting it be raised so
                 # that the test fails.
-                with salt.utils.fopen(cache_loc) as fp_:
+                with salt.utils.files.fopen(cache_loc) as fp_:
                     content = fp_.read()
                 log.debug('cache_loc = %s', cache_loc)
                 log.debug('content = %s', content)
@@ -354,7 +354,7 @@ class FileclientCacheTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderMod
                 # opening the file raises an exception, this is a problem, so
                 # we are not catching the exception and letting it be raised so
                 # that the test fails.
-                with salt.utils.fopen(cache_loc) as fp_:
+                with salt.utils.files.fopen(cache_loc) as fp_:
                     content = fp_.read()
                 log.debug('cache_loc = %s', cache_loc)
                 log.debug('content = %s', content)

--- a/tests/unit/fileserver/test_roots.py
+++ b/tests/unit/fileserver/test_roots.py
@@ -19,6 +19,7 @@ from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
 from salt.fileserver import roots
 from salt import fileclient
 import salt.utils
+import salt.utils.files
 
 try:
     import win32file
@@ -46,7 +47,7 @@ class RootsTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModuleMockMix
         if salt.utils.is_windows():
             root_dir = tempfile.mkdtemp(dir=TMP)
             source_sym = os.path.join(root_dir, 'source_sym')
-            with salt.utils.fopen(source_sym, 'w') as fp_:
+            with salt.utils.files.fopen(source_sym, 'w') as fp_:
                 fp_.write('hello world!\n')
             cwd = os.getcwd()
             try:

--- a/tests/unit/fileserver/test_roots.py
+++ b/tests/unit/fileserver/test_roots.py
@@ -66,7 +66,7 @@ class RootsTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModuleMockMix
         '''
         if salt.utils.is_windows():
             try:
-                salt.utils.rm_rf(cls.test_symlink_list_file_roots['base'][0])
+                salt.utils.files.rm_rf(cls.test_symlink_list_file_roots['base'][0])
             except OSError:
                 pass
 

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -231,7 +231,7 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                                 distro_mock = MagicMock(
                                     return_value=('SUSE test', 'version', 'arch')
                                 )
-                                with patch("salt.utils.fopen", mock_open()) as suse_release_file:
+                                with patch('salt.utils.files.fopen', mock_open()) as suse_release_file:
                                     suse_release_file.return_value.__iter__.return_value = os_release_map.get('suse_release_file', '').splitlines()
                                     with patch.object(core, 'linux_distribution', distro_mock):
                                         with patch.object(core, '_linux_gpu_data', empty_mock):
@@ -445,7 +445,7 @@ PATCHLEVEL = 3
                                 # Mock linux_distribution to give us the OS
                                 # name that we want.
                                 distro_mock = MagicMock(return_value=('Ubuntu', '16.04', 'xenial'))
-                                with patch("salt.utils.fopen", mock_open()) as suse_release_file:
+                                with patch('salt.utils.files.fopen', mock_open()) as suse_release_file:
                                     suse_release_file.return_value.__iter__.return_value = os_release_map.get(
                                         'suse_release_file', '').splitlines()
                                     with patch.object(core, 'linux_distribution', distro_mock):

--- a/tests/unit/loader/test_loader.py
+++ b/tests/unit/loader/test_loader.py
@@ -26,6 +26,7 @@ from tests.support.paths import TMP
 # Import Salt libs
 import salt.config
 import salt.utils
+import salt.utils.files
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
 from salt.ext.six.moves import range
@@ -81,7 +82,7 @@ class LazyLoaderTest(TestCase):
         self.module_dir = tempfile.mkdtemp(dir=TMP)
         self.module_file = os.path.join(self.module_dir,
                                         '{0}.py'.format(self.module_name))
-        with salt.utils.fopen(self.module_file, 'w') as fh:
+        with salt.utils.files.fopen(self.module_file, 'w') as fh:
             fh.write(loader_template)
             fh.flush()
             os.fsync(fh.fileno())
@@ -346,7 +347,7 @@ class LazyLoaderReloadingTest(TestCase):
 
     def update_module(self):
         self.count += 1
-        with salt.utils.fopen(self.module_path, 'wb') as fh:
+        with salt.utils.files.fopen(self.module_path, 'wb') as fh:
             fh.write(
                 salt.utils.to_bytes(
                     module_template.format(count=self.count)
@@ -484,7 +485,7 @@ class LazyLoaderVirtualAliasTest(TestCase):
         del cls.opts
 
     def update_module(self):
-        with salt.utils.fopen(self.module_path, 'wb') as fh:
+        with salt.utils.files.fopen(self.module_path, 'wb') as fh:
             fh.write(salt.utils.to_bytes(virtual_alias_module_template))
             fh.flush()
             os.fsync(fh.fileno())  # flush to disk
@@ -578,7 +579,7 @@ class LazyLoaderSubmodReloadingTest(TestCase):
 
     def update_module(self):
         self.count += 1
-        with salt.utils.fopen(self.module_path, 'wb') as fh:
+        with salt.utils.files.fopen(self.module_path, 'wb') as fh:
             fh.write(
                 salt.utils.to_bytes(
                     submodule_template.format(self.module_name, count=self.count)
@@ -602,7 +603,7 @@ class LazyLoaderSubmodReloadingTest(TestCase):
         for modname in list(sys.modules):
             if modname.startswith(self.module_name):
                 del sys.modules[modname]
-        with salt.utils.fopen(self.lib_path, 'wb') as fh:
+        with salt.utils.files.fopen(self.lib_path, 'wb') as fh:
             fh.write(
                 salt.utils.to_bytes(
                     submodule_lib_template.format(count=self.lib_count)
@@ -738,7 +739,7 @@ class LazyLoaderModulePackageTest(TestCase):
         dirname = os.path.dirname(pyfile)
         if not os.path.exists(dirname):
             os.makedirs(dirname)
-        with salt.utils.fopen(pyfile, 'wb') as fh:
+        with salt.utils.files.fopen(pyfile, 'wb') as fh:
             fh.write(salt.utils.to_bytes(contents))
             fh.flush()
             os.fsync(fh.fileno())  # flush to disk
@@ -827,7 +828,7 @@ class LazyLoaderDeepSubmodReloadingTest(TestCase):
         self.lib_count = collections.defaultdict(int)  # mapping of path -> count
 
         # bootstrap libs
-        with salt.utils.fopen(os.path.join(self.module_dir, '__init__.py'), 'w') as fh:
+        with salt.utils.files.fopen(os.path.join(self.module_dir, '__init__.py'), 'w') as fh:
             # No .decode() needed here as deep_init_base is defined as str and
             # not bytes.
             fh.write(deep_init_base.format(self.module_name))
@@ -881,7 +882,7 @@ class LazyLoaderDeepSubmodReloadingTest(TestCase):
                 del sys.modules[modname]
         path = os.path.join(self.lib_paths[lib_name], '__init__.py')
         self.lib_count[lib_name] += 1
-        with salt.utils.fopen(path, 'wb') as fh:
+        with salt.utils.files.fopen(path, 'wb') as fh:
             fh.write(
                 salt.utils.to_bytes(
                     submodule_lib_template.format(count=self.lib_count[lib_name])

--- a/tests/unit/modules/test_apache.py
+++ b/tests/unit/modules/test_apache.py
@@ -200,6 +200,6 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
         '''
         with patch('salt.modules.apache._parse_config',
                    MagicMock(return_value='Listen 22')):
-            with patch('salt.utils.fopen', mock_open()):
+            with patch('salt.utils.files.fopen', mock_open()):
                 self.assertEqual(apache.config('/ports.conf',
                                                [{'Listen': '22'}]), 'Listen 22')

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -251,7 +251,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         Tests return when provided shell is available
         '''
         with patch('os.path.exists', MagicMock(return_value=True)):
-            with patch('salt.utils.fopen', mock_open(read_data=MOCK_SHELL_FILE)):
+            with patch('salt.utils.files.fopen', mock_open(read_data=MOCK_SHELL_FILE)):
                 self.assertTrue(cmdmod._is_valid_shell('/bin/bash'))
 
     @skipIf(salt.utils.is_windows(), 'Do not run on Windows')
@@ -260,7 +260,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         Tests return when provided shell is not available
         '''
         with patch('os.path.exists', MagicMock(return_value=True)):
-            with patch('salt.utils.fopen', mock_open(read_data=MOCK_SHELL_FILE)):
+            with patch('salt.utils.files.fopen', mock_open(read_data=MOCK_SHELL_FILE)):
                 self.assertFalse(cmdmod._is_valid_shell('foo'))
 
     def test_os_environment_remains_intact(self):

--- a/tests/unit/modules/test_cp.py
+++ b/tests/unit/modules/test_cp.py
@@ -19,7 +19,7 @@ from tests.support.mock import (
 )
 
 # Import Salt Libs
-import salt.utils
+import salt.utils.files
 import salt.transport
 import salt.modules.cp as cp
 from salt.utils import templates
@@ -62,7 +62,7 @@ class CpTestCase(TestCase, LoaderModuleMockMixin):
                                               'data': file_data}
         with patch.dict(templates.TEMPLATE_REGISTRY,
                         {'jinja': mock_jinja}):
-            with patch('salt.utils.fopen', mock_open(read_data=file_data)):
+            with patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
                 self.assertRaises(CommandExecutionError,
                                   cp._render_filenames,
                                   path, dest, saltenv, template)
@@ -78,10 +78,10 @@ class CpTestCase(TestCase, LoaderModuleMockMixin):
         file_data = '/srv/salt/biscuits'
         mock_jinja = lambda *args, **kwargs: {'result': True,
                                               'data': file_data}
-        ret = (file_data, file_data)  # salt.utils.fopen can only be mocked once
+        ret = (file_data, file_data)  # salt.utils.files.fopen can only be mocked once
         with patch.dict(templates.TEMPLATE_REGISTRY,
                         {'jinja': mock_jinja}):
-            with patch('salt.utils.fopen', mock_open(read_data=file_data)):
+            with patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
                 self.assertEqual(cp._render_filenames(
                                  path, dest, saltenv, template), ret)
 
@@ -104,7 +104,7 @@ class CpTestCase(TestCase, LoaderModuleMockMixin):
         file_data = 'Remember to keep your files well salted.'
         saltenv = 'base'
         ret = file_data
-        with patch('salt.utils.fopen', mock_open(read_data=file_data)):
+        with patch('salt.utils.files.fopen', mock_open(read_data=file_data)):
             with patch('salt.modules.cp.cache_file',
                        MagicMock(return_value=dest)):
                 self.assertEqual(cp.get_file_str(path, dest), ret)
@@ -136,14 +136,14 @@ class CpTestCase(TestCase, LoaderModuleMockMixin):
                 patch.multiple('salt.modules.cp',
                                _auth=MagicMock(**{'return_value.gen_token.return_value': 'token'}),
                                __opts__={'id': 'abc', 'file_buffer_size': 10}), \
-                patch('salt.utils.fopen', mock_open(read_data='content')), \
+                patch('salt.utils.files.fopen', mock_open(read_data='content')), \
                 patch('salt.transport.Channel.factory', MagicMock()):
             response = cp.push('/saltines/test.file')
             self.assertEqual(response, True)
-            self.assertEqual(salt.utils.fopen().read.call_count, 2)  # pylint: disable=resource-leakage
+            self.assertEqual(salt.utils.files.fopen().read.call_count, 2)  # pylint: disable=resource-leakage
             salt.transport.Channel.factory({}).send.assert_called_once_with(
                 dict(
-                    loc=salt.utils.fopen().tell(),  # pylint: disable=resource-leakage
+                    loc=salt.utils.files.fopen().tell(),  # pylint: disable=resource-leakage
                     cmd='_file_recv',
                     tok='token',
                     path=['saltines', 'test.file'],

--- a/tests/unit/modules/test_data.py
+++ b/tests/unit/modules/test_data.py
@@ -48,7 +48,7 @@ class DataTestCase(TestCase, LoaderModuleMockMixin):
             mocked_fopen = MagicMock(return_value=True)
             mocked_fopen.__enter__ = MagicMock(return_value=mocked_fopen)
             mocked_fopen.__exit__ = MagicMock()
-            with patch('salt.utils.fopen', MagicMock(return_value=mocked_fopen)):
+            with patch('salt.utils.files.fopen', MagicMock(return_value=mocked_fopen)):
                 with patch('salt.payload.Serial.loads', MagicMock(return_value=True)):
                     with patch.dict(data.__opts__, {'cachedir': '/'}):
                         self.assertTrue(data.load())
@@ -60,7 +60,7 @@ class DataTestCase(TestCase, LoaderModuleMockMixin):
         Test if it replace the entire datastore with a passed data structure
         '''
         with patch.dict(data.__opts__, {'cachedir': '/'}):
-            with patch('salt.utils.fopen', mock_open()):
+            with patch('salt.utils.files.fopen', mock_open()):
                 self.assertTrue(data.dump('{"eggs": "spam"}'))
 
     def test_dump_isinstance(self):
@@ -76,7 +76,7 @@ class DataTestCase(TestCase, LoaderModuleMockMixin):
         '''
         with patch.dict(data.__opts__, {'cachedir': '/'}):
             mock = MagicMock(side_effect=IOError(''))
-            with patch('salt.utils.fopen', mock):
+            with patch('salt.utils.files.fopen', mock):
                 self.assertFalse(data.dump('{"eggs": "spam"}'))
 
     # 'update' function tests: 1

--- a/tests/unit/modules/test_ddns.py
+++ b/tests/unit/modules/test_ddns.py
@@ -122,7 +122,7 @@ class DDNSTestCase(TestCase, LoaderModuleMockMixin):
             return MockAnswer
 
         with patch.object(dns.query, 'udp', mock_udp_query()):
-            with patch('salt.utils.fopen', mock_open(read_data=file_data), create=True):
+            with patch('salt.utils.files.fopen', mock_open(read_data=file_data), create=True):
                 with patch.object(dns.tsigkeyring, 'from_text', return_value=True):
                     with patch.object(ddns, '_get_keyring', return_value=None):
                         with patch.object(ddns, '_config', return_value=None):

--- a/tests/unit/modules/test_dnsmasq.py
+++ b/tests/unit/modules/test_dnsmasq.py
@@ -98,7 +98,7 @@ class DnsmasqTestCase(TestCase, LoaderModuleMockMixin):
         '''
         with patch('os.path.isfile', MagicMock(return_value=True)):
             text_file_data = '\n'.join(["line here", "second line", "A=B", "#"])
-            with patch('salt.utils.fopen',
+            with patch('salt.utils.files.fopen',
                        mock_open(read_data=text_file_data),
                        create=True) as m:
                 m.return_value.__iter__.return_value = text_file_data.splitlines()

--- a/tests/unit/modules/test_dnsutil.py
+++ b/tests/unit/modules/test_dnsutil.py
@@ -67,14 +67,14 @@ if NO_MOCK is False:
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class DNSUtilTestCase(TestCase):
     def test_parse_hosts(self):
-        with patch('salt.utils.fopen', mock_open(read_data=mock_hosts_file)):
+        with patch('salt.utils.files.fopen', mock_open(read_data=mock_hosts_file)):
             self.assertEqual(dnsutil.parse_hosts(), {'::1': ['localhost'],
                                                      '255.255.255.255': ['broadcasthost'],
                                                      '127.0.0.1': ['localhost'],
                                                      'fe80::1%lo0': ['localhost']})
 
     def test_hosts_append(self):
-        with patch('salt.utils.fopen', mock_open(read_data=mock_hosts_file)) as m_open, \
+        with patch('salt.utils.files.fopen', mock_open(read_data=mock_hosts_file)) as m_open, \
                 patch('salt.modules.dnsutil.parse_hosts', MagicMock(return_value=mock_hosts_file_rtn)):
             dnsutil.hosts_append('/etc/hosts', '127.0.0.1', 'ad1.yuk.co,ad2.yuk.co')
             helper_open = m_open()
@@ -83,7 +83,7 @@ class DNSUtilTestCase(TestCase):
     def test_hosts_remove(self):
         to_remove = 'ad1.yuk.co'
         new_mock_file = mock_hosts_file + '\n127.0.0.1 ' + to_remove + '\n'
-        with patch('salt.utils.fopen', mock_open(read_data=new_mock_file)) as m_open:
+        with patch('salt.utils.files.fopen', mock_open(read_data=new_mock_file)) as m_open:
             dnsutil.hosts_remove('/etc/hosts', to_remove)
             helper_open = m_open()
             calls_list = helper_open.method_calls
@@ -91,7 +91,7 @@ class DNSUtilTestCase(TestCase):
 
     @skipIf(True, 'Waiting on bug report fixes')
     def test_parse_zone(self):
-        with patch('salt.utils.fopen', mock_open(read_data=mock_soa_zone)):
+        with patch('salt.utils.files.fopen', mock_open(read_data=mock_soa_zone)):
             log.debug(mock_soa_zone)
             log.debug(dnsutil.parse_zone('/var/lib/named/example.com.zone'))
 

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -14,7 +14,7 @@ from tests.support.unit import TestCase
 from tests.support.mock import MagicMock, patch
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 import salt.modules.file as filemod
 import salt.modules.config as configmod
 import salt.modules.cmdmod as cmdmod
@@ -77,7 +77,7 @@ class FileReplaceTestCase(TestCase, LoaderModuleMockMixin):
     def test_replace(self):
         filemod.replace(self.tfile.name, r'Etiam', 'Salticus', backup=False)
 
-        with salt.utils.fopen(self.tfile.name, 'r') as fp:
+        with salt.utils.files.fopen(self.tfile.name, 'r') as fp:
             self.assertIn('Salticus', fp.read())
 
     def test_replace_append_if_not_found(self):
@@ -96,19 +96,19 @@ class FileReplaceTestCase(TestCase, LoaderModuleMockMixin):
             tfile.write(base + '\n')
             tfile.flush()
             filemod.replace(tfile.name, **args)
-            with salt.utils.fopen(tfile.name) as tfile2:
+            with salt.utils.files.fopen(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), expected)
         # File not ending with a newline, no match
         with tempfile.NamedTemporaryFile('w+') as tfile:
             tfile.write(base)
             tfile.flush()
             filemod.replace(tfile.name, **args)
-            with salt.utils.fopen(tfile.name) as tfile2:
+            with salt.utils.files.fopen(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), expected)
         # A newline should not be added in empty files
         with tempfile.NamedTemporaryFile('w+') as tfile:
             filemod.replace(tfile.name, **args)
-            with salt.utils.fopen(tfile.name) as tfile2:
+            with salt.utils.files.fopen(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), args['repl'] + '\n')
         # Using not_found_content, rather than repl
         with tempfile.NamedTemporaryFile('w+') as tfile:
@@ -117,7 +117,7 @@ class FileReplaceTestCase(TestCase, LoaderModuleMockMixin):
             tfile.write(base)
             tfile.flush()
             filemod.replace(tfile.name, **args)
-            with salt.utils.fopen(tfile.name) as tfile2:
+            with salt.utils.files.fopen(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), expected)
         # not appending if matches
         with tempfile.NamedTemporaryFile('w+') as tfile:
@@ -126,7 +126,7 @@ class FileReplaceTestCase(TestCase, LoaderModuleMockMixin):
             tfile.write(base)
             tfile.flush()
             filemod.replace(tfile.name, **args)
-            with salt.utils.fopen(tfile.name) as tfile2:
+            with salt.utils.files.fopen(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), expected)
 
     def test_backup(self):
@@ -257,7 +257,7 @@ class FileBlockReplaceTestCase(TestCase, LoaderModuleMockMixin):
                              new_multiline_content,
                              backup=False)
 
-        with salt.utils.fopen(self.tfile.name, 'r') as fp:
+        with salt.utils.files.fopen(self.tfile.name, 'r') as fp:
             filecontent = fp.read()
         self.assertIn('#-- START BLOCK 1'
                       + "\n" + new_multiline_content
@@ -279,7 +279,7 @@ class FileBlockReplaceTestCase(TestCase, LoaderModuleMockMixin):
             append_if_not_found=False,
             backup=False
         )
-        with salt.utils.fopen(self.tfile.name, 'r') as fp:
+        with salt.utils.files.fopen(self.tfile.name, 'r') as fp:
             self.assertNotIn('#-- START BLOCK 2'
                              + "\n" + new_content
                              + '#-- END BLOCK 2', fp.read())
@@ -291,7 +291,7 @@ class FileBlockReplaceTestCase(TestCase, LoaderModuleMockMixin):
                              backup=False,
                              append_if_not_found=True)
 
-        with salt.utils.fopen(self.tfile.name, 'r') as fp:
+        with salt.utils.files.fopen(self.tfile.name, 'r') as fp:
             self.assertIn('#-- START BLOCK 2'
                           + "\n" + new_content
                           + '#-- END BLOCK 2', fp.read())
@@ -315,19 +315,19 @@ class FileBlockReplaceTestCase(TestCase, LoaderModuleMockMixin):
             tfile.write(base + '\n')
             tfile.flush()
             filemod.blockreplace(tfile.name, **args)
-            with salt.utils.fopen(tfile.name) as tfile2:
+            with salt.utils.files.fopen(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), expected)
         # File not ending with a newline
         with tempfile.NamedTemporaryFile(mode='w+') as tfile:
             tfile.write(base)
             tfile.flush()
             filemod.blockreplace(tfile.name, **args)
-            with salt.utils.fopen(tfile.name) as tfile2:
+            with salt.utils.files.fopen(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), expected)
         # A newline should not be added in empty files
         with tempfile.NamedTemporaryFile(mode='w+') as tfile:
             filemod.blockreplace(tfile.name, **args)
-            with salt.utils.fopen(tfile.name) as tfile2:
+            with salt.utils.files.fopen(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), block)
 
     def test_replace_prepend(self):
@@ -343,7 +343,7 @@ class FileBlockReplaceTestCase(TestCase, LoaderModuleMockMixin):
             prepend_if_not_found=False,
             backup=False
         )
-        with salt.utils.fopen(self.tfile.name, 'r') as fp:
+        with salt.utils.files.fopen(self.tfile.name, 'r') as fp:
             self.assertNotIn(
                 '#-- START BLOCK 2' + "\n"
                 + new_content + '#-- END BLOCK 2',
@@ -355,7 +355,7 @@ class FileBlockReplaceTestCase(TestCase, LoaderModuleMockMixin):
                              backup=False,
                              prepend_if_not_found=True)
 
-        with salt.utils.fopen(self.tfile.name, 'r') as fp:
+        with salt.utils.files.fopen(self.tfile.name, 'r') as fp:
             self.assertTrue(
                 fp.read().startswith(
                     '#-- START BLOCK 2'
@@ -369,7 +369,7 @@ class FileBlockReplaceTestCase(TestCase, LoaderModuleMockMixin):
                              'new content 1',
                              backup=False)
 
-        with salt.utils.fopen(self.tfile.name, 'r') as fp:
+        with salt.utils.files.fopen(self.tfile.name, 'r') as fp:
             filecontent = fp.read()
         self.assertIn('new content 1', filecontent)
         self.assertNotIn('to be removed', filecontent)
@@ -489,7 +489,7 @@ class FileModuleTestCase(TestCase, LoaderModuleMockMixin):
 
             filemod.sed(path, before, after, limit=limit)
 
-            with salt.utils.fopen(path, 'r') as newfile:
+            with salt.utils.files.fopen(path, 'r') as newfile:
                 self.assertEqual(
                     SED_CONTENT.replace(before, ''),
                     newfile.read()
@@ -505,19 +505,19 @@ class FileModuleTestCase(TestCase, LoaderModuleMockMixin):
             tfile.write('foo\n')
             tfile.flush()
             filemod.append(tfile.name, 'bar')
-            with salt.utils.fopen(tfile.name) as tfile2:
+            with salt.utils.files.fopen(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), 'foo\nbar\n')
         # File not ending with a newline
         with tempfile.NamedTemporaryFile(mode='w+') as tfile:
             tfile.write('foo')
             tfile.flush()
             filemod.append(tfile.name, 'bar')
-            with salt.utils.fopen(tfile.name) as tfile2:
+            with salt.utils.files.fopen(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), 'foo\nbar\n')
         # A newline should not be added in empty files
         with tempfile.NamedTemporaryFile(mode='w+') as tfile:
             filemod.append(tfile.name, 'bar')
-            with salt.utils.fopen(tfile.name) as tfile2:
+            with salt.utils.files.fopen(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), 'bar\n')
 
     def test_extract_hash(self):
@@ -769,7 +769,7 @@ class FileBasicsTestCase(TestCase, LoaderModuleMockMixin):
         self.addCleanup(os.remove, self.tfile.name)
         self.addCleanup(delattr, self, 'tfile')
         self.myfile = os.path.join(TMP, 'myfile')
-        with salt.utils.fopen(self.myfile, 'w+') as fp:
+        with salt.utils.files.fopen(self.myfile, 'w+') as fp:
             fp.write('Hello\n')
         self.addCleanup(os.remove, self.myfile)
         self.addCleanup(delattr, self, 'myfile')

--- a/tests/unit/modules/test_grub_legacy.py
+++ b/tests/unit/modules/test_grub_legacy.py
@@ -43,12 +43,12 @@ class GrublegacyTestCase(TestCase, LoaderModuleMockMixin):
         Test for Parse GRUB conf file
         '''
         mock = MagicMock(side_effect=IOError('foo'))
-        with patch('salt.utils.fopen', mock):
+        with patch('salt.utils.files.fopen', mock):
             with patch.object(grub_legacy, '_detect_conf', return_value='A'):
                 self.assertRaises(CommandExecutionError, grub_legacy.conf)
 
         file_data = '\n'.join(['#', 'A B C D,E,F G H'])
-        with patch('salt.utils.fopen',
+        with patch('salt.utils.files.fopen',
                    mock_open(read_data=file_data), create=True) as f_mock:
             f_mock.return_value.__iter__.return_value = file_data.splitlines()
             with patch.object(grub_legacy, '_detect_conf', return_value='A'):

--- a/tests/unit/modules/test_hosts.py
+++ b/tests/unit/modules/test_hosts.py
@@ -106,7 +106,7 @@ class HostsTestCase(TestCase, LoaderModuleMockMixin):
         with patch('salt.modules.hosts.__get_hosts_filename',
                    MagicMock(return_value='/etc/hosts')), \
                 patch('os.path.isfile', MagicMock(return_value=True)), \
-                    patch('salt.utils.fopen', mock_open()):
+                    patch('salt.utils.files.fopen', mock_open()):
             mock_opt = MagicMock(return_value=None)
             with patch.dict(hosts.__salt__, {'config.option': mock_opt}):
                 self.assertTrue(hosts.set_host('10.10.10.10', 'Salt1'))
@@ -147,7 +147,7 @@ class HostsTestCase(TestCase, LoaderModuleMockMixin):
                 '3.3.3.3 asdf.asdfadsf asdf',
             )) + '\n'
 
-            with patch('salt.utils.fopen', TmpStringIO):
+            with patch('salt.utils.files.fopen', TmpStringIO):
                 mock_opt = MagicMock(return_value=None)
                 with patch.dict(hosts.__salt__, {'config.option': mock_opt}):
                     self.assertTrue(hosts.set_host('1.1.1.1', ' '))
@@ -159,7 +159,7 @@ class HostsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Tests if specified host entry gets removed from the hosts file
         '''
-        with patch('salt.utils.fopen', mock_open()), \
+        with patch('salt.utils.files.fopen', mock_open()), \
                 patch('salt.modules.hosts.__get_hosts_filename',
                       MagicMock(return_value='/etc/hosts')), \
                 patch('salt.modules.hosts.has_pair',
@@ -182,7 +182,7 @@ class HostsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Tests if specified host entry gets added from the hosts file
         '''
-        with patch('salt.utils.fopen', mock_open()), \
+        with patch('salt.utils.files.fopen', mock_open()), \
                 patch('salt.modules.hosts.__get_hosts_filename',
                       MagicMock(return_value='/etc/hosts')):
             mock_opt = MagicMock(return_value=None)
@@ -193,7 +193,7 @@ class HostsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Tests if specified host entry gets added from the hosts file
         '''
-        with patch('salt.utils.fopen', mock_open()), \
+        with patch('salt.utils.files.fopen', mock_open()), \
                 patch('os.path.isfile', MagicMock(return_value=False)):
             mock_opt = MagicMock(return_value=None)
             with patch.dict(hosts.__salt__, {'config.option': mock_opt}):
@@ -203,7 +203,7 @@ class HostsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Tests if specified host entry gets added from the hosts file
         '''
-        with patch('salt.utils.fopen', mock_open()), \
+        with patch('salt.utils.files.fopen', mock_open()), \
                 patch('os.path.isfile', MagicMock(return_value=True)):
             mock_opt = MagicMock(return_value=None)
             with patch.dict(hosts.__salt__, {'config.option': mock_opt}):

--- a/tests/unit/modules/test_ini_manage.py
+++ b/tests/unit/modules/test_ini_manage.py
@@ -9,7 +9,7 @@ import tempfile
 from tests.support.unit import TestCase
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 import salt.modules.ini_manage as ini
 
 
@@ -119,7 +119,7 @@ empty_option=
         ini.set_option(self.tfile.name, {
             'SectionB': {'test3': 'new value 3B'},
         })
-        with salt.utils.fopen(self.tfile.name, 'r') as fp:
+        with salt.utils.files.fopen(self.tfile.name, 'r') as fp:
             file_content = fp.read()
         self.assertIn('\nempty_option = \n', file_content,
                       'empty_option was not preserved')
@@ -128,7 +128,7 @@ empty_option=
         ini.set_option(self.tfile.name, {
             'SectionB': {'test3': 'new value 3B'},
         })
-        with salt.utils.fopen(self.tfile.name, 'r') as fp:
+        with salt.utils.files.fopen(self.tfile.name, 'r') as fp:
             file_content = fp.read()
         self.assertEqual('''\
 # Comment on the first line

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -874,7 +874,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -895,7 +895,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -916,7 +916,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -937,7 +937,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -970,7 +970,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -1003,7 +1003,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -1032,7 +1032,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
     def test_install_config_load_causes_exception(self):
         with patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -1051,7 +1051,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
     def test_install_config_no_diff(self):
         with patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -1069,7 +1069,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('salt.modules.junos.fopen') as mock_fopen, \
@@ -1104,7 +1104,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('salt.modules.junos.fopen') as mock_fopen, \
@@ -1140,7 +1140,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -1173,7 +1173,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -1192,7 +1192,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -1212,7 +1212,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -1274,7 +1274,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
 
     def test_install_os(self):
         with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -1288,7 +1288,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
     def test_install_os_with_reboot_arg(self):
         with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
                 patch('jnpr.junos.utils.sw.SW.reboot') as mock_reboot, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -1305,7 +1305,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
 
     def test_install_os_pyez_install_throws_exception(self):
         with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
@@ -1320,7 +1320,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
     def test_install_os_with_reboot_raises_exception(self):
         with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
                 patch('jnpr.junos.utils.sw.SW.reboot') as mock_reboot, \
-                patch('salt.modules.junos.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
                 patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -570,7 +570,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.commit') as mock_commit, \
                 patch('jnpr.junos.utils.config.Config.rollback') as mock_rollback, \
-                patch('salt.modules.junos.fopen') as mock_fopen, \
+                patch('salt.utils.files.fopen') as mock_fopen, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff:
             mock_commit_check.return_value = True
             mock_diff.return_value = 'diff'
@@ -591,7 +591,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch('jnpr.junos.utils.config.Config.commit_check') as mock_commit_check, \
                 patch('jnpr.junos.utils.config.Config.commit') as mock_commit, \
                 patch('jnpr.junos.utils.config.Config.rollback') as mock_rollback, \
-                patch('salt.modules.junos.fopen') as mock_fopen, \
+                patch('salt.utils.files.fopen') as mock_fopen, \
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff:
             mock_commit_check.return_value = True
             mock_diff.return_value = None
@@ -744,7 +744,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             self.assertEqual(junos.cli('show version'), ret)
 
     def test_cli_write_output(self):
-        with patch('salt.modules.junos.fopen') as mock_fopen, \
+        with patch('salt.utils.files.fopen') as mock_fopen, \
                 patch('jnpr.junos.device.Device.cli') as mock_cli:
             mock_cli.return_vale = 'cli text output'
             args = {'__pub_user': 'root',
@@ -875,7 +875,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
@@ -896,7 +896,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
@@ -917,7 +917,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
@@ -938,7 +938,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
@@ -971,7 +971,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
@@ -1004,7 +1004,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
@@ -1033,7 +1033,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
@@ -1052,7 +1052,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
@@ -1070,9 +1070,9 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
-                patch('salt.modules.junos.fopen') as mock_fopen, \
+                patch('salt.utils.files.fopen') as mock_fopen, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
             mock_getsize.return_value = 10
@@ -1105,9 +1105,9 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
-                patch('salt.modules.junos.fopen') as mock_fopen, \
+                patch('salt.utils.files.fopen') as mock_fopen, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
             mock_getsize.return_value = 10
@@ -1141,7 +1141,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
@@ -1174,7 +1174,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
@@ -1193,7 +1193,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
@@ -1213,7 +1213,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.utils.config.Config.diff') as mock_diff, \
                 patch('jnpr.junos.utils.config.Config.load') as mock_load, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_isfile.return_value = True
@@ -1275,7 +1275,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
     def test_install_os(self):
         with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_getsize.return_value = 10
@@ -1289,7 +1289,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
                 patch('jnpr.junos.utils.sw.SW.reboot') as mock_reboot, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_getsize.return_value = 10
@@ -1306,7 +1306,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
     def test_install_os_pyez_install_throws_exception(self):
         with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_getsize.return_value = 10
@@ -1321,7 +1321,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
                 patch('jnpr.junos.utils.sw.SW.reboot') as mock_reboot, \
                 patch('salt.utils.files.safe_rm') as mock_safe_rm, \
-                patch('salt.modules.junos.files.mkstemp') as mock_mkstemp, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
                 patch('os.path.isfile') as mock_isfile, \
                 patch('os.path.getsize') as mock_getsize:
             mock_getsize.return_value = 10
@@ -1489,7 +1489,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             mock_execute.return_value = etree.XML(
                 '<rpc-reply>text rpc reply</rpc-reply>')
             m = mock_open()
-            with patch('salt.modules.junos.fopen', m, create=True):
+            with patch('salt.utils.files.fopen', m, create=True):
                 junos.rpc('get-chassis-inventory', '/path/to/file', 'text')
                 handle = m()
                 handle.write.assert_called_with('text rpc reply')
@@ -1499,7 +1499,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('salt.modules.junos.json.dumps') as mock_dumps:
             mock_dumps.return_value = 'json rpc reply'
             m = mock_open()
-            with patch('salt.modules.junos.fopen', m, create=True):
+            with patch('salt.utils.files.fopen', m, create=True):
                 junos.rpc('get-chassis-inventory', '/path/to/file', format='json')
                 handle = m()
                 handle.write.assert_called_with('json rpc reply')
@@ -1510,7 +1510,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 patch('jnpr.junos.device.Device.execute') as mock_execute:
             mock_tostring.return_value = 'xml rpc reply'
             m = mock_open()
-            with patch('salt.modules.junos.fopen', m, create=True):
+            with patch('salt.utils.files.fopen', m, create=True):
                 junos.rpc('get-chassis-inventory', '/path/to/file')
                 handle = m()
                 handle.write.assert_called_with('xml rpc reply')

--- a/tests/unit/modules/test_k8s.py
+++ b/tests/unit/modules/test_k8s.py
@@ -16,7 +16,7 @@ from tests.support.unit import TestCase
 from tests.support.helpers import skip_if_binaries_missing
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 import salt.modules.k8s as k8s
 
 # Import 3rd-party libs
@@ -86,7 +86,7 @@ class TestK8SSecrets(TestCase):
     def test_get_one_secret(self):
         name = self.name
         filename = "/tmp/{0}.json".format(name)
-        with salt.utils.fopen(filename, 'w') as f:
+        with salt.utils.files.fopen(filename, 'w') as f:
             json.dump(self.request, f)
 
         create = Popen(["kubectl", "--namespace=default", "create", "-f", filename], stdout=PIPE)
@@ -102,7 +102,7 @@ class TestK8SSecrets(TestCase):
     def test_get_decoded_secret(self):
         name = self.name
         filename = "/tmp/{0}.json".format(name)
-        with salt.utils.fopen(filename, 'w') as f:
+        with salt.utils.files.fopen(filename, 'w') as f:
             json.dump(self.request, f)
 
         create = Popen(["kubectl", "--namespace=default", "create", "-f", filename], stdout=PIPE)
@@ -118,7 +118,7 @@ class TestK8SSecrets(TestCase):
         expected_data = {}
         for i in range(2):
             names.append("/tmp/{0}-{1}".format(name, i))
-            with salt.utils.fopen("/tmp/{0}-{1}".format(name, i), 'w') as f:
+            with salt.utils.files.fopen("/tmp/{0}-{1}".format(name, i), 'w') as f:
                 expected_data["{0}-{1}".format(name, i)] = base64.b64encode("{0}{1}".format(name, i))
                 f.write("{0}{1}".format(name, i))
         res = k8s.create_secret("default", name, names, apiserver_url="http://127.0.0.1:8080")
@@ -132,7 +132,7 @@ class TestK8SSecrets(TestCase):
     def test_update_secret(self):
         name = self.name
         filename = "/tmp/{0}.json".format(name)
-        with salt.utils.fopen(filename, 'w') as f:
+        with salt.utils.files.fopen(filename, 'w') as f:
             json.dump(self.request, f)
 
         create = Popen(["kubectl", "--namespace=default", "create", "-f", filename], stdout=PIPE)
@@ -142,7 +142,7 @@ class TestK8SSecrets(TestCase):
         names = []
         for i in range(3):
             names.append("/tmp/{0}-{1}-updated".format(name, i))
-            with salt.utils.fopen("/tmp/{0}-{1}-updated".format(name, i), 'w') as f:
+            with salt.utils.files.fopen("/tmp/{0}-{1}-updated".format(name, i), 'w') as f:
                 expected_data["{0}-{1}-updated".format(name, i)] = base64.b64encode("{0}{1}-updated".format(name, i))
                 f.write("{0}{1}-updated".format(name, i))
 
@@ -158,7 +158,7 @@ class TestK8SSecrets(TestCase):
     def test_delete_secret(self):
         name = self.name
         filename = "/tmp/{0}.json".format(name)
-        with salt.utils.fopen(filename, 'w') as f:
+        with salt.utils.files.fopen(filename, 'w') as f:
             json.dump(self.request, f)
 
         create = Popen(["kubectl", "--namespace=default", "create", "-f", filename], stdout=PIPE)
@@ -205,7 +205,7 @@ spec:
     services: "5"
 """.format(name)
         filename = "/tmp/{0}.yaml".format(name)
-        with salt.utils.fopen(filename, 'w') as f:
+        with salt.utils.files.fopen(filename, 'w') as f:
             f.write(request)
 
         create = Popen(["kubectl", "--namespace={0}".format(namespace), "create", "-f", filename], stdout=PIPE)
@@ -239,7 +239,7 @@ spec:
     services: "5"
 """.format(name)
         filename = "/tmp/{0}.yaml".format(name)
-        with salt.utils.fopen(filename, 'w') as f:
+        with salt.utils.files.fopen(filename, 'w') as f:
             f.write(request)
 
         create = Popen(["kubectl", "--namespace={0}".format(namespace), "create", "-f", filename], stdout=PIPE)
@@ -286,7 +286,7 @@ spec:
     services: "5"
 """.format(name)
         filename = "/tmp/{0}.yaml".format(name)
-        with salt.utils.fopen(filename, 'w') as f:
+        with salt.utils.files.fopen(filename, 'w') as f:
             f.write(request)
 
         create = Popen(["kubectl", "--namespace={0}".format(namespace), "create", "-f", filename], stdout=PIPE)
@@ -352,7 +352,7 @@ spec:
             }
         }
         filename = "/tmp/{0}.yaml".format(name)
-        with salt.utils.fopen(filename, 'w') as f:
+        with salt.utils.files.fopen(filename, 'w') as f:
             f.write(request)
 
         create = Popen(["kubectl", "--namespace=default", "create", "-f", filename], stdout=PIPE)
@@ -390,7 +390,7 @@ spec:
     type: Container
 """.format(name)
         filename = "/tmp/{0}.yaml".format(name)
-        with salt.utils.fopen(filename, 'w') as f:
+        with salt.utils.files.fopen(filename, 'w') as f:
             f.write(request)
 
         create = Popen(["kubectl", "--namespace=default", "create", "-f", filename], stdout=PIPE)

--- a/tests/unit/modules/test_linux_sysctl.py
+++ b/tests/unit/modules/test_linux_sysctl.py
@@ -91,7 +91,7 @@ class LinuxSysctlTestCase(TestCase, LoaderModuleMockMixin):
         mock_cmd = MagicMock(return_value=cmd)
         with patch.dict(linux_sysctl.__salt__, {'cmd.run_stdout': mock_cmd,
                                                 'cmd.run_all': mock_asn_cmd}):
-            with patch('salt.utils.fopen', mock_open()) as m_open:
+            with patch('salt.utils.files.fopen', mock_open()) as m_open:
                 self.assertRaises(CommandExecutionError,
                                   linux_sysctl.persist,
                                   'net.ipv4.ip_forward',
@@ -110,7 +110,7 @@ class LinuxSysctlTestCase(TestCase, LoaderModuleMockMixin):
             sys_cmd = 'systemd 208\n+PAM +LIBWRAP'
             mock_sys_cmd = MagicMock(return_value=sys_cmd)
 
-            with patch('salt.utils.fopen', mock_open()) as m_open:
+            with patch('salt.utils.files.fopen', mock_open()) as m_open:
                 with patch.dict(linux_sysctl.__context__, {'salt.utils.systemd.version': 232}):
                     with patch.dict(linux_sysctl.__salt__,
                                     {'cmd.run_stdout': mock_sys_cmd,
@@ -136,7 +136,7 @@ class LinuxSysctlTestCase(TestCase, LoaderModuleMockMixin):
             sys_cmd = 'systemd 208\n+PAM +LIBWRAP'
             mock_sys_cmd = MagicMock(return_value=sys_cmd)
 
-            with patch('salt.utils.fopen', mock_open()):
+            with patch('salt.utils.files.fopen', mock_open()):
                 with patch.dict(linux_sysctl.__context__, {'salt.utils.systemd.version': 232}):
                     with patch.dict(linux_sysctl.__salt__,
                                     {'cmd.run_stdout': mock_sys_cmd,

--- a/tests/unit/modules/test_mac_sysctl.py
+++ b/tests/unit/modules/test_mac_sysctl.py
@@ -67,7 +67,7 @@ class DarwinSysctlTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Tests adding of config file failure
         '''
-        with patch('salt.utils.fopen', mock_open()) as m_open, \
+        with patch('salt.utils.files.fopen', mock_open()) as m_open, \
                 patch('os.path.isfile', MagicMock(return_value=False)):
             m_open.side_effect = IOError(13, 'Permission denied', '/file')
             self.assertRaises(CommandExecutionError,
@@ -79,7 +79,7 @@ class DarwinSysctlTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Tests successful add of config file when previously not one
         '''
-        with patch('salt.utils.fopen', mock_open()) as m_open, \
+        with patch('salt.utils.files.fopen', mock_open()) as m_open, \
                 patch('os.path.isfile', MagicMock(return_value=False)):
             mac_sysctl.persist('net.inet.icmp.icmplim', 50)
             helper_open = m_open()
@@ -92,7 +92,7 @@ class DarwinSysctlTestCase(TestCase, LoaderModuleMockMixin):
         '''
         to_write = '#\n# Kernel sysctl configuration\n#\n'
         m_calls_list = [call.writelines(['net.inet.icmp.icmplim=50', '\n'])]
-        with patch('salt.utils.fopen', mock_open(read_data=to_write)) as m_open, \
+        with patch('salt.utils.files.fopen', mock_open(read_data=to_write)) as m_open, \
                 patch('os.path.isfile', MagicMock(return_value=True)):
             mac_sysctl.persist('net.inet.icmp.icmplim', 50, config=to_write)
             helper_open = m_open()

--- a/tests/unit/modules/test_mount.py
+++ b/tests/unit/modules/test_mount.py
@@ -19,6 +19,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 import salt.modules.mount as mount
 
@@ -148,7 +149,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value=True)
         mock_read = MagicMock(side_effect=OSError)
         with patch.object(os.path, 'isfile', mock):
-            with patch.object(salt.utils, 'fopen', mock_read):
+            with patch.object(salt.utils.files, 'fopen', mock_read):
                 self.assertRaises(CommandExecutionError,
                                   mount.set_fstab, 'A', 'B', 'C')
 

--- a/tests/unit/modules/test_mount.py
+++ b/tests/unit/modules/test_mount.py
@@ -90,7 +90,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
             with patch.object(os.path, 'isfile', mock):
                 file_data = '\n'.join(['#',
                                        'A B C D,E,F G H'])
-                with patch('salt.utils.fopen',
+                with patch('salt.utils.files.fopen',
                            mock_open(read_data=file_data),
                            create=True) as m:
                     m.return_value.__iter__.return_value = file_data.splitlines()
@@ -113,7 +113,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
             with patch.object(os.path, 'isfile', mock):
                 file_data = '\n'.join(['#',
                                        'swap        -   /tmp                tmpfs    -   yes    size=2048m'])
-                with patch('salt.utils.fopen',
+                with patch('salt.utils.files.fopen',
                            mock_open(read_data=file_data),
                            create=True) as m:
                     m.return_value.__iter__.return_value = file_data.splitlines()
@@ -131,7 +131,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         mock_fstab = MagicMock(return_value={})
         with patch.dict(mount.__grains__, {'kernel': ''}):
             with patch.object(mount, 'fstab', mock_fstab):
-                with patch('salt.utils.fopen', mock_open()):
+                with patch('salt.utils.files.fopen', mock_open()):
                     self.assertTrue(mount.rm_fstab('name', 'device'))
 
     def test_set_fstab(self):
@@ -154,7 +154,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
 
         mock = MagicMock(return_value=True)
         with patch.object(os.path, 'isfile', mock):
-            with patch('salt.utils.fopen',
+            with patch('salt.utils.files.fopen',
                        mock_open(read_data=MOCK_SHELL_FILE)):
                 self.assertEqual(mount.set_fstab('A', 'B', 'C'), 'new')
 
@@ -260,7 +260,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         file_data = '\n'.join(['Filename Type Size Used Priority',
                                '/dev/sda1 partition 31249404 4100 -1'])
         with patch.dict(mount.__grains__, {'os': '', 'kernel': ''}):
-            with patch('salt.utils.fopen',
+            with patch('salt.utils.files.fopen',
                        mock_open(read_data=file_data),
                        create=True) as m:
                 m.return_value.__iter__.return_value = file_data.splitlines()

--- a/tests/unit/modules/test_network.py
+++ b/tests/unit/modules/test_network.py
@@ -234,7 +234,7 @@ class NetworkTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(network.__salt__,
                             {'cmd.run': MagicMock(return_value=None)}):
                 file_d = '\n'.join(['#', 'A B C D,E,F G H'])
-                with patch('salt.utils.fopen', mock_open(read_data=file_d),
+                with patch('salt.utils.files.fopen', mock_open(read_data=file_d),
                            create=True) as mfi:
                     mfi.return_value.__iter__.return_value = file_d.splitlines()
                     with patch.dict(network.__grains__, {'os_family': 'A'}):

--- a/tests/unit/modules/test_nfs3.py
+++ b/tests/unit/modules/test_nfs3.py
@@ -33,7 +33,7 @@ class NfsTestCase(TestCase, LoaderModuleMockMixin):
         Test for List configured exports
         '''
         file_d = '\n'.join(['A B1(23'])
-        with patch('salt.utils.fopen',
+        with patch('salt.utils.files.fopen',
                    mock_open(read_data=file_d), create=True) as mfi:
             mfi.return_value.__iter__.return_value = file_d.splitlines()
             self.assertDictEqual(nfs3.list_exports(),

--- a/tests/unit/modules/test_nftables.py
+++ b/tests/unit/modules/test_nftables.py
@@ -19,7 +19,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.modules.nftables as nftables
-import salt.utils
+import salt.utils.files
 from salt.exceptions import CommandExecutionError
 
 
@@ -79,7 +79,7 @@ class NftablesTestCase(TestCase, LoaderModuleMockMixin):
         Test if it return a data structure of the rules in the conf file
         '''
         with patch.dict(nftables.__grains__, {'os_family': 'Debian'}):
-            with patch.object(salt.utils, 'fopen', MagicMock(mock_open())):
+            with patch.object(salt.utils.files, 'fopen', MagicMock(mock_open())):
                 self.assertListEqual(nftables.get_saved_rules(), [])
 
     # 'get_rules' function tests: 1
@@ -105,10 +105,10 @@ class NftablesTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(nftables.__grains__, {'os_family': 'Debian'}):
             mock = MagicMock(return_value=False)
             with patch.dict(nftables.__salt__, {'cmd.run': mock}):
-                with patch.object(salt.utils, 'fopen', MagicMock(mock_open())):
+                with patch.object(salt.utils.files, 'fopen', MagicMock(mock_open())):
                     self.assertEqual(nftables.save(), '#! nft -f\n\n')
 
-                with patch.object(salt.utils, 'fopen',
+                with patch.object(salt.utils.files, 'fopen',
                                   MagicMock(side_effect=IOError)):
                     self.assertRaises(CommandExecutionError, nftables.save)
 

--- a/tests/unit/modules/test_pam.py
+++ b/tests/unit/modules/test_pam.py
@@ -34,7 +34,7 @@ class PamTestCase(TestCase):
         '''
         Test if the parsing function works
         '''
-        with patch('salt.utils.fopen', mock_open(read_data=MOCK_FILE)):
+        with patch('salt.utils.files.fopen', mock_open(read_data=MOCK_FILE)):
             self.assertListEqual(pam.read_file('/etc/pam.d/login'),
                                  [{'arguments': [], 'control_flag': 'ok',
                                    'interface': 'ok', 'module': 'ignore'}])

--- a/tests/unit/modules/test_poudriere.py
+++ b/tests/unit/modules/test_poudriere.py
@@ -76,7 +76,7 @@ class PoudriereTestCase(TestCase, LoaderModuleMockMixin):
         '''
         mock = MagicMock(return_value='/tmp/salt')
         with patch.dict(poudriere.__salt__, {'config.option': mock}), \
-                patch('salt.utils.fopen', mock_open()), \
+                patch('salt.utils.files.fopen', mock_open()), \
                 patch.object(poudriere, '_check_config_exists',
                               MagicMock(side_effect=[True, False])):
             self.assertDictEqual(poudriere.parse_config(), {})

--- a/tests/unit/modules/test_puppet.py
+++ b/tests/unit/modules/test_puppet.py
@@ -20,6 +20,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.utils
+import salt.utils.files
 import salt.modules.puppet as puppet
 from salt.exceptions import CommandExecutionError
 
@@ -80,11 +81,11 @@ class PuppetTestCase(TestCase, LoaderModuleMockMixin):
             with patch.object(os.path, 'isfile', mock):
                 self.assertFalse(puppet.disable())
 
-                with patch('salt.utils.fopen', mock_open()):
+                with patch('salt.utils.files.fopen', mock_open()):
                     self.assertTrue(puppet.disable())
 
                 try:
-                    with patch('salt.utils.fopen', mock_open()) as m_open:
+                    with patch('salt.utils.files.fopen', mock_open()) as m_open:
                         m_open.side_effect = IOError(13, 'Permission denied:', '/file')
                         self.assertRaises(CommandExecutionError, puppet.disable)
                 except StopIteration:
@@ -103,7 +104,7 @@ class PuppetTestCase(TestCase, LoaderModuleMockMixin):
 
             mock = MagicMock(side_effect=[False, True])
             with patch.object(os.path, 'isfile', mock):
-                with patch('salt.utils.fopen', mock_open(read_data="1")):
+                with patch('salt.utils.files.fopen', mock_open(read_data="1")):
                     mock = MagicMock(return_value=True)
                     with patch.object(os, 'kill', mock):
                         self.assertEqual(puppet.status(),
@@ -111,21 +112,21 @@ class PuppetTestCase(TestCase, LoaderModuleMockMixin):
 
             mock = MagicMock(side_effect=[False, True])
             with patch.object(os.path, 'isfile', mock):
-                with patch('salt.utils.fopen', mock_open()):
+                with patch('salt.utils.files.fopen', mock_open()):
                     mock = MagicMock(return_value=True)
                     with patch.object(os, 'kill', mock):
                         self.assertEqual(puppet.status(), "Stale lockfile")
 
             mock = MagicMock(side_effect=[False, False, True])
             with patch.object(os.path, 'isfile', mock):
-                with patch('salt.utils.fopen', mock_open(read_data="1")):
+                with patch('salt.utils.files.fopen', mock_open(read_data="1")):
                     mock = MagicMock(return_value=True)
                     with patch.object(os, 'kill', mock):
                         self.assertEqual(puppet.status(), "Idle daemon")
 
             mock = MagicMock(side_effect=[False, False, True])
             with patch.object(os.path, 'isfile', mock):
-                with patch('salt.utils.fopen', mock_open()):
+                with patch('salt.utils.files.fopen', mock_open()):
                     mock = MagicMock(return_value=True)
                     with patch.object(os, 'kill', mock):
                         self.assertEqual(puppet.status(), "Stale pidfile")
@@ -140,11 +141,11 @@ class PuppetTestCase(TestCase, LoaderModuleMockMixin):
         '''
         mock_lst = MagicMock(return_value=[])
         with patch.dict(puppet.__salt__, {'cmd.run': mock_lst}):
-            with patch('salt.utils.fopen',
+            with patch('salt.utils.files.fopen',
                         mock_open(read_data="resources: 1")):
                 self.assertDictEqual(puppet.summary(), {'resources': 1})
 
-            with patch('salt.utils.fopen', mock_open()) as m_open:
+            with patch('salt.utils.files.fopen', mock_open()) as m_open:
                 m_open.side_effect = IOError(13, 'Permission denied:', '/file')
                 self.assertRaises(CommandExecutionError, puppet.summary)
 

--- a/tests/unit/modules/test_seed.py
+++ b/tests/unit/modules/test_seed.py
@@ -19,7 +19,7 @@ from tests.support.mock import (
 
 
 # Import Salt Libs
-import salt.utils
+import salt.utils.files
 import salt.utils.odict
 import salt.modules.seed as seed
 
@@ -39,7 +39,7 @@ class SeedTestCase(TestCase, LoaderModuleMockMixin):
             ddd['b'] = 'b'
             ddd['a'] = 'b'
             data = seed.mkconfig(ddd, approve_key=False)
-            with salt.utils.fopen(data['config']) as fic:
+            with salt.utils.files.fopen(data['config']) as fic:
                 fdata = fic.read()
                 self.assertEqual(fdata, 'b: b\na: b\nmaster: foo\n')
 

--- a/tests/unit/modules/test_snapper.py
+++ b/tests/unit/modules/test_snapper.py
@@ -337,7 +337,7 @@ class SnapperTestCase(TestCase, LoaderModuleMockMixin):
                 patch('salt.modules.snapper.changed_files', MagicMock(return_value=["/tmp/foo2"])), \
                 patch('salt.modules.snapper._is_text_file', MagicMock(return_value=True)), \
                 patch('os.path.isfile', MagicMock(side_effect=[False, True])), \
-                patch('salt.utils.fopen', mock_open(read_data=FILE_CONTENT["/tmp/foo2"]['post'])), \
+                patch('salt.utils.files.fopen', mock_open(read_data=FILE_CONTENT["/tmp/foo2"]['post'])), \
                 patch('salt.modules.snapper.snapper.ListConfigs', MagicMock(return_value=DBUS_RET['ListConfigs'])):
             if sys.version_info < (2, 7):
                 self.assertEqual(snapper.diff(), {"/tmp/foo2": MODULE_RET['DIFF']['/tmp/foo26']})
@@ -360,7 +360,7 @@ class SnapperTestCase(TestCase, LoaderModuleMockMixin):
                 mock_open(read_data=FILE_CONTENT["/tmp/foo"]['post']).return_value,
                 mock_open(read_data=FILE_CONTENT["/tmp/foo2"]['post']).return_value,
             ]
-            with patch('salt.utils.fopen') as fopen_mock:
+            with patch('salt.utils.files.fopen') as fopen_mock:
                 fopen_mock.side_effect = fopen_effect
                 module_ret = {
                     "/tmp/foo": MODULE_RET['DIFF']["/tmp/foo"],
@@ -388,7 +388,7 @@ class SnapperTestCase(TestCase, LoaderModuleMockMixin):
                 mock_open(read_data="dummy binary").return_value,
                 mock_open(read_data="dummy binary").return_value,
             ]
-            with patch('salt.utils.fopen') as fopen_mock:
+            with patch('salt.utils.files.fopen') as fopen_mock:
                 fopen_mock.side_effect = fopen_effect
                 module_ret = {
                     "/tmp/foo3": MODULE_RET['DIFF']["/tmp/foo3"],

--- a/tests/unit/modules/test_ssh.py
+++ b/tests/unit/modules/test_ssh.py
@@ -16,6 +16,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.utils
+import salt.utils.files
 import salt.modules.ssh as ssh
 from salt.exceptions import CommandExecutionError
 
@@ -110,7 +111,7 @@ class SSHAuthKeyTestCase(TestCase, LoaderModuleMockMixin):
                 ssh._replace_auth_key('foo', key, config=temp_file.name)
 
         # The previous authorized key should have been replaced by the simpler one
-        with salt.utils.fopen(temp_file.name) as _fh:
+        with salt.utils.files.fopen(temp_file.name) as _fh:
             file_txt = _fh.read()
             self.assertIn(enc, file_txt)
             self.assertIn(key, file_txt)
@@ -121,7 +122,7 @@ class SSHAuthKeyTestCase(TestCase, LoaderModuleMockMixin):
         enc = 'ecdsa-sha2-nistp256'
         key = 'abcxyz'
 
-        with salt.utils.fopen(temp_file.name, 'a') as _fh:
+        with salt.utils.files.fopen(temp_file.name, 'a') as _fh:
             _fh.write('{0} {1}'.format(enc, key))
 
         # Replace the simple key from before with the more complicated options + new email
@@ -135,7 +136,7 @@ class SSHAuthKeyTestCase(TestCase, LoaderModuleMockMixin):
                 ssh._replace_auth_key('foo', key, enc=enc, comment=email, options=options, config=temp_file.name)
 
         # Assert that the new line was added as-is to the file
-        with salt.utils.fopen(temp_file.name) as _fh:
+        with salt.utils.files.fopen(temp_file.name) as _fh:
             file_txt = _fh.read()
             self.assertIn(enc, file_txt)
             self.assertIn(key, file_txt)

--- a/tests/unit/modules/test_state.py
+++ b/tests/unit/modules/test_state.py
@@ -801,10 +801,10 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                 patch('salt.modules.state.salt.payload', MockSerial):
             mock = MagicMock(side_effect=[True, True, False])
             with patch.object(os.path, 'isfile', mock):
-                with patch('salt.utils.fopen', mock_open()):
+                with patch('salt.utils.files.fopen', mock_open()):
                     self.assertDictEqual(state.check_request(), {'A': 'B'})
 
-                with patch('salt.utils.fopen', mock_open()):
+                with patch('salt.utils.files.fopen', mock_open()):
                     self.assertEqual(state.check_request("A"), 'B')
 
                 self.assertDictEqual(state.check_request(), {})
@@ -826,7 +826,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                     with patch.object(os, 'umask', mock):
                         with patch.object(salt.utils, 'is_windows', mock):
                             with patch.dict(state.__salt__, {'cmd.run': mock}):
-                                with patch('salt.utils.fopen', mock_open()):
+                                with patch('salt.utils.files.fopen', mock_open()):
                                     mock = MagicMock(return_value=True)
                                     with patch.object(os, 'umask', mock):
                                         self.assertTrue(state.request("A"))
@@ -893,7 +893,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                                                       'isfile',
                                                       mock):
                                         with patch(
-                                                   'salt.utils.fopen',
+                                                   'salt.utils.files.fopen',
                                                    mock_open()):
                                             self.assertTrue(
                                                             state.sls(arg,
@@ -941,7 +941,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                         with patch.object(state, '_set_retcode', mock):
                             with patch.dict(state.__opts__,
                                             {"test": True}):
-                                with patch('salt.utils.fopen', mock_open()):
+                                with patch('salt.utils.files.fopen', mock_open()):
                                     self.assertTrue(state.sls("core,edit"
                                                               ".vim dev",
                                                               None,
@@ -968,7 +968,7 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
 
                 MockTarFile.path = ""
                 MockJson.flag = True
-                with patch('salt.utils.fopen', mock_open()):
+                with patch('salt.utils.files.fopen', mock_open()):
                     self.assertListEqual(state.pkg("/tmp/state_pkg.tgz",
                                                    0,
                                                    "md5"),
@@ -976,6 +976,6 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
 
                 MockTarFile.path = ""
                 MockJson.flag = False
-                with patch('salt.utils.fopen', mock_open()):
+                with patch('salt.utils.files.fopen', mock_open()):
                     self.assertTrue(state.pkg("/tmp/state_pkg.tgz",
                                               0, "md5"))

--- a/tests/unit/modules/test_status.py
+++ b/tests/unit/modules/test_status.py
@@ -83,7 +83,7 @@ class StatusTestCase(TestCase, LoaderModuleMockMixin):
                 with patch('time.time', MagicMock(return_value=m.now)):
                     with patch('os.path.exists', MagicMock(return_value=True)):
                         proc_uptime = '{0} {1}'.format(m.ut, m.idle)
-                        with patch('salt.utils.fopen', mock_open(read_data=proc_uptime)):
+                        with patch('salt.utils.files.fopen', mock_open(read_data=proc_uptime)):
                             ret = status.uptime()
                             self.assertDictEqual(ret, m.ret)
 

--- a/tests/unit/modules/test_timezone.py
+++ b/tests/unit/modules/test_timezone.py
@@ -200,7 +200,7 @@ class TimezoneModuleTestCase(TestCase, LoaderModuleMockMixin):
         '''
         with patch.dict(timezone.__grains__, {'os_family': ['Gentoo']}):
             _fopen = mock_open()
-            with patch('salt.utils.fopen', _fopen):
+            with patch('salt.utils.files.fopen', _fopen):
                 assert timezone.set_zone(self.TEST_TZ)
                 name, args, kwargs = _fopen.mock_calls[0]
                 assert args == ('/etc/timezone', 'w')
@@ -218,7 +218,7 @@ class TimezoneModuleTestCase(TestCase, LoaderModuleMockMixin):
         '''
         with patch.dict(timezone.__grains__, {'os_family': ['Debian']}):
             _fopen = mock_open()
-            with patch('salt.utils.fopen', _fopen):
+            with patch('salt.utils.files.fopen', _fopen):
                 assert timezone.set_zone(self.TEST_TZ)
                 name, args, kwargs = _fopen.mock_calls[0]
                 assert args == ('/etc/timezone', 'w')
@@ -296,7 +296,7 @@ class TimezoneModuleTestCase(TestCase, LoaderModuleMockMixin):
         # Incomplete
         with patch.dict(timezone.__grains__, {'os_family': ['Solaris']}):
             assert timezone.get_hwclock() == 'UTC'
-            with patch('salt.utils.fopen', mock_open()):
+            with patch('salt.utils.files.fopen', mock_open()):
                 assert timezone.get_hwclock() == 'localtime'
 
     @patch('salt.utils.which', MagicMock(return_value=False))

--- a/tests/unit/modules/test_tls.py
+++ b/tests/unit/modules/test_tls.py
@@ -188,7 +188,7 @@ class TLSAddTestCase(TestCase, LoaderModuleMockMixin):
         ca_path = '/tmp/test_tls'
         ca_name = 'test_ca'
         mock_opt = MagicMock(return_value=ca_path)
-        with patch('salt.utils.fopen',
+        with patch('salt.utils.files.fopen',
                    mock_open(read_data=_TLS_TEST_DATA['ca_cert'])), \
                 patch.dict(tls.__salt__, {'config.option': mock_opt}), \
                 patch('os.path.exists', MagicMock(return_value=True)), \
@@ -269,7 +269,7 @@ class TLSAddTestCase(TestCase, LoaderModuleMockMixin):
                 if 'extensions' not in reference:
                     del source['extensions']
 
-            with patch('salt.utils.fopen',
+            with patch('salt.utils.files.fopen',
                        mock_open(read_data=_TLS_TEST_DATA['ca_cert'])):
                 try:
                     result = ignore_extensions(tls.cert_info(certp))

--- a/tests/unit/modules/test_xapi.py
+++ b/tests/unit/modules/test_xapi.py
@@ -367,14 +367,14 @@ class XapiTestCase(TestCase, LoaderModuleMockMixin):
             self.assertFalse(xapi.is_hyper())
 
         with patch.dict(xapi.__grains__, {'virtual_subtype': 'Xen Dom0'}):
-            with patch('salt.utils.fopen', mock_open(read_data="salt")):
+            with patch('salt.utils.files.fopen', mock_open(read_data="salt")):
                 self.assertFalse(xapi.is_hyper())
 
-            with patch('salt.utils.fopen', mock_open()) as mock_read:
+            with patch('salt.utils.files.fopen', mock_open()) as mock_read:
                 mock_read.side_effect = IOError
                 self.assertFalse(xapi.is_hyper())
 
-            with patch('salt.utils.fopen', mock_open(read_data="xen_")):
+            with patch('salt.utils.files.fopen', mock_open(read_data="xen_")):
                 with patch.dict(xapi.__grains__, {'ps': 'salt'}):
                     mock = MagicMock(return_value={'xenstore': 'salt'})
                     with patch.dict(xapi.__salt__, {'cmd.run': mock}):

--- a/tests/unit/modules/test_zcbuildout.py
+++ b/tests/unit/modules/test_zcbuildout.py
@@ -22,6 +22,7 @@ from tests.support.helpers import requires_network, skip_if_binaries_missing
 
 # Import Salt libs
 import salt.utils
+import salt.utils.files
 import salt.modules.zcbuildout as buildout
 import salt.modules.cmdmod as cmd
 
@@ -47,7 +48,7 @@ log = logging.getLogger(__name__)
 
 
 def download_to(url, dest):
-    with salt.utils.fopen(dest, 'w') as fic:
+    with salt.utils.files.fopen(dest, 'w') as fic:
         fic.write(urlopen(url, timeout=10).read())
 
 
@@ -294,14 +295,14 @@ class BuildoutTestCase(Base):
         bpy = os.path.join(b_dir, 'bootstrap.py')
         buildout.upgrade_bootstrap(b_dir)
         time1 = os.stat(bpy).st_mtime
-        with salt.utils.fopen(bpy) as fic:
+        with salt.utils.files.fopen(bpy) as fic:
             data = fic.read()
         self.assertTrue('setdefaulttimeout(2)' in data)
         flag = os.path.join(b_dir, '.buildout', '2.updated_bootstrap')
         self.assertTrue(os.path.exists(flag))
         buildout.upgrade_bootstrap(b_dir, buildout_ver=1)
         time2 = os.stat(bpy).st_mtime
-        with salt.utils.fopen(bpy) as fic:
+        with salt.utils.files.fopen(bpy) as fic:
             data = fic.read()
         self.assertTrue('setdefaulttimeout(2)' in data)
         flag = os.path.join(b_dir, '.buildout', '1.updated_bootstrap')

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -21,7 +21,7 @@ from tests.support.mock import (
 )
 
 # Import Salt libs
-import salt.utils
+import salt.utils.files
 import salt.modules.zypper as zypper
 from salt.exceptions import CommandExecutionError
 
@@ -46,7 +46,7 @@ def get_test_data(filename):
     '''
     Return static test data
     '''
-    with salt.utils.fopen(
+    with salt.utils.files.fopen(
             os.path.join(
                 os.path.join(
                     os.path.dirname(os.path.abspath(__file__)), 'zypp'), filename)) as rfh:

--- a/tests/unit/pillar/test_git.py
+++ b/tests/unit/pillar/test_git.py
@@ -34,7 +34,7 @@ FILE_DATA = {
              }
 
 # Import Salt Libs
-import salt.utils
+import salt.utils.files
 from salt.pillar import Pillar
 import salt.pillar.git_pillar as git_pillar
 
@@ -83,7 +83,7 @@ class GitPillarTestCase(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModul
         os.makedirs(repo)
         subprocess.check_call(['git', 'init', repo])
         for filename in FILE_DATA:
-            with salt.utils.fopen(os.path.join(repo, filename), 'w') as data_file:
+            with salt.utils.files.fopen(os.path.join(repo, filename), 'w') as data_file:
                 yaml.dump(FILE_DATA[filename], data_file)
 
         subprocess.check_call(['git', 'add', '.'], cwd=repo)

--- a/tests/unit/pillar/test_hg.py
+++ b/tests/unit/pillar/test_hg.py
@@ -27,7 +27,7 @@ FILE_DATA = {
 }
 
 # Import Salt Libs
-import salt.utils
+import salt.utils.files
 import salt.pillar.hg_pillar as hg_pillar
 HGLIB = hg_pillar.hglib
 
@@ -66,7 +66,7 @@ class HgPillarTestCase(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModule
         os.makedirs(hg_repo)
         subprocess.check_call(['hg', 'init', hg_repo])
         for filename in FILE_DATA:
-            with salt.utils.fopen(os.path.join(hg_repo, filename), 'w') as data_file:
+            with salt.utils.files.fopen(os.path.join(hg_repo, filename), 'w') as data_file:
                 yaml.dump(FILE_DATA[filename], data_file)
         subprocess.check_call(['hg', 'ci', '-A', '-R', hg_repo, '-m', 'first commit', '-u', COMMIT_USER_NAME])
         return hg_repo

--- a/tests/unit/returners/test_local_cache.py
+++ b/tests/unit/returners/test_local_cache.py
@@ -27,7 +27,9 @@ from tests.support.mock import (
 
 # Import Salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.jid
+import salt.utils.job
 import salt.returners.local_cache as local_cache
 import salt.ext.six as six
 
@@ -160,7 +162,7 @@ class LocalCacheCleanOldJobsTestCase(TestCase, LoaderModuleMockMixin):
             dir_name = '/'.join([temp_dir, 'jid'])
             os.mkdir(dir_name)
             jid_file_path = '/'.join([dir_name, 'jid'])
-            with salt.utils.fopen(jid_file_path, 'w') as jid_file:
+            with salt.utils.files.fopen(jid_file_path, 'w') as jid_file:
                 jid_file.write('this is a jid file')
 
         return temp_dir, jid_file_path

--- a/tests/unit/runners/test_winrepo.py
+++ b/tests/unit/runners/test_winrepo.py
@@ -13,7 +13,7 @@ from tests.support.unit import skipIf, TestCase
 from tests.support.mock import NO_MOCK, NO_MOCK_REASON
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 import salt.runners.winrepo as winrepo
 
 _WINREPO_SLS = r'''
@@ -102,6 +102,6 @@ class WinrepoTest(TestCase, LoaderModuleMockMixin):
         '''
         sls_file = os.path.join(self.winrepo_sls_dir, 'wireshark.sls')
         # Add a winrepo SLS file
-        with salt.utils.fopen(sls_file, 'w') as fp_:
+        with salt.utils.files.fopen(sls_file, 'w') as fp_:
             fp_.write(_WINREPO_SLS)
         self.assertEqual(winrepo.genrepo(), _WINREPO_GENREPO_DATA)

--- a/tests/unit/states/test_apache.py
+++ b/tests/unit/states/test_apache.py
@@ -17,7 +17,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.states.apache as apache
-import salt.utils
+import salt.utils.files
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -45,13 +45,13 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                    'changes': {},
                    'comment': ''}
 
-            with patch.object(salt.utils, 'fopen', mock_open(read_data=config)):
+            with patch.object(salt.utils.files, 'fopen', mock_open(read_data=config)):
                 mock_config = MagicMock(return_value=config)
                 with patch.dict(apache.__salt__, {'apache.config': mock_config}):
                     ret.update({'comment': 'Configuration is up to date.'})
                     self.assertDictEqual(apache.configfile(name, config), ret)
 
-            with patch.object(salt.utils, 'fopen', mock_open(read_data=config)):
+            with patch.object(salt.utils.files, 'fopen', mock_open(read_data=config)):
                 mock_config = MagicMock(return_value=new_config)
                 with patch.dict(apache.__salt__, {'apache.config': mock_config}):
                     ret.update({'comment': 'Configuration will update.',
@@ -61,7 +61,7 @@ class ApacheTestCase(TestCase, LoaderModuleMockMixin):
                     with patch.dict(apache.__opts__, {'test': True}):
                         self.assertDictEqual(apache.configfile(name, new_config), ret)
 
-            with patch.object(salt.utils, 'fopen', mock_open(read_data=config)):
+            with patch.object(salt.utils.files, 'fopen', mock_open(read_data=config)):
                 mock_config = MagicMock(return_value=new_config)
                 with patch.dict(apache.__salt__, {'apache.config': mock_config}):
                     ret.update({'comment': 'Successfully created configuration.',

--- a/tests/unit/states/test_augeas.py
+++ b/tests/unit/states/test_augeas.py
@@ -141,7 +141,7 @@ class AugeasTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(augeas.__salt__, mock_dict_):
                 mock_filename = MagicMock(return_value='/etc/services')
                 with patch.object(augeas, '_workout_filename', mock_filename):
-                    with patch('salt.utils.fopen', MagicMock(mock_open)):
+                    with patch('salt.utils.files.fopen', MagicMock(mock_open)):
                         mock_diff = MagicMock(return_value=['+ zabbix-agent'])
                         with patch('difflib.unified_diff', mock_diff):
                             self.assertDictEqual(augeas.change(self.name,
@@ -218,7 +218,7 @@ class AugeasTestCase(TestCase, LoaderModuleMockMixin):
             mock_dict_ = {'augeas.execute': mock_execute,
                         'augeas.method_map': self.mock_method_map}
             with patch.dict(augeas.__salt__, mock_dict_):
-                with patch('salt.utils.fopen', MagicMock(mock_open)):
+                with patch('salt.utils.files.fopen', MagicMock(mock_open)):
                     self.assertDictEqual(augeas.change(self.name,
                                         context=self.context,
                                         changes=self.changes),

--- a/tests/unit/states/test_boto_apigateway.py
+++ b/tests/unit/states/test_boto_apigateway.py
@@ -16,6 +16,7 @@ from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 # Import Salt libs
 import salt.config
 import salt.loader
+import salt.utils.files
 from salt.utils.versions import LooseVersion
 
 # pylint: disable=import-error,no-name-in-module
@@ -369,7 +370,7 @@ class TempSwaggerFile(object):
 
     def __enter__(self):
         self.swaggerfile = 'temp-swagger-sample.yaml'
-        with salt.utils.fopen(self.swaggerfile, 'w') as f:
+        with salt.utils.files.fopen(self.swaggerfile, 'w') as f:
             f.write(yaml.dump(self.swaggerdict))
         return self.swaggerfile
 

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -1011,7 +1011,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                         self.assertDictEqual(filestate.comment(name, regex), ret)
 
                     with patch.dict(filestate.__opts__, {'test': False}):
-                        with patch.object(salt.utils, 'fopen',
+                        with patch.object(salt.utils.files, 'fopen',
                                           MagicMock(mock_open())):
                             comt = ('Commented lines successfully')
                             ret.update({'comment': comt, 'result': True})

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -1066,7 +1066,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                         self.assertDictEqual(filestate.uncomment(name, regex), ret)
 
                     with patch.dict(filestate.__opts__, {'test': False}):
-                        with patch.object(salt.utils, 'fopen',
+                        with patch.object(salt.utils.files, 'fopen',
                                           MagicMock(mock_open())):
                             comt = ('Uncommented lines successfully')
                             ret.update({'comment': comt, 'result': True})
@@ -1130,7 +1130,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
 
                     ret.pop('data', None)
                     ret.update({'name': name})
-                    with patch.object(salt.utils, 'fopen',
+                    with patch.object(salt.utils.files, 'fopen',
                                       MagicMock(mock_open(read_data=''))):
                         with patch.object(salt.utils, 'istextfile', mock_f):
                             with patch.dict(filestate.__opts__, {'test': True}):

--- a/tests/unit/states/test_grains.py
+++ b/tests/unit/states/test_grains.py
@@ -17,7 +17,7 @@ from tests.support.unit import TestCase, skipIf
 from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 import salt.modules.grains as grainsmod
 import salt.states.grains as grains
 
@@ -62,7 +62,7 @@ class GrainsTestCase(TestCase, LoaderModuleMockMixin):
             grains_file = os.path.join(
                 os.path.dirname(grains.__opts__['conf_file']),
                 'grains')
-        with salt.utils.fopen(grains_file, "r") as grf:
+        with salt.utils.files.fopen(grains_file, "r") as grf:
             grains_data = grf.read()
         self.assertMultiLineEqual(grains_string, grains_data)
 
@@ -78,7 +78,7 @@ class GrainsTestCase(TestCase, LoaderModuleMockMixin):
                     grains_file = os.path.join(
                         os.path.dirname(grains.__opts__['conf_file']), 'grains')
                 cstr = yaml.safe_dump(grains_data, default_flow_style=False)
-                with salt.utils.fopen(grains_file, "w+") as grf:
+                with salt.utils.files.fopen(grains_file, "w+") as grf:
                     grf.write(cstr)
                 yield
 

--- a/tests/unit/states/test_kapacitor.py
+++ b/tests/unit/states/test_kapacitor.py
@@ -47,7 +47,7 @@ def _present(name='testname',
         'kapacitor.enable_task': enable_mock,
         'kapacitor.disable_task': disable_mock,
     }):
-        with patch('salt.utils.fopen', mock_open(read_data=script)) as open_mock:
+        with patch('salt.utils.files.fopen', mock_open(read_data=script)) as open_mock:
             retval = kapacitor.task_present(name, tick_script, task_type=task_type,
                 database=database, retention_policy=retention_policy, enable=enable)
 

--- a/tests/unit/states/test_syslog_ng.py
+++ b/tests/unit/states/test_syslog_ng.py
@@ -14,7 +14,7 @@ from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
-import salt.utils
+import salt.utils.files
 import salt.states.syslog_ng as syslog_ng
 import salt.modules.syslog_ng as syslog_ng_module
 
@@ -362,7 +362,7 @@ class SyslogNGTestCase(TestCase, LoaderModuleMockMixin):
                 got = syslog_ng.config(id, config=parsed_yaml_config, write=True)
 
             written_config = ""
-            with salt.utils.fopen(config_file_name, "r") as f:
+            with salt.utils.files.fopen(config_file_name, "r") as f:
                 written_config = f.read()
 
             config_without_whitespaces = remove_whitespaces(written_config)

--- a/tests/unit/templates/test_jinja.py
+++ b/tests/unit/templates/test_jinja.py
@@ -22,6 +22,7 @@ import salt.config
 import salt.ext.six as six
 import salt.loader
 import salt.utils
+import salt.utils.files
 from salt.exceptions import SaltRenderError
 from salt.ext.six.moves import builtins
 from salt.utils import get_context
@@ -173,7 +174,7 @@ class TestGetTemplate(TestCase):
         if the file is not contained in the searchpath
         '''
         fn_ = os.path.join(TEMPLATES_DIR, 'files', 'test', 'hello_simple')
-        with salt.utils.fopen(fn_) as fp_:
+        with salt.utils.files.fopen(fn_) as fp_:
             out = render_jinja_tmpl(
                 fp_.read(),
                 dict(
@@ -189,7 +190,7 @@ class TestGetTemplate(TestCase):
         if the file is not contained in the searchpath
         '''
         filename = os.path.join(TEMPLATES_DIR, 'files', 'test', 'hello_import')
-        with salt.utils.fopen(filename) as fp_:
+        with salt.utils.files.fopen(filename) as fp_:
             out = render_jinja_tmpl(
                 fp_.read(),
                 dict(
@@ -209,7 +210,7 @@ class TestGetTemplate(TestCase):
         fc = MockFileClient()
         with patch.object(SaltCacheLoader, 'file_client', MagicMock(return_value=fc)):
             filename = os.path.join(TEMPLATES_DIR, 'files', 'test', 'hello_import')
-            with salt.utils.fopen(filename) as fp_:
+            with salt.utils.files.fopen(filename) as fp_:
                 out = render_jinja_tmpl(
                     fp_.read(),
                     dict(opts={'cachedir': TEMPLATES_DIR, 'file_client': 'remote',
@@ -235,7 +236,7 @@ class TestGetTemplate(TestCase):
                                 'files', 'test', 'hello_import_generalerror')
         fc = MockFileClient()
         with patch.object(SaltCacheLoader, 'file_client', MagicMock(return_value=fc)):
-            with salt.utils.fopen(filename) as fp_:
+            with salt.utils.files.fopen(filename) as fp_:
                 self.assertRaisesRegex(
                     SaltRenderError,
                     expected,
@@ -259,7 +260,7 @@ class TestGetTemplate(TestCase):
                                 'files', 'test', 'hello_import_undefined')
         fc = MockFileClient()
         with patch.object(SaltCacheLoader, 'file_client', MagicMock(return_value=fc)):
-            with salt.utils.fopen(filename) as fp_:
+            with salt.utils.files.fopen(filename) as fp_:
                 self.assertRaisesRegex(
                     SaltRenderError,
                     expected,
@@ -283,7 +284,7 @@ class TestGetTemplate(TestCase):
                                 'files', 'test', 'hello_import_error')
         fc = MockFileClient()
         with patch.object(SaltCacheLoader, 'file_client', MagicMock(return_value=fc)):
-            with salt.utils.fopen(filename) as fp_:
+            with salt.utils.files.fopen(filename) as fp_:
                 self.assertRaisesRegex(
                     SaltRenderError,
                     expected,
@@ -295,7 +296,7 @@ class TestGetTemplate(TestCase):
         fc = MockFileClient()
         with patch.object(SaltCacheLoader, 'file_client', MagicMock(return_value=fc)):
             filename = os.path.join(TEMPLATES_DIR, 'files', 'test', 'hello_import')
-            with salt.utils.fopen(filename) as fp_:
+            with salt.utils.files.fopen(filename) as fp_:
                 out = render_jinja_tmpl(
                     fp_.read(),
                     dict(opts={'cachedir': TEMPLATES_DIR, 'file_client': 'remote',
@@ -306,7 +307,7 @@ class TestGetTemplate(TestCase):
             self.assertEqual(fc.requests[0]['path'], 'salt://macro')
 
             filename = os.path.join(TEMPLATES_DIR, 'files', 'test', 'non_ascii')
-            with salt.utils.fopen(filename) as fp_:
+            with salt.utils.files.fopen(filename) as fp_:
                 out = render_jinja_tmpl(
                     fp_.read(),
                     dict(opts={'cachedir': TEMPLATES_DIR, 'file_client': 'remote',
@@ -373,7 +374,7 @@ class TestGetTemplate(TestCase):
             saltenv='test',
             salt=self.local_salt
         )
-        with salt.utils.fopen(out['data']) as fp:
+        with salt.utils.files.fopen(out['data']) as fp:
             result = fp.read()
             if six.PY2:
                 result = result.decode('utf-8')

--- a/tests/unit/test_crypt.py
+++ b/tests/unit/test_crypt.py
@@ -10,6 +10,7 @@ from tests.support.mock import patch, call, mock_open, NO_MOCK, NO_MOCK_REASON, 
 
 # salt libs
 import salt.utils
+import salt.utils.files
 from salt import crypt
 
 # third-party libs
@@ -90,17 +91,17 @@ class CryptTestCase(TestCase):
     def test_gen_keys(self):
         with patch.multiple(os, umask=MagicMock(), chmod=MagicMock(), chown=MagicMock,
                             access=MagicMock(return_value=True)):
-            with patch('salt.utils.fopen', mock_open()):
+            with patch('salt.utils.files.fopen', mock_open()):
                 open_priv_wb = call('/keydir/keyname.pem', 'wb+')
                 open_pub_wb = call('/keydir/keyname.pub', 'wb+')
                 with patch('os.path.isfile', return_value=True):
                     self.assertEqual(crypt.gen_keys('/keydir', 'keyname', 2048), '/keydir/keyname.pem')
-                    self.assertNotIn(open_priv_wb, salt.utils.fopen.mock_calls)
-                    self.assertNotIn(open_pub_wb, salt.utils.fopen.mock_calls)
+                    self.assertNotIn(open_priv_wb, salt.utils.files.fopen.mock_calls)
+                    self.assertNotIn(open_pub_wb, salt.utils.files.fopen.mock_calls)
                 with patch('os.path.isfile', return_value=False):
-                    with patch('salt.utils.fopen', mock_open()):
+                    with patch('salt.utils.files.fopen', mock_open()):
                         crypt.gen_keys('/keydir', 'keyname', 2048)
-                        salt.utils.fopen.assert_has_calls([open_priv_wb, open_pub_wb], any_order=True)
+                        salt.utils.files.fopen.assert_has_calls([open_priv_wb, open_pub_wb], any_order=True)
 
     def test_sign_message(self):
         key = RSA.importKey(PRIVKEY_DATA)
@@ -108,5 +109,5 @@ class CryptTestCase(TestCase):
             self.assertEqual(SIG, salt.crypt.sign_message('/keydir/keyname.pem', MSG))
 
     def test_verify_signature(self):
-        with patch('salt.utils.fopen', mock_open(read_data=PUBKEY_DATA)):
+        with patch('salt.utils.files.fopen', mock_open(read_data=PUBKEY_DATA)):
             self.assertTrue(crypt.verify_signature('/keydir/keyname.pub', MSG, SIG))

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -14,11 +14,8 @@ import tempfile
 from tests.support.unit import TestCase
 
 # Import Salt libs
-import salt.utils
-from salt.utils import files as util_files
-
-# Import 3rd-party libs
 import salt.ext.six as six
+import salt.utils.files
 
 
 class FilesTestCase(TestCase):
@@ -38,7 +35,7 @@ class FilesTestCase(TestCase):
             os.makedirs(current_directory)
             for name, content in six.iteritems(files):
                 path = os.path.join(temp_directory, folder, name)
-                with salt.utils.fopen(path, 'w+') as fh:
+                with salt.utils.files.fopen(path, 'w+') as fh:
                     fh.write(content)
 
     def _validate_folder_structure_and_contents(self, target_directory,
@@ -46,7 +43,7 @@ class FilesTestCase(TestCase):
         for folder, files in six.iteritems(desired_structure):
             for name, content in six.iteritems(files):
                 path = os.path.join(target_directory, folder, name)
-                with salt.utils.fopen(path) as fh:
+                with salt.utils.files.fopen(path) as fh:
                     assert fh.read().strip() == content
 
     def setUp(self):
@@ -71,7 +68,7 @@ class FilesTestCase(TestCase):
         }
         self._create_temp_structure(test_target_directory, TARGET_STRUCTURE)
         try:
-            util_files.recursive_copy(self.temp_dir, test_target_directory)
+            salt.utils.files.recursive_copy(self.temp_dir, test_target_directory)
             DESIRED_STRUCTURE = copy.copy(TARGET_STRUCTURE)
             DESIRED_STRUCTURE.update(self.STRUCTURE)
             self._validate_folder_structure_and_contents(

--- a/tests/unit/test_pydsl.py
+++ b/tests/unit/test_pydsl.py
@@ -17,6 +17,7 @@ from tests.support.paths import TMP
 import salt.loader
 import salt.config
 import salt.utils
+import salt.utils.files
 from salt.state import HighState
 from salt.utils.pydsl import PyDslError
 
@@ -348,7 +349,7 @@ class PyDSLRendererTestCase(CommonTestCaseBoilerplate):
                 '''.format(output, output, output)))
 
             self.state_highstate({'base': ['aaa']}, dirpath)
-            with salt.utils.fopen(output, 'r') as f:
+            with salt.utils.files.fopen(output, 'r') as f:
                 self.assertEqual(''.join(f.read().split()), "XYZABCDEF")
 
         finally:
@@ -381,9 +382,9 @@ class PyDSLRendererTestCase(CommonTestCaseBoilerplate):
                 A()
                 '''.format(dirpath, dirpath, dirpath, dirpath)))
             self.state_highstate({'base': ['aaa']}, dirpath)
-            with salt.utils.fopen(os.path.join(dirpath, 'yyy.txt'), 'rt') as f:
+            with salt.utils.files.fopen(os.path.join(dirpath, 'yyy.txt'), 'rt') as f:
                 self.assertEqual(f.read(), 'hehe\nhoho\n')
-            with salt.utils.fopen(os.path.join(dirpath, 'xxx.txt'), 'rt') as f:
+            with salt.utils.files.fopen(os.path.join(dirpath, 'xxx.txt'), 'rt') as f:
                 self.assertEqual(f.read(), 'hehe\n')
         finally:
             shutil.rmtree(dirpath, ignore_errors=True)
@@ -456,5 +457,5 @@ class PyDSLRendererTestCase(CommonTestCaseBoilerplate):
 
 
 def write_to(fpath, content):
-    with salt.utils.fopen(fpath, 'w') as f:
+    with salt.utils.files.fopen(fpath, 'w') as f:
         f.write(content)

--- a/tests/unit/test_pyobjects.py
+++ b/tests/unit/test_pyobjects.py
@@ -17,7 +17,7 @@ from tests.support.unit import TestCase
 import tests.integration as integration
 import salt.config
 import salt.state
-import salt.utils
+import salt.utils.files
 from salt.template import compile_template
 from salt.utils.odict import OrderedDict
 from salt.utils.pyobjects import (StateFactory, State, Registry,
@@ -297,7 +297,7 @@ class RendererMixin(object):
 
     def write_template_file(self, filename, content):
         full_path = os.path.join(self.state_tree_dir, filename)
-        with salt.utils.fopen(full_path, 'w') as f:
+        with salt.utils.files.fopen(full_path, 'w') as f:
             f.write(content)
         return full_path
 

--- a/tests/unit/test_spm.py
+++ b/tests/unit/test_spm.py
@@ -12,7 +12,7 @@ from tests.support.mock import patch, MagicMock
 from tests.support.helpers import destructiveTest
 from tests.support.mixins import AdaptedConfigurationTestCaseMixin
 import salt.config
-import salt.utils
+import salt.utils.files
 import salt.spm
 
 _F1 = {
@@ -100,7 +100,7 @@ class SPMTest(TestCase, AdaptedConfigurationTestCaseMixin):
             dirname, _ = os.path.split(path)
             if not os.path.exists(dirname):
                 os.makedirs(dirname)
-            with salt.utils.fopen(path, 'w') as f:
+            with salt.utils.files.fopen(path, 'w') as f:
                 f.write(contents)
         return fdir
 
@@ -120,7 +120,7 @@ class SPMTest(TestCase, AdaptedConfigurationTestCaseMixin):
         for path, contents in _F1['contents']:
             path = os.path.join(self.minion_config['file_roots']['base'][0], _F1['definition']['name'], path)
             assert os.path.exists(path)
-            with salt.utils.fopen(path, 'r') as rfh:
+            with salt.utils.files.fopen(path, 'r') as rfh:
                 assert rfh.read() == contents
         # Check database
         with patch('salt.client.Caller', MagicMock(return_value=self.minion_opts)):

--- a/tests/unit/utils/test_context.py
+++ b/tests/unit/utils/test_context.py
@@ -11,11 +11,11 @@ import shutil
 # Import Salt testing libraries
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import NO_MOCK, NO_MOCK_REASON
-from salt.utils.cache import context_cache
 
 # Import Salt libraries
 import salt.payload
-import salt.utils
+import salt.utils.cache
+import salt.utils.files
 
 __context__ = {'a': 'b'}
 __opts__ = {'cachedir': '/tmp'}
@@ -38,7 +38,7 @@ class ContextCacheTest(TestCase):
         '''
         Tests to ensure the cache is written correctly
         '''
-        @context_cache
+        @salt.utils.cache.context_cache
         def _test_set_cache():
             '''
             This will inherit globals from the test module itself.
@@ -52,7 +52,7 @@ class ContextCacheTest(TestCase):
         self.assertTrue(os.path.isfile(target_cache_file), 'Context cache did not write cache file')
 
         # Test manual de-serialize
-        with salt.utils.fopen(target_cache_file, 'rb') as fp_:
+        with salt.utils.files.fopen(target_cache_file, 'rb') as fp_:
             target_cache_data = salt.payload.Serial(__opts__).load(fp_)
         self.assertDictEqual(__context__, target_cache_data)
 
@@ -66,13 +66,13 @@ class ContextCacheTest(TestCase):
         Tests to ensure that the context cache can rehydrate a wrapped function
         '''
         # First populate the cache
-        @context_cache
+        @salt.utils.cache.context_cache
         def _test_set_cache():
             pass
         _test_set_cache()
 
         # Then try to rehydate a func
-        @context_cache
+        @salt.utils.cache.context_cache
         def _test_refill_cache(comparison_context):
             self.assertEqual(__context__, comparison_context)
 

--- a/tests/unit/utils/test_extend.py
+++ b/tests/unit/utils/test_extend.py
@@ -18,9 +18,9 @@ from tests.support.unit import TestCase
 from tests.support.mock import MagicMock, patch
 
 # Import salt libs
-import salt.utils.extend
 import tests.integration as integration
-import salt.utils
+import salt.utils.extend
+import salt.utils.files
 
 
 class ExtendTestCase(TestCase):
@@ -44,5 +44,5 @@ class ExtendTestCase(TestCase):
             self.assertFalse(os.path.exists(os.path.join(out, 'template.yml')))
             self.assertTrue(os.path.exists(os.path.join(out, 'directory')))
             self.assertTrue(os.path.exists(os.path.join(out, 'directory', 'test.py')))
-            with salt.utils.fopen(os.path.join(out, 'directory', 'test.py'), 'r') as test_f:
+            with salt.utils.files.fopen(os.path.join(out, 'directory', 'test.py'), 'r') as test_f:
                 self.assertEqual(test_f.read(), year)

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+'''
+Unit Tests for functions located in salt.utils.files.py.
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import os
+
+# Import Salt libs
+import salt.utils.files
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+
+class FilesUtilTestCase(TestCase):
+    '''
+    Test case for files util.
+    '''
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_safe_rm(self):
+        with patch('os.remove') as os_remove_mock:
+            salt.utils.files.safe_rm('dummy_tgt')
+            self.assertTrue(os_remove_mock.called)
+
+    @skipIf(os.path.exists('/tmp/no_way_this_is_a_file_nope.sh'), 'Test file exists! Skipping safe_rm_exceptions test!')
+    def test_safe_rm_exceptions(self):
+        error = False
+        try:
+            salt.utils.files.safe_rm('/tmp/no_way_this_is_a_file_nope.sh')
+        except (IOError, OSError):
+            error = True
+        self.assertFalse(error, 'salt.utils.files.safe_rm raised exception when it should not have')

--- a/tests/unit/utils/test_find.py
+++ b/tests/unit/utils/test_find.py
@@ -14,7 +14,7 @@ from tests.support.paths import TMP
 
 # Import salt libs
 import salt.ext.six as six
-import salt.utils
+import salt.utils.files
 import salt.utils.find
 
 # Import 3rd-party libs
@@ -313,7 +313,7 @@ class TestGrepOption(TestCase):
 
     def test_grep_option_match_regular_file(self):
         hello_file = os.path.join(self.tmpdir, 'hello.txt')
-        with salt.utils.fopen(hello_file, 'w') as fp_:
+        with salt.utils.files.fopen(hello_file, 'w') as fp_:
             fp_.write('foo')
         option = salt.utils.find.GrepOption('grep', 'foo')
         self.assertEqual(
@@ -372,7 +372,7 @@ class TestPrintOption(TestCase):
 
     def test_print_option_execute(self):
         hello_file = os.path.join(self.tmpdir, 'hello.txt')
-        with salt.utils.fopen(hello_file, 'w') as fp_:
+        with salt.utils.files.fopen(hello_file, 'w') as fp_:
             fp_.write('foo')
 
         option = salt.utils.find.PrintOption('print', '')
@@ -561,7 +561,7 @@ class TestFinder(TestCase):
 
     def test_find(self):
         hello_file = os.path.join(self.tmpdir, 'hello.txt')
-        with salt.utils.fopen(hello_file, 'w') as fp_:
+        with salt.utils.files.fopen(hello_file, 'w') as fp_:
             fp_.write('foo')
 
         finder = salt.utils.find.Finder({})

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -263,7 +263,7 @@ class NetworkTestCase(TestCase):
                 patch('socket.gethostname', MagicMock(return_value='hostname')), \
                 patch('socket.getfqdn', MagicMock(return_value='hostname.domainname.blank')), \
                 patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'attrname', ('127.0.1.1', 0))])), \
-                patch('salt.utils.fopen', MagicMock(return_value=False)), \
+                patch('salt.utils.files.fopen', MagicMock(return_value=False)), \
                 patch('os.path.exists', MagicMock(return_value=False)), \
                 patch('salt.utils.network.ip_addrs', MagicMock(return_value=['1.2.3.4', '5.6.7.8'])):
             self.assertEqual(network._generate_minion_id(),
@@ -279,7 +279,7 @@ class NetworkTestCase(TestCase):
                 patch('socket.gethostname', MagicMock(return_value='127')), \
                 patch('socket.getfqdn', MagicMock(return_value='127.domainname.blank')), \
                 patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'attrname', ('127.0.1.1', 0))])), \
-                patch('salt.utils.fopen', MagicMock(return_value=False)), \
+                patch('salt.utils.files.fopen', MagicMock(return_value=False)), \
                 patch('os.path.exists', MagicMock(return_value=False)), \
                 patch('salt.utils.network.ip_addrs', MagicMock(return_value=['1.2.3.4', '5.6.7.8'])):
             self.assertEqual(network._generate_minion_id(),
@@ -295,7 +295,7 @@ class NetworkTestCase(TestCase):
                 patch('socket.gethostname', MagicMock(return_value='127890')), \
                 patch('socket.getfqdn', MagicMock(return_value='127890.domainname.blank')), \
                 patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'attrname', ('127.0.1.1', 0))])), \
-                patch('salt.utils.fopen', MagicMock(return_value=False)), \
+                patch('salt.utils.files.fopen', MagicMock(return_value=False)), \
                 patch('os.path.exists', MagicMock(return_value=False)), \
                 patch('salt.utils.network.ip_addrs', MagicMock(return_value=['1.2.3.4', '5.6.7.8'])):
             self.assertEqual(network._generate_minion_id(),
@@ -311,7 +311,7 @@ class NetworkTestCase(TestCase):
                 patch('socket.gethostname', MagicMock(return_value='hostname')), \
                 patch('socket.getfqdn', MagicMock(return_value='hostname')), \
                 patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'hostname', ('127.0.1.1', 0))])), \
-                patch('salt.utils.fopen', MagicMock(return_value=False)), \
+                patch('salt.utils.files.fopen', MagicMock(return_value=False)), \
                 patch('os.path.exists', MagicMock(return_value=False)), \
                 patch('salt.utils.network.ip_addrs', MagicMock(return_value=['1.2.3.4', '1.2.3.4', '1.2.3.4'])):
             self.assertEqual(network._generate_minion_id(), ['hostname', '1.2.3.4'])
@@ -327,7 +327,7 @@ class NetworkTestCase(TestCase):
                 patch('socket.gethostname', MagicMock(return_value='hostname')), \
                 patch('socket.getfqdn', MagicMock(return_value='')), \
                 patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'hostname', ('127.0.1.1', 0))])), \
-                patch('salt.utils.fopen', MagicMock(return_value=False)), \
+                patch('salt.utils.files.fopen', MagicMock(return_value=False)), \
                 patch('os.path.exists', MagicMock(return_value=False)), \
                 patch('salt.utils.network.ip_addrs', MagicMock(return_value=['1.2.3.4', '1.2.3.4', '1.2.3.4'])):
             self.assertEqual(network.generate_minion_id(), 'very.long.and.complex.domain.name')
@@ -342,7 +342,7 @@ class NetworkTestCase(TestCase):
                 patch('socket.gethostname', MagicMock(return_value='pick.me')), \
                 patch('socket.getfqdn', MagicMock(return_value='hostname.domainname.blank')), \
                 patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'hostname', ('127.0.1.1', 0))])), \
-                patch('salt.utils.fopen', MagicMock(return_value=False)), \
+                patch('salt.utils.files.fopen', MagicMock(return_value=False)), \
                 patch('os.path.exists', MagicMock(return_value=False)), \
                 patch('salt.utils.network.ip_addrs', MagicMock(return_value=['1.2.3.4', '1.2.3.4', '1.2.3.4'])):
             self.assertEqual(network.generate_minion_id(), 'hostname.domainname.blank')
@@ -357,7 +357,7 @@ class NetworkTestCase(TestCase):
                 patch('socket.gethostname', MagicMock(return_value='ip6-loopback')), \
                 patch('socket.getfqdn', MagicMock(return_value='ip6-localhost')), \
                 patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'localhost', ('127.0.1.1', 0))])), \
-                patch('salt.utils.fopen', MagicMock(return_value=False)), \
+                patch('salt.utils.files.fopen', MagicMock(return_value=False)), \
                 patch('os.path.exists', MagicMock(return_value=False)), \
                 patch('salt.utils.network.ip_addrs', MagicMock(return_value=['127.0.0.1', '::1', 'fe00::0', 'fe02::1', '1.2.3.4'])):
             self.assertEqual(network.generate_minion_id(), '1.2.3.4')
@@ -372,7 +372,7 @@ class NetworkTestCase(TestCase):
                 patch('socket.gethostname', MagicMock(return_value='ip6-loopback')), \
                 patch('socket.getfqdn', MagicMock(return_value='ip6-localhost')), \
                 patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'localhost', ('127.0.1.1', 0))])), \
-                patch('salt.utils.fopen', MagicMock(return_value=False)), \
+                patch('salt.utils.files.fopen', MagicMock(return_value=False)), \
                 patch('os.path.exists', MagicMock(return_value=False)), \
                 patch('salt.utils.network.ip_addrs', MagicMock(return_value=['127.0.0.1', '::1', 'fe00::0', 'fe02::1'])):
             self.assertEqual(network.generate_minion_id(), 'localhost')
@@ -387,7 +387,7 @@ class NetworkTestCase(TestCase):
                 patch('socket.gethostname', MagicMock(return_value='ip6-loopback')), \
                 patch('socket.getfqdn', MagicMock(return_value='pick.me')), \
                 patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'localhost', ('127.0.1.1', 0))])), \
-                patch('salt.utils.fopen', MagicMock(return_value=False)), \
+                patch('salt.utils.files.fopen', MagicMock(return_value=False)), \
                 patch('os.path.exists', MagicMock(return_value=False)), \
                 patch('salt.utils.network.ip_addrs', MagicMock(return_value=['127.0.0.1', '::1', 'fe00::0', 'fe02::1'])):
             self.assertEqual(network.generate_minion_id(), 'pick.me')
@@ -402,7 +402,7 @@ class NetworkTestCase(TestCase):
                 patch('socket.gethostname', MagicMock(return_value='ip6-loopback')), \
                 patch('socket.getfqdn', MagicMock(return_value='ip6-localhost')), \
                 patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'pick.me', ('127.0.1.1', 0))])), \
-                patch('salt.utils.fopen', MagicMock(return_value=False)), \
+                patch('salt.utils.files.fopen', MagicMock(return_value=False)), \
                 patch('os.path.exists', MagicMock(return_value=False)), \
                 patch('salt.utils.network.ip_addrs', MagicMock(return_value=['127.0.0.1', '::1', 'fe00::0', 'fe02::1'])):
             self.assertEqual(network.generate_minion_id(), 'pick.me')
@@ -417,7 +417,7 @@ class NetworkTestCase(TestCase):
                 patch('socket.gethostname', MagicMock(return_value='ip6-loopback')), \
                 patch('socket.getfqdn', MagicMock(return_value='ip6-localhost')), \
                 patch('socket.getaddrinfo', MagicMock(return_value=[(2, 3, 0, 'localhost', ('127.0.1.1', 0))])), \
-                patch('salt.utils.fopen', MagicMock(return_value=False)), \
+                patch('salt.utils.files.fopen', MagicMock(return_value=False)), \
                 patch('os.path.exists', MagicMock(return_value=False)), \
                 patch('salt.utils.network.ip_addrs', MagicMock(return_value=['127.0.0.1', '::1', 'fe00::0', 'fe02::1', '1.2.3.4'])):
             self.assertEqual(network.generate_minion_id(), '1.2.3.4')

--- a/tests/unit/utils/test_reactor.py
+++ b/tests/unit/utils/test_reactor.py
@@ -8,7 +8,7 @@ import os
 
 from contextlib import contextmanager
 
-import salt.utils
+import salt.utils.files
 from salt.utils.process import clean_proc
 import salt.utils.reactor as reactor
 
@@ -45,7 +45,7 @@ class TestReactor(TestCase, AdaptedConfigurationTestCaseMixin):
         self.opts = self.get_temp_config('master')
         self.tempdir = tempfile.mkdtemp(dir=TMP)
         self.sls_name = os.path.join(self.tempdir, 'test.sls')
-        with salt.utils.fopen(self.sls_name, 'w') as fh:
+        with salt.utils.files.fopen(self.sls_name, 'w') as fh:
             fh.write('''
 update_fileserver:
   runner.fileserver.update

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -128,21 +128,6 @@ class UtilsTestCase(TestCase):
         self.assertEqual(expected_dict, ret)
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
-    def test_safe_rm(self):
-        with patch('os.remove') as os_remove_mock:
-            utils.safe_rm('dummy_tgt')
-            self.assertTrue(os_remove_mock.called)
-
-    @skipIf(os.path.exists('/tmp/no_way_this_is_a_file_nope.sh'), 'Test file exists! Skipping safe_rm_exceptions test!')
-    def test_safe_rm_exceptions(self):
-        error = False
-        try:
-            utils.safe_rm('/tmp/no_way_this_is_a_file_nope.sh')
-        except (IOError, OSError):
-            error = True
-        self.assertFalse(error, 'utils.safe_rm raised exception when it should not have')
-
-    @skipIf(NO_MOCK, NO_MOCK_REASON)
     def test_format_call(self):
         with patch('salt.utils.arg_lookup') as arg_lookup:
             def dummy_func(first=None, second=None, third=None):

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -22,7 +22,6 @@ from salt.exceptions import (SaltInvocationError, SaltSystemExit, CommandNotFoun
 from salt import utils
 
 # Import Python libraries
-import os
 import datetime
 import yaml
 import zmq

--- a/tests/unit/utils/test_verify.py
+++ b/tests/unit/utils/test_verify.py
@@ -29,7 +29,7 @@ from tests.support.mock import (
 )
 
 # Import salt libs
-import salt.utils
+import salt.utils.files
 from salt.utils.verify import (
     check_user,
     verify_env,
@@ -156,7 +156,7 @@ class TestVerify(TestCase):
 
                     for n in range(prev, newmax):
                         kpath = os.path.join(keys_dir, str(n))
-                        with salt.utils.fopen(kpath, 'w') as fp_:
+                        with salt.utils.files.fopen(kpath, 'w') as fp_:
                             fp_.write(str(n))
 
                     opts = {
@@ -191,7 +191,7 @@ class TestVerify(TestCase):
                 newmax = mof_test
                 for n in range(prev, newmax):
                     kpath = os.path.join(keys_dir, str(n))
-                    with salt.utils.fopen(kpath, 'w') as fp_:
+                    with salt.utils.files.fopen(kpath, 'w') as fp_:
                         fp_.write(str(n))
 
                 opts = {

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -22,6 +22,7 @@ from tests.support.unit import TestCase, skipIf
 
 # Import salt libs
 import salt.utils
+import salt.utils.files
 import salt.utils.vt
 
 # Import 3rd-party libs
@@ -60,7 +61,7 @@ class VTTestCase(TestCase):
             # Get current number of PTY's
             try:
                 if os.path.exists('/proc/sys/kernel/pty/nr'):
-                    with salt.utils.fopen('/proc/sys/kernel/pty/nr') as fh_:
+                    with salt.utils.files.fopen('/proc/sys/kernel/pty/nr') as fh_:
                         return int(fh_.read().strip())
 
                 proc = subprocess.Popen(

--- a/tests/unit/utils/test_yamlloader.py
+++ b/tests/unit/utils/test_yamlloader.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 # Import Salt Libs
 from yaml.constructor import ConstructorError
 from salt.utils.yamlloader import SaltYamlSafeLoader
-import salt.utils
+import salt.utils.files
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
@@ -28,8 +28,8 @@ class YamlLoaderTestCase(TestCase):
         Takes a YAML string, puts it into a mock file, passes that to the YAML
         SaltYamlSafeLoader and then returns the rendered/parsed YAML data
         '''
-        with patch('salt.utils.fopen', mock_open(read_data=data)) as mocked_file:
-            with salt.utils.fopen(mocked_file) as mocked_stream:
+        with patch('salt.utils.files.fopen', mock_open(read_data=data)) as mocked_file:
+            with salt.utils.files.fopen(mocked_file) as mocked_stream:
                 return SaltYamlSafeLoader(mocked_stream).get_data()
 
     def test_yaml_basics(self):


### PR DESCRIPTION
There are several functions in `salt/utils/__init__.py` that are related to files. We already have a `salt.utils.files.py` utility, so this is the perfect place to move these functions.

This PR does several things in relation to this move in attempt to break up `salt/utils/__init__.py` since it has grown to be a monster file:
- Moves related file functions from `salt/utils/__init__.py` to `salt/utils/files.py`.
- Adds `deprecated` doc references and appropriate `warn_until` messages to functions that were moved. These should be removed in Salt `Neon`.
- Note that since we are importing `salt.utils` in `salt.utils.files.py`, we need to "late import" `salt.utils.file` in `salt.utils` to avoid circular dependency issues, which this PR does.
- Updates all references of moved functions in the salt code.

The list of functions that were moved from init.py to salt.utils.files.py are:
- fopen
- flopen
- fpopen
- safe_rm
- is_empty
- is_fcntl_available
- rm_rf

The list of imports on some files has changed more than just adding `import salt.utils.files`. I went through each file and removed the bare `salt.utils` imports if it was possible, since many files _only_ call out to something like `fopen`. We don't need to import `salt.utils` in these cases - we only need `salt.utils.files`. This will make the process of removing `salt.utils` easier in the future. This occasionally required adding new imports that were missing for various other utility files.

Let's see how the tests go! 