### PR TITLE
Add missing param lxc proxmox driver

### DIFF
--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -723,7 +723,7 @@ def create_node(vm_, newid):
         newnode['hostname'] = vm_['name']
         newnode['ostemplate'] = vm_['image']
 
-        static_props = ('cpuunits', 'cpulimit', 'rootfs', 'cores','description', 'memory', 'onboot', 'net0',
+        static_props = ('cpuunits', 'cpulimit', 'rootfs', 'cores', 'description', 'memory', 'onboot', 'net0',
                         'password', 'nameserver', 'swap', 'storage', 'rootfs')
         for prop in _get_properties('/nodes/{node}/lxc',
                                     'POST',

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -723,7 +723,7 @@ def create_node(vm_, newid):
         newnode['hostname'] = vm_['name']
         newnode['ostemplate'] = vm_['image']
 
-        static_props = ('cpuunits', 'description', 'memory', 'onboot', 'net0',
+        static_props = ('cpuunits', 'cpulimit', 'rootfs', 'cores','description', 'memory', 'onboot', 'net0',
                         'password', 'nameserver', 'swap', 'storage', 'rootfs')
         for prop in _get_properties('/nodes/{node}/lxc',
                                     'POST',


### PR DESCRIPTION
### What does this PR do?
Adds few more paramters handling to the proxmox driver for lxc

### What issues does this PR fix or reference?
Not a fix

### Previous Behavior
The proxmox driver was not able to handle cores, cpulimit and rootfs params

### New Behavior
The proxmox driver is now able to handle cores, cpulimit and rootfs params

### Tests written?
No
Tested on my own dev env, everything works as expected.

