### PR TITLE
INFRA-5737 - add new auth options to boto3 utils module

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -67,6 +67,7 @@ def _config_getter(get_opt,
                    user=None,
                    password=None,
                    ignore_retcode=False,
+                   output_encoding=None,
                    **kwargs):
     '''
     Common code for config.get_* functions, builds and runs the git CLI command
@@ -94,7 +95,8 @@ def _config_getter(get_opt,
         value_regex = None
 
     command = ['git', 'config']
-    command.extend(_which_git_config(global_, cwd, user, password))
+    command.extend(_which_git_config(global_, cwd, user, password,
+                                     output_encoding=output_encoding))
     command.append(get_opt)
     command.append(key)
     if value_regex is not None:
@@ -104,7 +106,8 @@ def _config_getter(get_opt,
                     user=user,
                     password=password,
                     ignore_retcode=ignore_retcode,
-                    failhard=False)
+                    failhard=False,
+                    output_encoding=output_encoding)
 
 
 def _expand_path(cwd, user):
@@ -188,7 +191,7 @@ def _format_git_opts(opts):
 
 def _git_run(command, cwd=None, user=None, password=None, identity=None,
              ignore_retcode=False, failhard=True, redirect_stderr=False,
-             saltenv='base', **kwargs):
+             saltenv='base', output_encoding=None, **kwargs):
     '''
     simple, throw an exception with the error message on an error return code.
 
@@ -196,6 +199,9 @@ def _git_run(command, cwd=None, user=None, password=None, identity=None,
     'cmd.run_all', and used as an alternative to 'cmd.run_all'. Some
     commands don't return proper retcodes, so this can't replace 'cmd.run_all'.
     '''
+    if salt.utils.platform.is_windows() and output_encoding is None:
+        output_encoding = 'utf-8'
+
     env = {}
 
     if identity:
@@ -300,6 +306,7 @@ def _git_run(command, cwd=None, user=None, password=None, identity=None,
                     log_callback=salt.utils.url.redact_http_basic_auth,
                     ignore_retcode=ignore_retcode,
                     redirect_stderr=redirect_stderr,
+                    output_encoding=output_encoding
                     **kwargs)
             finally:
                 # Cleanup the temporary ssh wrapper file
@@ -358,6 +365,7 @@ def _git_run(command, cwd=None, user=None, password=None, identity=None,
             log_callback=salt.utils.url.redact_http_basic_auth,
             ignore_retcode=ignore_retcode,
             redirect_stderr=redirect_stderr,
+            output_encoding=output_encoding,
             **kwargs)
 
         if result['retcode'] == 0:
@@ -379,7 +387,7 @@ def _git_run(command, cwd=None, user=None, password=None, identity=None,
             return result
 
 
-def _get_toplevel(path, user=None, password=None):
+def _get_toplevel(path, user=None, password=None, output_encoding=None):
     '''
     Use git rev-parse to return the top level of a repo
     '''
@@ -387,10 +395,11 @@ def _get_toplevel(path, user=None, password=None):
         ['git', 'rev-parse', '--show-toplevel'],
         cwd=path,
         user=user,
-        password=password)['stdout']
+        password=password,
+        output_encoding=output_encoding)['stdout']
 
 
-def _git_config(cwd, user, password):
+def _git_config(cwd, user, password, output_encoding=None):
     '''
     Helper to retrieve git config options
     '''
@@ -400,7 +409,8 @@ def _git_config(cwd, user, password):
                             opts=['--git-dir'],
                             user=user,
                             password=password,
-                            ignore_retcode=True)
+                            ignore_retcode=True,
+                            output_encoding=output_encoding)
         if not os.path.isabs(git_dir):
             paths = (cwd, git_dir, 'config')
         else:
@@ -409,7 +419,7 @@ def _git_config(cwd, user, password):
     return __context__[contextkey]
 
 
-def _which_git_config(global_, cwd, user, password):
+def _which_git_config(global_, cwd, user, password, output_encoding=None):
     '''
     Based on whether global or local config is desired, return a list of CLI
     args to include in the git config command.
@@ -422,7 +432,8 @@ def _which_git_config(global_, cwd, user, password):
         return ['--local']
     else:
         # For earlier versions, need to specify the path to the git config file
-        return ['--file', _git_config(cwd, user, password)]
+        return ['--file', _git_config(cwd, user, password,
+                                      output_encoding=output_encoding)]
 
 
 def add(cwd,
@@ -431,7 +442,8 @@ def add(cwd,
         git_opts='',
         user=None,
         password=None,
-        ignore_retcode=False):
+        ignore_retcode=False,
+        output_encoding=None):
     '''
     .. versionchanged:: 2015.8.0
         The ``--verbose`` command line argument is now implied
@@ -499,7 +511,8 @@ def add(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def archive(cwd,
@@ -510,6 +523,7 @@ def archive(cwd,
             user=None,
             password=None,
             ignore_retcode=False,
+            output_encoding=None,
             **kwargs):
     '''
     .. versionchanged:: 2015.8.0
@@ -637,7 +651,8 @@ def archive(cwd,
              cwd=cwd,
              user=user,
              password=password,
-             ignore_retcode=ignore_retcode)
+             ignore_retcode=ignore_retcode,
+             output_encoding=output_encoding)
     # No output (unless --verbose is used, and we don't want all files listed
     # in the output in case there are thousands), so just return True. If there
     # was an error in the git command, it will have already raised an exception
@@ -651,7 +666,8 @@ def branch(cwd,
            git_opts='',
            user=None,
            password=None,
-           ignore_retcode=False):
+           ignore_retcode=False,
+           output_encoding=None):
     '''
     Interface to `git-branch(1)`_
 
@@ -728,7 +744,8 @@ def branch(cwd,
              cwd=cwd,
              user=user,
              password=password,
-             ignore_retcode=ignore_retcode)
+             ignore_retcode=ignore_retcode,
+             output_encoding=output_encoding)
     return True
 
 
@@ -739,7 +756,8 @@ def checkout(cwd,
              git_opts='',
              user=None,
              password=None,
-             ignore_retcode=False):
+             ignore_retcode=False,
+             output_encoding=None):
     '''
     Interface to `git-checkout(1)`_
 
