### PR TITLE
Show documentation when no function is included

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -165,6 +165,11 @@ class BaseCaller(object):
             ret['jid']
         )
         if fun not in self.minion.functions:
+            docs = self.minion.functions['sys.doc']('{0}*'.format(fun))
+            if docs:
+                ret['out'] = 'nested'
+                ret['return'] = docs
+                return ret
             sys.stderr.write(self.minion.functions.missing_fun_string(fun))
             mod_name = fun.split('.')[0]
             if mod_name in self.minion.function_errors:

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -167,6 +167,7 @@ class BaseCaller(object):
         if fun not in self.minion.functions:
             docs = self.minion.functions['sys.doc']('{0}*'.format(fun))
             if docs:
+                docs[fun] = self.minion.functions.missing_fun_string(fun)
                 ret['out'] = 'nested'
                 ret['return'] = docs
                 return ret

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -442,7 +442,6 @@ class SyncClientMixin(object):
                 _use_fnmatch = True
             else:
                 target_mod = arg + '.' if not arg.endswith('.') else arg
-            log.debug('target_mod {}'.format(target_mod))
             if _use_fnmatch:
                 docs = [(fun, self.functions[fun].__doc__)
                         for fun in fnmatch.filter(self.functions, target_mod)]

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -5,6 +5,7 @@ A collection of mixins useful for the various *Client interfaces
 
 # Import Python libs
 from __future__ import absolute_import, print_function, with_statement
+import fnmatch
 import signal
 import logging
 import weakref
@@ -436,10 +437,19 @@ class SyncClientMixin(object):
         Return a dictionary of functions and the inline documentation for each
         '''
         if arg:
-            target_mod = arg + '.' if not arg.endswith('.') else arg
-            docs = [(fun, self.functions[fun].__doc__)
-                    for fun in sorted(self.functions)
-                    if fun == arg or fun.startswith(target_mod)]
+            if '*' in arg:
+                target_mod = arg
+                _use_fnmatch = True
+            else:
+                target_mod = arg + '.' if not arg.endswith('.') else arg
+            log.debug('target_mod {}'.format(target_mod))
+            if _use_fnmatch:
+                docs = [(fun, self.functions[fun].__doc__)
+                        for fun in fnmatch.filter(self.functions, target_mod)]
+            else:
+                docs = [(fun, self.functions[fun].__doc__)
+                        for fun in sorted(self.functions)
+                        if fun == arg or fun.startswith(target_mod)]
         else:
             docs = [(fun, self.functions[fun].__doc__)
                     for fun in sorted(self.functions)]

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1521,7 +1521,7 @@ class Minion(MinionBase):
                 ret['out'] = 'nested'
         else:
             docs = minion_instance.functions['sys.doc']('{0}*'.format(function_name))
-            if docs:
+            if all(docs[doc] for doc in docs):
                 ret['return'] = docs
             else:
                 ret['return'] = minion_instance.functions.missing_fun_string(function_name)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1520,12 +1520,16 @@ class Minion(MinionBase):
                 ret['return'] = '{0}: {1}'.format(msg, traceback.format_exc())
                 ret['out'] = 'nested'
         else:
-            ret['return'] = minion_instance.functions.missing_fun_string(function_name)
-            mod_name = function_name.split('.')[0]
-            if mod_name in minion_instance.function_errors:
-                ret['return'] += ' Possible reasons: \'{0}\''.format(
-                    minion_instance.function_errors[mod_name]
-                )
+            docs = minion_instance.functions['sys.doc']('{0}*'.format(function_name))
+            if docs:
+                ret['return'] = docs
+            else:
+                ret['return'] = minion_instance.functions.missing_fun_string(function_name)
+                mod_name = function_name.split('.')[0]
+                if mod_name in minion_instance.function_errors:
+                    ret['return'] += ' Possible reasons: \'{0}\''.format(
+                        minion_instance.function_errors[mod_name]
+                    )
             ret['success'] = False
             ret['retcode'] = 254
             ret['out'] = 'nested'

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1521,7 +1521,8 @@ class Minion(MinionBase):
                 ret['out'] = 'nested'
         else:
             docs = minion_instance.functions['sys.doc']('{0}*'.format(function_name))
-            if all(docs[doc] for doc in docs):
+            if docs:
+                docs[function_name] = minion_instance.functions.missing_fun_string(function_name)
                 ret['return'] = docs
             else:
                 ret['return'] = minion_instance.functions.missing_fun_string(function_name)

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -277,7 +277,10 @@ class Runner(RunnerClient):
                                 'jid': self.jid},
                                tag='salt/run/{0}/ret'.format(self.jid))
                 # Attempt to grab documentation
-                ret = self.get_docs('{0}*'.format(low['fun']))
+                if 'fun' in low:
+                    ret = self.get_docs('{0}*'.format(low['fun']))
+                else:
+                    ret = None
 
                 # If we didn't get docs returned then
                 # return the `not availble` message.

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -276,7 +276,13 @@ class Runner(RunnerClient):
                                 'fun_args': fun_args,
                                 'jid': self.jid},
                                tag='salt/run/{0}/ret'.format(self.jid))
-                ret = '{0}'.format(exc)
+                # Attempt to grab documentation
+                ret = self.get_docs('{0}*'.format(low['fun']))
+
+                # If we didn't get docs returned then
+                # return the `not availble` message.
+                if not ret:
+                    ret = '{0}'.format(exc)
                 if not self.opts.get('quiet', False):
                     display_output(ret, 'nested', self.opts)
             else:

--- a/tests/integration/files/file/base/_modules/runtests_decorators.py
+++ b/tests/integration/files/file/base/_modules/runtests_decorators.py
@@ -9,6 +9,11 @@ import salt.utils.decorators
 
 
 def _fallbackfunc():
+    '''
+    CLI Example:
+
+    .. code-block:: bash
+    '''
     return False, 'fallback'
 
 
@@ -33,11 +38,21 @@ def booldependsTrue():
 
 @salt.utils.decorators.depends(False)
 def booldependsFalse():
+    '''
+    CLI Example:
+
+    .. code-block:: bash
+    '''
     return True
 
 
 @salt.utils.decorators.depends('time')
 def depends():
+    '''
+    CLI Example:
+
+    .. code-block:: bash
+    '''
     ret = {'ret': True,
            'time': time.time()}
     return ret
@@ -45,6 +60,11 @@ def depends():
 
 @salt.utils.decorators.depends('time123')
 def missing_depends():
+    '''
+    CLI Example:
+
+    .. code-block:: bash
+    '''
     return True
 
 
@@ -62,6 +82,11 @@ def depends_will_not_fallback():
 
 @salt.utils.decorators.depends('time123', fallback_function=_fallbackfunc)
 def missing_depends_will_fallback():
+    '''
+    CLI Example:
+
+    .. code-block:: bash
+    '''
     ret = {'ret': True,
            'time': time.time()}
     return ret

--- a/tests/integration/modules/test_decorators.py
+++ b/tests/integration/modules/test_decorators.py
@@ -22,8 +22,9 @@ class DecoratorTest(ModuleCase):
         self.assertTrue(isinstance(ret['time'], float))
 
     def test_missing_depends(self):
-        self.assertIn(
-                'is not available',
+        self.assertEqual(
+                {'runtests_decorators.missing_depends_will_fallback': '\n    CLI Example:\n\n    ',
+                 'runtests_decorators.missing_depends': "'runtests_decorators.missing_depends' is not available."},
                 self.run_function('runtests_decorators.missing_depends'
                     )
                 )


### PR DESCRIPTION
### What does this PR do?
Updating salt-call, salt-run and salt to show documentation when a valid module but no function is passed.

### What issues does this PR fix or reference?
#42189 

### Previous Behavior
```
gareth@blackoil  ~/code/salt/salt   develop  sudo salt-run jobs
'jobs' is not available.
```

### New Behavior
New behavior will show the documentation for the jobs runner.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
