### PR TITLE
Docs are wrong cache_dir (bool) and cache_file (str) cannot be passed as params + 1 bug

### DIFF
--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -480,11 +480,17 @@ Alternatively the ``uninstaller`` can also simply repeat the URL of the msi file
 :param bool allusers: This parameter is specific to `.msi` installations. It
     tells `msiexec` to install the software for all users. The default is True.
 
-:param bool cache_dir: If true, the entire directory where the installer resides
-    will be recursively cached. This is useful for installers that depend on
-    other files in the same directory for installation.
+:param bool cache_dir: If true when installer URL begins with salt://, the
+    entire directory where the installer resides will be recursively cached.
+    This is useful for installers that depend on other files in the same
+    directory for installation.
 
-.. note:: Only applies to salt: installer URLs.
+:param str cache_file:
+    When installer URL begins with salt://, this indicates single file to copy
+    down for use with the installer. Copied to the same location as the
+    installer. Use this over ``cache_dir`` if there are many files in the
+    directory and you only need a specific file and don't want to cache
+    additional files that may reside in the installer directory.
 
 Here's an example for a software package that has dependent files:
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -913,18 +913,6 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                 # Version 1.2.3 will apply to packages foo and bar
                 salt '*' pkg.install foo,bar version=1.2.3
 
-        cache_file (str):
-            A single file to copy down for use with the installer. Copied to the
-            same location as the installer. Use this over ``cache_dir`` if there
-            are many files in the directory and you only need a specific file
-            and don't want to cache additional files that may reside in the
-            installer directory. Only applies to files on ``salt://``
-
-        cache_dir (bool):
-            True will copy the contents of the installer directory. This is
-            useful for installations that are not a single file. Only applies to
-            directories on ``salt://``
-
         extra_install_flags (str):
             Additional install flags that will be appended to the
             ``install_flags`` defined in the software definition file. Only

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1204,7 +1204,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         if use_msiexec:
             cmd = msiexec
             arguments = ['/i', cached_pkg]
-            if pkginfo['version_num'].get('allusers', True):
+            if pkginfo[version_num].get('allusers', True):
                 arguments.append('ALLUSERS="1"')
             arguments.extend(salt.utils.shlex_split(install_flags))
         else:


### PR DESCRIPTION
### What does this PR do?
Doco Fix for windows pkg.install

### Previous Behavior
`if pkginfo['version_num'].get('allusers', True):`

### New Behavior
`if pkginfo[version_num].get('allusers', True):`

