### PR TITLE
Return multiprocessing queue in LogSetupMock class

### DIFF
--- a/tests/unit/utils/test_parsers.py
+++ b/tests/unit/utils/test_parsers.py
@@ -78,7 +78,8 @@ class LogSetupMock(object):
         '''
         Mock
         '''
-        return None
+        import multiprocessing
+        return multiprocessing.Queue()
 
     def setup_multiprocessing_logging_listener(self, opts, *args):  # pylint: disable=invalid-name,unused-argument
         '''


### PR DESCRIPTION
### What does this PR do?
Returns a multiprocessing Queue in the `get_multiprocessing_logging_queue` method in the `LogSetupMock` class

### Previous Behavior
Returned None

### New Behavior
Returns Queue

### Tests written?
Yes