### PR TITLE
Updates to Salt SSH

### DIFF
--- a/salt/cli/ssh.py
+++ b/salt/cli/ssh.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+import sys
 import salt.client.ssh
 import salt.utils.parsers
 from salt.utils.verify import verify_log
@@ -13,6 +14,9 @@ class SaltSSH(salt.utils.parsers.SaltSSHOptionParser):
     '''
 
     def run(self):
+        if '-H' in sys.argv or '--hosts' in sys.argv:
+            sys.argv += ['x', 'x']  # Hack: pass a mandatory two options
+                                    # that won't be used anyways with -H or --hosts
         self.parse_args()
         self.setup_logfile_logger()
         verify_log(self.config)

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -685,8 +685,21 @@ class SSH(object):
         '''
         Execute the overall routine, print results via outputters
         '''
-        fstr = u'{0}.prep_jid'.format(self.opts[u'master_job_cache'])
-        jid = self.returners[fstr](passed_jid=jid or self.opts.get(u'jid', None))
+        if self.opts['list_hosts']:
+            self._get_roster()
+            ret = {}
+            for roster_file in self.__parsed_rosters:
+                if roster_file.startswith('#'):
+                    continue
+                ret[roster_file] = {}
+                for host_id in self.__parsed_rosters[roster_file]:
+                    hostname = self.__parsed_rosters[roster_file][host_id]['host']
+                    ret[roster_file][host_id] = hostname
+            salt.output.display_output(ret, 'nested', self.opts)
+            sys.exit()
+
+        fstr = '{0}.prep_jid'.format(self.opts['master_job_cache'])
+        jid = self.returners[fstr](passed_jid=jid or self.opts.get('jid', None))
 
         # Save the invocation information
         argv = self.opts[u'argv']

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -229,7 +229,7 @@ class SSH(object):
         self.opts = opts
         if self.opts['regen_thin']:
             self.opts['ssh_wipe'] = True
-        if not salt.utils.which('ssh'):
+        if not salt.utils.path.which('ssh'):
             raise salt.exceptions.SaltSystemExit('No ssh binary found in path -- ssh must be '
                                                  'installed for salt-ssh to run. Exiting.')
         self.opts['_ssh_version'] = ssh_version()

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -379,7 +379,7 @@ class SSH(object):
         roster_file = self._get_roster()
         if os.access(roster_file, os.W_OK):
             if self.__parsed_rosters[self.ROSTER_UPDATE_FLAG]:
-                with open(roster_file, 'a') as roster_fp:
+                with salt.utils.files.fopen(roster_file, 'a') as roster_fp:
                     roster_fp.write('# Automatically added by "{s_user}" at {s_time}\n{hostname}:\n    host: '
                                     '{hostname}\n    user: {user}'
                                     '\n    passwd: {passwd}\n'.format(s_user=getpass.getuser(),

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -361,12 +361,10 @@ class SSH(object):
                 if not isinstance(roster_data, bool):
                     for host_id in roster_data:
                         if hostname in [host_id, roster_data.get('host')]:
-                            needs_expansion = hostname != self.opts['tgt']
+                            if hostname != self.opts['tgt']:
+                                self.opts['tgt'] = hostname
                             self.__parsed_rosters[self.ROSTER_UPDATE_FLAG] = False
-                            break
-
-        if needs_expansion:
-            self.opts['tgt'] = hostname
+                            return
 
     def _update_roster(self):
         '''

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -236,7 +236,8 @@ class SSH(object):
         self.targets = self.roster.targets(
                 self.opts[u'tgt'],
                 self.tgt_type)
