### PR TITLE
Fixing a typo in the troubleshooting document

### DIFF
--- a/doc/topics/troubleshooting/master.rst
+++ b/doc/topics/troubleshooting/master.rst
@@ -141,7 +141,7 @@ If the master seems to be unresponsive, a SIGUSR1 can be passed to the
 salt-master threads to display what piece of code is executing. This debug
 information can be invaluable in tracking down bugs.
 
-To pass a SIGUSR1 to the master, first make sure the minion is running in the
+To pass a SIGUSR1 to the master, first make sure the master is running in the
 foreground. Stop the service if it is running as a daemon, and start it in the
 foreground like so:
 


### PR DESCRIPTION
### What does this PR do?
Fixing a typo in the troubleshooting document

### What issues does this PR fix or reference?
Documentation issue

### Previous Behavior
Document says we need to start minion in foreground instead of master

### New Behavior
Fixed the typo. 

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
