### PR TITLE
ESXi diskgroup and host cache creation/configuration + dependencies

### DIFF
--- a/salt/config/schemas/esxi.py
+++ b/salt/config/schemas/esxi.py
@@ -13,10 +13,48 @@
 from __future__ import absolute_import
 
 # Import Salt libs
-from salt.utils.schema import (Schema,
+from salt.utils.schema import (DefinitionsSchema,
+                               Schema,
+                               ComplexSchemaItem,
                                ArrayItem,
                                IntegerItem,
                                StringItem)
+
+
+class DiskGroupDiskIdItem(ComplexSchemaItem):
+    '''
+    Schema item of a ESXi host disk group containg disk ids
+    '''
+
+    title = 'Diskgroup Disk Id Item'
+    description = 'ESXi host diskgroup item containing disk ids'
+
+
+    cache_id = StringItem(
+        title='Cache Disk Id',
+        description='Specifies the id of the cache disk',
+        pattern=r'[^\s]+')
+
+    capacity_ids = ArrayItem(
+        title='Capacity Disk Ids',
+        description='Array with the ids of the capacity disks',
+        items=StringItem(pattern=r'[^\s]+'),
+        min_items=1)
+
+
+class DiskGroupsDiskIdSchema(DefinitionsSchema):
+    '''
+    Schema of ESXi host diskgroups containing disk ids
+    '''
+
+    title = 'Diskgroups Disk Id Schema'
+    description = 'ESXi host diskgroup schema containing disk ids'
+    diskgroups = ArrayItem(
+        title='DiskGroups',
+        description='List of disk groups in an ESXi host',
+        min_items = 1,
+        items=DiskGroupDiskIdItem(),
+        required=True)
 
 
 class EsxiProxySchema(Schema):

--- a/salt/config/schemas/esxi.py
+++ b/salt/config/schemas/esxi.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Alexandru Bleotu (alexandru.bleotu@morganstanley.com)`
+
+
+    salt.config.schemas.esxi
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+
+    ESXi host configuration schemas
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt libs
+from salt.utils.schema import (Schema,
+                               ArrayItem,
+                               IntegerItem,
+                               StringItem)
+
+
+class EsxiProxySchema(Schema):
+    '''
+    Schema of the esxi proxy input
+    '''
+
+    title = 'Esxi Proxy Schema'
+    description = 'Esxi proxy schema'
+    additional_properties = False
+    proxytype = StringItem(required=True,
+                           enum=['esxi'])
+    host = StringItem(pattern=r'[^\s]+') # Used when connecting directly
+    vcenter = StringItem(pattern=r'[^\s]+') # Used when connecting via a vCenter
+    esxi_host = StringItem()
+    username = StringItem()
+    passwords = ArrayItem(min_items=1,
+                          items=StringItem(),
+                          unique_items=True)
+    mechanism = StringItem(enum=['userpass', 'sspi'])
+    # TODO Should be changed when anyOf is supported for schemas
+    domain = StringItem()
+    principal = StringItem()
+    protocol = StringItem()
+    port = IntegerItem(minimum=1)

--- a/salt/config/schemas/esxi.py
+++ b/salt/config/schemas/esxi.py
@@ -17,9 +17,36 @@ from salt.utils.schema import (DefinitionsSchema,
                                Schema,
                                ComplexSchemaItem,
                                ArrayItem,
+                               DictItem,
                                IntegerItem,
                                BooleanItem,
-                               StringItem)
+                               StringItem,
+                               OneOfItem)
+
+
+class VMwareScsiAddressItem(StringItem):
+    pattern = r'vmhba\d+:C\d+:T\d+:L\d+'
+
+
+class DiskGroupDiskScsiAddressItem(ComplexSchemaItem):
+    '''
+    Schema item of a ESXi host disk group containing disk SCSI addresses
+    '''
+
+    title = 'Diskgroup Disk Scsi Address Item'
+    description = 'ESXi host diskgroup item containing disk SCSI addresses'
+
+
+    cache_scsi_addr = VMwareScsiAddressItem(
+        title='Cache Disk Scsi Address',
+        description='Specifies the SCSI address of the cache disk',
+        required=True)
+
+    capacity_scsi_addrs = ArrayItem(
+        title='Capacity Scsi Addresses',
+        description='Array with the SCSI addresses of the capacity disks',
+        items=VMwareScsiAddressItem(),
+        min_items=1)
 
 
 class DiskGroupDiskIdItem(ComplexSchemaItem):
@@ -41,6 +68,24 @@ class DiskGroupDiskIdItem(ComplexSchemaItem):
         description='Array with the ids of the capacity disks',
         items=StringItem(pattern=r'[^\s]+'),
         min_items=1)
+
+
+class DiskGroupsDiskScsiAddressSchema(DefinitionsSchema):
+    '''
+    Schema of ESXi host diskgroups containing disk SCSI addresses
+    '''
+
+    title = 'Diskgroups Disk Scsi Address Schema'
+    description = 'ESXi host diskgroup schema containing disk SCSI addresses'
+    disk_groups = ArrayItem(
+        title='Diskgroups',
+        description='List of diskgroups in an ESXi host',
+        min_items = 1,
+        items=DiskGroupDiskScsiAddressItem(),
+        required=True)
+    erase_disks = BooleanItem(
+        title='Erase Diskgroup Disks',
+        required=True)
 
 
 class DiskGroupsDiskIdSchema(DefinitionsSchema):

--- a/salt/config/schemas/esxi.py
+++ b/salt/config/schemas/esxi.py
@@ -17,7 +17,6 @@ from salt.utils.schema import (DefinitionsSchema,
                                Schema,
                                ComplexSchemaItem,
                                ArrayItem,
-                               DictItem,
                                IntegerItem,
                                BooleanItem,
                                StringItem,
@@ -35,7 +34,6 @@ class DiskGroupDiskScsiAddressItem(ComplexSchemaItem):
 
     title = 'Diskgroup Disk Scsi Address Item'
     description = 'ESXi host diskgroup item containing disk SCSI addresses'
-
 
     cache_scsi_addr = VMwareScsiAddressItem(
         title='Cache Disk Scsi Address',
@@ -56,7 +54,6 @@ class DiskGroupDiskIdItem(ComplexSchemaItem):
 
     title = 'Diskgroup Disk Id Item'
     description = 'ESXi host diskgroup item containing disk ids'
-
 
     cache_id = StringItem(
         title='Cache Disk Id',
@@ -80,7 +77,7 @@ class DiskGroupsDiskScsiAddressSchema(DefinitionsSchema):
     diskgroups = ArrayItem(
         title='Diskgroups',
         description='List of diskgroups in an ESXi host',
-        min_items = 1,
+        min_items=1,
         items=DiskGroupDiskScsiAddressItem(),
         required=True)
     erase_disks = BooleanItem(
@@ -98,7 +95,7 @@ class DiskGroupsDiskIdSchema(DefinitionsSchema):
     diskgroups = ArrayItem(
         title='DiskGroups',
         description='List of disk groups in an ESXi host',
-        min_items = 1,
+        min_items=1,
         items=DiskGroupDiskIdItem(),
         required=True)
 
@@ -207,8 +204,8 @@ class EsxiProxySchema(Schema):
     additional_properties = False
     proxytype = StringItem(required=True,
                            enum=['esxi'])
-    host = StringItem(pattern=r'[^\s]+') # Used when connecting directly
-    vcenter = StringItem(pattern=r'[^\s]+') # Used when connecting via a vCenter
+    host = StringItem(pattern=r'[^\s]+')  # Used when connecting directly
+    vcenter = StringItem(pattern=r'[^\s]+')  # Used when connecting via a vCenter
     esxi_host = StringItem()
     username = StringItem()
     passwords = ArrayItem(min_items=1,

--- a/salt/config/schemas/esxi.py
+++ b/salt/config/schemas/esxi.py
@@ -77,7 +77,7 @@ class DiskGroupsDiskScsiAddressSchema(DefinitionsSchema):
 
     title = 'Diskgroups Disk Scsi Address Schema'
     description = 'ESXi host diskgroup schema containing disk SCSI addresses'
-    disk_groups = ArrayItem(
+    diskgroups = ArrayItem(
         title='Diskgroups',
         description='List of diskgroups in an ESXi host',
         min_items = 1,
@@ -100,6 +100,84 @@ class DiskGroupsDiskIdSchema(DefinitionsSchema):
         description='List of disk groups in an ESXi host',
         min_items = 1,
         items=DiskGroupDiskIdItem(),
+        required=True)
+
+
+class VmfsDatastoreDiskIdItem(ComplexSchemaItem):
+    '''
+    Schema item of a VMFS datastore referencing a backing disk id
+    '''
+
+    title = 'VMFS Datastore Disk Id Item'
+    description = 'VMFS datastore item referencing a backing disk id'
+    name = StringItem(
+        title='Name',
+        description='Specifies the name of the VMFS datastore',
+        required=True)
+    backing_disk_id = StringItem(
+        title='Backing Disk Id',
+        description=('Specifies the id of the disk backing the VMFS '
+                     'datastore'),
+        pattern=r'[^\s]+',
+        required=True)
+    vmfs_version = IntegerItem(
+        title='VMFS Version',
+        description='VMFS version',
+        enum=[1, 2, 3, 5])
+
+
+class VmfsDatastoreDiskScsiAddressItem(ComplexSchemaItem):
+    '''
+    Schema item of a VMFS datastore referencing a backing disk SCSI address
+    '''
+
+    title = 'VMFS Datastore Disk Scsi Address Item'
+    description = 'VMFS datastore item referencing a backing disk SCSI address'
+    name = StringItem(
+        title='Name',
+        description='Specifies the name of the VMFS datastore',
+        required=True)
+    backing_disk_scsi_addr = VMwareScsiAddressItem(
+        title='Backing Disk Scsi Address',
+        description=('Specifies the SCSI address of the disk backing the VMFS '
+                     'datastore'),
+        required=True)
+    vmfs_version = IntegerItem(
+        title='VMFS Version',
+        description='VMFS version',
+        enum=[1, 2, 3, 5])
+
+
+class VmfsDatastoreSchema(DefinitionsSchema):
+    '''
+    Schema of a VMFS datastore
+    '''
+
+    title = 'VMFS Datastore Schema'
+    description = 'Schema of a VMFS datastore'
+    datastore = OneOfItem(
+        items=[VmfsDatastoreDiskScsiAddressItem(),
+               VmfsDatastoreDiskIdItem()],
+        required=True)
+
+
+class HostCacheSchema(DefinitionsSchema):
+    '''
+    Schema of ESXi host cache
+    '''
+
+    title = 'Host Cache Schema'
+    description = 'Schema of the ESXi host cache'
+    enabled = BooleanItem(
+        title='Enabled',
+        required=True)
+    datastore = VmfsDatastoreDiskScsiAddressItem(required=True)
+    swap_size = StringItem(
+        title='Host cache swap size (in GB or %)',
+        pattern=r'(\d+GiB)|(([0-9]|([1-9][0-9])|100)%)',
+        required=True)
+    erase_backing_disk = BooleanItem(
+        title='Erase Backup Disk',
         required=True)
 
 

--- a/salt/config/schemas/esxi.py
+++ b/salt/config/schemas/esxi.py
@@ -18,6 +18,7 @@ from salt.utils.schema import (DefinitionsSchema,
                                ComplexSchemaItem,
                                ArrayItem,
                                IntegerItem,
+                               BooleanItem,
                                StringItem)
 
 
@@ -55,6 +56,22 @@ class DiskGroupsDiskIdSchema(DefinitionsSchema):
         min_items = 1,
         items=DiskGroupDiskIdItem(),
         required=True)
+
+
+class SimpleHostCacheSchema(Schema):
+    '''
+    Simplified Schema of ESXi host cache
+    '''
+
+    title = 'Simple Host Cache Schema'
+    description = 'Simplified schema of the ESXi host cache'
+    enabled = BooleanItem(
+        title='Enabled',
+        required=True)
+    datastore_name = StringItem(title='Datastore Name',
+                                required=True)
+    swap_size_MiB = IntegerItem(title='Host cache swap size in MiB',
+                                minimum=1)
 
 
 class EsxiProxySchema(Schema):

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -442,6 +442,12 @@ class VMwareObjectRetrievalError(VMwareSaltError):
     '''
 
 
+class VMwareObjectExistsError(VMwareSaltError):
+    '''
+    Used when a VMware object exists
+    '''
+
+
 class VMwareObjectNotFoundError(VMwareSaltError):
     '''
     Used when a VMware object was not found

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -442,6 +442,12 @@ class VMwareObjectRetrievalError(VMwareSaltError):
     '''
 
 
+class VMwareObjectNotFoundError(VMwareSaltError):
+    '''
+    Used when a VMware object was not found
+    '''
+
+
 class VMwareApiError(VMwareSaltError):
     '''
     Used when representing a generic VMware API error

--- a/salt/modules/esxi.py
+++ b/salt/modules/esxi.py
@@ -56,3 +56,7 @@ def cmd(command, *args, **kwargs):
     proxy_cmd = proxy_prefix + '.ch_config'
 
     return __proxy__[proxy_cmd](command, *args, **kwargs)
+
+
+def get_details():
+    return __proxy__['esxi.get_details']()

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -5984,7 +5984,7 @@ def erase_disk_partitions(disk_id=None, scsi_address=None,
         Either ``disk_id`` or ``scsi_address`` needs to be specified
         (``disk_id`` supersedes ``scsi_address``.
 
-    scsi_address`
+    scsi_address
         Scsi address of the disk.
         ``disk_id`` or ``scsi_address`` needs to be specified
         (``disk_id`` supersedes ``scsi_address``.

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -180,7 +180,7 @@ import salt.utils.vsan
 import salt.utils.pbm
 from salt.exceptions import CommandExecutionError, VMwareSaltError, \
         ArgumentValueError, InvalidConfigError, VMwareObjectRetrievalError, \
-        VMwareApiError, InvalidEntityError
+        VMwareApiError, InvalidEntityError, VMwareObjectExistsError
 from salt.utils.decorators import depends, ignores_kwargs
 from salt.config.schemas.esxcluster import ESXClusterConfigSchema, \
         ESXClusterEntitySchema
@@ -5992,7 +5992,7 @@ def list_disks(disk_ids=None, scsi_addresses=None, service_instance=None):
         host_ref, hostname=hostname)
     canonical_name_to_scsi_address = {
         lun.canonicalName: scsi_addr
-        for scsi_addr, lun in scsi_address_to_lun.iteritems()}
+        for scsi_addr, lun in six.iteritems(scsi_address_to_lun)}
     for d in salt.utils.vmware.get_disks(host_ref, disk_ids, scsi_addresses,
                                          get_all_disks):
         ret_list.append({'id': d.canonicalName,
@@ -6052,7 +6052,7 @@ def erase_disk_partitions(disk_id=None, scsi_address=None,
                                             host_ref, disk_id,
                                             hostname=hostname)
     log.info('Erased disk partitions on disk \'{0}\' on host \'{1}\''
-             ''.format(disk_id, esxi_host))
+             ''.format(disk_id, hostname))
     return True
 
 
@@ -6220,7 +6220,7 @@ def create_diskgroup(cache_disk_id, capacity_disk_ids, safety_checks=True,
     for id in disk_ids:
         if not [d for d in disks if d.canonicalName == id]:
             raise VMwareObjectRetrievalError(
-                'No disk with id \'{0}\' was found in ESXi host \'{0}\''
+                'No disk with id \'{0}\' was found in ESXi host \'{1}\''
                 ''.format(id, hostname))
     cache_disk = [d for d in disks if d.canonicalName == cache_disk_id][0]
     capacity_disks = [d for d in disks if d.canonicalName in capacity_disk_ids]
@@ -6287,7 +6287,7 @@ def add_capacity_to_diskgroup(cache_disk_id, capacity_disk_ids,
     if not diskgroups:
         raise VMwareObjectRetrievalError(
             'No diskgroup with cache disk id \'{0}\' was found in ESXi '
-            'host \'{1}\''.format(cache_disk_id, esxi_host))
+            'host \'{1}\''.format(cache_disk_id, hostname))
     vsan_disk_mgmt_system = \
             salt.utils.vsan.get_vsan_disk_management_system(service_instance)
     salt.utils.vsan.add_capacity_to_diskgroup(service_instance,
@@ -6490,7 +6490,7 @@ def configure_host_cache(enabled, datastore=None, swap_size_MiB=None,
         if not ds_refs:
             raise VMwareObjectRetrievalError(
                 'Datastore \'{0}\' was not found on host '
-                '\'{1}\''.format(datastore_name, hostname))
+                '\'{1}\''.format(datastore, hostname))
         ds_ref = ds_refs[0]
     salt.utils.vmware.configure_host_cache(host_ref, ds_ref, swap_size_MiB)
     return True

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -5656,6 +5656,41 @@ def rename_datastore(datastore_name, new_datastore_name,
 
 
 @depends(HAS_PYVMOMI)
+@supports_proxies('esxi', 'esxcluster', 'esxdatacenter')
+@gets_service_instance_via_proxy
+def remove_datastore(datastore, service_instance=None):
+    '''
+    Removes a datastore. If multiple datastores an error is raised.
+
+    datastore
+        Datastore name
+
+    service_instance
+        Service instance (vim.ServiceInstance) of the vCenter/ESXi host.
+        Default is None.
+
+    .. code-block:: bash
+
+        salt '*' vsphere.remove_datastore ds_name
+    '''
+    log.trace('Removing datastore \'{0}\''.format(datastore))
+    target = _get_proxy_target(service_instance)
+    taget_name = target.name
+    datastores = salt.utils.vmware.get_datastores(
+        service_instance,
+        reference=target,
+        datastore_names=[datastore])
+    if not datastores:
+        raise VMwareObjectRetrievalError(
+            'Datastore \'{0}\' was not found'.format(datastore))
+    if len(datastores) > 1:
+        raise VMwareObjectRetrievalError(
+            'Multiple datastores \'{0}\' were found'.format(datastore))
+    salt.utils.vmware.remove_datastore(service_instance, datastores[0])
+    return True
+
+
+@depends(HAS_PYVMOMI)
 @supports_proxies('esxcluster', 'esxdatacenter')
 @gets_service_instance_via_proxy
 def list_licenses(service_instance=None):

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -5968,6 +5968,75 @@ def erase_disk_partitions(disk_id=None, scsi_address=None,
     return True
 
 
+@depends(HAS_PYVMOMI)
+@supports_proxies('esxi')
+@gets_service_instance_via_proxy
+def list_disk_partitions(disk_id=None, scsi_address=None,
+                          service_instance=None):
+    '''
+    Lists the partitions on a disk.
+    The disk can be specified either by the canonical name, or by the
+    scsi_address.
+
+    disk_id
+        Canonical name of the disk.
+        Either ``disk_id`` or ``scsi_address`` needs to be specified
+        (``disk_id`` supersedes ``scsi_address``.
+
+    scsi_address`
+        Scsi address of the disk.
+        ``disk_id`` or ``scsi_address`` needs to be specified
+        (``disk_id`` supersedes ``scsi_address``.
+
+    service_instance
+        Service instance (vim.ServiceInstance) of the vCenter/ESXi host.
+        Default is None.
+
+    .. code-block:: bash
+
+        salt '*' vsphere.list_disk_partitions scsi_address='vmhaba0:C0:T0:L0'
+
+        salt '*' vsphere.list_disk_partitions disk_id='naa.000000000000001'
+    '''
+    if not disk_id and not scsi_address:
+        raise ArgumentValueError('Either \'disk_id\' or \'scsi_address\' '
+                                 'needs to be specified')
+    host_ref = _get_proxy_target(service_instance)
+    hostname = __proxy__['esxi.get_details']()['esxi_host']
+    if not disk_id:
+        scsi_address_to_lun = \
+                salt.utils.vmware.get_scsi_address_to_lun_map(host_ref)
+        if scsi_address not in scsi_address_to_lun:
+            raise VMwareObjectRetrievalError(
+                'Scsi lun with address \'{0}\' was not found on host \'{1}\''
+                ''.format(scsi_address, hostname))
+        disk_id = scsi_address_to_lun[scsi_address].canonicalName
+        log.trace('[{0}] Got disk id \'{1}\' for scsi address \'{2}\''
+                  ''.format(hostname, disk_id, scsi_address))
+    log.trace('Listing disk partitions on disk \'{0}\' in host \'{1}\''
+              ''.format(disk_id, hostname))
+    partition_info = \
+            salt.utils.vmware.get_disk_partition_info(host_ref, disk_id)
+    ret_list = []
+    # NOTE: 1. The layout view has an extra 'None' partition for free space
+    #       2. The orders in the layout/partition views are not the same
+    for part_spec in partition_info.spec.partition:
+        part_layout = [p for p in partition_info.layout.partition
+                       if p.partition == part_spec.partition][0]
+        part_dict = {'hostname': hostname,
+                     'device': disk_id,
+                     'format': partition_info.spec.partitionFormat,
+                     'partition': part_spec.partition,
+                     'type': part_spec.type,
+                     'sectors':
+                     part_spec.endSector - part_spec.startSector + 1,
+                     'size_KB':
+                     (part_layout.end.block - part_layout.start.block + 1) *
+                     part_layout.start.blockSize / 1024}
+        ret_list.append(part_dict)
+    return ret_list
+
+
 def _check_hosts(service_instance, host, host_names):
     '''
     Helper function that checks to see if the host provided is a vCenter Server or

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -5941,7 +5941,7 @@ def list_hosts_via_proxy(hostnames=None, datacenter=None,
             raise salt.exceptions.ArgumentValueError(
                 'Datacenter is required when cluster is specified')
     get_all_hosts = False
-    if not hostnames and not datacenter and not cluster:
+    if not hostnames:
         get_all_hosts = True
     hosts = salt.utils.vmware.get_hosts(service_instance,
                                         datacenter_name=datacenter,

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -6320,6 +6320,37 @@ def remove_diskgroup(cache_disk_id, data_accessibility=True,
     return True
 
 
+@depends(HAS_PYVMOMI)
+@supports_proxies('esxi')
+@gets_service_instance_via_proxy
+def get_host_cache(service_instance=None):
+    '''
+    Returns the host cache configuration on the proxy host.
+
+    service_instance
+        Service instance (vim.ServiceInstance) of the vCenter/ESXi host.
+        Default is None.
+
+    .. code-block:: bash
+
+        salt '*' vsphere.get_host_cache
+    '''
+    # Default to getting all disks if no filtering is done
+    ret_dict = {}
+    host_ref = _get_proxy_target(service_instance)
+    hostname = __proxy__['esxi.get_details']()['esxi_host']
+    hci = salt.utils.vmware.get_host_cache(host_ref)
+    if not hci:
+        log.debug('Host cache not configured on host \'{0}\''.format(hostname))
+        ret_dict['enabled'] = False
+        return ret_dict
+
+    # TODO Support multiple host cache info objects (on multiple datastores)
+    return {'enabled': True,
+            'datastore': {'name': hci.key.name},
+            'swap_size': '{}MiB'.format(hci.swapSize)}
+
+
 def _check_hosts(service_instance, host, host_names):
     '''
     Helper function that checks to see if the host provided is a vCenter Server or

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -6147,6 +6147,70 @@ def create_diskgroup(cache_disk_id, capacity_disk_ids, safety_checks=True,
     return True
 
 
+@depends(HAS_PYVMOMI)
+@depends(HAS_JSONSCHEMA)
+@supports_proxies('esxi')
+@gets_service_instance_via_proxy
+def add_capacity_to_diskgroup(cache_disk_id, capacity_disk_ids,
+                              safety_checks=True, service_instance=None):
+    '''
+    Adds capacity disks to the disk group with the specified cache disk.
+
+    cache_disk_id
+        The canonical name of the cache disk.
+
+    capacity_disk_ids
+        A list containing canonical names of the capacity disks to add.
+
+    safety_checks
+        Specify whether to perform safety check or to skip the checks and try
+        performing the required task. Default value is True.
+
+    service_instance
+        Service instance (vim.ServiceInstance) of the vCenter/ESXi host.
+        Default is None.
+
+    .. code-block:: bash
+
+        salt '*' vsphere.add_capacity_to_diskgroup
+            cache_disk_id='naa.000000000000001'
+            capacity_disk_ids='[naa.000000000000002, naa.000000000000003]'
+    '''
+    log.trace('Validating diskgroup input')
+    schema = DiskGroupsDiskIdSchema.serialize()
+    try:
+        jsonschema.validate(
+            {'diskgroups': [{'cache_id': cache_disk_id,
+                             'capacity_ids': capacity_disk_ids}]},
+            schema)
+    except jsonschema.exceptions.ValidationError as exc:
+        raise ArgumentValueError(exc)
+    host_ref = _get_proxy_target(service_instance)
+    hostname = __proxy__['esxi.get_details']()['esxi_host']
+    disks = salt.utils.vmware.get_disks(host_ref, disk_ids=capacity_disk_ids)
+    if safety_checks:
+        for id in capacity_disk_ids:
+            if not [d for d in disks if d.canonicalName == id]:
+                raise VMwareObjectRetrievalError(
+                    'No disk with id \'{0}\' was found in ESXi host \'{1}\''
+                    ''.format(id, hostname))
+    diskgroups = \
+            salt.utils.vmware.get_diskgroups(
+                host_ref, cache_disk_ids=[cache_disk_id])
+    if not diskgroups:
+        raise VMwareObjectRetrievalError(
+            'No diskgroup with cache disk id \'{0}\' was found in ESXi '
+            'host \'{1}\''.format(cache_disk_id, esxi_host))
+    vsan_disk_mgmt_system = \
+            salt.utils.vsan.get_vsan_disk_management_system(service_instance)
+    salt.utils.vsan.add_capacity_to_diskgroup(service_instance,
+                                              vsan_disk_mgmt_system,
+                                              host_ref,
+                                              disk_groups[0],
+                                              disks)
+    return True
+
+
 def _check_hosts(service_instance, host, host_names):
     '''
     Helper function that checks to see if the host provided is a vCenter Server or

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -6495,3 +6495,19 @@ def _get_esxcluster_proxy_details():
             det.get('protocol'), det.get('port'), det.get('mechanism'), \
             det.get('principal'), det.get('domain'), det.get('datacenter'), \
             det.get('cluster')
+
+
+def _get_esxi_proxy_details():
+    '''
+    Returns the running esxi's proxy details
+    '''
+    det = __proxy__['esxi.get_details']()
+    host = det.get('host')
+    if det.get('vcenter'):
+        host = det['vcenter']
+    esxi_hosts = None
+    if det.get('esxi_host'):
+        esxi_hosts = [det['esxi_host']]
+    return host, det.get('username'), det.get('password'), \
+            det.get('protocol'), det.get('port'), det.get('mechanism'), \
+            det.get('principal'), det.get('domain'), esxi_hosts

--- a/salt/proxy/esxi.py
+++ b/salt/proxy/esxi.py
@@ -273,13 +273,22 @@ for standing up an ESXi host from scratch.
 # Import Python Libs
 from __future__ import absolute_import
 import logging
+import os
 
 # Import Salt Libs
 from salt.exceptions import SaltSystemExit
+from salt.config.schemas.esxi import EsxiProxySchema
+from salt.utils.dictupdate import merge
 
 # This must be present or the Salt loader won't load this module.
 __proxyenabled__ = ['esxi']
 
+# External libraries
+try:
+    import jsonschema
+    HAS_JSONSCHEMA = True
+except ImportError:
+    HAS_JSONSCHEMA = False
 
 # Variables are scoped to this module so we can have persistent data
 # across calls to fns in here.
@@ -288,20 +297,17 @@ DETAILS = {}
 
 # Set up logging
 log = logging.getLogger(__file__)
-
 # Define the module's virtual name
 __virtualname__ = 'esxi'
-
 
 def __virtual__():
     '''
     Only load if the ESXi execution module is available.
     '''
-    if 'vsphere.system_info' in __salt__:
+    if HAS_JSONSCHEMA:
         return __virtualname__
 
     return False, 'The ESXi Proxy Minion module did not load.'
-
 
 def init(opts):
     '''
@@ -309,32 +315,104 @@ def init(opts):
     ESXi devices, the host, login credentials, and, if configured,
     the protocol and port are cached.
     '''
-    if 'host' not in opts['proxy']:
-        log.critical('No \'host\' key found in pillar for this proxy.')
-        return False
-    if 'username' not in opts['proxy']:
-        log.critical('No \'username\' key found in pillar for this proxy.')
-        return False
-    if 'passwords' not in opts['proxy']:
-        log.critical('No \'passwords\' key found in pillar for this proxy.')
-        return False
-
-    host = opts['proxy']['host']
-
-    # Get the correct login details
+    log.debug('Initting esxi proxy module in process \'{}\''
+              ''.format(os.getpid()))
+    log.debug('Validating esxi proxy input')
+    schema = EsxiProxySchema.serialize()
+    log.trace('esxi_proxy_schema = {}'.format(schema))
+    proxy_conf = merge(opts.get('proxy', {}), __pillar__.get('proxy', {}))
+    log.trace('proxy_conf = {0}'.format(proxy_conf))
     try:
-        username, password = find_credentials(host)
-    except SaltSystemExit as err:
-        log.critical('Error: {0}'.format(err))
-        return False
+        jsonschema.validate(proxy_conf, schema)
+    except jsonschema.exceptions.ValidationError as exc:
+        raise excs.InvalidProxyInputError(exc)
 
-    # Set configuration details
-    DETAILS['host'] = host
-    DETAILS['username'] = username
-    DETAILS['password'] = password
-    DETAILS['protocol'] = opts['proxy'].get('protocol', 'https')
-    DETAILS['port'] = opts['proxy'].get('port', '443')
-    DETAILS['credstore'] = opts['proxy'].get('credstore')
+    DETAILS['proxytype'] = proxy_conf['proxytype']
+    if ('host' not in proxy_conf) and ('vcenter' not in proxy_conf):
+        log.critical('Neither \'host\' nor \'vcenter\' keys found in pillar '
+                     'for this proxy.')
+        return False
+    if 'host' in proxy_conf:
+        # We have started the proxy by connecting directly to the host
+        if 'username' not in proxy_conf:
+            log.critical('No \'username\' key found in pillar for this proxy.')
+            return False
+        if 'passwords' not in proxy_conf:
+            log.critical('No \'passwords\' key found in pillar for this proxy.')
+            return False
+        host = proxy_conf['host']
+
+        # Get the correct login details
+        try:
+            username, password = find_credentials(host)
+        except excs.SaltSystemExit as err:
+            log.critical('Error: {0}'.format(err))
+            return False
+
+        # Set configuration details
+        DETAILS['host'] = host
+        DETAILS['username'] = username
+        DETAILS['password'] = password
+        DETAILS['protocol'] = proxy_conf.get('protocol')
+        DETAILS['port'] = proxy_conf.get('port')
+        return True
+
+    if 'vcenter' in proxy_conf:
+        vcenter = proxy_conf['vcenter']
+        if not proxy_conf.get('esxi_host'):
+            log.critical('No \'esxi_host\' key found in pillar for this proxy.')
+        DETAILS['esxi_host'] = proxy_conf['esxi_host']
+        # We have started the proxy by connecting via the vCenter
+        if 'mechanism' not in proxy_conf:
+            log.critical('No \'mechanism\' key found in pillar for this proxy.')
+            return False
+        mechanism  = proxy_conf['mechanism']
+        # Save mandatory fields in cache
+        for key in ('vcenter', 'mechanism'):
+            DETAILS[key] = proxy_conf[key]
+
+        if mechanism == 'userpass':
+            if 'username' not in proxy_conf:
+                log.critical('No \'username\' key found in pillar for this '
+                             'proxy.')
+                return False
+            if not 'passwords' in proxy_conf and \
+                len(proxy_conf['passwords']) > 0:
+
+                log.critical('Mechanism is set to \'userpass\' , but no '
+                             '\'passwords\' key found in pillar for this '
+                             'proxy.')
+                return False
+            for key in ('username', 'passwords'):
+                DETAILS[key] = proxy_conf[key]
+        elif mechanism == 'sspi':
+            if not 'domain' in proxy_conf:
+                log.critical('Mechanism is set to \'sspi\' , but no '
+                             '\'domain\' key found in pillar for this proxy.')
+                return False
+            if not 'principal' in proxy_conf:
+                log.critical('Mechanism is set to \'sspi\' , but no '
+                             '\'principal\' key found in pillar for this '
+                             'proxy.')
+                return False
+            for key in ('domain', 'principal'):
+                DETAILS[key] = proxy_conf[key]
+
+        if mechanism == 'userpass':
+            # Get the correct login details
+            log.debug('Retrieving credentials and testing vCenter connection'
+                      ' for mehchanism \'userpass\'')
+            try:
+                username, password = find_credentials()
+                DETAILS['password'] = password
+            except excs.SaltSystemExit as err:
+                log.critical('Error: {0}'.format(err))
+                return False
+
+    # Save optional
+    DETAILS['protocol'] = proxy_conf.get('protocol', 'https')
+    DETAILS['port'] = proxy_conf.get('port', '443')
+    DETAILS['credstore'] = proxy_conf.get('credstore')
 
 
 def grains():
@@ -358,8 +436,9 @@ def grains_refresh():
 
 def ping():
     '''
-    Check to see if the host is responding. Returns False if the host didn't
-    respond, True otherwise.
+    Returns True if connection is to be done via a vCenter (no connection is attempted).
+    Check to see if the host is responding when connecting directly via an ESXi
+    host.
 
     CLI Example:
 
@@ -367,15 +446,19 @@ def ping():
 
         salt esxi-host test.ping
     '''
-    # find_credentials(DETAILS['host'])
-    try:
-        __salt__['vsphere.system_info'](host=DETAILS['host'],
-                                        username=DETAILS['username'],
-                                        password=DETAILS['password'])
-    except SaltSystemExit as err:
-        log.warning(err)
-        return False
-
+    if DETAILS.get('esxi_host'):
+        return True
+    else:
+        # TODO Check connection if mechanism is SSPI
+        if DETAILS['mechanism'] == 'userpass':
+            find_credentials(DETAILS['host'])
+            try:
+                __salt__['vsphere.system_info'](host=DETAILS['host'],
+                                                username=DETAILS['username'],
+                                                password=DETAILS['password'])
+            except excs.SaltSystemExit as err:
+                log.warning(err)
+                return False
     return True
 
 
@@ -461,3 +544,14 @@ def _grains(host, protocol=None, port=None):
                                           port=port)
     GRAINS_CACHE.update(ret)
     return GRAINS_CACHE
+
+
+def is_connected_via_vcenter():
+    return True if 'vcenter' in DETAILS else False
+
+
+def get_details():
+    '''
+    Return the proxy details
+    '''
+    return DETAILS

--- a/salt/proxy/esxi.py
+++ b/salt/proxy/esxi.py
@@ -405,7 +405,7 @@ def init(opts):
             log.debug('Retrieving credentials and testing vCenter connection'
                       ' for mehchanism \'userpass\'')
             try:
-                username, password = find_credentials()
+                username, password = find_credentials(DETAILS['vcenter'])
                 DETAILS['password'] = password
             except SaltSystemExit as err:
                 log.critical('Error: {0}'.format(err))

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -117,7 +117,7 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 try:
-    from pyVmomi import vim, vmodl, VmomiSupport
+    from pyVmomi import VmomiSupport
 
     # We check the supported vim versions to infer the pyVmomi version
     if 'vim25/6.0' in VmomiSupport.versionMap and \
@@ -1122,7 +1122,7 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
         capacity_disk_ids = []
         capacity_disk_displays = []
         for scsi_addr in dg['capacity_scsi_addrs']:
-            if not scsi_addr in scsi_addr_to_disk_map:
+            if scsi_addr not in scsi_addr_to_disk_map:
                 bad_scsi_addrs.append(scsi_addr)
                 continue
             capacity_disk_ids.append(scsi_addr_to_disk_map[scsi_addr]['id'])
@@ -1153,7 +1153,7 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
                                                    capacity_disk_displays])))
                 else:
                     # Erase disk group disks
-                    for disk_id in ([cache_disk_id] + capacity_disk_ids):
+                    for disk_id in [cache_disk_id] + capacity_disk_ids:
                         __salt__['vsphere.erase_disk_partitions'](
                             disk_id=disk_id, service_instance=si)
                     comments.append('Erased disks of diskgroup #{0}; '
@@ -1287,9 +1287,9 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
     __salt__['vsphere.disconnect'](si)
 
     #Build the final return message
-    result = (True if not (changes or errors) else # no changes/errors
-              None if __opts__['test'] else # running in test mode
-              False if errors else True) # found errors; defaults to True
+    result = (True if not (changes or errors) else  # no changes/errors
+              None if __opts__['test'] else  # running in test mode
+              False if errors else True)  # found errors; defaults to True
     ret.update({'result': result,
                 'comment': '\n'.join(comments)})
     if changes:
@@ -1385,7 +1385,7 @@ def host_cache_configured(name, enabled, datastore, swap_size='100%',
              '\'{0}\''.format(hostname))
     ret = {'name': hostname, 'comment': 'Default comments',
            'result': None, 'changes': {}, 'pchanges': {}}
-    result = None if __opts__['test'] else True #We assume success
+    result = None if __opts__['test'] else True  # We assume success
     needs_setting = False
     comments = []
     changes = {}
@@ -1518,7 +1518,6 @@ def host_cache_configured(name, enabled, datastore, swap_size='100%',
             log.trace('existing_datastore = {0}'.format(existing_datastore))
             log.info(comments[-1])
 
-
         if existing_datastore:
             # The following comparisons can be done if the existing_datastore
             # is set; it may not be set if running in test mode
@@ -1533,22 +1532,21 @@ def host_cache_configured(name, enabled, datastore, swap_size='100%',
             else:
                 raw_size_MiB = swap_size_value * 1024
             log.trace('raw_size = {0}MiB'.format(raw_size_MiB))
-            swap_size_MiB= int(raw_size_MiB/1024)*1024
+            swap_size_MiB = int(raw_size_MiB/1024)*1024
             log.trace('adjusted swap_size = {0}MiB'.format(swap_size_MiB))
             existing_swap_size_MiB = 0
-            m = re.match('(\d+)MiB', host_cache.get('swap_size')) if \
+            m = re.match(r'(\d+)MiB', host_cache.get('swap_size')) if \
                     host_cache.get('swap_size') else None
             if m:
                 # if swap_size from the host is set and has an expected value
                 # we are going to parse it to get the number of MiBs
                 existing_swap_size_MiB = int(m.group(1))
-            if not (existing_swap_size_MiB == swap_size_MiB):
+            if not existing_swap_size_MiB == swap_size_MiB:
                 needs_setting = True
                 changes.update(
                     {'swap_size':
                      {'old': '{}GiB'.format(existing_swap_size_MiB/1024),
                       'new': '{}GiB'.format(swap_size_MiB/1024)}})
-
 
         if needs_setting:
             if __opts__['test']:

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -101,7 +101,8 @@ import re
 from salt.ext import six
 import salt.utils.files
 from salt.exceptions import CommandExecutionError, InvalidConfigError, \
-        VMwareObjectRetrievalError, VMwareSaltError, VMwareApiError
+        VMwareObjectRetrievalError, VMwareSaltError, VMwareApiError, \
+        ArgumentValueError
 from salt.utils.decorators import depends
 from salt.config.schemas.esxi import DiskGroupsDiskScsiAddressSchema, \
         HostCacheSchema
@@ -1414,7 +1415,6 @@ def host_cache_configured(name, enabled, datastore, swap_size='100%',
             changes.update({'enabled': {'old': host_cache['enabled'],
                                         'new': enabled}})
             needs_setting = True
-
 
         # Check datastores
         existing_datastores = None

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -1909,7 +1909,7 @@ def get_datastores(service_instance, reference, datastore_names=None,
                 'is set'.format(reference.__class__.__name__))
     if (not get_all_datastores) and backing_disk_ids:
         # At this point we know the reference is a vim.HostSystem
-        log.debug('Filtering datastores with backing disk ids: {}'
+        log.trace('Filtering datastores with backing disk ids: {}'
                   ''.format(backing_disk_ids))
         storage_system = get_storage_system(service_instance, reference,
                                             obj_name)
@@ -1925,11 +1925,11 @@ def get_datastores(service_instance, reference, datastore_names=None,
                 # Skip volume if it doesn't contain an extent with a
                 # canonical name of interest
                 continue
-            log.debug('Found datastore \'{0}\' for disk id(s) \'{1}\''
+            log.trace('Found datastore \'{0}\' for disk id(s) \'{1}\''
                       ''.format(vol.name,
                                 [e.diskName for e in vol.extent]))
             disk_datastores.append(vol.name)
-        log.debug('Datastore found for disk filter: {}'
+        log.trace('Datastore found for disk filter: {}'
                   ''.format(disk_datastores))
         if datastore_names:
             datastore_names.extend(disk_datastores)

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -2006,7 +2006,7 @@ def rename_datastore(datastore_ref, new_datastore_name):
         New datastore name
     '''
     ds_name = get_managed_object_name(datastore_ref)
-    log.debug('Renaming datastore \'{0}\' to '
+    log.trace('Renaming datastore \'{0}\' to '
               '\'{1}\''.format(ds_name, new_datastore_name))
     try:
         datastore_ref.RenameDatastore(new_datastore_name)

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -2048,6 +2048,30 @@ def get_storage_system(service_instance, host_ref, hostname=None):
     return objs[0]['object']
 
 
+def _get_partition_info(storage_system, device_path):
+    '''
+    Returns partition informations for a device path, of type
+    vim.HostDiskPartitionInfo
+    '''
+    try:
+        partition_infos = \
+                storage_system.RetrieveDiskPartitionInfo(
+                    devicePath=[device_path])
+    except vim.fault.NoPermission as exc:
+        log.exception(exc)
+        raise salt.exceptions.VMwareApiError(
+            'Not enough permissions. Required privilege: '
+            '{0}'.format(exc.privilegeId))
+    except vim.fault.VimFault as exc:
+        log.exception(exc)
+        raise salt.exceptions.VMwareApiError(exc.msg)
+    except vmodl.RuntimeFault as exc:
+        log.exception(exc)
+        raise salt.exceptions.VMwareRuntimeError(exc.msg)
+    log.trace('partition_info = {0}'.format(partition_infos[0]))
+    return partition_infos[0]
+
+
 def get_hosts(service_instance, datacenter_name=None, host_names=None,
               cluster_name=None, get_all_hosts=False):
     '''

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -2473,7 +2473,7 @@ def get_scsi_address_to_lun_map(host_ref, storage_system=None, hostname=None):
     luns_to_key_map = {d.key: d for d in
                        get_all_luns(host_ref, storage_system, hostname)}
     return {scsi_addr: luns_to_key_map[lun_key] for scsi_addr, lun_key in
-            lun_ids_to_six.iteritems(scsi_addr_map)}
+            six.iteritems(lun_ids_to_scsi_addr_map)}
 
 
 def get_disks(host_ref, disk_ids=None, scsi_addresses=None,
@@ -2698,9 +2698,9 @@ def get_diskgroups(host_ref, cache_disk_ids=None, get_all_disk_groups=False):
     vsan_disk_mappings = vsan_storage_info.diskMapping
     if not vsan_disk_mappings:
         return []
-    disk_groups =  [dm for dm in vsan_disk_mappings if
-                    (get_all_disk_groups or
-                     (dm.ssd.canonicalName in cache_disk_ids))]
+    disk_groups = [dm for dm in vsan_disk_mappings if
+                   (get_all_disk_groups or
+                    (dm.ssd.canonicalName in cache_disk_ids))]
     log.trace('Retrieved disk groups on host \'{0}\', with cache disk ids : '
               '{1}'.format(hostname,
                            [d.ssd.canonicalName for d in disk_groups]))

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -2445,6 +2445,35 @@ def get_all_luns(host_ref, storage_system=None, hostname=None):
     return []
 
 
+def get_scsi_address_to_lun_map(host_ref, storage_system=None, hostname=None):
+    '''
+    Returns a map of all vim.ScsiLun objects on a ESXi host keyed by their
+    scsi address
+
+    host_ref
+        The vim.HostSystem object representing the host that contains the
+        requested disks.
+
+    storage_system
+        The host's storage system. Default is None.
+
+    hostname
+        Name of the host. This argument is optional.
+    '''
+    if not hostname:
+        hostname = get_managed_object_name(host_ref)
+    si = get_service_instance_from_managed_object(host_ref, name=hostname)
+    if not storage_system:
+        storage_system = get_storage_system(si, host_ref, hostname)
+    lun_ids_to_scsi_addr_map = \
+            _get_scsi_address_to_lun_key_map(si, host_ref, storage_system,
+                                             hostname)
+    luns_to_key_map = {d.key: d for d in
+                       get_all_luns(host_ref, storage_system, hostname)}
+    return {scsi_addr: luns_to_key_map[lun_key] for scsi_addr, lun_key in
+            lun_ids_to_scsi_addr_map.iteritems()}
+
+
 def list_hosts(service_instance):
     '''
     Returns a list of hosts associated with a given service instance.

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -2196,6 +2196,37 @@ def create_vmfs_datastore(host_ref, datastore_name, disk_ref,
     return ds_ref
 
 
+def get_host_datastore_system(host_ref, hostname=None):
+    '''
+    Returns a host's datastore system
+
+    host_ref
+        Reference to the ESXi host
+
+    hostname
+        Name of the host. This argument is optional.
+    '''
+
+    if not hostname:
+        hostname = get_managed_object_name(host_ref)
+    service_instance = get_service_instance_from_managed_object(host_ref)
+    traversal_spec = vmodl.query.PropertyCollector.TraversalSpec(
+        path='configManager.datastoreSystem',
+        type=vim.HostSystem,
+        skip=False)
+    objs = get_mors_with_properties(service_instance,
+                                    vim.HostDatastoreSystem,
+                                    property_list=['datastore'],
+                                    container_ref=host_ref,
+                                    traversal_spec=traversal_spec)
+    if not objs:
+        raise salt.exceptions.VMwareObjectRetrievalError(
+            'Host\'s \'{0}\' datastore system was not retrieved'
+            ''.format(hostname))
+    log.trace('[{0}] Retrieved datastore system'.format(hostname))
+    return objs[0]['object']
+
+
 def get_hosts(service_instance, datacenter_name=None, host_names=None,
               cluster_name=None, get_all_hosts=False):
     '''

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -2471,7 +2471,7 @@ def get_scsi_address_to_lun_map(host_ref, storage_system=None, hostname=None):
     luns_to_key_map = {d.key: d for d in
                        get_all_luns(host_ref, storage_system, hostname)}
     return {scsi_addr: luns_to_key_map[lun_key] for scsi_addr, lun_key in
-            lun_ids_to_scsi_addr_map.iteritems()}
+            lun_ids_to_six.iteritems(scsi_addr_map)}
 
 
 def get_disks(host_ref, disk_ids=None, scsi_addresses=None,
@@ -2513,8 +2513,9 @@ def get_disks(host_ref, disk_ids=None, scsi_addresses=None,
         lun_key_by_scsi_addr = _get_scsi_address_to_lun_key_map(si, host_ref,
                                                                 storage_system,
                                                                 hostname)
-        disk_keys = [key for scsi_addr, key in lun_key_by_scsi_addr.iteritems()
-                     if scsi_addr in  scsi_addresses]
+        disk_keys = [key for scsi_addr, key
+                     in six.iteritems(lun_key_by_scsi_addr)
+                     if scsi_addr in scsi_addresses]
         log.trace('disk_keys based on scsi_addresses = {0}'.format(disk_keys))
 
     scsi_luns = get_all_luns(host_ref, storage_system)
@@ -2695,8 +2696,8 @@ def get_diskgroups(host_ref, cache_disk_ids=None, get_all_disk_groups=False):
     vsan_disk_mappings = vsan_storage_info.diskMapping
     if not vsan_disk_mappings:
         return []
-    disk_groups =  [dm for dm in vsan_disk_mappings if \
-                    (get_all_disk_groups or \
+    disk_groups =  [dm for dm in vsan_disk_mappings if
+                    (get_all_disk_groups or
                      (dm.ssd.canonicalName in cache_disk_ids))]
     log.trace('Retrieved disk groups on host \'{0}\', with cache disk ids : '
               '{1}'.format(hostname,

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -2704,6 +2704,27 @@ def get_diskgroups(host_ref, cache_disk_ids=None, get_all_disk_groups=False):
     return disk_groups
 
 
+def _check_disks_in_diskgroup(disk_group, cache_disk_id, capacity_disk_ids):
+    '''
+    Checks that the disks in a disk group are as expected and raises
+    CheckError exceptions if the check fails
+    '''
+    if not disk_group.ssd.canonicalName == cache_disk_id:
+        raise salt.exceptions.ArgumentValueError(
+            'Incorrect diskgroup cache disk; got id: \'{0}\'; expected id: '
+            '\'{1}\''.format(disk_group.ssd.canonicalName, cache_disk_id))
+    if sorted([d.canonicalName for d in disk_group.nonSsd]) != \
+        sorted(capacity_disk_ids):
+
+        raise salt.exceptions.ArgumentValueError(
+            'Incorrect capacity disks; got ids: \'{0}\'; expected ids: \'{1}\''
+            ''.format(sorted([d.canonicalName for d in disk_group.nonSsd]),
+                      sorted(capacity_disk_ids)))
+    log.trace('Checked disks in diskgroup with cache disk id \'{0}\''
+              ''.format(cache_disk_id))
+    return True
+
+
 def list_hosts(service_instance):
     '''
     Returns a list of hosts associated with a given service instance.

--- a/salt/utils/vsan.py
+++ b/salt/utils/vsan.py
@@ -49,7 +49,8 @@ import logging
 import ssl
 
 # Import Salt Libs
-from salt.exceptions import VMwareApiError, VMwareRuntimeError
+from salt.exceptions import VMwareApiError, VMwareRuntimeError, \
+        VMwareObjectRetrievalError
 import salt.utils.vmware
 
 try:
@@ -282,7 +283,7 @@ def add_capacity_to_diskgroup(service_instance, vsan_disk_mgmt_system,
     spec.host = host_ref
     try:
         task = vsan_disk_mgmt_system.InitializeDiskMappings(spec)
-    except fault.NoPermission as exc:
+    except vim.fault.NoPermission as exc:
         log.exception(exc)
         raise VMwareApiError('Not enough permissions. Required privilege: '
                              '{0}'.format(exc.privilegeId))

--- a/salt/utils/vsan.py
+++ b/salt/utils/vsan.py
@@ -129,6 +129,30 @@ def get_vsan_cluster_config_system(service_instance):
     return vc_mos['vsan-cluster-config-system']
 
 
+def get_vsan_disk_management_system(service_instance):
+    '''
+    Returns a vim.VimClusterVsanVcDiskManagementSystem object
+
+    service_instance
+        Service instance to the host or vCenter
+    '''
+
+    #TODO Replace when better connection mechanism is available
+
+    #For python 2.7.9 and later, the defaul SSL conext has more strict
+    #connection handshaking rule. We may need turn of the hostname checking
+    #and client side cert verification
+    context = None
+    if sys.version_info[:3] > (2, 7, 8):
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+
+    stub = service_instance._stub
+    vc_mos = vsanapiutils.GetVsanVcMos(stub, context=context)
+    return vc_mos['vsan-disk-management-system']
+
+
 def get_cluster_vsan_info(cluster_ref):
     '''
     Returns the extended cluster vsan configuration object

--- a/salt/utils/vsan.py
+++ b/salt/utils/vsan.py
@@ -153,6 +153,35 @@ def get_vsan_disk_management_system(service_instance):
     return vc_mos['vsan-disk-management-system']
 
 
+def get_host_vsan_system(service_instance, host_ref, hostname=None):
+    '''
+    Returns a host's vsan system
+
+    service_instance
+        Service instance to the host or vCenter
+
+    host_ref
+        Refernce to ESXi host
+
+    hostname
+        Name of ESXi host. Default value is None.
+    '''
+    if not hostname:
+        hostname = salt.utils.vmware.get_managed_object_name(host_ref)
+    traversal_spec = vmodl.query.PropertyCollector.TraversalSpec(
+        path='configManager.vsanSystem',
+        type=vim.HostSystem,
+        skip=False)
+    objs = salt.utils.vmware.get_mors_with_properties(
+        service_instance, vim.HostVsanSystem, property_list=['config.enabled'],
+        container_ref=host_ref, traversal_spec=traversal_spec)
+    if not objs:
+        raise VMwareObjectRetrievalError('Host\'s \'{0}\' VSAN system was '
+                                         'not retrieved'.format(hostname))
+    log.trace('[{0}] Retrieved VSAN system'.format(hostname))
+    return objs[0]['object']
+
+
 def get_cluster_vsan_info(cluster_ref):
     '''
     Returns the extended cluster vsan configuration object

--- a/tests/unit/utils/vmware/test_host.py
+++ b/tests/unit/utils/vmware/test_host.py
@@ -14,6 +14,7 @@ from tests.support.unit import TestCase, skipIf
 from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
 
 # Import Salt libraries
+from salt.exceptions import ArgumentValueError
 import salt.utils.vmware
 # Import Third Party Libs
 try:
@@ -46,13 +47,22 @@ class GetHostsTestCase(TestCase):
         self.mock_host1, self.mock_host2, self.mock_host3 = MagicMock(), \
                 MagicMock(), MagicMock()
         self.mock_prop_host1 = {'name': 'fake_hostname1',
-                            'object': self.mock_host1}
+                                'object': self.mock_host1}
         self.mock_prop_host2 = {'name': 'fake_hostname2',
-                            'object': self.mock_host2}
+                                'object': self.mock_host2}
         self.mock_prop_host3 = {'name': 'fake_hostname3',
-                            'object': self.mock_host3}
+                                'object': self.mock_host3}
         self.mock_prop_hosts = [self.mock_prop_host1, self.mock_prop_host2,
                                 self.mock_prop_host3]
+
+    def test_cluster_no_datacenter(self):
+        with self.assertRaises(ArgumentValueError) as excinfo:
+            salt.utils.vmware.get_hosts(self.mock_si,
+                                        cluster_name='fake_cluster')
+        self.assertEqual(excinfo.exception.strerror,
+                         'Must specify the datacenter when specifying the '
+                         'cluster')
+
 
     def test_get_si_no_datacenter_no_cluster(self):
         mock_get_mors = MagicMock()
@@ -124,23 +134,20 @@ class GetHostsTestCase(TestCase):
         self.assertEqual(res, [])
 
     def test_filter_cluster(self):
-        cluster1 = vim.ClusterComputeResource('fake_good_cluster')
-        cluster2 = vim.ClusterComputeResource('fake_bad_cluster')
-        # Mock cluster1.name and cluster2.name
-        cluster1._stub = MagicMock(InvokeAccessor=MagicMock(
-            return_value='fake_good_cluster'))
-        cluster2._stub = MagicMock(InvokeAccessor=MagicMock(
-            return_value='fake_bad_cluster'))
-        self.mock_prop_host1['parent'] = cluster2
-        self.mock_prop_host2['parent'] = cluster1
-        self.mock_prop_host3['parent'] = cluster1
+        self.mock_prop_host1['parent'] = vim.ClusterComputeResource('cluster')
+        self.mock_prop_host2['parent'] = vim.ClusterComputeResource('cluster')
+        self.mock_prop_host3['parent'] = vim.Datacenter('dc')
+        mock_get_cl_name = MagicMock(
+            side_effect=['fake_bad_cluster', 'fake_good_cluster'])
         with patch('salt.utils.vmware.get_mors_with_properties',
                    MagicMock(return_value=self.mock_prop_hosts)):
-            res = salt.utils.vmware.get_hosts(self.mock_si,
-                                              datacenter_name='fake_datacenter',
-                                              cluster_name='fake_good_cluster',
-                                              get_all_hosts=True)
-        self.assertEqual(res, [self.mock_host2, self.mock_host3])
+            with patch('salt.utils.vmware.get_managed_object_name',
+                       mock_get_cl_name):
+                res = salt.utils.vmware.get_hosts(
+                    self.mock_si, datacenter_name='fake_datacenter',
+                    cluster_name='fake_good_cluster', get_all_hosts=True)
+        self.assertEqual(mock_get_cl_name.call_count, 2)
+        self.assertEqual(res, [self.mock_host2])
 
     def test_no_hosts(self):
         with patch('salt.utils.vmware.get_mors_with_properties',

--- a/tests/unit/utils/vmware/test_host.py
+++ b/tests/unit/utils/vmware/test_host.py
@@ -63,7 +63,6 @@ class GetHostsTestCase(TestCase):
                          'Must specify the datacenter when specifying the '
                          'cluster')
 
-
     def test_get_si_no_datacenter_no_cluster(self):
         mock_get_mors = MagicMock()
         mock_get_root_folder = MagicMock(return_value=self.mock_root_folder)


### PR DESCRIPTION
### What does this PR do?

This PR adds the ability to:
- add/manage VSAN diskgroups on ESXi hosts either via the `diskgroup_configured` state or via execution functions.
- add capacity disks to diskgroups (done automatically by the `diskgroup_configured` state)
- create VMFS datastores and assign them host caches on the ESXi hosts; the host caches can have a fixed size or a percentage of capacity of the backing datastores
- remove capacity disks from diskgroups, entire diskgroups, datastores or erase partitions on disks via execution functions only (state functions don't allow that)

Proxy functions:

- Added ability to esxi proxy to connect via the vCenter (not only directly to the ESXi host) - it requres a slightly different `proxy` config key

Utils functions:

- salt.utils.vsan.get_vsan_disk_management_system
- salt.utils.vsan.get_host_vsan_system
- salt.utils.vsan.create_diskgroup
- salt.utils.vsan.add_capacity_to_diskgroup
- salt.utils.vsan.remove_capacity_from_diskgroup
- salt.utils.vsan.remove_diskgroup
- salt.utils.vmware._get_partition_info
- salt.utils.vmware._get_new_computed_partition_spec
- salt.utils.vmware.create_vmfs_datastore
- salt.utils.vmware.get_host_datastore_system
- salt.utils.vmware.remove_datastore
- Improved logic to filter hosts based on parent in salt.utils.vmware.get_hosts
- salt.utils.vmware._get_scsi_address_to_lun_key_map
- salt.utils.vmware.get_all_luns
- salt.utils.vmware.get_scsi_address_to_lun_map
- salt.utils.vmware.get_disks
- salt.utils.vmware.get_disk_partition_info
- salt.utils.vmware.erase_disk_partitions
- salt.utils.get_diskgroups
- salt.utils._check_disks_in_diskgroup
- salt.utils.vmware.get_host_cache
- salt.utils.vmware.configure_host_cache

Execution functions: 

- salt.modules.list_hosts_via_proxy
- salt.modules.vsphere._get_proxy_target
- salt.modules.vsphere.list_disks
- salt.modules.vsphere.erase_disk_partitions
- salt.modules.vsphere.list_disk_partitions
- salt.modules.vsphere.list_diskgroups
- salt.modules.vsphere.create_diskgroup
- salt.modules.vsphere.add_capacity_to_diskgroup
- salt.modules.vsphere.remove_capacity_from_diskgroup
- salt.modules.vsphere.remove_diskgroup
- salt.modules.vsphere.get_host_cache
- salt.modules.vsphere.configure_host_cache
- salt.modules.vsphere.create_vmfs_datastore
- salt.modules.vsphere.remove_datastore

State functions:

- salt.states.esxi additional imports and pyVmomi/python compatibility check
- diskgroups_configured state that configures VSAN diskgroups on ESXi hosts
- host_cache_configured state that configures the host cache on ESXi hosts

### Tests written?

No (will add unit tests in the next PRs - I wanted to get the main code merged in)

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
