### PR TITLE
Add distributed as a master_type option

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -111,9 +111,10 @@ VALID_OPTS = {
     'master_port': (six.string_types, int),
 
     # The behaviour of the minion when connecting to a master. Can specify 'failover',
-    # 'disable' or 'func'. If 'func' is specified, the 'master' option should be set to an
-    # exec module function to run to determine the master hostname. If 'disable' is specified
-    # the minion will run, but will not try to connect to a master.
+    # 'disable', 'distributed', or 'func'. If 'func' is specified, the 'master' option should be
+    # set to an exec module function to run to determine the master hostname. If 'disable' is
+    # specified the minion will run, but will not try to connect to a master. If 'distributed'
+    # is specified the minion will try to deterministically pick a master based on its' id.
     'master_type': str,
 
     # Specify the format in which the master address will be specified. Can

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -400,7 +400,7 @@ class SaltRaetRoadStackJoiner(ioflo.base.deeding.Deed):
                                                      kind=kinds.applKinds.master))
                     except gaierror as ex:
                         log.warning("Unable to connect to master {0}: {1}".format(mha, ex))
-                        if self.opts.value.get('master_type') != 'failover':
+                        if self.opts.value.get(u'master_type') not in (u'failover', u'distributed'):
                             raise ex
                 if not stack.remotes:
                     raise ex


### PR DESCRIPTION
For bootstrapping in a large infrastructure, during initial or blue-green deployments, it would be helpful if `master_type` would support picking a master more deterministically from a list.

`master_type = func` requires an initial connection for the exec state, which creates a possible bottleneck in our environment. `master_shuffle = True` is a bit too nondeterministic and is subject to the same shortcoming.

If `salt-minion` could support some sort of deterministic selection of a master from a list; this would be helpful for provisioning at scale.

This PR adds `master_type = distributed`. It uses the checksum of the `minion_id` to select a master, and in our environment the distribution has been (surprisingly) uniform.

After a master is picked, other downstream options are respected (`master_shuffle`, for instance).

I will add tests if you all agree this is PR may be useful. I am lurking in #salt-dev. Thanks!