### PR TITLE
Fixes AttributeError thrown by chocolatey state

### DIFF
--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -92,7 +92,7 @@ def installed(name, version=None, source=None, force=False, pre_versions=False,
 
     # Determine action
     # Package not installed
-    if name not in [package.split('|')[0].lower() for package in pre_install.splitlines()]:
+    if name.lower() not in [package.lower() for package in pre_install.keys()]:
         if version:
             ret['changes'] = {name: 'Version {0} will be installed'
                                     ''.format(version)}
@@ -193,9 +193,13 @@ def uninstalled(name, version=None, uninstall_args=None, override_args=False):
     pre_uninstall = __salt__['chocolatey.list'](local_only=True)
 
     # Determine if package is installed
-    if name in [package.split('|')[0].lower() for package in pre_uninstall.splitlines()]:
-        ret['changes'] = {name: '{0} version {1} will be removed'
-                                ''.format(name, pre_uninstall[name][0])}
+    if name.lower() in [package.lower() for package in pre_uninstall.keys()]:
+        try:
+            ret['changes'] = {name: '{0} version {1} will be removed'
+                                    ''.format(name, pre_uninstall[name][0])}
+        except KeyError:
+            ret['changes'] = {name: '{0} will be removed'
+                                    ''.format(name)}
     else:
         ret['comment'] = 'The package {0} is not installed'.format(name)
         return ret


### PR DESCRIPTION
### What does this PR do?
Fixes #42521 
I also found line 197 can throw a KeyError due the case insensitive matching. I'm not sure of the best way to reference the index without using a case-insensitive dictionary, so I wrapped it in a try/except block.

### Previous Behavior
```
PS C:\Users\vagrant> salt-call state.single chocolatey.installed name=GoogleChrome
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "C:\salt\bin\lib\site-packages\salt\state.py", line 1837, in call
    **cdata['kwargs'])
  File "C:\salt\bin\lib\site-packages\salt\loader.py", line 1794, in wrapper
    return f(*args, **kwargs)
  File "C:\salt\bin\lib\site-packages\salt\states\chocolatey.py", line 95, in installed
    if name not in [package.split('|')[0].lower() for package in pre_install.splitlines()]:
AttributeError: 'dict' object has no attribute 'splitlines'

local:
----------
          ID: GoogleChrome
    Function: chocolatey.installed
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "C:\salt\bin\lib\site-packages\salt\state.py", line 1837, in call
                  **cdata['kwargs'])
                File "C:\salt\bin\lib\site-packages\salt\loader.py", line 1794, in wrapper
                  return f(*args, **kwargs)
                File "C:\salt\bin\lib\site-packages\salt\states\chocolatey.py", line 95, in installed
                  if name not in [package.split('|')[0].lower() for package in pre_install.splitlines()]:
              AttributeError: 'dict' object has no attribute 'splitlines'
     Started: 19:33:27.421000
    Duration: 1171.0 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   1.171 s
```

### New Behavior
```
PS C:\Users\vagrant> salt-call saltutil.sync_states saltenv=choco
local:
    - states.chocolatey
PS C:\Users\vagrant> salt-call state.single chocolatey.installed name=GoogleChrome
local:
----------
          ID: GoogleChrome
    Function: chocolatey.installed
      Result: True
     Comment:
     Started: 19:34:01.264000
    Duration: 35641.0 ms
     Changes:
              ----------
              GoogleChrome:
                  ----------
                  new:
                      - 59.0.3071.115
                  old:

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:  35.641 s
```

### Tests written?

No
