### PR TITLE
update salt-jenkins repo to 2017.7

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,7 +32,7 @@ provisioner:
   require_chef: false
   remote_states:
     name: git://github.com/gtmanfred/salt-jenkins.git
-    branch: 2016.11
+    branch: 2017.7
     repo: git
     testingdir: /testing
   salt_copy_filter:


### PR DESCRIPTION
### What does this PR do?
We need the 2017.7 branch of salt-jenkins for these tests

When this gets merged forward to develop, we need to change it to master.