### PR TITLE
Handle bogus newline before newly added keys

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -769,10 +769,13 @@ def set_auth_key(
             with salt.utils.files.fopen(fconfig, 'ab+') as _fh:
                 if new_file is False:
                     # Let's make sure we have a new line at the end of the file
-                    _fh.seek(1024, 2)
-                    if not _fh.read(1024).rstrip(six.b(' ')).endswith(six.b('\n')):
-                        _fh.seek(0, 2)
-                        _fh.write(six.b('\n'))
+					_fh.seek(0,2)
+					if _fh.tell() > 0:
+					   # File isn't empty, check if last byte is a newline
+					   # If not, add one
+					   _fh.seek(-1,2)
+					   if _fh.read(1) != six.b('\n')
+                          _fh.write(six.b('\n'))
                 if six.PY3:
                     auth_line = auth_line.encode(__salt_system_encoding__)
                 _fh.write(auth_line)

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -774,7 +774,7 @@ def set_auth_key(
 					   # File isn't empty, check if last byte is a newline
 					   # If not, add one
 					   _fh.seek(-1,2)
-					   if _fh.read(1) != six.b('\n')
+					   if _fh.read(1) != six.b('\n'):
                           _fh.write(six.b('\n'))
                 if six.PY3:
                     auth_line = auth_line.encode(__salt_system_encoding__)

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -768,14 +768,14 @@ def set_auth_key(
         try:
             with salt.utils.files.fopen(fconfig, 'ab+') as _fh:
                 if new_file is False:
-                   # Let's make sure we have a new line at the end of the file
-                   _fh.seek(0,2)
-                   if _fh.tell() > 0:
-                      # File isn't empty, check if last byte is a newline
-                      # If not, add one
-                      _fh.seek(-1,2)
-                      if _fh.read(1) != six.b('\n'):
-                         _fh.write(six.b('\n'))
+                    # Let's make sure we have a new line at the end of the file
+                    _fh.seek(0, 2)
+                    if _fh.tell() > 0:
+                        # File isn't empty, check if last byte is a newline
+                        # If not, add one
+                        _fh.seek(-1, 2)
+                        if _fh.read(1) != six.b('\n'):
+                            _fh.write(six.b('\n'))
                 if six.PY3:
                     auth_line = auth_line.encode(__salt_system_encoding__)
                 _fh.write(auth_line)

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -768,14 +768,14 @@ def set_auth_key(
         try:
             with salt.utils.files.fopen(fconfig, 'ab+') as _fh:
                 if new_file is False:
-                    # Let's make sure we have a new line at the end of the file
-					_fh.seek(0,2)
-					if _fh.tell() > 0:
-					   # File isn't empty, check if last byte is a newline
-					   # If not, add one
-					   _fh.seek(-1,2)
-					   if _fh.read(1) != six.b('\n'):
-                          _fh.write(six.b('\n'))
+                   # Let's make sure we have a new line at the end of the file
+                   _fh.seek(0,2)
+                   if _fh.tell() > 0:
+                      # File isn't empty, check if last byte is a newline
+                      # If not, add one
+                      _fh.seek(-1,2)
+                      if _fh.read(1) != six.b('\n'):
+                         _fh.write(six.b('\n'))
                 if six.PY3:
                     auth_line = auth_line.encode(__salt_system_encoding__)
                 _fh.write(auth_line)


### PR DESCRIPTION
### What does this PR do?
modules/ssh.py adds bogus newlines before a newly added key. This patch fixes it.
It seems the intention of the original code was to detect if the existing authorized keys file needed to have a newline added in the end when adding a new key to the file. The code's check
for the existence of a new line was:
  _fh.seek(1024, 2)
  if not _fh.read(1024).rstrip(' ').endswith('\n'):
This couldn't work. Seeking to a positive 1024 byte offset from the end of the file (2) would seek to the end of the file. From there no bytes could be read as we were already at the end of the file. Hence the check failed and a new line was being added.

The patch does seek to -1 from the end of the file, reads one byte and checks if that is a newline.
This should work even if the file is UTF-8 encoded because a new line character at the end of a UTF-8 encoded line would still be \n. Since we're checking the end of the file, there's either a \n or there isn't. If there is, we have a new line. If there isn't,  we don't care what the last character is and add a new line.

### What issues does this PR fix or reference?
#33793

### Previous Behavior
modules/ssh.py and hence the ssh_auth state would add bogus empty lines in authorized_keys when new keys are being added. 

### New Behavior
No more bogus empty lines in authorized_keys

### Tests written?
No