### PR TITLE
Ensure that anonymous is False when the bindpw is not set

### DIFF
--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -110,6 +110,10 @@ class _LDAPConnection(object):
             self.ldap.set_option(ldap.OPT_REFERRALS, 0)  # Needed for AD
 
             if not anonymous:
+                if self.bindpw is None or len(self.bindpw) < 1:
+                    raise CommandExecutionError(
+                        'LDAP bind password is not set: password cannot be empty if auth.ldap.anonymous is False'
+                    )
                 self.ldap.simple_bind_s(self.binddn, self.bindpw)
         except Exception as ldap_error:
             raise CommandExecutionError(


### PR DESCRIPTION
### What does this PR do?

If auth.ldap.anonymous is set to False then the bind password for the LDAP or Active Directory server can no longer be empty.