### PR TITLE
Fixes to modules/debian_ip

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1388,7 +1388,7 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
     for opt in ['up_cmds', 'pre_up_cmds', 'post_up_cmds',
                 'down_cmds', 'pre_down_cmds', 'post_down_cmds']:
         if opt in opts:
-            iface_data['inet'][opt] = opts[opt]
+            iface_data[def_addrfam][opt] = opts[opt]
 
     for addrfam in ['inet', 'inet6']:
         if 'addrfam' in iface_data[addrfam] and iface_data[addrfam]['addrfam'] == addrfam:


### PR DESCRIPTION
### What does this PR do?
When looping through the various pre, post, up and down commands put them into the interface dict using the right internet family variable.

### What issues does this PR fix or reference?
#44140 

### Previous Behavior
The pre, post, up and down commands did not show when configuring `bond` interfaces when the `bond` interface was configured with an IPv6 address.

### New Behavior
Updates the code to ensure the values are being placed in the right location in the interface dictionary data using the variable keeping track of the Internet family.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
