### PR TITLE
Fix ini_manage error and change handling

### DIFF
--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -368,7 +368,7 @@ class _Ini(_Section):
         super(_Ini, self).__init__(name, inicontents, separator, commenter)
 
     def refresh(self, inicontents=None):
-        if inicontents is None:
+        if inicontents is None and __opts__['test'] is False:
             try:
                 with salt.utils.fopen(self.name) as rfh:
                     inicontents = rfh.read()

--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -368,15 +368,16 @@ class _Ini(_Section):
         super(_Ini, self).__init__(name, inicontents, separator, commenter)
 
     def refresh(self, inicontents=None):
-        if inicontents is None and __opts__['test'] is False:
+        if inicontents is None:
             try:
                 with salt.utils.fopen(self.name) as rfh:
                     inicontents = rfh.read()
             except (OSError, IOError) as exc:
-                raise CommandExecutionError(
-                    "Unable to open file '{0}'. "
-                    "Exception: {1}".format(self.name, exc)
-                )
+                if __opts__['test'] is False:
+                    raise CommandExecutionError(
+                        "Unable to open file '{0}'. "
+                        "Exception: {1}".format(self.name, exc)
+                    )
         if not inicontents:
             return
         # Remove anything left behind from a previous run.

--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -93,7 +93,7 @@ def options_present(name, sections=None, separator='=', strict=False):
                     del changes[section_name]
         else:
             changes = __salt__['ini.set_option'](name, sections, separator)
-    except IOError as err:
+    except (IOError, KeyError) as err:
         ret['comment'] = "{0}".format(err)
         ret['result'] = False
         return ret
@@ -102,12 +102,10 @@ def options_present(name, sections=None, separator='=', strict=False):
         ret['comment'] = 'Errors encountered. {0}'.format(changes['error'])
         ret['changes'] = {}
     else:
-        if changes:
-            ret['changes'] = changes
-            ret['comment'] = 'Changes take effect'
-        else:
-            ret['changes'] = {}
-            ret['comment'] = 'No changes take effect'
+        for name, body in changes.items():
+            if body:
+                ret['comment'] = 'Changes take effect'
+                ret['changes'].update({name: changes[name]})
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes a problem where `ini_manage` will throw an exception in test mode when a managed file is not present yet. Additionally, the dictionary of changes handles them by sections, which means that scenarios in which changes do not occur still return a dictionary of keys with empty dictionaries as values. The previous method of `if changes:` would result in changes being detected when there weren't any.

### What issues does this PR fix or reference?
None

### Previous Behavior
Example of exception during test mode:
```
----------
          ID: test_config
    Function: ini.options_present
        Name: /etc/test.conf
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/site-packages/salt/state.py", line 1837, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1794, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/site-packages/salt/states/ini_manage.py", line 61, in options_present
                  cur_section = __salt__['ini.get_section'](name, section, separator)
                File "/usr/lib/python2.7/site-packages/salt/modules/ini_manage.py", line 158, in get_section
                  inifile = _Ini.get_ini_file(file_name, separator=separator)
                File "/usr/lib/python2.7/site-packages/salt/modules/ini_manage.py", line 411, in get_ini_file
                  inifile.refresh()
                File "/usr/lib/python2.7/site-packages/salt/modules/ini_manage.py", line 377, in refresh
                  "Exception: {1}".format(self.name, exc)
              CommandExecutionError: Unable to open file '/etc/test.conf'. Exception: [Errno 2] No such file or directory: '/etc/test.conf'
     Started: 13:07:02.077923
    Duration: 3.087 ms
     Changes:   
```

Also, changes would be detected in files where no changes were made due to ho the dictionary of changes is kept. Enforcing a property within a section such as:
```
[settings]
property = value
```
...would return:
```
{ 'settings': {} }
```
...in the changes dictionary when there weren't any changes for the `settings` section.

### New Behavior
File access to non-existent files is ignored in test mode.

The state now inspects each key in the changes dictionary for changes by section.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
