### PR TITLE
Reactor: Ensure that we pass a 'kwarg' key to the client

### DIFF
--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -273,6 +273,8 @@ class ReactWrap(object):
         try:
             f_call = salt.utils.format_call(l_fun, low)
             kwargs = f_call.get('kwargs', {})
+            if 'kwarg' not in kwargs:
+                kwargs['kwarg'] = {}
 
             # TODO: Setting the user doesn't seem to work for actual remote publishes
             if low['state'] in ('runner', 'wheel'):


### PR DESCRIPTION
As of 2017.7.0, we log a message when there is no 'kwarg' key in the low
data passed to the client. This is because all kwargs must now be passed
within the `kwarg` key. This key must be present in the low data even
when there are no kwargs passed.

However, in the reactor we only pass the `kwarg` if it was explicitly
defined. This leads to this message being spuriously logged. There is no
functional error here, as not passing any kwargs to a reactor job is the
same as the kwargs being an empty dict (which happens right after we log
the error).

This fix ensures that we pass a `kwarg` key to the client from the
reactor.

Fixes #42400 