### PR TITLE
Try to fix #26995

### DIFF
--- a/salt/modules/artifactory.py
+++ b/salt/modules/artifactory.py
@@ -202,45 +202,48 @@ def _get_snapshot_url(artifactory_url, repository, group_id, artifact_id, versio
     has_classifier = classifier is not None and classifier != ""
 
     if snapshot_version is None:
-        snapshot_version_metadata = _get_snapshot_version_metadata(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id, version=version, headers=headers)
+        try:
+            snapshot_version_metadata = _get_snapshot_version_metadata(artifactory_url=artifactory_url, repository=repository, group_id=group_id, artifact_id=artifact_id, version=version, headers=headers)
+            if packaging not in snapshot_version_metadata['snapshot_versions']:
+                error_message = '''Cannot find requested packaging '{packaging}' in the snapshot version metadata.
+                          artifactory_url: {artifactory_url}
+                          repository: {repository}
+                          group_id: {group_id}
+                          artifact_id: {artifact_id}
+                          packaging: {packaging}
+                          classifier: {classifier}
+                          version: {version}'''.format(
+                            artifactory_url=artifactory_url,
+                            repository=repository,
+                            group_id=group_id,
+                            artifact_id=artifact_id,
+                            packaging=packaging,
+                            classifier=classifier,
+                            version=version)
+                raise ArtifactoryError(error_message)
 
-        if packaging not in snapshot_version_metadata['snapshot_versions']:
-            error_message = '''Cannot find requested packaging '{packaging}' in the snapshot version metadata.
-                      artifactory_url: {artifactory_url}
-                      repository: {repository}
-                      group_id: {group_id}
-                      artifact_id: {artifact_id}
-                      packaging: {packaging}
-                      classifier: {classifier}
-                      version: {version}'''.format(
-                        artifactory_url=artifactory_url,
-                        repository=repository,
-                        group_id=group_id,
-                        artifact_id=artifact_id,
-                        packaging=packaging,
-                        classifier=classifier,
-                        version=version)
-            raise ArtifactoryError(error_message)
+            if has_classifier and classifier not in snapshot_version_metadata['snapshot_versions']:
+                error_message = '''Cannot find requested classifier '{classifier}' in the snapshot version metadata.
+                          artifactory_url: {artifactory_url}
+                          repository: {repository}
+                          group_id: {group_id}
+                          artifact_id: {artifact_id}
+                          packaging: {packaging}
+                          classifier: {classifier}
+                          version: {version}'''.format(
+                            artifactory_url=artifactory_url,
+                            repository=repository,
+                            group_id=group_id,
+                            artifact_id=artifact_id,
+                            packaging=packaging,
+                            classifier=classifier,
+                            version=version)
+                raise ArtifactoryError(error_message)
 
-        if has_classifier and classifier not in snapshot_version_metadata['snapshot_versions']:
-            error_message = '''Cannot find requested classifier '{classifier}' in the snapshot version metadata.
-                      artifactory_url: {artifactory_url}
-                      repository: {repository}
-                      group_id: {group_id}
-                      artifact_id: {artifact_id}
-                      packaging: {packaging}
-                      classifier: {classifier}
-                      version: {version}'''.format(
-                        artifactory_url=artifactory_url,
-                        repository=repository,
-                        group_id=group_id,
-                        artifact_id=artifact_id,
-                        packaging=packaging,
-                        classifier=classifier,
-                        version=version)
-            raise ArtifactoryError(error_message)
-
-        snapshot_version = snapshot_version_metadata['snapshot_versions'][packaging]
+            snapshot_version = snapshot_version_metadata['snapshot_versions'][packaging]
+        except CommandExecutionError as err:
+            log.error('Could not fetch maven-metadat.xml. Assuming snapshot_version=%s.', version)
+            snapshot_version = version
 
     group_url = __get_group_id_subpath(group_id)
 

--- a/salt/modules/artifactory.py
+++ b/salt/modules/artifactory.py
@@ -242,7 +242,7 @@ def _get_snapshot_url(artifactory_url, repository, group_id, artifact_id, versio
 
             snapshot_version = snapshot_version_metadata['snapshot_versions'][packaging]
         except CommandExecutionError as err:
-            log.error('Could not fetch maven-metadat.xml. Assuming snapshot_version=%s.', version)
+            log.error('Could not fetch maven-metadata.xml. Assuming snapshot_version=%s.', version)
             snapshot_version = version
 
     group_url = __get_group_id_subpath(group_id)


### PR DESCRIPTION
### What does this PR do?
Attempt to fix #26995.
When downloading a SNAPSHOT artefact from Artifactory, the `maven-metadata.xml` file could not be present if the artifact is unique. So, the snapshot_version should be equal to `version`.

### What issues does this PR fix or reference?
#26995

### Previous Behavior
State `artifactory.downloaded` failed when `maven-metadata.xml` couln't be retrived from Artifactory for a SNAPSHOT artifact.

### New Behavior
The artifactory module assume `snapshot_version=version` when the metadata couldn't be retrieved.

### Tests written?
No