### PR TITLE
Add a key in opts that identify that we are running salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -223,6 +223,7 @@ class SSH(object):
         else:
             self.event = None
         self.opts = opts
+        self.opts['__salt_ssh'] = True
         if self.opts[u'regen_thin']:
             self.opts[u'ssh_wipe'] = True
         if not salt.utils.path.which(u'ssh'):


### PR DESCRIPTION
This just gives us a reliable way to verify that we are running salt-ssh
@edlane this is the consistent tag that you needed