### PR TITLE
datacenter_configured state function

### DIFF
--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -212,7 +212,7 @@ def get_proxy_type():
 
         salt '*' vsphere.get_proxy_type
     '''
-    if __pillar__.get('proxy',{}).get('proxytype'):
+    if __pillar__.get('proxy', {}).get('proxytype'):
         return __pillar__['proxy']['proxytype']
     if __opts__.get('proxy', {}).get('proxytype'):
         return __opts__['proxy']['proxytype']

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -203,7 +203,8 @@ def __virtual__():
 
 def get_proxy_type():
     '''
-    Returns the proxy type
+    Returns the proxy type retrieved either from the pillar of from the proxy
+    minion's config.  Returns ``<undefined>`` otherwise.
 
     CLI Example:
 
@@ -211,7 +212,11 @@ def get_proxy_type():
 
         salt '*' vsphere.get_proxy_type
     '''
-    return __pillar__['proxy']['proxytype']
+    if __pillar__.get('proxy',{}).get('proxytype'):
+        return __pillar__['proxy']['proxytype']
+    if __opts__.get('proxy', {}).get('proxytype'):
+        return __opts__['proxy']['proxytype']
+    return '<undefined>'
 
 
 def _get_proxy_connection_details():

--- a/salt/states/esxdatacenter.py
+++ b/salt/states/esxdatacenter.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+'''
+Salt states to create and manage VMware vSphere datacenters (datacenters).
+
+:codeauthor: :email:`Alexandru Bleotu <alexandru.bleotu@morganstaley.com>`
+
+Dependencies
+============
+
+- pyVmomi Python Module
+
+States
+======
+
+datacenter_configured
+---------------------
+
+Makes sure a datacenter exists and is correctly configured.
+
+If the state is run by an ``esxdatacenter`` minion, the name of the datacenter
+is retrieved from the proxy details, otherwise the datacenter has the same name
+as the state.
+
+Supported proxies: esxdatacenter
+
+
+Example:
+
+1. Make sure that a datacenter named ``target_dc`` exists on the vCenter, using a
+``esxdatacenter`` proxy:
+
+Proxy minion configuration (connects passthrough to the vCenter):
+
+.. code-block:: yaml
+    proxy:
+      proxytype: esxdatacenter
+      datacenter: target_dc
+      vcenter: vcenter.fake.com
+      mechanism: sspi
+      domain: fake.com
+      principal: host
+
+State configuration:
+
+.. code-block:: yaml
+
+    datacenter_state:
+      esxdatacenter.datacenter_configured
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import logging
+
+# Import Salt Libs
+import salt.exceptions
+
+# Get Logging Started
+log = logging.getLogger(__name__)
+LOGIN_DETAILS = {}
+
+
+def __virtual__():
+    return 'esxdatacenter'
+
+
+def mod_init(low):
+    return True
+
+
+def datacenter_configured(name):
+    '''
+    Makes sure a datacenter exists.
+
+    If the state is run by an ``esxdatacenter`` minion, the name of the
+    datacenter is retrieved from the proxy details, otherwise the datacenter
+    has the same name as the state.
+
+    Supported proxies: esxdatacenter
+
+    name:
+        Datacenter name. Ignored if the proxytype is ``esxdatacenter``.
+    '''
+    proxy_type = __salt__['vsphere.get_proxy_type']()
+    if proxy_type == 'esxdatacenter':
+        dc_name = __salt__['esxdatacenter.get_details']()['datacenter']
+    else:
+        dc_name = name
+    log.info('Running datacenter_configured for datacenter \'{0}\''
+             ''.format(dc_name))
+    ret = {'name': name, 'changes': {}, 'pchanges': {},
+           'result': None, 'comment': 'Default'}
+    comments = []
+    changes = {}
+    pchanges = {}
+    si = None
+    try:
+        si = __salt__['vsphere.get_service_instance_via_proxy']()
+        dcs = __salt__['vsphere.list_datacenters_via_proxy'](
+            datacenter_names=[dc_name], service_instance=si)
+        if not dcs:
+            if __opts__['test']:
+                comments.append('State will create '
+                                'datacenter \'{0}\'.'.format(dc_name))
+                log.info(comments[-1])
+                pchanges.update({'new': {'name': dc_name}})
+            else:
+                log.debug ('Creating datacenter \'{0}\'. '.format(dc_name))
+                __salt__['vsphere.create_datacenter'](dc_name, si)
+                comments.append('Created datacenter \'{0}\'.'.format(dc_name))
+                log.info(comments[-1])
+                changes.update({'new': {'name': dc_name}})
+        else:
+            comments.append('Datacenter \'{0}\' already exists. Nothing to be '
+                            'done.'.format(dc_name))
+            log.info(comments[-1])
+        __salt__['vsphere.disconnect'](si)
+        if __opts__['test'] and pchanges:
+            ret_status = None
+        else:
+            ret_status = True
+        ret.update({'result': ret_status,
+                    'comment': '\n'.join(comments),
+                    'changes': changes,
+                    'pchanges': pchanges})
+        return ret
+    except salt.exceptions.CommandExecutionError as exc:
+        log.error('Error: {}'.format(exc))
+        if si:
+            __salt__['vsphere.disconnect'](si)
+        ret.update({
+            'result': False if not __opts__['test'] else None,
+            'comment': str(exc)})
+        return ret

