### PR TITLE
boto_elb.register_instances: do not skip instances being unregistered

### DIFF
--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -517,7 +517,8 @@ def register_instances(name, instances, region=None, key=None, keyid=None,
 
     health = __salt__['boto_elb.get_instance_health'](
             name, region, key, keyid, profile)
-    nodes = [value['instance_id'] for value in health]
+    nodes = [value['instance_id'] for value in health
+             if value['description'] != 'Instance deregistration currently in progress.']
     new = [value for value in instances if value not in nodes]
     if not len(new):
         msg = 'Instance/s {0} already exist.'.format(str(instances).strip('[]'))


### PR DESCRIPTION
`boto_elb.register_instances` currently skips nodes that are in the
process of being unregistered, which causes an instance to getting
registered again, if registration happens too fast after deregistration.

This patch skips instances, where describe-instance-health returns:

    {
        "InstanceId": "i-XXX",
        "State": "InService",
        "ReasonCode": "N/A",
        "Description": "Instance deregistration currently in progress."
    },

The normal state is:

    {
        "InstanceId": "i-XXX",
        "State": "InService",
        "ReasonCode": "N/A",
        "Description": "N/A"
    },

btw: for an instance being in the process of being registered it looks
like this:

    {
        "InstanceId": "i-XXX",
        "State": "OutOfService",
        "ReasonCode": "ELB",
        "Description": "Instance registration is still in progress."
    },

Ref: http://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_InstanceState.html

It should maybe also check for `state == 'InService'` in general (additionally)?!