### PR TITLE
Fix fileclient's get_url when redirecting to a redirect

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -623,10 +623,11 @@ class Client(object):
                 if write_body[1] is not False and write_body[2] is None:
                     if not hdr.strip() and 'Content-Type' not in write_body[1]:
                         # We've reached the end of the headers and not yet
-                        # found the Content-Type. Reset the values we're
-                        # tracking so that we properly follow the redirect.
-                        write_body[0] = None
-                        write_body[1] = False
+                        # found the Content-Type. Reset write_body[0] so that
+                        # we properly follow the redirect. Note that slicing is
+                        # used below to ensure that we re-use the same list
+                        # rather than creating a new one.
+                        write_body[0:2] = (None, False)
                         return
                     # Try to find out what content type encoding is used if
                     # this is a text file
@@ -648,9 +649,12 @@ class Client(object):
                         # If write_body[0] is False, this means that this
                         # header is a 30x redirect, so we need to reset
                         # write_body[0] to None so that we parse the HTTP
-                        # status code from the redirect target.
+                        # status code from the redirect target. Additionally,
+                        # we need to reset write_body[2] so that we inspect the
+                        # headers for the Content-Type of the URL we're
+                        # following.
                         if write_body[0] is write_body[1] is False:
-                            write_body[0] = None
+                            write_body[0] = write_body[2] = None
 
                 # Check the status line of the HTTP request
                 if write_body[0] is None:


### PR DESCRIPTION
When a 30x leads to a 200 OK, we properly reset ``write_body[0]`` so that we save the body of the response. However, when both A) a 30x redirects to another 30x and B) we've already determined the encoding from the Content-Type (and thus set ``write_body[2]``), then we don't properly set ``write_body[0]``, resulting in a zero-length file. This commit fixes this by also resetting the ``write_body[2]`` when following redirects, so that we make sure we are getting the encoding for the request to the URL that resulted in the 200 instead of the one that resulted in the 30x.

Note: Explanations of what the different elements of write_body do can be found there in fileclient.py above the ``on_header`` func.