### PR TITLE
Win fix chocolatey

### DIFF
--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -114,11 +114,15 @@ def installed(name, version=None, source=None, force=False, pre_versions=False,
             if salt.utils.compare_versions(
                     ver1=installed_version, oper="==", ver2=version):
                 if force:
-                    ret['changes'] = {name: 'Version {0} will be reinstalled'
-                                            ''.format(version)}
+                    ret['changes'] = {
+                        name: 'Version {0} will be reinstalled'.format(version)}
+                    ret['comment'] = 'Reinstall {0} {1}' \
+                                     ''.format(full_name, version)
                 else:
                     ret['comment'] = '{0} {1} is already installed' \
                                      ''.format(name, version)
+                    if __opts__['test']:
+                        ret['result'] = None
                     return ret
             else:
                 if allow_multiple:
@@ -126,19 +130,27 @@ def installed(name, version=None, source=None, force=False, pre_versions=False,
                         name: 'Version {0} will be installed side by side with '
                               'Version {1} if supported'
                               ''.format(version, installed_version)}
+                    ret['comment'] = 'Install {0} {1} side-by-side with {0} {2}' \
+                                     ''.format(full_name, version, installed_version)
                 else:
                     ret['changes'] = {
-                        name: 'Version {0} will be installed over Existing '
-                              'Version {1}'.format(version, installed_version)}
+                        name: 'Version {0} will be installed over Version {1} '
+                              ''.format(version, installed_version)}
+                    ret['comment'] = 'Install {0} {1} over {0} {2}' \
+                                     ''.format(full_name, version, installed_version)
                     force = True
         else:
             version = installed_version
             if force:
-                ret['changes'] = {name: 'Version {0} will be reinstalled'
-                                        ''.format(version)}
+                ret['changes'] = {
+                    name: 'Version {0} will be reinstalled'.format(version)}
+                ret['comment'] = 'Reinstall {0} {1}' \
+                                 ''.format(full_name, version)
             else:
                 ret['comment'] = '{0} {1} is already installed' \
                                  ''.format(name, version)
+                if __opts__['test']:
+                    ret['result'] = None
                 return ret
 
     if __opts__['test']:


### PR DESCRIPTION
### What does this PR do?
Fixes the logic behind the chocolatey state. Here's the gist:
```
If not installed:
    if version is passed:
        install that version
    else:
        install the latest version
else:
    if version is passed:
        if passed version is the same as the installed version:
            if force = True:
                reinstall the passed version
            else:
                do nothing
        else:
            if allow_multiple = True:
                Install side by side with existing version
            else:
                Install the passed version over the existing version
    else:
        if force = True:
            reinstall the currently installed version
        else:
            do nothing
```

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/43175

### Previous Behavior
Behavior did not match the documentation

### New Behavior
Now behaves as expected

### Tests written?
No