@@ -827,7 +845,8 @@ def checkout(cwd,
                     user=user,
                     password=password,
                     ignore_retcode=ignore_retcode,
-                    redirect_stderr=True)['stdout']
+                    redirect_stderr=True,
+                    output_encoding=output_encoding)['stdout']
 
 
 def clone(cwd,
@@ -841,7 +860,8 @@ def clone(cwd,
           https_user=None,
           https_pass=None,
           ignore_retcode=False,
-          saltenv='base'):
+          saltenv='base',
+          output_encoding=None):
     '''
     Interface to `git-clone(1)`_
 
@@ -976,7 +996,8 @@ def clone(cwd,
              password=password,
              identity=identity,
              ignore_retcode=ignore_retcode,
-             saltenv=saltenv)
+             saltenv=saltenv,
+             output_encoding=output_encoding)
     return True
 
 
@@ -987,7 +1008,8 @@ def commit(cwd,
            user=None,
            password=None,
            filename=None,
-           ignore_retcode=False):
+           ignore_retcode=False,
+           output_encoding=None):
     '''
     Interface to `git-commit(1)`_
 
@@ -1068,7 +1090,8 @@ def commit(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def config_get(key,
@@ -1076,6 +1099,7 @@ def config_get(key,
                user=None,
                password=None,
                ignore_retcode=False,
+               output_encoding=None,
                **kwargs):
     '''
     Get the value of a key in the git configuration file
@@ -1140,6 +1164,7 @@ def config_get(key,
                             user=user,
                             password=password,
                             ignore_retcode=ignore_retcode,
+                            output_encoding=output_encoding,
                             **kwargs)
 
     # git config --get exits with retcode of 1 when key does not exist
@@ -1162,6 +1187,7 @@ def config_get_regexp(key,
                       user=None,
                       password=None,
                       ignore_retcode=False,
+                      output_encoding=None,
                       **kwargs):
     r'''
     .. versionadded:: 2015.8.0
@@ -1225,6 +1251,7 @@ def config_get_regexp(key,
                             user=user,
                             password=password,
                             ignore_retcode=ignore_retcode,
+                            output_encoding=output_encoding,
                             **kwargs)
 
     # git config --get exits with retcode of 1 when key does not exist
@@ -1249,6 +1276,7 @@ def config_set(key,
                user=None,
                password=None,
                ignore_retcode=False,
+               output_encoding=None,
                **kwargs):
     '''
     .. versionchanged:: 2015.8.0
@@ -1362,7 +1390,8 @@ def config_set(key,
                  cwd=cwd,
                  user=user,
                  password=password,
-                 ignore_retcode=ignore_retcode)
+                 ignore_retcode=ignore_retcode,
+                 output_encoding=output_encoding)
     else:
         for idx, target in enumerate(multivar):
             command = copy.copy(command_prefix)
@@ -1375,12 +1404,14 @@ def config_set(key,
                      cwd=cwd,
                      user=user,
                      password=password,
-                     ignore_retcode=ignore_retcode)
+                     ignore_retcode=ignore_retcode,
+                     output_encoding=output_encoding)
     return config_get(key,
                       user=user,
                       password=password,
                       cwd=cwd,
                       ignore_retcode=ignore_retcode,
+                      output_encoding=output_encoding,
                       **{'all': True, 'global': global_})
 
 
@@ -1390,6 +1421,7 @@ def config_unset(key,
                  user=None,
                  password=None,
                  ignore_retcode=False,
+                 output_encoding=None,
                  **kwargs):
     '''
     .. versionadded:: 2015.8.0
@@ -1456,7 +1488,8 @@ def config_unset(key,
         command.append('--unset-all')
     else:
         command.append('--unset')
-    command.extend(_which_git_config(global_, cwd, user, password))
+    command.extend(_which_git_config(global_, cwd, user, password,
+                                     output_encoding=output_encoding))
 
     command.append(key)
     if value_regex is not None:
@@ -1466,7 +1499,8 @@ def config_unset(key,
                    user=user,
                    password=password,
                    ignore_retcode=ignore_retcode,
-                   failhard=False)
+                   failhard=False,
+                   output_encoding=output_encoding)
     retcode = ret['retcode']
     if retcode == 0:
         return True
@@ -1477,7 +1511,8 @@ def config_unset(key,
                       key,
                       user=user,
                       password=password,
-                      ignore_retcode=ignore_retcode) is None:
+                      ignore_retcode=ignore_retcode,
+                      output_encoding=output_encoding) is None:
             raise CommandExecutionError(
                 'Key \'{0}\' does not exist'.format(key)
             )
@@ -1501,7 +1536,8 @@ def config_unset(key,
 def current_branch(cwd,
                    user=None,
                    password=None,
-                   ignore_retcode=False):
+                   ignore_retcode=False,
+                   output_encoding=None):
     '''
     Returns the current branch name of a local checkout. If HEAD is detached,
     return the SHA1 of the revision which is currently checked out.
@@ -1538,14 +1574,16 @@ def current_branch(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def describe(cwd,
              rev='HEAD',
              user=None,
              password=None,
-             ignore_retcode=False):
+             ignore_retcode=False,
+             output_encoding=None):
     '''
     Returns the `git-describe(1)`_ string (or the SHA1 hash if there are no
     tags) for the given revision.
@@ -1591,7 +1629,8 @@ def describe(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def diff(cwd,
@@ -1603,7 +1642,8 @@ def diff(cwd,
          password=None,
          no_index=False,
          cached=False,
-         paths=None):
+         paths=None,
+         output_encoding=None):
     '''
     .. versionadded:: 2015.8.12,2016.3.3,2016.11.0
 
@@ -1750,7 +1790,8 @@ def diff(cwd,
                     password=password,
                     ignore_retcode=ignore_retcode,
                     failhard=failhard,
-                    redirect_stderr=True)['stdout']
+                    redirect_stderr=True,
+                    output_encoding=output_encoding)['stdout']
 
 
 def fetch(cwd,
@@ -1763,7 +1804,8 @@ def fetch(cwd,
           password=None,
           identity=None,
           ignore_retcode=False,
-          saltenv='base'):
+          saltenv='base',
+          output_encoding=None):
     '''
     .. versionchanged:: 2015.8.2
         Return data is now a dictionary containing information on branches and
@@ -1888,7 +1930,8 @@ def fetch(cwd,
                       identity=identity,
                       ignore_retcode=ignore_retcode,
                       redirect_stderr=True,
-                      saltenv=saltenv)['stdout']
+                      saltenv=saltenv,
+                      output_encoding=output_encoding)['stdout']
 
     update_re = re.compile(
         r'[\s*]*(?:([0-9a-f]+)\.\.([0-9a-f]+)|'
@@ -1926,7 +1969,8 @@ def init(cwd,
          git_opts='',
          user=None,
          password=None,
-         ignore_retcode=False):
+         ignore_retcode=False,
+         output_encoding=None):
     '''
     Interface to `git-init(1)`_
 
@@ -2025,12 +2069,14 @@ def init(cwd,
     return _git_run(command,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def is_worktree(cwd,
                 user=None,
-                password=None):
+                password=None,
+                output_encoding=None):
     '''
     .. versionadded:: 2015.8.0
 
@@ -2060,7 +2106,8 @@ def is_worktree(cwd,
     '''
     cwd = _expand_path(cwd, user)
     try:
-        toplevel = _get_toplevel(cwd, user=user, password=password)
+        toplevel = _get_toplevel(cwd, user=user, password=password,
+                                 output_encoding=output_encoding)
     except CommandExecutionError:
         return False
     gitdir = os.path.join(toplevel, '.git')
@@ -2091,7 +2138,8 @@ def list_branches(cwd,
                   remote=False,
                   user=None,
                   password=None,
-                  ignore_retcode=False):
+                  ignore_retcode=False,
+                  output_encoding=None):
     '''
     .. versionadded:: 2015.8.0
 
@@ -2141,13 +2189,15 @@ def list_branches(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout'].splitlines()
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout'].splitlines()
 
 
 def list_tags(cwd,
               user=None,
               password=None,
-              ignore_retcode=False):
+              ignore_retcode=False,
+              output_encoding=None):
     '''
     .. versionadded:: 2015.8.0
 
@@ -2186,13 +2236,15 @@ def list_tags(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout'].splitlines()
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout'].splitlines()
 
 
 def list_worktrees(cwd,
                    stale=False,
                    user=None,
                    password=None,
+                   output_encoding=None,
                    **kwargs):
     '''
     .. versionadded:: 2015.8.0
@@ -2259,14 +2311,16 @@ def list_worktrees(cwd,
             '\'all\' and \'stale\' cannot both be set to True'
         )
 
-    def _git_tag_points_at(cwd, rev, user=None, password=None):
+    def _git_tag_points_at(cwd, rev, user=None, password=None,
+                           output_encoding=None):
         '''
         Get any tags that point at a
         '''
         return _git_run(['git', 'tag', '--points-at', rev],
                         cwd=cwd,
                         user=user,
-                        password=password)['stdout'].splitlines()
+                        password=password,
+                        output_encoding=output_encoding)['stdout'].splitlines()
 
     def _desired(is_stale, all_, stale):
         '''
@@ -2303,7 +2357,8 @@ def list_worktrees(cwd,
         out = _git_run(['git', 'worktree', 'list', '--porcelain'],
                        cwd=cwd,
                        user=user,
-                       password=password)
+                       password=password,
+                       output_encoding=output_encoding)
         if out['retcode'] != 0:
             msg = 'Failed to list worktrees'
             if out['stderr']:
@@ -2373,7 +2428,8 @@ def list_worktrees(cwd,
                 tags_found = _git_tag_points_at(cwd,
                                                 wt_ptr['HEAD'],
                                                 user=user,
-                                                password=password)
+                                                password=password,
+                                                output_encoding=output_encoding)
                 if tags_found:
                     wt_ptr['tags'] = tags_found
             else:
@@ -2383,12 +2439,14 @@ def list_worktrees(cwd,
         return ret
 
     else:
-        toplevel = _get_toplevel(cwd, user=user, password=password)
+        toplevel = _get_toplevel(cwd, user=user, password=password,
+                                 output_encoding=output_encoding)
         try:
             worktree_root = rev_parse(cwd,
                                       opts=['--git-path', 'worktrees'],
                                       user=user,
-                                      password=password)
+                                      password=password,
+                                      output_encoding=output_encoding)
         except CommandExecutionError as exc:
             msg = 'Failed to find worktree location for ' + cwd
             log.error(msg, exc_info_on_loglevel=logging.DEBUG)
@@ -2454,7 +2512,8 @@ def list_worktrees(cwd,
                 wt_head = rev_parse(cwd,
                                     rev=head_ref,
                                     user=user,
-                                    password=password)
+                                    password=password,
+                                    output_encoding=output_encoding)
                 wt_detached = False
             else:
                 wt_branch = None
@@ -2472,7 +2531,8 @@ def list_worktrees(cwd,
                 tags_found = _git_tag_points_at(cwd,
                                                 wt_head,
                                                 user=user,
-                                                password=password)
+                                                password=password,
+                                                output_encoding=output_encoding)
                 if tags_found:
                     wt_ptr['tags'] = tags_found
 
@@ -2490,6 +2550,7 @@ def ls_remote(cwd=None,
               https_user=None,
               https_pass=None,
               ignore_retcode=False,
+              output_encoding=None,
               saltenv='base'):
     '''
     Interface to `git-ls-remote(1)`_. Returns the upstream hash for a remote
@@ -2620,7 +2681,8 @@ def ls_remote(cwd=None,
                       password=password,
                       identity=identity,
                       ignore_retcode=ignore_retcode,
-                      saltenv=saltenv)['stdout']
+                      saltenv=saltenv,
+                      output_encoding=output_encoding)['stdout']
     ret = {}
     for line in output.splitlines():
         try:
@@ -2638,6 +2700,7 @@ def merge(cwd,
           user=None,
           password=None,
           ignore_retcode=False,
+          output_encoding=None,
           **kwargs):
     '''
     Interface to `git-merge(1)`_
@@ -2713,7 +2776,8 @@ def merge(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def merge_base(cwd,
@@ -2727,6 +2791,7 @@ def merge_base(cwd,
                user=None,
                password=None,
                ignore_retcode=False,
+               output_encoding=None,
                **kwargs):
     '''
     .. versionadded:: 2015.8.0
@@ -2878,13 +2943,15 @@ def merge_base(cwd,
                                      opts=['--verify'],
                                      user=user,
                                      password=password,
-                                     ignore_retcode=ignore_retcode)
+                                     ignore_retcode=ignore_retcode,
+                                     output_encoding=output_encoding)
             return merge_base(cwd,
                               refs=refs,
                               is_ancestor=False,
                               user=user,
                               password=password,
-                              ignore_retcode=ignore_retcode) == first_commit
+                              ignore_retcode=ignore_retcode,
+                              output_encoding=output_encoding) == first_commit
 
     command = ['git'] + _format_git_opts(git_opts)
     command.append('merge-base')
@@ -2905,7 +2972,8 @@ def merge_base(cwd,
                       user=user,
                       password=password,
                       ignore_retcode=ignore_retcode,
-                      failhard=False if is_ancestor else True)
+                      failhard=False if is_ancestor else True,
+                      output_encoding=output_encoding)
     if is_ancestor:
         return result['retcode'] == 0
     all_bases = result['stdout'].splitlines()
