### PR TITLE
[2017.7] Changes to states/file.py and states/archived.py

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -772,7 +772,8 @@ def extracted(name,
         # Get rid of "file://" from start of source_match
         source_match = os.path.realpath(os.path.expanduser(urlparsed_source.path))
         if not os.path.isfile(source_match):
-            ret['comment'] = 'Source file \'{0}\' does not exist'.format(source_match)
+            ret['comment'] = 'Source file \'{0}\' does not exist'.format(
+                                salt.utils.url.redact_http_basic_auth(source_match))
             return ret
 
     valid_archive_formats = ('tar', 'rar', 'zip')
@@ -924,7 +925,7 @@ def extracted(name,
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = (
-                'Archive {0} would be ached (if necessary) and checked to '
+                'Archive {0} would be cached (if necessary) and checked to '
                 'discover if extraction is needed'.format(
                     salt.utils.url.redact_http_basic_auth(source_match)
                 )
@@ -938,7 +939,7 @@ def extracted(name,
             # file states would be unavailable.
             ret['comment'] = (
                 'Unable to cache {0}, file.cached state not available'.format(
-                    source_match
+                    salt.utils.url.redact_http_basic_auth(source_match)
                 )
             )
             return ret
@@ -950,7 +951,9 @@ def extracted(name,
                                                skip_verify=skip_verify,
                                                saltenv=__env__)
         except Exception as exc:
-            msg = 'Failed to cache {0}: {1}'.format(source_match, exc.__str__())
+            msg = 'Failed to cache {0}: {1}'.format(
+                    salt.utils.url.redact_http_basic_auth(source_match),
+                    exc.__str__())
             log.exception(msg)
             ret['comment'] = msg
             return ret
@@ -1181,7 +1184,8 @@ def extracted(name,
             if not ret['result']:
                 ret['comment'] = \
                     '{0} does not match the desired source_hash {1}'.format(
-                        source_match, source_sum['hsum']
+                        salt.utils.url.redact_http_basic_auth(source_match),
+                        source_sum['hsum']
                     )
                 return ret
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6573,7 +6573,8 @@ def cached(name,
             and parsed.scheme in salt.utils.files.REMOTE_PROTOS:
         ret['comment'] = (
             'Unable to verify upstream hash of source file {0}, please set '
-            'source_hash or set skip_verify to True'.format(name)
+            'source_hash or set skip_verify to True'.format(
+                salt.utils.url.redact_http_basic_auth(name))
         )
         return ret
 
@@ -6712,13 +6713,14 @@ def cached(name,
                 # for the 2017.7 release cycle.
                 #source_hash=source_sum.get('hsum'))
         except Exception as exc:
-            ret['comment'] = exc.__str__()
+            ret['comment'] = salt.utils.url.redact_http_basic_auth(exc.__str__())
             return ret
 
     if not local_copy:
         ret['comment'] = (
             'Failed to cache {0}, check minion log for more '
-            'information'.format(name)
+            'information'.format(
+                salt.utils.url.redact_http_basic_auth(name))
         )
         return ret
 


### PR DESCRIPTION
### What does this PR do?
When using URLs in archive.extracted, on failure the username & password is in the exception.  Calling salt.utils.url.redact_http_basic_auth to ensure the credentials are redacted.

### What issues does this PR fix or reference?
#43819 

### Previous Behavior
When using URLs in archive.extracted, on failure the username & password is in the exception

### New Behavior
Calling salt.utils.url.redact_http_basic_auth to ensure the credentials are redacted.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
