### PR TITLE
Fix `group.present` for Windows

### DIFF
--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -80,7 +80,7 @@ def add(name, **kwargs):
     return ret
 
 
-def delete(name):
+def delete(name, **kwargs):
     '''
     Remove the named group
 
@@ -213,7 +213,7 @@ def getent(refresh=False):
     return ret
 
 
-def adduser(name, username):
+def adduser(name, username, **kwargs):
     '''
     Add a user to a group
 
@@ -272,7 +272,7 @@ def adduser(name, username):
     return ret
 
 
-def deluser(name, username):
+def deluser(name, username, **kwargs):
     '''
     Remove a user from a group
 
@@ -331,7 +331,7 @@ def deluser(name, username):
     return ret
 
 
-def members(name, members_list):
+def members(name, members_list, **kwargs):
     '''
     Ensure a group contains only the members in the list
 

--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -3,8 +3,13 @@
 Management of user groups
 =========================
 
-The group module is used to create and manage unix group settings, groups
-can be either present or absent:
+The group module is used to create and manage group settings, groups can be
+either present or absent. User/Group names can be passed to the ``adduser``,
+``deluser``, and ``members`` parameters. ``adduser`` and ``deluser`` can be used
+together but not with ``members``.
+
+In Windows, if no domain is specified in the user or group name (ie:
+`DOMAIN\username``) the module will assume a local user or group.
 
 .. code-block:: yaml
 
@@ -36,6 +41,10 @@ import sys
 # Import 3rd-party libs
 import salt.ext.six as six
 
+# Import Salt libs
+import salt.utils
+import salt.utils.win_functions
+
 
 def _changes(name,
              gid=None,
@@ -50,6 +59,18 @@ def _changes(name,
     if not lgrp:
         return False
 
+    # User and Domain names are not case sensitive in Windows. Let's make them
+    # all lower case so we can compare properly
+    if salt.utils.is_windows():
+        if lgrp['members']:
+            lgrp['members'] = [user.lower() for user in lgrp['members']]
+        if members:
+            members = [salt.utils.win_functions.get_sam_name(user) for user in members]
+        if addusers:
+            addusers = [salt.utils.win_functions.get_sam_name(user) for user in addusers]
+        if delusers:
+            delusers = [salt.utils.win_functions.get_sam_name(user) for user in delusers]
+
     change = {}
     if gid:
         if lgrp['gid'] != gid:
@@ -57,7 +78,7 @@ def _changes(name,
 
     if members:
         # -- if new member list if different than the current
-        if set(lgrp['members']) ^ set(members):
+        if set(lgrp['members']).symmetric_difference(members):
             change['members'] = members
 
     if addusers:
@@ -82,28 +103,55 @@ def present(name,
     '''
     Ensure that a group is present
 
-    name
-        The name of the group to manage
+    Args:
 
-    gid
-        The group id to assign to the named group; if left empty, then the next
-        available group id will be assigned
+        name (str):
+            The name of the group to manage
 
-    system
-        Whether or not the named group is a system group.  This is essentially
-        the '-r' option of 'groupadd'.
+        gid (str):
+            The group id to assign to the named group; if left empty, then the
+            next available group id will be assigned. Ignored on Windows
 
-    addusers
-        List of additional users to be added as a group members.
+        system (bool):
+            Whether or not the named group is a system group.  This is essentially
+            the '-r' option of 'groupadd'. Ignored on Windows
 
-    delusers
-        Ensure these user are removed from the group membership.
+        addusers (list):
+            List of additional users to be added as a group members. Cannot
+            conflict with names in delusers. Cannot be used in conjunction with
+            members.
 
-    members
-        Replace existing group members with a list of new members.
+        delusers (list):
+            Ensure these user are removed from the group membership. Cannot
+            conflict with names in addusers. Cannot be used in conjunction with
+            members.
 
-    Note: Options 'members' and 'addusers/delusers' are mutually exclusive and
-          can not be used together.
+        members (list):
+            Replace existing group members with a list of new members. Cannot be
+            used in conjunction with addusers or delusers.
+
+    Example:
+
+    .. code-block:: yaml
+
+        # Adds DOMAIN\db_admins and Administrators to the local db_admin group
+        # Removes Users
+        db_admin:
+          group.present:
+            - addusers:
+              - DOMAIN\db_admins
+              - Administrators
+            - delusers:
+              - Users
+
+        # Ensures only DOMAIN\domain_admins and the local Administrator are
+        # members of the local Administrators group. All other users are
+        # removed
+        Administrators:
+          group.present:
+            - members:
+              - DOMAIN\domain_admins
+              - Administrator
     '''
     ret = {'name': name,
            'changes': {},
@@ -233,8 +281,17 @@ def absent(name):
     '''
     Ensure that the named group is absent
 
-    name
-        The name of the group to remove
+    Args:
+        name (str):
+            The name of the group to remove
+
+    Example:
+
+    .. code-block:: yaml
+
+        # Removes the local group `db_admin`
+        db_admin:
+          group.absent
     '''
     ret = {'name': name,
            'changes': {},

--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-'''
+r'''
 Management of user groups
 =========================
 
@@ -100,7 +100,7 @@ def present(name,
             addusers=None,
             delusers=None,
             members=None):
-    '''
+    r'''
     Ensure that a group is present
 
     Args:

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -4,6 +4,9 @@ Various functions to be used by windows during start up and to monkey patch
 missing functions in other modules
 '''
 from __future__ import absolute_import
+import platform
+
+# Import Salt Libs
 from salt.exceptions import CommandExecutionError
 
 # Import 3rd Party Libs
@@ -138,3 +141,19 @@ def get_current_user():
         return False
 
     return user_name
+
+
+def get_sam_name(username):
+    '''
+    Gets the SAM name for a user. It basically prefixes a username without a
+    backslash with the computer name. If the username contains a backslash, it
+    is returned as is.
+
+    Everything is returned lower case
+
+    i.e. salt.utils.fix_local_user('Administrator') would return 'computername\administrator'
+    '''
+    if '\\' not in username:
+        username = '{0}\\{1}'.format(platform.node(), username)
+
+    return username.lower()


### PR DESCRIPTION
### What does this PR do?
`group.present` now accepts group names without domains. `group.present` no longer fails when the domain is not specified in the usernames for `addusers`, `delusers` and `members_list`. If the domain is not specified it is assumed to be a local group.
When the domain name is passed, cases are all lowered for comparison.
Improved documentation.
Moved `__fixlocaluser` function from the module to salt.utils.win_functions as `get_sam_name`. This is used by the state to determine the hostname for groups without domains.
Added `**kwargs` to functions where there are additional parameters in their Linux counterparts.

### What issues does this PR fix or reference?
https://github.com/saltstack/zh/issues/1348
https://github.com/saltstack/zh/issues/1212

### Previous Behavior
Adding local users wasn't clear and impractical when spanning multiple machines. You would have to put the hostname for each machine in the Jinja.
Even when the domain name was passed the state would still fail due to comparison issues having to do with the case.

### New Behavior
Groups without domains are assumed to be local groups.

### Tests written?
No