### PR TITLE
Use correct mac prefix for kvm/qemu

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -656,7 +656,7 @@ def _nic_profile(profile_name, hypervisor, **kwargs):
             if key not in attributes or not attributes[key]:
                 attributes[key] = value
 
-    def _assign_mac(attributes):
+    def _assign_mac(attributes, hypervisor):
         dmac = kwargs.get('dmac', None)
         if dmac is not None:
             log.debug('DMAC address is {0}'.format(dmac))
@@ -666,11 +666,15 @@ def _nic_profile(profile_name, hypervisor, **kwargs):
                 msg = 'Malformed MAC address: {0}'.format(dmac)
                 raise CommandExecutionError(msg)
         else:
-            attributes['mac'] = salt.utils.network.gen_mac()
+            if hypervisor in ['qemu', 'kvm']:
+                attributes['mac'] = salt.utils.network.gen_mac(
+                    prefix='52:54:00')
+            else:
+                attributes['mac'] = salt.utils.network.gen_mac()
 
     for interface in interfaces:
         _normalize_net_types(interface)
-        _assign_mac(interface)
+        _assign_mac(interface, hypervisor)
         if hypervisor in overlays:
             _apply_default_overlay(interface)
 

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -428,6 +428,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         controllers = root.findall('.//devices/controller')
         # There should be no controller
         self.assertTrue(len(controllers) == 0)
+        # kvm mac address shoud start with 52:54:00
+        self.assertTrue("mac address='52:54:00" in xml_data)
 
     def test_mixed_dict_and_list_as_profile_objects(self):
 


### PR DESCRIPTION
Using the private mac range for vms makes it impossible to
distinguish between hypervisors.

Issues #44056

Signed-off-by: Marc Koderer <marc.koderer@sap.com>

### What does this PR do?

It generates proper mac addresses based on the configured HV

### What issues does this PR fix or reference?

Issues #44056

### Previous Behavior
Use private range for all hypervisors

### New Behavior
Use the correct one for KVM/QEMU

### Tests written?

No
