### PR TITLE
Issue #43479 No runners.config in 2017.7 branch

### DIFF
--- a/doc/ref/runners/all/salt.runners.mattermost.rst
+++ b/doc/ref/runners/all/salt.runners.mattermost.rst
@@ -1,6 +1,12 @@
 salt.runners.mattermost module
 ==============================
 
+**Note for 2017.7 releases!**
+
+Due to the `salt.runners.config <https://github.com/saltstack/salt/blob/develop/salt/runners/config.py>`_ module not being available in this release series, importing the `salt.runners.config <https://github.com/saltstack/salt/blob/develop/salt/runners/config.py>`_ module from the develop branch is required to make this module work.
+
+Ref: `Mattermost runner failing to retrieve config values due to unavailable config runner #43479 <https://github.com/saltstack/salt/issues/43479>`_
+
 .. automodule:: salt.runners.mattermost
     :members:
     :undoc-members:


### PR DESCRIPTION
### What does this PR do?
Add extra note about needing to import the runners.config module from the develop branch when running on a 2017.7 release.

### What issues does this PR fix or reference?
Issue #43479 
