### PR TITLE
fix salt consul.get module crush on empty keys

### DIFF
--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -205,7 +205,11 @@ def get(consul_url=None, key=None, recurse=False, decode=False, raw=False):
     if ret['res']:
         if decode:
             for item in ret['data']:
-                item['Value'] = base64.b64decode(item['Value'])
+                if item['Value'] != None:
+                   item['Value'] = base64.b64decode(item['Value'])
+                else:
+                   item['Value'] = ""
+
     return ret
 
 

--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -206,9 +206,9 @@ def get(consul_url=None, key=None, recurse=False, decode=False, raw=False):
         if decode:
             for item in ret['data']:
                 if item['Value'] != None:
-                   item['Value'] = base64.b64decode(item['Value'])
+                    item['Value'] = base64.b64decode(item['Value'])
                 else:
-                   item['Value'] = ""
+                    item['Value'] = ""
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?
it fixes issue with consul.get module crush on empty keys

### What issues does this PR fix or reference?

If decode='True' is used with consul.get module, it tries to decode key value 
`base64.b64decode(item['Value'])`
but if value is None it fails


### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
