### PR TITLE
Use superseded and deprecated configuration from pillar

### DIFF
--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -544,11 +544,11 @@ class _WithDeprecated(_DeprecationDecorator):
         opts = self._globals.get('__opts__', '{}')
         pillar = self._globals.get('__pillar__', '{}')
 
-        use_deprecated = full_name in opts.get(self.CFG_USE_DEPRECATED, list()) or \
-            full_name in pillar.get(self.CFG_USE_DEPRECATED, list())
+        use_deprecated = (full_name in opts.get(self.CFG_USE_DEPRECATED, list()) or
+                          full_name in pillar.get(self.CFG_USE_DEPRECATED, list()))
 
-        use_superseded = full_name in opts.get(self.CFG_USE_SUPERSEDED, list()) or \
-            full_name in pillar.get(self.CFG_USE_SUPERSEDED, list())
+        use_superseded = (full_name in opts.get(self.CFG_USE_SUPERSEDED, list()) or
+                          full_name in pillar.get(self.CFG_USE_SUPERSEDED, list()))
 
         if use_deprecated and use_superseded:
             raise SaltConfigurationError("Function '{0}' is mentioned both in deprecated "

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -571,6 +571,7 @@ class _WithDeprecated(_DeprecationDecorator):
             f_name=self._orig_f_name)
 
         return func_path in self._globals.get('__opts__').get(
+            self.CFG_USE_DEPRECATED, list()) or func_path in self._globals.get('__pillar__').get(
             self.CFG_USE_DEPRECATED, list()) or (self._policy == self.OPT_IN
                                                  and not (func_path in self._globals.get('__opts__', {}).get(
                                                           self.CFG_USE_SUPERSEDED, list()))

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -542,8 +542,14 @@ class _WithDeprecated(_DeprecationDecorator):
                 f_name=function.__name__))
 
         opts = self._globals.get('__opts__', '{}')
-        use_deprecated = full_name in opts.get(self.CFG_USE_DEPRECATED, list())
-        use_superseded = full_name in opts.get(self.CFG_USE_SUPERSEDED, list())
+        pillar = self._globals.get('__pillar__', '{}')
+
+        use_deprecated = full_name in opts.get(self.CFG_USE_DEPRECATED, list()) or \
+            full_name in pillar.get(self.CFG_USE_DEPRECATED, list())
+
+        use_superseded = full_name in opts.get(self.CFG_USE_SUPERSEDED, list()) or \
+            full_name in pillar.get(self.CFG_USE_SUPERSEDED, list())
+
         if use_deprecated and use_superseded:
             raise SaltConfigurationError("Function '{0}' is mentioned both in deprecated "
                                          "and superseded sections. Please remove any of that.".format(full_name))
@@ -567,6 +573,8 @@ class _WithDeprecated(_DeprecationDecorator):
         return func_path in self._globals.get('__opts__').get(
             self.CFG_USE_DEPRECATED, list()) or (self._policy == self.OPT_IN
                                                  and not (func_path in self._globals.get('__opts__', {}).get(
+                                                          self.CFG_USE_SUPERSEDED, list()))
+                                                 and not (func_path in self._globals.get('__pillar__', {}).get(
                                                           self.CFG_USE_SUPERSEDED, list()))), func_path
 
     def __call__(self, function):

--- a/tests/unit/utils/test_decorators.py
+++ b/tests/unit/utils/test_decorators.py
@@ -59,6 +59,7 @@ class DecoratorsTest(TestCase):
         self.globs = {
             '__virtualname__': 'test',
             '__opts__': {},
+            '__pillar__': {},
             'old_function': self.old_function,
             'new_function': self.new_function,
             '_new_function': self._new_function,
@@ -149,6 +150,23 @@ class DecoratorsTest(TestCase):
                          ['The function "test.new_function" is using its deprecated '
                           'version and will expire in version "Beryllium".'])
 
