### PR TITLE
Implement swap_total grain on OpenBSD

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -449,10 +449,15 @@ def _bsd_memdata(osdata):
     sysctl = salt.utils.path.which('sysctl')
     if sysctl:
         mem = __salt__['cmd.run']('{0} -n hw.physmem'.format(sysctl))
-        swap_total = __salt__['cmd.run']('{0} -n vm.swap_total'.format(sysctl))
         if osdata['kernel'] == 'NetBSD' and mem.startswith('-'):
             mem = __salt__['cmd.run']('{0} -n hw.physmem64'.format(sysctl))
         grains['mem_total'] = int(mem) // 1024 // 1024
+
+        if osdata['kernel'] == 'OpenBSD':
+            swapctl = salt.utils.path.which('swapctl')
+            swap_total = __salt__['cmd.run']('{0} -sk'.format(swapctl)).split(' ')[1]
+        else:
+            swap_total = __salt__['cmd.run']('{0} -n vm.swap_total'.format(sysctl))
         grains['swap_total'] = int(swap_total) // 1024 // 1024
     return grains
 

--- a/tests/integration/grains/test_core.py
+++ b/tests/integration/grains/test_core.py
@@ -19,6 +19,10 @@ if salt.utils.platform.is_windows():
         pass
 
 
+def _freebsd_or_openbsd():
+    return salt.utils.platform.is_freebsd() or salt.utils.platform.is_openbsd()
+
+
 class TestGrainsCore(ModuleCase):
     '''
     Test the core grains grains
@@ -28,7 +32,6 @@ class TestGrainsCore(ModuleCase):
         '''
         test grains['cpu_model']
         '''
-        opts = self.minion_opts
         cpu_model_text = salt.modules.reg.read_value(
                 'HKEY_LOCAL_MACHINE',
                 'HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0',
@@ -36,4 +39,26 @@ class TestGrainsCore(ModuleCase):
         self.assertEqual(
             self.run_function('grains.items')['cpu_model'],
             cpu_model_text
+        )
+
+    @skipIf(not _freebsd_or_openbsd(), 'Only run on FreeBSD or OpenBSD')
+    def test_freebsd_openbsd_mem_total(self):
+        '''
+        test grains['mem_total']
+        '''
+        physmem = self.run_function('sysctl.get', ['hw.physmem'])
+        self.assertEqual(
+            self.run_function('grains.items')['mem_total'],
+            int(physmem) / 1048576
+        )
+
+    @skipIf(not salt.utils.platform.is_openbsd(), 'Only run on OpenBSD')
+    def test_openbsd_swap_total(self):
+        '''
+        test grains['swap_total']
+        '''
+        swapmem = self.run_function('cmd.run', ['swapctl -sk']).split(' ')[1]
+        self.assertEqual(
+            self.run_function('grains.items')['swap_total'],
+            int(swapmem) / 1048576
         )


### PR DESCRIPTION
### What does this PR do?

Fix method of populating the swap_total grain on OpenBSD.

### Previous Behavior

(on OpenBSD)

    (saltenv) $ doas salt-call --local grains.get swap_total
    [ERROR   ] An un-handled exception was caught by salt's global exception handler:
    ...
    Traceback (most recent call last):
    ...
      File "/home/eradman/local/saltenv/lib/python2.7/site-packages/salt/grains/core.py", line 456, in _bsd_memdata
        grains['swap_total'] = int(swap_total) // 1024 // 1024
    ValueError: invalid literal for int() with base 10: 'sysctl: second level name swap_total in vm.swap_total is invalid'

### New Behavior

    (saltenv) $ doas salt-call --local grains.get swap_total
    local:
        8058

### Tests written?

No, manually tested on OpenBSD 6.2 and FreeBSD 11

### Commits signed with GPG?

Yes
