### PR TITLE
fix for #44595

### DIFF
--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -80,6 +80,7 @@ def _master_opts(cfg='master'):
     cfg = os.environ.get(
         'SALT_MASTER_CONFIG', os.path.join(default_dir, cfg))
     opts = config.master_config(cfg)
+    opts['output'] = 'quiet'
     return opts
 
 


### PR DESCRIPTION
  ** Overwrite output plugin for all client and runner instances in  salt-cloud lxc driver

### What does this PR do?
change output for salt-cloud lxc driver
### What issues does this PR fix or reference?
fix #44595
### Previous Behavior

```
# salt-cloud -Q --output json
lab-deb9-cloud01:
    True
lab-deb9-cloud02:
    True
lab-deb9-cloud01:
    True
lab-deb9-cloud01:
    True
lab-deb9-cloud02:
    True
lab-deb9-cloud02:
    True
lab-deb9-cloud01:
    ----------
    frozen:
        ----------
    running:
        ----------
    stopped:
        ----------
        test-container01:
            ----------
            config:
                /var/lib/lxc/test-container01/config
            ips:
            ipv4_ips:
            ipv6_ips:
            nics:
                |_
                  ----------
                  type:
                      empty
            private_ips:
            private_ipv4_ips:
            private_ipv6_ips:
            public_ips:
            public_ipv4_ips:
            public_ipv6_ips:
            rootfs:
                /var/lib/lxc/test-container01/rootfs
            size:
                None
            state:
                stopped
lab-deb9-cloud02:
    ----------
    frozen:
        ----------
    running:
        ----------
    stopped:
        ----------
        test-container02:
            ----------
            config:
                /var/lib/lxc/test-container02/config
            ips:
            ipv4_ips:
            ipv6_ips:
            nics:
                |_
                  ----------
                  type:
                      empty
            private_ips:
            private_ipv4_ips:
            private_ipv6_ips:
            public_ips:
            public_ipv4_ips:
            public_ipv6_ips:
            rootfs:
                /var/lib/lxc/test-container02/rootfs
            size:
                None
            state:
                stopped
{
    "lab-deb9-cloud01": {
        "lxc": {
            "test-container01": {
                "name": "test-container01", 
                "image": null, 
                "state": "stopped", 
                "private_ips": [], 
                "public_ips": [], 
                "id": "test-container01", 
                "size": null
            }
        }
    }, 
    "lab-deb9-cloud02": {
        "lxc": {
            "test-container02": {
                "name": "test-container02", 
                "image": null, 
                "state": "stopped", 
                "private_ips": [], 
                "public_ips": [], 
                "id": "test-container02", 
                "size": null
            }
        }
    }
}

```

### New Behavior
```
# salt-cloud -Q --output json
{
    "lab-deb9-cloud01": {
        "lxc": {
            "test-container01": {
                "name": "test-container01", 
                "image": null, 
                "state": "stopped", 
                "private_ips": [], 
                "public_ips": [], 
                "id": "test-container01", 
                "size": null
            }
        }
    }, 
    "lab-deb9-cloud02": {
        "lxc": {
            "test-container02": {
                "name": "test-container02", 
                "image": null, 
                "state": "stopped", 
                "private_ips": [], 
                "public_ips": [], 
                "id": "test-container02", 
                "size": null
            }
        }
    }
}

```

### Tests written?

No
I did check on my local env

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
