### PR TITLE
feature: override etcd_mod parameters using kwargs

### DIFF
--- a/salt/modules/etcd_mod.py
+++ b/salt/modules/etcd_mod.py
@@ -73,7 +73,7 @@ def __virtual__():
             'python etcd library not available.')
 
 
-def get_(key, recurse=False, profile=None):
+def get_(key, recurse=False, profile=None, **kwargs):
     '''
     .. versionadded:: 2014.7.0
 
@@ -86,15 +86,16 @@ def get_(key, recurse=False, profile=None):
         salt myminion etcd.get /path/to/key
         salt myminion etcd.get /path/to/key profile=my_etcd_config
         salt myminion etcd.get /path/to/key recurse=True profile=my_etcd_config
+        salt myminion etcd.get /path/to/key host=127.0.0.1 port=2379
     '''
-    client = __utils__['etcd_util.get_conn'](__opts__, profile)
+    client = __utils__['etcd_util.get_conn'](__opts__, profile, **kwargs)
     if recurse:
         return client.tree(key)
     else:
         return client.get(key, recurse=recurse)
 
 
-def set_(key, value, profile=None, ttl=None, directory=False):
+def set_(key, value, profile=None, ttl=None, directory=False, **kwargs):
     '''
     .. versionadded:: 2014.7.0
 
@@ -107,15 +108,16 @@ def set_(key, value, profile=None, ttl=None, directory=False):
 
         salt myminion etcd.set /path/to/key value
         salt myminion etcd.set /path/to/key value profile=my_etcd_config
+        salt myminion etcd.set /path/to/key value host=127.0.0.1 port=2379
         salt myminion etcd.set /path/to/dir '' directory=True
         salt myminion etcd.set /path/to/key value ttl=5
     '''
 
-    client = __utils__['etcd_util.get_conn'](__opts__, profile)
+    client = __utils__['etcd_util.get_conn'](__opts__, profile, **kwargs)
     return client.set(key, value, ttl=ttl, directory=directory)
 
 
-def update(fields, path='', profile=None):
+def update(fields, path='', profile=None, **kwargs):
     '''
     .. versionadded:: 2016.3.0
 
@@ -162,13 +164,14 @@ def update(fields, path='', profile=None):
 
         salt myminion etcd.update "{'/path/to/key': 'baz', '/another/key': 'bar'}"
         salt myminion etcd.update "{'/path/to/key': 'baz', '/another/key': 'bar'}" profile=my_etcd_config
+        salt myminion etcd.update "{'/path/to/key': 'baz', '/another/key': 'bar'}" host=127.0.0.1 port=2379
         salt myminion etcd.update "{'/path/to/key': 'baz', '/another/key': 'bar'}" path='/some/root'
     '''
-    client = __utils__['etcd_util.get_conn'](__opts__, profile)
+    client = __utils__['etcd_util.get_conn'](__opts__, profile, **kwargs)
     return client.update(fields, path)
 
 
-def watch(key, recurse=False, profile=None, timeout=0, index=None):
+def watch(key, recurse=False, profile=None, timeout=0, index=None, **kwargs):
     '''
     .. versionadded:: 2016.3.0
 
@@ -186,13 +189,14 @@ def watch(key, recurse=False, profile=None, timeout=0, index=None):
         salt myminion etcd.watch /path/to/key
         salt myminion etcd.watch /path/to/key timeout=10
         salt myminion etcd.watch /patch/to/key profile=my_etcd_config index=10
+        salt myminion etcd.watch /patch/to/key host=127.0.0.1 port=2379
     '''
 
-    client = __utils__['etcd_util.get_conn'](__opts__, profile)
+    client = __utils__['etcd_util.get_conn'](__opts__, profile, **kwargs)
     return client.watch(key, recurse=recurse, timeout=timeout, index=index)
 
 
