### PR TITLE
Don't put unserializable dict.keys() into state return

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -253,7 +253,7 @@ def run(**kwargs):
     if 'name' in kwargs:
         kwargs.pop('name')
     ret = {
-        'name': kwargs.keys(),
+        'name': list(kwargs),
         'changes': {},
         'comment': '',
         'result': None,


### PR DESCRIPTION
Running ``list()`` on the dictionary produces the same list, and has the benefit of not catastrophically failing on Python 3.

Fixes #43605.
Fixes #43909.