### PR TITLE
Back-port #42883 to 2016.11

### DIFF
--- a/tests/unit/modules/boto_elb_test.py
+++ b/tests/unit/modules/boto_elb_test.py
@@ -15,17 +15,17 @@ except ImportError:
     HAS_BOTO = False
 
 try:
-    from moto import mock_ec2, mock_elb
+    from moto import mock_ec2_deprecated, mock_elb
     HAS_MOTO = True
 except ImportError:
     HAS_MOTO = False
 
-    def mock_ec2(self):
+    def mock_ec2_deprecated(self):
         '''
-        if the mock_ec2 function is not available due to import failure
+        if the mock_ec2_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_vpc unit tests to use the @mock_ec2 decorator
-        without a "NameError: name 'mock_ec2' is not defined" error.
+        Allows boto_vpc unit tests to use the @mock_ec2_deprecated decorator
+        without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
         '''
         def stub_function(self):
             pass
@@ -33,10 +33,10 @@ except ImportError:
 
     def mock_elb(self):
         '''
-        if the mock_ec2 function is not available due to import failure
+        if the mock_ec2_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_vpc unit tests to use the @mock_ec2 decorator
-        without a "NameError: name 'mock_ec2' is not defined" error.
+        Allows boto_vpc unit tests to use the @mock_ec2_deprecated decorator
+        without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
         '''
         def stub_function(self):
             pass
@@ -83,7 +83,7 @@ class BotoElbTestCase(TestCase):
     '''
     TestCase for salt.modules.boto_elb module
     '''
-    @mock_ec2
+    @mock_ec2_deprecated
     @mock_elb
     def test_register_instances_valid_id_result_true(self):
         '''
@@ -102,7 +102,7 @@ class BotoElbTestCase(TestCase):
                                                       **conn_parameters)
         self.assertEqual(True, register_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @mock_elb
     def test_register_instances_valid_id_string(self):
         '''
@@ -125,7 +125,7 @@ class BotoElbTestCase(TestCase):
         log.debug(load_balancer_refreshed.instances)
         self.assertEqual([reservations.instances[0].id], registered_instance_ids)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @mock_elb
     def test_deregister_instances_valid_id_result_true(self):
         '''
@@ -146,7 +146,7 @@ class BotoElbTestCase(TestCase):
                                                           **conn_parameters)
         self.assertEqual(True, deregister_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @mock_elb
     def test_deregister_instances_valid_id_string(self):
         '''
@@ -172,7 +172,7 @@ class BotoElbTestCase(TestCase):
                             load_balancer_refreshed.instances]
         self.assertEqual(actual_instances, expected_instances)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @mock_elb
     def test_deregister_instances_valid_id_list(self):
         '''

--- a/tests/unit/modules/boto_elb_test.py
+++ b/tests/unit/modules/boto_elb_test.py
@@ -15,7 +15,7 @@ except ImportError:
     HAS_BOTO = False
 
 try:
-    from moto import mock_ec2_deprecated, mock_elb
+    from moto import mock_ec2_deprecated, mock_elb_deprecated
     HAS_MOTO = True
 except ImportError:
     HAS_MOTO = False
@@ -24,19 +24,19 @@ except ImportError:
         '''
         if the mock_ec2_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_vpc unit tests to use the @mock_ec2_deprecated decorator
+        Allows boto_elb unit tests to use the @mock_ec2_deprecated decorator
         without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
         '''
         def stub_function(self):
             pass
         return stub_function
 
-    def mock_elb(self):
+    def mock_elb_deprecated(self):
         '''
-        if the mock_ec2_deprecated function is not available due to import failure
+        if the mock_elb_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_vpc unit tests to use the @mock_ec2_deprecated decorator
-        without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
+        Allows boto_elb unit tests to use the @mock_elb_deprecated decorator
+        without a "NameError: name 'mock_elb_deprecated' is not defined" error.
         '''
         def stub_function(self):
             pass
@@ -84,7 +84,7 @@ class BotoElbTestCase(TestCase):
     TestCase for salt.modules.boto_elb module
     '''
     @mock_ec2_deprecated
-    @mock_elb
+    @mock_elb_deprecated
     def test_register_instances_valid_id_result_true(self):
         '''
         tests that given a valid instance id and valid ELB that
@@ -103,7 +103,7 @@ class BotoElbTestCase(TestCase):
         self.assertEqual(True, register_result)
 
     @mock_ec2_deprecated
-    @mock_elb
+    @mock_elb_deprecated
     def test_register_instances_valid_id_string(self):
         '''
         tests that given a string containing a instance id and valid ELB that
@@ -126,7 +126,7 @@ class BotoElbTestCase(TestCase):
         self.assertEqual([reservations.instances[0].id], registered_instance_ids)
 
     @mock_ec2_deprecated
-    @mock_elb
+    @mock_elb_deprecated
     def test_deregister_instances_valid_id_result_true(self):
         '''
         tests that given an valid id the boto_elb deregister_instances method
@@ -147,7 +147,7 @@ class BotoElbTestCase(TestCase):
         self.assertEqual(True, deregister_result)
 
     @mock_ec2_deprecated
-    @mock_elb
+    @mock_elb_deprecated
     def test_deregister_instances_valid_id_string(self):
         '''
         tests that given an valid id the boto_elb deregister_instances method
@@ -173,7 +173,7 @@ class BotoElbTestCase(TestCase):
         self.assertEqual(actual_instances, expected_instances)
 
     @mock_ec2_deprecated
