### PR TITLE
Fix RST headers for runners (2017.7 branch)

### DIFF
--- a/doc/ref/runners/all/salt.runners.digicertapi.rst
+++ b/doc/ref/runners/all/salt.runners.digicertapi.rst
@@ -1,5 +1,5 @@
-salt.runners.digicertapi module
-===============================
+salt.runners.digicertapi
+========================
 
 .. automodule:: salt.runners.digicertapi
     :members:

--- a/doc/ref/runners/all/salt.runners.mattermost.rst
+++ b/doc/ref/runners/all/salt.runners.mattermost.rst
@@ -1,5 +1,5 @@
-salt.runners.mattermost module
-==============================
+salt.runners.mattermost
+=======================
 
 **Note for 2017.7 releases!**
 

--- a/doc/ref/runners/all/salt.runners.vault.rst
+++ b/doc/ref/runners/all/salt.runners.vault.rst
@@ -1,5 +1,5 @@
-salt.runners.vault module
-=========================
+salt.runners.vault
+==================
 
 .. automodule:: salt.runners.vault
     :members:

--- a/doc/ref/runners/all/salt.runners.venafiapi.rst
+++ b/doc/ref/runners/all/salt.runners.venafiapi.rst
@@ -1,5 +1,5 @@
-salt.runners.venafiapi module
-=============================
+salt.runners.venafiapi
+======================
 
 .. automodule:: salt.runners.venafiapi
     :members:

--- a/salt/runners/mattermost.py
+++ b/salt/runners/mattermost.py
@@ -6,9 +6,10 @@ Module for sending messages to Mattermost
 
 :configuration: This module can be used by either passing an api_url and hook
     directly or by specifying both in a configuration profile in the salt
-    master/minion config.
-    For example:
+    master/minion config. For example:
+
     .. code-block:: yaml
+
         mattermost:
           hook: peWcBiMOS9HrZG15peWcBiMOS9HrZG15
           api_url: https://example.com


### PR DESCRIPTION
To conform with the rest of the rst files for runner docs, they should
only contain the module name.