### PR TITLE
Fix `unit.modules.test_win_groupadd` for Windows

### DIFF
--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -37,21 +37,43 @@ def __virtual__():
 
 
 def _get_computer_object():
+    '''
+    A helper function to get the object for the local machine
+
+    Returns:
+        object: Returns the computer object for the local machine
+    '''
     pythoncom.CoInitialize()
     nt = win32com.client.Dispatch('AdsNameSpaces')
     return nt.GetObject('', 'WinNT://.,computer')
 
 
 def _get_group_object(name):
+    '''
+    A helper function to get a specified group object
+
+    Args:
+
+        name (str): The name of the object
+
+    Returns:
+        object: The specified group object
+    '''
     pythoncom.CoInitialize()
     nt = win32com.client.Dispatch('AdsNameSpaces')
     return nt.GetObject('', 'WinNT://./' + name + ',group')
 
 
 def _get_all_groups():
+    '''
+    A helper function that gets a list of group objects for all groups on the
+    machine
+
+    Returns:
+        iter: A list of objects for all groups on the machine
+    '''
     pythoncom.CoInitialize()
     nt = win32com.client.Dispatch('AdsNameSpaces')
-
     results = nt.GetObject('', 'WinNT://.')
     results.Filter = ['group']
     return results
@@ -60,6 +82,9 @@ def _get_all_groups():
 def _get_username(member):
     '''
     Resolve the username from the member object returned from a group query
+
+    Returns:
+        str: The username converted to domain\\username format
     '''
     return member.ADSPath.replace('WinNT://', '').replace(
         '/', '\\').encode('ascii', 'backslashreplace')

--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -48,6 +48,15 @@ def _get_group_object(name):
     return nt.GetObject('', 'WinNT://./' + name + ',group')
 
 
+def _get_all_groups():
+    pythoncom.CoInitialize()
+    nt = win32com.client.Dispatch('AdsNameSpaces')
+
+    results = nt.GetObject('', 'WinNT://.')
+    results.Filter = ['group']
+    return results
+
+
 def _get_username(member):
     '''
     Resolve the username from the member object returned from a group query
@@ -425,15 +434,6 @@ def members(name, members_list, **kwargs):
                 #return ret
 
     return ret
-
-
-def _get_all_groups():
-    pythoncom.CoInitialize()
-    nt = win32com.client.Dispatch('AdsNameSpaces')
-
-    results = nt.GetObject('', 'WinNT://.')
-    results.Filter = ['group']
-    return results
 
 
 def list_groups(refresh=False):

--- a/tests/unit/modules/test_win_groupadd.py
+++ b/tests/unit/modules/test_win_groupadd.py
@@ -78,8 +78,6 @@ class WinGroupTestCase(TestCase, LoaderModuleMockMixin):
             win_groupadd: {'__opts__': {'test': False}}
         }
 
-    # 'add' function tests: 1
-
     def test_add(self):
         '''
         Test adding a new group
@@ -125,8 +123,6 @@ class WinGroupTestCase(TestCase, LoaderModuleMockMixin):
                                   'name': 'foo',
                                   'result': False,
                                   'comment': 'Failed to create group foo. C'})
-
-    # 'delete' function tests: 1
 
     def test_delete(self):
         '''
@@ -179,9 +175,6 @@ class WinGroupTestCase(TestCase, LoaderModuleMockMixin):
                  'result': False,
                  'comment': 'Failed to remove group foo.  C'})
 
-
-    # 'info' function tests: 1
-
     def test_info(self):
         '''
         Test if it return information about a group.
@@ -199,7 +192,7 @@ class WinGroupTestCase(TestCase, LoaderModuleMockMixin):
             return_value=[
                 MockGroupObj('salt', ['WinNT://HOST/steve']),
                 MockGroupObj('salty', ['WinNT://HOST/spongebob'])])
-        mock_g_to_g = MagicMock(side_effect=[1,2,3,4,5])
+        mock_g_to_g = MagicMock(side_effect=[1, 2])
         with patch.object(win_groupadd, '_get_all_groups', groupobj_mock),\
              patch.dict(win_groupadd.__salt__, {'file.group_to_gid': mock_g_to_g}):
             self.assertListEqual(
@@ -264,7 +257,6 @@ class WinGroupTestCase(TestCase, LoaderModuleMockMixin):
                  'comment': 'Failed to add HOST\\username to group foo.  C',
                  'result': False})
 
-
     def test_adduser_group_does_not_exist(self):
         groupobj_mock = MagicMock(side_effect=PYWINTYPES_ERROR)
         with patch.object(win_groupadd, '_get_group_object', groupobj_mock), \
@@ -275,8 +267,6 @@ class WinGroupTestCase(TestCase, LoaderModuleMockMixin):
                  'name': 'foo',
                  'comment': 'Failure accessing group foo. C',
                  'result': False})
-
-    # 'deluser' function tests: 3
 
     def test_deluser(self):
         '''
@@ -334,8 +324,6 @@ class WinGroupTestCase(TestCase, LoaderModuleMockMixin):
                  'name': 'foo',
                  'comment': 'Failure accessing group foo. C',
                  'result': False})
-
-    # 'members' function tests: 1
 
     def test_members(self):
         '''

--- a/tests/unit/modules/test_win_groupadd.py
+++ b/tests/unit/modules/test_win_groupadd.py
@@ -19,6 +19,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.modules.win_groupadd as win_groupadd
+import salt.utils.win_functions
 
 # Import Other Libs
 # pylint: disable=unused-import
@@ -30,6 +31,37 @@ try:
 except ImportError:
     HAS_WIN_LIBS = False
 # pylint: enable=unused-import
+
+
+class MockMember(object):
+    def __init__(self, name):
+        self.ADSPath = name
+
+
+class MockGroupObj(object):
+    def __init__(self, ads_users):
+        self._members = [MockMember(x) for x in ads_users]
+
+    def members(self):
+        return self._members
+
+    def Add(self):
+        '''
+        This should be a no-op unless we want to test raising an error, in
+        which case this should be overridden in a subclass.
+        '''
+        pass
+
+    def Remove(self):
+        '''
+        This should be a no-op unless we want to test raising an error, in
+        which case this should be overridden in a subclass.
+        '''
+        pass
+
+
+if not NO_MOCK:
+    sam_mock = MagicMock(side_effect=lambda x: 'HOST\\' + x)
 
 
 @skipIf(not HAS_WIN_LIBS, 'win_groupadd unit tests can only be run if win32com, pythoncom, and pywintypes are installed')
@@ -151,20 +183,13 @@ class WinGroupTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test if it return information about a group.
         '''
-        members = MagicMock(return_value=['HOST\\steve'])
-        with patch.object(win_groupadd, '_get_group_object', Mock()), \
-             patch.object(win_groupadd, '_get_group_members', members):
+        groupobj_mock = MagicMock(return_value=MockGroupObj(['WinNT://HOST/steve']))
+        with patch.object(win_groupadd, '_get_group_object', groupobj_mock):
             self.assertDictEqual(win_groupadd.info('salt'),
                                  {'gid': None,
-                                  'members': ['user1'],
+                                  'members': ['HOST\\steve'],
                                   'passwd': None,
                                   'name': 'salt'})
-
-        with patch(win_groupadd.win32.client, 'flag', 1):
-            self.assertFalse(win_groupadd.info('dc=salt'))
-
-        with patch(win_groupadd.win32.client, 'flag', 2):
-            self.assertFalse(win_groupadd.info('dc=salt'))
 
     # 'getent' function tests: 1
 
@@ -175,73 +200,70 @@ class WinGroupTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(win_groupadd.__context__, {'group.getent': True}):
             self.assertTrue(win_groupadd.getent())
 
-    # 'adduser' function tests: 1
+    # 'adduser' function tests: 3
 
     def test_adduser(self):
         '''
         Test adding a user to a group
         '''
-        members = MagicMock(return_value=['HOST\\steve'])
-        with patch.object(win_groupadd, '_get_group_object', Mock()),\
-                patch.object(win_groupadd, '_get_group_members', members),\
-                patch('salt.utils.win_functions.get_sam_name', return_value='HOST\\spongebob'):
+        groupobj_mock = MagicMock(return_value=MockGroupObj(['WinNT://HOST/steve']))
+        with patch.object(win_groupadd, '_get_group_object', groupobj_mock), \
+                patch.object(salt.utils.win_functions, 'get_sam_name', sam_mock):
             self.assertDictEqual(
                 win_groupadd.adduser('foo', 'spongebob'),
-                {'changes': {'Users Added': ['spongebob']},
+                {'changes': {'Users Added': ['HOST\\spongebob']},
                  'comment': '',
                  'name': 'foo',
                  'result': True})
 
-    def test_add_user_already_exists(self):
+    def test_adduser_already_exists(self):
         '''
         Test adding a user that already exists
         '''
-        members = MagicMock(return_value=['HOST\\steve'])
-        with patch.object(win_groupadd, '_get_group_object', Mock()), \
-             patch.object(win_groupadd, '_get_group_members', members), \
-             patch('salt.utils.win_functions.get_sam_name', return_value='HOST\\spongebob'):
+        groupobj_mock = MagicMock(return_value=MockGroupObj(['WinNT://HOST/steve']))
+        with patch.object(win_groupadd, '_get_group_object', groupobj_mock), \
+                patch.object(salt.utils.win_functions, 'get_sam_name', sam_mock):
             self.assertDictEqual(
-                win_groupadd.adduser('foo', 'spongebob'),
-                {'changes': {'Users Added': ['spongebob']},
-                 'comment': '',
+                win_groupadd.adduser('foo', 'HOST\\steve'),
+                {'changes': {'Users Added': []},
+                 'comment': 'User HOST\\steve is already a member of foo',
                  'name': 'foo',
-                 'result': True})
+                 'result': None})
 
-    def test_add_user_error(self):
+    def test_adduser_error(self):
         '''
         Test adding a user and encountering an error
         '''
-        # Create mock group object
-        class GroupObj(object):
+        # Create mock group object with mocked Add function which raises the
+        # exception we need in order to test the error case.
+        class GroupObj(MockGroupObj):
             def Add(self, name):
                 raise pywintypes.com_error(-2147352567, 'Exception occurred.', (0, None, 'C', None, 0, -2146788248), None)
 
-        groupobj_mock = MagicMock(return_value=GroupObj())
-        members = MagicMock(return_value=['HOST\\steve'])
-        with patch.object(win_groupadd, '_get_group_object', groupobj_mock):
-            with patch.object(win_groupadd, '_get_group_members', members):
-                comt = ('Failed to add username to group foo.  C')
-                self.assertDictEqual(
-                    win_groupadd.adduser('foo', 'username'),
-                    {'changes': {'Users Added': []},
-                     'name': 'foo',
-                     'comment': comt,
-                     'result': False})
+        groupobj_mock = MagicMock(return_value=GroupObj(['WinNT://HOST/steve']))
+        with patch.object(win_groupadd, '_get_group_object', groupobj_mock), \
+                patch.object(salt.utils.win_functions, 'get_sam_name', sam_mock):
+            self.assertDictEqual(
+                win_groupadd.adduser('foo', 'username'),
+                {'changes': {'Users Added': []},
+                 'name': 'foo',
+                 'comment': 'Failed to add HOST\\username to group foo.  C',
+                 'result': False})
 
-    # 'deluser' function tests: 1
+    # 'deluser' function tests: 3
 
     def test_deluser(self):
         '''
         Test removing a user from a group
         '''
         # Test removing a user
-        members = MagicMock(return_value=['HOST\\spongebob'])
-        with patch.object(win_groupadd, '_get_group_object', Mock()), \
-             patch.object(win_groupadd, '_get_group_members', members), \
-             patch('salt.utils.win_functions.get_sam_name', return_value='HOST\\spongebob'):
+        groupobj_mock = MagicMock(return_value=MockGroupObj(['WinNT://HOST/spongebob']))
+        with patch.object(win_groupadd, '_get_group_object', groupobj_mock), \
+                patch.object(salt.utils.win_functions, 'get_sam_name', sam_mock):
             ret = {'changes': {'Users Removed': ['spongebob']},
                    'comment': '',
-                   'name': 'foo', 'result': True}
+                   'name': 'foo',
+                   'result': True}
             self.assertDictEqual(win_groupadd.deluser('foo', 'spongebob'), ret)
 
     def test_deluser_no_user(self):
@@ -249,15 +271,13 @@ class WinGroupTestCase(TestCase, LoaderModuleMockMixin):
         Test removing a user from a group and that user is not a member of the
         group
         '''
-
-        # Test removing a user that's not in the group
-        members = MagicMock(return_value=['HOST\\steve'])
-        with patch.object(win_groupadd, '_get_group_object', Mock()), \
-                patch.object(win_groupadd, '_get_group_members', members), \
-                patch('salt.utils.win_functions.get_sam_name', return_value='HOST\\spongebob'):
+        groupobj_mock = MagicMock(return_value=MockGroupObj(['WinNT://HOST/steve']))
+        with patch.object(win_groupadd, '_get_group_object', groupobj_mock), \
+                patch.object(salt.utils.win_functions, 'get_sam_name', sam_mock):
             ret = {'changes': {'Users Removed': []},
-                   'comment': 'User username is not a member of foo',
-                   'name': 'foo', 'result': None}
+                   'comment': 'User HOST\\spongebob is not a member of foo',
+                   'name': 'foo',
+                   'result': None}
             self.assertDictEqual(win_groupadd.deluser('foo', 'username'), ret)
 
     def test_deluser_error(self):
@@ -268,18 +288,14 @@ class WinGroupTestCase(TestCase, LoaderModuleMockMixin):
             def Remove(self, name):
                 raise pywintypes.com_error(-2147352567, 'Exception occurred.', (0, None, 'C', None, 0, -2146788248), None)
 
-        groupobj_mock = MagicMock(return_value=GroupObj())
-
-        members = MagicMock(return_value=['HOST\\spongebob'])
+        groupobj_mock = MagicMock(return_value=GroupObj(['WinNT://HOST/spongebob']))
         with patch.object(win_groupadd, '_get_group_object', groupobj_mock), \
-                patch.object(win_groupadd, '_get_group_members', members), \
-                patch('salt.utils.win_functions.get_sam_name', return_value='HOST\\spongebob'):
-            comt = ('Failed to remove spongebob from group foo.  C')
+                patch.object(salt.utils.win_functions, 'get_sam_name', sam_mock):
             self.assertDictEqual(
                 win_groupadd.deluser('foo', 'spongebob'),
                 {'changes': {'Users Removed': []},
                  'name': 'foo',
-                 'comment': comt,
+                 'comment': 'Failed to remove spongebob from group foo.  C',
                  'result': False})
 
     # 'members' function tests: 1


### PR DESCRIPTION
### What does this PR do?
Properly mocks the pywin32 com objects for the test.
Adds additional tests for the group module on Windows

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes

### Commits signed with GPG?
Yes