### PR TITLE
Fix `unit.utils.test_which` for Windows

### DIFF
--- a/tests/unit/utils/test_which.py
+++ b/tests/unit/utils/test_which.py
@@ -44,18 +44,21 @@ class TestWhich(TestCase):
                 # The second, iterating through $PATH, should also return False,
                 # still checking for Linux
                 False,
+                # We will now also return False once so we get a .EXE back from
+                # the function, see PATHEXT below.
+                False,
                 # Lastly return True, this is the windows check.
                 True
             ]
             # Let's patch os.environ to provide a custom PATH variable
-            with patch.dict(os.environ, {'PATH': '/bin'}):
+            with patch.dict(os.environ, {'PATH': '/bin',
+                                         'PATHEXT': '.COM;.EXE;.BAT;.CMD'}):
                 # Let's also patch is_windows to return True
                 with patch('salt.utils.is_windows', lambda: True):
                     with patch('os.path.isfile', lambda x: True):
                         self.assertEqual(
                             salt.utils.which('this-binary-exists-under-windows'),
-                            # The returned path should return the .exe suffix
-                            '/bin/this-binary-exists-under-windows.EXE'
+                            os.path.join('/bin', 'this-binary-exists-under-windows.EXE')
                         )
 
     def test_missing_binary_in_windows(self):
@@ -106,6 +109,5 @@ class TestWhich(TestCase):
                     with patch('os.path.isfile', lambda x: True):
                         self.assertEqual(
                             salt.utils.which('this-binary-exists-under-windows'),
-                            # The returned path should return the .exe suffix
-                            '/bin/this-binary-exists-under-windows.CMD'
+                            os.path.join('/bin', 'this-binary-exists-under-windows.CMD')
                         )


### PR DESCRIPTION
### What does this PR do?
This test wasn't really written with Windows in mind. Uses PATHEXT that actually resembles a Windows environment.
The test value has the correct path separator for Windows.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes