### PR TITLE
Move PR #44053 to develop branch

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1588,8 +1588,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         Load a single item if you have it
         '''
         # if the key doesn't have a '.' then it isn't valid for this mod dict
-        if not isinstance(key, six.string_types) or u'.' not in key:
-            raise KeyError
+        if not isinstance(key, six.string_types):
+            raise KeyError(u'The key must be a string.')
+        if u'.' not in key:
+            raise KeyError(u'The key \'%s\' should contain a \'.\'', key)
         mod_name, _ = key.split(u'.', 1)
         if mod_name in self.missing_modules:
             return True

--- a/tests/unit/loader/test_loader.py
+++ b/tests/unit/loader/test_loader.py
@@ -278,6 +278,38 @@ class LazyLoaderWhitelistTest(TestCase):
         self.assertNotIn('grains.get', self.loader)
 
 
+class LazyLoaderSingleItem(TestCase):
+    '''
+    Test loading a single item via the _load() function
+    '''
+    @classmethod
+    def setUpClass(cls):
+        cls.opts = salt.config.minion_config(None)
+        cls.opts['grains'] = grains(cls.opts)
+
+    def setUp(self):
+        self.loader = LazyLoader(_module_dirs(copy.deepcopy(self.opts), 'modules', 'module'),
+                                 copy.deepcopy(self.opts),
+                                 tag='module')
+
+    def tearDown(self):
+        del self.loader
+
+    def test_single_item_no_dot(self):
+        '''
+        Checks that a KeyError is raised when the function key does not contain a '.'
+        '''
+        with self.assertRaises(KeyError) as err:
+            inspect.isfunction(self.loader['testing_no_dot'])
+
+        if six.PY2:
+            self.assertEqual(err.exception[0],
+                             'The key \'%s\' should contain a \'.\'')
+        else:
+            self.assertEqual(str(err.exception),
+                             str(("The key '%s' should contain a '.'", 'testing_no_dot')))
+
+
 module_template = '''
 __load__ = ['test', 'test_alias']
 __func_alias__ = dict(test_alias='working_alias')


### PR DESCRIPTION
### What does this PR do?
Moves the commit from #44053 to the `develop` branch, as this PR was closed since it was against the `2017.7.2` branch. After discussing the change, it was decided this bug fix should be submitted to develop.

Original PR message from @ari:
> Better exception

>  After spending an hour trying to figure out why I had a key error in an orchestration state I realised that saltstack requires a runner id with a dot. A clearer error message will save the next person wasting the same time.

### What issues does this PR fix or reference?
#44053

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
