### PR TITLE
Added missing docs to the tutorial index and fixed  spelling mistake

### DIFF
--- a/doc/topics/tutorials/index.rst
+++ b/doc/topics/tutorials/index.rst
@@ -33,3 +33,5 @@ Tutorials Index
 * :ref:`The macOS (Maverick) Developer Step By Step Guide To Salt Installation <tutorial-macos-walk-through>`
 * :ref:`SaltStack Walk-through <tutorial-salt-walk-through>`
 * :ref:`Writing Salt Tests <tutorial-salt-testing>`
+* :ref:`Running Salt States and Commands in Docker Containers <docker-sls>`
+* :ref:`Preseed Minion with Accepted Key <tutorial-preseed-key>`

--- a/doc/topics/tutorials/salt_bootstrap.rst
+++ b/doc/topics/tutorials/salt_bootstrap.rst
@@ -23,7 +23,7 @@ Supported Operating Systems
 .. note::
 
     In the event you do not see your distribution or version available please
-    review the develop branch on GitHub as it main contain updates that are
+    review the develop branch on GitHub as it may contain updates that are
     not present in the stable release:
     https://github.com/saltstack/salt-bootstrap/tree/develop
 


### PR DESCRIPTION
### What does this PR do?
This adds the `Running Salt States and Commands in Docker Containers` and `Preseed Minion with Accepted Key` tutorials to the tutorials index and fixes a spelling mistake in the `Salt Bootstrap` tutorial.

Also I noticed that there are some other files that aren't on the corresponding index pages. For example the `cloud modules` page isn't on the `modules` index page and the `oneandone` cloud module isn't on the `cloud modules` page. Is this intentional?