### PR TITLE
pip_state: Check if available upgrades fulfill version requirements.

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -82,6 +82,7 @@ import re
 import shutil
 import logging
 import sys
+from pkg_resources import parse_version
 
 # Import salt libs
 import salt.utils
@@ -1216,3 +1217,79 @@ def upgrade(bin_env=None,
     ret['changes'] = salt.utils.compare_dicts(old, new)
 
     return ret
+
+
+def list_all_versions(pkg,
+                      bin_env=None,
+                      include_alpha=False,
+                      include_beta=False,
+                      include_rc=False,
+                      user=None,
+                      cwd=None):
+    '''
+    .. versionadded:: 2017.7.3
+
+    List all available versions of a pip package
+
+    pkg
+        The package to check
+
+    bin_env
+        Path to pip bin or path to virtualenv. If doing a system install,
+        and want to use a specific pip bin (pip-2.7, pip-2.6, etc..) just
+        specify the pip bin you want.
+
+    include_alpha
+        Include alpha versions in the list
+
+    include_beta
+        Include beta versions in the list
+
+    include_rc
+        Include release candidates versions in the list
+
+    user
+        The user under which to run pip
+
+    cwd
+        Current working directory to run pip from
+
+    CLI Example:
+
+    .. code-block:: bash
+
+       salt '*' pip.list_all_versions <package name>
+    '''
+    pip_bin = _get_pip_bin(bin_env)
+
+    cmd = [pip_bin, 'install', '{0}==versions'.format(pkg)]
+
+    cmd_kwargs = dict(cwd=cwd, runas=user, output_loglevel='quiet', redirect_stderr=True)
+    if bin_env and os.path.isdir(bin_env):
+        cmd_kwargs['env'] = {'VIRTUAL_ENV': bin_env}
+
+    result = __salt__['cmd.run_all'](cmd, **cmd_kwargs)
+
+    filtered = []
+    if not include_alpha:
+        filtered.append('a')
+    if not include_beta:
+        filtered.append('b')
+    if not include_rc:
+        filtered.append('rc')
+    if filtered:
+        excludes = re.compile(r'^((?!{0}).)*$'.format('|'.join(filtered)))
+    else:
+        excludes = re.compile(r'')
+
+    versions = []
+    for line in result['stdout'].splitlines():
+        match = re.search(r'\s*Could not find a version.* \(from versions: (.*)\)', line)
+        if match:
+            versions = [v for v in match.group(1).split(', ') if v and excludes.match(v)]
+            versions.sort(key=parse_version)
+            break
+    if not versions:
+        return None
+
+    return versions


### PR DESCRIPTION
### What does this PR do?
Avoid `pip.installed` state to always try to install packages if `upgrade=True`.

This PR also adds a function `list_all_versions` to pip module which lists all available versions of a pip package.

### What issues does this PR fix or reference?
None I think.

### Previous Behavior
When installing a pip package if version requirements and `upgrade` is set to `True` Salt always runs `pip install` even if no upgrades are available which always returns state changes.

The following state is always marked as changed:
```yaml
borgbackup:
  pip.installed:
    - name: borgbackup >= 1.1, < 1.2 
    - upgrade: True
    - bin_env: '/usr/bin/pip3'
```
### New Behavior
If `upgrade` is set to `True` we check if there's an upgrade available for the package and if there is one, we check if it fulfills the version requirements.

### Tests written?

No

### Commits signed with GPG?

No
