### PR TITLE
Fix file.managed check_cmd file not found - Issue #42404

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2433,12 +2433,16 @@ def managed(name,
                 if sfn and os.path.isfile(sfn):
                     os.remove(sfn)
                 return ret
+
+            if sfn and os.path.isfile(sfn):
+                os.remove(sfn)
+
             # Since we generated a new tempfile and we are not returning here
             # lets change the original sfn to the new tempfile or else we will
             # get file not found
-            if sfn and os.path.isfile(sfn):
-                os.remove(sfn)
-                sfn = tmp_filename
+
+            sfn = tmp_filename
+
         else:
             ret = {'changes': {},
                    'comment': '',


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes #42404 

### Previous Behavior
PR #38063 fixing Issue #33708 changed the handling to clean up dangling salt.utils.files.mkstemp created during the check_cmd call.

Along with this though, it added the important sfn reassignment to point to the new tmp file created for testing with the check_cmd handler.  This is needed so that the fall through to the rest of the file.managed action will use that file to overwrite the target (if there are changes, and it passed check_cmd call.

### New Behavior

Simply removed the assignment back outside of the conditional that it should not have been a part of

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
