### PR TITLE
Fix `unit.modules.test_zypper` for Windows

### DIFF
--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -189,7 +189,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
         }
         with patch.dict('salt.modules.zypper.__salt__', {'cmd.run_all': MagicMock(return_value=ref_out)}):
             with self.assertRaisesRegex(CommandExecutionError,
-                    "^Zypper command failure: Some handled zypper internal error\nAnother zypper internal error$"):
+                    "^Zypper command failure: Some handled zypper internal error{0}Another zypper internal error$".format(os.linesep)):
                 zypper.list_upgrades(refresh=False)
 
         # Test unhandled error


### PR DESCRIPTION
### What does this PR do?
Uses `os.linesep` for newline in expected return

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes