### PR TITLE
Fix a potential Exception with an explicit error message

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -1373,10 +1373,19 @@ def create_certificate(
                 ['listen_in', 'preqrequired', '__prerequired__']:
             kwargs.pop(ignore, None)
 
-        cert_txt = __salt__['publish.publish'](
+        certs = __salt__['publish.publish'](
             tgt=ca_server,
             fun='x509.sign_remote_certificate',
-            arg=str(kwargs))[ca_server]
+            arg=str(kwargs))
+
+        if not any(certs):
+            raise salt.exceptions.SaltInvocationError(
+                    'ca_server did not respond'
+                    ' salt master must permit peers to'
+                    ' call the sign_remote_certificate function.')
+
+        cert_txt = certs[ca_server]
+
         if path:
             return write_pem(
                 text=cert_txt,


### PR DESCRIPTION
### What does this PR do?
if sign_remote_certificate is not authorized on master, execution fail
with explicite error instead of "KeyError" message.

### Previous Behavior
```
    Function: x509.certificate_managed
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1822, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1727, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/x509.py", line 497, in certificate_managed
                  new = __salt__['x509.create_certificate'](testrun=True, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/modules/x509.py", line 1376, in create_certificate
                  arg=str(kwargs))[ca_server]
              KeyError: 'master'
```

### New Behavior
```
    Function: x509.certificate_managed
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1822, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1727, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/x509.py", line 494, in certificate_managed
                  new = __salt__['x509.create_certificate'](testrun=True, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/modules/x509.py", line 1380, in create_certificate 
                  'ca_server did not respond' 
              SaltInvocationError: ca_server did not respond salt master must permit peers to call the sign_remote_certificate function.
```
