### PR TITLE
Require that bindpw be non-empty when auth.ldap.anonymous is False

### DIFF
--- a/doc/topics/eauth/index.rst
+++ b/doc/topics/eauth/index.rst
@@ -218,6 +218,7 @@ Server configuration values and their defaults:
 
     # Bind to LDAP anonymously to determine group membership
     # Active Directory does not allow anonymous binds without special configuration
+    # In addition, if auth.ldap.anonymous is True, empty bind passwords are not permitted.
     auth.ldap.anonymous: False
 
     # FOR TESTING ONLY, this is a VERY insecure setting.
@@ -250,7 +251,11 @@ and groups, it re-authenticates as the user running the Salt commands.
 
 If you are already aware of the structure of your DNs and permissions in your LDAP store are set such that
 users can look up their own group memberships, then the first and second users can be the same.  To tell Salt this is
-the case, omit the ``auth.ldap.bindpw`` parameter.  You can template the ``binddn`` like this:
+the case, omit the ``auth.ldap.bindpw`` parameter.  Note this is not the same thing as using an anonymous bind.
+Most LDAP servers will not permit anonymous bind, and as mentioned above, if `auth.ldap.anonymous` is False you
+cannot use an empty password.
+
+You can template the ``binddn`` like this:
 
 .. code-block:: yaml
 

--- a/doc/topics/releases/2016.11.8.rst
+++ b/doc/topics/releases/2016.11.8.rst
@@ -4,6 +4,11 @@ Salt 2016.11.8 Release Notes
 
 Version 2016.11.8 is a bugfix release for :ref:`2016.11.0 <release-2016-11-0>`.]
 
+Anonymous Binds and LDAP/Active Directory
+-----------------------------------------
+
+When auth.ldap.anonymous is set to False, the bind password can no longer be empty.
+
 Changes for v2016.11.7..v2016.11.8
 ----------------------------------
 

--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -110,6 +110,10 @@ class _LDAPConnection(object):
             self.ldap.set_option(ldap.OPT_REFERRALS, 0)  # Needed for AD
 
             if not anonymous:
+                if self.bindpw is None or len(self.bindpw) < 1:
+                    raise CommandExecutionError(
+                        'LDAP bind password is not set: password cannot be empty if auth.ldap.anonymous is False'
+                    )
                 self.ldap.simple_bind_s(self.binddn, self.bindpw)
         except Exception as ldap_error:
             raise CommandExecutionError(


### PR DESCRIPTION
### What does this PR do?

If auth.ldap.anonymous is set to False then the bind password for the LDAP or Active Directory server can no longer be empty.