### PR TITLE
Catch on empty Virtualbox network addr #43427

### DIFF
--- a/salt/utils/virtualbox.py
+++ b/salt/utils/virtualbox.py
@@ -281,7 +281,10 @@ def vb_get_network_addresses(machine_name=None, machine=None):
     # We can't trust virtualbox to give us up to date guest properties if the machine isn't running
     # For some reason it may give us outdated (cached?) values
     if machine.state == _virtualboxManager.constants.MachineState_Running:
-        total_slots = int(machine.getGuestPropertyValue('/VirtualBox/GuestInfo/Net/Count'))
+        try:
+            total_slots = int(machine.getGuestPropertyValue('/VirtualBox/GuestInfo/Net/Count'))
+        except ValueError:
+            total_slots = 0
         for i in range(total_slots):
             try:
                 address = machine.getGuestPropertyValue('/VirtualBox/GuestInfo/Net/{0}/V4/IP'.format(i))


### PR DESCRIPTION
### What does this PR do?
Catches an ValueError when trying to cast '' to an integer

### What issues does this PR fix or reference?
#43427

There's also the option of using wait_for here, I just don't know enough about whether it'd be a problem because this function is already wrapped with wait_for in other places.