### PR TITLE
Skip mac tests for user and group

### DIFF
--- a/tests/unit/modules/test_mac_group.py
+++ b/tests/unit/modules/test_mac_group.py
@@ -5,11 +5,15 @@
 
 # Import python libs
 from __future__ import absolute_import
-import grp
+HAS_GRP = True
+try:
+    import grp
+except ImportError:
+    HAS_GRP = False
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
-from tests.support.unit import TestCase
+from tests.support.unit import TestCase, skipIf
 from tests.support.mock import MagicMock, patch
 
 # Import Salt Libs
@@ -17,6 +21,7 @@ import salt.modules.mac_group as mac_group
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 
+@skipIf(not HAS_GRP, "Missing required library 'grp'")
 class MacGroupTestCase(TestCase, LoaderModuleMockMixin):
     '''
     TestCase for the salt.modules.mac_group module

--- a/tests/unit/modules/test_mac_user.py
+++ b/tests/unit/modules/test_mac_user.py
@@ -2,10 +2,13 @@
 '''
     :codeauthor: :email:`Nicole Thomas <nicole@saltstack.com>`
 '''
-
 # Import python libs
 from __future__ import absolute_import
-import pwd
+HAS_PWD = True
+try:
+    import pwd
+except ImportError:
+    HAS_PWD = False
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -17,6 +20,7 @@ import salt.modules.mac_user as mac_user
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 
+@skipIf(not HAS_PWD, "Missing required library 'pwd'")
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class MacUserTestCase(TestCase, LoaderModuleMockMixin):
     '''
@@ -26,14 +30,15 @@ class MacUserTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {mac_user: {}}
 
-    mock_pwall = [pwd.struct_passwd(('_amavisd', '*', 83, 83, 'AMaViS Daemon',
-                                    '/var/virusmails', '/usr/bin/false')),
-                  pwd.struct_passwd(('_appleevents', '*', 55, 55,
-                                     'AppleEvents Daemon',
-                                    '/var/empty', '/usr/bin/false')),
-                  pwd.struct_passwd(('_appowner', '*', 87, 87,
-                                     'Application Owner',
-                                     '/var/empty', '/usr/bin/false'))]
+    if HAS_PWD:
+        mock_pwall = [pwd.struct_passwd(('_amavisd', '*', 83, 83, 'AMaViS Daemon',
+                                        '/var/virusmails', '/usr/bin/false')),
+                      pwd.struct_passwd(('_appleevents', '*', 55, 55,
+                                         'AppleEvents Daemon',
+                                        '/var/empty', '/usr/bin/false')),
+                      pwd.struct_passwd(('_appowner', '*', 87, 87,
+                                         'Application Owner',
+                                         '/var/empty', '/usr/bin/false'))]
     mock_info_ret = {'shell': '/bin/bash', 'name': 'test', 'gid': 4376,
                      'groups': ['TEST_GROUP'], 'home': '/Users/foo',
                      'fullname': 'TEST USER', 'uid': 4376}


### PR DESCRIPTION
### What does this PR do?
Skips `unit.modules.test_mac_group` and `unit.modules.test_mac_user` on Windows

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
No