### PR TITLE
Fix failing boto tests

### DIFF
--- a/tests/unit/modules/test_boto_elb.py
+++ b/tests/unit/modules/test_boto_elb.py
@@ -16,7 +16,7 @@ except ImportError:
     HAS_BOTO = False
 
 try:
-    from moto import mock_ec2_deprecated, mock_elb
+    from moto import mock_ec2_deprecated, mock_elb_deprecated
     HAS_MOTO = True
 except ImportError:
     HAS_MOTO = False
@@ -25,19 +25,19 @@ except ImportError:
         '''
         if the mock_ec2_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_vpc unit tests to use the @mock_ec2_deprecated decorator
+        Allows boto_elb unit tests to use the @mock_ec2_deprecated decorator
         without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
         '''
         def stub_function(self):
             pass
         return stub_function
 
-    def mock_elb(self):
+    def mock_elb_deprecated(self):
         '''
-        if the mock_ec2_deprecated function is not available due to import failure
+        if the mock_elb_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_vpc unit tests to use the @mock_ec2_deprecated decorator
-        without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
+        Allows boto_elb unit tests to use the @mock_elb_deprecated decorator
+        without a "NameError: name 'mock_elb_deprecated' is not defined" error.
         '''
         def stub_function(self):
             pass
@@ -115,7 +115,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
         boto_elb.__virtual__()
 
     @mock_ec2_deprecated
-    @mock_elb
+    @mock_elb_deprecated
     def test_register_instances_valid_id_result_true(self):
         '''
         tests that given a valid instance id and valid ELB that
@@ -134,7 +134,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(True, register_result)
 
     @mock_ec2_deprecated
-    @mock_elb
+    @mock_elb_deprecated
     def test_register_instances_valid_id_string(self):
         '''
         tests that given a string containing a instance id and valid ELB that
@@ -157,7 +157,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual([reservations.instances[0].id], registered_instance_ids)
 
     @mock_ec2_deprecated
-    @mock_elb
+    @mock_elb_deprecated
     def test_deregister_instances_valid_id_result_true(self):
         '''
         tests that given an valid id the boto_elb deregister_instances method
@@ -178,7 +178,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(True, deregister_result)
 
     @mock_ec2_deprecated
-    @mock_elb
+    @mock_elb_deprecated
     def test_deregister_instances_valid_id_string(self):
         '''
         tests that given an valid id the boto_elb deregister_instances method
@@ -204,7 +204,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(actual_instances, expected_instances)
 
     @mock_ec2_deprecated
-    @mock_elb
+    @mock_elb_deprecated
     def test_deregister_instances_valid_id_list(self):
         '''
         tests that given an valid ids in the form of a list that the boto_elb

--- a/tests/unit/modules/test_boto_elb.py
+++ b/tests/unit/modules/test_boto_elb.py
@@ -16,17 +16,17 @@ except ImportError:
     HAS_BOTO = False
 
 try:
-    from moto import mock_ec2, mock_elb
+    from moto import mock_ec2_deprecated, mock_elb
     HAS_MOTO = True
 except ImportError:
     HAS_MOTO = False
 
-    def mock_ec2(self):
+    def mock_ec2_deprecated(self):
         '''
-        if the mock_ec2 function is not available due to import failure
+        if the mock_ec2_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_vpc unit tests to use the @mock_ec2 decorator
-        without a "NameError: name 'mock_ec2' is not defined" error.
+        Allows boto_vpc unit tests to use the @mock_ec2_deprecated decorator
+        without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
         '''
         def stub_function(self):
             pass
@@ -34,10 +34,10 @@ except ImportError:
 
     def mock_elb(self):
         '''
-        if the mock_ec2 function is not available due to import failure
+        if the mock_ec2_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_vpc unit tests to use the @mock_ec2 decorator
-        without a "NameError: name 'mock_ec2' is not defined" error.
+        Allows boto_vpc unit tests to use the @mock_ec2_deprecated decorator
+        without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
         '''
         def stub_function(self):
             pass
@@ -114,7 +114,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
         # __virtual__ must be caller in order for _get_conn to be injected
         boto_elb.__virtual__()
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @mock_elb
     def test_register_instances_valid_id_result_true(self):
         '''
