### PR TITLE
Allow proxy minions to load static grains

### DIFF
--- a/doc/topics/grains/index.rst
+++ b/doc/topics/grains/index.rst
@@ -86,6 +86,15 @@ same way as in the above example, only without a top-level ``grains:`` key:
 
     Grains are static, and since they are not often changed, they will need a grains refresh when they are updated. You can do this by calling: ``salt minion saltutil.refresh_modules``
 
+.. note::
+
+    You can equally configure static grains for Proxy Minions.
+    As multiple Proxy Minion processes can run on the same machine, you need
+    to index the files using the Minion ID, under ``/etc/salt/proxy.d/<minion ID>/grains``.
+    For example, the grains for the Proxy Minion ``router1`` can be defined
+    under ``/etc/salt/proxy.d/router1/grains``, while the grains for the
+    Proxy Minion ``switch7`` can be put in ``/etc/salt/proxy.d/switch7/grains``.
+
 Matching Grains in the Top File
 ===============================
 

--- a/salt/grains/extra.py
+++ b/salt/grains/extra.py
@@ -12,6 +12,7 @@ import logging
 # Import salt libs
 import salt.utils
 
+__proxyenabled__ = ['*']
 log = logging.getLogger(__name__)
 
 
@@ -31,16 +32,33 @@ def config():
     if 'conf_file' not in __opts__:
         return {}
     if os.path.isdir(__opts__['conf_file']):
-        gfn = os.path.join(
-                __opts__['conf_file'],
-                'grains'
-                )
+        if salt.utils.is_proxy():
+            gfn = os.path.join(
+                    __opts__['conf_file'],
+                    'proxy.d',
+                    __opts__['id'],
+                    'grains'
+                    )
+        else:
+            gfn = os.path.join(
+                    __opts__['conf_file'],
+                    'grains'
+                    )
     else:
-        gfn = os.path.join(
-                os.path.dirname(__opts__['conf_file']),
-                'grains'
-                )
+        if salt.utils.is_proxy():
+            gfn = os.path.join(
+                    os.path.dirname(__opts__['conf_file']),
+                    'proxy.d',
+                    __opts__['id'],
+                    'grains'
+                    )
+        else:
+            gfn = os.path.join(
+                    os.path.dirname(__opts__['conf_file']),
+                    'grains'
+                    )
     if os.path.isfile(gfn):
+        log.debug('Loading static grains from %s', gfn)
         with salt.utils.fopen(gfn, 'rb') as fp_:
             try:
                 return yaml.safe_load(fp_.read())


### PR DESCRIPTION
### What does this PR do?

Add the `__proxyenabled__` global var so the extra grains are loaded.
Inside the `config` function of the extra grains check if the minion
is a proxy, then try loading from `<conf_file>/proxy.d/<proxy id>/grains`.

### What issues does this PR fix or reference?

#42074

### Previous Behavior

Unable to configure static grains on Proxy Minions.

### New Behavior

Can configure static grains on Proxy Minions.

### Tests written?

No.

### Commits signed with GPG?

Yes.