### PR TITLE
Fix lack of align check output

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -97,7 +97,7 @@ def align_check(device, part_type, partition):
 
         salt '*' partition.align_check /dev/sda minimal 1
     '''
-    cmd = 'parted -m -s {0} align-check {1} {2}'.format(device, part_type, partition)
+    cmd = 'parted -m {0} align-check {1} {2}'.format(device, part_type, partition)
     out = __salt__['cmd.run'](cmd).splitlines()
     return out
 


### PR DESCRIPTION
### What does this PR do?
Patches parted.align_check() to ensure that stdout is returned. This is achieved by removing the '-s' (--script) argument to parted.

### What issues does this PR fix or reference?
Broken behaviour of the align_check function

### Previous Behavior
```
[root@saltmaster:~]# salt '*' partition.align_check /dev/sda minimal 1
minion_a:
minion_b:
minion_c:
[root@saltmaster:~]#
```
### New Behavior
```
[root@saltmaster:~]# salt '*' partition.align_check /dev/sda minimal 1
minion_a:
    - 1 aligned
minion_b:
    - 1 aligned
minion_c:
    - 1 aligned
[root@saltmaster:~]#
```
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
