### PR TITLE
Skip ZFS module check on OpenBSD

### DIFF
--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -77,6 +77,9 @@ def __virtual__():
     ) == 0:
         return 'zfs'
 
+    if __grains__['kernel'] == 'OpenBSD':
+        return False
+
     _zfs_fuse = lambda f: __salt__['service.' + f]('zfs-fuse')
     if _zfs_fuse('available') and (_zfs_fuse('status') or _zfs_fuse('start')):
         return 'zfs'


### PR DESCRIPTION
### What does this PR do?

Skip `zfs-fuse` service check OpenBSD since this platform does not have ZFS support

### Previous Behavior

`salt-call` would print this error

    [ERROR   ] Command '/usr/sbin/rcctl get zfs-fuse' failed with return code: 2
    [ERROR   ] output: rcctl: service zfs-fuse does not exist

### New Behavior

No erroneous output on OpenBSD

