### PR TITLE
update kitchen yaml to use master for salt-jenkins

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,7 +32,7 @@ provisioner:
   require_chef: false
   remote_states:
     name: git://github.com/gtmanfred/salt-jenkins.git
-    branch: 2017.7
+    branch: master
     repo: git
     testingdir: /testing
   salt_copy_filter:


### PR DESCRIPTION
### What does this PR do?
After this, we should be all setup with the kitchen.yml on all branches.