### PR TITLE
Checking install_time for None value

### DIFF
--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -104,8 +104,12 @@ def parse_pkginfo(line, osarch=None):
     if epoch not in ('(none)', '0'):
         version = ':'.join((epoch, version))
 
-    install_date = datetime.datetime.utcfromtimestamp(int(install_time)).isoformat() + "Z"
-    install_date_time_t = int(install_time)
+    if install_time:
+        install_date = datetime.datetime.utcfromtimestamp(int(install_time)).isoformat() + "Z"
+        install_date_time_t = int(install_time)
+    else:
+        install_date = None
+        install_date_time_t = None
 
     return pkginfo(name, version, arch, repoid, install_date, install_date_time_t)
 


### PR DESCRIPTION
### What does this PR do?

RedHat systems might in some cases return None as `install_time`,
which would cause a `ValueError`.

We are checking for None now. `install_date` and `install_date_time`
are being set to `None` in that case.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/43212

### Previous Behavior

`install_time` with value `None` would cause `ValueError`

### New Behavior

Checking for `None` now to prevent error.

### Tests written?

No
