### PR TITLE
Fix race condition in usage of weakvaluedict

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -372,17 +372,18 @@ class AsyncAuth(object):
         loop_instance_map = AsyncAuth.instance_map[io_loop]
 
         key = cls.__key(opts)
-        if key not in loop_instance_map:
+        auth = loop_instance_map.get(key)
+        if auth is None:
             log.debug('Initializing new AsyncAuth for {0}'.format(key))
             # we need to make a local variable for this, as we are going to store
             # it in a WeakValueDictionary-- which will remove the item if no one
             # references it-- this forces a reference while we return to the caller
-            new_auth = object.__new__(cls)
-            new_auth.__singleton_init__(opts, io_loop=io_loop)
-            loop_instance_map[key] = new_auth
+            auth = object.__new__(cls)
+            auth.__singleton_init__(opts, io_loop=io_loop)
+            loop_instance_map[key] = auth
         else:
             log.debug('Re-using AsyncAuth for {0}'.format(key))
-        return loop_instance_map[key]
+        return auth
 
     @classmethod
     def __key(cls, opts, io_loop=None):
@@ -1008,14 +1009,15 @@ class SAuth(AsyncAuth):
         Only create one instance of SAuth per __key()
         '''
         key = cls.__key(opts)
-        if key not in SAuth.instances:
+        auth = SAuth.instances.get(key)
+        if auth is None:
             log.debug('Initializing new SAuth for {0}'.format(key))
-            new_auth = object.__new__(cls)
-            new_auth.__singleton_init__(opts)
-            SAuth.instances[key] = new_auth
+            auth = object.__new__(cls)
+            auth.__singleton_init__(opts)
+            SAuth.instances[key] = auth
         else:
             log.debug('Re-using SAuth for {0}'.format(key))
-        return SAuth.instances[key]
+        return auth
 
     @classmethod
     def __key(cls, opts, io_loop=None):

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -248,15 +248,16 @@ class IPCClient(object):
         # FIXME
         key = str(socket_path)
 
-        if key not in loop_instance_map:
+        client = loop_instance_map.get(key)
+        if client is None:
             log.debug('Initializing new IPCClient for path: {0}'.format(key))
-            new_client = object.__new__(cls)
+            client = object.__new__(cls)
             # FIXME
-            new_client.__singleton_init__(io_loop=io_loop, socket_path=socket_path)
-            loop_instance_map[key] = new_client
+            client.__singleton_init__(io_loop=io_loop, socket_path=socket_path)
+            loop_instance_map[key] = client
         else:
             log.debug('Re-using IPCClient for {0}'.format(key))
-        return loop_instance_map[key]
+        return client
 
     def __singleton_init__(self, socket_path, io_loop=None):
         '''

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -221,17 +221,18 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
         loop_instance_map = cls.instance_map[io_loop]
 
         key = cls.__key(opts, **kwargs)
-        if key not in loop_instance_map:
+        obj = loop_instance_map.get(key)
+        if obj is None:
             log.debug('Initializing new AsyncTCPReqChannel for {0}'.format(key))
             # we need to make a local variable for this, as we are going to store
             # it in a WeakValueDictionary-- which will remove the item if no one
             # references it-- this forces a reference while we return to the caller
-            new_obj = object.__new__(cls)
-            new_obj.__singleton_init__(opts, **kwargs)
-            loop_instance_map[key] = new_obj
+            obj = object.__new__(cls)
+            obj.__singleton_init__(opts, **kwargs)
+            loop_instance_map[key] = obj
         else:
             log.debug('Re-using AsyncTCPReqChannel for {0}'.format(key))
-        return loop_instance_map[key]
+        return obj
 
     @classmethod
     def __key(cls, opts, **kwargs):


### PR DESCRIPTION
Example:
```python
import weakref

class O(object):
    pass

d = weakref.WeakValueDictionary()
key = 'key'
value = O()
d[key] = value
d[key]  # <O object at 0x...>
del value
key in d  # True
d.get(key)  # None
d[key]  # KeyError
```

### What does this PR do?
This PR uses `get()` instead of checking with `in`

### What issues does this PR fix or reference?
Fixes #42371

### Tests written?
No