### PR TITLE
Add support for multimaster setup

### DIFF
--- a/doc/topics/installation/windows.rst
+++ b/doc/topics/installation/windows.rst
@@ -48,7 +48,7 @@ Salt Minion Installation
 If the system is missing the appropriate version of the Visual C++
 Redistributable (vcredist) the user will be prompted to install it. Click ``OK``
 to install the vcredist. Click ``Cancel`` to abort the installation without
-making modifications to the systeml.
+making modifications to the system.
 
 If Salt is already installed on the system the user will be prompted to remove
 the previous installation. Click ``OK`` to uninstall Salt without removing the

--- a/doc/topics/installation/windows.rst
+++ b/doc/topics/installation/windows.rst
@@ -45,11 +45,27 @@ but leave any existing config, cache, and PKI information.
 Salt Minion Installation
 ========================
 
+If the system is missing the appropriate version of the Visual C++
+Redistributable (vcredist) the user will be prompted to install it. Click ``OK``
+to install the vcredist. Click ``Cancel`` to abort the installation without
+making modifications to the systeml.
+
+If Salt is already installed on the system the user will be prompted to remove
+the previous installation. Click ``OK`` to uninstall Salt without removing the
+configuration, PKI information, or cached files. Click ``Cancel`` to abort the
+installation before making any modifications to the system.
+
 After the Welcome and the License Agreement, the installer asks for two bits of
 information to configure the minion; the master hostname and the minion name.
-The installer will update the minion config with these options. If the installer
-finds an existing minion config file, these fields will be populated with values
-from the existing config.
+The installer will update the minion config with these options.
+
+If the installer finds an existing minion config file, these fields will be
+populated with values from the existing config, but they will be grayed out.
+There will also be a checkbox to use existing config. If you continue, the
+existing config will be used. If the checkbox is unchecked, default values are
+displayed and can be changed. If you continue the existing config file in
+``c:\salt\conf`` will be removed along with the ``c:\salt\conf\minion.d`
+directory. The values entered will be used with the default config.
 
 The final page allows you to start the minion service and optionally change its
 startup type. By default, the minion is set to ``Automatic``. You can change the
@@ -71,11 +87,6 @@ be managed there or from the command line like any other Windows service.
     sc start salt-minion
     net start salt-minion
 
-.. note::
-    If the minion won't start, you may need to install the Microsoft Visual C++
-    2008 x64 SP1 redistributable. Allow all Windows updates to run salt-minion
-    smoothly.
-
 Installation Prerequisites
 --------------------------
 
@@ -96,15 +107,29 @@ Minion silently:
 =========================  =====================================================
 Option                     Description
 =========================  =====================================================
-``/minion-name=``          A string value to set the minion name. Default is
-                           'hostname'
 ``/master=``               A string value to set the IP address or host name of
-                           the master. Default value is 'salt'
+                           the master. Default value is 'salt'. You can pass a
+                           single master or a comma-separated list of masters.
+                           Setting the master will replace existing config with
+                           the default config. Cannot be used in conjunction
+                           with ``/use-existing-config``
+``/minion-name=``          A string value to set the minion name. Default is
+                           'hostname'. Setting the minion name will replace
+                           existing config with the default config. Cannot be
+                           used in conjunction with ``/use-existing-config``
 ``/start-minion=``         Either a 1 or 0. '1' will start the salt-minion
                            service, '0' will not. Default is to start the
-                           service after installation.
+                           service after installation
 ``/start-minion-delayed``  Set the minion start type to
                            ``Automatic (Delayed Start)``
+``/use-existing-config``   Either a 1 or 0. '1' will use the existing config if
+                           present. '0' will replace existing config with the
+                           default config. Default is '1'. If this is set to '1'
+                           values passed in ``/master`` and ``/minion-name``
+                           will be ignored
+``/S``                     Runs the installation silently. Uses the above
+                           settings or the defaults
+``/?``                     Displays command line help
 =========================  =====================================================
 
 .. note::

--- a/doc/topics/installation/windows.rst
+++ b/doc/topics/installation/windows.rst
@@ -61,9 +61,9 @@ The installer will update the minion config with these options.
 
 If the installer finds an existing minion config file, these fields will be
 populated with values from the existing config, but they will be grayed out.
-There will also be a checkbox to use existing config. If you continue, the
+There will also be a checkbox to use the existing config. If you continue, the
 existing config will be used. If the checkbox is unchecked, default values are
-displayed and can be changed. If you continue the existing config file in
+displayed and can be changed. If you continue, the existing config file in
 ``c:\salt\conf`` will be removed along with the ``c:\salt\conf\minion.d`
 directory. The values entered will be used with the default config.
 

--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -142,10 +142,10 @@ The Windows installer will now display command-line help when a help switch
 (``/?``) is passed.
 
 Salt Cloud Features
-===================
+-------------------
 
 Pre-Flight Commands
--------------------
+===================
 
 Support has been added for specified "preflight commands" to run on a VM before
 the deploy script is run. These must be defined as a list in a cloud configuration

--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -116,11 +116,36 @@ The ``state_output`` parameter now supports ``full_id``, ``changes_id`` and ``te
 Just like ``mixed_id``, these use the state ID as name in the highstate output.
 For more information on these output modes, see the docs for the :mod:`Highstate Outputter <salt.output.highstate>`.
 
+Windows Installer: Changes to existing config handling
+------------------------------------------------------
+Behavior with existing configuration has changed. With previous installers the
+existing config was used and the master and minion id could be modified via the
+installer. It was problematic in that it didn't account for configuration that
+may be defined in the ``minion.d`` directory. This change gives you the option
+via a checkbox to either use the existing config with out changes or the default
+config using values you pass to the installer. If you choose to use the existing
+config then no changes are made. If not, the existing config is deleted, to
+include the ``minion.d`` directory, and the default config is used. A
+command-line switch (``/use-existing-config``) has also been added to control
+this behavior.
+
+Windows Installer: Multi-master configuration
+---------------------------------------------
+The installer now has the ability to apply a multi-master configuration either
+from the gui or the command line. The ``master`` field in the gui can accept
+either a single master or a comma-separated list of masters. The command-line
+switch (``/master=``) can accept the same.
+
+Windows Installer: Command-line help
+------------------------------------
+The Windows installer will now display command-line help when a help switch
+(``/?``) is passed.
+
 Salt Cloud Features
--------------------
+===================
 
 Pre-Flight Commands
-===================
+-------------------
 
 Support has been added for specified "preflight commands" to run on a VM before
 the deploy script is run. These must be defined as a list in a cloud configuration
@@ -344,7 +369,7 @@ Solaris Logical Domains In Virtual Grain
 ----------------------------------------
 
 Support has been added to the ``virtual`` grain for detecting Solaris LDOMs
-running on T-Series SPARC hardware.  The ``virtual_subtype`` grain is 
+running on T-Series SPARC hardware.  The ``virtual_subtype`` grain is
 populated as a list of domain roles.
 
 Lists of comments in state returns
@@ -359,7 +384,7 @@ Beacon configuration changes
 
 In order to remain consistent and to align with other Salt components such as states,
 support for configuring beacons using dictionary based configuration has been deprecated
-in favor of list based configuration.  All beacons have a validation function which will 
+in favor of list based configuration.  All beacons have a validation function which will
 check the configuration for the correct format and only load if the validation passes.
 
 - ``avahi_announce`` beacon

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -11,6 +11,7 @@
 !define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
 !define PRODUCT_UNINST_KEY_OTHER "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME_OTHER}"
 !define PRODUCT_UNINST_ROOT_KEY "HKLM"
+!define OUTFILE "Salt-Minion-${PRODUCT_VERSION}-Py${PYTHON_VERSION}-${CPUARCH}-Setup.exe"
 
 # Import Libraries
 !include "MUI2.nsh"
@@ -50,6 +51,15 @@ ${StrStrAdv}
     Push "${String}"
     Call Trim
     Pop "${ResultVar}"
+!macroend
+
+# Part of the Explode function for Strings
+!define Explode "!insertmacro Explode"
+!macro Explode Length Separator String
+    Push    `${Separator}`
+    Push    `${String}`
+    Call    Explode
+    Pop     `${Length}`
 !macroend
 
 
@@ -92,10 +102,17 @@ Var Dialog
 Var Label
 Var CheckBox_Minion_Start
 Var CheckBox_Minion_Start_Delayed
+Var ConfigMasterHost
 Var MasterHost
 Var MasterHost_State
