### PR TITLE
Fixes to osquery module

### DIFF
--- a/salt/modules/osquery.py
+++ b/salt/modules/osquery.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import
 
 # Import python libs
 import json
-import shlex
 
 # Import Salt libs
 import salt.utils

--- a/salt/modules/osquery.py
+++ b/salt/modules/osquery.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 
 # Import python libs
 import json
+import shlex
 
 # Import Salt libs
 import salt.utils
@@ -55,8 +56,8 @@ def _osquery(sql, format='json'):
         'result': True,
     }
 
-    cmd = 'osqueryi --json "{0}"'.format(sql)
-    res = __salt__['cmd.run_all'](cmd, python_shell=True)
+    cmd = ['osqueryi'] + ['--json'] + [sql]
+    res = __salt__['cmd.run_all'](cmd)
     if res['retcode'] == 0:
         ret['data'] = json.loads(res['stdout'])
     else:

--- a/salt/modules/osquery.py
+++ b/salt/modules/osquery.py
@@ -56,7 +56,7 @@ def _osquery(sql, format='json'):
     }
 
     cmd = 'osqueryi --json "{0}"'.format(sql)
-    res = __salt__['cmd.run_all'](cmd)
+    res = __salt__['cmd.run_all'](cmd, python_shell=True)
     if res['retcode'] == 0:
         ret['data'] = json.loads(res['stdout'])
     else:

--- a/salt/modules/osquery.py
+++ b/salt/modules/osquery.py
@@ -37,7 +37,7 @@ def _table_attrs(table):
     '''
     Helper function to find valid table attributes
     '''
-    cmd = 'osqueryi --json "pragma table_info({0})"'.format(table)
+    cmd = ['osqueryi'] + ['--json'] + ['pragma table_info{0}'.format(table)]
     res = __salt__['cmd.run_all'](cmd)
     if res['retcode'] == 0:
         attrs = []


### PR DESCRIPTION
### What does this PR do?
When running osquery commands through cmd.run we should pass python_shell=True to ensure everything is formatted right. 

### What issues does this PR fix or reference?
#42873

### Previous Behavior
Previous the osquery module would not work correctly on Windows beginning with the 2017.7 release, most likely related to the deprecation of the cmd.shell alias for cmd.run.

### New Behavior
This change forces python_shell=True to ensure everything is formatted correctly when passed to the cmd.run_all function.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
