### PR TITLE
Add clarification on how to participate once in the Contributors team

### DIFF
--- a/doc/topics/development/conventions/formulas.rst
+++ b/doc/topics/development/conventions/formulas.rst
@@ -214,18 +214,34 @@ Writing Formulas
 Each Formula is a separate repository in the `saltstack-formulas`_ organization
 on GitHub.
 
-.. note:: Get involved creating new Formulas
+Get involved creating new Formulas
+----------------------------------
 
-    The best way to create new Formula repositories for now is to create a
-    repository in your own account on GitHub and notify a SaltStack employee
-    when it is ready. We will add you to the contributors team on the
-    `saltstack-formulas`_ organization and help you transfer the repository
-    over. Ping a SaltStack employee on IRC (``#salt`` on Freenode) or send an
-    email to the `salt-users`_ mailing list.
+The best way to create new Formula repositories for now is to create a
+repository in your own account on GitHub and notify a SaltStack employee when
+it is ready. We will add you to the Contributors team on the
+`saltstack-formulas`_ organization and help you transfer the repository over.
+Ping a SaltStack employee on IRC (``#salt`` on Freenode) or send an email to
+the `salt-users`_ mailing list.
 
-    There are a lot of repositories in that organization! Team members can
-    manage which repositories they are subscribed to on GitHub's watching page:
-    https://github.com/watching.
+There are a lot of repositories in that organization! Team members can manage
+which repositories they are subscribed to on GitHub's watching page:
+https://github.com/watching.
+
+Members of the Contributors team are welcome to participate in reviewing pull
+requests across the Organization. Some repositories will have regular
+contributors and some repositories will not. As you get involved in a
+repository be sure to communicate with any other contributors there on pull
+requests that are large or have breaking changes.
+
+In general it is best to have another Contributor review and merge any pull
+requests that you open. Feel free to `at-mention`__ other regular contributors
+to a repository and request a review. However, there are a lot of formula
+repositories so if a repository does not yet have regular contributors or if
+your pull request has stayed open for more than a couple days feel free to
+"selfie-merge" your own pull request.
+
+__: https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-users-and-teams
 
 Style
 -----


### PR DESCRIPTION
The intent here is to make an implicit rule the community had been
practicing into an explicit one that can be linked/referenced.