### PR TITLE
Fix unicode handling on PR #43378

### DIFF
--- a/salt/utils/configparser.py
+++ b/salt/utils/configparser.py
@@ -101,7 +101,10 @@ class GitConfigParser(RawConfigParser, object):  # pylint: disable=undefined-var
                 optname = None
             # no section header in the file?
             elif cursect is None:
-                raise MissingSectionHeaderError(fpname, lineno, line)  # pylint: disable=undefined-variable
+                raise MissingSectionHeaderError(  # pylint: disable=undefined-variable
+                    salt.utils.stringutils.to_str(fpname),
+                    lineno,
+                    salt.utils.stringutils.to_str(line))
             # an option line?
             else:
                 mo = self._optcre.match(line.lstrip())
@@ -142,12 +145,11 @@ class GitConfigParser(RawConfigParser, object):  # pylint: disable=undefined-var
         if self._optcre is self.OPTCRE or value:
             is_list = isinstance(value, list)
             if is_list and not allow_list:
-                raise TypeError(u'option value cannot be a list unless '
-                                u'allow_list is True')
+                raise TypeError('option value cannot be a list unless allow_list is True')  # future lint: disable=non-unicode-string
             elif not is_list:
                 value = [value]
             if not all(isinstance(x, six.string_types) for x in value):
-                raise TypeError(u'option values must be strings')
+                raise TypeError('option values must be strings')  # future lint: disable=non-unicode-string
 
     def get(self, section, option, as_list=False):
         '''
@@ -183,7 +185,7 @@ class GitConfigParser(RawConfigParser, object):  # pylint: disable=undefined-var
                 sectdict[key] = [sectdict[key]]
                 sectdict[key].append(value)
         else:
-            raise TypeError(u'Expected str or list for option value, got %s' % type(value).__name__)
+            raise TypeError('Expected str or list for option value, got %s' % type(value).__name__)  # future lint: disable=non-unicode-string
 
     def set_multivar(self, section, option, value=u''):
         '''
@@ -201,7 +203,8 @@ class GitConfigParser(RawConfigParser, object):  # pylint: disable=undefined-var
             try:
                 sectdict = self._sections[section]
             except KeyError:
-                raise NoSectionError(section)  # pylint: disable=undefined-variable
+                raise NoSectionError(  # pylint: disable=undefined-variable
+                    salt.utils.stringutils.to_str(section))
         key = self.optionxform(option)
         self._add_option(sectdict, key, value)
 
@@ -216,7 +219,8 @@ class GitConfigParser(RawConfigParser, object):  # pylint: disable=undefined-var
             try:
                 sectdict = self._sections[section]
             except KeyError:
-                raise NoSectionError(section)  # pylint: disable=undefined-variable
+                raise NoSectionError(  # pylint: disable=undefined-variable
+                    salt.utils.stringutils.to_str(section))
         option = self.optionxform(option)
         if option not in sectdict:
             return False

--- a/tests/unit/utils/test_configparser.py
+++ b/tests/unit/utils/test_configparser.py
@@ -122,12 +122,14 @@ class TestGitConfigParser(TestCase):
             self.conf.get(u'alias', u'modified'),
             u"""! git status --porcelain | awk 'match($1, "M"){print $2}'"""
         )
+        # future lint: disable=non-unicode-string
         self.assertEqual(
             self.conf.get(u'alias', u'hist'),
             salt.utils.stringutils.to_unicode(
                 r"""log --pretty=format:\"%h %ad | %s%d [%an]\" --graph --date=short"""
             )
         )
+        # future lint: enable=non-unicode-string
 
     def test_read_space_indent(self):
         '''
@@ -180,7 +182,7 @@ class TestGitConfigParser(TestCase):
             [orig_refspec, new_refspec]
         )
         # Write the config object to a file
-        with salt.utils.files.fopen(self.new_config, 'w') as fp_:
+        with salt.utils.files.fopen(self.new_config, u'w') as fp_:
             self.conf.write(fp_)
         # Confirm that the new file was written correctly
         expected = self.fix_indent(ORIG_CONFIG)
@@ -257,10 +259,10 @@ class TestGitConfigParser(TestCase):
         '''
         Test writing using non-binary filehandle
         '''
-        self._test_write(mode='w')
+        self._test_write(mode=u'w')
 
     def test_write_binary(self):
         '''
         Test writing using binary filehandle
         '''
-        self._test_write(mode='wb')
+        self._test_write(mode=u'wb')


### PR DESCRIPTION
The strings passed to exceptions should not be unicode types, as this
can cause problems elsewhere when exception class instances are
referenced.