### PR TITLE
check_result: Correctly check the __extend__ state.

### DIFF
--- a/salt/utils/state.py
+++ b/salt/utils/state.py
@@ -134,7 +134,11 @@ def check_result(running, recurse=False, highstate=None):
 
     ret = True
     for state_id, state_result in six.iteritems(running):
-        if not recurse and not isinstance(state_result, dict):
+        expected_type = dict
+        # The __extend__ state is a list
+        if "__extend__" == state_id:
+            expected_type = list
+        if not recurse and not isinstance(state_result, expected_type):
             ret = False
         if ret and isinstance(state_result, dict):
             result = state_result.get('result', _empty)


### PR DESCRIPTION



### What does this PR do?
check_state_result() is expecting all highstate items to be a dict, but
states using extend are lists. This PR checks __extend__ states more accurately.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/42512

### Previous Behavior
check_result will return False when an otherwise valid state uses extends.

### New Behavior
check_result now correctly checks __extend__ states.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
