### PR TITLE
Increase sleep timeout for pillar refresh test

### DIFF
--- a/tests/integration/modules/test_saltutil.py
+++ b/tests/integration/modules/test_saltutil.py
@@ -186,7 +186,7 @@ class SaltUtilSyncPillarTest(ModuleCase):
                      '''))
 
         pillar_refresh = self.run_function('saltutil.refresh_pillar')
-        wait = self.run_function('test.sleep', [1])
+        wait = self.run_function('test.sleep', [5])
 
         post_pillar = self.run_function('pillar.raw')
         self.assertIn(pillar_key, post_pillar.get(pillar_key, 'didnotwork'))


### PR DESCRIPTION
### What does this PR do?
The `integration.modules.test_saltutil.SaltUtilSyncPillarTest.test_pillar_refresh` test is failing sometimes because we need to increase the sleep timeout since it takes some time to refresh the pillar data, sometimes more than one second. This will help ensure this test does not exhibit flaky behavior anymore.