### PR TITLE
Add handling for FreeBSD in timezone.zone_compare

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -342,7 +342,7 @@ def zone_compare(timezone):
 
     if 'FreeBSD' in __grains__['os_family']:
         if not os.path.isfile(_get_etc_localtime_path()):
-          return timezone == get_zone()
+            return timezone == get_zone()
 
     tzfile = _get_etc_localtime_path()
     zonepath = _get_zone_file(timezone)

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -340,6 +340,10 @@ def zone_compare(timezone):
     if 'Solaris' in __grains__['os_family'] or 'AIX' in __grains__['os_family']:
         return timezone == get_zone()
 
+    if 'FreeBSD' in __grains__['os_family']:
+        if not os.path.isfile(_get_etc_localtime_path()):
+          return timezone == get_zone()
+
     tzfile = _get_etc_localtime_path()
     zonepath = _get_zone_file(timezone)
     try:


### PR DESCRIPTION
### What does this PR do?
Adds code to call out specific case when /etc/localtime is absent on FreeBSD in the zone_compare method.  PR means zone_compare will not cause exception when FreeBSD is set to UTC by absent /etc/localtime link or file.

### What issues does this PR fix or reference?
timezone.system fails when /etc/localtime is missing on FreeBSD #44083
https://github.com/saltstack/salt/issues/44083

### Previous Behavior
method caused exception if /etc/localtime was missing on FreeBSD

### New Behavior
For FreeBSD - if /etc/localtime is absent, zone_compare will use the timezone reported by the OS to determine if set_zone needs to be executed.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
