### PR TITLE
allow pillar to be used in vault policies

### DIFF
--- a/salt/modules/vault.py
+++ b/salt/modules/vault.py
@@ -68,6 +68,8 @@ Functions to interact with Hashicorp Vault.
                     - web
                     - database
 
+        `pillar` can also be used.
+
         The minion will have the policies ``saltstack/by-role/web`` and
         ``saltstack/by-role/database``. Note however that list members which do
         not have simple string representations, such as dictionaries or objects,

--- a/salt/runners/vault.py
+++ b/salt/runners/vault.py
@@ -109,12 +109,12 @@ def _get_policies(minion_id, config):
     '''
     Get the policies that should be applied to a token for minion_id
     '''
-    _, grains, _ = salt.utils.minions.get_minion_data(minion_id, __opts__)
+    _, grains, pillar = salt.utils.minions.get_minion_data(minion_id, __opts__)
     policy_patterns = config.get(
                                  'policies',
                                  ['saltstack/minion/{minion}', 'saltstack/minions']
                                 )
-    mappings = {'minion': minion_id, 'grains': grains or {}}
+    mappings = {'minion': minion_id, 'grains': grains or {}, 'pillar': pillar or {}}
 
     policies = []
     for pattern in policy_patterns:


### PR DESCRIPTION
### What does this PR do?
Allows the more secure pillar object to be used in vault policies.

### What issues does this PR fix or reference?
Closes 
#43287 

### Tests written?

No