### PR TITLE
states.cron identifier defaults to name

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -299,7 +299,7 @@ def present(name,
 
     identifier
         Custom-defined identifier for tracking the cron line for future crontab
-        edits. This defaults to the state id
+        edits. This defaults to the state name
 
     special
         A special keyword to specify periodicity (eg. @reboot, @hourly...).
@@ -386,7 +386,7 @@ def absent(name,
 
     identifier
         Custom-defined identifier for tracking the cron line for future crontab
-        edits. This defaults to the state id
+        edits. This defaults to the state name
 
     special
         The special keyword used in the job (eg. @reboot, @hourly...).


### PR DESCRIPTION
It would have been nice if it were the state id, but it's better to fix the documentation than break installations.