### PR TITLE
Adding custom beacons with beacon module

### DIFF
--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -59,7 +59,7 @@ class Beacon(object):
 
             if 'enabled' in current_beacon_config:
                 if not current_beacon_config['enabled']:
-                    log.trace('Beacon {0} disabled'.format(mod))
+                    log.trace('Beacon %s disabled', mod)
                     continue
                 else:
                     # remove 'enabled' item before processing the beacon
@@ -68,7 +68,7 @@ class Beacon(object):
                     else:
                         self._remove_list_item(config[mod], 'enabled')
 
-            log.trace('Beacon processing: {0}'.format(mod))
+            log.trace('Beacon processing: %s', mod)
             fun_str = '{0}.beacon'.format(mod)
             validate_str = '{0}.validate'.format(mod)
             if fun_str in self.beacons:
@@ -77,10 +77,10 @@ class Beacon(object):
                 if interval:
                     b_config = self._trim_config(b_config, mod, 'interval')
                     if not self._process_interval(mod, interval):
-                        log.trace('Skipping beacon {0}. Interval not reached.'.format(mod))
+                        log.trace('Skipping beacon %s. Interval not reached.', mod)
                         continue
                 if self._determine_beacon_config(current_beacon_config, 'disable_during_state_run'):
-                    log.trace('Evaluting if beacon {0} should be skipped due to a state run.'.format(mod))
+                    log.trace('Evaluting if beacon %s should be skipped due to a state run.', mod)
                     b_config = self._trim_config(b_config, mod, 'disable_during_state_run')
                     is_running = False
                     running_jobs = salt.utils.minion.running(self.opts)
@@ -90,10 +90,10 @@ class Beacon(object):
                     if is_running:
                         close_str = '{0}.close'.format(mod)
                         if close_str in self.beacons:
-                            log.info('Closing beacon {0}. State run in progress.'.format(mod))
+                            log.info('Closing beacon %s. State run in progress.', mod)
                             self.beacons[close_str](b_config[mod])
                         else:
-                            log.info('Skipping beacon {0}. State run in progress.'.format(mod))
+                            log.info('Skipping beacon %s. State run in progress.', mod)
                         continue
                 # Update __grains__ on the beacon
                 self.beacons[fun_str].__globals__['__grains__'] = grains
@@ -120,7 +120,7 @@ class Beacon(object):
                 if runonce:
                     self.disable_beacon(mod)
             else:
-                log.warning('Unable to process beacon {0}'.format(mod))
+                log.warning('Unable to process beacon %s', mod)
         return ret
 
     def _trim_config(self, b_config, mod, key):
@@ -149,19 +149,19 @@ class Beacon(object):
         Process beacons with intervals
         Return True if a beacon should be run on this loop
         '''
-        log.trace('Processing interval {0} for beacon mod {1}'.format(interval, mod))
+        log.trace('Processing interval %s for beacon mod %s', interval, mod)
         loop_interval = self.opts['loop_interval']
         if mod in self.interval_map:
             log.trace('Processing interval in map')
             counter = self.interval_map[mod]
-            log.trace('Interval counter: {0}'.format(counter))
+            log.trace('Interval counter: %s', counter)
             if counter * loop_interval >= interval:
                 self.interval_map[mod] = 1
                 return True
             else:
                 self.interval_map[mod] += 1
         else:
-            log.trace('Interval process inserting mod: {0}'.format(mod))
+            log.trace('Interval process inserting mod: %s', mod)
             self.interval_map[mod] = 1
         return False
 
@@ -219,7 +219,7 @@ class Beacon(object):
         List the available beacons
         '''
         _beacons = ['{0}'.format(_beacon.replace('.beacon', ''))
-                    for _beacon in list(self.beacons) if '.beacon' in _beacon]
+                    for _beacon in self.beacons if '.beacon' in _beacon]
 
         # Fire the complete event back along with the list of beacons
         evt = salt.utils.event.get_event('minion', opts=self.opts)
