### PR TITLE
Insert missing verb in gitfs walkthrough

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -27,7 +27,7 @@ Installing Dependencies
 =======================
 
 Both pygit2_ and GitPython_ are supported Python interfaces to git. If
-compatible versions of both are installed, pygit2_ will preferred. In these
+compatible versions of both are installed, pygit2_ will be preferred. In these
 cases, GitPython_ can be forced using the :conf_master:`gitfs_provider`
 parameter in the master config file.
 


### PR DESCRIPTION
### What does this PR do?

This PR inserts a missing verb (be) in the gitfs walkthrough: "will be preferred" rather than "will preferred"

### What issues does this PR fix or reference?

None

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

Reviewed, and I think I am submitting this against the correct branch.  Let me know if you need it submitted differently.  Thank you!

