### PR TITLE
Document returning False in test=True mode

### DIFF
--- a/doc/ref/states/writing.rst
+++ b/doc/ref/states/writing.rst
@@ -135,19 +135,23 @@ A State Module must return a dict containing the following keys/values:
   ``test=True``, and changes would have been made if the state was not run in
   test mode.
 
-  +--------------------+-----------+-----------+
-  |                    | live mode | test mode |
-  +====================+===========+===========+
-  | no changes         | ``True``  | ``True``  |
-  +--------------------+-----------+-----------+
-  | successful changes | ``True``  | ``None``  |
-  +--------------------+-----------+-----------+
-  | failed changes     | ``False`` | ``None``  |
-  +--------------------+-----------+-----------+
+  +--------------------+-----------+------------------------+
+  |                    | live mode | test mode              |
+  +====================+===========+========================+
+  | no changes         | ``True``  | ``True``               |
+  +--------------------+-----------+------------------------+
+  | successful changes | ``True``  | ``None``               |
+  +--------------------+-----------+------------------------+
+  | failed changes     | ``False`` | ``False`` or ``None``  |
+  +--------------------+-----------+------------------------+
 
   .. note::
 
-      Test mode does not predict if the changes will be successful or not.
+      Test mode does not predict if the changes will be successful or not,
+      and hence the result for pending changes is usually ``None``.
+
+      However, if a state is going to fail and this can be determined
+      in test mode without applying the change, ``False`` can be returned.
 
 - **comment:** A string containing a summary of the result.
 


### PR DESCRIPTION
Currently, in test mode states always return None even on failure.
This masks failed states in highstate output,
which instead just look like they are going to make changes.

In some cases states can determine if they will fail even on a dry run,
e.g., if an API call to a service to determine the state of a
resource fails due to invalid credentials or a missing parameter.

In these cases, allow returning a result of False even in dry runs
to enable catching more errors at testing time.

### What does this PR do?
Document an extension to State module best practices

### What issues does this PR fix or reference?
#42553 

### Previous Behavior
States always return `None` in `test=True` mode

### New Behavior
States can return `False` on failure in `test=True` mode

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.