### PR TITLE
[2017.7] archive.extracted - obfuscate username password on failure

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -952,7 +952,9 @@ def extracted(name,
         except Exception as exc:
             # Look for username & passwords and obfuscate.
             if '@' in source_match:
-                source_match = re.sub('\/\w+\:\w+\@', '/xxxxxxx:xxxxxxx@', str)
+                source_match = re.sub(r'\/\w+\:\w+\@',
+                                      '/xxxxxxx:xxxxxxx@',
+                                      str)
 
             msg = 'Failed to cache {0}: {1}'.format(source_match, exc.__str__())
             log.exception(msg)
@@ -967,7 +969,9 @@ def extracted(name,
         else:
             # Look for username & passwords and obfuscate.
             if '@' in source_match:
-                source_match = re.sub('\/\w+\:\w+\@', '/xxxxxxx:xxxxxxx@', str)
+                source_match = re.sub(r'\/\w+\:\w+\@',
+                                      '/xxxxxxx:xxxxxxx@',
+                                      str)
 
             log.debug(
                 'failed to download %s',

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -950,6 +950,10 @@ def extracted(name,
                                                skip_verify=skip_verify,
                                                saltenv=__env__)
         except Exception as exc:
+            # Look for username & passwords and obfuscate.
+            if '@' in source_match:
+                source_match = re.sub('\/\w+\:\w+\@', '/xxxxxxx:xxxxxxx@', str)
+
             msg = 'Failed to cache {0}: {1}'.format(source_match, exc.__str__())
             log.exception(msg)
             ret['comment'] = msg
@@ -961,6 +965,10 @@ def extracted(name,
             # Get the path of the file in the minion cache
             cached = __salt__['cp.is_cached'](source_match)
         else:
+            # Look for username & passwords and obfuscate.
+            if '@' in source_match:
+                source_match = re.sub('\/\w+\:\w+\@', '/xxxxxxx:xxxxxxx@', str)
+
             log.debug(
                 'failed to download %s',
                 salt.utils.url.redact_http_basic_auth(source_match)


### PR DESCRIPTION
### What does this PR do?
Obfuscate the username and password on failure

### What issues does this PR fix or reference?
#43819

### Previous Behavior
When using URLs in archive.extracted, on failure the username & password is in the exception.

### New Behavior
This change obfuscates that information in the exception.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
