### PR TITLE
Add info about top file to pillar walk-through example to include edit.vim

### DIFF
--- a/doc/topics/tutorials/pillar.rst
+++ b/doc/topics/tutorials/pillar.rst
@@ -75,7 +75,7 @@ The default location for the pillar is in /srv/pillar.
 
 .. note::
 
-    The pillar location can be configured via the `pillar_roots` option inside
+    The pillar location can be configured via the ``pillar_roots`` option inside
     the master configuration file. It must not be in a subdirectory of the state
     tree or file_roots. If the pillar is under file_roots, any pillar targeting
     can be bypassed by minions.
@@ -242,7 +242,7 @@ set in the minion's pillar, then the default of ``httpd`` will be used.
 .. note::
 
     Under the hood, pillar is just a Python dict, so Python dict methods such
-    as `get` and `items` can be used.
+    as ``get`` and ``items`` can be used.
 
 Pillar Makes Simple States Grow Easily
 ======================================
@@ -302,6 +302,18 @@ Where the vimrc source location can now be changed via pillar:
     {% endif %}
 
 Ensuring that the right vimrc is sent out to the correct minions.
+
+The pillar top file must include a reference to the new sls pillar file:
+
+``/srv/pillar/top.sls``:
+
+.. code-block:: yaml
+
+    base:
+      '*':
+        - pkg
+        - edit.vim
+
 
 Setting Pillar Data on the Command Line
 =======================================


### PR DESCRIPTION
The pillar example in the "Pillar Makes Simple States Grow Easily" section does not mention that the new file `/srv/pillar/edit/vim.sls` created for the example must be included in the pillar top file in order for the references to work.

This PR adds that documentation so that the example works correctly.

Fixes #42405
