### PR TITLE
Fix some regressions in recent legacy git_pillar deprecation

### DIFF
--- a/tests/support/gitfs.py
+++ b/tests/support/gitfs.py
@@ -341,7 +341,8 @@ class GitPillarTestBase(GitTestBase, LoaderModuleMockMixin):
         with patch.dict(git_pillar.__opts__, ext_pillar_opts):
             return git_pillar.ext_pillar(
                 'minion',
-                ext_pillar_opts['ext_pillar'][0]['git'],
+                {},
+                *ext_pillar_opts['ext_pillar'][0]['git']
             )
 
     def make_repo(self, root_dir, user='root'):


### PR DESCRIPTION
These didn't get caught in #42823 because of how we invoke the git_pillar code in integration tests. Firstly, the "pillar" argument needed to stay. This is because even though we're not using it, _external_pillar_data() is still passing it now that git_pillar is not specially invoked there.  Secondly, since the input comes in as a list, and _external_pillar_data uses single-asterisk expansion, the repos are passed separately when they should be passed as a single list. To fix these issues, I've done the following:

1. Re-introduced the "pillar" argument in git_pillar's ext_pillar function.
2. Changed the "pillar" variable to avoid confusion with the (unused) "pillar" argument being passed in.
3. Instead of git_pillar accepting the repos as a list, the ext_pillar function now uses single-asterisk expansion to make it conform with how _external_pillar_data() invokes it.