@@ -240,8 +240,8 @@ class Beacon(object):
                 del beacon_data['enabled']
             valid, vcomment = self.beacons[validate_str](beacon_data)
         else:
-            log.info('Beacon {0} does not have a validate'
-                     ' function,  skipping validation.'.format(name))
+            log.info('Beacon %s does not have a validate'
+                     ' function,  skipping validation.', name)
             valid = True
 
         # Fire the complete event back along with the list of beacons
@@ -263,9 +263,9 @@ class Beacon(object):
 
         if name in self.opts['beacons']:
             log.info('Updating settings for beacon '
-                     'item: {0}'.format(name))
+                     'item: %s', name)
         else:
-            log.info('Added new beacon item {0}'.format(name))
+            log.info('Added new beacon item %s', name)
         self.opts['beacons'].update(data)
 
         # Fire the complete event back along with updated list of beacons
@@ -284,7 +284,7 @@ class Beacon(object):
         data[name] = beacon_data
 
         log.info('Updating settings for beacon '
-                 'item: {0}'.format(name))
+                 'item: %s', name)
         self.opts['beacons'].update(data)
 
         # Fire the complete event back along with updated list of beacons
@@ -300,7 +300,7 @@ class Beacon(object):
         '''
 
         if name in self.opts['beacons']:
-            log.info('Deleting beacon item {0}'.format(name))
+            log.info('Deleting beacon item %s', name)
             del self.opts['beacons'][name]
 
         # Fire the complete event back along with updated list of beacons

--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -214,6 +214,29 @@ class Beacon(object):
 
         return True
 
+    def validate_beacon(self, name, beacon_data):
+        '''
+        Return available beacon functions
+        '''
+        validate_str = '{}.validate'
+        # Run the validate function if it's available,
+        # otherwise there is a warning about it being missing
+        if validate_str in self.beacons:
+            valid, vcomment = self.beacons[validate_str](b_config[mod])
+
+            if not valid:
+                log.info('Beacon %s configuration invalid, '
+                         'not running.\n%s', mod, vcomment)
+                continue
+
+        # Fire the complete event back along with the list of beacons
+        evt = salt.utils.event.get_event('minion', opts=self.opts)
+        log.debug('=== self.beacons {} ==='.format(list(self.beacons)))
+        evt.fire_event({'complete': True, 'beacons': list(self.beacons)},
+                       tag='/salt/minion/minion_available_beacons')
+
+        return True
+
     def add_beacon(self, name, beacon_data):
         '''
         Add a beacon item

--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -214,26 +214,42 @@ class Beacon(object):
 
         return True
 
+    def list_available_beacons(self):
+        '''
+        List the available beacons
+        '''
+        _beacons = ['{0}'.format(_beacon.replace('.beacon', ''))
+                    for _beacon in list(self.beacons) if '.beacon' in _beacon]
+
+        # Fire the complete event back along with the list of beacons
+        evt = salt.utils.event.get_event('minion', opts=self.opts)
+        evt.fire_event({'complete': True, 'beacons': _beacons},
+                       tag='/salt/minion/minion_beacons_list_available_complete')
+
+        return True
+
     def validate_beacon(self, name, beacon_data):
         '''
         Return available beacon functions
         '''
-        validate_str = '{}.validate'
+        validate_str = '{}.validate'.format(name)
         # Run the validate function if it's available,
         # otherwise there is a warning about it being missing
         if validate_str in self.beacons:
-            valid, vcomment = self.beacons[validate_str](b_config[mod])
-
-            if not valid:
-                log.info('Beacon %s configuration invalid, '
-                         'not running.\n%s', mod, vcomment)
-                continue
+            if 'enabled' in beacon_data:
+                del beacon_data['enabled']
+            valid, vcomment = self.beacons[validate_str](beacon_data)
+        else:
+            log.info('Beacon {0} does not have a validate'
+                     ' function,  skipping validation.'.format(name))
+            valid = True
 
         # Fire the complete event back along with the list of beacons
         evt = salt.utils.event.get_event('minion', opts=self.opts)
