### PR TITLE
salt-call: account for instances where __pillar__ is empty

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -662,7 +662,7 @@ class State(object):
                     .format(', '.join(VALID_PILLAR_ENC))
                 )
         self._pillar_enc = pillar_enc
-        if initial_pillar is not None:
+        if initial_pillar:
             self.opts['pillar'] = initial_pillar
             if self._pillar_override:
                 self.opts['pillar'] = salt.utils.dictupdate.merge(


### PR DESCRIPTION
A regression was introduced in 8d6fdb7, which modified pillar handling
for salt-call so that we would not recompile pillar data if it was
compiled already at the time that states were being run. But this didn't
account for instances where pillar had yet to be compiled at all, and
thus the __pillar__ dict would be empty. This commit contains a one-line
fix that fixes the regression.

Resolves #44034