### PR TITLE
addresses issue #43307, disk.format_ to disk.format

### DIFF
--- a/salt/states/blockdev.py
+++ b/salt/states/blockdev.py
@@ -159,7 +159,7 @@ def formatted(name, fs_type='ext4', force=False, **kwargs):
         ret['result'] = None
         return ret
 
-    __salt__['disk.format_'](name, fs_type, force=force, **kwargs)
+    __salt__['disk.format'](name, fs_type, force=force, **kwargs)
 
     # Repeat fstype check up to 10 times with 3s sleeping between each
     # to avoid detection failing although mkfs has succeeded

--- a/tests/unit/states/test_blockdev.py
+++ b/tests/unit/states/test_blockdev.py
@@ -100,7 +100,7 @@ class BlockdevTestCase(TestCase, LoaderModuleMockMixin):
 
             # Test state return when block device format fails
             with patch.dict(blockdev.__salt__, {'cmd.run': MagicMock(return_value=mock_ext4),
-                                                'disk.format_': MagicMock(return_value=True)}):
+                                                'disk.format': MagicMock(return_value=True)}):
                 comt = ('Failed to format {0}'.format(name))
                 ret.update({'comment': comt, 'result': False})
                 with patch.object(salt.utils, 'which',


### PR DESCRIPTION
This change fixes breakage. It appears the disk.format_ func is
aliased to disk.format in modules/disk.py
