### PR TITLE
Use socket.AF_INET6 to get the correct value instead of doing an OS check

### DIFF
--- a/tests/unit/utils/network_test.py
+++ b/tests/unit/utils/network_test.py
@@ -12,7 +12,6 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 from salt.utils import network
-import salt.utils
 
 LINUX = '''\
 eth0      Link encap:Ethernet  HWaddr e0:3f:49:85:6a:af
@@ -115,14 +114,13 @@ class NetworkTestCase(TestCase):
         '''
         def _side_effect(host, *args):
             try:
-                ipv6_fam = 30 if salt.utils.is_darwin() else 10
                 return {
                     'github.com': [
                         (2, 1, 6, '', ('192.30.255.112', 0)),
                         (2, 1, 6, '', ('192.30.255.113', 0)),
                     ],
                     'ipv6host.foo': [
-                        (ipv6_fam, 1, 6, '', ('2001:a71::1', 0, 0, 0)),
+                        (socket.AF_INET6, 1, 6, '', ('2001:a71::1', 0, 0, 0)),
                     ],
                 }[host]
             except KeyError:


### PR DESCRIPTION
This builds on #43014 with a more future-proof solution.