### PR TITLE
Add PER_REMOTE_ONLY to init_remotes call in git_pillar runner

### DIFF
--- a/salt/runners/git_pillar.py
+++ b/salt/runners/git_pillar.py
@@ -86,7 +86,8 @@ def update(branch=None, repo=None):
         else:
             pillar = salt.utils.gitfs.GitPillar(__opts__)
             pillar.init_remotes(pillar_conf,
-                                salt.pillar.git_pillar.PER_REMOTE_OVERRIDES)
+                                salt.pillar.git_pillar.PER_REMOTE_OVERRIDES,
+                                salt.pillar.git_pillar.PER_REMOTE_ONLY)
             for remote in pillar.remotes:
                 # Skip this remote if it doesn't match the search criteria
                 if branch is not None:


### PR DESCRIPTION
When the mountpoint feature was added, it added a per-remote-only
parameter called `mountpoint`. While this is reflected in
salt.pillar.git_pillar, it was not in salt.runners.git_pillar. This
corrects that oversight, fixing a traceback when the `git_pillar.update`
runner is executed and one or more remotes have a `mountpoint` parameter
configured.