### PR TITLE
hash_and_stat_file should return a 2-tuple

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1257,7 +1257,7 @@ class RemoteClient(Client):
             if not os.path.isfile(path):
                 msg = 'specified file {0} is not present to generate hash: {1}'
                 log.warning(msg.format(path, err))
-                return {}
+                return {}, None
             else:
                 ret = {}
                 hash_type = self.opts.get('hash_type', 'md5')


### PR DESCRIPTION
### What does this PR do?

Callers of `hash_and_stat_file` expect a 2-tuple and an exception will
be raised if only a single value is returned.

### Tests written?

No