+Var ConfigMinionName
 Var MinionName
 Var MinionName_State
+Var ExistingConfigFound
+Var UseExistingConfig
+Var UseExistingConfig_State
+Var WarningExistingConfig
+Var WarningDefaultConfig
 Var StartMinion
 Var StartMinionDelayed
 Var DeleteInstallDir
@@ -115,19 +132,94 @@ Function pageMinionConfig
         Abort
     ${EndIf}
 
+    # Master IP or Hostname Dialog Control
     ${NSD_CreateLabel} 0 0 100% 12u "Master IP or Hostname:"
     Pop $Label
 
     ${NSD_CreateText} 0 13u 100% 12u $MasterHost_State
     Pop $MasterHost
 
+    # Minion ID Dialog Control
     ${NSD_CreateLabel} 0 30u 100% 12u "Minion Name:"
     Pop $Label
 
     ${NSD_CreateText} 0 43u 100% 12u $MinionName_State
     Pop $MinionName
 
+    # Use Existing Config Checkbox
+    ${NSD_CreateCheckBox} 0 65u 100% 12u "&Use Existing Config"
+    Pop $UseExistingConfig
+    ${NSD_OnClick} $UseExistingConfig pageMinionConfig_OnClick
+
+    # Add Existing Config Warning Label
+    ${NSD_CreateLabel} 0 80u 100% 60u "The values above are taken from an \
+        existing configuration found in `c:\salt\conf\minion`. Configuration \
+        settings defined in the `minion.d` directories, if they exist, are not \
+        shown here.$\r$\n\
+        $\r$\n\
+        Clicking `Install` will leave the existing config unchanged."
+    Pop $WarningExistingConfig
+    CreateFont $0 "Arial" 10 500 /ITALIC
+    SendMessage $WarningExistingConfig ${WM_SETFONT} $0 1
+    SetCtlColors $WarningExistingConfig 0xBB0000 transparent
+
+    # Add Default Config Warning Label
+    ${NSD_CreateLabel} 0 80u 100% 60u "Clicking `Install` will remove the \
+        the existing minion config file and remove the minion.d directories. \
+        The values above will be used in the new default config."
+    Pop $WarningDefaultConfig
+    CreateFont $0 "Arial" 10 500 /ITALIC
+    SendMessage $WarningDefaultConfig ${WM_SETFONT} $0 1
+    SetCtlColors $WarningDefaultConfig 0xBB0000 transparent
+
+    # If no existing config found, disable the checkbox and stuff
+    # Set UseExistingConfig_State to 0
+    ${If} $ExistingConfigFound == 0
+        StrCpy $UseExistingConfig_State 0
+        ShowWindow $UseExistingConfig ${SW_HIDE}
+        ShowWindow $WarningExistingConfig ${SW_HIDE}
+        ShowWindow $WarningDefaultConfig ${SW_HIDE}
+    ${Endif}
+
+    ${NSD_SetState} $UseExistingConfig $UseExistingConfig_State
+
+    Call pageMinionConfig_OnClick
+
     nsDialogs::Show
+
+FunctionEnd
+
+
+Function pageMinionConfig_OnClick
+
+    # You have to pop the top handle to keep the stack clean
+    Pop $R0
+
+    # Assign the current checkbox state to the variable
+    ${NSD_GetState} $UseExistingConfig $UseExistingConfig_State
+
+    # Validate the checkboxes
+    ${If} $UseExistingConfig_State == ${BST_CHECKED}
+        # Use Existing Config is checked, show warning
+        ShowWindow $WarningExistingConfig ${SW_SHOW}
+        EnableWindow $MasterHost 0
+        EnableWindow $MinionName 0
+        ${NSD_SetText} $MasterHost $ConfigMasterHost
+        ${NSD_SetText} $MinionName $ConfigMinionName
+        ${If} $ExistingConfigFound == 1
+            ShowWindow $WarningDefaultConfig ${SW_HIDE}
+        ${Endif}
+    ${Else}
+        # Use Existing Config is not checked, hide the warning
+        ShowWindow $WarningExistingConfig ${SW_HIDE}
+        EnableWindow $MasterHost 1
+        EnableWindow $MinionName 1
+        ${NSD_SetText} $MasterHost $MasterHost_State
+        ${NSD_SetText} $MinionName $MinionName_State
+        ${If} $ExistingConfigFound == 1
+            ShowWindow $WarningDefaultConfig ${SW_SHOW}
+        ${Endif}
+    ${EndIf}
 
 FunctionEnd
 
