### PR TITLE
Add Security Notes to 2016.3.8 Release Notes

### DIFF
--- a/doc/topics/releases/2016.3.8.rst
+++ b/doc/topics/releases/2016.3.8.rst
@@ -7,23 +7,9 @@ Version 2016.3.8 is a bugfix release for :ref:`2016.3.0 <release-2016-3-0>`.
 Changes for v2016.3.7..v2016.3.8
 --------------------------------
 
-New master configuration option `allow_minion_key_revoke`, defaults to True.  This option
-controls whether a minion can request that the master revoke its key.  When True, a minion
-can request a key revocation and the master will comply.  If it is False, the key will not
-be revoked by the msater.
+Security Fix
+============
 
-New master configuration option `require_minion_sign_messages`
-This requires that minions cryptographically sign the messages they
-publish to the master.  If minions are not signing, then log this information
-at loglevel 'INFO' and drop the message without acting on it.
+CVE-2017-14695 Directory traversal vulnerability in minion id validation in SaltStack. Allows remote minions with incorrect credentials to authenticate to a master via a crafted minion ID. Credit for discovering the security flaw goes to: Julian Brost (julian@0x4a42.net)
 
-New master configuration option `drop_messages_signature_fail`
-Drop messages from minions when their signatures do not validate.
-Note that when this option is False but `require_minion_sign_messages` is True
-minions MUST sign their messages but the validity of their signatures
-is ignored.
-
-New minion configuration option `minion_sign_messages`
-Causes the minion to cryptographically sign the payload of messages it places
-on the event bus for the master.  The payloads are signed with the minion's
-private key so the master can verify the signature with its public key.
+CVE-2017-14696 Remote Denial of Service with a specially crafted authentication request. Credit for discovering the security flaw goes to: Julian Brost (julian@0x4a42.net)

--- a/doc/topics/releases/2016.3.9.rst
+++ b/doc/topics/releases/2016.3.9.rst
@@ -1,0 +1,29 @@
+===========================
+Salt 2016.3.9 Release Notes
+===========================
+
+Version 2016.3.9 is a bugfix release for :ref:`2016.3.0 <release-2016-3-0>`.
+
+Changes for v2016.3.7..v2016.3.9
+--------------------------------
+
+New master configuration option `allow_minion_key_revoke`, defaults to True.  This option
+controls whether a minion can request that the master revoke its key.  When True, a minion
+can request a key revocation and the master will comply.  If it is False, the key will not
+be revoked by the msater.
+
+New master configuration option `require_minion_sign_messages`
+This requires that minions cryptographically sign the messages they
+publish to the master.  If minions are not signing, then log this information
+at loglevel 'INFO' and drop the message without acting on it.
+
+New master configuration option `drop_messages_signature_fail`
+Drop messages from minions when their signatures do not validate.
+Note that when this option is False but `require_minion_sign_messages` is True
+minions MUST sign their messages but the validity of their signatures
+is ignored.
+
+New minion configuration option `minion_sign_messages`
+Causes the minion to cryptographically sign the payload of messages it places
+on the event bus for the master.  The payloads are signed with the minion's
+private key so the master can verify the signature with its public key.


### PR DESCRIPTION
Accidentally submitted this to the 2016.3 branch previously here: https://github.com/saltstack/salt/pull/43977  Moving this to a 2016.11 branch so it gets merged forward and built properly.