### PR TITLE
Fix object_to_dict in azure

### DIFF
--- a/salt/utils/msazure.py
+++ b/salt/utils/msazure.py
@@ -186,7 +186,7 @@ def object_to_dict(obj):
         ret = obj
     else:
         ret = {}
-        for item in dir(obj):
+        for item in obj.__dict__:
             if item.startswith('_'):
                 continue
             # This is ugly, but inspect.isclass() doesn't seem to work


### PR DESCRIPTION
### What does this PR do?
Previously we were looking at `dir(obj)` and then acting on `obj.__dict__`, which behaves differently. This switches over to `obj.__dict__`.

### What issues does this PR fix or reference?
Fixes #43658

### Previous Behavior
```
KeyError: 'as_dict'
```
### New Behavior
Information displays properly.

### Tests written?
No, because the expected behavior hasn't changed.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
