### PR TITLE
Fix `unit.test_pillar` for Windows

### DIFF
--- a/tests/unit/test_pillar.py
+++ b/tests/unit/test_pillar.py
@@ -192,7 +192,7 @@ class PillarTestCase(TestCase):
     def _setup_test_topfile_mocks(self, Matcher, get_file_client,
                                   nodegroup_order, glob_order):
         # Write a simple topfile and two pillar state files
-        self.top_file = tempfile.NamedTemporaryFile(dir=TMP)
+        self.top_file = tempfile.NamedTemporaryFile(dir=TMP, delete=False)
         s = '''
 base:
     group:
@@ -209,19 +209,19 @@ base:
 '''.format(nodegroup_order=nodegroup_order, glob_order=glob_order)
         self.top_file.write(salt.utils.to_bytes(s))
         self.top_file.flush()
-        self.ssh_file = tempfile.NamedTemporaryFile(dir=TMP)
+        self.ssh_file = tempfile.NamedTemporaryFile(dir=TMP, delete=False)
         self.ssh_file.write(b'''
 ssh:
     foo
 ''')
         self.ssh_file.flush()
-        self.ssh_minion_file = tempfile.NamedTemporaryFile(dir=TMP)
+        self.ssh_minion_file = tempfile.NamedTemporaryFile(dir=TMP, delete=False)
         self.ssh_minion_file.write(b'''
 ssh:
     bar
 ''')
         self.ssh_minion_file.flush()
-        self.generic_file = tempfile.NamedTemporaryFile(dir=TMP)
+        self.generic_file = tempfile.NamedTemporaryFile(dir=TMP, delete=False)
         self.generic_file.write(b'''
 generic:
     key1:
@@ -231,7 +231,7 @@ generic:
         sub_key1: []
 ''')
         self.generic_file.flush()
-        self.generic_minion_file = tempfile.NamedTemporaryFile(dir=TMP)
+        self.generic_minion_file = tempfile.NamedTemporaryFile(dir=TMP, delete=False)
         self.generic_minion_file.write(b'''
 generic:
     key1:
@@ -260,7 +260,7 @@ generic:
         client.get_state.side_effect = get_state
 
     def _setup_test_include_mocks(self, Matcher, get_file_client):
-        self.top_file = top_file = tempfile.NamedTemporaryFile(dir=TMP)
+        self.top_file = top_file = tempfile.NamedTemporaryFile(dir=TMP, delete=False)
         top_file.write(b'''
 base:
     '*':
@@ -271,21 +271,21 @@ base:
         - test
 ''')
         top_file.flush()
-        self.init_sls = init_sls = tempfile.NamedTemporaryFile(dir=TMP)
+        self.init_sls = init_sls = tempfile.NamedTemporaryFile(dir=TMP, delete=False)
         init_sls.write(b'''
 include:
    - test.sub1
    - test.sub2
 ''')
         init_sls.flush()
-        self.sub1_sls = sub1_sls = tempfile.NamedTemporaryFile(dir=TMP)
+        self.sub1_sls = sub1_sls = tempfile.NamedTemporaryFile(dir=TMP, delete=False)
         sub1_sls.write(b'''
 p1:
    - value1_1
    - value1_2
 ''')
         sub1_sls.flush()
-        self.sub2_sls = sub2_sls = tempfile.NamedTemporaryFile(dir=TMP)
+        self.sub2_sls = sub2_sls = tempfile.NamedTemporaryFile(dir=TMP, delete=False)
         sub2_sls.write(b'''
 p1:
    - value1_3


### PR DESCRIPTION
### What does this PR do?
Use `delete=False` in NamedTemporaryFile command otherwise the handle to the file isn't released and the file can't be opened by the actual test. This only happens on Windows systems.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes