### PR TITLE
add wake-on-LAN feature to saltify create

### DIFF
--- a/doc/topics/cloud/misc.rst
+++ b/doc/topics/cloud/misc.rst
@@ -1,3 +1,5 @@
+.. _misc-salt-cloud-options:
+
 ================================
 Miscellaneous Salt Cloud Options
 ================================

--- a/doc/topics/cloud/saltify.rst
+++ b/doc/topics/cloud/saltify.rst
@@ -4,7 +4,7 @@
 Getting Started With Saltify
 ============================
 
-The Saltify driver is a new, experimental driver for installing Salt on existing
+The Saltify driver is a driver for installing Salt on existing
 machines (virtual or bare metal).
 
 
@@ -47,11 +47,14 @@ document.
 Profiles
 ========
 
-Saltify requires a profile to be configured for each machine that needs Salt
-installed. The initial profile can be set up at ``/etc/salt/cloud.profiles``
+Saltify requires a separate profile to be configured for each machine that
+needs Salt installed [#]_. The initial profile can be set up at
+``/etc/salt/cloud.profiles``
 or in the ``/etc/salt/cloud.profiles.d/`` directory. Each profile requires
 both an ``ssh_host`` and an ``ssh_username`` key parameter as well as either
 an ``key_filename`` or a ``password``.
+
+.. [#] Unless you are using a map file to provide the unique parameters.
 
 Profile configuration example:
 
@@ -74,45 +77,48 @@ The machine can now be "Salted" with the following command:
 This will install salt on the machine specified by the cloud profile,
 ``salt-this-machine``, and will give the machine the minion id of
 ``my-machine``. If the command was executed on the salt-master, its Salt
-key will automatically be signed on the master.
+key will automatically be accepted by the master.
 
 Once a salt-minion has been successfully installed on the instance, connectivity
 to it can be verified with Salt:
 
 .. code-block:: bash
 
-    salt my-machine test.ping
+    salt my-machine test.version
 
 Destroy Options
 ---------------
 
+.. versionadded:: Oxygen
+
 For obvious reasons, the ``destroy`` action does not actually vaporize hardware.
-If the salt  master is connected using salt-api, it can tear down parts of
-the client machines.  It will remove the client's key from the salt master,
-and will attempt the following options:
+If the salt  master is connected, it can tear down parts of the client machines.
+It will remove the client's key from the salt master,
+and can execute the following options:
 
 .. code-block:: yaml
 
   - remove_config_on_destroy: true
     # default: true
     # Deactivate salt-minion on reboot and
-    # delete the minion config and key files from its ``/etc/salt`` directory,
-    #   NOTE: If deactivation is unsuccessful (older Ubuntu machines) then when
+    # delete the minion config and key files from its "/etc/salt" directory,
+    #   NOTE: If deactivation was unsuccessful (older Ubuntu machines) then when
     #   salt-minion restarts it will automatically create a new, unwanted, set
-    #   of key files. The ``force_minion_config`` option must be used in that case.
+    #   of key files. Use the "force_minion_config" option to replace them.
 
   - shutdown_on_destroy: false
     # default: false
-    # send a ``shutdown`` command to the client.
-
-.. versionadded:: Oxygen
+    # last of all, send a "shutdown" command to the client.
 
 Wake On LAN
 -----------
+
+.. versionadded:: Oxygen
+
 In addition to connecting a hardware machine to a Salt master,
 you have the option of sending a wake-on-LAN
 `magic packet`_
-to start the machine running.
+to start that machine running.
 
 .. _magic packet: https://en.wikipedia.org/wiki/Wake-on-LAN
 

--- a/doc/topics/cloud/saltify.rst
+++ b/doc/topics/cloud/saltify.rst
@@ -107,6 +107,42 @@ and will attempt the following options:
 
 .. versionadded:: Oxygen
 
+Wake On LAN
+-----------
+In addition to connecting a hardware machine to a Salt master,
+you have the option of sending a wake-on-LAN
+`magic packet`_
+to start the machine running.
+
+.. _magic packet: https://en.wikipedia.org/wiki/Wake-on-LAN
+
+The "magic packet" must be sent by an existing salt minion which is on
+the same network segment as the target machine. (Or your router
+must be set up especially to route WoL packets.) Your target machine
+must be set up to listen for WoL and to respond appropriatly.
+
+You must provide the Salt node id of the machine which will send
+the WoL packet \(parameter ``wol_sender_node``\), and
+the hardware MAC address of the machine you intend to wake,
+\(parameter ``wake_on_lan_mac``\). If both parameters are defined,
+the WoL will be sent. The cloud master will then sleep a while
+\(parameter ``wol_boot_wait``) to give the target machine time to
+boot up before we start probing its SSH port to begin deploying
+Salt to it. The default sleep time is 30 seconds.
+
+.. code-block:: yaml
+
+    # /etc/salt/cloud.profiles.d/saltify.conf
+
+    salt-this-machine:
+      ssh_host: 12.34.56.78
+      ssh_username: root
+      key_filename: '/etc/salt/mysshkey.pem'
+      provider: my-saltify-config
+      wake_on_lan_mac: '00:e0:4c:70:2a:b2'  # found with ifconfig
+      wol_sender_node: bevymaster  # its on this network segment
+      wol_boot_wait: 45  # seconds to sleep
+
 Using Map Files
 ---------------
 The settings explained in the section above may also be set in a map file. An

--- a/doc/topics/cloud/saltify.rst
+++ b/doc/topics/cloud/saltify.rst
@@ -37,6 +37,12 @@ the role usually performed by a vendor's cloud management system. The salt maste
 must be running on the salt-cloud machine, and created nodes must be connected to the
 master.
 
+Additional information about which configuration options apply to which actions
+can be studied in the
+:ref:`Saltify Module documentation <saltify-module>`
+and the
+:ref:`Miscellaneous Salt Cloud Options <misc-salt-cloud-options>`
+document.
 
 Profiles
 ========
@@ -76,7 +82,6 @@ to it can be verified with Salt:
 .. code-block:: bash
 
     salt my-machine test.ping
-
 
 Destroy Options
 ---------------

--- a/salt/cloud/clouds/saltify.py
+++ b/salt/cloud/clouds/saltify.py
@@ -256,7 +256,7 @@ def create(vm_):
         wol_mac = config.get_cloud_config_value(
             'wake_on_lan_mac', vm_, __opts__, default='')
         wol_host = config.get_cloud_config_value(
-            'wol_sender_node', vm_, __opts__, default = '')
+            'wol_sender_node', vm_, __opts__, default='')
         if wol_mac and wol_host:
             log.info('sending wake-on-lan to %s using node %s',
                      wol_mac, wol_host)
@@ -267,7 +267,7 @@ def create(vm_):
             log.info('network.wol returned value %s', ret)
             if ret and ret[wol_host]:
                 sleep_time = config.get_cloud_config_value(
-                    'wol_boot_wait', vm_, __opts__, default = 30)
+                    'wol_boot_wait', vm_, __opts__, default=30)
                 if sleep_time > 0.0:
                     log.info('delaying %d seconds for boot', sleep_time)
                     time.sleep(sleep_time)

