### PR TITLE
Win build scripts

### DIFF
--- a/pkg/windows/build.bat
+++ b/pkg/windows/build.bat
@@ -89,7 +89,7 @@ if Defined x (
 if %Python%==2 (
     Set "PyDir=C:\Python27"
 ) else (
-    Set "PyDir=C:\Program Files\Python35"
+    Set "PyDir=C:\Python35"
 )
 Set "PATH=%PATH%;%PyDir%;%PyDir%\Scripts"
 

--- a/pkg/windows/build_env_2.ps1
+++ b/pkg/windows/build_env_2.ps1
@@ -175,7 +175,7 @@ If (Test-Path "$($ini['Settings']['Python2Dir'])\python.exe") {
     DownloadFileWithProgress $url $file
 
     Write-Output " - $script_name :: Installing $($ini[$bitPrograms]['Python2']) . . ."
-    $p    = Start-Process msiexec -ArgumentList "/i $file /qb ADDLOCAL=DefaultFeature,SharedCRT,Extensions,pip_feature,PrependPath TARGETDIR=$($ini['Settings']['Python2Dir'])" -Wait -NoNewWindow -PassThru
+    $p    = Start-Process msiexec -ArgumentList "/i $file /qb ADDLOCAL=DefaultFeature,SharedCRT,Extensions,pip_feature,PrependPath TARGETDIR=`"$($ini['Settings']['Python2Dir'])`"" -Wait -NoNewWindow -PassThru
 }
 
 #------------------------------------------------------------------------------
@@ -191,7 +191,7 @@ If (!($Path.ToLower().Contains("$($ini['Settings']['Scripts2Dir'])".ToLower())))
 
 #==============================================================================
 # Update PIP and SetupTools
-#    caching depends on environmant variable SALT_PIP_LOCAL_CACHE
+#    caching depends on environment variable SALT_PIP_LOCAL_CACHE
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
 Write-Output " - $script_name :: Updating PIP and SetupTools . . ."
@@ -212,7 +212,7 @@ if ( ! [bool]$Env:SALT_PIP_LOCAL_CACHE) {
 
 #==============================================================================
 # Install pypi resources using pip
-#    caching depends on environmant variable SALT_REQ_LOCAL_CACHE
+#    caching depends on environment variable SALT_REQ_LOCAL_CACHE
 #==============================================================================
 Write-Output " ----------------------------------------------------------------"
 Write-Output " - $script_name :: Installing pypi resources using pip . . ."
@@ -229,6 +229,24 @@ if ( ! [bool]$Env:SALT_REQ_LOCAL_CACHE) {
     Write-Output "    If a (new) ressource is missing, please delete all files in this cache, go online and repeat"
   Start_Process_and_test_exitcode "$($ini['Settings']['Python2Dir'])\python.exe" "-m pip install --no-index --find-links=$Env:SALT_REQ_LOCAL_CACHE -r $($script_path)\req_2.txt" "pip install"
 }
+
+#==============================================================================
+# Move PyWin32 DLL's to site-packages\win32
+#==============================================================================
+Write-Output " - $script_name :: Moving PyWin32 DLLs . . ."
+Move-Item "$($ini['Settings']['SitePkgs2Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['SitePkgs2Dir'])\win32" -Force
+
+# Remove pywin32_system32 directory
+Write-Output " - $script_name :: Removing pywin32_system32 Directory . . ."
+Remove-Item "$($ini['Settings']['SitePkgs2Dir'])\pywin32_system32"
+
+# Remove pythonwin directory
+Write-Output " - $script_name :: Removing pythonwin Directory . . ."
+Remove-Item "$($ini['Settings']['SitePkgs2Dir'])\pythonwin" -Force -Recurse
+
+# Remove PyWin32 PostInstall and testall Scripts
+Write-Output " - $script_name :: Removing PyWin32 scripts . . ."
+Remove-Item "$($ini['Settings']['Scripts2Dir'])\pywin32_*" -Force -Recurse
 
 #==============================================================================
 # Install PyYAML with CLoader

--- a/pkg/windows/build_env_3.ps1
+++ b/pkg/windows/build_env_3.ps1
@@ -175,7 +175,7 @@ If (Test-Path "$($ini['Settings']['Python3Dir'])\python.exe") {
     DownloadFileWithProgress $url $file
 
     Write-Output " - $script_name :: Installing $($ini[$bitPrograms]['Python3']) . . ."
-    $p    = Start-Process $file -ArgumentList '/passive InstallAllUsers=1 TargetDir="C:\Program Files\Python35" Include_doc=0 Include_tcltk=0 Include_test=0 Include_launcher=0 PrependPath=1 Shortcuts=0' -Wait -NoNewWindow -PassThru
+    $p    = Start-Process $file -ArgumentList "/passive InstallAllUsers=1 TargetDir=`"$($ini['Settings']['Python3Dir'])`" Include_doc=0 Include_tcltk=0 Include_test=0 Include_launcher=0 PrependPath=1 Shortcuts=0" -Wait -NoNewWindow -PassThru
 }
 
 #------------------------------------------------------------------------------
@@ -247,7 +247,7 @@ Start_Process_and_test_exitcode  "$($ini['Settings']['Scripts3Dir'])\pip.exe" "i
 
 # Move DLL's to Python Root
 Write-Output " - $script_name :: Moving PyWin32 DLLs . . ."
-Move-Item "$($ini['Settings']['SitePkgs3Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['Python3Dir'])" -Force
+Move-Item "$($ini['Settings']['SitePkgs3Dir'])\pywin32_system32\*.dll" "$($ini['Settings']['SitePkgs3Dir'])\win32" -Force
 
 # Remove pywin32_system32 directory
 Write-Output " - $script_name :: Removing pywin32_system32 Directory . . ."
@@ -256,6 +256,10 @@ Remove-Item "$($ini['Settings']['SitePkgs3Dir'])\pywin32_system32"
 # Remove pythonwin directory
 Write-Output " - $script_name :: Removing pythonwin Directory . . ."
 Remove-Item "$($ini['Settings']['SitePkgs3Dir'])\pythonwin" -Force -Recurse
+
+# Remove PyWin32 PostInstall and testall Scripts
+Write-Output " - $script_name :: Removing PyWin32 scripts . . ."
+Remove-Item "$($ini['Settings']['Scripts3Dir'])\pywin32_*" -Force -Recurse
 
 #==============================================================================
 # Fix PyCrypto

--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -56,7 +56,7 @@ if %Python%==2 (
     Set "PyVerMajor=2"
     Set "PyVerMinor=7"
 ) else (
-    Set "PyDir=C:\Program Files\Python35"
+    Set "PyDir=C:\Python35"
     Set "PyVerMajor=3"
     Set "PyVerMinor=5"
 )

--- a/pkg/windows/clean_env.bat
+++ b/pkg/windows/clean_env.bat
@@ -16,9 +16,10 @@ if %errorLevel%==0 (
 )
 echo.
 
+:CheckPython2
 if exist "\Python27" goto RemovePython2
-if exist "\Python35" goto RemovePython3
-goto eof
+
+goto CheckPython3
 
 :RemovePython2
     rem Uninstall Python 2.7
@@ -47,6 +48,11 @@ goto eof
 
     goto eof
 
+:CheckPython3
+if exist "\Python35" goto RemovePython3
+
+goto eof
+
 :RemovePython3
     echo %0 :: Uninstalling Python 3 ...
     echo ---------------------------------------------------------------------
@@ -63,9 +69,9 @@ goto eof
     )
 
     rem wipe the Python directory