@@ -2920,7 +2988,8 @@ def merge_tree(cwd,
                base=None,
                user=None,
                password=None,
-               ignore_retcode=False):
+               ignore_retcode=False,
+               output_encoding=None):
     '''
     .. versionadded:: 2015.8.0
 
@@ -2969,7 +3038,8 @@ def merge_tree(cwd,
     command = ['git', 'merge-tree']
     if base is None:
         try:
-            base = merge_base(cwd, refs=[ref1, ref2])
+            base = merge_base(cwd, refs=[ref1, ref2],
+                              output_encoding=output_encoding)
         except (SaltInvocationError, CommandExecutionError):
             raise CommandExecutionError(
                 'Unable to determine merge base for {0} and {1}'
@@ -2980,7 +3050,8 @@ def merge_tree(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def pull(cwd,
@@ -2990,7 +3061,8 @@ def pull(cwd,
          password=None,
          identity=None,
          ignore_retcode=False,
-         saltenv='base'):
+         saltenv='base',
+         output_encoding=None):
     '''
     Interface to `git-pull(1)`_
 
@@ -3077,7 +3149,8 @@ def pull(cwd,
                     password=password,
                     identity=identity,
                     ignore_retcode=ignore_retcode,
-                    saltenv=saltenv)['stdout']
+                    saltenv=saltenv,
+                    output_encoding=output_encoding)['stdout']
 
 
 def push(cwd,
@@ -3090,6 +3163,7 @@ def push(cwd,
          identity=None,
          ignore_retcode=False,
          saltenv='base',
+         output_encoding=None,
          **kwargs):
     '''
     Interface to `git-push(1)`_
@@ -3200,7 +3274,8 @@ def push(cwd,
                     password=password,
                     identity=identity,
                     ignore_retcode=ignore_retcode,
-                    saltenv=saltenv)['stdout']
+                    saltenv=saltenv,
+                    output_encoding=output_encoding)['stdout']
 
 
 def rebase(cwd,
@@ -3209,7 +3284,8 @@ def rebase(cwd,
            git_opts='',
            user=None,
            password=None,
-           ignore_retcode=False):
+           ignore_retcode=False,
+           output_encoding=None):
     '''
     Interface to `git-rebase(1)`_
 
@@ -3278,7 +3354,8 @@ def rebase(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def remote_get(cwd,
@@ -3286,7 +3363,8 @@ def remote_get(cwd,
                user=None,
                password=None,
                redact_auth=True,
-               ignore_retcode=False):
+               ignore_retcode=False,
+               output_encoding=None):
     '''
     Get the fetch and push URL for a specific remote
 
@@ -3337,7 +3415,8 @@ def remote_get(cwd,
                           user=user,
                           password=password,
                           redact_auth=redact_auth,
-                          ignore_retcode=ignore_retcode)
+                          ignore_retcode=ignore_retcode,
+                          output_encoding=output_encoding)
     if remote not in all_remotes:
         raise CommandExecutionError(
             'Remote \'{0}\' not present in git checkout located at {1}'
@@ -3355,6 +3434,7 @@ def remote_refs(url,
                 https_user=None,
                 https_pass=None,
                 ignore_retcode=False,
+                output_encoding=None,
                 saltenv='base'):
     '''
     .. versionadded:: 2015.8.0
@@ -3441,7 +3521,8 @@ def remote_refs(url,
                       password=password,
                       identity=identity,
                       ignore_retcode=ignore_retcode,
-                      saltenv=saltenv)['stdout']
+                      saltenv=saltenv,
+                      output_encoding=output_encoding)['stdout']
     ret = {}
     for line in salt.utils.itertools.split(output, '\n'):
         try:
@@ -3462,7 +3543,8 @@ def remote_set(cwd,
                push_url=None,
                push_https_user=None,
                push_https_pass=None,
-               ignore_retcode=False):
+               ignore_retcode=False,
+               output_encoding=None):
     '''
     cwd
         The path to the git checkout
@@ -3526,7 +3608,8 @@ def remote_set(cwd,
         salt myminion git.remote_set /path/to/repo https://github.com/user/repo.git remote=upstream push_url=git@github.com:user/repo.git
     '''
     # Check if remote exists
