### PR TITLE
Fix documentation misformat in salt.states.file.replace

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3797,12 +3797,13 @@ def replace(name,
         A regular expression, to be matched using Python's
         :py:func:`~re.search`.
 
-        ..note::
+        .. note::
+
             If you need to match a literal string that contains regex special
             characters, you may want to use salt's custom Jinja filter,
             ``escape_regex``.
 
-            ..code-block:: jinja
+            .. code-block:: jinja
 
                 {{ 'http://example.com?foo=bar%20baz' | escape_regex }}
 


### PR DESCRIPTION
### What does this PR do?
Fixes the documentation formatting error found in file.replace
https://docs.saltstack.com/en/latest/ref/states/all/salt.states.file.html#salt.states.file.replace
Issue is also present in develop