### PR TITLE
Add support for zfs-fuse to zfs.__virtual__()

### DIFF
--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -76,6 +76,11 @@ def __virtual__():
         cmd, output_loglevel='quiet', ignore_retcode=True
     ) == 0:
         return 'zfs'
+    
+    _zfs_fuse = lambda f: __salt__['service.' + f]('zfs-fuse')
+    if _zfs_fuse('available') and (_zfs_fuse('status') or _zfs_fuse('start')):
+        return 'zfs'
+    
     return (False, "The zfs module cannot be loaded: zfs not found")
 
 

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -76,11 +76,11 @@ def __virtual__():
         cmd, output_loglevel='quiet', ignore_retcode=True
     ) == 0:
         return 'zfs'
-    
+
     _zfs_fuse = lambda f: __salt__['service.' + f]('zfs-fuse')
     if _zfs_fuse('available') and (_zfs_fuse('status') or _zfs_fuse('start')):
         return 'zfs'
-    
+
     return (False, "The zfs module cannot be loaded: zfs not found")
 
 


### PR DESCRIPTION
### What does this PR do?

Some OS distributions which lack OS kernel support for ZFS can support the zfs module if the zfs-fuse (user space ZFS driver adapter) daemon is running.

zfs support is extended to all OS platforms with zfs-fuse support in addition to those with kernel support.

### Previous Behavior

zfs module will refuse to load even if all commands are available, which is weird because the zpool module works fine with zfs-fuse already.

### New Behavior

If the check for zfs kernel module fails, checks to see if the zfs-fuse service is available, and whether it is running or starts up, and returns appropriately. Tested on Debian Wheezy.

### Tests written?

No