### PR TITLE
Fix `unit.modules.test_win_service`

### DIFF
--- a/tests/unit/modules/test_win_service.py
+++ b/tests/unit/modules/test_win_service.py
@@ -143,14 +143,14 @@ class WinServiceTestCase(TestCase, LoaderModuleMockMixin):
                                            {'Status': 'Stop Pending'},
                                            {'Status': 'Stopped'}])
 
-        with patch.object(win_service, 'status', mock_false):
+        with patch.dict(win_service.__salt__, {'cmd.run': MagicMock(return_value="service was stopped")}):
             self.assertTrue(win_service.stop('spongebob'))
 
-        with patch.object(win_service, 'status', mock_true):
-            with patch.object(win32serviceutil, 'StopService', mock_true):
-                with patch.object(win_service, 'info', mock_info):
-                    with patch.object(win_service, 'status', mock_false):
-                        self.assertTrue(win_service.stop('spongebob'))
+        with patch.dict(win_service.__salt__, {'cmd.run': MagicMock(return_value="service was stopped")}), \
+                patch.object(win32serviceutil, 'StopService', mock_true), \
+                patch.object(win_service, 'info', mock_info), \
+                patch.object(win_service, 'status', mock_false):
+            self.assertTrue(win_service.stop('spongebob'))
 
     def test_restart(self):
         '''


### PR DESCRIPTION
Mock `cmd.run`

### What does this PR do?
Mocks the return of `cmd.run`
Removes unnecessary `win_service.status` mock

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes