### PR TITLE
Compile scripts with -E -s params for Salt on Mac

### DIFF
--- a/pkg/osx/build.sh
+++ b/pkg/osx/build.sh
@@ -86,9 +86,9 @@ sudo $PKGRESOURCES/build_env.sh $PYVER
 # Install Salt
 ############################################################################
 echo -n -e "\033]0;Build: Install Salt\007"
-sudo rm -rm $SRCDIR/build
-sudo rm -rm $SRCDIR/dist
-sudo $PYTHON $SRCDIR/setup.py install
+sudo rm -rf $SRCDIR/build
+sudo rm -rf $SRCDIR/dist
+sudo $PYTHON $SRCDIR/setup.py build -e "$PYTHON -E -s" install
 
 ############################################################################
 # Build Package


### PR DESCRIPTION
### What does this PR do?
Adds the `-E -s` parameters to the interpreter for the scripts that start salt (`salt-minion`, `salt-master`, etc).

`-E` prevents Python from loading any user-defined PYTHON* environment variables that may exist due to an existing installation of Python on the system. Python will use the defaults based on the location of the python binary which in our case is /opt/salt/bin.

`-s` prevents the user site-packages directory from being available to python.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/36733

### Tests written?
NA