### PR TITLE
Skip comment lines in /etc/iscsi/initiatorname.iscsi

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2515,6 +2515,7 @@ def _linux_iqn():
     if os.path.isfile(initiator):
         with salt.utils.files.fopen(initiator, 'r') as _iscsi:
             for line in _iscsi:
+                line = line.split('#', 1)[0]
                 if line.find('InitiatorName') != -1:
                     iqn = line.split('=')
                     ret.extend([iqn[1]])


### PR DESCRIPTION
### What does this PR do?

Add functionality to skip comment lines in grains._linux_lqn()

### What issues does this PR fix or reference?

Fix handling of /etc/iscsi/initiatorname.iscsi with comments in it.

### Previous Behavior
/etc/iscsi/initiatorname.iscsi:
```
## DO NOT EDIT OR REMOVE THIS FILE!
## If you remove this file, the iSCSI daemon will not start.
## If you change the InitiatorName, existing access control lists
## may reject this initiator.  The InitiatorName must be unique
## for each iSCSI initiator.  Do NOT duplicate iSCSI InitiatorNames.
InitiatorName=iqn.1993-08.org.debian:01:8b806bf3f071
```
master.log:
```
salt/grains/core.py", line 2520, in _linux_iqn
    ret.extend([iqn[1]])
IndexError: list index out of range
```
### New Behavior

No errors thrown

