### PR TITLE
Fix `unit.test_crypt` for Windows

### DIFF
--- a/tests/unit/test_crypt.py
+++ b/tests/unit/test_crypt.py
@@ -88,13 +88,13 @@ SIG = (
 class CryptTestCase(TestCase):
 
     def test_gen_keys(self):
-        with patch.multiple(os, umask=MagicMock(), chmod=MagicMock(), chown=MagicMock,
+        with patch.multiple(os, umask=MagicMock(), chmod=MagicMock(),
                             access=MagicMock(return_value=True)):
             with patch('salt.utils.fopen', mock_open()):
-                open_priv_wb = call('/keydir/keyname.pem', 'wb+')
-                open_pub_wb = call('/keydir/keyname.pub', 'wb+')
+                open_priv_wb = call('/keydir{0}keyname.pem'.format(os.sep), 'wb+')
+                open_pub_wb = call('/keydir{0}keyname.pub'.format(os.sep), 'wb+')
                 with patch('os.path.isfile', return_value=True):
-                    self.assertEqual(crypt.gen_keys('/keydir', 'keyname', 2048), '/keydir/keyname.pem')
+                    self.assertEqual(crypt.gen_keys('/keydir', 'keyname', 2048), '/keydir{0}keyname.pem'.format(os.sep))
                     self.assertNotIn(open_priv_wb, salt.utils.fopen.mock_calls)
                     self.assertNotIn(open_pub_wb, salt.utils.fopen.mock_calls)
                 with patch('os.path.isfile', return_value=False):


### PR DESCRIPTION
PLEASE REVIEW

### What does this PR do?
Fixes `unit.test_crypt` on Windows. The `os.chown` method could not be mocked for some reason. I removed it and the test passes on both Windows and Ubuntu. I don't know why. I've had problems mocking methods for imports that don't exist in Windows, but that's not the case here. `os.chown` exists in Windows.
Fixed problems with path separators.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439