@@ -136,6 +228,9 @@ Function pageMinionConfig_Leave
 
     ${NSD_GetText} $MasterHost $MasterHost_State
     ${NSD_GetText} $MinionName $MinionName_State
+    ${NSD_GetState} $UseExistingConfig $UseExistingConfig_State
+
+    Call RemoveExistingConfig
 
 FunctionEnd
 
@@ -194,7 +289,7 @@ FunctionEnd
 !else
     Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
 !endif
-OutFile "Salt-Minion-${PRODUCT_VERSION}-Py${PYTHON_VERSION}-${CPUARCH}-Setup.exe"
+OutFile "${OutFile}"
 InstallDir "c:\salt"
 InstallDirRegKey HKLM "${PRODUCT_DIR_REGKEY}" ""
 ShowInstDetails show
@@ -311,8 +406,6 @@ SectionEnd
 
 Function .onInit
 
-    Call getMinionConfig
-
     Call parseCommandLineSwitches
 
     # Check for existing installation
@@ -364,6 +457,23 @@ Function .onInit
 
     skipUninstall:
 
+    Call getMinionConfig
+
+    IfSilent 0 +2
+        Call RemoveExistingConfig
+
+FunctionEnd
+
+
+Function RemoveExistingConfig
+
+    ${If} $ExistingConfigFound == 1
+    ${AndIf} $UseExistingConfig_State == 0
+        # Wipe out the Existing Config
+        Delete "$INSTDIR\conf\minion"
+        RMDir /r "$INSTDIR\conf\minion.d"
+    ${EndIf}
+
 FunctionEnd
 
 
@@ -407,7 +517,9 @@ Section -Post
     nsExec::Exec "nssm.exe set salt-minion AppStopMethodConsole 24000"
     nsExec::Exec "nssm.exe set salt-minion AppStopMethodWindow 2000"
 
-    Call updateMinionConfig
+    ${If} $UseExistingConfig_State == 0
+        Call updateMinionConfig
+    ${EndIf}
 
     Push "C:\salt"
     Call AddToPath
@@ -534,18 +646,28 @@ FunctionEnd
 # Helper Functions
 ###############################################################################
 Function MsiQueryProductState
+    # Used for detecting VCRedist Installation
+    !define INSTALLSTATE_DEFAULT "5"
 
-  !define INSTALLSTATE_DEFAULT "5"
-
-  Pop $R0
-  StrCpy $NeedVcRedist "False"
-  System::Call "msi::MsiQueryProductStateA(t '$R0') i.r0"
-  StrCmp $0 ${INSTALLSTATE_DEFAULT} +2 0
-  StrCpy $NeedVcRedist "True"
+    Pop $R0
+    StrCpy $NeedVcRedist "False"
+    System::Call "msi::MsiQueryProductStateA(t '$R0') i.r0"
+    StrCmp $0 ${INSTALLSTATE_DEFAULT} +2 0
+    StrCpy $NeedVcRedist "True"
 
 FunctionEnd
 
 
+#------------------------------------------------------------------------------
+# Trim Function
+# - Trim whitespace from the beginning and end of a string
+# - Trims spaces, \r, \n, \t
+#
+# Usage:
+#   Push " some string "
+#   Call Trim
+#   Pop $0 ; "some string"
+#------------------------------------------------------------------------------
 Function Trim
 
     Exch $R1 # Original string
@@ -577,6 +699,79 @@ Function Trim
         Pop $R2
         Exch $R1
 
+FunctionEnd
+
+
+Function Explode
+    # Initialize variables
+    Var /GLOBAL explString
+    Var /GLOBAL explSeparator
+    Var /GLOBAL explStrLen
+    Var /GLOBAL explSepLen
+    Var /GLOBAL explOffset
+    Var /GLOBAL explTmp
+    Var /GLOBAL explTmp2
+    Var /GLOBAL explTmp3
+    Var /GLOBAL explArrCount
+
+    # Get input from user
+    Pop $explString
+    Pop $explSeparator
+
+    # Calculates initial values
+    StrLen $explStrLen $explString
+    StrLen $explSepLen $explSeparator
+    StrCpy $explArrCount 1
+
+    ${If} $explStrLen <= 1             #   If we got a single character
+    ${OrIf} $explSepLen > $explStrLen  #   or separator is larger than the string,
+        Push    $explString            #   then we return initial string with no change
+        Push    1                      #   and set array's length to 1
+        Return
+    ${EndIf}
+
+    # Set offset to the last symbol of the string
+    StrCpy $explOffset $explStrLen
+    IntOp  $explOffset $explOffset - 1
+
+    # Clear temp string to exclude the possibility of appearance of occasional data
+    StrCpy $explTmp   ""
+    StrCpy $explTmp2  ""
+    StrCpy $explTmp3  ""
+
+    # Loop until the offset becomes negative
+    ${Do}
+        # If offset becomes negative, it is time to leave the function
+        ${IfThen} $explOffset == -1 ${|} ${ExitDo} ${|}
+
+        # Remove everything before and after the searched part ("TempStr")
+        StrCpy $explTmp $explString $explSepLen $explOffset
+
+        ${If} $explTmp == $explSeparator
+            # Calculating offset to start copy from
+            IntOp   $explTmp2 $explOffset + $explSepLen    # Offset equals to the current offset plus length of separator
+            StrCpy  $explTmp3 $explString "" $explTmp2
+
+            Push    $explTmp3                              # Throwing array item to the stack
+            IntOp   $explArrCount $explArrCount + 1        # Increasing array's counter
+
+            StrCpy  $explString $explString $explOffset 0  # Cutting all characters beginning with the separator entry
+            StrLen  $explStrLen $explString
+        ${EndIf}
+
+        ${If} $explOffset = 0           # If the beginning of the line met and there is no separator,
+                                        # copying the rest of the string
+            ${If} $explSeparator == ""  # Fix for the empty separator
+                IntOp   $explArrCount   $explArrCount - 1
+            ${Else}
+                Push    $explString
+            ${EndIf}
+        ${EndIf}
+
+        IntOp   $explOffset $explOffset - 1
+    ${Loop}
+
+    Push $explArrCount
 FunctionEnd
 
 
@@ -816,6 +1011,9 @@ FunctionEnd
 ###############################################################################
 Function getMinionConfig
 
+    # Set Config Found Default Value
+    StrCpy $ExistingConfigFound 0
+
     confFind:
     IfFileExists "$INSTDIR\conf\minion" confFound confNotFound
 
@@ -828,24 +1026,42 @@ Function getMinionConfig
     ${EndIf}
 
     confFound:
+    StrCpy $ExistingConfigFound 1
     FileOpen $0 "$INSTDIR\conf\minion" r
 
-    ClearErrors
     confLoop:
-        FileRead $0 $1
-        IfErrors EndOfFile
-        ${StrLoc} $2 $1 "master:" ">"
-        ${If} $2 == 0
-            ${StrStrAdv} $2 $1 "master: " ">" ">" "0" "0" "0"
-            ${Trim} $2 $2
-                StrCpy $MasterHost_State $2
+        ClearErrors                                             # Clear Errors
+        FileRead $0 $1                                          # Read the next line
+        IfErrors EndOfFile                                      # Error is probably EOF
+        ${StrLoc} $2 $1 "master:" ">"                           # Find `master:` starting at the beginning
+        ${If} $2 == 0                                           # If it found it in the first position, then it is defined
+            ${StrStrAdv} $2 $1 "master: " ">" ">" "0" "0" "0"   # Read everything after `master: `
+            ${Trim} $2 $2                                       # Trim white space
+            ${If} $2 == ""                                      # If it's empty, it's probably a list
+                masterLoop:
+                ClearErrors                                     # Clear Errors
+                FileRead $0 $1                                  # Read the next line
+                IfErrors EndOfFile                              # Error is probably EOF
+                ${StrStrAdv} $2 $1 "- " ">" ">" "0" "0" "0"     # Read everything after `- `
+                ${Trim} $2 $2                                   # Trim white space
+                ${IfNot} $2 == ""                               # If it's not empty, we found something
+                    ${If} $ConfigMasterHost == ""               # Is the default `salt` there
+                        StrCpy $ConfigMasterHost $2             # If so, make the first item the new entry
+                    ${Else}
+                        StrCpy $ConfigMasterHost "$ConfigMasterHost,$2"  # Append the new master, comma separated
+                    ${EndIf}
+                    Goto masterLoop                             # Check the next one
+                ${EndIf}
+            ${Else}
+                StrCpy $ConfigMasterHost $2                     # A single master entry
             ${EndIf}
