### PR TITLE
Remove check_duplicates from create_network call

### DIFF
--- a/salt/states/docker_network.py
+++ b/salt/states/docker_network.py
@@ -144,8 +144,7 @@ def present(name,
             ret['changes']['created'] = __salt__['docker.create_network'](
                 name,
                 driver=driver,
-                driver_opts=driver_opts,
-                check_duplicate=True)
+                driver_opts=driver_opts)
 
         except Exception as exc:
             ret['comment'] = ('Failed to create network \'{0}\': {1}'

--- a/tests/unit/states/test_docker_network.py
+++ b/tests/unit/states/test_docker_network.py
@@ -64,8 +64,7 @@ class DockerNetworkTestCase(TestCase, LoaderModuleMockMixin):
                 )
         docker_create_network.assert_called_with('network_foo',
                                                  driver=None,
-                                                 driver_opts=None,
-                                                 check_duplicate=True)
+                                                 driver_opts=None)
         docker_connect_container_to_network.assert_called_with('abcd',
                                                                  'network_foo')
         self.assertEqual(ret, {'name': 'network_foo',


### PR DESCRIPTION
The create_network function in dockermod.py doesn't take a
check_duplicates argument so passing it here causes a failure.

Fixes #42976

### What does this PR do?
Fixes `docker_network.create`, which was failing because it was passing an unexpected argument to `dockermod.create_network`.

### What issues does this PR fix or reference?
#42976 

### Previous Behavior
`docker_network.create` state would fail with error:
```
Failed to create network 'network-name': create_network() got an unexpected keyword argument 'check_duplicate'
```

### New Behavior
`docker_network.create` state can be applied successfully.

### Tests written?
Yes (updated)