### PR TITLE
Fix ec2 list_nodes_full to work on 2017.7

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -3432,7 +3432,7 @@ def list_nodes_full(location=None, call=None):
         ret = {}
         locations = set(
             get_location(vm_) for vm_ in six.itervalues(__opts__['profiles'])
-            if _vm_provider_driver(vm_)
+            if vm_.get('driver') == 'ec2'
         )
 
         # If there aren't any profiles defined for EC2, check
@@ -3445,17 +3445,6 @@ def list_nodes_full(location=None, call=None):
         return ret
 
     return _list_nodes_full(location)
-
-
-def _vm_provider_driver(vm_):
-    alias, driver = vm_['driver'].split(':')
-    if alias not in __opts__['providers']:
-        return None
-
-    if driver not in __opts__['providers'][alias]:
-        return None
-
-    return driver == 'ec2'
 
 
 def _extract_name_tag(item):

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -3428,23 +3428,7 @@ def list_nodes_full(location=None, call=None):
             'or --function.'
         )
 
-    if not location:
-        ret = {}
-        locations = set(
-            get_location(vm_) for vm_ in six.itervalues(__opts__['profiles'])
-            if vm_.get('driver') == 'ec2'
-        )
-
-        # If there aren't any profiles defined for EC2, check
-        # the provider config file, or use the default location.
-        if not locations:
-            locations = [get_location()]
-
-        for loc in locations:
-            ret.update(_list_nodes_full(loc))
-        return ret
-
-    return _list_nodes_full(location)
+    return _list_nodes_full(location or get_location())
 
 
 def _extract_name_tag(item):


### PR DESCRIPTION
### What does this PR do?
Because of the provider/driver change in 2017.7, this function was broken doing the lookups, but after looking closer it appears that the extra logic isn't needed at all.

### Tests written?

No