### PR TITLE
runit module should also be loaded as runit

### DIFF
--- a/salt/modules/runit.py
+++ b/salt/modules/runit.py
@@ -80,7 +80,8 @@ for service_dir in VALID_SERVICE_DIRS:
 AVAIL_SVR_DIRS = []
 
 # Define the module's virtual name
-__virtualname__ = 'service'
+__virtualname__ = 'runit'
+__virtual_aliases__ = ('runit',)
 
 
 def __virtual__():
@@ -91,8 +92,12 @@ def __virtual__():
     if __grains__.get('init') == 'runit':
         if __grains__['os'] == 'Void':
             add_svc_avail_path('/etc/sv')
+        global __virtualname__
+        __virtualname__ = 'service'
         return __virtualname__
-    return False
+    if salt.utils.which('sv'):
+        return __virtualname__
+    return (False, 'Runit not available.  Please install sv')
 
 
 def _service_path(name):


### PR DESCRIPTION
### What does this PR do?
This will allow the use of both the system init and runit at the same time.

### What issues does this PR fix or reference?
Fixes #42375

### Previous Behavior
runit can only be loaded as the service module

### New Behavior
runit can be loaded as a service module, but also used to start service when it is not pid1/init

### Tests written?

No