### PR TITLE
Handle deprecation path for pki_dir in verify_env util

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -30,6 +30,7 @@ import salt.defaults.exitcodes
 import salt.utils.files
 import salt.utils.platform
 import salt.utils.user
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -194,13 +195,32 @@ def verify_files(files, user):
     return True
 
 
-def verify_env(dirs, user, permissive=False, sensitive_dirs=None, skip_extra=False):
+def verify_env(
+        dirs,
+        user,
+        permissive=False,
+        pki_dir='',
+        skip_extra=False,
+        sensitive_dirs=None):
     '''
     Verify that the named directories are in place and that the environment
     can shake the salt
     '''
+    if pki_dir:
+        salt.utils.versions.warn_until(
+            'Neon',
+            'Use of \'pki_dir\' was detected: \'pki_dir\' has been deprecated '
+            'in favor of \'sensitive_dirs\'. Support for \'pki_dir\' will be '
+            'removed in Salt Neon.'
+        )
+        sensitive_dirs = sensitive_dirs or []
+        sensitive_dirs.append(list(pki_dir))
+
     if salt.utils.platform.is_windows():
-        return win_verify_env(dirs, permissive, sensitive_dirs, skip_extra)
+        return win_verify_env(dirs,
+                              permissive=permissive,
+                              skip_extra=skip_extra,
+                              sensitive_dirs=sensitive_dirs)
     import pwd  # after confirming not running Windows
     try:
         pwnam = pwd.getpwnam(user)
@@ -526,11 +546,26 @@ def verify_log(opts):
         log.warning('Insecure logging configuration detected! Sensitive data may be logged.')
 
 
-def win_verify_env(dirs, permissive=False, sensitive_dirs=None, skip_extra=False):
+def win_verify_env(
+        dirs,
+        permissive=False,
+        pki_dir='',
+        skip_extra=False,
+        sensitive_dirs=None):
     '''
     Verify that the named directories are in place and that the environment
     can shake the salt
     '''
+    if pki_dir:
+        salt.utils.versions.warn_until(
+            'Neon',
+            'Use of \'pki_dir\' was detected: \'pki_dir\' has been deprecated '
+            'in favor of \'sensitive_dirs\'. Support for \'pki_dir\' will be '
+            'removed in Salt Neon.'
+        )
+        sensitive_dirs = sensitive_dirs or []
+        sensitive_dirs.append(list(pki_dir))
+
     import salt.utils.win_functions
     import salt.utils.win_dacl
 


### PR DESCRIPTION
### What does this PR do?
In PR #43474, a new option was added named "sensitive_dirs". This option was intended to replace "pki_dir". However, we don't want to drop support for pki_dir out from under people so we need to put pki_dir on a deprecation path.

I have also moved the new sensitive_dirs option to the _end_ of the list of kwargs. That way, if other users are using positional kwargs, we won't break those references either. People will have time to adjust their calls to verify_env when they see the warning.

Thanks to @s0undt3ch for pointing this out.
FYI @kstreee.

### What issues does this PR fix or reference?
#43474

### Previous Behavior
Use of `pki_dir` by external libs was not being handled.

### New Behavior
Deprecation warning will prompt users to update verify_env calls accordingly.

### Tests written?
No - there are already tests for this function.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
