### PR TITLE
Show missing minions in lists & nodegroups

### DIFF
--- a/salt/cli/cp.py
+++ b/salt/cli/cp.py
@@ -122,9 +122,10 @@ class SaltCP(object):
             if gzip \
             else salt.utils.itertools.read_file
 
-        minions = salt.utils.minions.CkMinions(self.opts).check_minions(
+        _res = salt.utils.minions.CkMinions(self.opts).check_minions(
             tgt,
             tgt_type=selected_target_option or 'glob')
+        minions = _res['minions']
 
         local = salt.client.get_local_client(self.opts['conf_file'])
 

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -325,6 +325,7 @@ class LocalClient(object):
 
         arg = salt.utils.args.condition_input(arg, kwarg)
 
+        log.debug('==== tgt {} ===='.format(tgt))
         try:
             pub_data = self.pub(
                 tgt,
@@ -1578,6 +1579,7 @@ class LocalClient(object):
         connected_minions = None
         return_count = 0
 
+        log.debug('==== minions {} ==='.format(minions))
         for ret in self.get_iter_returns(jid,
                                          minions,
                                          timeout=timeout,

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -348,7 +348,8 @@ class LocalClient(object):
         return self._check_pub_data(pub_data)
 
     def gather_minions(self, tgt, expr_form):
-        return salt.utils.minions.CkMinions(self.opts).check_minions(tgt, tgt_type=expr_form)
+        _res = salt.utils.minions.CkMinions(self.opts).check_minions(tgt, tgt_type=expr_form)
+        return _res['minions']
 
     @tornado.gen.coroutine
     def run_job_async(

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -585,11 +585,12 @@ class RemoteFuncs(object):
         if match_type.lower() == 'compound':
             match_type = 'compound_pillar_exact'
         checker = salt.utils.minions.CkMinions(self.opts)
-        minions = checker.check_minions(
+        _res = checker.check_minions(
                 load['tgt'],
                 match_type,
                 greedy=False
                 )
+        minions = _res['minions']
         for minion in minions:
             fdata = self.cache.fetch('minions/{0}'.format(minion), 'mine')
             if isinstance(fdata, dict):
@@ -908,9 +909,10 @@ class RemoteFuncs(object):
                 pub_load['tgt_type'] = load['tgt_type']
         ret = {}
         ret['jid'] = self.local.cmd_async(**pub_load)
-        ret['minions'] = self.ckminions.check_minions(
+        _res = self.ckminions.check_minions(
                 load['tgt'],
                 pub_load['tgt_type'])
+        ret['minions'] = _res['minions']
         auth_cache = os.path.join(
                 self.opts['cachedir'],
                 'publish_auth')
@@ -1203,11 +1205,12 @@ class LocalFuncs(object):
 
         # Retrieve the minions list
         delimiter = load.get('kwargs', {}).get('delimiter', DEFAULT_TARGET_DELIM)
-        minions = self.ckminions.check_minions(
+        _res = self.ckminions.check_minions(
             load['tgt'],
             load.get('tgt_type', 'glob'),
             delimiter
         )
+        minions = _res['minions']
 
         # Check for external auth calls
         if extra.get('token', False):

--- a/salt/pillar/consul_pillar.py
+++ b/salt/pillar/consul_pillar.py
@@ -167,7 +167,8 @@ def ext_pillar(minion_id,
         opts['target'] = match.group(1)
         temp = temp.replace(match.group(0), '')
         checker = salt.utils.minions.CkMinions(__opts__)
-        minions = checker.check_minions(opts['target'], 'compound')
+        _res = checker.check_minions(opts['target'], 'compound')
+        minions = _res['minions']
         if minion_id not in minions:
             return {}
 

--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -336,9 +336,10 @@ def ext_pillar(minion_id,
                 if (os.path.isdir(nodegroups_dir) and
                         nodegroup in master_ngroups):
                     ckminions = salt.utils.minions.CkMinions(__opts__)
-                    match = ckminions.check_minions(
+                    _res = ckminions.check_minions(
                         master_ngroups[nodegroup],
                         'compound')
+                    match = _res['minions']
                     if minion_id in match:
                         ngroup_dir = os.path.join(
                             nodegroups_dir, str(nodegroup))

--- a/salt/pillar/nodegroups.py
+++ b/salt/pillar/nodegroups.py
@@ -64,9 +64,10 @@ def ext_pillar(minion_id, pillar, pillar_name=None):
     ckminions = None
     for nodegroup_name in six.iterkeys(all_nodegroups):
         ckminions = ckminions or CkMinions(__opts__)
-        match = ckminions.check_minions(
+        _res = ckminions.check_minions(
             all_nodegroups[nodegroup_name],
             'compound')
+        match = _res['minions']
 
         if minion_id in match:
             nodegroups_minion_is_in.append(nodegroup_name)

--- a/salt/returners/couchbase_return.py
+++ b/salt/returners/couchbase_return.py
@@ -223,10 +223,11 @@ def save_load(jid, clear_load, minion=None):
     if 'tgt' in clear_load and clear_load['tgt'] != '':
         ckminions = salt.utils.minions.CkMinions(__opts__)
         # Retrieve the minions list
-        minions = ckminions.check_minions(
+        _res = ckminions.check_minions(
             clear_load['tgt'],
             clear_load.get('tgt_type', 'glob')
             )
+        minions = _res['minions']
         save_minions(jid, minions)
 
 

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -225,10 +225,11 @@ def save_load(jid, clear_load, minions=None, recurse_count=0):
         if minions is None:
             ckminions = salt.utils.minions.CkMinions(__opts__)
             # Retrieve the minions list
-            minions = ckminions.check_minions(
+            _res = ckminions.check_minions(
                     clear_load['tgt'],
                     clear_load.get('tgt_type', 'glob')
                     )
+            minions = _res['minions']
         # save the minions to a cache so we can see in the UI
         save_minions(jid, minions)
 

--- a/salt/roster/cache.py
+++ b/salt/roster/cache.py
@@ -117,7 +117,8 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
     The resulting roster can be configured using ``roster_order`` and ``roster_default``.
     '''
     minions = salt.utils.minions.CkMinions(__opts__)
-    minions = minions.check_minions(tgt, tgt_type)
+    _res = minions.check_minions(tgt, tgt_type)
+    minions = _res['minions']
 
     ret = {}
     if not minions:

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -827,8 +827,9 @@ class ZeroMQPubServerChannel(salt.transport.server.PubServerChannel):
         match_targets = ["pcre", "glob", "list"]
         if self.opts['zmq_filtering'] and load['tgt_type'] in match_targets:
             # Fetch a list of minions that match
-            match_ids = self.ckminions.check_minions(load['tgt'],
-                                                     tgt_type=load['tgt_type'])
+            _res = self.ckminions.check_minions(load['tgt'],
+                                                tgt_type=load['tgt_type'])
+            match_ids = _res['minions']
 
             log.debug("Publish Side Match: {0}".format(match_ids))
             # Send list of miions thru so zmq can target them

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -248,7 +248,8 @@ class MasterPillarUtil(object):
         # Return a list of minion ids that match the target and tgt_type
         minion_ids = []
         ckminions = salt.utils.minions.CkMinions(self.opts)
-        minion_ids = ckminions.check_minions(self.tgt, self.tgt_type)
+        _res = ckminions.check_minions(self.tgt, self.tgt_type)
+        minion_ids = _res['minions']
         if len(minion_ids) == 0:
             log.debug('No minions matched for tgt="{0}" and tgt_type="{1}"'.format(self.tgt, self.tgt_type))
             return {}

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -207,8 +207,15 @@ class CkMinions(object):
         '''
         Return the minions found by looking via a list
         '''
+        import inspect
+        curframe = inspect.currentframe()
+        calframe = inspect.getouterframes(curframe, 2)
+        log.debug('=== {} called _check_list_minions ==='.format(calframe[1][3]))
+
+        log.debug('== calling _check_list_minions ==')
         if isinstance(expr, six.string_types):
             expr = [m for m in expr.split(',') if m]
+        log.debug('== expr {} =='.format(expr))
         minions = self._pki_minions()
         return [x for x in expr if x in minions]
 
@@ -437,7 +444,7 @@ class CkMinions(object):
         '''
         Return the minions found by looking via compound matcher
         '''
-        log.debug('_check_compound_minions({0}, {1}, {2}, {3})'.format(expr, delimiter, greedy, pillar_exact))
+        log.debug('=== _check_compound_minions({0}, {1}, {2}, {3})'.format(expr, delimiter, greedy, pillar_exact))
         if not isinstance(expr, six.string_types) and not isinstance(expr, (list, tuple)):
             log.error('Compound target that is neither string, list nor tuple')
             return []
@@ -545,6 +552,7 @@ class CkMinions(object):
                     engine_args.append(greedy)
 
                     results.append(str(set(engine(*engine_args))))
+                    log.debug('== results {} =='.format(results))
                     if unmatched and unmatched[-1] == '-':
                         results.append(')')
                         unmatched.pop()
@@ -562,6 +570,7 @@ class CkMinions(object):
             results = ' '.join(results)
             log.debug('Evaluating final compound matching expr: {0}'
                       .format(results))
+            log.debug('=== unmatched {} ==='.format(unmatched))
             try:
                 return list(eval(results))  # pylint: disable=W0123
             except Exception:
@@ -633,6 +642,11 @@ class CkMinions(object):
         match the regex, this will then be used to parse the returns to
         make sure everyone has checked back in.
         '''
+        import inspect
+        curframe = inspect.currentframe()
+        calframe = inspect.getouterframes(curframe, 2)
+        log.debug('=== {} called check_minions ==='.format(calframe[1][3]))
+
         try:
             if expr is None:
                 expr = ''

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -202,7 +202,7 @@ class CkMinions(object):
         Return the minions found by looking via globs
         '''
         return {'minions': fnmatch.filter(self._pki_minions(), expr),
-                'missing': list()}
+                'missing': []}
 
     def _check_list_minions(self, expr, greedy):  # pylint: disable=unused-argument
         '''
@@ -220,7 +220,7 @@ class CkMinions(object):
         '''
         reg = re.compile(expr)
         return {'minions': [m for m in self._pki_minions() if reg.match(m)],
-                'missing': list()}
+                'missing': []}
 
     def _pki_minions(self):
         '''
@@ -268,8 +268,8 @@ class CkMinions(object):
         elif cache_enabled:
             minions = list_cached_minions()
         else:
-            return {'minions': list(),
-                    'missing': list()}
+            return {'minions': [],
+                    'missing': []}
 
         if cache_enabled:
             if greedy:
@@ -278,7 +278,7 @@ class CkMinions(object):
                 cminions = minions
             if not cminions:
                 return {'minions': minions,
-                        'missing': list()}
+                        'missing': []}
             minions = set(minions)
             for id_ in cminions:
                 if greedy and id_ not in minions:
@@ -297,7 +297,7 @@ class CkMinions(object):
                     minions.remove(id_)
             minions = list(minions)
         return {'minions': minions,
-                'missing': list()}
+                'missing': []}
 
     def _check_grain_minions(self, expr, delimiter, greedy):
         '''
@@ -352,8 +352,8 @@ class CkMinions(object):
         elif cache_enabled:
             minions = self.cache.list('minions')
         else:
-            return {'minions': list(),
-                    'missing': list()}
+            return {'minions': [],
+                    'missing': []}
 
         if cache_enabled:
             if greedy:
@@ -362,7 +362,7 @@ class CkMinions(object):
                 cminions = minions
             if cminions is None:
                 return {'minions': minions,
-                        'missing': list()}
+                        'missing': []}
 
             tgt = expr
             try:
@@ -374,8 +374,8 @@ class CkMinions(object):
                     tgt = ipaddress.ip_network(tgt)
                 except:  # pylint: disable=bare-except
                     log.error('Invalid IP/CIDR target: {0}'.format(tgt))
-                    return {'minions': list(),
-                            'missing': list()}
+                    return {'minions': [],
+                            'missing': []}
             proto = 'ipv{0}'.format(tgt.version)
 
             minions = set(minions)
@@ -397,7 +397,7 @@ class CkMinions(object):
                     minions.remove(id_)
 
         return {'minions': list(minions),
-                'missing': list()}
+                'missing': []}
 
     def _check_range_minions(self, expr, greedy):
         '''
@@ -423,13 +423,13 @@ class CkMinions(object):
                     if not fn_.startswith('.') and os.path.isfile(os.path.join(self.opts['pki_dir'], self.acc, fn_)):
                         mlist.append(fn_)
                 return {'minions': mlist,
-                        'missing': list()}
+                        'missing': []}
             elif cache_enabled:
                 return {'minions': self.cache.list('minions'),
-                        'missing': list()}
+                        'missing': []}
             else:
-                return {'minions': list(),
-                        'missing': list()}
+                return {'minions': [],
+                        'missing': []}
 
     def _check_compound_pillar_exact_minions(self, expr, delimiter, greedy):
         '''
@@ -452,7 +452,7 @@ class CkMinions(object):
         '''
         if not isinstance(expr, six.string_types) and not isinstance(expr, (list, tuple)):
             log.error('Compound target that is neither string, list nor tuple')
-            return {'minions': list(), 'missing': list()}
+            return {'minions': [], 'missing': []}
         minions = set(self._pki_minions())
         log.debug('minions: {0}'.format(minions))
 
@@ -488,7 +488,7 @@ class CkMinions(object):
                     if results:
                         if results[-1] == '(' and word in ('and', 'or'):
                             log.error('Invalid beginning operator after "(": {0}'.format(word))
-                            return {'minions': list(), 'missing': list()}
+                            return {'minions': [], 'missing': []}
                         if word == 'not':
                             if not results[-1] in ('&', '|', '('):
                                 results.append('&')
@@ -508,7 +508,7 @@ class CkMinions(object):
                                 log.error('Invalid compound expr (unexpected '
                                           'right parenthesis): {0}'
                                           .format(expr))
-                                return {'minions': list(), 'missing': list()}
+                                return {'minions': [], 'missing': []}
                             results.append(word)
                             unmatched.pop()
                             if unmatched and unmatched[-1] == '-':
@@ -517,7 +517,7 @@ class CkMinions(object):
                         else:  # Won't get here, unless oper is added
                             log.error('Unhandled oper in compound expr: {0}'
                                       .format(expr))
-                            return {'minions': list(), 'missing': list()}
+                            return {'minions': [], 'missing': []}
                     else:
                         # seq start with oper, fail
                         if word == 'not':
@@ -533,13 +533,13 @@ class CkMinions(object):
                                 'Expression may begin with'
                                 ' binary operator: {0}'.format(word)
                             )
-                            return {'minions': list(), 'missing': list()}
+                            return {'minions': [], 'missing': []}
 
                 elif target_info and target_info['engine']:
                     if 'N' == target_info['engine']:
                         # Nodegroups should already be expanded/resolved to other engines
                         log.error('Detected nodegroup expansion failure of "{0}"'.format(word))
-                        return {'minions': list(), 'missing': list()}
+                        return {'minions': [], 'missing': []}
                     engine = ref.get(target_info['engine'])
                     if not engine:
                         # If an unknown engine is called at any time, fail out
@@ -550,7 +550,7 @@ class CkMinions(object):
                                 word,
                             )
                         )
-                        return {'minions': list(), 'missing': list()}
+                        return {'minions': [], 'missing': []}
 
                     engine_args = [target_info['pattern']]
                     if target_info['engine'] in ('G', 'P', 'I', 'J'):
@@ -583,10 +583,10 @@ class CkMinions(object):
                 return {'minions': minions, 'missing': missing}
             except Exception:
                 log.error('Invalid compound target: {0}'.format(expr))
-                return {'minions': list(), 'missing': list()}
+                return {'minions': [], 'missing': []}
 
         return {'minions': list(minions),
-                'missing': list()}
+                'missing': []}
 
     def connected_ids(self, subset=None, show_ipv4=False, include_localhost=False):
         '''
@@ -638,7 +638,7 @@ class CkMinions(object):
         for fn_ in salt.utils.isorted(os.listdir(os.path.join(self.opts['pki_dir'], self.acc))):
             if not fn_.startswith('.') and os.path.isfile(os.path.join(self.opts['pki_dir'], self.acc, fn_)):
                 mlist.append(fn_)
-        return {'minions': mlist, 'missing': list()}
+        return {'minions': mlist, 'missing': []}
 
     def check_minions(self,
                       expr,
@@ -670,7 +670,7 @@ class CkMinions(object):
             log.exception(
                     'Failed matching available minions with {0} pattern: {1}'
                     .format(tgt_type, expr))
-            _res = {'minions': list(), 'missing': list()}
+            _res = {'minions': [], 'missing': []}
         return _res
 
     def _expand_matching(self, auth_entry):

--- a/tests/integration/client/test_standard.py
+++ b/tests/integration/client/test_standard.py
@@ -147,3 +147,33 @@ class StdTest(ModuleCase):
 
         finally:
             os.unlink(key_file)
+
+    def test_missing_minion_list(self):
+        '''
+        test cmd with missing minion in nodegroup
+        '''
+        ret = self.client.cmd(
+                'minion,ghostminion',
+                'test.ping',
+                tgt_type='list'
+                )
+        self.assertIn('minion', ret)
+        self.assertIn('ghostminion', ret)
+        self.assertEqual(True, ret['minion'])
+        self.assertEqual(u'Minion did not return. [No response]',
+                         ret['ghostminion'])
+
+    def test_missing_minion_nodegroup(self):
+        '''
+        test cmd with missing minion in nodegroup
+        '''
+        ret = self.client.cmd(
+                'missing_minion',
+                'test.ping',
+                tgt_type='nodegroup'
+                )
+        self.assertIn('minion', ret)
+        self.assertIn('ghostminion', ret)
+        self.assertEqual(True, ret['minion'])
+        self.assertEqual(u'Minion did not return. [No response]',
+                         ret['ghostminion'])

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -78,6 +78,7 @@ nodegroups:
   redundant_minions: N@min or N@mins
   nodegroup_loop_a: N@nodegroup_loop_b
   nodegroup_loop_b: N@nodegroup_loop_a
+  missing_minion: L@minion,ghostminion
 
 
 mysql.host: localhost

--- a/tests/unit/pillar/test_nodegroups.py
+++ b/tests/unit/pillar/test_nodegroups.py
@@ -27,8 +27,10 @@ fake_pillar_name = 'fake_pillar_name'
 
 def side_effect(group_sel, t):
     if group_sel.find(fake_minion_id) != -1:
-        return [fake_minion_id, ]
-    return ['another_minion_id', ]
+        return {'minions': [fake_minion_id, ],
+                'missing': []}
+    return {'minions': ['another_minion_id', ],
+            'missing': []}
 
 
 class NodegroupsPillarTestCase(TestCase, LoaderModuleMockMixin):

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -235,7 +235,7 @@ class MasterACLTestCase(ModuleCase):
         self.valid_clear_load['tgt'] = requested_tgt
         self.valid_clear_load['fun'] = requested_function
         _check_minions_return = {'minions': ['minion_glob1'], 'missing': []}
-        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_check_minions_return)): # Assume that there is a listening minion match
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_check_minions_return)):  # Assume that there is a listening minion match
             self.clear.publish(self.valid_clear_load)
         self.assertTrue(self.fire_event_mock.called, 'Did not fire {0} for minion tgt {1}'.format(requested_function, requested_tgt))
         self.assertEqual(self.fire_event_mock.call_args[0][0]['fun'], requested_function, 'Did not fire {0} for minion glob'.format(requested_function))

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -151,7 +151,8 @@ class MasterACLTestCase(ModuleCase):
         Test to ensure a simple name can auth against a given function.
         This tests to ensure test_user can access test.ping but *not* sys.doc
         '''
-        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value='some_minions')):
+        _check_minions_return = {'minions': ['some_minions'], 'missing': []}
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_check_minions_return)):
             # Can we access test.ping?
             self.clear.publish(self.valid_clear_load)
             self.assertEqual(self.fire_event_mock.call_args[0][0]['fun'], 'test.ping')
@@ -166,7 +167,8 @@ class MasterACLTestCase(ModuleCase):
         '''
         Tests to ensure test_group can access test.echo but *not* sys.doc
         '''
-        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value='some_minions')):
+        _check_minions_return = {'minions': ['some_minions'], 'missing': []}
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_check_minions_return)):
             self.valid_clear_load['kwargs']['user'] = 'new_user'
             self.valid_clear_load['fun'] = 'test.echo'
             self.valid_clear_load['arg'] = 'hello'
