### PR TITLE
Proper timestamp conversion in `redis.lastsave`

### DIFF
--- a/salt/modules/redismod.py
+++ b/salt/modules/redismod.py
@@ -18,6 +18,8 @@ Module to provide redis functionality to Salt
 # Import Python libs
 from __future__ import absolute_import
 from salt.ext.six.moves import zip
+from salt.ext import six
+from datetime import datetime
 
 # Import third party libs
 try:
@@ -513,8 +515,14 @@ def lastsave(host=None, port=None, db=None, password=None):
 
         salt '*' redis.lastsave
     '''
+    # Use of %s to get the timestamp is not supported by Python. The reason it
+    # works is because it's passed to the system strftime which may not support
+    # it. See: https://stackoverflow.com/a/11743262
     server = _connect(host, port, db, password)
-    return int(server.lastsave().strftime("%s"))
+    if six.PY2:
+        return int((server.lastsave() - datetime(1970, 1, 1)).total_seconds())
+    else:
+        return int(server.lastsave().timestamp())
 
 
 def llen(key, host=None, port=None, db=None, password=None):


### PR DESCRIPTION
### What does this PR do?
Properly handle timestamp conversion. `%s` is not supported to convert to a timestamp by Python. When used it is passed to the system `strftime` function and will work only if the system supports it.

The conversion is handled differently in Py2 and Py3.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
No