### PR TITLE
Fixed Jinja typo in faq.rst

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -325,7 +325,7 @@ The following example works on UNIX-like operating systems:
 
 .. code-block:: jinja
 
-    {%- if grains['os'] != 'Windows' %
+    {%- if grains['os'] != 'Windows' %}
     Restart Salt Minion:
       cmd.run:
         - name: 'salt-call --local service.restart salt-minion'


### PR DESCRIPTION
A closing curly brace was missing in the first block of Jinja code under the "Restart using states" section.

### What does this PR do?
Corrects typo in sample Jinja code.

### What issues does this PR fix or reference?
Fixes failing Salt state.

### Previous Behavior
Salt state fails with Jinja syntax error.

### New Behavior
Salt state runs successfully.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
