### PR TITLE
Import util modules on Master like it works on Minion

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -533,6 +533,9 @@
 # Add any additional locations to look for master runners:
 #runner_dirs: []
 
+# Add any additional locations to look for master utils:
+#utils_dirs: []
+
 # Enable Cython for master side modules:
 #cython_enable: False
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1731,6 +1731,22 @@ Set additional directories to search for runner modules.
     runner_dirs:
       - /var/lib/salt/runners
 
+.. conf_master:: utils_dirs
+
+``utils_dirs``
+---------------
+
+.. versionadded:: Oxygen
+
+Default: ``[]``
+
+Set additional directories to search for util modules.
+
+.. code-block:: yaml
+
+    utils_dirs:
+      - /var/lib/salt/utils
+
 .. conf_master:: cython_enable
 
 ``cython_enable``

--- a/doc/topics/utils/index.rst
+++ b/doc/topics/utils/index.rst
@@ -81,6 +81,10 @@ the ``foo`` utility module with a ``__virtual__`` function.
     def bar():
         return 'baz'
 
+.. versionadded:: Oxygen
+    Instantiating objects from classes declared in util modules works with
+    Master side modules, such as Runners, Outputters, etc.
+
 Also you could even write your utility modules in object oriented fashion:
 
 .. code-block:: python

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1473,8 +1473,9 @@ DEFAULT_MASTER_OPTS = {
     'syndic_forward_all_events': False,
     'syndic_log_file': os.path.join(salt.syspaths.LOGS_DIR, 'syndic'),
     'syndic_pidfile': os.path.join(salt.syspaths.PIDFILE_DIR, 'salt-syndic.pid'),
-    'runner_dirs': [],
     'outputter_dirs': [],
+    'runner_dirs': [],
+    'utils_dirs': [],
     'client_acl_verify': True,
     'publisher_acl': {},
     'publisher_acl_blacklist': {},
@@ -3601,12 +3602,23 @@ def apply_master_config(overrides=None, defaults=None):
     if len(opts['sock_dir']) > len(opts['cachedir']) + 10:
         opts['sock_dir'] = os.path.join(opts['cachedir'], '.salt-unix')
 
+    opts['token_dir'] = os.path.join(opts['cachedir'], 'tokens')
+    opts['syndic_dir'] = os.path.join(opts['cachedir'], 'syndics')
+    # Make sure ext_mods gets set if it is an untrue value
+    # (here to catch older bad configs)
     opts['extension_modules'] = (
         opts.get('extension_modules') or
         os.path.join(opts['cachedir'], 'extmods')
     )
-    opts['token_dir'] = os.path.join(opts['cachedir'], 'tokens')
-    opts['syndic_dir'] = os.path.join(opts['cachedir'], 'syndics')
+    # Set up the utils_dirs location from the extension_modules location
+    opts['utils_dirs'] = (
+        opts.get('utils_dirs') or
+        [os.path.join(opts['extension_modules'], 'utils')]
+    )
+
+    # Insert all 'utils_dirs' directories to the system path
+    insert_system_path(opts, opts['utils_dirs'])
+
     if (overrides or {}).get('ipc_write_buffer', '') == 'dynamic':
         opts['ipc_write_buffer'] = _DFLT_IPC_WBUFFER
     if 'ipc_write_buffer' not in overrides:


### PR DESCRIPTION
### What does this PR do?
The main purpose of this PR is to allow instantiating objects from classes declared in util modules to work with Master side modules, such as Runners, Outputters, etc, like it already possible to do in Minion modules.
Also, it introduces `utils_dirs` configuration option to add any directories as a source of utility modules without the need to follow a structure enforced by `extension_modules` or `module_dirs`.

### Previous Behavior
It was not possible to develop Master side module, which directly imports utils Python modules.

### New Behavior
All configured utils directories will be added to the system paths, so util modules become importable.

### Tests written?
No.
