### PR TITLE
Atomicfile only copies mode and not user/group perms

### DIFF
--- a/salt/utils/atomicfile.py
+++ b/salt/utils/atomicfile.py
@@ -13,7 +13,6 @@ import errno
 import time
 import random
 import shutil
-import stat
 import salt.ext.six as six
 
 
@@ -122,7 +121,7 @@ class _AtomicWFile(object):
         if os.path.isfile(self._filename):
             shutil.copymode(self._filename, self._tmp_filename)
             st = os.stat(self._filename)
-            os.chown(self._tmp_filename, st[stat.ST_UID], st[stat.ST_GID])
+            os.chown(self._tmp_filename, st.st_uid, st.st_gid)
         atomic_rename(self._tmp_filename, self._filename)
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/salt/utils/atomicfile.py
+++ b/salt/utils/atomicfile.py
@@ -13,6 +13,7 @@ import errno
 import time
 import random
 import shutil
+import stat
 import salt.ext.six as six
 
 
@@ -120,6 +121,8 @@ class _AtomicWFile(object):
         self._fh.close()
         if os.path.isfile(self._filename):
             shutil.copymode(self._filename, self._tmp_filename)
+            st = os.stat(self._filename)
+            os.chown(self._tmp_filename, st[stat.ST_UID], st[stat.ST_GID])
         atomic_rename(self._tmp_filename, self._filename)
 
     def __exit__(self, exc_type, exc_value, traceback):


### PR DESCRIPTION
### What does this PR do?
This PR fixes issue 38452 , in which file.line changes the user/group permissions of the file due to handling of temporary files in `atomicfile`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/38452

### Previous Behavior
`file.line` changes user and group membership to whatever account salt is running as (usually root). See issue for test cases.

### New Behavior
Use `os.chown` to set user/group permissions on the temporary file to the same as the existing file.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
