### PR TITLE
Fix `salt.utils.recursive_copy` for Windows

### DIFF
--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -57,7 +57,7 @@ def recursive_copy(source, dest):
     (identical to cp -r on a unix machine)
     '''
     for root, _, files in os.walk(source):
-        path_from_source = root.replace(source, '').lstrip('/')
+        path_from_source = root.replace(source, '').lstrip(os.sep)
         target_directory = os.path.join(dest, path_from_source)
         if not os.path.exists(target_directory):
             os.makedirs(target_directory)


### PR DESCRIPTION
### What does this PR do?
Uses os.sep instead of hard-coded `/`. The `/` was causing the test `unit.test_files.FilesTestCase.test_recursive_copy` to fail.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes