### PR TITLE
Enable test_deploy ssh test

### DIFF
--- a/tests/integration/ssh/test_deploy.py
+++ b/tests/integration/ssh/test_deploy.py
@@ -6,11 +6,9 @@ salt-ssh testing
 from __future__ import absolute_import
 
 # Import salt testing libs
-from tests.support.unit import skipIf
 from tests.support.case import SSHCase
 
 
-@skipIf(True, 'Not ready for production')
 class SSHTest(SSHCase):
     '''
     Test general salt-ssh functionality


### PR DESCRIPTION
### What does this PR do?
Re-enables the `test.ping` salt-ssh test. Not sure why this wouldn't be ready for production since we are using `--ssh-tests` and SSHCase in other parts of the test suite.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/43611