### PR TITLE
Always notify ryan-lane when changes occur on boto files

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,4 +1,11 @@
 {
+  "alwaysNotifyForPaths": [
+    {
+      "name": "ryan-lane",
+      "files": ["salt/**/*boto*.py"],
+      "skipTeamPrs": false
+    }
+  ],
  "skipTitle": "Merge forward",
  "userBlacklist": ["cvrebert", "markusgattol", "olliewalsh"]
 }


### PR DESCRIPTION
Adds @ryan-lane to the `alwaysNotifyForPaths` option in `.mention-bot` for any boto files in Salt so he can see when changes are made automatically.

@ryan-lane we discussed this in a meeting a couple of weeks ago. Let me know if the notification or file array spec needs to be adjusted. :)
