### PR TITLE
Fix grains.has_value when value is False

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -121,7 +121,7 @@ def get(key, default='', delimiter=DEFAULT_TARGET_DELIM, ordered=True):
 
 def has_value(key):
     '''
-    Determine whether a named value exists in the grains dictionary.
+    Determine whether a key exists in the grains dictionary.
 
     Given a grains dictionary that contains the following structure::
 
@@ -137,7 +137,10 @@ def has_value(key):
 
         salt '*' grains.has_value pkg:apache
     '''
-    return True if salt.utils.traverse_dict_and_list(__grains__, key, False) else False
+    return salt.utils.traverse_dict_and_list(
+        __grains__,
+        key,
+        KeyError) is not KeyError
 
 
 def items(sanitize=False):


### PR DESCRIPTION
This function returns a boolean based on the boolean result of the value returned when looking up the key. However, this means that if a key exists and has a value of 0, an empty string, or False/None, ``grains.has_value`` will incorrectly return ``False``. This fixes that by only returning ``False`` when the key is not present.