### PR TITLE
Fix preinstall script on OSX for 2017.7.2

### DIFF
--- a/pkg/osx/pkg-scripts/preinstall
+++ b/pkg/osx/pkg-scripts/preinstall
@@ -132,7 +132,7 @@ fi
 ###############################################################################
 # Remove the salt from the paths.d
 ###############################################################################
-if [ ! -f "/etc/paths.d/salt" ]; then
+if [ -f "/etc/paths.d/salt" ]; then
     echo "Path: Removing salt from the path..." >> "$TEMP_DIR/preinstall.txt"
     rm "/etc/paths.d/salt"
     echo "Path: Removed Successfully" >> "$TEMP_DIR/preinstall.txt"


### PR DESCRIPTION
### What does this PR do?
Fixes logic in `/etc/paths.d/salt` detection.

### What issues does this PR fix or reference?
Found during QA

### Previous Behavior
Installation would fail if `/etc/paths.d/salt` did not exist. The preinstall would try to delete a non-existant file and fail.

### New Behavior
Now it properly detects if the file exists before trying to remove it

### Tests written?
NA