### PR TITLE
[develop] Adding swap_total to core grains

### DIFF
--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -55,6 +55,7 @@ The new grains added are:
 
 * ``fc_wwn``: Show all fibre channel world wide port names for a host
 * ``iscsi_iqn``: Show the iSCSI IQN name for a host
+* ``swap_total``: Show the configured swap_total for Linux, *BSD, OS X and Solaris/SunOS
 
 Grains Changes
 --------------

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -395,63 +395,116 @@ def _sunos_cpudata():
     return grains
 
 
+def _linux_memdata():
+    '''
+    Return the memory information for Linux-like systems
+    '''
+    grains = {'mem_total': 0, 'swap_total': 0}
+
+    meminfo = '/proc/meminfo'
+    if os.path.isfile(meminfo):
+        with salt.utils.files.fopen(meminfo, 'r') as ifile:
+            for line in ifile:
+                comps = line.rstrip('\n').split(':')
+                if not len(comps) > 1:
+                    continue
+                if comps[0].strip() == 'MemTotal':
+                    # Use floor division to force output to be an integer
+                    grains['mem_total'] = int(comps[1].split()[0]) // 1024
+                if comps[0].strip() == 'SwapTotal':
+                    # Use floor division to force output to be an integer
+                    grains['swap_total'] = int(comps[1].split()[0]) // 1024
+    return grains
+
+
+def _osx_memdata():
+    '''
+    Return the memory information for BSD-like systems
+    '''
+    grains = {'mem_total': 0, 'swap_total': 0}
+
+    sysctl = salt.utils.path.which('sysctl')
+    if sysctl:
+        mem = __salt__['cmd.run']('{0} -n hw.memsize'.format(sysctl))
+        swap_total = __salt__['cmd.run']('{0} -n vm.swapusage').split()[2]
+        if swap_total.endswith('K'):
+            _power = 2**10
+        elif swap_total.endswith('M'):
+            _power = 2**20
+        elif swap_total.endswith('G'):
+            _power = 2**30
+        swap_total = swap_total[:-1] * _power
+
+        grains['mem_total'] = int(mem) // 1024 // 1024
+        grains['swap_total'] = int(swap_total) // 1024 // 1024
+    return grains
+
+
+def _bsd_memdata(osdata):
+    '''
+    Return the memory information for BSD-like systems
+    '''
+    grains = {'mem_total': 0, 'swap_total': 0}
+
+    sysctl = salt.utils.path.which('sysctl')
+    if sysctl:
+        mem = __salt__['cmd.run']('{0} -n hw.physmem'.format(sysctl))
+        swap_total = __salt__['cmd.run']('{0} -n vm.swap_total')
+        if osdata['kernel'] == 'NetBSD' and mem.startswith('-'):
+            mem = __salt__['cmd.run']('{0} -n hw.physmem64'.format(sysctl))
+        grains['mem_total'] = int(mem) // 1024 // 1024
+        grains['swap_total'] = int(swap_total) // 1024 // 1024
+    return grains
+
+
+def _sunos_memdata():
+    '''
+    Return the memory information for SunOS-like systems
+    '''
+    grains = {'mem_total': 0, 'swap_total': 0}
+
+    prtconf = '/usr/sbin/prtconf 2>/dev/null'
+    for line in __salt__['cmd.run'](prtconf, python_shell=True).splitlines():
+        comps = line.split(' ')
+        if comps[0].strip() == 'Memory' and comps[1].strip() == 'size:':
+            grains['mem_total'] = int(comps[2].strip())
+
+    swap_cmd = salt.utils.path.which('swap')
+    swap_total = __salt__['cmd.run']('{0} -s'.format(swap_cmd)).split()[1]
+    grains['swap_total'] = int(swap_total) // 1024
+    return grains
+
+
+def _windows_memdata():
+    '''
+    Return the memory information for Windows systems
+    '''
+    grains = {'mem_total': 0}
+    # get the Total Physical memory as reported by msinfo32
+    tot_bytes = win32api.GlobalMemoryStatusEx()['TotalPhys']
+    # return memory info in gigabytes
+    grains['mem_total'] = int(tot_bytes / (1024 ** 2))
+    return grains
+
+
 def _memdata(osdata):
     '''
     Gather information about the system memory
     '''
     # Provides:
     #   mem_total
+    #   swap_total, for supported systems.
     grains = {'mem_total': 0}
     if osdata['kernel'] == 'Linux':
