### PR TITLE
user.present: allow date param to be 0

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -67,7 +67,7 @@ def _changes(name,
              workphone='',
              homephone='',
              loginclass=None,
-             date=0,
+             date=None,
              mindays=0,
              maxdays=999999,
              inactdays=0,
@@ -134,7 +134,7 @@ def _changes(name,
                     change['passwd'] = password
         if empty_password and lshad['passwd'] != '':
             change['empty_password'] = True
-        if date and date is not 0 and lshad['lstchg'] != date:
+        if date is not None and lshad['lstchg'] != date:
             change['date'] = date
         if mindays and mindays is not 0 and lshad['min'] != mindays:
             change['mindays'] = mindays
@@ -675,7 +675,7 @@ def present(name,
                                          'empty password'.format(name)
                         ret['result'] = False
                     ret['changes']['password'] = ''
-                if date:
+                if date is not None:
                     __salt__['shadow.set_date'](name, date)
                     spost = __salt__['shadow.info'](name)
                     if spost['lstchg'] != date:


### PR DESCRIPTION
### What does this PR do?
Resolves #41044 

### Previous Behavior
Default value for `date` was `0`, and it is ignored.

### New Behavior
`date` can be set to `0`, which will require the user to change password on next login

The value of `0` doesn't make sense if the state is part of the top file, as it will reset the date.
However, it make sense if the state is ran manually via `state.sls` or as onchange of another state.
It also becomes consistent with `shadow.set_date` which allows `date` to be set to `0`.

### Tests written?

No
