### PR TITLE
Fix typo in win_lgpo module

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5374,7 +5374,7 @@ def set_(computer_policy=None, user_policy=None,
                                     _regedits[regedit]['policy']['Registry']['Type'])
                         else:
                             _ret = __salt__['reg.delete_value'](
-                                    _regedits[regedit]['polic']['Registry']['Hive'],
+                                    _regedits[regedit]['policy']['Registry']['Hive'],
                                     _regedits[regedit]['policy']['Registry']['Path'],
                                     _regedits[regedit]['policy']['Registry']['Value'])
                         if not _ret:


### PR DESCRIPTION
Correct a typo in the win_lgpo module where policy was incorrectly spelled as 'polic'

### What does this PR do?
Fixes a typo in the win_lgpo module

### What issues does this PR fix or reference?
#44432 
### Previous Behavior
Exception occurs and the policy is not set 

### New Behavior
The registry entry is deleted successfully

### Tests written?

No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
