### PR TITLE
Fix `unit.modules.test_ini_manage` for Windows

### DIFF
--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -318,17 +318,18 @@ class _Section(OrderedDict):
         yield '{0}[{1}]{0}'.format(os.linesep, self.name)
         sections_dict = OrderedDict()
         for name, value in six.iteritems(self):
+            # Handle Comment Lines
             if com_regx.match(name):
                 yield '{0}{1}'.format(value, os.linesep)
+            # Handle Sections
             elif isinstance(value, _Section):
                 sections_dict.update({name: value})
+            # Key / Value pairs
+            # Adds spaces between the separator
             else:
                 yield '{0}{1}{2}{3}'.format(
                     name,
-                    (
-                        ' {0} '.format(self.sep) if self.sep != ' '
-                        else self.sep
-                    ),
+                    ' {0} '.format(self.sep) if self.sep != ' ' else self.sep,
                     value,
                     os.linesep
                 )

--- a/tests/unit/modules/test_ini_manage.py
+++ b/tests/unit/modules/test_ini_manage.py
@@ -19,27 +19,27 @@ class IniManageTestCase(TestCase):
         '# Comment on the first line',
         '',
         '# First main option',
-        'option1 = main1',
+        'option1=main1',
         '',
         '# Second main option',
-        'option2 = main2',
+        'option2=main2',
         '',
         '',
         '[main]',
         '# Another comment',
-        'test1 = value 1',
+        'test1=value 1',
         '',
-        'test2 = value 2',
+        'test2=value 2',
         '',
         '[SectionB]',
-        'test1 = value 1B',
+        'test1=value 1B',
         '',
         '# Blank line should be above',
         'test3 = value 3B',
         '',
         '[SectionC]',
         '# The following option is empty',
-        'empty_option ='
+        'empty_option='
     ])
 
     maxDiff = None

--- a/tests/unit/modules/test_ini_manage.py
+++ b/tests/unit/modules/test_ini_manage.py
@@ -125,8 +125,8 @@ class IniManageTestCase(TestCase):
         })
         with salt.utils.fopen(self.tfile.name, 'r') as fp:
             file_content = fp.read()
-        self.assertIn('\nempty_option = \n', file_content,
-                      'empty_option was not preserved')
+        expected = '{0}{1}{0}'.format(os.linesep, 'empty_option = ')
+        self.assertIn(expected, file_content, 'empty_option was not preserved')
 
     def test_empty_lines_preserved_after_edit(self):
         ini.set_option(self.tfile.name, {

--- a/tests/unit/modules/test_ini_manage.py
+++ b/tests/unit/modules/test_ini_manage.py
@@ -41,10 +41,6 @@ class IniManageTestCase(TestCase):
         '# The following option is empty',
         'empty_option ='
     ])
-    print('*' * 68)
-    print('original')
-    print(repr(salt.utils.to_bytes(TEST_FILE_CONTENT)))
-    print('*' * 68)
 
     maxDiff = None
 


### PR DESCRIPTION
### What does this PR do?
Uses `os.linesep` where possible. Changes from multiline strings to os.linesep.join lists to create the source and test text. For some reason, on Windows, the multiline line endings always evaluate to `\n`... they're not OS specific.

I would like to note, however, that there may be an issue with the `ini_manage` module. There is a test named `test_empty_lines_preserved_after_edit`. If I go by the name of the test I would have to assume that the file should be formatted the same before and after an edit as far as blank lines go. I found that not to be the case (both on Linux and Windows). At the top of the test (line 18) there is a `TEST_FILE_CONTENT` string that defines the source file. There are two blank lines just before the `[main]` section of the INI. It doesn't seem like the `ini_manage` module handles the double-blank line scenario. It removes one of the blank lines, leaving only one blank line above `[main]`.
The test variable that it's checking against (line 131) has that blank line removed. I couldn't figure out how to make it keep the double blank lines.
The behavior is the same in Windows and Linux.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes