### PR TITLE
Fix RabbitMQ tags not properly set.

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -472,11 +472,11 @@ def set_user_tags(name, tags, runas=None):
     if runas is None:
         runas = salt.utils.get_user()
 
-    if tags and isinstance(tags, (list, tuple)):
-        tags = ' '.join(tags)
+    if not isinstance(tags, (list, tuple)):
+        tags = [tags]
 
-    res = __salt__['cmd.run'](
-        ['rabbitmqctl', 'set_user_tags', name, tags],
+    res = __salt__['cmd.run_all'](
+        ['rabbitmqctl', 'set_user_tags', name] + tags,
         runas=runas,
         python_shell=False)
     msg = "Tag(s) set"


### PR DESCRIPTION
### What does this PR do?
Fixes an issue when setting multiple tags to a RabbitMQ user. See issue #42686.  

### What issues does this PR fix or reference?
Fixes #42686

### Previous Behavior
`salt 'mymqnode' rabbitmq.set_user_tags 'my_user' tags='["tag1", "tag2"]'` used to set tag `tag1 tag2` to `my_user`.

### New Behavior
`salt 'mymqnode' rabbitmq.set_user_tags 'my_user' tags='["tag1", "tag2"]'` sets `tag1` and `tag2` to `my_user`.

### Tests written?

No, but we should probably write some. There are currently no tests over AMQP tags (AFAICS), but provided it didn't work, it would probably be a good idea.
