### PR TITLE
Only force saltenv/pillarenv to be a string when not None

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -264,14 +264,14 @@ def _get_opts(**kwargs):
 
     if 'saltenv' in kwargs:
         saltenv = kwargs['saltenv']
-        if not isinstance(saltenv, six.string_types):
+        if saltenv is not None and not isinstance(saltenv, six.string_types):
             opts['environment'] = str(kwargs['saltenv'])
         else:
             opts['environment'] = kwargs['saltenv']
 
     if 'pillarenv' in kwargs:
         pillarenv = kwargs['pillarenv']
-        if not isinstance(pillarenv, six.string_types):
+        if pillarenv is not None and not isinstance(pillarenv, six.string_types):
             opts['pillarenv'] = str(kwargs['pillarenv'])
         else:
             opts['pillarenv'] = kwargs['pillarenv']


### PR DESCRIPTION
This fixes a regression introduced to make numeric saltenv/pillarenv
work properly.

Fixes #42403 