--- a/salt/cloud/clouds/saltify.py
+++ b/salt/cloud/clouds/saltify.py
@@ -261,13 +261,16 @@ def create(vm_):
             log.info('sending wake-on-lan to %s using node %s',
                      wol_mac, wol_host)
             local = salt.client.LocalClient()
-            ret = local.cmd(wol_host, 'network.wol', [wol_mac])
+            if isinstance(wol_mac, six.string_types):
+                wol_mac = [wol_mac]  # a smart user may have passed more params
+            ret = local.cmd(wol_host, 'network.wol', wol_mac)
             log.info('network.wol returned value %s', ret)
             if ret and ret[wol_host]:
                 sleep_time = config.get_cloud_config_value(
                     'wol_boot_wait', vm_, __opts__, default = 30)
-                log.info('delaying %d seconds for boot', sleep_time)
-                time.sleep(sleep_time)
+                if sleep_time > 0.0:
+                    log.info('delaying %d seconds for boot', sleep_time)
+                    time.sleep(sleep_time)
         log.info('Provisioning existing machine %s', vm_['name'])
         ret = __utils__['cloud.bootstrap'](vm_, __opts__)
     else:

--- a/salt/cloud/clouds/vagrant.py
+++ b/salt/cloud/clouds/vagrant.py
@@ -8,7 +8,7 @@ Salt minion.
 
 Use of this module requires some configuration in cloud profile and provider
 files as described in the
-:ref:`Gettting Started with Vagrant <getting-started-with-vagrant>` documentation.
+:ref:`Getting Started with Vagrant <getting-started-with-vagrant>` documentation.
 
 .. versionadded:: Oxygen
 


### PR DESCRIPTION
### What does this PR do?

The saltify driver can shut a machine off using the `shutdown_on_destroy` parameter.

Now it can restart that machine by sending a WoL message before trying to bootstrap
Salt to it. This opens the door to completely reconfigure the target machine (depending
on how the bootstrap is configured.)

This PR may be a bit controversial, so I submitted it separately from the cleanup. 
This is the last work I anticipate on this module for a long time.

P.S. -- I also fixed a one-letter typo in a completely unrelated file.

### What issues does this PR fix or reference?

None.

### Previous Behavior

Target machine stays dead. Other means of starting it must be used.

### New Behavior

Target machine reacts to WoL packet, turns itself on, and boots up.

### Tests written?

Yes.
