### PR TITLE
Additional tests for functions in salt.modules.vsphere & salt.utils.vsan

### DIFF
--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -5672,7 +5672,6 @@ def remove_datastore(datastore, service_instance=None):
     '''
     log.trace('Removing datastore \'{0}\''.format(datastore))
     target = _get_proxy_target(service_instance)
-    taget_name = target.name
     datastores = salt.utils.vmware.get_datastores(
         service_instance,
         reference=target,
@@ -6340,7 +6339,7 @@ def remove_capacity_from_diskgroup(cache_disk_id, capacity_disk_ids,
                              'capacity_ids': capacity_disk_ids}]},
             schema)
     except jsonschema.exceptions.ValidationError as exc:
-        raise ArgumentValueError(exc)
+        raise ArgumentValueError(str(exc))
     host_ref = _get_proxy_target(service_instance)
     hostname = __proxy__['esxi.get_details']()['esxi_host']
     disks = salt.utils.vmware.get_disks(host_ref, disk_ids=capacity_disk_ids)
@@ -6390,7 +6389,6 @@ def remove_diskgroup(cache_disk_id, data_accessibility=True,
         salt '*' vsphere.remove_diskgroup cache_disk_id='naa.000000000000001'
     '''
     log.trace('Validating diskgroup input')
-    schema = DiskGroupsDiskIdSchema.serialize()
     host_ref = _get_proxy_target(service_instance)
     hostname = __proxy__['esxi.get_details']()['esxi_host']
     diskgroups = \

--- a/tests/unit/modules/test_vsphere.py
+++ b/tests/unit/modules/test_vsphere.py
@@ -1174,6 +1174,92 @@ class CreateDatacenterTestCase(TestCase, LoaderModuleMockMixin):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+class EraseDiskPartitionsTestCase(TestCase, LoaderModuleMockMixin):
+    '''Tests for salt.modules.vsphere.erase_disk_partitions'''
+    def setup_loader_modules(self):
+        return {
+            vsphere: {
+                '__virtual__': MagicMock(return_value='vsphere'),
+                '_get_proxy_connection_details': MagicMock(),
+                '__proxy__': {'esxi.get_details': MagicMock(
+                    return_value={'esxi_host': 'fake_host'})}
+            }
+        }
+
+    def setUp(self):
+        attrs = (('mock_si', MagicMock()),
+                 ('mock_host', MagicMock()))
+        for attr, mock_obj in attrs:
+            setattr(self, attr, mock_obj)
+            self.addCleanup(delattr, self, attr)
+        attrs = (('mock_proxy_target', MagicMock(return_value=self.mock_host)),
+                 ('mock_erase_disk_partitions', MagicMock()))
+        for attr, mock_obj in attrs:
+            setattr(self, attr, mock_obj)
+            self.addCleanup(delattr, self, attr)
+
+        patches = (
+            ('salt.utils.vmware.get_service_instance',
+             MagicMock(return_value=self.mock_si)),
+            ('salt.modules.vsphere.get_proxy_type',
+             MagicMock(return_value='esxi')),
+            ('salt.modules.vsphere._get_proxy_target',
+             MagicMock(return_value=self.mock_host)),
+            ('salt.utils.vmware.erase_disk_partitions',
+             self.mock_erase_disk_partitions))
+        for module, mock_obj in patches:
+            patcher = patch(module, mock_obj)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_supported_proxies(self):
+        supported_proxies = ['esxi']
+        for proxy_type in supported_proxies:
+            with patch('salt.modules.vsphere.get_proxy_type',
+                       MagicMock(return_value=proxy_type)):
+                vsphere.erase_disk_partitions(disk_id='fake_disk')
+
+    def test_no_disk_id_or_scsi_address(self):
+        with self.assertRaises(ArgumentValueError) as excinfo:
+            vsphere.erase_disk_partitions()
+        self.assertEqual('Either \'disk_id\' or \'scsi_address\' needs to '
+                         'be specified', excinfo.exception.strerror)
+
+    def test_get_proxy_target(self):
+        mock_test_proxy_target = MagicMock()
+        with patch('salt.modules.vsphere._get_proxy_target',
+                   mock_test_proxy_target):
+            vsphere.erase_disk_partitions(disk_id='fake_disk')
+        mock_test_proxy_target.assert_called_once_with(self.mock_si)
+
+    def test_scsi_address_not_found(self):
+        mock = MagicMock(return_value={'bad_scsi_address': 'bad_disk_id'})
+        with patch('salt.utils.vmware.get_scsi_address_to_lun_map', mock):
+            with self.assertRaises(VMwareObjectRetrievalError) as excinfo:
+                vsphere.erase_disk_partitions(scsi_address='fake_scsi_address')
+        self.assertEqual('Scsi lun with address \'fake_scsi_address\' was '
+                         'not found on host \'fake_host\'',
+                         excinfo.exception.strerror)
+
+    def test_scsi_address_to_disk_id_map(self):
+        mock_disk_id = MagicMock(canonicalName='fake_scsi_disk_id')
+        mock_get_scsi_addr_to_lun = \
+                MagicMock(return_value={'fake_scsi_address': mock_disk_id})
+        with patch('salt.utils.vmware.get_scsi_address_to_lun_map',
+                   mock_get_scsi_addr_to_lun):
+            vsphere.erase_disk_partitions(scsi_address='fake_scsi_address')
+        mock_get_scsi_addr_to_lun.assert_called_once_with(self.mock_host)
+        self.mock_erase_disk_partitions.assert_called_once_with(
+            self.mock_si, self.mock_host, 'fake_scsi_disk_id',
+            hostname='fake_host')
+
+    def test_erase_disk_partitions(self):
+        vsphere.erase_disk_partitions(disk_id='fake_disk_id')
+        self.mock_erase_disk_partitions.assert_called_once_with(
+            self.mock_si, self.mock_host, 'fake_disk_id', hostname='fake_host')
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
 class ListClusterTestCase(TestCase, LoaderModuleMockMixin):
     '''Tests for salt.modules.vsphere.list_cluster'''
     def setup_loader_modules(self):

--- a/tests/unit/utils/test_vsan.py
+++ b/tests/unit/utils/test_vsan.py
@@ -150,10 +150,6 @@ class GetVsanDiskManagementSystemTestCase(TestCase, LoaderModuleMockMixin):
             'ssl': MagicMock()}}
 
     def setUp(self):
-        self.stub_mock = MagicMock()
-        self.si_mock = MagicMock(_stub=self.stub_mock)
-
-    def setUp(self):
         self.mock_si = MagicMock()
         self.mock_ret = MagicMock()
         patches = (('salt.utils.vsan.vsanapiutils.GetVsanVcMos',
@@ -198,7 +194,6 @@ class GetVsanDiskManagementSystemTestCase(TestCase, LoaderModuleMockMixin):
     def test_return(self):
         ret = vsan.get_vsan_disk_management_system(self.mock_si)
         self.assertEqual(ret, self.mock_ret)
-
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -362,7 +357,7 @@ class CreateDiskgroupTestCase(TestCase):
                          'Fake privilege')
 
     def test_initialize_disk_mapping_raise_vim_fault(self):
-        err =  vim.fault.VimFault()
+        err = vim.fault.VimFault()
         err.msg = 'vim_fault'
         self.mock_vsan_disk_mgmt_system.InitializeDiskMappings = \
             MagicMock(side_effect=err)
@@ -497,7 +492,7 @@ class AddCapacityToDiskGroupTestCase(TestCase):
                          'Fake privilege')
 
     def test_initialize_disk_mapping_raise_vim_fault(self):
-        err =  vim.fault.VimFault()
+        err = vim.fault.VimFault()
         err.msg = 'vim_fault'
         self.mock_vsan_disk_mgmt_system.InitializeDiskMappings = \
             MagicMock(side_effect=err)
@@ -620,7 +615,7 @@ class RemoveCapacityFromDiskGroup(TestCase):
     def test_remove_disk_raise_no_permission(self):
         err = vim.fault.NoPermission()
         err.privilegeId = 'Fake privilege'
-        self.mock_host_vsan_system.RemoveDisk_Task= \
+        self.mock_host_vsan_system.RemoveDisk_Task = \
             MagicMock(side_effect=err)
         with self.assertRaises(VMwareApiError) as excinfo:
             vsan.remove_capacity_from_diskgroup(
@@ -631,9 +626,9 @@ class RemoveCapacityFromDiskGroup(TestCase):
                          'Fake privilege')
 
     def test_remove_disk_raise_vim_fault(self):
