### PR TITLE
Update some salt.utils.x paths for moved util functions

### DIFF
--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -451,7 +451,7 @@ For example:
         '''
         Only load if git exists on the system
         '''
-        if salt.utils.which('git') is None:
+        if salt.utils.path.which('git') is None:
             return (False,
                     'The git execution module cannot be loaded: git unavailable.')
         else:

--- a/salt/cli/cp.py
+++ b/salt/cli/cp.py
@@ -20,6 +20,7 @@ import sys
 import salt.client
 import salt.output
 import salt.utils
+import salt.utils.files
 import salt.utils.gzip_util
 import salt.utils.itertools
 import salt.utils.minions
@@ -112,7 +113,7 @@ class SaltCP(object):
             err = 'The referenced file, {0} is not available.'.format(fn_)
             sys.stderr.write(err + '\n')
             sys.exit(42)
-        with salt.utils.fopen(fn_, 'r') as fp_:
+        with salt.utils.files.fopen(fn_, 'r') as fp_:
             data = fp_.read()
         return {fn_: data}
 

--- a/salt/cloud/clouds/oneandone.py
+++ b/salt/cloud/clouds/oneandone.py
@@ -87,7 +87,6 @@ import pprint
 import time
 
 # Import salt libs
-import salt.utils
 import salt.config as config
 from salt.exceptions import (
     SaltCloudConfigError,
@@ -96,6 +95,7 @@ from salt.exceptions import (
     SaltCloudExecutionTimeout,
     SaltCloudSystemExit
 )
+import salt.utils.files
 
 # Import salt.cloud libs
 import salt.utils.cloud
@@ -805,7 +805,7 @@ def load_public_key(vm_):
                 )
             )
 
-        with salt.utils.fopen(public_key_filename, 'r') as public_key:
+        with salt.utils.files.fopen(public_key_filename, 'r') as public_key:
             key = public_key.read().replace('\n', '')
 
             return key

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -543,7 +543,7 @@ def _virtual(osdata):
             command = 'system_profiler'
             args = ['SPDisplaysDataType']
         elif osdata['kernel'] == 'SunOS':
-            virtinfo = salt.utils.which('virtinfo')
+            virtinfo = salt.utils.path.which('virtinfo')
             if virtinfo:
                 try:
                     ret = __salt__['cmd.run_all']('{0} -a'.format(virtinfo))

--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -148,7 +148,7 @@ def _linux_disks():
 
 
 def _windows_disks():
-    wmic = salt.utils.which('wmic')
+    wmic = salt.utils.path.which('wmic')
 
     namespace = r'\\root\microsoft\windows\storage'
     path = 'MSFT_PhysicalDisk'

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -80,7 +80,7 @@ def recv(files, dest):
             return 'Destination unavailable'
 
         try:
-            with salt.utils.fopen(final, 'w+') as fp_:
+            with salt.utils.files.fopen(final, 'w+') as fp_:
                 fp_.write(data)
             ret[final] = True
         except IOError:

--- a/salt/modules/runit.py
+++ b/salt/modules/runit.py
@@ -58,6 +58,7 @@ log = logging.getLogger(__name__)
 # Import salt libs
 from salt.exceptions import CommandExecutionError
 import salt.utils.files
