### PR TITLE
Added new Telegram module

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -417,6 +417,7 @@ execution modules
     system
     system_profiler
     systemd
+    telegram
     telemetry
     temp
     test

--- a/salt/modules/telegram.py
+++ b/salt/modules/telegram.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+'''
+Module for sending messages via Telegram.
+
+:configuration: In order to send a message via the Telegram, certain
+    configuration is required in /etc/salt/minion on the relevant minions or
+    in the pillar. Some sample configs might look like::
+
+        telegram.chat_id: '123456789'
+        telegram.token: '00000000:xxxxxxxxxxxxxxxxxxxxxxxx'
+
+'''
+from __future__ import absolute_import
+
+# Import Python libs
+import logging
+
+from salt.exceptions import SaltInvocationError
+
+# Import 3rd-party libs
+try:
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'telegram'
+
+
+def __virtual__():
+    '''
+    Return virtual name of the module.
+
+    :return: The virtual name of the module.
+    '''
+    if not HAS_REQUESTS:
+        return False
+    return __virtualname__
+
+
+def _get_chat_id():
+    '''
+    Retrieves and return the Telegram's configured chat id
+
+    :return:    String: the chat id string
+    '''
+    chat_id = __salt__['config.get']('telegram:chat_id') or \
+        __salt__['config.get']('telegram.chat_id')
+    if not chat_id:
+        raise SaltInvocationError('No Telegram chat id found')
+
+    return chat_id
+
+
+def _get_token():
+    '''
+    Retrieves and return the Telegram's configured token
+
+    :return:    String: the token string
+    '''
+    token = __salt__['config.get']('telegram:token') or \
+        __salt__['config.get']('telegram.token')
+    if not token:
+        raise SaltInvocationError('No Telegram token found')
+
+    return token
+
+
+def post_message(message, chat_id=None, token=None):
+    '''
+    Send a message to a Telegram chat.
+
+    :param message: The message to send to the Telegram chat.
+    :param chat_id: (optional) The Telegram chat id.
+    :param token:   (optional) The Telegram API token.
+    :return:        Boolean if message was sent successfully.
+
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' telegram.post_message message="Hello Telegram!"
+
+    '''
+    if not chat_id:
+        chat_id = _get_chat_id()
+
+    if not token:
+        token = _get_token()
+
+    if not message:
+        log.error('message is a required option.')
+
+    return _post_message(message=message, chat_id=chat_id, token=token)
+
+
+def _post_message(message, chat_id, token):
+    '''
+    Send a message to a Telegram chat.
+
+    :param chat_id:     The chat id.
+    :param message:     The message to send to the telegram chat.
+    :param token:       The Telegram API token.
+    :return:            Boolean if message was sent successfully.
+    '''
+    url = 'https://api.telegram.org/bot{0}/sendMessage'.format(token)
+
+    parameters = dict()
+    if chat_id:
+        parameters['chat_id'] = chat_id
+    if message:
+        parameters['text'] = message
+
+    try:
+        response = requests.post(
+            url,
+            data=parameters
+        )
+        result = response.json()
+
+        log.debug(
+            'Raw response of the telegram request is {0}'.format(response)
+        )
+
+    except Exception:
+        log.exception(
+            'Sending telegram api request failed'
+        )
+        return False
+
+    # Check if the Telegram Bot API returned successfully.
+    if not result.get('ok', False):
+        log.debug(
+            'Sending telegram api request failed due to error {0} ({1})'.format(
+                result.get('error_code'), result.get('description')
+            )
+        )
+        return False
+
+    return True

--- a/salt/returners/telegram_return.py
+++ b/salt/returners/telegram_return.py
@@ -27,13 +27,6 @@ from __future__ import absolute_import
 # Import Python libs
 import logging
 
-# Import 3rd-party libs
-try:
-    import requests
-    HAS_REQUESTS = True
-except ImportError:
-    HAS_REQUESTS = False
-
 # Import Salt Libs
 import salt.returners
 
@@ -48,8 +41,6 @@ def __virtual__():
 
     :return: The virtual name of the module.
     '''
-    if not HAS_REQUESTS:
-        return False
     return __virtualname__
 
 
@@ -61,7 +52,6 @@ def _get_options(ret=None):
     :return:        Dictionary containing the data and options needed to send
                     them to telegram.
     '''
-
     attrs = {'chat_id': 'chat_id',
             'token': 'token'}
 
