### PR TITLE
pillar.items pillar_env & pillar_override are never used

### DIFF
--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -257,8 +257,8 @@ def items(*args, **kwargs):
         __opts__,
         __grains__,
         __opts__['id'],
-        pillar_override=kwargs.get('pillar'),
-        pillarenv=kwargs.get('pillarenv') or __opts__['pillarenv'])
+        pillar_override=pillar_override,
+        pillarenv=pillarenv)
 
     return pillar.compile_pillar()
 


### PR DESCRIPTION
Fixes a few bugs in pillar_env determination and pillar_enc decryption because the  `pillarenv` and `pillar_override` are set with new behaviours and subsequently ignored.

### What issues does this PR fix or reference?

### Previous Behavior
Function ignores `pillarenv` and `pillar_override`; both might be different/broken from what's done depending on various conditions

### New Behavior
Take the newly parsed vars 


Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
