### PR TITLE
add python exec module for running python script

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -1727,7 +1727,7 @@ in the current Jinja context.
 
 .. code-block:: jinja
 
-    Context is: {{ show_full_context() }}
+    Context is: {{ show_full_context()|yaml(False) }}
 
 .. jinja_ref:: logs
 

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -582,7 +582,7 @@ def symmetric_difference(lst1, lst2):
 
 @jinja2.contextfunction
 def show_full_context(ctx):
-    return ctx
+    return salt.utils.simple_types_filter({key: value for key, value in ctx.items()})
 
 
 class SerializerExtension(Extension, object):


### PR DESCRIPTION
### What does this PR do?
For `show_full_context`, it is useful to have this as a serializable dictionary so that it can be dumped and actually parsed using

`{{show_full_context|yaml(False)}}`

### What issues does this PR fix or reference?


### Previous Behavior
show_full_context returns an object mapping

### New Behavior
show_full_context returns a serializable dictionary

### Tests written?

No

Moved from #43940