### PR TITLE
Fix a regression in `group.present` in Windows

### DIFF
--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -250,7 +250,7 @@ def adduser(name, username, **kwargs):
                 '/', '\\').encode('ascii', 'backslashreplace').lower())
 
     try:
-        if salt.utils.win_functions.get_sam_name(username) not in existingMembers:
+        if salt.utils.win_functions.get_sam_name(username).lower() not in existingMembers:
             if not __opts__['test']:
                 groupObj.Add('WinNT://' + username.replace('\\', '/'))
 
@@ -309,7 +309,7 @@ def deluser(name, username, **kwargs):
                 '/', '\\').encode('ascii', 'backslashreplace').lower())
 
     try:
-        if salt.utils.win_functions.get_sam_name(username) in existingMembers:
+        if salt.utils.win_functions.get_sam_name(username).lower() in existingMembers:
             if not __opts__['test']:
                 groupObj.Remove('WinNT://' + username.replace('\\', '/'))
 

--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -36,7 +36,7 @@ def __virtual__():
     return (False, "Module win_groupadd: module only works on Windows systems")
 
 
-def add(name, *args, **kwargs):
+def add(name, **kwargs):
     '''
     Add the specified group
 

--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -36,7 +36,7 @@ def __virtual__():
     return (False, "Module win_groupadd: module only works on Windows systems")
 
 
-def add(name, **kwargs):
+def add(name, *args, **kwargs):
     '''
     Add the specified group
 

--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -65,11 +65,11 @@ def _changes(name,
         if lgrp['members']:
             lgrp['members'] = [user.lower() for user in lgrp['members']]
         if members:
-            members = [salt.utils.win_functions.get_sam_name(user) for user in members]
+            members = [salt.utils.win_functions.get_sam_name(user).lower() for user in members]
         if addusers:
-            addusers = [salt.utils.win_functions.get_sam_name(user) for user in addusers]
+            addusers = [salt.utils.win_functions.get_sam_name(user).lower() for user in addusers]
         if delusers:
-            delusers = [salt.utils.win_functions.get_sam_name(user) for user in delusers]
+            delusers = [salt.utils.win_functions.get_sam_name(user).lower() for user in delusers]
 
     change = {}
     if gid:
@@ -267,7 +267,7 @@ def present(name,
                 ret['result'] = False
                 ret['comment'] = (
                     'Group {0} has been created but, some changes could not'
-                    ' be applied')
+                    ' be applied'.format(name))
                 ret['changes'] = {'Failed': changes}
         else:
             ret['result'] = False

--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -244,9 +244,7 @@ def present(name,
                 return ret
 
         # Group is not present, make it.
-        if __salt__['group.add'](name,
-                                 gid,
-                                 system=system):
+        if __salt__['group.add'](name, gid=gid, system=system):
             # if members to be added
             grp_members = None
             if members:

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -152,6 +152,8 @@ def get_sam_name(username):
     Everything is returned lower case
 
     i.e. salt.utils.fix_local_user('Administrator') would return 'computername\administrator'
+
+    .. note:: Long computer names are truncated to 15 characters
     '''
     if '\\' not in username:
         username = '{0}\\{1}'.format(platform.node()[:15], username)

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -111,7 +111,7 @@ def get_sid_from_name(name):
         sid = win32security.LookupAccountName(None, name)[0]
     except pywintypes.error as exc:
         raise CommandExecutionError(
-            'User {0} found: {1}'.format(name, exc.strerror))
+            'User {0} not found: {1}'.format(name, exc.strerror))
 
     return win32security.ConvertSidToStringSid(sid)
 
@@ -146,16 +146,16 @@ def get_current_user():
 def get_sam_name(username):
     '''
     Gets the SAM name for a user. It basically prefixes a username without a
-    backslash with the computer name. If the username contains a backslash, it
-    is returned as is.
+    backslash with the computer name. If the user does not exist, a SAM
+    compatible name will be returned using the local hostname as the domain.
 
-    Everything is returned lower case
-
-    i.e. salt.utils.get_same_name('Administrator') would return 'computername\administrator'
+    i.e. salt.utils.get_same_name('Administrator') would return 'DOMAIN.COM\Administrator'
 
     .. note:: Long computer names are truncated to 15 characters
     '''
-    if '\\' not in username:
-        username = '{0}\\{1}'.format(platform.node()[:15], username)
-
-    return username.lower()
+    try:
+        sid_obj = win32security.LookupAccountName(None, username)[0]
+    except pywintypes.error:
+        return '\\'.join([platform.node()[:15].upper(), username])
+    username, domain, _ = win32security.LookupAccountSid(None, sid_obj)
+    return '\\'.join([domain, username])

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -151,7 +151,7 @@ def get_sam_name(username):
 
     Everything is returned lower case
 
-    i.e. salt.utils.fix_local_user('Administrator') would return 'computername\administrator'
+    i.e. salt.utils.get_same_name('Administrator') would return 'computername\administrator'
 
     .. note:: Long computer names are truncated to 15 characters
     '''

--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -154,6 +154,6 @@ def get_sam_name(username):
     i.e. salt.utils.fix_local_user('Administrator') would return 'computername\administrator'
     '''
     if '\\' not in username:
-        username = '{0}\\{1}'.format(platform.node(), username)
+        username = '{0}\\{1}'.format(platform.node()[:15], username)
 
     return username.lower()


### PR DESCRIPTION
### What does this PR do?
Fixes a regression in `group.present` in Windows.
Caused by https://github.com/saltstack/salt/pull/43097

### What issues does this PR fix or reference?
Found in testing

### Previous Behavior
Because the state module is calling the execution module passing `gid` positionally it would fail with the following stack trace:
```
An exception occurred in this state: Traceback (most recent call last):
                File "C:\salt\bin\lib\site-packages\salt\state.py", line 1843, in call
                  **cdata['kwargs'])
                File "C:\salt\bin\lib\site-packages\salt\loader.py", line 1795, in wrapper
                  return f(*args, **kwargs)
                File "C:\salt\bin\lib\site-packages\salt\states\group.py", line 249, in present
                  system=system):
              TypeError: add() takes exactly 1 argument (3 given)
```

### New Behavior
State module passes `gid` as a keyword arg.

### Tests written?
No