### PR TITLE
Add docker network ipam support

### DIFF
--- a/salt/states/docker_network.py
+++ b/salt/states/docker_network.py
@@ -314,17 +314,16 @@ def present(name,
         except Exception as exc:
             ret['comment'] = ('Failed to create network \'{0}\': {1}'
                               .format(name, exc))
-        else:
-            result = True
-            for container in containers:
-                try:
-                    ret['changes']['connected'] = __salt__['docker.connect_container_to_network'](
-                        container['Id'], name)
-                except Exception as exc:
-                    ret['comment'] = ('Failed to connect container \'{0}\' to network \'{1}\' {2}'.format(
-                        container['Id'], name, exc))
-                    result = False
-            ret['result'] = result
+        result = True
+        for container in containers:
+            try:
+                ret['changes']['connected'] = __salt__['docker.connect_container_to_network'](
+                    container['Id'], name)
+            except Exception as exc:
+                ret['comment'] = ('Failed to connect container \'{0}\' to network \'{1}\' {2}'.format(
+                    container['Id'], name, exc))
+                result = False
+        ret['result'] = result
     return ret
 
 

--- a/salt/states/docker_network.py
+++ b/salt/states/docker_network.py
@@ -144,8 +144,7 @@ def present(name,
             ret['changes']['created'] = __salt__['docker.create_network'](
                 name,
                 driver=driver,
-                driver_opts=driver_opts,
-                check_duplicate=True)
+                driver_opts=driver_opts)
 
         except Exception as exc:
             ret['comment'] = ('Failed to create network \'{0}\': {1}'

--- a/salt/states/docker_network.py
+++ b/salt/states/docker_network.py
@@ -252,6 +252,7 @@ def present(name,
         except Exception as exc:
             ret['comment'] = ('Failed to create network \'{0}\': {1}'
                               .format(name, exc))
+            return ret
 
     # Finally, figure out the list of containers which should now be connected.
     containers_to_connect = {}

--- a/salt/states/docker_network.py
+++ b/salt/states/docker_network.py
@@ -34,6 +34,7 @@ from __future__ import absolute_import
 import logging
 
 # Import salt libs
+from salt.ext import six
 import salt.utils
 
 # Enable proper logging
@@ -277,7 +278,7 @@ def present(name,
     result = True
     reconnected_containers = []
     connected_containers = []
-    for container_id, container in containers_to_connect.iteritems():
+    for container_id, container in six.iteritems(containers_to_connect):
         if container_id not in network['Containers']:
             try:
                 connect_result = __salt__['docker.connect_container_to_network'](container_id, name)
@@ -306,7 +307,7 @@ def present(name,
     # Figure out if we removed any containers as a result of replacing the network and then not re-connecting the
     # containers, because they weren't specified in the state.
     disconnected_containers = []
-    for container_id, container in containers_disconnected.iteritems():
+    for container_id, container in six.iteritems(containers_disconnected):
         if container_id not in containers_to_connect:
             disconnected_containers.append(container['Name'])
 

--- a/salt/states/docker_network.py
+++ b/salt/states/docker_network.py
@@ -56,6 +56,9 @@ def __virtual__():
 def present(name,
             driver=None,
             driver_opts=None,
+            gateway=None,
+            ip_range=None,
+            subnet=None,
             containers=None):
     '''
     Ensure that a network is present.
@@ -69,8 +72,17 @@ def present(name,
     driver_opts
         Options for the network driver.
 
+    gateway
+        IPv4 or IPv6 gateway for the master subnet
+
+    ip_range
+        Allocate container IP from a sub-range within the subnet
+
     containers:
         List of container names that should be part of this network
+
+    subnet:
+        Subnet in CIDR format that represents a network segment
 
     Usage Examples:
 
@@ -90,6 +102,18 @@ def present(name,
             - containers:
                 - cont1
                 - cont2
+
+
+    .. code-block:: yaml
+
+        network_baz:
+          docker_network.present
+            - name: baz
+            - driver_opts:
+                - parent: eth0
+            - gateway: "172.20.0.1"
+            - ip_range: "172.20.0.128/25"
+            - subnet: "172.20.0.0/24"
 
     '''
     ret = {'name': name,
@@ -144,7 +168,10 @@ def present(name,
             ret['changes']['created'] = __salt__['docker.create_network'](
                 name,
                 driver=driver,
-                driver_opts=driver_opts)
+                driver_opts=driver_opts,
+                gateway=gateway,
+                ip_range=ip_range,
+                subnet=subnet)
 
         except Exception as exc:
             ret['comment'] = ('Failed to create network \'{0}\': {1}'

--- a/salt/states/docker_network.py
+++ b/salt/states/docker_network.py
@@ -124,10 +124,10 @@ def present(name,
     if salt.utils.is_dictlist(driver_opts):
         driver_opts = salt.utils.repack_dictlist(driver_opts)
 
-    if containers is None:
-        containers = []
-    # map containers to container's Ids.
-    containers = [__salt__['docker.inspect_container'](c)['Id'] for c in containers]
+    # If any containers are specified, get details of each one, we need the Id and Name fields later
+    if containers is not None:
+        containers = [__salt__['docker.inspect_container'](c) for c in containers]
+
     networks = __salt__['docker.networks'](names=[name])
     log.trace(
         'docker_network.present: current networks: {0}'.format(networks)
@@ -142,24 +142,162 @@ def present(name,
                 network = network_iter
                 break
 
+    # We might disconnect containers in the process of recreating the network, we'll need to keep track these containers
+    # so we can reconnect them later.
+    containers_disconnected = {}
+
+    # If the network already exists
     if network is not None:
-        if all(c in network['Containers'] for c in containers):
-            ret['result'] = True
-            ret['comment'] = 'Network \'{0}\' already exists.'.format(name)
+        log.debug('Network \'{0}\' already exists'.format(name))
+
+        # Set the comment now to say that it already exists, if we need to recreate the network with new config we'll
+        # update the comment later.
+        ret['comment'] = 'Network \'{0}\' already exists'.format(name)
+
+        # Update network details with result from network inspect, which will contain details of any containers
+        # attached to the network.
+        network = __salt__['docker.inspect_network'](network_id=network['Id'])
+
+        log.trace('Details of \'{0}\' network: {1}'.format(name, network))
+
+        # For the IPAM and driver config options which can be passed, check that if they are passed, they match the
+        # current configuration.
+        original_config = {}
+        new_config = {}
+
+        if driver and driver != network['Driver']:
+            new_config['driver'] = driver
+            original_config['driver'] = network['Driver']
+
+        if driver_opts and driver_opts != network['Options']:
+            new_config['driver_opts'] = driver_opts
+            original_config['driver_opts'] = network['Options']
+
+        # Multiple IPAM configs is probably not that common so for now we'll only worry about the simple case where
+        # there's a single IPAM config.  If there's more than one (or none at all) then we'll bail out.
+        if len(network['IPAM']['Config']) != 1:
+            ret['comment'] = ('docker_network.present does only supports Docker networks with a single IPAM config,'
+                              'network \'{0}\' has {1}'.format(name, len(network['IPAM']['Config'])))
             return ret
+
+        ipam = network['IPAM']['Config'][0]
+
+        if gateway and gateway != ipam['Gateway']:
+            new_config['gateway'] = gateway
+            original_config['gateway'] = ipam['Gateway']
+
+        if subnet and subnet != ipam['Subnet']:
+            new_config['subnet'] = subnet
+            original_config['subnet'] = ipam['Subnet']
+
+        if ip_range:
+            # IPRange isn't always configured so check it's even set before attempting to compare it.
+            if 'IPRange' in ipam and ip_range != ipam['IPRange']:
+                new_config['ip_range'] = ip_range
+                original_config['ip_range'] = ipam['IPRange']
+            elif 'IPRange' not in ipam:
+                new_config['ip_range'] = ip_range
+                original_config['ip_range'] = ''
+
+        if new_config != original_config:
+            log.debug('New config is different to current;\nnew: {0}\ncurrent: {1}'.format(new_config, original_config))
+
+            if __opts__['test']:
+                ret['result'] = None
+                ret['comment'] = 'Network {0} will be recreated with new config'.format(name)
+                return ret
+
+            remove_result = _remove_network(name, network['Containers'])
+            if not remove_result['result']:
+                return remove_result
+
+            # We've removed the network, so there are now no containers attached to it.
+            if network['Containers']:
+                containers_disconnected = network['Containers']
+                network['Containers'] = []
+
+            try:
+                __salt__['docker.create_network'](
+                    name,
+                    driver=driver,
+                    driver_opts=driver_opts,
+                    gateway=gateway,
+                    ip_range=ip_range,
+                    subnet=subnet)
+            except Exception as exc:
+                ret['comment'] = ('Failed to replace network \'{0}\': {1}'
+                                  .format(name, exc))
+                return ret
+
+            ret['changes']['updated'] = {name: {'old': original_config, 'new': new_config}}
+            ret['comment'] = 'Network \'{0}\' was replaced with updated config'.format(name)
+
+        # Figure out the list of containers should now now be connected.
+        containers_to_connect = {}
+        # If no containers were specified in the state but we have disconnected some in the process of recreating the
+        # network, we should reconnect those containers.
+        if containers is None and containers_disconnected:
+            containers_to_connect = containers_disconnected
+        # If containers were specified in the state, regardless of what we've disconnected, we should now just connect
+        # the containers specified.
+        elif containers:
+            for container in containers:
+                containers_to_connect[container['Id']] = container
+
+        # At this point, if all the containers we want connected are already connected to the network, we can set our
+        # result and finish.
+        if all(c in network['Containers'] for c in containers_to_connect):
+            ret['result'] = True
+            return ret
+
+        # If we've not exited by this point it's because we have containers which we need to connect to the network.
         result = True
-        for container in containers:
-            if container not in network['Containers']:
+        reconnected_containers = []
+        connected_containers = []
+        for container_id, container in containers_to_connect.iteritems():
+            if container_id not in network['Containers']:
                 try:
-                    ret['changes']['connected'] = __salt__['docker.connect_container_to_network'](
-                        container, name)
+                    connect_result = __salt__['docker.connect_container_to_network'](container_id, name)
+                    log.trace(
+                        'docker.connect_container_to_network({0}, {1}) result: {2}'.
+                        format(container, name, connect_result)
+                    )
+                    # If this container was one we disconnected earlier, add it to the reconnected list.
+                    if container_id in containers_disconnected:
+                        reconnected_containers.append(container['Name'])
+                    # Otherwise add it to the connected list.
+                    else:
+                        connected_containers.append(container['Name'])
+
                 except Exception as exc:
                     ret['comment'] = ('Failed to connect container \'{0}\' to network \'{1}\' {2}'.format(
-                        container, name, exc))
+                        container['Name'], name, exc))
                     result = False
-            ret['result'] = result
 
+        # If we populated any of our container lists then add them to our list of changes.
+        if connected_containers:
+            ret['changes']['connected'] = connected_containers
+        if reconnected_containers:
+            ret['changes']['reconnected'] = reconnected_containers
+
+        # Figure out if we removed any containers as a result of replacing the network and then not re-connecting the
+        # containers, because they weren't specified in the state.
+        disconnected_containers = []
+        for container_id, container in containers_disconnected.iteritems():
+            if container_id not in containers_to_connect:
+                disconnected_containers.append(container['Name'])
+
+        if disconnected_containers:
+            ret['changes']['disconnected'] = disconnected_containers
+
+        ret['result'] = result
+
+    # If the network does not yet exist, we create it
     else:
+        if containers is None:
+            containers = {}
+
+        log.debug('The network \'{0}\' will be created'.format(name))
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = ('The network \'{0}\' will be created'.format(name))
@@ -181,10 +319,10 @@ def present(name,
             for container in containers:
                 try:
                     ret['changes']['connected'] = __salt__['docker.connect_container_to_network'](
-                        container, name)
+                        container['Id'], name)
                 except Exception as exc:
                     ret['comment'] = ('Failed to connect container \'{0}\' to network \'{1}\' {2}'.format(
-                        container, name, exc))
+                        container['Id'], name, exc))
                     result = False
             ret['result'] = result
     return ret
@@ -234,16 +372,32 @@ def absent(name, driver=None):
         ret['comment'] = ('The network \'{0}\' will be removed'.format(name))
         return ret
 
-    for container in networks[0]['Containers']:
+    return _remove_network(network=name, containers=networks[0]['Containers'])
+
+
+def _remove_network(network, containers=None):
+    '''
+    Remove network, removing any specified containers from it beforehand
+    '''
+
+    ret = {'name': network,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if containers is None:
+        containers = []
+    for container in containers:
         try:
-            ret['changes']['disconnected'] = __salt__['docker.disconnect_container_from_network'](container, name)
+            ret['changes']['disconnected'] = __salt__['docker.disconnect_container_from_network'](container, network)
         except Exception as exc:
-            ret['comment'] = ('Failed to disconnect container \'{0}\' to network \'{1}\' {2}'.format(
-                container, name, exc))
+            ret['comment'] = ('Failed to disconnect container \'{0}\' from network \'{1}\' {2}'.format(
+                container, network, exc))
     try:
-        ret['changes']['removed'] = __salt__['docker.remove_network'](name)
+        ret['changes']['removed'] = __salt__['docker.remove_network'](network)
         ret['result'] = True
     except Exception as exc:
         ret['comment'] = ('Failed to remove network \'{0}\': {1}'
-                          .format(name, exc))
+                          .format(network, exc))
+
     return ret

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -184,10 +184,23 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
             with patch.object(docker_mod, '_get_client', get_client_mock):
                 docker_mod.create_network('foo',
                                           driver='bridge',
-                                          driver_opts={})
+                                          driver_opts={},
+                                          gateway='192.168.0.1',
+                                          ip_range='192.168.0.128/25',
+                                          subnet='192.168.0.0/24'
+                                          )
         client.create_network.assert_called_once_with('foo',
                                                       driver='bridge',
                                                       options={},
+                                                      ipam={
+                                                          'Config': [{
+                                                              'Gateway': '192.168.0.1',
+                                                              'IPRange': '192.168.0.128/25',
+                                                              'Subnet': '192.168.0.0/24'
+                                                          }],
+                                                          'Driver': 'default',
+                                                          'Options': {}
+                                                      },
                                                       check_duplicate=True)
 
     @skipIf(docker_version < (1, 5, 0),

--- a/tests/unit/states/test_docker_network.py
+++ b/tests/unit/states/test_docker_network.py
@@ -79,6 +79,86 @@ class DockerNetworkTestCase(TestCase, LoaderModuleMockMixin):
                                            'created': 'created'},
                                'result': True})
 
+    def test_present_with_change(self):
+        '''
+        Test docker_network.present when the specified network has properties differing from the already present network
+        '''
+        network_details = {
+            'Id': 'abcd',
+            'Name': 'network_foo',
+            'Driver': 'macvlan',
+            'Containers': {
+                'abcd': {}
+            },
+            'Options': {
+                'parent': 'eth0'
+            },
+            'IPAM': {
+                'Config': [
+                    {
+                        'Subnet': '192.168.0.0/24',
+                        'Gateway': '192.168.0.1'
+                    }
+                ]
+            }
+        }
+        docker_networks = Mock(return_value=[network_details])
+        network_details['Containers'] = {'abcd': {'Id': 'abcd', 'Name': 'container_bar'}}
+        docker_inspect_network = Mock(return_value=network_details)
+        docker_inspect_container = Mock(return_value={'Id': 'abcd', 'Name': 'container_bar'})
+        docker_disconnect_container_from_network = Mock(return_value='disconnected')
+        docker_remove_network = Mock(return_value='removed')
+        docker_create_network = Mock(return_value='created')
+        docker_connect_container_to_network = Mock(return_value='connected')
+
+        __salt__ = {'docker.networks': docker_networks,
+                    'docker.inspect_network': docker_inspect_network,
+                    'docker.inspect_container': docker_inspect_container,
+                    'docker.disconnect_container_from_network': docker_disconnect_container_from_network,
+                    'docker.remove_network': docker_remove_network,
+                    'docker.create_network': docker_create_network,
+                    'docker.connect_container_to_network': docker_connect_container_to_network,
+                    }
+        with patch.dict(docker_state.__dict__,
+                        {'__salt__': __salt__}):
+            ret = docker_state.present(
+                'network_foo',
+                driver='macvlan',
+                gateway='192.168.1.1',
+                subnet='192.168.1.0/24',
+                driver_opts={'parent': 'eth1'},
+                containers=['abcd']
+            )
+
+        docker_disconnect_container_from_network.assert_called_with('abcd', 'network_foo')
+        docker_remove_network.assert_called_with('network_foo')
+        docker_create_network.assert_called_with('network_foo',
+                                                 driver='macvlan',
+                                                 driver_opts={'parent': 'eth1'},
+                                                 gateway='192.168.1.1',
+                                                 ip_range=None,
+                                                 subnet='192.168.1.0/24')
+        docker_connect_container_to_network.assert_called_with('abcd', 'network_foo')
+
+        self.assertEqual(ret, {'name': 'network_foo',
+                               'comment': 'Network \'network_foo\' was replaced with updated config',
+                               'changes': {
+                                   'updated': {'network_foo': {
+                                       'old': {
+                                           'driver_opts': {'parent': 'eth0'},
+                                           'gateway': '192.168.0.1',
+                                           'subnet': '192.168.0.0/24'
+                                       },
+                                       'new': {
+                                           'driver_opts': {'parent': 'eth1'},
+                                           'gateway': '192.168.1.1',
+                                           'subnet': '192.168.1.0/24'
+                                       }
+                                   }},
+                                   'reconnected': ['container_bar']
+                               },
+                               'result': True})
+
     def test_absent(self):
         '''
         Test docker_network.absent

--- a/tests/unit/states/test_docker_network.py
+++ b/tests/unit/states/test_docker_network.py
@@ -64,8 +64,7 @@ class DockerNetworkTestCase(TestCase, LoaderModuleMockMixin):
                 )
         docker_create_network.assert_called_with('network_foo',
                                                  driver=None,
-                                                 driver_opts=None,
-                                                 check_duplicate=True)
+                                                 driver_opts=None)
         docker_connect_container_to_network.assert_called_with('abcd',
                                                                  'network_foo')
         self.assertEqual(ret, {'name': 'network_foo',

--- a/tests/unit/states/test_docker_network.py
+++ b/tests/unit/states/test_docker_network.py
@@ -61,10 +61,16 @@ class DockerNetworkTestCase(TestCase, LoaderModuleMockMixin):
             ret = docker_state.present(
                 'network_foo',
                 containers=['container'],
+                gateway='192.168.0.1',
+                ip_range='192.168.0.128/25',
+                subnet='192.168.0.0/24'
                 )
         docker_create_network.assert_called_with('network_foo',
                                                  driver=None,
-                                                 driver_opts=None)
+                                                 driver_opts=None,
+                                                 gateway='192.168.0.1',
+                                                 ip_range='192.168.0.128/25',
+                                                 subnet='192.168.0.0/24')
         docker_connect_container_to_network.assert_called_with('abcd',
                                                                  'network_foo')
         self.assertEqual(ret, {'name': 'network_foo',

--- a/tests/unit/states/test_docker_network.py
+++ b/tests/unit/states/test_docker_network.py
@@ -42,7 +42,7 @@ class DockerNetworkTestCase(TestCase, LoaderModuleMockMixin):
         '''
         docker_create_network = Mock(return_value='created')
         docker_connect_container_to_network = Mock(return_value='connected')
-        docker_inspect_container = Mock(return_value={'Id': 'abcd'})
+        docker_inspect_container = Mock(return_value={'Id': 'abcd', 'Name': 'container_bar'})
         # Get docker.networks to return a network with a name which is a superset of the name of
         # the network which is to be created, despite this network existing we should still expect
         # that the new network will be created.
@@ -75,7 +75,7 @@ class DockerNetworkTestCase(TestCase, LoaderModuleMockMixin):
                                                                  'network_foo')
         self.assertEqual(ret, {'name': 'network_foo',
                                'comment': '',
-                               'changes': {'connected': 'connected',
+                               'changes': {'connected': ['container_bar'],
                                            'created': 'created'},
                                'result': True})
 


### PR DESCRIPTION
### What does this PR do?
Adds IPAM config support to the `docker_network.present` state.

It also adds the ability to recreate the network in the event that config which is specified in the state differs from the current network configuration.  Note that if config isn't specified in the state, it won't be compared, which should prevent issues caused by Docker choosing a subnet when none is specified.

### What issues does this PR fix or reference?
#43047

### Previous Behavior
The `docker_network.present` state only supported `name`, `driver`, `driver_opts` and `containers` config options.

Applying the state would create a network if it wasn't already present, and would add any specified containers which weren't currently connected, but if the network was already present and the `driver` or `driver_opts` were set in the state but differed from those currently configured in the network, it wouldn't take any action.

### New Behavior
The following new options are supported, these all go within the `IPAM` section of the Docker network config: `gateway`, `ip_range`, `subnet`.

When applying state, if the module finds that the network already exists it compares any options specified in the state with the configuration of the existing network.  If any differences are found, all containers are disconnected from the network, the network is recreated using the new configuration, and the containers are connected again.

### Notes
The pre-existing behaviour of the module is that if the state specifies a set of containers and the network has more than those containers connected, it won't disconnect them.  I've not changed this behaviour because it felt like the scope of this PR was already creeping a lot by adding the network recreation functionality, though I could add it if the project maintainers would prefer.  IMO containers should be removed in this case, because otherwise the state is capable of adding but not removing, so if a container is later removed from the config it will require manual steps to remove on the hosts.

By not making this change yet the behaviour be slightly inconsistent - if changes to the network config itself (e.g. subnet) are detected and the containers specified in the state don't include a container which is currently connected to the network, then the effective behaviour is to disconnect that container from the network, as it won't be reconnected following network recreation.

### Tests written?
Yes, though given the size of the change potentially more are needed.  I wasn't sure how many is appropriate, or if I could use things like [data providers](https://pypi.python.org/pypi/unittest-data-provider/1.0.0) to reduce repetition.