### PR TITLE
Remove deprecated rc_info function from version.py

### DIFF
--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -62,6 +62,10 @@ Support has been added to the ``virtual`` grain for detecting Solaris LDOMs
 running on T-Series SPARC hardware.  The ``virtual_subtype`` grain is 
 populated as a list of domain roles.
 
+
+Deprecations
+============
+
 Configuration Option Deprecations
 ---------------------------------
 
@@ -154,3 +158,10 @@ The ``salt.utils.cloud.py`` file had the following change:
 
 - The ``fire_event`` function now requires a ``sock_dir`` argument. It was previously
   optional.
+
+Other Miscellaneous Deprecations
+--------------------------------
+
+The ``version.py`` file had the following changes:
+
+- The ``rc_info`` function was removed. Please use ``pre_info`` instead.

--- a/salt/version.py
+++ b/salt/version.py
@@ -312,16 +312,6 @@ class SaltStackVersion(object):
         )
 
     @property
-    def rc_info(self):
-        import salt.utils
-        salt.utils.warn_until(
-            'Oxygen',
-            'Please stop using the \'rc_info\' attribute and instead use '
-            '\'pre_info\'. \'rc_info\' will be supported until Salt {version}.'
-        )
-        return self.pre_info
-
-    @property
     def pre_info(self):
         return (
             self.major,


### PR DESCRIPTION
``pre_info`` should be used instead. Updated the release notes as well to reflect this change.