-        log.debug('=== self.beacons {} ==='.format(list(self.beacons)))
-        evt.fire_event({'complete': True, 'beacons': list(self.beacons)},
-                       tag='/salt/minion/minion_available_beacons')
+        evt.fire_event({'complete': True,
+                        'vcomment': vcomment,
+                        'valid': valid},
+                       tag='/salt/minion/minion_beacon_validation_complete')
 
         return True
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1930,6 +1930,8 @@ class Minion(MinionBase):
             self.beacons.disable_beacon(name)
         elif func == u'list':
             self.beacons.list_beacons()
+        elif func == u'validate_beacon':
+            self.beacons.validate_beacon(name, beacon_data)
 
     def environ_setenv(self, tag, data):
         '''

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1930,6 +1930,8 @@ class Minion(MinionBase):
             self.beacons.disable_beacon(name)
         elif func == u'list':
             self.beacons.list_beacons()
+        elif func == u'list_available':
+            self.beacons.list_available_beacons()
         elif func == u'validate_beacon':
             self.beacons.validate_beacon(name, beacon_data)
 

--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -242,11 +242,11 @@ def modify(name, beacon_data, **kwargs):
         _current_lines = []
         for _item in _current:
             _current_lines.extend(['{0}:{1}\n'.format(key, value)
-                                  for (key, value) in six.iteritems(_current[0])])
+                                  for (key, value) in six.iteritems(_item)])
         _new_lines = []
         for _item in _new:
             _new_lines.extend(['{0}:{1}\n'.format(key, value)
-                              for (key, value) in six.iteritems(_new[0])])
+                              for (key, value) in six.iteritems(_item)])
         _diff = difflib.unified_diff(_current_lines, _new_lines)
 
         ret['changes'] = {}

--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 import difflib
 import logging
 import os
+import six
 import yaml
 
 # Import Salt libs
@@ -69,6 +70,47 @@ def list_(return_yaml=True):
         return {'beacons': {}}
 
 
+def list_available(return_yaml=True):
+    '''
+    List the beacons currently available on the minion
+
+    :param return_yaml:     Whether to return YAML formatted output, default True
+    :return:                List of currently configured Beacons.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' beacons.list_available
+
+    '''
+    beacons = None
+
+    try:
+        eventer = salt.utils.event.get_event('minion', opts=__opts__)
+        res = __salt__['event.fire']({'func': 'list_available'}, 'manage_beacons')
+        if res:
+            event_ret = eventer.get_event(tag='/salt/minion/minion_beacons_list_available_complete', wait=30)
+            if event_ret and event_ret['complete']:
+                beacons = event_ret['beacons']
+    except KeyError:
+        # Effectively a no-op, since we can't really return without an event system
+        ret = {}
+        ret['result'] = False
+        ret['comment'] = 'Event module not available. Beacon add failed.'
+        return ret
+
+    if beacons:
+        if return_yaml:
+            tmp = {'beacons': beacons}
+            yaml_out = yaml.safe_dump(tmp, default_flow_style=False)
+            return yaml_out
+        else:
+            return beacons
+    else:
+        return {'beacons': {}}
+
+
 def add(name, beacon_data, **kwargs):
     '''
     Add a beacon on the minion
@@ -95,43 +137,34 @@ def add(name, beacon_data, **kwargs):
         ret['result'] = True
         ret['comment'] = 'Beacon: {0} would be added.'.format(name)
     else:
-        # Attempt to load the beacon module so we have access to the validate function
         try:
+            # Attempt to load the beacon module so we have access to the validate function
             eventer = salt.utils.event.get_event('minion', opts=__opts__)
