### PR TITLE
Update yumpkg.py

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -61,7 +61,7 @@ from salt.ext import six
 
 log = logging.getLogger(__name__)
 
-__HOLD_PATTERN = r'\w+(?:[.-][^-]+)*'
+__HOLD_PATTERN = r'[\w+]+(?:[.-][^-]+)*'
 
 # Define the module's virtual name
 __virtualname__ = 'pkg'


### PR DESCRIPTION
Fix issue #41978 - I've been using this amended regular expression for several months now, with around 800-900 versionlocks (all packages on a typical CentOS 7 instance), without issue.

### What does this PR do?
Changes the regular expression used to match yum versionlock strings to also match packages with a "+" in their name prior to the first "-" in their name.

### What issues does this PR fix or reference?

#41978

### Previous Behavior
Versionlock would always be re-applied for packages with a "+" in their name before the first "-" in their name, when "hold" is set in the salt pkg.installed state.


### New Behavior
Versionlock will now correctly identify existing holds on these packages.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
