### PR TITLE
Update release version number for jenkins.run function

### DIFF
--- a/salt/modules/jenkins.py
+++ b/salt/modules/jenkins.py
@@ -91,7 +91,7 @@ def _connect():
 
 def run(script):
     '''
-    .. versionadded:: Carbon
+    .. versionadded:: 2017.7.0
 
     Execute a groovy script on the jenkins master
 


### PR DESCRIPTION
This function was added for the 2017.7.0 release, not Carbon.
