### PR TITLE
Added basic lazy loading for call list_repo_pkgs in yumpkg.install method

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1066,6 +1066,18 @@ def clean_metadata(**kwargs):
     return refresh_db(**kwargs)
 
 
+class AvailablePackages(object):
+    def __init__(self, *args, **kwargs):
+        self._args = args
+        self._kwargs = kwargs
+        self._available_data = None
+
+    def get(self, *args, **kwargs):
+        if not self._available_data:
+            self._available_data = list_repo_pkgs(*self._args, **self._kwargs)
+        return self._available_data.get(*args, **kwargs)
+
+
 def install(name=None,
             refresh=False,
             skip_verify=False,
@@ -1279,7 +1291,7 @@ def install(name=None,
                     has_comparison.append(pkgname)
             except (TypeError, ValueError):
                 continue
-        _available = list_repo_pkgs(
+        _available = AvailablePackages(
             *has_wildcards + has_comparison,
             byrepo=False,
             **kwargs)


### PR DESCRIPTION
### What does this PR do?

Currently each use of yumpkg.install cause one call to list_repo_pkgs().
Depending on yum repository size and parameters, this call can take considerable amount of time (in my case almost 70% of time was consumed by list_repo_pkgs()).
Result is used only in wildcards handling, so this lazy load ensures that call is executed only when needed.


### What issues does this PR fix or reference?

### Previous Behavior
list_repo_pkgs() called on each yumpkg.install

### New Behavior
list_repo_pkgs() called only when wildcards passed to yumpkg.install

### Tests written?

No

