### PR TITLE
Fix `unit.states.test_mount` for Windows

### DIFF
--- a/tests/unit/states/test_mount.py
+++ b/tests/unit/states/test_mount.py
@@ -17,7 +17,6 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.states.mount as mount
-import salt.utils
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/states/test_mount.py
+++ b/tests/unit/states/test_mount.py
@@ -17,6 +17,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.states.mount as mount
+import salt.utils
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -33,11 +34,11 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test to verify that a device is mounted.
         '''
-        name = '/mnt/sdb'
-        device = '/dev/sdb5'
+        name = os.path.realpath('/mnt/sdb')
+        device = os.path.realpath('/dev/sdb5')
         fstype = 'xfs'
 
-        name2 = '/mnt/cifs'
+        name2 = os.path.realpath('/mnt/cifs')
         device2 = '//SERVER/SHARE/'
         fstype2 = 'cifs'
         opts2 = ['noowners']
@@ -62,12 +63,11 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         mock_str = MagicMock(return_value='salt')
         mock_user = MagicMock(return_value={'uid': 510})
         mock_group = MagicMock(return_value={'gid': 100})
-        umount1 = ("Forced unmount because devices don't match. "
-                   "Wanted: /dev/sdb6, current: /dev/sdb5, /dev/sdb5")
         with patch.dict(mount.__grains__, {'os': 'Darwin'}):
             with patch.dict(mount.__salt__, {'mount.active': mock_mnt,
                                              'cmd.run_all': mock_ret,
-                                             'mount.umount': mock_f}):
+                                             'mount.umount': mock_f}), \
+                    patch('os.path.exists', MagicMock(return_value=True)):
                 comt = ('Unable to find device with label /dev/sdb5.')
                 ret.update({'comment': comt})
                 self.assertDictEqual(mount.mounted(name, 'LABEL=/dev/sdb5',
@@ -81,7 +81,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                          ret)
 
                 with patch.dict(mount.__opts__, {'test': False}):
-                    comt = ('Unable to unmount /mnt/sdb: False.')
+                    comt = ('Unable to unmount {0}: False.'.format(name))
                     umount = ('Forced unmount and mount because'
                               ' options (noowners) changed')
                     ret.update({'comment': comt, 'result': False,
@@ -89,16 +89,19 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                     self.assertDictEqual(mount.mounted(name, device, 'nfs'),
                                          ret)
 
+                    umount1 = ("Forced unmount because devices don't match. "
+                               "Wanted: {0}, current: {1}, {1}".format(os.path.realpath('/dev/sdb6'), device))
                     comt = ('Unable to unmount')
                     ret.update({'comment': comt, 'result': None,
                                 'changes': {'umount': umount1}})
-                    self.assertDictEqual(mount.mounted(name, '/dev/sdb6',
+                    self.assertDictEqual(mount.mounted(name, os.path.realpath('/dev/sdb6'),
                                                        fstype, opts=[]), ret)
 
                 with patch.dict(mount.__salt__, {'mount.active': mock_emt,
                                                  'mount.mount': mock_str,
                                                  'mount.set_automaster': mock}):
-                    with patch.dict(mount.__opts__, {'test': True}):
+                    with patch.dict(mount.__opts__, {'test': True}), \
+                            patch('os.path.exists', MagicMock(return_value=False)):
                         comt = ('{0} does not exist and would not be created'.format(name))
                         ret.update({'comment': comt, 'changes': {}})
                         self.assertDictEqual(mount.mounted(name, device,
@@ -117,14 +120,16 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                             self.assertDictEqual(mount.mounted(name, device,
                                                                fstype), ret)
 
-                    with patch.dict(mount.__opts__, {'test': True}):
+                    with patch.dict(mount.__opts__, {'test': True}), \
+                            patch('os.path.exists', MagicMock(return_value=False)):
                         comt = ('{0} does not exist and would neither be created nor mounted. '
                                 '{0} needs to be written to the fstab in order to be made persistent.'.format(name))
                         ret.update({'comment': comt, 'result': None})
                         self.assertDictEqual(mount.mounted(name, device, fstype,
                                                            mount=False), ret)
 
-                    with patch.dict(mount.__opts__, {'test': False}):
+                    with patch.dict(mount.__opts__, {'test': False}), \
+                            patch('os.path.exists', MagicMock(return_value=False)):
                         comt = ('{0} not present and not mounted. '
                                 'Entry already exists in the fstab.'.format(name))
                         ret.update({'comment': comt, 'result': True})


### PR DESCRIPTION
### What does this PR do?
Use `os.path.realpath` to convert paths
Mock `os.path.exists`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes