### PR TITLE
Fixed issue with silently passing all tests in Testinfra module

### DIFF
--- a/salt/modules/testinframod.py
+++ b/salt/modules/testinframod.py
@@ -242,6 +242,8 @@ def _copy_function(module_name, name=None):
             elif hasattr(mod, '__call__'):
                 mod_sig = inspect.getargspec(mod.__call__)
             parameters = mod_sig.args
+        log.debug('Parameters accepted by module {0}: {1}'.format(module_name,
+                                                                  parameters))
         additional_args = {}
         for arg in set(parameters).intersection(set(methods.keys())):
             additional_args[arg] = methods.pop(arg)
@@ -251,12 +253,15 @@ def _copy_function(module_name, name=None):
             else:
                 modinstance = mod()
         except TypeError:
-            modinstance = None
-        methods = {}
+            log.exception('Module failed to instantiate')
+            raise
+        valid_methods = {}
+        log.debug('Called methods are: {0}'.format(methods))
         for meth_name in methods:
             if not meth_name.startswith('_'):
-                methods[meth_name] = methods[meth_name]
-        for meth, arg in methods.items():
+                valid_methods[meth_name] = methods[meth_name]
+        log.debug('Valid methods are: {0}'.format(valid_methods))
+        for meth, arg in valid_methods.items():
             result = _get_method_result(mod, modinstance, meth, arg)
             assertion_result = _apply_assertion(arg, result)
             if not assertion_result:


### PR DESCRIPTION
### What does this PR do?
The Testinfra module had a line where the collection of passed arguments was silently overwritten so that it would not actually perform any assertions. Updated the variable names to address the issue of the parameters being clobbered so that asertions are performed properly.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
All tests run via testinfra module would report as successful

### New Behavior
Tests run via testinfra module perform appropriate assertions

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
