### PR TITLE
Fix Traceback when using the `service.enabled` state on non-booted systems

### DIFF
--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -97,7 +97,10 @@ def _find_utmp():
             result[os.stat(utmp).st_mtime] = utmp
         except Exception:
             pass
-    return result[sorted(result).pop()]
+    if result > 0:
+        return result[sorted(result).pop()]
+    else:
+        return False
 
 
 def _default_runlevel():
@@ -148,12 +151,14 @@ def _runlevel():
     '''
     if 'upstart._runlevel' in __context__:
         return __context__['upstart._runlevel']
-    out = __salt__['cmd.run'](['runlevel', '{0}'.format(_find_utmp())], python_shell=False)
-    try:
-        ret = out.split()[1]
-    except IndexError:
-        # The runlevel is unknown, return the default
-        ret = _default_runlevel()
+    ret = _default_runlevel()
+    utmp = _find_utmp()
+    if utmp:
+        out = __salt__['cmd.run'](['runlevel', '{0}'.format(utmp)], python_shell=False)
+        try:
+            ret = out.split()[1]
+        except IndexError:
+            pass
     __context__['upstart._runlevel'] = ret
     return ret
 


### PR DESCRIPTION
### What does this PR do?

It fixes a traceback when using the `service.enabled` state on non-booted systems (e.g when bootstrapping plain filesystem images for containers using `systemd-nspawn -D …`).

### What issues does this PR fix or reference?
None

### Previous Behavior
`salt-call state.single service.enabled name=salt-minion`:

```
          ID: salt-minion
    Function: service.enabled
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1703, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1649, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/service.py", line 489, in enabled
                  ret.update(_enable(name, None, **kwargs))
                File "/usr/lib/python2.7/dist-packages/salt/states/service.py", line 97, in _enable
                  if not _available(name, ret):
                File "/usr/lib/python2.7/dist-packages/salt/states/service.py", line 275, in _available
                  avail = __salt__['service.available'](name)
                File "/usr/lib/python2.7/dist-packages/salt/modules/upstart.py", line 312, in available
                  return name in get_all()
                File "/usr/lib/python2.7/dist-packages/salt/modules/upstart.py", line 340, in get_all
                  return sorted(get_enabled() + get_disabled())
                File "/usr/lib/python2.7/dist-packages/salt/modules/upstart.py", line 274, in get_enabled
                  if _sysv_is_enabled(name):
                File "/usr/lib/python2.7/dist-packages/salt/modules/upstart.py", line 224, in _sysv_is_enabled
                  return not _sysv_is_disabled(name)
                File "/usr/lib/python2.7/dist-packages/salt/modules/upstart.py", line 216, in _sysv_is_disabled
                  return not bool(glob.glob('/etc/rc{0}.d/S*{1}'.format(_runlevel(), name)))
                File "/usr/lib/python2.7/dist-packages/salt/modules/upstart.py", line 151, in _runlevel
                  out = __salt__['cmd.run'](['runlevel', '{0}'.format(_find_utmp())], python_shell=False)
                File "/usr/lib/python2.7/dist-packages/salt/modules/upstart.py", line 100, in _find_utmp
                  return result[sorted(result).pop()]
              IndexError: pop from empty list
     Started: 16:28:03.914806
    Duration: 6.003 ms
     Changes:
```

### New Behavior
```
local:
----------
          ID: salt-minion
    Function: service.enabled
      Result: True
     Comment: Service salt-minion is already enabled, and is in the desired state
     Started: 16:32:58.136731
    Duration: 17.549 ms
     Changes:   
```

### Tests written?

No

### Commits signed with GPG?

Yes