### PR TITLE
Add a file.link state for hard links

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3179,8 +3179,9 @@ def link(src, path):
     try:
         os.link(src, path)
         return True
-    except (OSError, IOError):
-        raise CommandExecutionError('Could not create \'{0}\''.format(path))
+    except (OSError, IOError) as e:
+        msg = 'Could not create hard link \'{0}\' -> {1}: {2}'
+        raise CommandExecutionError(msg.format(path, src, e))
     return False
 
 
@@ -3227,8 +3228,9 @@ def symlink(src, path):
     try:
         os.symlink(src, path)
         return True
-    except (OSError, IOError):
-        raise CommandExecutionError('Could not create \'{0}\''.format(path))
+    except (OSError, IOError) as e:
+        msg = 'Could not create symlink \'{0}\' -> {1}: {2}'
+        raise CommandExecutionError(msg.format(path, src, e))
     return False
 
 


### PR DESCRIPTION
### What does this PR do?
Adds a file.link state that creates hard links.

TODO:
- Add some tests
- Add the versionadded tag

### What issues does this PR fix or reference?

### Previous Behavior
No file.link state was available, although there was an execution function.

### New Behavior
There is a file.link state.

### Tests written?
Not yet

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
