### PR TITLE
Fix `unit.netapi.rest_tornado.test_handlers` for Windows

### DIFF
--- a/salt/netapi/rest_tornado/__init__.py
+++ b/salt/netapi/rest_tornado/__init__.py
@@ -10,7 +10,7 @@ import os
 import salt.auth
 from salt.utils.versions import StrictVersion as _StrictVersion
 
-__virtualname__ = os.path.abspath(__file__).rsplit('/')[-2] or 'rest_tornado'
+__virtualname__ = os.path.abspath(__file__).rsplit(os.sep)[-2] or 'rest_tornado'
 
 logger = logging.getLogger(__virtualname__)
 


### PR DESCRIPTION
### What does this PR do?
Problem with the tornado api itself. Use os.sep instead of '/'
Also fixes `unit.netapi.rest_tornado.test_utils`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes