### PR TITLE
Notify systemd synchronously (via NOTIFY_SOCKET)

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -15,6 +15,7 @@ import contextlib
 import subprocess
 import multiprocessing
 import multiprocessing.util
+import socket
 
 
 # Import salt libs
@@ -55,7 +56,17 @@ def notify_systemd():
         import systemd.daemon
     except ImportError:
         if salt.utils.which('systemd-notify') and systemd_notify_call('--booted'):
-            return systemd_notify_call('--ready')
+            # Notify systemd synchronously
+            notify_socket = os.getenv('NOTIFY_SOCKET')
+            if notify_socket:
+                # Handle abstract namespace socket
+                if notify_socket.startswith('@'):
+                    notify_socket = '\0{0}'.format(notify_socket[1:])
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+                sock.connect(notify_socket)
+                sock.sendall('READY=1'.encode())
+                sock.close()
+                return True
         return False
 
     if systemd.daemon.booted():

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -62,10 +62,13 @@ def notify_systemd():
                 # Handle abstract namespace socket
                 if notify_socket.startswith('@'):
                     notify_socket = '\0{0}'.format(notify_socket[1:])
-                sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-                sock.connect(notify_socket)
-                sock.sendall('READY=1'.encode())
-                sock.close()
+                try:
+                    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+                    sock.connect(notify_socket)
+                    sock.sendall('READY=1'.encode())
+                    sock.close()
+                except socket.error:
+                    return systemd_notify_call('--ready')
                 return True
         return False
 


### PR DESCRIPTION
### What does this PR do?

This patch is an attempt to make the notification of systemd more reliable in the fallback case of `systemd.daemon` python library not being available. It notifies the systemd `NOTIFY_SOCKET` synchronously instead of forking the `systemd-notify` command.

### What issues does this PR fix or reference?

Forking the `systemd-notify` command is [known to be unreliable](https://bugzilla.redhat.com/show_bug.cgi?id=820448) at least with older versions of the kernel and/or systemd. When systemd receives the notification, the `systemd-notify` process may have already exited causing an error in the logs while waiting for a (90 seconds) timeout. This output is from a SLES12 system (systemd 210 and kernel 3.12.60-52.54-default):

```
Aug 15 11:34:50 client4-01 systemd[1]: Cannot find unit for notify message of PID 17264.
...
Aug 15 11:36:20 client4-01 systemd[1]: salt-minion.service start operation timed out. Terminating.
Aug 15 11:36:20 client4-01 salt-minion[17260]: [WARNING ] Minion received a SIGTERM. Exiting.
Aug 15 11:36:20 client4-01 salt-minion[17260]: The Salt Minion is shutdown. Minion received a SIGTERM. Exited.
Aug 15 11:36:20 client4-01 systemd[1]: Failed to start The Salt Minion.
Aug 15 11:36:20 client4-01 systemd[1]: Unit salt-minion.service entered failed state.
Aug 15 11:36:35 client4-01 systemd[1]: salt-minion.service holdoff time over, scheduling restart.
```

### Previous Behavior

In case the `systemd.daemon` library cannot be imported, systemd was notified asynchronously by forking the `systemd-notify` command.

### New Behavior

Notification of systemd is done **synchronously** via the `NOTIFY_SOCKET` and the python `socket` low level interface.

### Tests written?

No