### PR TITLE
[2017.7] scheduler fixes

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1139,7 +1139,8 @@ class Schedule(object):
                     # Sort the list of "whens" from earlier to later schedules
                     _when.sort()
 
-                    for i in _when:
+                    # Copy the list so we can loop through it
+                    for i in copy.deepcopy(_when):
                         if i < now and len(_when) > 1:
                             # Remove all missed schedules except the latest one.
                             # We need it to detect if it was triggered previously.


### PR DESCRIPTION
### What does this PR do?
Adding a copy.deepcopy to the for loop that looks for old jobs to avoid stale jobs ending up in the list.

### What issues does this PR fix or reference?
#44181 

### Previous Behavior
If a scheduled job contained multiple `when` times then certain items ended up getting stuck in the list.

### New Behavior
Updating the for loop so that rather than iterating over the list of `when` options, we iterate over a copy so we safely remove the old while still being able to continue iterating over the list.

### Tests written?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