@@ -232,7 +234,8 @@ class MasterACLTestCase(ModuleCase):
         requested_tgt = 'minion_glob1'
         self.valid_clear_load['tgt'] = requested_tgt
         self.valid_clear_load['fun'] = requested_function
-        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=['minion_glob1'])):  # Assume that there is a listening minion match
+        _check_minions_return = {'minions': ['minion_glob1'], 'missing': []}
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_check_minions_return)): # Assume that there is a listening minion match
             self.clear.publish(self.valid_clear_load)
         self.assertTrue(self.fire_event_mock.called, 'Did not fire {0} for minion tgt {1}'.format(requested_function, requested_tgt))
         self.assertEqual(self.fire_event_mock.call_args[0][0]['fun'], requested_function, 'Did not fire {0} for minion glob'.format(requested_function))
@@ -258,7 +261,8 @@ class MasterACLTestCase(ModuleCase):
             minion1:
                 - test.empty:
         '''
-        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value='minion1')):
+        _check_minions_return = {'minions': ['minion1'], 'missing': []}
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_check_minions_return)):
             self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
             self.valid_clear_load.update({'user': 'test_user_func',
                                           'tgt': 'minion1',
@@ -278,7 +282,8 @@ class MasterACLTestCase(ModuleCase):
                         - 'TEST'
                         - 'TEST.*'
         '''
