### PR TITLE
Fixes/improvements to Jenkins state/module

### DIFF
--- a/salt/modules/jenkins.py
+++ b/salt/modules/jenkins.py
@@ -451,7 +451,7 @@ def get_job_config(name=None):
 
     server = _connect()
 
-    job_exists(name)
+    if not job_exists(name)
         raise CommandExecutionError('Job \'{0}\' does not exist'.format(name))
 
     job_info = server.get_job_config(name)

--- a/salt/modules/jenkins.py
+++ b/salt/modules/jenkins.py
@@ -157,7 +157,7 @@ def job_exists(name=None):
 
     '''
     if not name:
-        raise SaltInvocationError('Required parameter `name` is missing.')
+        raise SaltInvocationError('Required parameter \'name\' is missing')
 
     server = _connect()
     if server.job_exists(name):
@@ -181,12 +181,12 @@ def get_job_info(name=None):
 
     '''
     if not name:
-        raise SaltInvocationError('Required parameter `name` is missing.')
+        raise SaltInvocationError('Required parameter \'name\' is missing')
 
     server = _connect()
 
     if not job_exists(name):
-        raise SaltInvocationError('Job `{0}` does not exist.'.format(name))
+        raise CommandExecutionError('Job \'{0}\' does not exist'.format(name))
 
     job_info = server.get_job_info(name)
     if job_info:
@@ -210,17 +210,19 @@ def build_job(name=None, parameters=None):
 
     '''
     if not name:
-        raise SaltInvocationError('Required parameter `name` is missing.')
+        raise SaltInvocationError('Required parameter \'name\' is missing')
 
     server = _connect()
 
     if not job_exists(name):
-        raise SaltInvocationError('Job `{0}` does not exist.'.format(name))
+        raise CommandExecutionError('Job \'{0}\' does not exist.'.format(name))
 
     try:
         server.build_job(name, parameters)
     except jenkins.JenkinsException as err:
-        raise SaltInvocationError('Something went wrong {0}.'.format(err))
+        raise CommandExecutionError(
+            'Encountered error building job \'{0}\': {1}'.format(name, err)
+        )
     return True
 
 
@@ -245,10 +247,10 @@ def create_job(name=None,
 
     '''
     if not name:
-        raise SaltInvocationError('Required parameter `name` is missing.')
+        raise SaltInvocationError('Required parameter \'name\' is missing')
 
     if job_exists(name):
-        raise SaltInvocationError('Job `{0}` already exists.'.format(name))
+        raise CommandExecutionError('Job \'{0}\' already exists'.format(name))
 
     if not config_xml:
         config_xml = jenkins.EMPTY_CONFIG_XML
@@ -262,7 +264,9 @@ def create_job(name=None,
     try:
         server.create_job(name, config_xml)
     except jenkins.JenkinsException as err:
-        raise SaltInvocationError('Something went wrong {0}.'.format(err))
+        raise CommandExecutionError(
+            'Encountered error creating job \'{0}\': {1}'.format(name, err)
+        )
     return config_xml
 
 
@@ -287,7 +291,7 @@ def update_job(name=None,
 
     '''
     if not name:
-        raise SaltInvocationError('Required parameter `name` is missing.')
+        raise SaltInvocationError('Required parameter \'name\' is missing')
 
     if not config_xml:
         config_xml = jenkins.EMPTY_CONFIG_XML
@@ -301,7 +305,9 @@ def update_job(name=None,
     try:
         server.reconfig_job(name, config_xml)
     except jenkins.JenkinsException as err:
-        raise SaltInvocationError('Something went wrong {0}.'.format(err))
+        raise CommandExecutionError(
+            'Encountered error updating job \'{0}\': {1}'.format(name, err)
+        )
     return config_xml
 
 
@@ -320,17 +326,19 @@ def delete_job(name=None):
 
     '''
     if not name:
-        raise SaltInvocationError('Required parameter `name` is missing.')
+        raise SaltInvocationError('Required parameter \'name\' is missing')
 
     server = _connect()
 
     if not job_exists(name):
-        raise SaltInvocationError('Job `{0}` does not exists.'.format(name))
+        raise CommandExecutionError('Job \'{0}\' does not exist'.format(name))
 
     try:
         server.delete_job(name)
     except jenkins.JenkinsException as err:
-        raise SaltInvocationError('Something went wrong {0}.'.format(err))
+        raise CommandExecutionError(
+            'Encountered error deleting job \'{0}\': {1}'.format(name, err)
+        )
     return True
 
 
@@ -349,17 +357,19 @@ def enable_job(name=None):
 
     '''
     if not name:
-        raise SaltInvocationError('Required parameter `name` is missing.')
+        raise SaltInvocationError('Required parameter \'name\' is missing')
 
     server = _connect()
 
     if not job_exists(name):
-        raise SaltInvocationError('Job `{0}` does not exists.'.format(name))
+        raise CommandExecutionError('Job \'{0}\' does not exist'.format(name))
 
     try:
         server.enable_job(name)
     except jenkins.JenkinsException as err:
-        raise SaltInvocationError('Something went wrong {0}.'.format(err))
+        raise CommandExecutionError(
+            'Encountered error enabling job \'{0}\': {1}'.format(name, err)
+        )
     return True
 
 
@@ -379,17 +389,19 @@ def disable_job(name=None):
     '''
 
     if not name:
-        raise SaltInvocationError('Required parameter `name` is missing.')
+        raise SaltInvocationError('Required parameter \'name\' is missing')
 
     server = _connect()
 
     if not job_exists(name):
-        raise SaltInvocationError('Job `{0}` does not exists.'.format(name))
+        raise CommandExecutionError('Job \'{0}\' does not exist'.format(name))
 
     try:
         server.disable_job(name)
     except jenkins.JenkinsException as err:
-        raise SaltInvocationError('Something went wrong {0}.'.format(err))
+        raise CommandExecutionError(
+            'Encountered error disabling job \'{0}\': {1}'.format(name, err)
+        )
     return True
 
 
@@ -409,12 +421,12 @@ def job_status(name=None):
     '''
 
     if not name:
-        raise SaltInvocationError('Required parameter `name` is missing.')
+        raise SaltInvocationError('Required parameter \'name\' is missing')
 
     server = _connect()
 
     if not job_exists(name):
-        raise SaltInvocationError('Job `{0}` does not exists.'.format(name))
+        raise CommandExecutionError('Job \'{0}\' does not exist'.format(name))
 
     return server.get_job_info('empty')['buildable']
 
@@ -435,12 +447,12 @@ def get_job_config(name=None):
     '''
 
     if not name:
-        raise SaltInvocationError('Required parameter `name` is missing.')
+        raise SaltInvocationError('Required parameter \'name\' is missing')
 
     server = _connect()
 
-    if not job_exists(name):
-        raise SaltInvocationError('Job `{0}` does not exists.'.format(name))
+    job_exists(name)
+        raise CommandExecutionError('Job \'{0}\' does not exist'.format(name))
 
     job_info = server.get_job_config(name)
     return job_info

--- a/salt/modules/jenkins.py
+++ b/salt/modules/jenkins.py
@@ -451,7 +451,7 @@ def get_job_config(name=None):
 
     server = _connect()
 
-    if not job_exists(name)
+    if not job_exists(name):
         raise CommandExecutionError('Job \'{0}\' does not exist'.format(name))
 
     job_info = server.get_job_config(name)

--- a/salt/states/jenkins.py
+++ b/salt/states/jenkins.py
@@ -15,7 +15,7 @@ import logging
 # Import Salt libs
 import salt.ext.six as six
 import salt.utils
-from salt.exceptions import CommandExecutionError, SaltInvocationError
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +43,6 @@ def present(name,
            'result': True,
            'changes': {},
            'comment': ['Job {0} is up to date.'.format(name)]}
-
 
     if __salt__['jenkins.job_exists'](name):
         _current_job_config = __salt__['jenkins.get_job_config'](name)
@@ -97,7 +96,6 @@ def absent(name,
            'result': True,
            'changes': {},
            'comment': []}
-
 
     if __salt__['jenkins.job_exists'](name):
         try:

--- a/salt/states/jenkins.py
+++ b/salt/states/jenkins.py
@@ -15,23 +15,28 @@ import logging
 # Import Salt libs
 import salt.ext.six as six
 import salt.utils
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 log = logging.getLogger(__name__)
+
+
+def _fail(ret, msg):
+    ret['comment'] = msg
+    ret['result'] = False
+    return ret
 
 
 def present(name,
             config=None,
             **kwargs):
     '''
-    Ensure the job is present in the Jenkins
-    configured jobs
+    Ensure the job is present in the Jenkins configured jobs
 
     name
         The unique name for the Jenkins job
 
     config
-        The Salt URL for the file to use for
-        configuring the job.
+        The Salt URL for the file to use for configuring the job
     '''
 
     ret = {'name': name,
@@ -39,9 +44,8 @@ def present(name,
            'changes': {},
            'comment': ['Job {0} is up to date.'.format(name)]}
 
-    _job_exists = __salt__['jenkins.job_exists'](name)
 
-    if _job_exists:
+    if __salt__['jenkins.job_exists'](name):
         _current_job_config = __salt__['jenkins.get_job_config'](name)
         buf = six.moves.StringIO(_current_job_config)
         _current_job_config = buf.readlines()
@@ -52,23 +56,30 @@ def present(name,
 
         if _current_job_config != new_config_xml:
             diff = difflib.unified_diff(_current_job_config, new_config_xml, lineterm='')
-            __salt__['jenkins.update_job'](name, config, __env__)
-            ret['changes'] = ''.join(diff)
-            ret['comment'].append('Job {0} updated.'.format(name))
+            try:
+                __salt__['jenkins.update_job'](name, config, __env__)
+            except CommandExecutionError as exc:
+                return _fail(ret, exc.strerror)
+            else:
+                ret['changes'] = ''.join(diff)
+                ret['comment'].append('Job \'{0}\' updated.'.format(name))
 
     else:
         cached_source_path = __salt__['cp.cache_file'](config, __env__)
         with salt.utils.fopen(cached_source_path) as _fp:
             new_config_xml = _fp.read()
 
-        __salt__['jenkins.create_job'](name, config, __env__)
+        try:
+            __salt__['jenkins.create_job'](name, config, __env__)
+        except CommandExecutionError as exc:
+            return _fail(ret, exc.strerror)
 
         buf = six.moves.StringIO(new_config_xml)
         _current_job_config = buf.readlines()
 
         diff = difflib.unified_diff('', buf, lineterm='')
         ret['changes'] = ''.join(diff)
-        ret['comment'].append('Job {0} added.'.format(name))
+        ret['comment'].append('Job \'{0}\' added.'.format(name))
 
     ret['comment'] = '\n'.join(ret['comment'])
     return ret
@@ -77,24 +88,24 @@ def present(name,
 def absent(name,
            **kwargs):
     '''
-    Ensure the job is present in the Jenkins
-    configured jobs
+    Ensure the job is absent from the Jenkins configured jobs
 
     name
-        The name of the Jenkins job to remove.
-
+        The name of the Jenkins job to remove
     '''
-
     ret = {'name': name,
            'result': True,
            'changes': {},
            'comment': []}
 
-    _job_exists = __salt__['jenkins.job_exists'](name)
 
-    if _job_exists:
-        __salt__['jenkins.delete_job'](name)
-        ret['comment'] = 'Job {0} deleted.'.format(name)
+    if __salt__['jenkins.job_exists'](name):
+        try:
+            __salt__['jenkins.delete_job'](name)
+        except CommandExecutionError as exc:
+            return _fail(ret, exc.strerror)
+        else:
+            ret['comment'] = 'Job \'{0}\' deleted.'.format(name)
     else:
-        ret['comment'] = 'Job {0} already absent.'.format(name)
+        ret['comment'] = 'Job \'{0}\' already absent.'.format(name)
     return ret


### PR DESCRIPTION
This PR makes the following changes:

### 1. Raise a `CommandExecutionError` if we fail to cache the config XML file

This prevents using invalid URLs from raising a cryptic error about coercing to Unicode.

### 2. Improve and correct exception raising

`SaltInvocationError` is for invalid arguments, we should be using `CommandExecutionError` elsewhere. Also, we don't use backticks as quotes. Finally, this changes the message in the errors we raise when the Jenkins bindings raise an exception, so that it's a bit more descriptive than "Something went wrong".

### 3. Catch exceptions when making changes in Jenkins states

This allows for a more graceful failure if an exception is raised in the process of making changes to the Jenkins configuration. Before this change, failing to make changes would result in a traceback being displayed in the state output.