### PR TITLE
Sync cloud modules

### DIFF
--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -38,6 +38,7 @@ def sync_all(saltenv='base', extmod_whitelist=None, extmod_blacklist=None):
     '''
     log.debug('Syncing all')
     ret = {}
+    ret['clouds'] = sync_clouds(saltenv=saltenv, extmod_whitelist=extmod_whitelist, extmod_blacklist=extmod_blacklist)
     ret['modules'] = sync_modules(saltenv=saltenv, extmod_whitelist=extmod_whitelist, extmod_blacklist=extmod_blacklist)
     ret['states'] = sync_states(saltenv=saltenv, extmod_whitelist=extmod_whitelist, extmod_blacklist=extmod_blacklist)
     ret['grains'] = sync_grains(saltenv=saltenv, extmod_whitelist=extmod_whitelist, extmod_blacklist=extmod_blacklist)


### PR DESCRIPTION
### What does this PR do?
A change was made in f7a6f3537075b965bf27114ac17554f2619050bf to add a `sync_clouds` function to `salt.runners.saltutil`, but no call to that function was added to `sync_all`. This change runs `sync_clouds` when `sync_all` is run.

### What issues does this PR fix or reference?
Fixes issue #12587

## Previous Behavior
`salt.runners.sync_all` would not sync cloud plugins

### New Behavior
`salt.runners.sync_all` now syncs cloud plugins

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
