### PR TITLE
Check file attributes if lsattr(1) is installed

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4700,6 +4700,7 @@ def check_file_meta(
     contents
         File contents
     '''
+    lsattr_cmd = salt.utils.path.which('lsattr')
     changes = {}
     if not source_sum:
         source_sum = {}
@@ -4764,13 +4765,14 @@ def check_file_meta(
         if mode is not None and mode != smode:
             changes['mode'] = mode
 
-        diff_attrs = _cmp_attrs(name, attrs)
-        if (
-            attrs is not None and
-            diff_attrs[0] is not None or
-            diff_attrs[1] is not None
-        ):
-            changes['attrs'] = attrs
+        if lsattr_cmd:
+            diff_attrs = _cmp_attrs(name, attrs)
+            if (
+                attrs is not None and
+                diff_attrs[0] is not None or
+                diff_attrs[1] is not None
+            ):
+                changes['attrs'] = attrs
 
     return changes
 

--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -504,6 +504,26 @@ class FileModuleTestCase(TestCase, LoaderModuleMockMixin):
             }
         }
 
+    def test_check_file_meta_no_lsattr(self):
+        '''
+        Ensure that we skip attribute comparison if lsattr(1) is not found
+        '''
+        source = "salt:///README.md"
+        name = "/home/git/proj/a/README.md"
+        source_sum = {}
+        stats_result = {'size': 22, 'group': 'wheel', 'uid': 0, 'type': 'file',
+                        'mode': '0600', 'gid': 0, 'target': name, 'user':
+                        'root', 'mtime': 1508356390, 'atime': 1508356390,
+                        'inode': 447, 'ctime': 1508356390}
+        with patch('salt.modules.file.stats') as m_stats:
+            m_stats.return_value = stats_result
+            with patch('salt.utils.path.which') as m_which:
+                m_which.return_value = None
+                result = filemod.check_file_meta(name, name, source, source_sum,
+                                                 'root', 'root', '755', None,
+                                                 'base')
+        self.assertTrue(result, None)
+
     @skipIf(salt.utils.platform.is_windows(), 'SED is not available on Windows')
     def test_sed_limit_escaped(self):
         with tempfile.NamedTemporaryFile(mode='w+') as tfile:


### PR DESCRIPTION
Similar to PR #43746

### What does this PR do?

Fix the case where states are run with `test=True` on platforms without lsattr(1)

Tested on OpenBSD 6.2

### Previous Behavior

    # doas salt-call --local --file-root=$PWD state.sls common.openbsd test=True
    local:
    ----------
              ID: /etc/doas.conf
        Function: file.managed
          Result: False
         Comment: Unable to manage file: Unable to run command '['lsattr', '/etc/doas.conf']' with the context '{...}, 'stdout': -1, 'close_fds': True, 'stdin': None, 'cwd': '/home/eradman'}', reason: command not found

### New Behavior

    # doas salt-call --local --file-root=$PWD state.sls common.openbsd test=True
    ...
    local:
    ----------
              ID: /etc/doas.conf
        Function: file.managed
          Result: True
         Comment: The file /etc/doas.conf is in the correct state
         Started: 09:48:15.526984
        Duration: 38.686 ms
         Changes:

