### PR TITLE
Add config option to ensure jid is unique

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -157,7 +157,7 @@ class BaseCaller(object):
         '''
         ret = {}
         fun = self.opts['fun']
-        ret['jid'] = salt.utils.jid.gen_jid()
+        ret['jid'] = salt.utils.jid.gen_jid(self.opts)
         proc_fn = os.path.join(
             salt.minion.get_proc_dir(self.opts['cachedir']),
             ret['jid']

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -299,7 +299,7 @@ class SyncClientMixin(object):
         # this is not to clutter the output with the module loading
         # if we have a high debug level.
         self.mminion  # pylint: disable=W0104
-        jid = low.get(u'__jid__', salt.utils.jid.gen_jid())
+        jid = low.get(u'__jid__', salt.utils.jid.gen_jid(self.opts))
         tag = low.get(u'__tag__', salt.utils.event.tagify(jid, prefix=self.tag_prefix))
 
         data = {u'fun': u'{0}.{1}'.format(self.client, fun),
@@ -512,7 +512,7 @@ class AsyncClientMixin(object):
 
     def _gen_async_pub(self, jid=None):
         if jid is None:
-            jid = salt.utils.jid.gen_jid()
+            jid = salt.utils.jid.gen_jid(self.opts)
         tag = salt.utils.event.tagify(jid, prefix=self.tag_prefix)
         return {u'tag': tag, u'jid': jid}
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -420,7 +420,8 @@ VALID_OPTS = {
 
     # Ensure that a generated jid is always unique. If this is set, the jid
     # format is different due to an underscore and process id being appended
-    # to the jid.
+    # to the jid. WARNING: A change to the jid format may break external
+    # applications that depend on the original format.
     'unique_jid': bool,
 
     # Tells the highstate outputter to show successful states. False will omit successes.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -418,6 +418,11 @@ VALID_OPTS = {
     # Tell the client to display the jid when a job is published
     'show_jid': bool,
 
+    # Ensure that a generated jid is always unique. If this is set, the jid
+    # format is different due to an underscore and process id being appended
+    # to the jid.
+    'unique_jid': bool,
+
     # Tells the highstate outputter to show successful states. False will omit successes.
     'state_verbose': bool,
 
@@ -1198,6 +1203,7 @@ DEFAULT_MINION_OPTS = {
     'gitfs_ref_types': ['branch', 'tag', 'sha'],
     'gitfs_refspecs': _DFLT_REFSPECS,
     'gitfs_disable_saltenv_mapping': False,
+    'unique_jid': False,
     'hash_type': 'sha256',
     'disable_modules': [],
     'disable_returners': [],
@@ -1442,6 +1448,7 @@ DEFAULT_MASTER_OPTS = {
     'hgfs_saltenv_blacklist': [],
     'show_timeout': True,
     'show_jid': False,
+    'unique_jid': False,
     'svnfs_remotes': [],
     'svnfs_mountpoint': '',
     'svnfs_root': '',

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -718,7 +718,7 @@ class RemoteFuncs(object):
         Handle the return data sent from the minions
         '''
         # Generate EndTime
-        endtime = salt.utils.jid.jid_to_time(salt.utils.jid.gen_jid())
+        endtime = salt.utils.jid.jid_to_time(salt.utils.jid.gen_jid(self.opts))
         # If the return data is invalid, just ignore it
         if any(key not in load for key in ('return', 'jid', 'id')):
             return False
@@ -1087,7 +1087,7 @@ class LocalFuncs(object):
                                                 'user {1}.').format(auth_type, username)))
 
         # Authenticated. Do the job.
