### PR TITLE
Fix infinite loop with salt-cloud and Windows nodes

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -806,21 +806,21 @@ def wait_for_winexesvc(host, port, username, password, timeout=900):
                 log.debug('winexe connected...')
                 return True
             log.debug('Return code was {0}'.format(ret_code))
-            time.sleep(1)
         except socket.error as exc:
             log.debug('Caught exception in wait_for_winexesvc: {0}'.format(exc))
-            time.sleep(1)
-            if time.time() - start > timeout:
-                log.error('winexe connection timed out: {0}'.format(timeout))
-                return False
-            log.debug(
-                'Retrying winexe connection to host {0} on port {1} '
-                '(try {2})'.format(
-                    host,
-                    port,
-                    try_count
-                )
+
+        if time.time() - start > timeout:
+            log.error('winexe connection timed out: {0}'.format(timeout))
+            return False
+        log.debug(
+            'Retrying winexe connection to host {0} on port {1} '
+            '(try {2})'.format(
+                host,
+                port,
+                try_count
             )
+        )
+        time.sleep(1)
 
 
 def wait_for_winrm(host, port, username, password, timeout=900):
@@ -846,19 +846,19 @@ def wait_for_winrm(host, port, username, password, timeout=900):
                 log.debug('WinRM session connected...')
                 return s
             log.debug('Return code was {0}'.format(r.status_code))
-            time.sleep(1)
         except WinRMTransportError as exc:
             log.debug('Caught exception in wait_for_winrm: {0}'.format(exc))
-            if time.time() - start > timeout:
-                log.error('WinRM connection timed out: {0}'.format(timeout))
-                return None
-            log.debug(
-                'Retrying WinRM connection to host {0} on port {1} '
-                '(try {2})'.format(
-                    host, port, trycount
-                )
+
+        if time.time() - start > timeout:
+            log.error('WinRM connection timed out: {0}'.format(timeout))
+            return None
+        log.debug(
+            'Retrying WinRM connection to host {0} on port {1} '
+            '(try {2})'.format(
+                host, port, trycount
             )
-            time.sleep(1)
+        )
+        time.sleep(1)
 
 
 def validate_windows_cred(host,


### PR DESCRIPTION
### What does this PR do?
Fixes two infinite loops that can occur when salt-cloud deployment fails for Windows nodes

### What issues does this PR fix or reference?
None

### Previous Behavior
Certain errors during Windows deployment would cause an infinite loop. This is caused by a logic error that only honored the timeout parameters when an exception was thrown. It is common for the called functions to return an error code, but not throw an exception. In this case, the process would loop forever.

### New Behavior
Loops respect the timeout parameters.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
