### PR TITLE
Publish port doc missing

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -315,7 +315,7 @@ option on the Salt master.
 
 .. code-block:: yaml
 
-    master_port: 4505
+    publish_port: 4505
 
 .. conf_minion:: user
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -303,6 +303,20 @@ option on the Salt master.
 
     master_port: 4506
 
+.. conf_minion:: publish_port
+
+``publish_port``
+---------------
+
+Default: ``4505``
+
+The port of the master publish server, this needs to coincide with the publish_port
+option on the Salt master.
+
+.. code-block:: yaml
+
+    master_port: 4505
+
 .. conf_minion:: user
 
 ``user``


### PR DESCRIPTION
### What does this PR do?

Updates the minion config documentation. shows the publish_port setting which was missing from the minion configuration documentation. 

### What issues does this PR fix or reference?

documentation for publish_port option was missing in minion configuration doc. 

### Tests written?

No - Documentation

### Commits signed with GPG?

Yes