### PR TITLE
opkg: Fix usage with pkgrepo.managed

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -129,7 +129,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def refresh_db():
+def refresh_db(**kwargs):  # pylint: disable=unused-argument
     '''
     Updates the opkg database to latest packages based upon repositories
 
@@ -456,7 +456,7 @@ def purge(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
     return remove(name=name, pkgs=pkgs)
 
 
-def upgrade(refresh=True):
+def upgrade(refresh=True, **kwargs):  # pylint: disable=unused-argument
     '''
     Upgrades all packages via ``opkg upgrade``
 
@@ -739,7 +739,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
     return ret
 
 
-def list_upgrades(refresh=True):
+def list_upgrades(refresh=True, **kwargs):  # pylint: disable=unused-argument
     '''
     List all available package upgrades.
 
@@ -908,7 +908,7 @@ def info_installed(*names, **kwargs):
     return ret
 
 
-def upgrade_available(name):
+def upgrade_available(name, **kwargs):  # pylint: disable=unused-argument
     '''
     Check whether or not an upgrade is available for a given package
 
@@ -921,7 +921,7 @@ def upgrade_available(name):
     return latest_version(name) != ''
 
 
-def version_cmp(pkg1, pkg2, ignore_epoch=False):
+def version_cmp(pkg1, pkg2, ignore_epoch=False, **kwargs):  # pylint: disable=unused-argument
     '''
     Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
     pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
@@ -969,7 +969,7 @@ def version_cmp(pkg1, pkg2, ignore_epoch=False):
     return None
 
 
-def list_repos():
+def list_repos(**kwargs):  # pylint: disable=unused-argument
     '''
     Lists all repos on /etc/opkg/*.conf
 
@@ -1006,7 +1006,7 @@ def list_repos():
     return repos
 
 
-def get_repo(alias):
+def get_repo(alias, **kwargs):  # pylint: disable=unused-argument
     '''
     Display a repo from the /etc/opkg/*.conf
 
@@ -1077,7 +1077,7 @@ def _mod_repo_in_file(alias, repostr, filepath):
         fhandle.writelines(output)
 
 
-def del_repo(alias):
+def del_repo(alias, **kwargs):  # pylint: disable=unused-argument
     '''
     Delete a repo from /etc/opkg/*.conf
 
@@ -1191,7 +1191,7 @@ def mod_repo(alias, **kwargs):
         refresh_db()
 
 
-def file_list(*packages):
+def file_list(*packages, **kwargs):  # pylint: disable=unused-argument
     '''
     List the files that belong to a package. Not specifying any packages will
     return a list of _every_ file on the system's package database (not
@@ -1212,7 +1212,7 @@ def file_list(*packages):
     return {'errors': output['errors'], 'files': files}
 
 
-def file_dict(*packages):
+def file_dict(*packages, **kwargs):  # pylint: disable=unused-argument
     '''
     List the files that belong to a package, grouped by package. Not
     specifying any packages will return a list of _every_ file on the system's
@@ -1254,7 +1254,7 @@ def file_dict(*packages):
     return {'errors': errors, 'packages': ret}
 
 
-def owner(*paths):
+def owner(*paths, **kwargs):  # pylint: disable=unused-argument
     '''
     Return the name of the package that owns the file. Multiple file paths can
     be passed. Like :mod:`pkg.version <salt.modules.opkg.version`, if a single


### PR DESCRIPTION
### What does this PR do?

Currently, when using `pkgrepo.managed`, the following error is reported:

```
TypeError: get_repo() got an unexpected keyword argument 'ppa_auth'
```

Fix this by adding `**kwargs` to `get_repo` so that it will absorb unused
kwargs instead of erroring out when given an unknown kwarg. Did the same
thing for all other public APIs in this file.

### Tests written?

No