### PR TITLE
skip cache_clean test if npm version is >= 5.0.0

### DIFF
--- a/tests/integration/states/npm.py
+++ b/tests/integration/states/npm.py
@@ -6,6 +6,7 @@
 '''
 # Import Python libs
 from __future__ import absolute_import
+from distutils.version import LooseVersion
 
 # Import Salt Testing libs
 from salttesting import skipIf
@@ -15,6 +16,9 @@ ensure_in_syspath('../../')
 # Import salt libs
 import integration
 import salt.utils
+import salt.modules.cmdmod as cmd
+
+MAX_NPM_VERSION = '5.0.0'
 
 
 @skipIf(salt.utils.which('npm') is None, 'npm not installed')
@@ -50,6 +54,7 @@ class NpmStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         ret = self.run_state('npm.installed', name=None, pkgs=['pm2', 'grunt'])
         self.assertSaltTrueReturn(ret)
 
+    @skipIf(LooseVersion(cmd.run('npm -v')) >= LooseVersion(MAX_NPM_VERSION), 'Skip with npm >= 5.0.0 until #41770 is fixed')
     @destructiveTest
     def test_npm_cache_clean(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Skip npm clean_cache test until #41770 is fixed.

Fixes saltstack/salt-jenkins#475

### Tests written?

Yes