### PR TITLE
Set fact gathering style to 'old' for test_junos

### DIFF
--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -52,6 +52,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 host='1.1.1.1',
                 user='test',
                 password='test123',
+                fact_style='old',
                 gather_facts=False)
             self.dev.open()
             self.dev.timeout = 30


### PR DESCRIPTION
Without this, we stacktrace because it does not appear that setting
'gather_facts' to False prevents the library from assuming the presence
of facts. I believe this to be an upstream bug with jnpr.

Because they have listed this as being a deprecated option in the future
this may re-break in the future.

This fixes failures found in `unit.modules.test_junos`.

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
