### PR TITLE
Add kernelpkg functions to remove kernel packages

### DIFF
--- a/doc/ref/modules/all/salt.modules.kernelpkg.rst
+++ b/doc/ref/modules/all/salt.modules.kernelpkg.rst
@@ -13,7 +13,7 @@ salt.modules.kernelpkg
 Execution Module                             Used for
 ============================================ ========================================
 :py:mod:`~salt.modules.kernelpkg_linux_apt`  Debian/Ubuntu-based distros which use
-                                             ``apt-get(8)`` for package management
+                                             ``apt-get`` for package management
 :py:mod:`~salt.modules.kernelpkg_linux_yum`  RedHat-based distros and derivatives
-                                             using ``yum(8)`` or ``dnf(8)``
+                                             using ``yum`` or ``dnf``
 ============================================ ========================================

--- a/salt/modules/kernelpkg_linux_apt.py
+++ b/salt/modules/kernelpkg_linux_apt.py
@@ -223,6 +223,34 @@ def remove(release):
     return {'removed': [target]}
 
 
+def cleanup(keep_latest=True):
+    '''
+    Remove all unused kernel packages from the system.
+
+    keep_latest : True
+        In the event that the active kernel is not the latest one installed, setting this to True
+        will retain the latest kernel package, in addition to the active one. If False, all kernel
+        packages other than the active one will be removed.
+    '''
+    removed = []
+
+    # Loop over all installed kernel packages
+    for kernel in list_installed():
+
+        # Keep the active kernel package
+        if kernel == active():
+            continue
+
+        # Optionally keep the latest kernel package
+        if keep_latest and kernel == latest_installed():
+            continue
+
+        # Remove the kernel package
+        removed.extend(remove(kernel)['removed'])
+
+    return {'removed': removed}
+
+
 def _package_prefix():
     '''
     Return static string for the package prefix

--- a/salt/modules/kernelpkg_linux_apt.py
+++ b/salt/modules/kernelpkg_linux_apt.py
@@ -241,11 +241,11 @@ def _cmp_version(item1, item2):
     '''
     Compare function for package version sorting
     '''
-    v1 = _LooseVersion(item1)
-    v2 = _LooseVersion(item2)
+    vers1 = _LooseVersion(item1)
+    vers2 = _LooseVersion(item2)
 
-    if v1 < v2:
+    if vers1 < vers2:
         return -1
-    if v1 > v2:
+    if vers1 > vers2:
         return 1
     return 0

--- a/salt/modules/kernelpkg_linux_apt.py
+++ b/salt/modules/kernelpkg_linux_apt.py
@@ -116,9 +116,9 @@ def latest_installed():
     .. note::
 
         This function may not return the same value as
-        :py:func:`~salt.modules.kernelpkg.active` if a new kernel
+        :py:func:`~salt.modules.kernelpkg_linux_apt.active` if a new kernel
         has been installed and the system has not yet been rebooted.
-        The :py:func:`~salt.modules.kernelpkg.needs_reboot` function
+        The :py:func:`~salt.modules.kernelpkg_linux_apt.needs_reboot` function
         exists to detect this condition.
     '''
     pkgs = list_installed()
@@ -206,8 +206,14 @@ def remove(release):
 
     release
         The release number of an installed kernel. This must be the entire release
-        number as returned by :py:func:`~salt.modules.kernelpkg.list_installed`,
+        number as returned by :py:func:`~salt.modules.kernelpkg_linux_apt.list_installed`,
         not the package name.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kernelpkg.remove 4.4.0-70-generic
     '''
     if release not in list_installed():
         raise CommandExecutionError('Kernel release \'{0}\' is not installed'.format(release))
@@ -231,6 +237,12 @@ def cleanup(keep_latest=True):
         In the event that the active kernel is not the latest one installed, setting this to True
         will retain the latest kernel package, in addition to the active one. If False, all kernel
         packages other than the active one will be removed.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kernelpkg.cleanup
     '''
     removed = []
 

--- a/salt/modules/kernelpkg_linux_yum.py
+++ b/salt/modules/kernelpkg_linux_yum.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 __virtualname__ = 'kernelpkg'
 
 # Import functions from yumpkg
