### PR TITLE
allow docker util to be reloaded with reload_modules

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -798,7 +798,7 @@ def get_client_args():
 
         salt myminion docker.get_client_args
     '''
-    return salt.utils.docker.get_client_args()
+    return __utils__['docker.get_client_args']()
 
 
 def _get_create_kwargs(image,

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -136,10 +136,11 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
                 with patch.dict(docker_mod.__salt__,
                                 {'mine.send': mine_send,
                                  'container_resource.run': MagicMock(),
-                                 'cp.cache_file': MagicMock(return_value=False),
-                                 'docker.get_client_args': client_args_mock}):
-                    with patch.object(docker_mod, '_get_client', client):
-                        command('container', *args)
+                                 'cp.cache_file': MagicMock(return_value=False)}):
+                    with patch.dict(docker_mod.__utils__,
+                                    {'docker.get_client_args': client_args_mock}):
+                        with patch.object(docker_mod, '_get_client', client):
+                            command('container', *args)
                 mine_send.assert_called_with('docker.ps', verbose=True, all=True,
                                              host=True)
 


### PR DESCRIPTION
### What does this PR do?
If we reference the actual import, the utils module won't be reloaded, but if
we use `__utils__` it can be reloaded on a pip install

### What issues does this PR fix or reference?
No issue, just reported in an issue that was partially related, but not

### Tests written?
No