### PR TITLE
Emit stopping/starting events when "salt-cloud -a stop/start" is used.

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2925,6 +2925,15 @@ def stop(name, call=None):
 
     instance_id = _get_node(name)['instanceId']
 
+    __utils__['cloud.fire_event'](
+        'event',
+        'stopping instance',
+        'salt/cloud/{0}/stopping'.format(name),
+        args={'name': name, 'instance_id': instance_id},
+        sock_dir=__opts__['sock_dir'],
+        transport=__opts__['transport']
+    )
+
     params = {'Action': 'StopInstances',
               'InstanceId.1': instance_id}
     result = aws.query(params,
@@ -2948,6 +2957,15 @@ def start(name, call=None):
     log.info('Starting node {0}'.format(name))
 
     instance_id = _get_node(name)['instanceId']
+
+    __utils__['cloud.fire_event'](
+        'event',
+        'starting instance',
+        'salt/cloud/{0}/starting'.format(name),
+        args={'name': name, 'instance_id': instance_id},
+        sock_dir=__opts__['sock_dir'],
+        transport=__opts__['transport']
+    )
 
     params = {'Action': 'StartInstances',
               'InstanceId.1': instance_id}


### PR DESCRIPTION
### What does this PR do?

salt-cloud emits numerous events when instances are created, configured and destroyed, but not when they are stopped or started.

New events were added using code from "destroy" method, so they follow the same naming pattern and have same attributes.

### What issues does this PR fix or reference?

### Previous Behavior

No events are fired when stop/start is used.

### New Behavior

New events will be seen on the event bus, for example:

```
salt/cloud/my-server.example.com/stopping {
    "_stamp": "2017-11-01T21:16:39.772554",
    "event": "stopping instance",
    "instance_id": "i-17517664499b5503a",
    "name": "my-server.example.com"
}
```

### Tests written?

No

### Commits signed with GPG?

Yes