### PR TITLE
Check if tagSet exists in the subnet, and skip it if it is missing to prevent keyErrors

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1129,15 +1129,17 @@ def _get_subnetname_id(subnetname):
     params = {'Action': 'DescribeSubnets'}
     for subnet in aws.query(params, location=get_location(),
                provider=get_provider(), opts=__opts__, sigver='4'):
-        tags = subnet.get('tagSet', {}).get('item', {})
-        if not isinstance(tags, list):
-            tags = [tags]
-        for tag in tags:
-            if tag['key'] == 'Name' and tag['value'] == subnetname:
-                log.debug('AWS Subnet ID of {0} is {1}'.format(
-                                        subnetname, subnet['subnetId'] )
-                )
-                return subnet['subnetId']
+        if "tagSet" in subnet:
+            tags = subnet.get('tagSet', {}).get('item', {})
+            if not isinstance(tags, list):
+                tags = [tags]
+            for tag in tags:
+                if tag['key'] == 'Name' and tag['value'] == subnetname:
+                    log.debug('AWS Subnet ID of {0} is {1}'.format(
+                        subnetname,
+                        subnet['subnetId'])
+                    )
+                    return subnet['subnetId']
     return None
 
 def get_subnetid(vm_):


### PR DESCRIPTION
### What does this PR do?
Fixes a fatal KeyError when converting AWS subnetname to subnetid.

### What issues does this PR fix or reference?

#44330 

### Previous Behavior
Throws a KeyError if a subnet in the for loop has no tagSet and therefore no 'key' to check.

### New Behavior
Skips the subnet completely if there are no tags.

### Tests written?
No

### Commits signed with GPG?
No