### PR TITLE
Add state tests and state request system to salt-ssh

### DIFF
--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -292,7 +292,7 @@ def apply_(mods=None,
 def request(mods=None,
             **kwargs):
     '''
-    .. versionadded:: 2015.5.0
+    .. versionadded:: 2017.7.3
 
     Request that the local admin execute a state run via
     `salt-call state.run_request`
@@ -333,7 +333,7 @@ def request(mods=None,
 
 def check_request(name=None):
     '''
-    .. versionadded:: 2015.5.0
+    .. versionadded:: 2017.7.3
 
     Return the state request information, if any
 
@@ -356,7 +356,7 @@ def check_request(name=None):
 
 def clear_request(name=None):
     '''
-    .. versionadded:: 2015.5.0
+    .. versionadded:: 2017.7.3
 
     Clear out the state execution request without executing it
 
@@ -397,7 +397,7 @@ def clear_request(name=None):
 
 def run_request(name='default', **kwargs):
     '''
-    .. versionadded:: 2015.5.0
+    .. versionadded:: 2017.7.3
 
     Execute the pending state request
 

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -289,6 +289,143 @@ def apply_(mods=None,
     return highstate(**kwargs)
 
 
+def request(mods=None,
+            **kwargs):
+    '''
+    .. versionadded:: 2015.5.0
+
+    Request that the local admin execute a state run via
+    `salt-call state.run_request`
+    All arguments match state.apply
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' state.request
+        salt '*' state.request test
+        salt '*' state.request test,pkgs
+    '''
+    kwargs['test'] = True
+    ret = apply_(mods, **kwargs)
+    notify_path = os.path.join(__opts__['cachedir'], 'req_state.p')
+    serial = salt.payload.Serial(__opts__)
+    req = check_request()
+    req.update({kwargs.get('name', 'default'): {
+            'test_run': ret,
+            'mods': mods,
+            'kwargs': kwargs
+            }
+        })
+    cumask = os.umask(0o77)
+    try:
+        if salt.utils.is_windows():
+            # Make sure cache file isn't read-only
+            __salt__['cmd.run']('attrib -R "{0}"'.format(notify_path))
+        with salt.utils.fopen(notify_path, 'w+b') as fp_:
+            serial.dump(req, fp_)
+    except (IOError, OSError):
+        msg = 'Unable to write state request file {0}. Check permission.'
+        log.error(msg.format(notify_path))
+    os.umask(cumask)
+    return ret
+
+
+def check_request(name=None):
+    '''
+    .. versionadded:: 2015.5.0
+
+    Return the state request information, if any
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' state.check_request
+    '''
+    notify_path = os.path.join(__opts__['cachedir'], 'req_state.p')
+    serial = salt.payload.Serial(__opts__)
+    if os.path.isfile(notify_path):
+        with salt.utils.fopen(notify_path, 'rb') as fp_:
+            req = serial.load(fp_)
+        if name:
+            return req[name]
+        return req
+    return {}
+
+
+def clear_request(name=None):
+    '''
+    .. versionadded:: 2015.5.0
+
+    Clear out the state execution request without executing it
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' state.clear_request
+    '''
+    notify_path = os.path.join(__opts__['cachedir'], 'req_state.p')
+    serial = salt.payload.Serial(__opts__)
+    if not os.path.isfile(notify_path):
+        return True
+    if not name:
+        try:
+            os.remove(notify_path)
+        except (IOError, OSError):
+            pass
+    else:
+        req = check_request()
+        if name in req:
+            req.pop(name)
+        else:
+            return False
+        cumask = os.umask(0o77)
+        try:
+            if salt.utils.is_windows():
+                # Make sure cache file isn't read-only
+                __salt__['cmd.run']('attrib -R "{0}"'.format(notify_path))
+            with salt.utils.fopen(notify_path, 'w+b') as fp_:
+                serial.dump(req, fp_)
+        except (IOError, OSError):
+            msg = 'Unable to write state request file {0}. Check permission.'
+            log.error(msg.format(notify_path))
+        os.umask(cumask)
+    return True
+
+
+def run_request(name='default', **kwargs):
+    '''
+    .. versionadded:: 2015.5.0
+
+    Execute the pending state request
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' state.run_request
+    '''
+    req = check_request()
+    if name not in req:
+        return {}
+    n_req = req[name]
+    if 'mods' not in n_req or 'kwargs' not in n_req:
+        return {}
+    req[name]['kwargs'].update(kwargs)
+    if 'test' in n_req['kwargs']:
+        n_req['kwargs'].pop('test')
+    if req:
+        ret = apply_(n_req['mods'], **n_req['kwargs'])
+        try:
+            os.remove(os.path.join(__opts__['cachedir'], 'req_state.p'))
+        except (IOError, OSError):
+            pass
+        return ret
+    return {}
+
+
 def highstate(test=None, **kwargs):
     '''
     Retrieve the state data from the salt master for this minion and execute it

--- a/tests/integration/files/file/base/ssh_state_tests.sls
+++ b/tests/integration/files/file/base/ssh_state_tests.sls
@@ -1,0 +1,4 @@
+ssh-file-test:
+  file.managed:
+    - name: /tmp/test
+    - contents: 'test'

--- a/tests/integration/ssh/test_state.py
+++ b/tests/integration/ssh/test_state.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+import os
+import shutil
+
+# Import Salt Testing Libs
+from tests.support.case import SSHCase
+
+SSH_SLS = 'ssh_state_tests'
+
+
+class SSHStateTest(SSHCase):
+    '''
+    testing the state system with salt-ssh
+    '''
+    def _check_dict_ret(self, ret, val, exp_ret):
+        for key, value in ret.items():
+            self.assertEqual(value[val], exp_ret)
+
+    def _check_request(self, empty=False):
+        check = self.run_function('state.check_request', wipe=False)
+        if empty:
+            self.assertFalse(bool(check))
+        else:
+            self._check_dict_ret(ret=check['default']['test_run']['local']['return'],
+                       val='__sls__', exp_ret=SSH_SLS)
+
+    def test_state_apply(self):
+        '''
+        test state.apply with salt-ssh
+        '''
+        ret = self.run_function('state.apply', ['ssh_state_tests'])
+        self._check_dict_ret(ret=ret, val='__sls__', exp_ret=SSH_SLS)
+
+        check_file = self.run_function('file.file_exists', ['/tmp/test'], wipe=False)
+        self.assertTrue(check_file)
+
+    def test_state_request_check_clear(self):
+        '''
+        test state.request system with salt-ssh
+        while also checking and clearing request
+        '''
+        request = self.run_function('state.request', [SSH_SLS], wipe=False)
+        self._check_dict_ret(ret=request, val='__sls__', exp_ret=SSH_SLS)
+
+        self._check_request()
+
+        clear = self.run_function('state.clear_request', wipe=False)
+        self._check_request(empty=True)
+
+    def test_state_run_request(self):
+        '''
+        test state.request system with salt-ssh
+        while also checking and clearing request
+        '''
+        request = self.run_function('state.request', [SSH_SLS], wipe=False)
+        self._check_dict_ret(ret=request, val='__sls__', exp_ret=SSH_SLS)
+
+        run = self.run_function('state.run_request', wipe=False)
+
+        check_file = self.run_function('file.file_exists', ['/tmp/test'], wipe=False)
+        self.assertTrue(check_file)
+
+    def tearDown(self):
+        '''
+        make sure to clean up any old ssh directories
+        '''
+        salt_dir = self.run_function('config.get', ['thin_dir'], wipe=False)
+        if os.path.exists(salt_dir):
+            shutil.rmtree(salt_dir)

--- a/tests/integration/ssh/test_state.py
+++ b/tests/integration/ssh/test_state.py
@@ -31,10 +31,10 @@ class SSHStateTest(SSHCase):
         '''
         test state.apply with salt-ssh
         '''
-        ret = self.run_function('state.apply', ['ssh_state_tests'])
+        ret = self.run_function('state.apply', [SSH_SLS])
         self._check_dict_ret(ret=ret, val='__sls__', exp_ret=SSH_SLS)
 
-        check_file = self.run_function('file.file_exists', ['/tmp/test'], wipe=False)
+        check_file = self.run_function('file.file_exists', ['/tmp/test'])
         self.assertTrue(check_file)
 
     def test_state_request_check_clear(self):
@@ -53,7 +53,7 @@ class SSHStateTest(SSHCase):
     def test_state_run_request(self):
         '''
         test state.request system with salt-ssh
-        while also checking and clearing request
+        while also running the request later
         '''
         request = self.run_function('state.request', [SSH_SLS], wipe=False)
         self._check_dict_ret(ret=request, val='__sls__', exp_ret=SSH_SLS)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -175,7 +175,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
     source_code_basedir = SALT_ROOT
 
     def _get_suites(self, include_unit=False, include_cloud_provider=False,
-                    include_proxy=False, include_ssh=False):
+                    include_proxy=False):
         '''
         Return a set of all test suites except unit and cloud provider tests
         unless requested
@@ -187,33 +187,28 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             suites -= set(['cloud_provider'])
         if not include_proxy:
             suites -= set(['proxy'])
-        if not include_ssh:
-            suites -= set(['ssh'])
 
         return suites
 
     def _check_enabled_suites(self, include_unit=False,
-                              include_cloud_provider=False,
-                              include_proxy=False, include_ssh=False):
+                              include_cloud_provider=False, include_proxy=False):
         '''
         Query whether test suites have been enabled
         '''
         suites = self._get_suites(include_unit=include_unit,
                                   include_cloud_provider=include_cloud_provider,
-                                  include_proxy=include_proxy,
-                                  include_ssh=include_ssh)
+                                  include_proxy=include_proxy)
 
         return any([getattr(self.options, suite) for suite in suites])
 
     def _enable_suites(self, include_unit=False, include_cloud_provider=False,
-                       include_proxy=False, include_ssh=False):
+                       include_proxy=False):
         '''
         Enable test suites for current test run
         '''
         suites = self._get_suites(include_unit=include_unit,
                                   include_cloud_provider=include_cloud_provider,
-                                  include_proxy=include_proxy,
-                                  include_ssh=include_ssh)
+                                  include_proxy=include_proxy)
 
         for suite in suites:
             setattr(self.options, suite, True)
