### PR TITLE
Additional highstate output modes; changes_id, filter_id, terse_id, full_id

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -589,11 +589,12 @@
 # all data that has a result of True and no changes will be suppressed.
 #state_verbose: True
 
-# The state_output setting changes if the output is the full multi line
-# output for each changed state if set to 'full', but if set to 'terse'
-# the output will be shortened to a single line.  If set to 'mixed', the output
-# will be terse unless a state failed, in which case that output will be full.
-# If set to 'changes', the output will be full unless the state didn't change.
+# The state_output setting controls which results will be output full multi line
+# full, terse - each state will be full/terse
+# mixed - only states with errors will be full
+# changes - states with changes and errors will be full
+# full_id, mixed_id, changes_id and terse_id are also allowed;
+# when set, the state ID will be used as name in the output
 #state_output: full
 
 # The state_output_diff setting changes whether or not the output from

--- a/conf/minion
+++ b/conf/minion
@@ -635,9 +635,12 @@
 # all data that has a result of True and no changes will be suppressed.
 #state_verbose: True
 
-# The state_output setting changes if the output is the full multi line
-# output for each changed state if set to 'full', but if set to 'terse'
-# the output will be shortened to a single line.
+# The state_output setting controls which results will be output full multi line
+# full, terse - each state will be full/terse
+# mixed - only states with errors will be full
+# changes - states with changes and errors will be full
+# full_id, mixed_id, changes_id and terse_id are also allowed;
+# when set, the state ID will be used as name in the output
 #state_output: full
 
 # The state_output_diff setting changes whether or not the output from

--- a/conf/proxy
+++ b/conf/proxy
@@ -498,9 +498,12 @@
 # all data that has a result of True and no changes will be suppressed.
 #state_verbose: True
 
-# The state_output setting changes if the output is the full multi line
-# output for each changed state if set to 'full', but if set to 'terse'
-# the output will be shortened to a single line.
+# The state_output setting controls which results will be output full multi line
+# full, terse - each state will be full/terse
+# mixed - only states with errors will be full
+# changes - states with changes and errors will be full
+# full_id, mixed_id, changes_id and terse_id are also allowed;
+# when set, the state ID will be used as name in the output
 #state_output: full
 
 # The state_output_diff setting changes whether or not the output from

--- a/conf/suse/master
+++ b/conf/suse/master
@@ -560,11 +560,12 @@ syndic_user: salt
 # all data that has a result of True and no changes will be suppressed.
 #state_verbose: True
 
-# The state_output setting changes if the output is the full multi line
-# output for each changed state if set to 'full', but if set to 'terse'
-# the output will be shortened to a single line.  If set to 'mixed', the output
-# will be terse unless a state failed, in which case that output will be full.
-# If set to 'changes', the output will be full unless the state didn't change.
+# The state_output setting controls which results will be output full multi line
+# full, terse - each state will be full/terse
+# mixed - only states with errors will be full
+# changes - states with changes and errors will be full
+# full_id, mixed_id, changes_id and terse_id are also allowed;
+# when set, the state ID will be used as name in the output
 #state_output: full
 
 # The state_output_diff setting changes whether or not the output from

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2011,11 +2011,14 @@ output for states that failed or states that have changes.
 
 Default: ``full``
 
-The state_output setting changes if the output is the full multi line
-output for each changed state if set to 'full', but if set to 'terse'
-the output will be shortened to a single line.  If set to 'mixed', the output
-will be terse unless a state failed, in which case that output will be full.
-If set to 'changes', the output will be full unless the state didn't change.
+The state_output setting controls which results will be output full multi line:
+
+* ``full``, ``terse`` - each state will be full/terse
+* ``mixed`` - only states with errors will be full
+* ``changes`` - states with changes and errors will be full
+
+``full_id``, ``mixed_id``, ``changes_id`` and ``terse_id`` are also allowed;
+when set, the state ID will be used as name in the output.
 
 .. code-block:: yaml
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1664,14 +1664,18 @@ output for states that failed or states that have changes.
 
 Default: ``full``
 
-The state_output setting changes if the output is the full multi line
-output for each changed state if set to 'full', but if set to 'terse'
-the output will be shortened to a single line.
+The state_output setting controls which results will be output full multi line:
+
+* ``full``, ``terse`` - each state will be full/terse
+* ``mixed`` - only states with errors will be full
+* ``changes`` - states with changes and errors will be full
+
+``full_id``, ``mixed_id``, ``changes_id`` and ``terse_id`` are also allowed;
+when set, the state ID will be used as name in the output.
 
 .. code-block:: yaml
 
     state_output: full
