### PR TITLE
Kubernetes module updates round one

### DIFF
--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -35,6 +35,7 @@ In case both are provided the `file` entry is prefered.
 
 # Import Python Futures
 from __future__ import absolute_import
+import sys
 import os.path
 import base64
 import logging
@@ -1447,6 +1448,13 @@ def __dict_to_object_meta(name, namespace, metadata):
     '''
     meta_obj = kubernetes.client.V1ObjectMeta()
     meta_obj.namespace = namespace
+
+    # Replicate `kubectl [create|replace|apply] --record`
+    if 'annotations' not in metadata:
+        metadata['annotations'] = {}
+    if 'kubernetes.io/change-cause' not in metadata['annotations']:
+        metadata['annotations']['kubernetes.io/change-cause'] = ' '.join(sys.argv)
+
     for key, value in iteritems(metadata):
         if hasattr(meta_obj, key):
             setattr(meta_obj, key, value)

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -164,12 +164,15 @@ def _setup_conn(**kwargs):
 
     if client_key_file:
         kubernetes.client.configuration.key_file = client_key_file
-    if client_key:
+    elif client_key:
         with tempfile.NamedTemporaryFile(prefix='salt-kube-', delete=False) as k:
             k.write(base64.b64decode(client_key))
             kubernetes.client.configuration.key_file = k.name
     else:
         kubernetes.client.configuration.key_file = None
+
+    # The return makes unit testing easier
+    return vars(kubernetes.client.configuration)
 
 
 def _cleanup(**kwargs):

--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -272,7 +272,7 @@ def node_labels(name, **kwargs):
     match = node(name, **kwargs)
 
     if match is not None:
-        return match.metadata.labels
+        return match['metadata']['labels']
 
     return {}
 

--- a/tests/unit/modules/test_kubernetes.py
+++ b/tests/unit/modules/test_kubernetes.py
@@ -147,3 +147,22 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
                 settings('kubernetes.client-key-file'),
                 config['key_file'],
             )
+
+    def test_node_labels(self):
+        '''
+        Test kubernetes.node_labels
+        :return:
+        '''
+        with patch('salt.modules.kubernetes.node') as mock_node:
+            mock_node.return_value = {
+                'metadata': {
+                    'labels': {
+                        u'kubernetes.io/hostname': 'minikube',
+                        u'kubernetes.io/os': 'linux',
+                    }
+                }
+            }
+            self.assertEqual(
+                kubernetes.node_labels('minikube'),
+                {u'kubernetes.io/hostname': 'minikube', u'kubernetes.io/os': 'linux'},
+            )

--- a/tests/unit/modules/test_kubernetes.py
+++ b/tests/unit/modules/test_kubernetes.py
@@ -129,3 +129,21 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertTrue(
                     kubernetes.kubernetes.client.ExtensionsV1beta1Api().
                     create_namespaced_deployment().to_dict.called)
+
+    def test_setup_client_key_file(self):
+        '''
+        Test that the `kubernetes.client-key-file` configuration isn't overwritten
+        :return:
+        '''
+        def settings(name, value=None):
+            data = {
+                'kubernetes.client-key-file': '/home/testuser/.minikube/client.key',
+            }
+            return data.get(name, value)
+
+        with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=settings)}):
+            config = kubernetes._setup_conn()
+            self.assertEqual(
+                settings('kubernetes.client-key-file'),
+                config['key_file'],
+            )


### PR DESCRIPTION
### What does this PR do?

Adds a `kubernetes.io/change-cause` annotation to all created objects exactly how kubectl does when you run `kubectl [apply|create|replace] --record`. This annotation is used by commands such as:

    kubectl rollout history deployment/$DEPLOYMENT_NAME

It shows the deployment change reason, and showing the exact command salt executed to change it would match kubectl.

It also fixes some bugs.

### What issues does this PR fix or reference?
* Fixes #44229
* Fixes #44230

### New Behavior

And newly created or updated objects will now have an annotation of `kubernetes.io/change-cause` added with the salt command executed to create them just like kubectl does when ran with `--record`.

### Tests written?

:+1: 