### PR TITLE
Update doc references in glusterfs.volume_present

### DIFF
--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -121,13 +121,13 @@ def volume_present(name, bricks, stripe=False, replica=False, device_vg=False,
     .. code-block:: yaml
 
         myvolume:
-          glusterfs.created:
+          glusterfs.volume_present:
             - bricks:
                 - host1:/srv/gluster/drive1
                 - host2:/srv/gluster/drive2
 
         Replicated Volume:
-          glusterfs.created:
+          glusterfs.volume_present:
             - name: volume2
             - bricks:
               - host1:/srv/gluster/drive2


### PR DESCRIPTION
The "created" option has been deprecated in favor of volume_present and the docs need to match.

Fixes #42683
