### PR TITLE
Stub out required functions in redis_cache

### DIFF
--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -115,7 +115,7 @@ from salt.exceptions import SaltCacheError
 
 __virtualname__ = 'redis'
 __func_alias__ = {
-    'list_': 'list'
+    'ls': 'list'
 }
 
 log = logging.getLogger(__file__)
@@ -144,6 +144,9 @@ def __virtual__():
 # -----------------------------------------------------------------------------
 # helper functions -- will not be exported
 # -----------------------------------------------------------------------------
+
+def init_kwargs(kwargs):
+    return {}
 
 
 def _get_redis_cache_opts():
@@ -415,7 +418,7 @@ def flush(bank, key=None):
     return True
 
 
-def list_(bank):
+def ls(bank):
     '''
     Lists entries stored in the specified bank.
     '''


### PR DESCRIPTION
Without these functions the masters are
not able to use the redis cache completely

Signed-off-by: Carson Anderson <ca@carsonoid.net>

### What does this PR do?

Adds some required stubs.

### What issues does this PR fix or reference?

N/A

### Previous Behavior

Masters could not use redis to get pillar data or check the responses from minions.

For example,. given a salt installation with two minions that are up and one that is down this is the result of a `test.ping`:

```
root@ip-172-30-6-82:~# salt \* test.ping
ip-172-30-7-18.ec2.internal:
    True
ip-172-30-8-18.ec2.internal:
    True
[ERROR   ] Exception raised when processing __virtual__ function for salt.loaded.int.cache.consul. Module will not be loaded: 'module' object has no attribute 'Consul'
[WARNING ] salt.loaded.int.cache.consul.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'consul', please fix this.
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
KeyError: 'redis.ls'
Traceback (most recent call last):
  File "/usr/bin/salt", line 10, in <module>
    salt_main()
  File "/usr/lib/python2.7/dist-packages/salt/scripts.py", line 476, in salt_main
    client.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/salt.py", line 173, in run
    for full_ret in cmd_func(**kwargs):
  File "/usr/lib/python2.7/dist-packages/salt/client/__init__.py", line 809, in cmd_cli
    **kwargs):
  File "/usr/lib/python2.7/dist-packages/salt/client/__init__.py", line 1601, in get_cli_event_returns
    connected_minions = salt.utils.minions.CkMinions(self.opts).connected_ids()
  File "/usr/lib/python2.7/dist-packages/salt/utils/minions.py", line 577, in connected_ids
    search = self.cache.ls('minions')
  File "/usr/lib/python2.7/dist-packages/salt/cache/__init__.py", line 244, in ls
    return self.modules[fun](bank, **self._kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1113, in __getitem__
    func = super(LazyLoader, self).__getitem__(item)
  File "/usr/lib/python2.7/dist-packages/salt/utils/lazy.py", line 101, in __getitem__
    raise KeyError(key)
KeyError: 'redis.ls'
Traceback (most recent call last):
  File "/usr/bin/salt", line 10, in <module>
    salt_main()
  File "/usr/lib/python2.7/dist-packages/salt/scripts.py", line 476, in salt_main
    client.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/salt.py", line 173, in run
    for full_ret in cmd_func(**kwargs):
  File "/usr/lib/python2.7/dist-packages/salt/client/__init__.py", line 809, in cmd_cli
    **kwargs):
  File "/usr/lib/python2.7/dist-packages/salt/client/__init__.py", line 1601, in get_cli_event_returns
    connected_minions = salt.utils.minions.CkMinions(self.opts).connected_ids()
  File "/usr/lib/python2.7/dist-packages/salt/utils/minions.py", line 577, in connected_ids
    search = self.cache.ls('minions')
  File "/usr/lib/python2.7/dist-packages/salt/cache/__init__.py", line 244, in ls
    return self.modules[fun](bank, **self._kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1113, in __getitem__
    func = super(LazyLoader, self).__getitem__(item)
  File "/usr/lib/python2.7/dist-packages/salt/utils/lazy.py", line 101, in __getitem__
    raise KeyError(key)
KeyError: 'redis.ls'

```

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
