### PR TITLE
disable modify yaml constructor

### DIFF
--- a/salt/modules/heat.py
+++ b/salt/modules/heat.py
@@ -102,8 +102,6 @@ def _construct_yaml_str(self, node):
     Construct for yaml
     '''
     return self.construct_scalar(node)
-YamlLoader.add_constructor(u'tag:yaml.org,2002:str',
-                           _construct_yaml_str)
 YamlLoader.add_constructor(u'tag:yaml.org,2002:timestamp',
                            _construct_yaml_str)
 

--- a/salt/states/heat.py
+++ b/salt/states/heat.py
@@ -80,8 +80,6 @@ def _construct_yaml_str(self, node):
     Construct for yaml
     '''
     return self.construct_scalar(node)
-YamlLoader.add_constructor(u'tag:yaml.org,2002:str',
-                           _construct_yaml_str)
 YamlLoader.add_constructor(u'tag:yaml.org,2002:timestamp',
                            _construct_yaml_str)
 


### PR DESCRIPTION
which will modify the default behavior of yaml load.

Foe example, for following example (t.sls), it will cause the difference
between the content of file testa and testb, but it should be identical!

$ cat t

> {%- load_yaml as vars %}
> toaddr:
>   \- test@test.com
> {%- endload -%}
> {{ vars.toaddr }}

$ cat t.sls

> /tmp/testa:
>   file.managed:
>     - source: salt://t
>     - user: root
>     - group: root
>     - mode: "0755"
>     - template: jinja
> 
> sys-power/acpid:
>   pkg.installed:
>     - refresh: False
> 
> /tmp/testb:
>   file.managed:
>     - source: salt://t
>     - user: root
>     - group: root
>     - mode: "0755"
>     - template: jinja

$ touch /tmp/test{a,b}
$ salt-call state.sls t

> local:
> ----------
>           ID: /tmp/testa
>     Function: file.managed
>       Result: None
>      Comment: The file /tmp/testa is set to be changed
>      Changes:
>               ----------
>               diff:
>                   ---
>                   +++
>                   @@ -0,0 +1 @@
>                   +['test@test.com']
> ----------
>           ID: /tmp/testb
>     Function: file.managed
>       Result: None
>      Comment: The file /tmp/testb is set to be changed
>      Changes:
>               ----------
>               diff:
>                   ---
>                   +++
>                   @@ -0,0 +1 @@
>                   +[u'test@test.com']