### PR TITLE
[DOCS] Add missing `utils` sub-dir listed for `extension_modules`

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -59,15 +59,14 @@
 
 # Directory for custom modules. This directory can contain subdirectories for
 # each of Salt's module types such as "runners", "output", "wheel", "modules",
-# "states", "returners", etc.
-#extension_modules: <no default>
+# "states", "returners", "engines", "utils", etc.
+#extension_modules: /var/cache/salt/master/extmods
 
 # Directory for custom modules. This directory can contain subdirectories for
 # each of Salt's module types such as "runners", "output", "wheel", "modules",
-# "states", "returners", "engines", etc.
+# "states", "returners", "engines", "utils", etc.
 # Like 'extension_modules' but can take an array of paths
-#module_dirs: <no default>
-#   - /var/cache/salt/minion/extmods
+#module_dirs: []
 
 # Verify and set permissions on configuration directories at startup:
 #verify_env: True

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -180,8 +180,8 @@ The directory to store the pki authentication keys.
 
 Directory for custom modules. This directory can contain subdirectories for
 each of Salt's module types such as ``runners``, ``output``, ``wheel``,
-``modules``, ``states``, ``returners``, ``engines``, etc. This path is appended to
-:conf_master:`root_dir`.
+``modules``, ``states``, ``returners``, ``engines``, ``utils``, etc.
+This path is appended to :conf_master:`root_dir`.
 
 .. code-block:: yaml
 

--- a/doc/topics/utils/index.rst
+++ b/doc/topics/utils/index.rst
@@ -87,8 +87,8 @@ Also you could even write your utility modules in object oriented fashion:
 
     # -*- coding: utf-8 -*-
     '''
-    My utils module
-    ---------------
+    My OOP-style utils module
+    -------------------------
 
     This module contains common functions for use in my other custom types.
     '''


### PR DESCRIPTION
### What does this PR do?
It adds `utils` sub directory as a valid extension module type described in Salt Master config example and documentation. Also, updates real default value for `extension_modules` option.
