### PR TITLE
multiprocessing minion option: documentation fixes (develop)

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -2404,11 +2404,14 @@ Thread Settings
 
 .. conf_minion:: multiprocessing
 
+``multiprocessing``
+-------
+
 Default: ``True``
 
-If `multiprocessing` is enabled when a minion receives a
+If ``multiprocessing`` is enabled when a minion receives a
 publication a new process is spawned and the command is executed therein.
-Conversely, if `multiprocessing` is disabled the new publication will be run
+Conversely, if ``multiprocessing`` is disabled the new publication will be run
 executed in a thread.
 
 


### PR DESCRIPTION
### What does this PR do?
Fixes the documentation and man page for `multiprocessing`: adds missing headers, corrects formatting.

### What issues does this PR fix or reference?
None.

### Tests written?
No