@@ -133,7 +133,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
                                                       **conn_parameters)
         self.assertEqual(True, register_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @mock_elb
     def test_register_instances_valid_id_string(self):
         '''
@@ -156,7 +156,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
         log.debug(load_balancer_refreshed.instances)
         self.assertEqual([reservations.instances[0].id], registered_instance_ids)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @mock_elb
     def test_deregister_instances_valid_id_result_true(self):
         '''
@@ -177,7 +177,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
                                                           **conn_parameters)
         self.assertEqual(True, deregister_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @mock_elb
     def test_deregister_instances_valid_id_string(self):
         '''
@@ -203,7 +203,7 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
                             load_balancer_refreshed.instances]
         self.assertEqual(actual_instances, expected_instances)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @mock_elb
     def test_deregister_instances_valid_id_list(self):
         '''

--- a/tests/unit/modules/test_boto_secgroup.py
+++ b/tests/unit/modules/test_boto_secgroup.py
@@ -213,7 +213,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         group = conn.create_security_group(name=group_name, description=group_name)
         group.authorize(ip_protocol=ip_protocol, from_port=from_port, to_port=to_port, cidr_ip=cidr_ip)
         # setup the expected get_config result
-        expected_get_config_result = OrderedDict([('name', group.name), ('group_id', group.id), ('owner_id', u'111122223333'),
+        expected_get_config_result = OrderedDict([('name', group.name), ('group_id', group.id),('owner_id', u'123456789012'),
                                                  ('description', group.description), ('tags', {}),
                                                  ('rules', [{'to_port': to_port, 'from_port': from_port,
                                                   'ip_protocol': ip_protocol, 'cidr_ip': cidr_ip}]),

--- a/tests/unit/modules/test_boto_secgroup.py
+++ b/tests/unit/modules/test_boto_secgroup.py
@@ -29,17 +29,17 @@ except ImportError:
     HAS_BOTO = False
 
 try:
-    from moto import mock_ec2
+    from moto import mock_ec2_deprecated
     HAS_MOTO = True
 except ImportError:
     HAS_MOTO = False
 
-    def mock_ec2(self):
+    def mock_ec2_deprecated(self):
         '''
-        if the mock_ec2 function is not available due to import failure
+        if the mock_ec2_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_secgroup unit tests to use the @mock_ec2 decorator
-        without a "NameError: name 'mock_ec2' is not defined" error.
+        Allows boto_secgroup unit tests to use the @mock_ec2_deprecated decorator
+        without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
         '''
         def stub_function(self):
             pass
@@ -117,7 +117,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
                        {'to_port': 80, 'from_port': 80, 'ip_protocol': u'tcp', 'cidr_ip': u'0.0.0.0/0'}]
         self.assertEqual(boto_secgroup._split_rules(rules), split_rules)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_create_ec2_classic(self):
         '''
         Test of creation of an EC2-Classic security group. The test ensures
@@ -137,7 +137,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
                                   secgroup_created_group[0].vpc_id]
         self.assertEqual(expected_create_result, secgroup_create_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_create_ec2_vpc(self):
         '''
         test of creation of an EC2-VPC security group. The test ensures that a
@@ -155,7 +155,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         secgroup_create_result = [secgroup_created_group[0].name, secgroup_created_group[0].description, secgroup_created_group[0].vpc_id]
         self.assertEqual(expected_create_result, secgroup_create_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_group_id_ec2_classic(self):
         '''
         tests that given a name of a group in EC2-Classic that the correct
@@ -177,7 +177,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
 
     @skipIf(True, 'test skipped because moto does not yet support group'
                   ' filters https://github.com/spulec/moto/issues/154')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_group_id_ec2_vpc(self):
         '''
         tests that given a name of a group in EC2-VPC that the correct
@@ -197,7 +197,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
                                                         **conn_parameters)
         self.assertEqual(group_vpc.id, retrieved_group_id)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_config_single_rule_group_name(self):
         '''
         tests return of 'config' when given group name. get_config returns an OrderedDict.
@@ -221,7 +221,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         secgroup_get_config_result = boto_secgroup.get_config(group_id=group.id, **conn_parameters)
         self.assertEqual(expected_get_config_result, secgroup_get_config_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_exists_true_name_classic(self):
         '''
         tests 'true' existence of a group in EC2-Classic when given name
@@ -234,11 +234,11 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         salt_exists_result = boto_secgroup.exists(name=group_name, **conn_parameters)
         self.assertTrue(salt_exists_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_exists_false_name_classic(self):
         pass
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_exists_true_name_vpc(self):
         '''
         tests 'true' existence of a group in EC2-VPC when given name and vpc_id
@@ -250,7 +250,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         salt_exists_result = boto_secgroup.exists(name=group_name, vpc_id=vpc_id, **conn_parameters)
         self.assertTrue(salt_exists_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_exists_false_name_vpc(self):
         '''
         tests 'false' existence of a group in vpc when given name and vpc_id
@@ -259,7 +259,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         salt_exists_result = boto_secgroup.exists(group_name, vpc_id=vpc_id, **conn_parameters)
         self.assertFalse(salt_exists_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_exists_true_group_id(self):
         '''
         tests 'true' existence of a group when given group_id
@@ -271,7 +271,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         salt_exists_result = boto_secgroup.exists(group_id=group.id, **conn_parameters)
         self.assertTrue(salt_exists_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_exists_false_group_id(self):
         '''
         tests 'false' existence of a group when given group_id
@@ -280,7 +280,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         salt_exists_result = boto_secgroup.exists(group_id=group_id, **conn_parameters)
         self.assertFalse(salt_exists_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_delete_group_ec2_classic(self):
         '''
         test deletion of a group in EC2-Classic. Test does the following:
@@ -306,11 +306,11 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         actual_groups = [group.id for group in conn.get_all_security_groups()]
         self.assertEqual(expected_groups, actual_groups)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_delete_group_name_ec2_vpc(self):
         pass
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test__get_conn_true(self):
         '''
         tests ensures that _get_conn returns an boto.ec2.connection.EC2Connection object.

--- a/tests/unit/modules/test_boto_secgroup.py
+++ b/tests/unit/modules/test_boto_secgroup.py
@@ -213,7 +213,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         group = conn.create_security_group(name=group_name, description=group_name)
         group.authorize(ip_protocol=ip_protocol, from_port=from_port, to_port=to_port, cidr_ip=cidr_ip)
         # setup the expected get_config result
-        expected_get_config_result = OrderedDict([('name', group.name), ('group_id', group.id),('owner_id', u'123456789012'),
+        expected_get_config_result = OrderedDict([('name', group.name), ('group_id', group.id), ('owner_id', u'123456789012'),
                                                  ('description', group.description), ('tags', {}),
                                                  ('rules', [{'to_port': to_port, 'from_port': from_port,
                                                   'ip_protocol': ip_protocol, 'cidr_ip': cidr_ip}]),

--- a/tests/unit/modules/test_boto_vpc.py
+++ b/tests/unit/modules/test_boto_vpc.py
@@ -40,17 +40,17 @@ except ImportError:
 
 try:
     import moto
-    from moto import mock_ec2
+    from moto import mock_ec2_deprecated
     HAS_MOTO = True
 except ImportError:
     HAS_MOTO = False
 
-    def mock_ec2(self):
+    def mock_ec2_deprecated(self):
         '''
-        if the mock_ec2 function is not available due to import failure
+        if the mock_ec2_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_vpc unit tests to use the @mock_ec2 decorator
-        without a "NameError: name 'mock_ec2' is not defined" error.
+        Allows boto_vpc unit tests to use the @mock_ec2_deprecated decorator
+        without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
         '''
 
         def stub_function(self):
@@ -63,7 +63,7 @@ except ImportError:
 # which was added in boto 2.8.0
 # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
 required_boto_version = '2.8.0'
-required_moto_version = '0.3.7'
+required_moto_version = '1.0.0'
 
 region = 'us-east-1'
 access_key = 'GKTADJGHEIQSXMKKRBJ08H'
@@ -272,7 +272,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     TestCase for salt.modules.boto_vpc module
     '''
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_id_and_a_vpc_exists_the_vpc_exists_method_returns_true(self):
         '''
         Tests checking vpc existence via id when the vpc already exists
@@ -283,7 +283,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_id_and_a_vpc_does_not_exist_the_vpc_exists_method_returns_false(
             self):
         '''
@@ -295,7 +295,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_name_and_a_vpc_exists_the_vpc_exists_method_returns_true(self):
         '''
         Tests checking vpc existence via name when vpc exists
@@ -306,7 +306,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_name_and_a_vpc_does_not_exist_the_vpc_exists_method_returns_false(
             self):
         '''
@@ -318,7 +318,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_tags_and_a_vpc_exists_the_vpc_exists_method_returns_true(self):
         '''
         Tests checking vpc existence via tag when vpc exists
@@ -329,7 +329,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_tags_and_a_vpc_does_not_exist_the_vpc_exists_method_returns_false(
             self):
         '''
@@ -341,7 +341,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_cidr_and_a_vpc_exists_the_vpc_exists_method_returns_true(self):
         '''
         Tests checking vpc existence via cidr when vpc exists
@@ -352,7 +352,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_cidr_and_a_vpc_does_not_exist_the_vpc_exists_method_returns_false(
             self):
         '''
@@ -364,7 +364,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_checking_if_a_vpc_exists_but_providing_no_filters_the_vpc_exists_method_raises_a_salt_invocation_error(self):
         '''
@@ -375,7 +375,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                          'cidr or tags.'):
             boto_vpc.exists(**conn_parameters)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_filtering_by_name(self):
         '''
         Tests getting vpc id when filtering by name
@@ -386,7 +386,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(vpc.id, get_id_result['id'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_filtering_by_invalid_name(self):
         '''
         Tests getting vpc id when filtering by invalid name
@@ -397,7 +397,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(get_id_result['id'], None)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_filtering_by_cidr(self):
         '''
         Tests getting vpc id when filtering by cidr
@@ -408,7 +408,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(vpc.id, get_id_result['id'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_filtering_by_invalid_cidr(self):
         '''
         Tests getting vpc id when filtering by invalid cidr
@@ -419,7 +419,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(get_id_result['id'], None)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_filtering_by_tags(self):
         '''
         Tests getting vpc id when filtering by tags
@@ -430,7 +430,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(vpc.id, get_id_result['id'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_filtering_by_invalid_tags(self):
         '''
         Tests getting vpc id when filtering by invalid tags
@@ -441,7 +441,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(get_id_result['id'], None)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_get_vpc_id_method_when_not_providing_filters_raises_a_salt_invocation_error(self):
         '''
@@ -450,7 +450,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         with self.assertRaisesRegex(SaltInvocationError, 'At least one of the following must be provided: vpc_id, vpc_name, cidr or tags.'):
             boto_vpc.get_id(**conn_parameters)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_more_than_one_vpc_is_matched_raises_a_salt_command_execution_error(self):
         '''
         Tests getting vpc id but providing no filters
@@ -461,7 +461,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         with self.assertRaisesRegex(CommandExecutionError, 'Found more than one VPC matching the criteria.'):
             boto_vpc.get_id(cidr=u'10.0.0.0/24', **conn_parameters)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_a_vpc_succeeds_the_create_vpc_method_returns_true(self):
         '''
         tests True VPC created.
@@ -470,7 +470,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_a_vpc_and_specifying_a_vpc_name_succeeds_the_create_vpc_method_returns_true(self):
         '''
         tests True VPC created.
@@ -479,7 +479,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_a_vpc_and_specifying_tags_succeeds_the_create_vpc_method_returns_true(self):
         '''
         tests True VPC created.
@@ -488,7 +488,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_creating_a_vpc_fails_the_create_vpc_method_returns_false(self):
         '''
@@ -499,7 +499,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             self.assertFalse(vpc_creation_result['created'])
             self.assertTrue('error' in vpc_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_deleting_an_existing_vpc_the_delete_vpc_method_returns_true(self):
         '''
         Tests deleting an existing vpc
@@ -510,7 +510,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_deleting_a_non_existent_vpc_the_delete_vpc_method_returns_false(self):
         '''
         Tests deleting a non-existent vpc
@@ -519,7 +519,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(delete_vpc_result['deleted'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_describing_vpc_by_id_it_returns_the_dict_of_properties_returns_true(self):
         '''
         Tests describing parameters via vpc id if vpc exist
@@ -546,7 +546,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(describe_vpc, {'vpc': vpc_properties})
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_describing_vpc_by_id_it_returns_the_dict_of_properties_returns_false(self):
         '''
         Tests describing parameters via vpc id if vpc does not exist
@@ -557,7 +557,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(describe_vpc['vpc'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_describing_vpc_by_id_on_connection_error_it_returns_error(self):
         '''
@@ -570,7 +570,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             describe_result = boto_vpc.describe(vpc_id=vpc.id, **conn_parameters)
             self.assertTrue('error' in describe_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_describing_vpc_but_providing_no_vpc_id_the_describe_method_raises_a_salt_invocation_error(self):
         '''
         Tests describing vpc without vpc id
@@ -588,7 +588,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         .format(required_boto_version, _get_boto_version()))
 @skipIf(_has_required_moto() is False, 'The moto version must be >= to version {0}'.format(required_moto_version))
 class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_subnet_association_single_subnet(self):
         '''
         tests that given multiple subnet ids in the same VPC that the VPC ID is
@@ -601,7 +601,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                              **conn_parameters)
         self.assertEqual(vpc.id, subnet_association['vpc_id'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_subnet_association_multiple_subnets_same_vpc(self):
         '''
         tests that given multiple subnet ids in the same VPC that the VPC ID is
@@ -614,7 +614,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                              **conn_parameters)
         self.assertEqual(vpc.id, subnet_association['vpc_id'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_subnet_association_multiple_subnets_different_vpc(self):
         '''
         tests that given multiple subnet ids in different VPCs that False is
@@ -628,7 +628,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                             **conn_parameters)
         self.assertEqual(set(subnet_association['vpc_ids']), set([vpc_a.id, vpc_b.id]))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_a_subnet_succeeds_the_create_subnet_method_returns_true(self):
         '''
         Tests creating a subnet successfully
@@ -640,7 +640,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertTrue(subnet_creation_result['created'])
         self.assertTrue('id' in subnet_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_a_subnet_and_specifying_a_name_succeeds_the_create_subnet_method_returns_true(self):
         '''
         Tests creating a subnet successfully when specifying a name
@@ -651,7 +651,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(subnet_creation_result['created'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_a_subnet_and_specifying_tags_succeeds_the_create_subnet_method_returns_true(self):
         '''
         Tests creating a subnet successfully when specifying a tag
@@ -663,7 +663,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(subnet_creation_result['created'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_creating_a_subnet_fails_the_create_subnet_method_returns_error(self):
         '''
@@ -675,7 +675,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             subnet_creation_result = boto_vpc.create_subnet(vpc.id, '10.0.0.0/24', **conn_parameters)
             self.assertTrue('error' in subnet_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_deleting_an_existing_subnet_the_delete_subnet_method_returns_true(self):
         '''
         Tests deleting an existing subnet
@@ -687,7 +687,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(subnet_deletion_result['deleted'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_deleting_a_non_existent_subnet_the_delete_vpc_method_returns_false(self):
         '''
         Tests deleting a subnet that doesn't exist
@@ -695,7 +695,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         delete_subnet_result = boto_vpc.delete_subnet(subnet_id='1234', **conn_parameters)
         self.assertTrue('error' in delete_subnet_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_subnet_exists_by_id_the_subnet_exists_method_returns_true(self):
         '''
         Tests checking if a subnet exists when it does exist
@@ -707,7 +707,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(subnet_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_a_subnet_does_not_exist_the_subnet_exists_method_returns_false(self):
         '''
         Tests checking if a subnet exists which doesn't exist
@@ -716,7 +716,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(subnet_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_subnet_exists_by_name_the_subnet_exists_method_returns_true(self):
         '''
         Tests checking subnet existence by name
@@ -728,7 +728,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(subnet_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_subnet_exists_by_name_the_subnet_does_not_exist_the_subnet_method_returns_false(self):
         '''
         Tests checking subnet existence by name when it doesn't exist
@@ -740,7 +740,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(subnet_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_subnet_exists_by_tags_the_subnet_exists_method_returns_true(self):
         '''
         Tests checking subnet existence by tag
@@ -752,7 +752,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(subnet_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_subnet_exists_by_tags_the_subnet_does_not_exist_the_subnet_method_returns_false(self):
         '''
         Tests checking subnet existence by tag when subnet doesn't exist
@@ -764,7 +764,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(subnet_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_checking_if_a_subnet_exists_but_providing_no_filters_the_subnet_exists_method_raises_a_salt_invocation_error(self):
         '''
@@ -776,7 +776,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             boto_vpc.subnet_exists(**conn_parameters)
 
     @skipIf(True, 'Skip these tests while investigating failures')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_describe_subnet_by_id_for_existing_subnet_returns_correct_data(self):
         '''
         Tests describing a subnet by id.
@@ -791,7 +791,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertEqual(set(describe_subnet_results['subnet'].keys()),
                          set(['id', 'cidr_block', 'availability_zone', 'tags']))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_describe_subnet_by_id_for_non_existent_subnet_returns_none(self):
         '''
         Tests describing a non-existent subnet by id.
@@ -805,7 +805,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertEqual(describe_subnet_results['subnet'], None)
 
     @skipIf(True, 'Skip these tests while investigating failures')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_describe_subnet_by_name_for_existing_subnet_returns_correct_data(self):
         '''
         Tests describing a subnet by name.
@@ -820,7 +820,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertEqual(set(describe_subnet_results['subnet'].keys()),
                          set(['id', 'cidr_block', 'availability_zone', 'tags']))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_describe_subnet_by_name_for_non_existent_subnet_returns_none(self):
         '''
         Tests describing a non-existent subnet by id.
@@ -834,7 +834,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertEqual(describe_subnet_results['subnet'], None)
 
     @skipIf(True, 'Skip these tests while investigating failures')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_describe_subnets_by_id_for_existing_subnet_returns_correct_data(self):
         '''
         Tests describing multiple subnets by id.
@@ -852,7 +852,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                          set(['id', 'cidr_block', 'availability_zone', 'tags']))
 
     @skipIf(True, 'Skip these tests while investigating failures')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_describe_subnets_by_name_for_existing_subnets_returns_correct_data(self):
         '''
         Tests describing multiple subnets by id.
@@ -869,7 +869,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertEqual(set(describe_subnet_results['subnets'][0].keys()),
                          set(['id', 'cidr_block', 'availability_zone', 'tags']))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_create_subnet_passes_availability_zone(self):
         '''
         Tests that the availability_zone kwarg is passed on to _create_resource
@@ -890,7 +890,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                        ' or equal to version {}. Installed: {}'
         .format(required_boto_version, _get_boto_version()))
 class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_internet_gateway_the_create_internet_gateway_method_returns_true(self):
         '''
         Tests creating an internet gateway successfully (with no vpc id or name)
@@ -901,7 +901,7 @@ class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                                keyid=access_key)
         self.assertTrue(igw_creation_result.get('created'))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_internet_gateway_with_non_existent_vpc_the_create_internet_gateway_method_returns_an_error(self):
         '''
         Tests that creating an internet gateway for a non-existent VPC fails.
@@ -913,7 +913,7 @@ class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                                vpc_name='non-existent-vpc')
         self.assertTrue('error' in igw_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_internet_gateway_with_vpc_name_specified_the_create_internet_gateway_method_returns_true(self):
         '''
         Tests creating an internet gateway with vpc name specified.
@@ -928,7 +928,7 @@ class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(igw_creation_result.get('created'))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_internet_gateway_with_vpc_id_specified_the_create_internet_gateway_method_returns_true(self):
         '''
         Tests creating an internet gateway with vpc name specified.
@@ -951,7 +951,7 @@ class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                        ' or equal to version {}. Installed: {}'
         .format(required_boto_version, _get_boto_version()))
 class BotoVpcNatGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_nat_gateway_the_create_nat_gateway_method_returns_true(self):
         '''
         Tests creating an nat gateway successfully (with subnet_id specified)
@@ -965,7 +965,7 @@ class BotoVpcNatGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                           keyid=access_key)
         self.assertTrue(ngw_creation_result.get('created'))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_nat_gateway_with_non_existent_subnet_the_create_nat_gateway_method_returns_an_error(self):
         '''
         Tests that creating an nat gateway for a non-existent subnet fails.
@@ -977,7 +977,7 @@ class BotoVpcNatGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                           subnet_name='non-existent-subnet')
         self.assertTrue('error' in ngw_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_nat_gateway_with_subnet_name_specified_the_create_nat_gateway_method_returns_true(self):
         '''
         Tests creating an nat gateway with subnet name specified.
@@ -1000,7 +1000,7 @@ class BotoVpcNatGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                        ' or equal to version {}. Installed: {}'
         .format(required_boto_version, _get_boto_version()))
 class BotoVpcCustomerGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_customer_gateway_the_create_customer_gateway_method_returns_true(self):
         '''
@@ -1010,7 +1010,7 @@ class BotoVpcCustomerGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         gw_creation_result = boto_vpc.create_customer_gateway('ipsec.1', '10.1.1.1', None)
         self.assertTrue(gw_creation_result.get('created'))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_checking_if_a_subnet_exists_by_id_the_subnet_exists_method_returns_true(self):
         '''
@@ -1021,7 +1021,7 @@ class BotoVpcCustomerGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         gw_exists_result = boto_vpc.customer_gateway_exists(customer_gateway_id=gw_creation_result['id'])
         self.assertTrue(gw_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_a_subnet_does_not_exist_the_subnet_exists_method_returns_false(self):
         '''
@@ -1039,7 +1039,7 @@ class BotoVpcCustomerGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         .format(required_boto_version, _get_boto_version()))
 @skipIf(_has_required_moto() is False, 'The moto version must be >= to version {0}'.format(required_moto_version))
 class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_dhcp_options_succeeds_the_create_dhcp_options_method_returns_true(self):
         '''
         Tests creating dhcp options successfully
@@ -1048,7 +1048,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_options_creation_result['created'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_dhcp_options_and_specifying_a_name_succeeds_the_create_dhcp_options_method_returns_true(
             self):
@@ -1060,7 +1060,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_options_creation_result['created'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_dhcp_options_and_specifying_tags_succeeds_the_create_dhcp_options_method_returns_true(
             self):
         '''
@@ -1071,7 +1071,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_options_creation_result['created'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_creating_dhcp_options_fails_the_create_dhcp_options_method_returns_error(self):
         '''
@@ -1082,7 +1082,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             r = dhcp_options_creation_result = boto_vpc.create_dhcp_options(**dhcp_options_parameters)
             self.assertTrue('error' in r)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_associating_an_existing_dhcp_options_set_to_an_existing_vpc_the_associate_dhcp_options_method_returns_true(
             self):
         '''
@@ -1096,7 +1096,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_options_association_result['associated'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_associating_a_non_existent_dhcp_options_set_to_an_existing_vpc_the_associate_dhcp_options_method_returns_error(
             self):
         '''
@@ -1108,7 +1108,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue('error' in dhcp_options_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_associating_an_existing_dhcp_options_set_to_a_non_existent_vpc_the_associate_dhcp_options_method_returns_false(
             self):
         '''
@@ -1121,7 +1121,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue('error' in dhcp_options_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_dhcp_options_set_to_an_existing_vpc_succeeds_the_associate_new_dhcp_options_method_returns_true(
             self):
         '''
@@ -1133,7 +1133,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_creation_result['created'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_creating_and_associating_dhcp_options_set_to_an_existing_vpc_fails_creating_the_dhcp_options_the_associate_new_dhcp_options_method_raises_exception(
             self):
@@ -1147,7 +1147,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             r = boto_vpc.associate_new_dhcp_options_to_vpc(vpc.id, **dhcp_options_parameters)
             self.assertTrue('error' in r)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_creating_and_associating_dhcp_options_set_to_an_existing_vpc_fails_associating_the_dhcp_options_the_associate_new_dhcp_options_method_raises_exception(self):
         '''
@@ -1160,7 +1160,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             r = boto_vpc.associate_new_dhcp_options_to_vpc(vpc.id, **dhcp_options_parameters)
             self.assertTrue('error' in r)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_dhcp_options_set_to_a_non_existent_vpc_the_dhcp_options_the_associate_new_dhcp_options_method_returns_false(
             self):
         '''
@@ -1170,7 +1170,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         r = boto_vpc.create_dhcp_options(vpc_name='fake', **dhcp_options_parameters)
         self.assertTrue('error' in r)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_dhcp_options_exists_the_dhcp_options_exists_method_returns_true(self):
         '''
         Tests existence of dhcp options successfully
@@ -1181,7 +1181,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_options_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_dhcp_options_do_not_exist_the_dhcp_options_exists_method_returns_false(self):
         '''
         Tests existence of dhcp options failure
@@ -1189,7 +1189,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         r = boto_vpc.dhcp_options_exists('fake', **conn_parameters)
         self.assertFalse(r['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_checking_if_dhcp_options_exists_but_providing_no_filters_the_dhcp_options_exists_method_raises_a_salt_invocation_error(self):
         '''
@@ -1206,7 +1206,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                        ' or equal to version {}. Installed: {}'
         .format(required_boto_version, _get_boto_version()))
 class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_network_acl_for_an_existing_vpc_the_create_network_acl_method_returns_true(self):
         '''
         Tests creation of network acl with existing vpc
@@ -1217,7 +1217,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_network_acl_for_an_existing_vpc_and_specifying_a_name_the_create_network_acl_method_returns_true(
             self):
         '''
@@ -1229,7 +1229,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_network_acl_for_an_existing_vpc_and_specifying_tags_the_create_network_acl_method_returns_true(
             self):
         '''
@@ -1241,7 +1241,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_network_acl_for_a_non_existent_vpc_the_create_network_acl_method_returns_an_error(self):
         '''
         Tests creation of network acl with a non-existent vpc
@@ -1250,7 +1250,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue('error' in network_acl_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_network_acl_fails_the_create_network_acl_method_returns_false(self):
         '''
@@ -1264,7 +1264,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(network_acl_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_deleting_an_existing_network_acl_the_delete_network_acl_method_returns_true(self):
         '''
         Tests deletion of existing network acl successfully
@@ -1276,7 +1276,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_deleting_a_non_existent_network_acl_the_delete_network_acl_method_returns_an_error(self):
         '''
         Tests deleting a non-existent network acl
@@ -1285,7 +1285,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue('error' in network_acl_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_a_network_acl_exists_the_network_acl_exists_method_returns_true(self):
         '''
         Tests existence of network acl
@@ -1297,7 +1297,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_a_network_acl_does_not_exist_the_network_acl_exists_method_returns_false(self):
         '''
         Tests checking network acl does not exist
@@ -1306,7 +1306,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(network_acl_deletion_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_checking_if_network_acl_exists_but_providing_no_filters_the_network_acl_exists_method_raises_a_salt_invocation_error(self):
         '''
@@ -1318,7 +1318,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         ):
             boto_vpc.dhcp_options_exists(**conn_parameters)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_network_acl_entry_successfully_the_create_network_acl_entry_method_returns_true(self):
         '''
@@ -1333,7 +1333,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_entry_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_network_acl_entry_for_a_non_existent_network_acl_the_create_network_acl_entry_method_returns_false(
             self):
@@ -1345,7 +1345,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(network_acl_entry_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_replacing_a_network_acl_entry_successfully_the_replace_network_acl_entry_method_returns_true(
             self):
@@ -1362,7 +1362,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_entry_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_replacing_a_network_acl_entry_for_a_non_existent_network_acl_the_replace_network_acl_entry_method_returns_false(
             self):
@@ -1373,7 +1373,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                                               **conn_parameters)
         self.assertFalse(network_acl_entry_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_deleting_an_existing_network_acl_entry_the_delete_network_acl_entry_method_returns_true(self):
         '''
@@ -1388,7 +1388,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_entry_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_deleting_a_non_existent_network_acl_entry_the_delete_network_acl_entry_method_returns_false(
             self):
@@ -1400,7 +1400,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(network_acl_entry_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_associating_an_existing_network_acl_to_an_existing_subnet_the_associate_network_acl_method_returns_true(
             self):
@@ -1416,7 +1416,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_associating_a_non_existent_network_acl_to_an_existing_subnet_the_associate_network_acl_method_returns_an_error(
             self):
         '''
@@ -1430,7 +1430,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue('error' in network_acl_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_associating_an_existing_network_acl_to_a_non_existent_subnet_the_associate_network_acl_method_returns_false(
             self):
@@ -1445,7 +1445,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(network_acl_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_and_associating_a_network_acl_to_a_subnet_succeeds_the_associate_new_network_acl_to_subnet_method_returns_true(
             self):
@@ -1460,7 +1460,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_creation_and_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_and_associating_a_network_acl_to_a_subnet_and_specifying_a_name_succeeds_the_associate_new_network_acl_to_subnet_method_returns_true(
             self):
@@ -1476,7 +1476,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_creation_and_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_and_associating_a_network_acl_to_a_subnet_and_specifying_tags_succeeds_the_associate_new_network_acl_to_subnet_method_returns_true(
             self):
@@ -1493,7 +1493,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_creation_and_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_and_associating_a_network_acl_to_a_non_existent_subnet_the_associate_new_network_acl_to_subnet_method_returns_false(
             self):
@@ -1507,7 +1507,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(network_acl_creation_and_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_a_network_acl_to_a_non_existent_vpc_the_associate_new_network_acl_to_subnet_method_returns_an_error(
             self):
         '''
@@ -1520,7 +1520,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue('error' in network_acl_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_disassociating_network_acl_succeeds_the_disassociate_network_acl_method_should_return_true(self):
         '''
@@ -1533,7 +1533,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_disassociate_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_disassociating_network_acl_for_a_non_existent_vpc_the_disassociate_network_acl_method_should_return_false(
             self):
@@ -1547,7 +1547,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(dhcp_disassociate_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_disassociating_network_acl_for_a_non_existent_subnet_the_disassociate_network_acl_method_should_return_false(
             self):
@@ -1568,7 +1568,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                        ' or equal to version {}. Installed: {}'
         .format(required_boto_version, _get_boto_version()))
 class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_route_table_succeeds_the_create_route_table_method_returns_true(self):
         '''
@@ -1580,7 +1580,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_table_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_route_table_on_a_non_existent_vpc_the_create_route_table_method_returns_false(self):
         '''
@@ -1590,7 +1590,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_table_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_deleting_a_route_table_succeeds_the_delete_route_table_method_returns_true(self):
         '''
@@ -1603,7 +1603,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_table_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_deleting_a_non_existent_route_table_the_delete_route_table_method_returns_false(self):
         '''
@@ -1613,7 +1613,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(route_table_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_route_table_exists_the_route_table_exists_method_returns_true(self):
         '''
@@ -1626,7 +1626,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_table_existence_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_route_table_does_not_exist_the_route_table_exists_method_returns_false(self):
         '''
@@ -1636,7 +1636,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(route_table_existence_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_checking_if_a_route_table_exists_but_providing_no_filters_the_route_table_exists_method_raises_a_salt_invocation_error(self):
         '''
@@ -1648,7 +1648,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         ):
             boto_vpc.dhcp_options_exists(**conn_parameters)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_associating_a_route_table_succeeds_the_associate_route_table_method_should_return_the_association_id(
             self):
@@ -1663,7 +1663,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(association_id)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_associating_a_route_table_with_a_non_existent_route_table_the_associate_route_table_method_should_return_false(
             self):
@@ -1677,7 +1677,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(association_id)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_associating_a_route_table_with_a_non_existent_subnet_the_associate_route_table_method_should_return_false(
             self):
@@ -1691,7 +1691,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(association_id)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_disassociating_a_route_table_succeeds_the_disassociate_route_table_method_should_return_true(
             self):
@@ -1708,7 +1708,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_disassociate_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_route_succeeds_the_create_route_method_should_return_true(self):
         '''
@@ -1721,7 +1721,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_route_with_a_non_existent_route_table_the_create_route_method_should_return_false(
             self):
@@ -1732,7 +1732,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(route_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_deleting_a_route_succeeds_the_delete_route_method_should_return_true(self):
         '''
@@ -1745,7 +1745,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_deleting_a_route_with_a_non_existent_route_table_the_delete_route_method_should_return_false(
             self):
@@ -1756,7 +1756,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(route_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_replacing_a_route_succeeds_the_replace_route_method_should_return_true(self):
         '''
@@ -1769,7 +1769,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_replacing_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_replacing_a_route_with_a_non_existent_route_table_the_replace_route_method_should_return_false(
             self):
@@ -1790,7 +1790,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 @skipIf(_has_required_moto() is False, 'The moto version must be >= to version {0}'.format(required_moto_version))
 class BotoVpcPeeringConnectionsTest(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_request_vpc_peering_connection(self):
         '''
         Run with 2 vpc ids and returns a message
@@ -1803,7 +1803,7 @@ class BotoVpcPeeringConnectionsTest(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             peer_vpc_id=other_vpc.id,
             **conn_parameters))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_raises_error_if_both_vpc_name_and_vpc_id_are_specified(self):
         '''
         Must specify only one

--- a/tests/unit/states/test_boto_vpc.py
+++ b/tests/unit/states/test_boto_vpc.py
@@ -34,18 +34,18 @@ except ImportError:
     HAS_BOTO = False
 
 try:
-    from moto import mock_ec2
+    from moto import mock_ec2_deprecated
 
     HAS_MOTO = True
 except ImportError:
     HAS_MOTO = False
 
-    def mock_ec2(self):
+    def mock_ec2_deprecated(self):
         '''
-        if the mock_ec2 function is not available due to import failure
+        if the mock_ec2_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_vpc unit tests to use the @mock_ec2 decorator
-        without a "NameError: name 'mock_ec2' is not defined" error.
+        Allows boto_vpc unit tests to use the @mock_ec2_deprecated decorator
+        without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
         '''
 
         def stub_function(self):
@@ -131,7 +131,7 @@ class BotoVpcTestCase(BotoVpcStateTestCaseBase, BotoVpcTestCaseMixin):
     TestCase for salt.states.boto_vpc state.module
     '''
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_present_when_vpc_does_not_exist(self):
         '''
         Tests present on a VPC that does not exist.
@@ -142,14 +142,14 @@ class BotoVpcTestCase(BotoVpcStateTestCaseBase, BotoVpcTestCaseMixin):
         self.assertTrue(vpc_present_result['result'])
         self.assertEqual(vpc_present_result['changes']['new']['vpc']['state'], 'available')
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_present_when_vpc_exists(self):
         vpc = self._create_vpc(name='test')
         vpc_present_result = self.salt_states['boto_vpc.present']('test', cidr_block)
         self.assertTrue(vpc_present_result['result'])
         self.assertEqual(vpc_present_result['changes'], {})
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_present_with_failure(self):
         with patch('moto.ec2.models.VPCBackend.create_vpc', side_effect=BotoServerError(400, 'Mocked error')):
@@ -157,7 +157,7 @@ class BotoVpcTestCase(BotoVpcStateTestCaseBase, BotoVpcTestCaseMixin):
             self.assertFalse(vpc_present_result['result'])
             self.assertTrue('Mocked error' in vpc_present_result['comment'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_absent_when_vpc_does_not_exist(self):
         '''
         Tests absent on a VPC that does not exist.
@@ -167,7 +167,7 @@ class BotoVpcTestCase(BotoVpcStateTestCaseBase, BotoVpcTestCaseMixin):
         self.assertTrue(vpc_absent_result['result'])
         self.assertEqual(vpc_absent_result['changes'], {})
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_absent_when_vpc_exists(self):
         vpc = self._create_vpc(name='test')
         with patch.dict(salt.utils.boto.__salt__, self.funcs):
@@ -175,7 +175,7 @@ class BotoVpcTestCase(BotoVpcStateTestCaseBase, BotoVpcTestCaseMixin):
         self.assertTrue(vpc_absent_result['result'])
         self.assertEqual(vpc_absent_result['changes']['new']['vpc'], None)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_absent_with_failure(self):
         vpc = self._create_vpc(name='test')
@@ -195,7 +195,7 @@ class BotoVpcResourceTestCaseMixin(BotoVpcTestCaseMixin):
         _create = getattr(self, '_create_' + self.resource_type)
         _create(vpc_id=vpc_id, name=name, **self.extra_kwargs)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_present_when_resource_does_not_exist(self):
         '''
         Tests present on a resource that does not exist.
@@ -210,7 +210,7 @@ class BotoVpcResourceTestCaseMixin(BotoVpcTestCaseMixin):
         exists = self.funcs['boto_vpc.resource_exists'](self.resource_type, 'test').get('exists')
         self.assertTrue(exists)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_present_when_resource_exists(self):
         vpc = self._create_vpc(name='test')
         resource = self._create_resource(vpc_id=vpc.id, name='test')
@@ -220,7 +220,7 @@ class BotoVpcResourceTestCaseMixin(BotoVpcTestCaseMixin):
         self.assertTrue(resource_present_result['result'])
         self.assertEqual(resource_present_result['changes'], {})
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_present_with_failure(self):
         vpc = self._create_vpc(name='test')
@@ -231,7 +231,7 @@ class BotoVpcResourceTestCaseMixin(BotoVpcTestCaseMixin):
             self.assertFalse(resource_present_result['result'])
             self.assertTrue('Mocked error' in resource_present_result['comment'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_absent_when_resource_does_not_exist(self):
         '''
         Tests absent on a resource that does not exist.
@@ -241,7 +241,7 @@ class BotoVpcResourceTestCaseMixin(BotoVpcTestCaseMixin):
         self.assertTrue(resource_absent_result['result'])
         self.assertEqual(resource_absent_result['changes'], {})
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_absent_when_resource_exists(self):
         vpc = self._create_vpc(name='test')
         self._create_resource(vpc_id=vpc.id, name='test')
@@ -253,7 +253,7 @@ class BotoVpcResourceTestCaseMixin(BotoVpcTestCaseMixin):
         exists = self.funcs['boto_vpc.resource_exists'](self.resource_type, 'test').get('exists')
         self.assertFalse(exists)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_absent_with_failure(self):
         vpc = self._create_vpc(name='test')
@@ -301,7 +301,7 @@ class BotoVpcRouteTableTestCase(BotoVpcStateTestCaseBase, BotoVpcResourceTestCas
     backend_create = 'RouteTableBackend.create_route_table'
     backend_delete = 'RouteTableBackend.delete_route_table'
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_present_with_subnets(self):
         vpc = self._create_vpc(name='test')
         subnet1 = self._create_subnet(vpc_id=vpc.id, name='test1')
@@ -326,7 +326,7 @@ class BotoVpcRouteTableTestCase(BotoVpcStateTestCaseBase, BotoVpcResourceTestCas
         new_subnets = changes['new']['subnets_associations']
         self.assertEqual(new_subnets[0]['subnet_id'], subnet2.id)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_present_with_routes(self):
         vpc = self._create_vpc(name='test')
         igw = self._create_internet_gateway(name='test', vpc_id=vpc.id)

--- a/tests/unit/states/test_boto_vpc.py
+++ b/tests/unit/states/test_boto_vpc.py
@@ -14,6 +14,7 @@ from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch
 import salt.config
 import salt.loader
 import salt.utils.boto
+from salt.ext import six
 from salt.utils.versions import LooseVersion
 import salt.states.boto_vpc as boto_vpc
 
@@ -291,6 +292,9 @@ class BotoVpcInternetGatewayTestCase(BotoVpcStateTestCaseBase, BotoVpcResourceTe
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(six.PY3, 'Disabled for Python 3 due to upstream bugs: '
+                 'https://github.com/spulec/moto/issues/548 and '
+                 'https://github.com/gabrielfalcao/HTTPretty/issues/325')
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
 @skipIf(HAS_MOTO is False, 'The moto module must be installed.')
 @skipIf(_has_required_boto() is False, 'The boto module must be greater than'


### PR DESCRIPTION
### What does this PR do?
There are ~90 boto unit tests that are failing when running on Python 3. There are several reasons for this.

- `@mock_ec2` calls must be replaced with `@mock_ec2_deprecated` calls:
  moto versions >= 1.0.0 have changed the way the mocked connections through boto are handled with the @mock_ec2 decorator. They use the boto3 connection method. However, since we are still using boto (and not boto3) in many places, we need to use the new @mock_ec2_deprecated decorator instead to handle the boto connection functions for the unit tests.

  Versions of moto < 1.0.0 are not Python 3 compatible, so salt-jenkins should be installing newer versions of moto for those tests. Unfortunately, we cannot install an older version of moto for Python2 that use the original @mock_ec2 call and also import the @mock_ec2_deprecated function for newer versions of moto simultaneously as the @mock_ec2_deprecated function doesn't exist in older versions of moto.

- @mock_elb needs to be changed to @mock_elb_deprecated as well
  Due to the same reasons mentioned above, the `@mock_elb` decorator must be changed to the `@mock_elb_deprecated` decorator.

- Update account id value in boto_secgroup module unit test
  This value was updated in moto 1.0.0 with the following commit:  spulec/moto@5f3fbff

- Skip 2 failing tests in Python 3 due to upstream bugs

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/478

### Previous Behavior
If running these tests with `moto==1.0.x`, the tests would fail.

### New Behavior
Running tests with `moto==1.0.x` passes on both Python2 and Python3 tests.

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

**NOTE**
This test run will have failures. This is expected because PR tests still have older versions of moto installed, which do not have the `@mock_ec2_deprecated` function and we will see import errors. A new PR will need to be created against https://github.com/saltstack/salt-jenkins in order for these to pass.

Once the moto version is updated in salt-jenkins, PRs that don't have this update will fail. This will also be true for branch tests on 2017.7 and develop until all changes are merged forward in both salt and salt-jenkins. Unfortunately, this is the only way to fix these test failures for both Python2 and Python3.