### PR TITLE
Checking install_time for '(none)' value

### DIFF
--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -104,7 +104,7 @@ def parse_pkginfo(line, osarch=None):
     if epoch not in ('(none)', '0'):
         version = ':'.join((epoch, version))
 
-    if install_time:
+    if install_time not in ('(none)', '0'):
         install_date = datetime.datetime.utcfromtimestamp(int(install_time)).isoformat() + "Z"
         install_date_time_t = int(install_time)
     else:


### PR DESCRIPTION
### What does this PR do?

This is a correction for this PR: https://github.com/saltstack/salt/pull/43214

I misinterpreted the issue. We have to check for `"(none)"` as a string and not `None`. Sorry!

---

RedHat systems might in some cases return '(none)' as install_time,
which would cause a ValueError.

We are checking for '(none)' now. install_date and install_date_time
are being set to None in that case.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/43212

### Previous Behavior

`install_time` with value `"(none)"` would cause `ValueError`

### New Behavior

Checking for `"(none)"` now to prevent error.

### Tests written?

No