### PR TITLE
Make aptpkg work with Deepin Linux

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -99,7 +99,7 @@ def __virtual__():
     '''
     Confirm this module is on a Debian based system
     '''
-    if __grains__.get('os_family') in ('Kali', 'Debian', 'neon'):
+    if __grains__.get('os_family') in ('Kali', 'Debian', 'neon', 'Deepin'):
         return __virtualname__
     elif __grains__.get('os_family', False) == 'Cumulus':
         return __virtualname__


### PR DESCRIPTION
### What does this PR do?
This just adds Deepin to the list of supported OS families for aptpkg. Deepin is based on Debian, and this change makes the pkg/aptpkg modules work (otherwise you get "Unsupported OS family").

### What issues does this PR fix or reference?
n/a

### Previous Behavior
Error when using any pkg functions:
`'aptpkg' __virtual__ returned False: The pkg module could not be loaded: unsupported OS family`

### New Behavior
`pkg` functions work correctly instead.

### Tests written?
No
