### PR TITLE
Fix 'preserve_minion_cache: True' functionality (fixes #35840)

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2186,6 +2186,16 @@ class SaltKeyOptionParser(six.with_metaclass(OptionParserMeta,
                   'Default: %default.')
         )
 
+        self.add_option(
+            '--preserve-minions',
+            default=False,
+            help=('Setting this to True prevents the master from deleting '
+                  'the minion cache when keys are deleted, this may have '
+                  'security implications if compromised minions auth with '
+                  'a previous deleted minion ID. '
+                  'Default: %default.')
+        )
+
         key_options_group = optparse.OptionGroup(
             self, 'Key Generation Options'
         )
@@ -2284,6 +2294,13 @@ class SaltKeyOptionParser(six.with_metaclass(OptionParserMeta,
                 self.options.rotate_aes_key = True
             elif self.options.rotate_aes_key.lower() == 'false':
                 self.options.rotate_aes_key = False
+
+    def process_preserve_minions(self):
+        if hasattr(self.options, 'preserve_minions') and isinstance(self.options.preserve_minions, str):
+            if self.options.preserve_minions.lower() == 'true':
+                self.options.preserve_minions = True
+            elif self.options.preserve_minions.lower() == 'false':
+                self.options.preserve_minions = False
 
     def process_list(self):
         # Filter accepted list arguments as soon as possible


### PR DESCRIPTION
### What does this PR do?
Fix 'preserve_minion_cache: True' functionality

### What issues does this PR fix or reference?
Fixes #35840

### Previous Behavior
preserve_minion_cache: True would still delete cache directories

### New Behavior
preserve_minion_cache: True works again

### Tests written?
No. tested manually

### Original Commit Message Follows:

Fix 'preserve_minion_cache: True' functionality (fixes #35840)

- Drop preserve_minions as a a condition used in the check_minion_cache()
  logic test. This should be more in line with the intent of the "Optionally,
  pass in a list of minions which should have their caches preserved. To
  preserve all caches, set __opts__['preserve_minion_cache']" comment
  documented in key.py.
- Add --preserve_minions as an optional CLI option to salt-key. This will
  allow the user to optionally preserve caches independently of the
  preserve_minion_cache option. Option does not override config file.
- This effectively reverts commit 661f5686bf1090554d571a6ed23f09d511f5a15a
  which introduced the regression with preserve_minion_cache set to True to
  fix a regression when preserve_minion_cache is set to False. Prior to that
  commit, the preserve_minion_cache option was completely ignored when set to
  True and when set to False cache directories were still preserved.
- Functional testing (three minions 'minion1', 'oldminion', and 'minion2')
  /etc/salt/master - preserve_minion_cache: False
  # salt-key -d minion1
    PASS: deletes 'minion1', deletes stale 'oldminion', preserve active 'minion2'
  # salt-key -d minion1 --preserve-minions=true
    PASS: preserves minion1 as requested, deletes oldminion as it was not in the
    match from the delete_key() comment "To preserve the master caches of
    minions who are matched", preserves active minion2
  /etc/salt/master - preserve_minion_cache: True
  # salt-key -d minion1
    PASS:  no directories deleted per config option
  # salt-key -d minion1 --preserve-minions=false
    PASS:  no directories deleted per config option, does not override config