-    @mock_elb
+    @mock_elb_deprecated
     def test_deregister_instances_valid_id_list(self):
         '''
         tests that given an valid ids in the form of a list that the boto_elb

--- a/tests/unit/modules/boto_secgroup_test.py
+++ b/tests/unit/modules/boto_secgroup_test.py
@@ -209,7 +209,7 @@ class BotoSecgroupTestCase(TestCase):
         group = conn.create_security_group(name=group_name, description=group_name)
         group.authorize(ip_protocol=ip_protocol, from_port=from_port, to_port=to_port, cidr_ip=cidr_ip)
         # setup the expected get_config result
-        expected_get_config_result = OrderedDict([('name', group.name), ('group_id', group.id),('owner_id', u'123456789012'),
+        expected_get_config_result = OrderedDict([('name', group.name), ('group_id', group.id), ('owner_id', u'123456789012'),
                                                  ('description', group.description), ('tags', {}),
                                                  ('rules', [{'to_port': to_port, 'from_port': from_port,
                                                   'ip_protocol': ip_protocol, 'cidr_ip': cidr_ip}]),

--- a/tests/unit/modules/boto_secgroup_test.py
+++ b/tests/unit/modules/boto_secgroup_test.py
@@ -29,17 +29,17 @@ except ImportError:
     HAS_BOTO = False
 
 try:
-    from moto import mock_ec2
+    from moto import mock_ec2_deprecated
     HAS_MOTO = True
 except ImportError:
     HAS_MOTO = False
 
-    def mock_ec2(self):
+    def mock_ec2_deprecated(self):
         '''
-        if the mock_ec2 function is not available due to import failure
+        if the mock_ec2_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_secgroup unit tests to use the @mock_ec2 decorator
-        without a "NameError: name 'mock_ec2' is not defined" error.
+        Allows boto_secgroup unit tests to use the @mock_ec2_deprecated decorator
+        without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
         '''
         def stub_function(self):
             pass
@@ -111,7 +111,7 @@ class BotoSecgroupTestCase(TestCase):
                        {'to_port': 80, 'from_port': 80, 'ip_protocol': u'tcp', 'cidr_ip': u'0.0.0.0/0'}]
         self.assertEqual(boto_secgroup._split_rules(rules), split_rules)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_create_ec2_classic(self):
         '''
         Test of creation of an EC2-Classic security group. The test ensures
