### PR TITLE
[2017.7] Fixes to scheduler __pub values in kwargs

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -842,7 +842,8 @@ class Schedule(object):
             if argspec.keywords:
                 # this function accepts **kwargs, pack in the publish data
                 for key, val in six.iteritems(ret):
-                    kwargs['__pub_{0}'.format(key)] = copy.deepcopy(val)
+                    is key is not 'kwargs':
+                        kwargs['__pub_{0}'.format(key)] = copy.deepcopy(val)
 
             ret['return'] = self.functions[func](*args, **kwargs)
 

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -842,7 +842,7 @@ class Schedule(object):
             if argspec.keywords:
                 # this function accepts **kwargs, pack in the publish data
                 for key, val in six.iteritems(ret):
-                    is key is not 'kwargs':
+                    if key is not 'kwargs':
                         kwargs['__pub_{0}'.format(key)] = copy.deepcopy(val)
 
             ret['return'] = self.functions[func](*args, **kwargs)


### PR DESCRIPTION
Adding a small check to ensure we do not continue to populate kwargs with __pub_ items from the kwargs item.

### What does this PR do?
Causes the scheduler to ignore the `kwargs` argument when creating the __pub values inside kwargs, otherwise we end with an ever growing dict of nested __pub values.

### What issues does this PR fix or reference?
#43386 

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
