### PR TITLE
Yield timed out minions from LocalClient.cmd_iter

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -844,6 +844,10 @@ class LocalClient(object):
         The function signature is the same as :py:meth:`cmd` with the
         following exceptions.
 
+        Normally :py:meth:`cmd_iter` does not yield results for minions that
+        are not connected. If you want it to return results for disconnected
+        minions set `expect_minions=True` in `kwargs`.
+
         :return: A generator yielding the individual minion returns
 
         .. code-block:: python

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -837,6 +837,7 @@ class LocalClient(object):
             tgt_type=u'glob',
             ret=u'',
             kwarg=None,
+            yield_all_minions=True,
             **kwargs):
         '''
         Yields the individual minion returns as they come in
@@ -883,7 +884,8 @@ class LocalClient(object):
             else:
                 if kwargs.get(u'yield_pub_data'):
                     yield pub_data
-                kwargs.setdefault('expect_minions', True)
+                if yield_all_minions:
+                    kwargs['expect_minions'] = True
                 for fn_ret in self.get_iter_returns(pub_data[u'jid'],
                                                     pub_data[u'minions'],
                                                     timeout=self._get_timeout(timeout),
@@ -909,6 +911,7 @@ class LocalClient(object):
             kwarg=None,
             show_jid=False,
             verbose=False,
+            yield_all_minions=True,
             **kwargs):
         '''
         Yields the individual minion returns as they come in, or None
@@ -958,6 +961,8 @@ class LocalClient(object):
             if not pub_data:
                 yield pub_data
             else:
+                if yield_all_minions:
+                    kwargs['expect_minions'] = True
                 for fn_ret in self.get_iter_returns(pub_data[u'jid'],
                                                     pub_data[u'minions'],
                                                     timeout=timeout,

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -883,6 +883,7 @@ class LocalClient(object):
             else:
                 if kwargs.get(u'yield_pub_data'):
                     yield pub_data
+                kwargs.setdefault('expect_minions', True)
                 for fn_ret in self.get_iter_returns(pub_data[u'jid'],
                                                     pub_data[u'minions'],
                                                     timeout=self._get_timeout(timeout),

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -883,7 +883,6 @@ class LocalClient(object):
             else:
                 if kwargs.get(u'yield_pub_data'):
                     yield pub_data
-                kwargs.setdefault('expect_minions', True)
                 for fn_ret in self.get_iter_returns(pub_data[u'jid'],
                                                     pub_data[u'minions'],
                                                     timeout=self._get_timeout(timeout),

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -837,7 +837,6 @@ class LocalClient(object):
             tgt_type=u'glob',
             ret=u'',
             kwarg=None,
-            yield_all_minions=True,
             **kwargs):
         '''
         Yields the individual minion returns as they come in
@@ -884,8 +883,7 @@ class LocalClient(object):
             else:
                 if kwargs.get(u'yield_pub_data'):
                     yield pub_data
-                if yield_all_minions:
-                    kwargs['expect_minions'] = True
+                kwargs.setdefault('expect_minions', True)
                 for fn_ret in self.get_iter_returns(pub_data[u'jid'],
                                                     pub_data[u'minions'],
                                                     timeout=self._get_timeout(timeout),
@@ -911,7 +909,6 @@ class LocalClient(object):
             kwarg=None,
             show_jid=False,
             verbose=False,
-            yield_all_minions=True,
             **kwargs):
         '''
         Yields the individual minion returns as they come in, or None
@@ -961,8 +958,6 @@ class LocalClient(object):
             if not pub_data:
                 yield pub_data
             else:
-                if yield_all_minions:
-                    kwargs['expect_minions'] = True
                 for fn_ret in self.get_iter_returns(pub_data[u'jid'],
                                                     pub_data[u'minions'],
                                                     timeout=timeout,


### PR DESCRIPTION
### What does this PR do?

Makes `LocalClient.cmd_iter` return value consistent with `LocalClient.cmd`

### What issues does this PR fix or reference?

Fixes #42711

### Previous Behavior

Timed out minions are not yielded from the iterator.

### New Behavior

Timed out minions are yielded from the iterator.

### Tests written?

No
