### PR TITLE
cloud driver isn't a provider

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -312,7 +312,7 @@ def bootstrap(vm_, opts):
             }
         }
 
-    if vm_.get('driver', 'none:none').split(':')[1] == 'saltify':
+    if vm_.get('driver') == 'saltify':
         saltify_driver = True
     else:
         saltify_driver = False


### PR DESCRIPTION
### What does this PR do?
This will not have a ':' in it at all, it is specifying which driver was used.

This was changed in 2017.7, so when [this](https://github.com/saltstack/salt/pull/42788) was merged forward, it broke salt-cloud deployments.

### Tests written?

Yes (when cloud tests run)