### PR TITLE
Define file.read state fun

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6430,3 +6430,49 @@ def shortcut(
                 ret['comment'] += (', but was unable to set ownership to '
                                    '{0}'.format(user))
     return ret
+
+
+def read(name, binary=False):
+    '''
+    Returns the contents of the file.
+
+    .. versionadded:: Oxygen
+
+    name
+        The location of the file to read.
+
+    binary: ``False``
+        Use the binary access mode.
+
+    SLS Example:
+
+    .. code-block:: yaml
+
+        read_my_managed_file:
+          file.read:
+            - name: /tmp/__salt_{{ opts.id }}.txt
+    '''
+    ret = {
+        'name': name,
+        'result': True,
+        'comment': '',
+        'changes': {}
+    }
+    if __opts__['test']:
+        ret.update({
+            'result': None,
+            'comment': 'It would read {name}'.format(name=name)
+        })
+        return ret
+    try:
+        file_contents = __salt__['file.read'](name, binary=binary)
+    except IOError as ioerr:
+        ret.update({
+            'result': False,
+            'comment': ioerr
+        })
+        return ret
+    ret['changes'] = {
+        'contents': file_contents
+    }
+    return ret


### PR DESCRIPTION
### What does this PR do?

I'm not sure if I have weird ideas, or I'm just the laziest around, but sometimes I need to check if the file managed has the right contents. So I'd like to be able to display the contents generated immediately after it gets managed:

```yaml
test_this_template:
  file.managed:
    - name: /tmp/__salt_ntp_{{ opts.id }}.txt
    - source: salt://ntp/templates/init.jinja
    - template: jinja
    - {{ salt.pillar.get('openconfig-system-ntp') }}
/tmp/__salt_ntp_{{ opts.id }}.txt:
  file.read
```

With the result:

```bash
vmx1:
----------
          ID: /tmp/__salt_ntp_vmx1.txt
    Function: file.read
      Result: True
     Comment:
     Started: 15:43:53.270864
    Duration: 0.7 ms
     Changes:
              ----------
              contents:
                  system {
                    ntp {
... snip ...
                    }
                  }

Summary for vmx1
------------
Succeeded: 2 (changed=1)
Failed:    0
------------
Total states run:     2
Total run time: 989.061 ms
```

So this doesn't bring much value for prod, but for lazy bastards like me that don't find an easier way to check if the templates render properly.