### PR TITLE
Allow zabbix module to call api from any host, not just the zabbix server

### DIFF
--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -43,12 +43,7 @@ __virtualname__ = 'zabbix'
 
 
 def __virtual__():
-    '''
-    Only load the module if Zabbix server is installed
-    '''
-    if salt.utils.which('zabbix_server'):
-        return __virtualname__
-    return (False, 'The zabbix execution module cannot be loaded: zabbix not installed.')
+    return __virtualname__
 
 
 def _frontend_url():


### PR DESCRIPTION
### What does this PR do?
Previously the zabbix module would only run from the zabbix server. But since it only calls the zabbix api, this restriction is not needed.

### What issues does this PR fix or reference?
#42467

### Previous Behavior
Zabbix module only ran on a host with the zabbix_server binary

### New Behavior
Zabbix module now loads from any host

### Tests written?
No