-        jid = salt.utils.jid.gen_jid()
+        jid = salt.utils.jid.gen_jid(self.opts)
         fun = load.pop('fun')
         tag = salt.utils.event.tagify(jid, prefix='wheel')
         data = {'fun': "wheel.{0}".format(fun),

--- a/salt/master.py
+++ b/salt/master.py
@@ -1776,7 +1776,7 @@ class ClearFuncs(object):
 
         # Authorized. Do the job!
         try:
-            jid = salt.utils.jid.gen_jid()
+            jid = salt.utils.jid.gen_jid(self.opts)
             fun = clear_load.pop(u'fun')
             tag = tagify(jid, prefix=u'wheel')
             data = {u'fun': u"wheel.{0}".format(fun),

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -120,7 +120,7 @@ def _wait(jid):
     Wait for all previously started state jobs to finish running
     '''
     if jid is None:
-        jid = salt.utils.jid.gen_jid()
+        jid = salt.utils.jid.gen_jid(__opts__)
     states = _prior_running_states(jid)
     while states:
         time.sleep(1)

--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -303,4 +303,4 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/returners/cassandra_cql_return.py
+++ b/salt/returners/cassandra_cql_return.py
@@ -454,4 +454,4 @@ def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/returners/cassandra_return.py
+++ b/salt/returners/cassandra_return.py
@@ -80,4 +80,4 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/returners/couchbase_return.py
+++ b/salt/returners/couchbase_return.py
@@ -160,7 +160,7 @@ def prep_jid(nocache=False, passed_jid=None):
     So do what you have to do to make sure that stays the case
     '''
     if passed_jid is None:
-        jid = salt.utils.jid.gen_jid()
+        jid = salt.utils.jid.gen_jid(__opts__)
     else:
         jid = passed_jid
 

--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -364,7 +364,7 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)
 
 
 def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument

--- a/salt/returners/django_return.py
+++ b/salt/returners/django_return.py
@@ -82,4 +82,4 @@ def prep_jid(nocache=False, passed_jid=None):
     '''
     Do any work necessary to prepare a JID, including sending a custom ID
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -362,7 +362,7 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)
 
 
 def save_load(jid, load, minions=None):

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -223,4 +223,4 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/returners/influxdb_return.py
+++ b/salt/returners/influxdb_return.py
@@ -328,4 +328,4 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -90,7 +90,7 @@ def prep_jid(nocache=False, passed_jid=None, recurse_count=0):
         log.error(err)
         raise salt.exceptions.SaltCacheError(err)
     if passed_jid is None:  # this can be a None or an empty string.
-        jid = salt.utils.jid.gen_jid()
+        jid = salt.utils.jid.gen_jid(__opts__)
     else:
         jid = passed_jid
 

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -134,7 +134,7 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)
 
 
 def returner(ret):

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -322,7 +322,7 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)
 
 
 def event_return(events):

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -231,7 +231,7 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)
 
 
 def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -460,7 +460,7 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)
 
 
 def _purge_jobs(timestamp):

--- a/salt/returners/odbc.py
+++ b/salt/returners/odbc.py
@@ -329,4 +329,4 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -416,4 +416,4 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -381,4 +381,4 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -189,7 +189,7 @@ def _gen_jid(cur):
     '''
     Generate an unique job id
     '''
-    jid = salt.utils.jid.gen_jid()
+    jid = salt.utils.jid.gen_jid(__opts__)
     sql = '''SELECT jid FROM jids WHERE jid = %s'''
     cur.execute(sql, (jid,))
     data = cur.fetchall()

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -312,4 +312,4 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/returners/sentry_return.py
+++ b/salt/returners/sentry_return.py
@@ -170,4 +170,4 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -264,7 +264,7 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)
 
 
 def event_return(events):

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -303,4 +303,4 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/returners/syslog_return.py
+++ b/salt/returners/syslog_return.py
@@ -213,4 +213,4 @@ def prep_jid(nocache=False,
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -348,7 +348,7 @@ def _call_function(name, returner=None, **kwargs):
         returners = salt.loader.returners(__opts__, __salt__)
         if returner in returners:
             returners[returner]({'id': __opts__['id'], 'ret': mret,
-                                 'fun': name, 'jid': salt.utils.jid.gen_jid()})
+                                 'fun': name, 'jid': salt.utils.jid.gen_jid(__opts__)})
 
     return mret
 
@@ -495,7 +495,7 @@ def _run(name, **kwargs):
                 'id': __opts__['id'],
                 'ret': mret,
                 'fun': name,
-                'jid': salt.utils.jid.gen_jid()}
+                'jid': salt.utils.jid.gen_jid(__opts__)}
         returners = salt.loader.returners(__opts__, __salt__)
         if kwargs['returner'] in returners:
             returners[kwargs['returner']](ret_ret)

--- a/salt/utils/jid.py
+++ b/salt/utils/jid.py
@@ -9,12 +9,22 @@ import os
 
 from salt.ext import six
 
+LAST_JID_DATETIME = None
 
-def gen_jid():
+
+def gen_jid(opts):
     '''
     Generate a jid
     '''
-    return '{0:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())
+    global LAST_JID_DATETIME  # pylint: disable=global-statement
+
+    if not opts.get('unique_jid', False):
+        return '{0:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())
+    jid_dt = datetime.datetime.now()
+    if LAST_JID_DATETIME and LAST_JID_DATETIME >= jid_dt:
+        jid_dt = LAST_JID_DATETIME + datetime.timedelta(microseconds=1)
+    LAST_JID_DATETIME = jid_dt
+    return '{0:%Y%m%d%H%M%S%f}_{1}'.format(jid_dt, os.getpid())
 
 
 def is_jid(jid):
@@ -23,10 +33,10 @@ def is_jid(jid):
     '''
     if not isinstance(jid, six.string_types):
         return False
-    if len(jid) != 20:
+    if len(jid) != 20 and (len(jid) <= 21 or jid[20] != '_'):
         return False
     try:
-        int(jid)
+        int(jid[:20])
         return True
     except ValueError:
         return False
@@ -37,7 +47,7 @@ def jid_to_time(jid):
     Convert a salt job id into the time when the job was invoked
     '''
     jid = str(jid)
-    if len(jid) != 20:
+    if len(jid) != 20 and (len(jid) <= 21 or jid[20] != '_'):
         return ''
     year = jid[:4]
     month = jid[4:6]
@@ -45,7 +55,7 @@ def jid_to_time(jid):
     hour = jid[8:10]
     minute = jid[10:12]
     second = jid[12:14]
-    micro = jid[14:]
+    micro = jid[14:20]
 
     ret = '{0}, {1} {2} {3}:{4}:{5}.{6}'.format(year,
                                                 months[int(month)],

--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -18,7 +18,7 @@ def store_job(opts, load, event=None, mminion=None):
     Store job information using the configured master_job_cache
     '''
     # Generate EndTime
-    endtime = salt.utils.jid.jid_to_time(salt.utils.jid.gen_jid())
+    endtime = salt.utils.jid.jid_to_time(salt.utils.jid.gen_jid(opts))
     # If the return data is invalid, just ignore it
     if any(key not in load for key in ('return', 'jid', 'id')):
         return False

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -764,7 +764,7 @@ class Schedule(object):
                'fun': func,
                'fun_args': [],
                'schedule': data['name'],
-               'jid': salt.utils.jid.gen_jid()}
+               'jid': salt.utils.jid.gen_jid(self.opts)}
 
         if 'metadata' in data:
             if isinstance(data['metadata'], dict):

