### PR TITLE
Fix scope of targets in .modules.pacman.install()

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -539,6 +539,7 @@ def install(name=None,
     cmd.append('pacman')
 
     errors = []
+    targets = []
     if pkg_type == 'file':
         cmd.extend(['-U', '--noprogressbar', '--noconfirm'])
         cmd.extend(pkg_params)
@@ -549,7 +550,6 @@ def install(name=None,
         if sysupgrade:
             cmd.append('-u')
         cmd.extend(['--noprogressbar', '--noconfirm', '--needed'])
-        targets = []
         wildcards = []
         for param, version_num in six.iteritems(pkg_params):
             if version_num is None:


### PR DESCRIPTION
### What does this PR do?
Resolves an exception related to variable scope that occurs on line 602 of `salt/modules/pacman.py` when trying to install packages via a file with `pacman` on Arch Linux.

### What issues does this PR fix or reference?
This PR fixes an exception `UnboundLocalError: local variable 'targets' referenced before assignment` that occurs when installing packages via a file on Arch Linux.

### Previous Behavior
Exception is encountered and installing packages fails.

### New Behavior
Packages install as expected

### Tests written?
No
