### PR TITLE
Fix `unit.modules.test_pw_group` for Windows

### DIFF
--- a/tests/unit/modules/test_pw_group.py
+++ b/tests/unit/modules/test_pw_group.py
@@ -18,6 +18,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.modules.pw_group as pw_group
+import salt.utils
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -44,6 +45,7 @@ class PwGroupTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(pw_group.__salt__, {'cmd.run_all': mock}):
             self.assertTrue(pw_group.delete('a'))
 
+    @skipIf(salt.utils.is_windows(), 'grp not available on Windows')
     def test_info(self):
         '''
         Tests to return information about a group
@@ -57,6 +59,7 @@ class PwGroupTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(pw_group.grinfo, mock):
             self.assertDictEqual(pw_group.info('name'), {})
 
+    @skipIf(salt.utils.is_windows(), 'grp not available on Windows')
     def test_getent(self):
         '''
         Tests for return info on all groups


### PR DESCRIPTION
### What does this PR do?
Skip `test_info` and `test_getent` because they require `grp`, which is not available on Windows

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes