### PR TITLE
Got Ansible own modules? Run them from within the Salt just like that!

### DIFF
--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -135,12 +135,16 @@ class AnsibleModuleCaller(object):
         md_exc = subprocess.Popen(['python', module.__file__],
                                   stdin=js_out.stdout, stdout=subprocess.PIPE)
         js_out.stdout.close()
-        js_out = md_exc.communicate()[0]
+        js_out, js_err = md_exc.communicate()
 
         try:
             out = json.loads(js_out)
         except ValueError as ex:
-            return {'Error': str(ex), "JSON": js_out}
+            out = {'Error': (js_err and (js_err + '.') or str(ex))}
+            if js_out:
+                out['Given JSON output'] = js_out
+            return out
+
         if 'invocation' in out:
             del out['invocation']
 

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -16,13 +16,67 @@
 # limitations under the License.
 
 import logging
+import os
 try:
     import ansible
+    import ansible.constants
+    import ansible.modules
+    from ansible.plugins import module_loader
 except ImportError:
     ansible = None
 
 __virtualname__ = 'ansible'
 log = logging.getLogger(__name__)
+
+
+class AnsibleModuleResolver(object):
+    '''
+    This class is to resolve all available modules in Ansible.
+    '''
+    def __init__(self, opts):
+        self._opts = opts
+        self._modules_map = self._get_modules_map()
+
+    def _get_modules_map(self, path=None):
+        '''
+        Get installed Ansible modules
+        :return:
+        '''
+        paths = {}
+        root = ansible.modules.__path__[0]
+        if not path:
+            path = root
+        for p_el in os.listdir(path):
+            p_el_path = os.path.join(path, p_el)
+            if os.path.islink(p_el_path): continue
+            if os.path.isdir(p_el_path):
+                paths.update(self._get_modules_map(p_el_path))
+            else:
+                if (any(p_el.startswith(elm) for elm in ['__', '.']) or
+                        not p_el.endswith('.py') or
+                        p_el in ansible.constants.IGNORE_FILES):
+                    continue
+                m_name = p_el.split('.')[0]
+                als_name = m_name[1:] if m_name.startswith('_') else m_name
+                paths[als_name] = p_el_path.replace(root, '')
+
+        return paths
+
+    def _introspect_module(self, module):
+        '''
+        Introspect Ansible module.
+
+        :param module:
+        :return:
+        '''
+
+    def resolve(self):
+        log.debug('Resolving Ansible modules')
+        return self
+
+    def install(self):
+        log.debug('Installing Ansible modules')
+        return self
 
 
 def __virtual__():
@@ -34,5 +88,6 @@ def __virtual__():
     msg = not ret and "Ansible is not installed on this system" or None
     if msg:
         log.warning(msg)
+    else:
+        AnsibleModuleResolver(__opts__).resolve().install()
     return ret, msg
-

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -61,9 +61,9 @@ class AnsibleModuleResolver(object):
                         not p_el.endswith('.py') or
                         p_el in ansible.constants.IGNORE_FILES):
                     continue
-                m_name = p_el.split('.')[0]
-                als_name = m_name[1:] if m_name.startswith('_') else m_name
-                paths[als_name] = p_el_path.replace(root, '')
+                p_el_path = p_el_path.replace(root, '').split('.')[0]
+                als_name = p_el_path.replace('.', '').replace('/', '', 1).replace('/', '.')
+                paths[als_name] = p_el_path
 
         return paths
 

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -170,7 +170,7 @@ def help(module=None, *args):
         raise CommandExecutionError('Please tell me what module you want to have a help on. '
                                     'Or call ansible.list to know what is available.')
     try:
-        module = _resolver.load_module(module.split('.')[-1])
+        module = _resolver.load_module(module)
     except ImportError as err:
         raise CommandExecutionError('Module "{0}" is currently not functional on your system.'.format(module))
 

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -116,8 +116,13 @@ def help(module=None, *args):
     :return:
     '''
     if not module:
-        return 'Please tell me what module you want to have a help on. Or call ansible.list to know what is available.'
-    module = _resolver.load_module(module)
+        raise CommandExecutionError('Please tell me what module you want to have a help on. '
+                                    'Or call ansible.list to know what is available.')
+    try:
+        module = _resolver.load_module(module.split('.')[-1])
+    except ImportError as err:
+        raise CommandExecutionError('Module "{0}" is currently not functional on your system.'.format(module))
+
     doc = {}
     ret = {}
     for docset in module.DOCUMENTATION.split('---'):

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Author: Bo Maryniuk <bo@suse.de>
+#
+# Copyright 2017 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+try:
+    import ansible
+except ImportError:
+    ansible = None
+
+__virtualname__ = 'ansible'
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Ansible module caller.
+    :return:
+    '''
+    ret = ansible is not None
+    msg = not ret and "Ansible is not installed on this system" or None
+    if msg:
+        log.warning(msg)
+    return ret, msg
+

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -30,7 +30,6 @@ try:
     import ansible
     import ansible.constants
     import ansible.modules
-    from ansible.plugins import module_loader
 except ImportError:
     ansible = None
 

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -124,6 +124,10 @@ class AnsibleModuleCaller(object):
         '''
 
         module = self._resolver.load_module(module)
+        if not hasattr(module, 'main'):
+            raise CommandExecutionError('This module is not callable '
+                                        '(see "ansible.help {0}")'.format(module.__name__.replace('ansible.modules.',
+                                                                                                  '')))
         if args:
             kwargs['_raw_params'] = ' '.join(args)
         js_args = '{{"ANSIBLE_MODULE_ARGS": {args}}}'.format(args=json.dumps(kwargs))

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import os
+import sys
 import logging
 import importlib
 import yaml

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -15,6 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+'''
+Ansible Support
+===============
+
+This module can have an optional minion-level
+configuration in /etc/salt/minion.d/ as follows:
+
+  ansible_timeout: 1200
+
+The timeout is how many seconds Salt should wait for
+any Ansible module to respond.
+'''
+
 from __future__ import absolute_import
 import os
 import sys

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -124,8 +124,17 @@ def _set_callables(modules):
             '''
             Call an Ansible module as a function from the Salt.
             '''
+            kwargs = {}
+            if kw.get('__pub_arg'):
+                for _kw in kw.get('__pub_arg', []):
+                    if isinstance(_kw, dict):
+                        kwargs = _kw
+                        break
+            else:
+                kw = {}
+
             global _caller
-            return _caller.call(cmd_name)
+            return _caller.call(cmd_name, *args, **kwargs)
         _cmd.__doc__ = doc
         return _cmd
 

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -161,7 +161,7 @@ def _set_callables(modules):
     Set all Ansible modules callables
     :return:
     '''
-    def _mkf(cmd_name, doc):
+    def _set_function(cmd_name, doc):
         '''
         Create a Salt function for the Ansible module.
         '''
@@ -181,7 +181,7 @@ def _set_callables(modules):
         return _cmd
 
     for mod in modules:
-        setattr(sys.modules[__name__], mod, _mkf(mod, 'Available'))
+        setattr(sys.modules[__name__], mod, _set_function(mod, 'Available'))
 
 
 def __virtual__():

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -222,6 +222,10 @@ def help(module=None, *args):
         except Exception as err:
             log.error("Error parsing doc section: {0}".format(err))
     if not args:
+        if 'description' in doc:
+            description = doc.get('description') or ''
+            del doc['description']
+            ret['Description'] = description
         ret['Available sections on module "{}"'.format(module.__name__.replace('ansible.modules.', ''))] = doc.keys()
     else:
         for arg in args:

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -174,8 +174,6 @@ def _set_callables(modules):
                     if isinstance(_kw, dict):
                         kwargs = _kw
                         break
-            else:
-                kw = {}
 
             global _caller
             return _caller.call(cmd_name, *args, **kwargs)

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -209,7 +209,7 @@ def help(module=None, *args):
                                     'Or call ansible.list to know what is available.')
     try:
         module = _resolver.load_module(module)
