### PR TITLE
Fix `unit.beacons.test_status` for Windows

### DIFF
--- a/tests/unit/beacons/test_status.py
+++ b/tests/unit/beacons/test_status.py
@@ -12,6 +12,7 @@
 
 # Python libs
 from __future__ import absolute_import
+import sys
 
 # Salt libs
 import salt.config
@@ -45,14 +46,32 @@ class StatusBeaconTestCase(TestCase, LoaderModuleMockMixin):
     def test_empty_config(self, *args, **kwargs):
         config = {}
         ret = status.beacon(config)
-        self.assertEqual(sorted(list(ret[0]['data'])), sorted(['loadavg', 'meminfo', 'cpustats', 'vmstats', 'time']))
+
+        if sys.platform.startswith('win'):
+            expected = []
+        else:
+            expected = sorted(['loadavg', 'meminfo', 'cpustats', 'vmstats', 'time'])
+
+        self.assertEqual(sorted(list(ret[0]['data'])), expected)
 
     def test_deprecated_dict_config(self):
         config = {'time': ['all']}
         ret = status.beacon(config)
-        self.assertEqual(list(ret[0]['data']), ['time'])
+
+        if sys.platform.startswith('win'):
+            expected = []
+        else:
+            expected = ['time']
+
+        self.assertEqual(list(ret[0]['data']), expected)
 
     def test_list_config(self):
         config = [{'time': ['all']}]
         ret = status.beacon(config)
-        self.assertEqual(list(ret[0]['data']), ['time'])
+
+        if sys.platform.startswith('win'):
+            expected = []
+        else:
+            expected = ['time']
+
+        self.assertEqual(list(ret[0]['data']), expected)


### PR DESCRIPTION
### What does this PR do?
Fixes unit tests `unit.beacons.test_status` for Windows. The status function in Windows returns an empty dict under `data`.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes