### PR TITLE
Fix test to reflect changes in YAML dumper

### DIFF
--- a/tests/unit/templates/test_jinja.py
+++ b/tests/unit/templates/test_jinja.py
@@ -561,7 +561,6 @@ class TestCustomExtensions(TestCase):
             # type of the rendered variable (should be unicode, which is the same as
             # six.text_type). This should cover all use cases but also allow the test
             # to pass on CentOS 6 running Python 2.7.
-            self.assertIn('!!python/unicode', rendered)
             self.assertIn('str value', rendered)
             self.assertIsInstance(rendered, six.text_type)
 


### PR DESCRIPTION
PR #42064 modified the YAML dumper to display unicode text as a unicode
literal rather than with the !!python/unicode extension prefix. This
updates the test to reflect the change in Salt's behavior.