### PR TITLE
Also catch cpstats AttributeError for bad CherryPy release ~5.6.0

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -474,11 +474,14 @@ logger = logging.getLogger(__name__)
 import cherrypy
 try:
     from cherrypy.lib import cpstats
-except ImportError:
+except AttributeError:
     cpstats = None
     logger.warn('Import of cherrypy.cpstats failed. '
         'Possible upstream bug: '
         'https://github.com/cherrypy/cherrypy/issues/1444')
+except ImportError:
+    cpstats = None
+    logger.warn('Import of cherrypy.cpstats failed.')
 
 import yaml
 import salt.ext.six as six


### PR DESCRIPTION
### What does this PR do?

Catch an AttributeError from an older bad CherryPy release.

### What issues does this PR fix or reference?

#43581

### Previous Behavior

Follow-up to the change in #42655. I didn't see the AtrributeError before because of the additional hasattr.