### PR TITLE
Simplify saltify cloud driver

### DIFF
--- a/doc/topics/cloud/saltify.rst
+++ b/doc/topics/cloud/saltify.rst
@@ -33,9 +33,9 @@ the salt-master:
 
 However, if you wish to use the more advanced capabilities of salt-cloud, such as
 rebooting, listing, and disconnecting machines, then the salt master must fill
-the role usually performed by a vendor's cloud management system. In order to do
-that, you must configure your salt master as a salt-api server, and supply credentials
-to use it. (See ``salt-api setup`` below.)
+the role usually performed by a vendor's cloud management system. The salt master
+must be running on the salt-cloud machine, and created nodes must be connected to the
+master.
 
 
 Profiles
@@ -165,69 +165,3 @@ Return values:
   - ``True``: Credential verification succeeded
   - ``False``: Credential verification succeeded
   - ``None``: Credential verification was not attempted.
-
-Provisioning salt-api
-=====================
-
-In order to query or control minions it created, saltify needs to send commands
-to the salt master.  It does that using the network interface to salt-api.
-
-The salt-api is not enabled by default. The following example will provide a
-simple installation.
-
-.. code-block:: yaml
-
-    # file /etc/salt/cloud.profiles.d/my_saltify_profiles.conf
-    hw_41:  # a theoretical example hardware machine
-      ssh_host: 10.100.9.41  # the hard address of your target
-      ssh_username: vagrant  # a user name which has passwordless sudo
-      password: vagrant      # on your target machine
-      provider: my_saltify_provider
-      shutdown_on_destroy: true  # halt the target on "salt-cloud -d" command
-
-
-
-.. code-block:: yaml
-
-    # file /etc/salt/cloud.providers.d/saltify_provider.conf
-    my_saltify_provider:
-      driver: saltify
-      eauth: pam
-      username: vagrant  # supply some sudo-group-member's name
-      password: vagrant  # and password on the salt master
-      minion:
-        master: 10.100.9.5  # the hard address of the master
-
-
-.. code-block:: yaml
-
-    # file /etc/salt/master.d/auth.conf
-    #  using salt-api ... members of the 'sudo' group can do anything ...
-    external_auth:
-      pam:
-        sudo%:
-          - .*
-          - '@wheel'
-          - '@runner'
-          - '@jobs'
-
-
-.. code-block:: yaml
-
-    # file /etc/salt/master.d/api.conf
-    # see https://docs.saltstack.com/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html
-    rest_cherrypy:
-      host: localhost
-      port: 8000
-      ssl_crt: /etc/pki/tls/certs/localhost.crt
-      ssl_key: /etc/pki/tls/certs/localhost.key
-      thread_pool: 30
-      socket_queue_size: 10
-
-
-Start your target machine as a Salt minion named "node41" by:
-
-.. code-block:: bash
-
-    $ sudo salt-cloud -p hw_41 node41
-

--- a/salt/cloud/clouds/saltify.py
+++ b/salt/cloud/clouds/saltify.py
@@ -19,7 +19,7 @@ import logging
 # Import salt libs
 import salt.utils.cloud
 import salt.config as config
-import salt.netapi
+import salt.client
 import salt.ext.six as six
 if six.PY3:
     import ipaddress
@@ -32,6 +32,7 @@ from salt.exceptions import SaltCloudException, SaltCloudSystemExit
 log = logging.getLogger(__name__)
 
 try:
+    # noinspection PyUnresolvedReferences
     from impacket.smbconnection import SessionError as smbSessionError
     from impacket.smb3 import SessionError as smb3SessionError
     HAS_IMPACKET = True
@@ -39,7 +40,9 @@ except ImportError:
     HAS_IMPACKET = False
 
 try:
+    # noinspection PyUnresolvedReferences
     from winrm.exceptions import WinRMTransportError
+    # noinspection PyUnresolvedReferences
     from requests.exceptions import (
         ConnectionError, ConnectTimeout, ReadTimeout, SSLError,
         ProxyError, RetryError, InvalidSchema)
@@ -55,24 +58,6 @@ def __virtual__():
     return True
 
 
-def _get_connection_info():
-    '''
-    Return connection information for the passed VM data
-    '''
-    vm_ = get_configured_provider()
-
-    try:
-        ret = {'username': vm_['username'],
-               'password': vm_['password'],
-               'eauth': vm_['eauth'],
-               'vm': vm_,
-               }
-    except KeyError:
-        raise SaltCloudException(
-            'Configuration must define salt-api "username", "password" and "eauth"')
-    return ret
-
-
 def avail_locations(call=None):
     '''
     This function returns a list of locations available.
@@ -81,7 +66,7 @@ def avail_locations(call=None):
 
         salt-cloud --list-locations my-cloud-provider
 
-    [ saltify will always returns an empty dictionary ]
+    [ saltify will always return an empty dictionary ]
     '''
 
     return {}
@@ -127,8 +112,6 @@ def list_nodes(call=None):
 
     returns a list of dictionaries of defined standard fields.
 
-    salt-api setup required for operation.
-
     ..versionadded:: Oxygen
 
     '''
@@ -172,8 +155,8 @@ def list_nodes_full(call=None):
         salt-cloud -F
 
     returns a list of dictionaries.
+
     for 'saltify' minions, returns dict of grains (enhanced).
-    salt-api setup required for operation.
 
     ..versionadded:: Oxygen
     '''
@@ -200,16 +183,9 @@ def _list_nodes_full(call=None):
     '''
     List the nodes, ask all 'saltify' minions, return dict of grains.
     '''
-    local = salt.netapi.NetapiClient(__opts__)
-    cmd = {'client': 'local',
-           'tgt': 'salt-cloud:driver:saltify',
-           'fun': 'grains.items',
-           'arg': '',
-           'tgt_type': 'grain',
-           }
-    cmd.update(_get_connection_info())
-
-    return local.run(cmd)
+    local = salt.client.LocalClient()
+    return local.cmd('salt-cloud:driver:saltify', 'grains.items', '',
+                      tgt_type='grain')
 
 
 def list_nodes_select(call=None):
@@ -226,15 +202,8 @@ def show_instance(name, call=None):
     '''
     List the a single node, return dict of grains.
     '''
-    local = salt.netapi.NetapiClient(__opts__)
-    cmd = {'client': 'local',
-           'tgt': 'name',
-           'fun': 'grains.items',
-           'arg': '',
-           'tgt_type': 'glob',
-           }
-    cmd.update(_get_connection_info())
-    ret = local.run(cmd)
+    local = salt.client.LocalClient()
+    ret = local.cmd(name, 'grains.items')
     ret.update(_build_required_items(ret))
     return ret
 
@@ -365,13 +334,20 @@ def destroy(name, call=None):
 
     .. versionadded:: Oxygen
 
