### PR TITLE
Properly handle UNC paths in salt.utils.path.readlink()

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -367,6 +367,16 @@ def _file_lists(load, form):
                         'roots: %s symlink destination is %s',
                         abs_path, link_dest
                     )
+                    if salt.utils.is_windows() \
+                            and link_dest.startswith('\\\\'):
+                        # Symlink points to a network path. Since you can't
+                        # join UNC and non-UNC paths, just assume the original
+                        # path.
+                        log.trace(
+                            'roots: %s is a UNCH path, using %s instead',
+                            link_dest, abs_path
+                        )
+                        link_dest = abs_path
                     if link_dest.startswith('..'):
                         joined = os.path.join(abs_path, link_dest)
                     else:

--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 import errno
 import logging
 import os
+import re
 import struct
 
 # Import 3rd-party libs
@@ -110,6 +111,11 @@ def readlink(path):
         # comes out in 8.3 form; convert it to LFN to make it look nicer
         target = win32file.GetLongPathName(target)
     except pywinerror as exc:
+        # If target is on a UNC share, the decoded target will be in the format
+        # "UNC\hostanme\sharename\additional\subdirs\under\share". So, in
+        # these cases, return the target path in the proper UNC path format.
+        if target.startswith('UNC\\'):
+            return re.sub(r'^UNC\\+', r'\\\\', target)
         # if file is not found (i.e. bad symlink), return it anyway like on *nix
         if exc.winerror == 2:
             return target


### PR DESCRIPTION
When unpacking the destination of a symbolic link in Windows, links
which point to UNC paths start with "UNC\" instead of "\\". This causes
win32file.GetLongFileName to raise an exception. This commit modifies
salt.utils.path.readlink() to return the path in the proper UNC format,
and it also updates the roots backend to simply use the link path rather
than the destination when following symlinks which point to a UNC path.

Resolves #43553.