### PR TITLE
Fix file.managed on Windows with test=True

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3368,6 +3368,10 @@ def stats(path, hash_type=None, follow_symlinks=True):
             pstat = os.lstat(path)
         except OSError:
             # Not a broken symlink, just a nonexistent path
+            # NOTE: The file.directory state checks the content of the error
+            # message in this exception. Any changes made to the message for this
+            # exception will reflect the file.directory state as well, and will
+            # likely require changes there.
             raise CommandExecutionError('Path not found: {0}'.format(path))
     else:
         if follow_symlinks:
@@ -4193,12 +4197,6 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
     # Check permissions
     perms = {}
     cur = stats(name, follow_symlinks=follow_symlinks)
-    if not cur:
-        # NOTE: The file.directory state checks the content of the error
-        # message in this exception. Any changes made to the message for this
-        # exception will reflect the file.directory state as well, and will
-        # likely require changes there.
-        raise CommandExecutionError('{0} does not exist'.format(name))
     perms['luser'] = cur['user']
     perms['lgroup'] = cur['group']
     perms['lmode'] = salt.utils.normalize_mode(cur['mode'])

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -789,7 +789,7 @@ def chgrp(path, group):
 
 def stats(path, hash_type='sha256', follow_symlinks=True):
     '''
-    Return a dict containing the stats for a given file
+    Return a dict containing the stats about a given file
 
     Under Windows, `gid` will equal `uid` and `group` will equal `user`.
 
@@ -1227,33 +1227,37 @@ def mkdir(path,
 
         path (str): The full path to the directory.
 
-        owner (str): The owner of the directory. If not passed, it will be the
-        account that created the directory, likely SYSTEM
+        owner (str):
+            The owner of the directory. If not passed, it will be the account
+            that created the directory, likely SYSTEM
 
-        grant_perms (dict): A dictionary containing the user/group and the basic
-        permissions to grant, ie: ``{'user': {'perms': 'basic_permission'}}``.
-        You can also set the ``applies_to`` setting here. The default is
-        ``this_folder_subfolders_files``. Specify another ``applies_to`` setting
-        like this:
+        grant_perms (dict):
+            A dictionary containing the user/group and the basic permissions to
+            grant, ie: ``{'user': {'perms': 'basic_permission'}}``. You can also
+            set the ``applies_to`` setting here. The default is
+            ``this_folder_subfolders_files``. Specify another ``applies_to``
+            setting like this:
 
-        .. code-block:: yaml
+            .. code-block:: yaml
 
-            {'user': {'perms': 'full_control', 'applies_to': 'this_folder'}}
+                {'user': {'perms': 'full_control', 'applies_to': 'this_folder'}}
 
-        To set advanced permissions use a list for the ``perms`` parameter, ie:
+            To set advanced permissions use a list for the ``perms`` parameter, ie:
 
-        .. code-block:: yaml
+            .. code-block:: yaml
 
-            {'user': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder'}}
+                {'user': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder'}}
 
-        deny_perms (dict): A dictionary containing the user/group and
-        permissions to deny along with the ``applies_to`` setting. Use the same
-        format used for the ``grant_perms`` parameter. Remember, deny
-        permissions supersede grant permissions.
+        deny_perms (dict):
+            A dictionary containing the user/group and permissions to deny along
+            with the ``applies_to`` setting. Use the same format used for the
+            ``grant_perms`` parameter. Remember, deny permissions supersede
+            grant permissions.
 
-        inheritance (bool): If True the object will inherit permissions from the
-        parent, if False, inheritance will be disabled. Inheritance setting will
-        not apply to parent directories if they must be created
+        inheritance (bool):
+            If True the object will inherit permissions from the parent, if
+            False, inheritance will be disabled. Inheritance setting will not
+            apply to parent directories if they must be created
 
     Returns:
         bool: True if successful
@@ -1312,33 +1316,37 @@ def makedirs_(path,
 
         path (str): The full path to the directory.
 
-        owner (str): The owner of the directory. If not passed, it will be the
-        account that created the directly, likely SYSTEM
+        owner (str):
+            The owner of the directory. If not passed, it will be the account
+            that created the directly, likely SYSTEM
 
-        grant_perms (dict): A dictionary containing the user/group and the basic
-        permissions to grant, ie: ``{'user': {'perms': 'basic_permission'}}``.
-        You can also set the ``applies_to`` setting here. The default is
-        ``this_folder_subfolders_files``. Specify another ``applies_to`` setting
-        like this:
+        grant_perms (dict):
+            A dictionary containing the user/group and the basic permissions to
+            grant, ie: ``{'user': {'perms': 'basic_permission'}}``. You can also
+            set the ``applies_to`` setting here. The default is
+            ``this_folder_subfolders_files``. Specify another ``applies_to``
+            setting like this:
 
-        .. code-block:: yaml
+            .. code-block:: yaml
 
-            {'user': {'perms': 'full_control', 'applies_to': 'this_folder'}}
+                {'user': {'perms': 'full_control', 'applies_to': 'this_folder'}}
 
-        To set advanced permissions use a list for the ``perms`` parameter, ie:
+            To set advanced permissions use a list for the ``perms`` parameter, ie:
 
-        .. code-block:: yaml
+            .. code-block:: yaml
 
-            {'user': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder'}}
+                {'user': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder'}}
 
-        deny_perms (dict): A dictionary containing the user/group and
-        permissions to deny along with the ``applies_to`` setting. Use the same
-        format used for the ``grant_perms`` parameter. Remember, deny
-        permissions supersede grant permissions.
+        deny_perms (dict):
+            A dictionary containing the user/group and permissions to deny along
+            with the ``applies_to`` setting. Use the same format used for the
+            ``grant_perms`` parameter. Remember, deny permissions supersede
+            grant permissions.
 
-        inheritance (bool): If True the object will inherit permissions from the
-        parent, if False, inheritance will be disabled. Inheritance setting will
-        not apply to parent directories if they must be created
+        inheritance (bool):
+            If True the object will inherit permissions from the parent, if
+            False, inheritance will be disabled. Inheritance setting will not
+            apply to parent directories if they must be created
 
     .. note::
 
@@ -1423,36 +1431,40 @@ def makedirs_perms(path,
 
         path (str): The full path to the directory.
 
-        owner (str): The owner of the directory. If not passed, it will be the
-        account that created the directory, likely SYSTEM
+        owner (str):
+            The owner of the directory. If not passed, it will be the account
+            that created the directory, likely SYSTEM
 
-        grant_perms (dict): A dictionary containing the user/group and the basic
-        permissions to grant, ie: ``{'user': {'perms': 'basic_permission'}}``.
-        You can also set the ``applies_to`` setting here. The default is
-        ``this_folder_subfolders_files``. Specify another ``applies_to`` setting
-        like this:
+        grant_perms (dict):
+            A dictionary containing the user/group and the basic permissions to
+            grant, ie: ``{'user': {'perms': 'basic_permission'}}``. You can also
+            set the ``applies_to`` setting here. The default is
+            ``this_folder_subfolders_files``. Specify another ``applies_to``
+            setting like this:
 
-        .. code-block:: yaml
+            .. code-block:: yaml
 
-            {'user': {'perms': 'full_control', 'applies_to': 'this_folder'}}
+                {'user': {'perms': 'full_control', 'applies_to': 'this_folder'}}
 
-        To set advanced permissions use a list for the ``perms`` parameter, ie:
+            To set advanced permissions use a list for the ``perms`` parameter, ie:
 
-        .. code-block:: yaml
+            .. code-block:: yaml
 
-            {'user': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder'}}
+                {'user': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder'}}
 
-        deny_perms (dict): A dictionary containing the user/group and
-        permissions to deny along with the ``applies_to`` setting. Use the same
-        format used for the ``grant_perms`` parameter. Remember, deny
-        permissions supersede grant permissions.
+        deny_perms (dict):
+            A dictionary containing the user/group and permissions to deny along
+            with the ``applies_to`` setting. Use the same format used for the
+            ``grant_perms`` parameter. Remember, deny permissions supersede
+            grant permissions.
 
-        inheritance (bool): If True the object will inherit permissions from the
-        parent, if False, inheritance will be disabled. Inheritance setting will
-        not apply to parent directories if they must be created
+        inheritance (bool):
+            If True the object will inherit permissions from the parent, if
+            False, inheritance will be disabled. Inheritance setting will not
+            apply to parent directories if they must be created
 
     Returns:
-        bool: True if successful, otherwise raise an error
+        bool: True if successful, otherwise raises an error
 
     CLI Example:
 
@@ -1505,45 +1517,55 @@ def check_perms(path,
                 deny_perms=None,
                 inheritance=True):
     '''