-def ls_(path='/', profile=None):
+def ls_(path='/', profile=None, **kwargs):
     '''
     .. versionadded:: 2014.7.0
 
@@ -206,12 +210,13 @@ def ls_(path='/', profile=None):
 
         salt myminion etcd.ls /path/to/dir/
         salt myminion etcd.ls /path/to/dir/ profile=my_etcd_config
+        salt myminion etcd.ls /path/to/dir/ host=127.0.0.1 port=2379
     '''
-    client = __utils__['etcd_util.get_conn'](__opts__, profile)
+    client = __utils__['etcd_util.get_conn'](__opts__, profile, **kwargs)
     return client.ls(path)
 
 
-def rm_(key, recurse=False, profile=None):
+def rm_(key, recurse=False, profile=None, **kwargs):
     '''
     .. versionadded:: 2014.7.0
 
@@ -225,13 +230,14 @@ def rm_(key, recurse=False, profile=None):
 
         salt myminion etcd.rm /path/to/key
         salt myminion etcd.rm /path/to/key profile=my_etcd_config
+        salt myminion etcd.rm /path/to/key host=127.0.0.1 port=2379
         salt myminion etcd.rm /path/to/dir recurse=True profile=my_etcd_config
     '''
-    client = __utils__['etcd_util.get_conn'](__opts__, profile)
+    client = __utils__['etcd_util.get_conn'](__opts__, profile, **kwargs)
     return client.rm(key, recurse=recurse)
 
 
-def tree(path='/', profile=None):
+def tree(path='/', profile=None, **kwargs):
     '''
     .. versionadded:: 2014.7.0
 
@@ -244,7 +250,8 @@ def tree(path='/', profile=None):
 
         salt myminion etcd.tree
         salt myminion etcd.tree profile=my_etcd_config
+        salt myminion etcd.tree host=127.0.0.1 port=2379
         salt myminion etcd.tree /path/to/keys profile=my_etcd_config
     '''
-    client = __utils__['etcd_util.get_conn'](__opts__, profile)
+    client = __utils__['etcd_util.get_conn'](__opts__, profile, **kwargs)
     return client.tree(path)

--- a/salt/states/etcd_mod.py
+++ b/salt/states/etcd_mod.py
@@ -41,6 +41,19 @@ or clusters are available.
     as this makes all master configuration settings available in all minion's
     pillars.
 
+Etcd profile configuration can be overriden using following arguments: ``host``,
+``port``, ``username``, ``password``, ``ca``, ``client_key`` and ``client_cert``.
+
+.. code-block:: yaml
+    my-value:
+      etcd.set:
+        - name: /path/to/key
+        - value: value
+        - host: 127.0.0.1
+        - port: 2379
+        - username: user
+        - password: pass
+
 Available Functions
 -------------------
 
@@ -132,7 +145,7 @@ def __virtual__():
     return __virtualname__ if HAS_ETCD else False
 
 
-def set_(name, value, profile=None):
+def set_(name, value, profile=None, **kwargs):
     '''
     Set a key in etcd and can be called as ``set``.
 
@@ -161,11 +174,11 @@ def set_(name, value, profile=None):
         'changes': {}
     }
 
-    current = __salt__['etcd.get'](name, profile=profile)
+    current = __salt__['etcd.get'](name, profile=profile, **kwargs)
     if not current:
         created = True
 
-    result = __salt__['etcd.set'](name, value, profile=profile)
+    result = __salt__['etcd.set'](name, value, profile=profile, **kwargs)
 
     if result and result != current:
         if created:
@@ -179,7 +192,7 @@ def set_(name, value, profile=None):
     return rtn
 
 
-def wait_set(name, value, profile=None):
+def wait_set(name, value, profile=None, **kwargs):
     '''
     Set a key in etcd only if the watch statement calls it. This function is
     also aliased as ``wait_set``.
@@ -208,7 +221,7 @@ def wait_set(name, value, profile=None):
     }
 
 
