### PR TITLE
Avoid confusing warning when using file.line

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3732,7 +3732,13 @@ def line(name, content=None, match=None, mode=None, location=None,
     if not name:
         return _error(ret, 'Must provide name to file.line')
 
-    managed(name, create=create, user=user, group=group, mode=file_mode)
+    managed(
+        name,
+        create=create,
+        user=user,
+        group=group,
+        mode=file_mode,
+        replace=False)
 
     check_res, check_msg = _check_file(name)
     if not check_res:


### PR DESCRIPTION
### What does this PR do?
This PR suppress a confusing warning, shown when using file.line.

### What issues does this PR fix or reference?
The issue fixed has not been reported.

### Previous Behavior
Using file.line in a state shows a warning that should only appear when using file.managed:

> Neither 'source' nor 'contents' nor 'contents_pillar' nor 'contents_grains' was defined, yet 'replace' was set to 'True'. As there is no source to replace the file with, 'replace' has been set to 'False' to avoid reading the file unnecessarily.

### New Behavior
No warning is shown when using file.line.

### Tests written?
No