--- a/tests/unit/states/test_saltmod.py
+++ b/tests/unit/states/test_saltmod.py
@@ -47,7 +47,7 @@ class SaltmodTestCase(TestCase, LoaderModuleMockMixin):
                     'transport': 'tcp'
                 },
                 '__salt__': {'saltutil.cmd': MagicMock()},
-                '__orchestration_jid__': salt.utils.jid.gen_jid(),
+                '__orchestration_jid__': salt.utils.jid.gen_jid({}),
                 '__utils__': utils,
             }
         }
@@ -298,7 +298,7 @@ class StatemodTests(TestCase, LoaderModuleMockMixin):
                     'extension_modules': os.path.join(self.tmp_cachedir, 'extmods'),
                 },
                 '__salt__': {'saltutil.cmd': MagicMock()},
-                '__orchestration_jid__': salt.utils.jid.gen_jid()
+                '__orchestration_jid__': salt.utils.jid.gen_jid({})
             }
         }
 

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -24,6 +24,7 @@ from salt.exceptions import (SaltInvocationError, SaltSystemExit, CommandNotFoun
 
 # Import Python libraries
 import datetime
+import os
 import yaml
 import zmq
 from collections import namedtuple
@@ -496,8 +497,13 @@ class UtilsTestCase(TestCase):
         now = datetime.datetime(2002, 12, 25, 12, 00, 00, 00)
         with patch('datetime.datetime'):
             datetime.datetime.now.return_value = now
-            ret = salt.utils.jid.gen_jid()
+            ret = salt.utils.jid.gen_jid({})
             self.assertEqual(ret, '20021225120000000000')
+            salt.utils.jid.LAST_JID_DATETIME = None
+            ret = salt.utils.jid.gen_jid({'unique_jid': True})
+            self.assertEqual(ret, '20021225120000000000_{0}'.format(os.getpid()))
+            ret = salt.utils.jid.gen_jid({'unique_jid': True})
+            self.assertEqual(ret, '20021225120000000001_{0}'.format(os.getpid()))
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
     def test_check_or_die(self):


### PR DESCRIPTION
### What does this PR do?

Having a jid that is occasionally not unique (eg two processes creating
jobs at about the same time) causes problems in my usage due to
job tracking assuming unique jids. Add a config option called `unique_jid`
that will enforce unique jids, but will change the jid format by
appending an underscore and the process id.

### Tests written?

Yes