### PR TITLE
Improve inheritance in salt.utils.gitfs

### DIFF
--- a/tests/unit/utils/test_gitfs.py
+++ b/tests/unit/utils/test_gitfs.py
@@ -66,7 +66,7 @@ class TestGitFSProvider(TestCase):
                 ('git_pillar', salt.utils.gitfs.GitPillar),
                 ('winrepo', salt.utils.gitfs.WinRepo)):
             key = '{0}_provider'.format(role_name)
-            for provider in salt.utils.gitfs.VALID_PROVIDERS:
+            for provider in salt.utils.gitfs.GIT_PROVIDERS:
                 verify = 'verify_gitpython'
                 mock1 = _get_mock(verify, provider)
                 with patch.object(role_class, verify, mock1):


### PR DESCRIPTION
This makes the following changes:

1. Renames the valid_providers param in GitBase to git_providers,
   allowing for a dictionary mapping provider names to their associated
   classes. This allows for alternate providers to be used with a
   GitBase subclass.
2. Renames the get_provider function to verify_provider to reduce
   confusion with git_providers.
3. Uses super() to run a parent class' dunder init instead of invoking
   the parent class directly.

CC: @thatch45 @msteed @edlane