### PR TITLE
use .get incase attrs are disabled on the filesystem

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4358,7 +4358,7 @@ def check_perms(name, ret, user, group, mode, attrs=None, follow_symlinks=False)
     is_dir = os.path.isdir(name)
     if not salt.utils.platform.is_windows() and not is_dir and lsattr_cmd:
         # List attributes on file
-        perms['lattrs'] = ''.join(lsattr(name)[name])
+        perms['lattrs'] = ''.join(lsattr(name).get('name', ''))
         # Remove attributes on file so changes can be enforced.
         if perms['lattrs']:
             chattr(name, operator='remove', attributes=perms['lattrs'])


### PR DESCRIPTION
### What does this PR do?
Filesystems like... aufs in docker do not have this capability (not sure if at all, or just turned on by default)

But if we don't get attributes back, we should just ignore the result.

### Tests written?

No
