### PR TITLE
Corrected custom port handling

### DIFF
--- a/salt/pillar/postgres.py
+++ b/salt/pillar/postgres.py
@@ -90,7 +90,8 @@ class POSTGRESExtPillar(SqlBaseExtPillar):
         conn = psycopg2.connect(host=_options['host'],
                                 user=_options['user'],
                                 password=_options['pass'],
-                                dbname=_options['db'])
+                                dbname=_options['db'],
+                                port=_options['port'])
         cursor = conn.cursor()
         try:
             yield cursor


### PR DESCRIPTION
### What does this PR do?
This pillar was only able to connect to a Postgres DB running on the default port (5432)
This commit extend this to a custom port

### What issues does this PR fix or reference?
issue #43659