### PR TITLE
Add Neon to version list

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -90,8 +90,8 @@ class SaltStackVersion(object):
         'Nitrogen'      : (MAX_SIZE - 102, 0),
         'Oxygen'        : (MAX_SIZE - 101, 0),
         'Fluorine'      : (MAX_SIZE - 100, 0),
+        'Neon'          : (MAX_SIZE - 99, 0),
         # pylint: disable=E8265
-        #'Neon'         : (MAX_SIZE - 99 , 0),
         #'Sodium'       : (MAX_SIZE - 98 , 0),
         #'Magnesium'    : (MAX_SIZE - 97 , 0),
         #'Aluminium'    : (MAX_SIZE - 96 , 0),


### PR DESCRIPTION
Follow up to #43445

When the `warn_util` version was bumped to Neon in #43445, we also should have exposed the reference in `version.py`.
