### PR TITLE
only read file if ret is not a string in http.query

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -779,7 +779,8 @@ def _render(template, render, renderer, template_dict, opts):
         blacklist = opts.get('renderer_blacklist')
         whitelist = opts.get('renderer_whitelist')
         ret = compile_template(template, rend, renderer, blacklist, whitelist, **template_dict)
-        ret = ret.read()
+        if salt.utils.stringio.is_readable(ret):
+            ret = ret.read()
         if str(ret).startswith('#!') and not str(ret).startswith('#!/'):
             ret = str(ret).split('\n', 1)[1]
         return ret


### PR DESCRIPTION
### What does this PR do?
Without this, we have the chance of running into 

```
     Comment: An exception occurred in this state: Traceback (most recent call last):             
                File "/home/ch3ll/git/salt/salt/state.py", line 1750, in call                     
                  **cdata['kwargs'])                                                              
                File "/home/ch3ll/git/salt/salt/loader.py", line 1705, in wrapper                 
                  return f(*args, **kwargs)      
                File "/home/ch3ll/git/salt/salt/states/http.py", line 90, in query                
                  data = __salt__['http.query'](name, **kwargs)                                   
                File "/home/ch3ll/git/salt/salt/modules/http.py", line 33, in query               
                  return salt.utils.http.query(url=url, opts=__opts__, **kwargs)                  
                File "/home/ch3ll/git/salt/salt/utils/http.py", line 196, in query                
                  data_file, data_render, data_renderer, template_dict, opts                      
                File "/home/ch3ll/git/salt/salt/utils/http.py", line 768, in _render              
                  ret = ret.read()               
              AttributeError: 'str' object has no attribute 'read'    
```
### Tests written?

No