### PR TITLE
Document key_text option in pkgrepo state and add some checks

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -259,6 +259,14 @@ def managed(name, ppa=None, **kwargs):
 
            Use either ``keyid``/``keyserver`` or ``key_url``, but not both.
 
+    key_text
+        The string representation of the GPG key to install.
+
+       .. note::
+
+           Use either ``keyid``/``keyserver``, ``key_url``, or ``key_text`` but
+           not more than one method.
+
     consolidate : False
        If set to ``True``, this will consolidate all sources definitions to the
        sources.list file, cleanup the now unused files, consolidate components

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -312,6 +312,16 @@ def managed(name, ppa=None, **kwargs):
         ret['result'] = False
         ret['comment'] = 'You may not use both "keyid"/"keyserver" and ' \
                          '"key_url" argument.'
+
+    if 'key_text' in kwargs and ('keyid' in kwargs or 'keyserver' in kwargs):
+        ret['result'] = False
+        ret['comment'] = 'You may not use both "keyid"/"keyserver" and ' \
+                         '"key_text" argument.'
+    if 'key_text' in kwargs and ('key_url' in kwargs):
+        ret['result'] = False
+        ret['comment'] = 'You may not use both "key_url" and ' \
+                         '"key_text" argument.'
+
     if 'repo' in kwargs:
         ret['result'] = False
         ret['comment'] = ('\'repo\' is not a supported argument for this '


### PR DESCRIPTION
### What does this PR do?
Document the `key_text` option in the `pkgrepo` state and add some checks to verify there are no conflicts with other options

### What issues does this PR fix or reference?
#37936

### New Behavior
Ensures there are no conflicts with `key_text` and the `keyid`/`keyserver` or `key_url` options.

### Tests written?
No

