### PR TITLE
Fix `unit.modules.test_alternatives` for Windows

### DIFF
--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -241,4 +241,4 @@ def _read_link(name):
     Throws an OSError if the link does not exist
     '''
     alt_link_path = '/etc/alternatives/{0}'.format(name)
-    return os.readlink(alt_link_path)
+    return __salt__['file.readlink'](alt_link_path)

--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -12,6 +12,7 @@ import logging
 
 # Import Salt libs
 import salt.utils
+import salt.utils.path
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -241,4 +242,4 @@ def _read_link(name):
     Throws an OSError if the link does not exist
     '''
     alt_link_path = '/etc/alternatives/{0}'.format(name)
-    return __salt__['file.readlink'](alt_link_path)
+    return salt.utils.path.readlink(alt_link_path)

--- a/tests/unit/modules/test_alternatives.py
+++ b/tests/unit/modules/test_alternatives.py
@@ -66,30 +66,28 @@ class AlternativesTestCase(TestCase, LoaderModuleMockMixin):
                 )
 
     def test_show_current(self):
-        with patch('os.readlink') as os_readlink_mock:
-            os_readlink_mock.return_value = '/etc/alternatives/salt'
+        mock = MagicMock(return_value='/etc/alternatives/salt')
+        with patch.dict(alternatives.__salt__, {'file.readlink': mock}):
             ret = alternatives.show_current('better-world')
             self.assertEqual('/etc/alternatives/salt', ret)
-            os_readlink_mock.assert_called_once_with(
-                '/etc/alternatives/better-world'
-            )
+            mock.assert_called_once_with('/etc/alternatives/better-world')
 
             with TestsLoggingHandler() as handler:
-                os_readlink_mock.side_effect = OSError('Hell was not found!!!')
+                mock.side_effect = OSError('Hell was not found!!!')
                 self.assertFalse(alternatives.show_current('hell'))
-                os_readlink_mock.assert_called_with('/etc/alternatives/hell')
+                mock.assert_called_with('/etc/alternatives/hell')
                 self.assertIn('ERROR:alternative: hell does not exist',
                               handler.messages)
 
     def test_check_installed(self):
-        with patch('os.readlink') as os_readlink_mock:
-            os_readlink_mock.return_value = '/etc/alternatives/salt'
+        mock = MagicMock(return_value='/etc/alternatives/salt')
+        with patch.dict(alternatives.__salt__, {'file.readlink': mock}):
             self.assertTrue(
                 alternatives.check_installed(
                     'better-world', '/etc/alternatives/salt'
                 )
             )
-            os_readlink_mock.return_value = False
+            mock.return_value = False
             self.assertFalse(
                 alternatives.check_installed(
                     'help', '/etc/alternatives/salt'

--- a/tests/unit/modules/test_alternatives.py
+++ b/tests/unit/modules/test_alternatives.py
@@ -18,6 +18,7 @@ from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
 # Import salt libs
 import salt.modules.alternatives as alternatives
+import salt.utils.path
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -67,7 +68,7 @@ class AlternativesTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_show_current(self):
         mock = MagicMock(return_value='/etc/alternatives/salt')
-        with patch.dict(alternatives.__salt__, {'file.readlink': mock}):
+        with patch('salt.utils.path.readlink', mock):
             ret = alternatives.show_current('better-world')
             self.assertEqual('/etc/alternatives/salt', ret)
             mock.assert_called_once_with('/etc/alternatives/better-world')
@@ -81,7 +82,7 @@ class AlternativesTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_check_installed(self):
         mock = MagicMock(return_value='/etc/alternatives/salt')
-        with patch.dict(alternatives.__salt__, {'file.readlink': mock}):
+        with patch('salt.utils.path.readlink', mock):
             self.assertTrue(
                 alternatives.check_installed(
                     'better-world', '/etc/alternatives/salt'

--- a/tests/unit/modules/test_alternatives.py
+++ b/tests/unit/modules/test_alternatives.py
@@ -18,7 +18,6 @@ from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
 
 # Import salt libs
 import salt.modules.alternatives as alternatives
-import salt.utils.path
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)


### PR DESCRIPTION
### What does this PR do?
Not sure this is necessary... I don't think `alternatives` is a thing in
Windows. Anyway, it uses `__salt__['file.readlink']` instead of
`os.readlink` as there is no `os.readlink` in Windows.
Modifies the tests to mock `__salt__['file.readlink']` instead of
`os.readlink`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes