### PR TITLE
Detect OpenBSD guest running under VMM(4)

### DIFF
--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -56,6 +56,12 @@ The new grains added are:
 * ``fc_wwn``: Show all fibre channel world wide port names for a host
 * ``iscsi_iqn``: Show the iSCSI IQN name for a host
 
+Grains Changes
+--------------
+
+* The ``virtual`` grain identifies reports KVM and VMM hypervisors when running
+  an OpenBSD guest
+
 New Modules
 -----------
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -848,6 +848,8 @@ def _virtual(osdata):
     elif osdata['kernel'] == 'OpenBSD':
         if osdata['manufacturer'] in ['QEMU', 'Red Hat']:
             grains['virtual'] = 'kvm'
+        if osdata['manufacturer'] == 'OpenBSD':
+            grains['virtual'] = 'vmm'
     elif osdata['kernel'] == 'SunOS':
         if grains['virtual'] == 'LDOM':
             roles = []


### PR DESCRIPTION
### What does this PR do?

Properly report `grains['virtual']` when OpenBSD is running under the [VMM](https://man.openbsd.org/vmm) hypervisor

### Previous Behavior

    $ salt-call --local grains.items
    ...
        virtual:
            physical

### New Behavior

    $ salt-call --local grains.items
    ...
        virtual:
            vmm

Tested using OpenBSD 6.1
