### PR TITLE
Fixes ignore push flag for docker.push module issue #42992

### DIFF
--- a/salt/modules/dockerng.py
+++ b/salt/modules/dockerng.py
@@ -4403,7 +4403,7 @@ def save(name,
     ret['Size_Human'] = _size_fmt(ret['Size'])
 
     # Process push
-    if kwargs.get(push, False):
+    if kwargs.get('push', False):
         ret['Push'] = __salt__['cp.push'](path)
 
     return ret


### PR DESCRIPTION
### What does this PR do?
Fixes the push the ignore push flag for docker.push module
### What issues does this PR fix or reference?
Fixed the kwargs .get for push so that it doesn't default to False always
### Previous Behavior
docker.save module ignored the push command

### New Behavior
docker.save now observes the push command and send to master as long as master is configured to receive files 

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