@@ -81,7 +71,6 @@ def returner(ret):
     :param ret:     The data to be sent.
     :return:        Boolean if message was sent successfully.
     '''
-
     _options = _get_options(ret)
 
     chat_id = _options.get('chat_id')
@@ -105,51 +94,6 @@ def returner(ret):
                     ret.get('jid'),
                     returns)
 
-    telegram = _post_message(chat_id,
-                            message,
-                            token)
-
-    return telegram
-
-
-def _post_message(chat_id, message, token):
-    '''
-    Send a message to a Telegram chat.
-
-    :param chat_id:     The chat id.
-    :param message:     The message to send to the telegram chat.
-    :param token:       The Telegram API token.
-    :return:            Boolean if message was sent successfully.
-    '''
-
-    url = 'https://api.telegram.org/bot{0}/sendMessage'.format(token)
-
-    parameters = dict()
-    if chat_id:
-        parameters['chat_id'] = chat_id
-    if message:
-        parameters['text'] = message
-
-    try:
-        response = requests.post(
-            url,
-            data=parameters
-        )
-        result = response.json()
-
-        log.debug(
-            'Raw response of the telegram request is {0}'.format(response))
-
-    except Exception:
-        log.exception(
-            'Sending telegram api request failed'
-        )
-        result = False
-
-    if response and 'message_id' in result:
-        success = True
-    else:
-        success = False
-
-    log.debug('result {0}'.format(success))
-    return bool(success)
+    return __salt__['telegram.post_message'](message,
+                                             chat_id=chat_id,
+                                             token=token)

--- a/tests/unit/modules/test_telegram.py
+++ b/tests/unit/modules/test_telegram.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for the Telegram execution module.
+
+:codeauthor: :email:`Roald Nefs (info@roaldnefs.com)`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    patch,
+    MagicMock,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+# Import Salt Libs
+import salt.modules.telegram as telegram
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class TelegramModuleTest(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.modules.telegram.
+    '''
+    def setup_loader_modules(self):
+        module_globals = {
+            telegram: {
+                '__salt__': {
+                    'config.get': MagicMock(return_value={
+                        'telegram': {
+                            'chat_id': '123456789',
+                            'token': '000000000:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+                        }
+                    })
+                }
+            }
+        }
+        if telegram.HAS_REQUESTS is False:
+            module_globals['sys.modules'] = {'requests': MagicMock()}
+        return module_globals
+
+    def test_post_message(self):
+        '''
+        Test the post_message function.
+        '''
+        message = 'Hello World!'
+
+        class MockRequests(object):
+            """
+            Mock of requests response.
+            """
+            def json(self):
+                return {'ok': True}
+
+        with patch('salt.modules.telegram.requests.post',
+                   MagicMock(return_value=MockRequests())):
+
+            self.assertTrue(telegram.post_message(message))

--- a/tests/unit/returners/test_telegram_return.py
+++ b/tests/unit/returners/test_telegram_return.py
@@ -38,16 +38,10 @@ class TelegramReturnerTestCase(TestCase, LoaderModuleMockMixin):
         options = {'chat_id': '',
                    'token': ''}
 
-        class MockRequest(object):
-            """
-            Mock of requests response
-            """
-            def json(self):
-                return {'message_id': ''}
-
         with patch('salt.returners.telegram_return._get_options',
                    MagicMock(return_value=options)), \
-                patch('salt.returners.telegram_return.requests.post',
-                      MagicMock(return_value=MockRequest())):
-
+                patch.dict('salt.returners.telegram_return.__salt__',
+                    {'telegram.post_message': MagicMock(return_value=True)}
+                ):
             self.assertTrue(telegram.returner(ret))
+

--- a/tests/unit/returners/test_telegram_return.py
+++ b/tests/unit/returners/test_telegram_return.py
@@ -44,4 +44,3 @@ class TelegramReturnerTestCase(TestCase, LoaderModuleMockMixin):
                     {'telegram.post_message': MagicMock(return_value=True)}
                 ):
             self.assertTrue(telegram.returner(ret))
-


### PR DESCRIPTION
### What does this PR do?

Added a new Telegram module, which allows to send a message via Telegram using the Telegram Bot API.

This PR also includes:
- Update for the Telegram returner (merged in #44148); the Telegram returner now fully utilizes the Telegram module.
- Update to the documentation in order to add the Telegram module to the list list of all modules.
### Tests written?

Yes, re-written the existing Telegram returner test, and added a simple unit test for the new Telegram module to ensure we have a way of knowing what the intended data structure is supposed to be.

### Commits signed with GPG?

Yes