### PR TITLE
Fix passing version in pkgs as shown in docs

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1073,8 +1073,11 @@ def installed(
 
         ``NOTE:`` For :mod:`apt <salt.modules.aptpkg>`,
         :mod:`ebuild <salt.modules.ebuild>`,
-        :mod:`pacman <salt.modules.pacman>`, :mod:`yumpkg <salt.modules.yumpkg>`,
-        and :mod:`zypper <salt.modules.zypper>`, version numbers can be specified
+        :mod:`pacman <salt.modules.pacman>`,
+        :mod:`winrepo <salt.modules.win_pkg>`,
+        :mod:`yumpkg <salt.modules.yumpkg>`, and
+        :mod:`zypper <salt.modules.zypper>`,
+        version numbers can be specified
         in the ``pkgs`` argument. For example:
 
         .. code-block:: yaml


### PR DESCRIPTION
### What does this PR do?
Fixes the `pkgs` parameter for `pkg.install` in Windows. Allow passing the version as a dict within the list.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/42757

### Previous Behavior
A stack-trace occurred if you passed a version in `pkgs`

### New Behavior
Version specified is now installed

### Tests written?
No