### PR TITLE
salt.pillar.file_tree: add support for environments, add test

### DIFF
--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -29,6 +29,13 @@ will follow symbolic links to other directories.
     Be careful when using ``follow_dir_links``, as a recursive symlink chain
     will result in unexpected results.
 
+.. versionchanged:: develop
+    If ``root_dir`` is a relative path, it will be treated as relative to the
+    :conf_master:`pillar_roots` of the environment specified by
+    :conf_minion:`pillarenv`. If an environment specifies multiple
+    roots, this module will search for files relative to all of them, in order,
+    merging the results.
+
 If ``keep_newline`` is set to ``True``, then the pillar values for files ending
 in newlines will keep that newline. The default behavior is to remove the
 end-of-file newline. ``keep_newline`` should be turned on if the pillar data is
@@ -189,6 +196,9 @@ import salt.template
 # Set up logging
 log = logging.getLogger(__name__)
 
+# The default option values
+__opts__ = {}
+
 
 def _on_walk_error(err):
     '''
@@ -310,6 +320,60 @@ def ext_pillar(minion_id,
     if not root_dir:
         log.error('file_tree: no root_dir specified')
         return {}
+
+    if not os.path.isabs(root_dir):
+        pillarenv = __opts__['pillarenv']
+        if pillarenv is None:
+            log.error('file_tree: root_dir is relative but pillarenv is not set')
+            return {}
+        log.debug('file_tree: pillarenv = %s', pillarenv)
+
+        env_roots = __opts__['pillar_roots'].get(pillarenv, None)
+        if env_roots is None:
+            log.error('file_tree: root_dir is relative but no pillar_roots are specified '
+                      ' for pillarenv %s', pillarenv)
+            return {}
+
+        env_dirs = []
+        for env_root in env_roots:
+            env_dir = os.path.normpath(os.path.join(env_root, root_dir))
+            # don't redundantly load consecutively, but preserve any expected precedence
+            if env_dir not in env_dirs or env_dir != env_dirs[-1]:
+                env_dirs.append(env_dir)
+        dirs = env_dirs
+    else:
+        dirs = [root_dir]
+
+    result_pillar = {}
+    for root in dirs:
+        dir_pillar = _ext_pillar(minion_id,
+                                 root,
+                                 follow_dir_links,
+                                 debug,
+                                 keep_newline,
+                                 render_default,
+                                 renderer_blacklist,
+                                 renderer_whitelist,
+                                 template)
+        result_pillar = salt.utils.dictupdate.merge(result_pillar,
+                                                    dir_pillar,
+                                                    strategy='recurse')
+    return result_pillar
+
+
+def _ext_pillar(minion_id,
+                root_dir,
+                follow_dir_links,
+                debug,
+                keep_newline,
+                render_default,
+                renderer_blacklist,
+                renderer_whitelist,
+                template):
+    '''
+    Compile pillar data for a single root_dir for the specified minion ID
+    '''
+    log.debug('file_tree: reading %s', root_dir)
 
     if not os.path.isdir(root_dir):
         log.error(

--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -29,7 +29,7 @@ will follow symbolic links to other directories.
     Be careful when using ``follow_dir_links``, as a recursive symlink chain
     will result in unexpected results.
 
-.. versionchanged:: develop
+.. versionchanged:: Oxygen
     If ``root_dir`` is a relative path, it will be treated as relative to the
     :conf_master:`pillar_roots` of the environment specified by
     :conf_minion:`pillarenv`. If an environment specifies multiple
@@ -195,9 +195,6 @@ import salt.template
 
 # Set up logging
 log = logging.getLogger(__name__)
-
-# The default option values
-__opts__ = {}
 
 
 def _on_walk_error(err):

--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -269,14 +269,14 @@ def _construct_pillar(top_dir,
                 log.error('file_tree: %s: not a regular file', file_path)
                 continue
 
-            contents = ''
+            contents = b''
             try:
                 with salt.utils.files.fopen(file_path, 'rb') as fhr:
                     buf = fhr.read(__opts__['file_buffer_size'])
                     while buf:
                         contents += buf
                         buf = fhr.read(__opts__['file_buffer_size'])
-                    if contents.endswith('\n') \
+                    if contents.endswith(b'\n') \
                             and _check_newline(prefix,
                                                file_name,
                                                keep_newline):

--- a/tests/unit/pillar/test_file_tree.py
+++ b/tests/unit/pillar/test_file_tree.py
@@ -24,12 +24,12 @@ MINION_ID = 'test-host'
 NODEGROUP_PATH = os.path.join('nodegroups', 'test-group', 'files')
 HOST_PATH = os.path.join('hosts', MINION_ID, 'files')
 
-BASE_PILLAR_CONTENT =   {'files': {'hostfile': 'base', 'groupfile': 'base'}}
-DEV_PILLAR_CONTENT =    {'files': {'hostfile': 'base', 'groupfile': 'dev2',
-                                   'hostfile1': 'dev1', 'groupfile1': 'dev1',
-                                   'hostfile2': 'dev2'}}
-PARENT_PILLAR_CONTENT = {'files': {'hostfile': 'base', 'groupfile': 'base',
-                                   'hostfile2': 'dev2'}}
+BASE_PILLAR_CONTENT = {'files': {'hostfile': b'base', 'groupfile': b'base'}}
+DEV_PILLAR_CONTENT = {'files': {'hostfile': b'base', 'groupfile': b'dev2',
+                                'hostfile1': b'dev1', 'groupfile1': b'dev1',
+                                'hostfile2': b'dev2'}}
+PARENT_PILLAR_CONTENT = {'files': {'hostfile': b'base', 'groupfile': b'base',
+                                   'hostfile2': b'dev2'}}
 
 FILE_DATA = {
     os.path.join('base', HOST_PATH, 'hostfile'): 'base',

--- a/tests/unit/pillar/test_file_tree.py
+++ b/tests/unit/pillar/test_file_tree.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+'''test for pillar file_tree.py'''
+
+# Import python libs
+from __future__ import absolute_import
+
+import os
+import tempfile
+import shutil
+
+# Import Salt Testing libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
+from tests.support.paths import TMP
+from tests.support.helpers import TestsLoggingHandler
+
+# Import Salt Libs
+import salt.utils.files
+import salt.pillar.file_tree as file_tree
+
+
+MINION_ID = 'test-host'
+NODEGROUP_PATH = os.path.join('nodegroups', 'test-group', 'files')
+HOST_PATH = os.path.join('hosts', MINION_ID, 'files')
+
+BASE_PILLAR_CONTENT =   {'files': {'hostfile': 'base', 'groupfile': 'base'}}
+DEV_PILLAR_CONTENT =    {'files': {'hostfile': 'base', 'groupfile': 'dev2',
+                                   'hostfile1': 'dev1', 'groupfile1': 'dev1',
+                                   'hostfile2': 'dev2'}}
+PARENT_PILLAR_CONTENT = {'files': {'hostfile': 'base', 'groupfile': 'base',
+                                   'hostfile2': 'dev2'}}
+
+FILE_DATA = {
+    os.path.join('base', HOST_PATH, 'hostfile'): 'base',
+    os.path.join('dev1', HOST_PATH, 'hostfile1'): 'dev1',
+    os.path.join('dev2', HOST_PATH, 'hostfile2'): 'dev2',
+    os.path.join('base', NODEGROUP_PATH, 'groupfile'): 'base',
+    os.path.join('dev1', NODEGROUP_PATH, 'groupfile1'): 'dev1',
+    os.path.join('dev2', NODEGROUP_PATH, 'groupfile'): 'dev2'  # test merging
+}
+
+_CHECK_MINIONS_RETURN = {'minions': [MINION_ID], 'missing': []}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class FileTreePillarTestCase(TestCase, LoaderModuleMockMixin):
+    'test file_tree pillar'
+    maxDiff = None
+
+    def setup_loader_modules(self):
+        self.tmpdir = tempfile.mkdtemp(dir=TMP)
+        self.addCleanup(shutil.rmtree, self.tmpdir)
+        cachedir = os.path.join(self.tmpdir, 'cachedir')
+        os.makedirs(os.path.join(cachedir, 'file_tree'))
+        self.pillar_path = self._create_pillar_files()
+        return {
+            file_tree: {
+                '__opts__':  {
+                    'cachedir': cachedir,
+                    'pillar_roots': {
+                        'base':   [os.path.join(self.pillar_path, 'base')],
+                        'dev':    [os.path.join(self.pillar_path, 'base'),
+                                   os.path.join(self.pillar_path, 'dev1'),
+                                   os.path.join(self.pillar_path, 'dev2')
+                                   ],
+                        'parent': [os.path.join(self.pillar_path, 'base', 'sub1'),
+                                   os.path.join(self.pillar_path, 'dev2', 'sub'),
+                                   os.path.join(self.pillar_path, 'base', 'sub2'),
+                                   ],
+                    },
+                    'pillarenv': 'base',
+                    'nodegroups': {'test-group': [MINION_ID]},
+                    'file_buffer_size': 262144,
+                    'file_roots': {'base': '', 'dev': '', 'parent': ''},
+                    'extension_modules': '',
+                    'renderer': 'yaml_jinja',
+                    'renderer_blacklist': [],
+                    'renderer_whitelist': []
+                }
+            }
+        }
+
+    def _create_pillar_files(self):
+        'create files in tempdir'
+        pillar_path = os.path.join(self.tmpdir, 'file_tree')
+        for filename in FILE_DATA:
+            filepath = os.path.join(pillar_path, filename)
+            os.makedirs(os.path.dirname(filepath))
+            with salt.utils.files.fopen(filepath, 'w') as data_file:
+                data_file.write(FILE_DATA[filename])
+        return pillar_path
+
+    def test_absolute_path(self):
+        'check file tree is imported correctly with an absolute path'
+        absolute_path = os.path.join(self.pillar_path, 'base')
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_CHECK_MINIONS_RETURN)):
+            mypillar = file_tree.ext_pillar(MINION_ID, None, absolute_path)
+            self.assertEqual(BASE_PILLAR_CONTENT, mypillar)
+
+            with patch.dict(file_tree.__opts__, {'pillarenv': 'dev'}):
+                mypillar = file_tree.ext_pillar(MINION_ID, None, absolute_path)
+                self.assertEqual(BASE_PILLAR_CONTENT, mypillar)
+
+    def test_relative_path(self):
+        'check file tree is imported correctly with a relative path'
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_CHECK_MINIONS_RETURN)):
+            mypillar = file_tree.ext_pillar(MINION_ID, None, '.')
+            self.assertEqual(BASE_PILLAR_CONTENT, mypillar)
+
+            with patch.dict(file_tree.__opts__, {'pillarenv': 'dev'}):
+                mypillar = file_tree.ext_pillar(MINION_ID, None, '.')
+                self.assertEqual(DEV_PILLAR_CONTENT, mypillar)
+
+    def test_parent_path(self):
+        'check if file tree is merged correctly with a .. path'
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_CHECK_MINIONS_RETURN)):
+            with patch.dict(file_tree.__opts__, {'pillarenv': 'parent'}):
+                mypillar = file_tree.ext_pillar(MINION_ID, None, '..')
+                self.assertEqual(PARENT_PILLAR_CONTENT, mypillar)
+
+    def test_no_pillarenv(self):
+        'check if file trees are merged correctly across multiple environments'
+        with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_CHECK_MINIONS_RETURN)):
+            with patch.dict(file_tree.__opts__, {'pillarenv': None}):
+                with TestsLoggingHandler() as handler:
+                    mypillar = file_tree.ext_pillar(MINION_ID, None, '.')
+                    self.assertEqual({}, mypillar)
+
+                    for message in handler.messages:
+                        if message.startswith('ERROR:') and 'pillarenv is not set' in message:
+                            break
+                    else:
+                        raise AssertionError('Did not find error message')

--- a/tests/unit/pillar/test_file_tree.py
+++ b/tests/unit/pillar/test_file_tree.py
@@ -120,7 +120,7 @@ class FileTreePillarTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertEqual(PARENT_PILLAR_CONTENT, mypillar)
 
     def test_no_pillarenv(self):
-        'check if file trees are merged correctly across multiple environments'
+        'confirm that file_tree yells when pillarenv is missing for a relative path'
         with patch('salt.utils.minions.CkMinions.check_minions', MagicMock(return_value=_CHECK_MINIONS_RETURN)):
             with patch.dict(file_tree.__opts__, {'pillarenv': None}):
                 with TestsLoggingHandler() as handler:


### PR DESCRIPTION
### What does this PR do?
This modifies this ext_pillar with basic support for environments by treating a relative root_dir as relative to the pillar_roots of the environment specified by pillarenv.

The behavior for absolute paths is unchanged.

Also adds a unit test for file_tree testing both old and new behavior.

### What issues does this PR fix or reference?
Resolves #44458.

### Previous Behavior
Using a relative root_dir had undocumented (and perhaps undefined) behavior. Only a single absolute root_dir could be specified for a master, preventing the use of different file_trees for different environments.

### New Behavior
A relative root_dir is treated as relative to the pillar_roots of the environment specified by pillarenv.  The behavior for an absolute root_dir is unchanged.

### Tests written?
Yes

### Commits signed with GPG?
No
