### PR TITLE
Add an `up_to_date` state to the `win_wua` state module

### DIFF
--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -110,7 +110,7 @@ def available(software=True,
             Include software updates in the results (default is True)
 
         drivers (bool):
-            Include driver updates in the results (default is False)
+            Include driver updates in the results (default is True)
 
         summary (bool):
             - True: Return a summary of updates available for each category.

--- a/salt/states/win_wua.py
+++ b/salt/states/win_wua.py
@@ -84,10 +84,12 @@ def installed(name, updates=None):
 
     Args:
 
-        name (str): The identifier of a single update to install.
+        name (str):
+            The identifier of a single update to install.
 
-        updates (list): A list of identifiers for updates to be installed.
-        Overrides ``name``. Default is None.
+        updates (list):
+            A list of identifiers for updates to be installed. Overrides
+            ``name``. Default is None.
 
     .. note:: Identifiers can be the GUID, the KB number, or any part of the
        Title of the Microsoft update. GUIDs and KBs are the preferred method
@@ -121,7 +123,7 @@ def installed(name, updates=None):
         # Install multiple updates
         install_updates:
           wua.installed:
-            - name:
+            - updates:
               - KB3194343
               - 28cf1b09-2b1a-458c-9bd1-971d1b26b211
     '''
@@ -215,10 +217,12 @@ def removed(name, updates=None):
 
     Args:
 
-        name (str): The identifier of a single update to uninstall.
+        name (str):
+            The identifier of a single update to uninstall.
 
-        updates (list): A list of identifiers for updates to be removed.
-        Overrides ``name``. Default is None.
+        updates (list):
+            A list of identifiers for updates to be removed. Overrides ``name``.
+            Default is None.
 
     .. note:: Identifiers can be the GUID, the KB number, or any part of the
        Title of the Microsoft update. GUIDs and KBs are the preferred method
@@ -327,5 +331,174 @@ def removed(name, updates=None):
         ret['comment'] = 'Updates failed'
     else:
         ret['comment'] = 'Updates removed successfully'
+
+    return ret
+
+
+def up_to_date(name,
+               software=True,
+               drivers=False,
+               skip_hidden=False,
+               skip_mandatory=False,
+               skip_reboot=True,
+               categories=None,
+               severities=None,):
+    '''
+    Ensure Microsoft Updates that match the passed criteria are installed.
+    Updates will be downloaded if needed.
+
+    This state allows you to update a system without specifying a specific
+    update to apply. All matching updates will be installed.
+
+    Args:
+
+        name (str):
+            The name has no functional value and is only used as a tracking
+            reference
+
+        software (bool):
+            Include software updates in the results (default is True)
+
+        drivers (bool):
+            Include driver updates in the results (default is False)
+
+        skip_hidden (bool):
+            Skip updates that have been hidden. Default is False.
+
+        skip_mandatory (bool):
+            Skip mandatory updates. Default is False.
+
+        skip_reboot (bool):
+            Skip updates that require a reboot. Default is True.
+
+        categories (list):
+            Specify the categories to list. Must be passed as a list. All
+            categories returned by default.
+
+            Categories include the following:
+
+            * Critical Updates
+            * Definition Updates
+            * Drivers (make sure you set drivers=True)
+            * Feature Packs
+            * Security Updates
+            * Update Rollups
+            * Updates
+            * Update Rollups
+            * Windows 7
+            * Windows 8.1
+            * Windows 8.1 drivers
+            * Windows 8.1 and later drivers
+            * Windows Defender
+
+        severities (list):
+            Specify the severities to include. Must be passed as a list. All
+            severities returned by default.
+
+            Severities include the following:
+
+            * Critical
+            * Important
+
+
+    Returns:
+        dict: A dictionary containing the results of the update
+
+    CLI Example:
+
+    .. code-block:: yaml
+
+        # Update the system using the state defaults
+        update_system:
+          wua.up_to_date
+
+        # Update the drivers
+        update_drivers:
+          wua.up_to_date:
+            - software: False
+            - drivers: True
+            - skip_reboot: False
+
+        # Apply all critical updates
+        update_critical:
+          wua.up_to_date:
+            - severities:
+              - Critical
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    wua = salt.utils.win_update.WindowsUpdateAgent()
+
+    available_updates = wua.available(
+        skip_hidden=skip_hidden, skip_installed=True,
+        skip_mandatory=skip_mandatory, skip_reboot=skip_reboot,
+        software=software, drivers=drivers, categories=categories,
+        severities=severities)
+
+    # No updates found
+    if available_updates.count() == 0:
+        ret['comment'] = 'No updates found'
+        return ret
+
+    updates = list(available_updates.list().keys())
+
+    # Search for updates
+    install_list = wua.search(updates)
+
+    # List of updates to download
+    download = salt.utils.win_update.Updates()
+    for item in install_list.updates:
+        if not salt.utils.is_true(item.IsDownloaded):
+            download.updates.Add(item)
+
+    # List of updates to install
+    install = salt.utils.win_update.Updates()
+    for item in install_list.updates:
+        if not salt.utils.is_true(item.IsInstalled):
+            install.updates.Add(item)
+
+    # Return comment of changes if test.
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Updates will be installed:'
+        for update in install.updates:
+            ret['comment'] += '\n'
+            ret['comment'] += ': '.join(
+                [update.Identity.UpdateID, update.Title])
+        return ret
+
+    # Download updates
+    wua.download(download)
+
+    # Install updates
+    wua.install(install)
+
+    # Refresh windows update info
+    wua.refresh()
+
+    post_info = wua.updates().list()
+
+    # Verify the installation
+    for item in install.list():
+        if not salt.utils.is_true(post_info[item]['Installed']):
+            ret['changes']['failed'] = {
+                item: {'Title': post_info[item]['Title'][:40] + '...',
+                       'KBs': post_info[item]['KBs']}
+            }
+            ret['result'] = False
+        else:
+            ret['changes']['installed'] = {
+                item: {'Title': post_info[item]['Title'][:40] + '...',
+                       'NeedsReboot': post_info[item]['NeedsReboot'],
+                       'KBs': post_info[item]['KBs']}
+            }
+
+    if ret['changes'].get('failed', False):
+        ret['comment'] = 'Updates failed'
+    else:
+        ret['comment'] = 'Updates installed successfully'
 
     return ret

--- a/salt/states/win_wua.py
+++ b/salt/states/win_wua.py
@@ -335,14 +335,14 @@ def removed(name, updates=None):
     return ret
 
 
-def up_to_date(name,
-               software=True,
-               drivers=False,
-               skip_hidden=False,
-               skip_mandatory=False,
-               skip_reboot=True,
-               categories=None,
-               severities=None,):
+def uptodate(name,
+             software=True,
+             drivers=False,
+             skip_hidden=False,
+             skip_mandatory=False,
+             skip_reboot=True,
+             categories=None,
+             severities=None,):
     '''
     Ensure Microsoft Updates that match the passed criteria are installed.
     Updates will be downloaded if needed.


### PR DESCRIPTION
### What does this PR do?
Adds an `wua.up_to_date` state that will apply all Windows Updates.
Fixes a documentation error on the `win_wua` execution module

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/43272

### Previous Behavior
You could use `wua.installed` to install specific updates, but not all updates matching certain criteria.

### New Behavior
You can now use `wua.up_to_date` to install all updates matching certain criteria

### Tests written?
No