### PR TITLE
Normalize the salt caching API

### DIFF
--- a/salt/cache/__init__.py
+++ b/salt/cache/__init__.py
@@ -224,7 +224,7 @@ class Cache(object):
         fun = '{0}.flush'.format(self.driver)
         return self.modules[fun](bank, key=key, **self._kwargs)
 
-    def ls(self, bank):
+    def list(self, bank):
         '''
         Lists entries stored in the specified bank.
 
@@ -240,10 +240,8 @@ class Cache(object):
             Raises an exception if cache driver detected an error accessing data
             in the cache backend (auth, permissions, etc).
         '''
-        fun = '{0}.ls'.format(self.driver)
+        fun = '{0}.list'.format(self.driver)
         return self.modules[fun](bank, **self._kwargs)
-
-    list = ls
 
     def contains(self, bank, key=None):
         '''

--- a/salt/cache/consul.py
+++ b/salt/cache/consul.py
@@ -61,7 +61,7 @@ api = None
 # Define the module's virtual name
 __virtualname__ = 'consul'
 
-__func_alias__ = {'list': 'ls'}
+__func_alias__ = {'list_': 'list'}
 
 
 def __virtual__():
@@ -139,7 +139,7 @@ def flush(bank, key=None):
         )
 
 
-def ls(bank):
+def list_(bank):
     '''
     Return an iterable object containing all entries stored in the specified bank.
     '''

--- a/salt/cache/localfs.py
+++ b/salt/cache/localfs.py
@@ -23,7 +23,7 @@ import salt.utils.atomicfile
 
 log = logging.getLogger(__name__)
 
-__func_alias__ = {'list': 'ls'}
+__func_alias__ = {'list_': 'list'}
 
 
 def __cachedir(kwargs=None):
@@ -143,7 +143,7 @@ def flush(bank, key=None, cachedir=None):
     return True
 
 
-def ls(bank, cachedir):
+def list_(bank, cachedir):
     '''
     Return an iterable object containing all entries stored in the specified bank.
     '''

--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -114,9 +114,7 @@ from salt.exceptions import SaltCacheError
 # -----------------------------------------------------------------------------
 
 __virtualname__ = 'redis'
-__func_alias__ = {
-    'ls': 'list'
-}
+__func_alias__ = {'list_': 'list'}
 
 log = logging.getLogger(__file__)
 
@@ -418,7 +416,7 @@ def flush(bank, key=None):
     return True
 
 
-def ls(bank):
+def list_(bank):
     '''
     Lists entries stored in the specified bank.
     '''

--- a/salt/key.py
+++ b/salt/key.py
@@ -496,7 +496,7 @@ class Key(object):
                     if minion not in minions and minion not in preserve_minions:
                         shutil.rmtree(os.path.join(m_cache, minion))
             cache = salt.cache.factory(self.opts)
-            clist = cache.ls(self.ACC)
+            clist = cache.list(self.ACC)
             if clist:
                 for minion in clist:
                     if minion not in minions and minion not in preserve_minions:
@@ -974,7 +974,7 @@ class RaetKey(Key):
                 if minion not in minions:
                     shutil.rmtree(os.path.join(m_cache, minion))
             cache = salt.cache.factory(self.opts)
-            clist = cache.ls(self.ACC)
+            clist = cache.list(self.ACC)
             if clist:
                 for minion in clist:
                     if minion not in minions and minion not in preserve_minions:

--- a/salt/thorium/__init__.py
+++ b/salt/thorium/__init__.py
@@ -69,7 +69,7 @@ class ThorState(salt.state.HighState):
         cache = {'grains': {}, 'pillar': {}}
         if self.grains or self.pillar:
             if self.opts.get('minion_data_cache'):
-                minions = self.cache.ls('minions')
+                minions = self.cache.list('minions')
                 if not minions:
                     return cache
                 for minion in minions:

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -122,7 +122,7 @@ class MasterPillarUtil(object):
                       'and enfore_mine_cache are both disabled.')
             return mine_data
         if not minion_ids:
-            minion_ids = self.cache.ls('minions')
+            minion_ids = self.cache.list('minions')
         for minion_id in minion_ids:
             if not salt.utils.verify.valid_id(self.opts, minion_id):
                 continue
@@ -141,7 +141,7 @@ class MasterPillarUtil(object):
                       'enabled.')
             return grains, pillars
         if not minion_ids:
-            minion_ids = self.cache.ls('minions')
+            minion_ids = self.cache.list('minions')
         for minion_id in minion_ids:
             if not salt.utils.verify.valid_id(self.opts, minion_id):
                 continue
@@ -364,7 +364,7 @@ class MasterPillarUtil(object):
             # in the same file, 'data.p'
             grains, pillars = self._get_cached_minion_data(*minion_ids)
         try:
-            c_minions = self.cache.ls('minions')
+            c_minions = self.cache.list('minions')
             for minion_id in minion_ids:
                 if not salt.utils.verify.valid_id(self.opts, minion_id):
                     continue

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -75,7 +75,7 @@ def get_minion_data(minion, opts):
     if opts.get('minion_data_cache', False):
         cache = salt.cache.factory(opts)
         if minion is None:
-            for id_ in cache.ls('minions'):
+            for id_ in cache.list('minions'):
                 data = cache.fetch('minions/{0}'.format(id_), 'data')
                 if data is None:
                     continue
@@ -342,13 +342,13 @@ class CkMinions(object):
         if greedy:
             minions = self._pki_minions()
         elif cache_enabled:
-            minions = self.cache.ls('minions')
+            minions = self.cache.list('minions')
         else:
             return []
 
         if cache_enabled:
             if greedy:
-                cminions = self.cache.ls('minions')
+                cminions = self.cache.list('minions')
             else:
                 cminions = minions
             if cminions is None:
@@ -412,7 +412,7 @@ class CkMinions(object):
                         mlist.append(fn_)
                 return mlist
             elif cache_enabled:
-                return self.cache.ls('minions')
+                return self.cache.list('minions')
             else:
                 return list()
 
@@ -574,7 +574,7 @@ class CkMinions(object):
         '''
         minions = set()
         if self.opts.get('minion_data_cache', False):
-            search = self.cache.ls('minions')
+            search = self.cache.list('minions')
             if search is None:
                 return minions
             addrs = salt.utils.network.local_port_tcp(int(self.opts['publish_port']))

--- a/tests/unit/cache/test_localfs.py
+++ b/tests/unit/cache/test_localfs.py
@@ -209,26 +209,26 @@ class LocalFSTest(TestCase, LoaderModuleMockMixin):
             with patch('os.remove', MagicMock(side_effect=OSError)):
                 self.assertRaises(SaltCacheError, localfs.flush, bank='', key='key', cachedir='/var/cache/salt')
 
-    # 'ls' function tests: 3
+    # 'list' function tests: 3
 
-    def test_ls_no_base_dir(self):
+    def test_list_no_base_dir(self):
         '''
         Tests that the ls function returns an empty list if the bank directory
         doesn't exist.
         '''
         with patch('os.path.isdir', MagicMock(return_value=False)):
-            self.assertEqual(localfs.ls(bank='', cachedir=''), [])
+            self.assertEqual(localfs.list_(bank='', cachedir=''), [])
 
-    def test_ls_error_raised_no_bank_directory_access(self):
+    def test_list_error_raised_no_bank_directory_access(self):
         '''
         Tests that a SaltCacheError is raised when there is a problem accessing the
         cache bank directory.
         '''
         with patch('os.path.isdir', MagicMock(return_value=True)):
             with patch('os.listdir', MagicMock(side_effect=OSError)):
-                self.assertRaises(SaltCacheError, localfs.ls, bank='', cachedir='')
+                self.assertRaises(SaltCacheError, localfs.list_, bank='', cachedir='')
 
-    def test_ls_success(self):
+    def test_list_success(self):
         '''
         Tests the return of the ls function containing bank entries.
         '''
@@ -240,7 +240,7 @@ class LocalFSTest(TestCase, LoaderModuleMockMixin):
 
         # Now test the return of the ls function
         with patch.dict(localfs.__opts__, {'cachedir': tmp_dir}):
-            self.assertEqual(localfs.ls(bank='bank', cachedir=tmp_dir), ['key'])
+            self.assertEqual(localfs.list_(bank='bank', cachedir=tmp_dir), ['key'])
 
     # 'contains' function tests: 1
 


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/40429 changed the attribute used in `salt/cache/__init__.py` without considering the usage of the cache system elsewhere in the codebase. This led to a cascade of additional changes to try to make everything work correctly.

This PR does 2 things:

1. Reverts the calls to the list function to use `list` instead of `ls` to conform with the established API used elsewhere in the codebase.

2. Modifies the cache modules so that they now use `list_` functions, aliased to `list` so that calls to cache loader instances' `*.list` functions elsewhere in the codebase will work.