### PR TITLE
Workaround Orchestrate problem that highstate outputter mutates data

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -408,8 +408,6 @@ class SyncClientMixin(object):
                     )
             data['success'] = False
 
-        namespaced_event.fire_event(data, 'ret')
-
         if self.store_job:
             try:
                 salt.utils.job.store_job(
@@ -426,6 +424,9 @@ class SyncClientMixin(object):
             except salt.exceptions.SaltCacheError:
                 log.error('Could not store job cache info. '
                           'Job details for this run may be unavailable.')
+
+        # Outputters _can_ mutate data so write to the job cache first!
+        namespaced_event.fire_event(data, 'ret')
 
         # if we fired an event, make sure to delete the event object.
         # This will ensure that we call destroy, which will do the 0MQ linger


### PR DESCRIPTION
### What does this PR do?

Save to the job cache _before_ doing something that will invoke an outputter.

### What issues does this PR fix or reference?

Partial workaround for issue #42747.

### Previous Behavior

Outputter was invoked before return was persisted to job cache.

### Tests written?

No