### PR TITLE
Bugfix: always return a string "list" on unknown job target type.

### DIFF
--- a/salt/returners/couchbase_return.py
+++ b/salt/returners/couchbase_return.py
@@ -313,7 +313,7 @@ def _format_job_instance(job):
            'Arguments': list(job.get('arg', [])),
            # unlikely but safeguard from invalid returns
            'Target': job.get('tgt', 'unknown-target'),
-           'Target-type': job.get('tgt_type', []),
+           'Target-type': job.get('tgt_type', 'list'),
            'User': job.get('user', 'root')}
 
     if 'metadata' in job:

--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -170,7 +170,7 @@ def _format_job_instance(job):
            'Arguments': json.loads(job.get('arg', '[]')),
            # unlikely but safeguard from invalid returns
            'Target': job.get('tgt', 'unknown-target'),
-           'Target-type': job.get('tgt_type', []),
+           'Target-type': job.get('tgt_type', 'list'),
            'User': job.get('user', 'root')}
     # TODO: Add Metadata support when it is merged from develop
     return ret

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -543,7 +543,7 @@ def _format_job_instance(job):
            'Arguments': list(job.get('arg', [])),
            # unlikely but safeguard from invalid returns
            'Target': job.get('tgt', 'unknown-target'),
-           'Target-type': job.get('tgt_type', []),
+           'Target-type': job.get('tgt_type', 'list'),
            'User': job.get('user', 'root')}
 
     if 'metadata' in job:

--- a/salt/utils/jid.py
+++ b/salt/utils/jid.py
@@ -75,7 +75,7 @@ def format_job_instance(job):
            'Arguments': list(job.get('arg', [])),
            # unlikely but safeguard from invalid returns
            'Target': job.get('tgt', 'unknown-target'),
-           'Target-type': job.get('tgt_type', []),
+           'Target-type': job.get('tgt_type', 'list'),
            'User': job.get('user', 'root')}
 
     if 'metadata' in job:


### PR DESCRIPTION
### What does this PR do?

Bugfix. The command `salt-run --out json jobs.list_job <your job id here>` returns either `[]` type or `"list` string if Job ID is non-existing or existing.

Before:
```json
{
    "Function": "unknown-function", 
    "jid": "b1946ac92492d2347c6235b4d2611184", 
    "Result": {}, 
    "Target": "unknown-target", 
    "StartTime": "", 
    "Target-type": [], 
    "Arguments": [], 
    "User": "root"
}
```

After (look at "Target-type"):
```json
{
    "Function": "unknown-function", 
    "jid": "b1946ac92492d2347c6235b4d2611184", 
    "Result": {}, 
    "Target": "unknown-target", 
    "StartTime": "", 
    "Target-type": "list", 
    "Arguments": [], 
    "User": "root"
}
```