### PR TITLE
Remove waits and retries from Saltify deployment

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -311,6 +311,11 @@ def bootstrap(vm_, opts):
             }
         }
 
+    if vm_.get('driver', 'none:none').split(':')[1] == 'saltify':
+        saltify_driver = True
+    else:
+        saltify_driver = False
+
     key_filename = salt.config.get_cloud_config_value(
         'key_filename', vm_, opts, search_global=False,
         default=salt.config.get_cloud_config_value(
@@ -475,6 +480,9 @@ def bootstrap(vm_, opts):
         'make_minion', vm_, opts, default=True
     )
 
+    if saltify_driver:
+        deploy_kwargs['wait_for_passwd_maxtries'] = 0  # No need to wait/retry with Saltify
+
     win_installer = salt.config.get_cloud_config_value(
         'win_installer', vm_, opts
     )
@@ -499,6 +507,8 @@ def bootstrap(vm_, opts):
         deploy_kwargs['winrm_port'] = salt.config.get_cloud_config_value(
             'winrm_port', vm_, opts, default=5986
         )
+        if saltify_driver:
+            deploy_kwargs['port_timeout'] = 1  # No need to wait/retry with Saltify
 
     # Store what was used to the deploy the VM
     event_kwargs = copy.deepcopy(deploy_kwargs)


### PR DESCRIPTION
### What does this PR do?
Remove retry/wait logic when using Saltify cloud provider.

The waits and retries are there to give a new VM a chance
to be created and booted. Saltify works against existing
VMs, so there is no need to wait for services to become
available.

### What issues does this PR fix or reference?
None

### Previous Behavior
Saltify would retry for 15 minutes before giving up on a Saltify deployment

### New Behavior
Saltify assumes the VM already exists and does not retry on failed attempts. There is a 1 minute retry interval when starting winexesvc on Windows, to give that service time to start.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
