### PR TITLE
Support for Bearer token authentication

### DIFF
--- a/salt/modules/kubernetes.py
+++ b/salt/modules/kubernetes.py
@@ -145,6 +145,9 @@ def _setup_conn(**kwargs):
     kubernetes.client.configuration.host = host
     kubernetes.client.configuration.user = username
     kubernetes.client.configuration.passwd = password
+    if __salt__['config.option']('kubernetes.api_key'):
+        kubernetes.client.configuration.api_key = { 'authorization': __salt__['config.option']('kubernetes.api_key')}
+        kubernetes.client.configuration.api_key_prefix = {'authorization': __salt__['config.option']('kubernetes.api_key_prefix')}
 
     if ca_cert_file:
         kubernetes.client.configuration.ssl_ca_cert = ca_cert_file


### PR DESCRIPTION
### What does this PR do?

This PR adds support for Bearer token authentication, which allows authenticating kubernetes of Google Cloud

### What issues does this PR fix or reference?

### Previous Behavior

It was not possible to pass bearer tokens in kubernetes configuration

### New Behavior

It is possible to authenticate kubernetes REST API with

`Token: Bearer abc123123123`

### Tests written?

No

### Commits signed with GPG?

No
