### PR TITLE
Fix `unit.test_doc test` for Windows

### DIFF
--- a/tests/unit/test_doc.py
+++ b/tests/unit/test_doc.py
@@ -6,6 +6,7 @@
 
 # Import Python libs
 from __future__ import absolute_import
+import os
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase
@@ -13,6 +14,7 @@ from tests.support.unit import TestCase
 # Import Salt libs
 import tests.integration as integration
 import salt.modules.cmdmod
+import salt.utils
 
 
 class DocTestCase(TestCase):
@@ -32,8 +34,15 @@ class DocTestCase(TestCase):
         https://github.com/saltstack/salt/issues/12788
         '''
         salt_dir = integration.CODE_DIR
-        salt_dir += '/'
-        cmd = 'grep -r :doc: ' + salt_dir
+
+        if salt.utils.is_windows():
+            # No grep in Windows, use findstr
+            # findstr in windows doesn't prepend 'Binary` to binary files, so
+            # use the '/P' switch to skip files with unprintable characters
+            cmd = 'findstr /C:":doc:" /S /P {0}\*'.format(salt_dir)
+        else:
+            salt_dir += '/'
+            cmd = 'grep -r :doc: ' + salt_dir
 
         grep_call = salt.modules.cmdmod.run_stdout(cmd=cmd).split('\n')
 
@@ -43,25 +52,32 @@ class DocTestCase(TestCase):
             if line.startswith('Binary'):
                 continue
 
-            key, val = line.split(':', 1)
+            if salt.utils.is_windows():
+                # Need the space after the colon so it doesn't split the drive
+                # letter
+                key, val = line.split(': ', 1)
+            else:
+                key, val = line.split(':', 1)
 
             # Don't test man pages, this file,
             # the page that documents to not use ":doc:", or
             # the doc/conf.py file
             if 'man' in key \
                     or key.endswith('test_doc.py') \
-                    or key.endswith('doc/conf.py') \
-                    or key.endswith('/conventions/documentation.rst') \
-                    or key.endswith('doc/topics/releases/2016.11.2.rst') \
-                    or key.endswith('doc/topics/releases/2016.11.3.rst') \
-                    or key.endswith('doc/topics/releases/2016.3.5.rst'):
+                    or key.endswith(os.sep.join(['doc', 'conf.py'])) \
+                    or key.endswith(os.sep.join(['conventions', 'documentation.rst'])) \
+                    or key.endswith(os.sep.join(['doc', 'topics', 'releases', '2016.11.2.rst'])) \
+                    or key.endswith(os.sep.join(['doc', 'topics', 'releases', '2016.11.3.rst'])) \
+                    or key.endswith(os.sep.join(['doc', 'topics', 'releases', '2016.3.5.rst'])):
                 continue
 
             # Set up test return dict
             if test_ret.get(key) is None:
-                test_ret[key] = [val.lstrip()]
+                test_ret[key] = [val.strip()]
             else:
-                test_ret[key].append(val.lstrip())
+                test_ret[key].append(val.strip())
+
+        print('*' * 68)
 
         # Allow test results to show files with :doc: ref, rather than truncating
         self.maxDiff = None

--- a/tests/unit/test_doc.py
+++ b/tests/unit/test_doc.py
@@ -39,7 +39,7 @@ class DocTestCase(TestCase):
             # No grep in Windows, use findstr
             # findstr in windows doesn't prepend 'Binary` to binary files, so
             # use the '/P' switch to skip files with unprintable characters
-            cmd = 'findstr /C:":doc:" /S /P {0}\*'.format(salt_dir)
+            cmd = 'findstr /C:":doc:" /S /P {0}\\*'.format(salt_dir)
         else:
             salt_dir += '/'
             cmd = 'grep -r :doc: ' + salt_dir
@@ -76,8 +76,6 @@ class DocTestCase(TestCase):
                 test_ret[key] = [val.strip()]
             else:
                 test_ret[key].append(val.strip())
-
-        print('*' * 68)
 
         # Allow test results to show files with :doc: ref, rather than truncating
         self.maxDiff = None


### PR DESCRIPTION
### What does this PR do?
This test fails on Windows because there is no Grep in Windows and the file paths were formatted for Unix.

Use findstr instead of grep on Windows
Use `os.linesep` for file paths

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Test