### PR TITLE
Improve napalm state output in debug mode

### DIFF
--- a/salt/states/netyang.py
+++ b/salt/states/netyang.py
@@ -38,7 +38,6 @@ except ImportError:
     HAS_NAPALM_YANG = False
 
 # Import salt modules
-import salt.output
 from salt.utils import fopen
 import salt.utils.napalm
 

--- a/salt/states/netyang.py
+++ b/salt/states/netyang.py
@@ -93,6 +93,13 @@ def managed(name,
         Use certain profiles to generate the config.
         If not specified, will use the platform default profile(s).
 
+    compliance_report: ``False``
+        Return the compliance report in the comment.
+        The compliance report structured object can be found however
+        in the ``pchanges`` field of the output (not displayed on the CLI).
+
+        .. versionadded:: 2017.7.3
+
     test: ``False``
         Dry run? If set as ``True``, will apply the config, discard
         and return the changes. Default: ``False`` and will commit

--- a/salt/states/netyang.py
+++ b/salt/states/netyang.py
@@ -38,6 +38,7 @@ except ImportError:
     HAS_NAPALM_YANG = False
 
 # Import salt modules
+import salt.output
 from salt.utils import fopen
 import salt.utils.napalm
 
@@ -140,6 +141,7 @@ def managed(name,
     debug = kwargs.get('debug', False) or __opts__.get('debug', False)
     commit = kwargs.get('commit', True) or __opts__.get('commit', True)
     replace = kwargs.get('replace', False) or __opts__.get('replace', False)
+    return_compliance_report = kwargs.get('compliance_report', False) or __opts__.get('compliance_report', False)
     profiles = kwargs.get('profiles', [])
     temp_file = __salt__['temp.file']()
     log.debug('Creating temp file: {0}'.format(temp_file))
@@ -180,7 +182,13 @@ def managed(name,
     log.debug('Loaded config result:')
     log.debug(loaded_changes)
     __salt__['file.remove'](temp_file)
-    return salt.utils.napalm.loaded_ret(ret, loaded_changes, test, debug)
+    loaded_changes['compliance_report'] = compliance_report
+    return salt.utils.napalm.loaded_ret(ret,
+                                        loaded_changes,
+                                        test,
+                                        debug,
+                                        opts=__opts__,
+                                        compliance_report=return_compliance_report)
 
 
 def configured(name,

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -24,6 +24,7 @@ from functools import wraps
 log = logging.getLogger(__file__)
 
 import salt.utils
+import salt.output
 
 # Import third party lib
 try:
@@ -454,10 +455,10 @@ def loaded_ret(ret, loaded, test, debug, compliance_report=False, opts=None):
     if debug and 'loaded_config' in loaded:
         changes['loaded_config'] = loaded['loaded_config']
         pchanges['loaded_config'] = loaded['loaded_config']
-    ret['pchanges']= pchanges
+    ret['pchanges'] = pchanges
     if changes.get('diff'):
         ret['comment'] = '{comment_base}\n\nConfiguration diff:\n\n{diff}'.format(comment_base=ret['comment'],
-                                                                                  diff=pchanges['diff'])
+                                                                                  diff=changes['diff'])
     if changes.get('loaded_config'):
         ret['comment'] = '{comment_base}\n\nLoaded config:\n\n{loaded_cfg}'.format(
             comment_base=ret['comment'],

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -435,10 +435,8 @@ def default_ret(name):
 def loaded_ret(ret, loaded, test, debug):
     '''
     Return the final state output.
-
     ret
         The initial state output structure.
-
     loaded
         The loaded dictionary.
     '''
@@ -447,9 +445,6 @@ def loaded_ret(ret, loaded, test, debug):
         'comment': loaded.get('comment', '')
     })
     pchanges = {}
-    if not loaded.get('result', False):
-        # Failure of some sort
-        return ret
     if debug:
         # Always check for debug
         pchanges.update({
@@ -458,6 +453,15 @@ def loaded_ret(ret, loaded, test, debug):
         ret.update({
             "pchanges": pchanges
         })
+    if not loaded.get('result', False):
+        # Failure of some sort
+        if debug:
+            ret['comment'] = '{base_err}\n\nLoaded config:\n\n{loaded_cfg}'.format(base_err=ret['comment'],
+                                                                                   loaded_cfg=loaded['loaded_config'])
+            if loaded.get('diff'):
+                ret['comment'] = '{comment_base}\n\nConfiguration diff:\n\n{diff}'.format(comment_base=ret['comment'],
+                                                                                          diff=loaded['diff'])
+        return ret
     if not loaded.get('already_configured', True):
         # We're making changes
         pchanges.update({
@@ -484,6 +488,7 @@ def loaded_ret(ret, loaded, test, debug):
         return ret
     # No changes
     ret.update({
-        'result': True
+        'result': True,
+        'changes': {}
     })
     return ret

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -432,7 +432,7 @@ def default_ret(name):
     return ret
 
 
-def loaded_ret(ret, loaded, test, debug):
+def loaded_ret(ret, loaded, test, debug, compliance_report=False, opts=None):
     '''
     Return the final state output.
     ret
@@ -445,6 +445,8 @@ def loaded_ret(ret, loaded, test, debug):
         'comment': loaded.get('comment', '')
     })
     pchanges = {}
+    if 'compliance_report' in loaded:
+        pchanges['compliance_report'] = loaded['compliance_report']
     if debug:
         # Always check for debug
         pchanges.update({
@@ -471,10 +473,17 @@ def loaded_ret(ret, loaded, test, debug):
             'pchanges': pchanges
         })
         if test:
-            for k, v in pchanges.items():
-                ret.update({
-                    "comment": "{}:\n{}\n\n{}".format(k, v, ret.get("comment", ''))
-                })
+            if pchanges.get('diff'):
+                ret['comment'] = '{comment_base}\n\nConfiguration diff:\n\n{diff}'.format(comment_base=ret['comment'],
+                                                                                          diff=pchanges['diff'])
+            if pchanges.get('loaded_config'):
+                ret['comment'] = '{comment_base}\n\nLoaded config:\n\n{loaded_cfg}'.format(
+                    comment_base=ret['comment'],
+                    loaded_cfg=pchanges['loaded_config'])
+            if compliance_report and pchanges.get('compliance_report'):
+                ret['comment'] = '{comment_base}\n\nCompliance report:\n\n{compliance}'.format(
+                    comment_base=ret['comment'],
+                    compliance=salt.output.string_format(pchanges['compliance_report'], 'nested', opts=opts))
             ret.update({
                 'result': None,
             })


### PR DESCRIPTION
### What does this PR do?

When in debug more, you may want to see what is the rendered config and the diff when available (otherwise you can't actually debug).
Additionally, when there are no changes, the `changes` key should return an empty dict, so the state displays correctly that there were no changes, i.e. `changed=0`.