@@ -481,8 +476,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
         if not self.options.name and not \
                 self._check_enabled_suites(include_unit=True,
                                            include_cloud_provider=True,
-                                           include_proxy=True,
-                                           include_ssh=True):
+                                           include_proxy=True):
             self._enable_suites(include_unit=True)
 
         self.start_coverage(
@@ -671,8 +665,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
 
         status = []
         # Return an empty status if no tests have been enabled
-        if not self._check_enabled_suites(include_cloud_provider=True,
-                                          include_proxy=True, include_ssh=True) and not self.options.name:
+        if not self._check_enabled_suites(include_cloud_provider=True, include_proxy=True) and not self.options.name:
             return status
 
         with TestDaemon(self):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -130,8 +130,8 @@ TEST_SUITES = {
     'returners':
         {'display_name': 'Returners',
          'path': 'integration/returners'},
-    'ssh':
-        {'display_name': 'SSH',
+    'ssh-int':
+        {'display_name': 'SSH Integration',
          'path': 'integration/ssh'},
     'spm':
         {'display_name': 'SPM',
@@ -414,6 +414,14 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             help='Run salt-ssh tests. These tests will spin up a temporary '
                  'SSH server on your machine. In certain environments, this '
                  'may be insecure! Default: False'
+        )
+        self.test_selection_group.add_option(
+            '--ssh-int',
+            dest='ssh-int',
+            action='store_true',
+            default=False,
+            help='Run salt-ssh integration tests. Requires to be run with --ssh'
+                 'to spin up the SSH server on your machine.'
         )
         self.test_selection_group.add_option(
             '-A',

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -130,6 +130,9 @@ TEST_SUITES = {
     'returners':
         {'display_name': 'Returners',
          'path': 'integration/returners'},
+    'ssh':
+        {'display_name': 'SSH',
+         'path': 'integration/ssh'},
     'spm':
         {'display_name': 'SPM',
          'path': 'integration/spm'},
@@ -172,7 +175,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
     source_code_basedir = SALT_ROOT
 
     def _get_suites(self, include_unit=False, include_cloud_provider=False,
-                    include_proxy=False):
+                    include_proxy=False, include_ssh=False):
         '''
         Return a set of all test suites except unit and cloud provider tests
         unless requested
@@ -184,28 +187,33 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             suites -= set(['cloud_provider'])
         if not include_proxy:
             suites -= set(['proxy'])
+        if not include_ssh:
+            suites -= set(['ssh'])
 
         return suites
 
     def _check_enabled_suites(self, include_unit=False,
-                              include_cloud_provider=False, include_proxy=False):
+                              include_cloud_provider=False,
+                              include_proxy=False, include_ssh=False):
         '''
         Query whether test suites have been enabled
         '''
         suites = self._get_suites(include_unit=include_unit,
                                   include_cloud_provider=include_cloud_provider,
-                                  include_proxy=include_proxy)
+                                  include_proxy=include_proxy,
+                                  include_ssh=include_ssh)
 
         return any([getattr(self.options, suite) for suite in suites])
 
     def _enable_suites(self, include_unit=False, include_cloud_provider=False,
-                       include_proxy=False):
+                       include_proxy=False, include_ssh=False):
         '''
         Enable test suites for current test run
         '''
         suites = self._get_suites(include_unit=include_unit,
                                   include_cloud_provider=include_cloud_provider,
-                                  include_proxy=include_proxy)
+                                  include_proxy=include_proxy,
+                                  include_ssh=include_ssh)
 
         for suite in suites:
             setattr(self.options, suite, True)
@@ -473,7 +481,8 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
         if not self.options.name and not \
                 self._check_enabled_suites(include_unit=True,
                                            include_cloud_provider=True,
-                                           include_proxy=True):
+                                           include_proxy=True,
+                                           include_ssh=True):
             self._enable_suites(include_unit=True)
 
         self.start_coverage(
@@ -662,7 +671,8 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
 
         status = []
         # Return an empty status if no tests have been enabled
-        if not self._check_enabled_suites(include_cloud_provider=True, include_proxy=True) and not self.options.name:
+        if not self._check_enabled_suites(include_cloud_provider=True,
+                                          include_proxy=True, include_ssh=True) and not self.options.name:
             return status
 
         with TestDaemon(self):

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -124,11 +124,13 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         arg_str = '-c {0} {1}'.format(self.get_config_dir(), arg_str)
         return self.run_script('salt', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr)
 
-    def run_ssh(self, arg_str, with_retcode=False, timeout=25, catch_stderr=False):
+    def run_ssh(self, arg_str, with_retcode=False, timeout=25,
+                catch_stderr=False, wipe=False):
         '''
         Execute salt-ssh
         '''
-        arg_str = '-c {0} -i --priv {1} --roster-file {2} localhost {3} --out=json'.format(
+        arg_str = '{0} -c {1} -i --priv {2} --roster-file {3} localhost {4} --out=json'.format(
+            ' -W' if wipe else '',
             self.get_config_dir(),
             os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'key_test'),
             os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'roster'),

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -453,11 +453,13 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
                                catch_stderr=catch_stderr,
                                timeout=timeout)
 
-    def run_ssh(self, arg_str, with_retcode=False, catch_stderr=False, timeout=60):  # pylint: disable=W0221
+    def run_ssh(self, arg_str, with_retcode=False, catch_stderr=False,
+                timeout=60, wipe=True):  # pylint: disable=W0221
         '''
         Execute salt-ssh
         '''
-        arg_str = '-ldebug -W -c {0} -i --priv {1} --roster-file {2} --out=json localhost {3}'.format(
+        arg_str = '-ldebug{0} -c {1} -i --priv {2} --roster-file {3} --out=json localhost {4}'.format(
+            ' -W' if wipe else '',
             self.get_config_dir(),
             os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'key_test'),
             os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'roster'),
@@ -797,11 +799,12 @@ class SSHCase(ShellCase):
     def _arg_str(self, function, arg):
         return '{0} {1}'.format(function, ' '.join(arg))
 
-    def run_function(self, function, arg=(), timeout=90, **kwargs):
+    def run_function(self, function, arg=(), timeout=90, wipe=True, **kwargs):
         '''
         We use a 90s timeout here, which some slower systems do end up needing
         '''
-        ret = self.run_ssh(self._arg_str(function, arg), timeout=timeout)
+        ret = self.run_ssh(self._arg_str(function, arg), timeout=timeout,
+                           wipe=wipe)
         try:
             return json.loads(ret)['localhost']
         except Exception:


### PR DESCRIPTION
### What does this PR do?
Adds the following functions to salt-ssh:
- `state.request`
- `state.check_request`
- `state.run_request`
- `state.clear_request`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/43629
https://github.com/saltstack/salt/issues/43628
https://github.com/saltstack/salt/issues/43630

### Previous Behavior
the functions listed above would try to look for state files in the local file_roots system. Moving these functions here allows salt-ssh to push the correct files when starting the command.

### Tests written?

Yes

### Commits signed with GPG?

Yes
