### PR TITLE
Fixes to versions function in manage runner

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -652,6 +652,7 @@ def versions():
         return ret
 
     labels = {
+        -2: 'Minion offline',
         -1: 'Minion requires update',
         0: 'Up to date',
         1: 'Minion newer than master',
@@ -663,12 +664,19 @@ def versions():
     master_version = salt.version.__saltstack_version__
 
     for minion in minions:
-        minion_version = salt.version.SaltStackVersion.parse(minions[minion])
-        ver_diff = cmp(minion_version, master_version)
+        if not minions[minion]:
+            minion_version = False
+            ver_diff = -2
+        else:
+            minion_version = salt.version.SaltStackVersion.parse(minions[minion])
+            ver_diff = cmp(minion_version, master_version)
 
         if ver_diff not in version_status:
             version_status[ver_diff] = {}
-        version_status[ver_diff][minion] = minion_version.string
+        if minion_version:
+            version_status[ver_diff][minion] = minion_version.string
+        else:
+            version_status[ver_diff][minion] = minion_version
 
     # Add version of Master to output
     version_status[2] = master_version.string


### PR DESCRIPTION
What does this PR do?

Updating the versions function inside the manage runner to account for when a minion is offline and we are unable to determine it's version.

What issues does this PR fix or reference?

#42374

Previous Behavior

If a minion was offline, this would result in a traceback.

New Behavior

Minions that are offline are now listed as being offline and their versions are marked as False.

Tests written?

No