### PR TITLE
Reverting previous augeas module changes

### DIFF
--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -199,7 +199,7 @@ def execute(context=None, lens=None, commands=(), load_path=None):
             method = METHOD_MAP[cmd]
             nargs = arg_map[method]
 
-            parts = salt.utils.shlex_split(arg, posix=False)
+            parts = salt.utils.shlex_split(arg)
 
             if len(parts) not in nargs:
                 err = '{0} takes {1} args: {2}'.format(method, nargs, parts)


### PR DESCRIPTION
### What does this PR do?
Reverting this change due to it breaking other uses.

### What issues does this PR fix or reference?
#42642 

### Previous Behavior
The previous change changed the call to shlex.split to disable posix, this caused other use cases to break.

### New Behavior
Removing the previous change so that posix mode is enabled.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
