### PR TITLE
Fix system.set_system_time when no hw clock is present

### DIFF
--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -168,7 +168,10 @@ def has_settable_hwclock():
     salt '*' system.has_settable_hwclock
     '''
     if salt.utils.which_bin(['hwclock']) is not None:
-        res = __salt__['cmd.run_all'](['hwclock', '--test', '--systohc'], python_shell=False)
+        res = __salt__['cmd.run_all'](
+            ['hwclock', '--test', '--systohc'], python_shell=False,
+            output_loglevel='quiet', ignore_retcode=True
+        )
         return res['retcode'] == 0
     return False
 


### PR DESCRIPTION
### What does this PR do?

If a hardware clock is not present, then the `cmd.run_all` call in
`has_settable_hwclock` will return a non-zero retcode. If
`ignore_retcode` is not set to True in that call, then it will set
`__context__['retcode']` to that code which will cause the job to
appear as if it failed (due to non-zero retcode) even though it
didn't really fail.

### Tests written?

No