### PR TITLE
Fix `unit.modules.test_status` for Windows

### DIFF
--- a/tests/unit/modules/test_status.py
+++ b/tests/unit/modules/test_status.py
@@ -2,6 +2,7 @@
 
 # Import Python libs
 from __future__ import absolute_import
+import os
 
 # Import Salt Libs
 import salt.utils
@@ -78,8 +79,9 @@ class StatusTestCase(TestCase, LoaderModuleMockMixin):
                             is_darwin=MagicMock(return_value=False),
                             is_freebsd=MagicMock(return_value=False),
                             is_openbsd=MagicMock(return_value=False),
-                            is_netbsd=MagicMock(return_value=False)):
-            with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value="1\n2\n3")}):
+                            is_netbsd=MagicMock(return_value=False),
+                            which=MagicMock(return_value=True)):
+            with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(['1', '2', '3']))}):
                 with patch('time.time', MagicMock(return_value=m.now)):
                     with patch('os.path.exists', MagicMock(return_value=True)):
                         proc_uptime = '{0} {1}'.format(m.ut, m.idle)
@@ -103,9 +105,10 @@ class StatusTestCase(TestCase, LoaderModuleMockMixin):
                             is_darwin=MagicMock(return_value=False),
                             is_freebsd=MagicMock(return_value=False),
                             is_openbsd=MagicMock(return_value=False),
-                            is_netbsd=MagicMock(return_value=False)):
+                            is_netbsd=MagicMock(return_value=False),
+                            which=MagicMock(return_value=True)):
 
-            with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value="1\n2\n3"),
+            with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(['1', '2', '3'])),
                                               'cmd.run_all': MagicMock(return_value=m2.ret)}):
                 with patch('time.time', MagicMock(return_value=m.now)):
                     ret = status.uptime()
@@ -125,8 +128,9 @@ class StatusTestCase(TestCase, LoaderModuleMockMixin):
                             is_darwin=MagicMock(return_value=True),
                             is_freebsd=MagicMock(return_value=False),
                             is_openbsd=MagicMock(return_value=False),
-                            is_netbsd=MagicMock(return_value=False)):
-            with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value="1\n2\n3"),
+                            is_netbsd=MagicMock(return_value=False),
+                            which=MagicMock(return_value=True)):
+            with patch.dict(status.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(['1', '2', '3'])),
                                               'sysctl.get': MagicMock(return_value=kern_boottime)}):
                 with patch('time.time', MagicMock(return_value=m.now)):
                     ret = status.uptime()


### PR DESCRIPTION
### What does this PR do?
Fixes `unit.modules.test_status` for Windows. Mocks the `salt.utils.which` for `who` and uses `os.linesep` to create the return for `cmd.run`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes