### PR TITLE
Fix test=true checks so that state runs in test mode don't report cha…

### DIFF
--- a/salt/states/postgres_extension.py
+++ b/salt/states/postgres_extension.py
@@ -121,14 +121,15 @@ def present(name,
             if flag in mtdata:
                 toupgrade = True
                 mode = 'upgrade'
-    if __opts__['test']:
-        ret['result'] = None
-        if mode:
-            ret['comment'] = 'Extension {0} is set to be {1}ed'.format(
-                name, mode).replace('eed', 'ed')
-        return ret
     cret = None
     if toinstall or toupgrade:
+        if __opts__['test']:
+            ret['result'] = None
+            if mode:
+                ret['comment'] = 'Extension {0} is set to be {1}ed'.format(
+                    name, mode).replace('eed', 'ed')
+            return ret
+
         cret = __salt__['postgres.create_extension'](
             name=name,
             if_not_exists=if_not_exists,

--- a/tests/unit/states/test_postgres.py
+++ b/tests/unit/states/test_postgres.py
@@ -422,8 +422,8 @@ class PostgresExtensionTestCase(TestCase, LoaderModuleMockMixin):
                 ret = postgres_extension.present('foo')
                 self.assertEqual(
                     ret,
-                    {'comment': "Extension foo is set to be created",
-                     'changes': {}, 'name': 'foo', 'result': None}
+                    {'comment': "Extension foo is already present",
+                     'changes': {}, 'name': 'foo', 'result': True}
 
                 )
                 ret = postgres_extension.present('foo')

--- a/tests/unit/states/test_postgres_extension.py
+++ b/tests/unit/states/test_postgres_extension.py
@@ -45,8 +45,8 @@ class PostgresExtensionTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(postgres_extension.__salt__,
                         {'postgres.create_metadata': mock}):
             with patch.dict(postgres_extension.__opts__, {'test': True}):
-                comt = ('Extension {0} is set to be created'.format(name))
-                ret.update({'comment': comt, 'result': None})
+                comt = ('Extension {0} is already present'.format(name))
+                ret.update({'comment': comt, 'result': True})
                 self.assertDictEqual(postgres_extension.present(name), ret)
 
             with patch.dict(postgres_extension.__opts__, {'test': False}):


### PR DESCRIPTION
…nges if there is nothing to do

Currently running this postgres_extension.present with test=true will always report changes, even if there is nothing to modify.

### What does this PR do?

Fixes `postgres_extension.present` so that it only reports changes in test mode if there are changes to be made.

### What issues does this PR fix or reference?

#44189 

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
