### PR TITLE
use a ruby gem that doesn't have dependencies

### DIFF
--- a/tests/integration/modules/test_gem.py
+++ b/tests/integration/modules/test_gem.py
@@ -19,9 +19,9 @@ from tornado.httpclient import HTTPClient
 
 GEM = 'tidy'
 GEM_VER = '1.1.2'
-OLD_GEM = 'test'
-OLD_VERSION = '0.2.0'
-NEW_VERSION = '1.0.0'
+OLD_GEM = 'brass'
+OLD_VERSION = '1.0.0'
+NEW_VERSION = '1.2.1'
 GEM_LIST = [GEM, OLD_GEM]
 
 


### PR DESCRIPTION
### What does this PR do?
The previous pr used a gem that had dependencies, and while testing, the dependencies didn't get removed, so they were passing, on the second run of the destructive tests.  This module also appears to not have been updated in a long time, and doesn't have any dependencies.

### Tests written?

Yes