### PR TITLE
Add **kwargs to mount.mounted state

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -699,7 +699,8 @@ def unmounted(name,
               device=None,
               config='/etc/fstab',
               persist=False,
-              user=None):
+              user=None,
+              **kwargs):
     '''
     .. versionadded:: 0.17.0
 

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -75,7 +75,8 @@ def mounted(name,
             extra_mount_invisible_keys=None,
             extra_mount_ignore_fs_keys=None,
             extra_mount_translate_options=None,
-            hidden_opts=None):
+            hidden_opts=None,
+            **kwargs):
     '''
     Verify that a device is mounted
 


### PR DESCRIPTION
This silences an error message when using prereq with the mount.mounted state.

See #29463 and #37090

### Tests written?
No