### PR TITLE
[sentry_returner] don't force transport config

### DIFF
--- a/salt/returners/sentry_return.py
+++ b/salt/returners/sentry_return.py
@@ -52,7 +52,6 @@ from salt.ext import six
 
 try:
     from raven import Client
-    from raven.transport.http import HTTPTransport
 
     has_raven = True
 except ImportError:
@@ -130,7 +129,7 @@ def returner(ret):
             return
 
         if raven_config.get('dsn'):
-            client = Client(raven_config.get('dsn'), transport=HTTPTransport)
+            client = Client(raven_config.get('dsn'))
         else:
             try:
                 servers = []
@@ -140,8 +139,7 @@ def returner(ret):
                     servers=servers,
                     public_key=raven_config['public_key'],
                     secret_key=raven_config['secret_key'],
-                    project=raven_config['project'],
-                    transport=HTTPTransport
+                    project=raven_config['project']
                 )
             except KeyError as missing_key:
                 logger.error(


### PR DESCRIPTION
transport can be configured in the DSN 

as an example this configuration issue with SNI servers https://github.com/getsentry/raven-python/issues/523#issuecomment-271180613 without this transport variable, it can be fixed by just changing the dsn in the pillar