-        self._update_targets()
+        if not self.targets:
+            self._update_targets()
         # If we're in a wfunc, we need to get the ssh key location from the
         # top level opts, stored in __master_opts__
         if u'__master_opts__' in self.opts:

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -351,6 +351,11 @@ class SSH(object):
         Figures out if the target is a reachable host without wildcards, expands if any.
         :return:
         '''
+        # TODO: Support -L
+        target = self.opts['tgt']
+        if isinstance(target, list):
+            return
+
         hostname = self.opts['tgt'].split('@')[-1]
         needs_expansion = '*' not in hostname and salt.utils.network.is_reachable_host(hostname)
         if needs_expansion:

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -230,7 +230,8 @@ class SSH(object):
         if self.opts['regen_thin']:
             self.opts['ssh_wipe'] = True
         if not salt.utils.which('ssh'):
-            raise salt.exceptions.SaltSystemExit('No ssh binary found in path -- ssh must be installed for salt-ssh to run. Exiting.')
+            raise salt.exceptions.SaltSystemExit('No ssh binary found in path -- ssh must be '
+                                                 'installed for salt-ssh to run. Exiting.')
         self.opts['_ssh_version'] = ssh_version()
         self.tgt_type = self.opts['selected_target_option'] \
             if self.opts['selected_target_option'] else 'glob'

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -235,7 +235,7 @@ class SSH(object):
         self.tgt_type = self.opts['selected_target_option'] \
             if self.opts['selected_target_option'] else 'glob'
         self._expand_target()
-        self.roster = salt.roster.Roster(opts, opts.get('roster', 'flat'))
+        self.roster = salt.roster.Roster(self.opts, self.opts.get('roster', 'flat'))
         self.targets = self.roster.targets(
                 self.opts[u'tgt'],
                 self.tgt_type)

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -17,12 +17,10 @@ import os
 import re
 import sys
 import time
-import yaml
 import uuid
 import tempfile
 import binascii
 import sys
-import ntpath
 
 # Import salt libs
 import salt.output

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -210,6 +210,21 @@ def ip_to_host(ip):
 # pylint: enable=C0103
 
 
+def is_reachable_host(entity_name):
+    '''
+    Returns a bool telling if the entity name is a reachable host (IPv4/IPv6/FQDN/etc).
+    :param hostname:
+    :return:
+    '''
+    try:
+        assert type(socket.getaddrinfo(entity_name, 0, 0, 0, 0)) == list
+        ret = True
+    except socket.gaierror:
+        ret = False
+
+    return ret
+
+
 def is_ip(ip):
     '''
     Returns a bool telling if the passed IP is a valid IPv4 or IPv6 address.

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -3038,6 +3038,14 @@ class SaltSSHOptionParser(six.with_metaclass(OptionParserMeta,
             action='store_true',
             help='Run command via sudo.'
         )
+        auth_group.add_option(
+            '--skip-roster',
+            dest='ssh_skip_roster',
+            default=False,
+            action='store_true',
+            help='If hostname is not found in the roster, do not store the information'
+                 'into the default roster file (flat).'
+        )
         self.add_option_group(auth_group)
 
         scan_group = optparse.OptionGroup(

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1059,6 +1059,13 @@ class TargetOptionsMixIn(six.with_metaclass(MixInMeta, object)):
         )
         self.add_option_group(group)
         group.add_option(
+            '-H', '--hosts',
+            default=False,
+            action='store_true',
+            dest='list_hosts',
+            help='List all known hosts to currently visible or other specified rosters'
+        )
+        group.add_option(
             '-E', '--pcre',
             default=False,
             action='store_true',


### PR DESCRIPTION
# What does this PR do?

This PR is first attempts for user-friendly updates to Salt SSH. Much more to come!

# New Behavior

All examples are supposed that hosts are within the domain `foo.bar`.

### No rosters (sometimes)

In order to contact _at least one_ machine, you need a roster. No roster — no joy. How about having none? Now you can do this, using typical SSH notation to set different than default user:

```bash
$ salt-ssh root@myhost --askpass cmd.run uptime
```

The command above will do the following:
- Resolve `myhost` to `myhost.foo.bar` (even if it is an DNS alias or incomplete)
- Use user `root` (optional). Or use the same username as `salt-ssh` is ran from.
- Automatically add all that information to the nearby writable roster, if possible. 

So the next call you can do just so:
```bash
$ salt-ssh myhost cmd.run uptime
```

### Tell me what you know already

Sometimes you want to know where your Salt SSH can connect to. So just query it with `-H` or `--hosts` command:
```bash
$ salt-ssh -H
```
It will list you known stuff just so:
```
/etc/salt/roster:
    ----------
    foo:
        myhost.foo.bar
    bar:
        anothermyhost.foo.bar
 ```

### Tests written?

No
