### PR TITLE
boto_efs_fix_tags: Fix #42688 invalid type for parameter tags

### DIFF
--- a/salt/modules/boto_efs.py
+++ b/salt/modules/boto_efs.py
@@ -158,7 +158,7 @@ def create_file_system(name,
     import os
     import base64
     creation_token = base64.b64encode(os.urandom(46), ['-', '_'])
-    tags = {"Key": "Name", "Value": name}
+    tags = [{"Key": "Name", "Value": name}]
 
     client = _get_conn(key=key, keyid=keyid, profile=profile, region=region)
 


### PR DESCRIPTION
Change-Id: Ibab5417074b1ac98ee025c421d04674070745edf

### What does this PR do?

Enables boto_efs.create_file_system to work without failure when it sends tags to create_tags

### What issues does this PR fix or reference?

#42688

### Previous Behavior

ID: setup-efs
Function: module.run
Name: boto_efs.create_file_system
Result: False
Comment: Module function boto_efs.create_file_system threw an exception. Exception: Parameter validation failed:
Invalid type for parameter Tags, value: {'Value': 'andytest', 'Key': 'Name'}, type: <type 'dict'>, valid types: <type 'list'>, <type 'tuple'>
Started: 21:33:07.938366
Duration: 385.241 ms
Changes:

### New Behavior
Passes

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
