### PR TITLE
Fix win_lgpo execution module

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2879,7 +2879,7 @@ def _findOptionValueInSeceditFile(option):
                     else:
                         break
                 else:
-                    log.error('error occured removing {0}'.format(_tfile))
+                    log.error('error occurred removing {0}'.format(_tfile))
             for _line in _secdata:
                 if _line.startswith(option):
                     return True, _line.split('=')[1].strip()

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -46,6 +46,7 @@ import logging
 import re
 import locale
 import ctypes
+import time
 
 # Import salt libs
 import salt.utils
@@ -2868,10 +2869,17 @@ def _findOptionValueInSeceditFile(option):
         if _ret:
             with io.open(_tfile, encoding='utf-16') as _reader:
                 _secdata = _reader.readlines()
-            while not _reader.closed:
-                _reader.close()
             if __salt__['file.file_exists'](_tfile):
-                _ret = __salt__['file.remove'](_tfile)
+                for _ in range(5):
+                    try:
+                        __salt__['file.remove'](_tfile)
+                    except WindowsError:
+                        time.sleep(.1)
+                        continue
+                    else:
+                        break
+                else:
+                    log.error('error occured removing {0}'.format(_tfile))
             for _line in _secdata:
                 if _line.startswith(option):
                     return True, _line.split('=')[1].strip()

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2873,7 +2873,7 @@ def _findOptionValueInSeceditFile(option):
                 for _ in range(5):
                     try:
                         __salt__['file.remove'](_tfile)
-                    except WindowsError:  # pylint: disable=E0602
+                    except CommandExecutionError:
                         time.sleep(.1)
                         continue
                     else:

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -34,7 +34,6 @@ Current known limitations
   - pywin32 Python module
   - lxml
   - uuid
-  - codecs
   - struct
   - salt.modules.reg
 '''
@@ -93,7 +92,6 @@ try:
     import win32net
     import win32security
     import uuid
-    import codecs
     import lxml
     import struct
     from lxml import etree
@@ -2872,6 +2870,7 @@ def _findOptionValueInSeceditFile(option):
                 _secdata = _reader.readlines()
             while not _reader.closed:
                 _reader.close()
+                _reader.
             if __salt__['file.file_exists'](_tfile):
                 _ret = __salt__['file.remove'](_tfile)
             for _line in _secdata:

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -128,7 +128,8 @@ try:
     # Not available in win32api, so we have to use ctypes
     # Default to `en-US` (1033)
     windll = ctypes.windll.kernel32
-    INSTALL_LANGUAGE = locale.windows_locale.get(windll.GetSystemDefaultUILanguage(), 1033)
+    INSTALL_LANGUAGE = locale.windows_locale.get(
+        windll.GetSystemDefaultUILanguage(), 1033).replace('_', '-')
 except ImportError:
     HAS_WINDOWS_MODULES = False
 
@@ -2799,7 +2800,7 @@ def _processPolicyDefinitions(policy_def_path='c:\\Windows\\PolicyDefinitions',
                            'language code will be tried.')
                     log.info(msg.format(display_language, t_admfile))
 
-                    adml_file = os.path.join(root, display_language[:2],
+                    adml_file = os.path.join(root, display_language.split('-')[0],
                             os.path.splitext(t_admfile)[0] + '.adml')
                     if not __salt__['file.file_exists'](adml_file):
                         msg = ('An ADML file in the specified ADML language code "{0}" '
@@ -2815,7 +2816,7 @@ def _processPolicyDefinitions(policy_def_path='c:\\Windows\\PolicyDefinitions',
                                    'fallback language code will be tried.')
                             log.info(msg.format(display_language_fallback, t_admfile))
 
-                            adml_file = os.path.join(root, display_language_fallback[:2],
+                            adml_file = os.path.join(root, display_language_fallback.split('-')[0],
                                     os.path.splitext(t_admfile)[0] + '.adml')
                             if not __salt__['file.file_exists'](adml_file):
                                 msg = ('An ADML file in the specified ADML language '

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -41,6 +41,7 @@ Current known limitations
 
 # Import python libs
 from __future__ import absolute_import
+import io
 import os
 import logging
 import re
@@ -2862,13 +2863,14 @@ def _findOptionValueInSeceditFile(option):
     '''
     try:
         _d = uuid.uuid4().hex
