### PR TITLE
Avoid loading system PYTHON* environment vars

### DIFF
--- a/pkg/windows/buildenv/salt-call.bat
+++ b/pkg/windows/buildenv/salt-call.bat
@@ -9,4 +9,4 @@ Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-call
 
 :: Launch Script
-"%Python%" -E "%Script%" %*
+"%Python%" -E -s "%Script%" %*

--- a/pkg/windows/buildenv/salt-call.bat
+++ b/pkg/windows/buildenv/salt-call.bat
@@ -8,9 +8,5 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-call
 
-:: Set PYTHONPATH
-Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
-
 :: Launch Script
-"%Python%" "%Script%" %*
-
+"%Python%" -E "%Script%" %*

--- a/pkg/windows/buildenv/salt-call.bat
+++ b/pkg/windows/buildenv/salt-call.bat
@@ -8,6 +8,9 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-call
 
+:: Set PYTHONPATH
+Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
+
 :: Launch Script
 "%Python%" "%Script%" %*
 

--- a/pkg/windows/buildenv/salt-cp.bat
+++ b/pkg/windows/buildenv/salt-cp.bat
@@ -8,9 +8,5 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-cp
 
-:: Set PYTHONPATH
-Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
-
 :: Launch Script
-"%Python%" "%Script%" %*
-
+"%Python%" -E "%Script%" %*

--- a/pkg/windows/buildenv/salt-cp.bat
+++ b/pkg/windows/buildenv/salt-cp.bat
@@ -9,4 +9,4 @@ Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-cp
 
 :: Launch Script
-"%Python%" -E "%Script%" %*
+"%Python%" -E -s "%Script%" %*

--- a/pkg/windows/buildenv/salt-cp.bat
+++ b/pkg/windows/buildenv/salt-cp.bat
@@ -8,6 +8,9 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-cp
 
+:: Set PYTHONPATH
+Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
+
 :: Launch Script
 "%Python%" "%Script%" %*
 

--- a/pkg/windows/buildenv/salt-key.bat
+++ b/pkg/windows/buildenv/salt-key.bat
@@ -8,6 +8,9 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-key
 
+:: Set PYTHONPATH
+Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
+
 :: Launch Script
 "%Python%" "%Script%" %*
 

--- a/pkg/windows/buildenv/salt-key.bat
+++ b/pkg/windows/buildenv/salt-key.bat
@@ -9,4 +9,4 @@ Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-key
 
 :: Launch Script
-"%Python%" -E "%Script%" %*
+"%Python%" -E -s "%Script%" %*

--- a/pkg/windows/buildenv/salt-key.bat
+++ b/pkg/windows/buildenv/salt-key.bat
@@ -8,9 +8,5 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-key
 
-:: Set PYTHONPATH
-Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
-
 :: Launch Script
-"%Python%" "%Script%" %*
-
+"%Python%" -E "%Script%" %*

--- a/pkg/windows/buildenv/salt-master.bat
+++ b/pkg/windows/buildenv/salt-master.bat
@@ -8,6 +8,9 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-master
 
+:: Set PYTHONPATH
+Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
+
 :: Launch Script
 "%Python%" "%Script%" %*
 

--- a/pkg/windows/buildenv/salt-master.bat
+++ b/pkg/windows/buildenv/salt-master.bat
@@ -9,4 +9,4 @@ Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-master
 
 :: Launch Script
-"%Python%" -E "%Script%" %*
+"%Python%" -E -s "%Script%" %*

--- a/pkg/windows/buildenv/salt-master.bat
+++ b/pkg/windows/buildenv/salt-master.bat
@@ -8,9 +8,5 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-master
 
-:: Set PYTHONPATH
-Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
-
 :: Launch Script
-"%Python%" "%Script%" %*
-
+"%Python%" -E "%Script%" %*

--- a/pkg/windows/buildenv/salt-minion-debug.bat
+++ b/pkg/windows/buildenv/salt-minion-debug.bat
@@ -8,6 +8,9 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-minion
 
+:: Set PYTHONPATH
+Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
+
 :: Stop the Salt Minion service
 net stop salt-minion
 

--- a/pkg/windows/buildenv/salt-minion-debug.bat
+++ b/pkg/windows/buildenv/salt-minion-debug.bat
@@ -8,12 +8,8 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-minion
 
-:: Set PYTHONPATH
-Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
-
 :: Stop the Salt Minion service
 net stop salt-minion
 
 :: Launch Script
-"%Python%" "%Script%" -l debug
-
+"%Python%" -E "%Script%" -l debug

--- a/pkg/windows/buildenv/salt-minion-debug.bat
+++ b/pkg/windows/buildenv/salt-minion-debug.bat
@@ -12,4 +12,4 @@ Set Script=%SaltDir%\bin\Scripts\salt-minion
 net stop salt-minion
 
 :: Launch Script
-"%Python%" -E "%Script%" -l debug
+"%Python%" -E -s "%Script%" -l debug

--- a/pkg/windows/buildenv/salt-minion.bat
+++ b/pkg/windows/buildenv/salt-minion.bat
@@ -9,4 +9,4 @@ Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-minion
 
 :: Launch Script
-"%Python%" -E "%Script%" %*
+"%Python%" -E -s "%Script%" %*

--- a/pkg/windows/buildenv/salt-minion.bat
+++ b/pkg/windows/buildenv/salt-minion.bat
@@ -8,6 +8,9 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-minion
 
+:: Set PYTHONPATH
+Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
+
 :: Launch Script
 "%Python%" "%Script%" %*
 

--- a/pkg/windows/buildenv/salt-minion.bat
+++ b/pkg/windows/buildenv/salt-minion.bat
@@ -8,9 +8,5 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-minion
 
-:: Set PYTHONPATH
-Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
-
 :: Launch Script
-"%Python%" "%Script%" %*
-
+"%Python%" -E "%Script%" %*

--- a/pkg/windows/buildenv/salt-run.bat
+++ b/pkg/windows/buildenv/salt-run.bat
@@ -8,9 +8,5 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-run
 
-:: Set PYTHONPATH
-Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
-
 :: Launch Script
-"%Python%" "%Script%" %*
-
+"%Python%" -E "%Script%" %*

--- a/pkg/windows/buildenv/salt-run.bat
+++ b/pkg/windows/buildenv/salt-run.bat
@@ -9,4 +9,4 @@ Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-run
 
 :: Launch Script
-"%Python%" -E "%Script%" %*
+"%Python%" -E -s "%Script%" %*

--- a/pkg/windows/buildenv/salt-run.bat
+++ b/pkg/windows/buildenv/salt-run.bat
@@ -8,6 +8,9 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt-run
 
+:: Set PYTHONPATH
+Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
+
 :: Launch Script
 "%Python%" "%Script%" %*
 

--- a/pkg/windows/buildenv/salt.bat
+++ b/pkg/windows/buildenv/salt.bat
@@ -9,4 +9,4 @@ Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt
 
 :: Launch Script
-"%Python%" -E "%Script%" %*
+"%Python%" -E -s "%Script%" %*

--- a/pkg/windows/buildenv/salt.bat
+++ b/pkg/windows/buildenv/salt.bat
@@ -8,6 +8,9 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt
 
+:: Set PYTHONPATH
+Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
+
 :: Launch Script
 "%Python%" "%Script%" %*
 

--- a/pkg/windows/buildenv/salt.bat
+++ b/pkg/windows/buildenv/salt.bat
@@ -8,9 +8,5 @@ Set SaltDir=%SaltDir:~0,-1%
 Set Python=%SaltDir%\bin\python.exe
 Set Script=%SaltDir%\bin\Scripts\salt
 
-:: Set PYTHONPATH
-Set PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages
-
 :: Launch Script
-"%Python%" "%Script%" %*
-
+"%Python%" -E "%Script%" %*

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -334,8 +334,7 @@ Section -Post
     WriteRegStr HKLM "${PRODUCT_MINION_REGKEY}" "Path" "$INSTDIR\bin\"
 
     ; Register the Salt-Minion Service
-    nsExec::Exec "nssm.exe install salt-minion $INSTDIR\bin\python.exe $INSTDIR\bin\Scripts\salt-minion -c $INSTDIR\conf -l quiet"
-    nsExec::Exec "nssm.exe set salt-minion AppEnvironmentExtra PYTHONHOME= PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages"
+    nsExec::Exec "nssm.exe install salt-minion $INSTDIR\bin\python.exe -E $INSTDIR\bin\Scripts\salt-minion -c $INSTDIR\conf -l quiet"
     nsExec::Exec "nssm.exe set salt-minion Description Salt Minion from saltstack.com"
     nsExec::Exec "nssm.exe set salt-minion AppNoConsole 1"
 

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -335,7 +335,7 @@ Section -Post
 
     ; Register the Salt-Minion Service
     nsExec::Exec "nssm.exe install salt-minion $INSTDIR\bin\python.exe $INSTDIR\bin\Scripts\salt-minion -c $INSTDIR\conf -l quiet"
-    nsExec::Exec "nssm.exe set salt-minion AppEnvironmentExtra PYTHONHOME="
+    nsExec::Exec "nssm.exe set salt-minion AppEnvironmentExtra PYTHONHOME= PYTHONPATH=C:\salt\bin;C:\salt\bin\Lib\site-packages"
     nsExec::Exec "nssm.exe set salt-minion Description Salt Minion from saltstack.com"
     nsExec::Exec "nssm.exe set salt-minion AppNoConsole 1"
 

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -334,7 +334,7 @@ Section -Post
     WriteRegStr HKLM "${PRODUCT_MINION_REGKEY}" "Path" "$INSTDIR\bin\"
 
     ; Register the Salt-Minion Service
-    nsExec::Exec "nssm.exe install salt-minion $INSTDIR\bin\python.exe -E $INSTDIR\bin\Scripts\salt-minion -c $INSTDIR\conf -l quiet"
+    nsExec::Exec "nssm.exe install salt-minion $INSTDIR\bin\python.exe -E -s $INSTDIR\bin\Scripts\salt-minion -c $INSTDIR\conf -l quiet"
     nsExec::Exec "nssm.exe set salt-minion Description Salt Minion from saltstack.com"
     nsExec::Exec "nssm.exe set salt-minion AppNoConsole 1"
 


### PR DESCRIPTION
### What does this PR do?
Adds `-E -s` to the Python Executable in the batch files as well as the salt-minion service.

`-E` prevents Python from loading any user-defined PYTHON* environment variables that may exist due to an existing installation of Python on the system. Python will use the defaults based on the location of the python binary which in our case is C:\salt\bin

`-s` prevents the user site-packages directory from being available to python.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/36733

### Tests written?
NA