### PR TITLE
Fix bug #42936 - win_iis module container settings

### DIFF
--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -837,6 +837,11 @@ def create_cert_binding(name, site, hostheader='', ipaddress='*', port=443,
         # IIS 7.5 and earlier have different syntax for associating a certificate with a site
         # Modify IP spec to IIS 7.5 format
         iis7path = binding_path.replace(r"\*!", "\\0.0.0.0!")
+        
+        # win 2008 uses the following format: ip!port and not ip!port!
+        if iis7path.endswith("!"):
+            iis7path = iis7path[:-1]
+        
 
         ps_cmd = ['New-Item',
                   '-Path', "'{0}'".format(iis7path),

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -1290,7 +1290,7 @@ def set_container_setting(name, container, settings):
             value = "'{0}'".format(settings[setting])
 
         # Map to numeric to support server 2008
-        if (setting == 'processModel.identityType' and settings[setting] in identityType_map2numeric.keys()):
+        if setting == 'processModel.identityType' and settings[setting] in identityType_map2numeric.keys():
             value = identityType_map2numeric[settings[setting]]
 
         ps_cmd.extend(['Set-ItemProperty',
@@ -1313,7 +1313,7 @@ def set_container_setting(name, container, settings):
 
     for setting in settings:
         # map identity type from numeric to string for comparing
-        if (setting == 'processModel.identityType' and settings[setting] in identityType_map2string.keys()):
+        if setting == 'processModel.identityType' and settings[setting] in identityType_map2string.keys():
             settings[setting] = identityType_map2string[settings[setting]]
 
         if str(settings[setting]) != str(new_settings[setting]):

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -1255,6 +1255,9 @@ def set_container_setting(name, container, settings):
         salt '*' win_iis.set_container_setting name='MyTestPool' container='AppPools'
             settings="{'managedPipeLineMode': 'Integrated'}"
     '''
+
+    identityType_map2string = {'0': 'LocalSystem', '1': 'LocalService', '2': 'NetworkService', '3': 'SpecificUser', '4': 'ApplicationPoolIdentity'}
+    identityType_map2numeric = {'LocalSystem': '0', 'LocalService': '1', 'NetworkService': '2', 'SpecificUser': '3', 'ApplicationPoolIdentity': '4'}
     ps_cmd = list()
     container_path = r"IIS:\{0}\{1}".format(container, name)
 
@@ -1281,6 +1284,10 @@ def set_container_setting(name, container, settings):
         except ValueError:
             value = "'{0}'".format(settings[setting])
 
+        # Map to numeric to support server 2008
+        if (setting == 'processModel.identityType' and settings[setting] in identityType_map2numeric.keys()):
+            value = identityType_map2numeric[settings[setting]]
+
         ps_cmd.extend(['Set-ItemProperty',
                        '-Path', "'{0}'".format(container_path),
                        '-Name', "'{0}'".format(setting),
@@ -1300,6 +1307,10 @@ def set_container_setting(name, container, settings):
     failed_settings = dict()
 
     for setting in settings:
+        # map identity type from numeric to string for comparing
+        if (setting == 'processModel.identityType' and settings[setting] in identityType_map2string.keys()):
+            settings[setting] = identityType_map2string[settings[setting]]
+
         if str(settings[setting]) != str(new_settings[setting]):
             failed_settings[setting] = settings[setting]
 

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -836,10 +836,10 @@ def create_cert_binding(name, site, hostheader='', ipaddress='*', port=443,
     if _iisVersion() < 8:
         # IIS 7.5 and earlier have different syntax for associating a certificate with a site
         # Modify IP spec to IIS 7.5 format
-        iis7path = binding_path.replace(r"\*!", "\\0.0.0.0!")        
+        iis7path = binding_path.replace(r"\*!", "\\0.0.0.0!")
         # win 2008 uses the following format: ip!port and not ip!port!
         if iis7path.endswith("!"):
-            iis7path = iis7path[:-1]    
+            iis7path = iis7path[:-1]
 
         ps_cmd = ['New-Item',
                   '-Path', "'{0}'".format(iis7path),

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -836,12 +836,10 @@ def create_cert_binding(name, site, hostheader='', ipaddress='*', port=443,
     if _iisVersion() < 8:
         # IIS 7.5 and earlier have different syntax for associating a certificate with a site
         # Modify IP spec to IIS 7.5 format
-        iis7path = binding_path.replace(r"\*!", "\\0.0.0.0!")
-        
+        iis7path = binding_path.replace(r"\*!", "\\0.0.0.0!")        
         # win 2008 uses the following format: ip!port and not ip!port!
         if iis7path.endswith("!"):
-            iis7path = iis7path[:-1]
-        
+            iis7path = iis7path[:-1]    
 
         ps_cmd = ['New-Item',
                   '-Path', "'{0}'".format(iis7path),

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -495,8 +495,7 @@ def container_setting(name, container, settings=None):
                     processModel.maxProcesses: 1
                     processModel.userName: TestUser
                     processModel.password: TestPassword
-                    processModel.identityType: SpecificUser
-      
+                    processModel.identityType: SpecificUser  
     
     Example of usage for the ``Sites`` container:
 
@@ -511,9 +510,9 @@ def container_setting(name, container, settings=None):
                     logFile.period: Daily
                     limits.maxUrlSegments: 32
     '''
-
-    identityType_map2string = {'0': 'LocalSystem', '1': 'LocalService', '2': 'NetworkService', '3': 'SpecificUser', '4': 'ApplicationPoolIdentity'}
-
+    
+    identityType_map2string = {0: 'LocalSystem', 1: 'LocalService', 2: 'NetworkService', 3: 'SpecificUser', 4: 'ApplicationPoolIdentity'}
+    
     ret = {'name': name,
            'changes': {},
            'comment': str(),

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -494,8 +494,8 @@ def container_setting(name, container, settings=None):
                     processModel.maxProcesses: 1
                     processModel.userName: TestUser
                     processModel.password: TestPassword
-                    processModel.identityType: SpecificUser  
-    
+                    processModel.identityType: SpecificUser
+
     Example of usage for the ``Sites`` container:
 
     .. code-block:: yaml
@@ -509,9 +509,8 @@ def container_setting(name, container, settings=None):
                     logFile.period: Daily
                     limits.maxUrlSegments: 32
     '''
-    
+
     identityType_map2string = {0: 'LocalSystem', 1: 'LocalService', 2: 'NetworkService', 3: 'SpecificUser', 4: 'ApplicationPoolIdentity'}
-    
     ret = {'name': name,
            'changes': {},
            'comment': str(),

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -481,7 +481,7 @@ def container_setting(name, container, settings=None):
     :param str container: The type of IIS container. The container types are:
         AppPools, Sites, SslBindings
     :param str settings: A dictionary of the setting names and their values.
-
+    
     Example of usage for the ``AppPools`` container:
 
     .. code-block:: yaml
@@ -496,7 +496,8 @@ def container_setting(name, container, settings=None):
                     processModel.userName: TestUser
                     processModel.password: TestPassword
                     processModel.identityType: SpecificUser
-
+      
+    
     Example of usage for the ``Sites`` container:
 
     .. code-block:: yaml
@@ -510,6 +511,9 @@ def container_setting(name, container, settings=None):
                     logFile.period: Daily
                     limits.maxUrlSegments: 32
     '''
+
+    identityType_map2string = {'0': 'LocalSystem', '1': 'LocalService', '2': 'NetworkService', '3': 'SpecificUser', '4': 'ApplicationPoolIdentity'}
+
     ret = {'name': name,
            'changes': {},
            'comment': str(),
@@ -529,6 +533,10 @@ def container_setting(name, container, settings=None):
                                                                  container=container,
                                                                  settings=settings.keys())
     for setting in settings:
+        # map identity type from numeric to string for comparing
+        if (setting == 'processModel.identityType' and settings[setting] in identityType_map2string.keys()):
+            settings[setting] = identityType_map2string[settings[setting]]
+
         if str(settings[setting]) != str(current_settings[setting]):
             ret_settings['changes'][setting] = {'old': current_settings[setting],
                                                 'new': settings[setting]}
@@ -541,8 +549,8 @@ def container_setting(name, container, settings=None):
         ret['changes'] = ret_settings
         return ret
 
-    __salt__['win_iis.set_container_setting'](name=name, container=container,
-                                              settings=settings)
+    __salt__['win_iis.set_container_setting'](name=name, container=container, settings=settings)
+
     new_settings = __salt__['win_iis.get_container_setting'](name=name,
                                                              container=container,
                                                              settings=settings.keys())

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -481,7 +481,6 @@ def container_setting(name, container, settings=None):
     :param str container: The type of IIS container. The container types are:
         AppPools, Sites, SslBindings
     :param str settings: A dictionary of the setting names and their values.
-    
     Example of usage for the ``AppPools`` container:
 
     .. code-block:: yaml
@@ -533,7 +532,7 @@ def container_setting(name, container, settings=None):
                                                                  settings=settings.keys())
     for setting in settings:
         # map identity type from numeric to string for comparing
-        if (setting == 'processModel.identityType' and settings[setting] in identityType_map2string.keys()):
+        if setting == 'processModel.identityType' and settings[setting] in identityType_map2string.keys():
             settings[setting] = identityType_map2string[settings[setting]]
 
         if str(settings[setting]) != str(current_settings[setting]):


### PR DESCRIPTION
### What does this PR do?
Fix bug #42936 - win_iis module container settings

### What issues does this PR fix or reference?
fix container appPools identity type setting:
- support string / numeric for server 2008 fixed
- action completed validation test fixed

### Previous Behavior
- to set identity type in server 2008 need to use numeric id
- the validation test failed cause it compared string & numeric

### Tests written?
NO

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