-        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value='minion1')):
+        _check_minions_return = {'minions': ['minion1'], 'missing': []}
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_check_minions_return)):
             self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
             self.valid_clear_load.update({'user': 'test_user_func',
                                           'tgt': 'minion1',
@@ -298,7 +303,8 @@ class MasterACLTestCase(ModuleCase):
                         - 'TEST'
                         - 'TEST.*'
         '''
-        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value='minion1')):
+        _check_minions_return = {'minions': ['minion1'], 'missing': []}
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_check_minions_return)):
             self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
             self.valid_clear_load.update({'user': 'test_user_func',
                                           'tgt': 'minion1',
@@ -323,7 +329,8 @@ class MasterACLTestCase(ModuleCase):
                         - 'TEST'
                         - 'TEST.*'
         '''
-        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value='minion1')):
+        _check_minions_return = {'minions': ['minion1'], 'missing': []}
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_check_minions_return)):
             self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
             # Wrong last arg
             self.valid_clear_load.update({'user': 'test_user_func',
@@ -355,7 +362,8 @@ class MasterACLTestCase(ModuleCase):
                     kwargs:
                         text: 'KWMSG:.*'
         '''
-        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value='some_minions')):
+        _check_minions_return = {'minions': ['some_minions'], 'missing': []}
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_check_minions_return)):
             self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
             self.valid_clear_load.update({'user': 'test_user_func',
                                           'tgt': '*',
@@ -377,7 +385,8 @@ class MasterACLTestCase(ModuleCase):
                     kwargs:
                         text: 'KWMSG:.*'
         '''
-        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value='some_minions')):
+        _check_minions_return = {'minions': ['some_minions'], 'missing': []}
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_check_minions_return)):
             self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
             self.valid_clear_load.update({'user': 'test_user_func',
                                           'tgt': '*',
@@ -430,7 +439,8 @@ class MasterACLTestCase(ModuleCase):
                         'kwa': 'kwa.*'
                         'kwb': 'kwb'
         '''
-        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value='some_minions')):
+        _check_minions_return = {'minions': ['some_minions'], 'missing': []}
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_check_minions_return)):
             self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
             self.valid_clear_load.update({'user': 'test_user_func',
                                           'tgt': '*',
@@ -460,7 +470,8 @@ class MasterACLTestCase(ModuleCase):
                         'kwa': 'kwa.*'
                         'kwb': 'kwb'
         '''
-        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value='some_minions')):
+        _check_minions_return = {'minions': ['some_minions'], 'missing': []}
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_check_minions_return)):
             self.valid_clear_load['kwargs'].update({'username': 'test_user_func'})
             self.valid_clear_load.update({'user': 'test_user_func',
                                           'tgt': '*',


### PR DESCRIPTION
### What does this PR do?
Marks non-existent nodes specified in a list or as part of a node group as failed when called via the `salt` command.

### What issues does this PR fix or reference?
#41326

### Previous Behavior
Non-existent nodes were silently ignored.

### New Behavior
Commands are not sent to non-existent nodes but they are included in the final output and marked as failed.

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
