### PR TITLE
Fix DeprecationWarning for use of 'salt.utils.is_windows'

### DIFF
--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -83,7 +83,7 @@ def __virtual__():
     return False, 'python kubernetes library not found'
 
 
-if not salt.utils.is_windows():
+if not salt.utils.platform.is_windows():
     @contextmanager
     def _time_limit(seconds):
         def signal_handler(signum, frame):
@@ -713,7 +713,7 @@ def delete_deployment(name, namespace='default', **kwargs):
             namespace=namespace,
             body=body)
         mutable_api_response = api_response.to_dict()
-        if not salt.utils.is_windows():
+        if not salt.utils.platform.is_windows():
             try:
                 with _time_limit(POLLING_TIME_LIMIT):
                     while show_deployment(name, namespace) is not None:

--- a/tests/unit/modules/test_hosts.py
+++ b/tests/unit/modules/test_hosts.py
@@ -94,7 +94,7 @@ class HostsTestCase(TestCase, LoaderModuleMockMixin):
         Tests true if the alias is set
         '''
         hosts_file = '/etc/hosts'
-        if salt.utils.is_windows():
+        if salt.utils.platform.is_windows():
             hosts_file = r'C:\Windows\System32\Drivers\etc\hosts'
 
         with patch('salt.modules.hosts.__get_hosts_filename',
@@ -198,7 +198,7 @@ class HostsTestCase(TestCase, LoaderModuleMockMixin):
         Tests if specified host entry gets added from the hosts file
         '''
         hosts_file = '/etc/hosts'
-        if salt.utils.is_windows():
+        if salt.utils.platform.is_windows():
             hosts_file = r'C:\Windows\System32\Drivers\etc\hosts'
 
         with patch('salt.utils.files.fopen', mock_open()), \

--- a/tests/unit/returners/test_local_cache.py
+++ b/tests/unit/returners/test_local_cache.py
@@ -97,7 +97,7 @@ class LocalCacheCleanOldJobsTestCase(TestCase, LoaderModuleMockMixin):
         local_cache.clean_old_jobs()
 
         # Get the name of the JID directory that was created to test against
-        if salt.utils.is_windows():
+        if salt.utils.platform.is_windows():
             jid_dir_name = jid_dir.rpartition('\\')[2]
         else:
             jid_dir_name = jid_dir.rpartition('/')[2]


### PR DESCRIPTION
### What does this PR do?

Fix some instances where this warning was missed

    [WARNING ] __init__.py:2618: DeprecationWarning: Use of 'salt.utils.is_windows' detected.
    This function has been moved to 'salt.utils.platform.is_windows' as of Salt Oxygen.
    This warning will be removed in Salt Neon.
