### PR TITLE
Fix `unit.modules.test_znc` for Windows

### DIFF
--- a/tests/unit/modules/test_znc.py
+++ b/tests/unit/modules/test_znc.py
@@ -54,7 +54,8 @@ class ZncTestCase(TestCase, LoaderModuleMockMixin):
         Tests write the active configuration state to config file
         '''
         mock = MagicMock(return_value='SALT')
-        with patch.dict(znc.__salt__, {'ps.pkill': mock}):
+        with patch.dict(znc.__salt__, {'ps.pkill': mock}), \
+                patch.object(znc, 'signal', MagicMock()):
             self.assertEqual(znc.dumpconf(), 'SALT')
 
     # 'rehashconf' function tests: 1
@@ -64,7 +65,8 @@ class ZncTestCase(TestCase, LoaderModuleMockMixin):
         Tests rehash the active configuration state from config file
         '''
         mock = MagicMock(return_value='SALT')
-        with patch.dict(znc.__salt__, {'ps.pkill': mock}):
+        with patch.dict(znc.__salt__, {'ps.pkill': mock}), \
+                patch.object(znc, 'signal', MagicMock()):
             self.assertEqual(znc.rehashconf(), 'SALT')
 
     # 'version' function tests: 1


### PR DESCRIPTION
### What does this PR do?
Mock the signal object as it's missing SIGUSR1 and SIGHUP on Windows

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes