### PR TITLE
yumpkg: Check pkgname instead of name to see if it is a kernel pkg

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1230,24 +1230,26 @@ def install(name=None,
                             to_install.append((pkgname, pkgstr))
                             break
                     else:
-                        if re.match('kernel(-.+)?', name):
-                            # kernel and its subpackages support multiple
-                            # installs as their paths do not conflict.
-                            # Performing a yum/dnf downgrade will be a no-op
-                            # so just do an install instead. It will fail if
-                            # there are other interdependencies that have
-                            # conflicts, and that's OK. We don't want to force
-                            # anything, we just want to properly handle it if
-                            # someone tries to install a kernel/kernel-devel of
-                            # a lower version than the currently-installed one.
-                            # TODO: find a better way to determine if a package
-                            # supports multiple installs.
-                            to_install.append((pkgname, pkgstr))
-                        else:
-                            # None of the currently-installed versions are
-                            # greater than the specified version, so this is a
-                            # downgrade.
-                            to_downgrade.append((pkgname, pkgstr))
+                        if pkgname is not None:
+                            if re.match('kernel(-.+)?', pkgname):
+                                # kernel and its subpackages support multiple
+                                # installs as their paths do not conflict.
+                                # Performing a yum/dnf downgrade will be a
+                                # no-op so just do an install instead. It will
+                                # fail if there are other interdependencies
+                                # that have conflicts, and that's OK. We don't
+                                # want to force anything, we just want to
+                                # properly handle it if someone tries to
+                                # install a kernel/kernel-devel of a lower
+                                # version than the currently-installed one.
+                                # TODO: find a better way to determine if a
+                                # package supports multiple installs.
+                                to_install.append((pkgname, pkgstr))
+                            else:
+                                # None of the currently-installed versions are
+                                # greater than the specified version, so this
+                                # is a downgrade.
+                                to_downgrade.append((pkgname, pkgstr))
 
     def _add_common_args(cmd):
         '''


### PR DESCRIPTION
We should have been checking pkgname instead of name all along, but this
never bit us until 6638749 started passing `None` for the name param.

Fixes #44150