### PR TITLE
don't filter if return is not a dict

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -863,8 +863,8 @@ def highstate(test=None, queue=False, **kwargs):
     finally:
         st_.pop_active()
 
-    if __salt__['config.option']('state_data', '') == 'terse' or \
-            kwargs.get('terse'):
+    if isinstance(ret, dict) and (__salt__['config.option']('state_data', '') == 'terse' or \
+            kwargs.get('terse')):
         ret = _filter_running(ret)
 
     serial = salt.payload.Serial(__opts__)

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -863,7 +863,7 @@ def highstate(test=None, queue=False, **kwargs):
     finally:
         st_.pop_active()
 
-    if isinstance(ret, dict) and (__salt__['config.option']('state_data', '') == 'terse' or \
+    if isinstance(ret, dict) and (__salt__['config.option']('state_data', '') == 'terse' or
             kwargs.get('terse')):
         ret = _filter_running(ret)
 


### PR DESCRIPTION
### What does this PR do?
If there is an error compiling the states, we get back a list of errors, not a dictionary.

### What issues does this PR fix or reference?
Fixes #44087 

### Tests written?

No