### PR TITLE
Fix loader.py's raw_mod() to look in all module dirs

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -270,7 +270,7 @@ def raw_mod(opts, name, functions, mod='modules'):
         testmod['test.ping']()
     '''
     loader = LazyLoader(
-        _module_dirs(opts, mod, 'rawmodule'),
+        _module_dirs(opts, mod, 'module'),
         opts,
         tag='rawmodule',
         virtual_enable=False,


### PR DESCRIPTION
### What does this PR do?

Previously, it wasn't looking in module dirs defined via
the `module_dirs` config option. Fix this issue.

### Tests written?

No