### PR TITLE
Silence error message in lvm.lv_present

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -159,7 +159,7 @@ def vgdisplay(vgname=''):
     return ret
 
 
-def lvdisplay(lvname=''):
+def lvdisplay(lvname='', quiet=False):
     '''
     Return information about the logical volume(s)
 
@@ -174,7 +174,10 @@ def lvdisplay(lvname=''):
     cmd = ['lvdisplay', '-c']
     if lvname:
         cmd.append(lvname)
-    cmd_ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+    if quiet:
+        cmd_ret = __salt__['cmd.run_all'](cmd, python_shell=False, output_loglevel='quiet')
+    else:
+        cmd_ret = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if cmd_ret['retcode'] != 0:
         return {}

--- a/salt/states/lvm.py
+++ b/salt/states/lvm.py
@@ -268,7 +268,7 @@ def lv_present(name,
     else:
         lvpath = '/dev/{0}/{1}'.format(vgname, name)
 
-    if __salt__['lvm.lvdisplay'](lvpath):
+    if __salt__['lvm.lvdisplay'](lvpath, quiet=True):
         ret['comment'] = 'Logical Volume {0} already present'.format(name)
     elif __opts__['test']:
         ret['comment'] = 'Logical Volume {0} is set to be created'.format(name)


### PR DESCRIPTION
### What does this PR do?
Whenever a lv is not yet present (and has to be created), an error message, is printed.
As lv_present assumes absense on error and tries to create a new lv in that case, we don't need the error message. If any other error would have been printed, lv_create will probably fail and print another error message anyway.

### Previous Behavior
Meaningless error is printed:
```
[ERROR   ] Command '['lvdisplay', '-c', '/dev/VG_default/test3']' failed with return code: 5
[ERROR   ] stderr:   Failed to find logical volume "VG_default/test3"
[ERROR   ] retcode: 5
```
### New Behavior
No meaningless error is printed

### Tests written?

No