### PR TITLE
Add multiprocessing option for NAPALM proxy

### DIFF
--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -67,6 +67,17 @@ provider: ``napalm_base``
 
     .. versionadded:: 2017.7.1
 
+multiprocessing: ``False``
+    Overrides the :conf_minion:`multiprocessing` option, per proxy minion.
+    The ``multiprocessing`` option must be turned off for SSH-based proxies.
+    However, some NAPALM drivers (e.g. Arista, NX-OS) are not SSH-based.
+    As multiple proxy minions may share the same configuration file,
+    this option permits the configuration of the ``multiprocessing`` option
+    more specifically, for some proxy minions.
+
+    .. versionadded:: 2017.7.1
+
+
 .. _`NAPALM Read the Docs page`: https://napalm.readthedocs.io/en/latest/#supported-network-operating-systems
 .. _`optional arguments`: http://napalm.readthedocs.io/en/latest/support/index.html#list-of-supported-optional-arguments
 

--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -75,7 +75,7 @@ multiprocessing: ``False``
     this option permits the configuration of the ``multiprocessing`` option
     more specifically, for some proxy minions.
 
-    .. versionadded:: 2017.7.1
+    .. versionadded:: 2017.7.2
 
 
 .. _`NAPALM Read the Docs page`: https://napalm.readthedocs.io/en/latest/#supported-network-operating-systems

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -243,6 +243,11 @@ def get_device_opts(opts, salt_obj=None):
     network_device = {}
     # by default, look in the proxy config details
     device_dict = opts.get('proxy', {}) or opts.get('napalm', {})
+    if opts.get('proxy') or opts.get('napalm'):
+        opts['multiprocessing'] = device_dict.get('multiprocessing', False)
+        # Most NAPALM drivers are SSH-based, so multiprocessing should default to False.
+        # But the user can be allows to have a different value for the multiprocessing, which will
+        #   override the opts.
     if salt_obj and not device_dict:
         # get the connection details from the opts
         device_dict = salt_obj['config.merge']('napalm')


### PR DESCRIPTION
Overrides the :conf_minion:`multiprocessing` option, per proxy minion.
The ``multiprocessing`` option must be turned off for SSH-based proxies.
However, some NAPALM drivers (e.g. Arista, NX-OS) are not SSH-based.
As multiple proxy minions may share the same configuration file,
this option permits the configuration of the ``multiprocessing`` option
more specifically, for some proxy minions.
Additionally, this helps to default the option to False,
in case the user does not configure it explicitly in the proxy config file.