### PR TITLE
 Adapt napalm modules to the new library structure

### DIFF
--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -16,9 +16,21 @@ Dependencies
 The ``napalm`` proxy module requires NAPALM_ library to be installed:  ``pip install napalm``
 Please check Installation_ for complete details.
 
-.. _NAPALM: https://napalm.readthedocs.io
-.. _Installation: https://napalm.readthedocs.io/en/latest/installation.html
+.. _NAPALM: https://napalm-automation.net/
+.. _Installation: http://napalm.readthedocs.io/en/latest/installation/index.html
 
+.. note::
+
+    Beginning with Salt release 2017.7.3, it is recommended to use
+    ``napalm`` >= ``2.0.0``. The library has been unified into a monolithic
+    package, as in opposite to separate packages per driver. For more details
+    you can check `this document <https://napalm-automation.net/reunification/>`_.
+    While it will still work with the old packages, bear in mind that the NAPALM
+    core team will maintain only the main ``napalm`` package.
+
+    Moreover, for additional capabilities, the users can always define a
+    library that extends NAPALM's base capabilities and configure the
+    ``provider`` option (see below).
 
 Pillar
 ------
@@ -59,7 +71,7 @@ always_alive: ``True``
     .. versionadded:: 2017.7.0
 
 provider: ``napalm_base``
-    The module that provides the ``get_network_device`` function.
+    The library that provides the ``get_network_device`` function.
     This option is useful when the user has more specific needs and requires
     to extend the NAPALM capabilities using a private library implementation.
     The only constraint is that the alternative library needs to have the

--- a/salt/proxy/napalm.py
+++ b/salt/proxy/napalm.py
@@ -129,17 +129,7 @@ from __future__ import absolute_import
 import logging
 log = logging.getLogger(__file__)
 
-# Import third party lib
-try:
-    # will try to import NAPALM
-    # https://github.com/napalm-automation/napalm
-    # pylint: disable=W0611
-    import napalm_base
-    # pylint: enable=W0611
-    HAS_NAPALM = True
-except ImportError:
-    HAS_NAPALM = False
-
+# Import Salt modules
 from salt.ext import six
 import salt.utils.napalm
 
@@ -163,7 +153,7 @@ DETAILS = {}
 
 
 def __virtual__():
-    return HAS_NAPALM or (False, 'Please install the NAPALM library: `pip install napalm`!')
+    return salt.utils.napalm.virtual(__opts__, 'napalm', __file__)
 
 # ----------------------------------------------------------------------------------------------------------------------
 # helper functions -- will not be exported

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -97,7 +97,7 @@ def virtual(opts, virtualname, filename):
     '''
     Returns the __virtual__.
     '''
-    if ( (HAS_NAPALM and NAPALM_MAJOR >= 2) or HAS_NAPALM_BASE ) and ( is_proxy(opts) or is_minion(opts) ):
+    if ((HAS_NAPALM and NAPALM_MAJOR >= 2) or HAS_NAPALM_BASE) and (is_proxy(opts) or is_minion(opts)):
         if HAS_NAPALM_BASE:
             log.info('You still seem to use napalm_base. Please consider upgrading to napalm >= 2.0.0')
         return virtualname

--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -31,11 +31,27 @@ try:
     # will try to import NAPALM
     # https://github.com/napalm-automation/napalm
     # pylint: disable=W0611
-    import napalm_base
+    import napalm
+    import napalm.base as napalm_base
     # pylint: enable=W0611
     HAS_NAPALM = True
+    HAS_NAPALM_BASE = False  # doesn't matter anymore, but needed for the logic below
+    log.debug('napalm seems to be installed')
+    try:
+        NAPALM_MAJOR = int(napalm.__version__.split('.')[0])
+        log.debug('napalm version: %s', napalm.__version__)
+    except AttributeError:
+        NAPALM_MAJOR = 0
 except ImportError:
+    log.info('napalm doesnt seem to be installed, trying to import napalm_base')
     HAS_NAPALM = False
+    try:
+        import napalm_base
+        log.debug('napalm_base seems to be installed')
+        HAS_NAPALM_BASE = True
+    except ImportError:
+        log.info('napalm_base doesnt seem to be installed either')
+        HAS_NAPALM_BASE = False
 
 try:
     # try importing ConnectionClosedException
@@ -81,7 +97,9 @@ def virtual(opts, virtualname, filename):
     '''
     Returns the __virtual__.
     '''
-    if HAS_NAPALM and (is_proxy(opts) or is_minion(opts)):
+    if ( (HAS_NAPALM and NAPALM_MAJOR >= 2) or HAS_NAPALM_BASE ) and ( is_proxy(opts) or is_minion(opts) ):
+        if HAS_NAPALM_BASE:
+            log.info('You still seem to use napalm_base. Please consider upgrading to napalm >= 2.0.0')
         return virtualname
     else:
         return (


### PR DESCRIPTION
Starting with November 2017, the NAPALM library has been reunified
into a monolithic package. This falls with a couple of changes into
the Salt codebase. While the users can continue using napalm_base,
it is recommended to upgrade to napalm 2.0.
At the same time, back in time, the napalm package used to have
a different meaning, so we need to check if the release version
is at least 2.0.