### PR TITLE
Improved delete_deployment test for kubernetes module

### DIFF
--- a/tests/unit/modules/test_kubernetes.py
+++ b/tests/unit/modules/test_kubernetes.py
@@ -97,19 +97,20 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_delete_deployments(self):
         '''
-        Tests deployment creation.
+        Tests deployment deletion
         :return:
         '''
         with patch('salt.modules.kubernetes.kubernetes') as mock_kubernetes_lib:
-            with patch.dict(kubernetes.__salt__, {'config.option': Mock(return_value="")}):
-                mock_kubernetes_lib.client.V1DeleteOptions = Mock(return_value="")
-                mock_kubernetes_lib.client.ExtensionsV1beta1Api.return_value = Mock(
-                    **{"delete_namespaced_deployment.return_value.to_dict.return_value": {'code': 200}}
-                )
-                self.assertEqual(kubernetes.delete_deployment("test"), {'code': 200})
-                self.assertTrue(
-                    kubernetes.kubernetes.client.ExtensionsV1beta1Api().
-                    delete_namespaced_deployment().to_dict.called)
+            with patch('salt.modules.kubernetes.show_deployment', Mock(return_value=None)):
+                with patch.dict(kubernetes.__salt__, {'config.option': Mock(return_value="")}):
+                    mock_kubernetes_lib.client.V1DeleteOptions = Mock(return_value="")
+                    mock_kubernetes_lib.client.ExtensionsV1beta1Api.return_value = Mock(
+                        **{"delete_namespaced_deployment.return_value.to_dict.return_value": {'code': ''}}
+                    )
+                    self.assertEqual(kubernetes.delete_deployment("test"), {'code': 200})
+                    self.assertTrue(
+                        kubernetes.kubernetes.client.ExtensionsV1beta1Api().
+                        delete_namespaced_deployment().to_dict.called)
 
     def test_create_deployments(self):
         '''


### PR DESCRIPTION
### What does this PR do?

This is a follow up of this PR: https://github.com/saltstack/salt/pull/43235

With the fix in PR 43235, we are polling the status of the deletion via
show_deployment. This is now also reflected in the tests with this change.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/pull/43235

### Previous Behavior

The previous behaviour emulated a direct answer from the server.

### New Behavior

Changed test, so that it also considers polling via `show_deployment`.


### Tests written?

Yes