### PR TITLE
Execute fire_master asynchronously in the main minion thread.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1251,7 +1251,7 @@ class Minion(MinionBase):
         ret = yield channel.send(load, timeout=timeout)
         raise tornado.gen.Return(ret)
 
-    def _fire_master(self, data=None, tag=None, events=None, pretag=None, timeout=60, sync=True):
+    def _fire_master(self, data=None, tag=None, events=None, pretag=None, timeout=60, sync=True, timeout_handler=None):
         '''
         Fire an event on the master, or drop message if unable to send.
         '''
@@ -1270,9 +1270,10 @@ class Minion(MinionBase):
         else:
             return
 
-        def timeout_handler(*_):
-            log.info('fire_master failed: master could not be contacted. Request timed out.')
-            return True
+        if timeout_handler is None:
+            def timeout_handler(*_):
+                log.info('fire_master failed: master could not be contacted. Request timed out.')
+                return True
 
         if sync:
             try:
@@ -2205,13 +2206,15 @@ class Minion(MinionBase):
         if ping_interval > 0 and self.connected:
             def ping_master():
                 try:
-                    if not self._fire_master('ping', 'minion_ping'):
+                    def ping_timeout_handler(*_):
                         if not self.opts.get('auth_safemode', True):
                             log.error('** Master Ping failed. Attempting to restart minion**')
                             delay = self.opts.get('random_reauth_delay', 5)
                             log.info('delaying random_reauth_delay {0}s'.format(delay))
                             # regular sys.exit raises an exception -- which isn't sufficient in a thread
                             os._exit(salt.defaults.exitcodes.SALT_KEEPALIVE)
+
+                    self._fire_master('ping', 'minion_ping', sync=False, timeout_handler=ping_timeout_handler)
                 except Exception:
                     log.warning('Attempt to ping master failed.', exc_on_loglevel=logging.DEBUG)
             self.periodic_callbacks['ping'] = tornado.ioloop.PeriodicCallback(ping_master, ping_interval * 1000, io_loop=self.io_loop)
@@ -2226,7 +2229,7 @@ class Minion(MinionBase):
             except Exception:
                 log.critical('The beacon errored: ', exc_info=True)
             if beacons and self.connected:
-                self._fire_master(events=beacons)
+                self._fire_master(events=beacons, sync=False)
 
         self.periodic_callbacks['beacons'] = tornado.ioloop.PeriodicCallback(handle_beacons, loop_interval * 1000, io_loop=self.io_loop)
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1270,11 +1270,6 @@ class Minion(MinionBase):
         else:
             return
 
-        if timeout_handler is None:
-            def timeout_handler(*_):
-                log.info('fire_master failed: master could not be contacted. Request timed out.')
-                return True
-
         if sync:
             try:
                 self._send_req_sync(load, timeout)
@@ -1285,6 +1280,12 @@ class Minion(MinionBase):
                 log.info('fire_master failed: {0}'.format(traceback.format_exc()))
                 return False
         else:
+            if timeout_handler is None:
+                def handle_timeout(*_):
+                    log.info('fire_master failed: master could not be contacted. Request timed out.')
+                    return True
+                timeout_handler = handle_timeout
+
             with tornado.stack_context.ExceptionStackContext(timeout_handler):
                 self._send_req_async(load, timeout, callback=lambda f: None)  # pylint: disable=unexpected-keyword-arg
         return True


### PR DESCRIPTION
In another case it will block minion execution if master is not
responding.
This is actual for MultiMaster configuration because blocks minion to
respond to the active master requests if another one is down.

### What issues does this PR fix or reference?
Fixes #42753 
Fixes #42803

### Previous Behavior
If `ping_interval` is set in minion config and/or one or more beacons returning something non-empty are configured.
When minion is connected to two or more masters and one of them goes down. When minion tries to ping master or report beacon results to masters the synchronous master call to the failed master blocks minion until timeout.
This makes minion unresponsive to other master for all that time.

### New Behavior
Ping master and return beacon results in an async coroutine.

### Tests written?
No