### PR TITLE
Made sure that unicoded data is sent to sha256()

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -278,7 +278,7 @@ def sig4(method, endpoint, params, prov_dict,
         algorithm,
         amzdate,
         credential_scope,
-        hashlib.sha256(canonical_request).hexdigest()
+        hashlib.sha256(canonical_request.encode(__salt_system_encoding__)).hexdigest()
     ))
 
     # Create the signing key using the function defined above.

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -260,7 +260,7 @@ def sig4(method, endpoint, params, prov_dict,
     # Create payload hash (hash of the request body content). For GET
     # requests, the payload is an empty string ('').
     if not payload_hash:
-        payload_hash = hashlib.sha256(data).hexdigest()
+        payload_hash = hashlib.sha256(data.encode('utf-8')).hexdigest()
 
     # Combine elements to create create canonical request
     canonical_request = '\n'.join((

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -260,7 +260,7 @@ def sig4(method, endpoint, params, prov_dict,
     # Create payload hash (hash of the request body content). For GET
     # requests, the payload is an empty string ('').
     if not payload_hash:
-        payload_hash = hashlib.sha256(data.encode(sys.getdefaultencoding())).hexdigest()
+        payload_hash = hashlib.sha256(data.encode(__salt_system_encoding__)).hexdigest()
 
     # Combine elements to create create canonical request
     canonical_request = '\n'.join((

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -260,7 +260,7 @@ def sig4(method, endpoint, params, prov_dict,
     # Create payload hash (hash of the request body content). For GET
     # requests, the payload is an empty string ('').
     if not payload_hash:
-        payload_hash = hashlib.sha256(data.encode('utf-8')).hexdigest()
+        payload_hash = hashlib.sha256(data.encode(sys.getdefaultencoding())).hexdigest()
 
     # Combine elements to create create canonical request
     canonical_request = '\n'.join((


### PR DESCRIPTION
### What does this PR do?
This is actually a Python 3 fix, that surfaces with `GET` requests, which pass an empty string as `data` to the `sha256()` function.
**Python 2:**
```
import hashlib; hashlib.sha256('').hexdigest()
'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
import hashlib; hashlib.sha256(''.encode('utf-8')).hexdigest()
'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
```
**Python 3:**
```
import hashlib; hashlib.sha256('').hexdigest()
TypeError: Unicode-objects must be encoded before hashing
import hashlib; hashlib.sha256(''.encode('utf-8')).hexdigest()
'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
```
### Tests written?
No.

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
