### PR TITLE
OpenNebula does not require the template_id to be specified

### DIFF
--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -4468,7 +4468,8 @@ def _list_nodes(full=False):
                 pass
 
         vms[name]['id'] = vm.find('ID').text
-        vms[name]['image'] = vm.find('TEMPLATE').find('TEMPLATE_ID').text
+        if vm.find('TEMPLATE').find('TEMPLATE_ID'):
+            vms[name]['image'] = vm.find('TEMPLATE').find('TEMPLATE_ID').text
         vms[name]['name'] = name
         vms[name]['size'] = {'cpu': cpu_size, 'memory': memory_size}
         vms[name]['state'] = vm.find('STATE').text


### PR DESCRIPTION
### What does this PR do?
Template_id is not always specified on the VMs, and if it is not, this kills the salt-cloud call when trying to query servers.

### Test Written?
No