-    except ImportError as err:
+    except (ImportError, LoaderError) as err:
         raise CommandExecutionError('Module "{0}" is currently not functional on your system.'.format(module))
 
     doc = {}

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -209,8 +209,8 @@ def help(module=None, *args):
     :return:
     '''
     if not module:
-        raise CommandExecutionError('Please tell me what module you want to have a help on. '
-                                    'Or call ansible.list to know what is available.')
+        raise CommandExecutionError('Please tell me what module you want to have helped with. '
+                                    'Or call "ansible.list" to know what is available.')
     try:
         module = _resolver.load_module(module)
     except (ImportError, LoaderError) as err:

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -176,7 +176,6 @@ def _set_callables(modules):
                         kwargs = _kw
                         break
 
-            global _caller
             return _caller.call(cmd_name, *args, **kwargs)
         _cmd.__doc__ = doc
         return _cmd

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -56,7 +56,8 @@ class AnsibleModuleResolver(object):
             path = root
         for p_el in os.listdir(path):
             p_el_path = os.path.join(path, p_el)
-            if os.path.islink(p_el_path): continue
+            if os.path.islink(p_el_path):
+                continue
             if os.path.isdir(p_el_path):
                 paths.update(self._get_modules_map(p_el_path))
             else:

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -109,6 +109,29 @@ class AnsibleModuleResolver(object):
 
 _resolver = None
 
+
+def _set_callables(modules):
+    '''
+    Set all Ansible modules callables
+    :return:
+    '''
+    def _mkf(cmd_name, doc):
+        '''
+        Create a Salt function for the Ansible module.
+        '''
+        def _cmd(*args, **kw):
+            '''
+            Call an Ansible module as a function from the Salt.
+            '''
+            global _caller
+            return _caller.call(cmd_name)
+        _cmd.__doc__ = doc
+        return _cmd
+
+    for mod in modules:
+        setattr(sys.modules[__name__], mod, _mkf(mod, 'Available'))
+
+
 def __virtual__():
     '''
     Ansible module caller.
@@ -121,6 +144,8 @@ def __virtual__():
     else:
         global _resolver
         _resolver = AnsibleModuleResolver(__opts__).resolve().install()
+    _set_callables(list())
+
     return ret, msg
 
 

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import sys
 import logging

--- a/salt/states/ansiblegate.py
+++ b/salt/states/ansiblegate.py
@@ -1,6 +1,22 @@
 # -*- coding: utf-8 -*-
+#
+# Author: Bo Maryniuk <bo@suse.de>
+#
+# Copyright 2017 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 r'''
-Author: Bo Maryniuk <bo@suse.de>
+:codeauthor: :email:`Bo Maryniuk <bo@suse.de>`
 
 Execution of Ansible modules from within states
 ===============================================

--- a/salt/states/ansiblegate.py
+++ b/salt/states/ansiblegate.py
@@ -61,12 +61,17 @@ class AnsibleState(object):
             'name': kwargs.pop('name'),
             'changes': {},
             'comment': '',
-            'result': None,
+            'result': True,
         }
 
         for mod_name, mod_params in kwargs.items():
             args, kwargs = self.get_args(mod_params)
-            ans_mod_out = __salt__['ansible.{0}'.format(mod_name)](*args, **kwargs)
+            try:
+                ans_mod_out = __salt__['ansible.{0}'.format(mod_name)](*args, **kwargs)
+            except Exception as err:
+                ans_mod_out = 'Module "{0}" failed. Error message: ({1}) {2}'.format(
+                    mod_name, err.__class__.__name__, err)
+                ret['result'] = False
             ret['changes'][mod_name] = ans_mod_out
 
         return ret

--- a/salt/states/ansiblegate.py
+++ b/salt/states/ansiblegate.py
@@ -97,5 +97,5 @@ def __virtual__():
     '''
     Disable, if Ansible is not available around on the Minion.
     '''
-    setattr(sys.modules[__name__], 'call', lambda **kwargs: AnsibleState()(**kwargs))
+    setattr(sys.modules[__name__], 'call', lambda **kwargs: AnsibleState()(**kwargs))   # pylint: disable=W0108
     return ansible is not None

--- a/salt/states/ansiblegate.py
+++ b/salt/states/ansiblegate.py
@@ -67,7 +67,7 @@ class AnsibleState(object):
         for mod_name, mod_params in kwargs.items():
             args, kwargs = self.get_args(mod_params)
             try:
-                ans_mod_out = __salt__['ansible.{0}'.format(mod_name)](*args, **kwargs)
+                ans_mod_out = __salt__['ansible.{0}'.format(mod_name)](**{'__pub_arg': [args, kwargs]})
             except Exception as err:
                 ans_mod_out = 'Module "{0}" failed. Error message: ({1}) {2}'.format(
                     mod_name, err.__class__.__name__, err)

