### PR TITLE
Capirca integration

### DIFF
--- a/salt/modules/capirca_acl.py
+++ b/salt/modules/capirca_acl.py
@@ -131,7 +131,8 @@ _TERM_FIELDS = {
     'flattened': False,
     'flattened_addr': None,
     'flattened_saddr': None,
-    'flattened_daddr': None
+    'flattened_daddr': None,
+    'priority': None
 }
 
 # IP-type fields
@@ -746,6 +747,7 @@ def get_term_config(platform,
         - flattened_addr
         - flattened_saddr
         - flattened_daddr
+        - priority
 
     .. note::
         The following fields can be also a single value and a list of values:

--- a/salt/modules/napalm_acl.py
+++ b/salt/modules/napalm_acl.py
@@ -282,6 +282,7 @@ def load_term_config(filter_name,
         - flattened_addr
         - flattened_saddr
         - flattened_daddr
+        - priority
 
     .. note::
         The following fields can be also a single value and a list of values:

--- a/salt/states/netacl.py
+++ b/salt/states/netacl.py
@@ -239,6 +239,7 @@ def term(name,
         - flattened_addr
         - flattened_saddr
         - flattened_daddr
+        - priority
 
     .. note::
         The following fields can be also a single value and a list of values:


### PR DESCRIPTION
### What does this PR do?
Add priority fields under Capirca's ACL module.

### What issues does this PR fix or reference?
Without 'priority' keyword supported by the Salt, the latest Capirca ACL generates an error:
```
[root@ip-10-0-0-87 /usr/local/mzb]# salt -v device2 capirca.get_policy_config juniper
Executing job with jid 20171111191259706113
-------------------------------------------

device2:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/local/lib/python2.7/site-packages/salt/minion.py", line 1468, in _thread_return
        return_data = executor.execute()
      File "/usr/local/lib/python2.7/site-packages/salt/executors/direct_call.py", line 28, in execute
        return self.func(*self.args, **self.kwargs)
      File "/usr/local/lib/python2.7/site-packages/salt/modules/capirca_acl.py", line 1178, in get_policy_config
        merge_pillar=merge_pillar)
      File "/usr/local/lib/python2.7/site-packages/salt/modules/capirca_acl.py", line 537, in _get_policy_object
        **term_fields)
      File "/usr/local/lib/python2.7/site-packages/salt/modules/capirca_acl.py", line 492, in _get_term_object
        log.debug(str(term))
      File "/usr/local/mzb/src/aclgen/lib/policy.py", line 729, in __str__
        if self.priority:
    AttributeError: '_Term' object has no attribute 'priority'
```

### Tests written?

No

### Commits signed with GPG?

No

