### PR TITLE
Fix references to functions moved to salt.utils.platform

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2381,7 +2381,7 @@ def _zpool_data(grains):
         return {}
 
     # quickly return if NetBSD (ZFS still under development)
-    if salt.utils.is_netbsd():
+    if salt.utils.platform.is_netbsd():
         return {}
 
     # quickly return if no zpool and zfs command

--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -34,7 +34,7 @@ def disks():
         return _freebsd_geom()
     elif salt.utils.platform.is_linux():
         return _linux_disks()
-    elif salt.utils.is_windows():
+    elif salt.utils.platform.is_windows():
         return _windows_disks()
     else:
         log.trace('Disk grain does not support OS')

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -40,7 +40,7 @@ import salt.utils.path
 import salt.utils.platform
 import salt.utils.templates
 
-if salt.utils.is_windows():
+if salt.utils.platform.is_windows():
     import win32file
 
 # TODO: Check that the passed arguments are correct
@@ -1063,7 +1063,7 @@ def unzip(zip_file,
                             continue
                     zfile.extract(target, dest, password)
                     if extract_perms:
-                        if not salt.utils.is_windows():
+                        if not salt.utils.platform.is_windows():
                             perm = zfile.getinfo(target).external_attr >> 16
                             if perm == 0:
                                 umask_ = os.umask(0)

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -174,7 +174,7 @@ def get_printout(out, opts=None, **kwargs):
     else:
         if opts.get('force_color', False):
             opts['color'] = True
-        elif opts.get('no_color', False) or salt.utils.is_windows():
+        elif opts.get('no_color', False) or salt.utils.platform.is_windows():
             opts['color'] = False
         else:
             pass

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1437,7 +1437,7 @@ def absent(name):
             ret['comment'] = 'File {0} is set for removal'.format(name)
             return ret
         try:
-            if salt.utils.is_windows():
+            if salt.utils.platform.is_windows():
                 __salt__['file.remove'](name, force=True)
             else:
                 __salt__['file.remove'](name)
@@ -1454,7 +1454,7 @@ def absent(name):
             ret['comment'] = 'Directory {0} is set for removal'.format(name)
             return ret
         try:
-            if salt.utils.is_windows():
+            if salt.utils.platform.is_windows():
                 __salt__['file.remove'](name, force=True)
             else:
                 __salt__['file.remove'](name)

--- a/salt/states/hg.py
+++ b/salt/states/hg.py
@@ -27,7 +27,7 @@ from salt.states.git import _fail, _neutral_test
 
 log = logging.getLogger(__name__)
 
-HG_BINARY = 'hg.exe' if salt.utils.is_windows() else 'hg'
+HG_BINARY = 'hg.exe' if salt.utils.platform.is_windows() else 'hg'
 
 
 def __virtual__():


### PR DESCRIPTION
These refs all were added from a branch point before #42572. This commit
updates them to avoid a deprecation warning.