--- a/salt/states/ansiblegate.py
+++ b/salt/states/ansiblegate.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+r'''
+Author: Bo Maryniuk <bo@suse.de>
+
+Execution of Ansible modules from within states
+===============================================
+
+With `ansible.call` these states allow individual Ansible module calls to be
+made via states. To call an Ansible module function use a :mod:`module.run <salt.states.ansible.call>`
+state:
+
+.. code-block:: yaml
+
+    some_set_of_tasks:
+      ansible:
+        - system.ping
+        - packaging.os.zypper
+          - name: emacs
+          - state: installed
+
+'''
+from __future__ import absolute_import
+
+__virtualname__ = 'ansible'
+
+
+def __virtual__():
+    return True
+
+
+def call(*args, **kwargs):
+    '''
+    :return:
+    '''
+
+    ret = {
+        'name': kwargs.keys(),
+        'changes': {},
+        'comment': '',
+        'result': None,
+    }
+    return ret
+
+

--- a/salt/states/ansiblegate.py
+++ b/salt/states/ansiblegate.py
@@ -20,25 +20,52 @@ state:
 
 '''
 from __future__ import absolute_import
+try:
+    import ansible
+except ImportError as err:
+    ansible = None
+
 
 __virtualname__ = 'ansible'
 
 
+class AnsibleState(object):
+    def __init__(self, available):
+        self.available = available
+
+    def call(self, **kwargs):
+        '''
+        Call Ansible module.
+
+        :return:
+        '''
+
+        ret = {
+            'name': kwargs.pop('name'),
+            'changes': {},
+            'comment': '',
+            'result': None,
+        }
+
+        print "\n\n\n>>>", kwargs, "\n\n\n"
+
+        return ret
+
+
+_ansible_state = AnsibleState(ansible is not None)
+
+
 def __virtual__():
-    return True
-
-
-def call(*args, **kwargs):
     '''
+    Disable, if Ansible is not available around on the Minion.
+    '''
+    return _ansible_state.available
+
+
+def call(**kwargs):
+    '''
+    Call the Ansible module.
+    :param kwargs:
     :return:
     '''
-
-    ret = {
-        'name': kwargs.keys(),
-        'changes': {},
-        'comment': '',
-        'result': None,
-    }
-    return ret
-
-
+    return _ansible_state.call(**kwargs)

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -16,7 +16,12 @@
 # limitations under the License.
 
 # Import Salt Testing Libs
-import pytest
+try:
+    import pytest
+except ImportError as import_error:
+    pytest = None
+NO_PYTEST = not bool(pytest)
+
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
@@ -31,6 +36,7 @@ from salt.exceptions import LoaderError
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(NO_PYTEST, False)
 class AnsiblegateTestCase(TestCase, LoaderModuleMockMixin):
     def setUp(self):
         self.resolver = ansible.AnsibleModuleResolver({})

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -103,12 +103,10 @@ description:
         mod = 'four.five.six'
         with pytest.raises(ImportError) as import_error:
             self.resolver.load_module(mod)
-        assert 'No module named ansible.modules.{0}'.format(mod) in str(import_error.value)
 
         mod = 'i.even.do.not.exist.at.all'
         with pytest.raises(LoaderError) as loader_error:
             self.resolver.load_module(mod)
-        assert 'Module "{0}" was not found'.format(mod) in str(loader_error.value)
 
     def test_resolver_module_loader(self):
         '''
@@ -128,4 +126,3 @@ description:
             patch('salt.modules.ansiblegate.importlib.import_module', lambda x: x):
             with pytest.raises(LoaderError) as loader_error:
                 self.resolver.load_module('something.strange')
-            assert 'Module "something.strange" was not found' in str(loader_error)

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 # Import Salt Testing Libs
+from __future__ import absolute_import
 try:
     import pytest
 except ImportError as import_error:
@@ -118,7 +119,7 @@ description:
             patch('salt.modules.ansiblegate.importlib.import_module', lambda x: x):
             assert self.resolver.load_module('four.five.six') == 'ansible.modules.four.five.six'
 
