### PR TITLE
.utils.aws.get_location() expects a dict

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -392,7 +392,7 @@ def query(params=None, setname=None, requesturl=None, location=None,
     service_url = prov_dict.get('service_url', 'amazonaws.com')
 
     if not location:
-        location = get_location(opts, provider)
+        location = get_location(opts, prov_dict)
 
     if endpoint is None:
         if not requesturl:


### PR DESCRIPTION
… as it's `provider` argument.

### What does this PR do?

Fixes a call to `salt.utils.aws.get_location(opts, provider)` inside `utils.aws.query()`

### Tests written?

No
