### PR TITLE
Mock open on /var/log/btmp and /var/log/wtmp

### DIFF
--- a/tests/unit/beacons/test_btmp_beacon.py
+++ b/tests/unit/beacons/test_btmp_beacon.py
@@ -59,8 +59,10 @@ class BTMPBeaconTestCase(TestCase, LoaderModuleMockMixin):
 
         self.assertEqual(ret, (True, 'Valid beacon configuration'))
 
-        ret = btmp.beacon(config)
-        self.assertEqual(ret, [])
+        with patch('salt.utils.files.fopen', mock_open()) as m_open:
+            ret = btmp.beacon(config)
+            m_open.assert_called_with(btmp.BTMP, 'rb')
+            self.assertEqual(ret, [])
 
     def test_match(self):
         with patch('salt.utils.files.fopen',

--- a/tests/unit/beacons/test_wtmp_beacon.py
+++ b/tests/unit/beacons/test_wtmp_beacon.py
@@ -60,8 +60,10 @@ class WTMPBeaconTestCase(TestCase, LoaderModuleMockMixin):
 
         self.assertEqual(ret, (True, 'Valid beacon configuration'))
 
-        ret = wtmp.beacon(config)
-        self.assertEqual(ret, [])
+        with patch('salt.utils.files.fopen', mock_open()) as m_open:
+            ret = wtmp.beacon(config)
+            m_open.assert_called_with(wtmp.WTMP, 'rb')
+            self.assertEqual(ret, [])
 
     def test_match(self):
         with patch('salt.utils.files.fopen',


### PR DESCRIPTION
### What does this PR do?

Unbreaks tests on OpenBSD, and makes these tests more deterministic on Linux

- btmp may not exist
- wtmp may not exist, or it may not contain ASCII data
