### PR TITLE
Fix reg.py for use with LGPO module

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -35,7 +35,6 @@ from __future__ import unicode_literals
 import sys
 import logging
 from salt.ext.six.moves import range  # pylint: disable=W0622,import-error
-from salt.ext import six
 
 # Import third party libs
 try:

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -76,16 +76,16 @@ def __virtual__():
 
 def _to_mbcs(vdata):
     '''
-    Converts unicode to to current users character encoding.
+    Converts unicode to to current users character encoding. Use this for values
+    returned by reg functions
     '''
     return salt.utils.to_unicode(vdata, 'mbcs')
 
 
 def _to_unicode(vdata):
     '''
-    Converts from current users character encoding to unicode.
-    When instr has a value of None, the return value of the function
-    will also be None.
+    Converts from current users character encoding to unicode. Use this for
+    parameters being pass to reg functions
     '''
     return salt.utils.to_unicode(vdata, 'utf-8')
 
@@ -161,13 +161,8 @@ def _key_exists(hive, key, use_32bit_registry=False):
     :return: Returns True if found, False if not found
     :rtype: bool
     '''
-
-    if PY2:
-        local_hive = _to_unicode(hive)
-        local_key = _to_unicode(key)
-    else:
-        local_hive = hive
-        local_key = key
+    local_hive = _to_unicode(hive)
+    local_key = _to_unicode(key)
 
     registry = Registry()
     hkey = registry.hkeys[local_hive]
@@ -357,7 +352,7 @@ def read_value(hive, key, vname=None, use_32bit_registry=False):
     # Setup the return array
     local_hive = _to_unicode(hive)
     local_key = _to_unicode(key)
-    local_vname = _to_unicode(vname) if vname else None
+    local_vname = _to_unicode(vname)
 
     ret = {'hive':  local_hive,
            'key':   local_key,
@@ -497,7 +492,7 @@ def set_value(hive,
     '''
     local_hive = _to_unicode(hive)
     local_key = _to_unicode(key)
-    local_vname = _to_unicode(vname) if vname else None
+    local_vname = _to_unicode(vname)
     local_vtype = _to_unicode(vtype)
 
     registry = Registry()
@@ -668,7 +663,7 @@ def delete_value(hive, key, vname=None, use_32bit_registry=False):
 
     local_hive = _to_unicode(hive)
     local_key = _to_unicode(key)
-    local_vname = _to_unicode(vname) if vname else None
+    local_vname = _to_unicode(vname)
 
     registry = Registry()
     hkey = registry.hkeys[local_hive]

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -589,7 +589,8 @@ def set_value(hive,
                 4: int,  # REG_DWORD
                 7: list,  # REG_MULTI_SZ
                 11: int}  # REG_QWORD (unsupported)
-    local_vdata = reg_type[vtype_value](local_vdata)
+    if not isinstance(local_vdata, reg_type[vtype_value]):
+        local_vdata = reg_type[vtype_value](local_vdata)
 
     if volatile:
         create_options = registry.opttype['REG_OPTION_VOLATILE']

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -583,8 +583,8 @@ def set_value(hive,
     # Check data type and cast to expected type
     # int will automatically become long on 64bit numbers
     # https://www.python.org/dev/peps/pep-0237/
-    reg_type = {1: str,  # REG_SZ
-                2: str,  # REG_EXPAND_SZ
+    reg_type = {1: six.text_type,  # REG_SZ
+                2: six.text_type,  # REG_EXPAND_SZ
                 3: bin,  # REG_BINARY
                 4: int,  # REG_DWORD
                 7: list,  # REG_MULTI_SZ

--- a/salt/states/reg.py
+++ b/salt/states/reg.py
@@ -59,6 +59,7 @@ from __future__ import absolute_import
 
 # Import python libs
 import logging
+import salt.utils
 
 log = logging.getLogger(__name__)
 
@@ -186,13 +187,14 @@ def present(name,
                                              use_32bit_registry=use_32bit_registry)
 
     if vdata == reg_current['vdata'] and reg_current['success']:
-        ret['comment'] = '{0} in {1} is already configured'.\
-            format(vname if vname else '(Default)', name)
+        ret['comment'] = u'{0} in {1} is already configured' \
+                         ''.format(salt.utils.to_unicode(vname, 'utf-8') if vname else u'(Default)',
+                                   salt.utils.to_unicode(name, 'utf-8'))
         return ret
 
     add_change = {'Key': r'{0}\{1}'.format(hive, key),
-                  'Entry': '{0}'.format(vname if vname else '(Default)'),
-                  'Value': '{0}'.format(vdata)}
+                  'Entry': u'{0}'.format(salt.utils.to_unicode(vname, 'utf-8') if vname else u'(Default)'),
+                  'Value': salt.utils.to_unicode(vdata, 'utf-8')}
 
     # Check for test option
     if __opts__['test']:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -3070,6 +3070,8 @@ def to_unicode(s, encoding=None):
     '''
     Given str or unicode, return unicode (str for python 3)
     '''
+    if s is None:
+        return s
     if six.PY3:
         return to_str(s, encoding)
     else:


### PR DESCRIPTION
### What does this PR do?
Modifies the `salt.utils.to_unicode` function to return `None` if passed `None`

Makes sure the `vdata` value type matches what is required by the type specified in `vtype`. The LGPO module was passing a unicode string 0 (`u'0'`) which was causing the RegSetValueEx function to fail because it was expecting an int type value.

This casts vdata to the following:
int for REG_DWORD and REG_QWORD
str for REG_SZ and REG_EXPAND_SZ
bin for REG_BINARY
list for REG_MULTI_SZ

Fixes many Unicode registry issues.
Uses `salt.utils.to_unicode` instead of the local `_unicode_to_mcbs` and `_mcbs_to_unicode` functions
Was using a mixture of _winreg and win32api... moved to win32api for better unicode handling

Tested with Unicode values
Tested with Unicode value names

Fixes `reg.py` state to handle Unicode value names and values
Can't pass Unicode values in the `name` portion of a state for some reason

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44192

### Previous Behavior
LGPO would fail

### New Behavior
Now it works

### Tests written?
No