-    if remote in remotes(cwd, user=user, password=password):
+    if remote in remotes(cwd, user=user, password=password,
+                         output_encoding=output_encoding):
         log.debug(
             'Remote \'%s\' already exists in git checkout located at %s, '
             'removing so it can be re-added', remote, cwd
@@ -3536,7 +3619,8 @@ def remote_set(cwd,
                  cwd=cwd,
                  user=user,
                  password=password,
-                 ignore_retcode=ignore_retcode)
+                 ignore_retcode=ignore_retcode,
+                 output_encoding=output_encoding)
     # Add remote
     try:
         url = salt.utils.url.add_http_basic_auth(url,
@@ -3550,7 +3634,8 @@ def remote_set(cwd,
              cwd=cwd,
              user=user,
              password=password,
-             ignore_retcode=ignore_retcode)
+             ignore_retcode=ignore_retcode,
+             output_encoding=output_encoding)
     if push_url:
         if not isinstance(push_url, six.string_types):
             push_url = six.text_type(push_url)
@@ -3566,19 +3651,22 @@ def remote_set(cwd,
                  cwd=cwd,
                  user=user,
                  password=password,
-                 ignore_retcode=ignore_retcode)
+                 ignore_retcode=ignore_retcode,
+                 output_encoding=output_encoding)
     return remote_get(cwd=cwd,
                       remote=remote,
                       user=user,
                       password=password,
-                      ignore_retcode=ignore_retcode)
+                      ignore_retcode=ignore_retcode,
+                      output_encoding=output_encoding)
 
 
 def remotes(cwd,
             user=None,
             password=None,
             redact_auth=True,
-            ignore_retcode=False):
+            ignore_retcode=False,
+            output_encoding=None):
     '''
     Get fetch and push URLs for each remote in a git checkout
 
@@ -3628,7 +3716,8 @@ def remotes(cwd,
                       cwd=cwd,
                       user=user,
                       password=password,
-                      ignore_retcode=ignore_retcode)['stdout']
+                      ignore_retcode=ignore_retcode,
+                      output_encoding=output_encoding)['stdout']
     for remote_line in salt.utils.itertools.split(output, '\n'):
         try:
             remote, remote_info = remote_line.split(None, 1)
@@ -3657,7 +3746,8 @@ def reset(cwd,
           git_opts='',
           user=None,
           password=None,
-          ignore_retcode=False):
+          ignore_retcode=False,
+          output_encoding=None):
     '''
     Interface to `git-reset(1)`_, returns the stdout from the git command
 
@@ -3718,7 +3808,8 @@ def reset(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def rev_parse(cwd,
@@ -3727,7 +3818,8 @@ def rev_parse(cwd,
               git_opts='',
               user=None,
               password=None,
-              ignore_retcode=False):
+              ignore_retcode=False,
+              output_encoding=None):
     '''
     .. versionadded:: 2015.8.0
 
@@ -3801,7 +3893,8 @@ def rev_parse(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def revision(cwd,
@@ -3809,7 +3902,8 @@ def revision(cwd,
              short=False,
              user=None,
              password=None,
-             ignore_retcode=False):
+             ignore_retcode=False,
+             output_encoding=None):
     '''
     Returns the SHA1 hash of a given identifier (hash, branch, tag, HEAD, etc.)
 
@@ -3853,7 +3947,8 @@ def revision(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def rm_(cwd,
@@ -3862,7 +3957,8 @@ def rm_(cwd,
         git_opts='',
         user=None,
         password=None,
-        ignore_retcode=False):
+        ignore_retcode=False,
+        output_encoding=None):
     '''
     Interface to `git-rm(1)`_
 
@@ -3930,7 +4026,8 @@ def rm_(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def stash(cwd,
@@ -3939,7 +4036,8 @@ def stash(cwd,
           git_opts='',
           user=None,
           password=None,
-          ignore_retcode=False):
+          ignore_retcode=False,
+          output_encoding=None):
     '''
     Interface to `git-stash(1)`_, returns the stdout from the git command
 
@@ -3999,13 +4097,15 @@ def stash(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def status(cwd,
            user=None,
            password=None,
-           ignore_retcode=False):
+           ignore_retcode=False,
+           output_encoding=None):
     '''
     .. versionchanged:: 2015.8.0
         Return data has changed from a list of lists to a dictionary
@@ -4051,7 +4151,8 @@ def status(cwd,
                       cwd=cwd,
                       user=user,
                       password=password,
-                      ignore_retcode=ignore_retcode)['stdout']
+                      ignore_retcode=ignore_retcode,
+                      output_encoding=output_encoding)['stdout']
     for line in output.split('\0'):
         try:
             state, filename = line.split(None, 1)
@@ -4070,6 +4171,7 @@ def submodule(cwd,
               identity=None,
               ignore_retcode=False,
               saltenv='base',
+              output_encoding=None,
               **kwargs):
     '''
     .. versionchanged:: 2015.8.0
@@ -4202,7 +4304,8 @@ def submodule(cwd,
                     password=password,
                     identity=identity,
                     ignore_retcode=ignore_retcode,
-                    saltenv=saltenv)['stdout']
+                    saltenv=saltenv,
+                    output_encoding=output_encoding)['stdout']
 
 
 def symbolic_ref(cwd,
@@ -4212,7 +4315,8 @@ def symbolic_ref(cwd,
                  git_opts='',
                  user=None,
                  password=None,
-                 ignore_retcode=False):
+                 ignore_retcode=False,
+                 output_encoding=None):
     '''
     .. versionadded:: 2015.8.0
 
@@ -4293,7 +4397,8 @@ def symbolic_ref(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
 def version(versioninfo=False):
@@ -4357,6 +4462,7 @@ def worktree_add(cwd,
                  user=None,
                  password=None,
                  ignore_retcode=False,
+                 output_encoding=None,
                  **kwargs):
     '''
     .. versionadded:: 2015.8.0
@@ -4480,7 +4586,8 @@ def worktree_add(cwd,
                     user=user,
                     password=password,
                     ignore_retcode=ignore_retcode,
-                    redirect_stderr=True)['stdout']
+                    redirect_stderr=True,
+                    output_encoding=output_encoding)['stdout']
 
 
 def worktree_prune(cwd,
@@ -4491,7 +4598,8 @@ def worktree_prune(cwd,
                    git_opts='',
                    user=None,
                    password=None,
-                   ignore_retcode=False):
+                   ignore_retcode=False,
+                   output_encoding=None):
     '''
     .. versionadded:: 2015.8.0
 
@@ -4581,10 +4689,11 @@ def worktree_prune(cwd,
                     cwd=cwd,
                     user=user,
                     password=password,
-                    ignore_retcode=ignore_retcode)['stdout']
+                    ignore_retcode=ignore_retcode,
+                    output_encoding=output_encoding)['stdout']
 
 
-def worktree_rm(cwd, user=None):
+def worktree_rm(cwd, user=None, output_encoding=None):
     '''
     .. versionadded:: 2015.8.0
 
