### PR TITLE
add -n with netstat so we don't resolve IPs

### DIFF
--- a/pkg/rpm/salt-minion
+++ b/pkg/rpm/salt-minion
@@ -67,7 +67,7 @@ _su_cmd() {
 
 
 _get_pid() {
-    netstat $NS_NOTRIM -ap --protocol=unix 2>$ERROR_TO_DEVNULL \
+    netstat -n $NS_NOTRIM -ap --protocol=unix 2>$ERROR_TO_DEVNULL \
         | sed -r -e "\|\s${SOCK_DIR}/minion_event_${MINION_ID_HASH}_pub\.ipc$|"'!d; s|/.*||; s/.*\s//;' \
         | uniq
 }
@@ -156,7 +156,7 @@ start() {
             printf "\nPROCESSES:\n" >&2
             ps wwwaxu | grep '[s]alt-minion' >&2
             printf "\nSOCKETS:\n" >&2
-            netstat $NS_NOTRIM -ap --protocol=unix | grep 'salt.*minion' >&2            
+            netstat -n $NS_NOTRIM -ap --protocol=unix | grep 'salt.*minion' >&2
             printf "\nLOG_FILE:\n" >&2
             tail -n 20 "$LOG_FILE" >&2
             printf "\nENVIRONMENT:\n" >&2


### PR DESCRIPTION
### What does this PR do?
We should use `-n` when using netstat so that we don't resolve the IPs. On large deployments with business systems and heavy use of `/etc/hosts`, this can cause starting/stopping/restarting minions to take an extremely long time. 

### What issues does this PR fix or reference?

minion taking extremely long to start/restart/stop because netstat is attempting to resolve IPs.

### Previous Behavior
Remove this section if not relevant

depending on certain factors with DNS and /etc/hosts, this can take minutes to start/stop/restart minion.

### New Behavior
Remove this section if not relevant

minion takes only seconds to start/stop/restart

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
