### PR TITLE
Fix param name in postgres_schema.py state file

### DIFF
--- a/salt/states/postgres_schema.py
+++ b/salt/states/postgres_schema.py
@@ -68,7 +68,7 @@ def present(dbname, name,
         'db_password': db_password,
         'db_host': db_host,
         'db_port': db_port,
-        'runas': user
+        'user': user
     }
 
     # check if schema exists
@@ -144,7 +144,7 @@ def absent(dbname, name, user=None,
         'db_password': db_password,
         'db_host': db_host,
         'db_port': db_port,
-        'runas': user
+        'user': user
         }
 
     # check if schema exists and remove it


### PR DESCRIPTION
### What does this PR do?
Changes parameter name in state _postgres_schema.present_ and _postgres_schema.absent_ passed to module _postgres.py_.

### What issues does this PR fix or reference?
This is a fix for [Bug 42980](https://github.com/saltstack/salt/issues/42980) introduced by [PR 42544](https://github.com/saltstack/salt/pull/42544)

### Previous Behavior
```
[INFO    ] Executing state postgres_schema.present for [some_schema]
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/state.py", line 1845, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1801, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/states/postgres_schema.py", line 75, in present
    schema_attr = __salt__['postgres.schema_get'](dbname, name, **db_args)
TypeError: schema_get() got an unexpected keyword argument 'runas'

[INFO    ] Completed state [some_schema] at time 14:35:03.455412 duration_in_ms=0.762
```

### Tests written?
No

