### PR TITLE
Add explicit non-zero retcode to napalm config functions

### DIFF
--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -153,6 +153,7 @@ def _config_logic(napalm_device,
         loaded_result['diff'] = None
         loaded_result['result'] = False
         loaded_result['comment'] = _compare.get('comment')
+        __context__['retcode'] = 1
         return loaded_result
 
     _loaded_res = loaded_result.get('result', False)
@@ -172,12 +173,15 @@ def _config_logic(napalm_device,
             # make sure it notifies
             # that something went wrong
             _explicit_close(napalm_device)
+            __context__['retcode'] = 1
             return loaded_result
 
         loaded_result['comment'] += 'Configuration discarded.'
         # loaded_result['result'] = False not necessary
         # as the result can be true when test=True
         _explicit_close(napalm_device)
+        if not loaded_result['result']:
+            __context__['retcode'] = 1
         return loaded_result
 
     if not test and commit_config:
@@ -208,10 +212,13 @@ def _config_logic(napalm_device,
                 loaded_result['result'] = False
                 # notify if anything goes wrong
                 _explicit_close(napalm_device)
+                __context__['retcode'] = 1
                 return loaded_result
             loaded_result['already_configured'] = True
             loaded_result['comment'] = 'Already configured.'
     _explicit_close(napalm_device)
+    if not loaded_result['result']:
+        __context__['retcode'] = 1
     return loaded_result
 
 


### PR DESCRIPTION
Thanks to @dmitrykuzmenko's explanation in #43187,
we can add explicit return code for napalm
configuration related functions: when loading
configuration fails for a reason or another
(there can be several different reasons), the
function will be considered as "failed". This will not change
any behaviour on the CLI, but it is useful in the --summary
mode to see what minions failed.