### PR TITLE
enable tox for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ tests/integration/cloud/providers/logs
 
 # Private keys from the integration tests
 tests/integration/cloud/providers/pki/minions
+
+# Ignore tox virtualenvs
+/.tox/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py27,py34,py35,py36
+
+[testenv]
+sitepackages = True
+deps =
+  py27,pylint: -r{toxinidir}/requirements/dev_python27.txt
+  py34,py35,py36: -r{toxinidir}/requirements/dev_python34.txt
+commands =
+  py27: python2 {toxinidir}/tests/runtests.py {posargs:-v --run-destructive}
+  py34,py35,py36: python3 {toxinidir}/tests/runtests.py {posargs:-v --run-destructive}
+
+[testenv:pylint]
+basepython = python2.7
+commands = pylint --rcfile={toxinidir}/.testing.pylintrc --disable=W1307 {posargs:setup.py salt/}
+           pylint --rcfile={toxinidir}/.testing.pylintrc --disable=W0232,E1002,W1307 {posargs:tests/}


### PR DESCRIPTION
### What does this PR do?

This allows people to get started on running tests and pylint locally more easily.

```
tox -e pylint
tox -e py27,py36
```

This will create a virtualenv in `/.tox/<envname>`, and then run the tests or pylint from there.

This will also make configuring and running tests against with kitchen-salt easier (can just use tox)

### Tests written?

No