### PR TITLE
cloud.action: list_nodes_min returns all EC2 instances

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -3472,16 +3472,15 @@ def list_nodes_min(location=None, call=None):
 
     for instance in instances:
         if isinstance(instance['instancesSet']['item'], list):
-            for item in instance['instancesSet']['item']:
-                state = item['instanceState']['name']
-                name = _extract_name_tag(item)
-                id = item['instanceId']
+            items = instance['instancesSet']['item']
         else:
-            item = instance['instancesSet']['item']
+            items = [instance['instancesSet']['item']]
+
+        for item in items:
             state = item['instanceState']['name']
             name = _extract_name_tag(item)
             id = item['instanceId']
-        ret[name] = {'state': state, 'id': id}
+            ret[name] = {'state': state, 'id': id}
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?
It makes the `list_nodes_min` action for the Salt Cloud to actually return all instances for EC2 provider. The issue is described below.

### What issues does this PR fix or reference?
It appears that calling `list_nodes` (`list_nodes_full`) and `list_nodes_min` actions for EC2 Salt Cloud provider producing completely different set of available instances.
The `list_nodes_min` should filter the instance attributes to return only instance ID and its state, but it does that for the last instance in the `instancesSet` returned by AWS API call for `DescribeInstances`.

It works just fine if you spin up instances one by one. And when you request multiple instances creation at once (then rename/alter later), the `salt-run cloud.action list_nodes_min provider=ec2` command just returns only one (the last one) in the set. This PR fixes that.

### Tests written?
No
