### PR TITLE
Osx update pkg scripts

### DIFF
--- a/pkg/osx/pkg-scripts/postinstall
+++ b/pkg/osx/pkg-scripts/postinstall
@@ -15,66 +15,130 @@
 #     This script is run as a part of the macOS Salt Installation
 #
 ###############################################################################
-echo "Post install started on:" > /tmp/postinstall.txt
-date >> /tmp/postinstall.txt
+
+###############################################################################
+# Define Variables
+###############################################################################
+# Get Minor Version
+OSX_VERSION=$(sw_vers | grep ProductVersion | cut -f 2 -d: | tr -d '[:space:]')
+MINOR=$(echo ${OSX_VERSION} | cut -f 2 -d.)
+# Path Variables
+INSTALL_DIR="/opt/salt"
+BIN_DIR="$INSTALL_DIR/bin"
+CONFIG_DIR="/etc/salt"
+TEMP_DIR="/tmp"
+SBIN_DIR="/usr/local/sbin"
+
+###############################################################################
+# Set up logging and error handling
+###############################################################################
+echo "Post install script started on:" > "$TEMP_DIR/postinstall.txt"
+date "+%Y/%m/%d %H:%m:%S" >> "$TEMP_DIR/postinstall.txt"
 trap 'quit_on_error $LINENO $BASH_COMMAND' ERR
 
 quit_on_error() {
-    echo "$(basename $0) caught error on line : $1 command was: $2" >> /tmp/postinstall.txt
+    echo "$(basename $0) caught error on line : $1 command was: $2" >> "$TEMP_DIR/postinstall.txt"
     exit -1
 }
 
 ###############################################################################
 # Check for existing minion config, copy if it doesn't exist
 ###############################################################################
-if [ ! -f /etc/salt/minion ]; then
-    echo "Config copy: Started..." >> /tmp/postinstall.txt
-    cp /etc/salt/minion.dist /etc/salt/minion
-    echo "Config copy: Successful" >> /tmp/postinstall.txt
+if [ ! -f "$CONFIG_DIR/minion" ]; then
+    echo "Config: Copy Started..." >> "$TEMP_DIR/postinstall.txt"
+    cp "$CONFIG_DIR/minion.dist" "$CONFIG_DIR/minion"
+    echo "Config: Copied Successfully" >> "$TEMP_DIR/postinstall.txt"
 fi
 
 ###############################################################################
 # Create symlink to salt-config.sh
 ###############################################################################
-# echo "Symlink: Creating symlink for salt-config..." >> /tmp/postinstall.txt
-if [ ! -d "/usr/local/sbin" ]; then
-    mkdir /usr/local/sbin
+if [ ! -d "$SBIN_DIR" ]; then
+    echo "Symlink: Creating $SBIN_DIR..." >> "$TEMP_DIR/postinstall.txt"
+    mkdir "$SBIN_DIR"
+    echo "Symlink: Created Successfully" >> "$TEMP_DIR/postinstall.txt"
 fi
-ln -sf /opt/salt/bin/salt-config.sh /usr/local/sbin/salt-config
+echo "Symlink: Creating symlink for salt-config..." >> "$TEMP_DIR/postinstall.txt"
+ln -sf "$BIN_DIR/salt-config.sh" "$SBIN_DIR/salt-config"
+echo "Symlink: Created Successfully" >> "$TEMP_DIR/postinstall.txt"
 
 ###############################################################################
 # Add salt to paths.d
 ###############################################################################
-# echo "Path: Adding salt to the path..." >> /tmp/postinstall.txt
 if [ ! -d "/etc/paths.d" ]; then
+    echo "Path: Creating paths.d directory..." >> "$TEMP_DIR/postinstall.txt"
     mkdir /etc/paths.d
+    echo "Path: Created Successfully" >> "$TEMP_DIR/postinstall.txt"
 fi
-sh -c 'echo "/opt/salt/bin" > /etc/paths.d/salt'
-sh -c 'echo "/usr/local/sbin" >> /etc/paths.d/salt'
+echo "Path: Adding salt to the path..." >> "$TEMP_DIR/postinstall.txt"
+sh -c "echo \"$BIN_DIR\" > /etc/paths.d/salt"
+sh -c "echo \"$SBIN_DIR\" >> /etc/paths.d/salt"
+echo "Path: Added Successfully" >> "$TEMP_DIR/postinstall.txt"
 
 ###############################################################################
 # Register Salt as a service
 ###############################################################################
-echo "Service start: Enabling service..." >> /tmp/postinstall.txt
-launchctl enable system/com.saltstack.salt.minion
-echo "Service start: Bootstrapping service..." >> /tmp/postinstall.txt
-launchctl bootstrap system /Library/LaunchDaemons/com.saltstack.salt.minion.plist
+setup_services_maverick() {
+    echo "Service: Using old (< 10.10) launchctl interface" >> "$TEMP_DIR/postinstall.txt"
+    if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
+        echo "Service: Stopping salt-minion..." >> "$TEMP_DIR/postinstall.txt"
+        launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist
+        echo "Service: Stopped Successfully" >> "$TEMP_DIR/postinstall.txt"
+    fi;
+    echo "Service: Starting salt-minion..." >> "$TEMP_DIR/postinstall.txt"
+    launchctl load -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist || return 1
+    echo "Service: Started Successfully" >> "$TEMP_DIR/postinstall.txt"
 
-if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-    echo "Service is running" >> /tmp/postinstall.txt
-else
-    echo "Service start: Kickstarting service..." >> /tmp/postinstall.txt
-    launchctl kickstart -kp system/com.saltstack.salt.minion
-fi
+    echo "Service: Disabling Master, Syndic, and API services..." >> "$TEMP_DIR/postinstall.txt"
+    launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.api.plist
+    launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.master.plist
+    launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.syndic.plist
+    echo "Service: Disabled Successfully" >> "$TEMP_DIR/postinstall.txt"
 
-echo "Service start: Successful" >> /tmp/postinstall.txt
+    return 0
+}
 
-echo "Service disable: Disabling Master, Syndic, and API" >> /tmp/postinstall.txt
+setup_services_yosemite_and_later() {
+    echo "Service: Using new (>= 10.10) launchctl interface" >> "$TEMP_DIR/postinstall.txt"
+    echo "Service: Enabling salt-minion..." >> "$TEMP_DIR/postinstall.txt"
+    launchctl enable system/com.saltstack.salt.minion
+    echo "Service: Enabled Successfully" >> "$TEMP_DIR/postinstall.txt"
 
-launchctl disable system/com.saltstack.salt.master
-launchctl disable system/com.saltstack.salt.syndic
-launchctl disable system/com.saltstack.salt.api
+    echo "Service: Bootstrapping salt-minion..." >> "$TEMP_DIR/postinstall.txt"
+    launchctl bootstrap system /Library/LaunchDaemons/com.saltstack.salt.minion.plist
+    echo "Service: Bootstrapped Successfully" >> "$TEMP_DIR/postinstall.txt"
 
-echo "Post install completed successfully" >> /tmp/postinstall.txt
+    if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
+        echo "Service: Service Running" >> "$TEMP_DIR/postinstall.txt"
+    else
+        echo "Service: Kickstarting Service..." >> "$TEMP_DIR/postinstall.txt"
+        launchctl kickstart -kp system/com.saltstack.salt.minion
+        echo "Service: Kickstarted Successfully" >> "$TEMP_DIR/postinstall.txt"
+    fi
+
+    echo "Service: Started Successfully" >> "$TEMP_DIR/postinstall.txt"
+
+    echo "Service: Disabling Master, Syndic, and API services" >> "$TEMP_DIR/postinstall.txt"
+    launchctl disable system/com.saltstack.salt.master
+    launchctl disable system/com.saltstack.salt.syndic
+    launchctl disable system/com.saltstack.salt.api
+    echo "Service: Disabled Successfully" >> "$TEMP_DIR/postinstall.txt"
+
+    return 0
+}
+
+echo "Service: Configuring..." >> "$TEMP_DIR/postinstall.txt"
+case $MINOR in
+        9 )
+                setup_services_maverick;
+                ;;
+        * )
+                setup_services_yosemite_and_later;
+                ;;
+esac
+echo "Service: Configured Successfully" >> "$TEMP_DIR/postinstall.txt"
+
+echo "Post install completed successfully on:" >> "$TEMP_DIR/postinstall.txt"
+date "+%Y/%m/%d %H:%m:%S" >> "$TEMP_DIR/postinstall.txt"
 
 exit 0