@@ -131,7 +131,7 @@ class BotoSecgroupTestCase(TestCase):
                                   secgroup_created_group[0].vpc_id]
         self.assertEqual(expected_create_result, secgroup_create_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_create_ec2_vpc(self):
         '''
         test of creation of an EC2-VPC security group. The test ensures that a
@@ -151,7 +151,7 @@ class BotoSecgroupTestCase(TestCase):
 
     @skipIf(True, 'test skipped due to error in moto return - fixed in'
                   ' https://github.com/spulec/moto/commit/cc0166964371f7b5247a49d45637a8f936ccbe6f')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_group_id_ec2_classic(self):
         '''
         tests that given a name of a group in EC2-Classic that the correct
@@ -173,7 +173,7 @@ class BotoSecgroupTestCase(TestCase):
 
     @skipIf(True, 'test skipped because moto does not yet support group'
                   ' filters https://github.com/spulec/moto/issues/154')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_group_id_ec2_vpc(self):
         '''
         tests that given a name of a group in EC2-VPC that the correct
@@ -193,7 +193,7 @@ class BotoSecgroupTestCase(TestCase):
                                                         **conn_parameters)
         self.assertEqual(group_vpc.id, retrieved_group_id)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_config_single_rule_group_name(self):
         '''
         tests return of 'config' when given group name. get_config returns an OrderedDict.
@@ -219,7 +219,7 @@ class BotoSecgroupTestCase(TestCase):
 
     @skipIf(True, 'test skipped due to error in moto return - fixed in '
                   'https://github.com/spulec/moto/commit/cc0166964371f7b5247a49d45637a8f936ccbe6f')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_exists_true_name_classic(self):
         '''
         tests 'true' existence of a group in EC2-Classic when given name
@@ -234,11 +234,11 @@ class BotoSecgroupTestCase(TestCase):
 
     @skipIf(True, 'test skipped because moto does not yet support group'
                   ' filters https://github.com/spulec/moto/issues/154')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_exists_false_name_classic(self):
         pass
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_exists_true_name_vpc(self):
         '''
         tests 'true' existence of a group in EC2-VPC when given name and vpc_id
@@ -250,7 +250,7 @@ class BotoSecgroupTestCase(TestCase):
         salt_exists_result = boto_secgroup.exists(name=group_name, vpc_id=vpc_id, **conn_parameters)
         self.assertTrue(salt_exists_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_exists_false_name_vpc(self):
         '''
         tests 'false' existence of a group in vpc when given name and vpc_id
@@ -259,7 +259,7 @@ class BotoSecgroupTestCase(TestCase):
         salt_exists_result = boto_secgroup.exists(group_name, vpc_id=vpc_id, **conn_parameters)
         self.assertFalse(salt_exists_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_exists_true_group_id(self):
         '''
         tests 'true' existence of a group when given group_id
@@ -271,7 +271,7 @@ class BotoSecgroupTestCase(TestCase):
         salt_exists_result = boto_secgroup.exists(group_id=group.id, **conn_parameters)
         self.assertTrue(salt_exists_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_exists_false_group_id(self):
         '''
         tests 'false' existence of a group when given group_id
@@ -282,7 +282,7 @@ class BotoSecgroupTestCase(TestCase):
 
     @skipIf(True, 'test skipped due to error in moto return - fixed in'
                   ' https://github.com/spulec/moto/commit/cc0166964371f7b5247a49d45637a8f936ccbe6f')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_delete_group_ec2_classic(self):
         '''
         test deletion of a group in EC2-Classic. Test does the following:
@@ -310,11 +310,11 @@ class BotoSecgroupTestCase(TestCase):
 
     @skipIf(True, 'test skipped because moto does not yet support group'
                   ' filters https://github.com/spulec/moto/issues/154')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_delete_group_name_ec2_vpc(self):
         pass
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test__get_conn_true(self):
         '''
         tests ensures that _get_conn returns an boto.ec2.connection.EC2Connection object.

--- a/tests/unit/modules/boto_secgroup_test.py
+++ b/tests/unit/modules/boto_secgroup_test.py
@@ -209,7 +209,7 @@ class BotoSecgroupTestCase(TestCase):
         group = conn.create_security_group(name=group_name, description=group_name)
         group.authorize(ip_protocol=ip_protocol, from_port=from_port, to_port=to_port, cidr_ip=cidr_ip)
         # setup the expected get_config result
-        expected_get_config_result = OrderedDict([('name', group.name), ('group_id', group.id), ('owner_id', u'111122223333'),
+        expected_get_config_result = OrderedDict([('name', group.name), ('group_id', group.id),('owner_id', u'123456789012'),
                                                  ('description', group.description), ('tags', {}),
                                                  ('rules', [{'to_port': to_port, 'from_port': from_port,
                                                   'ip_protocol': ip_protocol, 'cidr_ip': cidr_ip}]),

--- a/tests/unit/modules/boto_vpc_test.py
+++ b/tests/unit/modules/boto_vpc_test.py
@@ -39,17 +39,17 @@ except ImportError:
 
 try:
     import moto
-    from moto import mock_ec2
+    from moto import mock_ec2_deprecated
     HAS_MOTO = True
 except ImportError:
     HAS_MOTO = False
 
-    def mock_ec2(self):
+    def mock_ec2_deprecated(self):
         '''
-        if the mock_ec2 function is not available due to import failure
+        if the mock_ec2_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_vpc unit tests to use the @mock_ec2 decorator
-        without a "NameError: name 'mock_ec2' is not defined" error.
+        Allows boto_vpc unit tests to use the @mock_ec2_deprecated decorator
+        without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
         '''
 
         def stub_function(self):
@@ -62,7 +62,7 @@ except ImportError:
 # which was added in boto 2.8.0
 # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
 required_boto_version = '2.8.0'
-required_moto_version = '0.3.7'
+required_moto_version = '1.0.0'
 
 region = 'us-east-1'
 access_key = 'GKTADJGHEIQSXMKKRBJ08H'
@@ -265,7 +265,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     TestCase for salt.modules.boto_vpc module
     '''
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_id_and_a_vpc_exists_the_vpc_exists_method_returns_true(self):
         '''
         Tests checking vpc existence via id when the vpc already exists
@@ -276,7 +276,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_id_and_a_vpc_does_not_exist_the_vpc_exists_method_returns_false(
             self):
         '''
@@ -288,7 +288,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_name_and_a_vpc_exists_the_vpc_exists_method_returns_true(self):
         '''
         Tests checking vpc existence via name when vpc exists
@@ -299,7 +299,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_name_and_a_vpc_does_not_exist_the_vpc_exists_method_returns_false(
             self):
         '''
@@ -311,7 +311,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_tags_and_a_vpc_exists_the_vpc_exists_method_returns_true(self):
         '''
         Tests checking vpc existence via tag when vpc exists
@@ -322,7 +322,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_tags_and_a_vpc_does_not_exist_the_vpc_exists_method_returns_false(
             self):
         '''
@@ -334,7 +334,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_cidr_and_a_vpc_exists_the_vpc_exists_method_returns_true(self):
         '''
         Tests checking vpc existence via cidr when vpc exists
@@ -345,7 +345,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_vpc_exists_by_cidr_and_a_vpc_does_not_exist_the_vpc_exists_method_returns_false(
             self):
         '''
@@ -357,7 +357,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(vpc_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_checking_if_a_vpc_exists_but_providing_no_filters_the_vpc_exists_method_raises_a_salt_invocation_error(self):
         '''
@@ -368,7 +368,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                           'cidr or tags.'):
             boto_vpc.exists(**conn_parameters)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_filtering_by_name(self):
         '''
         Tests getting vpc id when filtering by name
@@ -379,7 +379,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(vpc.id, get_id_result['id'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_filtering_by_invalid_name(self):
         '''
         Tests getting vpc id when filtering by invalid name
@@ -390,7 +390,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(get_id_result['id'], None)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_filtering_by_cidr(self):
         '''
         Tests getting vpc id when filtering by cidr
@@ -401,7 +401,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(vpc.id, get_id_result['id'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_filtering_by_invalid_cidr(self):
         '''
         Tests getting vpc id when filtering by invalid cidr
@@ -412,7 +412,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(get_id_result['id'], None)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_filtering_by_tags(self):
         '''
         Tests getting vpc id when filtering by tags
@@ -423,7 +423,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(vpc.id, get_id_result['id'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_filtering_by_invalid_tags(self):
         '''
         Tests getting vpc id when filtering by invalid tags
@@ -434,7 +434,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(get_id_result['id'], None)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_get_vpc_id_method_when_not_providing_filters_raises_a_salt_invocation_error(self):
         '''
@@ -443,7 +443,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         with self.assertRaisesRegexp(SaltInvocationError, 'At least one of the following must be provided: vpc_id, vpc_name, cidr or tags.'):
             boto_vpc.get_id(**conn_parameters)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_vpc_id_method_when_more_than_one_vpc_is_matched_raises_a_salt_command_execution_error(self):
         '''
         Tests getting vpc id but providing no filters
@@ -454,7 +454,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         with self.assertRaisesRegexp(CommandExecutionError, 'Found more than one VPC matching the criteria.'):
             boto_vpc.get_id(cidr=u'10.0.0.0/24', **conn_parameters)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_a_vpc_succeeds_the_create_vpc_method_returns_true(self):
         '''
         tests True VPC created.
@@ -463,7 +463,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_a_vpc_and_specifying_a_vpc_name_succeeds_the_create_vpc_method_returns_true(self):
         '''
         tests True VPC created.
@@ -472,7 +472,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_a_vpc_and_specifying_tags_succeeds_the_create_vpc_method_returns_true(self):
         '''
         tests True VPC created.
@@ -481,7 +481,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_creating_a_vpc_fails_the_create_vpc_method_returns_false(self):
         '''
@@ -492,7 +492,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             self.assertFalse(vpc_creation_result['created'])
             self.assertTrue('error' in vpc_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_deleting_an_existing_vpc_the_delete_vpc_method_returns_true(self):
         '''
         Tests deleting an existing vpc
@@ -503,7 +503,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(vpc_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_deleting_a_non_existent_vpc_the_delete_vpc_method_returns_false(self):
         '''
         Tests deleting a non-existent vpc
@@ -512,7 +512,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(delete_vpc_result['deleted'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_describing_vpc_by_id_it_returns_the_dict_of_properties_returns_true(self):
         '''
         Tests describing parameters via vpc id if vpc exist
@@ -539,7 +539,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertEqual(describe_vpc, {'vpc': vpc_properties})
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_describing_vpc_by_id_it_returns_the_dict_of_properties_returns_false(self):
         '''
         Tests describing parameters via vpc id if vpc does not exist
@@ -550,7 +550,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(describe_vpc['vpc'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_describing_vpc_by_id_on_connection_error_it_returns_error(self):
         '''
@@ -563,7 +563,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             describe_result = boto_vpc.describe(vpc_id=vpc.id, **conn_parameters)
             self.assertTrue('error' in describe_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_describing_vpc_but_providing_no_vpc_id_the_describe_method_raises_a_salt_invocation_error(self):
         '''
         Tests describing vpc without vpc id
@@ -581,7 +581,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         .format(required_boto_version))
 @skipIf(_has_required_moto() is False, 'The moto version must be >= to version {0}'.format(required_moto_version))
 class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_subnet_association_single_subnet(self):
         '''
         tests that given multiple subnet ids in the same VPC that the VPC ID is
@@ -594,7 +594,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                              **conn_parameters)
         self.assertEqual(vpc.id, subnet_association['vpc_id'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_subnet_association_multiple_subnets_same_vpc(self):
         '''
         tests that given multiple subnet ids in the same VPC that the VPC ID is
@@ -607,7 +607,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                              **conn_parameters)
         self.assertEqual(vpc.id, subnet_association['vpc_id'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_get_subnet_association_multiple_subnets_different_vpc(self):
         '''
         tests that given multiple subnet ids in different VPCs that False is
@@ -621,7 +621,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                             **conn_parameters)
         self.assertEqual(set(subnet_association['vpc_ids']), set([vpc_a.id, vpc_b.id]))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_a_subnet_succeeds_the_create_subnet_method_returns_true(self):
         '''
         Tests creating a subnet successfully
@@ -633,7 +633,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertTrue(subnet_creation_result['created'])
         self.assertTrue('id' in subnet_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_a_subnet_and_specifying_a_name_succeeds_the_create_subnet_method_returns_true(self):
         '''
         Tests creating a subnet successfully when specifying a name
@@ -644,7 +644,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(subnet_creation_result['created'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_a_subnet_and_specifying_tags_succeeds_the_create_subnet_method_returns_true(self):
         '''
         Tests creating a subnet successfully when specifying a tag
@@ -656,7 +656,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(subnet_creation_result['created'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_creating_a_subnet_fails_the_create_subnet_method_returns_error(self):
         '''
@@ -668,7 +668,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             subnet_creation_result = boto_vpc.create_subnet(vpc.id, '10.0.0.0/24', **conn_parameters)
             self.assertTrue('error' in subnet_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_deleting_an_existing_subnet_the_delete_subnet_method_returns_true(self):
         '''
         Tests deleting an existing subnet
@@ -680,7 +680,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(subnet_deletion_result['deleted'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_deleting_a_non_existent_subnet_the_delete_vpc_method_returns_false(self):
         '''
         Tests deleting a subnet that doesn't exist
@@ -688,7 +688,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         delete_subnet_result = boto_vpc.delete_subnet(subnet_id='1234', **conn_parameters)
         self.assertTrue('error' in delete_subnet_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_subnet_exists_by_id_the_subnet_exists_method_returns_true(self):
         '''
         Tests checking if a subnet exists when it does exist
@@ -700,7 +700,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(subnet_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_a_subnet_does_not_exist_the_subnet_exists_method_returns_false(self):
         '''
         Tests checking if a subnet exists which doesn't exist
@@ -709,7 +709,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(subnet_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_subnet_exists_by_name_the_subnet_exists_method_returns_true(self):
         '''
         Tests checking subnet existence by name
@@ -721,7 +721,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(subnet_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_subnet_exists_by_name_the_subnet_does_not_exist_the_subnet_method_returns_false(self):
         '''
         Tests checking subnet existence by name when it doesn't exist
@@ -733,7 +733,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(subnet_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_subnet_exists_by_tags_the_subnet_exists_method_returns_true(self):
         '''
         Tests checking subnet existence by tag
@@ -745,7 +745,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(subnet_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_checking_if_a_subnet_exists_by_tags_the_subnet_does_not_exist_the_subnet_method_returns_false(self):
         '''
         Tests checking subnet existence by tag when subnet doesn't exist
@@ -757,7 +757,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(subnet_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_checking_if_a_subnet_exists_but_providing_no_filters_the_subnet_exists_method_raises_a_salt_invocation_error(self):
         '''
@@ -769,7 +769,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             boto_vpc.subnet_exists(**conn_parameters)
 
     @skipIf(True, 'Skip these tests while investigating failures')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_describe_subnet_by_id_for_existing_subnet_returns_correct_data(self):
         '''
         Tests describing a subnet by id.
@@ -784,7 +784,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertEqual(set(describe_subnet_results['subnet'].keys()),
                          set(['id', 'cidr_block', 'availability_zone', 'tags']))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_describe_subnet_by_id_for_non_existent_subnet_returns_none(self):
         '''
         Tests describing a non-existent subnet by id.
@@ -798,7 +798,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertEqual(describe_subnet_results['subnet'], None)
 
     @skipIf(True, 'Skip these tests while investigating failures')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_describe_subnet_by_name_for_existing_subnet_returns_correct_data(self):
         '''
         Tests describing a subnet by name.
@@ -813,7 +813,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertEqual(set(describe_subnet_results['subnet'].keys()),
                          set(['id', 'cidr_block', 'availability_zone', 'tags']))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_describe_subnet_by_name_for_non_existent_subnet_returns_none(self):
         '''
         Tests describing a non-existent subnet by id.
@@ -827,7 +827,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertEqual(describe_subnet_results['subnet'], None)
 
     @skipIf(True, 'Skip these tests while investigating failures')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_describe_subnets_by_id_for_existing_subnet_returns_correct_data(self):
         '''
         Tests describing multiple subnets by id.
@@ -845,7 +845,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                          set(['id', 'cidr_block', 'availability_zone', 'tags']))
 
     @skipIf(True, 'Skip these tests while investigating failures')
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_describe_subnets_by_name_for_existing_subnets_returns_correct_data(self):
         '''
         Tests describing multiple subnets by id.
@@ -862,7 +862,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertEqual(set(describe_subnet_results['subnets'][0].keys()),
                          set(['id', 'cidr_block', 'availability_zone', 'tags']))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_create_subnet_passes_availability_zone(self):
         '''
         Tests that the availability_zone kwarg is passed on to _create_resource
@@ -883,7 +883,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                        ' or equal to version {0}'
         .format(required_boto_version))
 class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_internet_gateway_the_create_internet_gateway_method_returns_true(self):
         '''
         Tests creating an internet gateway successfully (with no vpc id or name)
@@ -894,7 +894,7 @@ class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                                keyid=access_key)
         self.assertTrue(igw_creation_result.get('created'))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_internet_gateway_with_non_existent_vpc_the_create_internet_gateway_method_returns_an_error(self):
         '''
         Tests that creating an internet gateway for a non-existent VPC fails.
@@ -906,7 +906,7 @@ class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                                vpc_name='non-existent-vpc')
         self.assertTrue('error' in igw_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_internet_gateway_with_vpc_name_specified_the_create_internet_gateway_method_returns_true(self):
         '''
         Tests creating an internet gateway with vpc name specified.
@@ -921,7 +921,7 @@ class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(igw_creation_result.get('created'))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_internet_gateway_with_vpc_id_specified_the_create_internet_gateway_method_returns_true(self):
         '''
         Tests creating an internet gateway with vpc name specified.
@@ -944,7 +944,7 @@ class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                        ' or equal to version {0}'
         .format(required_boto_version))
 class BotoVpcNatGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_nat_gateway_the_create_nat_gateway_method_returns_true(self):
         '''
         Tests creating an nat gateway successfully (with subnet_id specified)
@@ -958,7 +958,7 @@ class BotoVpcNatGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                           keyid=access_key)
         self.assertTrue(ngw_creation_result.get('created'))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_nat_gateway_with_non_existent_subnet_the_create_nat_gateway_method_returns_an_error(self):
         '''
         Tests that creating an nat gateway for a non-existent subnet fails.
@@ -970,7 +970,7 @@ class BotoVpcNatGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                           subnet_name='non-existent-subnet')
         self.assertTrue('error' in ngw_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_an_nat_gateway_with_subnet_name_specified_the_create_nat_gateway_method_returns_true(self):
         '''
         Tests creating an nat gateway with subnet name specified.
@@ -993,7 +993,7 @@ class BotoVpcNatGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                        ' or equal to version {0}'
         .format(required_boto_version))
 class BotoVpcCustomerGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_customer_gateway_the_create_customer_gateway_method_returns_true(self):
         '''
@@ -1003,7 +1003,7 @@ class BotoVpcCustomerGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         gw_creation_result = boto_vpc.create_customer_gateway('ipsec.1', '10.1.1.1', None)
         self.assertTrue(gw_creation_result.get('created'))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_checking_if_a_subnet_exists_by_id_the_subnet_exists_method_returns_true(self):
         '''
@@ -1014,7 +1014,7 @@ class BotoVpcCustomerGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         gw_exists_result = boto_vpc.customer_gateway_exists(customer_gateway_id=gw_creation_result['id'])
         self.assertTrue(gw_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_a_subnet_does_not_exist_the_subnet_exists_method_returns_false(self):
         '''
@@ -1032,7 +1032,7 @@ class BotoVpcCustomerGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         .format(required_boto_version))
 @skipIf(_has_required_moto() is False, 'The moto version must be >= to version {0}'.format(required_moto_version))
 class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_dhcp_options_succeeds_the_create_dhcp_options_method_returns_true(self):
         '''
         Tests creating dhcp options successfully
@@ -1041,7 +1041,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_options_creation_result['created'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_dhcp_options_and_specifying_a_name_succeeds_the_create_dhcp_options_method_returns_true(
             self):
@@ -1053,7 +1053,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_options_creation_result['created'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_dhcp_options_and_specifying_tags_succeeds_the_create_dhcp_options_method_returns_true(
             self):
         '''
@@ -1064,7 +1064,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_options_creation_result['created'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_creating_dhcp_options_fails_the_create_dhcp_options_method_returns_error(self):
         '''
@@ -1075,7 +1075,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             r = dhcp_options_creation_result = boto_vpc.create_dhcp_options(**dhcp_options_parameters)
             self.assertTrue('error' in r)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_associating_an_existing_dhcp_options_set_to_an_existing_vpc_the_associate_dhcp_options_method_returns_true(
             self):
         '''
@@ -1089,7 +1089,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_options_association_result['associated'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_associating_a_non_existent_dhcp_options_set_to_an_existing_vpc_the_associate_dhcp_options_method_returns_error(
             self):
         '''
@@ -1101,7 +1101,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue('error' in dhcp_options_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_associating_an_existing_dhcp_options_set_to_a_non_existent_vpc_the_associate_dhcp_options_method_returns_false(
             self):
         '''
@@ -1114,7 +1114,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue('error' in dhcp_options_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_dhcp_options_set_to_an_existing_vpc_succeeds_the_associate_new_dhcp_options_method_returns_true(
             self):
         '''
@@ -1126,7 +1126,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_creation_result['created'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_creating_and_associating_dhcp_options_set_to_an_existing_vpc_fails_creating_the_dhcp_options_the_associate_new_dhcp_options_method_raises_exception(
             self):
@@ -1140,7 +1140,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             r = boto_vpc.associate_new_dhcp_options_to_vpc(vpc.id, **dhcp_options_parameters)
             self.assertTrue('error' in r)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_creating_and_associating_dhcp_options_set_to_an_existing_vpc_fails_associating_the_dhcp_options_the_associate_new_dhcp_options_method_raises_exception(self):
         '''
@@ -1153,7 +1153,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             r = boto_vpc.associate_new_dhcp_options_to_vpc(vpc.id, **dhcp_options_parameters)
             self.assertTrue('error' in r)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_creating_dhcp_options_set_to_a_non_existent_vpc_the_dhcp_options_the_associate_new_dhcp_options_method_returns_false(
             self):
         '''
@@ -1163,7 +1163,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         r = boto_vpc.create_dhcp_options(vpc_name='fake', **dhcp_options_parameters)
         self.assertTrue('error' in r)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_dhcp_options_exists_the_dhcp_options_exists_method_returns_true(self):
         '''
         Tests existence of dhcp options successfully
@@ -1174,7 +1174,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_options_exists_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_that_when_dhcp_options_do_not_exist_the_dhcp_options_exists_method_returns_false(self):
         '''
         Tests existence of dhcp options failure
@@ -1182,7 +1182,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         r = boto_vpc.dhcp_options_exists('fake', **conn_parameters)
         self.assertFalse(r['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_checking_if_dhcp_options_exists_but_providing_no_filters_the_dhcp_options_exists_method_raises_a_salt_invocation_error(self):
         '''
@@ -1199,8 +1199,7 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                        ' or equal to version {0}'
         .format(required_boto_version))
 class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
-    #@skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
+    @mock_ec2_deprecated
     def test_that_when_creating_network_acl_for_an_existing_vpc_the_create_network_acl_method_returns_true(self):
         '''
         Tests creation of network acl with existing vpc
@@ -1211,8 +1210,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_creation_result)
 
-    @mock_ec2
-    #@skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
+    @mock_ec2_deprecated
     def test_that_when_creating_network_acl_for_an_existing_vpc_and_specifying_a_name_the_create_network_acl_method_returns_true(
             self):
         '''
@@ -1224,8 +1222,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_creation_result)
 
-    @mock_ec2
-    #@skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
+    @mock_ec2_deprecated
     def test_that_when_creating_network_acl_for_an_existing_vpc_and_specifying_tags_the_create_network_acl_method_returns_true(
             self):
         '''
@@ -1237,8 +1234,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_creation_result)
 
-    @mock_ec2
-    #@skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
+    @mock_ec2_deprecated
     def test_that_when_creating_network_acl_for_a_non_existent_vpc_the_create_network_acl_method_returns_an_error(self):
         '''
         Tests creation of network acl with a non-existent vpc
@@ -1247,7 +1243,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue('error' in network_acl_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_network_acl_fails_the_create_network_acl_method_returns_false(self):
         '''
@@ -1261,8 +1257,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(network_acl_creation_result)
 
-    @mock_ec2
-    #@skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
+    @mock_ec2_deprecated
     def test_that_when_deleting_an_existing_network_acl_the_delete_network_acl_method_returns_true(self):
         '''
         Tests deletion of existing network acl successfully
@@ -1274,8 +1269,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_deletion_result)
 
-    @mock_ec2
-    #@skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
+    @mock_ec2_deprecated
     def test_that_when_deleting_a_non_existent_network_acl_the_delete_network_acl_method_returns_an_error(self):
         '''
         Tests deleting a non-existent network acl
@@ -1284,8 +1278,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue('error' in network_acl_deletion_result)
 
-    @mock_ec2
-    #@skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
+    @mock_ec2_deprecated
     def test_that_when_a_network_acl_exists_the_network_acl_exists_method_returns_true(self):
         '''
         Tests existence of network acl
@@ -1297,8 +1290,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_deletion_result)
 
-    @mock_ec2
-    #@skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
+    @mock_ec2_deprecated
     def test_that_when_a_network_acl_does_not_exist_the_network_acl_exists_method_returns_false(self):
         '''
         Tests checking network acl does not exist
@@ -1307,7 +1299,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(network_acl_deletion_result['exists'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_checking_if_network_acl_exists_but_providing_no_filters_the_network_acl_exists_method_raises_a_salt_invocation_error(self):
         '''
@@ -1319,7 +1311,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         ):
             boto_vpc.dhcp_options_exists(**conn_parameters)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_network_acl_entry_successfully_the_create_network_acl_entry_method_returns_true(self):
         '''
@@ -1334,7 +1326,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_entry_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_network_acl_entry_for_a_non_existent_network_acl_the_create_network_acl_entry_method_returns_false(
             self):
@@ -1346,7 +1338,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(network_acl_entry_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_replacing_a_network_acl_entry_successfully_the_replace_network_acl_entry_method_returns_true(
             self):
@@ -1363,7 +1355,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_entry_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_replacing_a_network_acl_entry_for_a_non_existent_network_acl_the_replace_network_acl_entry_method_returns_false(
             self):
@@ -1374,7 +1366,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                                                               **conn_parameters)
         self.assertFalse(network_acl_entry_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_deleting_an_existing_network_acl_entry_the_delete_network_acl_entry_method_returns_true(self):
         '''
@@ -1389,7 +1381,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_entry_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_deleting_a_non_existent_network_acl_entry_the_delete_network_acl_entry_method_returns_false(
             self):
@@ -1401,7 +1393,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(network_acl_entry_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_associating_an_existing_network_acl_to_an_existing_subnet_the_associate_network_acl_method_returns_true(
             self):
@@ -1417,8 +1409,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_association_result)
 
-    @mock_ec2
-    #@skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
+    @mock_ec2_deprecated
     def test_that_when_associating_a_non_existent_network_acl_to_an_existing_subnet_the_associate_network_acl_method_returns_an_error(
             self):
         '''
@@ -1432,7 +1423,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue('error' in network_acl_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_associating_an_existing_network_acl_to_a_non_existent_subnet_the_associate_network_acl_method_returns_false(
             self):
@@ -1447,7 +1438,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(network_acl_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_and_associating_a_network_acl_to_a_subnet_succeeds_the_associate_new_network_acl_to_subnet_method_returns_true(
             self):
@@ -1462,7 +1453,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_creation_and_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_and_associating_a_network_acl_to_a_subnet_and_specifying_a_name_succeeds_the_associate_new_network_acl_to_subnet_method_returns_true(
             self):
@@ -1478,7 +1469,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_creation_and_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_and_associating_a_network_acl_to_a_subnet_and_specifying_tags_succeeds_the_associate_new_network_acl_to_subnet_method_returns_true(
             self):
@@ -1495,7 +1486,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(network_acl_creation_and_association_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_and_associating_a_network_acl_to_a_non_existent_subnet_the_associate_new_network_acl_to_subnet_method_returns_false(
             self):
@@ -1509,8 +1500,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(network_acl_creation_and_association_result)
 
-    @mock_ec2
-    #@skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
+    @mock_ec2_deprecated
     def test_that_when_creating_a_network_acl_to_a_non_existent_vpc_the_associate_new_network_acl_to_subnet_method_returns_an_error(
             self):
         '''
@@ -1523,7 +1513,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue('error' in network_acl_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_disassociating_network_acl_succeeds_the_disassociate_network_acl_method_should_return_true(self):
         '''
@@ -1536,7 +1526,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_disassociate_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_disassociating_network_acl_for_a_non_existent_vpc_the_disassociate_network_acl_method_should_return_false(
             self):
@@ -1550,7 +1540,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(dhcp_disassociate_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_disassociating_network_acl_for_a_non_existent_subnet_the_disassociate_network_acl_method_should_return_false(
             self):
@@ -1571,7 +1561,7 @@ class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
                                        ' or equal to version {0}'
         .format(required_boto_version))
 class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_route_table_succeeds_the_create_route_table_method_returns_true(self):
         '''
@@ -1583,7 +1573,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_table_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_route_table_on_a_non_existent_vpc_the_create_route_table_method_returns_false(self):
         '''
@@ -1593,7 +1583,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_table_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_deleting_a_route_table_succeeds_the_delete_route_table_method_returns_true(self):
         '''
@@ -1606,7 +1596,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_table_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_deleting_a_non_existent_route_table_the_delete_route_table_method_returns_false(self):
         '''
@@ -1616,7 +1606,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(route_table_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_route_table_exists_the_route_table_exists_method_returns_true(self):
         '''
@@ -1629,7 +1619,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_table_existence_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_route_table_does_not_exist_the_route_table_exists_method_returns_false(self):
         '''
@@ -1639,7 +1629,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(route_table_existence_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_that_when_checking_if_a_route_table_exists_but_providing_no_filters_the_route_table_exists_method_raises_a_salt_invocation_error(self):
         '''
@@ -1651,7 +1641,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         ):
             boto_vpc.dhcp_options_exists(**conn_parameters)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_associating_a_route_table_succeeds_the_associate_route_table_method_should_return_the_association_id(
             self):
@@ -1666,7 +1656,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(association_id)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_associating_a_route_table_with_a_non_existent_route_table_the_associate_route_table_method_should_return_false(
             self):
@@ -1680,7 +1670,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(association_id)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_associating_a_route_table_with_a_non_existent_subnet_the_associate_route_table_method_should_return_false(
             self):
@@ -1694,7 +1684,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(association_id)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_disassociating_a_route_table_succeeds_the_disassociate_route_table_method_should_return_true(
             self):
@@ -1711,7 +1701,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(dhcp_disassociate_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_route_succeeds_the_create_route_method_should_return_true(self):
         '''
@@ -1724,7 +1714,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_creating_a_route_with_a_non_existent_route_table_the_create_route_method_should_return_false(
             self):
@@ -1735,7 +1725,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(route_creation_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_deleting_a_route_succeeds_the_delete_route_method_should_return_true(self):
         '''
@@ -1748,7 +1738,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_deleting_a_route_with_a_non_existent_route_table_the_delete_route_method_should_return_false(
             self):
@@ -1759,7 +1749,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertFalse(route_deletion_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_replacing_a_route_succeeds_the_replace_route_method_should_return_true(self):
         '''
@@ -1772,7 +1762,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
         self.assertTrue(route_replacing_result)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Moto has not implemented this feature. Skipping for now.')
     def test_that_when_replacing_a_route_with_a_non_existent_route_table_the_replace_route_method_should_return_false(
             self):
@@ -1793,7 +1783,7 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 @skipIf(_has_required_moto() is False, 'The moto version must be >= to version {0}'.format(required_moto_version))
 class BotoVpcPeeringConnectionsTest(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_request_vpc_peering_connection(self):
         '''
         Run with 2 vpc ids and returns a message
@@ -1806,7 +1796,7 @@ class BotoVpcPeeringConnectionsTest(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             peer_vpc_id=other_vpc.id,
             **conn_parameters))
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_raises_error_if_both_vpc_name_and_vpc_id_are_specified(self):
         '''
         Must specify only one

--- a/tests/unit/states/boto_vpc_test.py
+++ b/tests/unit/states/boto_vpc_test.py
@@ -15,10 +15,10 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import Salt libs
-import salt.config
-import salt.loader
 import salt.utils.boto
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
+from salt.ext import six
+from salt.utils.versions import LooseVersion
 
 # pylint: disable=import-error,unused-import
 from unit.modules.boto_vpc_test import BotoVpcTestCaseMixin
@@ -272,6 +272,9 @@ class BotoVpcInternetGatewayTestCase(BotoVpcStateTestCaseBase, BotoVpcResourceTe
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(six.PY3, 'Disabled for Python 3 due to upstream bugs: '
+                 'https://github.com/spulec/moto/issues/548 and '
+                 'https://github.com/gabrielfalcao/HTTPretty/issues/325')
 @skipIf(HAS_BOTO is False, 'The boto module must be installed.')
 @skipIf(HAS_MOTO is False, 'The moto module must be installed.')
 @skipIf(_has_required_boto() is False, 'The boto module must be greater than'

--- a/tests/unit/states/boto_vpc_test.py
+++ b/tests/unit/states/boto_vpc_test.py
@@ -34,18 +34,18 @@ except ImportError:
     HAS_BOTO = False
 
 try:
-    from moto import mock_ec2
+    from moto import mock_ec2_deprecated
 
     HAS_MOTO = True
 except ImportError:
     HAS_MOTO = False
 
-    def mock_ec2(self):
+    def mock_ec2_deprecated(self):
         '''
-        if the mock_ec2 function is not available due to import failure
+        if the mock_ec2_deprecated function is not available due to import failure
         this replaces the decorated function with stub_function.
-        Allows boto_vpc unit tests to use the @mock_ec2 decorator
-        without a "NameError: name 'mock_ec2' is not defined" error.
+        Allows boto_vpc unit tests to use the @mock_ec2_deprecated decorator
+        without a "NameError: name 'mock_ec2_deprecated' is not defined" error.
         '''
 
         def stub_function(self):
@@ -112,7 +112,7 @@ class BotoVpcTestCase(BotoVpcStateTestCaseBase, BotoVpcTestCaseMixin):
     TestCase for salt.states.boto_vpc state.module
     '''
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_present_when_vpc_does_not_exist(self):
         '''
         Tests present on a VPC that does not exist.
@@ -123,14 +123,14 @@ class BotoVpcTestCase(BotoVpcStateTestCaseBase, BotoVpcTestCaseMixin):
         self.assertTrue(vpc_present_result['result'])
         self.assertEqual(vpc_present_result['changes']['new']['vpc']['state'], 'available')
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_present_when_vpc_exists(self):
         vpc = self._create_vpc(name='test')
         vpc_present_result = salt_states['boto_vpc.present']('test', cidr_block)
         self.assertTrue(vpc_present_result['result'])
         self.assertEqual(vpc_present_result['changes'], {})
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_present_with_failure(self):
         with patch('moto.ec2.models.VPCBackend.create_vpc', side_effect=BotoServerError(400, 'Mocked error')):
@@ -138,7 +138,7 @@ class BotoVpcTestCase(BotoVpcStateTestCaseBase, BotoVpcTestCaseMixin):
             self.assertFalse(vpc_present_result['result'])
             self.assertTrue('Mocked error' in vpc_present_result['comment'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_absent_when_vpc_does_not_exist(self):
         '''
         Tests absent on a VPC that does not exist.
@@ -148,7 +148,7 @@ class BotoVpcTestCase(BotoVpcStateTestCaseBase, BotoVpcTestCaseMixin):
         self.assertTrue(vpc_absent_result['result'])
         self.assertEqual(vpc_absent_result['changes'], {})
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_absent_when_vpc_exists(self):
         vpc = self._create_vpc(name='test')
         with patch.dict('salt.utils.boto.__salt__', funcs):
@@ -156,7 +156,7 @@ class BotoVpcTestCase(BotoVpcStateTestCaseBase, BotoVpcTestCaseMixin):
         self.assertTrue(vpc_absent_result['result'])
         self.assertEqual(vpc_absent_result['changes']['new']['vpc'], None)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_absent_with_failure(self):
         vpc = self._create_vpc(name='test')
@@ -176,7 +176,7 @@ class BotoVpcResourceTestCaseMixin(BotoVpcTestCaseMixin):
         _create = getattr(self, '_create_' + self.resource_type)
         _create(vpc_id=vpc_id, name=name, **self.extra_kwargs)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_present_when_resource_does_not_exist(self):
         '''
         Tests present on a resource that does not exist.
@@ -191,7 +191,7 @@ class BotoVpcResourceTestCaseMixin(BotoVpcTestCaseMixin):
         exists = funcs['boto_vpc.resource_exists'](self.resource_type, 'test').get('exists')
         self.assertTrue(exists)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_present_when_resource_exists(self):
         vpc = self._create_vpc(name='test')
         resource = self._create_resource(vpc_id=vpc.id, name='test')
@@ -201,7 +201,7 @@ class BotoVpcResourceTestCaseMixin(BotoVpcTestCaseMixin):
         self.assertTrue(resource_present_result['result'])
         self.assertEqual(resource_present_result['changes'], {})
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_present_with_failure(self):
         vpc = self._create_vpc(name='test')
@@ -212,7 +212,7 @@ class BotoVpcResourceTestCaseMixin(BotoVpcTestCaseMixin):
             self.assertFalse(resource_present_result['result'])
             self.assertTrue('Mocked error' in resource_present_result['comment'])
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_absent_when_resource_does_not_exist(self):
         '''
         Tests absent on a resource that does not exist.
@@ -222,7 +222,7 @@ class BotoVpcResourceTestCaseMixin(BotoVpcTestCaseMixin):
         self.assertTrue(resource_absent_result['result'])
         self.assertEqual(resource_absent_result['changes'], {})
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_absent_when_resource_exists(self):
         vpc = self._create_vpc(name='test')
         self._create_resource(vpc_id=vpc.id, name='test')
@@ -234,7 +234,7 @@ class BotoVpcResourceTestCaseMixin(BotoVpcTestCaseMixin):
         exists = funcs['boto_vpc.resource_exists'](self.resource_type, 'test').get('exists')
         self.assertFalse(exists)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     @skipIf(True, 'Disabled pending https://github.com/spulec/moto/issues/493')
     def test_absent_with_failure(self):
         vpc = self._create_vpc(name='test')
@@ -282,7 +282,7 @@ class BotoVpcRouteTableTestCase(BotoVpcStateTestCaseBase, BotoVpcResourceTestCas
     backend_create = 'RouteTableBackend.create_route_table'
     backend_delete = 'RouteTableBackend.delete_route_table'
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_present_with_subnets(self):
         vpc = self._create_vpc(name='test')
         subnet1 = self._create_subnet(vpc_id=vpc.id, name='test1')
@@ -307,7 +307,7 @@ class BotoVpcRouteTableTestCase(BotoVpcStateTestCaseBase, BotoVpcResourceTestCas
         new_subnets = changes['new']['subnets_associations']
         self.assertEqual(new_subnets[0]['subnet_id'], subnet2.id)
 
-    @mock_ec2
+    @mock_ec2_deprecated
     def test_present_with_routes(self):
         vpc = self._create_vpc(name='test')
         igw = self._create_internet_gateway(name='test', vpc_id=vpc.id)


### PR DESCRIPTION
Back-port #42883 to 2016.11

This is needed for PRs submitted against 2016.11. During jenkins set up for pull requests, the `master` branch is used for the `salt-jenkins` states which installs moto 1.0.1 currently.