-    def test_resolver_module_loader_failure(self):
+    def test_resolver_module_loader_import_failure(self):
         '''
         Test Ansible module loader failure.
         :return:

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 # Import Salt Testing Libs
+import pytest
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
@@ -87,3 +88,12 @@ description:
         assert self.resolver.get_modules_list('one') == ['one.two.three', 'three.six.one']
         assert self.resolver.get_modules_list('one.two') == ['one.two.three']
         assert self.resolver.get_modules_list('four') == ['four.five.six']
+
+    def test_resolver_module_loader_failure(self):
+        '''
+        Test Ansible module loader.
+        :return:
+        '''
+        with pytest.raises(ImportError) as import_error:
+            self.resolver.load_module('four.five.six')
+        assert 'No module named ansible.modules.four.five.six' in import_error.value

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -20,10 +20,8 @@ import pytest
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
-    Mock,
-    MagicMock,
-    call,
     patch,
+    MagicMock,
     NO_MOCK,
     NO_MOCK_REASON
 )
@@ -104,3 +102,12 @@ description:
         with pytest.raises(LoaderError) as loader_error:
             self.resolver.load_module(mod)
         assert 'Module "{0}" was not found'.format(mod) in loader_error.value
+
+    def test_resolver_module_loader(self):
+        '''
+        Test Ansible module loader.
+        :return:
+        '''
+        with patch('salt.modules.ansiblegate.importlib', MagicMock()),\
+            patch('salt.modules.ansiblegate.importlib.import_module', lambda x: x):
+            assert self.resolver.load_module('four.five.six') == 'ansible.modules.four.five.six'

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -29,6 +29,7 @@ from tests.support.mock import (
 )
 
 import salt.modules.ansiblegate as ansible
+from salt.exceptions import LoaderError
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -94,6 +95,12 @@ description:
         Test Ansible module loader.
         :return:
         '''
+        mod = 'four.five.six'
         with pytest.raises(ImportError) as import_error:
-            self.resolver.load_module('four.five.six')
-        assert 'No module named ansible.modules.four.five.six' in import_error.value
+            self.resolver.load_module(mod)
+        assert 'No module named ansible.modules.{0}'.format(mod) in import_error.value
+
+        mod = 'i.even.do.not.exist.at.all'
+        with pytest.raises(LoaderError) as loader_error:
+            self.resolver.load_module(mod)
+        assert 'Module "{0}" was not found'.format(mod) in loader_error.value

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -128,4 +128,4 @@ description:
             patch('salt.modules.ansiblegate.importlib.import_module', lambda x: x):
             with pytest.raises(LoaderError) as loader_error:
                 self.resolver.load_module('something.strange')
