### PR TITLE
Allow no ip sg

### DIFF
--- a/salt/modules/boto_efs.py
+++ b/salt/modules/boto_efs.py
@@ -223,10 +223,23 @@ def create_mount_target(filesystemid,
 
     client = _get_conn(key=key, keyid=keyid, profile=profile, region=region)
 
-    return client.create_mount_point(FileSystemId=filesystemid,
-                                     SubnetId=subnetid,
-                                     IpAddress=ipaddress,
-                                     SecurityGroups=securitygroups)
+    if ipaddress is None and securitygroups is None:
+        return client.create_mount_target(FileSystemId=filesystemid,
+                                          SubnetId=subnetid)
+
+    if ipaddress is None:
+        return client.create_mount_target(FileSystemId=filesystemid,
+                                          SubnetId=subnetid,
+                                          SecurityGroups=securitygroups)
+    if securitygroups is None:
+        return client.create_mount_target(FileSystemId=filesystemid,
+                                          SubnetId=subnetid,
+                                          IpAddress=ipaddress)
+
+    return client.create_mount_target(FileSystemId=filesystemid,
+                                      SubnetId=subnetid,
+                                      IpAddress=ipaddress,
+                                      SecurityGroups=securitygroups)
 
 
 def create_tags(filesystemid,


### PR DESCRIPTION
### What does this PR do?

This PR will allow users to not supply ipaddress or securitygroups when running boto_efs.create_mount_target. The ipaddress can be autogenerated based on the subnetid and the securitygroup if not supplied will be set to the default sg for the VPC as per documentation - http://boto3.readthedocs.io/en/latest/reference/services/efs.html

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/42702

### Previous Behavior
Had to pass in an ipaddress and securitygroup

### New Behavior
Don't have to pass in an ipaddress and securitygroup but can pass in either

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
