### PR TITLE
Remove obsolete check for test mode in failhard

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2038,8 +2038,6 @@ class State(object):
         if self.opts.get(u'test', False):
             return False
         if (low.get(u'failhard', False) or self.opts[u'failhard']) and tag in running:
-            if running[tag][u'result'] is None:
-                return False
             return not running[tag][u'result']
         return False
 


### PR DESCRIPTION
There is an explicit check above to ignore failhard in test=True mode,
so this check to continue on results of `None` is obsolete.

### What does this PR do?
Remove an obsolete check.

### What issues does this PR fix or reference?
Essentially reverts #36078 as #36199 was merged later.
Discussion on the issue #18341.

### Previous Behavior
Failhard is ignored in test=True mode.

### New Behavior
Unchanged

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