-        meminfo = '/proc/meminfo'
-
-        if os.path.isfile(meminfo):
-            with salt.utils.files.fopen(meminfo, 'r') as ifile:
-                for line in ifile:
-                    comps = line.rstrip('\n').split(':')
-                    if not len(comps) > 1:
-                        continue
-                    if comps[0].strip() == 'MemTotal':
-                        # Use floor division to force output to be an integer
-                        grains['mem_total'] = int(comps[1].split()[0]) // 1024
-                    if comps[0].strip() == 'SwapTotal':
-                        # Use floor division to force output to be an integer
-                        grains['swap_total'] = int(comps[1].split()[0]) // 1024
-    elif osdata['kernel'] in ('FreeBSD', 'OpenBSD', 'NetBSD', 'Darwin'):
-        sysctl = salt.utils.path.which('sysctl')
-        if sysctl:
-            if osdata['kernel'] == 'Darwin':
-                mem = __salt__['cmd.run']('{0} -n hw.memsize'.format(sysctl))
-                swap_total = __salt__['cmd.run']('{0} -n vm.swapusage').split()[2]
-                if swap_total.endswith('K'):
-                    _power = 2**10
-                elif swap_total.endswith('M'):
-                    _power = 2**20
-                elif swap_total.endswith('G'):
-                    _power = 2**30
-                swap_total = swap_total[:-1] * _power
-            else:
-                mem = __salt__['cmd.run']('{0} -n hw.physmem'.format(sysctl))
-                swap_total = __salt__['cmd.run']('{0} -n vm.swap_total')
-            if osdata['kernel'] == 'NetBSD' and mem.startswith('-'):
-                mem = __salt__['cmd.run']('{0} -n hw.physmem64'.format(sysctl))
-            grains['mem_total'] = int(mem) // 1024 // 1024
-            grains['swap_total'] = int(swap_total) // 1024 // 1024
+        grains.update(_linux_memdata())
+    elif osdata['kernel'] in ('FreeBSD', 'OpenBSD', 'NetBSD'):
+        grains.update(_bsd_memdata(osdata))
+    elif osdata['kernel'] == 'Darwin':
+        grains.update(_osx_memdata())
     elif osdata['kernel'] == 'SunOS':
-        prtconf = '/usr/sbin/prtconf 2>/dev/null'
-        for line in __salt__['cmd.run'](prtconf, python_shell=True).splitlines():
-            comps = line.split(' ')
-            if comps[0].strip() == 'Memory' and comps[1].strip() == 'size:':
-                grains['mem_total'] = int(comps[2].strip())
-
-        swap_cmd = salt.utils.path.which('swap')
-        swap_total = __salt__['cmd.run']('{0} -s'.format(swap_cmd)).split()[1]
-        grains['swap_total'] = int(swap_total) // 1024
+        grains.update(_sunos_memdata())
     elif osdata['kernel'] == 'Windows' and HAS_WMI:
-        # get the Total Physical memory as reported by msinfo32
-        tot_bytes = win32api.GlobalMemoryStatusEx()['TotalPhys']
-        # return memory info in gigabytes
-        grains['mem_total'] = int(tot_bytes / (1024 ** 2))
+        grains.update(_windows_memdata())
     return grains
 
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -414,22 +414,39 @@ def _memdata(osdata):
                     if comps[0].strip() == 'MemTotal':
                         # Use floor division to force output to be an integer
                         grains['mem_total'] = int(comps[1].split()[0]) // 1024
+                    if comps[0].strip() == 'SwapTotal':
+                        # Use floor division to force output to be an integer
+                        grains['swap_total'] = int(comps[1].split()[0]) // 1024
     elif osdata['kernel'] in ('FreeBSD', 'OpenBSD', 'NetBSD', 'Darwin'):
         sysctl = salt.utils.path.which('sysctl')
         if sysctl:
             if osdata['kernel'] == 'Darwin':
                 mem = __salt__['cmd.run']('{0} -n hw.memsize'.format(sysctl))
+                swap_total = __salt__['cmd.run']('{0} -n vm.swapusage').split()[2]
+                if swap_total.endswith('K'):
+                    _power = 2**10
+                elif swap_total.endswith('M'):
+                    _power = 2**20
+                elif swap_total.endswith('G'):
+                    _power = 2**30
+                swap_total = swap_total[:-1] * _power
             else:
                 mem = __salt__['cmd.run']('{0} -n hw.physmem'.format(sysctl))
+                swap_total = __salt__['cmd.run']('{0} -n vm.swap_total')
             if osdata['kernel'] == 'NetBSD' and mem.startswith('-'):
                 mem = __salt__['cmd.run']('{0} -n hw.physmem64'.format(sysctl))
             grains['mem_total'] = int(mem) // 1024 // 1024
+            grains['swap_total'] = int(swap_total) // 1024 // 1024
     elif osdata['kernel'] == 'SunOS':
         prtconf = '/usr/sbin/prtconf 2>/dev/null'
         for line in __salt__['cmd.run'](prtconf, python_shell=True).splitlines():
             comps = line.split(' ')
             if comps[0].strip() == 'Memory' and comps[1].strip() == 'size:':
                 grains['mem_total'] = int(comps[2].strip())
+
+        swap_cmd = salt.utils.path.which('swap')
+        swap_total = __salt__['cmd.run']('{0} -s'.format(swap_cmd)).split()[1]
+        grains['swap_total'] = int(swap_total) // 1024
     elif osdata['kernel'] == 'Windows' and HAS_WMI:
         # get the Total Physical memory as reported by msinfo32
         tot_bytes = win32api.GlobalMemoryStatusEx()['TotalPhys']

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -449,7 +449,7 @@ def _bsd_memdata(osdata):
     sysctl = salt.utils.path.which('sysctl')
     if sysctl:
         mem = __salt__['cmd.run']('{0} -n hw.physmem'.format(sysctl))
