### PR TITLE
use KillMode=process for salt-minion.service

### DIFF
--- a/pkg/deb/salt-minion.service
+++ b/pkg/deb/salt-minion.service
@@ -4,6 +4,7 @@ After=network.target salt-master.service
 
 [Service]
 Type=notify
+KillMode=process
 NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion

--- a/pkg/salt-minion.service
+++ b/pkg/salt-minion.service
@@ -4,6 +4,7 @@ Documentation=man:salt-minion(1) file:///usr/share/doc/salt/html/contents.html h
 After=network.target salt-master.service
 
 [Service]
+KillMode=process
 Type=notify
 NotifyAccess=all
 LimitNOFILE=8192


### PR DESCRIPTION
### What does this PR do?
Set KillMode=process  for salt-minion systemd service. 

### What issues does this PR fix or reference?
With KillMode=process systemd will not kill all process in same group. (default is KillMode=control-group, man 5 systemd.kill )
That allow shutdown(upgrade) salt-minion without side effects.

### Previous Behavior
Systemd kill all processes in same group. 

### New Behavior
only the main process itself is killed.

### Tests written?
No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
