### PR TITLE
Add deprecation notes for the NAPALM native templates

### DIFF
--- a/salt/modules/napalm_network.py
+++ b/salt/modules/napalm_network.py
@@ -29,6 +29,7 @@ log = logging.getLogger(__name__)
 from salt.ext import six
 import salt.utils.templates
 import salt.utils.napalm
+import salt.utils.versions
 from salt.utils.napalm import proxy_napalm_wrap
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -1072,6 +1073,10 @@ def load_template(template_name,
 
     To replace the config, set ``replace`` to ``True``.
 
+    .. warning::
+        The support for native NAPALM templates will be dropped in Salt Fluorine.
+        Implicitly, the ``template_path`` argument will be removed.
+
     template_name
         Identifies path to the template source.
         The template can be either stored on the local machine, either remotely.
@@ -1107,6 +1112,9 @@ def load_template(template_name,
         E.g.: if ``template_name`` is specified as ``my_template.jinja``,
         in order to find the template, this argument must be provided:
         ``template_path: /absolute/path/to/``.
+
+        .. note::
+            This argument will be deprecated beginning with release codename ``Fluorine``.
 
     template_hash: None
         Hash of the template file. Format: ``{hash_type: 'md5', 'hsum': <md5sum>}``
@@ -1274,7 +1282,11 @@ def load_template(template_name,
         'out': None
     }
     loaded_config = None
-
+    if template_path:
+        salt.utils.versions.warn_until(
+            'Fluorine',
+            'Use of `template_path` detected. This argument will be removed in Salt Fluorine.'
+        )
     # prechecks
     if template_engine not in salt.utils.templates.TEMPLATE_REGISTRY:
         _loaded.update({

--- a/salt/states/netconfig.py
+++ b/salt/states/netconfig.py
@@ -25,6 +25,7 @@ log = logging.getLogger(__name__)
 
 # import NAPALM utils
 import salt.utils.napalm
+import salt.utils.versions
 
 # ----------------------------------------------------------------------------------------------------------------------
 # state properties
@@ -132,6 +133,10 @@ def managed(name,
     buffer is not cleared/merged in the running config.
 
     To replace the config, set ``replace`` to ``True``. This option is recommended to be used with caution!
+
+    .. warning::
+        The spport for NAPALM native templates will be dropped beginning with Salt Fluorine.
+        Implicitly, the ``template_path`` argument will be depreacted and removed.
 
     template_name
         Identifies path to the template source. The template can be either stored on the local machine,
@@ -320,7 +325,11 @@ def managed(name,
             }
         }
     '''
-
+    if template_path:
+        salt.utils.versions.warn_until(
+            'Fluorine',
+            'Use of `template_path` detected. This argument will be removed in Salt Fluorine.'
+        )
     ret = salt.utils.napalm.default_ret(name)
 
     # the user can override the flags the equivalent CLI args


### PR DESCRIPTION
Relying on NAPALM native templates was a very bad idea.
In Salt Fluroine I plan to revisit the `net.load_template` function
and the NetConfig state, so they will be in-line with the behaviour
of the `file.managed` execution/state function, the main difference being
that the network-related functions will load the result of rendered
source into the network device targeted.
Additionally, there will be a couple of new equivalent features
such as: keep_source, context, show_changes, contents,
contents_pillar, contents_grains, contents_newline, allow_empty,
and so on (there are several that wouldn't make sense).

I am targeting the 2017.7 so the warning will be included in the 2017.7.3 docs. If that's not acceptable, please feel free to move to `develop` instead.

### New Behavior

Will log a warning when the `template_path` arg is used.

### Tests written?

No

### Commits signed with GPG?

Yes