### PR TITLE
Fix broken negation in iptables

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -501,8 +501,11 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
                 after_jump.append('--{0} {1}'.format(after_jump_argument, value))
             del kwargs[after_jump_argument]
 
-    for key, value in kwargs.items():
+    for key in kwargs:
         negation = maybe_add_negation(key)
+        # don't use .items() since maybe_add_negation removes the prefix from
+        # the value in the kwargs, thus we need to fetch it after that has run
+        value = kwargs[key]
         flag = '-' if len(key) == 1 else '--'
         value = '' if value in (None, '') else ' {0}'.format(value)
         rule.append('{0}{1}{2}{3}'.format(negation, flag, key, value))

--- a/tests/unit/modules/test_iptables.py
+++ b/tests/unit/modules/test_iptables.py
@@ -60,6 +60,9 @@ class IptablesTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(iptables.build_rule(**{'if': 'not eth0'}),
                              '! -i eth0')
 
+            self.assertEqual(iptables.build_rule(**{'proto': 'tcp', 'syn': '!'}),
+                            '-p tcp ! --syn')
+
             self.assertEqual(iptables.build_rule(dports=[80, 443], proto='tcp'),
                              '-p tcp -m multiport --dports 80,443')
 


### PR DESCRIPTION
Introduced in 7c6ff77c and released with 2017.7 (noticed this when accidentally upgrading a node to 2017.7.1 yesterday). Can this be backported to 2017.7?

### What does this PR do?
Fix broken handling of negated flags to the iptables module.
Setting `syn: '!'` would generate a rule like `! --syn !`, instead of the correct `! --syn`.

### What issues does this PR fix or reference?
None filed yet afaik.

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
