### PR TITLE
Fix RST headers for runners (2016.11 branch)

### DIFF
--- a/doc/ref/runners/all/salt.runners.auth.rst
+++ b/doc/ref/runners/all/salt.runners.auth.rst
@@ -1,5 +1,5 @@
-salt.runners.auth module
-========================
+salt.runners.auth
+=================
 
 .. automodule:: salt.runners.auth
     :members:

--- a/doc/ref/runners/all/salt.runners.event.rst
+++ b/doc/ref/runners/all/salt.runners.event.rst
@@ -1,5 +1,5 @@
-salt.runners.event module
-=========================
+salt.runners.event
+==================
 
 .. automodule:: salt.runners.event
     :members:

--- a/doc/ref/runners/all/salt.runners.smartos_vmadm.rst
+++ b/doc/ref/runners/all/salt.runners.smartos_vmadm.rst
@@ -1,5 +1,5 @@
-salt.runners.smartos_vmadm module
-=================================
+salt.runners.smartos_vmadm
+==========================
 
 .. automodule:: salt.runners.smartos_vmadm
     :members:

--- a/doc/ref/runners/all/salt.runners.vistara.rst
+++ b/doc/ref/runners/all/salt.runners.vistara.rst
@@ -1,5 +1,5 @@
-salt.runners.vistara module
-===========================
+salt.runners.vistara
+====================
 
 .. automodule:: salt.runners.vistara
     :members:


### PR DESCRIPTION
To conform with the rest of the rst files for runner docs, they should
only contain the module name.