### PR TITLE
Add some space in new opsgenie docs for rst formmating

### DIFF
--- a/salt/modules/opsgenie.py
+++ b/salt/modules/opsgenie.py
@@ -6,8 +6,11 @@ Module for sending data to OpsGenie
 
 :configuration: This module can be used in Reactor System for
     posting data to OpsGenie as a remote-execution function.
+
     For example:
+
     .. code-block:: yaml
+
         opsgenie_event_poster:
           local.opsgenie.post_data:
             - tgt: 'salt-minion'
@@ -40,6 +43,9 @@ def post_data(api_key=None, name='OpsGenie Execution Module', reason=None,
     module with your designated tag (og-tag in this case).
 
     CLI Example:
+
+    .. code-block:: bash
+
         salt-call event.send 'og-tag' '{"reason" : "Overheating CPU!"}'
 
     Required parameters:

--- a/salt/states/opsgenie.py
+++ b/salt/states/opsgenie.py
@@ -2,10 +2,14 @@
 '''
 Create/Close an alert in OpsGenie
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 .. versionadded:: Oxygen
+
 This state is useful for creating or closing alerts in OpsGenie
 during state runs.
+
 .. code-block:: yaml
+
     used_space:
       disk.status:
         - name: /


### PR DESCRIPTION
Follow up to #43821

These fixes will help the docs render correctly with the various examples given.
