### PR TITLE
Send Unix timestamps to database in pgjsonb returner

### DIFF
--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -254,14 +254,14 @@ def returner(ret):
         with _get_serv(ret, commit=True) as cur:
             sql = '''INSERT INTO salt_returns
                     (fun, jid, return, id, success, full_ret, alter_time)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s)'''
+                    VALUES (%s, %s, %s, %s, %s, %s, to_timestamp(%s))'''
 
             cur.execute(sql, (ret['fun'], ret['jid'],
                               psycopg2.extras.Json(ret['return']),
                               ret['id'],
                               ret.get('success', False),
                               psycopg2.extras.Json(ret),
-                              time.strftime('%Y-%m-%d %H:%M:%S %z', time.localtime())))
+                              time.time()))
     except salt.exceptions.SaltMasterError:
         log.critical('Could not store return with pgjsonb returner. PostgreSQL server unavailable.')
 
@@ -278,9 +278,9 @@ def event_return(events):
             tag = event.get('tag', '')
             data = event.get('data', '')
             sql = '''INSERT INTO salt_events (tag, data, master_id, alter_time)
-                     VALUES (%s, %s, %s, %s)'''
+                     VALUES (%s, %s, %s, to_timestamp(%s))'''
             cur.execute(sql, (tag, psycopg2.extras.Json(data),
-                              __opts__['id'], time.strftime('%Y-%m-%d %H:%M:%S %z', time.localtime())))
+                              __opts__['id'], time.time()))
 
 
 def save_load(jid, load, minions=None):


### PR DESCRIPTION
This pull request is made against `2016.11`, but the instructions are not particularly clear. "[Sending a GitHub pull request](https://docs.saltstack.com/en/latest/topics/development/contributing.html#sending-a-github-pull-request)" says to use "the oldest release branch that contains the bug", which would have been 2014.1. "[Salt's Branch Topology](https://docs.saltstack.com/en/latest/topics/development/contributing.html#salt-s-branch-topology)", instead, says to use "the oldest supported main release branch affected by the the bug". But according to "[Product Lifecycle](https://saltstack.com/product-support-lifecycle/)", "supported" is not a well-defined term. Since this is not a CVE fix, I chose `2016.11` as the oldest one in Phase 2 support or better.

Anyway, this bug has been present ever since the `pgjsonb` returner was intruduced up to current `develop`. Please back- and forward-port as required.

### What does this PR do?

The `pgjsonb` returner wants a database with a timestamp column using the type `TIMESTAMP WITH TIME ZONE`. Despite this, it's inserted its timestamps as a date-time-zone string. This means that the minion has needed to waste time formatting the timetamp, and then PostgreSQL has wasted even more time parsing it back into a Unix timestamp for storage.

Also, the code has been buggy on Python 2, which doesn't properly support the `%z` format specifier to `strftime()` and has therefore sent timestamps using the wrong time zone.

Solve both these problems by having the minion retrieve a Unix timestamp by calling `time.time()`, sending it unmolested to PostgreSQL, and using the PostgreSQL function `to_timestamp()` to store it.

### What issues does this PR fix or reference?

Closes #44544.

### Previous Behavior

Timestamps were stored with the value of the minion local clock, but a time zone of UTC, making them wrong by the difference between UTC and minion local time.

### New Behavior

Timestamps are handled as Unix timestamps, making time zones irrelevant for transport and storage, and therefore correct.

### Tests written?

No

### Commits signed with GPG?

Yes