### PR TITLE
Fixes removal of double-quotes by shlex_split in winrepo for 2016.11

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1206,10 +1206,10 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             arguments = ['/i', cached_pkg]
             if pkginfo[version_num].get('allusers', True):
                 arguments.append('ALLUSERS="1"')
-            arguments.extend(salt.utils.shlex_split(install_flags))
+            arguments.extend(salt.utils.shlex_split(install_flags, posix=False))
         else:
             cmd = cached_pkg
-            arguments = salt.utils.shlex_split(install_flags)
+            arguments = salt.utils.shlex_split(install_flags, posix=False)
 
         # Install the software
         # Check Use Scheduler Option
@@ -1513,10 +1513,10 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
                 if use_msiexec:
                     cmd = msiexec
                     arguments = ['/x']
-                    arguments.extend(salt.utils.shlex_split(uninstall_flags))
+                    arguments.extend(salt.utils.shlex_split(uninstall_flags, posix=False))
                 else:
                     cmd = expanded_cached_pkg
-                    arguments = salt.utils.shlex_split(uninstall_flags)
+                    arguments = salt.utils.shlex_split(uninstall_flags, posix=False)
 
                 # Create Scheduled Task
                 __salt__['task.create_task'](name='update-salt-software',
@@ -1543,7 +1543,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
                     cmd.extend([msiexec, '/x', expanded_cached_pkg])
                 else:
                     cmd.append(expanded_cached_pkg)
-                cmd.extend(salt.utils.shlex_split(uninstall_flags))
+                cmd.extend(salt.utils.shlex_split(uninstall_flags, posix=False))
                 # Launch the command
                 result = __salt__['cmd.run_all'](cmd,
                                                  output_loglevel='trace',


### PR DESCRIPTION
### What does this PR do?
Fixes issue with doublequotes being removed in Windows by setting `posix=False` in the `salt.utils.shlex_split` call.

### What issues does this PR fix or reference?
Found by a member of the salt-users group:
https://groups.google.com/forum/#!topic/salt-users/WLaM4tkVptQ

### Previous Behavior
Quotes in the software definition file were being removed by the shlex_split command.

### New Behavior
Quoting is maintained.

### Tests written?
No