### PR TITLE
Remove logging from top of napalm util file

### DIFF
--- a/salt/utils/napalm.py
+++ b/salt/utils/napalm.py
@@ -15,18 +15,19 @@ Utils for the NAPALM modules and proxy.
 .. versionadded:: 2017.7.0
 '''
 
+# Import Python libs
 from __future__ import absolute_import
-
 import traceback
 import logging
 import importlib
 from functools import wraps
-log = logging.getLogger(__file__)
 
-import salt.utils
+# Import Salt libs
+from salt.ext import six as six
 import salt.output
+import salt.utils
 
-# Import third party lib
+# Import third party libs
 try:
     # will try to import NAPALM
     # https://github.com/napalm-automation/napalm
@@ -36,21 +37,16 @@ try:
     # pylint: enable=W0611
     HAS_NAPALM = True
     HAS_NAPALM_BASE = False  # doesn't matter anymore, but needed for the logic below
-    log.debug('napalm seems to be installed')
     try:
         NAPALM_MAJOR = int(napalm.__version__.split('.')[0])
-        log.debug('napalm version: %s', napalm.__version__)
     except AttributeError:
         NAPALM_MAJOR = 0
 except ImportError:
-    log.info('napalm doesnt seem to be installed, trying to import napalm_base')
     HAS_NAPALM = False
     try:
         import napalm_base
-        log.debug('napalm_base seems to be installed')
         HAS_NAPALM_BASE = True
     except ImportError:
-        log.info('napalm_base doesnt seem to be installed either')
         HAS_NAPALM_BASE = False
 
 try:
@@ -62,7 +58,7 @@ try:
 except ImportError:
     HAS_CONN_CLOSED_EXC_CLASS = False
 
-from salt.ext import six as six
+log = logging.getLogger(__file__)
 
 
 def is_proxy(opts):
@@ -98,8 +94,6 @@ def virtual(opts, virtualname, filename):
     Returns the __virtual__.
     '''
     if ((HAS_NAPALM and NAPALM_MAJOR >= 2) or HAS_NAPALM_BASE) and (is_proxy(opts) or is_minion(opts)):
-        if HAS_NAPALM_BASE:
-            log.info('You still seem to use napalm_base. Please consider upgrading to napalm >= 2.0.0')
         return virtualname
     else:
         return (


### PR DESCRIPTION
### What does this PR do?
Logging should not be done anywhere in a file before a module is loaded. This includes the `__virtual__()` function as well. This is because these messages will be logged when they shouldn't be, which muddies the logs when the function(s) being called do not need to use that particular module. 

In this case, on a simple `test.ping`, I am seeing logs about missing napalm. But I shouldn't need napalm by default.

### What issues does this PR fix or reference?
Refs PR #44439 

### Previous Behavior
```
# salt-call --local test.ping -linfo
[INFO    ] napalm doesnt seem to be installed, trying to import napalm_base
[INFO    ] napalm_base doesnt seem to be installed either
```

### New Behavior
Log lines are no longer present.

### Tests written?
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.

******

@mirceaulinic The logging was added in one of your recent PRs. Apologies for not catching that sooner, but I am pinging you here so you don't go looking for those log lines later. :)

As far as I know, we don't have this standard documented anywhere, so I will make a PR adding documentation about not logging at the top of the file. I will cross reference the documentation change here when I submit it.