### PR TITLE
Fix ldap token groups auth.

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -370,7 +370,7 @@ class LoadAuth(object):
 
         if token:
             name = token['name']
-            groups = token['groups']
+            groups = token.get('groups')
         else:
             name = self.load_name(load)  # The username we are attempting to auth with
             groups = self.get_groups(load)  # The groups this user belongs to

--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -306,7 +306,7 @@ def groups(username, **kwargs):
     '''
     group_list = []
 
-    bind = _bind(username, kwargs['password'],
+    bind = _bind(username, kwargs.get('password'),
                  anonymous=_config('anonymous', mandatory=False))
     if bind:
         log.debug('ldap bind to determine group membership succeeded!')
@@ -371,7 +371,7 @@ def groups(username, **kwargs):
             search_results = bind.search_s(search_base,
                                            ldap.SCOPE_SUBTREE,
                                            search_string,
-                                           [_config('accountattributename'), 'cn'])
+                                           [_config('accountattributename'), 'cn', _config('groupattribute')])
             for _, entry in search_results:
                 if username in entry[_config('accountattributename')]:
                     group_list.append(entry['cn'][0])

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -1055,12 +1055,7 @@ class LocalFuncs(object):
                 return dict(error=dict(name=err_name,
                                        message='Authentication failure of type "token" occurred.'))
             username = token['name']
-            if self.opts['keep_acl_in_token'] and 'auth_list' in token:
-                auth_list = token['auth_list']
-            else:
-                load['eauth'] = token['eauth']
-                load['username'] = username
-                auth_list = self.loadauth.get_auth_list(load)
+            auth_list = self.loadauth.get_auth_list(load, token)
         else:
             auth_type = 'eauth'
             err_name = 'EauthAuthenticationError'
@@ -1102,12 +1097,7 @@ class LocalFuncs(object):
                 return dict(error=dict(name=err_name,
                                        message='Authentication failure of type "token" occurred.'))
             username = token['name']
-            if self.opts['keep_acl_in_token'] and 'auth_list' in token:
-                auth_list = token['auth_list']
-            else:
-                load['eauth'] = token['eauth']
-                load['username'] = username
-                auth_list = self.loadauth.get_auth_list(load)
+            auth_list = self.loadauth.get_auth_list(load, token)
         elif 'eauth' in load:
             auth_type = 'eauth'
             err_name = 'EauthAuthenticationError'
@@ -1217,12 +1207,7 @@ class LocalFuncs(object):
                 return ''
 
             # Get acl from eauth module.
-            if self.opts['keep_acl_in_token'] and 'auth_list' in token:
-                auth_list = token['auth_list']
-            else:
-                extra['eauth'] = token['eauth']
-                extra['username'] = token['name']
-                auth_list = self.loadauth.get_auth_list(extra)
+            auth_list = self.loadauth.get_auth_list(extra, token)
 
             # Authorize the request
             if not self.ckminions.auth_check(

--- a/salt/master.py
+++ b/salt/master.py
@@ -1705,12 +1705,7 @@ class ClearFuncs(object):
                                        message='Authentication failure of type "token" occurred.'))
 
             # Authorize
-            if self.opts['keep_acl_in_token'] and 'auth_list' in token:
-                auth_list = token['auth_list']
-            else:
-                clear_load['eauth'] = token['eauth']
-                clear_load['username'] = token['name']
-                auth_list = self.loadauth.get_auth_list(clear_load)
+            auth_list = self.loadauth.get_auth_list(clear_load, token)
 
             if not self.ckminions.runner_check(auth_list, clear_load['fun']):
                 return dict(error=dict(name='TokenAuthenticationError',
@@ -1774,12 +1769,7 @@ class ClearFuncs(object):
                                        message='Authentication failure of type "token" occurred.'))
 
             # Authorize
-            if self.opts['keep_acl_in_token'] and 'auth_list' in token:
-                auth_list = token['auth_list']
-            else:
-                clear_load['eauth'] = token['eauth']
-                clear_load['username'] = token['name']
-                auth_list = self.loadauth.get_auth_list(clear_load)
+            auth_list = self.loadauth.get_auth_list(clear_load, token)
             if not self.ckminions.wheel_check(auth_list, clear_load['fun']):
                 return dict(error=dict(name='TokenAuthenticationError',
                                        message=('Authentication failure of type "token" occurred for '
@@ -1900,12 +1890,7 @@ class ClearFuncs(object):
                 return ''
 
             # Get acl
-            if self.opts['keep_acl_in_token'] and 'auth_list' in token:
-                auth_list = token['auth_list']
-            else:
-                extra['eauth'] = token['eauth']
-                extra['username'] = token['name']
-                auth_list = self.loadauth.get_auth_list(extra)
+            auth_list = self.loadauth.get_auth_list(extra, token)
 
             # Authorize the request
             if not self.ckminions.auth_check(


### PR DESCRIPTION
### What does this PR do?
Implemented back the logic that retrieves the user's group list and places it into the token during making token procedure and correctly provide it to `get_auth_list` during authorization.
It was missed during auth redesign.
Also corrected groups retrieving in ldap module (for some cases).

### What issues does this PR fix or reference?
Fixes #42459

### Tests written?
No