### PR TITLE
Move new utils functions out of salt.utils and into separate files

### DIFF
--- a/salt/modules/purefa.py
+++ b/salt/modules/purefa.py
@@ -41,7 +41,6 @@ from datetime import datetime
 
 # Import Salt libs
 from salt.exceptions import CommandExecutionError
-from salt.utils import xor
 
 # Import 3rd party modules
 try:
@@ -967,7 +966,7 @@ def pg_create(name, hostgroup=None, host=None, volume=None, enabled=True):
                 return False
         else:
             return False
-    elif xor(hostgroup, host, volume):
+    elif __utils__['value.xor'](hostgroup, host, volume):
         if _get_pgroup(name, array) is None:
             try:
                 array.create_pgroup(name)

--- a/salt/modules/purefa.py
+++ b/salt/modules/purefa.py
@@ -32,19 +32,18 @@ Installation Prerequisites
 :requires: purestorage
 :platform: all
 '''
-from __future__ import absolute_import
 
+# Import Python libs
+from __future__ import absolute_import
 import os
 import platform
 from datetime import datetime
 
-# 3rd party modules
-# pylint: disable=import-error,no-name-in-module,redefined-builtin
+# Import Salt libs
 from salt.exceptions import CommandExecutionError
-from salt.utils import xor, human_to_bytes
-# pylint: enable=import-error,no-name-in-module
+from salt.utils import xor
 
-
+# Import 3rd party modules
 try:
     import purestorage
     HAS_PURESTORAGE = True
@@ -430,7 +429,7 @@ def volume_extend(name, size):
     array = _get_system()
     vol = _get_volume(name, array)
     if vol is not None:
-        if human_to_bytes(size) > vol['size']:
+        if __utils__['stringutils.human_to_bytes'](size) > vol['size']:
             try:
                 array.extend_volume(name, size)
                 return True

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -3321,13 +3321,3 @@ def check_state_result(running, recurse=False, highstate=None):
     return salt.utils.state.check_result(
         running, recurse=recurse, highstate=highstate
     )
-
-
-def xor(*vars):
-    '''
-    XOR definition for multiple variables
-    '''
-    sum = bool(False)
-    for value in vars:
-        sum = sum ^ bool(value)
-    return sum

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -3331,28 +3331,3 @@ def xor(*vars):
     for value in vars:
         sum = sum ^ bool(value)
     return sum
-
-
-def human_to_bytes(size):
-    '''
-    Given a human-readable byte string (e.g. 2G, 30M),
-    return the number of bytes.  Will return 0 if the argument has
-    unexpected form.
-    '''
-    sbytes = size[:-1]
-    unit = size[-1]
-    if sbytes.isdigit():
-        sbytes = int(sbytes)
-        if unit == 'P':
-            sbytes *= 1125899906842624
-        elif unit == 'T':
-            sbytes *= 1099511627776
-        elif unit == 'G':
-            sbytes *= 1073741824
-        elif unit == 'M':
-            sbytes *= 1048576
-        else:
-            sbytes = 0
-    else:
-        sbytes = 0
-    return sbytes

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -170,3 +170,30 @@ def contains_whitespace(text):
     Returns True if there are any whitespace characters in the string
     '''
     return any(x.isspace() for x in text)
+
+
+def human_to_bytes(size):
+    '''
+    Given a human-readable byte string (e.g. 2G, 30M),
+    return the number of bytes.  Will return 0 if the argument has
+    unexpected form.
+
+    .. versionadded:: Oxygen
+    '''
+    sbytes = size[:-1]
+    unit = size[-1]
+    if sbytes.isdigit():
+        sbytes = int(sbytes)
+        if unit == 'P':
+            sbytes *= 1125899906842624
+        elif unit == 'T':
+            sbytes *= 1099511627776
+        elif unit == 'G':
+            sbytes *= 1073741824
+        elif unit == 'M':
+            sbytes *= 1048576
+        else:
+            sbytes = 0
+    else:
+        sbytes = 0
+    return sbytes

--- a/salt/utils/value.py
+++ b/salt/utils/value.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+'''
+Utility functions used for values.
+
+.. versionadded:: Oxygen
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+
+
+def xor(*variables):
+    '''
+    XOR definition for multiple variables
+    '''
+    sum_ = False
+    for value in variables:
+        sum_ = sum_ ^ bool(value)
+    return sum_


### PR DESCRIPTION
### What does this PR do?
Moves `salt.utils.human_to_bytes` to `salt.utils.stringutils.py` and moves `salt.utils.xor` to `salt.utils.value.py`.

These functions were added recently to `develop` in #43321, so they do not need any deprecation notices.

The `value.py` file is new to this PR, but there are other utility functions I am going to move over to this file once this PR is merged.

### What issues does this PR fix or reference?
Refs PR #43321

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
