### PR TITLE
Try to correctly parse debian codename from /etc/os-release

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1367,7 +1367,10 @@ def os_data():
                             .format(' '.join(init_cmdline))
                         )
 
-        # Add lsb grains on any distro with lsb-release
+        # Add lsb grains on any distro with lsb-release. Note that this import
+        # can fail on systems with lsb-release installed if the system package
+        # does not install the python package for the python interpreter used by
+        # Salt (i.e. python2 or python3)
         try:
             import lsb_release  # pylint: disable=import-error
             release = lsb_release.get_distro_information()
@@ -1416,7 +1419,13 @@ def os_data():
                     if 'VERSION_ID' in os_release:
                         grains['lsb_distrib_release'] = os_release['VERSION_ID']
                     if 'PRETTY_NAME' in os_release:
-                        grains['lsb_distrib_codename'] = os_release['PRETTY_NAME']
+                        codename = os_release['PRETTY_NAME']
+                        # https://github.com/saltstack/salt/issues/44108
+                        if os_release['ID'] == 'debian':
+                            codename_match = re.search(r'\((\w+)\)$', codename)
+                            if codename_match:
+                                codename = codename_match.group(1)
+                        grains['lsb_distrib_codename'] = codename
                     if 'CPE_NAME' in os_release:
                         if ":suse:" in os_release['CPE_NAME'] or ":opensuse:" in os_release['CPE_NAME']:
                             grains['os'] = "SUSE"


### PR DESCRIPTION
This is a proposed fix for https://github.com/saltstack/salt/issues/44108.

If the python module `lsb_release` is not importable, the grain falls back on parsing `/etc/os-release`, which contains a line like this:

```
PRETTY_NAME="Debian GNU/Linux 8 (jessie)"
```

Currently, the grains code just takes this variable and uses it for `lsb_dist_codename`. This is inconsistent with what you'd expect the codename to be. The best we can do with this is to match what's inside the parenthesis.

### Tests written?
No. I wanted to, but opened `tests/unit/grains/test_core.py` and got lost.