### PR TITLE
Catch OSError/IOError when check minion cache

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -501,7 +501,13 @@ class Key(object):
             if os.path.isdir(m_cache):
                 for minion in os.listdir(m_cache):
                     if minion not in minions and minion not in preserve_minions:
-                        shutil.rmtree(os.path.join(m_cache, minion))
+                        try:
+                            shutil.rmtree(os.path.join(m_cache, minion))
+                        except (OSError, IOError) as ex:
+                            log.warning('Key: Delete cache for %s got OSError/IOError: %s \n',
+                                        minion,
+                                        ex)
+                            continue
             cache = salt.cache.factory(self.opts)
             clist = cache.list(self.ACC)
             if clist:
@@ -979,7 +985,13 @@ class RaetKey(Key):
             if os.path.isdir(m_cache):
                 for minion in os.listdir(m_cache):
                     if minion not in minions and minion not in preserve_minions:
-                        shutil.rmtree(os.path.join(m_cache, minion))
+                        try:
+                            shutil.rmtree(os.path.join(m_cache, minion))
+                        except (OSError, IOError) as ex:
+                            log.warning('RaetKey: Delete cache for %s got OSError/IOError: %s \n',
+                                        minion,
+                                        ex)
+                            continue
                 cache = salt.cache.factory(self.opts)
                 clist = cache.list(self.ACC)
                 if clist:


### PR DESCRIPTION
Signed-off-by: 申艳芬 <SYF@shenyanfens-MacBook-Pro.local>

### What does this PR do?
Catch OSError/IOError when check minion cache. 
I think, one minion cache delete failed shoud not affect on other minions.  
If we don't catch these exceptions,  we may not be able to delete the cache that we really want to delete by call `delete_key`.

### What issues does this PR fix or reference?
When I call the api `delete_key` in my project like this:
```
from salt.config import master_config
from salt.key import Key
host = 'Host1'
salt_keys = Key(master_config('/etc/salt/master'))
keys = salt_keys.list_keys()
if host in keys['minions']:
    salt_keys.delete_key([host])
```
I can get exception `OSError [Errno 2] No such file or directory: '/var/cache/salt/master/minions/Host1'` sometimes. 

### Previous Behavior
Multiple hosts run these codes at the same time.  



### Tests written?

No

