### PR TITLE
Adding salt rendering to saltcheck tests

### DIFF
--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -10,6 +10,7 @@ Tests for a state should be created in files ending in *.tst and placed in the s
 
 Multiple tests can be created in a file.
 Multiple *.tst files can be created in the saltcheck-tests folder.
+Salt rendering is supported in test files e.g. yaml + jinja.
 The "id" of a test works in the same manner as in salt state files.
 They should be unique and descriptive.
 
@@ -50,6 +51,7 @@ from __future__ import absolute_import
 import logging
 import os
 import time
+from json import loads, dumps
 import yaml
 try:
     import salt.utils
@@ -196,6 +198,14 @@ def run_highstate_tests():
     out_list.sort()
     out_list.append({"TEST RESULTS": {'Passed': passed, 'Failed': failed, 'Missing Tests': missing_tests}})
     return out_list
+
+
+def _render_file(file_path):
+    '''call the salt utility to render a file'''
+    # salt-call slsutil.renderer /srv/salt/jinjatest/saltcheck-tests/test1.tst
+    rendered = __salt__['slsutil.renderer'](file_path)
+    log.info("rendered: {}".format(rendered))
+    return rendered
 
 
 def _is_valid_module(module):
@@ -534,7 +544,8 @@ class StateTestLoader(object):
         '''load tests either from one file, or a set of files'''
         self.test_dict = {}
         for myfile in self.test_files:
-            self.load_file(myfile)
+            # self.load_file(myfile)
+            self.load_file_salt_rendered(myfile)
         self.test_files = []
 
     def load_file(self, filepath):
@@ -542,13 +553,26 @@ class StateTestLoader(object):
         loads in one test file
         '''
         try:
-            with salt.utils.files.fopen(filepath, 'r') as myfile:
+            with __utils__['files.fopen'](filepath, 'r') as myfile:
+                # with salt.utils.files.fopen(filepath, 'r') as myfile:
                 # with open(filepath, 'r') as myfile:
                 contents_yaml = yaml.load(myfile)
                 for key, value in contents_yaml.items():
                     self.test_dict[key] = value
         except:
             raise
+        return
+
+    def load_file_salt_rendered(self, filepath):
+        '''
+        loads in one test file
+        '''
+        # use the salt renderer module to interpret jinja and etc
+        tests = _render_file(filepath)
+        # use json as a convenient way to convert the OrderedDicts from salt renderer
+        mydict = loads(dumps(tests))
+        for key, value in mydict.items():
+            self.test_dict[key] = value
         return
 
     def gather_files(self, filepath):


### PR DESCRIPTION
### What does this PR do?
Adds ability to use rendering in saltcheck test files
### What issues does this PR fix or reference?
None
### Previous Behavior
Only supported saltcheck tests in yaml format

### New Behavior
Supports standard salt rendering (e.g. yaml + jinja)

### Tests written?

No - simply calling salt rendering module

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
