### PR TITLE
Improve yamldumper.safe_dump output readability

### DIFF
--- a/salt/utils/yamldumper.py
+++ b/salt/utils/yamldumper.py
@@ -27,6 +27,17 @@ except ImportError:
     HAS_IOFLO = False
 
 
+class IndentMixin(object):
+    '''
+    Mixin that improves YAML dumped list readability
+    by indenting them by two spaces,
+    instead of being flush with the key they are under.
+    '''
+
+    def increase_indent(self, flow=False, indentless=False):
+        return super(IndentMixin, self).increase_indent(flow, False)
+
+
 class OrderedDumper(Dumper):
     '''
     A YAML dumper that represents python OrderedDict as simple YAML map.
@@ -37,6 +48,14 @@ class SafeOrderedDumper(SafeDumper):
     '''
     A YAML safe dumper that represents python OrderedDict as simple YAML map.
     '''
+
+
+class IndentedSafeOrderedDumper(IndentMixin, SafeOrderedDumper):
+    '''
+    A YAML safe dumper that represents python OrderedDict as simple YAML map,
+    and also indents lists by two spaces.
+    '''
+    pass
 
 
 def represent_ordereddict(dumper, data):
@@ -58,6 +77,14 @@ SafeOrderedDumper.add_representer(
 if HAS_IOFLO:
     OrderedDumper.add_representer(odict, represent_ordereddict)
     SafeOrderedDumper.add_representer(odict, represent_ordereddict)
+
+
+def get_dumper(dumper_name):
+    return {
+        'OrderedDumper': OrderedDumper,
+        'SafeOrderedDumper': SafeOrderedDumper,
+        'IndentedSafeOrderedDumper': IndentedSafeOrderedDumper,
+    }.get(dumper_name)
 
 
 def safe_dump(data, stream=None, **kwargs):


### PR DESCRIPTION
By default, the YAML dumper will output lists that are values in a
dictionary flush with the key they are under:
```
key1: value1
key2:
- a
- b
- c
```

This change causes the list members to be indented by two spaces,
improving readability:
```
key1: value1
key2:
  - a
  - b
  - c
```

### What does this PR do?
Improve YAML dump output

### What issues does this PR fix or reference?
None

### Previous Behavior
Dumped lists are not indented

### New Behavior
Dumped lists are indented

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.