### PR TITLE
Added use_literal_group_id argument to artifactory.downloaded

### DIFF
--- a/salt/modules/artifactory.py
+++ b/salt/modules/artifactory.py
@@ -468,7 +468,7 @@ def __save_artifact(artifact_url, target_file, headers):
     try:
         request = urllib.request.Request(artifact_url, None, headers)
         f = urllib.request.urlopen(request)
-        with salt.utils.fopen(target_file, "wb") as local_file:
+        with salt.utils.files.fopen(target_file, "wb") as local_file:
             local_file.write(f.read())
         result['status'] = True
         result['comment'] = __append_comment(('Artifact downloaded from URL: {0}'.format(artifact_url)), result['comment'])

--- a/salt/modules/artifactory.py
+++ b/salt/modules/artifactory.py
@@ -10,7 +10,7 @@ import base64
 import logging
 
 # Import Salt libs
-import salt.utils.files
+import salt.utils
 import salt.ext.six.moves.http_client  # pylint: disable=import-error,redefined-builtin,no-name-in-module
 from salt.ext.six.moves import urllib  # pylint: disable=no-name-in-module
 from salt.ext.six.moves.urllib.error import HTTPError, URLError  # pylint: disable=no-name-in-module
@@ -38,7 +38,7 @@ def __virtual__():
         return True
 
 
-def get_latest_snapshot(artifactory_url, repository, group_id, artifact_id, packaging, target_dir='/tmp', target_file=None, classifier=None, username=None, password=None):
+def get_latest_snapshot(artifactory_url, repository, group_id, artifact_id, packaging, target_dir='/tmp', target_file=None, classifier=None, username=None, password=None, use_literal_group_id=False):
     '''
        Gets latest snapshot of the given artifact
 
@@ -69,15 +69,15 @@ def get_latest_snapshot(artifactory_url, repository, group_id, artifact_id, pack
     headers = {}
     if username and password:
         headers['Authorization'] = 'Basic {0}'.format(base64.encodestring('{0}:{1}'.format(username, password)).replace('\n', ''))
-    artifact_metadata = _get_artifact_metadata(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id, headers=headers)
+    artifact_metadata = _get_artifact_metadata(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id, headers=headers, use_literal_group_id=use_literal_group_id)
     version = artifact_metadata['latest_version']
-    snapshot_url, file_name = _get_snapshot_url(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id, version=version, packaging=packaging, classifier=classifier, headers=headers)
+    snapshot_url, file_name = _get_snapshot_url(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id, version=version, packaging=packaging, classifier=classifier, headers=headers, use_literal_group_id=use_literal_group_id)
     target_file = __resolve_target_file(file_name, target_dir, target_file)
 
     return __save_artifact(snapshot_url, target_file, headers)
 
 
-def get_snapshot(artifactory_url, repository, group_id, artifact_id, packaging, version, snapshot_version=None, target_dir='/tmp', target_file=None, classifier=None, username=None, password=None):
+def get_snapshot(artifactory_url, repository, group_id, artifact_id, packaging, version, snapshot_version=None, target_dir='/tmp', target_file=None, classifier=None, username=None, password=None, use_literal_group_id=False):
     '''
        Gets snapshot of the desired version of the artifact
 
