### PR TITLE
Make git_pillar runner return None when no changes are fetched

### DIFF
--- a/salt/runners/git_pillar.py
+++ b/salt/runners/git_pillar.py
@@ -28,6 +28,11 @@ def update(branch=None, repo=None):
         fetched, and ``False`` if there were errors or no new commits were
         fetched.
 
+    .. versionchanged:: Oxygen
+        The return for a given git_pillar remote will now be ``None`` when no
+        changes were fetched. ``False`` now is reserved only for instances in
+        which there were errors.
+
     Fetch one or all configured git_pillar remotes.
 
     .. note::

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1145,7 +1145,7 @@ class GitPython(GitProvider):
                 new_objs = True
 
         cleaned = self.clean_stale_refs()
-        return bool(new_objs or cleaned)
+        return True if (new_objs or cleaned) else None
 
     def file_list(self, tgt_env):
         '''
@@ -1621,7 +1621,9 @@ class Pygit2(GitProvider):
             log.debug('%s remote \'%s\' is up-to-date', self.role, self.id)
         refs_post = self.repo.listall_references()
         cleaned = self.clean_stale_refs(local_refs=refs_post)
-        return bool(received_objects or refs_pre != refs_post or cleaned)
+        return True \
+            if (received_objects or refs_pre != refs_post or cleaned) \
+            else None
 
     def file_list(self, tgt_env):
         '''


### PR DESCRIPTION
This distinguishes cases in which no changes were fetched from those when there were errors.

Resolves #43383.