### PR TITLE
Removes proxy minions false alarms and security risks

### DIFF
--- a/salt/proxy/dummy.py
+++ b/salt/proxy/dummy.py
@@ -8,7 +8,9 @@ from __future__ import absolute_import
 import os
 import pickle
 import logging
-import tempfile
+
+# Import Salt modules
+import salt.utils.files
 
 # This must be present or the Salt loader won't load this module
 __proxyenabled__ = ['dummy']
@@ -20,7 +22,7 @@ DETAILS = {}
 
 DETAILS['services'] = {'apache': 'running', 'ntp': 'running', 'samba': 'stopped'}
 DETAILS['packages'] = {'coreutils': '1.0', 'apache': '2.4', 'tinc': '1.4', 'redbull': '999.99'}
-FILENAME = tempfile.mkstemp()[1]
+FILENAME = salt.utils.files.mkstemp()
 # Want logging!
 log = logging.getLogger(__file__)
 

--- a/salt/proxy/dummy.py
+++ b/salt/proxy/dummy.py
@@ -6,8 +6,9 @@ from __future__ import absolute_import
 
 # Import python libs
 import os
-import logging
 import pickle
+import logging
+import tempfile
 
 # This must be present or the Salt loader won't load this module
 __proxyenabled__ = ['dummy']
@@ -19,7 +20,7 @@ DETAILS = {}
 
 DETAILS['services'] = {'apache': 'running', 'ntp': 'running', 'samba': 'stopped'}
 DETAILS['packages'] = {'coreutils': '1.0', 'apache': '2.4', 'tinc': '1.4', 'redbull': '999.99'}
-FILENAME = os.tmpnam()
+FILENAME = tempfile.mkstemp()[1]
 # Want logging!
 log = logging.getLogger(__file__)
 

--- a/salt/proxy/fx2.py
+++ b/salt/proxy/fx2.py
@@ -196,9 +196,7 @@ def __virtual__():
     Only return if all the modules are available
     '''
     if not salt.utils.which('racadm'):
-        log.critical('fx2 proxy minion needs "racadm" to be installed.')
-        return False
-
+        return False, 'fx2 proxy minion needs "racadm" to be installed.'
     return True
 
 


### PR DESCRIPTION
### What does this PR do?

When starting a proxy minion, although not using the `dummy` or `fx2` module, one can notice the following errors in the logs, although not related:

```
[WARNING ] /home/admin/salt/salt/proxy/dummy.py:22: RuntimeWarning: tmpnam is a potential security risk to your program
  FILENAME = os.tmpnam()

[CRITICAL] fx2 proxy minion needs "racadm" to be installed.
```

1. The `dummy` proxy minion module presents a severe vulnerability due to the fact that executes `os.tmpnam` at the module top level, thus `os.tmpnam` is always called by the Salt loader.
This function is dangerous and the Python documentation recommends avoiding it: https://docs.python.org/2/library/os.html#os.tmpnam
I have replaced it with `tempfile.mkstemp`: https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp

2. The `fx2` proxy minion module logs a gratuitous critical log, so I moved the message to be handled by the Salt loader instead.

### Commits signed with GPG?

Yes
