### PR TITLE
Clean up doc formatting in selinux state & module

### DIFF
--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -374,8 +374,10 @@ def list_semod():
 
 def _validate_filetype(filetype):
     '''
-    Checks if the given filetype is a valid SELinux filetype specification.
-    Throws an SaltInvocationError if it isn't.
+    .. versionadded:: 2017.7.0
+
+    Checks if the given filetype is a valid SELinux filetype
+    specification. Throws an SaltInvocationError if it isn't.
     '''
     if filetype not in _SELINUX_FILETYPES.keys():
         raise SaltInvocationError('Invalid filetype given: {0}'.format(filetype))
@@ -384,6 +386,8 @@ def _validate_filetype(filetype):
 
 def _context_dict_to_string(context):
     '''
+    .. versionadded:: 2017.7.0
+
     Converts an SELinux file context from a dict to a string.
     '''
     return '{sel_user}:{sel_role}:{sel_type}:{sel_level}'.format(**context)
@@ -391,6 +395,8 @@ def _context_dict_to_string(context):
 
 def _context_string_to_dict(context):
     '''
+    .. versionadded:: 2017.7.0
+
     Converts an SELinux file context from string to dict.
     '''
     if not re.match('[^:]+:[^:]+:[^:]+:[^:]+$', context):
@@ -405,8 +411,11 @@ def _context_string_to_dict(context):
 
 def filetype_id_to_string(filetype='a'):
     '''
-    Translates SELinux filetype single-letter representation
-    to a more human-readable version (which is also used in `semanage fcontext -l`).
+    .. versionadded:: 2017.7.0
+
+    Translates SELinux filetype single-letter representation to a more
+    human-readable version (which is also used in `semanage fcontext
+    -l`).
     '''
     _validate_filetype(filetype)
     return _SELINUX_FILETYPES.get(filetype, 'error')
@@ -414,20 +423,27 @@ def filetype_id_to_string(filetype='a'):
 
 def fcontext_get_policy(name, filetype=None, sel_type=None, sel_user=None, sel_level=None):
     '''
-    Returns the current entry in the SELinux policy list as a dictionary.
-    Returns None if no exact match was found
+    .. versionadded:: 2017.7.0
+
+    Returns the current entry in the SELinux policy list as a
+    dictionary. Returns None if no exact match was found.
+
     Returned keys are:
-    - filespec (the name supplied and matched)
-    - filetype (the descriptive name of the filetype supplied)
-    - sel_user, sel_role, sel_type, sel_level (the selinux context)
+
+    * filespec (the name supplied and matched)
+    * filetype (the descriptive name of the filetype supplied)
+    * sel_user, sel_role, sel_type, sel_level (the selinux context)
+
     For a more in-depth explanation of the selinux context, go to
     https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Security-Enhanced_Linux/chap-Security-Enhanced_Linux-SELinux_Contexts.html
 
-    name: filespec of the file or directory. Regex syntax is allowed.
-    filetype: The SELinux filetype specification.
-              Use one of [a, f, d, c, b, s, l, p].
-              See also `man semanage-fcontext`.
-              Defaults to 'a' (all files)
+    name
+        filespec of the file or directory. Regex syntax is allowed.
+
+    filetype
+        The SELinux filetype specification. Use one of [a, f, d, c, b,
+        s, l, p]. See also `man semanage-fcontext`. Defaults to 'a'
+        (all files).
 
     CLI Example:
 
@@ -460,20 +476,34 @@ def fcontext_get_policy(name, filetype=None, sel_type=None, sel_user=None, sel_l
 
 def fcontext_add_or_delete_policy(action, name, filetype=None, sel_type=None, sel_user=None, sel_level=None):
     '''
-    Sets or deletes the SELinux policy for a given filespec and other optional parameters.
-    Returns the result of the call to semanage.
-    Note that you don't have to remove an entry before setting a new one for a given
-    filespec and filetype, as adding one with semanage automatically overwrites a
-    previously configured SELinux context.
+    .. versionadded:: 2017.7.0
 
-    name: filespec of the file or directory. Regex syntax is allowed.
-    file_type: The SELinux filetype specification.
-              Use one of [a, f, d, c, b, s, l, p].
-              See also ``man semanage-fcontext``.
-              Defaults to 'a' (all files)
-    sel_type: SELinux context type. There are many.
-    sel_user: SELinux user. Use ``semanage login -l`` to determine which ones are available to you
-    sel_level: The MLS range of the SELinux context.
+    Sets or deletes the SELinux policy for a given filespec and other
+    optional parameters.
+
+    Returns the result of the call to semanage.
+
+    Note that you don't have to remove an entry before setting a new
+    one for a given filespec and filetype, as adding one with semanage
+    automatically overwrites a previously configured SELinux context.
+
+    name
+        filespec of the file or directory. Regex syntax is allowed.
+
+    file_type
+        The SELinux filetype specification. Use one of [a, f, d, c, b,
+        s, l, p]. See also ``man semanage-fcontext``. Defaults to 'a'
+        (all files).
+
+    sel_type
+        SELinux context type. There are many.
+
+    sel_user
+        SELinux user. Use ``semanage login -l`` to determine which ones
+        are available to you.
+
+    sel_level
+        The MLS range of the SELinux context.
 
     CLI Example:
 
