### PR TITLE
grafana4: datasource: handle missing keys in datasource description.

### DIFF
--- a/salt/states/grafana4_datasource.py
+++ b/salt/states/grafana4_datasource.py
@@ -151,6 +151,12 @@ def present(name,
         ret['changes'] = data
         return ret
 
+    # At this stage, the datasource exists; however, the object provided by
+    # Grafana may lack some null keys compared to our "data" dict:
+    for key in data:
+        if key not in datasource:
+            datasource[key] = None
+
     if data == datasource:
         ret['changes'] = None
         ret['comment'] = 'Data source {0} already up-to-date'.format(name)


### PR DESCRIPTION
### What does this PR do? What issues does this PR fix or reference?
This PR brings a fix that improves the way grafana4_datasource.present() compares the datasource settings provided by end users with those provided by Grafana.

### Previous Behavior
Before that change, grafana4_datasource.present would:

- get the current, existing Grafana datasource from the Grafana API as a first dict
- build a second dict representing the target state for that datasource, from both user-supplied and Grafana-supplied data
- compare those dicts and, if needed, update the existing datasource through the Grafana API

However, the Grafana-supplied dict lacks some keys (it seems Grafana does not bother sending null attributes) and the comparison is liable to yield irrelevant differences  which, in turn, will trigger a useless update of the datasource and report irrelevant changes. Basically, grafana4_datasource.present is currently not idempotent.

### New  Behavior
After that change, grafana4_datasource.present fills up the Grafana-supplied dict with the missing keys, assuming that an expected but missing key implies a null (JSON) / None (Python) value. The comparison works better and hopefully, grafana4_datasource.present is idempotent again.

### Tests written?
No.