### PR TITLE
Fix the installer for Windows 10

### DIFF
--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -248,6 +248,7 @@ Section -Post
 
   ExecWait "nssm.exe install salt-minion $INSTDIR\bin\python.exe $INSTDIR\bin\Scripts\salt-minion -c $INSTDIR\conf -l quiet"
   ExecWait "nssm.exe set salt-minion AppEnvironmentExtra PYTHONHOME="
+  ExecWait "nssm.exe set salt-minion AppNoConsole 1"
   RMDir /R "$INSTDIR\var\cache\salt" ; removing cache from old version
 
   Call updateMinionConfig


### PR DESCRIPTION
### What does this PR do?
Adds `AppNoConsole 1` setting to installer script
The service will not start on Windows 10 without the setting

Patched on 2016.11+ with https://github.com/saltstack/salt/pull/40686

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/40657

### Tests written?
No