### PR TITLE
Fix `unit.modules.test_poudriere` for Windows

### DIFF
--- a/tests/unit/modules/test_poudriere.py
+++ b/tests/unit/modules/test_poudriere.py
@@ -50,10 +50,12 @@ class PoudriereTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test if it make jail ``jname`` pkgng aware.
         '''
-        ret1 = 'Could not create or find required directory /tmp/salt'
-        ret2 = 'Looks like file /tmp/salt/salt-make.conf could not be created'
-        ret3 = {'changes': 'Created /tmp/salt/salt-make.conf'}
-        mock = MagicMock(return_value='/tmp/salt')
+        temp_dir = os.path.join('tmp', 'salt')
+        conf_file = os.path.join('tmp', 'salt', 'salt-make.conf')
+        ret1 = 'Could not create or find required directory {0}'.format(temp_dir)
+        ret2 = 'Looks like file {0} could not be created'.format(conf_file)
+        ret3 = {'changes': 'Created {0}'.format(conf_file)}
+        mock = MagicMock(return_value=temp_dir)
         mock_true = MagicMock(return_value=True)
         with patch.dict(poudriere.__salt__, {'config.option': mock,
                                              'file.write': mock_true}):


### PR DESCRIPTION
### What does this PR do?
Fixes `unit.modules.test_poudriere` for Windows. Uses os agnostic paths.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes