### PR TITLE
Move 2 arg-related utility functions into salt.utils.args.py

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -29,6 +29,7 @@ import salt.config
 import salt.loader
 import salt.transport.client
 import salt.utils
+import salt.utils.args
 import salt.utils.files
 import salt.utils.minions
 import salt.utils.versions
@@ -69,7 +70,7 @@ class LoadAuth(object):
         if fstr not in self.auth:
             return ''
         try:
-            pname_arg = salt.utils.arg_lookup(self.auth[fstr])['args'][0]
+            pname_arg = salt.utils.args.arg_lookup(self.auth[fstr])['args'][0]
             return load[pname_arg]
         except IndexError:
             return ''
@@ -642,7 +643,7 @@ class Resolver(object):
                    'not available').format(eauth))
             return ret
 
-        args = salt.utils.arg_lookup(self.auth[fstr])
+        args = salt.utils.args.arg_lookup(self.auth[fstr])
         for arg in args['args']:
             if arg in self.opts:
                 ret[arg] = self.opts[arg]

--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -14,8 +14,9 @@ client applications.
     http://docs.saltstack.com/ref/clients/index.html
 
 '''
-from __future__ import absolute_import
+
 # Import Python libs
+from __future__ import absolute_import
 import os
 
 # Import Salt libs
@@ -24,9 +25,9 @@ import salt.auth
 import salt.client
 import salt.runner
 import salt.wheel
-import salt.utils
+import salt.utils.args
+import salt.utils.event
 import salt.syspaths as syspaths
-from salt.utils.event import tagify
 from salt.exceptions import EauthAuthenticationError
 
 
@@ -229,7 +230,7 @@ class APIClient(object):
                 functions = self.wheelClient.functions
             elif client == u'runner':
                 functions = self.runnerClient.functions
-            result = {u'master': salt.utils.argspec_report(functions, module)}
+            result = {u'master': salt.utils.args.argspec_report(functions, module)}
         return result
 
     def create_token(self, creds):
@@ -322,4 +323,4 @@ class APIClient(object):
         Need to convert this to a master call with appropriate authentication
 
         '''
-        return self.event.fire_event(data, tagify(tag, u'wui'))
+        return self.event.fire_event(data, salt.utils.event.tagify(tag, u'wui'))

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -204,7 +204,7 @@ def send(func, *args, **kwargs):
     if mine_func not in __salt__:
         return False
     data = {}
-    arg_data = salt.utils.arg_lookup(__salt__[mine_func])
+    arg_data = salt.utils.args.arg_lookup(__salt__[mine_func])
     func_data = copy.deepcopy(kwargs)
     for ind, _ in enumerate(arg_data.get('args', [])):
         try:

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -12,8 +12,8 @@ import logging
 import salt.loader
 import salt.runner
 import salt.state
-import salt.utils
-import salt.utils.schema as S
+import salt.utils.args
+import salt.utils.schema
 from salt.utils.doc import strip_rst as _strip_rst
 from salt.ext.six.moves import zip
 
@@ -450,7 +450,7 @@ def argspec(module=''):
         salt '*' sys.argspec 'pkg.*'
 
     '''
-    return salt.utils.argspec_report(__salt__, module)
+    return salt.utils.args.argspec_report(__salt__, module)
 
 
 def state_argspec(module=''):
@@ -476,7 +476,7 @@ def state_argspec(module=''):
 
     '''
     st_ = salt.state.State(__opts__)
-    return salt.utils.argspec_report(st_.states, module)
+    return salt.utils.args.argspec_report(st_.states, module)
 
 
 def returner_argspec(module=''):
@@ -502,7 +502,7 @@ def returner_argspec(module=''):
 
     '''
     returners_ = salt.loader.returners(__opts__, [])
-    return salt.utils.argspec_report(returners_, module)
+    return salt.utils.args.argspec_report(returners_, module)
 
 
 def runner_argspec(module=''):
@@ -527,7 +527,7 @@ def runner_argspec(module=''):
         salt '*' sys.runner_argspec 'winrepo.*'
     '''
     run_ = salt.runner.Runner(__opts__)
