### PR TITLE
make cache dirs when spm starts

### DIFF
--- a/salt/cli/spm.py
+++ b/salt/cli/spm.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 # Import Salt libs
 import salt.spm
 import salt.utils.parsers as parsers
-from salt.utils.verify import verify_log
+from salt.utils.verify import verify_log, verify_env
 
 
 class SPM(parsers.SPMParser):
@@ -29,6 +29,10 @@ class SPM(parsers.SPMParser):
         ui = salt.spm.SPMCmdlineInterface()
         self.parse_args()
         self.setup_logfile_logger()
+        v_dirs = [
+            self.config['cachedir'],
+        ]
+        verify_env(v_dirs, self.config['user'],)
         verify_log(self.config)
         client = salt.spm.SPMClient(ui, self.config)
         client.run(self.args)


### PR DESCRIPTION
### What does this PR do?
if the cachedir isn't created, as in the salt-master started before spm is run or run on a masterless minion, then spm will fail on the first run.

### Tests written?

No

@techhat can you think of some other directories we should add to this?

Thanks,
Daniel