### PR TITLE
Add --skip-grains option to salt-run

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2782,6 +2782,12 @@ class SaltRunOptionParser(six.with_metaclass(OptionParserMeta,
             action='store_true',
             help=('Start the runner operation and immediately return control.')
         )
+        self.add_option(
+            '--skip-grains',
+            default=False,
+            action='store_true',
+            help=('Do not load grains.')
+        )
         group = self.output_options_group = optparse.OptionGroup(
             self, 'Output Options', 'Configure your preferred output format.'
         )


### PR DESCRIPTION
### What does this PR do?

This will allow the user to skip grains generation and save the
2+ seconds it takes to generate grains for each call to `salt-run`.
Grains are not commonly used in runners.

### Tests written?

No