### PR TITLE
Fix for `list` and `contains` redis cache logic.

### DIFF
--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -421,18 +421,17 @@ def list_(bank):
     Lists entries stored in the specified bank.
     '''
     redis_server = _get_redis_server()
-    bank_keys_redis_key = _get_bank_keys_redis_key(bank)
-    bank_keys = None
+    bank_redis_key = _get_bank_redis_key(bank)
     try:
-        bank_keys = redis_server.smembers(bank_keys_redis_key)
+        banks = redis_server.smembers(bank_redis_key)
     except (RedisConnectionError, RedisResponseError) as rerr:
-        mesg = 'Cannot list the Redis cache key {rkey}: {rerr}'.format(rkey=bank_keys_redis_key,
+        mesg = 'Cannot list the Redis cache key {rkey}: {rerr}'.format(rkey=bank_redis_key,
                                                                        rerr=rerr)
         log.error(mesg)
         raise SaltCacheError(mesg)
-    if not bank_keys:
+    if not banks:
         return []
-    return list(bank_keys)
+    return list(banks)
 
 
 def contains(bank, key):
@@ -440,15 +439,14 @@ def contains(bank, key):
     Checks if the specified bank contains the specified key.
     '''
     redis_server = _get_redis_server()
-    bank_keys_redis_key = _get_bank_keys_redis_key(bank)
-    bank_keys = None
+    bank_redis_key = _get_bank_redis_key(bank)
     try:
-        bank_keys = redis_server.smembers(bank_keys_redis_key)
+        banks = redis_server.smembers(bank_redis_key)
     except (RedisConnectionError, RedisResponseError) as rerr:
-        mesg = 'Cannot retrieve the Redis cache key {rkey}: {rerr}'.format(rkey=bank_keys_redis_key,
+        mesg = 'Cannot retrieve the Redis cache key {rkey}: {rerr}'.format(rkey=bank_redis_key,
                                                                            rerr=rerr)
         log.error(mesg)
         raise SaltCacheError(mesg)
-    if not bank_keys:
+    if not banks:
         return False
-    return key in bank_keys
+    return key in banks

--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -441,12 +441,9 @@ def contains(bank, key):
     redis_server = _get_redis_server()
     bank_redis_key = _get_bank_redis_key(bank)
     try:
-        banks = redis_server.smembers(bank_redis_key)
+        return redis_server.sismember(bank_redis_key, key)
     except (RedisConnectionError, RedisResponseError) as rerr:
         mesg = 'Cannot retrieve the Redis cache key {rkey}: {rerr}'.format(rkey=bank_redis_key,
                                                                            rerr=rerr)
         log.error(mesg)
         raise SaltCacheError(mesg)
-    if not banks:
-        return False
-    return key in banks


### PR DESCRIPTION
### What does this PR do?
Fixes `list` and `contains` redis cache logic.
Wrong keys was used to retrieve the data. Updated those functions to use right keys (keys used to store the being retrieved data).

### What issues does this PR fix or reference?
Fix #43381 

### Previous Behavior
Cache list returns an empty minions list. So master decides to send publish to all allowed minions to make them to check the matcher and decide to run the job or not.

### New Behavior
Return the actual list of minions that master have cached data for. So master checks the matcher against cached data and send publish to the only matched minions.

### Tests written?
No