+import salt.utils.path
 
 # Function alias to not shadow built-ins.
 __func_alias__ = {
@@ -95,7 +96,7 @@ def __virtual__():
         global __virtualname__
         __virtualname__ = 'service'
         return __virtualname__
-    if salt.utils.which('sv'):
+    if salt.utils.path.which('sv'):
         return __virtualname__
     return (False, 'Runit not available.  Please install sv')
 

--- a/salt/modules/slsutil.py
+++ b/salt/modules/slsutil.py
@@ -2,12 +2,15 @@
 '''
 Utility functions for use with or in SLS files
 '''
+
+# Import Python libs
 from __future__ import absolute_import
 
+# Import Salt libs
 import salt.exceptions
 import salt.loader
 import salt.template
-import salt.utils
+import salt.utils.args
 import salt.utils.dictupdate
 
 
@@ -172,7 +175,7 @@ def serialize(serializer, obj, **mod_kwargs):
         {% set json_string = salt.slsutil.serialize('json',
             {'foo': 'Foo!'}) %}
     '''
-    kwargs = salt.utils.clean_kwargs(**mod_kwargs)
+    kwargs = salt.utils.args.clean_kwargs(**mod_kwargs)
     return _get_serialize_fn(serializer, 'serialize')(obj, **kwargs)
 
 
@@ -196,6 +199,6 @@ def deserialize(serializer, stream_or_string, **mod_kwargs):
         {% set python_object = salt.slsutil.deserialize('json',
             '{"foo": "Foo!"}') %}
     '''
-    kwargs = salt.utils.clean_kwargs(**mod_kwargs)
+    kwargs = salt.utils.args.clean_kwargs(**mod_kwargs)
     return _get_serialize_fn(serializer, 'deserialize')(stream_or_string,
             **kwargs)

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -15,6 +15,7 @@ import random
 # Import Salt libs
 import salt
 import salt.utils
+import salt.utils.args
 import salt.utils.hashutils
 import salt.utils.platform
 import salt.version
@@ -323,7 +324,7 @@ def arg_clean(*args, **kwargs):
 
         salt '*' test.arg_clean 1 "two" 3.1 txt="hello" wow='{a: 1, b: "hello"}'
     '''
-    return dict(args=args, kwargs=salt.utils.clean_kwargs(**kwargs))
+    return dict(args=args, kwargs=salt.utils.args.clean_kwargs(**kwargs))
 
 
 def fib(num):

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -4025,14 +4025,14 @@ def _write_regpol_data(data_to_write,
         reg_pol_header = u'\u5250\u6765\x01\x00'
         if not os.path.exists(policy_file_path):
             ret = __salt__['file.makedirs'](policy_file_path)
-        with salt.utils.fopen(policy_file_path, 'wb') as pol_file:
+        with salt.utils.files.fopen(policy_file_path, 'wb') as pol_file:
             if not data_to_write.startswith(reg_pol_header):
                 pol_file.write(reg_pol_header.encode('utf-16-le'))
             pol_file.write(data_to_write.encode('utf-16-le'))
         try:
             gpt_ini_data = ''
             if os.path.exists(gpt_ini_path):
-                with salt.utils.fopen(gpt_ini_path, 'rb') as gpt_file:
+                with salt.utils.files.fopen(gpt_ini_path, 'rb') as gpt_file:
                     gpt_ini_data = gpt_file.read()
             if not _regexSearchRegPolData(r'\[General\]\r\n', gpt_ini_data):
                 gpt_ini_data = '[General]\r\n' + gpt_ini_data
@@ -4087,7 +4087,7 @@ def _write_regpol_data(data_to_write,
                         int("{0}{1}".format(str(version_nums[0]).zfill(4), str(version_nums[1]).zfill(4)), 16),
                         gpt_ini_data[general_location.end():])
             if gpt_ini_data:
-                with salt.utils.fopen(gpt_ini_path, 'wb') as gpt_file:
+                with salt.utils.files.fopen(gpt_ini_path, 'wb') as gpt_file:
                     gpt_file.write(gpt_ini_data)
         except Exception as e:
             msg = 'An error occurred attempting to write to {0}, the exception was {1}'.format(

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2834,7 +2834,7 @@ def _parse_repo_file(filename):
 
     # Try to extract leading comments
     headers = ''
-    with salt.utils.fopen(filename, 'r') as rawfile:
+    with salt.utils.files.fopen(filename, 'r') as rawfile:
         for line in rawfile:
             if line.strip().startswith('#'):
                 headers += '{0}\n'.format(line.strip())

--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -42,7 +42,7 @@ import sys
 from salt.ext import six
 
 # Import Salt libs
-import salt.utils
+import salt.utils.platform
 import salt.utils.win_functions
 
 
@@ -61,7 +61,7 @@ def _changes(name,
 
     # User and Domain names are not case sensitive in Windows. Let's make them
     # all lower case so we can compare properly
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         if lgrp['members']:
             lgrp['members'] = [user.lower() for user in lgrp['members']]
         if members:

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -10,7 +10,6 @@ import sys
 import tempfile
 
 # Import Salt Libs
-import salt.utils
 import salt.utils.platform
 import salt.modules.cmdmod as cmdmod
 from salt.exceptions import CommandExecutionError
@@ -264,7 +263,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
             with patch('salt.utils.files.fopen', mock_open(read_data=MOCK_SHELL_FILE)):
                 self.assertFalse(cmdmod._is_valid_shell('foo'))
 
-    @skipIf(salt.utils.is_windows(), 'Do not run on Windows')
+    @skipIf(salt.utils.platform.is_windows(), 'Do not run on Windows')
     def test_os_environment_remains_intact(self):
         '''
         Make sure the OS environment is not tainted after running a command

--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -10,7 +10,7 @@ from tests.support.unit import skipIf, TestCase
 from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
 # Import salt libs
-import salt.utils
+import salt.utils.platform
 import salt.modules.pip as pip
 from salt.exceptions import CommandExecutionError
 
@@ -297,7 +297,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             mock_path.join = join
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
             with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-                if salt.utils.is_windows():
+                if salt.utils.platform.is_windows():
                     venv_path = 'c:\\test_env'
                     bin_path = os.path.join(venv_path, 'Scripts', 'pip.exe').encode('string-escape')
                 else:

--- a/tests/unit/modules/test_timezone.py
+++ b/tests/unit/modules/test_timezone.py
@@ -20,7 +20,6 @@ from tests.support.mock import (
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 import salt.modules.timezone as timezone
 from salt.ext import six
-import salt.utils
 import salt.utils.platform
 import salt.utils.stringutils
 
@@ -193,7 +192,7 @@ class TimezoneModuleTestCase(TestCase, LoaderModuleMockMixin):
             name, args, kwargs = timezone.__salt__['file.sed'].mock_calls[0]
             assert args == ('/etc/sysconfig/clock', '^TIMEZONE=.*', 'TIMEZONE="UTC"')
 
-    @skipIf(salt.utils.is_windows(), 'os.symlink not available in Windows')
+    @skipIf(salt.utils.platform.is_windows(), 'os.symlink not available in Windows')
     @patch('salt.utils.path.which', MagicMock(return_value=False))
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.unlink', MagicMock())

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -550,7 +550,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                                               'G12', 'G12', 'G12', 'G12', 'G12'])
             mock_if = MagicMock(side_effect=[True, False, False, False, False,
                                              False, False, False])
