### PR TITLE
Sort lists before comparing them in python 3 unit test

### DIFF
--- a/tests/unit/templates/test_jinja.py
+++ b/tests/unit/templates/test_jinja.py
@@ -497,7 +497,7 @@ class TestCustomExtensions(TestCase):
         env = Environment(extensions=[SerializerExtension])
         if six.PY3:
             rendered = env.from_string('{{ dataset|unique }}').render(dataset=dataset).strip("'{}").split("', '")
-            self.assertEqual(rendered, list(unique))
+            self.assertEqual(sorted(rendered), sorted(list(unique)))
         else:
             rendered = env.from_string('{{ dataset|unique }}').render(dataset=dataset)
             self.assertEqual(rendered, u"{0}".format(unique))


### PR DESCRIPTION
I have seen this test fail occasionally on Python3 because we're trying to compare two lists that have different orders in Python 3. This is the same fix as used in #42206, but for a different test.