### PR TITLE
Deprecate Authorize class and any_auth function

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -31,6 +31,7 @@ import salt.transport.client
 import salt.utils
 import salt.utils.files
 import salt.utils.minions
+import salt.utils.versions
 import salt.payload
 
 log = logging.getLogger(__name__)
@@ -410,6 +411,13 @@ class Authorize(object):
     The authorization engine used by EAUTH
     '''
     def __init__(self, opts, load, loadauth=None):
+        salt.utils.versions.warn_until(
+            'Neon',
+            'The \'Authorize\' class has been deprecated. Please use the '
+            '\'LoadAuth\', \'Reslover\', or \'AuthUser\' classes instead. '
+            'Support for the \'Authorze\' class will be removed in Salt '
+            '{version}.'
+        )
         self.opts = salt.config.master_config(opts['conf_file'])
         self.load = load
         self.ckminions = salt.utils.minions.CkMinions(opts)

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -723,6 +723,13 @@ class CkMinions(object):
         '''
         Read in the form and determine which auth check routine to execute
         '''
+        # This function is only called from salt.auth.Authorize(), which is also
+        # deprecated and will be removed in Neon.
+        salt.utils.versions.warn_until(
+            'Neon',
+            'The \'any_auth\' function has been deprecated. Support for this '
+            'function will be removed in Salt {version}.'
+        )
         if form == 'publish':
             return self.auth_check(
                     auth_list,


### PR DESCRIPTION
The Authorize class in salt.auth is not used in Salt code any where and is dead code. This puts a deprecation path on the class.

The salt.utils.minions.CkMinions.any_auth functions is also marked for deprecation. This function is only called by the "rights_check" function in the Authorize class.

Since the Authorize class will be removed in Salt Neon, then the any_auth function should be removed in Neon as well.
