### PR TITLE
Better exception

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1575,8 +1575,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         Load a single item if you have it
         '''
         # if the key doesn't have a '.' then it isn't valid for this mod dict
-        if not isinstance(key, six.string_types) or '.' not in key:
-            raise KeyError
+        if not isinstance(key, six.string_types):
+            raise KeyError('The key must be a string.')
+        if '.' not in key:
+            raise KeyError('The key ' + key + ' should contain a `.`')
         mod_name, _ = key.split('.', 1)
         if mod_name in self.missing_modules:
             return True


### PR DESCRIPTION
After spending an hour trying to figure out why I had a key error in an orchestration state I realised that saltstack requires a runner id with a dot. A clearer error message will save the next person wasting the same time.

### What does this PR do?
Improve error message.
