### PR TITLE
Have docker.save use the image name when valid if not use image id, i…

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -3880,8 +3880,9 @@ def save(name,
         saved_path = salt.utils.files.mkstemp()
     else:
         saved_path = path
-
-    cmd = ['docker', 'save', '-o', saved_path, inspect_image(name)['Id']]
+    # use the image name if its valid if not use the image id
+    image_to_save = name if name in inspect_image(name)['RepoTags'] else inspect_image(name)['Id']
+    cmd = ['docker', 'save', '-o', saved_path, image_to_save]
     time_started = time.time()
     result = __salt__['cmd.run_all'](cmd, python_shell=False)
     if result['retcode'] != 0:


### PR DESCRIPTION
…ssue when loading and image is savid with id issue #43043

### What does this PR do?
It selects the image name:tag or image id depending if the image name is valid 
### What issues does this PR fix or reference?
Issue #43043
### Previous Behavior
Module would select the imageid as the save name, this causes problems on docker.load
### New Behavior
Module uses the image name:tag if valid or else defaults to use the image id
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
