### PR TITLE
Fix azurerm query to show IPs

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -407,13 +407,14 @@ def list_nodes_full(conn=None, call=None):  # pylint: disable=unused-argument
     for group in list_resource_groups():
         nodes = compconn.virtual_machines.list(group)
         for node in nodes:
+            private_ips, public_ips = __get_ips_from_node(group, node)
             ret[node.name] = object_to_dict(node)
             ret[node.name]['id'] = node.id
             ret[node.name]['name'] = node.name
             ret[node.name]['size'] = node.hardware_profile.vm_size
             ret[node.name]['state'] = node.provisioning_state
-            ret[node.name]['private_ips'] = node.network_profile.network_interfaces
-            ret[node.name]['public_ips'] = node.network_profile.network_interfaces
+            ret[node.name]['private_ips'] = private_ips
+            ret[node.name]['public_ips'] = public_ips
             ret[node.name]['storage_profile']['data_disks'] = []
             ret[node.name]['resource_group'] = group
             for disk in node.storage_profile.data_disks:
@@ -431,6 +432,30 @@ def list_nodes_full(conn=None, call=None):  # pylint: disable=unused-argument
                 except TypeError:
                     ret[node.name]['image'] = None
     return ret
+
+
+def __get_ips_from_node(resource_group, node):
+    '''
+    List private and public IPs from a VM interface
+    '''
+    global netconn  # pylint: disable=global-statement,invalid-name
+    if not netconn:
+        netconn = get_conn(NetworkManagementClient)
+
+    private_ips = []
+    public_ips = []
+    for node_iface in node.network_profile.network_interfaces:
+        node_iface_name = node_iface.id.split('/')[-1]
+        network_interface = netconn.network_interfaces.get(resource_group, node_iface_name)
+        for ip_configuration in network_interface.ip_configurations:
+            if ip_configuration.private_ip_address:
+                private_ips.append(ip_configuration.private_ip_address)
+            if ip_configuration.public_ip_address and ip_configuration.public_ip_address.id:
+                public_iface_name = ip_configuration.public_ip_address.id.split('/')[-1]
+                public_iface = netconn.public_ip_addresses.get(resource_group, public_iface_name)
+                public_ips.append(public_iface.ip_address)
+
+    return private_ips, public_ips
 
 
 def list_resource_groups(conn=None, call=None):  # pylint: disable=unused-argument


### PR DESCRIPTION
### What does this PR do?
azurearm.py edited to show IPs instead of interfaces id at queries (salt-cloud -Q)

### Previous Behavior
       us1-dns-node01:
            ----------
            id:
                /subscriptions/51df7c77-5922-45c6-96e1-b2de5fa69477/resourceGroups/infra-us1/providers/Microsoft.Compute/virtualMachines/us1-dns-node01
            image:
                Canonical|UbuntuServer|16.04-LTS|latest
            name:
                us1-dns-node01
            private_ips:
                - <azure.mgmt.compute.models.network_interface_reference.NetworkInterfaceReference object at 0x7f0385844ad0>
            public_ips:
                - <azure.mgmt.compute.models.network_interface_reference.NetworkInterfaceReference object at 0x7f0385844ad0>
            size:
                Standard_DS1_v2
            state:
                Succeeded

### New Behavior
        us1-dns-node01:
            ----------
            id:
                /subscriptions/51df7c77-5922-45c6-96e1-b2de5fa69477/resourceGroups/infra-us1/providers/Microsoft.Compute/virtualMachines/us1-dns-node01
            image:
                Canonical|UbuntuServer|16.04-LTS|latest
            name:
                us1-dns-node01
            private_ips:
                - 10.10.1.4
            public_ips:
                - 52.161.102.146
            size:
                Standard_DS1_v2
            state:
                Succeeded
