### PR TITLE
Fix bug in on_header callback when no Content-Type is found in headers

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -621,6 +621,13 @@ class Client(object):
 
             def on_header(hdr):
                 if write_body[1] is not False and write_body[2] is None:
+                    if not hdr.strip() and 'Content-Type' not in write_body[1]:
+                        # We've reached the end of the headers and not yet
+                        # found the Content-Type. Reset the values we're
+                        # tracking so that we properly follow the redirect.
+                        write_body[0] = None
+                        write_body[1] = False
+                        return
                     # Try to find out what content type encoding is used if
                     # this is a text file
                     write_body[1].parse_line(hdr)  # pylint: disable=no-member


### PR DESCRIPTION
01d6ee176d347fd341e7d45236cc62871a6dda21 modified our header-parsing callback to parse the headers for the encoding. However, this did not take into account the cases in which there is a 30x redirect with no `Content-Type` header. In these cases, we fail to reset the values we use to track both a) the headers and b) whether or not we've parsed the HTTP status code, leading to a `ValueError` when the HTTP status line is passed to the callback after following the redirect.

This commit fixes this case by detecting the blank line at the end of the HTTP headers, and if no `Content-Type` has been found, the tracking values are reset so that we properly process the headers post-redirect.

Resolves #42941.