### PR TITLE
using salt rendering for test files

### DIFF
--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -13,6 +13,7 @@ Multiple *.tst files can be created in the saltcheck-tests folder.
 The "id" of a test works in the same manner as in salt state files.
 They should be unique and descriptive.
 Note: saltcheck supports the salt rendering system.  e.g. jinja + yaml will work = dynamically built tests
+      can pull from pillars, grains, and etc.
 
 Example file system layout:
 /srv/salt/apache/

--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -12,6 +12,7 @@ Multiple tests can be created in a file.
 Multiple *.tst files can be created in the saltcheck-tests folder.
 The "id" of a test works in the same manner as in salt state files.
 They should be unique and descriptive.
+Note: saltcheck supports the salt rendering system.  e.g. jinja + yaml will work = dynamically built tests
 
 Example file system layout:
 /srv/salt/apache/


### PR DESCRIPTION
### What does this PR do?
Allows saltcheck tests to be rendered by salt.  

### What issues does this PR fix or reference?
New feature

### Previous Behavior
Only allowed tests in yaml

### New Behavior
Allows tests to be rendered by whatever salt supports (e.g. yaml + jinja)

### Tests written?

No - using salt module to render

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
