### PR TITLE
Fixes to slack engine

### DIFF
--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -181,11 +181,20 @@ def start(token,
                                             if 'aliases' in groups[group]:
                                                 aliases.update(groups[group]['aliases'])
 
+                                if 'user' not in _m:
+                                    if 'message' in _m and 'user' in _m['message']:
+                                        log.debug('Message was edited, '
+                                                  'so we look for user in '
+                                                  'the original message.')
+                                        _user = _m['message']['user']
+                                else:
+                                    _user = _m['user']
+
                                 # Ensure the user is allowed to run commands
                                 if valid_users:
-                                    log.debug('{0} {1}'.format(all_users, _m['user']))
-                                    if _m['user'] not in valid_users and all_users.get(_m['user'], None) not in valid_users:
-                                        channel.send_message('{0} not authorized to run Salt commands'.format(all_users[_m['user']]))
+                                    log.debug('{0} {1}'.format(all_users, _user))
+                                    if _user not in valid_users and all_users.get(_user, None) not in valid_users:
+                                        channel.send_message('{0} not authorized to run Salt commands'.format(all_users[_user]))
                                         return
 
                                 # Trim the ! from the front
@@ -219,7 +228,7 @@ def start(token,
                                 # Ensure the command is allowed
                                 if valid_commands:
                                     if cmd not in valid_commands:
-                                        channel.send_message('{0} is not allowed to use command {1}.'.format(all_users[_m['user']], cmd))
+                                        channel.send_message('{0} is not allowed to use command {1}.'.format(all_users[_user], cmd))
                                         return
 
                                 # Parse args and kwargs


### PR DESCRIPTION
### What does this PR do?
Fixing a bug that prevented editing Slack messages and having the commands resent to the Slack engine.

### What issues does this PR fix or reference?
Fixing a bug that prevented editing Slack messages and having the commands resent to the Slack engine.

### Previous Behavior
Slack engine would crash and restart if messages were edited.

### New Behavior
If the message is edited the `user` attribute is in a different location.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
