### PR TITLE
Fix up some test kitchen stuff

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,6 +19,8 @@ driver:
   disable_upstart: false
   provision_command:
     - echo 'L /run/docker.sock - - - - /docker.sock' > /etc/tmpfiles.d/docker.conf
+transport:
+  name: sftp
 <% end %>
 
 sudo: false

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,6 @@
 ---
 <% vagrant = system('which vagrant 2>/dev/null >/dev/null') %>
-<% version = '2017.7.2' %>
+<% version = '2017.7.1' %>
 <% platformsfile = ENV['SALT_KITCHEN_PLATFORMS'] || '.kitchen/platforms.yml' %>
 <% driverfile = ENV['SALT_KITCHEN_DRIVER'] || '.kitchen/driver.yml' %>
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -164,6 +164,9 @@ suites:
           clone_repo: false
           salttesting_namespec: salttesting==2017.6.1
   - name: py3
+    excludes:
+      - centos-6
+      - ubuntu-14.04
     provisioner:
       pillars:
         top.sls:

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gem 'test-kitchen'
 gem 'kitchen-salt', :git => 'https://github.com/saltstack/kitchen-salt.git'
+gem 'kitchen-sync'
 gem 'git'
 
 group :docker do

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 # This file is only used for running the test suite with kitchen-salt.
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "test-kitchen"
-gem "kitchen-salt", :git => 'https://github.com/saltstack/kitchen-salt.git'
+gem 'test-kitchen'
+gem 'kitchen-salt', :git => 'https://github.com/saltstack/kitchen-salt.git'
 gem 'git'
 
 group :docker do


### PR DESCRIPTION
### What does this PR do?

ubuntu 14.04 and centos 6 should not have py3 test instances.

2017.7.2 is broken when trying to download the busybox binary for the docker tests, until 2017.7.3 includes https://github.com/saltstack/salt/pull/44016 , kitchen tests need to use 2017.7.1