-            res = __salt__['event.fire']({'name': name, 'func': 'available_beacons'}, 'manage_beacons')
+            res = __salt__['event.fire']({'name': name,
+                                          'beacon_data': beacon_data,
+                                          'func': 'validate_beacon'},
+                                         'manage_beacons')
             if res:
-                event_ret = eventer.get_event(tag='/salt/minion/minion_available_beacons', wait=30)
-                log.debug('=== event_ret {} ==='.format(event_ret))
+                event_ret = eventer.get_event(tag='/salt/minion/minion_beacon_validation_complete', wait=30)
+                valid = event_ret['valid']
+                vcomment = event_ret['vcomment']
 
-            beacon_module = __import__('salt.beacons.' + name, fromlist=['validate'])
-            log.debug('Successfully imported beacon.')
-        except ImportError:
-            ret['comment'] = 'Beacon {0} does not exist'.format(name)
-            return ret
+            if not valid:
+                ret['result'] = False
+                ret['comment'] = ('Beacon {0} configuration invalid, '
+                                  'not adding.\n{1}'.format(name, vcomment))
+                return ret
 
-        # Attempt to validate
-        if hasattr(beacon_module, 'validate'):
-            _beacon_data = beacon_data
-            if 'enabled' in _beacon_data:
-                del _beacon_data['enabled']
-            valid, vcomment = beacon_module.validate(_beacon_data)
-        else:
-            log.info('Beacon {0} does not have a validate'
-                     ' function,  skipping validation.'.format(name))
-            valid = True
-
-        if not valid:
-            ret['result'] = False
-            ret['comment'] = ('Beacon {0} configuration invalid, '
-                              'not adding.\n{1}'.format(name, vcomment))
-            return ret
+        except KeyError:
+            # Effectively a no-op, since we can't really return without an event system
+            ret['comment'] = 'Event module not available. Beacon add failed.'
 
         try:
-            eventer = salt.utils.event.get_event('minion', opts=__opts__)
-            res = __salt__['event.fire']({'name': name, 'beacon_data': beacon_data, 'func': 'add'}, 'manage_beacons')
+            res = __salt__['event.fire']({'name': name,
+                                          'beacon_data': beacon_data,
+                                          'func': 'add'}, 'manage_beacons')
             if res:
                 event_ret = eventer.get_event(tag='/salt/minion/minion_beacon_add_complete', wait=30)
-                log.debug('=== event_ret {} ==='.format(event_ret))
                 if event_ret and event_ret['complete']:
                     beacons = event_ret['beacons']
                     if name in beacons and beacons[name] == beacon_data:
@@ -171,29 +204,32 @@ def modify(name, beacon_data, **kwargs):
         ret['result'] = True
         ret['comment'] = 'Beacon: {0} would be added.'.format(name)
     else:
-        # Attempt to load the beacon module so we have access to the validate function
         try:
-            beacon_module = __import__('salt.beacons.' + name, fromlist=['validate'])
-            log.debug('Successfully imported beacon.')
-        except ImportError:
-            ret['comment'] = 'Beacon {0} does not exist'.format(name)
-            return ret
+            # Attempt to load the beacon module so we have access to the validate function
+            eventer = salt.utils.event.get_event('minion', opts=__opts__)
+            res = __salt__['event.fire']({'name': name,
+                                          'beacon_data': beacon_data,
+                                          'func': 'validate_beacon'},
+                                         'manage_beacons')
+            if res:
+                event_ret = eventer.get_event(tag='/salt/minion/minion_beacon_validation_complete', wait=30)
+                valid = event_ret['valid']
+                vcomment = event_ret['vcomment']
 
