### PR TITLE
Fix issue with mutable 'virt:disk' object

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -9,6 +9,7 @@ Work with virtual machines managed by libvirt
 
 # Import python libs
 from __future__ import absolute_import
+import copy
 import os
 import re
 import sys
@@ -553,7 +554,8 @@ def _disk_profile(profile, hypervisor, **kwargs):
     else:
         overlay = {}
 
-    disklist = __salt__['config.get']('virt:disk', {}).get(profile, default)
+    disklist = copy.deepcopy(
+        __salt__['config.get']('virt:disk', {}).get(profile, default))
     for key, val in six.iteritems(overlay):
         for i, disks in enumerate(disklist):
             for disk in disks:


### PR DESCRIPTION
Images stored in 'virt:disk:{profile}:image' , if exist, have
higher priority than 'image' argument for 'virt' module.

But if different nodes will use different images for the same disk
{profile} during the run, then the image used for the first node
will be re-used for all the rest because it is stored in the
mutable object.

Use copy.deepcopy to avoid such issue.

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
