### PR TITLE
Use $HOME to get the user home directory instead using '~' char

### DIFF
--- a/pkg/salt.bash
+++ b/pkg/salt.bash
@@ -35,7 +35,8 @@ _salt_get_keys(){
 }
 
 _salt(){
-    local _salt_cache_functions=${SALT_COMP_CACHE_FUNCTIONS:='~/.cache/salt-comp-cache_functions'}
+    CACHE_DIR="$HOME/.cache/salt-comp-cache_functions"
+    local _salt_cache_functions=${SALT_COMP_CACHE_FUNCTIONS:=$CACHE_DIR}
     local _salt_cache_timeout=${SALT_COMP_CACHE_TIMEOUT:='last hour'}
 
     if [ ! -d "$(dirname ${_salt_cache_functions})" ]; then


### PR DESCRIPTION
### What does this PR do?
This PR fixes a problem with the Salt bash completion which does not expand the '~' char in order to get a right directory to store the functions cache.

### Previous Behavior
When using the Salt bash completion, a `~` directory is created on my present directory (containing the `.cache` dir) instead of expanding `~` to the user home directory and creating the `.cache` directory there

### New Behavior
The user home directory now is obtained from $HOME environment variable.

### Tests written?
No