### PR TITLE
Mark selinux._filetype_id_to_string as public function

### DIFF
--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -404,7 +404,7 @@ def _context_string_to_dict(context):
     return ret
 
 
-def _filetype_id_to_string(filetype='a'):
+def filetype_id_to_string(filetype='a'):
     '''
     Translates SELinux filetype single-letter representation
     to a more human-readable version (which is also used in `semanage fcontext -l`).
@@ -445,7 +445,7 @@ def fcontext_get_policy(name, filetype=None, sel_type=None, sel_user=None, sel_l
                   'sel_role': '[^:]+',  # se_role for file context is always object_r
                   'sel_type': sel_type or '[^:]+',
                   'sel_level': sel_level or '[^:]+'}
-    cmd_kwargs['filetype'] = '[[:alpha:] ]+' if filetype is None else _filetype_id_to_string(filetype)
+    cmd_kwargs['filetype'] = '[[:alpha:] ]+' if filetype is None else filetype_id_to_string(filetype)
     cmd = 'semanage fcontext -l | egrep ' + \
           "'^{filespec}{spacer}{filetype}{spacer}{sel_user}:{sel_role}:{sel_type}:{sel_level}$'".format(**cmd_kwargs)
     current_entry_text = __salt__['cmd.shell'](cmd)


### PR DESCRIPTION
_filetype_id_to_string is a private function in the selinux
module.
The selinux state module calls the function as filetype_id_to_string
which fails of course.

Rename the function from the private one to a public one to make
the state call work.

Resolves #42505.
