### PR TITLE
Do not change the arguments of the function when memoizing

### DIFF
--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -251,9 +251,8 @@ def memoize(func):
                 str_args.append(str(arg))
             else:
                 str_args.append(arg)
-        args = str_args
 
-        args_ = ','.join(list(args) + ['{0}={1}'.format(k, kwargs[k]) for k in sorted(kwargs)])
+        args_ = ','.join(list(str_args) + ['{0}={1}'.format(k, kwargs[k]) for k in sorted(kwargs)])
         if args_ not in cache:
             cache[args_] = func(*args, **kwargs)
         return cache[args_]


### PR DESCRIPTION
### What does this PR do?

Ensures the memoize decorator does not alter arguments before it calls the function it is memoizing.

### What issues does this PR fix or reference?

Fixes #42707 

### Previous Behavior

service.start and friends would fail on FreeBSD.

### New Behavior

service.start and other functions using the memoize decorator should not fail as a result of having values like integers and `None` cast to strings.
