### PR TITLE
added mountpoint to default PER_REMOTE_ONLY

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -41,7 +41,7 @@ import salt.ext.six as six
 VALID_PROVIDERS = ('pygit2', 'gitpython')
 # Optional per-remote params that can only be used on a per-remote basis, and
 # thus do not have defaults in salt/config.py.
-PER_REMOTE_ONLY = ('name',)
+PER_REMOTE_ONLY = ('name', 'mountpoint')
 SYMLINK_RECURSE_DEPTH = 100
 
 # Auth support (auth params can be global or per-remote, too)


### PR DESCRIPTION
### What does this PR do?
add the mountpoint to PER_REMOTE_ONLY in utils/gitfs.py
Currently, the command: `salt-run git_pillar.update -l debug`
fails with:
```
[DEBUG   ] pygit2 git_pillar_provider enabled
[CRITICAL] Invalid git_pillar configuration parameter 'mountpoint' in remote 'master git@git1.dev4-noc.bluecoatcloud.com:wss/salt-master.git'. Valid parameters are: env, root, ssl_verify, refspecs, user, password, pubkey, privkey, passphrase, insecure_auth, name.
[DEBUG   ] Sending event: tag = salt/run/20170721220818106737/ret; data = {'fun_args': [], 'jid': '20170721220818106737', 'return': 'Exception occurred in runner git_pillar.update: Traceback (most recent call last):\n  File "/usr/lib/python2.7/dist-packages/salt/client/mixins.py", line 392, in _low\n    data[\'return\'] = self.functions[fun](*args, **kwargs)\n  File "/usr/lib/python2.7/dist-packages/salt/runners/git_pillar.py", line 89, in update\n    salt.pillar.git_pillar.PER_REMOTE_OVERRIDES)\n  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 2029, in init_remotes\n    self.role\n  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 1266, in __init__\n    per_remote_only, override_params, cache_root, role)\n  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 277, in __init__\n    failhard(self.role)\n  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 166, in failhard\n    raise FileserverConfigError(\'Failed to load {0}\'.format(role))\nFileserverConfigError: Failed to load git_pillar\n', 'success': False, '_stamp': '2017-07-21T22:08:18.510331', 'user': 'sudo_tim_vanderhorst', 'fun': 'runner.git_pillar.update'}
[DEBUG   ] LazyLoaded nested.output
Exception occurred in runner git_pillar.update: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/client/mixins.py", line 392, in _low
    data['return'] = self.functions[fun](*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/runners/git_pillar.py", line 89, in update
    salt.pillar.git_pillar.PER_REMOTE_OVERRIDES)
  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 2029, in init_remotes
    self.role
  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 1266, in __init__
    per_remote_only, override_params, cache_root, role)
  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 277, in __init__
    failhard(self.role)
  File "/usr/lib/python2.7/dist-packages/salt/utils/gitfs.py", line 166, in failhard
    raise FileserverConfigError('Failed to load {0}'.format(role))
FileserverConfigError: Failed to load git_pillar
```

ext_pillar config:
```
ext_pillar:
  - git:
    - master git@git1.dev4-noc.bluecoatcloud.com:wss/salt-master.git:
      - mountpoint: current_sp/comp/salt-master
```
versions report:
```
Salt Version:
           Salt: 2017.7.0
 
Dependency Versions:
           cffi: 1.5.2
       cherrypy: Not Installed
       dateutil: Not Installed
      docker-py: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.8
        libgit2: 0.24.0
        libnacl: Not Installed
       M2Crypto: Not Installed
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.4.6
   mysql-python: Not Installed
      pycparser: 2.14
       pycrypto: 2.6.1
   pycryptodome: Not Installed
         pygit2: 0.24.0
         Python: 2.7.12 (default, Nov 19 2016, 06:48:10)
   python-gnupg: Not Installed
         PyYAML: 3.11
          PyZMQ: 15.2.0
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.1.4
 
System Versions:
           dist: Ubuntu 16.04 xenial
         locale: UTF-8
        machine: x86_64
        release: 4.4.0-81-generic
         system: Linux
        version: Ubuntu 16.04 xenial
```


### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
