### PR TITLE
Bugfix: runners/survey.py Python 3 compatibility fix

### DIFF
--- a/salt/runners/survey.py
+++ b/salt/runners/survey.py
@@ -171,7 +171,7 @@ def _get_pool_results(*args, **kwargs):
 
     # hash minion return values as a string
     for minion in sorted(minions):
-        digest = hashlib.sha256(str(minions[minion])).hexdigest()
+        digest = hashlib.sha256(str(minions[minion]).encode('utf-8')).hexdigest()
         if digest not in ret:
             ret[digest] = {}
             ret[digest]['pool'] = []

--- a/salt/runners/survey.py
+++ b/salt/runners/survey.py
@@ -171,7 +171,7 @@ def _get_pool_results(*args, **kwargs):
 
     # hash minion return values as a string
     for minion in sorted(minions):
-        digest = hashlib.sha256(str(minions[minion]).encode('utf-8')).hexdigest()
+        digest = hashlib.sha256(str(minions[minion])).hexdigest()
         if digest not in ret:
             ret[digest] = {}
             ret[digest]['pool'] = []

--- a/salt/runners/survey.py
+++ b/salt/runners/survey.py
@@ -171,7 +171,7 @@ def _get_pool_results(*args, **kwargs):
 
     # hash minion return values as a string
     for minion in sorted(minions):
-        digest = hashlib.sha256(str(minions[minion])).hexdigest()
+        digest = hashlib.sha256(str(minions[minion]).encode('utf-8')).hexdigest() 
         if digest not in ret:
             ret[digest] = {}
             ret[digest]['pool'] = []


### PR DESCRIPTION
### What does this PR do?
Fix Survey Runner for Python 3

### What issues does this PR fix or reference?
none

### Previous Behavior
Error when using Python3:
File "/usr/local/lib/python3.6/site-packages/salt/runners/survey.py", line 174, in _get_pool_results
digest = hashlib.sha256(str(minions[minion])).hexdigest()
TypeError: Unicode-objects must be encoded before hashing


### New Behavior
fixed issue

### Tests written?

No