### PR TITLE
Fix disable_<tag-name> config option

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1094,7 +1094,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             virtual_funcs = []
         self.virtual_funcs = virtual_funcs
 
-        self.disabled = set(self.opts.get('disable_{0}s'.format(self.tag), []))
+        self.disabled = set(self.opts.get('disable_{0}{1}'.format(
+            self.tag, '' if self.tag[-1] == 's' else 's'), []))
 
         self.refresh_file_mapping()
 


### PR DESCRIPTION
### What does this PR do?

Previously, the logic always looked for `disable_<tag-name>s` in
the config options. The issue with this is that the following tag names
already end with 's': `beacons`, `engines`, `grains`, `log_handlers`,
`serializers`, `states`, and `utils`. So previously, if you wanted to
disable a beacon, the config option to set is `disable_beaconss` (with
'ss' at the end). Fix this so that we only append an 's' if the tag name
does not already end with an 's'.

### Tests written?

No