### PR TITLE
External pillar that includes extra minion data in the minion pillar

### DIFF
--- a/salt/pillar/extra_minion_data_in_pillar.py
+++ b/salt/pillar/extra_minion_data_in_pillar.py
@@ -15,13 +15,18 @@ Complete example in etc/salt/master
 
     ext_pillar:
       - extra_minion_data_in_pillar:
-          include: <all>
+          include: *
 
     ext_pillar:
       - extra_minion_data_in_pillar:
           include:
               - key1
               - key2:subkey2
+
+    ext_pillar:
+      - extra_minion_data_in_pillar:
+          include: <all>
+
 '''
 
 
@@ -78,7 +83,7 @@ def ext_pillar(minion_id, pillar, include, extra_minion_data=None):
 
     if not extra_minion_data:
         return {}
-    if include == '<all>':
+    if include in ['*', '<all>']:
         return extra_minion_data
     data = {}
     for key in include:

--- a/salt/pillar/extra_minion_data_in_pillar.py
+++ b/salt/pillar/extra_minion_data_in_pillar.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+'''
+Add all extra minion data to the pillar.
+
+:codeauthor: Alexandru.Bleotu@morganstanley.ms.com
+
+One can filter on the keys to include in the pillar by using the ``include``
+parameter. For subkeys the ':' notation is supported (i.e. 'key:subkey')
+The keyword ``<all>`` includes all keys.
+
+Complete example in etc/salt/master
+=====================================
+
+.. code-block:: yaml
+
+    ext_pillar:
+      - extra_minion_data_in_pillar:
+          include: <all>
+
+    ext_pillar:
+      - extra_minion_data_in_pillar:
+          include:
+              - key1
+              - key2:subkey2
+'''
+
+
+from __future__ import absolute_import
+import os
+import logging
+
+
+# Set up logging
+log = logging.getLogger(__name__)
+
+
+__virtualname__ = 'extra_minion_data_in_pillar'
+
+def __virtual__():
+    return __virtualname__
+
+
+def ext_pillar(minion_id, pillar, include, extra_minion_data=None):
+
+    def get_subtree(key, source_dict):
+        '''
+        Returns a subtree corresponfing to the specified key.
+
+        key
+            Key. Supports the ':' notation (e.g. 'key:subkey')
+
+        source_dict
+            Source dictionary
+        '''
+        ret_dict = aux_dict = {}
+        subtree = source_dict
+        subkeys = key.split(':')
+        # Build an empty intermediate subtree following the subkeys
+        for subkey in subkeys[:-1]:
+            # The result will be built in aux_dict
+            aux_dict[subkey] = {}
+            aux_dict = aux_dict[subkey]
+            if not subkey in subtree:
+                # The subkey is not in
+                return {}
+            subtree = subtree[subkey]
+        if subkeys[-1] not in subtree:
+            # Final subkey is not in subtree
+            return {}
+        # Assign the subtree value to the result
+        aux_dict[subkeys[-1]] = subtree[subkeys[-1]]
+        return ret_dict
+
+    log.trace('minion_id = {0}'.format(minion_id))
+    log.trace('include = {0}'.format(include))
+    log.trace('extra_minion_data = {0}'.format(extra_minion_data))
+    data = {}
+
+    if not extra_minion_data:
+        return {}
+    if include == '<all>':
+        return extra_minion_data
+    data = {}
+    for key in include:
+        data.update(get_subtree(key, extra_minion_data))
+    return data

--- a/salt/pillar/extra_minion_data_in_pillar.py
+++ b/salt/pillar/extra_minion_data_in_pillar.py
@@ -31,15 +31,14 @@ Complete example in etc/salt/master
 
 
 from __future__ import absolute_import
-import os
 import logging
 
 
 # Set up logging
 log = logging.getLogger(__name__)
 
-
 __virtualname__ = 'extra_minion_data_in_pillar'
+
 
 def __virtual__():
     return __virtualname__
@@ -65,7 +64,7 @@ def ext_pillar(minion_id, pillar, include, extra_minion_data=None):
             # The result will be built in aux_dict
             aux_dict[subkey] = {}
             aux_dict = aux_dict[subkey]
-            if not subkey in subtree:
+            if subkey not in subtree:
                 # The subkey is not in
                 return {}
             subtree = subtree[subkey]

--- a/tests/unit/pillar/test_extra_minion_data_in_pillar.py
+++ b/tests/unit/pillar/test_extra_minion_data_in_pillar.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import
+
+# Import Salt Testing libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock
+
+# Import Salt Libs
+from salt.pillar import extra_minion_data_in_pillar
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class ExtraMinionDataInPillarTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.pillar.extra_minion_data_in_pillar
+    '''
+    def setup_loader_modules(self):
+        return {
+            extra_minion_data_in_pillar : {
+                '__virtual__': True,
+            }
+        }
+
+    def setUp(self):
+        self.pillar = MagicMock()
+        self.extra_minion_data = {'key1': {'subkey1': 'value1'},
+                                  'key2': {'subkey2': {'subsubkey2': 'value2'}},
+                                  'key3': 'value3',
+                                  'key4': {'subkey4': 'value4'}}
+
+    def test_extra_values_none_or_empty(self):
+        ret = extra_minion_data_in_pillar.ext_pillar('fake_id', self.pillar,
+                                                     'fake_include', None)
+        self.assertEqual(ret, {})
+        ret = extra_minion_data_in_pillar.ext_pillar('fake_id', self.pillar,
+                                                     'fake_include', {})
+        self.assertEqual(ret, {})
+
+    def test_include_all(self):
+        ret = extra_minion_data_in_pillar.ext_pillar(
+            'fake_id', self.pillar, '<all>', self.extra_minion_data)
+        self.assertEqual(ret, self.extra_minion_data)
+
+    def test_include_specific_keys(self):
+        # Tests partially existing key, key with and without subkey,
+        ret = extra_minion_data_in_pillar.ext_pillar(
+            'fake_id', self.pillar,
+            include=['key1:subkey1', 'key2:subkey3', 'key3', 'key4'],
+            extra_minion_data=self.extra_minion_data)
+        self.assertEqual(ret, {'key1': {'subkey1': 'value1'},
+                               'key3': 'value3',
+                               'key4': {'subkey4': 'value4'}})