+    Disconnect a minion from the master, and remove its keys.
+
+    Optionally, (if ``remove_config_on_destroy`` is ``True``),
+      disables salt-minion from running on the minion, and
+      erases the Salt configuration files from it.
+
+    Optionally, (if ``shutdown_on_destroy`` is ``True``),
+      orders the minion to halt.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-cloud --destroy mymachine
-
-    salt-api setup required for operation.
 
     '''
     if call == 'function':
@@ -391,15 +367,9 @@ def destroy(name, call=None):
         transport=opts['transport']
     )
 
-    local = salt.netapi.NetapiClient(opts)
-    cmd = {'client': 'local',
-           'tgt': name,
-           'fun': 'grains.get',
-           'arg': ['salt-cloud'],
-           }
-    cmd.update(_get_connection_info())
-    vm_ = cmd['vm']
-    my_info = local.run(cmd)
+    vm_ = get_configured_provider()
+    local = salt.client.LocalClient()
+    my_info = local.cmd(name, 'grains.get', ['salt-cloud'])
     try:
         vm_.update(my_info[name])  # get profile name to get config value
     except (IndexError, TypeError):
@@ -407,25 +377,22 @@ def destroy(name, call=None):
     if config.get_cloud_config_value(
            'remove_config_on_destroy', vm_, opts, default=True
             ):
-        cmd.update({'fun': 'service.disable', 'arg': ['salt-minion']})
-        ret = local.run(cmd)  # prevent generating new keys on restart
+        ret = local.cmd(name,  # prevent generating new keys on restart
+                        'service.disable',
+                        ['salt-minion'])
         if ret and ret[name]:
             log.info('disabled salt-minion service on %s', name)
-        cmd.update({'fun': 'config.get', 'arg': ['conf_file']})
-        ret = local.run(cmd)
+        ret = local.cmd(name, 'config.get', ['conf_file'])
         if ret and ret[name]:
             confile = ret[name]
-            cmd.update({'fun': 'file.remove', 'arg': [confile]})
-            ret = local.run(cmd)
+            ret = local.cmd(name, 'file.remove', [confile])
             if ret and ret[name]:
                 log.info('removed minion %s configuration file %s',
                          name, confile)
-        cmd.update({'fun': 'config.get', 'arg': ['pki_dir']})
-        ret = local.run(cmd)
+        ret = local.cmd(name, 'config.get', ['pki_dir'])
         if ret and ret[name]:
             pki_dir = ret[name]
-            cmd.update({'fun': 'file.remove', 'arg': [pki_dir]})
-            ret = local.run(cmd)
+            ret = local.cmd(name, 'file.remove', [pki_dir])
             if ret and ret[name]:
                 log.info(
                     'removed minion %s key files in %s',
@@ -435,8 +402,7 @@ def destroy(name, call=None):
     if config.get_cloud_config_value(
         'shutdown_on_destroy', vm_, opts, default=False
         ):
-        cmd.update({'fun': 'system.shutdown', 'arg': ''})
-        ret = local.run(cmd)
+        ret = local.cmd(name, 'system.shutdown')
         if ret and ret[name]:
             log.info('system.shutdown for minion %s successful', name)
 
@@ -456,8 +422,6 @@ def reboot(name, call=None):
     '''
     Reboot a saltify minion.
 
-    salt-api setup required for operation.
-
     ..versionadded:: Oxygen
 
     name
@@ -475,13 +439,5 @@ def reboot(name, call=None):
             'The reboot action must be called with -a or --action.'
         )
 
-    local = salt.netapi.NetapiClient(__opts__)
-    cmd = {'client': 'local',
-           'tgt': name,
-           'fun': 'system.reboot',
-           'arg': '',
-           }
-    cmd.update(_get_connection_info())
-    ret = local.run(cmd)
-
-    return ret
+    local = salt.client.LocalClient()
+    return local.cmd(name, 'system.reboot')

--- a/tests/unit/cloud/clouds/test_saltify.py
+++ b/tests/unit/cloud/clouds/test_saltify.py
@@ -172,7 +172,7 @@ class SaltifyTestCase(TestCase, LoaderModuleMockMixin):
                 {'nodeS1':  # last call shuts down the minion
                      'system.shutdown worked' },
             ]
-        mm_cmd = MagicMock(return_value=True, side_effect=result_list)
+        mm_cmd = MagicMock(side_effect=result_list)
         lcl = salt.client.LocalClient()
         lcl.cmd = mm_cmd
         with patch('salt.client.LocalClient', return_value=lcl):

--- a/tests/unit/cloud/clouds/test_saltify.py
+++ b/tests/unit/cloud/clouds/test_saltify.py
@@ -8,32 +8,53 @@ from __future__ import absolute_import
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
-from tests.support.unit import TestCase
-from tests.support.mock import (
-    MagicMock,
-    patch
-)
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import MagicMock, NO_MOCK, NO_MOCK_REASON, patch, ANY
+
 
 # Import Salt Libs
+import salt.client
 from salt.cloud.clouds import saltify
 
+TEST_PROFILES = {
+    'testprofile1': NotImplemented,
+    'testprofile2': {'ssh_username': 'fred',
+                     'ssh_host': 'betty',
+                     'remove_config_on_destroy': False,
+                     'shutdown_on_destroy': True
+                     }
+    }
+TEST_PROFILE_NAMES = ['testprofile1', 'testprofile2']
 
