### PR TITLE
Move mkstemp util function to salt.utils.files.py

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -3505,13 +3505,15 @@ def mkstemp(*args, **kwargs):
     accepts another argument, `close_fd`, which, by default, is true and closes
     the fd before returning the file path. Something commonly done throughout
     Salt's code.
+
+    .. deprecated:: Oxygen
     '''
-    if 'prefix' not in kwargs:
-        kwargs['prefix'] = '__salt.tmp.'
-    close_fd = kwargs.pop('close_fd', True)
-    fd_, fpath = tempfile.mkstemp(*args, **kwargs)
-    if close_fd is False:
-        return (fd_, fpath)
-    os.close(fd_)
-    del fd_
-    return fpath
+    warn_until(
+        'Neon',
+        'Use of \'salt.utils.mkstemp\' detected. This function has been moved to '
+        '\'salt.utils.files.mkstemp\' as of Salt Oxygen. This warning will be '
+        'removed in Salt Neon.'
+    )
+    # Late import to avoid circular import.
+    import salt.utils.files
+    return salt.utils.files.mkstemp(*args, **kwargs)

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -9,6 +9,7 @@ import logging
 import os
 import shutil
 import subprocess
+import tempfile
 import time
 
 # Import salt libs
@@ -43,10 +44,20 @@ def guess_archive_type(name):
 
 def mkstemp(*args, **kwargs):
     '''
-    Should eventually reside here, but for now point back at old location in
-    salt.utils
+    Helper function which does exactly what ``tempfile.mkstemp()`` does but
+    accepts another argument, ``close_fd``, which, by default, is true and closes
+    the fd before returning the file path. Something commonly done throughout
+    Salt's code.
     '''
-    return salt.utils.mkstemp(*args, **kwargs)
+    if 'prefix' not in kwargs:
+        kwargs['prefix'] = '__salt.tmp.'
+    close_fd = kwargs.pop('close_fd', True)
+    fd_, f_path = tempfile.mkstemp(*args, **kwargs)
+    if close_fd is False:
+        return fd_, f_path
+    os.close(fd_)
+    del fd_
+    return f_path
 
 
 def recursive_copy(source, dest):


### PR DESCRIPTION
The references for this function have already been updated throughout Salt's code. This move the function from `salt/utils/__init__.py` to `salt.utils.files.py` and puts the function in the init file on a
deprecation path.
