### PR TITLE
add changes to test return

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2258,6 +2258,7 @@ def directory(name,
     if __opts__['test']:
         ret['result'] = presult
         ret['comment'] = pcomment
+        ret['changes'] = ret['pchanges']
         return ret
 
     if not os.path.isdir(name):

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -792,7 +792,8 @@ class FileTestCase(TestCase):
                     with patch.dict(filestate.__opts__, {'test': True}):
                         comt = ('The following files will be changed:\n{0}:'
                                 ' directory - new\n'.format(name))
-                        ret.update({'comment': comt, 'result': None, 'pchanges': {'/etc/grub.conf': {'directory': 'new'}}})
+                        ret.update({'comment': comt, 'result': None, 'pchanges': {'/etc/grub.conf': {'directory': 'new'}},
+                                    'changes': {'/etc/grub.conf': {'directory': 'new'}}})
                         self.assertDictEqual(filestate.directory(name,
                                                                  user=user,
                                                                  group=group),

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -803,7 +803,7 @@ class FileTestCase(TestCase):
                         with patch.object(os.path, 'isdir', mock_f):
                             comt = ('No directory to create {0} in'
                                     .format(name))
-                            ret.update({'comment': comt, 'result': False})
+                            ret.update({'comment': comt, 'result': False, 'changes': {}})
                             self.assertDictEqual(filestate.directory
                                                  (name, user=user, group=group),
                                                  ret)


### PR DESCRIPTION
### What does this PR do?
Adds changes to the test return for file.directory so that listen and watch both get run when test=True

### What issues does this PR fix or reference?
Fixes #44155

### Tests written?

No