### PR TITLE
Fix failing tests in Fedora

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2539,7 +2539,7 @@ def _parse_repo_file(filename):
 
     for section in parsed._sections:
         section_dict = dict(parsed._sections[section])
-        section_dict.pop('__name__')
+        section_dict.pop('__name__', None)
         config[section] = section_dict
 
     # Try to extract leading comments

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -764,8 +764,8 @@ def list_repo_pkgs(*args, **kwargs):
                 _parse_output(out['stdout'], strict=True)
     else:
         for repo in repos:
-            cmd = [_yum(), '--quiet', 'repository-packages', repo,
-                   'list', '--showduplicates']
+            cmd = [_yum(), '--quiet', '--showduplicates',
+                   'repository-packages', repo, 'list']
             # Can't concatenate because args is a tuple, using list.extend()
             cmd.extend(args)
 


### PR DESCRIPTION
This fixes two issues:

1. Python 3's configparser seems not to insert a `__name__` key into each section, so ca1b1bb6334da6597b97ae411d65b98844c8f661 causes some breakage in Python 3.

2. In Fedora 26, dnf interprets arguments after the repository-packages subcommand as arguments to the subcommand, not to dnf itself.

This should fix the tests failing in https://github.com/saltstack/salt-jenkins/issues/496