### PR TITLE
safe_filename_leaf(file_basename) and safe_filepath(file_path_name)

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -163,6 +163,37 @@ def is_empty(filename):
         return False
 
 
+def safe_filename_leaf(file_basename):
+    '''
+    input the basename of a file, without the directory tree, and returns a safe name to use
+    i.e. only the required characters are converted by urllib.quote
+    If the input is a PY2 String, output a PY2 String. If input is Unicode output Unicode.
+    For consistency all platforms are treated the same. Hard coded to utf8 as its ascii compatible
+    windows is \ / : * ? " < > | posix is /
+    '''
+    def _replace(re_obj):
+        return urllib.quote(re_obj.group(0), safe=u'')
+    if not isinstance(file_basename, six.text_type):
+        # the following string is not prefixed with u
+	return re.sub('[\\\/:*?"<>|]',
+                      _replace,six.text_type(file_basename, 'utf8').encode('ascii', 'backslashreplace'))
+    # the following string is prefixed with u
+    return re.sub(u'[\\\/:*?"<>|]', _replace, file_basename, flags=re.UNICODE)
+
+
+def safe_filepath(file_path_name):
+    '''
+    input the full path and filename, splits on directory separator and calls safe_filename_leaf for
+    each part of the path.
+    '''
+    (drive,path) = os.path.splitdrive(file_path_name)
+    path = os.sep.join([safe_filename_leaf(file_section) for file_section in file_path_name.rsplit(os.sep)])
+    if drive:
+        return os.sep.join([drive, path])
+    else:
+        return path
+
+
 def is_hex(value):
     '''
     Returns True if value is a hexidecimal string, otherwise returns False

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -16,6 +16,7 @@ import json
 import logging
 import numbers
 import os
+import os.path
 import posixpath
 import random
 import re
@@ -32,6 +33,7 @@ import warnings
 import string
 import subprocess
 import getpass
+import urllib
 
 # Import 3rd-party libs
 from salt.ext import six

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -177,11 +177,11 @@ def safe_filename_leaf(file_basename):
         return urllib.quote(re_obj.group(0), safe=u'')
     if not isinstance(file_basename, six.text_type):
         # the following string is not prefixed with u
-        return re.sub('[\\\/:*?"<>|]',
+        return re.sub('[\\\\:/*?"<>|]',
                       _replace,
                       six.text_type(file_basename, 'utf8').encode('ascii', 'backslashreplace'))
     # the following string is prefixed with u
-    return re.sub(u'[\\\/:*?"<>|]', _replace, file_basename, flags=re.UNICODE)
+    return re.sub(u'[\\\\:/*?"<>|]', _replace, file_basename, flags=re.UNICODE)
 
 
 def safe_filepath(file_path_name):

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -177,8 +177,9 @@ def safe_filename_leaf(file_basename):
         return urllib.quote(re_obj.group(0), safe=u'')
     if not isinstance(file_basename, six.text_type):
         # the following string is not prefixed with u
-	return re.sub('[\\\/:*?"<>|]',
-                      _replace,six.text_type(file_basename, 'utf8').encode('ascii', 'backslashreplace'))
+        return re.sub('[\\\/:*?"<>|]',
+                      _replace,
+                      six.text_type(file_basename, 'utf8').encode('ascii', 'backslashreplace'))
     # the following string is prefixed with u
     return re.sub(u'[\\\/:*?"<>|]', _replace, file_basename, flags=re.UNICODE)
 
@@ -188,7 +189,7 @@ def safe_filepath(file_path_name):
     input the full path and filename, splits on directory separator and calls safe_filename_leaf for
     each part of the path.
     '''
-    (drive,path) = os.path.splitdrive(file_path_name)
+    (drive, path) = os.path.splitdrive(file_path_name)
     path = os.sep.join([safe_filename_leaf(file_section) for file_section in file_path_name.rsplit(os.sep)])
     if drive:
         return os.sep.join([drive, path])

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -171,7 +171,7 @@ def safe_filename_leaf(file_basename):
     i.e. only the required characters are converted by urllib.quote
     If the input is a PY2 String, output a PY2 String. If input is Unicode output Unicode.
     For consistency all platforms are treated the same. Hard coded to utf8 as its ascii compatible
-    windows is \ / : * ? " < > | posix is /
+    windows is \\ / : * ? " < > | posix is /
     '''
     def _replace(re_obj):
         return urllib.quote(re_obj.group(0), safe=u'')


### PR DESCRIPTION
### What does this PR do?

Introduce two new functions into salt.utils these are design to handle filenames in Unicode and PY2 Strings.

safe_filename_leaf
    input the basename of a file, without the directory tree, and returns a safe name to use
    i.e. only the required characters are converted by urllib.quote
    If the input is a PY2 String, output a PY2 String. If input is Unicode output Unicode.
    For consistency all platforms are treated the same. Hard coded to utf8 as its ascii compatible
    windows is \ / : * ? " < > | posix is /

safe_filepath
    input the full path and filename, splits on directory separator and calls safe_filename_leaf for
    each part of the path.



### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/42706 `Parallel Cache Failure` and PR https://github.com/saltstack/salt/pull/43018
Provides functions which can be used as part of resolving the above issues

https://github.com/saltstack/salt/issues/43022 `develop salt.utils.sanitize_win_path_string breaks state.apply/highstate on windows`
And Step towards replacing salt.utils.sanitize_win_path_string

### Previous Behavior
New Function

### New Behavior
New Function

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
