### PR TITLE
Add NetBox execution module

### DIFF
--- a/salt/modules/netbox.py
+++ b/salt/modules/netbox.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+'''
+NetBox
+======
+
+Module to query NetBox
+
+:codeauthor: Zach Moody <zmoody@do.co>
+:maturity:   new
+:depends:    pynetbox
+
+The following config should be in the minion config file. In order to
+work with ``secrets`` you should provide a token and path to your
+private key file:
+
+.. code-block:: yaml
+
+  netbox:
+    url: <NETBOX_URL>
+    token: <NETBOX_USERNAME_API_TOKEN (OPTIONAL)>
+    keyfile: </PATH/TO/NETBOX/KEY (OPTIONAL)>
+
+.. versionadded:: Oxygen
+'''
+
+from __future__ import absolute_import
+import logging
+
+from salt.exceptions import CommandExecutionError
+from salt.utils.args import clean_kwargs
+
+log = logging.getLogger(__name__)
+
+try:
+    import pynetbox
+    HAS_PYNETBOX = True
+except ImportError:
+    HAS_PYNETBOX = False
+
+AUTH_ENDPOINTS = (
+    'secrets',
+)
+
+
+def __virtual__():
+    '''
+    pynetbox must be installed.
+    '''
+    if not HAS_PYNETBOX:
+        return (
+            False,
+            'The netbox execution module cannot be loaded: '
+            'pynetbox library is not installed.'
+        )
+    else:
+        return True
+
+
+def _config():
+    config = __salt__['config.get']('netbox')
+    if not config:
+        raise CommandExecutionError(
+            'NetBox execution module configuration could not be found'
+        )
+    return config
+
+
+def _nb_obj(auth_required=False):
+    pynb_kwargs = {}
+    if auth_required:
+        pynb_kwargs['token'] = _config().get('token')
+        pynb_kwargs['private_key_file'] = _config().get('keyfile')
+    return pynetbox.api(_config().get('url'), **pynb_kwargs)
+
+
+def _strip_url_field(input_dict):
+    if 'url' in input_dict.keys():
+        del input_dict['url']
+    for k, v in input_dict.items():
+        if isinstance(v, dict):
+            _strip_url_field(v)
+    return input_dict
+
+
+def filter(app, endpoint, **kwargs):
+    '''
+    Get a list of items from NetBox.
+
+    .. code-block:: bash
+
+        salt myminion netbox.filter dcim devices status=1 role=router
+    '''
+    ret = []
+    nb = _nb_obj(auth_required=True if app in AUTH_ENDPOINTS else False)
+    nb_query = getattr(getattr(nb, app), endpoint).filter(
+        **clean_kwargs(**kwargs)
+    )
+    if nb_query:
+        ret = [_strip_url_field(dict(i)) for i in nb_query]
+    return sorted(ret)
+
+
+def get(app, endpoint, id=None, **kwargs):
+    '''
+    Get a single item from NetBox.
+
+    To get an item based on ID.
+
+    .. code-block:: bash
+
+        salt myminion netbox.get dcim devices id=123
+
+    Or using named arguments that correspond with accepted filters on
+    the NetBox endpoint.
+
+    .. code-block:: bash
+
+        salt myminion netbox.get dcim devices name=my-router
+    '''
+    nb = _nb_obj(auth_required=True if app in AUTH_ENDPOINTS else False)
+    if id:
+        return dict(getattr(getattr(nb, app), endpoint).get(id))
+    else:
+        return dict(
+            getattr(getattr(nb, app), endpoint).get(**clean_kwargs(**kwargs))
+        )

--- a/tests/unit/modules/test_netbox.py
+++ b/tests/unit/modules/test_netbox.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Zach Moody <zmoody@do.co>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+try:
+    import pynetbox
+    HAS_PYNETBOX = True
+except ImportError:
+    HAS_PYNETBOX = False
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    patch,
+    MagicMock,
+    call,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+import salt.modules.netbox as netbox
+
+NETBOX_RESPONSE_STUB = {
+    'device_name': 'test1-router1',
+    'url': 'http://test/',
+    'device_role': {
+        'name': 'router',
+        'url': 'http://test/'
+    }
+}
+
+
+@skipIf(HAS_PYNETBOX is False, 'pynetbox lib not installed')
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.modules.netbox._config', MagicMock())
+class NetBoxTestCase(TestCase, LoaderModuleMockMixin):
+
+    def setup_loader_modules(self):
+        return {
+            netbox: {},
+        }
+
+    def test_get_by_id(self):
+        with patch('pynetbox.api', MagicMock()) as mock:
+            netbox.get('dcim', 'devices', id=1)
+            self.assertEqual(
+                mock.mock_calls[1],
+                call().dcim.devices.get(1)
+            )
+
+    def test_get_by_name(self):
+        with patch('pynetbox.api', MagicMock()) as mock:
+            netbox.get('dcim', 'devices', name='test')
+            self.assertEqual(
+                mock.mock_calls[1],
+                call().dcim.devices.get(name='test')
+            )
+
+    def test_filter_by_site(self):
+        with patch('pynetbox.api', MagicMock()) as mock:
+            netbox.filter('dcim', 'devices', site='test')
+            self.assertEqual(
+                mock.mock_calls[1],
+                call().dcim.devices.filter(site='test')
+            )
+
+    def test_filter_url(self):
+        strip_url = netbox._strip_url_field(NETBOX_RESPONSE_STUB)
+        self.assertTrue(
+            'url' not in strip_url and 'url' not in strip_url['device_role']
+        )
+
+    def test_get_secret(self):
+        with patch('pynetbox.api', MagicMock()) as mock:
+            netbox.get('secrets', 'secrets', name='test')
+            self.assertTrue(
+                'token' and 'private_key_file' in mock.call_args[1]
+            )

--- a/tests/unit/modules/test_netbox.py
+++ b/tests/unit/modules/test_netbox.py
@@ -7,7 +7,7 @@
 from __future__ import absolute_import
 
 try:
-    import pynetbox
+    import pynetbox  # pylint: disable=unused-import
     HAS_PYNETBOX = True
 except ImportError:
     HAS_PYNETBOX = False


### PR DESCRIPTION
### What does this PR do?
Adds an execution module for querying [Netbox](http://github.com/digitalocean/netbox).

### What issues does this PR fix or reference?
None

### New Behavior
Allows Salt to query NetBox's API.

### Tests written?

Yes

### Commits signed with GPG?

No
