### PR TITLE
Properly handle `prereq` having lost requisites.

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2071,13 +2071,17 @@ class State(object):
                         req_val = lreq[req_key]
                         comment += \
                             '{0}{1}: {2}\n'.format(' ' * 23, req_key, req_val)
-                running[tag] = {'changes': {},
-                                'result': False,
-                                'comment': comment,
-                                '__run_num__': self.__run_num,
-                                '__sls__': low['__sls__']}
+                if low.get('__prereq__'):
+                    run_dict = self.pre
+                else:
+                    run_dict = running
+                run_dict[tag] = {'changes': {},
+                                 'result': False,
+                                 'comment': comment,
+                                 '__run_num__': self.__run_num,
+                                 '__sls__': low['__sls__']}
                 self.__run_num += 1
-                self.event(running[tag], len(chunks), fire_event=low.get('fire_event'))
+                self.event(run_dict[tag], len(chunks), fire_event=low.get('fire_event'))
                 return running
             for chunk in reqs:
                 # Check to see if the chunk has been run, only run it if


### PR DESCRIPTION
### What does this PR do?
Fixes infinity recursion in case if a prerequired condition don't met it's requirements.

The fix adds the result of the prerequired state to the `self.pre` dictionary as it's done in case if all requirements met (see. `if status == 'met'`). But for the case when conditions doesn't met the result (error report) has been being added into the `running` dictionary that is wrong.

### What issues does this PR fix or reference?
Fixes #15171.

### Tests written?
No