### PR TITLE
[network.interface_ip] Correct handling of interfaces without IP

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1039,7 +1039,8 @@ def interface_ip(iface):
     iface_info, error = _get_iface_info(iface)
 
     if error is False:
-        return iface_info.get(iface, {}).get('inet', {})[0].get('address', '')
+        inet = iface_info.get(iface, {}).get('inet', None)
+        return inet[0].get('address', '') if inet else ''
     else:
         return error
 


### PR DESCRIPTION
**Issue:**
If an interface have no any assigned IP address, then the func fails with the following traceback:
```
root@cfg01:/home/ubuntu# salt-call network.interface_ip eth10 --local
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
KeyError: 0
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/dist-packages/salt/scripts.py", line 372, in salt_call
    client.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/call.py", line 58, in run
    caller.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 134, in run
    ret = self.call()
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 197, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/modules/network.py", line 792, in interface_ip
    return salt.utils.network.interface_ip(iface)
  File "/usr/lib/python2.7/dist-packages/salt/utils/network.py", line 847, in interface_ip
    return iface_info.get(iface, {}).get('inet', {})[0].get('address', '')
KeyError: 0

```

**Expected result:**
 - the call must returns empty string if there is no IP assigned to network interface.

**Steps to reproduce:**

1. Create a veth pair as example of net interfaces without IP:
```
ip link add veth0 type veth peer name veth1
```

2. Try to achive IP using `network.interface_ip` module:
```
salt-call network.interface_ip  veth0 --local
```
