### PR TITLE
Removed '--quiet' to avoid continuous renewal

### DIFF
--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -125,7 +125,8 @@ def cert(name,
         salt 'gitlab.example.com' acme.cert dev.example.com "[gitlab.example.com]" test_cert=True renew=14 webroot=/opt/gitlab/embedded/service/gitlab-rails/public
     '''
 
-    cmd = [LEA, 'certonly', '--quiet']
+    # cmd = [LEA, 'certonly', '--quiet']
+    cmd = [LEA, 'certonly']
 
     cert_file = _cert_file(name, 'cert')
     if not __salt__['file.file_exists'](cert_file):


### PR DESCRIPTION
### What does this PR do?
runs certbot without `--quiet`

### What issues does this PR fix or reference?
running `certbot` with `--quiet` the if
```
if 'no action taken' in res['stdout']:
```

will never match, forcing continuous renewal of certificates

### Previous Behavior
Certificates where always renewed

### New Behavior
Certificates are renewed only when needed

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
