### PR TITLE
Fix possible exceptions in the loader for boto modules

### DIFF
--- a/salt/modules/boto3_elasticache.py
+++ b/salt/modules/boto3_elasticache.py
@@ -77,6 +77,8 @@ def __virtual__():
     '''
     if not HAS_BOTO3:
         return (False, 'The boto3_elasticache module could not be loaded: boto3 libraries not found')
+    if 'boto3.assign_funcs' not in __utils__:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0, boto3 >= 1.2.6 and botocore >= 1.3.23')
     return True
 
 

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -78,6 +78,8 @@ def __virtual__():
     '''
     if not HAS_BOTO3:
         return (False, 'The boto3_route53 module could not be loaded: boto3 libraries not found')
+    if 'boto3.assign_funcs' not in __utils__:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0, boto3 >= 1.2.6 and botocore >= 1.3.23')
     return True
 
 

--- a/salt/modules/boto_asg.py
+++ b/salt/modules/boto_asg.py
@@ -86,8 +86,10 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, 'The boto_asg module could not be loaded: boto libraries not found')
-
-    __utils__['boto.assign_funcs'](__name__, 'asg', module='ec2.autoscale', pack=__salt__)
+    if 'boto3.assign_funcs' in __utils__:
+        __utils__['boto.assign_funcs'](__name__, 'asg', module='ec2.autoscale', pack=__salt__)
+    else:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0, boto3 >= 1.2.6 and botocore >= 1.3.23')
     setattr(sys.modules[__name__], '_get_ec2_conn',
             __utils__['boto.get_connection_func']('ec2'))
     return True

--- a/salt/modules/boto_cfn.py
+++ b/salt/modules/boto_cfn.py
@@ -59,6 +59,8 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, 'The module boto_cfs could not be loaded: boto libraries not found')
+    if 'boto.assign_funcs' not in __utils__:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0.')
     return True
 
 

--- a/salt/modules/boto_cloudtrail.py
+++ b/salt/modules/boto_cloudtrail.py
@@ -92,6 +92,8 @@ def __virtual__():
     elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
         return (False, 'The boto_cloudtrial module could not be loaded: '
                 'boto version {0} or later must be installed.'.format(required_boto3_version))
+    elif 'boto3.assign_funcs' not in __utils__:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0, boto3 >= 1.2.6 and botocore >= 1.3.23')
     else:
         return True
 

--- a/salt/modules/boto_cloudwatch.py
+++ b/salt/modules/boto_cloudwatch.py
@@ -75,9 +75,12 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, 'The boto_cloudwatch module cannot be loaded: boto libraries are unavailable.')
-    __utils__['boto.assign_funcs'](__name__, 'cloudwatch',
-                                   module='ec2.cloudwatch',
-                                   pack=__salt__)
+    if 'boto.assign_funcs' in __utils__:
+        __utils__['boto.assign_funcs'](__name__, 'cloudwatch',
+                                       module='ec2.cloudwatch',
+                                       pack=__salt__)
+    else:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0.')
     return True
 
 

--- a/salt/modules/boto_cloudwatch_event.py
+++ b/salt/modules/boto_cloudwatch_event.py
@@ -76,6 +76,8 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, 'The boto_cloudwatch_event module cannot be loaded: boto libraries are unavailable.')
+    if 'boto3.assign_funcs' not in __utils__:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0, boto3 >= 1.2.6 and botocore >= 1.3.23')
     return True
 
 

--- a/salt/modules/boto_dynamodb.py
+++ b/salt/modules/boto_dynamodb.py
@@ -76,7 +76,10 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, 'The module boto_dynamodb could not be loaded: boto libraries not found')
-    __utils__['boto.assign_funcs'](__name__, 'dynamodb2', pack=__salt__)
+    if 'boto.assign_funcs' in __utils__:
+        __utils__['boto.assign_funcs'](__name__, 'dynamodb2', pack=__salt__)
+    else:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0.')
     return True
 
 

--- a/salt/modules/boto_ec2.py
+++ b/salt/modules/boto_ec2.py
@@ -87,7 +87,10 @@ def __virtual__():
     elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
         return (False, "The boto_ec2 module cannot be loaded: boto library version incorrect ")
     else:
-        __utils__['boto.assign_funcs'](__name__, 'ec2', pack=__salt__)
+        if 'boto.assign_funcs' in __utils__:
+            __utils__['boto.assign_funcs'](__name__, 'ec2', pack=__salt__)
+        else:
+            return (False, 'Requires the following to be installed: boto >= 2.0.0.')
         return True
 
 

--- a/salt/modules/boto_elasticache.py
+++ b/salt/modules/boto_elasticache.py
@@ -76,7 +76,10 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, 'The modle boto_elasticache could not be loaded: boto libraries not found')
-    __utils__['boto.assign_funcs'](__name__, 'elasticache', pack=__salt__)
+    if 'boto.assign_funcs' in __utils__:
+        __utils__['boto.assign_funcs'](__name__, 'elasticache', pack=__salt__)
+    else:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0.')
     return True
 
 

