### PR TITLE
Fix boto3 util pack error

### DIFF
--- a/salt/modules/boto_sqs.py
+++ b/salt/modules/boto_sqs.py
@@ -78,7 +78,7 @@ def __virtual__():
     '''
     if not HAS_BOTO3:
         return (False, 'The boto_sqs module could not be loaded: boto3 libraries not found')
-    __utils__['boto3.assign_funcs'](__name__, 'sqs', pack=__salt__)
+    __utils__['boto3.assign_funcs'](__name__, 'sqs')
     return True
 
 

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -329,16 +329,6 @@ def paged_call(function, *args, **kwargs):
         kwargs[marker_arg] = marker
 
 
-def get_role_arn(name, region=None, key=None, keyid=None, profile=None):
-    if name.startswith('arn:aws:iam:'):
-        return name
-
-    account_id = __salt__['boto_iam.get_account_id'](
-        region=region, key=key, keyid=keyid, profile=profile
-    )
-    return 'arn:aws:iam::{0}:role/{1}'.format(account_id, name)
-
-
 def ordered(obj):
     if isinstance(obj, (list, tuple)):
         return sorted(ordered(x) for x in obj)


### PR DESCRIPTION
### What does this PR do?

Removes a ton of logspam that I inadvertently introduced in #42624.

The first commit removes the only usage of `__salt__` in the boto3 utils module.
The second commit removes the bad usage of the `pack` argument from `boto_sqs`.
This is only available for the boto utils module, not in boto3.
The boto utils module needs this as it uses `__salt__` internally,
but boto3 does not and thus does not need a `pack` argument.

### What issues does this PR fix or reference?

#30279 - First addition of `pack` to boto utils module.
#30867 - Usage of `pack` to all boto* modules.
#30041 - Added unused `boto3.get_role_arn` function
#42624 - Switch of boto_sqs to boto3.

### Previous Behavior
Tons of logspam in Jenkins output.

### New Behavior
Logspam is gone.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