-    echo %0 :: Removing the C:\Program Files\Python35 Directory ...
+    echo %0 :: Removing the C:\Python35 Directory ...
     echo ---------------------------------------------------------------------
-    rd /s /q "C:\Program Files\Python35"
+    rd /s /q "C:\Python35"
     if %errorLevel%==0 (
         echo Successful
     ) else (

--- a/pkg/windows/clean_env.bat
+++ b/pkg/windows/clean_env.bat
@@ -17,7 +17,7 @@ if %errorLevel%==0 (
 echo.
 
 if exist "\Python27" goto RemovePython2
-if exist "\Program Files\Python35" goto RemovePython3
+if exist "\Python35" goto RemovePython3
 goto eof
 
 :RemovePython2
@@ -53,13 +53,13 @@ goto eof
     :: 64 bit
     if exist "%LOCALAPPDATA%\Package Cache\{b94f45d6-8461-440c-aa4d-bf197b2c2499}" (
         echo %0 :: - 3.5.3 64bit
-        "%LOCALAPPDATA%\Package Cache\{b94f45d6-8461-440c-aa4d-bf197b2c2499}\python-3.5.3-amd64.exe" /uninstall
+        "%LOCALAPPDATA%\Package Cache\{b94f45d6-8461-440c-aa4d-bf197b2c2499}\python-3.5.3-amd64.exe" /uninstall /passive
     )
 
     :: 32 bit
     if exist "%LOCALAPPDATA%\Package Cache\{a10037e1-4247-47c9-935b-c5ca049d0299}" (
         echo %0 :: - 3.5.3 32bit
-        "%LOCALAPPDATA%\Package Cache\{a10037e1-4247-47c9-935b-c5ca049d0299}\python-3.5.3" /uninstall
+        "%LOCALAPPDATA%\Package Cache\{a10037e1-4247-47c9-935b-c5ca049d0299}\python-3.5.3" /uninstall /passive
     )
 
     rem wipe the Python directory

--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -19,9 +19,9 @@ Function Get-Settings {
             "Python2Dir"   = "C:\Python27"
             "Scripts2Dir"  = "C:\Python27\Scripts"
             "SitePkgs2Dir" = "C:\Python27\Lib\site-packages"
-            "Python3Dir"   = "C:\Program Files\Python35"
-            "Scripts3Dir"  = "C:\Program Files\Python35\Scripts"
-            "SitePkgs3Dir" = "C:\Program Files\Python35\Lib\site-packages"
+            "Python3Dir"   = "C:\Python35"
+            "Scripts3Dir"  = "C:\Python35\Scripts"
+            "SitePkgs3Dir" = "C:\Python35\Lib\site-packages"
             "DownloadDir" = "$env:Temp\DevSalt"
             }
         # The script deletes the DownLoadDir (above) for each install.


### PR DESCRIPTION
### What does this PR do?
Puts the PyWin32 dlls in the `site-packages\win32` directory
Removes the PyWin32 post install scripts
Uninstalls Py3 silently
Installs Py3 to C:\Python35 to be consistent with Python27
Removes both Py2 and Py3 in a single run

### Tests written?
NA