### PR TITLE
Update joyent.py

### DIFF
--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -749,12 +749,13 @@ def list_nodes(full=False, call=None):
                 log.error('Invalid response when listing Joyent nodes: {0}'.format(result[1]))
 
     else:
-        result = query(command='my/machines', location=DEFAULT_LOCATION,
+        location = get_location()
+        result = query(command='my/machines', location=location,
                        method='GET')
         nodes = result[1]
         for node in nodes:
             if 'name' in node:
-                node['location'] = DEFAULT_LOCATION
+                node['location'] = location
                 ret[node['name']] = reformat_node(item=node, full=full)
     return ret
 


### PR DESCRIPTION
Location parameter defined in the cloud provider config was ignored in the list_nodes function. This caused an issue when querying a node after creation.

### What does this PR do?

Allows location parameter to be used with the list_nodes function.

### What issues does this PR fix or reference?

After a quick search, this seems to fix issue #37077. 

### Previous Behavior
[DEBUG   ] User: 'xxxx' on PATH: https://us-east-1.lan/my/machines
[DEBUG   ] Requesting URL https://us-east-1.lan/my/machines using GET method
[DEBUG   ] Joyent Response Status Code: 0
[DEBUG   ] Failed to execute 'joyent.list_nodes()' while querying for running nodes: 'headers'
Traceback (most recent call last):
  File "/opt/local/lib/python2.7/site-packages/salt/cloud/__init__.py", line 2395, in run_parallel_map_providers_query
    cloud.clouds[data['fun']]()
  File "/opt/local/lib/python2.7/site-packages/salt/cloud/clouds/joyent.py", line 755, in list_nodes
    method='GET')
  File "/opt/local/lib/python2.7/site-packages/salt/cloud/clouds/joyent.py", line 1108, in query
    if 'Content-Length' in result['headers']:
KeyError: 'headers'

### New Behavior
[DEBUG   ] User: 'xxxx' on PATH: https://cloudapi.lan/my/machines
[DEBUG   ] Requesting URL https://cloudapi.lan/my/machines using GET method
[DEBUG   ] Response Status Code: 200
[DEBUG   ] Joyent Response Status Code: 200
[DEBUG   ] LazyLoaded nested.output

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
