### PR TITLE
Add runas_passwd as a global for states

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -519,7 +519,8 @@ runas
 
 .. versionadded:: 2017.7.0
 
-The ``runas`` global option is used to set the user which will be used to run the command in the ``cmd.run`` module.
+The ``runas`` global option is used to set the user which will be used to run
+the command in the ``cmd.run`` module.
 
 .. code-block:: yaml
 
@@ -531,6 +532,26 @@ The ``runas`` global option is used to set the user which will be used to run th
           - pkg: python-pip
 
 In the above state, the pip command run by ``cmd.run`` will be run by the daniel user.
+
+runas_passwd
+~~~~~~~~~~~~
+
+.. versionadded:: 2017.7.2
+
+The ``runas_passwd`` global option is used to set the password used by the runas
+global option. This is required by ``cmd.run`` on Windows when ``runas`` is
+specified. It will be set when ``password`` is defined in the state.
+
+.. code-block:: yaml
+
+    run_script:
+      cmd.run:
+        - name: Powershell -NonInteractive -ExecutionPolicy Bypass -File C:\\Temp\\script.ps1
+        - runas: frank
+        - password: supersecret
+
+In the above state, the Powershell script run by ``cmd.run`` will be run by the
+frank user with the password ``supersecret``.
 
 .. _requisites-require-in:
 .. _requisites-watch-in:

--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -533,8 +533,8 @@ the command in the ``cmd.run`` module.
 
 In the above state, the pip command run by ``cmd.run`` will be run by the daniel user.
 
-runas_passwd
-~~~~~~~~~~~~
+runas_password
+~~~~~~~~~~~~~~
 
 .. versionadded:: 2017.7.2
 

--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -538,9 +538,9 @@ runas_passwd
 
 .. versionadded:: 2017.7.2
 
-The ``runas_passwd`` global option is used to set the password used by the runas
-global option. This is required by ``cmd.run`` on Windows when ``runas`` is
-specified. It will be set when ``password`` is defined in the state.
+The ``runas_password`` global option is used to set the password used by the
+runas global option. This is required by ``cmd.run`` on Windows when ``runas``
+is specified. It will be set when ``runas_password`` is defined in the state.
 
 .. code-block:: yaml
 
@@ -548,7 +548,7 @@ specified. It will be set when ``password`` is defined in the state.
       cmd.run:
         - name: Powershell -NonInteractive -ExecutionPolicy Bypass -File C:\\Temp\\script.ps1
         - runas: frank
-        - password: supersecret
+        - runas_password: supersecret
 
 In the above state, the Powershell script run by ``cmd.run`` will be run by the
 frank user with the password ``supersecret``.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -294,6 +294,9 @@ def _run(cmd,
     if runas is None and '__context__' in globals():
         runas = __context__.get('runas')
 
+    if password is None and '__context__' in globals():
+        password = __context__.get('runas_passwd')
+
     # Set the default working directory to the home directory of the user
     # salt-minion is running as. Defaults to home directory of user under which
     # the minion is running.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -295,7 +295,7 @@ def _run(cmd,
         runas = __context__.get('runas')
 
     if password is None and '__context__' in globals():
-        password = __context__.get('runas_passwd')
+        password = __context__.get('runas_password')
 
     # Set the default working directory to the home directory of the user
     # salt-minion is running as. Defaults to home directory of user under which

--- a/salt/state.py
+++ b/salt/state.py
@@ -1751,6 +1751,7 @@ class State(object):
             ret = {'result': False, 'name': low['name'], 'changes': {}}
 
         self.state_con['runas'] = low.get('runas', None)
+        self.state_con['runas_passwd'] = low.get('runas_passwd', None)
 
         if not low.get('__prereq__'):
             log.info(

--- a/salt/state.py
+++ b/salt/state.py
@@ -97,6 +97,7 @@ STATE_RUNTIME_KEYWORDS = frozenset([
     'reload_grains',
     'reload_pillar',
     'runas',
+    'runas_password',
     'fire_event',
     'saltenv',
     'use',
@@ -1751,7 +1752,7 @@ class State(object):
             ret = {'result': False, 'name': low['name'], 'changes': {}}
 
         self.state_con['runas'] = low.get('runas', None)
-        self.state_con['runas_passwd'] = low.get('runas_passwd', None)
+        self.state_con['runas_password'] = low.get('runas_password', None)
 
         if not low.get('__prereq__'):
             log.info(

--- a/salt/state.py
+++ b/salt/state.py
@@ -1866,6 +1866,9 @@ class State(object):
                 sys.modules[self.states[cdata['full']].__module__].__opts__[
                     'test'] = test
 
+            self.state_con.pop('runas')
+            self.state_con.pop('runas_password')
+
         # If format_call got any warnings, let's show them to the user
         if 'warnings' in cdata:
             ret.setdefault('warnings', []).extend(cdata['warnings'])

--- a/salt/state.py
+++ b/salt/state.py
@@ -1752,7 +1752,11 @@ class State(object):
             ret = {'result': False, 'name': low['name'], 'changes': {}}
 
         self.state_con['runas'] = low.get('runas', None)
-        self.state_con['runas_password'] = low.get('runas_password', None)
+
+        if low['state'] == 'cmd' and 'password' in low:
+            self.state_con['runas_password'] = low['password']
+        else:
+            self.state_con['runas_password'] = low.get('runas_password', None)
 
         if not low.get('__prereq__'):
             log.info(

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -839,6 +839,7 @@ def run(name,
             'Neon',
             'The legacy password argument is deprecated. Use runas_password'
             'instead. This warning will be removed in Salt Neon')
+
     if runas is not None:
         __context__['runas'] = runas
     if runas_password is not None:
@@ -1089,6 +1090,7 @@ def script(name,
             'Neon',
             'The legacy password argument is deprecated. Use runas_password'
             'instead. This warning will be removed in Salt Neon')
+
     if runas is not None:
         __context__['runas'] = runas
     if runas_password is not None:
@@ -1212,8 +1214,29 @@ def call(name,
            'result': False,
            'comment': ''}
 
+    if 'user' in kwargs or 'group' in kwargs:
+        salt.utils.warn_until(
+            'Oxygen',
+            'The legacy user/group arguments are deprecated. '
+            'Replace them with runas. '
+            'These arguments will be removed in Salt Oxygen.'
+        )
+        if 'user' in kwargs and kwargs['user'] is not None and runas is None:
+            runas = kwargs.pop('user')
+
+    if 'password' in kwargs:
+        runas_password = kwargs.pop('password')
+        salt.utils.warn_until(
+            'Neon',
+            'The legacy password argument is deprecated. Use runas_password'
+            'instead. This warning will be removed in Salt Neon')
+
+    if runas is not None:
+        __context__['runas'] = runas
+    if runas_password is not None:
+        __context__['runas_password'] = runas_password
+
     cmd_kwargs = {'cwd': kwargs.get('cwd'),
-                  'runas': kwargs.get('user'),
                   'shell': kwargs.get('shell') or __grains__['shell'],
                   'env': kwargs.get('env'),
                   'use_vt': use_vt,

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -654,7 +654,6 @@ def run(name,
         creates=None,
         cwd=None,
         runas=None,
-        runas_password=None,
         shell=None,
         env=None,
         stateful=False,
@@ -687,9 +686,6 @@ def run(name,
 
     runas
         The user name to run the command as
-
-    runas_password
-        The password of the user specified in runas. Required for Windows
 
     shell
         The shell to use for execution, defaults to the shell grain
@@ -833,20 +829,9 @@ def run(name,
         if 'user' in kwargs and kwargs['user'] is not None and runas is None:
             runas = kwargs.pop('user')
 
-    if 'password' in kwargs:
-        runas_password = kwargs.pop('password')
-        salt.utils.warn_until(
-            'Neon',
-            'The legacy password argument is deprecated. Use runas_password'
-            'instead. This warning will be removed in Salt Neon')
-
-    if runas is not None:
-        __context__['runas'] = runas
-    if runas_password is not None:
-        __context__['runas_password'] = runas_password
-
     cmd_kwargs = copy.deepcopy(kwargs)
     cmd_kwargs.update({'cwd': cwd,
+                       'runas': runas,
                        'use_vt': use_vt,
                        'shell': shell or __grains__['shell'],
                        'env': env,
@@ -906,7 +891,6 @@ def script(name,
            creates=None,
            cwd=None,
            runas=None,
-           runas_password=None,
            shell=None,
            env=None,
            stateful=False,
@@ -948,9 +932,6 @@ def script(name,
 
     runas
         The name of the user to run the command as
-
-    runas_password
-        The password of the user specified in runas. Required for Windows
 
     shell
         The shell to use for execution. The default is set in grains['shell']
@@ -1084,20 +1065,9 @@ def script(name,
         if 'user' in kwargs and kwargs['user'] is not None and runas is None:
             runas = kwargs.pop('user')
 
-    if 'password' in kwargs:
-        runas_password = kwargs.pop('password')
-        salt.utils.warn_until(
-            'Neon',
-            'The legacy password argument is deprecated. Use runas_password'
-            'instead. This warning will be removed in Salt Neon')
-
-    if runas is not None:
-        __context__['runas'] = runas
-    if runas_password is not None:
-        __context__['runas_password'] = runas_password
-
     cmd_kwargs = copy.deepcopy(kwargs)
-    cmd_kwargs.update({'shell': shell or __grains__['shell'],
+    cmd_kwargs.update({'runas': runas,
+                       'shell': shell or __grains__['shell'],
                        'env': env,
                        'onlyif': onlyif,
                        'unless': unless,
@@ -1112,6 +1082,7 @@ def script(name,
 
     run_check_cmd_kwargs = {
         'cwd': cwd,
+        'runas': runas,
         'shell': shell or __grains__['shell']
     }
 
@@ -1214,29 +1185,8 @@ def call(name,
            'result': False,
            'comment': ''}
 
-    if 'user' in kwargs or 'group' in kwargs:
-        salt.utils.warn_until(
-            'Oxygen',
-            'The legacy user/group arguments are deprecated. '
-            'Replace them with runas. '
-            'These arguments will be removed in Salt Oxygen.'
-        )
-        if 'user' in kwargs and kwargs['user'] is not None and runas is None:
-            runas = kwargs.pop('user')
-
-    if 'password' in kwargs:
-        runas_password = kwargs.pop('password')
-        salt.utils.warn_until(
-            'Neon',
-            'The legacy password argument is deprecated. Use runas_password'
-            'instead. This warning will be removed in Salt Neon')
-
-    if runas is not None:
-        __context__['runas'] = runas
-    if runas_password is not None:
-        __context__['runas_password'] = runas_password
-
     cmd_kwargs = {'cwd': kwargs.get('cwd'),
+                  'runas': kwargs.get('user'),
                   'shell': kwargs.get('shell') or __grains__['shell'],
                   'env': kwargs.get('env'),
                   'use_vt': use_vt,

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -654,6 +654,7 @@ def run(name,
         creates=None,
         cwd=None,
         runas=None,
+        runas_password=None,
         shell=None,
         env=None,
         stateful=False,
@@ -686,6 +687,9 @@ def run(name,
 
     runas
         The user name to run the command as
+
+    runas_password
+        The password of the user specified in runas. Required for Windows
 
     shell
         The shell to use for execution, defaults to the shell grain
@@ -829,9 +833,19 @@ def run(name,
         if 'user' in kwargs and kwargs['user'] is not None and runas is None:
             runas = kwargs.pop('user')
 
+    if 'password' in kwargs:
+        runas_password = kwargs.pop('password')
+        salt.utils.warn_until(
+            'Neon',
+            'The legacy password argument is deprecated. Use runas_password'
+            'instead. This warning will be removed in Salt Neon')
+    if runas is not None:
+        __context__['runas'] = runas
+    if runas_password is not None:
+        __context__['runas_password'] = runas_password
+
     cmd_kwargs = copy.deepcopy(kwargs)
     cmd_kwargs.update({'cwd': cwd,
-                       'runas': runas,
                        'use_vt': use_vt,
                        'shell': shell or __grains__['shell'],
                        'env': env,
@@ -891,6 +905,7 @@ def script(name,
            creates=None,
            cwd=None,
            runas=None,
+           runas_password=None,
            shell=None,
            env=None,
            stateful=False,
@@ -932,6 +947,9 @@ def script(name,
 
     runas
         The name of the user to run the command as
+
+    runas_password
+        The password of the user specified in runas. Required for Windows
 
     shell
         The shell to use for execution. The default is set in grains['shell']
@@ -1065,9 +1083,19 @@ def script(name,
         if 'user' in kwargs and kwargs['user'] is not None and runas is None:
             runas = kwargs.pop('user')
 
+    if 'password' in kwargs:
+        runas_password = kwargs.pop('password')
+        salt.utils.warn_until(
+            'Neon',
+            'The legacy password argument is deprecated. Use runas_password'
+            'instead. This warning will be removed in Salt Neon')
+    if runas is not None:
+        __context__['runas'] = runas
+    if runas_password is not None:
+        __context__['runas_password'] = runas_password
+
     cmd_kwargs = copy.deepcopy(kwargs)
-    cmd_kwargs.update({'runas': runas,
-                       'shell': shell or __grains__['shell'],
+    cmd_kwargs.update({'shell': shell or __grains__['shell'],
                        'env': env,
                        'onlyif': onlyif,
                        'unless': unless,
@@ -1082,7 +1110,6 @@ def script(name,
 
     run_check_cmd_kwargs = {
         'cwd': cwd,
-        'runas': runas,
         'shell': shell or __grains__['shell']
     }
 


### PR DESCRIPTION
### What does this PR do?
The following PR added `runas` as a global state variable. 

https://github.com/saltstack/salt/pull/39248

This breaks runas functionality in Windows as Windows also requires a password. This adds another global state variable named `runas_passwd`.

### What issues does this PR fix or reference?
Found while helping Charles

### Previous Behavior
Runas would fail on Windows when run from a state.

### New Behavior
Runas now works from a state

### Tests written?
No