### PR TITLE
 [2016.11] Fixes to augeas module

### DIFF
--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -199,7 +199,7 @@ def execute(context=None, lens=None, commands=(), load_path=None):
             method = METHOD_MAP[cmd]
             nargs = arg_map[method]
 
-            parts = salt.utils.shlex_split(arg)
+            parts = salt.utils.shlex_split(arg, posix=False)
 
             if len(parts) not in nargs:
                 err = '{0} takes {1} args: {2}'.format(method, nargs, parts)


### PR DESCRIPTION
### What does this PR do?
Updating the call to shlex_split to pass the posix=False argument so that quotes are preserved.

### What issues does this PR fix or reference?
#42642 

### Previous Behavior
If a change was passed to the augeas state, any quotes that were in the command were removed by the shlex_split function, causing the change to fail.

### New Behavior
Adds the posix=False flag to preserve quotes in commands.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
