### PR TITLE
Logical Domains support in virtual grain

### DIFF
--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -55,6 +55,13 @@ Salt Cloud and Newer PyWinRM Versions
 Versions of ``pywinrm>=0.2.1`` are finally able to disable validation of self
 signed certificates.  :ref:`Here<new-pywinrm>` for more information.
 
+Solaris Logical Domains In Virtual Grain
+----------------------------------------
+
+Support has been added to the ``virtual`` grain for detecting Solaris LDOMs
+running on T-Series SPARC hardware.  The ``virtual_subtype`` grain is 
+populated as a list of domain roles.
+
 Configuration Option Deprecations
 ---------------------------------
 


### PR DESCRIPTION
Support for Logical Domains on Oracle T-Series hardware and Solaris 11.
Provides 'LDOM' in virtual grain, and a list of the domain's roles (if
any) in virtual_subtype.

Tested on T4, T5, and T7.  Also tested on M3000 for fallback to physical.
Test OS was Solaris 11.3 SRU 19.5.