### PR TITLE
Make sure EBS volume exists before querying

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1988,7 +1988,7 @@ def request_instance(vm_=None, call=None):
             params[termination_key] = str(set_del_root_vol_on_destroy).lower()
 
             # Use default volume type if not specified
-            if ex_blockdevicemappings and 'Ebs.VolumeType' not in ex_blockdevicemappings[dev_index]:
+            if ex_blockdevicemappings and dev_index < len(ex_blockdevicemappings) and 'Ebs.VolumeType' not in ex_blockdevicemappings[dev_index]:
                 type_key = '{0}BlockDeviceMapping.{1}.Ebs.VolumeType'.format(spot_prefix, dev_index)
                 params[type_key] = rd_type
 


### PR DESCRIPTION
### What does this PR do?
Fixes a problem in `salt-cloud` that could cause EC2 instances not to be set up.

### What issues does this PR fix or reference?
Fixes an issue introduced in #33115 where specifying a secondary volume without a root volume would cause the setup to fail. Probably also fixes #41894 and #39257 as these point to the same piece of code.

### Previous Behavior
If you didn't specify a root volume it would crash with a `IndexError: list index out of range`

### New Behavior
No longer crashes and uses fallback as appropriately

### Tests written?

No
