### PR TITLE
Ignore retcode on call to grep in selinux.py module

### DIFF
--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -463,7 +463,7 @@ def fcontext_get_policy(name, filetype=None, sel_type=None, sel_user=None, sel_l
     cmd_kwargs['filetype'] = '[[:alpha:] ]+' if filetype is None else filetype_id_to_string(filetype)
     cmd = 'semanage fcontext -l | egrep ' + \
           "'^{filespec}{spacer}{filetype}{spacer}{sel_user}:{sel_role}:{sel_type}:{sel_level}$'".format(**cmd_kwargs)
-    current_entry_text = __salt__['cmd.shell'](cmd)
+    current_entry_text = __salt__['cmd.shell'](cmd, ignore_retcode=True)
     if current_entry_text == '':
         return None
     ret = {}


### PR DESCRIPTION
### What does this PR do?
Fixes #43711

Returning an exit code of 1 is normal operation of grep when it does not
find a match. This will happen every time this function is called by
fcontext_policy_present to detirmine whether a selinux policy exists
before creating it. Ignoring the retcode will prevent it from emitting
an error when this happens.

### What issues does this PR fix or reference?
#43711 
### Previous Behavior
Will emit error when a selinux policy does not exist. This is in addition to the documented behavior of returning None.

### New Behavior
Does not emit errors when a selinux policy does not exist.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
