### PR TITLE
Fixed code snippet in unit testing documentation

### DIFF
--- a/doc/topics/development/tests/unit.rst
+++ b/doc/topics/development/tests/unit.rst
@@ -123,7 +123,7 @@ to the module being tests one should do:
            }
 
 Consider this more extensive example from 
-``tests/unit/modules/test_libcloud_dns.py``::
+``tests/unit/modules/test_libcloud_dns.py``:
 
 .. code-block:: python
 
@@ -319,7 +319,7 @@ function into ``__salt__`` that's actually a MagicMock instance.
 
     def show_patch(self):
         with patch.dict(my_module.__salt__,
-                        {'function.to_replace': MagicMock()}:
+                        {'function.to_replace': MagicMock()}):
             # From this scope, carry on with testing, with a modified __salt__!
 
 


### PR DESCRIPTION
### What does this PR do?
Fixes the broken code snippet on the [Unit Tests documentation](https://docs.saltstack.com/en/latest/topics/development/tests/unit.html#mocking-loader-modules) and adds a missing closing bracket on the same page further [down](https://docs.saltstack.com/en/latest/topics/development/tests/unit.html#modifying-salt-in-place).