### PR TITLE
Remove extraneous "deprecated" notation

### DIFF
--- a/salt/modules/htpasswd.py
+++ b/salt/modules/htpasswd.py
@@ -35,8 +35,6 @@ def useradd(pwfile, user, password, opts='', runas=None):
     Add a user to htpasswd file using the htpasswd command. If the htpasswd
     file does not exist, it will be created.
 
-    .. deprecated:: 2016.3.0
-
     pwfile
         Path to htpasswd file
 


### PR DESCRIPTION
This deprecated notation was supposed to be on the "useradd_all" function, but somehow was moved to the "useradd" function.

Fixes #42870
