### PR TITLE
Use config data as pillar overrides

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -2113,6 +2113,38 @@ It will be interpreted as megabytes.
 
     file_recv_max_size: 100
 
+.. conf_minion:: add_to_pillar
+
+``add_to_pillar``
+-----------------
+
+Specify a list of configuration options whose values become pillar overrides.
+The values are included in the pillar requests sent to the master, are merged
+into the pillar and can be accessed in external pillar retrieval functions.
+
+Suboptions can be specified using the ':' notation (i.e. ``option:suboption``)
+
+If the config contains
+
+.. code-block:: yaml
+
+    opt1: value1
+    opt2:
+      subopt1: value2
+      subopt2: value3
+
+    add_to_pillar:
+      - opt1
+      - opt2: subopt1
+
+the pillar will contain
+
+.. code-block:: yaml
+
+    opt1: value1
+    opt2:
+      subopt1: value2
+
 Security Settings
 =================
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1078,6 +1078,10 @@ VALID_OPTS = {
     # (in other words, require that minions have 'minion_sign_messages'
     # turned on)
     'require_minion_sign_messages': bool,
+
+    # The list of config entries to be used as pillar overrides
+    # Subconfig entries can be specified by using the ':' notation (e.g. key:subkey)
+    'add_to_pillar': (six.string_types, list),
 }
 
 # default configurations

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -119,7 +119,7 @@ class RemotePillarMixin(object):
         return pillar_override
 
 
-class AsyncRemotePillar(object):
+class AsyncRemotePillar(RemotePillarMixin):
     '''
     Get the pillar from the master
     '''
@@ -133,10 +133,12 @@ class AsyncRemotePillar(object):
         self.channel = salt.transport.client.AsyncReqChannel.factory(opts)
         if pillarenv is not None:
             self.opts['pillarenv'] = pillarenv
-        self.pillar_override = pillar_override or {}
-        if not isinstance(self.pillar_override, dict):
-            self.pillar_override = {}
+        if pillar_override and not isinstance(pillar_override, dict):
+            pillar_override = {}
             log.error('Pillar data must be a dictionary')
+        self.pillar_override = salt.utils.dictupdate.update(
+            self.get_pillar_override_from_opts(opts),
+            pillar_override or {})
 
     @tornado.gen.coroutine
     def compile_pillar(self):
@@ -170,7 +172,7 @@ class AsyncRemotePillar(object):
         raise tornado.gen.Return(ret_pillar)
 
 
-class RemotePillar(object):
+class RemotePillar(RemotePillarMixin):
     '''
     Get the pillar from the master
     '''
@@ -184,10 +186,12 @@ class RemotePillar(object):
         self.channel = salt.transport.Channel.factory(opts)
         if pillarenv is not None:
             self.opts['pillarenv'] = pillarenv
-        self.pillar_override = pillar_override or {}
-        if not isinstance(self.pillar_override, dict):
-            self.pillar_override = {}
+        if pillar_override and not isinstance(pillar_override, dict):
+            pillar_override = {}
             log.error('Pillar data must be a dictionary')
+        self.pillar_override = salt.utils.dictupdate.update(
+            self.get_pillar_override_from_opts(opts),
+            pillar_override or {})
 
     def compile_pillar(self):
         '''

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -23,6 +23,7 @@ import salt.transport
 import salt.utils.url
 import salt.utils.cache
 import salt.utils.crypt
+import salt.utils.dictupdate
 from salt.exceptions import SaltClientError
 from salt.template import compile_template
 from salt.utils.dictupdate import merge
@@ -73,6 +74,49 @@ def get_async_pillar(opts, grains, minion_id, saltenv=None, ext=None, funcs=None
     }.get(file_client, AsyncPillar)
     return ptype(opts, grains, minion_id, saltenv, ext, functions=funcs,
                  pillar_override=pillar_override, pillarenv=pillarenv)
+
+
+class RemotePillarMixin(object):
+    '''
+    Common remote pillar functionality
+    '''
+    def get_pillar_override_from_opts(self, opts):
+        '''
+        Returns the pillar overrides from the opts dict (the config file)
+        '''
+        def get_subconfig(opts_key):
+            '''
+            Returns a dict containing the opts key subtree, while maintaining
+            the opts structure
+            '''
+            ret_dict = aux_dict = {}
+            config_val = opts
+            subkeys = opts_key.split(':')
+            # Build an empty dict with the opts path
+            for subkey in subkeys[:-1]:
+                aux_dict[subkey] = {}
+                aux_dict = aux_dict[subkey]
+                if not config_val.get(subkey):
+                    # The subkey is not in the config
+                    return {}
+                config_val = config_val[subkey]
+            if subkeys[-1] not in config_val:
+                return {}
+            aux_dict[subkeys[-1]] = config_val[subkeys[-1]]
+            return ret_dict
+
+        pillar_override = {}
+        if 'add_to_pillar' in opts:
+            if not isinstance(opts['add_to_pillar'], list):
+                log.exception('\'add_to_pillar\' config is malformed.')
+                raise SaltClientError('\'add_to_pillar\' config is malformed.')
+            for key in opts['add_to_pillar']:
+                salt.utils.dictupdate.update(pillar_override,
+                                             get_subconfig(key),
+                                             recursive_update=True,
+                                             merge_lists=True)
+        log.trace('opts_pillar_override = {0}'.format(pillar_override))
+        return pillar_override
 
 
 class AsyncRemotePillar(object):

--- a/tests/unit/test_pillar.py
+++ b/tests/unit/test_pillar.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
+    :codeauthor: :email:`Alexandru Bleotu (alexandru.bleotu@morganstanley.com)`
 
 
     tests.unit.pillar_test
@@ -18,6 +19,7 @@ from tests.support.paths import TMP
 
 # Import salt libs
 import salt.pillar
+import salt.exceptions
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -317,3 +319,107 @@ p2:
             }[sls]
 
         client.get_state.side_effect = get_state
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.transport.Channel.factory', MagicMock())
+class RemotePillarTestCase(TestCase):
+    '''
+    Tests for instantiating a RemotePillar in salt.pillar
+    '''
+    def setUp(self):
+        self.grains = {}
+
+    def tearDown(self):
+        for attr in ('grains',):
+            try:
+                delattr(self, attr)
+            except AttributeError:
+                continue
+
+    def test_get_opts_in_pillar_override_call(self):
+        mock_get_pillar_override_from_opts = MagicMock(return_value={})
+        with patch('salt.pillar.RemotePillarMixin.get_pillar_override_from_opts',
+                   mock_get_pillar_override_from_opts):
+            salt.pillar.RemotePillar({}, self.grains, 'mocked-minion', 'dev')
+        mock_get_pillar_override_from_opts.assert_called_once_with(
+            {'environment': 'dev'})
+
+    def test_multiple_keys_in_opts_added_to_pillar(self):
+        opts = {
+            'renderer': 'json',
+            'path_to_add': 'fake_data',
+            'path_to_add2': {'fake_data2': ['fake_data3', 'fake_data4']},
+            'add_to_pillar': ['path_to_add', 'path_to_add2']
+        }
+        pillar = salt.pillar.RemotePillar(opts, self.grains,
+                                          'mocked-minion', 'dev')
+        self.assertEqual(pillar.pillar_override,
+                         {'path_to_add': 'fake_data',
+                          'path_to_add2': {'fake_data2': ['fake_data3',
+                                                          'fake_data4']}})
+
+    def test_subkey_in_opts_added_to_pillar(self):
+        opts = {
+            'renderer': 'json',
+            'path_to_add': 'fake_data',
+            'path_to_add2': {'fake_data5': 'fake_data6',
+                             'fake_data2': ['fake_data3', 'fake_data4']},
+            'add_to_pillar': ['path_to_add2:fake_data5']
+        }
+        pillar = salt.pillar.RemotePillar(opts, self.grains,
+                                          'mocked-minion', 'dev')
+        self.assertEqual(pillar.pillar_override,
+                         {'path_to_add2': {'fake_data5': 'fake_data6'}})
+
+    def test_pillar_overrides_merge_on_keys_in_opts(self):
+        opts = {
+            'renderer': 'json',
+            'path_to_add': 'fake_data',
+            'path_to_add2': {'fake_data2': ['fake_data3', 'fake_data4']},
+            'add_to_pillar': ['path_to_add', 'path_to_add2']
+        }
+        pillar = salt.pillar.RemotePillar(opts, self.grains, 'mocked-minion', 'dev',
+                                          pillar_override={'path_to_add2':
+                                                           'fake_override'})
+        self.assertEqual(pillar.pillar_override,
+                         {'path_to_add': 'fake_data',
+                          'path_to_add2': 'fake_override'})
+
+    def test_non_existent_leaf_opt_in_add_to_pillar(self):
+        opts = {
+            'renderer': 'json',
+            'path_to_add': 'fake_data',
+            'path_to_add2': {'fake_data5': 'fake_data6',
+                             'fake_data2': ['fake_data3', 'fake_data4']},
+            'add_to_pillar': ['path_to_add2:fake_data_non_exist']
+        }
+        pillar = salt.pillar.RemotePillar(opts, self.grains,
+                                          'mocked-minion', 'dev')
+        self.assertEqual(pillar.pillar_override, {})
+
+
+    def test_non_existent_intermediate_opt_in_add_to_pillar(self):
+        opts = {
+            'renderer': 'json',
+            'path_to_add': 'fake_data',
+            'path_to_add2': {'fake_data5': 'fake_data6',
+                             'fake_data2': ['fake_data3', 'fake_data4']},
+            'add_to_pillar': ['path_to_add_no_exist']
+        }
+        pillar = salt.pillar.RemotePillar(opts, self.grains,
+                                          'mocked-minion', 'dev')
+        self.assertEqual(pillar.pillar_override, {})
+
+    def test_malformed_add_to_pillar(self):
+        opts = {
+            'renderer': 'json',
+            'path_to_add': 'fake_data',
+            'path_to_add2': {'fake_data5': 'fake_data6',
+                             'fake_data2': ['fake_data3', 'fake_data4']},
+            'add_to_pillar': MagicMock()
+        }
+        with self.assertRaises(salt.exceptions.SaltClientError) as excinfo:
+            salt.pillar.RemotePillar(opts, self.grains, 'mocked-minion', 'dev')
+        self.assertEqual(excinfo.exception.strerror,
+                         '\'add_to_pillar\' config is malformed.')

--- a/tests/unit/test_pillar.py
+++ b/tests/unit/test_pillar.py
@@ -398,7 +398,6 @@ class RemotePillarTestCase(TestCase):
                                           'mocked-minion', 'dev')
         self.assertEqual(pillar.pillar_override, {})
 
-
     def test_non_existent_intermediate_opt_in_add_to_pillar(self):
         opts = {
             'renderer': 'json',

--- a/tests/unit/test_pillar.py
+++ b/tests/unit/test_pillar.py
@@ -423,3 +423,29 @@ class RemotePillarTestCase(TestCase):
             salt.pillar.RemotePillar(opts, self.grains, 'mocked-minion', 'dev')
         self.assertEqual(excinfo.exception.strerror,
                          '\'add_to_pillar\' config is malformed.')
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.transport.client.AsyncReqChannel.factory', MagicMock())
+class AsyncRemotePillarTestCase(TestCase):
+    '''
+    Tests for instantiating a AsyncRemotePillar in salt.pillar
+    '''
+    def setUp(self):
+        self.grains = {}
+
+    def tearDown(self):
+        for attr in ('grains',):
+            try:
+                delattr(self, attr)
+            except AttributeError:
+                continue
+
+    def test_get_opts_in_pillar_override_call(self):
+        mock_get_pillar_override_from_opts = MagicMock(return_value={})
+        with patch('salt.pillar.RemotePillarMixin.get_pillar_override_from_opts',
+                   mock_get_pillar_override_from_opts):
+            salt.pillar.AsyncRemotePillar({}, self.grains,
+                                          'mocked-minion', 'dev')
+        mock_get_pillar_override_from_opts.assert_called_once_with(
+            {'environment': 'dev'})


### PR DESCRIPTION
### What does this PR do?
Added ability to use config data as pillar overrides; the data can then be used as input in external pillar functions. 

This is specially useful if the proxy configuration (`proxy` key) is set in the configuration file and not in the pillar, but any additional configuration data can be included in the pillar so there is more info about the minion, in addition to the `minion_id`

### What issues does this PR fix or reference?
https://github.com/saltstack/morganstanley/issues/20

### Previous Behavior
Config data could not be included as pillar overrides

### New Behavior
`add_to_pillar` key can be added to the config containing the list of config keys to be included as pillar overrides. Subkeys are supported using the the : notation (i.e. `key:subkey`)

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