--- a/salt/modules/boto_elb.py
+++ b/salt/modules/boto_elb.py
@@ -86,7 +86,10 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, "The boto_elb module cannot be loaded: boto library not found")
-    __utils__['boto.assign_funcs'](__name__, 'elb', module='ec2.elb', pack=__salt__)
+    if 'boto.assign_funcs' in __utils__:
+        __utils__['boto.assign_funcs'](__name__, 'elb', module='ec2.elb', pack=__salt__)
+    else:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0, boto3 >= 1.2.6 and botocore >= 1.3.23')
     return True
 
 

--- a/salt/modules/boto_elbv2.py
+++ b/salt/modules/boto_elbv2.py
@@ -68,7 +68,10 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, "The boto_elbv2 module cannot be loaded: boto3 library not found")
-    __utils__['boto3.assign_funcs'](__name__, 'elbv2')
+    if 'boto3.assign_funcs' in __utils__:
+        __utils__['boto3.assign_funcs'](__name__, 'elbv2')
+    else:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0, boto3 >= 1.2.6 and botocore >= 1.3.23')
     return True
 
 

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -69,6 +69,8 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, 'The boto_iam module could not be loaded: boto libraries not found')
+    if 'boto.assign_funcs' not in __utils__:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0')
     return True
 
 

--- a/salt/modules/boto_kinesis.py
+++ b/salt/modules/boto_kinesis.py
@@ -73,7 +73,10 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return False
-    __utils__['boto3.assign_funcs'](__name__, 'kinesis')
+    if 'boto3.assign_funcs' in __utils__:
+        __utils__['boto3.assign_funcs'](__name__, 'kinesis')
+    else:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0, boto3 >= 1.2.6 and botocore >= 1.3.23')
     return True
 
 

--- a/salt/modules/boto_kms.py
+++ b/salt/modules/boto_kms.py
@@ -74,6 +74,8 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, 'The boto_kms module could not be loaded: boto libraries not found')
+    if 'boto.assign_funcs' not in __utils__:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0.')
     return True
 
 

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -128,6 +128,8 @@ def __virtual__():
     a given version.
     '''
     required_boto3_version = '1.3.1'
+    if 'boto3.assign_funcs' not in __utils__:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0, boto3 >= 1.2.6 and botocore >= 1.3.23')
     if not HAS_BOTO:
         return (False, 'The boto_rds module could not be loaded: '
                 'boto libraries not found')

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -87,6 +87,8 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     '''
+    if 'boto3.assign_funcs' not in __utils__:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0, boto3 >= 1.2.6 and botocore >= 1.3.23')
     required_boto3_version = '1.2.1'
     # the boto_lambda execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0

--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -86,7 +86,10 @@ def __virtual__():
     elif _LooseVersion(boto.__version__) < _LooseVersion(required_boto_version):
         return (False, 'The boto_secgroup module could not be loaded: boto library v2.4.0 not found')
     else:
-        __utils__['boto.assign_funcs'](__name__, 'ec2', pack=__salt__)
+        if 'boto.assign_funcs' in __utils__:
+            __utils__['boto.assign_funcs'](__name__, 'ec2', pack=__salt__)
+        else:
+            return (False, 'Requires the following to be installed: boto >= 2.0.0.')
         return True
 
 

--- a/salt/modules/boto_sns.py
+++ b/salt/modules/boto_sns.py
@@ -66,7 +66,10 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, 'The boto_sns module could not be loaded: boto libraries not found')
-    __utils__['boto.assign_funcs'](__name__, 'sns', pack=__salt__)
+    if 'boto.assign_funcs' in __utils__:
+        __utils__['boto.assign_funcs'](__name__, 'sns', pack=__salt__)
+    else:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0.')
     return True
 
 

--- a/salt/modules/boto_sqs.py
+++ b/salt/modules/boto_sqs.py
@@ -73,7 +73,10 @@ def __virtual__():
     '''
     if not HAS_BOTO:
         return (False, 'The boto_sqs module could not be loaded: boto libraries not found')
-    __utils__['boto.assign_funcs'](__name__, 'sqs', pack=__salt__)
+    if 'boto.assign_funcs' in __utils__:
+        __utils__['boto.assign_funcs'](__name__, 'sqs', pack=__salt__)
+    else:
+        return (False, 'Requires the following to be installed: boto >= 2.0.0.')
     return True
 
 


### PR DESCRIPTION
If the minimum dependencies in the boto* utility modules are not met,
the execution modules will end up bubbling those exceptions up to the loader.

This checks to see if the needed utility functions are present and if they
are not, do not load the execution module.

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
