### PR TITLE
Fix manage.present to show lost minions

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -578,10 +578,9 @@ class CkMinions(object):
             if search is None:
                 return minions
             addrs = salt.utils.network.local_port_tcp(int(self.opts['publish_port']))
-            if '127.0.0.1' in addrs or '0.0.0.0' in addrs:
-                # Add in possible ip addresses of a locally connected minion
+            if '127.0.0.1' in addrs:
+                # Add in the address of a possible locally-connected minion.
                 addrs.discard('127.0.0.1')
-                addrs.discard('0.0.0.0')
                 addrs.update(set(salt.utils.network.ip_addrs(include_loopback=include_localhost)))
             if subset:
                 search = subset


### PR DESCRIPTION
### What does this PR do?

Fixes `manage.present` and related runners to reflect lost minions as not being `present`.

### What issues does this PR fix or reference?

Fixes #38367 and #43936.

### Previous Behavior

`manage.present` and related runner commands included non-present minions.

### New Behavior

`manage.present` and related runner commands do not include non-present minions.

### Tests written?

~Yes, but they don't work!  If someone with more experience with the integration tests could give me a pointer, I would be appreciative.  Otherwise, I'll try to figure this out myself when I can.~  No, the original integration tests I tried to write tried to simulate events, which don't actually seem to matter for `manage.present`... it always checks the existing TCP connections.  If a test was to be written, that's what would need to be mocked or whatever.