-        _tfile = '{0}\\{1}'.format(__salt__['config.get']('cachedir'),
+        _tfile = '{0}\\{1}'.format(__opts__['cachedir'],
                                    'salt-secedit-dump-{0}.txt'.format(_d))
         _ret = __salt__['cmd.run']('secedit /export /cfg {0}'.format(_tfile))
         if _ret:
-            _reader = codecs.open(_tfile, 'r', encoding='utf-16')
-            _secdata = _reader.readlines()
-            _reader.close()
+            with io.open(_tfile, encoding='utf-16') as _reader:
+                _secdata = _reader.readlines()
+            while not _reader.closed:
+                _reader.close()
             if __salt__['file.file_exists'](_tfile):
                 _ret = __salt__['file.remove'](_tfile)
             for _line in _secdata:
@@ -2886,9 +2888,9 @@ def _importSeceditConfig(infdata):
     '''
     try:
         _d = uuid.uuid4().hex
-        _tSdbfile = '{0}\\{1}'.format(__salt__['config.get']('cachedir'),
+        _tSdbfile = '{0}\\{1}'.format(__opts__['cachedir'],
                                       'salt-secedit-import-{0}.sdb'.format(_d))
-        _tInfFile = '{0}\\{1}'.format(__salt__['config.get']('cachedir'),
+        _tInfFile = '{0}\\{1}'.format(__opts__['cachedir'],
                                       'salt-secedit-config-{0}.inf'.format(_d))
         # make sure our temp files don't already exist
         if __salt__['file.file_exists'](_tSdbfile):

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2873,7 +2873,7 @@ def _findOptionValueInSeceditFile(option):
                 for _ in range(5):
                     try:
                         __salt__['file.remove'](_tfile)
-                    except WindowsError:
+                    except WindowsError:  # pylint: disable=E0602
                         time.sleep(.1)
                         continue
                     else:

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2870,7 +2870,6 @@ def _findOptionValueInSeceditFile(option):
                 _secdata = _reader.readlines()
             while not _reader.closed:
                 _reader.close()
-                _reader.
             if __salt__['file.file_exists'](_tfile):
                 _ret = __salt__['file.remove'](_tfile)
             for _line in _secdata:


### PR DESCRIPTION
### What does this PR do?
The _processPolicyDefinitions function loads the `adml` files for the corresponding `admx`. The `adml` file usually resides in a subfolder in the `C:\Windows\PolicyDefinitions` directory that is the language code. The default is `en-US`.
When the System Center Operations Manager (SCOM) agent is installed, it adds some additional policy definitions. However, the corresponding `adml` files are not in the standard location (`en-US`). Instead, they are placed in the `en` directory.
This PR will cause the win_lgpo module to check in the `en-US` directory first and then check the `en` directory if still not found.

Additionally, this PR fixes an issue in the `_findOptionValueInSeceditFile` function where the `file.remove` operation would fail due to a lock on the dump file. We don't know where this lock was coming from as python has released the file. Possibly antivirus software.
This adds an additional try/except/else block to catch the error, sleep, and try again. If it fails after 5 tries, it doesn't throw an error, it will just leave the dump file on the system instead of causing the whole module to fail.

@lomeroe Would you mind taking a look? Also, I would like to have your contact information... Could you send me an email at slee@saltstack.com?

### What issues does this PR fix or reference?
Customer Support Issue

### Previous Behavior
```
minion-name:
----------
          ID: configure_windows_update
    Function: lgpo.set
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "c:\salt\bin\lib\site-packages\salt\state.py", line 1843, in call
                  **cdata['kwargs'])
                File "c:\salt\bin\lib\site-packages\salt\loader.py", line 1795, in wrapper
                  return f(*args, **kwargs)
                File "c:\salt\bin\lib\site-packages\salt\states\win_lgpo.py", line 233, in set_
                  adml_language=adml_language)
                File "c:\salt\bin\lib\site-packages\salt\modules\win_lgpo.py", line 4799, in get_policy_info
                  display_language=adml_language)
                File "c:\salt\bin\lib\site-packages\salt\modules\win_lgpo.py", line 2791, in _processPolicyDefinitions
                  t_admfile))
              SaltInvocationError: An ADML file in the specified ADML language "en-US" and the fallback language "en-US" do not exist for the ADMX "HealthService.admx".
     Started: 13:46:29.740000
    Duration: 172.0 ms
     Changes:
```

### New Behavior
State applied successfully.

### Tests written?
No