### PR TITLE
genesis.bootstrap deboostrap fix

### DIFF
--- a/salt/modules/genesis.py
+++ b/salt/modules/genesis.py
@@ -180,13 +180,9 @@ def bootstrap(
 
     if pkgs is None:
         pkgs = []
-    elif isinstance(pkgs, six.string_types):
-        pkgs = pkgs.split(',')
 
     if exclude_pkgs is None:
         exclude_pkgs = []
-    elif isinstance(exclude_pkgs, six.string_types):
-        exclude_pkgs = exclude_pkgs.split(',')
 
     if platform in ('rpm', 'yum'):
         _bootstrap_yum(
@@ -331,6 +327,8 @@ def _bootstrap_yum(
     '''
     if pkgs is None:
         pkgs = []
+    elif isinstance(pkgs, six.string_types):
+        pkgs = pkgs.split(',')
 
     default_pkgs = ('yum', 'centos-release', 'iputils')
     for pkg in default_pkgs:
@@ -339,6 +337,8 @@ def _bootstrap_yum(
 
     if exclude_pkgs is None:
         exclude_pkgs = []
+    elif isinstance(exclude_pkgs, six.string_types):
+        exclude_pkgs = exclude_pkgs.split(',')
 
     for pkg in exclude_pkgs:
         pkgs.remove(pkg)
@@ -403,6 +403,11 @@ def _bootstrap_deb(
         log.error('Required tool debootstrap is not installed.')
         return False
 
+    if isinstance(pkgs, (list, tuple)):
+        pkgs = ','.join(pkgs)
+    if isinstance(exclude_pkgs, (list, tuple)):
+        exclude_pkgs = ','.join(exclude_pkgs)
+
     deb_args = [
         'debootstrap',
         '--foreign',
@@ -410,9 +415,9 @@ def _bootstrap_deb(
         _cmd_quote(arch)]
 
     if pkgs:
-        deb_args += ['--include'] + pkgs
+        deb_args += ['--include', _cmd_quote(pkgs)]
     if exclude_pkgs:
-        deb_args += ['--exclude'] + exclude_pkgs
+        deb_args += ['--exclude', _cmd_quote(exclude_pkgs)]
 
     deb_args += [
         _cmd_quote(flavor),
@@ -482,6 +487,8 @@ def _bootstrap_pacman(
 
     if pkgs is None:
         pkgs = []
+    elif isinstance(pkgs, six.string_types):
+        pkgs = pkgs.split(',')
 
     default_pkgs = ('pacman', 'linux', 'systemd-sysvcompat', 'grub')
     for pkg in default_pkgs:
@@ -490,6 +497,8 @@ def _bootstrap_pacman(
 
     if exclude_pkgs is None:
         exclude_pkgs = []
+    elif isinstance(exclude_pkgs, six.string_types):
+        exclude_pkgs = exclude_pkgs.split(',')
 
     for pkg in exclude_pkgs:
         pkgs.remove(pkg)

--- a/tests/unit/modules/genesis_test.py
+++ b/tests/unit/modules/genesis_test.py
@@ -60,31 +60,31 @@ class GenesisTestCase(TestCase):
 
             {'params': {},
              'cmd': ['debootstrap', '--foreign', '--arch', 'amd64',
-                              'stable', 'root', 'http://ftp.debian.org/debian/']
+                     'stable', 'root', 'http://ftp.debian.org/debian/']
              },
 
             {'params': {'pkgs': 'vim'},
              'cmd': ['debootstrap', '--foreign', '--arch', 'amd64',
-                              '--include', 'vim',
-                              'stable', 'root', 'http://ftp.debian.org/debian/']
+                     '--include', 'vim',
+                     'stable', 'root', 'http://ftp.debian.org/debian/']
              },
 
             {'params': {'pkgs': 'vim,emacs'},
              'cmd': ['debootstrap', '--foreign', '--arch', 'amd64',
-                              '--include', 'vim,emacs',
-                              'stable', 'root', 'http://ftp.debian.org/debian/']
+                     '--include', 'vim,emacs',
+                     'stable', 'root', 'http://ftp.debian.org/debian/']
              },
 
             {'params': {'pkgs': ['vim', 'emacs']},
              'cmd': ['debootstrap', '--foreign', '--arch', 'amd64',
-                              '--include', 'vim,emacs',
-                              'stable', 'root', 'http://ftp.debian.org/debian/']
+                     '--include', 'vim,emacs',
+                     'stable', 'root', 'http://ftp.debian.org/debian/']
              },
 
             {'params': {'pkgs': ['vim', 'emacs'], 'exclude_pkgs': ['vim', 'foo']},
              'cmd': ['debootstrap', '--foreign', '--arch', 'amd64',
-                              '--include', 'vim,emacs', '--exclude', 'vim,foo',
-                              'stable', 'root', 'http://ftp.debian.org/debian/']
+                     '--include', 'vim,emacs', '--exclude', 'vim,foo',
+                     'stable', 'root', 'http://ftp.debian.org/debian/']
              },
 
         ]

--- a/tests/unit/modules/genesis_test.py
+++ b/tests/unit/modules/genesis_test.py
@@ -59,38 +59,33 @@ class GenesisTestCase(TestCase):
         param_sets = [
 
             {'params': {},
-             'commandlines': [
-                 ['debootstrap', '--foreign', '--arch', 'amd64',
-                 'stable', 'root', 'http://ftp.debian.org/debian/'],
-            ]},
+             'cmd': ['debootstrap', '--foreign', '--arch', 'amd64',
+                              'stable', 'root', 'http://ftp.debian.org/debian/']
+             },
 
             {'params': {'pkgs': 'vim'},
-             'commandlines': [
-                 ['debootstrap', '--foreign', '--arch', 'amd64',
-                  '--include', 'vim',
-                  'stable', 'root', 'http://ftp.debian.org/debian/'],
-            ]},
+             'cmd': ['debootstrap', '--foreign', '--arch', 'amd64',
+                              '--include', 'vim',
+                              'stable', 'root', 'http://ftp.debian.org/debian/']
+             },
 
             {'params': {'pkgs': 'vim,emacs'},
-             'commandlines': [
-                 ['debootstrap', '--foreign', '--arch', 'amd64',
-                  '--include', 'vim,emacs',
-                  'stable', 'root', 'http://ftp.debian.org/debian/'],
-            ]},
+             'cmd': ['debootstrap', '--foreign', '--arch', 'amd64',
+                              '--include', 'vim,emacs',
+                              'stable', 'root', 'http://ftp.debian.org/debian/']
+             },
 
             {'params': {'pkgs': ['vim', 'emacs']},
-             'commandlines': [
-                 ['debootstrap', '--foreign', '--arch', 'amd64',
-                  '--include', 'vim,emacs',
-                  'stable', 'root', 'http://ftp.debian.org/debian/'],
-            ]},
+             'cmd': ['debootstrap', '--foreign', '--arch', 'amd64',
+                              '--include', 'vim,emacs',
+                              'stable', 'root', 'http://ftp.debian.org/debian/']
+             },
 
             {'params': {'pkgs': ['vim', 'emacs'], 'exclude_pkgs': ['vim', 'foo']},
-             'commandlines': [
-                 ['debootstrap', '--foreign', '--arch', 'amd64',
-                  '--include', 'vim,emacs', '--exclude', 'vim,foo',
-                  'stable', 'root', 'http://ftp.debian.org/debian/'],
-            ]},
+             'cmd': ['debootstrap', '--foreign', '--arch', 'amd64',
+                              '--include', 'vim,emacs', '--exclude', 'vim,foo',
+                              'stable', 'root', 'http://ftp.debian.org/debian/']
+             },
 
         ]
 
@@ -99,13 +94,12 @@ class GenesisTestCase(TestCase):
             with patch.dict(genesis.__salt__, {'mount.umount': MagicMock(),
                                                'file.rmdir': MagicMock(),
                                                'file.directory_exists': MagicMock(),
-                                               'cmd.run': MagicMock()}):
-                with patch.dict(genesis.__salt__, {'disk.blkid': MagicMock(return_value={})}):
+                                               'cmd.run': MagicMock(),
+                                               'disk.blkid': MagicMock(return_value={})}):
+                with patch('salt.modules.genesis.salt.utils.which', return_value=True):
                     param_set['params'].update(common_parms)
-                    self.assertEqual(genesis.bootstrap(**param_set['params']),
-                                     None)
-                    for commandline in param_set['commandlines']:
-                        genesis.__salt__['cmd.run'].assert_any_call(commandline, python_shell=False)
+                    self.assertEqual(genesis.bootstrap(**param_set['params']), None)
+                    genesis.__salt__['cmd.run'].assert_any_call(param_set['cmd'], python_shell=False)
 
         with patch.object(genesis, '_bootstrap_pacman', return_value='A') as pacman_patch:
             with patch.dict(genesis.__salt__, {'mount.umount': MagicMock(),

--- a/tests/unit/modules/genesis_test.py
+++ b/tests/unit/modules/genesis_test.py
@@ -66,14 +66,14 @@ class GenesisTestCase(TestCase):
 
             {'params': {'pkgs': 'vim'},
              'commandlines': [
-                 ['debootstrap', '--foreign', '--arch', 'amd64', 
+                 ['debootstrap', '--foreign', '--arch', 'amd64',
                   '--include', 'vim',
                   'stable', 'root', 'http://ftp.debian.org/debian/'],
             ]},
 
             {'params': {'pkgs': 'vim,emacs'},
              'commandlines': [
-                 ['debootstrap', '--foreign', '--arch', 'amd64', 
+                 ['debootstrap', '--foreign', '--arch', 'amd64',
                   '--include', 'vim,emacs',
                   'stable', 'root', 'http://ftp.debian.org/debian/'],
             ]},


### PR DESCRIPTION
### What does this PR do?

It fixes `genesis.bootstrap` deboostrap part by:

 * allowing empty/comma separated strings in `pkgs`/`exclude_pkgs` parameters
 * failing gracefully if no debootstrap command is found in path

### What issues does this PR fix or reference?

closes #43101 
