### PR TITLE
if expect_minions is passed use that instead

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1582,7 +1582,7 @@ class LocalClient(object):
                                          timeout=timeout,
                                          tgt=tgt,
                                          tgt_type=tgt_type,
-                                         expect_minions=(verbose or show_timeout),
+                                         expect_minions=(kwargs.pop('expect_minions', False) or verbose or show_timeout),
                                          **kwargs
                                          ):
             log.debug('return event: %s', ret)

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1582,6 +1582,9 @@ class LocalClient(object):
                                          timeout=timeout,
                                          tgt=tgt,
                                          tgt_type=tgt_type,
+                                         # (gtmanfred) expect_minions is popped here incase it is passed from a client
+                                         # call. If this is not popped, then it would be passed twice to
+                                         # get_iter_returns.
                                          expect_minions=(kwargs.pop('expect_minions', False) or verbose or show_timeout),
                                          **kwargs
                                          ):


### PR DESCRIPTION
### What does this PR do?
In the salt/states/saltmod.py, we set expect minions sometimes and pass that
through.  In this instance, we should use the expect_minions that is passed so
that it does not get passed along twice.

### What issues does this PR fix or reference?
Fixes #43918 

### Tests written?

No