### PR TITLE
Teach pkg state to optionally install capabilities

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -2190,11 +2190,15 @@ def resolve_capabilities(pkgs, refresh, **kwargs):
             except CommandExecutionError:
                 # no package this such a name found
                 # search for a package which provides this name
-                result = search(name, provides=True, match='exact')
-                if len(result) == 1:
-                    name = result.keys()[0]
-                elif len(result) > 1:
-                    log.warn("Found ambiguous match for capability '{0}'.".format(pkg))
+                try:
+                    result = search(name, provides=True, match='exact')
+                    if len(result) == 1:
+                        name = result.keys()[0]
+                    elif len(result) > 1:
+                        log.warn("Found ambiguous match for capability '{0}'.".format(pkg))
+                except CommandExecutionError:
+                    # when search throw an exception stay with original name and version
+                    pass
 
         if version:
             ret.append({name: version})

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -2196,7 +2196,6 @@ def resolve_capabilities(pkgs, refresh, **kwargs):
                 except CommandExecutionError as exc:
                     # when search throws an exception stay with original name and version
                     log.debug("Search failed with: {0}".format(exc))
-                    pass
 
         if version:
             ret.append({name: version})

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -20,7 +20,6 @@ import re
 import os
 import time
 import datetime
-import copy
 
 # Import 3rd-party libs
 # pylint: disable=import-error,redefined-builtin,no-name-in-module
@@ -1865,7 +1864,7 @@ def search(criteria, refresh=False, **kwargs):
     out = {}
     for solvable in solvables:
         out[solvable.getAttribute('name')] = dict()
-        for k,v in solvable.attributes.items():
+        for k, v in solvable.attributes.items():
             out[solvable.getAttribute('name')][k] = v
 
     return out
@@ -2122,6 +2121,7 @@ def list_installed_patches():
     '''
     return _get_patches(installed_only=True)
 
+
 def list_provides(**kwargs):
     '''
     List package provides currently installed as a dict.
@@ -2143,6 +2143,7 @@ def list_provides(**kwargs):
         __context__['pkg.list_provides'] = ret
 
     return ret
+
 
 def resolve_capabilities(pkgs, refresh, **kwargs):
     '''

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -2187,13 +2187,13 @@ def resolve_capabilities(pkgs, refresh, **kwargs):
         if kwargs.get('resolve_capabilities', False):
             try:
                 search(name, match='exact')
-            except CommandExecutionError as e:
+            except CommandExecutionError:
                 # no package this such a name found
                 # search for a package which provides this name
                 result = search(name, provides=True, match='exact')
-                if len(result.keys()) == 1:
+                if len(result) == 1:
                     name = result.keys()[0]
-                elif len(result.keys()) > 1:
+                elif len(result) > 1:
                     log.warn("Found ambiguous match for capability '{0}'.".format(pkg))
 
         if version:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -399,6 +399,14 @@ def _systemd_scope():
         and __salt__['config.get']('systemd.scope', True)
 
 
+def _clean_cache():
+    '''
+    Clean cached results
+    '''
+    for cache_name in ['list_pkgs', 'list_provides']:
+    __context__.pop(cache_name, None)
+
+
 def list_upgrades(refresh=True, **kwargs):
     '''
     List all available package upgrades on this system
@@ -1201,8 +1209,7 @@ def install(name=None,
         downgrades = downgrades[500:]
         __zypper__(no_repo_failure=ignore_repo_failure).call(*cmd)
 
-    __context__.pop('pkg.list_pkgs', None)
-    __context__.pop('pkg.list_provides', None)
+    _clean_cache()
     new = list_pkgs(attr=diff_attr) if not downloadonly else list_downloaded()
 
     # Handle packages which report multiple new versions
@@ -1319,8 +1326,7 @@ def upgrade(refresh=True,
     old = list_pkgs()
 
     __zypper__(systemd_scope=_systemd_scope()).noraise.call(*cmd_update)
-    __context__.pop('pkg.list_pkgs', None)
-    __context__.pop('pkg.list_provides', None)
+    _clean_cache()
     new = list_pkgs()
 
     # Handle packages which report multiple new versions
@@ -1369,8 +1375,7 @@ def _uninstall(name=None, pkgs=None):
         __zypper__(systemd_scope=systemd_scope).call('remove', *targets[:500])
         targets = targets[500:]
 
-    __context__.pop('pkg.list_pkgs', None)
-    __context__.pop('pkg.list_provides', None)
+    _clean_cache()
     ret = salt.utils.data.compare_dicts(old, list_pkgs())
 
     if errors:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -2202,8 +2202,9 @@ def resolve_capabilities(pkgs, refresh, **kwargs):
                         name = result.keys()[0]
                     elif len(result) > 1:
                         log.warn("Found ambiguous match for capability '{0}'.".format(pkg))
-                except CommandExecutionError:
-                    # when search throw an exception stay with original name and version
+                except CommandExecutionError as exc:
+                    # when search throws an exception stay with original name and version
+                    log.debug("Search failed with: {0}".format(exc))
                     pass
 
         if version:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1823,7 +1823,7 @@ def search(criteria, refresh=False, **kwargs):
     if refresh:
         refresh_db()
 
-    cmd = ['se']
+    cmd = ['search']
     if kwargs.get('match') == 'exact':
         cmd.append('--match-exact')
     elif kwargs.get('match') == 'words':
@@ -1853,7 +1853,8 @@ def search(criteria, refresh=False, **kwargs):
     if kwargs.get('installed_only'):
         cmd.append('--installed-only')
     if kwargs.get('not_installed_only'):
-        cmd.append('--not-installed-only')
+        # long parameter was renamed in the past
+        cmd.append('-u')
     if kwargs.get('details'):
         cmd.append('--details')
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -2120,8 +2120,16 @@ def list_installed_patches():
 
 def list_provides(**kwargs):
     '''
-    List package provides currently installed as a dict.
-    {'<provided_name>': ['<package_name', 'package_name', ...]}
+    .. versionadded:: Oxygen
+
+    List package provides of installed packages as a dict.
+    {'<provided_name>': ['<package_name>', '<package_name>', ...]}
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' pkg.list_provides
     '''
     ret = __context__.get('pkg.list_provides')
     if not ret:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1171,10 +1171,7 @@ def install(name=None,
         fromrepoopt = ''
     cmd_install = ['install', '--auto-agree-with-licenses']
 
-    if kwargs.get('resolve_capabilities', False):
-        cmd_install.append('--capability')
-    else:
-        cmd_install.append('--name')
+    cmd_install.append(kwargs.get('resolve_capabilities') and '--capability' or '--name')
 
     if not refresh:
         cmd_install.insert(0, '--no-refresh')

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -2178,8 +2178,8 @@ def resolve_capabilities(pkgs, refresh, **kwargs):
     ret = list()
     for pkg in pkgs:
         if isinstance(pkg, dict):
-            for name, version in pkg.items():
-                break
+            name = next(iter(pkg))
+            version = pkg[name]
         else:
             name = pkg
             version = None

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1821,6 +1821,20 @@ def search(criteria, refresh=False, **kwargs):
 
         salt '*' pkg.search <criteria>
     '''
+    ALLOWED_SEARCH_OPTIONS = {
+            'provides': '--provides',
+            'recommends': '--recommends',
+            'requires': '--requires',
+            'suggests': '--suggests',
+            'conflicts': '--conflicts',
+            'obsoletes': '--obsoletes',
+            'file_list': '--file-list',
+            'search_descriptions': '--search-descriptions',
+            'case_sensitive': '--case-sensitive',
+            'installed_only': '--installed-only',
+            'not_installed_only': '-u',
+            'details': '--details'
+            }
     if refresh:
         refresh_db()
 
@@ -1832,32 +1846,9 @@ def search(criteria, refresh=False, **kwargs):
     elif kwargs.get('match') == 'substrings':
         cmd.append('--match-substrings')
 
-    if kwargs.get('provides'):
-        cmd.append('--provides')
-    if kwargs.get('recommends'):
-        cmd.append('--recommends')
-    if kwargs.get('requires'):
-        cmd.append('--requires')
-    if kwargs.get('suggests'):
-        cmd.append('--suggests')
-    if kwargs.get('conflicts'):
-        cmd.append('--conflicts')
-    if kwargs.get('obsoletes'):
-        cmd.append('--obsoletes')
-
-    if kwargs.get('file_list'):
-        cmd.append('--file-list')
-    if kwargs.get('search_descriptions'):
-        cmd.append('--search-descriptions')
-    if kwargs.get('case_sensitive'):
-        cmd.append('--case-sensitive')
-    if kwargs.get('installed_only'):
-        cmd.append('--installed-only')
-    if kwargs.get('not_installed_only'):
-        # long parameter was renamed in the past
-        cmd.append('-u')
-    if kwargs.get('details'):
-        cmd.append('--details')
+    for opt in kwargs:
+        if opt in ALLOWED_SEARCH_OPTIONS:
+            cmd.append(ALLOWED_SEARCH_OPTIONS.get(opt))
 
     cmd.append(criteria)
     solvables = __zypper__.nolock.noraise.xml.call(*cmd).getElementsByTagName('solvable')

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -403,8 +403,8 @@ def _clean_cache():
     '''
     Clean cached results
     '''
-    for cache_name in ['list_pkgs', 'list_provides']:
-    __context__.pop(cache_name, None)
+    for cache_name in ['pkg.list_pkgs', 'pkg.list_provides']:
+        __context__.pop(cache_name, None)
 
 
 def list_upgrades(refresh=True, **kwargs):

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -508,8 +508,11 @@ def _find_install_targets(name=None,
         # add it to the kwargs.
         kwargs['refresh'] = refresh
 
+
+    resolve_capabilities = kwargs.get('resolve_capabilities', False) and 'pkg.list_provides' in __salt__
     try:
         cur_pkgs = __salt__['pkg.list_pkgs'](versions_as_list=True, **kwargs)
+        cur_prov = resolve_capabilities and __salt__['pkg.list_provides'](**kwargs) or dict()
     except CommandExecutionError as exc:
         return {'name': name,
                 'changes': {},
@@ -669,6 +672,9 @@ def _find_install_targets(name=None,
     failed_verify = False
     for key, val in six.iteritems(desired):
         cver = cur_pkgs.get(key, [])
+        if resolve_capabilities and not cver and key in cur_prov:
+            cver = cur_pkgs.get(cur_prov.get(key)[0], [])
+
         # Package not yet installed, so add to targets
         if not cver:
             targets[key] = val
@@ -786,7 +792,7 @@ def _find_install_targets(name=None,
             warnings, was_refreshed)
 
 
-def _verify_install(desired, new_pkgs, ignore_epoch=False):
+def _verify_install(desired, new_pkgs, ignore_epoch=False, new_caps={}):
     '''
     Determine whether or not the installed packages match what was requested in
     the SLS file.
@@ -809,6 +815,8 @@ def _verify_install(desired, new_pkgs, ignore_epoch=False):
             cver = new_pkgs.get(pkgname.split('=')[0])
         else:
             cver = new_pkgs.get(pkgname)
+            if not cver and pkgname in new_caps:
+                cver = new_pkgs.get(new_caps.get(pkgname)[0])
 
         if not cver:
             failed.append(pkgname)
@@ -871,6 +879,27 @@ def _nested_output(obj):
     nested.__opts__ = __opts__
     ret = nested.output(obj).rstrip()
     return ret
+
+def _resolve_capabilities(pkgs, refresh=False, **kwargs):
+    '''
+    Resolve capabilities in ``pkgs`` and exchange them with real package
+    names, when the result is distinct.
+    This feature can be turned on while setting the paramter
+    ``resolve_capabilities`` to True.
+
+    Return the input dictionary with replaced capability names and as
+    second return value a bool which indicate if a refresh was run.
+
+    In case of ``resolve_capabilities`` is False (disabled) or not
+    supported by the implementation the input is returned unchanged.
+    '''
+    was_refreshed = False
+    if not pkgs or 'pkg.resolve_capabilities' not in __salt__:
+        return (pkgs, was_refreshed)
+
+    ret = __salt__['pkg.resolve_capabilities'](pkgs, refresh=refresh, **kwargs)
+    was_refreshed = refresh
+    return (ret, was_refreshed)
 
 
 def installed(
@@ -1104,6 +1133,11 @@ def installed(
         Force strict package naming. Disables lookup of package alternatives.
 
         .. versionadded:: 2014.1.1
+
+    :param bool resolve_capabilities:
+        Turn on resolving capabilities. This allow to name "provides" or alias names for packages.
+
+        .. versionadded:: Oxygen
 
     :param bool allow_updates:
         Allow the package to be updated outside Salt's control (e.g. auto
@@ -1448,6 +1482,14 @@ def installed(
 
     kwargs['saltenv'] = __env__
     refresh = salt.utils.pkg.check_refresh(__opts__, refresh)
+
+    # check if capabilities should be checked and modify the requested packages
+    # accordingly.
+    if pkgs:
+        (pkgs, was_refreshed) = _resolve_capabilities(pkgs, refresh=refresh, **kwargs)
+        if was_refreshed:
+            refresh = False
+
     if not isinstance(pkg_verify, list):
         pkg_verify = pkg_verify is True
     if (pkg_verify or isinstance(pkg_verify, list)) \
@@ -1707,8 +1749,13 @@ def installed(
         if __grains__['os'] == 'FreeBSD':
             kwargs['with_origin'] = True
         new_pkgs = __salt__['pkg.list_pkgs'](versions_as_list=True, **kwargs)
+        if kwargs.get('resolve_capabilities', False) and 'pkg.list_provides' in __salt__:
+            new_caps = __salt__['pkg.list_provides'](**kwargs)
+        else:
+            new_caps = {}
         ok, failed = _verify_install(desired, new_pkgs,
-                                     ignore_epoch=ignore_epoch)
+                                     ignore_epoch=ignore_epoch,
+                                     new_caps=new_caps)
         modified = [x for x in ok if x in targets]
         not_modified = [x for x in ok
                         if x not in targets
@@ -1927,6 +1974,11 @@ def downloaded(name,
                       - dos2unix
                       - salt-minion: 2015.8.5-1.el6
 
+    :param bool resolve_capabilities:
+        Turn on resolving capabilities. This allow to name "provides" or alias names for packages.
+
+        .. versionadded:: Oxygen
+
     CLI Example:
 
     .. code-block:: yaml
@@ -1952,10 +2004,23 @@ def downloaded(name,
         ret['comment'] = 'No packages to download provided'
         return ret
 
+    # If just a name (and optionally a version) is passed, just pack them into
+    # the pkgs argument.
+    if name and not pkgs:
+        if version:
+            pkgs = [{name: version}]
+            version = None
+        else:
+            pkgs = [name]
+
     # It doesn't make sense here to received 'downloadonly' as kwargs
     # as we're explicitely passing 'downloadonly=True' to execution module.
     if 'downloadonly' in kwargs:
         del kwargs['downloadonly']
+
+    (pkgs, was_refreshed) = _resolve_capabilities(pkgs, **kwargs)
+    if was_refreshed:
+        refresh = False
 
     # Only downloading not yet downloaded packages
     targets = _find_download_targets(name,
@@ -2203,6 +2268,10 @@ def latest(
             This parameter is available only on Debian based distributions and
             has no effect on the rest.
 
+    :param bool resolve_capabilities:
+        Turn on resolving capabilities. This allow to name "provides" or alias names for packages.
+
+        .. versionadded:: Oxygen
 
     Multiple Package Installation Options:
 
@@ -2299,6 +2368,12 @@ def latest(
             desired_pkgs = [name]
 
     kwargs['saltenv'] = __env__
+
+    # check if capabilities should be checked and modify the requested packages
+    # accordingly.
+    (desired_pkgs, was_refreshed) = _resolve_capabilities(desired_pkgs, refresh=refresh, **kwargs)
+    if was_refreshed:
+        refresh = False
 
     try:
         avail = __salt__['pkg.latest_version'](*desired_pkgs,
@@ -2822,6 +2897,11 @@ def uptodate(name, refresh=False, pkgs=None, **kwargs):
             This parameter available only on Debian based distributions, and
             have no effect on the rest.
 
+    :param bool resolve_capabilities:
+        Turn on resolving capabilities. This allow to name "provides" or alias names for packages.
+
+        .. versionadded:: Oxygen
+
     kwargs
         Any keyword arguments to pass through to ``pkg.upgrade``.
 
@@ -2841,7 +2921,11 @@ def uptodate(name, refresh=False, pkgs=None, **kwargs):
         ret['comment'] = '\'fromrepo\' argument not supported on this platform'
         return ret
 
+
     if isinstance(refresh, bool):
+        (pkgs, was_refreshed) = _resolve_capabilities(pkgs, refresh=refresh, **kwargs)
+        if was_refreshed:
+            refresh = False
         try:
             packages = __salt__['pkg.list_upgrades'](refresh=refresh, **kwargs)
             if isinstance(pkgs, list):

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -888,18 +888,16 @@ def _resolve_capabilities(pkgs, refresh=False, **kwargs):
     ``resolve_capabilities`` to True.
 
     Return the input dictionary with replaced capability names and as
-    second return value a bool which indicate if a refresh was run.
+    second return value a bool which say if a refresh need to be run.
 
     In case of ``resolve_capabilities`` is False (disabled) or not
     supported by the implementation the input is returned unchanged.
     '''
-    was_refreshed = False
     if not pkgs or 'pkg.resolve_capabilities' not in __salt__:
-        return (pkgs, was_refreshed)
+        return pkgs, refresh
 
     ret = __salt__['pkg.resolve_capabilities'](pkgs, refresh=refresh, **kwargs)
-    was_refreshed = refresh
-    return (ret, was_refreshed)
+    return ret, False
 
 
 def installed(
@@ -1486,9 +1484,7 @@ def installed(
     # check if capabilities should be checked and modify the requested packages
     # accordingly.
     if pkgs:
-        pkgs, was_refreshed = _resolve_capabilities(pkgs, refresh=refresh, **kwargs)
-        if was_refreshed:
-            refresh = False
+        pkgs, refresh = _resolve_capabilities(pkgs, refresh=refresh, **kwargs)
 
     if not isinstance(pkg_verify, list):
         pkg_verify = pkg_verify is True
@@ -2018,9 +2014,7 @@ def downloaded(name,
     if 'downloadonly' in kwargs:
         del kwargs['downloadonly']
 
-    pkgs, was_refreshed = _resolve_capabilities(pkgs, **kwargs)
-    if was_refreshed:
-        refresh = False
+    pkgs, _refresh = _resolve_capabilities(pkgs, **kwargs)
 
     # Only downloading not yet downloaded packages
     targets = _find_download_targets(name,
@@ -2371,9 +2365,7 @@ def latest(
 
     # check if capabilities should be checked and modify the requested packages
     # accordingly.
-    desired_pkgs, was_refreshed = _resolve_capabilities(desired_pkgs, refresh=refresh, **kwargs)
-    if was_refreshed:
-        refresh = False
+    desired_pkgs, refresh = _resolve_capabilities(desired_pkgs, refresh=refresh, **kwargs)
 
     try:
         avail = __salt__['pkg.latest_version'](*desired_pkgs,
@@ -2923,7 +2915,7 @@ def uptodate(name, refresh=False, pkgs=None, **kwargs):
 
 
     if isinstance(refresh, bool):
-        pkgs, was_refreshed = _resolve_capabilities(pkgs, refresh=refresh, **kwargs)
+        pkgs, refresh = _resolve_capabilities(pkgs, refresh=refresh, **kwargs)
         if was_refreshed:
             refresh = False
         try:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1486,7 +1486,7 @@ def installed(
     # check if capabilities should be checked and modify the requested packages
     # accordingly.
     if pkgs:
-        (pkgs, was_refreshed) = _resolve_capabilities(pkgs, refresh=refresh, **kwargs)
+        pkgs, was_refreshed = _resolve_capabilities(pkgs, refresh=refresh, **kwargs)
         if was_refreshed:
             refresh = False
 
@@ -2018,7 +2018,7 @@ def downloaded(name,
     if 'downloadonly' in kwargs:
         del kwargs['downloadonly']
 
-    (pkgs, was_refreshed) = _resolve_capabilities(pkgs, **kwargs)
+    pkgs, was_refreshed = _resolve_capabilities(pkgs, **kwargs)
     if was_refreshed:
         refresh = False
 
@@ -2371,7 +2371,7 @@ def latest(
 
     # check if capabilities should be checked and modify the requested packages
     # accordingly.
-    (desired_pkgs, was_refreshed) = _resolve_capabilities(desired_pkgs, refresh=refresh, **kwargs)
+    desired_pkgs, was_refreshed = _resolve_capabilities(desired_pkgs, refresh=refresh, **kwargs)
     if was_refreshed:
         refresh = False
 
@@ -2923,7 +2923,7 @@ def uptodate(name, refresh=False, pkgs=None, **kwargs):
 
 
     if isinstance(refresh, bool):
-        (pkgs, was_refreshed) = _resolve_capabilities(pkgs, refresh=refresh, **kwargs)
+        pkgs, was_refreshed = _resolve_capabilities(pkgs, refresh=refresh, **kwargs)
         if was_refreshed:
             refresh = False
         try:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -508,7 +508,6 @@ def _find_install_targets(name=None,
         # add it to the kwargs.
         kwargs['refresh'] = refresh
 
-
     resolve_capabilities = kwargs.get('resolve_capabilities', False) and 'pkg.list_provides' in __salt__
     try:
         cur_pkgs = __salt__['pkg.list_pkgs'](versions_as_list=True, **kwargs)
@@ -792,13 +791,15 @@ def _find_install_targets(name=None,
             warnings, was_refreshed)
 
 
-def _verify_install(desired, new_pkgs, ignore_epoch=False, new_caps={}):
+def _verify_install(desired, new_pkgs, ignore_epoch=False, new_caps=None):
     '''
     Determine whether or not the installed packages match what was requested in
     the SLS file.
     '''
     ok = []
     failed = []
+    if not new_caps:
+        new_caps = dict()
     for pkgname, pkgver in desired.items():
         # FreeBSD pkg supports `openjdk` and `java/openjdk7` package names.
         # Homebrew for Mac OSX does something similar with tap names
@@ -879,6 +880,7 @@ def _nested_output(obj):
     nested.__opts__ = __opts__
     ret = nested.output(obj).rstrip()
     return ret
+
 
 def _resolve_capabilities(pkgs, refresh=False, **kwargs):
     '''
@@ -2913,11 +2915,8 @@ def uptodate(name, refresh=False, pkgs=None, **kwargs):
         ret['comment'] = '\'fromrepo\' argument not supported on this platform'
         return ret
 
-
     if isinstance(refresh, bool):
         pkgs, refresh = _resolve_capabilities(pkgs, refresh=refresh, **kwargs)
-        if was_refreshed:
-            refresh = False
         try:
             packages = __salt__['pkg.list_upgrades'](refresh=refresh, **kwargs)
             if isinstance(pkgs, list):

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -37,9 +37,13 @@ _PKG_TARGETS = {
     'Debian': ['python-plist', 'apg'],
     'RedHat': ['units', 'zsh-html'],
     'FreeBSD': ['aalib', 'pth'],
-    'Suse': ['aalib', 'python-pssh'],
+    'Suse': ['aalib', 'rpm-python'],
     'MacOS': ['libpng', 'jpeg'],
     'Windows': ['firefox', '7zip'],
+}
+
+_PKG_CAP_TARGETS = {
+    'Suse': [('w3m_ssl', 'w3m')],
 }
 
 _PKG_TARGETS_32 = {
@@ -793,3 +797,262 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret_comment, 'An error was encountered while installing/updating group '
                                       '\'handle_missing_pkg_group\': Group \'handle_missing_pkg_group\' '
                                       'not found.')
+
+    @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
+    @requires_system_grains
+    def test_pkg_cap_001_installed(self, grains=None):
+        '''
+        This is a destructive test as it installs and then removes a package
+        '''
+        # Skip test if package manager not available
+        if not pkgmgr_avail(self.run_function, self.run_function('grains.items')):
+            self.skipTest('Package manager is not available')
+
+        os_family = grains.get('os_family', '')
+        pkg_cap_targets = _PKG_CAP_TARGETS.get(os_family, [])
+        if not len(pkg_cap_targets) > 0:
+            self.skipTest('Capability not provided')
+
+        target, realpkg = pkg_cap_targets[0]
+        version = self.run_function('pkg.version', [target])
+        realver = self.run_function('pkg.version', [realpkg])
+
+        # If this assert fails, we need to find new targets, this test needs to
+        # be able to test successful installation of packages, so this package
+        # needs to not be installed before we run the states below
+        self.assertFalse(version)
+        self.assertFalse(realver)
+
+        ret = self.run_state('pkg.installed', name=target, refresh=False, resolve_capabilities=True, test=True)
+        self.assertInSaltComment("The following packages would be installed/updated: {0}".format(realpkg), ret)
+        ret = self.run_state('pkg.installed', name=target, refresh=False, resolve_capabilities=True)
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('pkg.removed', name=realpkg)
+        self.assertSaltTrueReturn(ret)
+
+    @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
+    @requires_system_grains
+    def test_pkg_cap_002_already_installed(self, grains=None):
+        '''
+        This is a destructive test as it installs and then removes a package
+        '''
+        # Skip test if package manager not available
+        if not pkgmgr_avail(self.run_function, self.run_function('grains.items')):
+            self.skipTest('Package manager is not available')
+
+        os_family = grains.get('os_family', '')
+        pkg_cap_targets = _PKG_CAP_TARGETS.get(os_family, [])
+        if not len(pkg_cap_targets) > 0:
+            self.skipTest('Capability not provided')
+
+        target, realpkg = pkg_cap_targets[0]
+        version = self.run_function('pkg.version', [target])
+        realver = self.run_function('pkg.version', [realpkg])
+
+        # If this assert fails, we need to find new targets, this test needs to
+        # be able to test successful installation of packages, so this package
+        # needs to not be installed before we run the states below
+        self.assertFalse(version)
+        self.assertFalse(realver)
+
+        # install the package already
+        ret = self.run_state('pkg.installed', name=realpkg, refresh=False)
+
+        ret = self.run_state('pkg.installed', name=target, refresh=False, resolve_capabilities=True, test=True)
+        self.assertInSaltComment("All specified packages are already installed", ret)
+
+        ret = self.run_state('pkg.installed', name=target, refresh=False, resolve_capabilities=True)
+        self.assertSaltTrueReturn(ret)
+
+        self.assertInSaltComment("packages are already installed", ret)
+        ret = self.run_state('pkg.removed', name=realpkg)
+        self.assertSaltTrueReturn(ret)
+
+    @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
+    @requires_system_grains
+    def test_pkg_cap_003_installed_multipkg_with_version(self, grains=None):
+        '''
+        This is a destructive test as it installs and then removes two packages
+        '''
+        # Skip test if package manager not available
+        if not pkgmgr_avail(self.run_function, self.run_function('grains.items')):
+            self.skipTest('Package manager is not available')
+
+        os_family = grains.get('os_family', '')
+        pkg_cap_targets = _PKG_CAP_TARGETS.get(os_family, [])
+        if not len(pkg_cap_targets) > 0:
+            self.skipTest('Capability not provided')
+        pkg_targets = _PKG_TARGETS.get(os_family, [])
+
+        # Don't perform this test on FreeBSD since version specification is not
+        # supported.
+        if os_family == 'FreeBSD':
+            return
+
+        # Make sure that we have targets that match the os_family. If this
+        # fails then the _PKG_TARGETS dict above needs to have an entry added,
+        # with two packages that are not installed before these tests are run
+        self.assertTrue(bool(pkg_cap_targets))
+        self.assertTrue(bool(pkg_targets))
+
+        if os_family == 'Arch':
+            for idx in range(13):
+                if idx == 12:
+                    raise Exception('Package database locked after 60 seconds, '
+                                    'bailing out')
+                if not os.path.isfile('/var/lib/pacman/db.lck'):
+                    break
+                time.sleep(5)
+
+        capability, realpkg = pkg_cap_targets[0]
+        version = latest_version(self.run_function, pkg_targets[0])
+        realver = latest_version(self.run_function, realpkg)
+
+        # If this assert fails, we need to find new targets, this test needs to
+        # be able to test successful installation of packages, so these
+        # packages need to not be installed before we run the states below
+        self.assertTrue(bool(version))
+        self.assertTrue(bool(realver))
+
+        pkgs = [{pkg_targets[0]: version}, pkg_targets[1], {capability: realver}]
+        ret = self.run_state('pkg.installed',
+                             name='test_pkg_cap_003_installed_multipkg_with_version-install',
+                             pkgs=pkgs,
+                             refresh=False)
+        self.assertSaltFalseReturn(ret)
+
+        ret = self.run_state('pkg.installed',
+                             name='test_pkg_cap_003_installed_multipkg_with_version-install-capability',
+                             pkgs=pkgs,
+                             refresh=False, resolve_capabilities=True, test=True)
+        self.assertInSaltComment("packages would be installed/updated", ret)
+        self.assertInSaltComment("{0}={1}".format(realpkg, realver), ret)
+
+        ret = self.run_state('pkg.installed',
+                             name='test_pkg_cap_003_installed_multipkg_with_version-install-capability',
+                             pkgs=pkgs,
+                             refresh=False, resolve_capabilities=True)
+        self.assertSaltTrueReturn(ret)
+        cleanup_pkgs = pkg_targets
+        cleanup_pkgs.append(realpkg)
+        ret = self.run_state('pkg.removed',
+                             name='test_pkg_cap_003_installed_multipkg_with_version-remove',
+                             pkgs=cleanup_pkgs)
+        self.assertSaltTrueReturn(ret)
+
+    @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
+    @requires_system_grains
+    def test_pkg_cap_004_latest(self, grains=None):
+        '''
+        This tests pkg.latest with a package that has no epoch (or a zero
+        epoch).
+        '''
+        # Skip test if package manager not available
+        if not pkgmgr_avail(self.run_function, self.run_function('grains.items')):
+            self.skipTest('Package manager is not available')
+
+        os_family = grains.get('os_family', '')
+        pkg_cap_targets = _PKG_CAP_TARGETS.get(os_family, [])
+        if not len(pkg_cap_targets) > 0:
+            self.skipTest('Capability not provided')
+
+        target, realpkg = pkg_cap_targets[0]
+        version = self.run_function('pkg.version', [target])
+        realver = self.run_function('pkg.version', [realpkg])
+
+        # If this assert fails, we need to find new targets, this test needs to
+        # be able to test successful installation of packages, so this package
+        # needs to not be installed before we run the states below
+        self.assertFalse(version)
+        self.assertFalse(realver)
+
+        ret = self.run_state('pkg.latest', name=target, refresh=False, resolve_capabilities=True, test=True)
+        self.assertInSaltComment("The following packages would be installed/upgraded: {0}".format(realpkg), ret)
+        ret = self.run_state('pkg.latest', name=target, refresh=False, resolve_capabilities=True)
+        self.assertSaltTrueReturn(ret)
+
+        ret = self.run_state('pkg.latest', name=target, refresh=False, resolve_capabilities=True)
+        self.assertSaltTrueReturn(ret)
+        self.assertInSaltComment("is already up-to-date", ret)
+
+        ret = self.run_state('pkg.removed', name=realpkg)
+        self.assertSaltTrueReturn(ret)
+
+    @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
+    @requires_system_grains
+    def test_pkg_cap_005_downloaded(self, grains=None):
+        '''
+        This is a destructive test as it installs and then removes a package
+        '''
+        # Skip test if package manager not available
+        if not pkgmgr_avail(self.run_function, self.run_function('grains.items')):
+            self.skipTest('Package manager is not available')
+
+        os_family = grains.get('os_family', '')
+        pkg_cap_targets = _PKG_CAP_TARGETS.get(os_family, [])
+        if not len(pkg_cap_targets) > 0:
+            self.skipTest('Capability not provided')
+
+        target, realpkg = pkg_cap_targets[0]
+        version = self.run_function('pkg.version', [target])
+        realver = self.run_function('pkg.version', [realpkg])
+
+        # If this assert fails, we need to find new targets, this test needs to
+        # be able to test successful installation of packages, so this package
+        # needs to not be installed before we run the states below
+        self.assertFalse(version)
+        self.assertFalse(realver)
+
+        ret = self.run_state('pkg.downloaded', name=target, refresh=False)
+        self.assertSaltFalseReturn(ret)
+
+        ret = self.run_state('pkg.downloaded', name=target, refresh=False, resolve_capabilities=True, test=True)
+        self.assertInSaltComment("The following packages would be downloaded: {0}".format(realpkg), ret)
+
+        ret = self.run_state('pkg.downloaded', name=target, refresh=False, resolve_capabilities=True)
+        self.assertSaltTrueReturn(ret)
+
+    @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
+    @requires_system_grains
+    def test_pkg_cap_006_uptodate(self, grains=None):
+        '''
+        This is a destructive test as it installs and then removes a package
+        '''
+        # Skip test if package manager not available
+        if not pkgmgr_avail(self.run_function, self.run_function('grains.items')):
+            self.skipTest('Package manager is not available')
+
+        os_family = grains.get('os_family', '')
+        pkg_cap_targets = _PKG_CAP_TARGETS.get(os_family, [])
+        if not len(pkg_cap_targets) > 0:
+            self.skipTest('Capability not provided')
+
+        target, realpkg = pkg_cap_targets[0]
+        version = self.run_function('pkg.version', [target])
+        realver = self.run_function('pkg.version', [realpkg])
+
+        # If this assert fails, we need to find new targets, this test needs to
+        # be able to test successful installation of packages, so this package
+        # needs to not be installed before we run the states below
+        self.assertFalse(version)
+        self.assertFalse(realver)
+
+        ret = self.run_state('pkg.installed', name=target,
+                             refresh=False, resolve_capabilities=True)
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('pkg.uptodate',
+                             name='test_pkg_cap_006_uptodate',
+                             pkgs=[target],
+                             refresh=False,
+                             resolve_capabilities=True)
+        self.assertSaltTrueReturn(ret)
+        self.assertInSaltComment("System is already up-to-date", ret)
+        ret = self.run_state('pkg.removed', name=realpkg)
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('pkg.uptodate',
+                             name='test_pkg_cap_006_uptodate',
+                             refresh=False,
+                             test=True)
+        self.assertInSaltComment("System update will be performed", ret)
+
+

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -1054,5 +1054,3 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
                              refresh=False,
                              test=True)
         self.assertInSaltComment("System update will be performed", ret)
-
-

--- a/tests/unit/modules/test_zypper.py
+++ b/tests/unit/modules/test_zypper.py
@@ -669,8 +669,8 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 zypper_mock.assert_called_once_with(
                     '--no-refresh',
                     'install',
-                    '--name',
                     '--auto-agree-with-licenses',
+                    '--name',
                     '--download-only',
                     'vim'
                 )
@@ -699,8 +699,8 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 zypper_mock.assert_called_once_with(
                     '--no-refresh',
                     'install',
-                    '--name',
                     '--auto-agree-with-licenses',
+                    '--name',
                     '--download-only',
                     'vim'
                 )
@@ -724,8 +724,8 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 zypper_mock.assert_called_once_with(
                     '--no-refresh',
                     'install',
-                    '--name',
                     '--auto-agree-with-licenses',
+                    '--name',
                     'patch:SUSE-PATCH-1234'
                 )
                 self.assertDictEqual(ret, {"vim": {"old": "1.1", "new": "1.2"}})


### PR DESCRIPTION
### What does this PR do?

pkg.installed, pkg.latest, pkg.downloaded and pkg.uptodate got the capability to look
for capabilities instead of real package names.

This requires that the package module implements it and the `resolve_capabilities` parameter is
set to True,

This is useful when packages were renamed:

A package in openSUSE x (python-xyz) gets renamed in openSUSE y into "python-pyXYZ". 
To write one state which serve both openSUSE versions requires currently jinja templating.
This feature allows you to write the following to achieve the same:

```
myid:
  pkg.installed:
    - name: python-xyz
    - resolve_capabilities: True
```

The renamed package should have a `Provides: python-xyz` which is used to install python-pyXYZ
if no package with the name python-xyz exists.

### Previous Behavior

Package not found.

### New Behavior

If the option is set, and one package providing the capability name is found it gets installed.

### Tests written?

Yes

### Commits signed with GPG?

No
