### PR TITLE
check if the filesystem support lsattr

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -552,11 +552,11 @@ def lsattr(path):
         raise SaltInvocationError("File or directory does not exist.")
 
     cmd = ['lsattr', path]
-    result = __salt__['cmd.run'](cmd, python_shell=False)
+    result = __salt__['cmd.run'](cmd, ignore_retcode=True, python_shell=False)
 
     results = {}
     for line in result.splitlines():
-        if not line.startswith('lsattr'):
+        if not line.startswith('lsattr: '):
             vals = line.split(None, 1)
             results[vals[1]] = re.findall(r"[acdijstuADST]", vals[0])
 


### PR DESCRIPTION
### What does this PR do?
For systems where lsattr is not supported, there is a ton of error messages being spammed out.

(Specifically in docker containers)

### Tests written?

No

### Commits signed with GPG?

Yes