### PR TITLE
Windows: Fix usage of pkgrepo state

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -29,7 +29,6 @@ import json
 import yaml
 # pylint: disable=no-name-in-module,import-error,redefined-builtin
 import salt.ext.six as six
-from salt.ext.six.moves import range
 from salt.ext.six.moves.urllib.error import HTTPError
 from salt.ext.six.moves.urllib.request import Request as _Request, urlopen as _urlopen
 # pylint: enable=no-name-in-module,import-error,redefined-builtin
@@ -1558,7 +1557,7 @@ def _consolidate_repo_sources(sources):
             combined_comps = set(repo.comps).union(set(combined.comps))
             consolidated[key].comps = list(combined_comps)
         else:
-            consolidated[key] = sourceslist.SourceEntry(_strip_uri(repo.line))
+            consolidated[key] = sourceslist.SourceEntry(salt.utils.pkg.deb.strip_uri(repo.line))
 
         if repo.file != base_file:
             delete_files.add(repo.file)
@@ -1666,7 +1665,7 @@ def list_repos():
         repo['dist'] = source.dist
         repo['type'] = source.type
         repo['uri'] = source.uri.rstrip('/')
-        repo['line'] = _strip_uri(source.line.strip())
+        repo['line'] = salt.utils.pkg.deb.strip_uri(source.line.strip())
         repo['architectures'] = getattr(source, 'architectures', [])
         repos.setdefault(source.uri, []).append(repo)
     return repos
@@ -2412,18 +2411,6 @@ def file_dict(*packages):
     return __salt__['lowpkg.file_dict'](*packages)
 
 
-def _strip_uri(repo):
-    '''
-    Remove the trailing slash from the URI in a repo definition
-    '''
-    splits = repo.split()
-    for idx in range(len(splits)):
-        if any(splits[idx].startswith(x)
-               for x in ('http://', 'https://', 'ftp://')):
-            splits[idx] = splits[idx].rstrip('/')
-    return ' '.join(splits)
-
-
 def expand_repo_def(**kwargs):
     '''
     Take a repository definition and expand it to the full pkg repository dict
@@ -2439,7 +2426,7 @@ def expand_repo_def(**kwargs):
     _check_apt()
 
     sanitized = {}
-    repo = _strip_uri(kwargs['repo'])
+    repo = salt.utils.pkg.deb.strip_uri(kwargs['repo'])
     if repo.startswith('ppa:') and __grains__['os'] in ('Ubuntu', 'Mint', 'neon'):
         dist = __grains__['lsb_distrib_codename']
         owner_name, ppa_name = repo[4:].split('/', 1)

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -92,7 +92,6 @@ import sys
 
 # Import salt libs
 from salt.exceptions import CommandExecutionError, SaltInvocationError
-from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 import salt.utils
 import salt.utils.pkg.deb
@@ -104,18 +103,6 @@ def __virtual__():
     Only load if modifying repos is available for this package type
     '''
     return 'pkg.mod_repo' in __salt__
-
-
-def _strip_uri(repo):
-    '''
-    Remove the trailing slash from the URI in a repo definition
-    '''
-    splits = repo.split()
-    for idx in range(len(splits)):
-        if any(splits[idx].startswith(x)
-               for x in ('http://', 'https://', 'ftp://')):
-            splits[idx] = splits[idx].rstrip('/')
-    return ' '.join(splits)
 
 
 def managed(name, ppa=None, **kwargs):
@@ -381,7 +368,7 @@ def managed(name, ppa=None, **kwargs):
         sanitizedkwargs = kwargs
 
     if os_family == 'debian':
-        repo = _strip_uri(repo)
+        repo = salt.utils.pkg.deb.strip_uri(repo)
 
     if pre:
         for kwarg in sanitizedkwargs:

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -92,7 +92,7 @@ import sys
 
 # Import salt libs
 from salt.exceptions import CommandExecutionError, SaltInvocationError
-from salt.modules.aptpkg import _strip_uri
+from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 import salt.utils
 import salt.utils.pkg.deb
@@ -104,6 +104,18 @@ def __virtual__():
     Only load if modifying repos is available for this package type
     '''
     return 'pkg.mod_repo' in __salt__
+
+
+def _strip_uri(repo):
+    '''
+    Remove the trailing slash from the URI in a repo definition
+    '''
+    splits = repo.split()
+    for idx in range(len(splits)):
+        if any(splits[idx].startswith(x)
+               for x in ('http://', 'https://', 'ftp://')):
+            splits[idx] = splits[idx].rstrip('/')
+    return ' '.join(splits)
 
 
 def managed(name, ppa=None, **kwargs):

--- a/salt/utils/pkg/deb.py
+++ b/salt/utils/pkg/deb.py
@@ -26,3 +26,15 @@ def combine_comments(comments):
         else:
             comments = [comments]
     return ' '.join(comments).strip()
+
+
+def strip_uri(repo):
+    '''
+    Remove the trailing slash from the URI in a repo definition
+    '''
+    splits = repo.split()
+    for idx in range(len(splits)):
+        if any(splits[idx].startswith(x)
+               for x in ('http://', 'https://', 'ftp://')):
+            splits[idx] = splits[idx].rstrip('/')
+    return ' '.join(splits)


### PR DESCRIPTION
### What does this PR do?

`pkgrepo.py` contains this line:

```
from salt.modules.aptpkg import _strip_uri
```

However, `salt.modules.aptpkg` is just not importable on Windows.
Instead of trying to make this module importable on Windows (which
clearly isn't the intent of the module), placed a copy of `_strip_uri`
into `pkgrepo.py` as this is a small function.

### Tests written?

No