### PR TITLE
SaltClass: Correct when dict is NoneType because of the value doesn't exist

### DIFF
--- a/salt/utils/saltclass.py
+++ b/salt/utils/saltclass.py
@@ -104,11 +104,12 @@ def dict_search_and_replace(d, old, new, expanded):
 def find_value_to_expand(x, v):
     a = x
     for i in v[2:-1].split(':'):
+        if a is None:
+            return v
         if i in a:
             a = a.get(i)
         else:
-            a = v
-            return a
+            return v
     return a
 
 

--- a/tests/integration/files/saltclass/examples/classes/default/init.yml
+++ b/tests/integration/files/saltclass/examples/classes/default/init.yml
@@ -9,9 +9,11 @@ pillars:
   default:
     network:
       dns:
+{% if __grains__['os'] == 'should_never_match' %}
         srv1: 192.168.0.1
         srv2: 192.168.0.2
         domain: example.com
+{% endif %}
       ntp:
         srv1: 192.168.10.10
         srv2: 192.168.10.20

--- a/tests/integration/files/saltclass/examples/nodes/fake_id.yml
+++ b/tests/integration/files/saltclass/examples/nodes/fake_id.yml
@@ -1,6 +1,6 @@
 environment: base
 
 classes:
-{% for class in ['default'] %}
+{% for class in ['default', 'roles.app'] %}
   - {{ class }}
 {% endfor %}

--- a/tests/unit/pillar/test_saltclass.py
+++ b/tests/unit/pillar/test_saltclass.py
@@ -34,10 +34,17 @@ class SaltclassPillarTestCase(TestCase, LoaderModuleMockMixin):
                            }}
 
     def _runner(self, expected_ret):
-        full_ret = saltclass.ext_pillar(fake_minion_id, fake_pillar, fake_args)
-        parsed_ret = full_ret['__saltclass__']['classes']
+        full_ret = {}
+        parsed_ret = []
+        try:
+            full_ret = saltclass.ext_pillar(fake_minion_id, fake_pillar, fake_args)
+            parsed_ret = full_ret['__saltclass__']['classes']
+        # Fail the test if we hit our NoneType error
+        except TypeError as err:
+            self.fail(err)
+        # Else give the parsed content result
         self.assertListEqual(parsed_ret, expected_ret)
 
     def test_succeeds(self):
-        ret = ['default.users', 'default.motd', 'default']
+        ret = ['default.users', 'default.motd', 'default', 'roles.app']
         self._runner(ret)


### PR DESCRIPTION
Example:

``` yaml
pillars:
  default:
    commands:
{% if grains['os'] == 'RedHat' %}
      pkg_grains: /usr/bin/rpm_grains
{% endif %}
```

In this case `pkg_grains` wouldn't be found on anything else that RedHat systems and would be NoneType which would return an error and break the module.