### PR TITLE
Add virtual func for cron state module

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -150,6 +150,13 @@ from salt.modules.cron import (
 )
 
 
+def __virtual__():
+    if 'cron.list_tab' in __salt__:
+        return True
+    else:
+        return (False, 'cron module could not be loaded')
+
+
 def _check_cron(user,
                 cmd,
                 minute=None,


### PR DESCRIPTION
This prevents a traceback when you attempt to use a cron state without
cron being installed.

Refs: https://github.com/saltstack/salt/issues/42853#issue-249436529