-_yum = salt.utils.namespaced_function(salt.modules.yumpkg._yum, globals())
+_yum = salt.utils.namespaced_function(salt.modules.yumpkg._yum, globals())  # pylint: disable=invalid-name, protected-access
 
 
 def __virtual__():
@@ -250,11 +250,11 @@ def _cmp_version(item1, item2):
     '''
     Compare function for package version sorting
     '''
-    v1 = _LooseVersion(item1)
-    v2 = _LooseVersion(item2)
+    vers1 = _LooseVersion(item1)
+    vers2 = _LooseVersion(item2)
 
-    if v1 < v2:
+    if vers1 < vers2:
         return -1
-    if v1 > v2:
+    if vers1 > vers2:
         return 1
     return 0

--- a/salt/modules/kernelpkg_linux_yum.py
+++ b/salt/modules/kernelpkg_linux_yum.py
@@ -239,6 +239,34 @@ def remove(release):
     return {'removed': [target]}
 
 
+def cleanup(keep_latest=True):
+    '''
+    Remove all unused kernel packages from the system.
+
+    keep_latest : True
+        In the event that the active kernel is not the latest one installed, setting this to True
+        will retain the latest kernel package, in addition to the active one. If False, all kernel
+        packages other than the active one will be removed.
+    '''
+    removed = []
+
+    # Loop over all installed kernel packages
+    for kernel in list_installed():
+
+        # Keep the active kernel package
+        if kernel == active():
+            continue
+
+        # Optionally keep the latest kernel package
+        if keep_latest and kernel == latest_installed():
+            continue
+
+        # Remove the kernel package
+        removed.extend(remove(kernel)['removed'])
+
+    return {'removed': removed}
+
+
 def _package_name():
     '''
     Return static string for the package name

--- a/salt/modules/kernelpkg_linux_yum.py
+++ b/salt/modules/kernelpkg_linux_yum.py
@@ -108,9 +108,9 @@ def latest_installed():
     .. note::
 
         This function may not return the same value as
-        :py:func:`~salt.modules.kernelpkg.active` if a new kernel
+        :py:func:`~salt.modules.kernelpkg_linux_yum.active` if a new kernel
         has been installed and the system has not yet been rebooted.
-        The :py:func:`~salt.modules.kernelpkg.needs_reboot` function
+        The :py:func:`~salt.modules.kernelpkg_linux_yum.needs_reboot` function
         exists to detect this condition.
     '''
     pkgs = list_installed()
@@ -197,8 +197,14 @@ def remove(release):
 
     release
         The release number of an installed kernel. This must be the entire release
-        number as returned by :py:func:`~salt.modules.kernelpkg.list_installed`,
+        number as returned by :py:func:`~salt.modules.kernelpkg_linux_yum.list_installed`,
         not the package name.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kernelpkg.remove 3.10.0-327.el7
     '''
     if release not in list_installed():
         raise CommandExecutionError('Kernel release \'{0}\' is not installed'.format(release))
@@ -247,6 +253,12 @@ def cleanup(keep_latest=True):
         In the event that the active kernel is not the latest one installed, setting this to True
         will retain the latest kernel package, in addition to the active one. If False, all kernel
         packages other than the active one will be removed.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kernelpkg.cleanup
     '''
     removed = []
 

--- a/salt/states/kernelpkg.py
+++ b/salt/states/kernelpkg.py
@@ -114,7 +114,8 @@ def latest_active(name, at_time=None, **kwargs):  # pylint: disable=unused-argum
         state will reboot the system.
 
         See :mod:`kernelpkg.upgrade <salt.modules.kernelpkg.upgrade>` and
-        :mod:`kernelpkg.latest_installed <salt.states.kernelpkg.latest_installed>` for ways to install new kernel packages.
+        :mod:`kernelpkg.latest_installed <salt.states.kernelpkg.latest_installed>`
+        for ways to install new kernel packages.
 
         This module does not attempt to understand or manage boot loader configurations
         it is possible to have a new kernel installed, but a boot loader configuration
@@ -122,7 +123,8 @@ def latest_active(name, at_time=None, **kwargs):  # pylint: disable=unused-argum
         schedule this state to run automatically.
 
         Because this state function may cause the system to reboot, it may be preferable