-            if salt.utils.is_windows():
+            if salt.utils.platform.is_windows():
                 mock_ret = MagicMock(return_value=ret)
             else:
                 mock_ret = MagicMock(return_value=(ret, None))
@@ -590,7 +590,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
 
                 # Group argument is ignored on Windows systems. Group is set to
                 # user
-                if salt.utils.is_windows():
+                if salt.utils.platform.is_windows():
                     comt = ('User salt is not available Group salt'
                             ' is not available')
                 else:
@@ -732,7 +732,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
 
         mock_t = MagicMock(return_value=True)
         mock_f = MagicMock(return_value=False)
-        if salt.utils.is_windows():
+        if salt.utils.platform.is_windows():
             mock_perms = MagicMock(return_value=ret)
         else:
             mock_perms = MagicMock(return_value=(ret, ''))
@@ -803,7 +803,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
 
                 with patch.object(os.path, 'isfile', mock_f):
                     with patch.dict(filestate.__opts__, {'test': True}):
-                        if salt.utils.is_windows():
+                        if salt.utils.platform.is_windows():
                             comt = 'The directory "{0}" will be changed' \
                                    ''.format(name)
                             p_chg = {'directory': 'new'}
@@ -889,7 +889,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                                              'cp.list_master': mock_l}):
 
             # Group argument is ignored on Windows systems. Group is set to user
-            if salt.utils.is_windows():
+            if salt.utils.platform.is_windows():
                 comt = ('User salt is not available Group salt'
                         ' is not available')
             else:
