### PR TITLE
Fixing default redis.host in documentation

### DIFF
--- a/salt/modules/redismod.py
+++ b/salt/modules/redismod.py
@@ -9,7 +9,7 @@ Module to provide redis functionality to Salt
 
 .. code-block:: yaml
 
-    redis.host: 'localhost'
+    redis.host: 'salt'
     redis.port: 6379
     redis.db: 0
     redis.password: None


### PR DESCRIPTION
### What does this PR do?
Fixing default redis.host in documentation

### What issues does this PR fix or reference?
Default redis.host is 'salt' but documented as 'localhost'

### Previous Behavior
Wrong documentation

### New Behavior
Right documentation
### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
