### PR TITLE
mine_interval option is minutes not seconds

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -373,7 +373,7 @@
 #    interface: eth0
 #    cidr: '10.0.0.0/8'
 
-# The number of minutes between when a mine update runs.
+# The number of minutes between mine updates.
 #mine_interval: 60
 
 # Windows platforms lack posix IPC and must rely on slower TCP based inter-

--- a/conf/minion
+++ b/conf/minion
@@ -373,7 +373,7 @@
 #    interface: eth0
 #    cidr: '10.0.0.0/8'
 
-# The number of seconds a mine update runs.
+# The number of minutes between when a mine update runs.
 #mine_interval: 60
 
 # Windows platforms lack posix IPC and must rely on slower TCP based inter-

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -674,7 +674,7 @@ Note these can be defined in the pillar for a minion as well.
 
 Default: ``60``
 
-The number of minutes between when a mine update runs.
+The number of minutes between mine updates.
 
 .. code-block:: yaml
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -674,7 +674,7 @@ Note these can be defined in the pillar for a minion as well.
 
 Default: ``60``
 
-The number of seconds a mine update runs.
+The number of minutes between when a mine update runs.
 
 .. code-block:: yaml
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -313,7 +313,7 @@ VALID_OPTS = {
     # Whether or not scheduled mine updates should be accompanied by a job return for the job cache
     'mine_return_job': bool,
 
-    # The number of minutes between mine updates. 
+    # The number of minutes between mine updates.
     'mine_interval': int,
 
     # The ipc strategy. (i.e., sockets versus tcp, etc)

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -313,7 +313,7 @@ VALID_OPTS = {
     # Whether or not scheduled mine updates should be accompanied by a job return for the job cache
     'mine_return_job': bool,
 
-    # Schedule a mine update every n number of seconds
+    # The number of minutes between mine updates. 
     'mine_interval': int,
 
     # The ipc strategy. (i.e., sockets versus tcp, etc)


### PR DESCRIPTION
### What does this PR do?
Update documentation regarding the configuration of the `mine_interval` option. Documentation at https://docs.saltstack.com/en/latest/ref/configuration/minion.html#mine-interval and https://github.com/saltstack/salt/blob/0931281ebd1ca794b27bf7dc4e918efd3a05c612/conf/minion#L376 currently show that the option is configured in seconds. However, the documentation at https://docs.saltstack.com/en/latest/topics/mine/#mine-interval infers that the option is configured in minutes.