-        # Attempt to validate
-        if hasattr(beacon_module, 'validate'):
-            _beacon_data = beacon_data
-            if 'enabled' in _beacon_data:
-                del _beacon_data['enabled']
-            valid, vcomment = beacon_module.validate(_beacon_data)
-        else:
-            log.info('Beacon {0} does not have a validate'
-                     ' function,  skipping validation.'.format(name))
-            valid = True
+            if not valid:
+                ret['result'] = False
+                ret['comment'] = ('Beacon {0} configuration invalid, '
+                                  'not adding.\n{1}'.format(name, vcomment))
+                return ret
+
+        except KeyError:
+            # Effectively a no-op, since we can't really return without an event system
+            ret['comment'] = 'Event module not available. Beacon modify failed.'
 
         if not valid:
             ret['result'] = False
             ret['comment'] = ('Beacon {0} configuration invalid, '
-                              'not adding.\n{1}'.format(name, vcomment))
+                              'not modifying.\n{1}'.format(name, vcomment))
             return ret
 
         _current = current_beacons[name]
@@ -203,10 +239,14 @@ def modify(name, beacon_data, **kwargs):
             ret['comment'] = 'Job {0} in correct state'.format(name)
             return ret
 
-        _current_lines = ['{0}:{1}\n'.format(key, value)
-                          for (key, value) in sorted(_current.items())]
-        _new_lines = ['{0}:{1}\n'.format(key, value)
-                      for (key, value) in sorted(_new.items())]
+        _current_lines = []
+        for _item in _current:
+            _current_lines.extend(['{0}:{1}\n'.format(key, value)
+                                  for (key, value) in six.iteritems(_current[0])])
+        _new_lines = []
+        for _item in _new:
+            _new_lines.extend(['{0}:{1}\n'.format(key, value)
+                              for (key, value) in six.iteritems(_new[0])])
         _diff = difflib.unified_diff(_current_lines, _new_lines)
 
         ret['changes'] = {}

--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -11,10 +11,10 @@ from __future__ import absolute_import
 import difflib
 import logging
 import os
-import six
 import yaml
 
 # Import Salt libs
+import salt.ext.six as six
 import salt.utils.event
 import salt.utils.files
 from salt.ext.six.moves import map

--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -97,6 +97,12 @@ def add(name, beacon_data, **kwargs):
     else:
         # Attempt to load the beacon module so we have access to the validate function
         try:
+            eventer = salt.utils.event.get_event('minion', opts=__opts__)
+            res = __salt__['event.fire']({'name': name, 'func': 'available_beacons'}, 'manage_beacons')
+            if res:
+                event_ret = eventer.get_event(tag='/salt/minion/minion_available_beacons', wait=30)
+                log.debug('=== event_ret {} ==='.format(event_ret))
+
             beacon_module = __import__('salt.beacons.' + name, fromlist=['validate'])
             log.debug('Successfully imported beacon.')
         except ImportError:

--- a/tests/unit/modules/test_beacons.py
+++ b/tests/unit/modules/test_beacons.py
@@ -60,6 +60,10 @@ class BeaconsTestCase(TestCase, LoaderModuleMockMixin):
                           'tag': '/salt/minion/minion_beacons_list_complete',
                           'beacons': {}},
                          {'complete': True,
+                          'valid': True,
+                          'vcomment': '',
+                          'tag': '/salt/minion/minion_beacons_list_complete'},
+                         {'complete': True,
                           'tag': '/salt/minion/minion_beacon_add_complete',
                           'beacons': {'ps': [{'processes': {'salt-master': 'stopped', 'apache2': 'stopped'}}]}}]
 


### PR DESCRIPTION
### What does this PR do?
Fixes the bug that would prevent custom beacons from being added or modified using the beacon module and state module.

### What issues does this PR fix or reference?
#38934 

### Previous Behavior
Because of the way the validation was being done, eg. importing the beacon module inside the `add` and `modify` functions, this prevented the beacon module & state module from adding new & modifying 
configured beacons.

### New Behavior
This change changes the way the validation is called, rather than importing the module and running it, the validation is called via an event similar to how other functions are performed.

### Tests written?
Tests exist.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
