### PR TITLE
win_pki: Don't fail on certs without DnsNames

### DIFF
--- a/salt/modules/win_pki.py
+++ b/salt/modules/win_pki.py
@@ -155,7 +155,7 @@ def get_certs(context=_DEFAULT_CONTEXT, store=_DEFAULT_STORE):
             if key not in blacklist_keys:
                 cert_info[key.lower()] = item[key]
 
-        cert_info['dnsnames'] = [name['Unicode'] for name in item['DnsNameList'] or []]
+        cert_info['dnsnames'] = [name.get('Unicode') for name in item.get('DnsNameList', {})]
         ret[item['Thumbprint']] = cert_info
     return ret
 

--- a/salt/modules/win_pki.py
+++ b/salt/modules/win_pki.py
@@ -155,7 +155,7 @@ def get_certs(context=_DEFAULT_CONTEXT, store=_DEFAULT_STORE):
             if key not in blacklist_keys:
                 cert_info[key.lower()] = item[key]
 
-        cert_info['dnsnames'] = [name['Unicode'] for name in item['DnsNameList']]
+        cert_info['dnsnames'] = [name['Unicode'] for name in item['DnsNameList'] or []]
         ret[item['Thumbprint']] = cert_info
     return ret
 


### PR DESCRIPTION
### What does this PR do?
`item['DnsNameList']` is None for some certificates (among others a handful included in the default Windows root CA store). This PR makes this case not crash.

### What issues does this PR fix or reference?
#42455

### Previous Behavior
Crash

### New Behavior
Normal operation

### Tests written?
No
