### PR TITLE
salt.utils.openstack.nova: make identity service type configurable

### DIFF
--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -290,8 +290,9 @@ class SaltNova(object):
         self.session = keystoneauth1.session.Session(auth=options, verify=verify)
         conn = client.Client(version=self.version, session=self.session, **self.client_kwargs)
         self.kwargs['auth_token'] = conn.client.session.get_token()
-        self.catalog = conn.client.session.get('/auth/catalog', endpoint_filter={'service_type': 'identity'}).json().get('catalog', [])
-        if conn.client.get_endpoint(service_type='identity').endswith('v3'):
+        identity_service_type = kwargs.get('identity_service_type', 'identity')
+        self.catalog = conn.client.session.get('/auth/catalog', endpoint_filter={'service_type': identity_service_type}).json().get('catalog', [])
+        if conn.client.get_endpoint(service_type=identity_service_type).endswith('v3'):
             self._v3_setup(region_name)
         else:
             self._v2_setup(region_name)


### PR DESCRIPTION
At my $DAYJOB, OpenStack catalog contains identity endpoints v2 and v3.
In order to differentiate between them, admins came up with identityv3
service type. This patch allows me to write:

    provider-id:
        driver: nova
        identity_service_type: identityv3

to make use of identityv3 endpoint in this setup.

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
