### PR TITLE
Vagrant and saltify cloud minor revisions

### DIFF
--- a/doc/topics/cloud/vagrant.rst
+++ b/doc/topics/cloud/vagrant.rst
@@ -99,7 +99,8 @@ Profile configuration example:
       # vagrant_up_timeout: 300 # (seconds) timeout for cmd.run of the "vagrant up" command
       # vagrant_provider: '' # option for "vagrant up" like: "--provider vmware_fusion"
       # ssh_host: None  # "None" means try to find the routable IP address from "ifconfig"
-      # target_network: None  # Expected CIDR address of your bridged network
+      # ssh_username: '' # also required when ssh_host is used.
+      # target_network: None  # Expected CIDR address range of your bridged network
       # force_minion_config: false  # Set "true" to re-purpose an existing VM
 
 The machine can now be created and configured with the following command:

--- a/salt/cloud/clouds/saltify.py
+++ b/salt/cloud/clouds/saltify.py
@@ -258,19 +258,30 @@ def create(vm_):
         wol_host = config.get_cloud_config_value(
             'wol_sender_node', vm_, __opts__, default='')
         if wol_mac and wol_host:
-            log.info('sending wake-on-lan to %s using node %s',
-                     wol_mac, wol_host)
-            local = salt.client.LocalClient()
-            if isinstance(wol_mac, six.string_types):
-                wol_mac = [wol_mac]  # a smart user may have passed more params
-            ret = local.cmd(wol_host, 'network.wol', wol_mac)
-            log.info('network.wol returned value %s', ret)
-            if ret and ret[wol_host]:
-                sleep_time = config.get_cloud_config_value(
-                    'wol_boot_wait', vm_, __opts__, default=30)
-                if sleep_time > 0.0:
-                    log.info('delaying %d seconds for boot', sleep_time)
-                    time.sleep(sleep_time)
+            good_ping = False
+            ssh_host = config.get_cloud_config_value(
+                'ssh_host', vm_, __opts__, default='')
+            if ssh_host:
+                log.info('trying to ping %s', ssh_host)
+                count = 'n' if salt.utils.platform.is_windows() else 'c'
+                cmd = 'ping -{} 1 {}'.format(count, ssh_host)
+                good_ping = __salt__['cmd.retcode'](cmd) == 0
+            if good_ping:
+                log.info('successful ping.')
+            else:
+                log.info('sending wake-on-lan to %s using node %s',
+                         wol_mac, wol_host)
+                local = salt.client.LocalClient()
+                if isinstance(wol_mac, six.string_types):
+                    wol_mac = [wol_mac]  # a smart user may have passed more params
+                ret = local.cmd(wol_host, 'network.wol', wol_mac)
+                log.info('network.wol returned value %s', ret)
+                if ret and ret[wol_host]:
+                    sleep_time = config.get_cloud_config_value(
+                        'wol_boot_wait', vm_, __opts__, default=30)
+                    if sleep_time > 0.0:
+                        log.info('delaying %d seconds for boot', sleep_time)
+                        time.sleep(sleep_time)
         log.info('Provisioning existing machine %s', vm_['name'])
         ret = __utils__['cloud.bootstrap'](vm_, __opts__)
     else:

--- a/salt/cloud/clouds/vagrant.py
+++ b/salt/cloud/clouds/vagrant.py
@@ -287,29 +287,32 @@ def destroy(name, call=None):
         transport=opts['transport']
     )
     my_info = _get_my_info(name)
-    profile_name = my_info[name]['profile']
-    profile = opts['profiles'][profile_name]
-    host = profile['host']
-    local = salt.client.LocalClient()
-    ret = local.cmd(host, 'vagrant.destroy', [name])
+    if my_info:
+        profile_name = my_info[name]['profile']
+        profile = opts['profiles'][profile_name]
+        host = profile['host']
+        local = salt.client.LocalClient()
+        ret = local.cmd(host, 'vagrant.destroy', [name])
 
-    if ret[host]:
-        __utils__['cloud.fire_event'](
-            'event',
-            'destroyed instance',
-            'salt/cloud/{0}/destroyed'.format(name),
-            args={'name': name},
-            sock_dir=opts['sock_dir'],
-            transport=opts['transport']
-        )
+        if ret[host]:
+            __utils__['cloud.fire_event'](
+                'event',
+                'destroyed instance',
+                'salt/cloud/{0}/destroyed'.format(name),
+                args={'name': name},
+                sock_dir=opts['sock_dir'],
+                transport=opts['transport']
+            )
 
-        if opts.get('update_cachedir', False) is True:
-            __utils__['cloud.delete_minion_cachedir'](
-                name, __active_provider_name__.split(':')[0], opts)
+            if opts.get('update_cachedir', False) is True:
+                __utils__['cloud.delete_minion_cachedir'](
+                    name, __active_provider_name__.split(':')[0], opts)
 
-        return {'Destroyed': '{0} was destroyed.'.format(name)}
+            return {'Destroyed': '{0} was destroyed.'.format(name)}
+        else:
+            return {'Error': 'Error destroying {}'.format(name)}
     else:
-        return {'Error': 'Error destroying {}'.format(name)}
+        return {'Error': 'No response from {}. Cannot destroy.'.format(name)}
 
 
 # noinspection PyTypeChecker


### PR DESCRIPTION
### What does this PR do?

This PR updates two different salt-cloud drivers, both of which are updates to my code. I hope that is okay.

- Add a line to the  vagrant cloud documentation stating that ssh_username is required when ssh_host is defined.

- Adds an optimization to the saltify Wake-on-Lan option so that it attempts to ping the target machine before sending the wake-on-lan.  This skips over the time that it would wait for the machine to boot up before deploying Salt to it.  In other words: when re-deploying to a machine which is already running, do not wait for it to boot up.

- Catches errors to give better user-friendly messages when ssh connections to Vagrant boxes do not work as expected (usually due to errors in the definitions).

### What issues does this PR fix or reference?

None

### Tests written?

No - existing tests do not cover these use cases.

### Commits signed with GPG?

Yes
