### PR TITLE
Skip Master, Minion, and Syndic parser tests

### DIFF
--- a/tests/unit/utils/test_parsers.py
+++ b/tests/unit/utils/test_parsers.py
@@ -21,6 +21,7 @@ import salt.utils.parsers
 import salt.log.setup as log
 import salt.config
 import salt.syspaths
+import salt.utils
 
 
 class ErrorMock(object):  # pylint: disable=too-few-public-methods
@@ -488,6 +489,7 @@ class LogSettingsParserTests(TestCase):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(salt.utils.is_windows(), 'Windows uses a logging listener')
 class MasterOptionParserTestCase(LogSettingsParserTests):
     '''
     Tests parsing Salt Master options
@@ -514,6 +516,7 @@ class MasterOptionParserTestCase(LogSettingsParserTests):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(salt.utils.is_windows(), 'Windows uses a logging listener')
 class MinionOptionParserTestCase(LogSettingsParserTests):
     '''
     Tests parsing Salt Minion options
@@ -567,6 +570,7 @@ class ProxyMinionOptionParserTestCase(LogSettingsParserTests):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(salt.utils.is_windows(), 'Windows uses a logging listener')
 class SyndicOptionParserTestCase(LogSettingsParserTests):
     '''
     Tests parsing Salt Syndic options


### PR DESCRIPTION
### What does this PR do?
Skips LogSettingsParserTests on Windows.

### Previous Behavior
Tests would fail because the logger settings are handled differently in Windows

### New Behavior
Tests are skipped until we write tests for Multiprocessing

### Tests written?
Skipped