### PR TITLE
Fix Pylint deprecated option warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -255,8 +255,8 @@ ignore-imports=no
 
 
 [BASIC]
-# Required attributes for module, separated by a comma
-required-attributes=
+# Required attributes for module, separated by a comma (will be removed in Pylint 2.0)
+#required-attributes=
 
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter,apply,input
@@ -362,7 +362,8 @@ spelling-store-unknown-words=no
 [CLASSES]
 # List of interface methods to ignore, separated by a comma. This is used for
 # instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+# Will be removed in Pylint 2.0
+#ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp


### PR DESCRIPTION
### What does this PR do?
It stops Pylint complaining about deprecated options `required-attributes` and `ignore-iface-methods`.
Since they are defined with default values, it's safe just to comment them out.

### Previous Behavior
```
$ pylint --version
This option u'ignore-iface-methods' will be removed in Pylint 2.0This option u'required-attributes' will be removed in Pylint 2.0pylint 1.6.5, 
astroid 1.4.9
Python 2.7.13 (default, Jan 19 2017, 14:48:08) 
[GCC 6.3.0 20170118]
```

### New Behavior
Everything's clean.

