### PR TITLE
fix a bug of setting default encoding on windows minion with cp936 as…

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1349,7 +1349,7 @@ def fopen(*args, **kwargs):
             if 'b' in kwargs['mode']:
                 binary = True
         if not binary:
-            kwargs['encoding'] = __salt_system_encoding__
+            kwargs['encoding'] = 'utf-8'
 
     if six.PY3 and not binary and not kwargs.get('newline', None):
         kwargs['newline'] = ''


### PR DESCRIPTION
### What does this PR do?
fix bug
### What issues does this PR fix or reference?
fix a bug when run salt '*' pkg.refresh_db on windows minion with cp936 encoding
### Previous Behavior
 run the following command on master : salt '*' pkg.refresh_db
will result following error when the minion is a windows minion with cp936 encoding:
 ERROR: Error occurred while generating repo db. Additional info follows:
    
    failed:
        1
    failed_list:
        ----------
        salt-winrepo-ng\skype-msi.sls:
            - Failed to read 'salt-winrepo-ng\skype-msi.sls': 'gbk' codec can't decode byte 0xa2 in position 48: illegal multibyte sequence
    success:
        238
    total:
        239

### New Behavior
salt '*' pkg.refresh_db
----------
    failed:
        0
    success:
        239
    total:
        239
### Tests written?

No

### Commits signed with GPG?

Yes