+@skipIf(NO_MOCK, NO_MOCK_REASON)
 class SaltifyTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.cloud.clouds.saltify
     '''
-    # 'create' function tests: 1
+    LOCAL_OPTS = {
+        'providers': {
+            'sfy1': {
+                'saltify' : {
+                    'driver': 'saltify',
+                    'profiles': TEST_PROFILES
+                    }
+                },
+            },
+        'profiles': TEST_PROFILES,
+        'sock_dir': '/var/sockxxx',
+        'transport': 'tcp',
+        }
 
     def setup_loader_modules(self):
-        return {
-            saltify: {
+        saltify_globals = {
                 '__active_provider_name__': '',
                 '__utils__': {
-                    'cloud.bootstrap': MagicMock()
-                },
-                '__opts__': {'providers': {}}
-            }
-        }
+                    'cloud.bootstrap': MagicMock(),
+                    'cloud.fire_event': MagicMock(),
+                    },
+                '__opts__': self.LOCAL_OPTS,
+                }
+        return {saltify: saltify_globals}
 
     def test_create_no_deploy(self):
         '''
@@ -43,5 +64,118 @@ class SaltifyTestCase(TestCase, LoaderModuleMockMixin):
             vm = {'deploy':  False,
                   'driver': 'saltify',
                   'name': 'dummy'
-                 }
+                  }
             self.assertTrue(saltify.create(vm))
+
+    def test_create_and_deploy(self):
+        '''
+        Test if deployment can be done.
+        '''
+        mock_cmd = MagicMock(return_value=True)
+        with patch.dict(
+            'salt.cloud.clouds.saltify.__utils__',
+            {'cloud.bootstrap': mock_cmd}):
+            vm_ = {'deploy':  True,
+                  'driver': 'saltify',
+                  'name': 'testprofile2',
+                 }
+            result = saltify.create(vm_)
+            mock_cmd.assert_called_once_with(vm_, ANY)
+            self.assertTrue(result)
+
+    def test_avail_locations(self):
+        '''
+        Test the avail_locations will always return {}
+        '''
+        self.assertEqual(saltify.avail_locations(), {})
+
+
+    def test_avail_sizes(self):
+        '''
+        Test the avail_sizes will always return {}
+        '''
+        self.assertEqual(saltify.avail_sizes(), {})
+
+    def test_avail_images(self):
+        '''
+        Test the avail_images will return profiles
+        '''
+        testlist = list(TEST_PROFILE_NAMES)  # copy
+        self.assertEqual(
+            saltify.avail_images()['Profiles'].sort(),
+            testlist.sort())
+
+
+    def test_list_nodes(self):
+        '''
+        Test list_nodes will return required fields only
+        '''
+        testgrains = {
+            'nodeX1': {
+                'id': 'nodeX1',
+                'ipv4': [
+                    '127.0.0.1', '192.1.2.22', '172.16.17.18'],
+                'ipv6': [
+                    '::1', 'fdef:bad:add::f00', '3001:DB8::F00D'],
+                'salt-cloud': {
+                    'driver': 'saltify',
+                    'provider': 'saltyfy',
+                    'profile': 'testprofile2'
+                   },
+                'extra_stuff': 'does not belong'
+                }
+            }
+        expected_result = {
+            'nodeX1': {
+                'id': 'nodeX1',
+                'image': 'testprofile2',
+                'private_ips': [
+                    '172.16.17.18', 'fdef:bad:add::f00'],
+                'public_ips': [
+                    '192.1.2.22', '3001:DB8::F00D'],
+                'size': '',
+                'state': 'running'
+                }
+            }
+        mm_cmd = MagicMock(return_value=testgrains)
+        lcl = salt.client.LocalClient()
+        lcl.cmd = mm_cmd
+        with patch('salt.client.LocalClient', return_value=lcl):
+            self.assertEqual(
+                saltify.list_nodes(),
+                expected_result)
+
+    def test_saltify_reboot(self):
+        mm_cmd = MagicMock(return_value=True)
+        lcl = salt.client.LocalClient()
+        lcl.cmd = mm_cmd
+        with patch('salt.client.LocalClient', return_value=lcl):
+            result = saltify.reboot('nodeS1', 'action')
+            mm_cmd.assert_called_with('nodeS1', 'system.reboot')
+            self.assertTrue(result)
+
+    def test_saltify_destroy(self):
+        # destroy calls local.cmd several times and expects
+        # different results, so we will provide a list of
+        # results. Each call will get the next value.
+        # NOTE: this assumes that the call order never changes,
+        # so to keep things simple, we will not use remove_config...
+        result_list = [
+                {'nodeS1': {  # first call returns grains.get
+                    'driver': 'saltify',
+                    'provider': 'saltify',
+                    'profile': 'testprofile2'}
+                    #  Note:
+                    #    testprofile2 has remove_config_on_destroy: False
+                    #    and shutdown_on_destroy: True
+                },
+                {'nodeS1':  # last call shuts down the minion
+                     'system.shutdown worked' },
+            ]
+        mm_cmd = MagicMock(return_value=True, side_effect=result_list)
+        lcl = salt.client.LocalClient()
+        lcl.cmd = mm_cmd
+        with patch('salt.client.LocalClient', return_value=lcl):
+            result = saltify.destroy('nodeS1', 'action')
+            mm_cmd.assert_called_with('nodeS1', 'system.shutdown')
+            self.assertTrue(result)

