### PR TITLE
Fix `unit.fileserver.test_gitfs` for Windows

### DIFF
--- a/tests/unit/fileserver/test_gitfs.py
+++ b/tests/unit/fileserver/test_gitfs.py
@@ -206,6 +206,7 @@ class GitFSTest(TestCase, LoaderModuleMockMixin):
 
         if 'USERNAME' not in os.environ:
             try:
+                import salt.utils
                 if salt.utils.is_windows():
                     import salt.utils.win_functions
                     os.environ['USERNAME'] = salt.utils.win_functions.get_current_user()


### PR DESCRIPTION
### What does this PR do?
Put `import pwd` in a try/except block
Set `os.environ['USERNAME']` in windows using win_functions
Add error function for `shutil.rmtree`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes