### PR TITLE
Include client mixin globals in scheduler for runner modules

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,7 @@
 driver:
   name: docker
   use_sudo: false
+  hostname: salt
   privileged: true
   username: root
   volume:

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -334,6 +334,7 @@ import errno
 import random
 import yaml
 import copy
+import weakref
 
 # Import Salt libs
 import salt.config
@@ -849,20 +850,20 @@ class Schedule(object):
             if self.opts['__role'] == 'master':
                 jid = salt.utils.jid.gen_jid()
                 tag = salt.utils.event.tagify(jid, prefix='salt/scheduler/')
-        
+
                 event = salt.utils.event.get_event(
                         self.opts['__role'],
                         self.opts['sock_dir'],
                         self.opts['transport'],
                         opts=self.opts,
                         listen=False)
-        
+
                 namespaced_event = salt.utils.event.NamespacedEvent(
                     event,
                     tag,
                     print_func=None
                 )
-        
+
                 func_globals = {
                     '__jid__': jid,
                     '__user__': salt.utils.get_user(),


### PR DESCRIPTION
### What does this PR do?
These things are included in the runners modules from the RunnerClient,
but do not get included by the loader, and need to be made available explicitly
when the modules are being run by the scheduler.

### What issues does this PR fix or reference?
Fixes #44565

### Tests written?

No