### PR TITLE
Add missing support for use/use_in requisites to state.sls_id

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1303,6 +1303,9 @@ def sls_id(id_, mods, test=None, queue=False, **kwargs):
     finally:
         st_.pop_active()
     errors += st_.state.verify_high(high_)
+    # Apply requisites to high data
+    high_, req_in_errors = st_.state.requisite_in(high_)
+    errors.extend(req_in_errors)
     if errors:
         __context__['retcode'] = 1
         return errors

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1305,7 +1305,10 @@ def sls_id(id_, mods, test=None, queue=False, **kwargs):
     errors += st_.state.verify_high(high_)
     # Apply requisites to high data
     high_, req_in_errors = st_.state.requisite_in(high_)
-    errors.extend(req_in_errors)
+    if req_in_errors:
+        # This if statement should not be necessary if there were no errors,
+        # but it is required to get the unit tests to pass.
+        errors.extend(req_in_errors)
     if errors:
         __context__['retcode'] = 1
         return errors

--- a/tests/unit/modules/state_test.py
+++ b/tests/unit/modules/state_test.py
@@ -132,6 +132,9 @@ class MockState(object):
             data = data
             return True
 
+        def requisite_in(self, data):  # pylint: disable=unused-argument
+            return data, []
+
     class HighState(object):
         '''
             Mock HighState class


### PR DESCRIPTION
Because requisite resolution doesn't happen until we run call_high, and state.sls_id doesn't run call_high (but rather calls a single low chunk from the compiled low chunks), the use/use_in requisites are ignored.  This fixes that oversight by resolving requisites in state.sls_id before we compile the high data.

Resolves #43373