### PR TITLE
Fix exception when master_type=disable

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1985,8 +1985,9 @@ class Minion(MinionBase):
         elif tag.startswith('_minion_mine'):
             self._mine_send(tag, data)
         elif tag.startswith('fire_master'):
-            log.debug('Forwarding master event tag={tag}'.format(tag=data['tag']))
-            self._fire_master(data['data'], data['tag'], data['events'], data['pretag'])
+            if self.connected:
+                log.debug('Forwarding master event tag={tag}'.format(tag=data['tag']))
+                self._fire_master(data['data'], data['tag'], data['events'], data['pretag'])
         elif tag.startswith(master_event(type='disconnected')) or tag.startswith(master_event(type='failback')):
             # if the master disconnect event is for a different master, raise an exception
             if tag.startswith(master_event(type='disconnected')) and data['master'] != self.opts['master']:


### PR DESCRIPTION
### What does this PR do?

The following exception occasionally occurs when `master_type=disable`:

```
  File "/usr/lib/python2.7/site-packages/salt/minion.py", line 1989,
  in handle_event
    self._fire_master(data['data'], data['tag'], data['events'],
    data['pretag'])
  File "/usr/lib/python2.7/site-packages/salt/minion.py", line 1261, in
  _fire_master
    'tok': self.tok}
AttributeError: 'Minion' object has no attribute 'tok'
```

This occurs because it tries to fire a master event when the minion
is not connected to the master, in this case due to an action from a
beacon.

### Tests written?

No