### PR TITLE
Report 'onlyif' and 'unless' conditions as true or false

### DIFF
--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -551,19 +551,19 @@ def _check_onlyif_unless(onlyif, unless):
     if onlyif is not None:
         if not isinstance(onlyif, six.string_types):
             if not onlyif:
-                ret = {'comment': 'onlyif execution failed', 'result': True}
+                ret = {'comment': 'onlyif condition is false', 'result': True}
         elif isinstance(onlyif, six.string_types):
             if retcode(onlyif) != 0:
-                ret = {'comment': 'onlyif execution failed', 'result': True}
-                log.debug('onlyif execution failed')
+                ret = {'comment': 'onlyif condition is false', 'result': True}
+                log.debug('onlyif condition is false')
     if unless is not None:
         if not isinstance(unless, six.string_types):
             if unless:
-                ret = {'comment': 'unless execution succeeded', 'result': True}
+                ret = {'comment': 'unless condition is true', 'result': True}
         elif isinstance(unless, six.string_types):
             if retcode(unless) == 0:
-                ret = {'comment': 'unless execution succeeded', 'result': True}
-                log.debug('unless execution succeeded')
+                ret = {'comment': 'unless condition is true', 'result': True}
+                log.debug('unless condition is true')
     return ret
 
 

--- a/salt/modules/zcbuildout.py
+++ b/salt/modules/zcbuildout.py
@@ -1031,17 +1031,17 @@ def _check_onlyif_unless(onlyif, unless, directory, runas=None, env=()):
         if onlyif is not None:
             if not isinstance(onlyif, six.string_types):
                 if not onlyif:
-                    _valid(status, 'onlyif execution failed')
+                    _valid(status, 'onlyif condition is false')
             elif isinstance(onlyif, six.string_types):
                 if retcode(onlyif, cwd=directory, runas=runas, env=env) != 0:
-                    _valid(status, 'onlyif execution failed')
+                    _valid(status, 'onlyif condition is false')
         if unless is not None:
             if not isinstance(unless, six.string_types):
                 if unless:
-                    _valid(status, 'unless execution succeeded')
+                    _valid(status, 'unless condition is true')
             elif isinstance(unless, six.string_types):
                 if retcode(unless, cwd=directory, runas=runas, env=env, python_shell=False) == 0:
-                    _valid(status, 'unless execution succeeded')
+                    _valid(status, 'unless condition is true')
     if status['status']:
         ret = status
     return ret

--- a/salt/state.py
+++ b/salt/state.py
@@ -826,12 +826,12 @@ class State(object):
                     entry, ignore_retcode=True, python_shell=True, **cmd_opts)
                 log.debug(u'Last command return code: %s', cmd)
                 if cmd != 0 and ret[u'result'] is False:
