### PR TITLE
Remove '-s' (--script) argument to parted within align_check function

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -216,7 +216,7 @@ def align_check(device, part_type, partition):
             'Invalid partition passed to partition.align_check'
         )
 
-    cmd = 'parted -m -s {0} align-check {1} {2}'.format(
+    cmd = 'parted -m {0} align-check {1} {2}'.format(
         device, part_type, partition
     )
     out = __salt__['cmd.run'](cmd).splitlines()


### PR DESCRIPTION
The -s argument results in no stdout output from parted in this context,
so the user must infer success or failure from the exit status.

### What does this PR do?
Patches parted.align_check() to ensure that stdout is returned. This is achieved by removing the '-s' (--script) argument to parted.

### What issues does this PR fix or reference?
Broken behaviour of the align_check function

### Previous Behavior
```
[root@saltmaster:~]# salt '*' partition.align_check /dev/sda minimal 1
minion_a:
minion_b:
minion_c:
[root@saltmaster:~]#
```

### New Behavior
```
[root@saltmaster:~]# salt '*' partition.align_check /dev/sda minimal 1
minion_a:
    - 1 aligned
minion_b:
    - 1 aligned
minion_c:
    - 1 aligned
[root@saltmaster:~]#
```

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
