### PR TITLE
Fix `unit.modules.test_chef` for Windows

### DIFF
--- a/tests/unit/modules/test_chef.py
+++ b/tests/unit/modules/test_chef.py
@@ -36,7 +36,8 @@ class ChefTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test if it execute a chef client run and return a dict
         '''
-        self.assertDictEqual(chef.client(), {})
+        with patch.dict(chef.__opts__, {'cachedir': r'c:\salt\var\cache\salt\minion'}):
+            self.assertDictEqual(chef.client(), {})
 
     # 'solo' function tests: 1
 
@@ -44,4 +45,5 @@ class ChefTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test if it execute a chef solo run and return a dict
         '''
-        self.assertDictEqual(chef.solo('/dev/sda1'), {})
+        with patch.dict(chef.__opts__, {'cachedir': r'c:\salt\var\cache\salt\minion'}):
+            self.assertDictEqual(chef.solo('/dev/sda1'), {})


### PR DESCRIPTION
### What does this PR do?
Mocks the __opts__ to contain cachedir

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes