### PR TITLE
fix vmware for python 3.4.2 in salt.utils.vmware

### DIFF
--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -238,7 +238,7 @@ def _get_service_instance(host, username, password, protocol,
                     pwd=password,
                     protocol=protocol,
                     port=port,
-                    sslContext=ssl._create_unverified_context(),
+                    sslContext=getattr(ssl, '_create_unverified_context', getattr(ssl, '_create_stdlib_context'))(),
                     b64token=token,
                     mechanism=mechanism)
             else:


### PR DESCRIPTION
### What does this PR do?
Debian 8 has python 3.4.2. In 3.4.3, this pep https://www.python.org/dev/peps/pep-0476/#id31 changed the variable name.

### Tests written?

Yes