### PR TITLE
Set appropriate Windows file attributes during archive.extracted

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -1218,6 +1218,7 @@ def extracted(name,
                                                       options=options,
                                                       trim_output=trim_output,
                                                       password=password,
+                                                      extract_perms=extract_perms,
                                                       **kwargs)
             elif archive_format == 'rar':
                 try:


### PR DESCRIPTION
### What does this PR do?
This PR enables the usage of the extract_perms parameter of salt.states.archive.extracted during unzip. It also sets the appropriate Windows file attributes when extracting a zip file in Windows (salt.modules.archive).

### What issues does this PR fix or reference?
It fixes an issue where when extracting a zip file in Windows using salt.states.archive.extracted, all of the extracted files have incorrect Windows file attributes. The observed behavior was that all files were set to read-only, which is not expected. The expected behavior is that all of the extracted files have the same file attributes as the files in the zip file.

Not only was salt.states.archive.extracted not using the extract_perms parameter (even though it is listed  as on option in code and docs), the extract_params feature in salt.modules.archive.unzip was only valid for Unix.

### Previous Behavior
When using salt.states.archive.extracted on Windows, all extracted files were set to read-only.

### New Behavior
When using salt.states.archive.extracted on Windows, all extracted files have the same attributes as the files in the zip file do.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
