### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,60 @@
+# SALTSTACK CODE OWNERS
+
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# See https://help.github.com/articles/about-codeowners/
+# for more info about the CODEOWNERS file
+
+# Team Boto
+salt/**/*boto*                      @saltstack/team-boto
+
+# Team Core
+salt/auth/                          @saltstack/team-core
+salt/cache/                         @saltstack/team-core
+salt/cli/                           @saltstack/team-core
+salt/client/*                       @saltstack/team-core
+salt/config/*                       @saltstack/team-core
+salt/daemons/                       @saltstack/team-core
+salt/pillar/                        @saltstack/team-core
+salt/loader.py                      @saltstack/team-core
+salt/payload.py                     @saltstack/team-core
+salt/**/master*                     @saltstack/team-core
+salt/**/minion*                     @saltstack/team-core
+
+# Team Cloud
+salt/cloud/                         @saltstack/team-cloud
+salt/utils/openstack/               @saltstack/team-cloud
+salt/utils/aws.py                   @saltstack/team-cloud
+salt/**/*cloud*                     @saltstack/team-cloud
+
+# Team NetAPI
+salt/cli/api.py                     @saltstack/team-netapi
+salt/client/netapi.py               @saltstack/team-netapi
+salt/netapi/                        @saltstack/team-netapi
+
+# Team Network
+salt/proxy/                         @saltstack/team-proxy
+
+# Team SPM
+salt/cli/spm.py                     @saltstack/team-spm
+salt/spm/                           @saltstack/team-spm
+
+# Team SSH
+salt/cli/ssh.py                     @saltstack/team-ssh
+salt/client/ssh/                    @saltstack/team-ssh
+salt/runners/ssh.py                 @saltstack/team-ssh
+salt/**/thin.py                     @saltstack/team-ssh
+
+# Team State
+salt/state.py                       @saltstack/team-state
+
+# Team Transport
+salt/transport/                     @saltstack/team-transport
+salt/utils/zeromq.py                @saltstack/team-transport
+
+# Team Windows
+salt/**/*win*                       @saltstack/team-windows


### PR DESCRIPTION
This commit adds the code owners file. This is organized based on teams defined by the SaltStack organization to help with pull request reviews. When PRs are submitted that touch files defined in the owners file, PR reviews are requested from members that team automatically.