### PR TITLE
Fix log message in salt.utils.gitfs

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -437,7 +437,7 @@ class GitProvider(object):
             return root_dir
         log.error(
             'Root path \'%s\' not present in %s remote \'%s\', '
-            'skipping.', self.root, self.role, self.id
+            'skipping.', self.root(), self.role, self.id
         )
         return None
 


### PR DESCRIPTION
This needed to be using the config overlay function and not referencing
the attribute directly.