-    return salt.utils.argspec_report(run_.functions, module)
+    return salt.utils.args.argspec_report(run_.functions, module)
 
 
 def list_state_functions(*args, **kwargs):  # pylint: disable=unused-argument
@@ -844,28 +844,28 @@ def _argspec_to_schema(mod, spec):
     }
 
     for i in args_req:
-        types[i] = S.OneOfItem(items=(
-            S.BooleanItem(title=i, description=i, required=True),
-            S.IntegerItem(title=i, description=i, required=True),
-            S.NumberItem(title=i, description=i, required=True),
-            S.StringItem(title=i, description=i, required=True),
+        types[i] = salt.utils.schema.OneOfItem(items=(
+            salt.utils.schema.BooleanItem(title=i, description=i, required=True),
+            salt.utils.schema.IntegerItem(title=i, description=i, required=True),
+            salt.utils.schema.NumberItem(title=i, description=i, required=True),
+            salt.utils.schema.StringItem(title=i, description=i, required=True),
 
             # S.ArrayItem(title=i, description=i, required=True),
             # S.DictItem(title=i, description=i, required=True),
         ))
 
     for i, j in args_defaults:
-        types[i] = S.OneOfItem(items=(
-            S.BooleanItem(title=i, description=i, default=j),
-            S.IntegerItem(title=i, description=i, default=j),
-            S.NumberItem(title=i, description=i, default=j),
-            S.StringItem(title=i, description=i, default=j),
+        types[i] = salt.utils.schema.OneOfItem(items=(
+            salt.utils.schema.BooleanItem(title=i, description=i, default=j),
+            salt.utils.schema.IntegerItem(title=i, description=i, default=j),
+            salt.utils.schema.NumberItem(title=i, description=i, default=j),
+            salt.utils.schema.StringItem(title=i, description=i, default=j),
 
             # S.ArrayItem(title=i, description=i, default=j),
             # S.DictItem(title=i, description=i, default=j),
         ))
 
-    return type(mod, (S.Schema,), types).serialize()
+    return type(mod, (salt.utils.schema.Schema,), types).serialize()
 
 
 def state_schema(module=''):

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -860,7 +860,7 @@ def format_call(fun,
 
     aspec = salt.utils.args.get_function_argspec(fun, is_class_method=is_class_method)
 
-    arg_data = arg_lookup(fun, aspec)
+    arg_data = salt.utils.args.arg_lookup(fun, aspec)
     args = arg_data['args']
     kwargs = arg_data['kwargs']
 
@@ -965,21 +965,6 @@ def format_call(fun,
 
         # Lets pack the current extra kwargs as template context
         ret.setdefault('context', {}).update(extra)
-    return ret
-
-
-def arg_lookup(fun, aspec=None):
-    '''
-    Return a dict containing the arguments and default arguments to the
-    function.
-    '''
-    import salt.utils.args
-    ret = {'kwargs': {}}
-    if aspec is None:
-        aspec = salt.utils.args.get_function_argspec(fun)
-    if aspec.defaults:
-        ret['kwargs'] = dict(zip(aspec.args[::-1], aspec.defaults[::-1]))
-    ret['args'] = [arg for arg in aspec.args if arg not in ret['kwargs']]
     return ret
 
 
@@ -2547,6 +2532,25 @@ def shlex_split(s, **kwargs):
         'warning will be removed in Salt Neon.'
     )
     return salt.utils.args.shlex_split(s, **kwargs)
+
+
+def arg_lookup(fun, aspec=None):
+    '''
+    Return a dict containing the arguments and default arguments to the
+    function.
+
+    .. deprecated:: Oxygen
+    '''
+    # Late import to avoid circular import.
+    import salt.utils.versions
+    import salt.utils.args
+    salt.utils.versions.warn_until(
+        'Neon',
+        'Use of \'salt.utils.arg_lookup\' detected. This function has been '
+        'moved to \'salt.utils.args.arg_lookup\' as of Salt Oxygen. This '
+        'warning will be removed in Salt Neon.'
+    )
+    return salt.utils.args.arg_lookup(fun, aspec=aspec)
 
 
 def which(exe=None):

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -38,7 +38,6 @@ from salt.ext import six
 # pylint: disable=import-error
 # pylint: disable=redefined-builtin
 from salt.ext.six.moves import range
-from salt.ext.six.moves import zip
 # pylint: enable=import-error,redefined-builtin
 
 if six.PY3:
@@ -1693,52 +1692,6 @@ def compare_lists(old=None, new=None):
     return ret
 
 
-def argspec_report(functions, module=''):
-    '''
-    Pass in a functions dict as it is returned from the loader and return the
-    argspec function signatures
-    '''
-    import salt.utils.args
-    ret = {}
-    if '*' in module or '.' in module:
-        for fun in fnmatch.filter(functions, module):
-            try:
-                aspec = salt.utils.args.get_function_argspec(functions[fun])
-            except TypeError:
-                # this happens if not callable
-                continue
-
-            args, varargs, kwargs, defaults = aspec
-
-            ret[fun] = {}
-            ret[fun]['args'] = args if args else None
-            ret[fun]['defaults'] = defaults if defaults else None
-            ret[fun]['varargs'] = True if varargs else None
-            ret[fun]['kwargs'] = True if kwargs else None
-
-    else:
-        # "sys" should just match sys without also matching sysctl
-        moduledot = module + '.'
-
-        for fun in functions:
-            if fun.startswith(moduledot):
-                try:
-                    aspec = salt.utils.args.get_function_argspec(functions[fun])
-                except TypeError:
-                    # this happens if not callable
-                    continue
-
-                args, varargs, kwargs, defaults = aspec
-
-                ret[fun] = {}
-                ret[fun]['args'] = args if args else None
-                ret[fun]['defaults'] = defaults if defaults else None
-                ret[fun]['varargs'] = True if varargs else None
-                ret[fun]['kwargs'] = True if kwargs else None
-
-    return ret
-
-
 @jinja_filter('json_decode_list')
 def decode_list(data):
     '''
@@ -2551,6 +2504,25 @@ def arg_lookup(fun, aspec=None):
         'warning will be removed in Salt Neon.'
     )
     return salt.utils.args.arg_lookup(fun, aspec=aspec)
+
+
+def argspec_report(functions, module=''):
+    '''
+    Pass in a functions dict as it is returned from the loader and return the
+    argspec function signatures
+
+    .. deprecated:: Oxygen
+    '''
+    # Late import to avoid circular import.
+    import salt.utils.versions
+    import salt.utils.args
+    salt.utils.versions.warn_until(
+        'Neon',
+        'Use of \'salt.utils.argspec_report\' detected. This function has been '
+        'moved to \'salt.utils.args.argspec_report\' as of Salt Oxygen. This '
+        'warning will be removed in Salt Neon.'
+    )
+    return salt.utils.args.argspec_report(functions, module=module)
 
 
 def which(exe=None):

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -268,3 +268,17 @@ def shlex_split(s, **kwargs):
         return shlex.split(s, **kwargs)
     else:
         return s
+
+
+def arg_lookup(fun, aspec=None):
+    '''
+    Return a dict containing the arguments and default arguments to the
+    function.
+    '''
+    ret = {'kwargs': {}}
+    if aspec is None:
+        aspec = get_function_argspec(fun)
+    if aspec.defaults:
+        ret['kwargs'] = dict(zip(aspec.args[::-1], aspec.defaults[::-1]))
+    ret['args'] = [arg for arg in aspec.args if arg not in ret['kwargs']]
+    return ret

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -11,11 +11,10 @@ import re
 import shlex
 
 # Import salt libs
-import salt.utils.jid
 from salt.exceptions import SaltInvocationError
-
-# Import 3rd-party libs
 from salt.ext import six
+from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
+import salt.utils.jid
 
 
 if six.PY3:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -49,7 +49,8 @@ class LoadAuthTestCase(TestCase):
         self.assertEqual(ret, '', "Did not bail when the auth loader didn't have the auth type.")
 
         # Test a case with valid params
-        with patch('salt.utils.arg_lookup', MagicMock(return_value={'args': ['username', 'password']})) as format_call_mock:
+        with patch('salt.utils.args.arg_lookup',
+                   MagicMock(return_value={'args': ['username', 'password']})) as format_call_mock:
             expected_ret = call('fake_func_str')
             ret = self.lauth.load_name(valid_eauth_load)
             format_call_mock.assert_has_calls((expected_ret,), any_order=True)

--- a/tests/unit/utils/test_args.py
+++ b/tests/unit/utils/test_args.py
@@ -11,6 +11,7 @@ import salt.utils.args
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
+    create_autospec,
     DEFAULT,
     NO_MOCK,
     NO_MOCK_REASON,
@@ -82,3 +83,14 @@ class ArgsTestCase(TestCase):
             ret = salt.utils.format_call(dummy_func, {'first': 2, 'second': 2, 'third': 3},
                                          expected_extra_kws=('first', 'second', 'third'))
             self.assertDictEqual(ret, {'args': [], 'kwargs': {}})
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_argspec_report(self):
+        def _test_spec(arg1, arg2, kwarg1=None):
+            pass
+
+        sys_mock = create_autospec(_test_spec)
+        test_functions = {'test_module.test_spec': sys_mock}
+        ret = salt.utils.args.argspec_report(test_functions, 'test_module.test_spec')
+        self.assertDictEqual(ret, {'test_module.test_spec':
+                                       {'kwargs': True, 'args': None, 'defaults': None, 'varargs': True}})

--- a/tests/unit/utils/test_args.py
+++ b/tests/unit/utils/test_args.py
@@ -5,10 +5,17 @@ from __future__ import absolute_import
 from collections import namedtuple
 
 # Import Salt Libs
+from salt.exceptions import SaltInvocationError
 import salt.utils.args
 
 # Import Salt Testing Libs
-from tests.support.unit import TestCase
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    DEFAULT,
+    NO_MOCK,
+    NO_MOCK_REASON,
+    patch
+)
 
 
 class ArgsTestCase(TestCase):
@@ -45,3 +52,33 @@ class ArgsTestCase(TestCase):
 
         ret = salt.utils.args.parse_kwarg('foobar')
         self.assertEqual(ret, (None, None))
+
+    def test_arg_lookup(self):
+        def dummy_func(first, second, third, fourth='fifth'):
+            pass
+
+        expected_dict = {'args': ['first', 'second', 'third'], 'kwargs': {'fourth': 'fifth'}}
+        ret = salt.utils.args.arg_lookup(dummy_func)
+        self.assertEqual(expected_dict, ret)
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_format_call(self):
+        with patch('salt.utils.args.arg_lookup') as arg_lookup:
+            def dummy_func(first=None, second=None, third=None):
+                pass
+
+            arg_lookup.return_value = {'args': ['first', 'second', 'third'], 'kwargs': {}}
+            get_function_argspec = DEFAULT
+            get_function_argspec.return_value = namedtuple('ArgSpec', 'args varargs keywords defaults')(
+                args=['first', 'second', 'third', 'fourth'], varargs=None, keywords=None, defaults=('fifth',))
+
+            # Make sure we raise an error if we don't pass in the requisite number of arguments
+            self.assertRaises(SaltInvocationError, salt.utils.format_call, dummy_func, {'1': 2})
+
+            # Make sure we warn on invalid kwargs
+            ret = salt.utils.format_call(dummy_func, {'first': 2, 'second': 2, 'third': 3})
+            self.assertGreaterEqual(len(ret['warnings']), 1)
+
+            ret = salt.utils.format_call(dummy_func, {'first': 2, 'second': 2, 'third': 3},
+                                         expected_extra_kws=('first', 'second', 'third'))
+            self.assertDictEqual(ret, {'args': [], 'kwargs': {}})

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
     patch,
-    create_autospec,
     NO_MOCK,
     NO_MOCK_REASON
 )
@@ -352,17 +351,6 @@ class UtilsTestCase(TestCase):
         ret = salt.utils.compare_dicts(old={'foo': 'bar'}, new={'foo': 'woz'})
         expected_ret = {'foo': {'new': 'woz', 'old': 'bar'}}
         self.assertDictEqual(ret, expected_ret)
-
-    @skipIf(NO_MOCK, NO_MOCK_REASON)
-    def test_argspec_report(self):
-        def _test_spec(arg1, arg2, kwarg1=None):
-            pass
-
-        sys_mock = create_autospec(_test_spec)
-        test_functions = {'test_module.test_spec': sys_mock}
-        ret = salt.utils.argspec_report(test_functions, 'test_module.test_spec')
-        self.assertDictEqual(ret, {'test_module.test_spec':
-                                       {'kwargs': True, 'args': None, 'defaults': None, 'varargs': True}})
 
     def test_decode_list(self):
         test_data = [u'unicode_str', [u'unicode_item_in_list', 'second_item_in_list'], {'dict_key': u'dict_val'}]

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
-    patch, DEFAULT,
+    patch,
     create_autospec,
     NO_MOCK,
     NO_MOCK_REASON
@@ -20,14 +20,13 @@ import salt.utils
 import salt.utils.jid
 import salt.utils.yamlencoding
 import salt.utils.zeromq
-from salt.exceptions import (SaltInvocationError, SaltSystemExit, CommandNotFoundError)
+from salt.exceptions import SaltSystemExit, CommandNotFoundError
 
 # Import Python libraries
 import datetime
 import os
 import yaml
 import zmq
-from collections import namedtuple
 
 # Import 3rd-party libs
 try:
@@ -99,35 +98,6 @@ class UtilsTestCase(TestCase):
                          '(?:[\\s]+)?$'
         ret = salt.utils.build_whitespace_split_regex(' '.join(LOREM_IPSUM.split()[:5]))
         self.assertEqual(ret, expected_regex)
-
-    def test_arg_lookup(self):
-        def dummy_func(first, second, third, fourth='fifth'):
-            pass
-
-        expected_dict = {'args': ['first', 'second', 'third'], 'kwargs': {'fourth': 'fifth'}}
-        ret = salt.utils.arg_lookup(dummy_func)
-        self.assertEqual(expected_dict, ret)
-
-    @skipIf(NO_MOCK, NO_MOCK_REASON)
-    def test_format_call(self):
-        with patch('salt.utils.arg_lookup') as arg_lookup:
-            def dummy_func(first=None, second=None, third=None):
-                pass
-            arg_lookup.return_value = {'args': ['first', 'second', 'third'], 'kwargs': {}}
-            get_function_argspec = DEFAULT
-            get_function_argspec.return_value = namedtuple('ArgSpec', 'args varargs keywords defaults')(
-                args=['first', 'second', 'third', 'fourth'], varargs=None, keywords=None, defaults=('fifth',))
-
-            # Make sure we raise an error if we don't pass in the requisite number of arguments
-            self.assertRaises(SaltInvocationError, salt.utils.format_call, dummy_func, {'1': 2})
-
-            # Make sure we warn on invalid kwargs
-            ret = salt.utils.format_call(dummy_func, {'first': 2, 'second': 2, 'third': 3})
-            self.assertGreaterEqual(len(ret['warnings']), 1)
-
-            ret = salt.utils.format_call(dummy_func, {'first': 2, 'second': 2, 'third': 3},
-                                    expected_extra_kws=('first', 'second', 'third'))
-            self.assertDictEqual(ret, {'args': [], 'kwargs': {}})
 
     def test_isorted(self):
         test_list = ['foo', 'Foo', 'bar', 'Bar']


### PR DESCRIPTION
### What does this PR do?
- Moves `salt.utils.arg_lookup` to `salt.utils.args.py`
- Moves `salt.utils.argspec_report` to `salt.utils.args.py`

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
