### PR TITLE
enable calling SaltSSH minions from the salt master

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -96,8 +96,8 @@ The user to run the Salt processes
 
 .. conf_master:: ret_port
 
-``enable_ssh``
---------------
+``enable_ssh_minions``
+----------------------
 
 Default: ``False``
 
@@ -105,8 +105,12 @@ Tell the master to also use SaltSSH when running commands against minions.
 
 .. code-block:: yaml
 
-    enable_ssh: True
-    
+    enable_ssh_minions: True
+
+.. note::
+
+    Cross minion type communication is still not possible.  The SaltMine and
+    publish.publish do not work between minion types.
 
 ``ret_port``
 ------------

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -96,6 +96,18 @@ The user to run the Salt processes
 
 .. conf_master:: ret_port
 
+``enable_ssh``
+--------------
+
+Default: ``False``
+
+Tell the master to also use SaltSSH when running commands against minions.
+
+.. code-block:: yaml
+
+    enable_ssh: True
+    
+
 ``ret_port``
 ------------
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -99,6 +99,7 @@ The user to run the Salt processes
 ``enable_ssh_minions``
 ----------------------
 
+
 Default: ``False``
 
 Tell the master to also use SaltSSH when running commands against minions.

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -102,7 +102,7 @@ The user to run the Salt processes
 
 Default: ``False``
 
-Tell the master to also use SaltSSH when running commands against minions.
+Tell the master to also use salt-ssh when running commands against minions.
 
 .. code-block:: yaml
 
@@ -110,7 +110,7 @@ Tell the master to also use SaltSSH when running commands against minions.
 
 .. note::
 
-    Cross minion type communication is still not possible.  The SaltMine and
+    Cross-minion communication is still not possible.  The Salt mine and
     publish.publish do not work between minion types.
 
 ``ret_port``

--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -107,6 +107,15 @@ Salt CLI.
 
     salt myminion docker.create image=foo/bar:baz command=/path/to/command start=True
 
+Use SaltSSH Minions like regular Master-Minions
+-----------------------------------------------
+
+The Master process can now also call SSH minions as if they were connected to
+the master using ZeroMQ.  By setting `enable_ssh_minions: True` in the the
+master config file, the master will create a SaltSSH client process which
+connects to the minion and returns the output for the `salt` commandline to use
+like a regular minion. This can be used anywhere the LocalClient is used.
+
 Comparison Operators in Package Installation
 --------------------------------------------
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -214,7 +214,7 @@ class SSH(object):
     def __init__(self, opts):
         self.__parsed_rosters = {SSH.ROSTER_UPDATE_FLAG: True}
         pull_sock = os.path.join(opts['sock_dir'], 'master_event_pull.ipc')
-        if os.path.isfile(pull_sock) and HAS_ZMQ:
+        if os.path.exists(pull_sock) and HAS_ZMQ:
             self.event = salt.utils.event.get_event(
                     'master',
                     opts['sock_dir'],
@@ -667,6 +667,12 @@ class SSH(object):
                         salt.utils.event.tagify(
                             [jid, 'ret', host],
                             'job'))
+                for _, data in six.iteritems(ret):
+                    self.event.fire_event(
+                            data,
+                            salt.utils.event.tagify(
+                                [jid, 'ret', host],
+                                'job'))
             yield ret
 
     def cache_job(self, jid, id_, ret, fun):
@@ -776,6 +782,12 @@ class SSH(object):
                         salt.utils.event.tagify(
                             [jid, 'ret', host],
                             'job'))