@@ -499,10 +529,14 @@ def fcontext_add_or_delete_policy(action, name, filetype=None, sel_type=None, se
 
 def fcontext_policy_is_applied(name, recursive=False):
     '''
-    Returns an empty string if the SELinux policy for a given filespec is applied,
-    returns string with differences in policy and actual situation otherwise.
+    .. versionadded:: 2017.7.0
 
-    name: filespec of the file or directory. Regex syntax is allowed.
+    Returns an empty string if the SELinux policy for a given filespec
+    is applied, returns string with differences in policy and actual
+    situation otherwise.
+
+    name
+        filespec of the file or directory. Regex syntax is allowed.
 
     CLI Example:
 
@@ -519,11 +553,17 @@ def fcontext_policy_is_applied(name, recursive=False):
 
 def fcontext_apply_policy(name, recursive=False):
     '''
-    Applies SElinux policies to filespec using `restorecon [-R] filespec`.
-    Returns dict with changes if succesful, the output of the restorecon command otherwise.
+    .. versionadded:: 2017.7.0
 
-    name: filespec of the file or directory. Regex syntax is allowed.
-    recursive: Recursively apply SELinux policies.
+    Applies SElinux policies to filespec using `restorecon [-R]
+    filespec`. Returns dict with changes if succesful, the output of
+    the restorecon command otherwise.
+
+    name
+        filespec of the file or directory. Regex syntax is allowed.
+
+    recursive
+        Recursively apply SELinux policies.
 
     CLI Example:
 

--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -310,17 +310,27 @@ def module_remove(name):
 
 def fcontext_policy_present(name, sel_type, filetype='a', sel_user=None, sel_level=None):
     '''
-    Makes sure a SELinux policy for a given filespec (name),
-    filetype and SELinux context type is present.
+    .. versionadded:: 2017.7.0
 
-    name: filespec of the file or directory. Regex syntax is allowed.
-    sel_type: SELinux context type. There are many.
-    filetype: The SELinux filetype specification.
-              Use one of [a, f, d, c, b, s, l, p].
-              See also `man semanage-fcontext`.
-              Defaults to 'a' (all files)
-    sel_user: The SELinux user.
-    sel_level: The SELinux MLS range
+    Makes sure a SELinux policy for a given filespec (name), filetype
+    and SELinux context type is present.
+
+    name
+        filespec of the file or directory. Regex syntax is allowed.
+
+    sel_type
+        SELinux context type. There are many.
+
+    filetype
+        The SELinux filetype specification. Use one of [a, f, d, c, b,
+        s, l, p]. See also `man semanage-fcontext`. Defaults to 'a'
+        (all files).
+
+    sel_user
+        The SELinux user.
+
+    sel_level
+        The SELinux MLS range.
     '''
     ret = {'name': name, 'result': False, 'changes': {}, 'comment': ''}
     new_state = {}
@@ -383,17 +393,27 @@ def fcontext_policy_present(name, sel_type, filetype='a', sel_user=None, sel_lev
 
 def fcontext_policy_absent(name, filetype='a', sel_type=None, sel_user=None, sel_level=None):
     '''
-    Makes sure an SELinux file context policy for a given filespec (name),
-    filetype and SELinux context type is absent.
+    .. versionadded:: 2017.7.0
 
-    name: filespec of the file or directory. Regex syntax is allowed.
-    filetype: The SELinux filetype specification.
-              Use one of [a, f, d, c, b, s, l, p].
-              See also `man semanage-fcontext`.
-              Defaults to 'a' (all files).
-    sel_type: The SELinux context type. There are many.
-    sel_user: The SELinux user.
-    sel_level: The SELinux MLS range
+    Makes sure an SELinux file context policy for a given filespec
+    (name), filetype and SELinux context type is absent.
+
+    name
+        filespec of the file or directory. Regex syntax is allowed.
+
+    filetype
+        The SELinux filetype specification. Use one of [a, f, d, c, b,
+        s, l, p]. See also `man semanage-fcontext`. Defaults to 'a'
+        (all files).
+
+    sel_type
+        The SELinux context type. There are many.
+
+    sel_user
+        The SELinux user.
+
+    sel_level
+        The SELinux MLS range.
     '''
     ret = {'name': name, 'result': False, 'changes': {}, 'comment': ''}
     new_state = {}
@@ -433,7 +453,10 @@ def fcontext_policy_absent(name, filetype='a', sel_type=None, sel_user=None, sel
 
 def fcontext_policy_applied(name, recursive=False):
     '''
-    Checks and makes sure the SELinux policies for a given filespec are applied.
+    .. versionadded:: 2017.7.0
+
+    Checks and makes sure the SELinux policies for a given filespec are
+    applied.
     '''
     ret = {'name': name, 'result': False, 'changes': {}, 'comment': ''}
 


### PR DESCRIPTION
Fixes the formatting of the docstrings so that they'll render properly in the online documentation. https://docs.saltstack.com/en/latest/ref/states/all/salt.states.selinux.html.