### PR TITLE
[develop] Fixes to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -868,6 +868,8 @@ class SaltDistribution(distutils.dist.Distribution):
          'Salt\'s pre-configured SPM formulas directory'),
         ('salt-spm-pillar-dir=', None,
          'Salt\'s pre-configured SPM pillar directory'),
+        ('salt-spm-reactor-dir=', None,
+         'Salt\'s pre-configured SPM reactor directory'),
         ('salt-home-dir=', None,
          'Salt\'s pre-configured user home directory'),
     ]

--- a/setup.py
+++ b/setup.py
@@ -234,6 +234,7 @@ class GenerateSaltSyspaths(Command):
                 spm_formula_path=self.distribution.salt_spm_formula_dir,
                 spm_pillar_path=self.distribution.salt_spm_pillar_dir,
                 spm_reactor_path=self.distribution.salt_spm_reactor_dir,
+                home_dir=self.distribution.salt_home_dir,
             )
         )
 
@@ -724,6 +725,7 @@ PIDFILE_DIR = {pidfile_dir!r}
 SPM_FORMULA_PATH = {spm_formula_path!r}
 SPM_PILLAR_PATH = {spm_pillar_path!r}
 SPM_REACTOR_PATH = {spm_reactor_path!r}
+HOME_DIR = {home_dir!r}
 '''
 
 
@@ -892,6 +894,7 @@ class SaltDistribution(distutils.dist.Distribution):
         self.salt_spm_formula_dir = None
         self.salt_spm_pillar_dir = None
         self.salt_spm_reactor_dir = None
+        self.salt_home_dir = None
 
         self.name = 'salt-ssh' if PACKAGED_FOR_SALT_SSH else 'salt'
         self.salt_version = __version__  # pylint: disable=undefined-variable

--- a/setup.py
+++ b/setup.py
@@ -868,8 +868,8 @@ class SaltDistribution(distutils.dist.Distribution):
          'Salt\'s pre-configured SPM formulas directory'),
         ('salt-spm-pillar-dir=', None,
          'Salt\'s pre-configured SPM pillar directory'),
-        ('salt-spm-reactor-dir=', None,
-         'Salt\'s pre-configured SPM reactor directory'),
+        ('salt-home-dir=', None,
+         'Salt\'s pre-configured user home directory'),
     ]
 
     def __init__(self, attrs=None):


### PR DESCRIPTION
### What does this PR do?
Following the change in #42103 if Salt is installed via setup.py then the generated _syspaths.py does not contain the HOME_DIR which results in a failure.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
HOME_DIR was not be included in the _syspaths.py generated via setup.py

### New Behavior
HOME_DIR is not included.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
