### PR TITLE
Shell grain: check %COMSPEC% for the shell for Windows

### DIFF
--- a/salt/grains/extra.py
+++ b/salt/grains/extra.py
@@ -11,6 +11,7 @@ import logging
 
 # Import salt libs
 import salt.utils.files
+import salt.utils.platform
 
 log = logging.getLogger(__name__)
 
@@ -21,7 +22,14 @@ def shell():
     '''
     # Provides:
     #   shell
-    return {'shell': os.environ.get('SHELL', '/bin/sh')}
+    if salt.utils.platform.is_windows():
+        env_var = 'COMSPEC'
+        default = r'C:\Windows\system32\cmd.exe'
+    else:
+        env_var = 'SHELL'
+        default = '/bin/sh'
+
+    return {'shell': os.environ.get(env_var, default)}
 
 
 def config():


### PR DESCRIPTION
### What does this PR do?
Return the command processor instead of /bin/sh for the shell grain on Windows

### What issues does this PR fix or reference?
#43506 

### Previous Behavior
Windows returns '/bin/sh' as its shell

### New Behavior
Windows expands the environment variable `%COMSPEC%` to identify the shell, or returns 'C:\Windows\system32\cmd.exe' as the default.