### PR TITLE
Fix unicode constructor in custom YAML loader

### DIFF
--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -45,9 +45,9 @@ class SaltYamlSafeLoader(yaml.SafeLoader, object):
             self.add_constructor(
                 u'tag:yaml.org,2002:omap',
                 type(self).construct_yaml_map)
-            self.add_constructor(
-                u'tag:yaml.org,2002:python/unicode',
-                type(self).construct_unicode)
+        self.add_constructor(
+            u'tag:yaml.org,2002:python/unicode',
+            type(self).construct_unicode)
         self.dictclass = dictclass
 
     def construct_yaml_map(self, node):


### PR DESCRIPTION
2e7f743 added this in the wrong place, it should not have been added
within the if block since we will _always_ want this constructor
available.