### PR TITLE
Document changes to Windows Update in Windows 10/Server 2016

### DIFF
--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -945,12 +945,26 @@ def set_wu_settings(level=None,
     Change Windows Update settings. If no parameters are passed, the current
     value will be returned.
 
+    Supported:
+        - Windows Vista / Server 2008
+        - Windows 7 / Server 2008R2
+        - Windows 8 / Server 2012
+        - Windows 8.1 / Server 2012R2
+
+    .. note:
+        Microsoft began using the Unified Update Platform (UUP) starting with
+        Windows 10 / Server 2016. The Windows Update settings have changed and
+        the ability to 'Save' Windows Update settings has been removed. Windows
+        Update settings are read-only. See msdn documentation:
+        https://msdn.microsoft.com/en-us/library/aa385829(v=vs.85).aspx
+
     :param int level:
         Number from 1 to 4 indicating the update level:
             1. Never check for updates
             2. Check for updates but let me choose whether to download and install them
             3. Download updates but let me choose whether to install them
             4. Install updates automatically
+
     :param bool recommended:
         Boolean value that indicates whether to include optional or recommended
         updates when a search for updates and installation of updates is
@@ -993,8 +1007,28 @@ def set_wu_settings(level=None,
         salt '*' win_wua.set_wu_settings level=4 recommended=True featured=False
 
     """
-    ret = {}
-    ret['Success'] = True
+    # The AutomaticUpdateSettings.Save() method used in this function does not
+    # work on Windows 10 / Server 2016. It is called in throughout this function
+    # like this:
+    #
+    #     obj_au = win32com.client.Dispatch('Microsoft.Update.AutoUpdate')
+    #     obj_au_settings = obj_au.Settings
+    #     obj_au_settings.Save()
+    #
+    # The `Save()` method reports success but doesn't actually change anything.
+    # Windows Update settings are read-only in Windows 10 / Server 2016. There's
+    # a little blurb on MSDN that mentions this, but gives no alternative for
+    # changing these settings in Windows 10 / Server 2016.
+    #
+    # https://msdn.microsoft.com/en-us/library/aa385829(v=vs.85).aspx
+    #
+    # Apparently the Windows Update framework in Windows Vista - Windows 8.1 has
+    # been changed quite a bit in Windows 10 / Server 2016. It is now called the
+    # Unified Update Platform (UUP). I haven't found an API or a Powershell
+    # commandlet for working with the the UUP. Perhaps there will be something
+    # forthcoming. The `win_lgpo` module might be an option for changing the
+    # Windows Update settings using local group policy.
+    ret = {'Success': True}
 
     # Initialize the PyCom system
     pythoncom.CoInitialize()

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -955,7 +955,7 @@ def set_wu_settings(level=None,
         Microsoft began using the Unified Update Platform (UUP) starting with
         Windows 10 / Server 2016. The Windows Update settings have changed and
         the ability to 'Save' Windows Update settings has been removed. Windows
-        Update settings are read-only. See msdn documentation:
+        Update settings are read-only. See MSDN documentation:
         https://msdn.microsoft.com/en-us/library/aa385829(v=vs.85).aspx
 
     :param int level:


### PR DESCRIPTION
### What does this PR do?
The Windows Update framework was changed quite a bit in Windows 10 / Server 2016. It is now called the Unified Updated Platform. As a result, Windows Update settings are now read-only. This documents this in the module documentation and in the code.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/42238