### PR TITLE
Fix `unit.netapi.rest_cherrypy.test_tools` for Windows

### DIFF
--- a/salt/netapi/rest_cherrypy/__init__.py
+++ b/salt/netapi/rest_cherrypy/__init__.py
@@ -20,7 +20,7 @@ try:
 except ImportError as exc:
     cpy_error = exc
 
-__virtualname__ = os.path.abspath(__file__).rsplit('/')[-2] or 'rest_cherrypy'
+__virtualname__ = os.path.abspath(__file__).rsplit(os.sep)[-2] or 'rest_cherrypy'
 
 logger = logging.getLogger(__virtualname__)
 cpy_min = '3.2.2'


### PR DESCRIPTION
### What does this PR do?
Problem with the cherrypy api itself. Use os.sep instead of '/'

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes