### PR TITLE
Introduce process_count_max minion configuration parameter (develop)

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -692,8 +692,8 @@
 # Limit the maximum amount of processes or threads created by salt-minion.
 # This is useful to avoid resource exhaustion in case the minion receives more
 # publications than it is able to handle, as it limits the number of spawned
-# processes or threads. -1 disables the limit.
-#process_count_max: 20
+# processes or threads. -1 is the default and disables the limit.
+#process_count_max: -1
 
 
 #####         Logging settings       #####

--- a/conf/minion
+++ b/conf/minion
@@ -689,6 +689,12 @@
 # for a full explanation.
 #multiprocessing: True
 
+# Limit the maximum amount of processes or threads created by salt-minion.
+# This is useful to avoid resource exhaustion in case the minion receives more
+# publications than it is able to handle, as it limits the number of spawned
+# processes or threads. -1 disables the limit.
+#process_count_max: 20
+
 
 #####         Logging settings       #####
 ##########################################

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -2419,6 +2419,23 @@ executed in a thread.
 
     multiprocessing: True
 
+.. conf_minion:: process_count_max
+
+``process_count_max``
+-------
+
+.. versionadded:: Oxygen
+
+Default: ``20``
+
+Limit the maximum amount of processes or threads created by ``salt-minion``.
+This is useful to avoid resource exhaustion in case the minion receives more
+publications than it is able to handle, as it limits the number of spawned
+processes or threads. ``-1`` disables the limit.
+
+.. code-block:: yaml
+
+    process_count_max: 20
 
 .. _minion-logging-settings:
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -2426,16 +2426,16 @@ executed in a thread.
 
 .. versionadded:: Oxygen
 
-Default: ``20``
+Default: ``-1``
 
 Limit the maximum amount of processes or threads created by ``salt-minion``.
 This is useful to avoid resource exhaustion in case the minion receives more
 publications than it is able to handle, as it limits the number of spawned
-processes or threads. ``-1`` disables the limit.
+processes or threads. ``-1`` is the default and disables the limit.
 
 .. code-block:: yaml
 
-    process_count_max: 20
+    process_count_max: -1
 
 .. _minion-logging-settings:
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -337,6 +337,9 @@ VALID_OPTS = {
     # Whether or not processes should be forked when needed. The alternative is to use threading.
     'multiprocessing': bool,
 
+    # Maximum number of concurrently active processes at any given point in time
+    'process_count_max': int,
+
     # Whether or not the salt minion should run scheduled mine updates
     'mine_enabled': bool,
 
@@ -1258,6 +1261,7 @@ DEFAULT_MINION_OPTS = {
     'auto_accept': True,
     'autosign_timeout': 120,
     'multiprocessing': True,
+    'process_count_max': 20,
     'mine_enabled': True,
     'mine_return_job': False,
     'mine_interval': 60,

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1261,7 +1261,7 @@ DEFAULT_MINION_OPTS = {
     'auto_accept': True,
     'autosign_timeout': 120,
     'multiprocessing': True,
-    'process_count_max': 20,
+    'process_count_max': -1,
     'mine_enabled': True,
     'mine_return_job': False,
     'mine_interval': 60,

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -69,7 +69,7 @@ class MinionTestCase(TestCase):
         mock_jid_queue = [123]
         try:
             minion = salt.minion.Minion(mock_opts, jid_queue=copy.copy(mock_jid_queue), io_loop=tornado.ioloop.IOLoop())
-            ret = minion._handle_decoded_payload(mock_data)
+            ret = minion._handle_decoded_payload(mock_data).result()
             self.assertEqual(minion.jid_queue, mock_jid_queue)
             self.assertIsNone(ret)
         finally:
@@ -98,7 +98,7 @@ class MinionTestCase(TestCase):
                 # Call the _handle_decoded_payload function and update the mock_jid_queue to include the new
                 # mock_jid. The mock_jid should have been added to the jid_queue since the mock_jid wasn't
                 # previously included. The minion's jid_queue attribute and the mock_jid_queue should be equal.
-                minion._handle_decoded_payload(mock_data)
+                minion._handle_decoded_payload(mock_data).result()
                 mock_jid_queue.append(mock_jid)
                 self.assertEqual(minion.jid_queue, mock_jid_queue)
             finally:
@@ -126,7 +126,7 @@ class MinionTestCase(TestCase):
 
                 # Call the _handle_decoded_payload function and check that the queue is smaller by one item
                 # and contains the new jid
-                minion._handle_decoded_payload(mock_data)
+                minion._handle_decoded_payload(mock_data).result()
                 self.assertEqual(len(minion.jid_queue), 2)
                 self.assertEqual(minion.jid_queue, [456, 789])
             finally:


### PR DESCRIPTION
### What does this PR do?
This adds a minion configuration parameter to limit the number of processes or threads a minion will start in response to published messages, preventing resource exhaustion in case a high number of concurrent jobs is scheduled in a short time.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/43665

### Previous Behavior
`salt-minion` could consume significant resources if a large number of functions calls is scheduled in parallel, as it would spawn one process for each.

### New Behavior
By default, nothing changes. If `process_count_max` is specified, `salt-minion` will not spawn more than a certain amount of processes/threads.

### Tests written?
One new unit test was added and existing tests were updated.
