### PR TITLE
debian_ip: don't lowercase iface name

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1772,7 +1772,6 @@ def build_routes(iface, **settings):
         salt '*' ip.build_routes eth0 <settings>
     '''
 
-    iface = iface.lower()
     opts = _parse_routes(iface, settings)
     try:
         template = JINJA.get_template('route_eth.jinja')

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1703,7 +1703,6 @@ def build_interface(iface, iface_type, enabled, **settings):
         salt '*' ip.build_interface eth0 eth <settings>
     '''
 
-    iface = iface.lower()
     iface_type = iface_type.lower()
 
     if iface_type not in _IFACE_TYPES:

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -1079,7 +1079,6 @@ def build_routes(iface, **settings):
         pass
     log.debug('Template name: ' + template)
 
-    iface = iface.lower()
     opts = _parse_routes(iface, settings)
     log.debug("Opts: \n {0}".format(opts))
     try:


### PR DESCRIPTION
AArch64, ppc64 and ppc64le have network interfaces with uppercase
characters in their names, e.g. enP5p144s0.

PR #39103 ("fixes #31393 don't convert the iface to lower case")
fixed this issue, but only for RHEL systems. The same change is
required on Debian systems as well.

### What does this PR do?

This fixes an issue where ppc64 and ppc64le machines have interfaces that have uppercase letters in the device names, this time for Debian systems.

What issues does this PR fix or reference?

### What issues does this PR fix or reference?
This fixes #31393 on Debian systems as well

### Previous Behavior
Interface names are converted to lowercase (enP5p144s0 => enp5p144s0).

### New Behavior
Interface names are left unchanged (enP5p144s0 => enP5p144s0).

### Tests written?
No

### Commits signed with GPG?
Yes