### PR TITLE
Activate jid_queue also for SingleMinions (occurs on reconnect)

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -970,7 +970,7 @@ class Minion(MinionBase):
         # Flag meaning minion has finished initialization including first connect to the master.
         # True means the Minion is fully functional and ready to handle events.
         self.ready = False
-        self.jid_queue = jid_queue
+        self.jid_queue = jid_queue or []
 
         if io_loop is None:
             if HAS_ZMQ:


### PR DESCRIPTION
### What does this PR do?

set jid_queue to emtpy list if not specified

### What issues does this PR fix or reference?

see above

### Tests written?

No