### PR TITLE
Fix docker.compare_container for containers with links

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -558,6 +558,7 @@ def _prep_pull():
     '''
     __context__['docker._pull_status'] = [x[:12] for x in images(all=True)]
 
+
 def _scrub_links(links, name):
     '''
     Remove container name from HostConfig:Links values to enable comparing
@@ -571,6 +572,7 @@ def _scrub_links(links, name):
         ret = links
 
     return ret
+
 
 def _size_fmt(num):
     '''


### PR DESCRIPTION
### What does this PR do?
Fixes docker.compare_container when comparing containers with links to other containers by ignoring the container name part of the HostConfig:Links value.
I believe this is safe to do since docker.compare_container is currently only used by the docker_container.running state and the current logic for comparing links makes no sense there.

### What issues does this PR fix or reference?
Fixes #42741

### Previous Behavior
Containers with links would always be found to have differences.

### New Behavior
Only report a difference if the link name or link target has changed.

### Tests written?

No

