### PR TITLE
Properly merge pillar data when using multiple nodegroups

### DIFF
--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -343,14 +343,15 @@ def ext_pillar(minion_id,
                     if minion_id in match:
                         ngroup_dir = os.path.join(
                             nodegroups_dir, str(nodegroup))
-                        ngroup_pillar.update(
+                        ngroup_pillar = salt.utils.dictupdate.merge(ngroup_pillar,
                             _construct_pillar(ngroup_dir,
                                               follow_dir_links,
                                               keep_newline,
                                               render_default,
                                               renderer_blacklist,
                                               renderer_whitelist,
-                                              template)
+                                              template),
+                            strategy='recurse'
                         )
         else:
             if debug is True:


### PR DESCRIPTION
### What does this PR do?
Properly merges pillar data spread over multiple nodegroups even if top hierarchy is using the same keys.

### What issues does this PR fix or reference?

#43788 

### Previous Behavior
If the key at the top of a nodegroup file hierarchy was the same, only data from one of the files would be put into the minions pillar data, regardless of different. This is due to calling dict.update() only looking at itself,  not recursing into children dict() down the tree.

### New Behavior
Merge a minions pillar data in file_tree/nodegroups recursively using salt.utils.dictupdate.merge(..., strategy="recurse").


### Tests written?
No

