### PR TITLE
fix_boto_efs_create_mount_target: Stop boto_efs.create_mount_target r…

### DIFF
--- a/salt/modules/boto_efs.py
+++ b/salt/modules/boto_efs.py
@@ -223,7 +223,7 @@ def create_mount_target(filesystemid,
 
     client = _get_conn(key=key, keyid=keyid, profile=profile, region=region)
 
-    return client.create_mount_point(FileSystemId=filesystemid,
+    return client.create_mount_target(FileSystemId=filesystemid,
                                      SubnetId=subnetid,
                                      IpAddress=ipaddress,
                                      SecurityGroups=securitygroups)


### PR DESCRIPTION
…eturning exception 'EFS' object has no attribute 'create_mount_point'

Change-Id: I9daaad14a5aa78725309e9a65c53408f9857c6db

### What does this PR do?

Currently, when running this the following error is returned:-

Comment: Module function boto_efs.create_mount_target threw an exception. Exception: 'EFS' object has no attribute 'create_mount_point'

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/42699

### Previous Behavior

Comment: Module function boto_efs.create_mount_target threw an exception. Exception: 'EFS' object has no attribute 'create_mount_point'

### New Behavior

Runs successfully

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
