### PR TITLE
Move weird tearDown test to an actual tearDown

### DIFF
--- a/tests/integration/shell/test_auth.py
+++ b/tests/integration/shell/test_auth.py
@@ -54,7 +54,6 @@ class AuthTest(ShellCase):
     group = 'saltops'
 
     def setUp(self):
-        # This is a little wasteful but shouldn't be a problem
         for user in (self.userA, self.userB):
             try:
                 pwd.getpwnam(user)
@@ -67,6 +66,21 @@ class AuthTest(ShellCase):
         except KeyError:
             self.run_call('group.add {0}'.format(self.group))
             self.run_call('user.chgroups {0} {1} True'.format(self.userB, self.group))
+
+    def tearDown(self):
+        for user in (self.userA, self.userB):
+            try:
+                pwd.getpwnam(user)
+            except KeyError:
+                pass
+            else:
+                self.run_call('user.delete {0}'.format(user))
+        try:
+            grp.getgrnam(self.group)
+        except KeyError:
+            pass
+        else:
+            self.run_call('group.delete {0}'.format(self.group))
 
     def test_pam_auth_valid_user(self):
         '''
@@ -121,10 +135,3 @@ class AuthTest(ShellCase):
         self.assertTrue(
             'minion:' in resp
         )
-
-    def test_zzzz_tearDown(self):
-        for user in (self.userA, self.userB):
-            if pwd.getpwnam(user):
-                self.run_call('user.delete {0}'.format(user))
-        if grp.getgrnam(self.group):
-            self.run_call('group.delete {0}'.format(self.group))


### PR DESCRIPTION
Also catch KeyError when user doesn't exist