### PR TITLE
Remove wmi monkeypatching

### DIFF
--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -6,8 +6,7 @@ or for problem solving if your minion is having problems.
 
 .. versionadded:: 0.12.0
 
-:depends:   - pythoncom
-            - wmi
+:depends:  - wmi
 '''
 
 # Import Python Libs

--- a/tests/unit/modules/test_win_network.py
+++ b/tests/unit/modules/test_win_network.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import
 
 # Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
     MagicMock,
@@ -63,13 +64,14 @@ class Mockwinapi(object):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-class WinNetworkTestCase(TestCase):
+class WinNetworkTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.modules.win_network
     '''
-    def setUp(self):
+    def setup_loader_modules(self):
         self.WMI = Mock()
         self.addCleanup(delattr, self, 'WMI')
+        return {win_network: {}}
 
     # 'ping' function tests: 1
 

--- a/tests/unit/modules/test_win_network.py
+++ b/tests/unit/modules/test_win_network.py
@@ -7,7 +7,6 @@
 from __future__ import absolute_import
 
 # Import Salt Testing Libs
-from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
     MagicMock,
@@ -64,15 +63,13 @@ class Mockwinapi(object):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-class WinNetworkTestCase(TestCase, LoaderModuleMockMixin):
+class WinNetworkTestCase(TestCase):
     '''
     Test cases for salt.modules.win_network
     '''
-    def setup_loader_modules(self):
-        # wmi modules are platform specific...
+    def setUp(self):
         self.WMI = Mock()
         self.addCleanup(delattr, self, 'WMI')
-        return {win_network: {'wmi': wmi}}
 
     # 'ping' function tests: 1
 

--- a/tests/unit/modules/test_win_status.py
+++ b/tests/unit/modules/test_win_status.py
@@ -3,7 +3,6 @@
 # Import python libs
 from __future__ import absolute_import
 import sys
-import types
 
 # Import Salt libs
 import salt.ext.six as six
@@ -12,25 +11,16 @@ import salt.ext.six as six
 from tests.support.unit import skipIf, TestCase
 from tests.support.mock import NO_MOCK, NO_MOCK_REASON, Mock, patch, ANY
 
-# wmi and pythoncom modules are platform specific...
-wmi = types.ModuleType('wmi')
-sys.modules['wmi'] = wmi
-
-pythoncom = types.ModuleType('pythoncom')
-sys.modules['pythoncom'] = pythoncom
-
-if NO_MOCK is False:
-    WMI = Mock()
-    wmi.WMI = Mock(return_value=WMI)
-    pythoncom.CoInitialize = Mock()
-    pythoncom.CoUninitialize = Mock()
+try:
+    import wmi
+except ImportError:
+    pass
 
 # This is imported late so mock can do its job
 import salt.modules.win_status as status
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@skipIf(sys.stdin.encoding != 'UTF-8', 'UTF-8 encoding required for this test is not supported')
 @skipIf(status.HAS_WMI is False, 'This test requires Windows')
 class TestProcsBase(TestCase):
     def __init__(self, *args, **kwargs):
@@ -55,8 +45,10 @@ class TestProcsBase(TestCase):
         self.__processes.append(process)
 
     def call_procs(self):
+        WMI = Mock()
         WMI.win32_process = Mock(return_value=self.__processes)
-        self.result = status.procs()
+        with patch.object(wmi, 'WMI', Mock(return_value=WMI)):
+            self.result = status.procs()
 
 
 class TestProcsCount(TestProcsBase):
@@ -101,6 +93,7 @@ class TestProcsAttributes(TestProcsBase):
         self.assertEqual(self.proc['user_domain'], self._expected_domain)
 
 
+@skipIf(sys.stdin.encoding != 'UTF-8', 'UTF-8 encoding required for this test is not supported')
 class TestProcsUnicodeAttributes(TestProcsBase):
     def setUp(self):
         unicode_str = u'\xc1'


### PR DESCRIPTION
### What does this PR do?
The WMI object was being monkey patched in the global namespace causing other tests to fail. This PR removes the monkey patching puts the mocks in the right place.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Previous Behavior
I believe this is causing the pydsl test failures.

### Tests written?
Yes

### Commits signed with GPG?
Yes