### PR TITLE
Change service shutdown timeouts for salt-minion service (Windows)

### DIFF
--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -386,8 +386,6 @@ Section -Post
     nsExec::Exec "nssm.exe set salt-minion AppStopMethodConsole 24000"
     nsExec::Exec "nssm.exe set salt-minion AppStopMethodWindow 2000"
 
-    RMDir /R "$INSTDIR\var\cache\salt" ; removing cache from old version
-
     Call updateMinionConfig
 
     Push "C:\salt"

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -383,6 +383,8 @@ Section -Post
     nsExec::Exec "nssm.exe set salt-minion Description Salt Minion from saltstack.com"
     nsExec::Exec "nssm.exe set salt-minion Start SERVICE_AUTO_START"
     nsExec::Exec "nssm.exe set salt-minion AppNoConsole 1"
+    nsExec::Exec "nssm.exe set salt-minion AppStopMethodConsole 24000"
+    nsExec::Exec "nssm.exe set salt-minion AppStopMethodWindow 2000"
 
     RMDir /R "$INSTDIR\var\cache\salt" ; removing cache from old version
 


### PR DESCRIPTION
### What does this PR do?
Windows default for stopping a service is 30 seconds. This changes the
default timeouts for the salt-minion service to more closely resemble
how it is handled in Windows. This gives Python a chance to cleanly exit
before being forcibly closed.

Also removes the line that wipes out the minion cache. This was added years ago when there was a problem upgrading from an old version of Salt. It no longer applies.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/pull/42861#issuecomment-321701017
https://github.com/saltstack/salt/issues/38590

### Previous Behavior
A ctrl+c shutdown was generated and timed out after 1.5 seconds, then a WM_CLOSE was generated, followed by WM_QUIT, each with a 1.5-second timeout. Finally, the process is just terminated. Giving python about 4.5 seconds to exit cleanly.

### New Behavior
Ctrl+c is issued with a 24 sec timeout, followed by WM_CLOSE with a 2-second timeout, then WM_QUIT with a 1.5-second timeout. Finally, the process is terminated. This gives Python 27.5 seconds to exit cleanly.

### Tests written?
NA