### PR TITLE
Fix issue with using roster_defaults with flat or cloud rosters.

### DIFF
--- a/salt/roster/cache.py
+++ b/salt/roster/cache.py
@@ -98,6 +98,7 @@ from __future__ import absolute_import
 # Python
 import logging
 import re
+import copy
 
 # Salt libs
 import salt.utils.minions
@@ -151,7 +152,7 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
         except LookupError:
             continue
 
-        minion_res = __opts__.get('roster_defaults', {}).copy()
+        minion_res = copy.deepcopy(__opts__.get('roster_defaults', {}))
         for param, order in roster_order.items():
             if not isinstance(order, (list, tuple)):
                 order = [order]

--- a/salt/roster/cloud.py
+++ b/salt/roster/cloud.py
@@ -63,7 +63,7 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
         ))
         preferred_ip = extract_ipv4(roster_order, ip_list)
 
-        ret[minion_id] = __opts__.get('roster_defaults', {})
+        ret[minion_id] = __opts__.get('roster_defaults', {}).copy()
         ret[minion_id].update({'host': preferred_ip})
 
         ssh_username = salt.utils.cloud.ssh_usernames(vm_, cloud_opts)

--- a/salt/roster/cloud.py
+++ b/salt/roster/cloud.py
@@ -21,6 +21,7 @@ usually located at /etc/salt/cloud. For example, add the following:
 # Import python libs
 from __future__ import absolute_import
 import os
+import copy
 
 # Import Salt libs
 import salt.loader
@@ -63,7 +64,7 @@ def targets(tgt, tgt_type='glob', **kwargs):  # pylint: disable=W0613
         ))
         preferred_ip = extract_ipv4(roster_order, ip_list)
 
-        ret[minion_id] = __opts__.get('roster_defaults', {}).copy()
+        ret[minion_id] = copy.deepcopy(__opts__.get('roster_defaults', {}))
         ret[minion_id].update({'host': preferred_ip})
 
         ssh_username = salt.utils.cloud.ssh_usernames(vm_, cloud_opts)

--- a/salt/roster/clustershell.py
+++ b/salt/roster/clustershell.py
@@ -15,6 +15,7 @@ When you want to use host globs for target matching, use ``--roster clustershell
 # Import python libs
 from __future__ import absolute_import
 import socket
+import copy
 from salt.ext.six.moves import map  # pylint: disable=import-error,redefined-builtin
 
 REQ_ERROR = None
@@ -43,7 +44,7 @@ def targets(tgt, tgt_type='glob', **kwargs):
 
     for host, addr in host_addrs.items():
         addr = str(addr)
-        ret[addr] = __opts__.get('roster_defaults', {}).copy()
+        ret[addr] = copy.deepcopy(__opts__.get('roster_defaults', {}))
         for port in ports:
             try:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 # Import python libs
 import fnmatch
 import re
+import copy
 
 # Try to import range from https://github.com/ytoolshed/range
 HAS_RANGE = False
@@ -142,7 +143,7 @@ class RosterMatcher(object):
         '''
         Return the configured ip
         '''
-        ret = __opts__.get('roster_defaults', {}).copy()
+        ret = copy.deepcopy(__opts__.get('roster_defaults', {}))
         if isinstance(self.raw[minion], string_types):
             ret.update({'host': self.raw[minion]})
             return ret

--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -142,7 +142,7 @@ class RosterMatcher(object):
         '''
         Return the configured ip
         '''
-        ret = __opts__.get('roster_defaults', {})
+        ret = __opts__.get('roster_defaults', {}).copy()
         if isinstance(self.raw[minion], string_types):
             ret.update({'host': self.raw[minion]})
             return ret

--- a/salt/roster/range.py
+++ b/salt/roster/range.py
@@ -13,6 +13,7 @@ When you want to use a range query for target matching, use ``--roster range``. 
 '''
 from __future__ import absolute_import
 import fnmatch
+import copy
 
 import logging
 log = logging.getLogger(__name__)
@@ -68,7 +69,7 @@ def targets(tgt, tgt_type='range', **kwargs):
 def target_range(tgt, hosts):
     ret = {}
     for host in hosts:
-        ret[host] = __opts__.get('roster_defaults', {}).copy()
+        ret[host] = copy.deepcopy(__opts__.get('roster_defaults', {}))
         ret[host].update({'host': host})
         if __opts__.get('ssh_user'):
             ret[host].update({'user': __opts__['ssh_user']})
@@ -79,7 +80,7 @@ def target_glob(tgt, hosts):
     ret = {}
     for host in hosts:
         if fnmatch.fnmatch(tgt, host):
-            ret[host] = __opts__.get('roster_defaults', {}).copy()
+            ret[host] = copy.deepcopy(__opts__.get('roster_defaults', {}))
             ret[host].update({'host': host})
             if __opts__.get('ssh_user'):
                 ret[host].update({'user': __opts__['ssh_user']})

--- a/salt/roster/scan.py
+++ b/salt/roster/scan.py
@@ -7,6 +7,7 @@ Scan a netmask or ipaddr for open ssh ports
 from __future__ import absolute_import
 import socket
 import logging
+import copy
 
 # Import salt libs
 import salt.utils.network
@@ -55,7 +56,7 @@ class RosterMatcher(object):
                 pass
         for addr in addrs:
             addr = str(addr)
-            ret[addr] = __opts__.get('roster_defaults', {}).copy()
+            ret[addr] = copy.deepcopy(__opts__.get('roster_defaults', {}))
             log.trace('Scanning host: {0}'.format(addr))
             for port in ports:
                 log.trace('Scanning port: {0}'.format(port))


### PR DESCRIPTION
### What does this PR do?
If you use the roster_defaults feature with a flat roster and give salt-ssh a command over more than one host, it would result in the command being run on a single one of the hosts N times where N is the number of hosts that the command was intended for. See one of the fixed issues for more info and console output.

### What issues does this PR fix or reference?
fixes #43449
fixes #43643

### Tests written?

No
