### PR TITLE
Fix versionadded reference for new eauth token modularity

### DIFF
--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -529,7 +529,7 @@ def sync_roster(saltenv='base', extmod_whitelist=None, extmod_blacklist=None):
 
 def sync_eauth_tokens(saltenv='base', extmod_whitelist=None, extmod_blacklist=None):
     '''
-    .. versionadded:: 2017.7.2
+    .. versionadded:: Oxygen
 
     Sync eauth token modules from ``salt://_tokens`` to the master
 


### PR DESCRIPTION
The version should be `Oxygen`, not `2017.7.2`.

Refs #42720