-    Set owner and permissions for each directory created.
+    Set owner and permissions for each directory created. Used mostly by the
+    state system.
 
     Args:
 
         path (str): The full path to the directory.
 
-        ret (dict): A dictionary to append changes to and return. If not passed,
-        will create a new dictionary to return.
+        ret (dict):
+            A dictionary to append changes to and return. If not passed, will
+            create a new dictionary to return. If file is not found, the passed
+            dictionary will be returned, otherwise an error will be raised.
 
-        owner (str): The owner of the directory. If not passed, it will be the
-        account that created the directory, likely SYSTEM
+        owner (str):
+            The owner of the directory. If not passed, it will be the account
+            that created the directory, likely SYSTEM
 
-        grant_perms (dict): A dictionary containing the user/group and the basic
-        permissions to grant, ie: ``{'user': {'perms': 'basic_permission'}}``.
-        You can also set the ``applies_to`` setting here. The default is
-        ``this_folder_subfolders_files``. Specify another ``applies_to`` setting
-        like this:
+        grant_perms (dict):
+            A dictionary containing the user/group and the basic permissions to
+            grant, ie: ``{'user': {'perms': 'basic_permission'}}``. You can also
+            set the ``applies_to`` setting here. The default is
+            ``this_folder_subfolders_files``. Specify another ``applies_to``
+            setting like this:
 
