### PR TITLE
Bring `_use_fnmatch` into scope

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -445,6 +445,7 @@ class SyncClientMixin(object):
                 _use_fnmatch = True
             else:
                 target_mod = arg + u'.' if not arg.endswith(u'.') else arg
+                _use_fnmatch = False
             if _use_fnmatch:
                 docs = [(fun, self.functions[fun].__doc__)
                         for fun in fnmatch.filter(self.functions, target_mod)]


### PR DESCRIPTION
/cc @garethgreenaway refs 343b970a00c17f14f740e41b02d01bc614be82ef

### What does this PR do?
Prevents an out of scope variable usage