### PR TITLE
Fixes error in file.absent re: missing force=true to remove a windows directory

### DIFF
--- a/salt/netapi/rest_tornado/__init__.py
+++ b/salt/netapi/rest_tornado/__init__.py
@@ -115,6 +115,7 @@ def start():
             ssl_opts.update({'keyfile': mod_opts['ssl_key']})
         kwargs['ssl_options'] = ssl_opts
 
+    import tornado.httpserver
     http_server = tornado.httpserver.HTTPServer(get_application(__opts__), **kwargs)
     try:
         http_server.bind(mod_opts['port'],

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -21,6 +21,7 @@ the jinja templating system would look like this:
         - user: root
         - group: root
         - mode: 644
+        - attrs: ai
         - template: jinja
         - defaults:
             custom_var: "default value"
@@ -74,6 +75,7 @@ salt fileserver. Here's an example:
         - user: foo
         - group: users
         - mode: 644
+        - attrs: i
         - backup: minion
 
 .. note::
@@ -94,6 +96,7 @@ In this example ``foo.conf`` in the ``dev`` environment will be used instead.
         - user: foo
         - group: users
         - mode: '0644'
+        - attrs: i
 
 .. warning::
 
@@ -317,7 +320,7 @@ def _load_accumulators():
         serial = salt.payload.Serial(__opts__)
         ret = {'accumulators': {}, 'accumulators_deps': {}}
         try:
-            with salt.utils.fopen(path, 'rb') as f:
+            with salt.utils.files.fopen(path, 'rb') as f:
                 loaded = serial.load(f)
                 return loaded if loaded else ret
         except (IOError, NameError):
@@ -335,7 +338,7 @@ def _persist_accummulators(accumulators, accumulators_deps):
 
     serial = salt.payload.Serial(__opts__)
     try:
-        with salt.utils.fopen(_get_accumulator_filepath(), 'w+b') as f:
+        with salt.utils.files.fopen(_get_accumulator_filepath(), 'w+b') as f:
             serial.dump(accumm_data, f)
     except NameError:
         # msgpack error from salt-ssh
@@ -1062,7 +1065,7 @@ def _get_template_texts(source_list=None,
         log.debug(msg.format(rndrd_templ_fn, source))
         if rndrd_templ_fn:
             tmplines = None
-            with salt.utils.fopen(rndrd_templ_fn, 'rb') as fp_:
+            with salt.utils.files.fopen(rndrd_templ_fn, 'rb') as fp_:
                 tmplines = fp_.read()
                 if six.PY3:
                     tmplines = tmplines.decode(__salt_system_encoding__)
@@ -1433,7 +1436,10 @@ def absent(name):
             ret['comment'] = 'File {0} is set for removal'.format(name)
             return ret
         try:
-            __salt__['file.remove'](name)
+            if salt.utils.is_windows():
+                __salt__['file.remove'](name, force=True)
+            else:
+                __salt__['file.remove'](name)
             ret['comment'] = 'Removed file {0}'.format(name)
             ret['changes']['removed'] = name
             return ret
@@ -1447,7 +1453,10 @@ def absent(name):
             ret['comment'] = 'Directory {0} is set for removal'.format(name)
             return ret
         try:
-            __salt__['file.remove'](name)
+            if salt.utils.is_windows():
+                __salt__['file.remove'](name, force=True)
+            else:
+                __salt__['file.remove'](name)
             ret['comment'] = 'Removed directory {0}'.format(name)
             ret['changes']['removed'] = name
             return ret
@@ -1515,6 +1524,7 @@ def managed(name,
             user=None,
             group=None,
             mode=None,
+            attrs=None,
             template=None,
             makedirs=False,
             dir_mode=None,
@@ -1742,6 +1752,16 @@ def managed(name,
             unable to stat the file as it exists on the fileserver and thus
             cannot mirror the mode on the salt-ssh minion
 
+    attrs
+        The attributes to have on this file, e.g. ``a``, ``i``. The attributes
+        can be any or a combination of the following characters:
+        ``acdijstuADST``.
+
+        .. note::
+            This option is **not** supported on Windows.
+
+        .. versionadded: Oxygen
+
     template
         If this setting is applied, the named templating engine will be used to
         render the downloaded file. The following templates are supported:
@@ -1837,6 +1857,7 @@ def managed(name,
                 - user: deployer
                 - group: deployer
                 - mode: 600
+                - attrs: a
                 - contents_pillar: userdata:deployer:id_rsa
 
         This would populate ``/home/deployer/.ssh/id_rsa`` with the contents of
@@ -1959,6 +1980,7 @@ def managed(name,
                 - user: root
                 - group: root
                 - mode: 0440
+                - attrs: i
                 - source: salt://sudoers/files/sudoers.jinja
                 - template: jinja
                 - check_cmd: /usr/sbin/visudo -c -f
@@ -2069,6 +2091,9 @@ def managed(name,
 
     if mode is not None and salt.utils.is_windows():
         return _error(ret, 'The \'mode\' option is not supported on Windows')
+
+    if attrs is not None and salt.utils.is_windows():
+        return _error(ret, 'The \'attrs\' option is not supported on Windows')
 
     try:
         keep_mode = mode.lower() == 'keep'
@@ -2267,11 +2292,11 @@ def managed(name,
         # Check and set the permissions if necessary
         if salt.utils.is_windows():
             ret = __salt__['file.check_perms'](
-                name, ret, win_owner, win_perms, win_deny_perms,
+                name, ret, win_owner, win_perms, win_deny_perms, None,
                 win_inheritance)
         else:
             ret, _ = __salt__['file.check_perms'](
-                name, ret, user, group, mode, follow_symlinks)
+                name, ret, user, group, mode, attrs, follow_symlinks)
         if __opts__['test']:
             ret['comment'] = 'File {0} not updated'.format(name)
         elif not ret['changes'] and ret['result']:
@@ -2296,6 +2321,7 @@ def managed(name,
                     user,
                     group,
                     mode,
+                    attrs,
                     template,
                     context,
                     defaults,
@@ -2308,7 +2334,7 @@ def managed(name,
 
                 if salt.utils.is_windows():
                     ret = __salt__['file.check_perms'](
-                        name, ret, win_owner, win_perms, win_deny_perms,
+                        name, ret, win_owner, win_perms, win_deny_perms, None,
                         win_inheritance)
 
             if isinstance(ret['pchanges'], tuple):
@@ -2348,6 +2374,7 @@ def managed(name,
             user,
             group,
             mode,
+            attrs,
             __env__,
             context,
             defaults,
@@ -2386,6 +2413,7 @@ def managed(name,
                 user,
                 group,
                 mode,
+                attrs,
                 __env__,
                 backup,
                 makedirs,
@@ -2459,6 +2487,7 @@ def managed(name,
                 user,
                 group,
                 mode,
+                attrs,
                 __env__,
                 backup,
                 makedirs,
@@ -2880,10 +2909,10 @@ def directory(name,
     if not children_only:
         if salt.utils.is_windows():
             ret = __salt__['file.check_perms'](
-                name, ret, win_owner, win_perms, win_deny_perms, win_inheritance)
+                name, ret, win_owner, win_perms, win_deny_perms, None, win_inheritance)
         else:
             ret, perms = __salt__['file.check_perms'](
-                name, ret, user, group, dir_mode, follow_symlinks)
+                name, ret, user, group, dir_mode, None, follow_symlinks)
 
     errors = []
     if recurse or clean:
@@ -2951,11 +2980,11 @@ def directory(name,
                     try:
                         if salt.utils.is_windows():
                             ret = __salt__['file.check_perms'](
-                                full, ret, win_owner, win_perms, win_deny_perms,
+                                full, ret, win_owner, win_perms, win_deny_perms, None,
                                 win_inheritance)
                         else:
                             ret, _ = __salt__['file.check_perms'](
-                                full, ret, user, group, file_mode, follow_symlinks)
+                                full, ret, user, group, file_mode, None, follow_symlinks)
                     except CommandExecutionError as exc:
                         if not exc.strerror.endswith('does not exist'):
                             errors.append(exc.strerror)
@@ -2966,11 +2995,11 @@ def directory(name,
                     try:
                         if salt.utils.is_windows():
                             ret = __salt__['file.check_perms'](
-                                full, ret, win_owner, win_perms, win_deny_perms,
+                                full, ret, win_owner, win_perms, win_deny_perms, None,
                                 win_inheritance)
                         else:
                             ret, _ = __salt__['file.check_perms'](
-                                full, ret, user, group, dir_mode, follow_symlinks)
+                                full, ret, user, group, dir_mode, None, follow_symlinks)
                     except CommandExecutionError as exc:
                         if not exc.strerror.endswith('does not exist'):
                             errors.append(exc.strerror)
@@ -3327,6 +3356,7 @@ def recurse(name,
             user=user,
             group=group,
             mode='keep' if keep_mode else file_mode,
+            attrs=None,
             template=template,
             makedirs=True,
             context=context,
@@ -3798,12 +3828,13 @@ def replace(name,
         A regular expression, to be matched using Python's
         :py:func:`~re.search`.
 
-        ..note::
+        .. note::
+
             If you need to match a literal string that contains regex special
             characters, you may want to use salt's custom Jinja filter,
             ``escape_regex``.
 
-            ..code-block:: jinja
+            .. code-block:: jinja
 
                 {{ 'http://example.com?foo=bar%20baz' | escape_regex }}
 
@@ -4294,7 +4325,7 @@ def comment(name, regex, char='#', backup='.bak'):
         ret['comment'] = 'File {0} is set to be updated'.format(name)
         ret['result'] = None
         return ret
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
@@ -4303,7 +4334,7 @@ def comment(name, regex, char='#', backup='.bak'):
     # Perform the edit
     __salt__['file.comment_line'](name, regex, char, True, backup)
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
@@ -4402,7 +4433,7 @@ def uncomment(name, regex, char='#', backup='.bak'):
         ret['result'] = None
         return ret
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
@@ -4411,7 +4442,7 @@ def uncomment(name, regex, char='#', backup='.bak'):
     # Perform the edit
     __salt__['file.comment_line'](name, regex, char, False, backup)
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
@@ -4635,7 +4666,7 @@ def append(name,
 
     text = _validate_str_list(text)
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
@@ -4686,7 +4717,7 @@ def append(name,
     else:
         ret['comment'] = 'File {0} is in correct state'.format(name)
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
@@ -4827,7 +4858,7 @@ def prepend(name,
 
     text = _validate_str_list(text)
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         slines = fp_.read()
         if six.PY3:
             slines = slines.decode(__salt_system_encoding__)
@@ -4876,7 +4907,7 @@ def prepend(name,
 
     # if header kwarg is True, use verbatim compare
     if header:
-        with salt.utils.fopen(name, 'rb') as fp_:
+        with salt.utils.files.fopen(name, 'rb') as fp_:
             # read as many lines of target file as length of user input
             contents = fp_.read()
             if six.PY3:
@@ -4897,7 +4928,7 @@ def prepend(name,
     else:
         __salt__['file.prepend'](name, *preface)
 
-    with salt.utils.fopen(name, 'rb') as fp_:
+    with salt.utils.files.fopen(name, 'rb') as fp_:
         nlines = fp_.read()
         if six.PY3:
             nlines = nlines.decode(__salt_system_encoding__)
@@ -5519,7 +5550,6 @@ def serialize(name,
               mode=None,
               backup='',
               makedirs=False,
-              show_diff=None,
               show_changes=True,
               create=True,
               merge_if_exists=False,
@@ -5591,12 +5621,6 @@ def serialize(name,
         Create parent directories for destination file.
 
         .. versionadded:: 2014.1.3
-
-    show_diff
-        DEPRECATED: Please use show_changes.
-
-        If set to ``False``, the diff will not be shown in the return data if
-        changes are made.
 
     show_changes
         Output a unified diff of the old file and the new file. If ``False``
@@ -5719,7 +5743,7 @@ def serialize(name,
                         'name': name,
                         'result': False}
 
-            with salt.utils.fopen(name, 'r') as fhr:
+            with salt.utils.files.fopen(name, 'r') as fhr:
                 existing_data = __serializers__[deserializer_name](fhr)
 
             if existing_data is not None:
@@ -5736,14 +5760,6 @@ def serialize(name,
     # Make sure that any leading zeros stripped by YAML loader are added back
     mode = salt.utils.normalize_mode(mode)
 
-    if show_diff is not None:
-        show_changes = show_diff
-        msg = (
-            'The \'show_diff\' argument to the file.serialized state has been '
-            'deprecated, please use \'show_changes\' instead.'
-        )
-        salt.utils.warn_until('Oxygen', msg)
-
     if __opts__['test']:
         ret['changes'] = __salt__['file.check_managed_changes'](
             name=name,
@@ -5753,6 +5769,7 @@ def serialize(name,
             user=user,
             group=group,
             mode=mode,
+            attrs=None,
             template=None,
             context=None,
             defaults=None,
@@ -5782,6 +5799,7 @@ def serialize(name,
                                         user=user,
                                         group=group,
                                         mode=mode,
+                                        attrs=None,
                                         saltenv=__env__,
                                         backup=backup,
                                         makedirs=makedirs,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2430,12 +2430,16 @@ def managed(name,
                 if sfn and os.path.isfile(sfn):
                     os.remove(sfn)
                 return ret
+
+            if sfn and os.path.isfile(sfn):
+                os.remove(sfn)
+
             # Since we generated a new tempfile and we are not returning here
             # lets change the original sfn to the new tempfile or else we will
             # get file not found
-            if sfn and os.path.isfile(sfn):
-                os.remove(sfn)
-                sfn = tmp_filename
+
+            sfn = tmp_filename
+
         else:
             ret = {'changes': {},
                    'comment': '',

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2465,7 +2465,6 @@ def managed(name,
                 user,
                 group,
                 mode,
-                attrs,
                 __env__,
                 backup,
                 makedirs,
@@ -3806,7 +3805,6 @@ def replace(name,
         :py:func:`~re.search`.
 
         ..note::
-
             If you need to match a literal string that contains regex special
             characters, you may want to use salt's custom Jinja filter,
             ``escape_regex``.
@@ -5603,7 +5601,8 @@ def serialize(name,
     show_diff
         DEPRECATED: Please use show_changes.
 
-        If set to ''False'', the diff will not be shown in the return data if changes are made.
+        If set to ''False'', the diff will not be shown in the return data if
+        changes are made.
 
     show_changes
         Output a unified diff of the old file and the new file. If ``False``
@@ -5747,10 +5746,10 @@ def serialize(name,
         show_changes = show_diff
 
         mgs = (
-            'The \'show_diff\' argument to the file.serialized state has been'
+            'The \'show_diff\' argument to the file.serialized state has been '
             'deprecated, please use \'show_changes\' instead.'
         )
-        salt.util.warn_until('Oxygen', msg)
+        salt.utils.warn_until('Oxygen', msg)
 
     if __opts__['test']:
         ret['changes'] = __salt__['file.check_managed_changes'](

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -5601,7 +5601,7 @@ def serialize(name,
     show_diff
         DEPRECATED: Please use show_changes.
 
-        If set to ''False'', the diff will not be shown in the return data if
+        If set to ``False``, the diff will not be shown in the return data if
         changes are made.
 
     show_changes
@@ -5744,8 +5744,7 @@ def serialize(name,
 
     if show_diff is not None:
         show_changes = show_diff
-
-        mgs = (
+        msg = (
             'The \'show_diff\' argument to the file.serialized state has been '
             'deprecated, please use \'show_changes\' instead.'
         )

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -273,6 +273,8 @@ class ReactWrap(object):
         try:
             f_call = salt.utils.format_call(l_fun, low)
             kwargs = f_call.get('kwargs', {})
+            if 'arg' not in kwargs:
+                kwargs['arg'] = []
             if 'kwarg' not in kwargs:
                 kwargs['kwarg'] = {}
 


### PR DESCRIPTION
### What does this PR do?
Provides an additional check when file.absent is being applied to a directory. This allows windows directories to be forcefully removed by setting the force field equal to true.

This PR fixes an inconsistency that is currently seen when using file.absent to remove a single file on windows vs removing a windows directory.

Currently removing windows...
- file uses file.remove with force=true
- directory uses files.remove with force=false

As a result, this PR will ensure that the removal of windows files and directories with file.absent is executed with the same logic.

### What issues does this PR fix or reference?
Inability for users to forcefully remove windows directories.
Inconsistencies between the removal of windows files and windows directories with file.absent.

### Previous Behavior
Prior to this PR, the functionality of forceful removal was not implemented for directories.
This poses an issue for windows users due to permission constraints.

### New Behavior
Windows users have the ability to forcefully remove directories without the interference of permissions. The changes implemented for directories now follow the same logic that was previously set for files.

### Tests written?

No
