### PR TITLE
Show all nodes if no resource_group specified

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -401,8 +401,9 @@ def list_nodes(conn=None, call=None):  # pylint: disable=unused-argument
         pass
 
     for node in nodes:
-        if not nodes[node]['resource_group'] == active_resource_group:
-            continue
+        if active_resource_group is not None:
+            if nodes[node]['resource_group'] != active_resource_group:
+                continue
         ret[node] = {'name': node}
         for prop in ('id', 'image', 'size', 'state', 'private_ips', 'public_ips'):
             ret[node][prop] = nodes[node].get(prop)


### PR DESCRIPTION
### What does this PR do?
If no `resource_group` is configured in the provider, all nodes will not be shown (with `list_nodes()`).

### What issues does this PR fix or reference?
None known.

### Previous Behavior
If no `resource_group` was configured, then no nodes would be shown when using `list_nodes()`.

### Tests written?
No. Expected behavior did not change.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
