### PR TITLE
Fixes ignored push flag for docker.push module issue #42992

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -3949,7 +3949,7 @@ def save(name,
     ret['Size_Human'] = _size_fmt(ret['Size'])
 
     # Process push
-    if kwargs.get(push, False):
+    if kwargs.get('push', False):
         ret['Push'] = __salt__['cp.push'](path)
 
     return ret


### PR DESCRIPTION
### What does this PR do?
BugFix for docker.push module
### What issues does this PR fix or reference?
Fixes issue where the push param is ignored on the docker.push module
### Previous Behavior
Remove this section if not relevant
Even though specifying push=True on the docker.push module it was ignored. 
### New Behavior
It now pulls the value if passed as kwargs if not it defaults to false

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
