### PR TITLE
API changes for Kubernetes version 2.0.0

### DIFF
--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -2,7 +2,7 @@
 '''
 Module for handling kubernetes calls.
 
-:optdepends:    - kubernetes Python client
+:optdepends:    - kubernetes Python client >= version 2.0.0
 :configuration: The k8s API settings are provided either in a pillar, in
     the minion's config file, or in master's config file::
 
@@ -762,7 +762,7 @@ def create_deployment(
     '''
     body = __create_object_body(
         kind='Deployment',
-        obj_class=kubernetes.client.V1beta1Deployment,
+        obj_class=kubernetes.client.AppsV1beta1Deployment,
         spec_creator=__dict_to_deployment_spec,
         name=name,
         namespace=namespace,
@@ -1013,7 +1013,7 @@ def replace_deployment(name,
     '''
     body = __create_object_body(
         kind='Deployment',
-        obj_class=kubernetes.client.V1beta1Deployment,
+        obj_class=kubernetes.client.AppsV1beta1Deployment,
         spec_creator=__dict_to_deployment_spec,
         name=name,
         namespace=namespace,
@@ -1276,9 +1276,9 @@ def __dict_to_object_meta(name, namespace, metadata):
 
 def __dict_to_deployment_spec(spec):
     '''
-    Converts a dictionary into kubernetes V1beta1DeploymentSpec instance.
+    Converts a dictionary into kubernetes AppsV1beta1DeploymentSpec instance.
     '''
-    spec_obj = kubernetes.client.V1beta1DeploymentSpec()
+    spec_obj = kubernetes.client.AppsV1beta1DeploymentSpec()
     for key, value in iteritems(spec):
         if hasattr(spec_obj, key):
             setattr(spec_obj, key, value)

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -2,7 +2,7 @@
 '''
 Module for handling kubernetes calls.
 
-:optdepends:    - kubernetes Python client up to version 2.0.0
+:optdepends:    - kubernetes Python client
 :configuration: The k8s API settings are provided either in a pillar, in
     the minion's config file, or in master's config file::
 

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -2,7 +2,7 @@
 '''
 Module for handling kubernetes calls.
 
-:optdepends:    - kubernetes Python client >= version 2.0.0
+:optdepends:    - kubernetes Python client up to version 2.0.0
 :configuration: The k8s API settings are provided either in a pillar, in
     the minion's config file, or in master's config file::
 
@@ -39,6 +39,14 @@ try:
     HAS_LIBS = True
 except ImportError:
     HAS_LIBS = False
+
+try:
+    # There is an API change in Kubernetes >= 2.0.0.
+    from kubernetes.client import V1beta1Deployment as AppsV1beta1Deployment
+    from kubernetes.client import V1beta1DeploymentSpec as AppsV1beta1DeploymentSpec
+except ImportError:
+    from kubernetes.client import AppsV1beta1Deployment
+    from kubernetes.client import AppsV1beta1DeploymentSpec
 
 
 log = logging.getLogger(__name__)
@@ -762,7 +770,7 @@ def create_deployment(
     '''
     body = __create_object_body(
         kind='Deployment',
-        obj_class=kubernetes.client.AppsV1beta1Deployment,
+        obj_class=AppsV1beta1Deployment,
         spec_creator=__dict_to_deployment_spec,
         name=name,
         namespace=namespace,
@@ -1013,7 +1021,7 @@ def replace_deployment(name,
     '''
     body = __create_object_body(
         kind='Deployment',
-        obj_class=kubernetes.client.AppsV1beta1Deployment,
+        obj_class=AppsV1beta1Deployment,
         spec_creator=__dict_to_deployment_spec,
         name=name,
         namespace=namespace,
@@ -1278,7 +1286,7 @@ def __dict_to_deployment_spec(spec):
     '''
     Converts a dictionary into kubernetes AppsV1beta1DeploymentSpec instance.
     '''
-    spec_obj = kubernetes.client.AppsV1beta1DeploymentSpec()
+    spec_obj = AppsV1beta1DeploymentSpec()
     for key, value in iteritems(spec):
         if hasattr(spec_obj, key):
             setattr(spec_obj, key, value)


### PR DESCRIPTION
### What does this PR do?

~~Switching to the new [Kubernetes client lib](https://pypi.python.org/pypi/kubernetes/2.0.0) API introduced with version 2.0.0.~~
Made Saltstack Kubernetes module version agnostic to Kubernetes Python client.

### What issues does this PR fix or reference?

#42843

### Previous Behavior
You had to use Kubernetes Python client version 1.0.2.

### New Behavior
Now you can use Kubernetes Python client version 2.0.0 and below.
### Tests written?

No
