### PR TITLE
Fix CSR not recreated if key changes

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -625,6 +625,8 @@ def read_csr(csr):
         # Get size returns in bytes. The world thinks of key sizes in bits.
         'Subject': _parse_subject(csr.get_subject()),
         'Subject Hash': _dec2hex(csr.get_subject().as_hash()),
+        'Public Key Hash': hashlib.sha1(csr.get_pubkey().get_modulus())\
+        .hexdigest()
     }
 
     ret['X509v3 Extensions'] = _get_csr_extensions(csr)


### PR DESCRIPTION
### Fix CSR not recreated if key changes

### What issues does this PR fix or reference?

### Previous Behavior
If the private key were changed, a new CSR is not created, the one with the old key
is retained. When signed there is a mismatch between the certificate and the private
key.

### New Behavior
If the key changes the CSR will be regenerated. This is done by adding the has of the
public key to the comparison dict

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