+    def test_with_deprecated_notfound_in_pillar(self):
+        '''
+        Test with_deprecated should raise an exception, if a same name
+        function with the "_" prefix not implemented.
+
+        :return:
+        '''
+        del self.globs['_new_function']
+        self.globs['__pillar__']['use_deprecated'] = ['test.new_function']
+        depr = decorators.with_deprecated(self.globs, "Beryllium")
+        depr._curr_version = self._mk_version("Helium")[1]
+        with self.assertRaises(CommandExecutionError):
+            depr(self.new_function)()
+        self.assertEqual(self.messages,
+                         ['The function "test.new_function" is using its deprecated '
+                          'version and will expire in version "Beryllium".'])
+
     def test_with_deprecated_found(self):
         '''
         Test with_deprecated should not raise an exception, if a same name
@@ -166,6 +184,23 @@ class DecoratorsTest(TestCase):
                    'and will expire in version "Beryllium".']
         self.assertEqual(self.messages, log_msg)
 
+    def test_with_deprecated_found_in_pillar(self):
+        '''
+        Test with_deprecated should not raise an exception, if a same name
+        function with the "_" prefix is implemented, but should use
+        an old version instead, if "use_deprecated" is requested.
+
+        :return:
+        '''
+        self.globs['__pillar__']['use_deprecated'] = ['test.new_function']
+        self.globs['_new_function'] = self.old_function
+        depr = decorators.with_deprecated(self.globs, "Beryllium")
+        depr._curr_version = self._mk_version("Helium")[1]
+        self.assertEqual(depr(self.new_function)(), self.old_function())
+        log_msg = ['The function "test.new_function" is using its deprecated version '
+                   'and will expire in version "Beryllium".']
+        self.assertEqual(self.messages, log_msg)
+
     def test_with_deprecated_found_eol(self):
         '''
         Test with_deprecated should raise an exception, if a same name
@@ -175,6 +210,25 @@ class DecoratorsTest(TestCase):
         :return:
         '''
         self.globs['__opts__']['use_deprecated'] = ['test.new_function']
+        self.globs['_new_function'] = self.old_function
+        depr = decorators.with_deprecated(self.globs, "Helium")
+        depr._curr_version = self._mk_version("Beryllium")[1]
+        with self.assertRaises(CommandExecutionError):
+            depr(self.new_function)()
+        self.assertEqual(self.messages,
+                         ['Although function "new_function" is called, an alias "new_function" '
+                          'is configured as its deprecated version. The lifetime of the function '
+                          '"new_function" expired. Please use its successor "new_function" instead.'])
+
+    def test_with_deprecated_found_eol_in_pillar(self):
+        '''
+        Test with_deprecated should raise an exception, if a same name
+        function with the "_" prefix is implemented, "use_deprecated" is requested
+        and EOL is reached.
+
+        :return:
+        '''
+        self.globs['__pillar__']['use_deprecated'] = ['test.new_function']
         self.globs['_new_function'] = self.old_function
         depr = decorators.with_deprecated(self.globs, "Helium")
         depr._curr_version = self._mk_version("Beryllium")[1]
@@ -260,6 +314,19 @@ class DecoratorsTest(TestCase):
         assert depr(self.new_function)() == self.new_function()
         assert not self.messages
 
+    def test_with_deprecated_opt_in_use_superseded_in_pillar(self):
+        '''
+        Test with_deprecated using opt-in policy,
+        where newer function is used as per configuration.
+
+        :return:
+        '''
+        self.globs['__pillar__']['use_superseded'] = ['test.new_function']
+        depr = decorators.with_deprecated(self.globs, "Beryllium", policy=decorators._DeprecationDecorator.OPT_IN)
+        depr._curr_version = self._mk_version("Helium")[1]
+        assert depr(self.new_function)() == self.new_function()
+        assert not self.messages
+
     def test_with_deprecated_opt_in_use_superseded_and_deprecated(self):
         '''
         Test with_deprecated misconfiguration.
@@ -268,6 +335,19 @@ class DecoratorsTest(TestCase):
         '''
         self.globs['__opts__']['use_deprecated'] = ['test.new_function']
         self.globs['__opts__']['use_superseded'] = ['test.new_function']
+        depr = decorators.with_deprecated(self.globs, "Beryllium")
+        depr._curr_version = self._mk_version("Helium")[1]
+        with self.assertRaises(SaltConfigurationError):
+            assert depr(self.new_function)() == self.new_function()
+
+    def test_with_deprecated_opt_in_use_superseded_and_deprecated_in_pillar(self):
+        '''
+        Test with_deprecated misconfiguration.
+
+        :return:
+        '''
+        self.globs['__pillar__']['use_deprecated'] = ['test.new_function']
+        self.globs['__pillar__']['use_superseded'] = ['test.new_function']
         depr = decorators.with_deprecated(self.globs, "Beryllium")
         depr._curr_version = self._mk_version("Helium")[1]
         with self.assertRaises(SaltConfigurationError):


### PR DESCRIPTION
### What does this PR do?
Updating the superseded and deprecated decorators to work when specified as pillar values.

### What issues does this PR fix or reference?
#42514 

### Previous Behavior
Previously the list of functions for use_superseded and use_deprecated were specified in minion configuration.

### New Behavior
Specify the list of functions for use_superseded and use_deprecated as pillar values.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
