### PR TITLE
Fix `unit.modules.test_pam` for Windows

### DIFF
--- a/tests/unit/modules/test_pam.py
+++ b/tests/unit/modules/test_pam.py
@@ -34,7 +34,8 @@ class PamTestCase(TestCase):
         '''
         Test if the parsing function works
         '''
-        with patch('salt.utils.fopen', mock_open(read_data=MOCK_FILE)):
+        with patch('os.path.exists', return_value=True), \
+                patch('salt.utils.fopen', mock_open(read_data=MOCK_FILE)):
             self.assertListEqual(pam.read_file('/etc/pam.d/login'),
                                  [{'arguments': [], 'control_flag': 'ok',
                                    'interface': 'ok', 'module': 'ignore'}])


### PR DESCRIPTION
### What does this PR do?
Mocks os.path.exists

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes