### PR TITLE
add ability to customize cloud config options in cloud runner functio…

### DIFF
--- a/salt/runners/cloud.py
+++ b/salt/runners/cloud.py
@@ -115,7 +115,7 @@ def profile(prof=None, instances=None, opts=None, **kwargs):
     return info
 
 
-def map_run(path=None, , opts=None, **kwargs):
+def map_run(path=None, opts=None, **kwargs):
     '''
     Execute a salt cloud map file
     '''

--- a/salt/runners/cloud.py
+++ b/salt/runners/cloud.py
@@ -115,20 +115,24 @@ def profile(prof=None, instances=None, opts=None, **kwargs):
     return info
 
 
-def map_run(path=None, **kwargs):
+def map_run(path=None, , opts=None, **kwargs):
     '''
     Execute a salt cloud map file
     '''
     client = _get_client()
+    if isinstance(opts, dict):
+        client.opts.update(opts)
     info = client.map_run(path, **salt.utils.args.clean_kwargs(**kwargs))
     return info
 
 
-def destroy(instances):
+def destroy(instances, opts=None):
     '''
     Destroy the named vm(s)
     '''
     client = _get_client()
+    if isinstance(opts, dict):
+        client.opts.update(opts)
     info = client.destroy(instances)
     return info
 
@@ -138,6 +142,7 @@ def action(func=None,
            instances=None,
            provider=None,
            instance=None,
+           opts=None,
            **kwargs):
     '''
     Execute a single action on the given map/provider/instance
@@ -150,6 +155,8 @@ def action(func=None,
     '''
     info = {}
     client = _get_client()
+    if isinstance(opts, dict):
+        client.opts.update(opts)
     try:
         info = client.action(
             func,


### PR DESCRIPTION
add ability to customize cloud config options in cloud runner functions: destroy, action and map_run
### What does this PR do?
This adds the ability to pass in custom cloud config options, like providers, through the opts variable.

### What issues does this PR fix or reference?
N/A

### Tests written?

No

### Commits signed with GPG?

Yes

