### PR TITLE
fix #42600 in develop

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -3983,78 +3983,77 @@ def _write_regpol_data(data_to_write,
     gpt_extension_guid: admx registry extension guid for the class
     '''
     try:
-        if data_to_write:
-            reg_pol_header = u'\u5250\u6765\x01\x00'
-            if not os.path.exists(policy_file_path):
-                ret = __salt__['file.makedirs'](policy_file_path)
-            with salt.utils.files.fopen(policy_file_path, 'wb') as pol_file:
-                if not data_to_write.startswith(reg_pol_header):
-                    pol_file.write(reg_pol_header.encode('utf-16-le'))
-                pol_file.write(data_to_write.encode('utf-16-le'))
-            try:
-                gpt_ini_data = ''
-                if os.path.exists(gpt_ini_path):
-                    with salt.utils.files.fopen(gpt_ini_path, 'rb') as gpt_file:
-                        gpt_ini_data = gpt_file.read()
-                if not _regexSearchRegPolData(r'\[General\]\r\n', gpt_ini_data):
-                    gpt_ini_data = '[General]\r\n' + gpt_ini_data
-                if _regexSearchRegPolData(r'{0}='.format(re.escape(gpt_extension)), gpt_ini_data):
-                    # ensure the line contains the ADM guid
-                    gpt_ext_loc = re.search(r'^{0}=.*\r\n'.format(re.escape(gpt_extension)),
-                                            gpt_ini_data,
-                                            re.IGNORECASE | re.MULTILINE)
-                    gpt_ext_str = gpt_ini_data[gpt_ext_loc.start():gpt_ext_loc.end()]
-                    if not _regexSearchRegPolData(r'{0}'.format(re.escape(gpt_extension_guid)),
-                                                  gpt_ext_str):
-                        gpt_ext_str = gpt_ext_str.split('=')
-                        gpt_ext_str[1] = gpt_extension_guid + gpt_ext_str[1]
-                        gpt_ext_str = '='.join(gpt_ext_str)
-                        gpt_ini_data = gpt_ini_data[0:gpt_ext_loc.start()] + gpt_ext_str + gpt_ini_data[gpt_ext_loc.end():]
-                else:
-                    general_location = re.search(r'^\[General\]\r\n',
-                                                 gpt_ini_data,
-                                                 re.IGNORECASE | re.MULTILINE)
-                    gpt_ini_data = "{0}{1}={2}\r\n{3}".format(
-                            gpt_ini_data[general_location.start():general_location.end()],
-                            gpt_extension, gpt_extension_guid,
-                            gpt_ini_data[general_location.end():])
-                # https://technet.microsoft.com/en-us/library/cc978247.aspx
-                if _regexSearchRegPolData(r'Version=', gpt_ini_data):
-                    version_loc = re.search(r'^Version=.*\r\n',
-                                            gpt_ini_data,
-                                            re.IGNORECASE | re.MULTILINE)
-                    version_str = gpt_ini_data[version_loc.start():version_loc.end()]
-                    version_str = version_str.split('=')
-                    version_nums = struct.unpack('>2H', struct.pack('>I', int(version_str[1])))
-                    if gpt_extension.lower() == 'gPCMachineExtensionNames'.lower():
-                        version_nums = (version_nums[0], version_nums[1] + 1)
-                    elif gpt_extension.lower() == 'gPCUserExtensionNames'.lower():
-                        version_nums = (version_nums[0] + 1, version_nums[1])
-                    version_num = struct.unpack('>I', struct.pack('>2H', *version_nums))[0]
-                    gpt_ini_data = "{0}{1}={2}\r\n{3}".format(
-                            gpt_ini_data[0:version_loc.start()],
-                            'Version', version_num,
-                            gpt_ini_data[version_loc.end():])
-                else:
-                    general_location = re.search(r'^\[General\]\r\n',
-                                                 gpt_ini_data,
-                                                 re.IGNORECASE | re.MULTILINE)
-                    if gpt_extension.lower() == 'gPCMachineExtensionNames'.lower():
-                        version_nums = (0, 1)
-                    elif gpt_extension.lower() == 'gPCUserExtensionNames'.lower():
-                        version_nums = (1, 0)
-                    gpt_ini_data = "{0}{1}={2}\r\n{3}".format(
-                            gpt_ini_data[general_location.start():general_location.end()],
-                            'Version',
-                            int("{0}{1}".format(str(version_nums[0]).zfill(4), str(version_nums[1]).zfill(4)), 16),
-                            gpt_ini_data[general_location.end():])
-                if gpt_ini_data:
-                    with salt.utils.files.fopen(gpt_ini_path, 'wb') as gpt_file:
-                        gpt_file.write(gpt_ini_data)
-            except Exception as e:
-                msg = 'An error occurred attempting to write to {0}, the exception was {1}'.format(
-                        gpt_ini_path, e)
-                raise CommandExecutionError(msg)
+        reg_pol_header = u'\u5250\u6765\x01\x00'
+        if not os.path.exists(policy_file_path):
+            ret = __salt__['file.makedirs'](policy_file_path)
+        with salt.utils.files.fopen(policy_file_path, 'wb') as pol_file:
+            if not data_to_write.startswith(reg_pol_header):
+                pol_file.write(reg_pol_header.encode('utf-16-le'))
+            pol_file.write(data_to_write.encode('utf-16-le'))
+        try:
+            gpt_ini_data = ''
+            if os.path.exists(gpt_ini_path):
+                with salt.utils.files.fopen(gpt_ini_path, 'rb') as gpt_file:
+                    gpt_ini_data = gpt_file.read()
+            if not _regexSearchRegPolData(r'\[General\]\r\n', gpt_ini_data):
+                gpt_ini_data = '[General]\r\n' + gpt_ini_data
+            if _regexSearchRegPolData(r'{0}='.format(re.escape(gpt_extension)), gpt_ini_data):
+                # ensure the line contains the ADM guid
+                gpt_ext_loc = re.search(r'^{0}=.*\r\n'.format(re.escape(gpt_extension)),
+                                        gpt_ini_data,
+                                        re.IGNORECASE | re.MULTILINE)
+                gpt_ext_str = gpt_ini_data[gpt_ext_loc.start():gpt_ext_loc.end()]
+                if not _regexSearchRegPolData(r'{0}'.format(re.escape(gpt_extension_guid)),
+                                              gpt_ext_str):
+                    gpt_ext_str = gpt_ext_str.split('=')
+                    gpt_ext_str[1] = gpt_extension_guid + gpt_ext_str[1]
+                    gpt_ext_str = '='.join(gpt_ext_str)
+                    gpt_ini_data = gpt_ini_data[0:gpt_ext_loc.start()] + gpt_ext_str + gpt_ini_data[gpt_ext_loc.end():]
+            else:
+                general_location = re.search(r'^\[General\]\r\n',
+                                             gpt_ini_data,
+                                             re.IGNORECASE | re.MULTILINE)
+                gpt_ini_data = "{0}{1}={2}\r\n{3}".format(
+                        gpt_ini_data[general_location.start():general_location.end()],
+                        gpt_extension, gpt_extension_guid,
+                        gpt_ini_data[general_location.end():])
+            # https://technet.microsoft.com/en-us/library/cc978247.aspx
+            if _regexSearchRegPolData(r'Version=', gpt_ini_data):
+                version_loc = re.search(r'^Version=.*\r\n',
+                                        gpt_ini_data,
+                                        re.IGNORECASE | re.MULTILINE)
+                version_str = gpt_ini_data[version_loc.start():version_loc.end()]
+                version_str = version_str.split('=')
+                version_nums = struct.unpack('>2H', struct.pack('>I', int(version_str[1])))
+                if gpt_extension.lower() == 'gPCMachineExtensionNames'.lower():
+                    version_nums = (version_nums[0], version_nums[1] + 1)
+                elif gpt_extension.lower() == 'gPCUserExtensionNames'.lower():
+                    version_nums = (version_nums[0] + 1, version_nums[1])
+                version_num = struct.unpack('>I', struct.pack('>2H', *version_nums))[0]
+                gpt_ini_data = "{0}{1}={2}\r\n{3}".format(
+                        gpt_ini_data[0:version_loc.start()],
+                        'Version', version_num,
+                        gpt_ini_data[version_loc.end():])
+            else:
+                general_location = re.search(r'^\[General\]\r\n',
+                                             gpt_ini_data,
+                                             re.IGNORECASE | re.MULTILINE)
+                if gpt_extension.lower() == 'gPCMachineExtensionNames'.lower():
+                    version_nums = (0, 1)
+                elif gpt_extension.lower() == 'gPCUserExtensionNames'.lower():
+                    version_nums = (1, 0)
+                gpt_ini_data = "{0}{1}={2}\r\n{3}".format(
+                        gpt_ini_data[general_location.start():general_location.end()],
+                        'Version',
+                        int("{0}{1}".format(str(version_nums[0]).zfill(4), str(version_nums[1]).zfill(4)), 16),
+                        gpt_ini_data[general_location.end():])
+            if gpt_ini_data:
+                with salt.utils.files.fopen(gpt_ini_path, 'wb') as gpt_file:
+                    gpt_file.write(gpt_ini_data)
+        except Exception as e:
+            msg = 'An error occurred attempting to write to {0}, the exception was {1}'.format(
+                    gpt_ini_path, e)
+            raise CommandExecutionError(msg)
     except Exception as e:
         msg = 'An error occurred attempting to write to {0}, the exception was {1}'.format(policy_file_path, e)
         raise CommandExecutionError(msg)


### PR DESCRIPTION
### What does this PR do?
Alters the logic to write ADM policy files even if the data passed to the _write_regpol_data function is empty.

### What issues does this PR fix or reference?
#42600

### Previous Behavior
If data passed to _write_regpol_data was empty (i.e. no ADM policy data), the regpol file would not be written to.  In the event that a single ADM policy was configured but then subsequently set to "Not Configured", the policy would not properly be "Not Configured" due to this.

### New Behavior
regpol file is written even if the data passed to the function is empty (but an ADM policy must be in the list of policies to change -- i.e. the regpol file would not be written if a registry only policy is changed)

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
