### PR TITLE
Change AF_INET6 family for mac in test_host_to_ips

### DIFF
--- a/tests/unit/utils/network_test.py
+++ b/tests/unit/utils/network_test.py
@@ -12,6 +12,7 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 from salt.utils import network
+import salt.utils
 
 LINUX = '''\
 eth0      Link encap:Ethernet  HWaddr e0:3f:49:85:6a:af
@@ -114,13 +115,14 @@ class NetworkTestCase(TestCase):
         '''
         def _side_effect(host, *args):
             try:
+                ipv6_fam = 30 if salt.utils.is_darwin() else 10
                 return {
                     'github.com': [
                         (2, 1, 6, '', ('192.30.255.112', 0)),
                         (2, 1, 6, '', ('192.30.255.113', 0)),
                     ],
                     'ipv6host.foo': [
-                        (10, 1, 6, '', ('2001:a71::1', 0, 0, 0)),
+                        (ipv6_fam, 1, 6, '', ('2001:a71::1', 0, 0, 0)),
                     ],
                 }[host]
             except KeyError:


### PR DESCRIPTION
### What does this PR do?
The test `unit.utils.network_test.NetworkTestCase.test_host_to_ips ` is failing on macosx with the following error:

```
Error Message

None != ['2001:a71::1']
Stacktrace

Traceback (most recent call last):
  File "/testing/tests/unit/utils/network_test.py", line 136, in test_host_to_ips
    self.assertEqual(ret, ['2001:a71::1'])
AssertionError: None != ['2001:a71::1']
```

This is because AF_INET6 is 30 in macosx instead of 10. So this changes the mocking side effect to 30 if on macosx.
