### PR TITLE
add documentation for venv_bin in virtualenv_mod state

### DIFF
--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -63,6 +63,10 @@ def managed(name,
     name
         Path to the virtualenv.
 
+    venv_bin: virtualenv
+        The name (and optionally path) of the virtualenv command. This can also
+        be set globally in the minion config file as ``virtualenv.venv_bin``.
+
     requirements: None
         Path to a pip requirements file. If the path begins with ``salt://``
         the file will be transferred from the master file server.


### PR DESCRIPTION
### What does this PR do?
Add documentation for venv_bin within the virtualenv_mod state.  Description copied from [virtualenv_mod module][0].

I was running into some issues creating a virtualenv and having information about venv_bin in the state would be helpful.  

[0]: https://github.com/saltstack/salt/blob/bfcfcd75e8e902812b3abc4450118cd8d85fac6d/salt/modules/virtualenv_mod.py#L67-L70