### PR TITLE
Pin request install to version for npm tests

### DIFF
--- a/tests/integration/states/npm.py
+++ b/tests/integration/states/npm.py
@@ -40,7 +40,7 @@ class NpmStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         '''
         Determine if URL-referenced NPM module can be successfully installed.
         '''
-        ret = self.run_state('npm.installed', name='git://github.com/request/request')
+        ret = self.run_state('npm.installed', name='request/request#v2.81.1')
         self.assertSaltTrueReturn(ret)
         ret = self.run_state('npm.removed', name='git://github.com/request/request')
         self.assertSaltTrueReturn(ret)


### PR DESCRIPTION
### What does this PR do?
This fails on centos 6 because its node is too old to support the version of
hawk bumped here https://github.com/request/request/pull/2751, we can still
test the functionality.  This will pull from github, and install a specific tag
version, and we still do the uninstall using the github path.

This should be more stable.

### What issues does this PR fix or reference?
Fixes saltstack/salt-jenkins#495
### Tests written?

Yes