### PR TITLE
DOCS: unify hash sum with hash type format

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -710,18 +710,21 @@ def check_hash(path, file_hash):
 
     hash
         The hash to check against the file specified in the ``path`` argument.
-        For versions 2016.11.4 and newer, the hash can be specified without an
+
+        .. versionchanged:: 2016.11.4
+
+        For this and newer versions the hash can be specified without an
         accompanying hash type (e.g. ``e138491e9d5b97023cea823fe17bac22``),
         but for earlier releases it is necessary to also specify the hash type
-        in the format ``<hash_type>:<hash_value>`` (e.g.
-        ``md5:e138491e9d5b97023cea823fe17bac22``).
+        in the format ``<hash_type>=<hash_value>`` (e.g.
+        ``md5=e138491e9d5b97023cea823fe17bac22``).
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' file.check_hash /etc/fstab e138491e9d5b97023cea823fe17bac22
-        salt '*' file.check_hash /etc/fstab md5:e138491e9d5b97023cea823fe17bac22
+        salt '*' file.check_hash /etc/fstab md5=e138491e9d5b97023cea823fe17bac22
     '''
     path = os.path.expanduser(path)
 


### PR DESCRIPTION
### What does this PR do?
It unifies hash sum format parameter across state modules. In the `file.managed` and `archive.extracted` state functions, the `source_hash` parameter accepts hash in form of `[hash_type=]hash_sum` according to the documentation. But the `file.check_hash` execution function recommends using `:` (colon) separator between optional hash type and hash sum. Although both forms are valid and working, it's better to stick with one consistent way across documentation pages.

Having different forms in different places brings confusion and users may occasionally introduce unnecessary conversions between two forms in their states, being misguided by official manual.
