### PR TITLE
Updated testinfra modules to work with more recent versions

### DIFF
--- a/salt/modules/testinframod.py
+++ b/salt/modules/testinframod.py
@@ -285,13 +285,17 @@ def _register_functions():
     functions, and then register them in the module namespace so that they
     can be called via salt.
     """
-    for module_ in modules.__all__:
+    try:
+        modules_ = [_to_snake_case(module_) for module_ in modules.__all__]
+    except AttributeError:
+        modules_ = [module_ for module_ in modules.modules]
+
+    for mod_name in modules_:
         mod_name = _to_snake_case(module_)
         mod_func = _copy_function(mod_name, str(mod_name))
-        mod_func.__doc__ = _build_doc(module_)
+        mod_func.__doc__ = _build_doc(mod_name)
         __all__.append(mod_name)
         globals()[mod_name] = mod_func
-
 
 if TESTINFRA_PRESENT:
     _register_functions()

--- a/salt/states/testinframod.py
+++ b/salt/states/testinframod.py
@@ -52,8 +52,12 @@ def _to_snake_case(pascal_case):
 
 
 def _generate_functions():
-    for module in modules.__all__:
-        module_name = _to_snake_case(module)
+    try:
+        modules_ = [_to_snake_case(module_) for module_ in modules.__all__]
+    except AttributeError:
+        modules_ = [module_ for module_ in modules.modules]
+
+    for module_name in modules_:
         func_name = 'testinfra.{0}'.format(module_name)
         __all__.append(module_name)
         log.debug('Generating state for module %s as function %s',


### PR DESCRIPTION
### What does this PR do?
The TestInfra library changed the package layout recently which caused
the extension module to stop working. This patch addresses those
updates and will work across all versions of the library.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
If the installed version of TestInfra is updated past 1.5.5 then the extension/state modules will no longer load due to AttributeErrors

### New Behavior
The testinfra extension and state modules will now work with versions of TestInfra newer thatn 1.5.5

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