-def directory(name, profile=None):
+def directory(name, profile=None, **kwargs):
     '''
     Create a directory in etcd.
 
@@ -234,11 +247,11 @@ def directory(name, profile=None):
         'changes': {}
     }
 
-    current = __salt__['etcd.get'](name, profile=profile, recurse=True)
+    current = __salt__['etcd.get'](name, profile=profile, recurse=True, **kwargs)
     if not current:
         created = True
 
-    result = __salt__['etcd.set'](name, None, directory=True, profile=profile)
+    result = __salt__['etcd.set'](name, None, directory=True, profile=profile, **kwargs)
 
     if result and result != current:
         if created:
@@ -250,7 +263,7 @@ def directory(name, profile=None):
     return rtn
 
 
-def rm_(name, recurse=False, profile=None):
+def rm_(name, recurse=False, profile=None, **kwargs):
     '''
     Deletes a key from etcd. This function is also aliased as ``rm``.
 
@@ -275,11 +288,11 @@ def rm_(name, recurse=False, profile=None):
         'changes': {}
     }
 
-    if not __salt__['etcd.get'](name, profile=profile):
+    if not __salt__['etcd.get'](name, profile=profile, **kwargs):
         rtn['comment'] = 'Key does not exist'
         return rtn
 
-    if __salt__['etcd.rm'](name, recurse=recurse, profile=profile):
+    if __salt__['etcd.rm'](name, recurse=recurse, profile=profile, **kwargs):
         rtn['comment'] = 'Key removed'
         rtn['changes'] = {
             name: 'Deleted'
@@ -290,7 +303,7 @@ def rm_(name, recurse=False, profile=None):
     return rtn
 
 
-def wait_rm(name, recurse=False, profile=None):
+def wait_rm(name, recurse=False, profile=None, **kwargs):
     '''
     Deletes a key from etcd only if the watch statement calls it.
     This function is also aliased as ``wait_rm``.

--- a/salt/utils/etcd_util.py
+++ b/salt/utils/etcd_util.py
@@ -79,7 +79,8 @@ class EtcdUtilWatchTimeout(Exception):
 
 
 class EtcdClient(object):
-    def __init__(self, opts, profile=None):
+    def __init__(self, opts, profile=None,
+                 host=None, port=None, username=None, password=None, ca=None, client_key=None, client_cert=None, **kwargs):
         opts_pillar = opts.get('pillar', {})
         opts_master = opts_pillar.get('master', {})
 
@@ -93,13 +94,13 @@ class EtcdClient(object):
         else:
             self.conf = opts_merged
 
-        host = self.conf.get('etcd.host', '127.0.0.1')
-        port = self.conf.get('etcd.port', 4001)
-        username = self.conf.get('etcd.username')
-        password = self.conf.get('etcd.password')
-        ca_cert = self.conf.get('etcd.ca')
-        cli_key = self.conf.get('etcd.client_key')
-        cli_cert = self.conf.get('etcd.client_cert')
+        host = host or self.conf.get('etcd.host', '127.0.0.1')
+        port = port or self.conf.get('etcd.port', 4001)
+        username = username or self.conf.get('etcd.username')
+        password = password or self.conf.get('etcd.password')
+        ca_cert = ca or self.conf.get('etcd.ca')
+        cli_key = client_key or self.conf.get('etcd.client_key')
+        cli_cert = client_cert or self.conf.get('etcd.client_cert')
 
         auth = {}
         if username and password:
@@ -351,8 +352,8 @@ class EtcdClient(object):
         return ret
 
 
-def get_conn(opts, profile=None):
-    client = EtcdClient(opts, profile)
+def get_conn(opts, profile=None, **kwargs):
+    client = EtcdClient(opts, profile, **kwargs)
     return client
 
 


### PR DESCRIPTION
### What does this PR do?

Implement overrides to etcd profile parameters currently available only via minion/master configuration.

### What issues does this PR fix or reference?

#42677

### Previous Behavior
Etcd profile parameters can be only specified in master/minion configuration.

### New Behavior
Etcd profile can now be overridden by specifying kwargs in state/module.

### Tests written?

No
