### PR TITLE
Bump deprecation warning for boto_vpc.describe_route_table

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -2456,7 +2456,8 @@ def describe_route_table(route_table_id=None, route_table_name=None,
 
     '''
 
-    salt.utils.warn_until('Oxygen',
+    salt.utils.warn_until(
+        'Neon',
          'The \'describe_route_table\' method has been deprecated and '
          'replaced by \'describe_route_tables\'.'
     )


### PR DESCRIPTION
This deprecation warning needs to be bumped out to Neon instead of Oxygen.

See Issue #43223 for more details.
