### PR TITLE
Fix shadow module unit test if not root or the module is not present

### DIFF
--- a/tests/unit/modules/test_shadow.py
+++ b/tests/unit/modules/test_shadow.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 import salt.utils.platform
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
+from tests.support.helpers import skip_if_not_root
 
 # Import salt libs
 try:

--- a/tests/unit/modules/test_shadow.py
+++ b/tests/unit/modules/test_shadow.py
@@ -42,6 +42,7 @@ _HASHES = dict(
 
 
 @skipIf(not salt.utils.platform.is_linux(), 'minion is not Linux')
+@skipIf(not HAS_SHADOW, 'shadow module is not available')
 class LinuxShadowTest(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
@@ -62,8 +63,7 @@ class LinuxShadowTest(TestCase, LoaderModuleMockMixin):
                 hash_info['pw_hash']
             )
 
-    # 'list_users' function tests: 1
-
+    @skip_if_not_root
     def test_list_users(self):
         '''
         Test if it returns a list of all users


### PR DESCRIPTION
### What does this PR do?
Fixes the shadow module unit test from failing when it isn't run as root.

### What issues does this PR fix or reference?
Function and test were added by #41136

### Previous Behavior
#41136 added the `shadow.list_users` function which will return nothing if it isn't run by the root user. Therefore the corresponding test fails in that case.

### New Behavior
Test is skipped when not run as root and also if the shadow module is not present for some reason.