### PR TITLE
Fix /etc/hosts not being modified when hostname is changed

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -2027,18 +2027,11 @@ def build_network_settings(**settings):
         # Write settings
         _write_file_network(network, _DEB_NETWORKING_FILE, True)
 
-    # Write hostname to /etc/hostname
+    # Get hostname and domain from opts
     sline = opts['hostname'].split('.', 1)
     opts['hostname'] = sline[0]
-    hostname = '{0}\n' . format(opts['hostname'])
     current_domainname = current_network_settings['domainname']
     current_searchdomain = current_network_settings['searchdomain']
-
-    # Only write the hostname if it has changed
-    if not opts['hostname'] == current_network_settings['hostname']:
-        if not ('test' in settings and settings['test']):
-            # TODO  replace wiht a call to network.mod_hostname instead
-            _write_file_network(hostname, _DEB_HOSTNAME_FILE)
 
     new_domain = False
     if len(sline) > 1:


### PR DESCRIPTION


### What does this PR do?
This PR fix `/etc/hosts` not being modified when the hostname is changed using module `network.system`
### What issues does this PR fix or reference?
Fixes #42926
### Previous Behavior
Because `/etc/hostname` was changed during `build_network_settings` in `salt.modules.debian_ip.py`,
`/etc/hosts` was not updated by `mod_hostname` in `salt.modules.network.py` (see issue).

### New Behavior
`/etc/hosts` is now updated accordingly
### Tests written?

No