### PR TITLE
Move parse_docstring from salt.utils to salt.utils.doc.py

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -849,10 +849,13 @@ def required_module_list(docstring=None):
     Return a list of python modules required by a salt module that aren't
     in stdlib and don't exist on the current pythonpath.
     '''
+    # Late import to avoid circular import.
+    import salt.utils.doc
+
     if not docstring:
         return []
     ret = []
-    modules = parse_docstring(docstring).get('deps', [])
+    modules = salt.utils.doc.parse_docstring(docstring).get('deps', [])
     for mod in modules:
         try:
             if six.PY3:
@@ -2191,30 +2194,18 @@ def parse_docstring(docstring):
             'full': full docstring,
             'deps': list of dependencies (empty list if none)
         }
+
+    .. deprecated:: Oxygen
     '''
-    # First try with regex search for :depends:
-    ret = {}
-    ret['full'] = docstring
-    regex = r'([ \t]*):depends:[ \t]+- (\w+)[^\n]*\n(\1[ \t]+- (\w+)[^\n]*\n)*'
-    match = re.search(regex, docstring, re.M)
-    if match:
-        deps = []
-        regex = r'- (\w+)'
-        for line in match.group(0).strip().splitlines():
-            deps.append(re.search(regex, line).group(1))
-        ret['deps'] = deps
-        return ret
-    # Try searching for a one-liner instead
-    else:
-        txt = 'Required python modules: '
-        data = docstring.splitlines()
-        dep_list = list(x for x in data if x.strip().startswith(txt))
-        if not dep_list:
-            ret['deps'] = []
-            return ret
-        deps = dep_list[0].replace(txt, '').strip().split(', ')
-        ret['deps'] = deps
-        return ret
+    warn_until(
+        'Neon',
+        'Use of \'salt.utils.parse_docstring\' detected. This function has been moved to '
+        '\'salt.utils.doc.parse_docstring\' as of Salt Oxygen. This warning will be '
+        'removed in Salt Neon.'
+    )
+    # Late import to avoid circular import.
+    import salt.utils.doc
+    return salt.utils.doc.parse_docstring(docstring)
 
 
 def print_cli(msg, retries=10, step=0.01):

--- a/salt/utils/doc.py
+++ b/salt/utils/doc.py
@@ -24,3 +24,40 @@ def strip_rst(docs):
         if docstring != docstring_new:
             docs[func] = docstring_new
     return docs
+
+
+def parse_docstring(docstring):
+    '''
+    Parse a docstring into its parts.
+
+    Currently only parses dependencies, can be extended to parse whatever is
+    needed.
+
+    Parses into a dictionary:
+        {
+            'full': full docstring,
+            'deps': list of dependencies (empty list if none)
+        }
+    '''
+    # First try with regex search for :depends:
+    ret = {'full': docstring}
+    regex = r'([ \t]*):depends:[ \t]+- (\w+)[^\n]*\n(\1[ \t]+- (\w+)[^\n]*\n)*'
+    match = re.search(regex, docstring, re.M)
+    if match:
+        deps = []
+        regex = r'- (\w+)'
+        for line in match.group(0).strip().splitlines():
+            deps.append(re.search(regex, line).group(1))
+        ret['deps'] = deps
+        return ret
+    # Try searching for a one-liner instead
+    else:
+        txt = 'Required python modules: '
+        data = docstring.splitlines()
+        dep_list = list(x for x in data if x.strip().startswith(txt))
+        if not dep_list:
+            ret['deps'] = []
+            return ret
+        deps = dep_list[0].replace(txt, '').strip().split(', ')
+        ret['deps'] = deps
+        return ret

--- a/tests/unit/utils/test_doc.py
+++ b/tests/unit/utils/test_doc.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+'''
+Unit Tests for functions located in salt.utils.doc.py.
+'''
+
+# Import python libs
+from __future__ import absolute_import
+
+# Import Salt libs
+import salt.utils.doc
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase
+
+
+class DocUtilsTestCase(TestCase):
+    '''
+    Test case for doc util.
+    '''
+
+    def test_parse_docstring(self):
+        test_keystone_str = '''Management of Keystone users
+                                ============================
+
+                                :depends:   - keystoneclient Python module
+                                :configuration: See :py:mod:`salt.modules.keystone` for setup instructions.
+'''
+
+        ret = salt.utils.doc.parse_docstring(test_keystone_str)
+        expected_dict = {'deps': ['keystoneclient'],
+                         'full': 'Management of Keystone users\n                                '
+                                 '============================\n\n                                '
+                                 ':depends:   - keystoneclient Python module\n                                '
+                                 ':configuration: See :py:mod:`salt.modules.keystone` for setup instructions.\n'}
+        self.assertDictEqual(ret, expected_dict)

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -787,22 +787,6 @@ class UtilsTestCase(TestCase):
         self.assertEqual('baz', utils.option('foo:bar', {'not_found': 'nope'}, pillar={'master': test_two_level_dict}))
         self.assertEqual('baz', utils.option('foo:bar', {'not_found': 'nope'}, pillar=test_two_level_dict))
 
-    def test_parse_docstring(self):
-        test_keystone_str = '''Management of Keystone users
-                                ============================
-
-                                :depends:   - keystoneclient Python module
-                                :configuration: See :py:mod:`salt.modules.keystone` for setup instructions.
-'''
-
-        ret = utils.parse_docstring(test_keystone_str)
-        expected_dict = {'deps': ['keystoneclient'],
-                         'full': 'Management of Keystone users\n                                '
-                                 '============================\n\n                                '
-                                 ':depends:   - keystoneclient Python module\n                                '
-                                 ':configuration: See :py:mod:`salt.modules.keystone` for setup instructions.\n'}
-        self.assertDictEqual(ret, expected_dict)
-
     def test_get_hash_exception(self):
         self.assertRaises(ValueError, utils.get_hash, '/tmp/foo/', form='INVALID')
 


### PR DESCRIPTION
- Moves function to new location in salt.utils.doc.py
- Adds deprecation warning to salt.utils.parse_docstring
- Moves related unit test in test_utils.py to new test_doc.py file
