### PR TITLE
Fix names of NACL dec. methods

### DIFF
--- a/salt/renderers/nacl.py
+++ b/salt/renderers/nacl.py
@@ -22,8 +22,7 @@ To set things up, first generate a keypair. On the master, run the following:
 
 .. code-block:: bash
 
-    # salt-call --local nacl.keygen keyfile=/root/.nacl
-    # salt-call --local nacl.keygen_pub keyfile_pub=/root/.nacl.pub
+    # salt-call --local nacl.keygen sk_file=/root/.nacl
 
 
 Using encrypted pillar
@@ -33,7 +32,7 @@ To encrypt secrets, copy the public key to your local machine and run:
 
 .. code-block:: bash
 
-    $ salt-call --local nacl.enc_pub datatoenc keyfile_pub=/root/.nacl.pub
+    $ salt-call --local nacl.enc datatoenc pk_file=/root/.nacl.pub
 
 
 To apply the renderer on a file-by-file basis add the following line to the
@@ -80,7 +79,7 @@ def _decrypt_object(obj, **kwargs):
         return _decrypt_object(obj.getvalue(), **kwargs)
     if isinstance(obj, six.string_types):
         if re.search(NACL_REGEX, obj) is not None:
-            return __salt__['nacl.dec_pub'](re.search(NACL_REGEX, obj).group(1), **kwargs)
+            return __salt__['nacl.dec'](re.search(NACL_REGEX, obj).group(1), **kwargs)
         else:
             return obj
     elif isinstance(obj, dict):

--- a/tests/unit/renderers/test_nacl.py
+++ b/tests/unit/renderers/test_nacl.py
@@ -38,7 +38,7 @@ class NaclTestCase(TestCase, LoaderModuleMockMixin):
         secret_list = [secret]
         crypted_list = [crypted]
 
-        with patch.dict(nacl.__salt__, {'nacl.dec_pub': MagicMock(return_value=secret)}):
+        with patch.dict(nacl.__salt__, {'nacl.dec': MagicMock(return_value=secret)}):
             self.assertEqual(nacl._decrypt_object(secret), secret)
             self.assertEqual(nacl._decrypt_object(crypted), secret)
             self.assertEqual(nacl._decrypt_object(crypted_map), secret_map)
@@ -51,5 +51,5 @@ class NaclTestCase(TestCase, LoaderModuleMockMixin):
         '''
         secret = 'Use more salt.'
         crypted = 'NACL[MRN3cc+fmdxyQbz6WMF+jq1hKdU5X5BBI7OjK+atvHo1ll+w1gZ7XyWtZVfq9gK9rQaMfkDxmidJKwE0Mw==]'
-        with patch.dict(nacl.__salt__, {'nacl.dec_pub': MagicMock(return_value=secret)}):
+        with patch.dict(nacl.__salt__, {'nacl.dec': MagicMock(return_value=secret)}):
             self.assertEqual(nacl.render(crypted), secret)


### PR DESCRIPTION
### What does this PR do?
Latest develp branch code called nacl.dec_pub method that is no longer available as we updated the original nacl implementation. Latest "dec" method recognize sealed_box and secret_box and use the appropriate method. 

### What issues does this PR fix or reference?
No issue, I tested in isolated environment.
Withing a week I will provide a blog article for a reference for env. setup.