-        .. code-block:: yaml
+            .. code-block:: yaml
 
-            {'user': {'perms': 'full_control', 'applies_to': 'this_folder'}}
+                {'user': {'perms': 'full_control', 'applies_to': 'this_folder'}}
 
-        To set advanced permissions use a list for the ``perms`` parameter, ie:
+            To set advanced permissions use a list for the ``perms`` parameter, ie:
 
-        .. code-block:: yaml
+            .. code-block:: yaml
 
-            {'user': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder'}}
+                {'user': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'this_folder'}}
 
-        deny_perms (dict): A dictionary containing the user/group and
-        permissions to deny along with the ``applies_to`` setting. Use the same
-        format used for the ``grant_perms`` parameter. Remember, deny
-        permissions supersede grant permissions.
+        deny_perms (dict):
+            A dictionary containing the user/group and permissions to deny along
+            with the ``applies_to`` setting. Use the same format used for the
+            ``grant_perms`` parameter. Remember, deny permissions supersede
+            grant permissions.
 
-        inheritance (bool): If True the object will inherit permissions from the
-        parent, if False, inheritance will be disabled. Inheritance setting will
-        not apply to parent directories if they must be created
+        inheritance (bool):
+            If True the object will inherit permissions from the parent, if
+            False, inheritance will be disabled. Inheritance setting will not
+            apply to parent directories if they must be created
 
     Returns:
-        bool: True if successful, otherwise raise an error
+        dict: A dictionary of changes made to the object
+
+    Raises:
+        CommandExecutionError: If the object does not exist
 
     CLI Example:
 

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -821,7 +821,7 @@ def stats(path, hash_type='sha256', follow_symlinks=True):
     # This is to mirror the behavior of file.py. `check_file_meta` expects an
     # empty dictionary when the file does not exist
     if not os.path.exists(path):
