### PR TITLE
Resolve image ID during container comparison

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -902,6 +902,11 @@ def compare_container(first, second, ignore=None):
             if item in ('OomKillDisable',):
                 if bool(val1) != bool(val2):
                     ret.setdefault(conf_dict, {})[item] = {'old': val1, 'new': val2}
+            elif item == 'Image':
+                image1 = inspect_image(val1)['Id']
+                image2 = inspect_image(val2)['Id']
+                if image1 != image2:
+                    ret.setdefault(conf_dict, {})[item] = {'old': image1, 'new': image2}
             else:
                 if item == 'Links':
                     val1 = _scrub_links(val1, first)
@@ -920,6 +925,11 @@ def compare_container(first, second, ignore=None):
             if item in ('OomKillDisable',):
                 if bool(val1) != bool(val2):
                     ret.setdefault(conf_dict, {})[item] = {'old': val1, 'new': val2}
+            elif item == 'Image':
+                image1 = inspect_image(val1)['Id']
+                image2 = inspect_image(val2)['Id']
+                if image1 != image2:
+                    ret.setdefault(conf_dict, {})[item] = {'old': image1, 'new': image2}
             else:
                 if item == 'Links':
                     val1 = _scrub_links(val1, first)

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -700,7 +700,8 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_compare_container_image_id_resolution(self):
         '''
-        Compare
+        Test comparing two containers when one's inspect output is an ID and
+        not formatted in image:tag notation.
         '''
         def _inspect_container_effect(id_):
             return {

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -697,3 +697,29 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
             result = docker_mod.images()
         self.assertEqual(result,
                          {'sha256:abcdefg': {'RepoTags': ['image:latest']}})
+
+    def test_compare_container_image_id_resolution(self):
+        '''
+        Compare
+        '''
+        def _inspect_container_effect(id_):
+            return {
+                'container1': {'Config': {'Image': 'realimage:latest'},
+                               'HostConfig':{}},
+                'container2': {'Config': {'Image': 'image_id'},
+                               'HostConfig':{}},
+            }[id_]
+
+        def _inspect_image_effect(id_):
+            return {
+                'realimage:latest': {'Id': 'image_id'},
+                'image_id': {'Id': 'image_id'},
+            }[id_]
+
+        inspect_container_mock = MagicMock(side_effect=_inspect_container_effect)
+        inspect_image_mock = MagicMock(side_effect=_inspect_image_effect)
+
+        with patch.object(docker_mod, 'inspect_container', inspect_container_mock):
+            with patch.object(docker_mod, 'inspect_image', inspect_image_mock):
+                ret = docker_mod.compare_container('container1', 'container2')
+                self.assertEqual(ret, {})

--- a/tests/unit/modules/test_dockermod.py
+++ b/tests/unit/modules/test_dockermod.py
@@ -705,9 +705,9 @@ class DockerTestCase(TestCase, LoaderModuleMockMixin):
         def _inspect_container_effect(id_):
             return {
                 'container1': {'Config': {'Image': 'realimage:latest'},
-                               'HostConfig':{}},
+                               'HostConfig': {}},
                 'container2': {'Config': {'Image': 'image_id'},
-                               'HostConfig':{}},
+                               'HostConfig': {}},
             }[id_]
 
         def _inspect_image_effect(id_):


### PR DESCRIPTION
This fixes an issue where inspecting the container returns an image ID
instead of an image name, resulting in a spurious report of a changed
image. By resolving the image down to its ID for both the existing and
new containers, we ensure we're comparing ID to ID.