### PR TITLE
Workaround progressbar failure if minion is behind syndic.

### DIFF
--- a/salt/output/progress.py
+++ b/salt/output/progress.py
@@ -23,7 +23,14 @@ def output(ret, bar, **kwargs):  # pylint: disable=unused-argument
     Update the progress bar
     '''
     if 'return_count' in ret:
-        bar.update(ret['return_count'])
+        val = ret['return_count']
+        # Avoid to fail if targets are behind a syndic. In this case actual return count will be
+        # higher than targeted by MoM itself.
+        # TODO: implement a way to get the proper target minions count and remove this workaround.
+        # Details are in #44239.
+        if val > bar.maxval:
+            bar.maxval = val
+        bar.update(val)
     return ''
 
 


### PR DESCRIPTION
### What does this PR do?
If minion is behind a syndic the `salt` command receives more responses that the count of targets calculated by MoM. It's because syndic master compiles it's own list of connected matching minions. This produces an exception in `salt --progress` call. It's because `salt` tries to set more than MAX in the progress bar. 
This PR is a quick-fix workaround that stops `salt` to fail in this situations. Not a final but quick solution.

### What issues does this PR fix or reference?
#44239 

### Tests written?
No

### Commits signed with GPG?
Yes