### PR TITLE
Fix apache.config with multiple statement

### DIFF
--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -446,11 +446,15 @@ def config(name, config, edit=True):
         salt '*' apache.config /etc/httpd/conf.d/ports.conf config="[{'Listen': '22'}]"
     '''
 
+    configs = []
     for entry in config:
         key = next(six.iterkeys(entry))
-        configs = _parse_config(entry[key], key)
-        if edit:
-            with salt.utils.fopen(name, 'w') as configfile:
-                configfile.write('# This file is managed by Salt.\n')
-                configfile.write(configs)
-    return configs
+        configs.append(_parse_config(entry[key], key))
+
+    # Python auto-correct line endings
+    configstext = "\n".join(configs)
+    if edit:
+        with salt.utils.fopen(name, 'w') as configfile:
+            configfile.write('# This file is managed by Salt.\n')
+            configfile.write(configstext)
+    return configstext


### PR DESCRIPTION
### What does this PR do?
At this moment when you post more than one statement in config only last
is used. Also file is rewrite multiple times until last statement is
written.

### What issues does this PR fix or reference?

### Previous Behavior
salt '*' apache.config /etc/httpd/conf.d/ports.conf config="[{'Listen': '8080'}, {'Proxy': "Something"}]"
Ends only with
   Proxy Something
and ignore Listen 8080,


### New Behavior
salt '*' apache.config /etc/httpd/conf.d/ports.conf config="[{'Listen': '8080'}, {'Proxy': "Something"}]"
   Listen 8080
   Proxy Something

### Tests written?

No
