### PR TITLE
Fix pkg.install salt-minion using salt-call

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1211,20 +1211,21 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         #Compute msiexec string
         use_msiexec, msiexec = _get_msiexec(pkginfo[version_num].get('msiexec', False))
 
+        # Build cmd and arguments
+        # cmd and arguments must be seperated for use with the task scheduler
+        if use_msiexec:
+            cmd = msiexec
+            arguments = ['/i', cached_pkg]
+            if pkginfo['version_num'].get('allusers', True):
+                arguments.append('ALLUSERS="1"')
+            arguments.extend(salt.utils.shlex_split(install_flags))
+        else:
+            cmd = cached_pkg
+            arguments = salt.utils.shlex_split(install_flags)
+
         # Install the software
         # Check Use Scheduler Option
         if pkginfo[version_num].get('use_scheduler', False):
-
-            # Build Scheduled Task Parameters
-            if use_msiexec:
-                cmd = msiexec
-                arguments = ['/i', cached_pkg]
-                if pkginfo['version_num'].get('allusers', True):
-                    arguments.append('ALLUSERS="1"')
-                arguments.extend(salt.utils.shlex_split(install_flags))
-            else:
-                cmd = cached_pkg
-                arguments = salt.utils.shlex_split(install_flags)
 
             # Create Scheduled Task
             __salt__['task.create_task'](name='update-salt-software',
@@ -1239,21 +1240,43 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                                          start_time='01:00',
                                          ac_only=False,
                                          stop_if_on_batteries=False)
+
             # Run Scheduled Task
-            if not __salt__['task.run_wait'](name='update-salt-software'):
-                log.error('Failed to install {0}'.format(pkg_name))
-                log.error('Scheduled Task failed to run')
-                ret[pkg_name] = {'install status': 'failed'}
-        else:
-            # Build the install command
-            cmd = []
-            if use_msiexec:
-                cmd.extend([msiexec, '/i', cached_pkg])
-                if pkginfo[version_num].get('allusers', True):
-                    cmd.append('ALLUSERS="1"')
+            # Special handling for installing salt
+            if pkg_name in ['salt-minion', 'salt-minion-py3']:
+                ret[pkg_name] = {'install status': 'task started'}
+                if not __salt__['task.run'](name='update-salt-software'):
+                    log.error('Failed to install {0}'.format(pkg_name))
+                    log.error('Scheduled Task failed to run')
+                    ret[pkg_name] = {'install status': 'failed'}
+                else:
+
+                    # Make sure the task is running, try for 5 secs
+                    from time import time
+                    t_end = time() + 5
+                    while time() < t_end:
+                        task_running = __salt__['task.status'](
+                                'update-salt-software') == 'Running'
+                        if task_running:
+                            break
+
+                    if not task_running:
+                        log.error(
+                            'Failed to install {0}'.format(pkg_name))
+                        log.error('Scheduled Task failed to run')
+                        ret[pkg_name] = {'install status': 'failed'}
+
+            # All other packages run with task scheduler
             else:
-                cmd.append(cached_pkg)
-            cmd.extend(salt.utils.shlex_split(install_flags))
+                if not __salt__['task.run_wait'](name='update-salt-software'):
+                    log.error('Failed to install {0}'.format(pkg_name))
+                    log.error('Scheduled Task failed to run')
+                    ret[pkg_name] = {'install status': 'failed'}
+        else:
+
+            # Combine cmd and arguments
+            cmd = [cmd].extend(arguments)
+
             # Launch the command
             result = __salt__['cmd.run_all'](cmd,
                                              cache_path,

--- a/salt/modules/win_task.py
+++ b/salt/modules/win_task.py
@@ -1259,7 +1259,7 @@ def status(name, location='\\'):
     task_service = win32com.client.Dispatch("Schedule.Service")
     task_service.Connect()
 
-    # get the folder to delete the folder from
+    # get the folder where the task is defined
     task_folder = task_service.GetFolder(location)
     task = task_folder.GetTask(name)
 


### PR DESCRIPTION
### What does this PR do?
When executing `pkg.install salt-minion` using salt-call there is still a Python process running maintaining locks on files that the installer is trying to overwrite. This is because the `install` function is using `task.run_wait` which waits for the task to finish before returning success. This is fine for standard programs that install using the scheduler, but bad for salt.

This change will use `task.run` and check that the task is actually running and then return that the task was started, not waiting for it to finish. This will apply only if the task was scheduled for `salt-minion` or `salt-minion-py3`.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40947

### Previous Behavior
When installing salt using `salt-call pkg.install salt-minion` the installation was left in an unknown state due to issues with locked files.

### New Behavior
All Python processes related to the `salt-call` now close, allowing the installation to complete successfully.

### Tests written?
No