### PR TITLE
Update modules --> states in kubernetes doc module

### DIFF
--- a/doc/ref/states/all/salt.states.kubernetes.rst
+++ b/doc/ref/states/all/salt.states.kubernetes.rst
@@ -1,6 +1,6 @@
-=======================
-salt.modules.kubernetes
-=======================
+======================
+salt.states.kubernetes
+======================
 
-.. automodule:: salt.modules.kubernetes
+.. automodule:: salt.states.kubernetes
     :members:


### PR DESCRIPTION
The kubernetes state docs are not rendering/building due to a typo in the doc module.

Fixes #42639