-        swap_total = __salt__['cmd.run']('{0} -n vm.swap_total')
+        swap_total = __salt__['cmd.run']('{0} -n vm.swap_total'.format(sysctl))
         if osdata['kernel'] == 'NetBSD' and mem.startswith('-'):
             mem = __salt__['cmd.run']('{0} -n hw.physmem64'.format(sysctl))
         grains['mem_total'] = int(mem) // 1024 // 1024

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -622,4 +622,3 @@ SwapTotal:       4789244 kB'''
 
         self.assertEqual(os_grains.get('mem_total'), 2023)
         self.assertEqual(os_grains.get('swap_total'), 400)
-

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -463,3 +463,163 @@ PATCHLEVEL = 3
         self.assertEqual(os_grains.get('osrelease'), os_release_map['osrelease'])
         self.assertListEqual(list(os_grains.get('osrelease_info')), os_release_map['osrelease_info'])
         self.assertEqual(os_grains.get('osmajorrelease'), os_release_map['osmajorrelease'])
+
+    @skipIf(not salt.utils.platform.is_linux(), 'System is not Linux')
+    def test_linux_memdata(self):
+        '''
+        Test memdata on Linux systems
+        '''
+        _path_exists_map = {
+            '/proc/1/cmdline': False,
+            '/proc/meminfo': True
+        }
+        _path_isfile_map = {
+            '/proc/meminfo': True
+        }
+        _cmd_run_map = {
+            'dpkg --print-architecture': 'amd64'
+        }
+
+        path_exists_mock = MagicMock(side_effect=lambda x: _path_exists_map[x])
+        path_isfile_mock = MagicMock(
+            side_effect=lambda x: _path_isfile_map.get(x, False)
+        )
+        cmd_run_mock = MagicMock(
+            side_effect=lambda x: _cmd_run_map[x]
+        )
+        empty_mock = MagicMock(return_value={})
+
+        _proc_meminfo_file = '''MemTotal:       16277028 kB
+SwapTotal:       4789244 kB'''
+
+        orig_import = __import__
+        if six.PY2:
+            built_in = '__builtin__'
+        else:
+            built_in = 'builtins'
+
+        def _import_mock(name, *args):
+            if name == 'lsb_release':
+                raise ImportError('No module named lsb_release')
+            return orig_import(name, *args)
+
+        # Skip the first if statement
+        with patch.object(salt.utils.platform, 'is_proxy',
+                          MagicMock(return_value=False)):
+            # Skip the selinux/systemd stuff (not pertinent)
+            with patch.object(core, '_linux_bin_exists',
+                              MagicMock(return_value=False)):
+                # Skip the init grain compilation (not pertinent)
+                with patch.object(os.path, 'exists', path_exists_mock):
+                    # Ensure that lsb_release fails to import
+                    with patch('{0}.__import__'.format(built_in),
+                               side_effect=_import_mock):
+                        # Skip all the /etc/*-release stuff (not pertinent)
+                        with patch.object(os.path, 'isfile', path_isfile_mock):
+                            # Make a bunch of functions return empty dicts,
+                            # we don't care about these grains for the
+                            # purposes of this test.
+                            with patch.object(
+                                    core,
+                                    '_linux_cpudata',
+                                    empty_mock):
+                                with patch.object(
+                                        core,
+                                        '_linux_gpu_data',
+                                        empty_mock):
+                                    with patch('salt.utils.files.fopen', mock_open()) as _proc_meminfo:
+                                        _proc_meminfo.return_value.__iter__.return_value = _proc_meminfo_file.splitlines()
+                                        with patch.object(
+                                                core,
+                                                '_hw_data',
+                                                empty_mock):
+                                            with patch.object(
+                                                    core,
+                                                    '_virtual',
+                                                    empty_mock):
+                                                with patch.object(
+                                                        core,
+                                                        '_ps',
+                                                        empty_mock):
+                                                    # Mock the osarch
+                                                    with patch.dict(
+                                                            core.__salt__,
+                                                            {'cmd.run': cmd_run_mock}):
+                                                        os_grains = core.os_data()
+
+        self.assertEqual(os_grains.get('mem_total'), 15895)
+        self.assertEqual(os_grains.get('swap_total'), 4676)
+
+    def test_bsd_memdata(self):
+        '''
+        Test to memdata on *BSD systems
+        '''
+        _path_exists_map = {}
+        _path_isfile_map = {}
+        _cmd_run_map = {
+            'freebsd-version -u': '10.3-RELEASE',
+            '/sbin/sysctl -n hw.physmem': '2121781248',
+            '/sbin/sysctl -n vm.swap_total': '419430400'
+        }
+
+        path_exists_mock = MagicMock(side_effect=lambda x: _path_exists_map[x])
+        path_isfile_mock = MagicMock(
+            side_effect=lambda x: _path_isfile_map.get(x, False)
+        )
+        cmd_run_mock = MagicMock(
+            side_effect=lambda x: _cmd_run_map[x]
+        )
+        empty_mock = MagicMock(return_value={})
+
+        mock_freebsd_uname = ('FreeBSD',
+                              'freebsd10.3-hostname-8148',
+                              '10.3-RELEASE',
+                              'FreeBSD 10.3-RELEASE #0 r297264: Fri Mar 25 02:10:02 UTC 2016     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/sys/GENERIC',
+                              'amd64',
+                              'amd64')
+
+        with patch('platform.uname',
+                   MagicMock(return_value=mock_freebsd_uname)):
+            with patch.object(salt.utils.platform, 'is_linux',
+                              MagicMock(return_value=False)):
+                with patch.object(salt.utils.platform, 'is_freebsd',
+                                  MagicMock(return_value=True)):
+                    # Skip the first if statement
+                    with patch.object(salt.utils.platform, 'is_proxy',
+                                      MagicMock(return_value=False)):
+                        # Skip the init grain compilation (not pertinent)
+                        with patch.object(os.path, 'exists', path_exists_mock):
+                            with patch('salt.utils.path.which') as mock:
+                                mock.return_value = '/sbin/sysctl'
+                                # Make a bunch of functions return empty dicts,
+                                # we don't care about these grains for the
+                                # purposes of this test.
+                                with patch.object(
+                                        core,
+                                        '_bsd_cpudata',
+                                        empty_mock):
+                                    with patch.object(
+                                            core,
+                                            '_hw_data',
+                                            empty_mock):
+                                        with patch.object(
+                                                core,
+                                                '_zpool_data',
+                                                empty_mock):
+                                            with patch.object(
+                                                    core,
+                                                    '_virtual',
+                                                    empty_mock):
+                                                with patch.object(
+                                                        core,
+                                                        '_ps',
+                                                        empty_mock):
+                                                    # Mock the osarch
+                                                    with patch.dict(
+                                                            core.__salt__,
+                                                            {'cmd.run': cmd_run_mock}):
+                                                        os_grains = core.os_data()
+
+        self.assertEqual(os_grains.get('mem_total'), 2023)
+        self.assertEqual(os_grains.get('swap_total'), 400)
+


### PR DESCRIPTION
### What does this PR do?
Provide a grain for total amount of swap for Linux, *BSD, OS X and Solaris/SunOS.

### What issues does this PR fix or reference?
#43825 

### Previous Behavior
Previously swap_total was not included in grains.

### New Behavior
Adds a new grain for swap_total.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