@@ -4620,7 +4729,7 @@ def worktree_rm(cwd, user=None):
     cwd = _expand_path(cwd, user)
     if not os.path.exists(cwd):
         raise CommandExecutionError(cwd + ' does not exist')
-    elif not is_worktree(cwd):
+    elif not is_worktree(cwd, output_encoding=output_encoding):
         raise CommandExecutionError(cwd + ' is not a git worktree')
     try:
         salt.utils.files.rm_rf(cwd)

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -306,7 +306,7 @@ def _git_run(command, cwd=None, user=None, password=None, identity=None,
                     log_callback=salt.utils.url.redact_http_basic_auth,
                     ignore_retcode=ignore_retcode,
                     redirect_stderr=redirect_stderr,
-                    output_encoding=output_encoding
+                    output_encoding=output_encoding,
                     **kwargs)
             finally:
                 # Cleanup the temporary ssh wrapper file
@@ -490,8 +490,31 @@ def add(cwd,
 
         .. versionadded:: 2015.8.0
 
-    .. _`git-add(1)`: http://git-scm.com/docs/git-add
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-add(1)`: http://git-scm.com/docs/git-add
 
     CLI Examples:
 
@@ -615,8 +638,31 @@ def archive(cwd,
 
         .. versionadded:: 2015.8.0
 
-    .. _`git-archive(1)`: http://git-scm.com/docs/git-archive
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-archive(1)`: http://git-scm.com/docs/git-archive
 
     CLI Example:
 
@@ -718,8 +764,31 @@ def branch(cwd,
 
         .. versionadded:: 2015.8.0
 
-    .. _`git-branch(1)`: http://git-scm.com/docs/git-branch
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-branch(1)`: http://git-scm.com/docs/git-branch
 
     CLI Examples:
 
@@ -808,8 +877,31 @@ def checkout(cwd,
 
         .. versionadded:: 2015.8.0
 
-    .. _`git-checkout(1)`: http://git-scm.com/docs/git-checkout
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-checkout(1)`: http://git-scm.com/docs/git-checkout
 
     CLI Examples:
 
@@ -951,6 +1043,30 @@ def clone(cwd,
 
         .. versionadded:: 2016.3.1
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
     .. _`git-clone(1)`: http://git-scm.com/docs/git-clone
 
     CLI Example:
@@ -1068,8 +1184,31 @@ def commit(cwd,
 
         .. versionadded:: 2015.8.0
 
-    .. _`git-commit(1)`: http://git-scm.com/docs/git-commit
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-commit(1)`: http://git-scm.com/docs/git-commit
 
     CLI Examples:
 
@@ -1144,6 +1283,29 @@ def config_get(key,
 
         .. versionadded:: 2015.8.0
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Examples:
 
@@ -1232,6 +1394,29 @@ def config_get_regexp(key,
         If ``True``, do not log an error to the minion log if the git command
         returns a nonzero exit status.
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Examples:
 
@@ -1334,7 +1519,31 @@ def config_set(key,
     global : False
         If ``True``, set a global variable
 
-    CLI Example:
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    CLI Examples:
 
     .. code-block:: bash
 
@@ -1461,6 +1670,29 @@ def config_unset(key,
         If ``True``, do not log an error to the minion log if the git command
         returns a nonzero exit status.
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Example:
 
@@ -1561,6 +1793,29 @@ def current_branch(cwd,
 
         .. versionadded:: 2015.8.0
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Example:
 
@@ -1610,8 +1865,31 @@ def describe(cwd,
 
         .. versionadded:: 2015.8.0
 
-    .. _`git-describe(1)`: http://git-scm.com/docs/git-describe
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-describe(1)`: http://git-scm.com/docs/git-describe
 
     CLI Examples:
 
@@ -1711,8 +1989,31 @@ def diff(cwd,
         File paths to pass to the ``git diff`` command. Can be passed as a
         comma-separated list or a Python list.
 
-    .. _`git-diff(1)`: http://git-scm.com/docs/git-diff
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-diff(1)`: http://git-scm.com/docs/git-diff
 
     CLI Example:
 
@@ -1895,8 +2196,31 @@ def fetch(cwd,
 
         .. versionadded:: 2016.3.1
 
-    .. _`git-fetch(1)`: http://git-scm.com/docs/git-fetch
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-fetch(1)`: http://git-scm.com/docs/git-fetch
 
     CLI Example:
 
@@ -2032,6 +2356,30 @@ def init(cwd,
 
         .. versionadded:: 2015.8.0
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
     .. _`git-init(1)`: http://git-scm.com/docs/git-init
     .. _`template directory`: http://git-scm.com/docs/git-init#_template_directory
 
@@ -2097,6 +2445,29 @@ def is_worktree(cwd,
 
       .. versionadded:: 2016.3.4
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Example:
 
@@ -2174,6 +2545,29 @@ def list_branches(cwd,
 
         .. versionadded:: 2015.8.0
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Examples:
 
@@ -2222,6 +2616,29 @@ def list_tags(cwd,
 
         .. versionadded:: 2015.8.0
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Examples:
 
@@ -2287,8 +2704,31 @@ def list_worktrees(cwd,
     .. note::
         Only one of ``all`` and ``stale`` can be set to ``True``.
 
-    .. _`git-worktree(1)`: http://git-scm.com/docs/git-worktree
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-worktree(1)`: http://git-scm.com/docs/git-worktree
 
     CLI Examples:
 
@@ -2650,8 +3090,31 @@ def ls_remote(cwd=None,
 
         .. versionadded:: 2016.3.1
 
-    .. _`git-ls-remote(1)`: http://git-scm.com/docs/git-ls-remote
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-ls-remote(1)`: http://git-scm.com/docs/git-ls-remote
 
     CLI Example:
 
@@ -2748,8 +3211,31 @@ def merge(cwd,
 
         .. versionadded:: 2015.8.0
 
-    .. _`git-merge(1)`: http://git-scm.com/docs/git-merge
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-merge(1)`: http://git-scm.com/docs/git-merge
 
     CLI Example:
 
@@ -2878,9 +3364,32 @@ def merge_base(cwd,
         if ``True``, do not log an error to the minion log if the git command
         returns a nonzero exit status.
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
     .. _`git-merge-base(1)`: http://git-scm.com/docs/git-merge-base
     .. _here: http://git-scm.com/docs/git-merge-base#_discussion
-
 
     CLI Examples:
 
@@ -3024,8 +3533,31 @@ def merge_tree(cwd,
         if ``True``, do not log an error to the minion log if the git command
         returns a nonzero exit status.
 
-    .. _`git-merge-tree(1)`: http://git-scm.com/docs/git-merge-tree
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-merge-tree(1)`: http://git-scm.com/docs/git-merge-tree
 
     CLI Examples:
 
@@ -3130,6 +3662,30 @@ def pull(cwd,
         The default salt environment to pull sls files from
 
         .. versionadded:: 2016.3.1
+
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     .. _`git-pull(1)`: http://git-scm.com/docs/git-pull
 
@@ -3245,6 +3801,30 @@ def push(cwd,
 
         .. versionadded:: 2016.3.1
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
     .. _`git-push(1)`: http://git-scm.com/docs/git-push
     .. _refspec: http://git-scm.com/book/en/v2/Git-Internals-The-Refspec
 
@@ -3329,6 +3909,30 @@ def rebase(cwd,
 
         .. versionadded:: 2015.8.0
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
     .. _`git-rebase(1)`: http://git-scm.com/docs/git-rebase
 
 
@@ -3402,6 +4006,29 @@ def remote_get(cwd,
 
         .. versionadded:: 2015.8.0
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Examples:
 
@@ -3497,6 +4124,30 @@ def remote_refs(url,
         The default salt environment to pull sls files from
 
         .. versionadded:: 2016.3.1
+
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Example:
 
@@ -3598,6 +4249,29 @@ def remote_set(cwd,
 
         .. versionadded:: 2015.8.0
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Examples:
 
@@ -3702,6 +4376,29 @@ def remotes(cwd,
 
         .. versionadded:: 2015.8.0
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Example:
 
@@ -3788,8 +4485,31 @@ def reset(cwd,
 
         .. versionadded:: 2015.8.0
 
-    .. _`git-reset(1)`: http://git-scm.com/docs/git-reset
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-reset(1)`: http://git-scm.com/docs/git-reset
 
     CLI Examples:
 
@@ -3863,10 +4583,33 @@ def rev_parse(cwd,
         If ``True``, do not log an error to the minion log if the git command
         returns a nonzero exit status.
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
     .. _`git-rev-parse(1)`: http://git-scm.com/docs/git-rev-parse
     .. _`SPECIFYING REVISIONS`: http://git-scm.com/docs/git-rev-parse#_specifying_revisions
     .. _`Options for Files`: http://git-scm.com/docs/git-rev-parse#_options_for_files
-
 
     CLI Examples:
 
@@ -3931,6 +4674,30 @@ def revision(cwd,
         returns a nonzero exit status.
 
         .. versionadded:: 2015.8.0
+
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Example:
 
@@ -4006,8 +4773,31 @@ def rm_(cwd,
 
         .. versionadded:: 2015.8.0
 
-    .. _`git-rm(1)`: http://git-scm.com/docs/git-rm
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-rm(1)`: http://git-scm.com/docs/git-rm
 
     CLI Examples:
 
@@ -4077,8 +4867,31 @@ def stash(cwd,
 
         .. versionadded:: 2015.8.0
 
-    .. _`git-stash(1)`: http://git-scm.com/docs/git-stash
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-stash(1)`: http://git-scm.com/docs/git-stash
 
     CLI Examples:
 
@@ -4131,6 +4944,29 @@ def status(cwd,
 
         .. versionadded:: 2015.8.0
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Example:
 
@@ -4263,6 +5099,30 @@ def submodule(cwd,
 
         .. versionadded:: 2016.3.1
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
     .. _`git-submodule(1)`: http://git-scm.com/docs/git-submodule
 
     CLI Example:
@@ -4366,8 +5226,31 @@ def symbolic_ref(cwd,
 
         .. versionadded:: 2015.8.0
 
-    .. _`git-symbolic-ref(1)`: http://git-scm.com/docs/git-symbolic-ref
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-symbolic-ref(1)`: http://git-scm.com/docs/git-symbolic-ref
 
     CLI Examples:
 
@@ -4410,7 +5293,6 @@ def version(versioninfo=False):
     versioninfo : False
         If ``True``, return the version in a versioninfo list (e.g. ``[2, 5,
         0]``)
-
 
     CLI Example:
 
@@ -4539,8 +5421,31 @@ def worktree_add(cwd,
 
         .. versionadded:: 2015.8.0
 
-    .. _`git-worktree(1)`: http://git-scm.com/docs/git-worktree
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
 
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
+    .. _`git-worktree(1)`: http://git-scm.com/docs/git-worktree
 
     CLI Examples:
 
@@ -4662,9 +5567,32 @@ def worktree_prune(cwd,
 
         .. versionadded:: 2015.8.0
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
+
     .. _`git-worktree(1)`: http://git-scm.com/docs/git-worktree
     .. _`git-config(1)`: http://git-scm.com/docs/git-config/2.5.1
-
 
     CLI Examples:
 
@@ -4718,6 +5646,29 @@ def worktree_rm(cwd, user=None, output_encoding=None):
         running. Setting this option will change the home directory from which
         path expansion is performed.
 
+    output_encoding
+        Use this option to specify which encoding to use to decode the output
+        from any git commands which are run. This should not be needed in most
+        cases.
+
+        .. note::
+
+            On Windows, this option works slightly differently in the git state
+            and execution module than it does in the :mod:`"cmd" execution
+            module <salt.modules.cmdmod>`. The filenames in most git
+            repositories are created using a UTF-8 locale, and the system
+            encoding on Windows (CP1252) will successfully (but incorrectly)
+            decode many UTF-8 characters. This makes interacting with
+            repositories containing UTF-8 filenames on Windows unreliable.
+            Therefore, Windows will default to decoding the output from git
+            commands using UTF-8 unless this option is explicitly used to
+            specify the encoding.
+
+            On non-Windows platforms, the default output decoding behavior will
+            be observed (i.e. the encoding specified by the locale will be
+            tried first, and if that fails, UTF-8 will be used as a fallback).
+
+        .. versionadded:: 2018.3.1
 
     CLI Examples:
 

--- a/salt/utils/boto3.py
+++ b/salt/utils/boto3.py
@@ -43,7 +43,7 @@ from functools import partial
 
 # Import salt libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
-from salt.exceptions import SaltInvocationError, CommandExecutionError
+from salt.exceptions import SaltInvocationError, CommandExecutionError  # pylint: disable=unused-import
 from salt.utils.versions import LooseVersion as _LooseVersion
 from salt.ext import six
 import salt.utils.stringutils
@@ -129,7 +129,7 @@ def _get_profile(service, region=None, key=None, keyid=None, profile=None,
             hash_string = salt.utils.stringutils.to_bytes(hash_string)
         cxkey = label + hashlib.md5(hash_string).hexdigest()
     elif aws_session_token:
-        hash_string = region + aws_session_key
+        hash_string = region + aws_session_token
         if six.PY3:
             hash_string = salt.utils.to_bytes(hash_string)
         cxkey = label + hashlib.md5(hash_string).hexdigest()
@@ -311,7 +311,6 @@ def assign_funcs(modname, service, module=None,
     mod = sys.modules[modname]
     setattr(mod, get_conn_funcname, get_connection_func(service, module=module))
     setattr(mod, cache_id_funcname, cache_id_func(service))
-
     # TODO: Remove this and import salt.utils.exactly_one into boto_* modules instead
     # Leaving this way for now so boto3 modules can be back ported
     if exactly_one_funcname is not None:

--- a/tests/integration/modules/test_git.py
+++ b/tests/integration/modules/test_git.py
@@ -147,7 +147,8 @@ class GitModuleTest(ModuleCase):
         TODO: maybe move this behavior to ModuleCase itself?
         '''
         return salt.utils.data.decode(
-            super(GitModuleTest, self).run_function(*args, **kwargs)
+            super(GitModuleTest, self).run_function(*args, **kwargs),
+            encoding='utf-8'
         )
 
     def tearDown(self):
@@ -206,7 +207,8 @@ class GitModuleTest(ModuleCase):
             self.run_function('cmd.run', ['cp ' + tar_archive + ' /root/'])
             with closing(tarfile.open(tar_archive, 'r')) as tar_obj:
                 self.assertEqual(
-                    sorted(salt.utils.data.decode(tar_obj.getnames())),
+                    sorted(salt.utils.data.decode(tar_obj.getnames(),
+                                                  encoding='utf-8')),
                     sorted([
                         'foo', 'foo/bar', 'foo/baz', 'foo/foo', 'foo/питон',
                         'foo/qux', 'foo/qux/bar', 'foo/qux/baz', 'foo/qux/foo',
@@ -236,7 +238,8 @@ class GitModuleTest(ModuleCase):
             self.assertTrue(tarfile.is_tarfile(tar_archive))
             with closing(tarfile.open(tar_archive, 'r')) as tar_obj:
                 self.assertEqual(
-                    sorted(salt.utils.data.decode(tar_obj.getnames())),
+                    sorted(salt.utils.data.decode(tar_obj.getnames(),
+                                                  encoding='utf-8')),
                     sorted(['foo', 'foo/bar', 'foo/baz', 'foo/foo', 'foo/питон'])
                 )
         finally:


### PR DESCRIPTION
Transparently adds several new auth options to boto3 based modules.  That is, they all default to None, so they'll have no effect on existing modules; but new modules can be written to leverage them, and old modules updated, if and when desired.  Specifically, this adds:
- aws_session_token:  Utilize a previously generated AWS session token to bind
- botocore_session:  Use a previously generated botocore internal connection ID
- aws_profile:  Most usefully, use creds stored in ~/.aws/credentials or ~/.aws/config (or any other profile location supported by boto3).  This is essentially equivalent to using the AWS_PROFILE environment variable, except the latter only works when calling boto exec functions locally, not when running states or otherwise running through the master.

These are all native auth types for boto3, above and beyond the normal practice of passing in literal key/keyid strings (which to me has always presented several uncomfortable security issues).

The new auth options are leveraged in (and required by) the new boto3 EMR modules I'm working on, which will be in a separate PR very shortly...