+                for _, data in six.iteritems(ret):
+                    self.event.fire_event(
+                            data,
+                            salt.utils.event.tagify(
+                                [jid, 'ret', host],
+                                'job'))
         if self.opts.get('static'):
             salt.output.display_output(
                     sret,

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1266,7 +1266,7 @@ ARGS = {10}\n'''.format(self.minion_config,
         self.argv = _convert_args(self.argv)
         log.debug(
             'Performing shimmed, blocking command as follows:\n%s',
-            ' '.join(self.argv)
+            ' '.join([six.text_type(arg) for arg in self.argv])
         )
         cmd_str = self._cmd_str()
         stdout, stderr, retcode = self.shim_cmd(cmd_str)

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -662,6 +662,7 @@ class SSH(object):
             host = next(six.iterkeys(ret))
             self.cache_job(jid, host, ret[host], fun)
             if self.event:
+                jobid = jid
                 self.event.fire_event(
                         ret,
                         salt.utils.event.tagify(
@@ -670,6 +671,7 @@ class SSH(object):
                 for _, data in six.iteritems(ret):
                     if not isinstance(data, dict):
                         continue
+                    data['jid'] = jobid
                     self.event.fire_event(
                             data,
                             salt.utils.event.tagify(
@@ -779,6 +781,7 @@ class SSH(object):
                         outputter,
                         self.opts)
             if self.event:
+                jobid = jid
                 self.event.fire_event(
                         ret,
                         salt.utils.event.tagify(
@@ -787,6 +790,7 @@ class SSH(object):
                 for _, data in six.iteritems(ret):
                     if not isinstance(data, dict):
                         continue
+                    data['jid'] = jobid
                     self.event.fire_event(
                             data,
                             salt.utils.event.tagify(

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -662,21 +662,12 @@ class SSH(object):
             host = next(six.iterkeys(ret))
             self.cache_job(jid, host, ret[host], fun)
             if self.event:
-                jobid = jid
+                _, data = next(six.iteritems(ret))
                 self.event.fire_event(
-                        ret,
-                        salt.utils.event.tagify(
-                            [jid, 'ret', host],
-                            'job'))
-                for _, data in six.iteritems(ret):
-                    if not isinstance(data, dict):
-                        continue
-                    data['jid'] = jobid
-                    self.event.fire_event(
-                            data,
-                            salt.utils.event.tagify(
-                                [jid, 'ret', host],
-                                'job'))
+                    data,
+                    salt.utils.event.tagify(
+                        [jid, 'ret', host],
+                        'job'))
             yield ret
 
     def cache_job(self, jid, id_, ret, fun):
@@ -781,21 +772,12 @@ class SSH(object):
                         outputter,
                         self.opts)
             if self.event:
-                jobid = jid
+                _, data = next(six.iteritems(ret))
                 self.event.fire_event(
-                        ret,
-                        salt.utils.event.tagify(
-                            [jid, 'ret', host],
-                            'job'))
-                for _, data in six.iteritems(ret):
-                    if not isinstance(data, dict):
-                        continue
-                    data['jid'] = jobid
-                    self.event.fire_event(
-                            data,
-                            salt.utils.event.tagify(
-                                [jid, 'ret', host],
-                                'job'))
+                    data,
+                    salt.utils.event.tagify(
+                        [jid, 'ret', host],
+                        'job'))
         if self.opts.get('static'):
             salt.output.display_output(
                     sret,

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -663,6 +663,7 @@ class SSH(object):
             self.cache_job(jid, host, ret[host], fun)
             if self.event:
                 _, data = next(six.iteritems(ret))
+                data['jid'] = jid  # make the jid in the payload the same as the jid in the tag
                 self.event.fire_event(
                     data,
                     salt.utils.event.tagify(
@@ -773,6 +774,7 @@ class SSH(object):
                         self.opts)
             if self.event:
                 _, data = next(six.iteritems(ret))
+                data['jid'] = jid  # make the jid in the payload the same as the jid in the tag
                 self.event.fire_event(
                     data,
                     salt.utils.event.tagify(

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -668,6 +668,8 @@ class SSH(object):
                             [jid, 'ret', host],
                             'job'))
                 for _, data in six.iteritems(ret):
+                    if not isinstance(data, dict):
+                        continue
                     self.event.fire_event(
                             data,
                             salt.utils.event.tagify(
@@ -783,6 +785,8 @@ class SSH(object):
                             [jid, 'ret', host],
                             'job'))
                 for _, data in six.iteritems(ret):
+                    if not isinstance(data, dict):
+                        continue
                     self.event.fire_event(
                             data,
                             salt.utils.event.tagify(

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1183,6 +1183,9 @@ VALID_OPTS = {
 
     # Scheduler should be a dictionary
     'schedule': dict,
+
+    # Enable calling ssh minions from the salt master
+    'enable_ssh': bool,
 }
 
 # default configurations
@@ -1799,6 +1802,7 @@ DEFAULT_MASTER_OPTS = {
         'mapping': {},
     },
     'schedule': {},
+    'enable_ssh': False,
 }
 
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1185,7 +1185,7 @@ VALID_OPTS = {
     'schedule': dict,
 
     # Enable calling ssh minions from the salt master
-    'enable_ssh': bool,
+    'enable_ssh_minions': bool,
 }
 
 # default configurations
@@ -1803,6 +1803,7 @@ DEFAULT_MASTER_OPTS = {
     },
     'schedule': {},
     'enable_ssh': False,
+    'enable_ssh_minions': False,
 }
 
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -1958,7 +1958,7 @@ class ClearFuncs(object):
         payload = self._prep_pub(minions, jid, clear_load, extra, missing)
 
         # Send it!
-        if self.opts[u'enable_ssh'] is True:
+        if self.opts[u'enable_ssh_minions'] is True:
             log.debug('Use SSHClient for rostered minions')
             ssh = salt.client.ssh.client.SSHClient()
             ssh_minions = ssh._prep_ssh(**clear_load).targets.keys()

--- a/salt/master.py
+++ b/salt/master.py
@@ -1958,7 +1958,8 @@ class ClearFuncs(object):
         payload = self._prep_pub(minions, jid, clear_load, extra, missing)
 
         # Send it!
-        if self.opts[u'enable_ssh_minions'] is True:
+        if self.opts[u'enable_ssh_minions'] is True and isinstance(clear_load[u'tgt'], six.string_types):
+            # The isinstances makes sure that syndics work
             log.debug('Use SSHClient for rostered minions')
             ssh = salt.client.ssh.client.SSHClient()
             ssh_minions = ssh._prep_ssh(**clear_load).targets.keys()

--- a/salt/master.py
+++ b/salt/master.py
@@ -1965,7 +1965,10 @@ class ClearFuncs(object):
             ssh_minions = ssh._prep_ssh(**clear_load).targets.keys()
             if ssh_minions:
                 minions.extend(ssh_minions)
-                multiprocessing.Process(target=ssh.cmd, kwargs=clear_load).start()
+                def wrap_ssh(**kwargs):
+                    salt.utils.process.daemonize(False)
+                    ssh.cmd(**kwargs)
+                salt.utils.process.SignalHandlingMultiprocessingProcess(target=wrap_ssh, kwargs=clear_load).start()
 
         self._send_pub(payload)
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -1965,6 +1965,7 @@ class ClearFuncs(object):
             ssh_minions = ssh._prep_ssh(**clear_load).targets.keys()
             if ssh_minions:
                 minions.extend(ssh_minions)
+
                 def wrap_ssh(**kwargs):
                     salt.utils.process.daemonize(False)
                     ssh.cmd(**kwargs)

--- a/salt/master.py
+++ b/salt/master.py
@@ -49,6 +49,7 @@ import tornado.gen  # pylint: disable=F0401
 # Import salt libs
 import salt.crypt
 import salt.client
+import salt.client.ssh.client
 import salt.payload
 import salt.pillar
 import salt.state
@@ -1957,6 +1958,14 @@ class ClearFuncs(object):
         payload = self._prep_pub(minions, jid, clear_load, extra, missing)
 
         # Send it!
+        if self.opts[u'enable_ssh'] is True:
+            log.debug('Use SSHClient for rostered minions')
+            ssh = salt.client.ssh.client.SSHClient()
+            ssh_minions = ssh._prep_ssh(**clear_load).targets.keys()
+            if ssh_minions:
+                minions.extend(ssh_minions)
+                multiprocessing.Process(target=ssh.cmd, kwargs=clear_load).start()
+
         self._send_pub(payload)
 
         return {

--- a/salt/master.py
+++ b/salt/master.py
@@ -1959,15 +1959,7 @@ class ClearFuncs(object):
         payload = self._prep_pub(minions, jid, clear_load, extra, missing)
 
         # Send it!
-        if self.opts[u'enable_ssh_minions'] is True and isinstance(clear_load[u'tgt'], six.string_types):
-            # The isinstances makes sure that syndics work
-            log.debug('Use SSHClient for rostered minions')
-            ssh = salt.client.ssh.client.SSHClient()
-            ssh_minions = ssh._prep_ssh(**clear_load).targets.keys()
-            if ssh_minions:
-                minions.extend(ssh_minions)
-                threading.Thread(target=ssh.cmd, kwargs=clear_load).start()
-
+        minions.extend(self._send_ssh_pub(payload))
         self._send_pub(payload)
 
         return {
@@ -2029,6 +2021,21 @@ class ClearFuncs(object):
         for transport, opts in iter_transport_opts(self.opts):
             chan = salt.transport.server.PubServerChannel.factory(opts)
             chan.publish(load)
+
+    def _send_ssh_pub(self, load):
+        '''
+        Take a load and send it across the network to connected minions
+        '''
+        minions = []
+        if self.opts['enable_ssh_minions'] is True and isinstance(load['tgt'], six.string_types):
+            # The isinstances makes sure that syndics work
+            log.debug('Use SSHClient for rostered minions')
+            ssh = salt.client.ssh.client.SSHClient()
+            ssh_minions = ssh._prep_ssh(**load).targets.keys()
+            if ssh_minions:
+                minions.extend(ssh_minions)
+                threading.Thread(target=ssh.cmd, kwargs=clear_load).start()
+        return minions
 
     def _prep_pub(self, minions, jid, clear_load, extra, missing):
         '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -19,6 +19,7 @@ import logging
 import collections
 import multiprocessing
 import salt.serializers.msgpack
+import threading
 
 # Import third party libs
 try:
@@ -1965,11 +1966,7 @@ class ClearFuncs(object):
             ssh_minions = ssh._prep_ssh(**clear_load).targets.keys()
             if ssh_minions:
                 minions.extend(ssh_minions)
-
-                def wrap_ssh(**kwargs):
-                    salt.utils.process.daemonize(False)
-                    ssh.cmd(**kwargs)
-                salt.utils.process.SignalHandlingMultiprocessingProcess(target=wrap_ssh, kwargs=clear_load).start()
+                threading.Thread(target=ssh.cmd, kwargs=clear_load).start()
 
         self._send_pub(payload)
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -2034,7 +2034,7 @@ class ClearFuncs(object):
             ssh_minions = ssh._prep_ssh(**load).targets.keys()
             if ssh_minions:
                 minions.extend(ssh_minions)
-                threading.Thread(target=ssh.cmd, kwargs=clear_load).start()
+                threading.Thread(target=ssh.cmd, kwargs=load).start()
         return minions
 
     def _prep_pub(self, minions, jid, clear_load, extra, missing):


### PR DESCRIPTION
### What does this PR do?
This adds the ability to let the salt-master spin off a new process which starts an SSHClient, and then returns the data back for the `salt` command to print it out.

### What issues does this PR fix or reference?
Closes #40997

### Tests written?

No

### Commits signed with GPG?

Yes