-        err =  vim.fault.VimFault()
+        err = vim.fault.VimFault()
         err.msg = 'vim_fault'
-        self.mock_host_vsan_system.RemoveDisk_Task= \
+        self.mock_host_vsan_system.RemoveDisk_Task = \
             MagicMock(side_effect=err)
         with self.assertRaises(VMwareApiError) as excinfo:
             vsan.remove_capacity_from_diskgroup(
@@ -644,7 +639,7 @@ class RemoveCapacityFromDiskGroup(TestCase):
     def test_remove_disk_raise_runtime_fault(self):
         err = vmodl.RuntimeFault()
         err.msg = 'runtime_fault'
-        self.mock_host_vsan_system.RemoveDisk_Task= \
+        self.mock_host_vsan_system.RemoveDisk_Task = \
             MagicMock(side_effect=err)
         with self.assertRaises(VMwareRuntimeError) as excinfo:
             vsan.remove_capacity_from_diskgroup(
@@ -744,7 +739,7 @@ class RemoveDiskgroup(TestCase):
             self.mock_si, self.mock_host_ref, self.mock_diskgroup)
         err = vim.fault.NoPermission()
         err.privilegeId = 'Fake privilege'
-        self.mock_host_vsan_system.RemoveDiskMapping_Task= \
+        self.mock_host_vsan_system.RemoveDiskMapping_Task = \
             MagicMock(side_effect=err)
         with self.assertRaises(VMwareApiError) as excinfo:
             vsan.remove_diskgroup(
@@ -754,9 +749,9 @@ class RemoveDiskgroup(TestCase):
                          'Fake privilege')
 
     def test_remove_disk_mapping_raise_vim_fault(self):
-        err =  vim.fault.VimFault()
+        err = vim.fault.VimFault()
         err.msg = 'vim_fault'
-        self.mock_host_vsan_system.RemoveDiskMapping_Task= \
+        self.mock_host_vsan_system.RemoveDiskMapping_Task = \
             MagicMock(side_effect=err)
         with self.assertRaises(VMwareApiError) as excinfo:
             vsan.remove_diskgroup(
@@ -766,7 +761,7 @@ class RemoveDiskgroup(TestCase):
     def test_remove_disk_mapping_raise_runtime_fault(self):
         err = vmodl.RuntimeFault()
         err.msg = 'runtime_fault'
-        self.mock_host_vsan_system.RemoveDiskMapping_Task= \
+        self.mock_host_vsan_system.RemoveDiskMapping_Task = \
             MagicMock(side_effect=err)
         with self.assertRaises(VMwareRuntimeError) as excinfo:
             vsan.remove_diskgroup(

--- a/tests/unit/utils/test_vsan.py
+++ b/tests/unit/utils/test_vsan.py
@@ -416,6 +416,145 @@ class CreateDiskgroupTestCase(TestCase):
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
 @skipIf(not HAS_PYVSAN, 'The \'vsan\' ext library is missing')
+class AddCapacityToDiskGroupTestCase(TestCase):
+    '''Tests for salt.utils.vsan.add_capacity_to_diskgroup'''
+    def setUp(self):
+        self.mock_si = MagicMock()
+        self.mock_task = MagicMock()
+        self.mock_initialise_disk_mapping = \
+                MagicMock(return_value=self.mock_task)
+        self.mock_vsan_disk_mgmt_system = MagicMock(
+            InitializeDiskMappings=self.mock_initialise_disk_mapping)
+        self.mock_host_ref = MagicMock()
+        self.mock_cache_disk = MagicMock()
+        self.mock_diskgroup = MagicMock(ssd=self.mock_cache_disk)
+        self.mock_cap_disk1 = MagicMock()
+        self.mock_cap_disk2 = MagicMock()
+        self.mock_spec = MagicMock()
+        patches = (
+            ('salt.utils.vmware.get_managed_object_name',
+             MagicMock(return_value='fake_hostname')),
+            ('salt.utils.vsan.vim.VimVsanHostDiskMappingCreationSpec',
+             MagicMock(return_value=self.mock_spec)),
+            ('salt.utils.vsan._wait_for_tasks', MagicMock()))
+        for mod, mock in patches:
+            patcher = patch(mod, mock)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_get_hostname(self):
+        mock_get_managed_object_name = MagicMock(return_value='fake_hostname')
+        with patch('salt.utils.vmware.get_managed_object_name',
+                   mock_get_managed_object_name):
+            vsan.add_capacity_to_diskgroup(
+                self.mock_si, self.mock_vsan_disk_mgmt_system,
+                self.mock_host_ref, self.mock_diskgroup,
+                [self.mock_cap_disk1, self.mock_cap_disk2])
+        mock_get_managed_object_name.assert_called_once_with(
+            self.mock_host_ref)
+
+    def test_vsan_spec_all_flash(self):
+        self.mock_cap_disk1.ssd = True
+        vsan.add_capacity_to_diskgroup(
+            self.mock_si, self.mock_vsan_disk_mgmt_system,
+            self.mock_host_ref, self.mock_diskgroup,
+            [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.assertEqual(self.mock_spec.capacityDisks, [self.mock_cap_disk1,
+                                                        self.mock_cap_disk2])
+        self.assertEqual(self.mock_spec.cacheDisks, [self.mock_cache_disk])
+        self.assertEqual(self.mock_spec.creationType, 'allFlash')
+        self.assertEqual(self.mock_spec.host, self.mock_host_ref)
+
+    def test_vsan_spec_hybrid(self):
+        self.mock_cap_disk1.ssd = False
+        vsan.add_capacity_to_diskgroup(
+            self.mock_si, self.mock_vsan_disk_mgmt_system,
+            self.mock_host_ref, self.mock_diskgroup,
+            [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.mock_cap_disk1.ssd = False
+        self.assertEqual(self.mock_spec.creationType, 'hybrid')
+
+    def test_initialize_disk_mapping(self):
+        vsan.add_capacity_to_diskgroup(
+            self.mock_si, self.mock_vsan_disk_mgmt_system,
+            self.mock_host_ref, self.mock_diskgroup,
+            [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.mock_initialise_disk_mapping.assert_called_once_with(
+            self.mock_spec)
+
+    def test_initialize_disk_mapping_raise_no_permission(self):
+        err = vim.fault.NoPermission()
+        err.privilegeId = 'Fake privilege'
+        self.mock_vsan_disk_mgmt_system.InitializeDiskMappings = \
+            MagicMock(side_effect=err)
+        with self.assertRaises(VMwareApiError) as excinfo:
+            vsan.add_capacity_to_diskgroup(
+                self.mock_si, self.mock_vsan_disk_mgmt_system,
+                self.mock_host_ref, self.mock_diskgroup,
+                [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.assertEqual(excinfo.exception.strerror,
+                         'Not enough permissions. Required privilege: '
+                         'Fake privilege')
+
+    def test_initialize_disk_mapping_raise_vim_fault(self):
+        err =  vim.fault.VimFault()
+        err.msg = 'vim_fault'
+        self.mock_vsan_disk_mgmt_system.InitializeDiskMappings = \
+            MagicMock(side_effect=err)
+        with self.assertRaises(VMwareApiError) as excinfo:
+            vsan.add_capacity_to_diskgroup(
+                self.mock_si, self.mock_vsan_disk_mgmt_system,
+                self.mock_host_ref, self.mock_diskgroup,
+                [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.assertEqual(excinfo.exception.strerror, 'vim_fault')
+
+    def test_initialize_disk_mapping_raise_method_not_found(self):
+        err = vmodl.fault.MethodNotFound()
+        err.method = 'fake_method'
+        self.mock_vsan_disk_mgmt_system.InitializeDiskMappings = \
+            MagicMock(side_effect=err)
+        with self.assertRaises(VMwareRuntimeError) as excinfo:
+            vsan.add_capacity_to_diskgroup(
+                self.mock_si, self.mock_vsan_disk_mgmt_system,
+                self.mock_host_ref, self.mock_diskgroup,
+                [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.assertEqual(excinfo.exception.strerror,
+                         'Method \'fake_method\' not found')
+
+    def test_initialize_disk_mapping_raise_runtime_fault(self):
+        err = vmodl.RuntimeFault()
+        err.msg = 'runtime_fault'
+        self.mock_vsan_disk_mgmt_system.InitializeDiskMappings = \
+            MagicMock(side_effect=err)
+        with self.assertRaises(VMwareRuntimeError) as excinfo:
+            vsan.add_capacity_to_diskgroup(
+                self.mock_si, self.mock_vsan_disk_mgmt_system,
+                self.mock_host_ref, self.mock_diskgroup,
+                [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.assertEqual(excinfo.exception.strerror, 'runtime_fault')
+
+    def test__wait_for_tasks(self):
+        mock___wait_for_tasks = MagicMock()
+        with patch('salt.utils.vsan._wait_for_tasks',
+                   mock___wait_for_tasks):
+            vsan.add_capacity_to_diskgroup(
+                self.mock_si, self.mock_vsan_disk_mgmt_system,
+                self.mock_host_ref, self.mock_diskgroup,
+                [self.mock_cap_disk1, self.mock_cap_disk2])
+        mock___wait_for_tasks.assert_called_once_with(
+            [self.mock_task], self.mock_si)
+
+    def test_result(self):
+        res = vsan.add_capacity_to_diskgroup(
+            self.mock_si, self.mock_vsan_disk_mgmt_system,
+            self.mock_host_ref, self.mock_diskgroup,
+            [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.assertTrue(res)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
+@skipIf(not HAS_PYVSAN, 'The \'vsan\' ext library is missing')
 class GetClusterVsanInfoTestCase(TestCase, LoaderModuleMockMixin):
     '''Tests for salt.utils.vsan.get_cluster_vsan_info'''
     def setup_loader_modules(self):

--- a/tests/unit/utils/test_vsan.py
+++ b/tests/unit/utils/test_vsan.py
@@ -555,6 +555,123 @@ class AddCapacityToDiskGroupTestCase(TestCase):
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
 @skipIf(not HAS_PYVSAN, 'The \'vsan\' ext library is missing')
+class RemoveCapacityFromDiskGroup(TestCase):
+    '''Tests for salt.utils.vsan.remove_capacity_from_diskgroup'''
+    def setUp(self):
+        self.mock_si = MagicMock()
+        self.mock_task = MagicMock()
+        self.mock_remove_disk = \
+                MagicMock(return_value=self.mock_task)
+        self.mock_host_vsan_system = MagicMock(
+            RemoveDisk_Task=self.mock_remove_disk)
+        self.mock_host_ref = MagicMock()
+        self.mock_cache_disk = MagicMock()
+        self.mock_diskgroup = MagicMock(ssd=self.mock_cache_disk)
+        self.mock_cap_disk1 = MagicMock()
+        self.mock_cap_disk2 = MagicMock()
+        self.mock_spec = MagicMock()
+        patches = (
+            ('salt.utils.vmware.get_managed_object_name',
+             MagicMock(return_value='fake_hostname')),
+            ('salt.utils.vsan.get_host_vsan_system',
+             MagicMock(return_value=self.mock_host_vsan_system)),
+            ('salt.utils.vsan.vim.HostMaintenanceSpec',
+             MagicMock(return_value=self.mock_spec)),
+            ('salt.utils.vsan.vim.VsanHostDecommissionMode', MagicMock()),
+            ('salt.utils.vmware.wait_for_task', MagicMock()))
+        for mod, mock in patches:
+            patcher = patch(mod, mock)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_get_hostname(self):
+        mock_get_managed_object_name = MagicMock(return_value='fake_hostname')
+        with patch('salt.utils.vmware.get_managed_object_name',
+                   mock_get_managed_object_name):
+            vsan.remove_capacity_from_diskgroup(
+                self.mock_si, self.mock_host_ref, self.mock_diskgroup,
+                [self.mock_cap_disk1, self.mock_cap_disk2])
+        mock_get_managed_object_name.assert_called_once_with(
+            self.mock_host_ref)
+
+    def test_maintenance_mode_evacuate_all_data(self):
+        vsan.remove_capacity_from_diskgroup(
+            self.mock_si, self.mock_host_ref, self.mock_diskgroup,
+            [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.assertEqual(self.mock_spec.vsanMode.objectAction,
+                         vim.VsanHostDecommissionModeObjectAction.evacuateAllData)
+
+    def test_maintenance_mode_no_action(self):
+        vsan.remove_capacity_from_diskgroup(
+            self.mock_si, self.mock_host_ref, self.mock_diskgroup,
+            [self.mock_cap_disk1, self.mock_cap_disk2],
+            data_evacuation=False)
+        self.assertEqual(self.mock_spec.vsanMode.objectAction,
+                         vim.VsanHostDecommissionModeObjectAction.noAction)
+
+    def test_remove_disk(self):
+        vsan.remove_capacity_from_diskgroup(
+            self.mock_si, self.mock_host_ref, self.mock_diskgroup,
+            [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.mock_remove_disk.assert_called_once_with(
+            disk=[self.mock_cap_disk1, self.mock_cap_disk2],
+            maintenanceSpec=self.mock_spec)
+
+    def test_remove_disk_raise_no_permission(self):
+        err = vim.fault.NoPermission()
+        err.privilegeId = 'Fake privilege'
+        self.mock_host_vsan_system.RemoveDisk_Task= \
+            MagicMock(side_effect=err)
+        with self.assertRaises(VMwareApiError) as excinfo:
+            vsan.remove_capacity_from_diskgroup(
+                self.mock_si, self.mock_host_ref, self.mock_diskgroup,
+                [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.assertEqual(excinfo.exception.strerror,
+                         'Not enough permissions. Required privilege: '
+                         'Fake privilege')
+
+    def test_remove_disk_raise_vim_fault(self):
+        err =  vim.fault.VimFault()
+        err.msg = 'vim_fault'
+        self.mock_host_vsan_system.RemoveDisk_Task= \
+            MagicMock(side_effect=err)
+        with self.assertRaises(VMwareApiError) as excinfo:
+            vsan.remove_capacity_from_diskgroup(
+                self.mock_si, self.mock_host_ref, self.mock_diskgroup,
+                [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.assertEqual(excinfo.exception.strerror, 'vim_fault')
+
+    def test_remove_disk_raise_runtime_fault(self):
+        err = vmodl.RuntimeFault()
+        err.msg = 'runtime_fault'
+        self.mock_host_vsan_system.RemoveDisk_Task= \
+            MagicMock(side_effect=err)
+        with self.assertRaises(VMwareRuntimeError) as excinfo:
+            vsan.remove_capacity_from_diskgroup(
+                self.mock_si, self.mock_host_ref, self.mock_diskgroup,
+                [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.assertEqual(excinfo.exception.strerror, 'runtime_fault')
+
+    def test_wait_for_tasks(self):
+        mock_wait_for_task = MagicMock()
+        with patch('salt.utils.vmware.wait_for_task',
+                   mock_wait_for_task):
+            vsan.remove_capacity_from_diskgroup(
+                self.mock_si, self.mock_host_ref, self.mock_diskgroup,
+                [self.mock_cap_disk1, self.mock_cap_disk2])
+        mock_wait_for_task.assert_called_once_with(
+            self.mock_task, 'fake_hostname', 'remove_capacity')
+
+    def test_result(self):
+        res = vsan.remove_capacity_from_diskgroup(
+            self.mock_si, self.mock_host_ref, self.mock_diskgroup,
+            [self.mock_cap_disk1, self.mock_cap_disk2])
+        self.assertTrue(res)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
+@skipIf(not HAS_PYVSAN, 'The \'vsan\' ext library is missing')
 class GetClusterVsanInfoTestCase(TestCase, LoaderModuleMockMixin):
     '''Tests for salt.utils.vsan.get_cluster_vsan_info'''
     def setup_loader_modules(self):


### PR DESCRIPTION
### What does this PR do?

Additional tests for functions in `salt.modules.vsphere` & `salt.utils.vsan`

Functions:
- salt.modules.vsphere.erase_disk_partitions
- salt.modules.vsphere.remove_datastore
- salt.modules.vsphere.remove_diskgroup
- salt.modules.vsphere.remove_capacity_from_diskgroup
- salt.utils.vsan.get_vsan_disk_management_system
- salt.utils.vsan.get_host_vsan_system
- salt.utils.vsan.create_diskgroup
- salt.utils.vsan.add_capacity_to_diskgroup
- salt.utils.vsan.remove_capacity_from_diskgroup
-  salt.utils.vsan.remove_diskgroup

### Tests written?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
