### PR TITLE
ignore invalid characters when getting decoding error in cmd run

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -590,7 +590,7 @@ def _run(cmd,
         except AttributeError:
             out = u''
         except UnicodeDecodeError:
-            log.error("UnicodeDecodeError while decoding output of cmd {0}".format(cmd))
+            log.error('UnicodeDecodeError while decoding output of cmd {0}'.format(cmd))
             out = proc.stdout.decode(__salt_system_encoding__, 'replace')
 
         try:
@@ -598,7 +598,7 @@ def _run(cmd,
         except AttributeError:
             err = u''
         except UnicodeDecodeError:
-            log.error("UnicodeDecodeError while decoding error of cmd {0}".format(cmd))
+            log.error('UnicodeDecodeError while decoding error of cmd {0}'.format(cmd))
             err = proc.stderr.decode(__salt_system_encoding__, 'replace')
 
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -601,7 +601,6 @@ def _run(cmd,
             log.error('UnicodeDecodeError while decoding error of cmd {0}'.format(cmd))
             err = proc.stderr.decode(__salt_system_encoding__, 'replace')
 
-
         if rstrip:
             if out is not None:
                 out = out.rstrip()

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -589,11 +589,18 @@ def _run(cmd,
             out = proc.stdout.decode(__salt_system_encoding__)
         except AttributeError:
             out = u''
+        except UnicodeDecodeError:
+            log.error("UnicodeDecodeError while decoding output of cmd {0}".format(cmd))
+            out = proc.stdout.decode(__salt_system_encoding__, 'ignore')
 
         try:
             err = proc.stderr.decode(__salt_system_encoding__)
         except AttributeError:
             err = u''
+        except UnicodeDecodeError:
+            log.error("UnicodeDecodeError while decoding error of cmd {0}".format(cmd))
+            err = proc.stderr.decode(__salt_system_encoding__, 'ignore')
+
 
         if rstrip:
             if out is not None:

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -591,7 +591,7 @@ def _run(cmd,
             out = u''
         except UnicodeDecodeError:
             log.error("UnicodeDecodeError while decoding output of cmd {0}".format(cmd))
-            out = proc.stdout.decode(__salt_system_encoding__, 'ignore')
+            out = proc.stdout.decode(__salt_system_encoding__, 'replace')
 
         try:
             err = proc.stderr.decode(__salt_system_encoding__)
@@ -599,7 +599,7 @@ def _run(cmd,
             err = u''
         except UnicodeDecodeError:
             log.error("UnicodeDecodeError while decoding error of cmd {0}".format(cmd))
-            err = proc.stderr.decode(__salt_system_encoding__, 'ignore')
+            err = proc.stderr.decode(__salt_system_encoding__, 'replace')
 
 
         if rstrip:


### PR DESCRIPTION
### What does this PR do?

When you use cmd.run and the command return latin-1 characters, salt just throw the UnicodeDecodeError. 
This PR write an error message and call decode() with `ignore` to get at least a bit of the output.

### Tests written?

No

### Commits signed with GPG?

No
