### PR TITLE
Fix autosign file permission check

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -312,7 +312,8 @@
 
 # If the autosign_file is specified, incoming keys specified in the
 # autosign_file will be automatically accepted. This is insecure.  Regular
-# expressions as well as globing lines are supported.
+# expressions as well as globing lines are supported. The file must be readonly
+# except for the owner. User permissive_pki_access to allow the group write access.
 #autosign_file: /etc/salt/autosign.conf
 
 # Works like autosign_file, but instead allows you to specify minion IDs for

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1153,6 +1153,9 @@ Default: ``not defined``
 If the ``autosign_file`` is specified incoming keys specified in the autosign_file
 will be automatically accepted. Matches will be searched for first by string
 comparison, then by globbing, then by full-string regex matching.
+The file must be readonly except for it's owner.
+If :conf_master:`permissive_pki_access` is ``True`` the owning group can also
+have write access, but if salt is running as ``root`` it must be a member of that group.
 This should still be considered a less than secure option, due to the fact
 that trust is based on just the requesting minion id.
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -306,7 +306,7 @@ class AutoKey(object):
             return True
 
         # After we've ascertained we're not on windows
-        groups = salt.utils.user.get_gid_list(self.opts['user'], include_default=False)
+        groups = salt.utils.get_gid_list(self.opts['user'], include_default=False)
         fmode = os.stat(filename)
 
         if stat.S_IWOTH & fmode.st_mode:

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -306,46 +306,23 @@ class AutoKey(object):
             return True
 
         # After we've ascertained we're not on windows
-        try:
-            user = self.opts['user']
-            pwnam = pwd.getpwnam(user)
-            uid = pwnam[2]
-            gid = pwnam[3]
-            groups = salt.utils.get_gid_list(user, include_default=False)
-        except KeyError:
-            log.error(
-                'Failed to determine groups for user {0}. The user is not '
-                'available.\n'.format(
-                    user
-                )
-            )
-            return False
-
+        groups = salt.utils.user.get_gid_list(self.opts['user'], include_default=False)
         fmode = os.stat(filename)
 
-        if os.getuid() == 0:
-            if fmode.st_uid == uid or fmode.st_gid != gid:
-                return True
-            elif self.opts.get('permissive_pki_access', False) \
-                    and fmode.st_gid in groups:
-                return True
-        else:
-            if stat.S_IWOTH & fmode.st_mode:
-                # don't allow others to write to the file
+        if stat.S_IWOTH & fmode.st_mode:
+            # don't allow others to write to the file
+            return False
+
+        if stat.S_IWGRP & fmode.st_mode:
+            # if the group has write access only allow with permissive_pki_access
+            if not self.opts.get('permissive_pki_access', False):
+                return False
+            elif os.getuid() == 0 and fmode.st_gid not in groups:
+                # if salt is root it has to be in the group that has write access
+                # this gives the group 'permission' to have write access
                 return False
 
-            # check group flags
-            if self.opts.get('permissive_pki_access', False) and stat.S_IWGRP & fmode.st_mode:
-                return True
-            elif stat.S_IWGRP & fmode.st_mode:
-                return False
-
-            # check if writable by group or other
-            if not (stat.S_IWGRP & fmode.st_mode or
-                    stat.S_IWOTH & fmode.st_mode):
-                return True
-
-        return False
+        return True
 
     def check_signing_file(self, keyid, signing_file):
         '''

--- a/tests/unit/daemons/test_masterapi.py
+++ b/tests/unit/daemons/test_masterapi.py
@@ -50,7 +50,7 @@ class AutoKeyTest(TestCase):
                 self.auto_key.opts['permissive_pki_access'] = permissive_pki
                 with patch('os.stat', self.os_stat_mock), \
                         patch('os.getuid', MagicMock(return_value=uid)), \
-                        patch('salt.utils.user.get_gid_list', MagicMock(return_value=groups)), \
+                        patch('salt.utils.get_gid_list', MagicMock(return_value=groups)), \
                         patch('salt.utils.is_windows', MagicMock(return_value=is_windows)):
                     func(self)
             return wrapper

--- a/tests/unit/daemons/test_masterapi.py
+++ b/tests/unit/daemons/test_masterapi.py
@@ -6,7 +6,6 @@ from functools import wraps
 import stat
 
 # Import Salt libs
-import salt.config
 import salt.daemons.masterapi as masterapi
 
 # Import Salt Testing Libs

--- a/tests/unit/daemons/test_masterapi.py
+++ b/tests/unit/daemons/test_masterapi.py
@@ -51,7 +51,7 @@ class AutoKeyTest(TestCase):
                 with patch('os.stat', self.os_stat_mock), \
                         patch('os.getuid', MagicMock(return_value=uid)), \
                         patch('salt.utils.user.get_gid_list', MagicMock(return_value=groups)), \
-                        patch('salt.utils.platform.is_windows', MagicMock(return_value=is_windows)):
+                        patch('salt.utils.is_windows', MagicMock(return_value=is_windows)):
                     func(self)
             return wrapper
         return decorator

--- a/tests/unit/daemons/test_masterapi.py
+++ b/tests/unit/daemons/test_masterapi.py
@@ -11,7 +11,7 @@ import salt.daemons.masterapi as masterapi
 
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
-from salttesting.mock import patch, NO_MOCK, NO_MOCK_REASON
+from salttesting.mock import patch, MagicMock, NO_MOCK, NO_MOCK_REASON
 
 
 def gen_permissions(owner='', group='', others=''):

--- a/tests/unit/daemons/test_masterapi.py
+++ b/tests/unit/daemons/test_masterapi.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+from functools import wraps
+import stat
+
+# Import Salt libs
+import salt.config
+import salt.daemons.masterapi as masterapi
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import patch, NO_MOCK, NO_MOCK_REASON
+
+
+def gen_permissions(owner='', group='', others=''):
+    '''
+    Helper method to generate file permission bits
+    Usage: gen_permissions('rw', 'r', 'r')
+    '''
+    ret = 0
+    for c in owner:
+        ret |= getattr(stat, 'S_I{}USR'.format(c.upper()), 0)
+    for c in group:
+        ret |= getattr(stat, 'S_I{}GRP'.format(c.upper()), 0)
+    for c in others:
+        ret |= getattr(stat, 'S_I{}OTH'.format(c.upper()), 0)
+    return ret
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class AutoKeyTest(TestCase):
+    '''
+    Tests for the salt.daemons.masterapi.AutoKey class
+    '''
+
+    def setUp(self):
+        opts = {'user': 'test_user'}
+        self.auto_key = masterapi.AutoKey(opts)
+        self.stats = {}
+
+    def _patch_check_permissions(uid=1, groups=None, is_windows=False, permissive_pki=False):
+        if not groups:
+            groups = [uid]
+
+        def decorator(func):
+            @wraps(func)
+            def wrapper(self):
+                self.auto_key.opts['permissive_pki_access'] = permissive_pki
+                with patch('os.stat', self.os_stat_mock), \
+                        patch('os.getuid', MagicMock(return_value=uid)), \
+                        patch('salt.utils.user.get_gid_list', MagicMock(return_value=groups)), \
+                        patch('salt.utils.platform.is_windows', MagicMock(return_value=is_windows)):
+                    func(self)
+            return wrapper
+        return decorator
+
+    def os_stat_mock(self, filename):
+        fmode = MagicMock()
+        fstats = self.stats.get(filename, {})
+        fmode.st_mode = fstats.get('mode', 0)
+        fmode.st_gid = fstats.get('gid', 0)
+        return fmode
+
+    @_patch_check_permissions(uid=0, is_windows=True)
+    def test_check_permissions_windows(self):
+        '''
+        Assert that all files are accepted on windows
+        '''
+        self.stats['testfile'] = {'mode': gen_permissions('rwx', 'rwx', 'rwx'), 'gid': 2}
+        self.assertTrue(self.auto_key.check_permissions('testfile'))
+
+    @_patch_check_permissions(permissive_pki=True)
+    def test_check_permissions_others_can_write(self):
+        '''
+        Assert that no file is accepted, when others can write to it
+        '''
+        self.stats['testfile'] = {'mode': gen_permissions('', '', 'w'), 'gid': 1}
+        self.assertFalse(self.auto_key.check_permissions('testfile'))
+
+    @_patch_check_permissions()
+    def test_check_permissions_group_can_write_not_permissive(self):
+        '''
+        Assert that a file is accepted, when group can write to it and perkissive_pki_access=False
+        '''
+        self.stats['testfile'] = {'mode': gen_permissions('w', 'w', ''), 'gid': 1}
+        self.assertFalse(self.auto_key.check_permissions('testfile'))
+
+    @_patch_check_permissions(permissive_pki=True)
+    def test_check_permissions_group_can_write_permissive(self):
+        '''
+        Assert that a file is accepted, when group can write to it and perkissive_pki_access=True
+        '''
+        self.stats['testfile'] = {'mode': gen_permissions('w', 'w', ''), 'gid': 1}
+        self.assertTrue(self.auto_key.check_permissions('testfile'))
+
+    @_patch_check_permissions(uid=0, permissive_pki=True)
+    def test_check_permissions_group_can_write_permissive_root_in_group(self):
+        '''
+        Assert that a file is accepted, when group can write to it, perkissive_pki_access=False,
+        salt is root and in the file owning group
+        '''
+        self.stats['testfile'] = {'mode': gen_permissions('w', 'w', ''), 'gid': 0}
+        self.assertTrue(self.auto_key.check_permissions('testfile'))
+
+    @_patch_check_permissions(uid=0, permissive_pki=True)
+    def test_check_permissions_group_can_write_permissive_root_not_in_group(self):
+        '''
+        Assert that no file is accepted, when group can write to it, perkissive_pki_access=False,
+        salt is root and **not** in the file owning group
+        '''
+        self.stats['testfile'] = {'mode': gen_permissions('w', 'w', ''), 'gid': 1}
+        self.assertFalse(self.auto_key.check_permissions('testfile'))
+
+    @_patch_check_permissions()
+    def test_check_permissions_only_owner_can_write(self):
+        '''
+        Assert that a file is accepted, when only the owner can write to it
+        '''
+        self.stats['testfile'] = {'mode': gen_permissions('w', '', ''), 'gid': 1}
+        self.assertTrue(self.auto_key.check_permissions('testfile'))
+
+    @_patch_check_permissions(uid=0)
+    def test_check_permissions_only_owner_can_write_root(self):
+        '''
+        Assert that a file is accepted, when only the owner can write to it and salt is root
+        '''
+        self.stats['testfile'] = {'mode': gen_permissions('w', '', ''), 'gid': 0}
+        self.assertTrue(self.auto_key.check_permissions('testfile'))


### PR DESCRIPTION
### What does this PR do?
Fixes autosign file permission check `salt.daemons.masterapi.AutoKey._check_permissions()`.

### What issues does this PR fix or reference?
There seems to have been a similar problem in #1870 back in 2012, but the resulting commit 
a8b302b doesn't look much better to me.

### Previous Behavior
The `salt.daemons.masterapi.AutoKey._check_permissions()` function used to check the permissions of an autosign file does some seemingly arbitrary file checks and some of those even twice to check if an `autosign_file` is secure enough to use.

As far as I can tell a file is allowed if **any** of these apply:
- salt is `root` and owns the file
- salt is `root` but it's primary `group` does **not** own the file
- salt is `root` and the `permissive_pki_access` config option is true and the `root` user is a member of the file owning group
- salt is **not** `root` and `others` do **not** have write access and `permissive_pki_access` is true and the owning group has write access
- salt is **not** `root` and `others` do **not** have write access and the owning `group` does **not** have write access

Which seems pretty random to me, especially since basically anything is allowed as long as salt runs as `root` and owns the file, even if anybody can write to the file.

### New Behavior
The function checks exactly that:
- `Others` must **not** have write access to the file.
- if the `group` has write access to the file: `permissive_pki_access` must be true
    - if salt is `root`: the `root` user must also be part of that `group`

### Tests written?
No, but I could write a unit test if you think it makes sense.