### PR TITLE
Fix _assign_floating_ips in openstack.py

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -907,9 +907,9 @@ def _assign_floating_ips(vm_, conn, kwargs):
                             floating.append(idx)
                             break
                 if not floating:
-                    raise SaltCloudSystemExit(
+                    log.warning(
                         'There are no more floating IP addresses '
-                        'available, please create some more'
+                        'available, please create some more if necessary'
                     )
             except Exception as e:
                 if str(e).startswith('404'):


### PR DESCRIPTION
### What does this PR do?
In [salt/cloud/clouds/openstack.py](https://github.com/saltstack/salt/blob/2016.11/salt/cloud/clouds/openstack.py) :
- `_assign_floating_ips()` should not raise `SaltCloudSystemExit()` just yet.
- Instead, it should let `_query_node_data()` a chance to get the IP from `node['public_ips']`.

### What issues does this PR fix or reference?
Fixes #42417

### Previous Behavior
`Error: There was a profile error: There are no more floating IP addresses available, please create some more` even with a valid IP in `node['public_ips']`.

### New Behavior
Salt-cloud is able to find the IP in `node['public_ips']`.

### Tests written?
No
