### PR TITLE
Disk grain: attempt to retrieve HDD and SSD info on Windows

### DIFF
--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -165,7 +165,7 @@ def _windows_disks():
     else:
         for line in cmdret['stdout'].splitlines():
             info = line.split()
-            if len(info) != 2 or not info[0].isdigit or not info[1].isdigit:
+            if len(info) != 2 or not info[0].isdigit() or not info[1].isdigit():
                 continue
             device = r'\\.\PhysicalDrive{0}'.format(info[0])
             mediatype = info[1]


### PR DESCRIPTION
### What does this PR do?
Instead of skipping the disk grain on Windows, attempt to the retrieve the 'MediaType' property for physical drives using wmic.

### Previous Behavior
Disk grain is always empy on Windows.

### New Behavior
Disk grain is set on Windows, if the [MSFT_PhysicalDisk](https://msdn.microsoft.com/en-us/library/windows/desktop/hh830532(v=vs.85).aspx) WMI class is available (should work on anything newer than Windows 7 / Server 2008R2).

### Tests written?
No