--- a/tests/unit/pillar/test_extra_minion_data_in_pillar.py
+++ b/tests/unit/pillar/test_extra_minion_data_in_pillar.py
@@ -40,9 +40,10 @@ class ExtraMinionDataInPillarTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(ret, {})
 
     def test_include_all(self):
-        ret = extra_minion_data_in_pillar.ext_pillar(
-            'fake_id', self.pillar, '<all>', self.extra_minion_data)
-        self.assertEqual(ret, self.extra_minion_data)
+        for include_all in ['*', '<all>']:
+            ret = extra_minion_data_in_pillar.ext_pillar(
+                'fake_id', self.pillar, include_all, self.extra_minion_data)
+            self.assertEqual(ret, self.extra_minion_data)
 
     def test_include_specific_keys(self):
         # Tests partially existing key, key with and without subkey,

--- a/tests/unit/pillar/test_extra_minion_data_in_pillar.py
+++ b/tests/unit/pillar/test_extra_minion_data_in_pillar.py
@@ -19,7 +19,7 @@ class ExtraMinionDataInPillarTestCase(TestCase, LoaderModuleMockMixin):
     '''
     def setup_loader_modules(self):
         return {
-            extra_minion_data_in_pillar : {
+            extra_minion_data_in_pillar: {
                 '__virtual__': True,
             }
         }


### PR DESCRIPTION
### What does this PR do?

Extra minion data can be sent from the minion to provide additional minion specific data to external pillar calls. This `extra_minion_data_in_pillar` external pillar includes the extra data in the pillar.

The external pillar supports an `includes` argument. It's values can be either `<all>` or the specific set of keys to include; `:` notation is supported (e.g `key:subkey`)

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
