### PR TITLE
Update old "ref" references to "rev" in git.detached state

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -2213,7 +2213,7 @@ def detached(name,
 
     # Determine if supplied ref is a hash
     remote_rev_type = 'ref'
-    if len(ref) <= 40 \
+    if len(rev) <= 40 \
             and all(x in string.hexdigits for x in rev):
         rev = rev.lower()
         remote_rev_type = 'hash'
@@ -2419,7 +2419,7 @@ def detached(name,
                 https_pass=https_pass,
                 ignore_retcode=False)
 
-            if 'refs/remotes/'+remote+'/'+ref in all_remote_refs:
+            if 'refs/remotes/'+remote+'/'+rev in all_remote_refs:
                 checkout_commit_id = all_remote_refs['refs/remotes/' + remote + '/' + rev]
             elif 'refs/tags/' + rev in all_remote_refs:
                 checkout_commit_id = all_remote_refs['refs/tags/' + rev]


### PR DESCRIPTION
Fixes #42381

The "rev" kwarg was added to replace "ref" in #38898. However, when switching the state over to "rev" as the deprecation warning instructs, some stacktraces occur due to some remaining "ref" references. 

This changes those stray `ref`s to `rev`s.
