### PR TITLE
Issue #43036 Bhyve virtual grain in Linux VMs

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -764,6 +764,8 @@ def _virtual(osdata):
                         grains['virtual_subtype'] = 'ovirt'
                     elif 'Google' in output:
                         grains['virtual'] = 'gce'
+                    elif 'BHYVE' in output:
+                        grains['virtual'] = 'bhyve'
             except IOError:
                 pass
     elif osdata['kernel'] == 'FreeBSD':


### PR DESCRIPTION
### What does this PR do?
Updates the virtual grain detection method to correctly identify Bhyve in Linux VMs.
### What issues does this PR fix or reference?
#43036 
### Previous Behavior
Remove this section if not relevant
Virtual grains on CentOS and Ubuntu VMs under a Bhyve hypervisor were reporting as "physical"
### New Behavior
Remove this section if not relevant
Virtual grains correctly identified as "bhyve"
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
