### PR TITLE
Fix malformed requisite for Windows

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2122,11 +2122,14 @@ class State(object):
                                 reqs[r_state].append(chunk)
                             continue
                         try:
-                            if (fnmatch.fnmatch(chunk['name'], req_val) or
-                                fnmatch.fnmatch(chunk['__id__'], req_val)):
-                                if req_key == 'id' or chunk['state'] == req_key:
-                                    found = True
-                                    reqs[r_state].append(chunk)
+                            if isinstance(req_val, six.string_types):
+                                if (fnmatch.fnmatch(chunk['name'], req_val) or
+                                        fnmatch.fnmatch(chunk['__id__'], req_val)):
+                                    if req_key == 'id' or chunk['state'] == req_key:
+                                        found = True
+                                        reqs[r_state].append(chunk)
+                            else:
+                                raise KeyError
                         except KeyError as exc:
                             raise SaltRenderError(
                                 'Could not locate requisite of [{0}] present in state with name [{1}]'.format(


### PR DESCRIPTION
### What does this PR do?
Makes sure the requisite is a string value, otherwise `normpath` will fail. This probably needs another set of eyes.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Previous Behavior
In Windows the test `unit.test_state.StateCompilerTestCase.test_render_error_on_invalid_requisite` sends a malformed requisite in the form or an OrderedDict.
```
OrderedDict([('test1', 'test')])
```
In Windows, this calls `fnmatch.fnmatch('git', OrderedDict([('test1', 'test')])`. The one of the things `fnmatch` does is do an `os.path.normcase` on the Pattern which is the `OrderedDict` above. The `normcase` happens to be the Windows version (`C:\Python27\lib\ntpath.py`), which tries to do a `str.replace("/", "\\").lower()` which fails because there is no `replace` attribute for an OrderedDict.

Here's the stack trace:
```
   -> unit.test_state.StateCompilerTestCase.test_render_error_on_invalid_requisite
       Traceback (most recent call last):
         File "c:\salt-dev\salt\tests\unit\test_state.py", line 63, in test_render_error_on_invalid_requisite
           state_obj.call_high(high_data)
         File "c:\salt-dev\salt\salt\state.py", line 2524, in call_high
           ret = self.call_chunks(chunks)
         File "c:\salt-dev\salt\salt\state.py", line 2017, in call_chunks
           running = self.call_chunk(low, running, chunks)
         File "c:\salt-dev\salt\salt\state.py", line 2254, in call_chunk
           status, reqs = self.check_requisite(low, running, chunks, pre=True)
         File "c:\salt-dev\salt\salt\state.py", line 2125, in check_requisite
           if (fnmatch.fnmatch(chunk['name'], req_val) or
         File "C:\Python27\lib\fnmatch.py", line 46, in fnmatch
           pat = os.path.normcase(pat)
         File "C:\Python27\lib\ntpath.py", line 47, in normcase
           return s.replace("/", "\\").lower()
       AttributeError: 'OrderedDict' object has no attribute 'replace'
```

### New Behavior
Make sure the pattern is a string value before running `fnmatch`. If it's not, it raises a KeyError, which will then cause the SaltRenderError to be raised correctly.

The problem is that an OrderedDict may be a valid option for a requisite... I don't know if it is or not. I assume they threw an OrderedDict in the test to force an Error...

### Tests written?
No