-        to move it to the very end of the state run. See :mod:`kernelpkg.latest_wait <salt.states.kernelpkg.latest_wait>`
+        to move it to the very end of the state run.
+        See :mod:`kernelpkg.latest_wait <salt.states.kernelpkg.latest_wait>`
         for a waitable state that can be called with the `listen` requesite.
 
     name

--- a/salt/states/kernelpkg.py
+++ b/salt/states/kernelpkg.py
@@ -52,7 +52,7 @@ log = logging.getLogger(__name__)
 
 def __virtual__():
     '''
-    Only make these states available if a pkg provider has been detected or
+    Only make these states available if a kernelpkg provider has been detected or
     assigned for this minion
     '''
     return 'kernelpkg.upgrade' in __salt__
@@ -67,8 +67,8 @@ def latest_installed(name, **kwargs):  # pylint: disable=unused-argument
 
         This state only installs the kernel, but does not activate it.
         The new kernel should become active at the next reboot.
-        See :mod:`kernelpkg.needs_reboot <salt.modules.kernelpkg.needs_reboot>` for details on
-        how to detect this condition, :mod:`kernelpkg.latest_active <salt.states.kernelpkg.latest_active>`
+        See :py:func:`kernelpkg.needs_reboot <salt.modules.kernelpkg_linux_yum.needs_reboot>` for details on
+        how to detect this condition, and :py:func:`~salt.states.kernelpkg.latest_active`
         to initiale a reboot when needed.
 
     name
@@ -113,8 +113,8 @@ def latest_active(name, at_time=None, **kwargs):  # pylint: disable=unused-argum
         system. If the running version is not the latest one installed, this
         state will reboot the system.
 
-        See :mod:`kernelpkg.upgrade <salt.modules.kernelpkg.upgrade>` and
-        :mod:`kernelpkg.latest_installed <salt.states.kernelpkg.latest_installed>`
+        See :py:func:`kernelpkg.upgrade <salt.modules.kernelpkg_linux_yum.upgrade>` and
+        :py:func:`~salt.states.kernelpkg.latest_installed`
         for ways to install new kernel packages.
 
         This module does not attempt to understand or manage boot loader configurations
@@ -124,7 +124,7 @@ def latest_active(name, at_time=None, **kwargs):  # pylint: disable=unused-argum
 
         Because this state function may cause the system to reboot, it may be preferable
         to move it to the very end of the state run.
-        See :mod:`kernelpkg.latest_wait <salt.states.kernelpkg.latest_wait>`
+        See :py:func:`~salt.states.kernelpkg.latest_wait`
         for a waitable state that can be called with the `listen` requesite.
 
     name
@@ -170,7 +170,7 @@ def latest_active(name, at_time=None, **kwargs):  # pylint: disable=unused-argum
 def latest_wait(name, at_time=None, **kwargs):  # pylint: disable=unused-argument
     '''
     Initiate a reboot if the running kernel is not the latest one installed. This is the
-    waitable version of :mod:`kernelpkg.latest_active <salt.states.kernelpkg.latest_active>` and
+    waitable version of :py:func:`~salt.states.kernelpkg.latest_active` and
     will not take any action unless triggered by a watch or listen requesite.
 
     .. note::

--- a/tests/unit/modules/test_kernelpkg.py
+++ b/tests/unit/modules/test_kernelpkg.py
@@ -5,6 +5,8 @@
     :maturity: develop
     versionadded:: oxygen
 '''
+# pylint: disable=invalid-name,no-member
+
 from __future__ import absolute_import
 
 # Salt testing libs
@@ -17,7 +19,7 @@ except ImportError:
 
 class KernelPkgTestCase(object):
     '''
-    Test cases for salt.modules.yumkernelpkg
+    Test cases shared by all kernelpkg virtual modules
     '''
 
     def test_active(self):

--- a/tests/unit/modules/test_kernelpkg.py
+++ b/tests/unit/modules/test_kernelpkg.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 # Salt testing libs
 try:
     from tests.support.mock import MagicMock, patch
+    from salt.exceptions import CommandExecutionError
 except ImportError:
     pass
 
@@ -171,3 +172,25 @@ class KernelPkgTestCase(object):
         with patch.object(self._kernelpkg, 'latest_available', return_value=self.KERNEL_LIST[0]):
             with patch.object(self._kernelpkg, 'latest_installed', return_value=self.KERNEL_LIST[-1]):
                 self.assertFalse(self._kernelpkg.upgrade_available())
