### PR TITLE
Skip `unit.modules.test_snapper` on Windows

### DIFF
--- a/tests/unit/modules/test_snapper.py
+++ b/tests/unit/modules/test_snapper.py
@@ -141,6 +141,7 @@ MODULE_RET = {
 }
 
 
+@skipIf(sys.platform.startswith('win'), 'Snapper not available on Windows')
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class SnapperTestCase(TestCase, LoaderModuleMockMixin):
 


### PR DESCRIPTION
### What does this PR do?
Skips `unit.modules.test_snapper` on Windows

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes