### PR TITLE
Add grain swap_total

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -414,6 +414,9 @@ def _memdata(osdata):
                     if comps[0].strip() == 'MemTotal':
                         # Use floor division to force output to be an integer
                         grains['mem_total'] = int(comps[1].split()[0]) // 1024
+                    elif comps[0].strip() == 'SwapTotal':
+                        # Use floor division to force output to be an integer
+                        grains['swap_total'] = int(comps[1].split()[0]) // 1024
     elif osdata['kernel'] in ('FreeBSD', 'OpenBSD', 'NetBSD', 'Darwin'):
         sysctl = salt.utils.path.which('sysctl')
         if sysctl:


### PR DESCRIPTION
Total swap memory is calculated the same way as mem_total on Linux.

### What does this PR do?
Add new grain swap_total

### What issues does this PR fix or reference?
#43825 

### New Behavior
Remove this section if not relevant

### Tests written?
No
