### PR TITLE
Remove master config file from minion-only installer

### DIFF
--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -108,9 +108,9 @@ xcopy /E /Q "%PyDir%" "%BinDir%\"
 @echo Copying configs to buildenv\conf...
 @echo ----------------------------------------------------------------------
 @echo xcopy /E /Q "%SrcDir%\conf\master" "%CnfDir%\"
-xcopy /Q "%SrcDir%\conf\master" "%CnfDir%\"
+xcopy /Q /Y "%SrcDir%\conf\master" "%CnfDir%\"
 @echo xcopy /E /Q "%SrcDir%\conf\minion" "%CnfDir%\"
-xcopy /Q "%SrcDir%\conf\minion" "%CnfDir%\"
+xcopy /Q /Y "%SrcDir%\conf\minion" "%CnfDir%\"
 @echo.
 
 @echo Copying VCRedist to Prerequisites
@@ -581,6 +581,10 @@ If Exist "%BinDir%\Scripts\salt-run*"^
     del /Q "%BinDir%\Scripts\salt-run*" 1>nul
 If Exist "%BldDir%\salt-run.bat"^
     del /Q "%BldDir%\salt-run.bat" 1>nul
+
+:: Remove the master config file
+if Exist "%CnfDir%\master"^
+    del /Q "%CnfDir%\master" 1>nul
 
 :: Make the Salt Minion Installer
 makensis.exe /DSaltVersion=%Version% /DPythonVersion=%Python% "%InsDir%\Salt-Minion-Setup.nsi"


### PR DESCRIPTION
### What does this PR do?
Removes the master config file for the Minion-Only installer.
Also, doesn't prompt you to overwrite an existing minion/master conf when creating the source for the build. (this is the build process, not the installation process)

### Previous Behavior
master conf file found in `c:\salt\conf` on minion only installation.
when building the packages, if the master and minion config files are already in the build source, the script would prompt to overwrite them.

### New Behavior
master config file removed before minion-only installation is created.
minion/master config files overwritten without prompt

### Tests written?
NA