-            assert 'Module "something.strange" was not found' in loader_error.value
+            assert 'Module "something.strange" was not found' in str(loader_error)

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -74,12 +74,12 @@ description:
    describe the second part
         """
 
-        ansible._resolver = self.resolver
-        ansible._resolver.load_module = MagicMock(return_value=Module())
-        ret = ansible.help('dummy')
-        assert sorted(ret.get('Available sections on module "{0}"'.format(
-            Module().__name__))) == ['one', 'two']
-        assert ret.get('Description') == 'describe the second part'
+        with patch.object(ansible, '_resolver', self.resolver), \
+            patch.object(ansible._resolver, 'load_module', MagicMock(return_value=Module())):
+            ret = ansible.help('dummy')
+            assert sorted(ret.get('Available sections on module "{0}"'.format(
+                Module().__name__))) == ['one', 'two']
+            assert ret.get('Description') == 'describe the second part'
 
     def test_module_resolver_modlist(self):
         '''

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -62,3 +62,23 @@ description:
         assert sorted(ret.get('Available sections on module "{0}"'.format(
             Module().__name__))) == ['one', 'two']
         assert ret.get('Description') == 'describe the second part'
+
+    def test_module_resolver_modlist(self):
+        '''
+        Test Ansible resolver modules list.
+        :return:
+        '''
+        resolver = ansible.AnsibleModuleResolver({})
+        resolver._modules_map = {
+            'one.two.three': '/one/two/three.py',
+            'four.five.six': '/four/five/six.py',
+            'three.six.one': '/three/six/one.py',
+        }
+        assert resolver.get_modules_list() == ['four.five.six', 'one.two.three', 'three.six.one']
+        for ptr in ['five', 'fi', 've']:
+            assert resolver.get_modules_list(ptr) == ['four.five.six']
+        for ptr in ['si', 'ix', 'six']:
+            assert resolver.get_modules_list(ptr) == ['four.five.six', 'three.six.one']
+        assert resolver.get_modules_list('one') == ['one.two.three', 'three.six.one']
+        assert resolver.get_modules_list('one.two') == ['one.two.three']
+        assert resolver.get_modules_list('four') == ['four.five.six']

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -111,3 +111,14 @@ description:
         with patch('salt.modules.ansiblegate.importlib', MagicMock()),\
             patch('salt.modules.ansiblegate.importlib.import_module', lambda x: x):
             assert self.resolver.load_module('four.five.six') == 'ansible.modules.four.five.six'
+
+    def test_resolver_module_loader_failure(self):
+        '''
+        Test Ansible module loader failure.
+        :return:
+        '''
+        with patch('salt.modules.ansiblegate.importlib', MagicMock()),\
+            patch('salt.modules.ansiblegate.importlib.import_module', lambda x: x):
+            with pytest.raises(LoaderError) as loader_error:
+                self.resolver.load_module('something.strange')
+            assert 'Module "something.strange" was not found' in loader_error.value

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -103,12 +103,12 @@ description:
         mod = 'four.five.six'
         with pytest.raises(ImportError) as import_error:
             self.resolver.load_module(mod)
-        assert 'No module named ansible.modules.{0}'.format(mod) in import_error.value
+        assert 'No module named ansible.modules.{0}'.format(mod) in str(import_error.value)
 
         mod = 'i.even.do.not.exist.at.all'
         with pytest.raises(LoaderError) as loader_error:
             self.resolver.load_module(mod)
-        assert 'Module "{0}" was not found'.format(mod) in loader_error.value
+        assert 'Module "{0}" was not found'.format(mod) in str(loader_error.value)
 
     def test_resolver_module_loader(self):
         '''

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Author: Bo Maryniuk <bo@suse.de>
+#
+# Copyright 2017 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    Mock,
+    MagicMock,
+    call,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+import salt.modules.ansiblegate as ansible
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class AnsiblegateTestCase(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        return {ansible: {}}
+
+    def test_ansible_modules_listing(self):
+        pass
+
+    def test_ansible_module_help(self):
+        pass

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -35,8 +35,30 @@ class AnsiblegateTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {ansible: {}}
 
-    def test_ansible_modules_listing(self):
-        pass
-
     def test_ansible_module_help(self):
-        pass
+        '''
+        Test help extraction from the module
+        :return:
+        '''
+        class Module(object):
+            '''
+            An ansible module mock.
+            '''
+            __name__ = 'foo'
+            DOCUMENTATION = """
+---
+one:
+   text here
+---
+two:
+   text here
+description:
+   describe the second part
+        """
+
+        ansible._resolver = MagicMock()
+        ansible._resolver.load_module = MagicMock(return_value=Module())
+        ret = ansible.help('dummy')
+        assert sorted(ret.get('Available sections on module "{0}"'.format(
+            Module().__name__))) == ['one', 'two']
+        assert ret.get('Description') == 'describe the second part'

--- a/tests/unit/modules/test_ansiblegate.py
+++ b/tests/unit/modules/test_ansiblegate.py
@@ -56,7 +56,7 @@ description:
    describe the second part
         """
 
