### PR TITLE
Do not assume fallback language in win_lgpo module

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -86,6 +86,7 @@ TEXT_ELEMENT_XPATH = None
 try:
     import win32net
     import win32security
+    import wmi
     import uuid
     import codecs
     import lxml
@@ -2706,7 +2707,10 @@ def _processPolicyDefinitions(policy_def_path='c:\\Windows\\PolicyDefinitions',
     helper function to process all ADMX files in the specified policy_def_path
     and build a single XML doc that we can search/use for ADMX policy processing
     '''
-    display_language_fallback = 'en-US'
+    wmi_c = wmi.WMI()
+    query = "SELECT MUILanguages FROM Win32_OperatingSystem"
+    display_language_fallback = wmi_c.query(query)[0].MUILanguages[0]
+
     t_policy_definitions = lxml.etree.Element('policyDefinitions')
     t_policy_definitions.append(lxml.etree.Element('categories'))
     t_policy_definitions.append(lxml.etree.Element('policies'))


### PR DESCRIPTION
### What does this PR do?
Instead of hardcoding the fallback language for the templates to "en-US", this PR gets the installed languages via WMI, and picks one of the language as fallback language.

This allows one to use the same GPO settings for any machine without explicitly setting the language:

```
Workstation policy:
    lgpo.set:
        - user_policy:
            CPL_Personalization_EnableScreenSaver: Enabled
            CPL_Personalization_ScreenSaverIsSecure: Enabled
            CPL_Personalization_ScreenSaverTimeOut: 
              ScreenSaverTimeOutFreqSpin: 900
            CPL_Personalization_SetScreenSaver: 
              ScreenSaverFilename: "%WINDIR%\\system32\\rundll32.exe user32.dll,LockWorkStation"
```

### What issues does this PR fix or reference?
/

### Previous Behavior
The fallback language was set to en-US.

### New Behavior
The fallback language is set to one of the installed languages.

### Tests written?
No

### Commits signed with GPG?
Yes