### PR TITLE
Fix gce make_master

### DIFF
--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -2580,7 +2580,10 @@ def create(vm_=None, call=None):
     ssh_user, ssh_key = __get_ssh_credentials(vm_)
     vm_['ssh_host'] = __get_host(node_data, vm_)
     vm_['key_filename'] = ssh_key
-    __utils__['cloud.bootstrap'](vm_, __opts__)
+
+    ret = __utils__['cloud.bootstrap'](vm_, __opts__)
+
+    ret.update(node_dict)
 
     log.info('Created Cloud VM \'{0[name]}\''.format(vm_))
     log.trace(
@@ -2598,7 +2601,7 @@ def create(vm_=None, call=None):
         transport=__opts__['transport']
     )
 
-    return node_dict
+    return ret
 
 
 def update_pricing(kwargs=None, call=None):


### PR DESCRIPTION
### What does this PR do?

returns result from cloud.bootstrap from the provider create function, as seen in eg. linode provider.

### What issues does this PR fix or reference?

Fixes #43997

### Previous Behavior
`make_master: True` with gce provider will always fail.

### New Behavior
`make_master: True` with gce provider works.

### Tests written?

No