### PR TITLE
Fix rh_ip template use for Fedora

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -1013,7 +1013,10 @@ def build_interface(iface, iface_type, enabled, **settings):
         salt '*' ip.build_interface eth0 eth <settings>
     '''
     if __grains__['os'] == 'Fedora':
-        rh_major = '6'
+        if __grains__['osmajorrelease'] >= 18:
+            rh_major = '7'
+        else:
+            rh_major = '6'
     else:
         rh_major = __grains__['osrelease'][:1]
 

--- a/tests/unit/modules/test_rh_ip.py
+++ b/tests/unit/modules/test_rh_ip.py
@@ -58,7 +58,7 @@ class RhipTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test to build an interface script for a network interface.
         '''
-        with patch.dict(rh_ip.__grains__, {'os': 'Fedora'}):
+        with patch.dict(rh_ip.__grains__, {'os': 'Fedora', 'osmajorrelease': 26}):
             with patch.object(rh_ip, '_raise_error_iface', return_value=None):
 
                 self.assertRaises(AttributeError,


### PR DESCRIPTION
Salt assumes that all Fedora releases conform to the RHEL6 version.
This means that on current Fedora releases an older interface template
is used resulting in non-working routes.

The logic could probably use a bit of rework as I could see future
Fedora releases diverging more from RHEL but for now an additional
check was added that handles Fedora 18 and higher as RHEL7 (which was
branched off from F18).