-
 
 .. conf_minion:: state_output_diff
 

--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -92,7 +92,8 @@ Additional output modes
 ------------------
 
 The ``state_output`` parameter now supports ``full_id``, ``changes_id`` and ``terse_id``.
-Just like ``mixed_id``, these use the state ID as name in the highstate output
+Just like ``mixed_id``, these use the state ID as name in the highstate output.
+For more information on these output modes, see the docs for the :mod:`Highstate Outputter <salt.output.highstate>`.
 
 Salt Cloud Features
 -------------------

--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -88,6 +88,12 @@ environments (i.e. ``saltenvs``) have been added:
    ignore all tags and use branches only, and also to keep SHAs from being made
    available as saltenvs.
 
+Additional output modes
+------------------
+
+The ``state_output`` parameter now supports ``full_id``, ``changes_id`` and ``terse_id``.
+Just like ``mixed_id``, these use the state ID as name in the highstate output
+
 Salt Cloud Features
 -------------------
 

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -246,7 +246,7 @@ def _format_host(host, data):
             state_output = __opts__.get('state_output', 'full').lower()
             comps = [sdecode(comp) for comp in tname.split('_|-')]
 
-            if state_output == 'mixed_id':
+            if state_output.endswith('_id'):
                 # Swap in the ID for the name. Refs #35137
                 comps[2] = comps[1]
 

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -16,30 +16,30 @@ state_verbose:
     instruct the highstate outputter to omit displaying anything in green, this
     means that nothing with a result of True and no changes will not be printed
 state_output:
-    The highstate outputter has six output modes, ``full``, ``terse``,
-    ``mixed``, ``mixed_id``, ``changes`` and ``filter``.
-
+    The highstate outputter has six output modes,
+    ``full``, ``terse``, ``mixed``, ``changes`` and ``filter``
     * The default is set to ``full``, which will display many lines of detailed
       information for each executed chunk.
     * If ``terse`` is used, then the output is greatly simplified and shown in
       only one line.
     * If ``mixed`` is used, then terse output will be used unless a state
       failed, in which case full output will be used.
-    * If ``mixed_id`` is used, then the mixed form will be used, but the value for ``name``
-      will be drawn from the state ID. This is useful for cases where the name
-      value might be very long and hard to read.
     * If ``changes`` is used, then terse output will be used if there was no
       error and no changes, otherwise full output will be used.
     * If ``filter`` is used, then either or both of two different filters can be
       used: ``exclude`` or ``terse``.
-      * for ``exclude``, state.highstate expects a list of states to be excluded
-        (or ``None``)
-        followed by ``True`` for terse output or ``False`` for regular output.
-        Because of parsing nuances, if only one of these is used, it must still
-        contain a comma. For instance: `exclude=True,`.
-      * for ``terse``, state.highstate expects simply ``True`` or ``False``.
+        * for ``exclude``, state.highstate expects a list of states to be excluded (or ``None``)
+          followed by ``True`` for terse output or ``False`` for regular output.
+          Because of parsing nuances, if only one of these is used, it must still
+          contain a comma. For instance: `exclude=True,`.
+        * for ``terse``, state.highstate expects simply ``True`` or ``False``.
       These can be set as such from the command line, or in the Salt config as
       `state_output_exclude` or `state_output_terse`, respectively.
+    The output modes have one modifier:
+    ``full_id``, ``terse_id``, ``mixed_id``, ``changes_id`` and ``filter_id``
+    If ``_id`` is used, then the corresponding form will be used, but the value for ``name``
+    will be drawn from the state ID. This is useful for cases where the name
+    value might be very long and hard to read.
 state_tabular:
     If `state_output` uses the terse output, set this to `True` for an aligned
     output format.  If you wish to use a custom format, this can be set to a


### PR DESCRIPTION
### What does this PR do?
Add support for _id to all output modes

### What issues does this PR fix or reference?
Follows #35137
Supersedes #42063
Requires #43501 

### New Behavior
`mixed_id` was added a while back and I personally fell in love with it's output. Except I want to see the changes in full and `changes_id` isn't there.
