### PR TITLE
Esxcluster proxy minion and support in vsphere module

### DIFF
--- a/salt/config/schemas/esxcluster.py
+++ b/salt/config/schemas/esxcluster.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Alexandru Bleotu (alexandru.bleotu@morganstanley.com)`
+
+
+    salt.config.schemas.esxcluster
+    ~~~~~~~~~~~~~~~~~~~~~~~
+
+    ESX Cluster configuration schemas
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt libs
+from salt.utils.schema import (Schema,
+                               ArrayItem,
+                               IntegerItem,
+                               StringItem)
+
+
+class EsxclusterProxySchema(Schema):
+    '''
+    Schema of the esxcluster proxy input
+    '''
+
+    title = 'Esxcluster Proxy Schema'
+    description = 'Esxcluster proxy schema'
+    additional_properties = False
+    proxytype = StringItem(required=True,
+                           enum=['esxcluster'])
+    vcenter = StringItem(required=True, pattern='[^\s]+')
+    datacenter = StringItem(required=True)
+    cluster = StringItem(required=True)
+    mechanism = StringItem(required=True, enum=['userpass', 'sspi'])
+    username = StringItem()
+    passwords = ArrayItem(min_items=1,
+                          items=StringItem(),
+                          unique_items=True)
+    # TODO Should be changed when anyOf is supported for schemas
+    domain = StringItem()
+    principal = StringItem()
+    protocol = StringItem()
+    port = IntegerItem(minimum=1)

--- a/salt/config/schemas/esxcluster.py
+++ b/salt/config/schemas/esxcluster.py
@@ -29,7 +29,7 @@ class EsxclusterProxySchema(Schema):
     additional_properties = False
     proxytype = StringItem(required=True,
                            enum=['esxcluster'])
-    vcenter = StringItem(required=True, pattern='[^\s]+')
+    vcenter = StringItem(required=True, pattern=r'[^\s]+')
     datacenter = StringItem(required=True)
     cluster = StringItem(required=True)
     mechanism = StringItem(required=True, enum=['userpass', 'sspi'])

--- a/salt/modules/esxcluster.py
+++ b/salt/modules/esxcluster.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+'''
+Module used to access the esxcluster proxy connection methods
+'''
+from __future__ import absolute_import
+
+# Import python libs
+import logging
+import salt.utils.platform
+
+
+log = logging.getLogger(__name__)
+
+__proxyenabled__ = ['esxcluster']
+# Define the module's virtual name
+__virtualname__ = 'esxcluster'
+
+
+def __virtual__():
+    '''
+    Only work on proxy
+    '''
+    if salt.utils.platform.is_proxy():
+        return __virtualname__
+    return (False, 'Must be run on a proxy minion')
+
+
+def get_details():
+    return __proxy__['esxcluster.get_details']()

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -4294,3 +4294,14 @@ def _get_esxdatacenter_proxy_details():
     return det.get('vcenter'), det.get('username'), det.get('password'), \
             det.get('protocol'), det.get('port'), det.get('mechanism'), \
             det.get('principal'), det.get('domain'), det.get('datacenter')
+
+
+def _get_esxcluster_proxy_details():
+    '''
+    Returns the running esxcluster's proxy details
+    '''
+    det = __salt__['esxcluster.get_details']()
+    return det.get('vcenter'), det.get('username'), det.get('password'), \
+            det.get('protocol'), det.get('port'), det.get('mechanism'), \
+            det.get('principal'), det.get('domain'), det.get('datacenter'), \
+            det.get('cluster')

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -195,7 +195,7 @@ else:
 log = logging.getLogger(__name__)
 
 __virtualname__ = 'vsphere'
-__proxyenabled__ = ['esxi', 'esxdatacenter']
+__proxyenabled__ = ['esxi', 'esxcluster', 'esxdatacenter']
 
 
 def __virtual__():
@@ -227,6 +227,8 @@ def _get_proxy_connection_details():
     proxytype = get_proxy_type()
     if proxytype == 'esxi':
         details = __salt__['esxi.get_details']()
+    elif proxytype == 'esxcluster':
+        details = __salt__['esxcluster.get_details']()
     elif proxytype == 'esxdatacenter':
         details = __salt__['esxdatacenter.get_details']()
     else:
@@ -267,7 +269,7 @@ def gets_service_instance_via_proxy(fn):
     proxy details and passes the connection (vim.ServiceInstance) to
     the decorated function.
 
-    Supported proxies: esxi, esxdatacenter.
+    Supported proxies: esxi, esxcluster, esxdatacenter.
 
     Notes:
         1. The decorated function must have a ``service_instance`` parameter
@@ -354,7 +356,7 @@ def gets_service_instance_via_proxy(fn):
 
 
 @depends(HAS_PYVMOMI)
-@supports_proxies('esxi', 'esxdatacenter')
+@supports_proxies('esxi', 'esxcluster', 'esxdatacenter')
 def get_service_instance_via_proxy(service_instance=None):
     '''
     Returns a service instance to the proxied endpoint (vCenter/ESXi host).
@@ -374,7 +376,7 @@ def get_service_instance_via_proxy(service_instance=None):
 
 
 @depends(HAS_PYVMOMI)
-@supports_proxies('esxi', 'esxdatacenter')
+@supports_proxies('esxi', 'esxcluster', 'esxdatacenter')
 def disconnect(service_instance):
     '''
     Disconnects from a vCenter or ESXi host
@@ -1909,7 +1911,7 @@ def get_vsan_eligible_disks(host, username, password, protocol=None, port=None, 
 
 
 @depends(HAS_PYVMOMI)
-@supports_proxies('esxi', 'esxdatacenter')
+@supports_proxies('esxi', 'esxcluster', 'esxdatacenter')
 @gets_service_instance_via_proxy
 def test_vcenter_connection(service_instance=None):
     '''
@@ -3598,7 +3600,7 @@ def vsan_enable(host, username, password, protocol=None, port=None, host_names=N
 
 
 @depends(HAS_PYVMOMI)
-@supports_proxies('esxdatacenter')
+@supports_proxies('esxdatacenter', 'esxcluster')
 @gets_service_instance_via_proxy
 def list_datacenters_via_proxy(datacenter_names=None, service_instance=None):
     '''

--- a/salt/proxy/esxcluster.py
+++ b/salt/proxy/esxcluster.py
@@ -1,0 +1,310 @@
+# -*- coding: utf-8 -*-
+'''
+Proxy Minion interface module for managing VMWare ESXi clusters.
+
+Dependencies
+============
+
+- pyVmomi
+- jsonschema
+
+Configuration
+=============
+To use this integration proxy module, please configure the following:
+
+Pillar
+------
+
+Proxy minions get their configuration from Salt's Pillar. This can now happen
+from the proxy's configuration file.
+
+Example pillars:
+
+``userpass`` mechanism:
+
+.. code-block:: yaml
+
+    proxy:
+      proxytype: esxcluster
+      cluster: <cluster name>
+      datacenter: <datacenter name>
+      vcenter: <ip or dns name of parent vcenter>
+      mechanism: userpass
+      username: <vCenter username>
+      passwords: (required if userpass is used)
+        - first_password
+        - second_password
+        - third_password
+
+``sspi`` mechanism:
+
+.. code-block:: yaml
+
+    proxy:
+      proxytype: esxcluster
+      cluster: <cluster name>
+      datacenter: <datacenter name>
+      vcenter: <ip or dns name of parent vcenter>
+      mechanism: sspi
+      domain: <user domain>
+      principal: <host kerberos principal>
+
+proxytype
+^^^^^^^^^
+To use this Proxy Module, set this to ``esxdatacenter``.
+
+cluster
+^^^^^^^
+Name of the managed cluster. Required.
+
+datacenter
+^^^^^^^^^^
+Name of the datacenter the managed cluster is in. Required.
+
+vcenter
+^^^^^^^
+The location of the VMware vCenter server (host of ip) where the datacenter
+should be managed. Required.
+
+mechanism
+^^^^^^^^
+The mechanism used to connect to the vCenter server. Supported values are
+``userpass`` and ``sspi``. Required.
+
+Note:
+    Connections are attempted using all (``username``, ``password``)
+    combinations on proxy startup.
+
+username
+^^^^^^^^
+The username used to login to the host, such as ``root``. Required if mechanism
+is ``userpass``.
+
+passwords
+^^^^^^^^^
+A list of passwords to be used to try and login to the vCenter server. At least
+one password in this list is required if mechanism is ``userpass``.  When the
+proxy comes up, it will try the passwords listed in order.
+
+domain
+^^^^^^
+User domain. Required if mechanism is ``sspi``.
+
+principal
+^^^^^^^^
+Kerberos principal. Rquired if mechanism is ``sspi``.
+
+protocol
+^^^^^^^^
+If the ESXi host is not using the default protocol, set this value to an
+alternate protocol. Default is ``https``.
+
+port
+^^^^
+If the ESXi host is not using the default port, set this value to an
+alternate port. Default is ``443``.
+
+Salt Proxy
+----------
+
+After your pillar is in place, you can test the proxy. The proxy can run on
+any machine that has network connectivity to your Salt Master and to the
+vCenter server in the pillar. SaltStack recommends that the machine running the
+salt-proxy process also run a regular minion, though it is not strictly
+necessary.
+
+To start a proxy minion one needs to establish its identity <id>:
+
+.. code-block:: bash
+
+    salt-proxy --proxyid <proxy_id>
+
+On the machine that will run the proxy, make sure there is a configuration file
+present. By default this is ``/etc/salt/proxy``. If in a different location, the
+``<configuration_folder>`` has to be specified when running the proxy:
+file with at least the following in it:
+
+.. code-block:: bash
+
+    salt-proxy --proxyid <proxy_id> -c <configuration_folder>
+
+Commands
+--------
+
+Once the proxy is running it will connect back to the specified master and
+individual commands can be runs against it:
+
+.. code-block:: bash
+
+    # Master - minion communication
+    salt <cluster_name> test.ping
+
+    # Test vcenter connection
+    salt <cluster_name> vsphere.test_vcenter_connection
+
+States
+------
+
+Associated states are documented in
+:mod:`salt.states.esxcluster </ref/states/all/salt.states.esxcluster>`.
+Look there to find an example structure for Pillar as well as an example
+``.sls`` file for configuring an ESX cluster from scratch.
+'''
+
+
+# Import Python Libs
+from __future__ import absolute_import
+import logging
+import os
+
+# Import Salt Libs
+import salt.exceptions
+from  salt.config.schemas.esxcluster import EsxclusterProxySchema
+from salt.utils.dictupdate import merge
+
+# This must be present or the Salt loader won't load this module.
+__proxyenabled__ = ['esxcluster']
+
+# External libraries
+try:
+    import jsonschema
+    HAS_JSONSCHEMA = True
+except ImportError:
+    HAS_JSONSCHEMA = False
+
+# Variables are scoped to this module so we can have persistent data
+# across calls to fns in here.
+GRAINS_CACHE = {}
+DETAILS = {}
+
+
+# Set up logging
+log = logging.getLogger(__name__)
+# Define the module's virtual name
+__virtualname__ = 'esxcluster'
+
+
+def __virtual__():
+    '''
+    Only load if the vsphere execution module is available.
+    '''
+    if HAS_JSONSCHEMA:
+        return __virtualname__
+
+    return False, 'The esxcluster proxy module did not load.'
+
+
+def init(opts):
+    '''
+    This function gets called when the proxy starts up. For
+    login
+    the protocol and port are cached.
+    '''
+    log.debug('Initting esxcluster proxy module in process '
+              '{}'.format(os.getpid()))
+    log.debug('Validating esxcluster proxy input')
+    schema = EsxclusterProxySchema.serialize()
+    log.trace('schema = {}'.format(schema))
+    proxy_conf = merge(opts.get('proxy', {}), __pillar__.get('proxy', {}))
+    log.trace('proxy_conf = {0}'.format(proxy_conf))
+    try:
+        jsonschema.validate(proxy_conf, schema)
+    except jsonschema.exceptions.ValidationError as exc:
+        raise salt.exceptions.InvalidConfigError(exc)
+
+    # Save mandatory fields in cache
+    for key in ('vcenter', 'datacenter', 'cluster', 'mechanism'):
+        DETAILS[key] = proxy_conf[key]
+
+    # Additional validation
+    if DETAILS['mechanism'] == 'userpass':
+        if 'username' not in proxy_conf:
+            raise salt.exceptions.InvalidConfigError(
+                'Mechanism is set to \'userpass\', but no '
+                '\'username\' key found in proxy config.')
+        if not 'passwords' in proxy_conf:
+            raise salt.exceptions.InvalidConfigError(
+                'Mechanism is set to \'userpass\', but no '
+                '\'passwords\' key found in proxy config.')
+        for key in ('username', 'passwords'):
+            DETAILS[key] = proxy_conf[key]
+    else:
+        if not 'domain' in proxy_conf:
+            raise salt.exceptions.InvalidConfigError(
+                'Mechanism is set to \'sspi\', but no '
+                '\'domain\' key found in proxy config.')
+        if not 'principal' in proxy_conf:
+            raise salt.exceptions.InvalidConfigError(
+                'Mechanism is set to \'sspi\', but no '
+                '\'principal\' key found in proxy config.')
+        for key in ('domain', 'principal'):
+            DETAILS[key] = proxy_conf[key]
+
+    # Save optional
+    DETAILS['protocol'] = proxy_conf.get('protocol')
+    DETAILS['port'] = proxy_conf.get('port')
+
+    # Test connection
+    if DETAILS['mechanism'] == 'userpass':
+        # Get the correct login details
+        log.debug('Retrieving credentials and testing vCenter connection for '
+                  'mehchanism \'userpass\'')
+        try:
+            username, password = find_credentials()
+            DETAILS['password'] = password
+        except salt.exceptions.SaltSystemExit as err:
+            log.critical('Error: {0}'.format(err))
+            return False
+    return True
+
+
+def ping():
+    '''
+    Returns True.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt esx-cluster test.ping
+    '''
+    return True
+
+
+def shutdown():
+    '''
+    Shutdown the connection to the proxy device. For this proxy,
+    shutdown is a no-op.
+    '''
+    log.debug('esxcluster proxy shutdown() called...')
+
+
+def find_credentials():
+    '''
+    Cycle through all the possible credentials and return the first one that
+    works.
+    '''
+
+    # if the username and password were already found don't fo though the
+    # connection process again
+    if 'username' in DETAILS and 'password' in DETAILS:
+        return DETAILS['username'], DETAILS['password']
+
+    passwords = DETAILS['passwords']
+    for password in passwords:
+        DETAILS['password'] = password
+        if not __salt__['vsphere.test_vcenter_connection']():
+            # We are unable to authenticate
+            continue
+        # If we have data returned from above, we've successfully authenticated.
+        return DETAILS['username'], password
+    # We've reached the end of the list without successfully authenticating.
+    raise salt.exceptions.VMwareConnectionError('Cannot complete login due to '
+                                                'incorrect credentials.')
+
+
+def get_details():
+    '''
+    Function that returns the cached details
+    '''
+    return DETAILS

--- a/salt/proxy/esxcluster.py
+++ b/salt/proxy/esxcluster.py
@@ -159,7 +159,7 @@ import os
 
 # Import Salt Libs
 import salt.exceptions
-from  salt.config.schemas.esxcluster import EsxclusterProxySchema
+from salt.config.schemas.esxcluster import EsxclusterProxySchema
 from salt.utils.dictupdate import merge
 
 # This must be present or the Salt loader won't load this module.
@@ -222,18 +222,18 @@ def init(opts):
             raise salt.exceptions.InvalidConfigError(
                 'Mechanism is set to \'userpass\', but no '
                 '\'username\' key found in proxy config.')
-        if not 'passwords' in proxy_conf:
+        if 'passwords' not in proxy_conf:
             raise salt.exceptions.InvalidConfigError(
                 'Mechanism is set to \'userpass\', but no '
                 '\'passwords\' key found in proxy config.')
         for key in ('username', 'passwords'):
             DETAILS[key] = proxy_conf[key]
     else:
-        if not 'domain' in proxy_conf:
+        if 'domain' not in proxy_conf:
             raise salt.exceptions.InvalidConfigError(
                 'Mechanism is set to \'sspi\', but no '
                 '\'domain\' key found in proxy config.')
-        if not 'principal' in proxy_conf:
+        if 'principal' not in proxy_conf:
             raise salt.exceptions.InvalidConfigError(
                 'Mechanism is set to \'sspi\', but no '
                 '\'principal\' key found in proxy config.')

--- a/tests/unit/modules/test_esxcluster.py
+++ b/tests/unit/modules/test_esxcluster.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Alexandru Bleotu <alexandru.bleotu@morganstanley.com>`
+
+    Tests for functions in salt.modules.esxcluster
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Libs
+import salt.modules.esxcluster as esxcluster
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class GetDetailsTestCase(TestCase, LoaderModuleMockMixin):
+    '''Tests for salt.modules.esxcluster.get_details'''
+    def setup_loader_modules(self):
+        return {esxcluster: {'__virtual__':
+                             MagicMock(return_value='esxcluster'),
+                             '__proxy__': {}}}
+
+    def test_get_details(self):
+        mock_get_details = MagicMock()
+        with patch.dict(esxcluster.__proxy__,
+                        {'esxcluster.get_details': mock_get_details}):
+            esxcluster.get_details()
+        mock_get_details.assert_called_once_with()

--- a/tests/unit/modules/test_vsphere.py
+++ b/tests/unit/modules/test_vsphere.py
@@ -630,7 +630,7 @@ class _GetProxyConnectionDetailsTestCase(TestCase, LoaderModuleMockMixin):
                                       'domain': 'fake_domain'}
         self.esxcluster_details = {'vcenter': 'fake_vcenter',
                                    'datacenter': 'fake_dc',
-                                   'cluster', 'fake_cluster',
+                                   'cluster': 'fake_cluster',
                                    'username': 'fake_username',
                                    'password': 'fake_password',
                                    'protocol': 'fake_protocol',
@@ -638,8 +638,6 @@ class _GetProxyConnectionDetailsTestCase(TestCase, LoaderModuleMockMixin):
                                    'mechanism': 'fake_mechanism',
                                    'principal': 'fake_principal',
                                    'domain': 'fake_domain'}
-
-
 
     def tearDown(self):
         for attrname in ('esxi_host_details', 'esxi_vcenter_details',

--- a/tests/unit/modules/test_vsphere.py
+++ b/tests/unit/modules/test_vsphere.py
@@ -620,6 +620,7 @@ class _GetProxyConnectionDetailsTestCase(TestCase, LoaderModuleMockMixin):
                                      'principal': 'fake_principal',
                                      'domain': 'fake_domain'}
         self.esxdatacenter_details = {'vcenter': 'fake_vcenter',
+                                      'datacenter': 'fake_dc',
                                       'username': 'fake_username',
                                       'password': 'fake_password',
                                       'protocol': 'fake_protocol',
@@ -627,9 +628,22 @@ class _GetProxyConnectionDetailsTestCase(TestCase, LoaderModuleMockMixin):
                                       'mechanism': 'fake_mechanism',
                                       'principal': 'fake_principal',
                                       'domain': 'fake_domain'}
+        self.esxcluster_details = {'vcenter': 'fake_vcenter',
+                                   'datacenter': 'fake_dc',
+                                   'cluster', 'fake_cluster',
+                                   'username': 'fake_username',
+                                   'password': 'fake_password',
+                                   'protocol': 'fake_protocol',
+                                   'port': 'fake_port',
+                                   'mechanism': 'fake_mechanism',
+                                   'principal': 'fake_principal',
+                                   'domain': 'fake_domain'}
+
+
 
     def tearDown(self):
-        for attrname in ('esxi_host_details', 'esxi_vcenter_details'):
+        for attrname in ('esxi_host_details', 'esxi_vcenter_details',
+                         'esxdatacenter_details', 'esxcluster_details'):
             try:
                 delattr(self, attrname)
             except AttributeError:
@@ -651,8 +665,22 @@ class _GetProxyConnectionDetailsTestCase(TestCase, LoaderModuleMockMixin):
                    MagicMock(return_value='esxdatacenter')):
             with patch.dict(vsphere.__salt__,
                             {'esxdatacenter.get_details': MagicMock(
-                                return_value=self.esxdatacenter_details)}):
+                             return_value=self.esxdatacenter_details)}):
                 ret = vsphere._get_proxy_connection_details()
+        self.assertEqual(('fake_vcenter', 'fake_username', 'fake_password',
+                          'fake_protocol', 'fake_port', 'fake_mechanism',
+                          'fake_principal', 'fake_domain'), ret)
+
+    def test_esxcluster_proxy_details(self):
+        with patch('salt.modules.vsphere.get_proxy_type',
+                   MagicMock(return_value='esxcluster')):
+            with patch.dict(vsphere.__salt__,
+                            {'esxcluster.get_details': MagicMock(
+                             return_value=self.esxcluster_details)}):
+                ret = vsphere._get_proxy_connection_details()
+        self.assertEqual(('fake_vcenter', 'fake_username', 'fake_password',
+                          'fake_protocol', 'fake_port', 'fake_mechanism',
+                          'fake_principal', 'fake_domain'), ret)
 
     def test_esxi_proxy_vcenter_details(self):
         with patch('salt.modules.vsphere.get_proxy_type',
@@ -862,8 +890,8 @@ class GetServiceInstanceViaProxyTestCase(TestCase, LoaderModuleMockMixin):
             }
         }
 
