### PR TITLE
Remove leading dash from options in archive.tar docs (2015.8/2016.3/2016.11)

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -89,14 +89,14 @@ def tar(options, tarfile, sources=None, dest=None,
 
         .. code-block:: bash
 
-            salt '*' archive.tar -cjvf /tmp/salt.tar.bz2 {{grains.saltpath}} template=jinja
+            salt '*' archive.tar cjvf /tmp/salt.tar.bz2 {{grains.saltpath}} template=jinja
 
     CLI Examples:
 
     .. code-block:: bash
 
         # Create a tarfile
-        salt '*' archive.tar -cjvf /tmp/tarfile.tar.bz2 /tmp/file_1,/tmp/file_2
+        salt '*' archive.tar cjvf /tmp/tarfile.tar.bz2 /tmp/file_1,/tmp/file_2
         # Unpack a tarfile
         salt '*' archive.tar xf foo.tar dest=/target/directory
     '''


### PR DESCRIPTION
### What does this PR do?

Fixes #44336 for branches 2015.8, 2016.3, and 2016.11.
