### PR TITLE
Fixed digitalocean cloud module doc file not being renamed by #43588

### DIFF
--- a/doc/ref/clouds/all/salt.cloud.clouds.digitalocean.rst
+++ b/doc/ref/clouds/all/salt.cloud.clouds.digitalocean.rst
@@ -1,6 +1,6 @@
-===============================
+==============================
 salt.cloud.clouds.digitalocean
-===============================
+==============================
 
 .. automodule:: salt.cloud.clouds.digitalocean
     :members:


### PR DESCRIPTION
### What does this PR do?
In #43588 the `digitalocean` cloud module got renamed from `digital_ocean`. It seems they missed the doc file used to include the docstrings. Sphinx doesn't recognize the old file and therefore generates a new one on each build. This PR fixes this by removing the old file and adding the new, correct one.

