### PR TITLE
Small cleanup to dockermod.save

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -3843,7 +3843,6 @@ def save(name,
     if os.path.exists(path) and not overwrite:
         raise CommandExecutionError('{0} already exists'.format(path))
 
-    compression = kwargs.get('compression')
     if compression is None:
         if path.endswith('.tar.gz') or path.endswith('.tgz'):
             compression = 'gzip'


### PR DESCRIPTION
Removes the call to get ``compression`` out of the kwargs dict as ``compression`` is already listed in the list of positional kwargs in the ``save`` definition.