### PR TITLE
Change reboot from 5 min to 2 sec when Joining/Un-Joining domain

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -664,7 +664,7 @@ def join_domain(domain,
         ret = {'Domain': domain,
                'Restart': False}
         if restart:
-            ret['Restart'] = reboot()
+            ret['Restart'] = reboot(timeout=2, in_seconds=True)
         return ret
 
     log.error(win32api.FormatMessage(err[0]).rstrip())
@@ -752,7 +752,7 @@ def unjoin_domain(username=None,
             ret = {'Workgroup': workgroup,
                    'Restart': False}
             if restart:
-                ret['Restart'] = reboot()
+                ret['Restart'] = reboot(timeout=2, in_seconds=True)
 
             return ret
         else:


### PR DESCRIPTION
### What does this PR do?
Passes timeout settings to the reboot command so that the reboot occurs immediately instead of the default 5 minutes. I chose 2 seconds to give the minion time to return before the shutdown initiates.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44166

### Previous Behavior
When a computer was joined/unjoined to the domain and `restart=True` the reboot function was called with default settings which is `timeout=5` and `in_seconds=False`. This caused the computer to wait 5 minutes before rebooting which causes issues with orchestration.

### New Behavior
The reboot function is now called with `timeout=2` and `in_seconds=True`.

### Tests written?
No