### PR TITLE
Add a cmp compatibility function utility

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -22,6 +22,7 @@ from salt.ext.six.moves.urllib.request import urlopen as _urlopen  # pylint: dis
 # Import salt libs
 import salt.key
 import salt.utils
+import salt.utils.compat
 import salt.utils.minions
 import salt.client
 import salt.client.ssh
@@ -669,7 +670,7 @@ def versions():
             ver_diff = -2
         else:
             minion_version = salt.version.SaltStackVersion.parse(minions[minion])
-            ver_diff = cmp(minion_version, master_version)
+            ver_diff = salt.utils.compat.cmp(minion_version, master_version)
 
         if ver_diff not in version_status:
             version_status[ver_diff] = {}

--- a/salt/states/bigip.py
+++ b/salt/states/bigip.py
@@ -85,7 +85,7 @@ def _check_for_changes(entity_type, ret, existing, modified):
         if 'generation' in existing['content'].keys():
             del existing['content']['generation']
 
-        if cmp(modified['content'], existing['content']) == 0:
+        if modified['content'] == existing['content']:
             ret['comment'] = '{entity_type} is currently enforced to the desired state.  No changes made.'.format(entity_type=entity_type)
         else:
             ret['comment'] = '{entity_type} was enforced to the desired state.  Note: Only parameters specified ' \
@@ -94,7 +94,7 @@ def _check_for_changes(entity_type, ret, existing, modified):
             ret['changes']['new'] = modified['content']
 
     else:
-        if cmp(modified, existing) == 0:
+        if modified == existing:
             ret['comment'] = '{entity_type} is currently enforced to the desired state.  No changes made.'.format(entity_type=entity_type)
         else:
             ret['comment'] = '{entity_type} was enforced to the desired state.  Note: Only parameters specified ' \

--- a/salt/states/boto_cfn.py
+++ b/salt/states/boto_cfn.py
@@ -43,6 +43,9 @@ from __future__ import absolute_import
 import logging
 import json
 
+# Import Salt libs
+import salt.utils.compat
+
 # Import 3rd party libs
 try:
     from salt._compat import ElementTree as ET
@@ -158,7 +161,7 @@ def present(name, template_body=None, template_url=None, parameters=None, notifi
         template = template['GetTemplateResponse']['GetTemplateResult']['TemplateBody'].encode('ascii', 'ignore')
         template = json.loads(template)
         _template_body = json.loads(template_body)
-        compare = cmp(template, _template_body)
+        compare = salt.utils.compat.cmp(template, _template_body)
         if compare != 0:
             log.debug('Templates are not the same. Compare value is {0}'.format(compare))
             # At this point we should be able to run update safely since we already validated the template

--- a/salt/states/cisconso.py
+++ b/salt/states/cisconso.py
@@ -8,6 +8,12 @@ For documentation on setting up the cisconso proxy minion look in the documentat
 for :mod:`salt.proxy.cisconso <salt.proxy.cisconso>`.
 '''
 
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt libs
+import salt.utils.compat
+
 
 def __virtual__():
     return 'cisconso.set_data_value' in __salt__
@@ -53,7 +59,7 @@ def value_present(name, datastore, path, config):
 
     existing = __salt__['cisconso.get_data'](datastore, path)
 
-    if cmp(existing, config):
+    if salt.utils.compat.cmp(existing, config):
         ret['result'] = True
         ret['comment'] = 'Config is already set'
 

--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -206,7 +206,7 @@ def sections_present(name, sections=None, separator='='):
                 ret['result'] = False
                 ret['comment'] = "{0}".format(err)
                 return ret
-            if cmp(dict(sections[section]), cur_section) == 0:
+            if dict(sections[section]) == cur_section:
                 ret['comment'] += 'Section unchanged {0}.\n'.format(section)
                 continue
             elif cur_section:

--- a/salt/states/zabbix_usergroup.py
+++ b/salt/states/zabbix_usergroup.py
@@ -84,7 +84,7 @@ def present(name, **kwargs):
                     for right in kwargs['rights']:
                         for key in right:
                             right[key] = str(right[key])
-                    if cmp(sorted(kwargs['rights']), sorted(usergroup['rights'])) != 0:
+                    if sorted(kwargs['rights']) != sorted(usergroup['rights']):
                         update_rights = True
                 else:
                     update_rights = True

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -58,6 +58,7 @@ import salt.config
 import salt.loader
 import salt.template
 import salt.utils
+import salt.utils.compat
 import salt.utils.event
 from salt.utils import vt
 from salt.utils.nb_popen import NonBlockingPopen
@@ -3041,7 +3042,7 @@ def diff_node_cache(prov_dir, node, new_data, opts):
     # Perform a simple diff between the old and the new data, and if it differs,
     # return both dicts.
     # TODO: Return an actual diff
-    diff = cmp(new_data, cache_data)
+    diff = salt.utils.compat.cmp(new_data, cache_data)
     if diff != 0:
         fire_event(
             'event',

--- a/salt/utils/compat.py
+++ b/salt/utils/compat.py
@@ -46,3 +46,15 @@ def deepcopy_bound(name):
     finally:
         copy._deepcopy_dispatch = pre_dispatch
     return ret
+
+
+def cmp(x, y):
+    '''
+    Compatibility helper function to replace the ``cmp`` function from Python 2. The
+    ``cmp`` function is no longer available in Python 3.
+
+    cmp(x, y) -> integer
+
+    Return negative if x<y, zero if x==y, positive if x>y.
+    '''
+    return (x > y) - (x < y)


### PR DESCRIPTION
The ``cmp`` function has been removed in Python 3. This PR adds the functionality as a salt utility, so the function can be used across all Python versions.

Fixes #42697

This PR also updates all other calls to the "cmp" function: Some should just use the new utility function, while others can just be compared more directly without using `cmp`.


