### PR TITLE
Reenable cpstats for rest_cherrypy

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -467,8 +467,10 @@ import signal
 import tarfile
 from multiprocessing import Process, Pipe
 
+logger = logging.getLogger(__name__)
+
 # Import third-party libs
-# pylint: disable=import-error, 3rd-party-module-not-gated
+# pylint: disable=import-error
 import cherrypy
 try:
     from cherrypy.lib import cpstats
@@ -480,8 +482,7 @@ except ImportError:
 
 import yaml
 import salt.ext.six as six
-# pylint: enable=import-error, 3rd-party-module-not-gated
-
+# pylint: enable=import-error
 
 # Import Salt libs
 import salt
@@ -490,8 +491,6 @@ import salt.utils.event
 
 # Import salt-api libs
 import salt.netapi
-
-logger = logging.getLogger(__name__)
 
 # Imports related to websocket
 try:


### PR DESCRIPTION
### What does this PR do?

Fixes the `/stats` endpoint. Follow-up to #33806. The import needs to be available at module-parse-time in order to fully enable the tool.