### PR TITLE
Fix `unit.modules.test_gem` for Windows

### DIFF
--- a/tests/unit/modules/test_gem.py
+++ b/tests/unit/modules/test_gem.py
@@ -65,7 +65,8 @@ class TestGemModule(TestCase, LoaderModuleMockMixin):
         with patch.dict(gem.__salt__,
                         {'rvm.is_installed': MagicMock(return_value=False),
                          'rbenv.is_installed': MagicMock(return_value=True),
-                         'rbenv.do': mock}):
+                         'rbenv.do': mock}),\
+                patch('salt.utils.is_windows', return_value=False):
             gem._gem(['install', 'rails'])
             mock.assert_called_once_with(
                 ['gem', 'install', 'rails'],


### PR DESCRIPTION
### What does this PR do?
Mock `salt.utils.is_windows` to return False so the test will run on Windows

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes