### PR TITLE
Fixing output so --force-color and --no-color override master and min…

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -168,6 +168,13 @@ def get_printout(out, opts=None, **kwargs):
             opts['color'] = False
         else:
             opts['color'] = True
+    else:
+        if opts.get('force_color', False):
+            opts['color'] = True
+        elif opts.get('no_color', False) or salt.utils.is_windows():
+            opts['color'] = False
+        else:
+            pass
 
     outputters = salt.loader.outputters(opts)
     if out not in outputters:


### PR DESCRIPTION
…ion config color value

### What does this PR do?

Ensure that's the parameters --force-color and --no-color will take precedence over the 'color' parameter set in the configuration file.

### What issues does this PR fix or reference?

This PR addresses bug #37312 directly.

Additionally, it should also fix the problem mentioned in #40354.  If 'color: True' is specified in the minion config it will cause the odd sed error reported from the init script.  

### Previous Behavior
If the 'color' value is defined in the configuration file the use of --force-color or --no-color will have no effect.

### New Behavior
The 'color' value in the configuration file is ignored if --force-color or --no-color is used.

### Tests written?

No