--- a/salt/states/esxdatacenter.py
+++ b/salt/states/esxdatacenter.py
@@ -105,7 +105,7 @@ def datacenter_configured(name):
                 log.info(comments[-1])
                 pchanges.update({'new': {'name': dc_name}})
             else:
-                log.debug ('Creating datacenter \'{0}\'. '.format(dc_name))
+                log.debug('Creating datacenter \'{0}\'. '.format(dc_name))
                 __salt__['vsphere.create_datacenter'](dc_name, si)
                 comments.append('Created datacenter \'{0}\'.'.format(dc_name))
                 log.info(comments[-1])

--- a/tests/unit/states/test_esxdatacenter.py
+++ b/tests/unit/states/test_esxdatacenter.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Alexandru Bleotu <alexandru.bleotu@morganstanley.com>`
+
+    Tests for functions in salt.states.esxdatacenter
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Libs
+import salt.states.esxdatacenter as esxdatacenter
+from salt.exceptions import CommandExecutionError
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+
+#Globals
+esxdatacenter.__salt__ = {}
+esxdatacenter.__opts__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class DatacenterConfiguredTestCase(TestCase, LoaderModuleMockMixin):
+    '''Tests for salt.modules.esxdatacenter.datacenter_configured'''
+
+    def setup_loader_modules(self):
+        return {
+            esxdatacenter: {
+                '__virtual__': MagicMock(return_value='esxdatacenter')}}
+
+    def setUp(self):
+        self.mock_si = MagicMock()
+        self.mock_dc = MagicMock()
+
+        patcher = patch.dict(
+            esxdatacenter.__salt__,
+            {'vsphere.get_proxy_type': MagicMock(),
+             'vsphere.get_service_instance_via_proxy':
+             MagicMock(return_value=self.mock_si),
+             'vsphere.list_datacenters_via_proxy':
+             MagicMock(return_value=[self.mock_dc]),
+             'vsphere.disconnect': MagicMock()})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = patch.dict(esxdatacenter.__opts__, {'test': False})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def tearDown(self):
+        for attrname in ('mock_si'):
+            try:
+                delattr(self, attrname)
+            except AttributeError:
+                continue
+
+    def test_dc_name_different_proxy(self):
+        with patch.dict(esxdatacenter.__salt__,
+                        {'vsphere.get_proxy_type':
+                         MagicMock(return_value='different_proxy')}):
+            res = esxdatacenter.datacenter_configured('fake_dc')
+        self.assertDictEqual(res, {'name': 'fake_dc',
+                                   'changes': {},
+                                   'pchanges': {},
+                                   'result': True,
+                                   'comment': 'Datacenter \'fake_dc\' already '
+                                   'exists. Nothing to be done.'})
+
+    def test_dc_name_esxdatacenter_proxy(self):
+        with patch.dict(esxdatacenter.__salt__,
+                        {'vsphere.get_proxy_type':
+                         MagicMock(return_value='esxdatacenter'),
+                         'esxdatacenter.get_details':
+                         MagicMock(return_value={'datacenter': 'proxy_dc'})}):
+            res = esxdatacenter.datacenter_configured('fake_dc')
+        self.assertDictEqual(res, {'name': 'fake_dc',
+                                   'changes': {},
+                                   'pchanges': {},
+                                   'result': True,
+                                   'comment': 'Datacenter \'proxy_dc\' '
+                                   'already exists. Nothing to be done.'})
+
+    def test_get_service_instance(self):
+        mock_get_service_instance = MagicMock()
+        with patch.dict(esxdatacenter.__salt__,
+                        {'vsphere.get_service_instance_via_proxy':
+                         mock_get_service_instance}):
+            esxdatacenter.datacenter_configured('fake_dc')
+        mock_get_service_instance.assert_called_once_with()
+
+    def test_list_datacenters(self):
+        mock_list_datacenters = MagicMock()
+        with patch.dict(esxdatacenter.__salt__,
+                        {'vsphere.list_datacenters_via_proxy':
+                         mock_list_datacenters}):
+            esxdatacenter.datacenter_configured('fake_dc')
+        mock_list_datacenters.assert_called_once_with(
+            datacenter_names=['fake_dc'], service_instance=self.mock_si)
+
+    def test_create_datacenter(self):
+        mock_create_datacenter = MagicMock()
+        with patch.dict(esxdatacenter.__salt__,
+                        {'vsphere.list_datacenters_via_proxy':
+                         MagicMock(return_value=[]),
+                         'vsphere.create_datacenter':
+                         mock_create_datacenter}):
+            res = esxdatacenter.datacenter_configured('fake_dc')
+        mock_create_datacenter.assert_called_once_with('fake_dc', self.mock_si)
+        self.assertDictEqual(res,
+                             {'name': 'fake_dc',
+                              'changes': {'new': {'name': 'fake_dc'}},
+                              'pchanges': {},
+                              'result': True,
+                              'comment': 'Created datacenter \'fake_dc\'.'})
+
+    def test_create_datacenter_test_mode(self):
+        with patch.dict(esxdatacenter.__opts__, {'test': True}):
+            with patch.dict(esxdatacenter.__salt__,
+                            {'vsphere.list_datacenters_via_proxy':
+                             MagicMock(return_value=[])}):
+                res = esxdatacenter.datacenter_configured('fake_dc')
+        self.assertDictEqual(res,
+                             {'name': 'fake_dc',
+                              'changes': {},
+                              'pchanges': {'new': {'name': 'fake_dc'}},
+                              'result': None,
+                              'comment': 'State will create '
+                              'datacenter \'fake_dc\'.'})
+
+    def test_nothing_to_be_done_test_mode(self):
+        with patch.dict(esxdatacenter.__opts__, {'test': True}):
+            with patch.dict(esxdatacenter.__salt__,
+                            {'vsphere.get_proxy_type':
+                             MagicMock(return_value='different_proxy')}):
+                res = esxdatacenter.datacenter_configured('fake_dc')
+        self.assertDictEqual(res, {'name': 'fake_dc',
+                                   'changes': {},
+                                   'pchanges': {},
+                                   'result': True,
+                                   'comment': 'Datacenter \'fake_dc\' already '
+                                   'exists. Nothing to be done.'})
+
+    def test_state_get_service_instance_raise_command_execution_error(self):
+        mock_disconnect = MagicMock()
+        with patch.dict(esxdatacenter.__salt__,
+                        {'vsphere.disconnect': mock_disconnect,
+                         'vsphere.get_service_instance_via_proxy':
+                         MagicMock(
+                             side_effect=CommandExecutionError('Error'))}):
+            res = esxdatacenter.datacenter_configured('fake_dc')
+        self.assertEqual(mock_disconnect.call_count, 0)
+        self.assertDictEqual(res, {'name': 'fake_dc',
+                                   'changes': {},
+                                   'pchanges': {},
+                                   'result': False,
+                                   'comment': 'Error'})
+
+    def test_state_raise_command_execution_error_after_si(self):
+        mock_disconnect = MagicMock()
+        with patch.dict(esxdatacenter.__salt__,
+                        {'vsphere.disconnect': mock_disconnect,
+                         'vsphere.list_datacenters_via_proxy':
+                         MagicMock(
+                             side_effect=CommandExecutionError('Error'))}):
+            res = esxdatacenter.datacenter_configured('fake_dc')
+        mock_disconnect.assert_called_once_with(self.mock_si)
+        self.assertDictEqual(res, {'name': 'fake_dc',
+                                   'changes': {},
+                                   'pchanges': {},
+                                   'result': False,
+                                   'comment': 'Error'})
+
+    def test_state_raise_command_execution_error_test_mode(self):
+        with patch.dict(esxdatacenter.__opts__, {'test': True}):
+            with patch.dict(esxdatacenter.__salt__,
+                            {'vsphere.list_datacenters_via_proxy':
+                             MagicMock(
+                                 side_effect=CommandExecutionError('Error'))}):
+                res = esxdatacenter.datacenter_configured('fake_dc')
+        self.assertDictEqual(res, {'name': 'fake_dc',
+                                   'changes': {},
+                                   'pchanges': {},
+                                   'result': None,
+                                   'comment': 'Error'})

--- a/tests/unit/states/test_esxdatacenter.py
+++ b/tests/unit/states/test_esxdatacenter.py
@@ -23,11 +23,6 @@ from tests.support.mock import (
 )
 
 
-#Globals
-esxdatacenter.__salt__ = {}
-esxdatacenter.__opts__ = {}
-
-
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class DatacenterConfiguredTestCase(TestCase, LoaderModuleMockMixin):
     '''Tests for salt.modules.esxdatacenter.datacenter_configured'''
@@ -56,7 +51,7 @@ class DatacenterConfiguredTestCase(TestCase, LoaderModuleMockMixin):
         self.addCleanup(patcher.stop)
 
     def tearDown(self):
-        for attrname in ('mock_si'):
+        for attrname in ('mock_si',):
             try:
                 delattr(self, attrname)
             except AttributeError:


### PR DESCRIPTION
### What does this PR do?

Added the `datacenter_configured` state function that checks that a VMware datacenter exists, otherwise is creates it
Updated vsphere.get_proxy_type to work if the proxy config is defined in the proxy minion's config file, in addition to it being defined in the  the pillar

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
