### PR TITLE
Allow VMWare profiles to set nested folders by use of / character

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2473,7 +2473,12 @@ def create(vm_):
     # Either a datacenter or a folder can be optionally specified when cloning, required when creating.
     # If not specified when cloning, the existing VM/template\'s parent folder is used.
     if folder:
-        folder_ref = salt.utils.vmware.get_mor_by_property(si, vim.Folder, folder, container_ref=container_ref)
+        folder_parts = folder.split('/')
+        search_reference = container_ref
+        for folder_part in folder_parts:
+            if folder_part:
+                folder_ref = salt.utils.vmware.get_mor_by_property(si, vim.Folder, folder_part, container_ref=search_reference)
+                search_reference = folder_ref
         if not folder_ref:
             log.error("Specified folder: '{0}' does not exist".format(folder))
             log.debug("Using folder in which {0} {1} is present".format(clone_type, vm_['clonefrom']))


### PR DESCRIPTION
### What does this PR do?
Enhances Salt Cloud's VMWare Profiles with the ability to create VMs in nested folder structure by using the / character. For example: ```folder:  Dev/Webservers```


### What issues does this PR fix or reference?
No issue found or filed.

### Previous Behavior
Only folders one level deep could be used for creating VMs.

### New Behavior
Now nested folders can be targeted for creating VMs.

### Tests written?
No

### Commits signed with GPG?
No

