### PR TITLE
Do not try to match pillarenv with __env__

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -562,7 +562,7 @@ def ext_pillar(minion_id, repo, pillar_dirs):
         )
         for pillar_dir, env in six.iteritems(pillar.pillar_dirs):
             # If pillarenv is set, only grab pillars with that match pillarenv
-            if opts['pillarenv'] and env != opts['pillarenv']:
+            if opts['pillarenv'] and env != opts['pillarenv'] and env != '__env__':
                 log.debug(
                     'env \'%s\' for pillar dir \'%s\' does not match '
                     'pillarenv \'%s\', skipping',


### PR DESCRIPTION
### What does this PR do?
Fix issue outlined in #43040 

### What issues does this PR fix or reference?
#43040 

### Previous Behavior
When using gitFS and `__env__` was used in ext_pillars, minions got empty pillars when requesting a specific pillarenv other than base

### New Behavior
Minions see the correct pillars 

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
