### PR TITLE
Change to GitPython version 2.1.1

### DIFF
--- a/pkg/osx/req.txt
+++ b/pkg/osx/req.txt
@@ -7,7 +7,7 @@ CherryPy==11.0.0
 click==6.7
 enum34==1.1.6
 gitdb==0.6.4
-GitPython==2.1.5
+GitPython==2.1.1
 idna==2.5
 ipaddress==1.0.18
 Jinja2==2.9.6


### PR DESCRIPTION
### What does this PR do?
Changes to GitPython Version 2.1.1. The newer version requires that git be installed... which means installing xcode command line tools in osx. Git is still required for GitPython.

### What issues does this PR fix or reference?
Found during testing

### Previous Behavior
Stacktrace on minion start up if xcode command line tools is not installed.

### New Behavior
Minion starts successfully without xcode command line tools.

### Tests written?
NA