-        ansible._resolver = MagicMock()
+        ansible._resolver = ansible.AnsibleModuleResolver({})
         ansible._resolver.load_module = MagicMock(return_value=Module())
         ret = ansible.help('dummy')
         assert sorted(ret.get('Available sections on module "{0}"'.format(


### PR DESCRIPTION
### What does this PR do?

In case you want to migrate away from Ansible, but have already modules written for it — no worries. Just toss them in and run them from Salt and Salt states.

### Limitations

Currently, only Python-written modules are supported. Support for other languages are still in progress.

### Requirements

The entire Ansible should be installed on the Minion. No remote execution at the moment. Continuation of this work can pull required files from the Ansible through the Salt transport. These files should be installed on Master only (in a future) and then thus get executed on the Minions.

### Description and Usage

Normally Salt modules are usually `module.function`. That is, a typical call of a function from the module will be: `salt hostname module.function some=parameters`. But since we are connecting the entire Ansible world to the Salt universe, we would like to keep the namespace as this is inside the Ansible. That said, any Ansible module is placed in the sub-directory that potentially can clash with other same-named module. Regardless the future plans of Ansible community, we already have a namespace introduced. Therefore any Ansible module is called with a full "path", prefixed with `ansible`:

    salt \* ansible.system.ping data="Hello from Ansible via Salt"

If you use typical development environment, this will result to the following:
```
saltdevel:
    ----------
    ping:
        Hello from Ansible via Salt
```

### Listing available Ansible modules

In order to list all available Ansible modules, call `ansible.list`:

    salt yourminion ansible.list

To filter them out, just type a string that matches inside them, e.g. "linux":
```
$ salt saltdevel ansible.list info
saltdevel:
    - net_tools.ipinfoio_facts
    - network.cloudengine.ce_info_center_debug
    - network.cloudengine.ce_info_center_global
    - network.cloudengine.ce_info_center_log
    - network.cloudengine.ce_info_center_trap
```

### Getting more information about the module

You can read all the details about any Ansible modules by issuing `ansible.help`. For example:
```
$ salt saltdevel ansible.help net_tools.ipinfoio_facts
saltdevel:
    ----------
    Available sections on module "net_tools.ipinfoio_facts":
        - version_added
        - author
        - short_description
        - notes
        - options
        - module
    Description:
        - Gather IP geolocation facts of a host's IP address using ipinfo.io API
```
At this point you may ask for `short_description`, `notes` etc. For example, to know how to use it, call `options`:
```
$ salt saltdevel ansible.help net_tools.ipinfoio_facts options
saltdevel:
    ----------
    options:
        ----------
        http_agent:
            ----------
            default:
                ansible-ipinfoio-module/0.0.1
            description:
                - Set http user agent
            required:
                False
        timeout:
            ----------
            default:
                10
            description:
                - HTTP connection timeout in seconds
            required:
                False
```

### Calling Ansible modules

Calling Ansible modules are just like any other Salt modules, straight-forward, except they will be needing to stay within their own namespace, which is different than we are using typically in Salt:
```
$ salt saltdevel ansible.net_tools.ipinfoio_facts                                    
saltdevel:
    ----------
    ansible_facts:
        ----------
        city:
            Nuremberg
        country:
            DE
        hostname:
            charybdis-ext.suse.de
        ip:
            195.135.221.2
        loc:
            49.4478,11.0683
        org:
            AS29298 SUSE LINUX GmbH
        postal:
            90409
        region:
            Bavaria
    changed:
        False
```

### Calling from the SLS files

That is also supported. Naturally, you can use typical `module.run` if you like, but you've also got a dedicated Ansible state module. The syntax/example is the same as for new syntax for `module.run`. It also supports a "batch mode", or "Ansible playbook mode" where tasks can be executed from within one SLS file:
```yaml
task_id:        # ID of your task
  ansible.call:  # Mandatory. This calls the modules
    - namespace.module:
      - params
    - namespace.another.module:
      - params
      - some: keywords
```

For example, this state will fail, because `foo.bar` module does not exist, as well as `network.junos.junos_package` requires some parameters. However it will still call everything one after another:

```yaml
run_test_echo:
  ansible.call:
    - system.ping:
        - data: "Hello from Salt"
    - network.junos.junos_package:
    - foo.bar:
 ```
This results to the following output:
```
$ salt saltdevel state.apply ans
saltdevel:
----------
          ID: run_test_echo
    Function: ansible.call
      Result: False
     Comment: 
     Started: 15:33:04.367029
    Duration: 1409.689 ms
     Changes:   
              ----------
              foo.bar:
                  Module "foo.bar" failed. Error message: (KeyError) 'ansible.foo.bar'
              net_tools.ipinfoio_facts:
                  ----------
              network.junos.junos_package:
                  ----------
                  failed:
                      True
                  msg:
                      missing required arguments: src
              system.ping:
                  ----------
                  ping:
                      Hello from Salt

Summary for saltdevel
------------
Succeeded: 0 (changed=1)
Failed:    1
------------
Total states run:     1
Total run time:   1.410 s
```

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
