### PR TITLE
Ensure salt-cloud with libvirt provider does not write low level errors to stderr

### DIFF
--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -41,6 +41,7 @@ Example profile:
         master_port: 5506
 
 Tested on:
+- Fedora 26 (libvirt 3.2.1, qemu 2.9.1)
 - Fedora 25 (libvirt 1.3.3.2, qemu 2.6.1)
 - Fedora 23 (libvirt 1.2.18, qemu 2.4.1)
 - Centos 7 (libvirt 1.2.17, qemu 1.5.3)

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -100,7 +100,8 @@ __virtualname__ = 'libvirt'
 # Set up logging
 log = logging.getLogger(__name__)
 
-def libvirtErrorHandler(ctx, error):
+
+def libvirt_error_handler(ctx, error):  # pylint: disable=unused-argument
     '''
     Redirect stderr prints from libvirt to salt logging.
     '''
@@ -108,7 +109,8 @@ def libvirtErrorHandler(ctx, error):
 
 
 if HAS_LIBVIRT:
-    libvirt.registerErrorHandler(f=libvirtErrorHandler, ctx=None)
+    libvirt.registerErrorHandler(f=libvirt_error_handler, ctx=None)
+
 
 def __virtual__():
     '''

--- a/salt/cloud/clouds/libvirt.py
+++ b/salt/cloud/clouds/libvirt.py
@@ -82,9 +82,6 @@ from salt.exceptions import (
     SaltCloudSystemExit
 )
 
-# Get logging started
-log = logging.getLogger(__name__)
-
 VIRT_STATE_NAME_MAP = {0: 'running',
                        1: 'running',
                        2: 'running',
@@ -99,6 +96,18 @@ IP_LEARNING_XML = """<filterref filter='clean-traffic'>
 
 __virtualname__ = 'libvirt'
 
+# Set up logging
+log = logging.getLogger(__name__)
+
+def libvirtErrorHandler(ctx, error):
+    '''
+    Redirect stderr prints from libvirt to salt logging.
+    '''
+    log.debug("libvirt error {0}".format(error))
+
+
+if HAS_LIBVIRT:
+    libvirt.registerErrorHandler(f=libvirtErrorHandler, ctx=None)
 
 def __virtual__():
     '''


### PR DESCRIPTION
### What does this PR do?

Back port of the relevant fixes in:  #43684

- Fix libvirt spamming stderr when errors happen (that are not errors at all, like when checking if a VM is absent/present) libvirt errors are now redirected to salt's logging at debug level.
- Mention Fedora 26 support

### What issues does this PR fix or reference?

None.

### Previous Behavior

When instantiating a new domain some messages from the libvirt library were printed to stderr.

### New Behavior

Libvirt messages are now written to salt debug log.

### Tests written?

No

Question: Is this the right branch to backport to ? Should I also cherry-pick the changes to 2017.7.2 ?
