### PR TITLE
Disable ZFS in the core grain for NetBSD

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2351,6 +2351,10 @@ def _zpool_data(grains):
     if salt.utils.is_windows() or 'proxyminion' in __opts__:
         return {}
 
+    # quickly return if NetBSD (ZFS still under development)
+    if salt.utils.is_netbsd():
+        return {}
+
     # quickly return if no zpool and zfs command
     if not salt.utils.which('zpool'):
         return {}


### PR DESCRIPTION
### What does this PR do?

Skip ZFS commands in the core grain for NetBSD.

### What issues does this PR fix or reference?

ZFS on NetBSD is not considered stable but because the zpool command is present the core grain attempts to retrieve zpool data. When the command is run it triggers debug messages on the console and there is a possibility of undefined behavior if any kernel modules get dynamically loaded. This PR skips the zpool commands for NetBSD, to be re-enabled once the ZFS port is considered stable.

### Previous Behavior
Core grain on NetBSD triggers ZFS development messages.

### New Behavior
Core grain on NetBSD skips collecting zpool info.

### Tests written?
No