### PR TITLE
parted: Cast boundary to string when checking unit type

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -93,7 +93,7 @@ def _validate_partition_boundary(boundary):
     '''
     try:
         for unit in VALID_UNITS:
-            if boundary.endswith(unit):
+            if str(boundary).endswith(unit):
                 return
         int(boundary)
     except Exception:


### PR DESCRIPTION
It could be that just a number (integer) is passed to as either
start or end to the module which is then already a int.

The endswith() method will then fail because that is a String function.

By casting it to a String while checking we make sure that the function
works.

Signed-off-by: Wido den Hollander <wido@widodh.nl>