### PR TITLE
Try to fix #42989

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1050,17 +1050,17 @@ class GitPython(GitProvider):
             else:
                 new = True
 
-        try:
-            ssl_verify = self.repo.git.config('--get', 'http.sslVerify')
-        except git.exc.GitCommandError:
-            ssl_verify = ''
-        desired_ssl_verify = str(self.ssl_verify).lower()
-        if ssl_verify != desired_ssl_verify:
-            self.repo.git.config('http.sslVerify', desired_ssl_verify)
+            try:
+                ssl_verify = self.repo.git.config('--get', 'http.sslVerify')
+            except git.exc.GitCommandError:
+                ssl_verify = ''
+            desired_ssl_verify = str(self.ssl_verify).lower()
+            if ssl_verify != desired_ssl_verify:
+                self.repo.git.config('http.sslVerify', desired_ssl_verify)
 
-        # Ensure that refspecs for the "origin" remote are set up as configured
-        if hasattr(self, 'refspecs'):
-            self.configure_refspecs()
+            # Ensure that refspecs for the "origin" remote are set up as configured
+            if hasattr(self, 'refspecs'):
+                self.configure_refspecs()
 
         return new
 
@@ -1528,18 +1528,18 @@ class Pygit2(GitProvider):
             else:
                 new = True
 
-        try:
-            ssl_verify = self.repo.config.get_bool('http.sslVerify')
-        except KeyError:
-            ssl_verify = None
-        if ssl_verify != self.ssl_verify:
-            self.repo.config.set_multivar('http.sslVerify',
-                                          '',
-                                          str(self.ssl_verify).lower())
+            try:
+                ssl_verify = self.repo.config.get_bool('http.sslVerify')
+            except KeyError:
+                ssl_verify = None
+            if ssl_verify != self.ssl_verify:
+                self.repo.config.set_multivar('http.sslVerify',
+                                            '',
+                                            str(self.ssl_verify).lower())
 
-        # Ensure that refspecs for the "origin" remote are set up as configured
-        if hasattr(self, 'refspecs'):
-            self.configure_refspecs()
+            # Ensure that refspecs for the "origin" remote are set up as configured
+            if hasattr(self, 'refspecs'):
+                self.configure_refspecs()
 
         return new
 


### PR DESCRIPTION
### What does this PR do?

In 2017.7 release, gitfs became quite slow. See bug #42989 for details and logs.

It seems that d35c2f810cd35be980ae1703d022c1441b7581ea change the way some things are checked:

In 2016.11, the SSL verify things and the remote thing is done only when there is no remote: https://github.com/saltstack/salt/blob/2016.11/salt/utils/gitfs.py#L884
In 2017.7, https://github.com/saltstack/salt/blob/2017.7/salt/utils/gitfs.py#L968, this is not done in the if block but in all cases ( https://github.com/saltstack/salt/blob/2017.7/salt/utils/gitfs.py#L979-L989 ) 

I'm not sure if it's done on purpose, but putting those think back to the if block reduced the issue for me , highstate taking 160s (gitfs) to 33s (pygit2) to only 8s (gitfs 'fixed') (yes, random numbers from my setup, but still).

If it's not the correct was to fix it I'm sorry for this useless pull request ^^

### What issues does this PR fix or reference?
#42989

### Previous Behavior
Slow gitfs

### New Behavior
Gitfs is fast again :)

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