--- a/tests/unit/cloud/clouds/test_saltify.py
+++ b/tests/unit/cloud/clouds/test_saltify.py
@@ -18,13 +18,14 @@ from salt.cloud.clouds import saltify
 
 TEST_PROFILES = {
     'testprofile1': NotImplemented,
-    'testprofile2': {'ssh_username': 'fred',
-                     'ssh_host': 'betty',
-                     'remove_config_on_destroy': False,
-                     'shutdown_on_destroy': True
+    'testprofile2': {  # this profile is used in test_saltify_destroy()
+                     'ssh_username': 'fred',
+                     'remove_config_on_destroy': False,  # expected for test
+                     'shutdown_on_destroy': True  # expected value for test
                      }
     }
 TEST_PROFILE_NAMES = ['testprofile1', 'testprofile2']
+
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class SaltifyTestCase(TestCase, LoaderModuleMockMixin):
@@ -34,7 +35,7 @@ class SaltifyTestCase(TestCase, LoaderModuleMockMixin):
     LOCAL_OPTS = {
         'providers': {
             'sfy1': {
-                'saltify' : {
+                'saltify': {
                     'driver': 'saltify',
                     'profiles': TEST_PROFILES
                     }
@@ -89,7 +90,6 @@ class SaltifyTestCase(TestCase, LoaderModuleMockMixin):
         '''
         self.assertEqual(saltify.avail_locations(), {})
 
-
     def test_avail_sizes(self):
         '''
         Test the avail_sizes will always return {}
@@ -104,7 +104,6 @@ class SaltifyTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             saltify.avail_images()['Profiles'].sort(),
             testlist.sort())
-
 
     def test_list_nodes(self):
         '''
@@ -161,16 +160,16 @@ class SaltifyTestCase(TestCase, LoaderModuleMockMixin):
         # NOTE: this assumes that the call order never changes,
         # so to keep things simple, we will not use remove_config...
         result_list = [
-                {'nodeS1': {  # first call returns grains.get
+                {'nodeS1': {  # first call is grains.get
                     'driver': 'saltify',
                     'provider': 'saltify',
                     'profile': 'testprofile2'}
-                    #  Note:
-                    #    testprofile2 has remove_config_on_destroy: False
-                    #    and shutdown_on_destroy: True
                 },
+                #  Note:
+                #    testprofile2 has remove_config_on_destroy: False
+                #    and shutdown_on_destroy: True
                 {'nodeS1':  # last call shuts down the minion
-                     'system.shutdown worked' },
+                     'a system.shutdown worked message'},
             ]
         mm_cmd = MagicMock(side_effect=result_list)
         lcl = salt.client.LocalClient()


### PR DESCRIPTION
### What does this PR do?

Using the lessons learned during development of the Vagrant driver, switch from using
NetAPI calls to LocalAPI calls, thus making the code, and the setup, much smaller.

Also, add unit tests for most of the functions.

### What issues does this PR fix or reference?

None.

### New Behavior

Salt-api is no longer required to operate the advanced functions.

### Tests written?

Yes!.
