### PR TITLE
Correctly detect Solaris operating systems in Salt 2016.11.x

### DIFF
--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -27,7 +27,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris
     '''
-    if __grains__['os'] == 'Solaris':
+    if __grains__['os_family'] == 'Solaris':
         return __virtualname__
     return (False, 'The pkgutil execution module cannot be loaded: '
             'only available on Solaris systems.')

--- a/salt/modules/solarisips.py
+++ b/salt/modules/solarisips.py
@@ -56,7 +56,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris 11
     '''
-    if __grains__['os'] == 'Solaris' \
+    if __grains__['os_family'] == 'Solaris' \
             and float(__grains__['kernelrelease']) > 5.10 \
             and salt.utils.which('pkg'):
         return __virtualname__

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -30,7 +30,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris
     '''
-    if __grains__['os'] == 'Solaris' and float(__grains__['kernelrelease']) <= 5.10:
+    if __grains__['os_family'] == 'Solaris' and float(__grains__['kernelrelease']) <= 5.10:
         return __virtualname__
     return (False,
             'The solarispkg execution module failed to load: only available '

--- a/salt/modules/zoneadm.py
+++ b/salt/modules/zoneadm.py
@@ -62,7 +62,7 @@ def __virtual__():
     Solaris 10, OmniOS, OpenIndiana, OpenSolaris, or Smartos.
     '''
     if _is_globalzone() and salt.utils.which('zoneadm'):
-        if __grains__['os_family'] == 'Solaris':
+        if __grains__['os'] in ['Oracle Solaris', 'OpenSolaris', 'SmartOS', 'OmniOS', 'OpenIndiana']:
             return __virtualname__
 
     return (

--- a/salt/modules/zoneadm.py
+++ b/salt/modules/zoneadm.py
@@ -62,9 +62,10 @@ def __virtual__():
     Solaris 10, OmniOS, OpenIndiana, OpenSolaris, or Smartos.
     '''
     if _is_globalzone() and salt.utils.which('zoneadm'):
-        if __grains__['os'] in ['Oracle Solaris', 'OpenSolaris', 'SmartOS', 'OmniOS', 'OpenIndiana']:
+        if __grains__['os'] in ['OpenSolaris', 'SmartOS', 'OmniOS', 'OpenIndiana']:
             return __virtualname__
-
+        elif __grains__['os'] == 'Oracle Solaris' and int(__grains__['osmajorrelease']) == 10:
+            return __virtualname__
     return (
         False,
         '{0} module can only be loaded in a solaris globalzone.'.format(

--- a/salt/modules/zoneadm.py
+++ b/salt/modules/zoneadm.py
@@ -61,9 +61,8 @@ def __virtual__():
     We are available if we are have zoneadm and are the global zone on
     Solaris 10, OmniOS, OpenIndiana, OpenSolaris, or Smartos.
     '''
-    ## note: we depend on PR#37472 to distinguish between Solaris and Oracle Solaris
     if _is_globalzone() and salt.utils.which('zoneadm'):
-        if __grains__['os'] in ['Solaris', 'OpenSolaris', 'SmartOS', 'OmniOS', 'OpenIndiana']:
+        if __grains__['os_family'] == 'Solaris':
             return __virtualname__
 
     return (

--- a/salt/modules/zonecfg.py
+++ b/salt/modules/zonecfg.py
@@ -98,7 +98,7 @@ def __virtual__():
     Solaris 10, OmniOS, OpenIndiana, OpenSolaris, or Smartos.
     '''
     if _is_globalzone() and salt.utils.which('zonecfg'):
-        if __grains__['os_family'] == 'Solaris':
+        if __grains__['os'] in ['Oracle Solaris', 'OpenSolaris', 'SmartOS', 'OmniOS', 'OpenIndiana']:
             return __virtualname__
 
     return (

--- a/salt/modules/zonecfg.py
+++ b/salt/modules/zonecfg.py
@@ -98,9 +98,10 @@ def __virtual__():
     Solaris 10, OmniOS, OpenIndiana, OpenSolaris, or Smartos.
     '''
     if _is_globalzone() and salt.utils.which('zonecfg'):
-        if __grains__['os'] in ['Oracle Solaris', 'OpenSolaris', 'SmartOS', 'OmniOS', 'OpenIndiana']:
+        if __grains__['os'] in ['OpenSolaris', 'SmartOS', 'OmniOS', 'OpenIndiana']:
             return __virtualname__
-
+        elif __grains__['os'] == 'Oracle Solaris' and int(__grains__['osmajorrelease']) == 10:
+            return __virtualname__
     return (
         False,
         '{0} module can only be loaded in a solaris globalzone.'.format(

--- a/salt/modules/zonecfg.py
+++ b/salt/modules/zonecfg.py
@@ -97,9 +97,8 @@ def __virtual__():
     We are available if we are have zonecfg and are the global zone on
     Solaris 10, OmniOS, OpenIndiana, OpenSolaris, or Smartos.
     '''
-    # note: we depend on PR#37472 to distinguish between Solaris and Oracle Solaris
     if _is_globalzone() and salt.utils.which('zonecfg'):
-        if __grains__['os'] in ['Solaris', 'OpenSolaris', 'SmartOS', 'OmniOS', 'OpenIndiana']:
+        if __grains__['os_family'] == 'Solaris':
             return __virtualname__
 
     return (


### PR DESCRIPTION
### What does this PR do?
Switches references from
 `__grains__['os'] == 'Solaris'` to `__grains__['os_family'] == 'Solaris'`

This includes refernces in the zoneadm/zonecfg modules that looked for a list of different solaris distributions in `__grains__['os']` but did not include the new (as of 2016.11.2) 'Oracle Solaris' os grain for Solaris proper.

### What issues does this PR fix or reference?
Fixes #39461

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