+        ${EndIf}
 
         ${StrLoc} $2 $1 "id:" ">"
         ${If} $2 == 0
             ${StrStrAdv} $2 $1 "id: " ">" ">" "0" "0" "0"
             ${Trim} $2 $2
-            StrCpy $MinionName_State $2
+            StrCpy $ConfigMinionName $2
         ${EndIf}
 
     Goto confLoop
@@ -854,6 +1070,14 @@ Function getMinionConfig
     FileClose $0
 
     confReallyNotFound:
+
+    # Set Default Config Values if not found
+    ${If} $ConfigMasterHost == ""
+        StrCpy $ConfigMasterHost "salt"
+    ${EndIf}
+    ${If} $ConfigMinionName == ""
+        StrCpy $ConfigMinionName "hostname"
+    ${EndIf}
 
 FunctionEnd
 
@@ -869,12 +1093,28 @@ Function updateMinionConfig
     FileRead $0 $2                                       # read line from target file
     IfErrors done                                        # end if errors are encountered (end of line)
 
+
     ${If} $MasterHost_State != ""                        # if master is empty
     ${AndIf} $MasterHost_State != "salt"                 # and if master is not 'salt'
         ${StrLoc} $3 $2 "master:" ">"                    # where is 'master:' in this line
         ${If} $3 == 0                                    # is it in the first...
         ${OrIf} $3 == 1                                  # or second position (account for comments)
-            StrCpy $2 "master: $MasterHost_State$\r$\n"  # write the master
+
+            ${Explode} $9 "," $MasterHost_state
+            ${If} $9 == 1
+                StrCpy $2 "master: $MasterHost_State$\r$\n"  # write the master
+            ${Else}
+                StrCpy $2 "master:"
+
+                loop_explode:
+                pop $8
+                ${Trim} $8 $8
+                StrCpy $2 "$2$\r$\n  - $8"
+                IntOp $9 $9 - 1
+                ${If} $9 >= 1
+                    Goto loop_explode
+                ${EndIf}
+            ${EndIf}                                     # close if statement
         ${EndIf}                                         # close if statement
     ${EndIf}                                             # close if statement
 
@@ -905,6 +1145,67 @@ Function parseCommandLineSwitches
     # Load the parameters
     ${GetParameters} $R0
 
