### PR TITLE
Bugs/43124 users regex

### DIFF
--- a/doc/ref/publisheracl.rst
+++ b/doc/ref/publisheracl.rst
@@ -25,6 +25,9 @@ configuration:
         - web*:
           - test.*
           - pkg.*
+      # Allow managers to use saltutil module functions
+      manager_.*:
+        - saltutil.*
 
 Permission Issues
 -----------------

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -377,46 +377,13 @@ class LoadAuth(object):
         eauth_config = self.opts['external_auth'][eauth]
         if not groups:
             groups = []
-        group_perm_keys = [item for item in eauth_config if item.endswith('%')]  # The configured auth groups
-
-        # First we need to know if the user is allowed to proceed via any of their group memberships.
-        group_auth_match = False
-        for group_config in group_perm_keys:
-            if group_config.rstrip('%') in groups:
-                group_auth_match = True
-                break
-        # If a group_auth_match is set it means only that we have a
-        # user which matches at least one or more of the groups defined
-        # in the configuration file.
-
-        external_auth_in_db = False
-        for entry in eauth_config:
-            if entry.startswith('^'):
-                external_auth_in_db = True
-                break
-
-        # If neither a catchall, a named membership or a group
-        # membership is found, there is no need to continue. Simply
-        # deny the user access.
-        if not ((name in eauth_config) |
-                ('*' in eauth_config) |
-                group_auth_match | external_auth_in_db):
-            # Auth successful, but no matching user found in config
-            log.warning('Authorization failure occurred.')
-            return None
 
         # We now have an authenticated session and it is time to determine
         # what the user has access to.
-        auth_list = []
-        if name in eauth_config:
-            auth_list = eauth_config[name]
-        elif '*' in eauth_config:
-            auth_list = eauth_config['*']
-        if group_auth_match:
-            auth_list = self.ckminions.fill_auth_list_from_groups(
-                    eauth_config,
-                    groups,
-                    auth_list)
+        auth_list = self.ckminions.fill_auth_list(
+                eauth_config,
+                name,
+                groups)
 
         auth_list = self.__process_acl(load, auth_list)
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -717,6 +717,10 @@ VALID_OPTS = {
     'fileserver_limit_traversal': bool,
     'fileserver_verify_config': bool,
 
+    # Optionally apply '*' permissioins to any user. By default '*' is a fallback case that is
+    # applied only if the user didn't matched by other matchers.
+    'permissive_acl': bool,
+
     # Optionally enables keeping the calculated user's auth list in the token file.
     'keep_acl_in_token': bool,
 
@@ -1466,6 +1470,7 @@ DEFAULT_MASTER_OPTS = {
     'external_auth': {},
     'token_expire': 43200,
     'token_expire_user_override': False,
+    'permissive_acl': False,
     'keep_acl_in_token': False,
     'eauth_acl_module': '',
     'extension_modules': os.path.join(salt.syspaths.CACHE_DIR, 'master', 'extmods'),

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -985,10 +985,37 @@ class CkMinions(object):
                         auth_list.append(matcher)
         return auth_list
 
+    def fill_auth_list(self, auth_provider, name, groups, auth_list=None, permissive=None):
+        '''
+        Returns a list of authorisation matchers that a user is eligible for.
+        This list is a combination of the provided personal matchers plus the
+        matchers of any group the user is in.
+        '''
+        if auth_list is None:
+            auth_list = []
+        if permissive is None:
+            permissive = self.opts.get('permissive_acl')
+        name_matched = False
+        for match in auth_provider:
+            if match == '*' and not permissive:
+                continue
+            if match.endswith('%'):
+                if match.rstrip('%') in groups:
+                    auth_list.extend(auth_provider[match])
+            else:
+                if salt.utils.expr_match(match, name):
+                    name_matched = True
+                    auth_list.extend(auth_provider[match])
+        if not permissive and not name_matched and '*' in auth_provider:
+            auth_list.extend(auth_provider['*'])
+        return auth_list
+
     def wheel_check(self, auth_list, fun):
         '''
         Check special API permissions
         '''
+        if not auth_list:
+            return False
         comps = fun.split('.')
         if len(comps) != 2:
             return False
@@ -1020,6 +1047,8 @@ class CkMinions(object):
         '''
         Check special API permissions
         '''
+        if not auth_list:
+            return False
         comps = fun.split('.')
         if len(comps) != 2:
             return False
@@ -1051,6 +1080,8 @@ class CkMinions(object):
         '''
         Check special API permissions
         '''
+        if not auth_list:
+            return False
         if form != 'cloud':
             comps = fun.split('.')
             if len(comps) != 2:


### PR DESCRIPTION
### What does this PR do?
This PR adds missing regex and glob patterns support in `publisher_acl` and `external_auth` for user names.

### What issues does this PR fix or reference?
Fix #43124 

### Previous Behavior
For `publisher_acl` most of the logic was working as expected. The problem was in the master user keys initialization. It was requiring all the items in the `publisher_acl` list to be an existing user despite that it could be a pattern.
For `external_auth` there was no logic testing the user names in this way.

### New Behavior
For `publisher_acl` don't fail if an entry isn't an existing user. Check all the existing users for the patterns in the list.
For `external_auth` match user name to the list items considering the items are patterns, not the exact matches.

### Tests written?
No