### PR TITLE
Update __init__.py

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -5,7 +5,7 @@ correct cloud modules
 '''
 
 # Import python libs
-from __future__ import absolute_import, print_function, generators
+from __future__ import absolute_import, print_function, generators,unicode_literals
 import os
 import copy
 import glob

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -5,7 +5,7 @@ correct cloud modules
 '''
 
 # Import python libs
-from __future__ import absolute_import, print_function, generators,unicode_literals
+from __future__ import absolute_import, print_function, generators, unicode_literals
 import os
 import copy
 import glob


### PR DESCRIPTION
add support for unicode symbols in vm names.
fix for '''UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 5: ordinal not in range(128)'''

### What does this PR do?
add support for unicode symbols in vm names.
fix for '''UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 5: ordinal not in range(128)'''


### Previous Behavior
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 5: ordinal not in range(128)

### New Behavior
works!

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.