### PR TITLE
service should return false on exception

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -893,7 +893,7 @@ def mod_watch(name,
     try:
         result = func(name, **func_kwargs)
     except CommandExecutionError as exc:
-        ret['result'] = True
+        ret['result'] = False
         ret['comment'] = exc.strerror
         return ret
 


### PR DESCRIPTION
### What does this PR do?
If there is an exception from the service module, we should return a result equal to False

### What issues does this PR fix or reference?
Fixes #43008

### Tests written?

No