@@ -1364,7 +1364,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
 
                     # Group argument is ignored on Windows systems. Group is set
                     # to user
-                    if salt.utils.is_windows():
+                    if salt.utils.platform.is_windows():
                         comt = ('User salt is not available Group salt'
                                 ' is not available')
                     else:

--- a/tests/unit/test_doc.py
+++ b/tests/unit/test_doc.py
@@ -14,7 +14,7 @@ from tests.support.unit import TestCase
 # Import Salt libs
 import tests.integration as integration
 import salt.modules.cmdmod
-import salt.utils
+import salt.utils.platform
 
 
 class DocTestCase(TestCase):
@@ -35,7 +35,7 @@ class DocTestCase(TestCase):
         '''
         salt_dir = integration.CODE_DIR
 
-        if salt.utils.is_windows():
+        if salt.utils.platform.is_windows():
             # No grep in Windows, use findstr
             # findstr in windows doesn't prepend 'Binary` to binary files, so
             # use the '/P' switch to skip files with unprintable characters
@@ -52,7 +52,7 @@ class DocTestCase(TestCase):
             if line.startswith('Binary'):
                 continue
 
-            if salt.utils.is_windows():
+            if salt.utils.platform.is_windows():
                 # Need the space after the colon so it doesn't split the drive
                 # letter
                 key, val = line.split(': ', 1)

--- a/tests/unit/utils/test_url.py
+++ b/tests/unit/utils/test_url.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 # Import Salt Libs
+import salt.utils.platform
 import salt.utils.url
 
 # Import Salt Testing Libs
@@ -38,7 +39,7 @@ class UrlTestCase(TestCase):
         '''
         path = '?funny/path with {interesting|chars}'
         url = 'salt://' + path
-        if salt.utils.is_windows():
+        if salt.utils.platform.is_windows():
             path = '_funny/path with {interesting_chars}'
 
         self.assertEqual(salt.utils.url.parse(url), (path, None))
@@ -50,7 +51,7 @@ class UrlTestCase(TestCase):
         saltenv = 'ambience'
         path = '?funny/path&with {interesting|chars}'
         url = 'salt://' + path + '?saltenv=' + saltenv
-        if salt.utils.is_windows():
+        if salt.utils.platform.is_windows():
             path = '_funny/path&with {interesting_chars}'
 
         self.assertEqual(salt.utils.url.parse(url), (path, saltenv))
@@ -63,7 +64,7 @@ class UrlTestCase(TestCase):
         '''
         path = '? interesting/&path.filetype'
         url = 'salt://' + path
-        if salt.utils.is_windows():
+        if salt.utils.platform.is_windows():
             url = 'salt://_ interesting/&path.filetype'
 
         self.assertEqual(salt.utils.url.create(path), url)
@@ -74,7 +75,7 @@ class UrlTestCase(TestCase):
         '''
         saltenv = 'raumklang'
         path = '? interesting/&path.filetype'
-        if salt.utils.is_windows():
+        if salt.utils.platform.is_windows():
             path = '_ interesting/&path.filetype'
 
         url = 'salt://' + path + '?saltenv=' + saltenv
@@ -157,7 +158,7 @@ class UrlTestCase(TestCase):
         '''
         path = 'dir/file.conf'
         escaped_path = '|' + path
-        if salt.utils.is_windows():
+        if salt.utils.platform.is_windows():
             escaped_path = path
 
         self.assertEqual(salt.utils.url.escape(path), escaped_path)
@@ -177,7 +178,7 @@ class UrlTestCase(TestCase):
         path = 'dir/file.conf'
         url = 'salt://' + path
         escaped_url = 'salt://|' + path
-        if salt.utils.is_windows():
+        if salt.utils.platform.is_windows():
             escaped_url = url
 
         self.assertEqual(salt.utils.url.escape(url), escaped_url)


### PR DESCRIPTION
Through merge forwards, some of the old-style paths have made their way into develop. This PR corrects some of these instances on the more popular functions.
