### PR TITLE
Simpler fallback check for zfs-fuse.

### DIFF
--- a/salt/grains/zfs.py
+++ b/salt/grains/zfs.py
@@ -70,10 +70,8 @@ def _zfs_support():
             on_supported_platform = _check_retcode('ls /sys/module/zfs')
 
         # NOTE: fallback to zfs-fuse if needed
-        if not on_supported_platform:
-            _zfs_fuse = lambda f: __salt__['service.' + f]('zfs-fuse')
-            if _zfs_fuse('available') and (_zfs_fuse('status') or _zfs_fuse('start')):
-                on_supported_platform = True
+        if not on_supported_platform and salt.utils.path.which('zfs-fuse'):
+            on_supported_platform = True
 
     # Additional check for the zpool command
     if on_supported_platform and salt.utils.path.which('zpool'):


### PR DESCRIPTION
### What does this PR do?
The older zfs-fuse check was causing a trace when it was moved to the grains.
Instead of checking if the service exists, we check if the zfs-fuse binary is installed.

### What issues does this PR fix or reference?
Fixes #44447

### Previous Behavior
Some complex checks on the zfs-fuse service, this already cause some issues in the past on OpenBSD. Now it was causing a trace due to the service module not being available yet.

### New Behavior
We check if the zfs-fuse binary is installed.

### Tests written?
No

### Commits signed with GPG?
No