### PR TITLE
Document requirements for win_pki

### DIFF
--- a/salt/modules/win_pki.py
+++ b/salt/modules/win_pki.py
@@ -1,8 +1,17 @@
 # -*- coding: utf-8 -*-
 '''
-Microsoft certificate management via the Pki PowerShell module.
+Microsoft certificate management via the PKIClient PowerShell module.
+https://technet.microsoft.com/en-us/itpro/powershell/windows/pkiclient/pkiclient
+
+The PKI Client PowerShell module is only available on Windows 8+ and Windows
+Server 2012+.
+https://technet.microsoft.com/en-us/library/hh848636(v=wps.620).aspx
 
 :platform:      Windows
+
+:depends:
+    - PowerShell 4
+    - PKIClient Module (Windows 8+ / Windows Server 2012+)
 
 .. versionadded:: 2016.11.0
 '''
@@ -29,10 +38,16 @@ __virtualname__ = 'win_pki'
 
 def __virtual__():
     '''
-    Only works on Windows systems with the PKI PowerShell module installed.
+    Requires Windows
+    Requires Windows 8+ / Windows Server 2012+
+    Requires PowerShell
+    Requires PKIClient PowerShell module installed.
     '''
     if not salt.utils.is_windows():
         return False, 'Only available on Windows Systems'
+
+    if salt.utils.version_cmp(__grains__['osversion'], '6.2.9200') == -1:
+        return False, 'Only available on Windows 8+ / Windows Server 2012 +'
 
     if not __salt__['cmd.shell_info']('powershell')['installed']:
         return False, 'Powershell not available'

--- a/salt/modules/win_pki.py
+++ b/salt/modules/win_pki.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Microsoft certificate management via the PKIClient PowerShell module.
+Microsoft certificate management via the PKI Client PowerShell module.
 https://technet.microsoft.com/en-us/itpro/powershell/windows/pkiclient/pkiclient
 
 The PKI Client PowerShell module is only available on Windows 8+ and Windows
@@ -11,7 +11,7 @@ https://technet.microsoft.com/en-us/library/hh848636(v=wps.620).aspx
 
 :depends:
     - PowerShell 4
-    - PKIClient Module (Windows 8+ / Windows Server 2012+)
+    - PKI Client Module (Windows 8+ / Windows Server 2012+)
 
 .. versionadded:: 2016.11.0
 '''
@@ -41,7 +41,7 @@ def __virtual__():
     Requires Windows
     Requires Windows 8+ / Windows Server 2012+
     Requires PowerShell
-    Requires PKIClient PowerShell module installed.
+    Requires PKI Client PowerShell module installed.
     '''
     if not salt.utils.is_windows():
         return False, 'Only available on Windows Systems'


### PR DESCRIPTION
### What does this PR do?
The PKI Client PowerShell module is only available on Windows 8+ and Windows Server 2012+. Therefore the `win_pki` module will not work on Windows 7/Windows Server 2008R2.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/41633

### Previous Behavior
Module would fail to load on Windows 7/Server 2008R2 saying the PKI module is not available.
No documentation about requirements

### New Behavior
Now it fails to load warning that it's only available on Windows 8+/Server 2012+
Docs at the top of the module

### Tests written?
No