### PR TITLE
fixes issue #44272

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -444,8 +444,9 @@ def stop(name):
     try:
         win32serviceutil.StopService(name)
     except pywintypes.error as exc:
-        raise CommandExecutionError(
-            'Failed To Stop {0}: {1}'.format(name, exc[2]))
+        if exc[0] != 1062:
+            raise CommandExecutionError(
+                'Failed To Stop {0}: {1}'.format(name, exc[2]))
 
     attempts = 0
     while info(name)['Status'] in ['Running', 'Stop Pending'] \


### PR DESCRIPTION
The method stop() in the state module win_service fails if the service has already been stopped.

### What does this PR do?

checks if the exception thrown by win32serviceutil.StopService() has the number 1062, which means ERROR_SERVICE_NOT_ACTIVE because the service has already been stopped by invoking "net stop" earlier in this method.

### What issues does this PR fix or reference?

fixes issue #44272 

### Previous Behavior

Exception thrown although service was stopped.

### New Behavior

No Exception thrown

### Tests written?

No

### Commits signed with GPG?

No, as this was only mentioned in the contributing docs after the git commit.