### PR TITLE
Fixes to error reporting for osquery module

### DIFF
--- a/salt/modules/osquery.py
+++ b/salt/modules/osquery.py
@@ -58,11 +58,11 @@ def _osquery(sql, format='json'):
 
     cmd = 'osqueryi --json "{0}"'.format(sql)
     res = __salt__['cmd.run_all'](cmd)
-    if res['retcode'] == 0:
-        ret['data'] = json.loads(res['stdout'])
-    else:
+    if res['stderr']:
         ret['result'] = False
         ret['error'] = res['stderr']
+    else:
+        ret['data'] = json.loads(res['stdout'])
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?
Running osquery commands through cmd.run_all, when something goes wrong it still returns a retcode of 0.  So look for something in stderr when errors occur instead.

### What issues does this PR fix or reference?
None

### Previous Behavior
Errors would return as a confusing return from Salt because the retcode would be 0 regardless.

### New Behavior
Handle errors properly by looking for stderr contents instead of retcode.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