-        return {}
+        raise CommandExecutionError('Path not found: {0}'.format(path))
 
     if follow_symlinks and sys.getwindowsversion().major >= 6:
         path = _resolve_symlink(path)

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -818,8 +818,10 @@ def stats(path, hash_type='sha256', follow_symlinks=True):
 
         salt '*' file.stats /etc/passwd
     '''
+    # This is to mirror the behavior of file.py. `check_file_meta` expects an
+    # empty dictionary when the file does not exist
     if not os.path.exists(path):
-        raise CommandExecutionError('Path not found: {0}'.format(path))
+        return {}
 
     if follow_symlinks and sys.getwindowsversion().major >= 6:
         path = _resolve_symlink(path)
@@ -1556,6 +1558,13 @@ def check_perms(path,
         # Specify advanced attributes with a list
         salt '*' file.check_perms C:\\Temp\\ Administrators "{'jsnuffy': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'files_only'}}"
     '''
+    # This is to work with the state module.
+    if not os.path.exists(path):
+        if ret:
+            return ret
+        else:
+            raise CommandExecutionError('The directory does not exist.')
+
     path = os.path.expanduser(path)
 
     if not ret:

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1526,8 +1526,7 @@ def check_perms(path,
 
         ret (dict):
             A dictionary to append changes to and return. If not passed, will
-            create a new dictionary to return. If file is not found, the passed
-            dictionary will be returned, otherwise an error will be raised.
+            create a new dictionary to return.
 
         owner (str):
             The owner of the directory. If not passed, it will be the account
@@ -1580,12 +1579,8 @@ def check_perms(path,
         # Specify advanced attributes with a list
         salt '*' file.check_perms C:\\Temp\\ Administrators "{'jsnuffy': {'perms': ['read_attributes', 'read_ea'], 'applies_to': 'files_only'}}"
     '''
-    # This is to work with the state module.
     if not os.path.exists(path):
-        if ret:
-            return ret
-        else:
-            raise CommandExecutionError('The directory does not exist.')
+        raise CommandExecutionError('Path not found: {0}'.format(path))
 
     path = os.path.expanduser(path)
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -758,7 +758,7 @@ def _check_directory_win(name,
     changes = {}
 
     if not os.path.isdir(name):
-        changes = {'directory': 'new'}
+        changes = {name: {'directory': 'new'}}
     else:
         # Check owner
         owner = salt.utils.win_dacl.get_owner(name)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2988,7 +2988,7 @@ def directory(name,
                             ret, _ = __salt__['file.check_perms'](
                                 full, ret, user, group, dir_mode, follow_symlinks)
                     except CommandExecutionError as exc:
-                        if not exc.strerror.endswith('does not exist'):
+                        if not exc.strerror.startswith('Path not found'):
                             errors.append(exc.strerror)
 
     if clean:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -886,7 +886,7 @@ def _check_dir_meta(name,
     try:
         stats = __salt__['file.stats'](name, None, follow_symlinks)
     except CommandExecutionError:
-        state = {}
+        stats = {}
 
     changes = {}
     if not stats:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -883,7 +883,11 @@ def _check_dir_meta(name,
     '''
     Check the changes in directory metadata
     '''
-    stats = __salt__['file.stats'](name, None, follow_symlinks)
+    try:
+        stats = __salt__['file.stats'](name, None, follow_symlinks)
+    except CommandExecutionError:
+        state = {}
+
     changes = {}
     if not stats:
         changes['directory'] = 'new'

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -73,7 +73,7 @@ def _test_managed_file_mode_keep_helper(testcase, local=False):
 
     # Get the current mode so that we can put the file back the way we
     # found it when we're done.
-    grail_fs_mode = int(testcase.run_function('file.get_mode', [grail_fs_path]))
+    grail_fs_mode = int(testcase.run_function('file.get_mode', [grail_fs_path]), 8)
     initial_mode = 504    # 0770 octal
     new_mode_1 = 384      # 0600 octal
     new_mode_2 = 420      # 0644 octal

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -73,7 +73,7 @@ def _test_managed_file_mode_keep_helper(testcase, local=False):
 
     # Get the current mode so that we can put the file back the way we
     # found it when we're done.
-    grail_fs_mode = testcase.run_function('file.get_mode', [grail_fs_path])
+    grail_fs_mode = int(testcase.run_function('file.get_mode', [grail_fs_path]))
     initial_mode = 504    # 0770 octal
     new_mode_1 = 384      # 0600 octal
     new_mode_2 = 420      # 0644 octal
@@ -1964,6 +1964,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             fp_.write(
                 os.linesep.join(sls_template).format(testcase_filedest))
 
+        ret = self.run_function('state.sls', mods='issue-8343')
         for name, step in six.iteritems(ret):
             self.assertSaltTrueReturn({name: step})
 

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -586,7 +586,7 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             tmp_dir = os.path.join(TMP, 'pgdata')
             sym_dir = os.path.join(TMP, 'pg_data')
             os.mkdir(tmp_dir, 0o700)
-            os.symlink(tmp_dir, sym_dir)
+            self.run_function('file.symlink', [tmp_dir, sym_dir])
 
             ret = self.run_state(
                 'file.directory', test=True, name=sym_dir, follow_symlinks=True,
@@ -595,9 +595,9 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             self.assertSaltTrueReturn(ret)
         finally:
             if os.path.isdir(tmp_dir):
-                shutil.rmtree(tmp_dir)
+                self.run_function('file.remove', [tmp_dir])
             if os.path.islink(sym_dir):
-                os.unlink(sym_dir)
+                self.run_function('file.remove', [sym_dir])
 
     @skip_if_not_root
     @skipIf(IS_WINDOWS, 'Mode not available in Windows')

--- a/tests/unit/modules/test_win_file.py
+++ b/tests/unit/modules/test_win_file.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 import os
 
 # Import Salt Testing Libs
-from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
     patch,
@@ -18,18 +17,19 @@ from tests.support.mock import (
 # Import Salt Libs
 import salt.modules.win_file as win_file
 from salt.exceptions import CommandExecutionError
+import salt.utils
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-class WinFileTestCase(TestCase, LoaderModuleMockMixin):
+class WinFileTestCase(TestCase):
     '''
         Test cases for salt.modules.win_file
     '''
     FAKE_RET = {'fake': 'ret data'}
-    FAKE_PATH = os.sep.join(['C:', 'path', 'does', 'not', 'exist'])
-
-    def setup_loader_modules(self):
-        return {win_file: {}}
+    if salt.utils.is_windows():
+        FAKE_PATH = os.sep.join(['C:', 'path', 'does', 'not', 'exist'])
+    else:
+        FAKE_PATH = os.sep.join(['path', 'does', 'not', 'exist'])
 
     def test_issue_43328_stats(self):
         '''

--- a/tests/unit/modules/test_win_file.py
+++ b/tests/unit/modules/test_win_file.py
@@ -36,8 +36,9 @@ class WinFileTestCase(TestCase):
         Make sure that an empty dictionary is returned if the file doesn't exist
         '''
         with patch('os.path.exists', return_value=False):
-            ret = win_file.stats(self.FAKE_PATH)
-            self.assertEqual(ret, {})
+            self.assertRaises(CommandExecutionError,
+                              win_file.stats,
+                              self.FAKE_PATH)
 
     def test_issue_43328_check_perms_ret_passed(self):
         '''

--- a/tests/unit/modules/test_win_file.py
+++ b/tests/unit/modules/test_win_file.py
@@ -33,26 +33,18 @@ class WinFileTestCase(TestCase):
 
     def test_issue_43328_stats(self):
         '''
-        Make sure that an empty dictionary is returned if the file doesn't exist
+        Make sure that a CommandExecutionError is raised if the file does NOT
+        exist
         '''
         with patch('os.path.exists', return_value=False):
             self.assertRaises(CommandExecutionError,
                               win_file.stats,
                               self.FAKE_PATH)
 
-    def test_issue_43328_check_perms_ret_passed(self):
-        '''
-        Make sure that ret is returned if the file doesn't exist and ret is
-        passed
-        '''
-        with patch('os.path.exists', return_value=False):
-            ret = win_file.check_perms(self.FAKE_PATH, ret=self.FAKE_RET)
-            self.assertEqual(ret, self.FAKE_RET)
-
     def test_issue_43328_check_perms_no_ret(self):
         '''
-        Make sure that a CommandExecutionError is raised if the file doesn't
-        exist and ret is NOT passed
+        Make sure that a CommandExecutionError is raised if the file does NOT
+        exist
         '''
         with patch('os.path.exists', return_value=False):
             self.assertRaises(

--- a/tests/unit/modules/test_win_file.py
+++ b/tests/unit/modules/test_win_file.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+'''
+:codeauthor: :email:`Shane Lee <slee@saltstack.com>`
+'''
+# Import Python Libs
+from __future__ import absolute_import
+import os
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt Libs
+import salt.modules.win_file as win_file
+from salt.exceptions import CommandExecutionError
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class WinFileTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+        Test cases for salt.modules.win_file
+    '''
+    FAKE_RET = {'fake': 'ret data'}
+    FAKE_PATH = os.sep.join(['C:', 'path', 'does', 'not', 'exist'])
+
+    def setup_loader_modules(self):
+        return {win_file: {}}
+
+    def test_issue_43328_stats(self):
+        '''
+        Make sure that an empty dictionary is returned if the file doesn't exist
+        '''
+        with patch('os.path.exists', return_value=False):
+            ret = win_file.stats(self.FAKE_PATH)
+            self.assertEqual(ret, {})
+
+    def test_issue_43328_check_perms_ret_passed(self):
+        '''
+        Make sure that ret is returned if the file doesn't exist and ret is
+        passed
+        '''
+        with patch('os.path.exists', return_value=False):
+            ret = win_file.check_perms(self.FAKE_PATH, ret=self.FAKE_RET)
+            self.assertEqual(ret, self.FAKE_RET)
+
+    def test_issue_43328_check_perms_no_ret(self):
+        '''
+        Make sure that a CommandExecutionError is raised if the file doesn't
+        exist and ret is NOT passed
+        '''
+        with patch('os.path.exists', return_value=False):
+            self.assertRaises(
+                CommandExecutionError, win_file.check_perms, self.FAKE_PATH)

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -743,7 +743,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
         mock_check = MagicMock(return_value=(
             None,
             'The directory "{0}" will be changed'.format(name),
-            {'directory': 'new'}))
+            {name: {'directory': 'new'}}))
         mock_error = CommandExecutionError
         with patch.dict(filestate.__salt__, {'config.manage_mode': mock_t,
                                              'file.user_to_uid': mock_uid,
@@ -801,16 +801,15 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                                                                  group=group),
                                              ret)
 
-                with patch.object(os.path, 'isfile', mock_f):
+                with patch.object(os.path, 'isdir', mock_f):
                     with patch.dict(filestate.__opts__, {'test': True}):
                         if salt.utils.is_windows():
                             comt = 'The directory "{0}" will be changed' \
                                    ''.format(name)
-                            p_chg = {'directory': 'new'}
                         else:
                             comt = ('The following files will be changed:\n{0}:'
                                     ' directory - new\n'.format(name))
-                            p_chg = {'/etc/grub.conf': {'directory': 'new'}}
+                        p_chg = {'/etc/grub.conf': {'directory': 'new'}}
                         ret.update({
                             'comment': comt,
                             'result': None,


### PR DESCRIPTION
### What does this PR do?
Fix file.managed with makedirs=True on Windows when the target directory structure is missing and test=True

Regression caused by https://github.com/saltstack/salt/pull/39773

Fix formatting issues in the docs

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/43328

### Tests written?
No