### PR TITLE
Fix utils.files.guess_archive_type to recognize the "tbz" extension as well

### DIFF
--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -59,7 +59,9 @@ def guess_archive_type(name):
     Guess an archive type (tar, zip, or rar) by its file extension
     '''
     name = name.lower()
-    for ending in ('tar', 'tar.gz', 'tar.bz2', 'tar.xz', 'tgz', 'tbz2', 'txz',
+    for ending in ('tar', 'tar.gz', 'tgz',
+                   'tar.bz2', 'tbz2', 'tbz',
+                   'tar.xz', 'txz',
                    'tar.lzma', 'tlz'):
         if name.endswith('.' + ending):
             return 'tar'


### PR DESCRIPTION
(also tidy up list of extensions)

### What does this PR do?

As per subject. `.tbz`s should be recognized as tarballs as well.

### Tests written?

No

### Commits signed with GPG?

Yes
