### PR TITLE
Fix missing PER_REMOTE_ONLY in cache.clear_git_lock runner

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -90,7 +90,8 @@ def init_git_pillar(opts):
                 pillar = salt.utils.gitfs.GitPillar(opts)
                 pillar.init_remotes(
                     opts_dict['git'],
-                    git_pillar.PER_REMOTE_OVERRIDES
+                    git_pillar.PER_REMOTE_OVERRIDES,
+                    git_pillar.PER_REMOTE_ONLY
                 )
                 ret.append(pillar)
     return ret

--- a/salt/master.py
+++ b/salt/master.py
@@ -61,7 +61,6 @@ import salt.search
 import salt.key
 import salt.acl
 import salt.engines
-import salt.fileserver
 import salt.daemons.masterapi
 import salt.defaults.exitcodes
 import salt.transport.server
@@ -182,7 +181,8 @@ class Maintenance(SignalHandlingMultiprocessingProcess):
         in the parent process, then once the fork happens you'll start getting
         errors like "WARNING: Mixing fork() and threads detected; memory leaked."
         '''
-        # Init fileserver manager
+        # Avoid circular import
+        import salt.fileserver
         self.fileserver = salt.fileserver.Fileserver(self.opts)
         # Load Runners
         ropts = dict(self.opts)
@@ -463,6 +463,8 @@ class Master(SMaster):
                 'Cannot change to root directory ({0})'.format(err)
             )
 
+        # Avoid circular import
+        import salt.fileserver
         fileserver = salt.fileserver.Fileserver(self.opts)
         if not fileserver.servers:
             errors.append(
@@ -496,13 +498,15 @@ class Master(SMaster):
         if non_legacy_git_pillars:
             try:
                 new_opts = copy.deepcopy(self.opts)
-                from salt.pillar.git_pillar \
-                    import PER_REMOTE_OVERRIDES as overrides
+                import salt.pillar.git_pillar
                 for repo in non_legacy_git_pillars:
                     new_opts['ext_pillar'] = [repo]
                     try:
                         git_pillar = salt.utils.gitfs.GitPillar(new_opts)
-                        git_pillar.init_remotes(repo['git'], overrides)
+                        git_pillar.init_remotes(
+                            repo['git'],
+                            salt.pillar.git_pillar.PER_REMOTE_OVERRIDES,
+                            salt.pillar.git_pillar.PER_REMOTE_ONLY)
                     except FileserverConfigError as exc:
                         critical_errors.append(exc.strerror)
             finally:
@@ -972,6 +976,8 @@ class AESFuncs(object):
         '''
         Set the local file objects from the file server interface
         '''
+        # Avoid circular import
+        import salt.fileserver
         self.fs_ = salt.fileserver.Fileserver(self.opts)
         self._serve_file = self.fs_.serve_file
         self._file_find = self.fs_._find_file

--- a/salt/modules/win_repo.py
+++ b/salt/modules/win_repo.py
@@ -25,7 +25,8 @@ from salt.exceptions import CommandExecutionError, SaltRenderError
 from salt.runners.winrepo import (
     genrepo as _genrepo,
     update_git_repos as _update_git_repos,
-    PER_REMOTE_OVERRIDES
+    PER_REMOTE_OVERRIDES,
+    PER_REMOTE_ONLY
 )
 from salt.ext import six
 try:

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -763,9 +763,12 @@ class Pillar(object):
                     and self.opts.get('__role') != 'minion':
                 # Avoid circular import
                 import salt.utils.gitfs
-                from salt.pillar.git_pillar import PER_REMOTE_OVERRIDES
+                import salt.pillar.git_pillar
                 git_pillar = salt.utils.gitfs.GitPillar(self.opts)
-                git_pillar.init_remotes(self.ext['git'], PER_REMOTE_OVERRIDES)
+                git_pillar.init_remotes(
+                    self.ext['git'],
+                    salt.pillar.git_pillar.PER_REMOTE_OVERRIDES,
+                    salt.pillar.git_pillar.PER_REMOTE_ONLY)
                 git_pillar.fetch_remotes()
         except TypeError:
             # Handle malformed ext_pillar

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -328,6 +328,12 @@ except ImportError:
 
 PER_REMOTE_OVERRIDES = ('env', 'root', 'ssl_verify')
 
+# Fall back to default per-remote-only. This isn't technically needed since
+# salt.utils.gitfs.GitBase.init_remotes() will default to
+# salt.utils.gitfs.PER_REMOTE_ONLY for this value, so this is mainly for
+# runners and other modules that import salt.pillar.git_pillar.
+PER_REMOTE_ONLY = salt.utils.gitfs.PER_REMOTE_ONLY
+
 # Set up logging
 log = logging.getLogger(__name__)
 
@@ -380,7 +386,7 @@ def ext_pillar(minion_id, repo, pillar_dirs):
         opts['pillar_roots'] = {}
         opts['__git_pillar'] = True
         pillar = salt.utils.gitfs.GitPillar(opts)
-        pillar.init_remotes(repo, PER_REMOTE_OVERRIDES)
+        pillar.init_remotes(repo, PER_REMOTE_OVERRIDES, PER_REMOTE_ONLY)
         if __opts__.get('__role') == 'minion':
             # If masterless, fetch the remotes. We'll need to remove this once
             # we make the minion daemon able to run standalone.

--- a/salt/runners/git_pillar.py
+++ b/salt/runners/git_pillar.py
@@ -86,7 +86,8 @@ def update(branch=None, repo=None):
         else:
             pillar = salt.utils.gitfs.GitPillar(__opts__)
             pillar.init_remotes(pillar_conf,
-                                salt.pillar.git_pillar.PER_REMOTE_OVERRIDES)
+                                salt.pillar.git_pillar.PER_REMOTE_OVERRIDES,
+                                salt.pillar.git_pillar.PER_REMOTE_ONLY)
             for remote in pillar.remotes:
                 # Skip this remote if it doesn't match the search criteria
                 if branch is not None:

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -31,6 +31,12 @@ log = logging.getLogger(__name__)
 # Global parameters which can be overridden on a per-remote basis
 PER_REMOTE_OVERRIDES = ('ssl_verify',)
 
+# Fall back to default per-remote-only. This isn't technically needed since
+# salt.utils.gitfs.GitBase.init_remotes() will default to
+# salt.utils.gitfs.PER_REMOTE_ONLY for this value, so this is mainly for
+# runners and other modules that import salt.runners.winrepo.
+PER_REMOTE_ONLY = salt.utils.gitfs.PER_REMOTE_ONLY
+
 
 def genrepo(opts=None, fire_event=True):
     '''
@@ -260,7 +266,8 @@ def update_git_repos(opts=None, clean=False, masterless=False):
             # New winrepo code utilizing salt.utils.gitfs
             try:
                 winrepo = salt.utils.gitfs.WinRepo(opts, base_dir)
-                winrepo.init_remotes(remotes, PER_REMOTE_OVERRIDES)
+                winrepo.init_remotes(
+                    remotes, PER_REMOTE_OVERRIDES, PER_REMOTE_ONLY)
                 winrepo.fetch_remotes()
                 # Since we're not running update(), we need to manually call
                 # clear_old_remotes() to remove directories from remotes that


### PR DESCRIPTION
This allows for the runner to clear the git lock if any of the
per-remote-only params was present in the configuration.

This also adds PER_REMOTE_ONLY attributes to the winrepo runner and
git_pillar external pillar, and fixes all refs to GitBase's init_remotes
function to include PER_REMOTE_ONLY arguments. This will insulate us
against future headaches if either git_pillar or winrepo gain extra
per-remote-only params, as we will only need to make the change to the
attribute in their respective modules.

Resolves #42082