### PR TITLE
Set force=true when removing a windows directory

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1456,7 +1456,7 @@ def absent(name):
         	if salt.utils.is_windows():
                 __salt__['file.remove'](name, force=True)
             else:
-            	__salt__['file.remove'](name)
+                __salt__['file.remove'](name)
             ret['comment'] = 'Removed directory {0}'.format(name)
             ret['changes']['removed'] = name
             return ret

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1453,7 +1453,10 @@ def absent(name):
             ret['comment'] = 'Directory {0} is set for removal'.format(name)
             return ret
         try:
-            __salt__['file.remove'](name)
+        	if salt.utils.is_windows():
+                __salt__['file.remove'](name, force=True)
+            else:
+            	__salt__['file.remove'](name)
             ret['comment'] = 'Removed directory {0}'.format(name)
             ret['changes']['removed'] = name
             return ret

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1453,7 +1453,7 @@ def absent(name):
             ret['comment'] = 'Directory {0} is set for removal'.format(name)
             return ret
         try:
-        	if salt.utils.is_windows():
+            if salt.utils.is_windows():
                 __salt__['file.remove'](name, force=True)
             else:
                 __salt__['file.remove'](name)


### PR DESCRIPTION
### What does this PR do?

Provides an additional check when file.absent is being applied to a directory. This allows windows directories to be forcefully removed by setting the force field equal to true.

This PR fixes an inconsistency that currently exsists when using file.absent to remove a single file on windows vs removing a windows directory.

Currently removing windows...
- file uses file.remove with force=true
- directory uses file.remove with force=false

As a result, this PR will ensure that the removal of windows directories is executed with the same logic.

### What issues does this PR fix or reference?

Inability for users to forcefully remove windows directories (becomes an issue with permissions).
Inconsistencies between the removal of windows files and windows directories with file.absent.

### Previous Behavior

Prior to this PR, the functionality of forceful removal was not implemented for directories.
This poses an issue for windows users due to permission constraints.

### New Behavior

Windows users have the ability to forcefully remove directories without the interference of permissions. The changes implemented for directories now follow the same logic that was previously set for files.

### Tests written?

No