+
+    def test_remove_active(self):
+        '''
+        Test - remove kernel package
+        '''
+        mock = MagicMock(return_value={'retcode': 0, 'stderr': []})
+        with patch.dict(self._kernelpkg.__salt__, {'cmd.run_all': mock}):
+            with patch.object(self._kernelpkg, 'active', return_value=self.KERNEL_LIST[-1]):
+                with patch.object(self._kernelpkg, 'list_installed', return_value=self.KERNEL_LIST):
+                    self.assertRaises(CommandExecutionError, self._kernelpkg.remove, release=self.KERNEL_LIST[-1])
+                    self._kernelpkg.__salt__['cmd.run_all'].assert_not_called()
+
+    def test_remove_invalid(self):
+        '''
+        Test - remove kernel package
+        '''
+        mock = MagicMock(return_value={'retcode': 0, 'stderr': []})
+        with patch.dict(self._kernelpkg.__salt__, {'cmd.run_all': mock}):
+            with patch.object(self._kernelpkg, 'active', return_value=self.KERNEL_LIST[-1]):
+                with patch.object(self._kernelpkg, 'list_installed', return_value=self.KERNEL_LIST):
+                    self.assertRaises(CommandExecutionError, self._kernelpkg.remove, release='invalid')
+                    self._kernelpkg.__salt__['cmd.run_all'].assert_not_called()

--- a/tests/unit/modules/test_kernelpkg_linux_apt.py
+++ b/tests/unit/modules/test_kernelpkg_linux_apt.py
@@ -5,6 +5,7 @@
     :maturity: develop
     versionadded:: oxygen
 '''
+# pylint: disable=invalid-name,no-member
 
 # Import Python Libs
 from __future__ import absolute_import
@@ -28,6 +29,9 @@ except ImportError:
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(not HAS_MODULES, 'Salt modules could not be loaded')
 class AptKernelPkgTestCase(KernelPkgTestCase, TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.modules.kernelpkg_linux_apt
+    '''
 
     _kernelpkg = kernelpkg
     KERNEL_LIST = ['4.4.0-70-generic', '4.4.0-71-generic', '4.5.1-14-generic']
@@ -39,7 +43,7 @@ class AptKernelPkgTestCase(KernelPkgTestCase, TestCase, LoaderModuleMockMixin):
         cls.LATEST = '{0}.{1}'.format(version.group(1), version.group(2))
 
         for kernel in cls.KERNEL_LIST:
-            pkg = '{0}-{1}'.format(kernelpkg._package_prefix(), kernel)
+            pkg = '{0}-{1}'.format(kernelpkg._package_prefix(), kernel)  # pylint: disable=protected-access
             cls.PACKAGE_DICT[pkg] = pkg
 
     def setup_loader_modules(self):
@@ -62,7 +66,7 @@ class AptKernelPkgTestCase(KernelPkgTestCase, TestCase, LoaderModuleMockMixin):
         '''
         Test - Return return the latest installed kernel version
         '''
-        PACKAGE_LIST = ['{0}-{1}'.format(kernelpkg._package_prefix(), kernel) for kernel in self.KERNEL_LIST]
+        PACKAGE_LIST = ['{0}-{1}'.format(kernelpkg._package_prefix(), kernel) for kernel in self.KERNEL_LIST]  # pylint: disable=protected-access
 
         mock = MagicMock(return_value=PACKAGE_LIST)
         with patch.dict(self._kernelpkg.__salt__, {'pkg.list_pkgs': mock}):
@@ -85,7 +89,7 @@ class AptKernelPkgTestCase(KernelPkgTestCase, TestCase, LoaderModuleMockMixin):
                 result = self._kernelpkg.remove(release=self.KERNEL_LIST[0])
                 self._kernelpkg.__salt__['pkg.purge'].assert_called_once()
                 self.assertIn('removed', result)
-                target = '{0}-{1}'.format(self._kernelpkg._package_prefix(), self.KERNEL_LIST[0])
+                target = '{0}-{1}'.format(self._kernelpkg._package_prefix(), self.KERNEL_LIST[0])  # pylint: disable=protected-access
                 self.assertListEqual(result['removed'], [target])
 
     def test_remove_error(self):

--- a/tests/unit/modules/test_kernelpkg_linux_apt.py
+++ b/tests/unit/modules/test_kernelpkg_linux_apt.py
@@ -87,7 +87,6 @@ class AptKernelPkgTestCase(KernelPkgTestCase, TestCase, LoaderModuleMockMixin):
         with patch.object(self._kernelpkg, 'active', return_value=self.KERNEL_LIST[-1]):
             with patch.object(self._kernelpkg, 'list_installed', return_value=self.KERNEL_LIST):
                 result = self._kernelpkg.remove(release=self.KERNEL_LIST[0])
-                self._kernelpkg.__salt__['pkg.purge'].assert_called_once()
                 self.assertIn('removed', result)
                 target = '{0}-{1}'.format(self._kernelpkg._package_prefix(), self.KERNEL_LIST[0])  # pylint: disable=protected-access
                 self.assertListEqual(result['removed'], [target])
@@ -101,4 +100,3 @@ class AptKernelPkgTestCase(KernelPkgTestCase, TestCase, LoaderModuleMockMixin):
             with patch.object(self._kernelpkg, 'active', return_value=self.KERNEL_LIST[-1]):
                 with patch.object(self._kernelpkg, 'list_installed', return_value=self.KERNEL_LIST):
                     self.assertRaises(CommandExecutionError, self._kernelpkg.remove, release=self.KERNEL_LIST[0])
-                    self._kernelpkg.__salt__['pkg.purge'].assert_called_once()

--- a/tests/unit/modules/test_kernelpkg_linux_yum.py
+++ b/tests/unit/modules/test_kernelpkg_linux_yum.py
@@ -19,6 +19,7 @@ try:
     from tests.unit.modules.test_kernelpkg import KernelPkgTestCase
     import salt.modules.kernelpkg_linux_yum as kernelpkg
     import salt.modules.yumpkg as pkg
+    from salt.exceptions import CommandExecutionError
     HAS_MODULES = True
 except ImportError:
     HAS_MODULES = False
@@ -32,18 +33,22 @@ class YumKernelPkgTestCase(KernelPkgTestCase, TestCase, LoaderModuleMockMixin):
     KERNEL_LIST = ['3.10.0-327.el7', '3.11.0-327.el7', '4.9.1-100.el7']
     LATEST = KERNEL_LIST[-1]
     OS_ARCH = 'x86_64'
