### PR TITLE
[bugfix] Add hash cache invalidation to azurefs

### DIFF
--- a/salt/fileserver/azurefs.py
+++ b/salt/fileserver/azurefs.py
@@ -265,6 +265,11 @@ def update():
             os.unlink(lk_fn)
         except Exception:
             pass
+        try:
+            hash_cachedir = os.path.join(__opts__['cachedir'], 'azurefs', 'hashes')
+            shutil.rmtree(hash_cachedir)
+        except Exception:
+            log.exception('Problem occurred trying to invalidate hash cach for azurefs')
 
 
 def file_hash(load, fnd):


### PR DESCRIPTION
### What does this PR do?

Adds hash cache invalidation to azurefs

### What issues does this PR fix or reference?

n/a

### Previous Behavior

Hash cache was not being invalidated, which meant that if a file had already been served, new versions of that file would not be detected at later `cp.cache_file` calls.

### New Behavior

Hash cache will be invalidated on each fileserver update, as is the case in gitfs

### Tests written?

No