### PR TITLE
Add **kwargs to salt.state state

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -83,7 +83,8 @@ def state(name,
         batch=None,
         queue=False,
         subset=None,
-        orchestration_jid=None):
+        orchestration_jid=None,
+        **kwargs):
     '''
     Invoke a state run on a given target
 


### PR DESCRIPTION
This silences an error message when using prereq with the salt.state state.

See #29463 and #37090