### PR TITLE
Fix file.line diff formatting.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1856,10 +1856,8 @@ def line(path, content, match=None, mode=None, location=None,
     if changed:
         if show_changes:
             with salt.utils.fopen(path, 'r') as fp_:
-                path_content = _splitlines_preserving_trailing_newline(
-                    fp_.read())
-            changes_diff = ''.join(difflib.unified_diff(
-                path_content, _splitlines_preserving_trailing_newline(body)))
+                path_content = fp_.read().splitlines(True)
+            changes_diff = ''.join(difflib.unified_diff(path_content, body.splitlines(True)))
         if __opts__['test'] is False:
             fh_ = None
             try:

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1861,7 +1861,9 @@ def line(path, content, match=None, mode=None, location=None,
         if __opts__['test'] is False:
             fh_ = None
             try:
-                fh_ = salt.utils.atomicfile.atomic_open(path, 'w')
+                # Make sure we match the file mode from salt.utils.fopen
+                mode = 'wb' if six.PY2 and salt.utils.is_windows() else 'w'
+                fh_ = salt.utils.atomicfile.atomic_open(path, mode)
                 fh_.write(body)
             finally:
                 if fh_:

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -67,7 +67,7 @@ from salt.modules.file import (check_hash,  # pylint: disable=W0611
         lstat, path_exists_glob, write, pardir, join, HASHES, HASHES_REVMAP,
         comment, uncomment, _add_flags, comment_line, _regex_to_static,
         _get_line_indent, apply_template_on_contents, dirname, basename,
-        list_backups_dir)
+        list_backups_dir, _assert_occurrence, _starts_till)
 from salt.modules.file import normpath as normpath_
 
 from salt.utils import namespaced_function as _namespaced_function
@@ -98,7 +98,7 @@ def __virtual__():
             global write, pardir, join, _add_flags, apply_template_on_contents
             global path_exists_glob, comment, uncomment, _mkstemp_copy
             global _regex_to_static, _get_line_indent, dirname, basename
-            global list_backups_dir, normpath_
+            global list_backups_dir, normpath_, _assert_occurrence, _starts_till
 
             replace = _namespaced_function(replace, globals())
             search = _namespaced_function(search, globals())
@@ -165,6 +165,8 @@ def __virtual__():
             basename = _namespaced_function(basename, globals())
             list_backups_dir = _namespaced_function(list_backups_dir, globals())
             normpath_ = _namespaced_function(normpath_, globals())
+            _assert_occurrence = _namespaced_function(_assert_occurrence, globals())
+            _starts_till = _namespaced_function(_starts_till, globals())
 
             return __virtualname__
     return (False, "Module win_file: module only works on Windows systems")

--- a/tests/integration/modules/file.py
+++ b/tests/integration/modules/file.py
@@ -33,6 +33,7 @@ import integration
 import salt.utils
 from salt.modules import file as filemod
 
+
 def symlink(source, link_name):
     '''
     Handle symlinks on Windows with Python < 3.2

--- a/tests/integration/modules/file.py
+++ b/tests/integration/modules/file.py
@@ -301,7 +301,7 @@ class FileModuleTest(integration.ModuleCase):
         '''
         ret = self.minion_run('file.line', self.myfile, 'Goodbye',
                               mode='insert', after='Hello')
-        self.assertIn('Hello\n+Goodbye', ret)
+        self.assertIn('Hello' + os.linesep + '+Goodbye', ret)
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/integration/modules/file.py
+++ b/tests/integration/modules/file.py
@@ -323,6 +323,13 @@ class FileModuleTest(integration.ModuleCase):
                               mode='insert', after='Hello')
         self.assertIn('Hello' + os.linesep + '+Goodbye', ret)
 
+    def test_file_line_content(self):
+        self.minion_run('file.line', self.myfile, 'Goodbye',
+                        mode='insert', after='Hello')
+        with salt.utils.fopen(self.myfile, 'r') as fp:
+            content = fp.read()
+        self.assertEqual(content, 'Hello' + os.linesep + 'Goodbye' + os.linesep)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(FileModuleTest)

--- a/tests/integration/modules/file.py
+++ b/tests/integration/modules/file.py
@@ -293,6 +293,16 @@ class FileModuleTest(integration.ModuleCase):
         else:
             self.assertItemsEqual(ret, ['file://' + self.myfile, 'filehash'])
 
+    def test_file_line_changes_format(self):
+        '''
+        Test file.line changes output formatting.
+
+        Issue #41474
+        '''
+        ret = self.minion_run('file.line', self.myfile, 'Goodbye',
+                              mode='insert', after='Hello')
+        self.assertIn('Hello\n+Goodbye', ret)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(FileModuleTest)


### PR DESCRIPTION
### What does this PR do?

Fix file.line diff formatting.

Using _splitlines_preserving_trailing_newline() strips off line endings, mangling the unified_diff output. Switching to splitlines with the keepends option resolves this issue, while still preserving trailing newline.

### What issues does this PR fix or reference?

Fixes #41474

### Previous Behavior
Changes diff displays compressed output on a single line.

```
Changes:
         ----------
         diff:
             ---
             +++
             @@ -1,4 +1,5 @@
              egg bacon+sausage spam
```

### New Behavior
Changes diff displays multiline output.

```
Changes:
         ----------
         diff:
             ---
             +++
             @@ -1,3 +1,4 @@
              egg
              bacon
             +sausage
              spam
```

### Tests written?

Yes

### Commits signed with GPG?

Yes