### PR TITLE
Fix iptables.get_rules when rules contain --nfmask or --ctmask

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -1455,6 +1455,8 @@ def _parser():
     add_arg('--or-mark', dest='or-mark', action='append')
     add_arg('--xor-mark', dest='xor-mark', action='append')
     add_arg('--set-mark', dest='set-mark', action='append')
+    add_arg('--nfmask', dest='nfmask', action='append')
+    add_arg('--ctmask', dest='ctmask', action='append')
     ## CONNSECMARK
     add_arg('--save', dest='save', action='append')
     add_arg('--restore', dest='restore', action='append')


### PR DESCRIPTION
### What does this PR do?

This PR fixes the`iptables.get_rules` in case iptables rules containing `--nfmask` or `--ctmask` exist on the minion, which also fixes the `iptables.append` state in such a case.

### What issues does this PR fix or reference?

`iptables-save` can return rules like this one:

```
-A PREROUTING -m connmark ! --mark 0x0/0xffff0000 -j CONNMARK --restore-mark --nfmask 0xffff0000 --ctmask 0xffff0000
```

which leads to the following behavior:

```console
$ salt '*' iptables.get_rules
minion:
    Minion did not return. [No response]
```

### Previous Behavior

```console
$ salt '*' iptables.get_rules
minion:
    Minion did not return. [No response]
```

### New Behavior

```console
$ salt '*' iptables.get_rules
minion:
    ----------
    filter:
        ----------
        FORWARD:
            ----------
            byte count:
                0
            packet count:
                0
            policy:
                ACCEPT
            rules:
            rules_comment:
                ----------
        INPUT:
            ----------
            byte count:
                3168
            packet count:
                36
            policy:
                ACCEPT
            rules:
            rules_comment:
                ----------
        OUTPUT:
            ----------
            byte count:
                3612
            packet count:
                28
            policy:
                ACCEPT
            rules:
            rules_comment:
                ----------
    nat:
        ----------
        INPUT:
            ----------
            byte count:
                0
            packet count:
                0
            policy:
                ACCEPT
            rules:
            rules_comment:
                ----------
        OUTPUT:
            ----------
            byte count:
                624
            packet count:
                9
            policy:
                ACCEPT
            rules:
            rules_comment:
                ----------
        POSTROUTING:
            ----------
            byte count:
                624
            packet count:
                9
            policy:
                ACCEPT
            rules:
            rules_comment:
                ----------
        PREROUTING:
            ----------
            byte count:
                0
            packet count:
                0
            policy:
                ACCEPT
            rules:
                |_
                  ----------
                  ctmask:
                      - 0xffff0000
                  jump:
                      - CONNMARK
                  mark:
                      - ! 0x0/0xffff0000
                  match:
                      - connmark
                  nfmask:
                      - 0xffff0000
                  restore-mark:
            rules_comment:
                ----------
```

### Tests written?

No