-    def test_supported_proxes(self):
-        supported_proxies = ['esxi', 'esxdatacenter']
+    def test_supported_proxies(self):
+        supported_proxies = ['esxi', 'esxcluster', 'esxdatacenter']
         for proxy_type in supported_proxies:
             with patch('salt.modules.vsphere.get_proxy_type',
                        MagicMock(return_value=proxy_type)):
@@ -905,8 +933,8 @@ class DisconnectTestCase(TestCase, LoaderModuleMockMixin):
             }
         }
 
-    def test_supported_proxes(self):
-        supported_proxies = ['esxi', 'esxdatacenter']
+    def test_supported_proxies(self):
+        supported_proxies = ['esxi', 'esxcluster', 'esxdatacenter']
         for proxy_type in supported_proxies:
             with patch('salt.modules.vsphere.get_proxy_type',
                        MagicMock(return_value=proxy_type)):
@@ -946,8 +974,8 @@ class TestVcenterConnectionTestCase(TestCase, LoaderModuleMockMixin):
             }
         }
 
-    def test_supported_proxes(self):
-        supported_proxies = ['esxi', 'esxdatacenter']
+    def test_supported_proxies(self):
+        supported_proxies = ['esxi', 'esxcluster', 'esxdatacenter']
         for proxy_type in supported_proxies:
             with patch('salt.modules.vsphere.get_proxy_type',
                        MagicMock(return_value=proxy_type)):
@@ -1022,7 +1050,7 @@ class ListDatacentersViaProxyTestCase(TestCase, LoaderModuleMockMixin):
         }
 
     def test_supported_proxies(self):
-        supported_proxies = ['esxdatacenter']
+        supported_proxies = ['esxcluster', 'esxdatacenter']
         for proxy_type in supported_proxies:
             with patch('salt.modules.vsphere.get_proxy_type',
                        MagicMock(return_value=proxy_type)):
@@ -1099,7 +1127,7 @@ class CreateDatacenterTestCase(TestCase, LoaderModuleMockMixin):
             }
         }
 
-    def test_supported_proxes(self):
+    def test_supported_proxies(self):
         supported_proxies = ['esxdatacenter']
         for proxy_type in supported_proxies:
             with patch('salt.modules.vsphere.get_proxy_type',

--- a/tests/unit/proxy/test_esxcluster.py
+++ b/tests/unit/proxy/test_esxcluster.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Alexandru Bleotu <alexandru.bleotu@morganstanley.com>`
+
+    Tests for esxcluster proxy
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import external libs
+try:
+    import jsonschema
+    HAS_JSONSCHEMA = True
+except ImportError:
+    HAS_JSONSCHEMA = False
+
+# Import Salt Libs
+import salt.proxy.esxcluster as esxcluster
+import salt.exceptions
+from salt.config.schemas.esxcluster import EsxclusterProxySchema
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(not HAS_JSONSCHEMA, 'jsonschema is required')
+class InitTestCase(TestCase, LoaderModuleMockMixin):
+    '''Tests for salt.proxy.esxcluster.init'''
+    def setup_loader_modules(self):
+        return {esxcluster: {'__virtual__':
+                             MagicMock(return_value='esxcluster'),
+                             'DETAILS': {}, '__pillar__': {}}}
+
+    def setUp(self):
+        self.opts_userpass = {'proxy': {'proxytype': 'esxcluster',
+                                        'vcenter': 'fake_vcenter',
+                                        'datacenter': 'fake_dc',
+                                        'cluster': 'fake_cluster',
+                                        'mechanism': 'userpass',
+                                        'username': 'fake_username',
+                                        'passwords': ['fake_password'],
+                                        'protocol': 'fake_protocol',
+                                        'port': 100}}
+        self.opts_sspi = {'proxy': {'proxytype': 'esxcluster',
+                                    'vcenter': 'fake_vcenter',
+                                    'datacenter': 'fake_dc',
+                                    'cluster': 'fake_cluster',
+                                    'mechanism': 'sspi',
+                                    'domain': 'fake_domain',
+                                    'principal': 'fake_principal',
+                                    'protocol': 'fake_protocol',
+                                    'port': 100}}
+        patches = (('salt.proxy.esxcluster.merge',
+                    MagicMock(return_value=self.opts_sspi['proxy'])),)
+        for mod, mock in patches:
+            patcher = patch(mod, mock)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_merge(self):
+        mock_pillar_proxy = MagicMock()
+        mock_opts_proxy = MagicMock()
+        mock_merge = MagicMock(return_value=self.opts_sspi['proxy'])
+        with patch.dict(esxcluster.__pillar__,
+                        {'proxy': mock_pillar_proxy}):
+            with patch('salt.proxy.esxcluster.merge', mock_merge):
+                esxcluster.init(opts={'proxy': mock_opts_proxy})
+        mock_merge.assert_called_once_with(mock_opts_proxy, mock_pillar_proxy)
+
+    def test_esxcluster_schema(self):
+        mock_json_validate = MagicMock()
+        serialized_schema = EsxclusterProxySchema().serialize()
+        with patch('salt.proxy.esxcluster.jsonschema.validate',
+                   mock_json_validate):
+            esxcluster.init(self.opts_sspi)
+        mock_json_validate.assert_called_once_with(
+            self.opts_sspi['proxy'], serialized_schema)
+
+    def test_invalid_proxy_input_error(self):
+        with patch('salt.proxy.esxcluster.jsonschema.validate',
+                   MagicMock(side_effect=jsonschema.exceptions.ValidationError(
+                       'Validation Error'))):
+            with self.assertRaises(salt.exceptions.InvalidConfigError) as \
+                    excinfo:
+                esxcluster.init(self.opts_userpass)
+        self.assertEqual(excinfo.exception.strerror.message,
+                         'Validation Error')
+
+    def test_no_username(self):
+        opts = self.opts_userpass.copy()
+        del opts['proxy']['username']
+        with patch('salt.proxy.esxcluster.merge',
+                   MagicMock(return_value=opts['proxy'])):
+            with self.assertRaises(salt.exceptions.InvalidConfigError) as \
+                    excinfo:
+                esxcluster.init(opts)
+        self.assertEqual(excinfo.exception.strerror,
+                         'Mechanism is set to \'userpass\', but no '
+                         '\'username\' key found in proxy config.')
+
+    def test_no_passwords(self):
+        opts = self.opts_userpass.copy()
+        del opts['proxy']['passwords']
+        with patch('salt.proxy.esxcluster.merge',
+                   MagicMock(return_value=opts['proxy'])):
+            with self.assertRaises(salt.exceptions.InvalidConfigError) as \
+                    excinfo:
+                esxcluster.init(opts)
+        self.assertEqual(excinfo.exception.strerror,
+                         'Mechanism is set to \'userpass\', but no '
+                         '\'passwords\' key found in proxy config.')
+
+    def test_no_domain(self):
+        opts = self.opts_sspi.copy()
+        del opts['proxy']['domain']
+        with patch('salt.proxy.esxcluster.merge',
+                   MagicMock(return_value=opts['proxy'])):
+            with self.assertRaises(salt.exceptions.InvalidConfigError) as \
+                    excinfo:
+                esxcluster.init(opts)
+        self.assertEqual(excinfo.exception.strerror,
+                         'Mechanism is set to \'sspi\', but no '
+                         '\'domain\' key found in proxy config.')
+
+    def test_no_principal(self):
+        opts = self.opts_sspi.copy()
+        del opts['proxy']['principal']
+        with patch('salt.proxy.esxcluster.merge',
+                   MagicMock(return_value=opts['proxy'])):
+            with self.assertRaises(salt.exceptions.InvalidConfigError) as \
+                    excinfo:
+                esxcluster.init(opts)
+        self.assertEqual(excinfo.exception.strerror,
+                         'Mechanism is set to \'sspi\', but no '
+                         '\'principal\' key found in proxy config.')
+
+    def test_find_credentials(self):
+        mock_find_credentials = MagicMock(return_value=('fake_username',
+                                                        'fake_password'))
+        with patch('salt.proxy.esxcluster.merge',
+                   MagicMock(return_value=self.opts_userpass['proxy'])):
+            with patch('salt.proxy.esxcluster.find_credentials',
+                       mock_find_credentials):
+                esxcluster.init(self.opts_userpass)
+        mock_find_credentials.assert_called_once_with()
+
+    def test_details_userpass(self):
+        mock_find_credentials = MagicMock(return_value=('fake_username',
+                                                        'fake_password'))
+        with patch('salt.proxy.esxcluster.merge',
+                   MagicMock(return_value=self.opts_userpass['proxy'])):
+            with patch('salt.proxy.esxcluster.find_credentials',
+                       mock_find_credentials):
+                esxcluster.init(self.opts_userpass)
+        self.assertDictEqual(esxcluster.DETAILS,
+                             {'vcenter': 'fake_vcenter',
+                              'datacenter': 'fake_dc',
+                              'cluster': 'fake_cluster',
+                              'mechanism': 'userpass',
+                              'username': 'fake_username',
+                              'password': 'fake_password',
+                              'passwords': ['fake_password'],
+                              'protocol': 'fake_protocol',
+                              'port': 100})
+
+    def test_details_sspi(self):
+        esxcluster.init(self.opts_sspi)
+        self.assertDictEqual(esxcluster.DETAILS,
+                             {'vcenter': 'fake_vcenter',
+                              'datacenter': 'fake_dc',
+                              'cluster': 'fake_cluster',
+                              'mechanism': 'sspi',
+                              'domain': 'fake_domain',
+                              'principal': 'fake_principal',
+                              'protocol': 'fake_protocol',
+                              'port': 100})


### PR DESCRIPTION
### What does this PR do?
Added the esxcluster minon and internal functions so it can run `vsphere` execution functions.
Connectivity to the vCenter server can be tested by running the `vsphere.test_vcenter_connection` execution function

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