+    OS_NAME = 'RedHat'
 
     def setup_loader_modules(self):
         return {
             kernelpkg: {
                 '__grains__': {
+                    'os': self.OS_NAME,
                     'kernelrelease': '{0}.{1}'.format(self.KERNEL_LIST[0], self.OS_ARCH)
                 },
                 '__salt__': {
                     'pkg.normalize_name': pkg.normalize_name,
                     'pkg.upgrade': MagicMock(return_value={}),
+                    'pkg.list_pkgs': MagicMock(return_value={}),
                     'pkg.version': MagicMock(return_value=self.KERNEL_LIST),
-                    'system.reboot': MagicMock(return_value=None)
+                    'system.reboot': MagicMock(return_value=None),
+                    'config.get': MagicMock(return_value=True)
                 }
             },
             pkg: {
@@ -68,3 +73,28 @@ class YumKernelPkgTestCase(KernelPkgTestCase, TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value=None)
         with patch.dict(self._kernelpkg.__salt__, {'pkg.version': mock}):
             self.assertListEqual(self._kernelpkg.list_installed(), [])
+
+    def test_remove_success(self):
+        '''
+        Test - remove kernel package
+        '''
+        mock = MagicMock(return_value={'retcode': 0, 'stderr': []})
+        with patch.dict(self._kernelpkg.__salt__, {'cmd.run_all': mock}):
+            with patch.object(self._kernelpkg, 'active', return_value=self.KERNEL_LIST[-1]):
+                with patch.object(self._kernelpkg, 'list_installed', return_value=self.KERNEL_LIST):
+                    result = self._kernelpkg.remove(release=self.KERNEL_LIST[0])
+                    self._kernelpkg.__salt__['cmd.run_all'].assert_called_once()
+                    self.assertIn('removed', result)
+                    target = '{0}-{1}'.format(self._kernelpkg._package_name(), self.KERNEL_LIST[0])
+                    self.assertListEqual(result['removed'], [target])
+
+    def test_remove_error(self):
+        '''
+        Test - remove kernel package
+        '''
+        mock = MagicMock(return_value={'retcode': -1, 'stderr': []})
+        with patch.dict(self._kernelpkg.__salt__, {'cmd.run_all': mock}):
+            with patch.object(self._kernelpkg, 'active', return_value=self.KERNEL_LIST[-1]):
+                with patch.object(self._kernelpkg, 'list_installed', return_value=self.KERNEL_LIST):
+                    self.assertRaises(CommandExecutionError, self._kernelpkg.remove, release=self.KERNEL_LIST[0])
+                    self._kernelpkg.__salt__['cmd.run_all'].assert_called_once()

--- a/tests/unit/modules/test_kernelpkg_linux_yum.py
+++ b/tests/unit/modules/test_kernelpkg_linux_yum.py
@@ -87,7 +87,6 @@ class YumKernelPkgTestCase(KernelPkgTestCase, TestCase, LoaderModuleMockMixin):
             with patch.object(self._kernelpkg, 'active', return_value=self.KERNEL_LIST[-1]):
                 with patch.object(self._kernelpkg, 'list_installed', return_value=self.KERNEL_LIST):
                     result = self._kernelpkg.remove(release=self.KERNEL_LIST[0])
-                    self._kernelpkg.__salt__['cmd.run_all'].assert_called_once()
                     self.assertIn('removed', result)
                     target = '{0}-{1}'.format(self._kernelpkg._package_name(), self.KERNEL_LIST[0])  # pylint: disable=protected-access
                     self.assertListEqual(result['removed'], [target])
@@ -101,4 +100,3 @@ class YumKernelPkgTestCase(KernelPkgTestCase, TestCase, LoaderModuleMockMixin):
             with patch.object(self._kernelpkg, 'active', return_value=self.KERNEL_LIST[-1]):
                 with patch.object(self._kernelpkg, 'list_installed', return_value=self.KERNEL_LIST):
                     self.assertRaises(CommandExecutionError, self._kernelpkg.remove, release=self.KERNEL_LIST[0])
-                    self._kernelpkg.__salt__['cmd.run_all'].assert_called_once()

--- a/tests/unit/modules/test_kernelpkg_linux_yum.py
+++ b/tests/unit/modules/test_kernelpkg_linux_yum.py
@@ -5,6 +5,7 @@
     :maturity: develop
     versionadded:: oxygen
 '''
+# pylint: disable=invalid-name,no-member
 
 # Import Python Libs
 from __future__ import absolute_import
@@ -28,6 +29,9 @@ except ImportError:
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(not HAS_MODULES, 'Salt modules could not be loaded')
 class YumKernelPkgTestCase(KernelPkgTestCase, TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.modules.kernelpkg_linux_yum
+    '''
 
     _kernelpkg = kernelpkg
     KERNEL_LIST = ['3.10.0-327.el7', '3.11.0-327.el7', '4.9.1-100.el7']
@@ -85,7 +89,7 @@ class YumKernelPkgTestCase(KernelPkgTestCase, TestCase, LoaderModuleMockMixin):
                     result = self._kernelpkg.remove(release=self.KERNEL_LIST[0])
                     self._kernelpkg.__salt__['cmd.run_all'].assert_called_once()
                     self.assertIn('removed', result)
-                    target = '{0}-{1}'.format(self._kernelpkg._package_name(), self.KERNEL_LIST[0])
+                    target = '{0}-{1}'.format(self._kernelpkg._package_name(), self.KERNEL_LIST[0])  # pylint: disable=protected-access
                     self.assertListEqual(result['removed'], [target])
 
     def test_remove_error(self):

--- a/tests/unit/states/test_kernelpkg.py
+++ b/tests/unit/states/test_kernelpkg.py
@@ -5,6 +5,7 @@
     :maturity: develop
     versionadded:: oxygen
 '''
+# pylint: disable=invalid-name,no-member
 
 # Import Python libs
 from __future__ import absolute_import


### PR DESCRIPTION
### What does this PR do?
1) Add `kernelpkg.remove()` function to uninstall a specific kernel version
2) Add `kernelpkg.cleanup()` function to uninstall all unused kernel versions
3) Documentation and linter updates to all `kernelpkg` files

### What issues does this PR fix or reference?
None

### Tests written?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
