### PR TITLE
fix no __salt__ in salt-cloud

### DIFF
--- a/salt/cloud/clouds/saltify.py
+++ b/salt/cloud/clouds/saltify.py
@@ -259,19 +259,20 @@ def create(vm_):
             'wol_sender_node', vm_, __opts__, default='')
         if wol_mac and wol_host:
             good_ping = False
+            local = salt.client.LocalClient()
             ssh_host = config.get_cloud_config_value(
                 'ssh_host', vm_, __opts__, default='')
             if ssh_host:
                 log.info('trying to ping %s', ssh_host)
                 count = 'n' if salt.utils.platform.is_windows() else 'c'
                 cmd = 'ping -{} 1 {}'.format(count, ssh_host)
-                good_ping = __salt__['cmd.retcode'](cmd) == 0
+                good_ping = local.cmd(wol_host, 'cmd.retcode', [cmd]) == 0
             if good_ping:
                 log.info('successful ping.')
             else:
                 log.info('sending wake-on-lan to %s using node %s',
                          wol_mac, wol_host)
-                local = salt.client.LocalClient()
+
                 if isinstance(wol_mac, six.string_types):
                     wol_mac = [wol_mac]  # a smart user may have passed more params
                 ret = local.cmd(wol_host, 'network.wol', wol_mac)


### PR DESCRIPTION
### What does this PR do?

Correct a bug in the saltify wake-on-lan implementation.

The bug was probably an artifact of a bad merge.  The code as tested on my test network was approximately like this version. Somehow, the tested code did not make its way into the repo.

Salt-cloud does not have a definition for the \_\_salt\_\_ global, so attempting to use it causes a Python error. As an author, I missed that idiosyncrasy -- as did both reviewers.  This uses a salt local API call to perform the intended action.

### What issues does this PR fix or reference?

None

### Previous Behavior

Python traceback when wake-on-lan is attempted.

### New Behavior

Works as intended

### Tests written?

No

### Commits signed with GPG?

Yes
