### PR TITLE
create route to send traffic by natting for_GCP

### DIFF
--- a/salt/modules/gcp_addon.py
+++ b/salt/modules/gcp_addon.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+'''
+A route is a rule that specifies how certain packets should be handled by the
+virtual network. Routes are associated with virtual machine instances by tag,
+and the set of routes for a particular VM is called its routing table.
+For each packet leaving a virtual machine, the system searches that machine's
+routing table for a single best matching route.
+
+This module will create a route to send traffic destined to the Internet
+through your gateway instance.
+
+:codeauthor: :email:`Pratik Bandarkar <pratik.bandarkar@gmail.com>`
+:maturity:   new
+:depends:    google-api-python-client
+:platform:   Linux
+'''
+from __future__ import absolute_import
+import logging
+log = logging.getLogger(__name__)
+
+try:
+    import googleapiclient.discovery
+    import oauth2client.service_account
+    HAS_LIB = True
+except ImportError:
+    HAS_LIB = False
+
+__virtualname__ = 'gcp'
+
+
+def __virtual__():
+    '''
+    Check for googleapiclient api
+    '''
+    if HAS_LIB is False:
+        log.info("Required google API's(googleapiclient, oauth2client) not found")
+    return (HAS_LIB, "Required google API's(googleapiclient, oauth2client) not found")
+
+
+def _get_network(project_id, network_name, service):
+    '''
+    Fetch network selfLink from network name.
+    '''
+    return service.networks().get(project=project_id,
+                                  network=network_name).execute()
+
+
+def _get_instance(project_id, instance_zone, name, service):
+    '''
+    Get instance details
+    '''
+    return service.instances().get(project=project_id,
+                                   zone=instance_zone,
+                                   instance=name).execute()
+
+
+def route_create(credential_file=None,
+                 project_id=None,
+                 name=None,
+                 dest_range=None,
+                 next_hop_instance=None,
+                 instance_zone=None,
+                 tags=None,
+                 network=None,
+                 priority=None
+                 ):
+    '''
+    Create a route to send traffic destined to the Internet through your
+    gateway instance
+
+    credential_file : string
+        File location of application default credential. For more information,
+        refer: https://developers.google.com/identity/protocols/application-default-credentials
+    project_id : string
+        Project ID where instance and network resides.
+    name : string
+        name of the route to create
+    next_hop_instance : string
+        the name of an instance that should handle traffic matching this route.
+    instance_zone : string
+        zone where instance("next_hop_instance") resides
+    network : string
+        Specifies the network to which the route will be applied.
+    dest_range : string
+        The destination range of outgoing packets that the route will apply to.
+    tags : list
+        (optional) Identifies the set of instances that this route will apply to.
+    priority : int
+        (optional) Specifies the priority of this route relative to other routes.
+        default=1000
+
+    CLI Example:
+
+    salt 'salt-master.novalocal' gcp.route_create
+        credential_file=/root/secret_key.json
+        project_id=cp100-170315
+        name=derby-db-route1
+        next_hop_instance=instance-1
+        instance_zone=us-central1-a
+        network=default
+        dest_range=0.0.0.0/0
+        tags=['no-ip']
+        priority=700
+
+    In above example, the instances which are having tag "no-ip" will route the
+    packet to instance "instance-1"(if packet is intended to other network)
+    '''
+
+    credentials = oauth2client.service_account.ServiceAccountCredentials.\
+        from_json_keyfile_name(credential_file)
+    service = googleapiclient.discovery.build('compute', 'v1',
+                                              credentials=credentials)
+    routes = service.routes()
+
+    routes_config = {
+        'name': str(name),
+        'network': _get_network(project_id, str(network),
+                                service=service)['selfLink'],
+        'destRange': str(dest_range),
+        'nextHopInstance': _get_instance(project_id, instance_zone,
+                                         next_hop_instance,
+                                         service=service)['selfLink'],
+        'tags': tags,
+        'priority': priority
+    }
+    route_create_request = routes.insert(project=project_id,
+                                         body=routes_config)
+    return route_create_request.execute()


### PR DESCRIPTION
In GCP,  route is a rule that specifies how certain packets should be handled by the
irtual network. Routes are associated with virtual machine instances by tag,
and the set of routes for a particular VM is called its routing table.
For each packet leaving a virtual machine, the system searches that machine's
routing table for a single best matching route.

This module will create a route to send traffic destined to the Internet
through your gateway instance.

### What does this PR do?
For GCP, added execution module which creates route to nat the network traffic via specified instance. For more information refer: https://cloud.google.com/compute/docs/vpc/special-configurations#natgateway

### What issues does this PR fix or reference?
I dont find any existing execution module for this requirement.

### Tests written?
No.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
