### PR TITLE
Fix doc typo in docker_container/read_only

### DIFF
--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -300,7 +300,7 @@ def running(name,
           Additionally, the specified selinux context will be set within the
           container.
 
-        ``<read_only>`` can be either ``ro`` for read-write access, or ``ro``
+        ``<read_only>`` can be either ``rw`` for read-write access, or ``ro``
         for read-only access. When omitted, it is assumed to be read-write.
 
         ``<selinux_context>`` can be ``z`` if the volume is shared between


### PR DESCRIPTION
Minor documentation fix for state module docker_container

### What does this PR do?
Following the examples, the <read_only> parameter should be 'rw' instead of 'ro' for read-write access. This pull request changes the docs accordingly.

### What issues does this PR fix or reference?
none

### Tests written?

No

### Commits signed with GPG?

No

