### PR TITLE
docker_container.running sort list of links

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -915,8 +915,8 @@ def compare_container(first, second, ignore=None):
                     ret.setdefault(conf_dict, {})[item] = {'old': image1, 'new': image2}
             else:
                 if item == 'Links':
-                    val1 = _scrub_links(val1, first)
-                    val2 = _scrub_links(val2, second)
+                    val1 = sorted(_scrub_links(val1, first))
+                    val2 = sorted(_scrub_links(val2, second))
                 if val1 != val2:
                     ret.setdefault(conf_dict, {})[item] = {'old': val1, 'new': val2}
         # Check for optionally-present items that were in the second container
@@ -938,8 +938,8 @@ def compare_container(first, second, ignore=None):
                     ret.setdefault(conf_dict, {})[item] = {'old': image1, 'new': image2}
             else:
                 if item == 'Links':
-                    val1 = _scrub_links(val1, first)
-                    val2 = _scrub_links(val2, second)
+                    val1 = sorted(_scrub_links(val1, first))
+                    val2 = sorted(_scrub_links(val2, second))
                 if val1 != val2:
                     ret.setdefault(conf_dict, {})[item] = {'old': val1, 'new': val2}
     return ret


### PR DESCRIPTION
### What does this PR do?

When the docker_container.running module is comparing the defined state
and the current state of a container, the list of linked containers in
the current state is is a non-deterministic order. This results in a
container recreation even though the links are the same (just in a
different order).

This patches the comparison function to lexically sort both the existing
and desired list of links, making the comparison deterministic and not
recreating a container when the links have not changed.

### What issues does this PR fix or reference?

Fixes #44258.

### Previous Behavior

Containers are recreated even if the links are not changed.

### New Behavior

Containers are only recreated when the links are changed.

### Tests written?

No

### Commits signed with GPG?

Yes