### PR TITLE
Fix `unit.modules.test_inspect_collector` on Windows

### DIFF
--- a/salt/modules/inspectlib/collector.py
+++ b/salt/modules/inspectlib/collector.py
@@ -29,6 +29,7 @@ from salt.modules.inspectlib.entities import (AllowedDir, IgnoredDir, Package,
                                               PayloadFile, PackageCfgFile)
 
 import salt.utils
+import salt.utils.path
 from salt.utils import fsutils
 from salt.utils import reinit_crypto
 from salt.exceptions import CommandExecutionError
@@ -311,7 +312,7 @@ class Inspector(EnvLoader):
                         continue
                 if not valid or not os.path.exists(obj) or not os.access(obj, os.R_OK):
                     continue
-                if os.path.islink(obj):
+                if salt.utils.path.islink(obj):
                     links.append(obj)
                 elif os.path.isdir(obj):
                     dirs.append(obj)

--- a/salt/modules/inspectlib/kiwiproc.py
+++ b/salt/modules/inspectlib/kiwiproc.py
@@ -17,11 +17,14 @@
 # Import python libs
 from __future__ import absolute_import
 import os
-import grp
-import pwd
 from xml.dom import minidom
 import platform
 import socket
+try:
+    import grp
+    import pwd
+except ImportError:
+    pass
 
 # Import salt libs
 import salt.utils

--- a/tests/unit/modules/test_inspect_collector.py
+++ b/tests/unit/modules/test_inspect_collector.py
@@ -49,9 +49,15 @@ class InspectorCollectorTestCase(TestCase):
 
         :return:
         '''
-        inspector = Inspector(cachedir='/foo/cache', piddir='/foo/pid', pidfilename='bar.pid')
-        self.assertEqual(inspector.dbfile, '/foo/cache/_minion_collector.db')
-        self.assertEqual(inspector.pidfile, '/foo/pid/bar.pid')
+        cachedir = os.sep + os.sep.join(['foo', 'cache'])
+        piddir = os.sep + os.sep.join(['foo', 'pid'])
+        inspector = Inspector(cachedir=cachedir, piddir=piddir, pidfilename='bar.pid')
+        self.assertEqual(
+            inspector.dbfile,
+            os.sep + os.sep.join(['foo', 'cache', '_minion_collector.db']))
+        self.assertEqual(
+            inspector.pidfile,
+            os.sep + os.sep.join(['foo', 'pid', 'bar.pid']))
 
     def test_file_tree(self):
         '''
@@ -60,12 +66,29 @@ class InspectorCollectorTestCase(TestCase):
         :return:
         '''
 
-        inspector = Inspector(cachedir='/test', piddir='/test', pidfilename='bar.pid')
+        inspector = Inspector(cachedir=os.sep + 'test',
+                              piddir=os.sep + 'test',
+                              pidfilename='bar.pid')
         tree_root = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'inspectlib', 'tree_test')
-        expected_tree = (['/a/a/dummy.a', '/a/b/dummy.b', '/b/b.1', '/b/b.2', '/b/b.3'],
-                         ['/a', '/a/a', '/a/b', '/a/c', '/b', '/c'],
-                         ['/a/a/dummy.ln.a', '/a/b/dummy.ln.b', '/a/c/b.1', '/b/b.4',
-                          '/b/b.5', '/c/b.1', '/c/b.2', '/c/b.3'])
+        expected_tree = ([os.sep + os.sep.join(['a', 'a', 'dummy.a']),
+                          os.sep + os.sep.join(['a', 'b', 'dummy.b']),
+                          os.sep + os.sep.join(['b', 'b.1']),
+                          os.sep + os.sep.join(['b', 'b.2']),
+                          os.sep + os.sep.join(['b', 'b.3'])],
+                         [os.sep + 'a',
+                          os.sep + os.sep.join(['a', 'a']),
+                          os.sep + os.sep.join(['a', 'b']),
+                          os.sep + os.sep.join(['a', 'c']),
+                          os.sep + 'b',
+                          os.sep + 'c'],
+                         [os.sep + os.sep.join(['a', 'a', 'dummy.ln.a']),
+                          os.sep + os.sep.join(['a', 'b', 'dummy.ln.b']),
+                          os.sep + os.sep.join(['a', 'c', 'b.1']),
+                          os.sep + os.sep.join(['b', 'b.4']),
+                          os.sep + os.sep.join(['b', 'b.5']),
+                          os.sep + os.sep.join(['c', 'b.1']),
+                          os.sep + os.sep.join(['c', 'b.2']),
+                          os.sep + os.sep.join(['c', 'b.3'])])
         tree_result = []
         for chunk in inspector._get_all_files(tree_root):
             buff = []


### PR DESCRIPTION
### What does this PR do?
Uses os.sep instead of unix-style paths in the test
Uses salt.utils.path.islink() to detect symlinks instead of
os.path.islink(). os.path.islink() does not correctly detect symlinks in
Windows
Put grp and pwd imports inside a try/except block

Need to find where the test suite clones the salt repo for testing to add the following switch to the command:
```
git clone -c core.symlinks=true https://github.com/saltstack/salt
```
In versions of git starting with 2.11.1 symlinked files and directories are now supported, but it requires that additional switch `-c core.symlinks=true`

The test will fail in Windows without the repository being cloned correctly.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes