### PR TITLE
Groupadd test gid_min/gid_max values should be ints

### DIFF
--- a/tests/integration/modules/test_groupadd.py
+++ b/tests/integration/modules/test_groupadd.py
@@ -79,7 +79,7 @@ class GroupModuleTest(ModuleCase):
         gid_max = login_defs.get('SYS_GID_MAX',
                                  int(login_defs.get('GID_MIN', 1000)) - 1)
 
-        return gid_min, gid_max
+        return int(gid_min), int(gid_max)
 
     def __get_free_system_gid(self):
         '''


### PR DESCRIPTION
### What does this PR do?
This fixes an issue with the groupadd integration tests. There were two tests failing on CentOS 7 that check to ensure that the gid for the newly added system group is between the gid_min and gid_max values.

These checks were failing because the test gid was an int, but the compairison gids (min and max values) were strings, depending on the distro.

This change ensures that we're compairing ints across the board.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-jenkins/issues/550

### Previous Behavior
Two tests failing on CentOS 7 for groupadd integration tests.

### New Behavior
Tests are passing.

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
