### PR TITLE
Fix `unit.test_doc` for Windows

### DIFF
--- a/tests/unit/test_doc.py
+++ b/tests/unit/test_doc.py
@@ -7,6 +7,7 @@
 # Import Python libs
 from __future__ import absolute_import
 import os
+import re
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase
@@ -44,7 +45,7 @@ class DocTestCase(TestCase):
             salt_dir += '/'
             cmd = 'grep -r :doc: ' + salt_dir
 
-        grep_call = salt.modules.cmdmod.run_stdout(cmd=cmd).split('\n')
+        grep_call = salt.modules.cmdmod.run_stdout(cmd=cmd).split(os.linesep)
 
         test_ret = {}
         for line in grep_call:
@@ -52,12 +53,10 @@ class DocTestCase(TestCase):
             if line.startswith('Binary'):
                 continue
 
-            if salt.utils.is_windows():
-                # Need the space after the colon so it doesn't split the drive
-                # letter
-                key, val = line.split(': ', 1)
-            else:
-                key, val = line.split(':', 1)
+            # Only split on colons not followed by a '\' as is the case with
+            # Windows Drives
+            regex = re.compile(r':(?!\\)')
+            key, val = regex.split(line, 1)
 
             # Don't test man pages, this file,
             # the page that documents to not use ":doc:", or


### PR DESCRIPTION
### What does this PR do?
Uses regex to split lines. Only splits on the first colon that is not followed by a `\` as would be the case with a Windows drive letter (`c:\`).

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
Yes

### Commits signed with GPG?
Yes