+    # Display Help
+    ClearErrors
+    ${GetOptions} $R0 "/?" $R1
+    IfErrors display_help_not_found
+
+        System::Call 'kernel32::GetStdHandle(i -11)i.r0'
+        System::Call 'kernel32::AttachConsole(i -1)i.r1'
+        ${If} $0 = 0
+        ${OrIf} $1 = 0
+            System::Call 'kernel32::AllocConsole()'
+            System::Call 'kernel32::GetStdHandle(i -11)i.r0'
+        ${EndIf}
+        FileWrite $0 "$\n"
+        FileWrite $0 "$\n"
+        FileWrite $0 "Help for Salt Minion installation$\n"
+        FileWrite $0 "===============================================================================$\n"
+        FileWrite $0 "$\n"
+        FileWrite $0 "/minion-name=$\t$\tA string value to set the minion name. Default is$\n"
+        FileWrite $0 "$\t$\t$\t'hostname'. Setting the minion name will replace$\n"
+        FileWrite $0 "$\t$\t$\texisting config with a default config. Cannot be$\n"
+        FileWrite $0 "$\t$\t$\tused in conjunction with /use-existing-config=1$\n"
+        FileWrite $0 "$\n"
+        FileWrite $0 "/master=$\t$\tA string value to set the IP address or hostname of$\n"
+        FileWrite $0 "$\t$\t$\tthe master. Default value is 'salt'. You may pass a$\n"
+        FileWrite $0 "$\t$\t$\tsingle master, or a comma separated list of masters.$\n"
+        FileWrite $0 "$\t$\t$\tSetting the master will replace existing config with$\n"
+        FileWrite $0 "$\t$\t$\ta default config. Cannot be used in conjunction with$\n"
+        FileWrite $0 "$\t$\t$\t/use-existing-config=1$\n"
+        FileWrite $0 "$\n"
+        FileWrite $0 "/start-minion=$\t$\t1 will start the service, 0 will not. Default is 1$\n"
+        FileWrite $0 "$\n"
+        FileWrite $0 "/start-minion-delayed$\tSet the minion start type to 'Automatic (Delayed Start)'$\n"
+        FileWrite $0 "$\n"
+        FileWrite $0 "/use-existing-config=$\t1 will use the existing config if present, 0 will$\n"
+        FileWrite $0 "$\t$\t$\treplace existing config with a default config. Default$\n"
+        FileWrite $0 "$\t$\t$\tis 1. If this is set to 1, values passed in$\n"
+        FileWrite $0 "$\t$\t$\t/minion-name and /master will be ignored$\n"
+        FileWrite $0 "$\n"
+        FileWrite $0 "/S$\t$\t$\tInstall Salt silently$\n"
+        FileWrite $0 "$\n"
+        FileWrite $0 "/?$\t$\t$\tDisplay this help screen$\n"
+        FileWrite $0 "$\n"
+        FileWrite $0 "-------------------------------------------------------------------------------$\n"
+        FileWrite $0 "$\n"
+        FileWrite $0 "Examples:$\n"
+        FileWrite $0 "$\n"
+        FileWrite $0 "${OutFile} /S$\n"
+        FileWrite $0 "$\n"
+        FileWrite $0 "${OutFile} /S /minion-name=myminion /master=master.mydomain.com /start-minion-delayed$\n"
+        FileWrite $0 "$\n"
+        FileWrite $0 "===============================================================================$\n"
+        FileWrite $0 "Press Enter to continue..."
+        System::Free $0
+        System::Free $1
+        System::Call 'kernel32::FreeConsole()'
+        Abort
+    display_help_not_found:
+
+    # Set default value for Use Existing Config
+    StrCpy $UseExistingConfig_State 1
+
     # Check for start-minion switches
     # /start-service is to be deprecated, so we must check for both
     ${GetOptions} $R0 "/start-service=" $R1
@@ -930,19 +1231,31 @@ Function parseCommandLineSwitches
     start_minion_delayed_not_found:
 
     # Minion Config: Master IP/Name
+    # If setting master, we don't want to use existing config
     ${GetOptions} $R0 "/master=" $R1
     ${IfNot} $R1 == ""
         StrCpy $MasterHost_State $R1
+        StrCpy $UseExistingConfig_State 0
     ${ElseIf} $MasterHost_State == ""
         StrCpy $MasterHost_State "salt"
     ${EndIf}
 
     # Minion Config: Minion ID
+    # If setting minion id, we don't want to use existing config
     ${GetOptions} $R0 "/minion-name=" $R1
     ${IfNot} $R1 == ""
         StrCpy $MinionName_State $R1
+        StrCpy $UseExistingConfig_State 0
     ${ElseIf} $MinionName_State == ""
         StrCpy $MinionName_State "hostname"
+    ${EndIf}
+
+    # Use Existing Config
+    # Overrides above settings with user passed settings
+    ${GetOptions} $R0 "/use-existing-config=" $R1
+    ${IfNot} $R1 == ""
+        # Use Existing Config was passed something, set it
+        StrCpy $UseExistingConfig_State $R1
     ${EndIf}
 
 FunctionEnd


### PR DESCRIPTION
### What does this PR do?
Allows you to pass a comma-delimited list of masters to the master combo box or the /master command line switch
Parses the existing minion config file to get multi-master settings
Adds a checkbox to use the existing config in the minion config page
When the box is checked, show the existing config grayed out
When unchecked, show default values
Adds the `/use-existing-config=` command line switch for use from the command line
Adds support for a help switch on the command line (`/?`) to display the supported command line parameters

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/26990

### Previous Behavior
Existing config was overwritten, and perhaps not even correct depending on the existence of additional config in the `minion.d` directory which wasn't being checked our accounted for.

### New Behavior
You either use existing config unchanged, or you use default config with passed parameters

### Tests written?
NA
