### PR TITLE
Add a late-import for the salt.utils.master.py file in salt.auth

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -29,7 +29,6 @@ import salt.transport.client
 import salt.utils.args
 import salt.utils.dictupdate
 import salt.utils.files
-import salt.utils.master
 import salt.utils.minions
 import salt.utils.user
 import salt.utils.versions
@@ -444,6 +443,8 @@ class LoadAuth(object):
                         auth_ret = True
 
             if auth_ret is not True:
+                # Avoid a circular import
+                import salt.utils.master
                 auth_list = salt.utils.master.get_values_of_matching_keys(
                     self.opts['publisher_acl'], auth_ret)
                 if not auth_list:


### PR DESCRIPTION
### What does this PR do?
Moves the `salt.utils.master` import lower down in `salt.auth`.

PR #43703 inadvertently moved a "late import" statement up to the top of the auth file, which caused the problem reported in the PR itself and issue #44435.

### What issues does this PR fix or reference?
Fixes #44435 

### Previous Behavior
```
salt/minion.py", line 115, in <module>
    from salt.config import DEFAULT_MINION_OPTS
ImportError: cannot import name DEFAULT_MINION_OPTS
```

### New Behavior
Moving the salt.utils.master import lower down in the file fixes the circular import issue.
