### PR TITLE
Forward events to all masters syndic connected to

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2589,6 +2589,8 @@ class SyndicManager(MinionBase):
         '''
         if kwargs is None:
             kwargs = {}
+        successful = False
+        # Call for each master
         for master, syndic_future in self.iter_master_options(master_id):
             if not syndic_future.done() or syndic_future.exception():
                 log.error('Unable to call {0} on {1}, that syndic is not connected'.format(func, master))
@@ -2596,12 +2598,12 @@ class SyndicManager(MinionBase):
 
             try:
                 getattr(syndic_future.result(), func)(*args, **kwargs)
-                return
+                successful = True
             except SaltClientError:
                 log.error('Unable to call {0} on {1}, trying another...'.format(func, master))
                 self._mark_master_dead(master)
-                continue
-        log.critical('Unable to call {0} on any masters!'.format(func))
+        if not successful:
+            log.critical('Unable to call {0} on any masters!'.format(func))
 
     def _return_pub_syndic(self, values, master_id=None):
         '''


### PR DESCRIPTION
### What does this PR do?
Fixes syndic events forwarding reliability issue.

Syndic forwards 2 kinds of loads:
1. Minion returns that are responses to master requests. If master sets it's ID in the request minion includes it into the response therefore syndic knows who's to receive the response.
2. Minion events that are initiated by minion. Here syndic has nothing to understood what master needs this event.

In the current implementation for the 2nd case Syndic forwards the events to a random master.
This PR makes Syndic to forward events to all connected masters.

### What issues does this PR fix or reference?
Fix #43447 

### Tests written?
No