-                    ret.update({u'comment': u'onlyif execution failed',
+                    ret.update({u'comment': u'onlyif condition is false',
                                 u'skip_watch': True,
                                 u'result': True})
                     return ret
                 elif cmd == 0:
-                    ret.update({u'comment': u'onlyif execution succeeded', u'result': False})
+                    ret.update({u'comment': u'onlyif condition is true', u'result': False})
             return ret
 
         if u'unless' in low_data:
@@ -841,17 +841,17 @@ class State(object):
                 low_data_unless = low_data[u'unless']
             for entry in low_data_unless:
                 if not isinstance(entry, six.string_types):
-                    ret.update({u'comment': u'unless execution failed, bad type passed', u'result': False})
+                    ret.update({u'comment': u'unless condition is false, bad type passed', u'result': False})
                     return ret
                 cmd = self.functions[u'cmd.retcode'](
                     entry, ignore_retcode=True, python_shell=True, **cmd_opts)
                 log.debug(u'Last command return code: %s', cmd)
                 if cmd == 0 and ret[u'result'] is False:
-                    ret.update({u'comment': u'unless execution succeeded',
+                    ret.update({u'comment': u'unless condition is true',
                                 u'skip_watch': True,
                                 u'result': True})
                 elif cmd != 0:
-                    ret.update({u'comment': u'unless execution failed', u'result': False})
+                    ret.update({u'comment': u'unless condition is false', u'result': False})
                     return ret
 
         # No reason to stop, return ret

--- a/salt/states/cloud.py
+++ b/salt/states/cloud.py
@@ -100,17 +100,17 @@ def present(name, cloud_provider, onlyif=None, unless=None, opts=None, **kwargs)
     if onlyif is not None:
         if not isinstance(onlyif, six.string_types):
             if not onlyif:
-                return _valid(name, comment='onlyif execution failed')
+                return _valid(name, comment='onlyif condition is false')
         elif isinstance(onlyif, six.string_types):
             if retcode(onlyif, python_shell=True) != 0:
-                return _valid(name, comment='onlyif execution failed')
+                return _valid(name, comment='onlyif condition is false')
     if unless is not None:
         if not isinstance(unless, six.string_types):
             if unless:
-                return _valid(name, comment='unless execution succeeded')
+                return _valid(name, comment='unless condition is true')
         elif isinstance(unless, six.string_types):
             if retcode(unless, python_shell=True) == 0:
-                return _valid(name, comment='unless execution succeeded')
+                return _valid(name, comment='unless condition is true')
 
     # provider=None not cloud_provider because
     # need to ensure ALL providers don't have the instance
@@ -177,17 +177,17 @@ def absent(name, onlyif=None, unless=None):
     if onlyif is not None:
         if not isinstance(onlyif, six.string_types):
             if not onlyif:
-                return _valid(name, comment='onlyif execution failed')
+                return _valid(name, comment='onlyif condition is false')
         elif isinstance(onlyif, six.string_types):
             if retcode(onlyif, python_shell=True) != 0:
-                return _valid(name, comment='onlyif execution failed')
+                return _valid(name, comment='onlyif condition is false')
     if unless is not None:
         if not isinstance(unless, six.string_types):
             if unless:
-                return _valid(name, comment='unless execution succeeded')
+                return _valid(name, comment='unless condition is true')
         elif isinstance(unless, six.string_types):
             if retcode(unless, python_shell=True) == 0:
-                return _valid(name, comment='unless execution succeeded')
+                return _valid(name, comment='unless condition is true')
 
     if not __salt__['cloud.has_instance'](name=name, provider=None):
         ret['result'] = True
@@ -253,17 +253,17 @@ def profile(name, profile, onlyif=None, unless=None, opts=None, **kwargs):
     if onlyif is not None:
         if not isinstance(onlyif, six.string_types):
             if not onlyif:
-                return _valid(name, comment='onlyif execution failed')
+                return _valid(name, comment='onlyif condition is false')
         elif isinstance(onlyif, six.string_types):
             if retcode(onlyif, python_shell=True) != 0:
-                return _valid(name, comment='onlyif execution failed')
+                return _valid(name, comment='onlyif condition is false')
     if unless is not None:
         if not isinstance(unless, six.string_types):
             if unless:
-                return _valid(name, comment='unless execution succeeded')
+                return _valid(name, comment='unless condition is true')
         elif isinstance(unless, six.string_types):
             if retcode(unless, python_shell=True) == 0:
-                return _valid(name, comment='unless execution succeeded')
+                return _valid(name, comment='unless condition is true')
     instance = _get_instance([name])
     if instance and not any('Not Actioned' in key for key in instance):
         ret['result'] = True

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -343,7 +343,7 @@ def mod_run_check(cmd_kwargs, onlyif, unless, creates):
             cmd = __salt__['cmd.retcode'](onlyif, ignore_retcode=True, python_shell=True, **cmd_kwargs)
             log.debug('Last command return code: {0}'.format(cmd))
             if cmd != 0:
-                return {'comment': 'onlyif execution failed',
+                return {'comment': 'onlyif condition is false',
                         'skip_watch': True,
                         'result': True}
         elif isinstance(onlyif, list):
@@ -351,13 +351,13 @@ def mod_run_check(cmd_kwargs, onlyif, unless, creates):
                 cmd = __salt__['cmd.retcode'](entry, ignore_retcode=True, python_shell=True, **cmd_kwargs)
                 log.debug('Last command \'{0}\' return code: {1}'.format(entry, cmd))
                 if cmd != 0:
-                    return {'comment': 'onlyif execution failed: {0}'.format(entry),
+                    return {'comment': 'onlyif condition is false: {0}'.format(entry),
                             'skip_watch': True,
                             'result': True}
         elif not isinstance(onlyif, string_types):
             if not onlyif:
                 log.debug('Command not run: onlyif did not evaluate to string_type')
-                return {'comment': 'onlyif execution failed',
+                return {'comment': 'onlyif condition is false',
                         'skip_watch': True,
                         'result': True}
 
@@ -366,7 +366,7 @@ def mod_run_check(cmd_kwargs, onlyif, unless, creates):
             cmd = __salt__['cmd.retcode'](unless, ignore_retcode=True, python_shell=True, **cmd_kwargs)
             log.debug('Last command return code: {0}'.format(cmd))
             if cmd == 0:
-                return {'comment': 'unless execution succeeded',
+                return {'comment': 'unless condition is true',
                         'skip_watch': True,
                         'result': True}
         elif isinstance(unless, list):
@@ -375,13 +375,13 @@ def mod_run_check(cmd_kwargs, onlyif, unless, creates):
                 cmd.append(__salt__['cmd.retcode'](entry, ignore_retcode=True, python_shell=True, **cmd_kwargs))
                 log.debug('Last command return code: {0}'.format(cmd))
             if all([c == 0 for c in cmd]):
-                return {'comment': 'unless execution succeeded',
+                return {'comment': 'unless condition is true',
                         'skip_watch': True,
                         'result': True}
         elif not isinstance(unless, string_types):
             if unless:
                 log.debug('Command not run: unless did not evaluate to string_type')
-                return {'comment': 'unless execution succeeded',
+                return {'comment': 'unless condition is true',
                         'skip_watch': True,
                         'result': True}
 

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -3002,13 +3002,13 @@ def mod_run_check(cmd_kwargs, onlyif, unless):
     cmd_kwargs['python_shell'] = True
     if onlyif:
         if __salt__['cmd.retcode'](onlyif, **cmd_kwargs) != 0:
-            return {'comment': 'onlyif execution failed',
+            return {'comment': 'onlyif condition is false',
                     'skip_watch': True,
                     'result': True}
 
     if unless:
         if __salt__['cmd.retcode'](unless, **cmd_kwargs) == 0:
-            return {'comment': 'unless execution succeeded',
+            return {'comment': 'unless condition is true',
                     'skip_watch': True,
                     'result': True}
 

--- a/salt/states/mac_package.py
+++ b/salt/states/mac_package.py
@@ -253,13 +253,13 @@ def _mod_run_check(cmd_kwargs, onlyif, unless):
     '''
     if onlyif:
         if __salt__['cmd.retcode'](onlyif, **cmd_kwargs) != 0:
-            return {'comment': 'onlyif execution failed',
+            return {'comment': 'onlyif condition is false',
                     'skip_watch': True,
                     'result': True}
 
     if unless:
         if __salt__['cmd.retcode'](unless, **cmd_kwargs) == 0:
-            return {'comment': 'unless execution succeeded',
+            return {'comment': 'unless condition is true',
                     'skip_watch': True,
                     'result': True}
 

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -910,7 +910,7 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_function('state.sls', mods='requisites.use')
         self.assertReturnNonEmptySaltType(ret)
         for item, descr in six.iteritems(ret):
-            self.assertEqual(descr['comment'], 'onlyif execution failed')
+            self.assertEqual(descr['comment'], 'onlyif condition is false')
 
         # TODO: issue #8802 : use recursions undetected
         # issue is closed as use does not actually inherit requisites

--- a/tests/integration/states/test_cmd.py
+++ b/tests/integration/states/test_cmd.py
@@ -105,7 +105,7 @@ class CMDRunRedirectTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltTrueReturn(sls)
         # We must assert against the comment here to make sure the comment reads that the
         # command "echo "hello"" was run. This ensures that we made it to the last unless
-        # command in the state. If the comment reads "unless execution succeeded", or similar,
+        # command in the state. If the comment reads "unless condition is true", or similar,
         # then the unless state run bailed out after the first unless command succeeded,
         # which is the bug we're regression testing for.
         self.assertEqual(sls['cmd_|-cmd_run_unless_multiple_|-echo "hello"_|-run']['comment'],

--- a/tests/unit/modules/test_zcbuildout.py
+++ b/tests/unit/modules/test_zcbuildout.py
@@ -130,10 +130,10 @@ class BuildoutTestCase(Base):
     def test_onlyif_unless(self):
         b_dir = os.path.join(self.tdir, 'b')
         ret = buildout.buildout(b_dir, onlyif='/bin/false')
-        self.assertTrue(ret['comment'] == 'onlyif execution failed')
+        self.assertTrue(ret['comment'] == 'onlyif condition is false')
         self.assertTrue(ret['status'] is True)
         ret = buildout.buildout(b_dir, unless='/bin/true')
-        self.assertTrue(ret['comment'] == 'unless execution succeeded')
+        self.assertTrue(ret['comment'] == 'unless condition is true')
         self.assertTrue(ret['status'] is True)
 
     @requires_network()

--- a/tests/unit/states/test_cloud.py
+++ b/tests/unit/states/test_cloud.py
@@ -47,7 +47,7 @@ class CloudTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(cloud.__salt__, {'cmd.retcode': mock,
                                          'cloud.has_instance': mock_bool,
                                          'cloud.create': mock_dict}):
-            comt = ('onlyif execution failed')
+            comt = ('onlyif condition is false')
             ret.update({'comment': comt})
             self.assertDictEqual(cloud.present(name, cloud_provider,
                                                onlyif=False), ret)
@@ -55,7 +55,7 @@ class CloudTestCase(TestCase, LoaderModuleMockMixin):
             self.assertDictEqual(cloud.present(name, cloud_provider, onlyif=''),
                                  ret)
 
-            comt = ('unless execution succeeded')
+            comt = ('unless condition is true')
             ret.update({'comment': comt})
             self.assertDictEqual(cloud.present(name, cloud_provider,
                                                unless=True), ret)
@@ -98,13 +98,13 @@ class CloudTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(cloud.__salt__, {'cmd.retcode': mock,
                                          'cloud.has_instance': mock_bool,
                                          'cloud.destroy': mock_dict}):
-            comt = ('onlyif execution failed')
+            comt = ('onlyif condition is false')
             ret.update({'comment': comt})
             self.assertDictEqual(cloud.absent(name, onlyif=False), ret)
 
             self.assertDictEqual(cloud.absent(name, onlyif=''), ret)
 
-            comt = ('unless execution succeeded')
+            comt = ('unless condition is true')
             ret.update({'comment': comt})
             self.assertDictEqual(cloud.absent(name, unless=True), ret)
 
@@ -152,14 +152,14 @@ class CloudTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(cloud.__salt__, {'cmd.retcode': mock,
                                          'cloud.profile': mock_d,
                                          'cloud.action': mock_dict}):
-            comt = ('onlyif execution failed')
+            comt = ('onlyif condition is false')
             ret.update({'comment': comt})
             self.assertDictEqual(cloud.profile(name, profile, onlyif=False),
                                  ret)
 
             self.assertDictEqual(cloud.profile(name, profile, onlyif=''), ret)
 
-            comt = ('unless execution succeeded')
+            comt = ('unless condition is true')
             ret.update({'comment': comt})
             self.assertDictEqual(cloud.profile(name, profile, unless=True), ret)
 

--- a/tests/unit/states/test_cmd.py
+++ b/tests/unit/states/test_cmd.py
@@ -41,7 +41,7 @@ class CmdTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value=1)
         with patch.dict(cmd.__salt__, {'cmd.retcode': mock}):
             with patch.dict(cmd.__opts__, {'test': True}):
-                ret = {'comment': 'onlyif execution failed', 'result': True,
+                ret = {'comment': 'onlyif condition is false', 'result': True,
                        'skip_watch': True}
                 self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, '', '', creates), ret)
 
@@ -50,13 +50,13 @@ class CmdTestCase(TestCase, LoaderModuleMockMixin):
         mock = MagicMock(return_value=1)
         with patch.dict(cmd.__salt__, {'cmd.retcode': mock}):
             with patch.dict(cmd.__opts__, {'test': True}):
-                ret = {'comment': 'onlyif execution failed: ', 'result': True,
+                ret = {'comment': 'onlyif condition is false: ', 'result': True,
                        'skip_watch': True}
                 self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, [''], '', creates), ret)
 
         mock = MagicMock(return_value=0)
         with patch.dict(cmd.__salt__, {'cmd.retcode': mock}):
-            ret = {'comment': 'unless execution succeeded', 'result': True,
+            ret = {'comment': 'unless condition is true', 'result': True,
                    'skip_watch': True}
             self.assertDictEqual(cmd.mod_run_check(cmd_kwargs, None, '', creates), ret)
 
@@ -143,7 +143,7 @@ class CmdTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value=1)
             with patch.dict(cmd.__salt__, {'cmd.retcode': mock}):
                 with patch.dict(cmd.__opts__, {'test': False}):
-                    comt = ('onlyif execution failed')
+                    comt = ('onlyif condition is false')
                     ret.update({'comment': comt, 'result': True,
                                 'skip_watch': True})
                     self.assertDictEqual(cmd.run(name, onlyif=''), ret)
@@ -186,7 +186,7 @@ class CmdTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value=1)
             with patch.dict(cmd.__salt__, {'cmd.retcode': mock}):
                 with patch.dict(cmd.__opts__, {'test': False}):
-                    comt = ('onlyif execution failed')
+                    comt = ('onlyif condition is false')
                     ret.update({'comment': comt, 'result': True,
                                 'skip_watch': True, 'changes': {}})
                     self.assertDictEqual(cmd.script(name, onlyif=''), ret)
@@ -222,7 +222,7 @@ class CmdTestCase(TestCase, LoaderModuleMockMixin):
             self.assertDictEqual(cmd.call(name, func), ret)
 
             flag = False
-            comt = ('onlyif execution failed')
+            comt = ('onlyif condition is false')
             ret.update({'comment': '', 'result': False,
                         'changes': {'retval': []}})
             self.assertDictEqual(cmd.call(name, func), ret)
@@ -230,7 +230,7 @@ class CmdTestCase(TestCase, LoaderModuleMockMixin):
             mock = MagicMock(return_value=1)
             with patch.dict(cmd.__salt__, {'cmd.retcode': mock}):
                 with patch.dict(cmd.__opts__, {'test': True}):
-                    comt = ('onlyif execution failed')
+                    comt = ('onlyif condition is false')
                     ret.update({'comment': comt, 'skip_watch': True,
                                 'result': True, 'changes': {}})
                     self.assertDictEqual(cmd.call(name, func, onlyif=''), ret)

--- a/tests/unit/states/test_mac_package.py
+++ b/tests/unit/states/test_mac_package.py
@@ -337,7 +337,7 @@ class MacPackageTestCase(TestCase, LoaderModuleMockMixin):
         '''
         expected = {
             'changes': {},
-            'comment': 'onlyif execution failed',
+            'comment': 'onlyif condition is false',
             'skip_watch': True,
             'result': True,
             'name': '/path/to/file.pkg',
@@ -355,7 +355,7 @@ class MacPackageTestCase(TestCase, LoaderModuleMockMixin):
         '''
         expected = {
             'changes': {},
-            'comment': 'unless execution succeeded',
+            'comment': 'unless condition is true',
             'skip_watch': True,
             'result': True,
             'name': '/path/to/file.pkg',

--- a/tests/unit/states/test_zcbuildout.py
+++ b/tests/unit/states/test_zcbuildout.py
@@ -64,14 +64,14 @@ class BuildoutTestCase(Base):
         ret = buildout.installed(b_dir,
                                  python=self.py_st,
                                  onlyif='/bin/false')
-        self.assertEqual(ret['comment'], '\nonlyif execution failed')
+        self.assertEqual(ret['comment'], '\nonlyif condition is false')
         self.assertEqual(ret['result'], True)
         self.assertTrue('/b' in ret['name'])
         b_dir = os.path.join(self.tdir, 'b')
         ret = buildout.installed(b_dir,
                                  python=self.py_st,
                                  unless='/bin/true')
-        self.assertEqual(ret['comment'], '\nunless execution succeeded')
+        self.assertEqual(ret['comment'], '\nunless condition is true')
         self.assertEqual(ret['result'], True)
         self.assertTrue('/b' in ret['name'])
         ret = buildout.installed(b_dir, python=self.py_st)


### PR DESCRIPTION
### What does this PR do?

Elide terminology _execution failed/succeeded_ since the result of these conditions does not indicate a failure in state execution. Instead simply report the result of each condition.

### Previous Behavior

    [INFO    ] Executing command 'test -e /pg_data/10/recovery.conf' as user 'postgres' in directory '/var/lib/pgsql'
    [INFO    ] onlyif execution failed

### New Behavior

    [INFO    ] Executing command 'test -e /pg_data/10/recovery.conf' as user 'postgres' in directory '/var/lib/pgsql'
    [INFO    ] onlyif condition is false

### Tests written?

Existing tests cover this

### Commits signed with GPG?

Yes