### PR TITLE
Cmd arg kwarg parsing test

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -306,14 +306,16 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
         else:
             string_kwarg = salt.utils.args.parse_input([arg], condition=False)[1]  # pylint: disable=W0632
             if string_kwarg:
-                log.critical(
-                    'String kwarg(s) %s passed to '
-                    'salt.minion.load_args_and_kwargs(). This is no longer '
-                    'supported, so the kwarg(s) will be ignored. Arguments '
-                    'passed to salt.minion.load_args_and_kwargs() should be '
-                    'passed to salt.utils.args.parse_input() first to load '
-                    'and condition them properly.', string_kwarg
-                )
+                if argspec.keywords or next(six.iterkeys(string_kwarg)) in argspec.args:
+                    # Function supports **kwargs or is a positional argument to
+                    # the function.
+                    _kwargs.update(string_kwarg)
+                else:
+                    # **kwargs not in argspec and parsed argument name not in
+                    # list of positional arguments. This keyword argument is
+                    # invalid.
+                    for key, val in six.iteritems(string_kwarg):
+                         invalid_kwargs.append('{0}={1}'.format(key, val))
             else:
                 _args.append(arg)
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -315,7 +315,7 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
                     # list of positional arguments. This keyword argument is
                     # invalid.
                     for key, val in six.iteritems(string_kwarg):
-                         invalid_kwargs.append('{0}={1}'.format(key, val))
+                        invalid_kwargs.append('{0}={1}'.format(key, val))
             else:
                 _args.append(arg)
 

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -311,6 +311,18 @@ def arg_repr(*args, **kwargs):
     return {"args": repr(args), "kwargs": repr(kwargs)}
 
 
+def arg_clean(*args, **kwargs):
+    '''
+    Like test.arg but cleans kwargs of the __pub* items
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' test.arg_clean 1 "two" 3.1 txt="hello" wow='{a: 1, b: "hello"}'
+    '''
+    return dict(args=args, kwargs=salt.utils.clean_kwargs(**kwargs))
+
+
 def fib(num):
     '''
     Return the num-th Fibonacci number, and the time it took to compute in

--- a/tests/integration/client/test_kwarg.py
+++ b/tests/integration/client/test_kwarg.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
 
-
 class StdTest(ModuleCase):
     '''
     Test standard client calls
@@ -94,3 +93,25 @@ class StdTest(ModuleCase):
         ret = self.client.cmd('minion', 'test.ping', full_return=True)
         for mid, data in ret.items():
             self.assertIn('retcode', data)
+
+    def test_cmd_arg_kwarg_parsing(self):
+        ret = self.client.cmd('minion', 'test.arg_clean',
+            arg=[
+                'foo',
+                'bar=off',
+                'baz={qux: 123}'
+            ],
+            kwarg={
+                'quux': 'Quux',
+            })
+
+        self.assertEqual(ret['minion'], {
+            'args': ['foo'],
+            'kwargs': {
+                'bar': False,
+                'baz': {
+                    'qux': 123,
+                },
+                'quux': 'Quux',
+            },
+        })

--- a/tests/integration/client/test_kwarg.py
+++ b/tests/integration/client/test_kwarg.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
 
+
 class StdTest(ModuleCase):
     '''
     Test standard client calls


### PR DESCRIPTION
### What does this PR do?

Fixes `name=val` parsing in various places. This is a short-term fix for a point-release and should be followed up by a longer term refactor of when and how `parse_input`, `condition_input`, and `load_args_and_kwargs` divide duties and are called.

### What issues does this PR fix or reference?

Follow-up to #39646.