--- a/pkg/osx/pkg-scripts/preinstall
+++ b/pkg/osx/pkg-scripts/preinstall
@@ -7,7 +7,7 @@
 #
 # Description: This script stops the salt minion service before attempting to
 #              install Salt on macOS. It also removes the /opt/salt/bin
-#              directory.
+#              directory, symlink to salt-config, and salt from paths.d.
 #
 # Requirements:
 #    - None

--- a/pkg/osx/pkg-scripts/preinstall
+++ b/pkg/osx/pkg-scripts/preinstall
@@ -6,7 +6,8 @@
 # Date: December 2015
 #
 # Description: This script stops the salt minion service before attempting to
-#              install Salt on macOS
+#              install Salt on macOS. It also removes the /opt/salt/bin
+#              directory.
 #
 # Requirements:
 #    - None
@@ -15,26 +16,93 @@
 #     This script is run as a part of the macOS Salt Installation
 #
 ###############################################################################
-echo "Preinstall started on:" > /tmp/preinstall.txt
-date >> /tmp/preinstall.txt
+
+###############################################################################
+# Define Variables
+###############################################################################
+# Get Minor Version
+OSX_VERSION=$(sw_vers | grep ProductVersion | cut -f 2 -d: | tr -d '[:space:]')
+MINOR=$(echo ${OSX_VERSION} | cut -f 2 -d.)
+# Path Variables
+INSTALL_DIR="/opt/salt"
+BIN_DIR="$INSTALL_DIR/bin"
+CONFIG_DIR="/etc/salt"
+TEMP_DIR="/tmp"
+SBIN_DIR="/usr/local/sbin"
+
+###############################################################################
+# Set up logging and error handling
+###############################################################################
+echo "Preinstall started on:" > "$TEMP_DIR/preinstall.txt"
+date "+%Y/%m/%d %H:%m:%S" >> "$TEMP_DIR/preinstall.txt"
 trap 'quit_on_error $LINENO $BASH_COMMAND' ERR
 
 quit_on_error() {
-    echo "$(basename $0) caught error on line : $1 command was: $2" >> /tmp/preinstall.txt
+    echo "$(basename $0) caught error on line : $1 command was: $2" >> "$TEMP_DIR/preinstall.txt"
     exit -1
 }
 
 ###############################################################################
 # Stop the service
 ###############################################################################
-if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-    echo "Stop service: Started..." >> /tmp/preinstall.txt
-#    /bin/launchctl unload "/Library/LaunchDaemons/com.saltstack.salt.minion.plist"
-    launchctl disable system/com.saltstack.salt.minion
-    launchctl bootout system /Library/LaunchDaemons/com.saltstack.salt.minion.plist
-    echo "Stop service: Successful" >> /tmp/preinstall.txt
+stop_service_maverick() {
+    echo "Service: Using old (< 10.10) launchctl interface" >> "$TEMP_DIR/preinstall.txt"
+    if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
+        echo "Service: Unloading..." >> "$TEMP_DIR/preinstall.txt"
+        launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist
+        launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.api.plist
+        launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.master.plist
+        launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.syndic.plist
+        echo "Service: Unloaded Successfully" >> "$TEMP_DIR/preinstall.txt"
+    fi
+}
+
+stop_service_yosemite_and_later() {
+    echo "Service: Using new (>= 10.10) launchctl interface" >> "$TEMP_DIR/preinstall.txt"
+    if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
+        echo "Service: Stopping..." >> "$TEMP_DIR/preinstall.txt"
+        launchctl disable system/com.saltstack.salt.minion
+        launchctl disable system/com.saltstack.salt.master
+        launchctl disable system/com.saltstack.salt.syndic
+        launchctl disable system/com.saltstack.salt.api
+        launchctl bootout system /Library/LaunchDaemons/com.saltstack.salt.minion.plist
+        launchctl bootout system /Library/LaunchDaemons/com.saltstack.salt.master.plist
+        launchctl bootout system /Library/LaunchDaemons/com.saltstack.salt.syndic.plist
+        launchctl bootout system /Library/LaunchDaemons/com.saltstack.salt.api.plist
+        echo "Service: Stopped Successfully" >> "$TEMP_DIR/preinstall.txt"
+    fi
+}
+
+echo "Service: Configuring..." >> "$TEMP_DIR/preinstall.txt"
+case $MINOR in
+        9 )
+                stop_service_maverick;
+                ;;
+        * )
+                stop_service_yosemite_and_later;
+                ;;
+esac
+echo "Service: Configured Successfully" >> "$TEMP_DIR/preinstall.txt"
+
+###############################################################################
+# Remove the Symlink to salt-config.sh
+###############################################################################
+if [ -L "$SBIN_DIR/salt-config" ]; then
+    echo "Cleanup: Removing Symlink $BIN_DIR/salt-config" >> "$TEMP_DIR/preinstall.txt"
+    rm "$SBIN_DIR/salt-config"
+    echo "Cleanup: Removed Successfully" >> "$TEMP_DIR/preinstall.txt"
 fi
 
-echo "Preinstall Completed Successfully" >> /tmp/preinstall.txt
+###############################################################################
+# Remove the $BIN_DIR directory
+###############################################################################
+if [ -d "$BIN_DIR" ]; then
+    echo "Cleanup: Removing $BIN_DIR" >> "$TEMP_DIR/preinstall.txt"
+    rm -rf "$BIN_DIR"
+    echo "Cleanup: Removed Successfully" >> "$TEMP_DIR/preinstall.txt"
+fi
+
+echo "Preinstall Completed Successfully on:" >> "$TEMP_DIR/preinstall.txt"
+date "+%Y/%m/%d %H:%m:%S" >> "$TEMP_DIR/preinstall.txt"
 
 exit 0

--- a/pkg/osx/pkg-scripts/preinstall
+++ b/pkg/osx/pkg-scripts/preinstall
@@ -48,11 +48,23 @@ quit_on_error() {
 stop_service_maverick() {
     echo "Service: Using old (< 10.10) launchctl interface" >> "$TEMP_DIR/preinstall.txt"
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-        echo "Service: Unloading..." >> "$TEMP_DIR/preinstall.txt"
+        echo "Service: Unloading minion..." >> "$TEMP_DIR/preinstall.txt"
         launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.minion.plist
-        launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.api.plist
+        echo "Service: Unloaded Successfully" >> "$TEMP_DIR/preinstall.txt"
+    fi
+    if /bin/launchctl list "com.saltstack.salt.master" &> /dev/null; then
+        echo "Service: Unloading master..." >> "$TEMP_DIR/preinstall.txt"
         launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.master.plist
+        echo "Service: Unloaded Successfully" >> "$TEMP_DIR/preinstall.txt"
+    fi
+    if /bin/launchctl list "com.saltstack.salt.syndic" &> /dev/null; then
+        echo "Service: Unloading syndic..." >> "$TEMP_DIR/preinstall.txt"
         launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.syndic.plist
+        echo "Service: Unloaded Successfully" >> "$TEMP_DIR/preinstall.txt"
+    fi
+    if /bin/launchctl list "com.saltstack.salt.api" &> /dev/null; then
+        echo "Service: Unloading api..." >> "$TEMP_DIR/preinstall.txt"
+        launchctl unload -w /Library/LaunchDaemons/com.saltstack.salt.api.plist
         echo "Service: Unloaded Successfully" >> "$TEMP_DIR/preinstall.txt"
     fi
 }
@@ -60,14 +72,26 @@ stop_service_maverick() {
 stop_service_yosemite_and_later() {
     echo "Service: Using new (>= 10.10) launchctl interface" >> "$TEMP_DIR/preinstall.txt"
     if /bin/launchctl list "com.saltstack.salt.minion" &> /dev/null; then
-        echo "Service: Stopping..." >> "$TEMP_DIR/preinstall.txt"
+        echo "Service: Stopping minion..." >> "$TEMP_DIR/preinstall.txt"
         launchctl disable system/com.saltstack.salt.minion
-        launchctl disable system/com.saltstack.salt.master
-        launchctl disable system/com.saltstack.salt.syndic
-        launchctl disable system/com.saltstack.salt.api
         launchctl bootout system /Library/LaunchDaemons/com.saltstack.salt.minion.plist
+        echo "Service: Stopped Successfully" >> "$TEMP_DIR/preinstall.txt"
+    fi
+    if /bin/launchctl list "com.saltstack.salt.master" &> /dev/null; then
+        echo "Service: Stopping master..." >> "$TEMP_DIR/preinstall.txt"
+        launchctl disable system/com.saltstack.salt.master
         launchctl bootout system /Library/LaunchDaemons/com.saltstack.salt.master.plist
+        echo "Service: Stopped Successfully" >> "$TEMP_DIR/preinstall.txt"
+    fi
+    if /bin/launchctl list "com.saltstack.salt.syndic" &> /dev/null; then
+        echo "Service: Stopping syndic..." >> "$TEMP_DIR/preinstall.txt"
+        launchctl disable system/com.saltstack.salt.syndic
         launchctl bootout system /Library/LaunchDaemons/com.saltstack.salt.syndic.plist
+        echo "Service: Stopped Successfully" >> "$TEMP_DIR/preinstall.txt"
+    fi
+    if /bin/launchctl list "com.saltstack.salt.api" &> /dev/null; then
+        echo "Service: Stopping api..." >> "$TEMP_DIR/preinstall.txt"
+        launchctl disable system/com.saltstack.salt.api
         launchctl bootout system /Library/LaunchDaemons/com.saltstack.salt.api.plist
         echo "Service: Stopped Successfully" >> "$TEMP_DIR/preinstall.txt"
     fi

--- a/pkg/osx/pkg-scripts/preinstall
+++ b/pkg/osx/pkg-scripts/preinstall
@@ -102,6 +102,15 @@ if [ -d "$BIN_DIR" ]; then
     echo "Cleanup: Removed Successfully" >> "$TEMP_DIR/preinstall.txt"
 fi
 
+###############################################################################
+# Remove the salt from the paths.d
+###############################################################################
+if [ ! -f "/etc/paths.d/salt" ]; then
+    echo "Path: Removing salt from the path..." >> "$TEMP_DIR/preinstall.txt"
+    rm "/etc/paths.d/salt"
+    echo "Path: Removed Successfully" >> "$TEMP_DIR/preinstall.txt"
+fi
+
 echo "Preinstall Completed Successfully on:" >> "$TEMP_DIR/preinstall.txt"
 date "+%Y/%m/%d %H:%m:%S" >> "$TEMP_DIR/preinstall.txt"
 

--- a/pkg/osx/pkg-scripts/preinstall
+++ b/pkg/osx/pkg-scripts/preinstall
@@ -118,11 +118,11 @@ if [ -L "$SBIN_DIR/salt-config" ]; then
 fi
 
 ###############################################################################
-# Remove the $BIN_DIR directory
+# Remove the $INSTALL_DIR directory
 ###############################################################################
-if [ -d "$BIN_DIR" ]; then
-    echo "Cleanup: Removing $BIN_DIR" >> "$TEMP_DIR/preinstall.txt"
-    rm -rf "$BIN_DIR"
+if [ -d "$INSTALL_DIR" ]; then
+    echo "Cleanup: Removing $INSTALL_DIR" >> "$TEMP_DIR/preinstall.txt"
+    rm -rf "$INSTALL_DIR"
     echo "Cleanup: Removed Successfully" >> "$TEMP_DIR/preinstall.txt"
 fi
 


### PR DESCRIPTION
### What does this PR do?
Improves logging
Removes `/opt/salt` directory before install
Removes symlink to `salt-config` before install
Removes salt from `paths.d`

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1347

### Previous Behavior
`/opt/salt` was not deleted, causing issues when salt was upgraded. Files removed in newer versions of salt were still present in `/opt/salt`

### New Behavior
All services are now stopped and files removed before install takes place.

### Tests written?
NA