@@ -109,13 +109,13 @@ def get_snapshot(artifactory_url, repository, group_id, artifact_id, packaging, 
     headers = {}
     if username and password:
         headers['Authorization'] = 'Basic {0}'.format(base64.encodestring('{0}:{1}'.format(username, password)).replace('\n', ''))
-    snapshot_url, file_name = _get_snapshot_url(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id, version=version, packaging=packaging, snapshot_version=snapshot_version, classifier=classifier, headers=headers)
+    snapshot_url, file_name = _get_snapshot_url(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id, version=version, packaging=packaging, snapshot_version=snapshot_version, classifier=classifier, headers=headers, use_literal_group_id=use_literal_group_id)
     target_file = __resolve_target_file(file_name, target_dir, target_file)
 
     return __save_artifact(snapshot_url, target_file, headers)
 
 
-def get_latest_release(artifactory_url, repository, group_id, artifact_id, packaging, target_dir='/tmp', target_file=None, classifier=None, username=None, password=None):
+def get_latest_release(artifactory_url, repository, group_id, artifact_id, packaging, target_dir='/tmp', target_file=None, classifier=None, username=None, password=None, use_literal_group_id=False):
     '''
        Gets the latest release of the artifact
 
@@ -146,13 +146,13 @@ def get_latest_release(artifactory_url, repository, group_id, artifact_id, packa
     if username and password:
         headers['Authorization'] = 'Basic {0}'.format(base64.encodestring('{0}:{1}'.format(username, password)).replace('\n', ''))
     version = __find_latest_version(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id, headers=headers)
-    release_url, file_name = _get_release_url(repository, group_id, artifact_id, packaging, version, artifactory_url, classifier)
+    release_url, file_name = _get_release_url(repository, group_id, artifact_id, packaging, version, artifactory_url, classifier, use_literal_group_id)
     target_file = __resolve_target_file(file_name, target_dir, target_file)
 
     return __save_artifact(release_url, target_file, headers)
 
 
-def get_release(artifactory_url, repository, group_id, artifact_id, packaging, version, target_dir='/tmp', target_file=None, classifier=None, username=None, password=None):
+def get_release(artifactory_url, repository, group_id, artifact_id, packaging, version, target_dir='/tmp', target_file=None, classifier=None, username=None, password=None, use_literal_group_id=False):
     '''
        Gets the specified release of the artifact
 
@@ -184,7 +184,7 @@ def get_release(artifactory_url, repository, group_id, artifact_id, packaging, v
     headers = {}
     if username and password:
         headers['Authorization'] = 'Basic {0}'.format(base64.encodestring('{0}:{1}'.format(username, password)).replace('\n', ''))
-    release_url, file_name = _get_release_url(repository, group_id, artifact_id, packaging, version, artifactory_url, classifier)
+    release_url, file_name = _get_release_url(repository, group_id, artifact_id, packaging, version, artifactory_url, classifier, use_literal_group_id)
     target_file = __resolve_target_file(file_name, target_dir, target_file)
 
     return __save_artifact(release_url, target_file, headers)
@@ -196,7 +196,7 @@ def __resolve_target_file(file_name, target_dir, target_file=None):
     return target_file
 
 
-def _get_snapshot_url(artifactory_url, repository, group_id, artifact_id, version, packaging, snapshot_version=None, classifier=None, headers=None):
+def _get_snapshot_url(artifactory_url, repository, group_id, artifact_id, version, packaging, snapshot_version=None, classifier=None, headers=None, use_literal_group_id=False):
     if headers is None:
         headers = {}
     has_classifier = classifier is not None and classifier != ""
@@ -242,7 +242,7 @@ def _get_snapshot_url(artifactory_url, repository, group_id, artifact_id, versio
 
         snapshot_version = snapshot_version_metadata['snapshot_versions'][packaging]
 
-    group_url = __get_group_id_subpath(group_id)
+    group_url = __get_group_id_subpath(group_id, use_literal_group_id)
 
     file_name = '{artifact_id}-{snapshot_version}{classifier}.{packaging}'.format(
         artifact_id=artifact_id,
@@ -262,8 +262,8 @@ def _get_snapshot_url(artifactory_url, repository, group_id, artifact_id, versio
     return snapshot_url, file_name
 
 
-def _get_release_url(repository, group_id, artifact_id, packaging, version, artifactory_url, classifier=None):
-    group_url = __get_group_id_subpath(group_id)
+def _get_release_url(repository, group_id, artifact_id, packaging, version, artifactory_url, classifier=None, use_literal_group_id=False):
+    group_url = __get_group_id_subpath(group_id, use_literal_group_id)
 
     # for released versions the suffix for the file is same as version
     file_name = '{artifact_id}-{version}{classifier}.{packaging}'.format(
@@ -283,8 +283,8 @@ def _get_release_url(repository, group_id, artifact_id, packaging, version, arti
     return release_url, file_name
 
 
-def _get_artifact_metadata_url(artifactory_url, repository, group_id, artifact_id):
-    group_url = __get_group_id_subpath(group_id)
+def _get_artifact_metadata_url(artifactory_url, repository, group_id, artifact_id, use_literal_group_id=False):
+    group_url = __get_group_id_subpath(group_id, use_literal_group_id)
     # for released versions the suffix for the file is same as version
     artifact_metadata_url = '{artifactory_url}/{repository}/{group_url}/{artifact_id}/maven-metadata.xml'.format(
                                  artifactory_url=artifactory_url,
@@ -295,13 +295,14 @@ def _get_artifact_metadata_url(artifactory_url, repository, group_id, artifact_i
     return artifact_metadata_url
 
 
-def _get_artifact_metadata_xml(artifactory_url, repository, group_id, artifact_id, headers):
+def _get_artifact_metadata_xml(artifactory_url, repository, group_id, artifact_id, headers, use_literal_group_id=False):
 
     artifact_metadata_url = _get_artifact_metadata_url(
         artifactory_url=artifactory_url,
         repository=repository,
         group_id=group_id,
-        artifact_id=artifact_id
+        artifact_id=artifact_id,
+        use_literal_group_id=use_literal_group_id
     )
 
     try:
@@ -318,8 +319,8 @@ def _get_artifact_metadata_xml(artifactory_url, repository, group_id, artifact_i
     return artifact_metadata_xml
 
 
-def _get_artifact_metadata(artifactory_url, repository, group_id, artifact_id, headers):
-    metadata_xml = _get_artifact_metadata_xml(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id, headers=headers)
+def _get_artifact_metadata(artifactory_url, repository, group_id, artifact_id, headers, use_literal_group_id=False):
+    metadata_xml = _get_artifact_metadata_xml(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id, headers=headers, use_literal_group_id=use_literal_group_id)
     root = ET.fromstring(metadata_xml)
 
     assert group_id == root.find('groupId').text
@@ -331,8 +332,8 @@ def _get_artifact_metadata(artifactory_url, repository, group_id, artifact_id, h
 
 
 # functions for handling snapshots
-def _get_snapshot_version_metadata_url(artifactory_url, repository, group_id, artifact_id, version):
-    group_url = __get_group_id_subpath(group_id)
+def _get_snapshot_version_metadata_url(artifactory_url, repository, group_id, artifact_id, version, use_literal_group_id=False):
+    group_url = __get_group_id_subpath(group_id, use_literal_group_id)
     # for released versions the suffix for the file is same as version
     snapshot_version_metadata_url = '{artifactory_url}/{repository}/{group_url}/{artifact_id}/{version}/maven-metadata.xml'.format(
                                          artifactory_url=artifactory_url,
@@ -344,14 +345,15 @@ def _get_snapshot_version_metadata_url(artifactory_url, repository, group_id, ar
     return snapshot_version_metadata_url
 
 
-def _get_snapshot_version_metadata_xml(artifactory_url, repository, group_id, artifact_id, version, headers):
+def _get_snapshot_version_metadata_xml(artifactory_url, repository, group_id, artifact_id, version, headers, use_literal_group_id=False):
 
     snapshot_version_metadata_url = _get_snapshot_version_metadata_url(
         artifactory_url=artifactory_url,
         repository=repository,
         group_id=group_id,
         artifact_id=artifact_id,
-        version=version
+        version=version,
+        use_literal_group_id=use_literal_group_id
     )
 
     try:
@@ -388,8 +390,8 @@ def _get_snapshot_version_metadata(artifactory_url, repository, group_id, artifa
     }
 
 
-def __get_latest_version_url(artifactory_url, repository, group_id, artifact_id):
-    group_url = __get_group_id_subpath(group_id)
+def __get_latest_version_url(artifactory_url, repository, group_id, artifact_id, use_literal_group_id=False):
+    group_url = __get_group_id_subpath(group_id, use_literal_group_id)
     # for released versions the suffix for the file is same as version
     latest_version_url = '{artifactory_url}/api/search/latestVersion?g={group_url}&a={artifact_id}&repos={repository}'.format(
                                  artifactory_url=artifactory_url,
@@ -400,13 +402,14 @@ def __get_latest_version_url(artifactory_url, repository, group_id, artifact_id)
     return latest_version_url
 
 
-def __find_latest_version(artifactory_url, repository, group_id, artifact_id, headers):
+def __find_latest_version(artifactory_url, repository, group_id, artifact_id, headers, use_literal_group_id=False):
 
     latest_version_url = __get_latest_version_url(
         artifactory_url=artifactory_url,
         repository=repository,
         group_id=group_id,
-        artifact_id=artifact_id
+        artifact_id=artifact_id,
+        use_literal_group_id=use_literal_group_id
     )
 
     try:
@@ -465,7 +468,7 @@ def __save_artifact(artifact_url, target_file, headers):
     try:
         request = urllib.request.Request(artifact_url, None, headers)
         f = urllib.request.urlopen(request)
-        with salt.utils.files.fopen(target_file, "wb") as local_file:
+        with salt.utils.fopen(target_file, "wb") as local_file:
             local_file.write(f.read())
         result['status'] = True
         result['comment'] = __append_comment(('Artifact downloaded from URL: {0}'.format(artifact_url)), result['comment'])
@@ -478,9 +481,11 @@ def __save_artifact(artifact_url, target_file, headers):
     return result
 
 
-def __get_group_id_subpath(group_id):
-    group_url = group_id.replace('.', '/')
-    return group_url
+def __get_group_id_subpath(group_id, use_literal_group_id):
+    if not use_literal_group_id:
+        group_url = group_id.replace('.', '/')
+        return group_url
+    return group_id
 
 
 def __get_classifier_url(classifier):

--- a/salt/modules/artifactory.py
+++ b/salt/modules/artifactory.py
@@ -481,7 +481,7 @@ def __save_artifact(artifact_url, target_file, headers):
     return result
 
 
-def __get_group_id_subpath(group_id, use_literal_group_id):
+def __get_group_id_subpath(group_id, use_literal_group_id=False):
     if not use_literal_group_id:
         group_url = group_id.replace('.', '/')
         return group_url

--- a/salt/states/artifactory.py
+++ b/salt/states/artifactory.py
@@ -11,10 +11,10 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def downloaded(name, artifact, target_dir='/tmp', target_file=None):
+def downloaded(name, artifact, target_dir='/tmp', target_file=None, use_literal_group_id=False):
     '''
     Ensures that the artifact from artifactory exists at given location. If it doesn't exist, then
-    it will be downloaded. It it already exists then the checksum of existing file is checked against checksum
+    it will be downloaded. If it already exists then the checksum of existing file is checked against checksum
     in artifactory. If it is different then the step will fail.
 
     artifact
@@ -84,7 +84,7 @@ def downloaded(name, artifact, target_dir='/tmp', target_file=None):
            'comment': ''}
 
     try:
-        fetch_result = __fetch_from_artifactory(artifact, target_dir, target_file)
+        fetch_result = __fetch_from_artifactory(artifact, target_dir, target_file, use_literal_group_id)
     except Exception as exc:
         ret['result'] = False
         ret['comment'] = str(exc)
@@ -100,7 +100,7 @@ def downloaded(name, artifact, target_dir='/tmp', target_file=None):
     return ret
 
 
-def __fetch_from_artifactory(artifact, target_dir, target_file):
+def __fetch_from_artifactory(artifact, target_dir, target_file, use_literal_group_id):
     if ('latest_snapshot' in artifact and artifact['latest_snapshot']) or artifact['version'] == 'latest_snapshot':
         fetch_result = __salt__['artifactory.get_latest_snapshot'](artifactory_url=artifact['artifactory_url'],
                                                                    repository=artifact['repository'],
@@ -111,7 +111,8 @@ def __fetch_from_artifactory(artifact, target_dir, target_file):
                                                                    target_dir=target_dir,
                                                                    target_file=target_file,
                                                                    username=artifact['username'] if 'username' in artifact else None,
-                                                                   password=artifact['password'] if 'password' in artifact else None)
+                                                                   password=artifact['password'] if 'password' in artifact else None,
+                                                                   use_literal_group_id=use_literal_group_id)
     elif artifact['version'].endswith('SNAPSHOT'):
         fetch_result = __salt__['artifactory.get_snapshot'](artifactory_url=artifact['artifactory_url'],
                                                             repository=artifact['repository'],
@@ -123,7 +124,8 @@ def __fetch_from_artifactory(artifact, target_dir, target_file):
                                                             target_dir=target_dir,
                                                             target_file=target_file,
                                                             username=artifact['username'] if 'username' in artifact else None,
-                                                            password=artifact['password'] if 'password' in artifact else None)
+                                                            password=artifact['password'] if 'password' in artifact else None,
+                                                            use_literal_group_id=use_literal_group_id)
     elif artifact['version'] == 'latest':
         fetch_result = __salt__['artifactory.get_latest_release'](artifactory_url=artifact['artifactory_url'],
                                                                    repository=artifact['repository'],
@@ -134,7 +136,8 @@ def __fetch_from_artifactory(artifact, target_dir, target_file):
                                                                    target_dir=target_dir,
                                                                    target_file=target_file,
                                                                    username=artifact['username'] if 'username' in artifact else None,
-                                                                   password=artifact['password'] if 'password' in artifact else None)
+                                                                   password=artifact['password'] if 'password' in artifact else None,
+                                                                   use_literal_group_id=use_literal_group_id)
     else:
         fetch_result = __salt__['artifactory.get_release'](artifactory_url=artifact['artifactory_url'],
                                                            repository=artifact['repository'],
@@ -146,5 +149,6 @@ def __fetch_from_artifactory(artifact, target_dir, target_file):
                                                            target_dir=target_dir,
                                                            target_file=target_file,
                                                            username=artifact['username'] if 'username' in artifact else None,
-                                                           password=artifact['password'] if 'password' in artifact else None)
+                                                           password=artifact['password'] if 'password' in artifact else None,
+                                                           use_literal_group_id=use_literal_group_id)
     return fetch_result


### PR DESCRIPTION
### What does this PR do?
This adds an argument to the artifactory.downloaded module that allows the user to specify whether or not to use the literal group_id when building the artifactory url to download from.

This argument defaults to false and is optional, so if not provided behavior won't change at all. If true, dots in provided group_id will not be replaced with slashes when building the artifactory url.

### What issues does this PR fix or reference?
It addresses this issue: https://github.com/saltstack/salt/issues/42510

### Previous Behavior
If a user provided a group_id that contained dots, e.g. com.company, it would change this to com/company when building the URL to download from. If the URL actually contained com.company, this would result in an incorrect URL and failed download.

### New Behavior
Now the user can add an argument to artifactory.downloaded to tell it to keep the dots in the provided group_id.

### Tests written?

No
