### PR TITLE
Kubernetes client certificate file usage fix

### DIFF
--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -164,7 +164,7 @@ def _setup_conn(**kwargs):
 
     if client_key_file:
         kubernetes.client.configuration.key_file = client_key_file
-    if client_key:
+    elif client_key:
         with tempfile.NamedTemporaryFile(prefix='salt-kube-', delete=False) as k:
             k.write(base64.b64decode(client_key))
             kubernetes.client.configuration.key_file = k.name


### PR DESCRIPTION
### What does this PR do?
The Kubernetes module can deal with either client certificate paths or embedded data. 
Due to a small logic error the former accidentally gets emptied if the latter doesn't exist.

Without embedding the certificate data in `kubernetes.client-cert`, certificate authentication is therefore broken.
