### PR TITLE
ipset add new options

### DIFF
--- a/salt/modules/ipset.py
+++ b/salt/modules/ipset.py
@@ -36,11 +36,12 @@ _IPSET_FAMILIES = {
         'ip6': 'inet6',
         }
 
-_IPSET_SET_TYPES = [
+_IPSET_SET_TYPES = set([
         'bitmap:ip',
         'bitmap:ip,mac',
         'bitmap:port',
         'hash:ip',
+        'hash:mac',
         'hash:ip,port',
         'hash:ip,port,ip',
         'hash:ip,port,net',
@@ -49,32 +50,37 @@ _IPSET_SET_TYPES = [
         'hash:net,iface',
         'hash:net,port',
         'hash:net,port,net',
+        'hash:ip,mark',
         'list:set'
-        ]
+        ])
 
 
 _CREATE_OPTIONS = {
-    'bitmap:ip': ['range', 'netmask', 'timeout', 'counters', 'comment'],
-    'bitmap:ip,mac': ['range', 'timeout', 'counters', 'comment'],
-    'bitmap:port': ['range', 'timeout', 'counters', 'comment'],
-    'hash:ip': ['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment'],
-    'hash:net': ['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment'],
-    'hash:net,net': ['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment'],
-    'hash:net,port': ['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment'],
-    'hash:net,port,net': ['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment'],
-    'hash:ip,port,ip': ['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment'],
-    'hash:ip,port,net': ['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment'],
-    'hash:ip,port': ['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment'],
-    'hash:net,iface': ['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment'],
-    'list:set': ['size', 'timeout', 'counters', 'comment'],
+    'bitmap:ip': set(['range', 'netmask', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'bitmap:ip,mac': set(['range', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'bitmap:port': set(['range', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'hash:ip': set(['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'hash:mac': set(['hashsize', 'maxelem', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'hash:net': set(['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'hash:net,net': set(['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'hash:net,port': set(['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'hash:net,port,net': set(['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'hash:ip,port,ip': set(['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'hash:ip,port,net': set(['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'hash:ip,port': set(['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'hash:ip,mark': set(['family', 'markmask', 'hashsize', 'maxelem', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'hash:net,iface': set(['family', 'hashsize', 'maxelem', 'netmask', 'timeout', 'counters', 'comment', 'skbinfo']),
+    'list:set': set(['size', 'timeout', 'counters', 'comment']),
 }
 
+_CREATE_OPTIONS_WITHOUT_VALUE = set(['comment', 'counters', 'skbinfo'])
 
 _CREATE_OPTIONS_REQUIRED = {
     'bitmap:ip': ['range'],
     'bitmap:ip,mac': ['range'],
     'bitmap:port': ['range'],
     'hash:ip': [],
+    'hash:mac': [],
     'hash:net': [],
     'hash:net,net': [],
     'hash:ip,port': [],
@@ -83,24 +89,27 @@ _CREATE_OPTIONS_REQUIRED = {
     'hash:ip,port,net': [],
     'hash:net,port,net': [],
     'hash:net,iface': [],
+    'hash:ip,mark': [],
     'list:set': []
 }
 
 
 _ADD_OPTIONS = {
-    'bitmap:ip': ['timeout', 'packets', 'bytes'],
-    'bitmap:ip,mac': ['timeout', 'packets', 'bytes'],
-    'bitmap:port': ['timeout', 'packets', 'bytes'],
-    'hash:ip': ['timeout', 'packets', 'bytes'],
-    'hash:net': ['timeout', 'nomatch', 'packets', 'bytes'],
-    'hash:net,net': ['timeout', 'nomatch', 'packets', 'bytes'],
-    'hash:net,port': ['timeout', 'nomatch', 'packets', 'bytes'],
-    'hash:net,port,net': ['timeout', 'nomatch', 'packets', 'bytes'],
-    'hash:ip,port,ip': ['timeout', 'packets', 'bytes'],
-    'hash:ip,port,net': ['timeout', 'nomatch', 'packets', 'bytes'],
-    'hash:ip,port': ['timeout', 'nomatch', 'packets', 'bytes'],
-    'hash:net,iface': ['timeout', 'nomatch', 'packets', 'bytes'],
-    'list:set': ['timeout', 'packets', 'bytes'],
+    'bitmap:ip': set(['timeout', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
+    'bitmap:ip,mac': set(['timeout', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
+    'bitmap:port': set(['timeout', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbprio']),
+    'hash:ip': set(['timeout', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
+    'hash:mac': set(['timeout', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
+    'hash:net': set(['timeout', 'nomatch', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
+    'hash:net,net': set(['timeout', 'nomatch', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
+    'hash:net,port': set(['timeout', 'nomatch', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
+    'hash:net,port,net': set(['timeout', 'nomatch', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
+    'hash:ip,port,ip': set(['timeout', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
+    'hash:ip,port,net': set(['timeout', 'nomatch', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
+    'hash:ip,port': set(['timeout', 'nomatch', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
+    'hash:net,iface': set(['timeout', 'nomatch', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
+    'hash:ip,mark': set(['timeout', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
+    'list:set': set(['timeout', 'packets', 'bytes', 'skbmark', 'skbprio', 'skbqueue']),
 }
 
 
@@ -173,7 +182,10 @@ def new_set(set=None, set_type=None, family='ipv4', comment=False, **kwargs):
 
     for item in _CREATE_OPTIONS[set_type]:
         if item in kwargs:
-            cmd = '{0} {1} {2} '.format(cmd, item, kwargs[item])
+            if item in _CREATE_OPTIONS_WITHOUT_VALUE:
+                cmd = '{0} {1} '.format(cmd, item)
+            else:
+                cmd = '{0} {1} {2} '.format(cmd, item, kwargs[item])
 
     # Family only valid for certain set types
     if 'family' in _CREATE_OPTIONS[set_type]:
@@ -307,7 +319,7 @@ def check_set(set=None, family='ipv4'):
     return True
 
 
-def add(set=None, entry=None, family='ipv4', **kwargs):
+def add(setname=None, entry=None, family='ipv4', **kwargs):
     '''
     Append an entry to the specified set.
 
@@ -320,14 +332,14 @@ def add(set=None, entry=None, family='ipv4', **kwargs):
         salt '*' ipset.add setname 192.168.0.3,AA:BB:CC:DD:EE:FF
 
     '''
-    if not set:
+    if not setname:
         return 'Error: Set needs to be specified'
     if not entry:
         return 'Error: Entry needs to be specified'
 
-    setinfo = _find_set_info(set)
+    setinfo = _find_set_info(setname)
     if not setinfo:
-        return 'Error: Set {0} does not exist'.format(set)
+        return 'Error: Set {0} does not exist'.format(setname)
 
     settype = setinfo['Type']
 
@@ -335,27 +347,32 @@ def add(set=None, entry=None, family='ipv4', **kwargs):
 
     if 'timeout' in kwargs:
         if 'timeout' not in setinfo['Header']:
-            return 'Error: Set {0} not created with timeout support'.format(set)
+            return 'Error: Set {0} not created with timeout support'.format(setname)
 
     if 'packets' in kwargs or 'bytes' in kwargs:
         if 'counters' not in setinfo['Header']:
-            return 'Error: Set {0} not created with counters support'.format(set)
+            return 'Error: Set {0} not created with counters support'.format(setname)
 
     if 'comment' in kwargs:
         if 'comment' not in setinfo['Header']:
-            return 'Error: Set {0} not created with comment support'.format(set)
-        cmd = '{0} comment "{1}"'.format(cmd, kwargs['comment'])
+            return 'Error: Set {0} not created with comment support'.format(setname)
+        if 'comment' not in entry:
+            cmd = '{0} comment "{1}"'.format(cmd, kwargs['comment'])
+
+    if len(set(['skbmark', 'skbprio', 'skbqueue']) & set(kwargs.keys())) > 0:
+        if 'skbinfo' not in setinfo['Header']:
+            return 'Error: Set {0} not created with skbinfo support'.format(setname)
 
     for item in _ADD_OPTIONS[settype]:
         if item in kwargs:
             cmd = '{0} {1} {2}'.format(cmd, item, kwargs[item])
 
-    current_members = _find_set_members(set)
+    current_members = _find_set_members(setname)
     if cmd in current_members:
-        return 'Warn: Entry {0} already exists in set {1}'.format(cmd, set)
+        return 'Warn: Entry {0} already exists in set {1}'.format(cmd, setname)
 
     # Using -exist to ensure entries are updated if the comment changes
-    cmd = '{0} add -exist {1} {2}'.format(_ipset_cmd(), set, cmd)
+    cmd = '{0} add -exist {1} {2}'.format(_ipset_cmd(), setname, cmd)
     out = __salt__['cmd.run'](cmd, python_shell=False)
 
     if len(out) == 0:

--- a/salt/states/ipset.py
+++ b/salt/states/ipset.py
@@ -204,7 +204,7 @@ def present(name, entry=None, family='ipv4', **kwargs):
             entry_opts = 'timeout {0} {1}'.format(kwargs['timeout'], entry_opts)
         if 'comment' in kwargs and 'comment' not in entry_opts:
             entry_opts = '{0} comment "{1}"'.format(entry_opts, kwargs['comment'])
-        _entry = ' '.join([entry, entry_opts]).strip()
+        _entry = ' '.join([entry, entry_opts.lstrip()]).strip()
 
         if __salt__['ipset.check'](kwargs['set_name'],
                                    _entry,

--- a/salt/states/ipset.py
+++ b/salt/states/ipset.py
@@ -221,7 +221,7 @@ def present(name, entry=None, family='ipv4', **kwargs):
                     kwargs['set_name'],
                     family)
             else:
-                command = __salt__['ipset.add'](kwargs['set_name'], entry, family, **kwargs)
+                command = __salt__['ipset.add'](kwargs['set_name'], _entry, family, **kwargs)
                 if 'Error' not in command:
                     ret['changes'] = {'locale': name}
                     ret['comment'] += 'entry {0} added to set {1} for family {2}\n'.format(
@@ -293,7 +293,7 @@ def absent(name, entry=None, entries=None, family='ipv4', **kwargs):
                     kwargs['set_name'],
                     family)
             else:
-                command = __salt__['ipset.delete'](kwargs['set_name'], entry, family, **kwargs)
+                command = __salt__['ipset.delete'](kwargs['set_name'], _entry, family, **kwargs)
                 if 'Error' not in command:
                     ret['changes'] = {'locale': name}
                     ret['result'] = True


### PR DESCRIPTION
### What does this PR do?
Add options hash:mac and hash:ip,mark and skbinfo create options
### What issues does this PR fix or reference?
Fix discarding options with state and entries
### New Behavior
```
test_setname:
  ipset.set_present:
    - set_type: bitmap:ip
    - range: 192.168.0.0/16
    - comment: True
    - skbinfo: True

test_entries:
  ipset.present:
    - set_name: test_setname
    - comment: Test
    - entry:
        - 192.168.1.1 comment Test2
        - 192.168.1.2
        - 192.168.1.3
        - 192.168.1.4
        - 192.168.1.5
        - 192.168.1.6
        - 192.168.1.7
        - 192.168.1.8
        - 192.168.1.9
        - 192.168.1.10
        - 192.168.1.11
        - 192.168.1.12
        - 192.168.1.13
        - 192.168.1.14 skbprio 1:10
```

### Tests written?

No

### Commits signed with GPG?

No
