### PR TITLE
Ignore error values when listing Windows SNMP community strings

### DIFF
--- a/salt/modules/win_snmp.py
+++ b/salt/modules/win_snmp.py
@@ -303,6 +303,11 @@ def get_community_names():
     # Windows SNMP service GUI.
     if isinstance(current_values, list):
         for current_value in current_values:
+
+            # Ignore error values
+            if not isinstance(current_value, dict):
+                continue
+
             permissions = str()
             for permission_name in _PERMISSION_TYPES:
                 if current_value['vdata'] == _PERMISSION_TYPES[permission_name]:


### PR DESCRIPTION
### What does this PR do?
Fix an error in `win_snmp.get_community_names()`.

### What issues does this PR fix or reference?
None

### Previous Behavior
The function would fail if SNMP was not installed, because the registry key would not exist.

### New Behavior
Return an empty set of community strings if SNMP is not installed.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
