### PR TITLE
acme.cert: avoid IOError on failure.

### DIFF
--- a/salt/states/acme.py
+++ b/salt/states/acme.py
@@ -116,9 +116,14 @@ def cert(name,
     if res['result'] is None:
         ret['changes'] = {}
     else:
+        if not __salt__['acme.has'](name):
+            new = None
+        else:
+            new = __salt__['acme.info'](name)
+
         ret['changes'] = {
             'old': old,
-            'new': __salt__['acme.info'](name)
+            'new': new
         }
 
     return ret


### PR DESCRIPTION
### What does this PR do?
Fixes the behavior of `acme.cert` when certbot fails to obtain a new certificate.

### What issues does this PR fix or reference?
Issue #43464 

### Previous Behavior
If certbot did not obtain the requested certificate, `acme.cert` would blindly call `__salt__['acme.info'](name)`, which would raise an IOError. The output from certbot--with important information about the failure--would never be seen by the user.

### New Behavior
Check for the existence of the new certificate before calling `acme.info`. This matches earlier code that conditionally calls `acme.info` on any existing certificate.

### Tests written?
No

### Other notes
This is a minimal fix that attempts to be consistent with existing patterns. I might suggest that it would be safer, cleaner, and more efficient to just have `salt.modules.acme.info` return `None` for nonexistent certificates.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
