### PR TITLE
Add vmware vm management

### DIFF
--- a/salt/config/schemas/esxvm.py
+++ b/salt/config/schemas/esxvm.py
@@ -1,0 +1,395 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Agnes Tevesz (agnes.tevesz@morganstanley.com)`
+
+    salt.config.schemas.esxvm
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    ESX Virtual Machine configuration schemas
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+
+from salt.utils.schema import (DefinitionsSchema,
+                               ComplexSchemaItem,
+                               ArrayItem,
+                               IntegerItem,
+                               NumberItem,
+                               BooleanItem,
+                               StringItem,
+                               IPv4Item,
+                               SchemaItem,
+                               AnyOfItem,
+                               NullItem)
+
+
+class ESXVirtualMachineSerialBackingItem(ComplexSchemaItem):
+    '''
+    Configuration Schema Item for ESX Virtual Machine Serial Port Backing
+    '''
+    title = 'ESX Virtual Machine Serial Port Backing'
+    description = 'ESX virtual machine serial port backing'
+    required=True
+
+    uri = StringItem()
+    direction = StringItem(enum=('client', 'server'))
+    filename = StringItem()
+
+
+class ESXVirtualMachineDeviceConnectionItem(ComplexSchemaItem):
+    '''
+    Configuration Schema Item for ESX Virtual Machine Serial Port Connection
+    '''
+    title = 'ESX Virtual Machine Serial Port Connection'
+    description = 'ESX virtual machine serial port connection'
+    required=True
+
+    allow_guest_control = BooleanItem(default=True)
+    start_connected = BooleanItem(default=True)
+
+
+class ESXVirtualMachinePlacementSchemaItem(ComplexSchemaItem):
+    '''
+    Configuration Schema Item for ESX Virtual Machine Placement
+    '''
+    title = 'ESX Virtual Machine Placement Information'
+    description = 'ESX virtual machine placement property'
+    required = True
+
+    cluster = StringItem(title='Virtual Machine Cluster',
+                         description='Cluster of the virtual machine if it is placed to a cluster')
+    host = StringItem(title='Virtual Machine Host',
+                      description='Host of the virtual machine if it is placed to a standalone host')
+    resourcepool = StringItem(title='Virtual Machine Resource Pool',
+                              description='Resource pool of the virtual machine if it is placed to a resource pool')
+    folder = StringItem(title='Virtual Machine Folder',
+                        description='Folder of the virtual machine where it should be deployed, default is the datacenter vmFolder')
+
+
+class ESXVirtualMachineCdDriveClientSchemaItem(ComplexSchemaItem):
+    '''
+    Configuration Schema Item for ESX Virtual Machine CD Drive Client
+    '''
+    title = 'ESX Virtual Machine Serial CD Client'
+    description = 'ESX virtual machine CD/DVD drive client properties'
+
+    mode = StringItem(required=True, enum=('passthrough', 'atapi'))
+
+
+class ESXVirtualMachineCdDriveIsoSchemaItem(ComplexSchemaItem):
+    '''
+    Configuration Schema Item for ESX Virtual Machine CD Drive ISO
+    '''
+    title = 'ESX Virtual Machine Serial CD ISO'
+    description = 'ESX virtual machine CD/DVD drive ISO properties'
+
+    path = StringItem(required=True)
+
+
+class ESXVirtualMachineCdDriveSchemaItem(ComplexSchemaItem):
+    '''
+    Configuration Schema Item for ESX Virtual Machine CD Drives
+    '''
+    title = 'ESX Virtual Machine Serial CD'
+    description = 'ESX virtual machine CD/DVD drive properties'
+
+    adapter = StringItem(title='Virtual Machine CD/DVD Adapter',
+                         description='Unique adapter name for virtual machine cd/dvd drive',
+                         required=True)
+    controller = StringItem(required=True)
+    device_type = StringItem(title='Virtual Machine Device Type',
+                             description='CD/DVD drive of the virtual machine if it is placed to a cluster',
+                             required=True,
+                             default='client_device',
+                             enum=('datastore_iso_file', 'client_device'))
+    client_device = ESXVirtualMachineCdDriveClientSchemaItem()
+    datastore_iso_file = ESXVirtualMachineCdDriveIsoSchemaItem()
+    connectable = ESXVirtualMachineDeviceConnectionItem()
+
+
+class ESXVirtualMachineSerialSchemaItem(ComplexSchemaItem):
+    '''
+    Configuration Schema Item for ESX Virtual Machine Serial Port
+    '''
+    title = 'ESX Virtual Machine Serial Port Configuration'
+    description = 'ESX virtual machine serial port properties'
+
+    type = StringItem(title='Virtual Machine Serial Port Type',
+                      required=True,
+                      enum=('network', 'pipe', 'file', 'device'))
+    adapter = StringItem(title='Virtual Machine Serial Port Name',
+                         description='Unique adapter name for virtual machine serial port' \
+                                     'for creation an arbitrary value should be specified',
+                         required=True)
+    backing = ESXVirtualMachineSerialBackingItem()
+    connectable = ESXVirtualMachineDeviceConnectionItem()
+    yield_port = BooleanItem(title='Serial Port Yield',
+                             description='Serial port yield',
+                             default=False)
+
+
+class ESXVirtualMachineScsiSchemaItem(ComplexSchemaItem):
+    '''
+    Configuration Schema Item for ESX Virtual Machine SCSI Controller
+    '''
+    title = 'ESX Virtual Machine SCSI Controller Configuration'
+    description = 'ESX virtual machine scsi controller properties'
+    required = True
+
+    adapter = StringItem(title='Virtual Machine SCSI Controller Name',
+                         description='Unique SCSI controller name' \
+                                     'for creation an arbitrary value should be specified',
+                         required=True)
+    type = StringItem(title='Virtual Machine SCSI type',
+                      description='Type of the SCSI controller',
+                      required=True,
+                      enum = ('lsilogic', 'lsilogic_sas', 'paravirtual', 'buslogic'))
+    bus_sharing = StringItem(title='Virtual Machine SCSI bus sharing',
+                             description='Sharing type of the SCSI bus',
+                             required=True,
+                             enum=('virtual_sharing', 'physical_sharing', 'no_sharing'))
+    bus_number = NumberItem(title='Virtual Machine SCSI bus number',
+                            description='Unique bus number of the SCSI device',
+                            required=True)
+
+
+class ESXVirtualMachineSataSchemaItem(ComplexSchemaItem):
+    '''
+    Configuration Schema Item for ESX Virtual Machine SATA Controller
+    '''
+    title = 'ESX Virtual Machine SATA Controller Configuration'
+    description = 'ESX virtual machine SATA controller properties'
+    required = False
+    adapter = StringItem(title='Virtual Machine SATA Controller Name',
+                         description='Unique SATA controller name' \
+                                     'for creation an arbitrary value should be specified',
+                         required=True)
+    bus_number = NumberItem(title='Virtual Machine SATA bus number',
+                            description='Unique bus number of the SATA device',
+                            required=True)
+
+
+class ESXVirtualMachineDiskSchemaItem(ComplexSchemaItem):
+    '''
+    Configuration Schema Item for ESX Virtual Machine Disk
+    '''
+    title = 'ESX Virtual Machine Disk Configuration'
+    description= 'ESX virtual machine disk properties'
+    required = True
+
+    size = NumberItem(title='Disk size',
+                      description='Size of the disk in GB',
+                      required=True)
+    unit = StringItem(title='Disk size unit',
+                      description='Unit of the disk size, to VMware a '
+                                  'GB is the same as GiB = 1024MiB',
+                      required=False,
+                      default='GB',
+                      enum=('KB', 'MB', 'GB'))
+    adapter = StringItem(title='Virtual Machine Adapter Name',
+                         description='Unique adapter name for virtual machine'
+                                     'for creation an arbitrary value should be specified',
+                         required=True)
+    filename = StringItem(title='Virtual Machine Disk File',
+                          description='File name of the virtual machine vmdk')
+    datastore = StringItem(title='Virtual Machine Disk Datastore',
+                           description='Disk datastore where the virtual machine files will be placed',
+                           required=True)
+    address = StringItem(title='Virtual Machine SCSI Address',
+                         description='Address of the SCSI adapter for the virtual machine',
+                         pattern='\d:\d')
+    thin_provision = BooleanItem(title='Virtual Machine Disk Provision Type',
+                                 description='Provision type of the disk',
+                                 default=True,
+                                 required=False)
+    eagerly_scrub = AnyOfItem(required=False,
+                              items=[BooleanItem(), NullItem()])
+    controller = StringItem(title='Virtual Machine SCSI Adapter',
+                            description='Name of the SCSI adapter where the disk will be connected',
+                            required=True)
+
+
+class ESXVirtualMachineNicMapSchemaItem(ComplexSchemaItem):
+    '''
+    Configuration Schema Item for ESX Virtual Machine Nic Map
+    '''
+    title = 'ESX Virtual Machine Nic Configuration'
+    description = 'ESX Virtual Machine nic properties'
+    required = False
+
+    domain = StringItem()
+    gateway = IPv4Item()
+    ip_addr = IPv4Item()
+    subnet_mask = IPv4Item()
+
+
+class ESXVirtualMachineInterfaceSchemaItem(ComplexSchemaItem):
+    '''
+    Configuration Schema Item for ESX Virtual Machine Network Interface
+    '''
+    title = 'ESX Virtual Machine Network Interface Configuration'
+    description = 'ESX Virtual Machine network adapter properties'
+    required = True
+
+    name = StringItem(title='Virtual Machine Port Group',
+                      description='Specifies the port group name for the virtual machine connection',
+                      required=True)
+    adapter = StringItem(title='Virtual Machine Network Adapter',
+                         description='Unique name of the network adapter, ' \
+                                     'for creation an arbitrary value should be specified',
+                         required=True)
+    adapter_type = StringItem(title='Virtual Machine Adapter Type',
+                              description='Network adapter type of the virtual machine',
+                              required=True,
+                              enum=('vmxnet', 'vmxnet2', 'vmxnet3', 'e1000', 'e1000e'),
+                              default='vmxnet3')
+    switch_type = StringItem(title='Virtual Machine Switch Type',
+                             description='Specifies the type of the virtual switch for the virtual machine connection',
+                             required=True,
+                             default='standard',
+                             enum=('standard', 'distributed'))
+    mac = StringItem(title='Virtual Machine MAC Address',
+                     description='Mac address of the virtual machine',
+                     required=False,
+                     pattern='^([0-9a-f]{1,2}[:]){5}([0-9a-f]{1,2})$')
+    mapping = ESXVirtualMachineNicMapSchemaItem()
+    connectable = ESXVirtualMachineDeviceConnectionItem()
+
+
+class ESXVirtualMachineMemorySchemaItem(ComplexSchemaItem):
+    '''
+    Configurtation Schema Item for ESX Virtual Machine Memory
+    '''
+    title = 'ESX Virtual Machine Memory Configuration'
+    description = 'ESX Virtual Machine memory property'
+    required = True
+
+    size = IntegerItem(title='Memory size',
+                       description='Size of the memory',
+                       required=True)
+
+    unit = StringItem(title='Memory unit',
+                      description='Unit of the memory, to VMware a '
+                                  'GB is the same as GiB = 1024MiB',
+                      required=False,
+                      default='MB',
+                      enum=('MB', 'GB'))
+    hotadd = BooleanItem(required=False, default=False)
+    reservation_max = BooleanItem(required=False, default=False)
+
+
+class ESXVirtualMachineCpuSchemaItem(ComplexSchemaItem):
+    '''
+    Configurtation Schema Item for ESX Virtual Machine CPU
+    '''
+    title = 'ESX Virtual Machine Memory Configuration'
+    description = 'ESX Virtual Machine memory property'
+    required = True
+
+    count = IntegerItem(title='CPU core count',
+                        description='CPU core count',
+                        required=True)
+    cores_per_socket = IntegerItem(title='CPU cores per socket',
+                                   description='CPU cores per socket count',
+                                   required=False)
+    nested = BooleanItem(title='Virtual Machine Nested Property',
+                         description='Nested virtualization support',
+                         default=False)
+    hotadd = BooleanItem(title='Virtual Machine CPU hot add',
+                         description='CPU hot add',
+                         default=False)
+    hotremove = BooleanItem(title='Virtual Machine CPU hot remove',
+                            description='CPU hot remove',
+                            default=False)
+
+
+class ESXVirtualMachineConfigSchema(DefinitionsSchema):
+    '''
+    Configuration Schema for ESX Virtual Machines
+    '''
+    title = 'ESX Virtual Machine Configuration Schema'
+    description = 'ESX Virtual Machine configuration schema'
+
+    vm_name = StringItem(title='Virtual Machine name',
+                         description='Name of the virtual machine',
+                         required=True)
+    cpu = ESXVirtualMachineCpuSchemaItem()
+    memory = ESXVirtualMachineMemorySchemaItem()
+    image = StringItem(title='Virtual Machine guest OS',
+                       description='Guest OS type',
+                       required=True)
+    version = StringItem(title='Virtual Machine hardware version',
+                         description='Container hardware version property',
+                         required=True)
+    interfaces = ArrayItem(items=ESXVirtualMachineInterfaceSchemaItem(),
+                           min_items=1,
+                           required=True,
+                           unique_items=True)
+    disks = ArrayItem(items=ESXVirtualMachineDiskSchemaItem(),
+                      min_items=1,
+                      required=True,
+                      unique_items=True)
+    scsi_devices = ArrayItem(items=ESXVirtualMachineScsiSchemaItem(),
+                             min_items=1,
+                             required=True,
+                             unique_items=True)
+    serial_ports = ArrayItem(items=ESXVirtualMachineSerialSchemaItem(),
+                             min_items=0,
+                             required=False,
+                             unique_items=True)
+    cd_dvd_drives = ArrayItem(items=ESXVirtualMachineCdDriveSchemaItem(),
+                              min_items=0,
+                              required=False,
+                              unique_items=True)
+    sata_controllers = ArrayItem(items=ESXVirtualMachineSataSchemaItem(),
+                                 min_items=0,
+                                 required=False,
+                                 unique_items=True)
+    datacenter = StringItem(title='Virtual Machine Datacenter',
+                            description='Datacenter of the virtual machine',
+                            required=True)
+    datastore = StringItem(title='Virtual Machine Datastore',
+                           description='Datastore of the virtual machine',
+                           required=True)
+    placement = ESXVirtualMachinePlacementSchemaItem()
+    template = BooleanItem(title='Virtual Machine Template',
+                           description='Template to create the virtual machine from',
+                           default=False)
+    tools = BooleanItem(title='Virtual Machine VMware Tools',
+                        description='Install VMware tools on the guest machine',
+                        default=False)
+    power_on = BooleanItem(title='Virtual Machine Power',
+                           description='Power on virtual machine afret creation',
+                           default=False)
+    deploy = BooleanItem(title='Virtual Machine Deploy Salt',
+                         description='Deploy salt after successful installation',
+                         default=False)
+
+
+class ESXVirtualMachineRemoveSchema(DefinitionsSchema):
+    '''
+    Remove Schema for ESX Virtual Machines to delete or unregister virtual machines
+    '''
+    name = StringItem(title='Virtual Machine name',
+                      description='Name of the virtual machine',
+                      required=True)
+    datacenter = StringItem(title='Virtual Machine Datacenter',
+                            description='Datacenter of the virtual machine',
+                            required=True)
+    placement = AnyOfItem(required=False,
+                          items=[ESXVirtualMachinePlacementSchemaItem(), NullItem()])
+    power_off = BooleanItem(title='Power off vm',
+                            description='Power off vm before delete operation',
+                            required=False)
+
+
+class ESXVirtualMachineDeleteSchema(ESXVirtualMachineRemoveSchema):
+    '''
+    Deletion Schema for ESX Virtual Machines
+    '''
+
+class ESXVirtualMachineUnregisterSchema(ESXVirtualMachineRemoveSchema):
+    '''
+    Unregister Schema for ESX Virtual Machines
+    '''

--- a/salt/config/schemas/esxvm.py
+++ b/salt/config/schemas/esxvm.py
@@ -324,15 +324,15 @@ class ESXVirtualMachineConfigSchema(DefinitionsSchema):
                          required=True)
     interfaces = ArrayItem(items=ESXVirtualMachineInterfaceSchemaItem(),
                            min_items=1,
-                           required=True,
+                           required=False,
                            unique_items=True)
     disks = ArrayItem(items=ESXVirtualMachineDiskSchemaItem(),
                       min_items=1,
-                      required=True,
+                      required=False,
                       unique_items=True)
     scsi_devices = ArrayItem(items=ESXVirtualMachineScsiSchemaItem(),
                              min_items=1,
-                             required=True,
+                             required=False,
                              unique_items=True)
     serial_ports = ArrayItem(items=ESXVirtualMachineSerialSchemaItem(),
                              min_items=0,

--- a/salt/config/schemas/esxvm.py
+++ b/salt/config/schemas/esxvm.py
@@ -19,7 +19,6 @@ from salt.utils.schema import (DefinitionsSchema,
                                BooleanItem,
                                StringItem,
                                IPv4Item,
-                               SchemaItem,
                                AnyOfItem,
                                NullItem)
 
@@ -30,7 +29,7 @@ class ESXVirtualMachineSerialBackingItem(ComplexSchemaItem):
     '''
     title = 'ESX Virtual Machine Serial Port Backing'
     description = 'ESX virtual machine serial port backing'
-    required=True
+    required = True
 
     uri = StringItem()
     direction = StringItem(enum=('client', 'server'))
@@ -43,7 +42,7 @@ class ESXVirtualMachineDeviceConnectionItem(ComplexSchemaItem):
     '''
     title = 'ESX Virtual Machine Serial Port Connection'
     description = 'ESX virtual machine serial port connection'
-    required=True
+    required = True
 
     allow_guest_control = BooleanItem(default=True)
     start_connected = BooleanItem(default=True)
@@ -119,7 +118,7 @@ class ESXVirtualMachineSerialSchemaItem(ComplexSchemaItem):
                       required=True,
                       enum=('network', 'pipe', 'file', 'device'))
     adapter = StringItem(title='Virtual Machine Serial Port Name',
-                         description='Unique adapter name for virtual machine serial port' \
+                         description='Unique adapter name for virtual machine serial port'
                                      'for creation an arbitrary value should be specified',
                          required=True)
     backing = ESXVirtualMachineSerialBackingItem()
@@ -138,13 +137,13 @@ class ESXVirtualMachineScsiSchemaItem(ComplexSchemaItem):
     required = True
 
     adapter = StringItem(title='Virtual Machine SCSI Controller Name',
-                         description='Unique SCSI controller name' \
+                         description='Unique SCSI controller name'
                                      'for creation an arbitrary value should be specified',
                          required=True)
     type = StringItem(title='Virtual Machine SCSI type',
                       description='Type of the SCSI controller',
                       required=True,
-                      enum = ('lsilogic', 'lsilogic_sas', 'paravirtual', 'buslogic'))
+                      enum=('lsilogic', 'lsilogic_sas', 'paravirtual', 'buslogic'))
     bus_sharing = StringItem(title='Virtual Machine SCSI bus sharing',
                              description='Sharing type of the SCSI bus',
                              required=True,
@@ -162,7 +161,7 @@ class ESXVirtualMachineSataSchemaItem(ComplexSchemaItem):
     description = 'ESX virtual machine SATA controller properties'
     required = False
     adapter = StringItem(title='Virtual Machine SATA Controller Name',
-                         description='Unique SATA controller name' \
+                         description='Unique SATA controller name'
                                      'for creation an arbitrary value should be specified',
                          required=True)
     bus_number = NumberItem(title='Virtual Machine SATA bus number',
@@ -175,7 +174,7 @@ class ESXVirtualMachineDiskSchemaItem(ComplexSchemaItem):
     Configuration Schema Item for ESX Virtual Machine Disk
     '''
     title = 'ESX Virtual Machine Disk Configuration'
-    description= 'ESX virtual machine disk properties'
+    description = 'ESX virtual machine disk properties'
     required = True
 
     size = NumberItem(title='Disk size',
@@ -198,7 +197,7 @@ class ESXVirtualMachineDiskSchemaItem(ComplexSchemaItem):
                            required=True)
     address = StringItem(title='Virtual Machine SCSI Address',
                          description='Address of the SCSI adapter for the virtual machine',
-                         pattern='\d:\d')
+                         pattern=r'\d:\d')
     thin_provision = BooleanItem(title='Virtual Machine Disk Provision Type',
                                  description='Provision type of the disk',
                                  default=True,
@@ -236,7 +235,7 @@ class ESXVirtualMachineInterfaceSchemaItem(ComplexSchemaItem):
                       description='Specifies the port group name for the virtual machine connection',
                       required=True)
     adapter = StringItem(title='Virtual Machine Network Adapter',
-                         description='Unique name of the network adapter, ' \
+                         description='Unique name of the network adapter, '
                                      'for creation an arbitrary value should be specified',
                          required=True)
     adapter_type = StringItem(title='Virtual Machine Adapter Type',
@@ -388,6 +387,7 @@ class ESXVirtualMachineDeleteSchema(ESXVirtualMachineRemoveSchema):
     '''
     Deletion Schema for ESX Virtual Machines
     '''
+
 
 class ESXVirtualMachineUnregisterSchema(ESXVirtualMachineRemoveSchema):
     '''

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -397,6 +397,18 @@ class TemplateError(SaltException):
     '''
 
 
+class ArgumentValueError(CommandExecutionError):
+    '''
+    Used when an invalid argument was passed to a command execution
+    '''
+
+
+class CheckError(CommandExecutionError):
+    '''
+    Used when a check fails
+    '''
+
+
 # Validation related exceptions
 class InvalidConfigError(CommandExecutionError):
     '''
@@ -455,13 +467,79 @@ class VMwareObjectNotFoundError(VMwareSaltError):
     '''
 
 
+class VMwareObjectExistsError(VMwareSaltError):
+    '''
+    Used when a VMware object already exists
+    '''
+
+
+class VMwareMultipleObjectsError(VMwareObjectRetrievalError):
+    '''
+    Used when multiple objects were retrieived (and one was expected)
+    '''
+
+
+class VMwareNotFoundError(VMwareSaltError):
+    '''
+    Used when a VMware object was not found
+    '''
+
+
 class VMwareApiError(VMwareSaltError):
     '''
     Used when representing a generic VMware API error
     '''
 
 
+class VMwareFileNotFoundError(VMwareApiError):
+    '''
+    Used when representing a generic VMware error if a file not found
+    '''
+
+
 class VMwareSystemError(VMwareSaltError):
     '''
     Used when representing a generic VMware system error
+    '''
+
+
+class VMwareObjectRetrievalException(VMwareSaltError):
+    '''
+    Used when a VMware object is not found
+    '''
+
+
+class VMwareObjectDuplicateException(VMwareSaltError):
+    '''
+    Used when multiple VMware objects exist with the same property and they shouldn't
+    '''
+
+
+class VMwarePowerOnException(VMwareSaltError):
+    '''
+    Used when object is already powered on
+    '''
+
+
+class VMwarePowerOnError(VMwareSaltError):
+    '''
+    Used when error occurred during power on
+    '''
+
+
+class VMwareVmRegisterError(VMwareSaltError):
+    '''
+    Used when a configuration parameter is incorrect
+    '''
+
+
+class VMwareVmCreationError(VMwareSaltError):
+    '''
+    Used when a configuration parameter is incorrect
+    '''
+
+
+class VMwareVmDeviceConfigException(VMwareSaltError):
+    '''
+    Used when a device parameter is incorrect
     '''

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -475,7 +475,7 @@ class VMwareObjectExistsError(VMwareSaltError):
 
 class VMwareMultipleObjectsError(VMwareObjectRetrievalError):
     '''
-    Used when multiple objects were retrieived (and one was expected)
+    Used when multiple objects were retrieved (and one was expected)
     '''
 
 
@@ -503,24 +503,6 @@ class VMwareSystemError(VMwareSaltError):
     '''
 
 
-class VMwareObjectRetrievalException(VMwareSaltError):
-    '''
-    Used when a VMware object is not found
-    '''
-
-
-class VMwareObjectDuplicateException(VMwareSaltError):
-    '''
-    Used when multiple VMware objects exist with the same property and they shouldn't
-    '''
-
-
-class VMwarePowerOnException(VMwareSaltError):
-    '''
-    Used when object is already powered on
-    '''
-
-
 class VMwarePowerOnError(VMwareSaltError):
     '''
     Used when error occurred during power on
@@ -536,10 +518,4 @@ class VMwareVmRegisterError(VMwareSaltError):
 class VMwareVmCreationError(VMwareSaltError):
     '''
     Used when a configuration parameter is incorrect
-    '''
-
-
-class VMwareVmDeviceConfigException(VMwareSaltError):
-    '''
-    Used when a device parameter is incorrect
     '''

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -416,12 +416,6 @@ class InvalidConfigError(CommandExecutionError):
     '''
 
 
-class ArgumentValueError(CommandExecutionError):
-    '''
-    Used when an invalid argument was passed to a command execution
-    '''
-
-
 class InvalidEntityError(CommandExecutionError):
     '''
     Used when an entity fails validation
@@ -452,12 +446,6 @@ class VMwareConnectionError(VMwareSaltError):
 class VMwareObjectRetrievalError(VMwareSaltError):
     '''
     Used when a VMware object cannot be retrieved
-    '''
-
-
-class VMwareObjectExistsError(VMwareSaltError):
-    '''
-    Used when a VMware object exists
     '''
 
 

--- a/salt/modules/esxvm.py
+++ b/salt/modules/esxvm.py
@@ -20,18 +20,10 @@ def __virtual__():
     '''
     Only work on proxy
     '''
-    if salt.utils.is_proxy():
+    if salt.utils.platform.is_proxy():
         return __virtualname__
     return False
 
 
 def get_details():
     return __proxy__['esxvm.get_details']()
-
-
-def grains():
-    return __proxy__['esxvm.grains']()
-
-
-
-

--- a/salt/modules/esxvm.py
+++ b/salt/modules/esxvm.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+'''
+Module used to access the esx proxy connection methods
+'''
+from __future__ import absolute_import
+
+# Import python libs
+import logging
+import salt.utils
+
+
+log = logging.getLogger(__name__)
+
+__proxyenabled__ = ['esxvm']
+# Define the module's virtual name
+__virtualname__ = 'esxvm'
+
+
+def __virtual__():
+    '''
+    Only work on proxy
+    '''
+    if salt.utils.is_proxy():
+        return __virtualname__
+    return False
+
+
+def get_details():
+    return __proxy__['esxvm.get_details']()
+
+
+def grains():
+    return __proxy__['esxvm.grains']()
+
+
+
+

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -177,6 +177,8 @@ import salt.utils.path
 import salt.utils.pbm
 import salt.utils.vmware
 import salt.utils.vsan
+from salt.utils.listdiffer import list_diff
+from salt.utils.dictdiffer import recursive_diff
 from salt.exceptions import CommandExecutionError, VMwareSaltError, \
         ArgumentValueError, InvalidConfigError, VMwareObjectRetrievalError, \
         VMwareApiError, InvalidEntityError, VMwareObjectExistsError
@@ -255,6 +257,8 @@ def _get_proxy_connection_details():
         details = __salt__['esxdatacenter.get_details']()
     elif proxytype == 'vcenter':
         details = __salt__['vcenter.get_details']()
+    elif proxytype == 'esxvm':
+        details = __salt__['esxvm.get_details']()
     else:
         raise CommandExecutionError('\'{0}\' proxy is not supported'
                                     ''.format(proxytype))
@@ -380,7 +384,7 @@ def gets_service_instance_via_proxy(fn):
 
 
 @depends(HAS_PYVMOMI)
-@supports_proxies('esxi', 'esxcluster', 'esxdatacenter', 'vcenter')
+@supports_proxies('esxi', 'esxcluster', 'esxdatacenter', 'vcenter', 'esxvm')
 def get_service_instance_via_proxy(service_instance=None):
     '''
     Returns a service instance to the proxied endpoint (vCenter/ESXi host).
@@ -400,7 +404,7 @@ def get_service_instance_via_proxy(service_instance=None):
 
 
 @depends(HAS_PYVMOMI)
-@supports_proxies('esxi', 'esxcluster', 'esxdatacenter', 'vcenter')
+@supports_proxies('esxi', 'esxcluster', 'esxdatacenter', 'vcenter', 'esxvm')
 def disconnect(service_instance):
     '''
     Disconnects from a vCenter or ESXi host
@@ -7212,3 +7216,2105 @@ def _get_esxi_proxy_details():
     return host, det.get('username'), det.get('password'), \
             det.get('protocol'), det.get('port'), det.get('mechanism'), \
             det.get('principal'), det.get('domain'), esxi_hosts
+
+
+@gets_service_instance_via_proxy
+def get_vm(name, datacenter=None, vm_properties=None, traversal_spec=None,
+           parent_ref=None, service_instance=None):
+    '''
+    Returns vm object properties.
+
+    name
+        Name of the virtual machine.
+
+    datacenter
+        Datacenter name
+
+    vm_properties
+        List of vm properties.
+
+    traversal_spec
+        Traversal Spec object(s) for searching.
+
+    parent_ref
+        Container Reference object for searching under a given object.
+
+    service_instance
+        Service instance (vim.ServiceInstance) of the vCenter.
+        Default is None.
+    '''
+    virtual_machine = salt.utils.vmware.get_vm_by_property(service_instance,
+                                                           name, datacenter=datacenter,
+                                                           vm_properties=vm_properties,
+                                                           traversal_spec=traversal_spec,
+                                                           parent_ref=parent_ref)
+    return virtual_machine
+
+
+@depends(HAS_PYVMOMI)
+@gets_service_instance_via_proxy
+def get_vm_config_file(name, datacenter, placement, datastore, service_instance=None):
+    '''
+    Queries the virtual machine config file and returns vim.host.DatastoreBrowser.SearchResults object
+    on success None on failure
+
+    name
+        Name of the virtual machine
+
+    datacenter
+        Datacenter name
+
+    datastore
+        Datastore where the virtual machine files are stored
+
+    service_instance
+        Service instance (vim.ServiceInstance) of the vCenter.
+        Default is None.
+    '''
+
+    browser_spec = vim.host.DatastoreBrowser.SearchSpec()
+    directory = name
+    browser_spec.query = [vim.host.DatastoreBrowser.VmConfigQuery()]
+    datacenter_object = salt.utils.vmware.get_datacenter(service_instance, datacenter)
+    if 'cluster' in placement:
+        container_object = salt.utils.vmware.get_cluster(datacenter_object, placement['cluster'])
+    else:
+        container_objects = salt.utils.vmware.get_hosts(service_instance,
+                                                       datacenter_name=datacenter,
+                                                       host_names=[placement['host']])
+        if not container_objects:
+            raise salt.exceptions.VMwareObjectRetrievalError('ESXi host named \'{0}\' '
+                                                  'wasn\'t found.'.format(placement['host']))
+        container_object = container_objects[0]
+
+
+    # list of vim.host.DatastoreBrowser.SearchResults objects
+    files = salt.utils.vmware.get_datastore_files(service_instance, directory, [datastore],
+                                                  container_object, browser_spec)
+    if files and len(files[0].file) > 1:
+        raise salt.exceptions.VMwareObjectDuplicateException('Multiple configuration files found in '
+                                                  'the same virtual machine folder')
+    elif files and files[0].file:
+        return files[0]
+    else:
+        return None
+
+
+@depends(HAS_PYVMOMI)
+@supports_proxies('esxvm')
+@gets_service_instance_via_proxy
+def register_vm(name, datacenter, placement, vmx_path, service_instance=None):
+    '''
+    Registers a virtual machine to the inventory with the given vmx file.
+    Returns comments and change list
+
+    name
+        Name of the virtual machine
+
+    datacenter
+        Datacenter of the virtual machine
+
+    placement
+        Placement dictionary of the virtual machine, host or cluster
+
+    vmx_path:
+        Full path to the vmx file, datastore name should be included
+
+    service_instance
+        Service instance (vim.ServiceInstance) of the vCenter.
+        Default is None.
+    '''
+    log.trace('Registering virtual machine with properties '
+              'datacenter={0}, placement={1}, vmx_path={2}'.format(datacenter, placement, vmx_path))
+    datacenter_object = salt.utils.vmware.get_datacenter(service_instance, datacenter)
+    if 'cluster' in placement:
+        cluster_obj = salt.utils.vmware.get_cluster(datacenter_object, placement['cluster'])
+        cluster_props = salt.utils.vmware.get_properties_of_managed_object(cluster_obj, properties=['resourcePool'])
+        if 'resourcePool' in cluster_props:
+            resourcepool = cluster_props['resourcePool']
+        else:
+            raise salt.exceptions.VMwareObjectRetrievalError('The cluster\'s resource pool object could not be retrieved.')
+        salt.utils.vmware.register_vm(datacenter_object, name, vmx_path, resourcepool=resourcepool)
+    elif 'host' in placement:
+        hosts = salt.utils.vmware.get_hosts(service_instance, datacenter_name=datacenter,
+                                            host_names=[placement['host']])
+        if not hosts:
+            raise salt.exceptions.VMwareObjectRetrievalError('ESXi host named \'{0}\' '
+                                                  'wasn\'t found.'.format(placement['host']))
+        host_obj = hosts[0]
+        salt.utils.vmware.register_vm(datacenter_object, name, vmx_path, host=host_obj)
+    result = {'comment': 'Virtual machine registration action succeeded',
+              'changes': {'register_vm': True}}
+    return result
+
+
+@depends(HAS_PYVMOMI)
+@supports_proxies('esxvm', 'esxcluster', 'esxdatacenter')
+@gets_service_instance_via_proxy
+def power_on_vm(name, datacenter=None, service_instance=None):
+    '''
+    Powers on a virtual machine specified by it's name.
+
+    name
+        Name of the virtual machine
+
+    datacenter
+        Datacenter of the virtual machine
+
+    service_instance
+        Service instance (vim.ServiceInstance) of the vCenter.
+        Default is None.
+    '''
+    log.trace('Powering on virtual machine {0}'.format(name))
+    vm_properties = [
+        'name',
+        'summary.runtime.powerState'
+    ]
+    virtual_machine = salt.utils.vmware.get_vm_by_property(service_instance, name,
+                                                           datacenter=datacenter,
+                                                           vm_properties=vm_properties)
+    if virtual_machine['summary.runtime.powerState'] == 'poweredOn':
+        result = {'comment': 'Virtual machine is already powered on',
+                  'changes': {'power_on': True}}
+        return result
+    salt.utils.vmware.power_cycle_vm(virtual_machine['object'], action='on')
+    result = {'comment': 'Virtual machine power on action succeeded',
+              'changes': {'power_on': True}}
+    return result
+
+
+@depends(HAS_PYVMOMI)
+@supports_proxies('esxvm', 'esxcluster', 'esxdatacenter')
+@gets_service_instance_via_proxy
+def power_off_vm(name, datacenter=None, service_instance=None):
+    '''
+    Powers off a virtual machine specified by it's name.
+
+    name
+        Name of the virtual machine
+
+    datacenter
+        Datacenter of the virtual machine
+
+    service_instance
+        Service instance (vim.ServiceInstance) of the vCenter.
+        Default is None.
+    '''
+    log.trace('Powering off virtual machine {0}'.format(name))
+    vm_properties = [
+        'name',
+        'summary.runtime.powerState'
+    ]
+    virtual_machine = salt.utils.vmware.get_vm_by_property(service_instance, name,
+                                                           datacenter=datacenter,
+                                                           vm_properties=vm_properties)
+    if virtual_machine['summary.runtime.powerState'] == 'poweredOff':
+        result = {'comment': 'Virtual machine is already powered off',
+                  'changes': {'power_off': True}}
+        return result
+    salt.utils.vmware.power_cycle_vm(virtual_machine['object'], action='off')
+    result = {'comment': 'Virtual machine power off action succeeded',
+              'changes': {'power_off': True}}
+    return result
+
+
+def _apply_hardware_version(hardware_version, config_spec, operation='add'):
+    '''
+    Specifies vm container version or schedules upgrade,
+    returns True on change and False if nothing have been changed.
+
+    hardware_version
+        Hardware version string eg. vmx-08
+
+    config_spec
+        Configuration spec object
+
+    operation
+        Defines the operation which should be used,
+        the possibles values: 'add' and 'edit', the default value is 'add'
+    '''
+    log.trace('Configuring virtual machine hardware version version={0}'.format(hardware_version))
+    if operation == 'edit':
+        log.trace('Scheduling hardware version upgrade to {0}'.format(hardware_version))
+        scheduled_hardware_upgrade = vim.vm.ScheduledHardwareUpgradeInfo()
+        scheduled_hardware_upgrade.upgradePolicy = 'always'
+        scheduled_hardware_upgrade.versionKey = hardware_version
+        config_spec.scheduledHardwareUpgradeInfo = scheduled_hardware_upgrade
+    elif operation == 'add':
+        config_spec.version = str(hardware_version)
+
+
+def _apply_cpu_config(config_spec, cpu_props):
+    '''
+    Sets CPU core count to the given value
+
+    config_spec
+        vm.ConfigSpec object
+
+    cpu_props
+        CPU properties dict
+    '''
+    log.trace('Configuring virtual machine CPU settings cpu_props={0}'.format(cpu_props))
+    if 'count' in cpu_props:
+        config_spec.numCPUs = int(cpu_props['count'])
+    if 'cores_per_socket' in cpu_props:
+        config_spec.numCoresPerSocket = int(cpu_props['cores_per_socket'])
+    if 'nested' in cpu_props and cpu_props['nested']:
+        config_spec.nestedHVEnabled = cpu_props['nested']  # True
+    if 'hotadd' in cpu_props and cpu_props['hotadd']:
+        config_spec.cpuHotAddEnabled = cpu_props['hotadd']  # True
+    if 'hotremove' in cpu_props and cpu_props['hotremove']:
+        config_spec.cpuHotRemoveEnabled = cpu_props['hotremove']  # True
+
+
+def _apply_memory_config(config_spec, memory):
+    '''
+    Sets memory size to the given value
+
+    config_spec
+        vm.ConfigSpec object
+
+    memory
+        Memory size and unit
+    '''
+    log.trace('Configuring virtual machine memory settings memory={0}'.format(memory))
+    if 'size' in memory and 'unit' in memory:
+        try:
+            if memory['unit'].lower() == 'kb':
+                memory_mb = memory['size'] / 1024L
+            elif memory['unit'].lower() == 'mb':
+                memory_mb = int(memory['size'])
+            elif memory['unit'].lower() == 'gb':
+                memory_mb = int(float(memory['size']) * 1024L)
+        except (TypeError, ValueError):
+            memory_mb = int(memory['size'])
+        config_spec.memoryMB = memory_mb
+    if 'reservation_max' in memory:
+        config_spec.memoryReservationLockedToMax = memory['reservation_max']
+    if 'hotadd' in memory:
+        config_spec.memoryHotAddEnabled = memory['hotadd']
+
+
+def _apply_advanced_config(config_spec, advanced_config):
+    '''
+    Sets configuration parameters for the vm
+
+    config_spec
+        vm.ConfigSpec object
+
+    advanced_config
+        config key value pairs
+
+    vm_ref
+        Virtual machine object vim.VirtualMachine
+    '''
+    log.trace('Configuring advanced configuration parameters {0}'.format(advanced_config))
+    vm_extra_config = []
+    if isinstance(advanced_config, str):
+        raise salt.exceptions.ArgumentValueError('The specified \'advanced_configs\' configuration'
+                                      ' option cannot be parsed, please check the parameters')
+    for key, value in six.iteritems(advanced_config):
+        for option in vm_extra_config:
+            if option.key == key and option.value == str(value):
+                break
+        else:
+            option = vim.option.OptionValue(key=key, value=value)
+            config_spec.extraConfig.append(option)
+
+
+def _delete_advanced_config(config_spec, advanced_config):
+    '''
+    Removes configuration parameters for the vm
+
+    config_spec
+        vm.ConfigSpec object
+
+    advanced_config
+        config key value pairs
+
+    vm_ref
+        Virtual machine object vim.VirtualMachine
+    '''
+    log.trace('Removing advanced configuration parameters {0}'.format(advanced_config))
+    vm_extra_config = []
+    if isinstance(advanced_config, str):
+        raise salt.exceptions.ArgumentValueError('The specified \'advanced_configs\' configuration'
+                                      ' option cannot be parsed, please check the parameters')
+    for key, value in six.iteritems(advanced_config):
+        option = vim.option.OptionValue(key=key, value='')
+        config_spec.extraConfig.append(option)
+
+
+@gets_service_instance_via_proxy
+def delete_advanced_configs(vm_name, datacenter, advanced_configs, service_instance=None):
+    '''
+    Removes extra config parameters from a virtual machine
+
+    vm_name
+        Virtual machine name
+
+    datacenter
+        Datacenter name where the virtual machine is available
+
+    advanced_configs
+        Dictionary with advanced parameter key value pairs, for removal an
+        empty string should be supplied as a value for a key
+
+    service_instance
+        vCenter service instance for connection and configuration
+    '''
+    current_config = get_vm_config(vm_name,
+                                   datacenter=datacenter,
+                                   objects=True,
+                                   service_instance=service_instance)
+    diffs = compare_vm_configs({'name': vm_name,
+                                'advanced_configs': advanced_configs},
+                               current_config)
+    datacenter_ref = salt.utils.vmware.get_datacenter(service_instance, datacenter)
+    vm_ref = salt.utils.vmware.get_mor_by_property(service_instance,
+                                                   vim.VirtualMachine,
+                                                   vm_name,
+                                                   property_name='name',
+                                                   container_ref=datacenter_ref)
+    config_spec = vim.vm.ConfigSpec()
+    changes = diffs['advanced_configs'].diffs
+    if _delete_advanced_config(config_spec, diffs['advanced_configs'].diffs):
+        salt.utils.vmware.update_vm(vm_ref, config_spec)
+
+    return changes
+
+
+def _get_scsi_controller_key(bus_number, scsi_ctrls):
+    '''
+    Returns key number of the SCSI controller keys
+
+    bus_number
+        Controller bus number from the adapter
+
+    scsi_ctrls
+        List of SCSI Controller objects (old+newly created)
+    '''
+    # list of new/old VirtualSCSIController objects, both new and old objects
+    # should contain a key attribute key should be a negative integer in case of a new object
+    keys = [ctrl.key for ctrl in scsi_ctrls if
+            scsi_ctrls and ctrl.busNumber == bus_number]
+    if not keys:
+        raise salt.exceptions.VMwareVmCreationError('SCSI controller number '
+                                         '{0} doesn\'t exist'.format(bus_number))
+    return keys[0]
+
+
+def _apply_hard_disk(unit_number, key, operation, disk_label=None, size=None, unit='GB', controller_key=None,
+                     thin_provision=None, eagerly_scrub=None, datastore=None, filename=None):
+    '''
+    Returns a vim.vm.device.VirtualDeviceSpec object specifying to add/edit a virtual disk device
+
+    unit_number
+        Add network adapter to this address
+
+    key
+        Device key number
+
+    operation
+        Action which should be done on the device add or edit
+
+    disk_label
+        Label of the new disk, can be overriden
+
+    size
+        Size of the disk
+
+    unit
+        Unit of the size, can be GB, MB, KB
+
+    controller_key
+        Unique umber of the controller key
+
+    thin_provision
+        Boolean for thin provision
+
+    eagerly_scrub
+        Boolean for eagerly scrubbing
+
+    datastore
+        Datastore name where the disk will be located
+
+    filename
+        Full file name of the vm disk
+    '''
+    log.trace('Configuring hard disk {0} size={1}, unit={2}, controller_key={3}, thin_provision={4}, '
+              'eagerly_scrub={5}, datastore={6}, filename={7}'.format(disk_label, size, unit,
+                                                                      controller_key, thin_provision,
+                                                                      eagerly_scrub, datastore,
+                                                                      filename))
+    disk_spec = vim.vm.device.VirtualDeviceSpec()
+    disk_spec.device = vim.vm.device.VirtualDisk()
+    disk_spec.device.key = key
+    disk_spec.device.unitNumber = unit_number
+    disk_spec.device.deviceInfo = vim.Description()
+    size_kb = None
+    if unit.lower() == 'gb':
+        size_kb = int(size * 1024L * 1024L)
+    elif unit.lower() == 'mb':
+        size_kb = int(size * 1024L)
+    elif unit.lower() == 'kb':
+        size_kb = long(size)
+    if size_kb:
+        disk_spec.device.capacityInKB = size_kb
+    if disk_label:
+        disk_spec.device.deviceInfo.label = disk_label
+    if thin_provision is not None or eagerly_scrub is not None:
+        disk_spec.device.backing = vim.vm.device.VirtualDisk.FlatVer2BackingInfo()
+        disk_spec.device.backing.diskMode = 'persistent'
+    if thin_provision is not None:
+        disk_spec.device.backing.thinProvisioned = thin_provision
+    if eagerly_scrub is not None and eagerly_scrub != 'None':
+        disk_spec.device.backing.eagerlyScrub = eagerly_scrub
+    if controller_key:
+        disk_spec.device.controllerKey = controller_key
+    if operation == 'add':
+        disk_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+        disk_spec.device.backing.fileName = '[{0}] {1}'.format(
+            salt.utils.vmware.get_managed_object_name(datastore), filename)
+        disk_spec.fileOperation = vim.vm.device.VirtualDeviceSpec.FileOperation.create
+    elif operation == 'edit':
+        disk_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+    return disk_spec
+
+
+def _create_adapter_type(network_adapter, adapter_type, network_adapter_label=''):
+    '''
+    Returns a vim.vm.device.VirtualEthernetCard object specifying a virtual ethernet card information
+
+    network_adapter
+        None or VirtualEthernet object
+
+    adapter_type
+        String, type of adapter
+
+    network_adapter_label
+        string, network adapter name
+    '''
+    log.trace('Configuring virtual machine network adapter adapter_type={0}'.format(adapter_type))
+    if adapter_type in ['vmxnet', 'vmxnet2', 'vmxnet3', 'e1000', 'e1000e']:
+        edited_network_adapter = salt.utils.vmware.get_network_adapter_type(adapter_type)
+        if isinstance(network_adapter, type(edited_network_adapter)):
+            edited_network_adapter = network_adapter
+        else:
+            if network_adapter:
+                log.trace('Changing type of \'{0}\' from'
+                          ' \'{1}\' to \'{2}\''.format(network_adapter.deviceInfo.label,
+                                                       type(network_adapter).__name__.rsplit(
+                                                           ".", 1)[1][7:].lower(),
+                                                       adapter_type))
+    else:
+        # If device is edited and type not specified or does not match, don't change adapter type
+        if network_adapter:
+            if adapter_type:
+                log.error(
+                    'Cannot change type of \'{0}\' to '
+                    '\'{1}\'. Not changing type'.format(network_adapter.deviceInfo.label,
+                                                        adapter_type))
+            edited_network_adapter = network_adapter
+        else:
+            if not adapter_type:
+                log.trace('The type of \'{0}\' has not been specified. '
+                          'Creating of default type \'vmxnet3\''.format(
+                    network_adapter_label))
+            edited_network_adapter = vim.vm.device.VirtualVmxnet3()
+    return edited_network_adapter
+
+
+def _create_network_backing(network_name, switch_type, parent_ref):
+    '''
+    Returns a vim.vm.device.VirtualDevice.BackingInfo object specifying a
+    virtual ethernet card backing information
+
+    network_name
+        string, network name
+
+    switch_type
+        string, type of switch
+
+    parent_ref
+        Parent reference to search for network
+    '''
+    log.trace('Configuring virtual machine network backing network_name={0} switch_type={1} '
+              'parent={2}'.format(network_name, switch_type,
+                                  salt.utils.vmware.get_managed_object_name(parent_ref)))
+    backing = {}
+    if network_name:
+        if switch_type == 'standard':
+            networks = salt.utils.vmware.get_networks(parent_ref, network_names=[network_name])
+            if not networks:
+                raise salt.exceptions.VMwareObjectRetrievalError('The network \'{0}\' could '
+                                                      'not be retrieved.'.format(network_name))
+            network_ref = networks[0]
+            backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
+            backing.deviceName = network_name
+            backing.network = network_ref
+        elif switch_type == 'distributed':
+            networks = salt.utils.vmware.get_dvportgroups(
+                parent_ref,
+                portgroup_names=[network_name])
+            if not networks:
+                raise salt.exceptions.VMwareObjectRetrievalError('The port group \'{0}\' could '
+                                                      'not be retrieved.'.format(network_name))
+            network_ref = networks[0]
+            dvs_port_connection = vim.dvs.PortConnection(
+                portgroupKey=network_ref.key,
+                switchUuid=network_ref.config.distributedVirtualSwitch.uuid)
+            backing = vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
+            backing.port = dvs_port_connection
+    return backing
+
+
+def _apply_network_adapter_config(key, network_name, adapter_type, switch_type,
+                                  network_adapter_label=None, operation='add',
+                                  connectable=None, mac=None, parent=None):
+    '''
+    Returns a vim.vm.device.VirtualDeviceSpec object specifying to add/edit a network device
+
+    network_adapter_label
+        Network adapter label
+
+    key
+        Unique key for device creation
+
+    network_name
+        Network or port group name
+
+    adapter_type
+        Type of the adapter eg. vmxnet3
+
+    switch_type
+        Type of the switch: standard or distributed
+
+    operation
+        Type of operation: add or edit
+
+    connectable
+        Dictionary with the device connection properties
+
+    mac
+        MAC address of the network adapter
+
+    parent
+        Parent object reference
+    '''
+    adapter_type.strip().lower()
+    switch_type.strip().lower()
+    log.trace('Configuring virtual machine network adapter '
+              'network_adapter_label={0} network_name={1} '
+              'adapter_type={2} switch_type={3} mac={4}'.format(network_adapter_label,
+                                                                network_name,
+                                                                adapter_type,
+                                                                switch_type,
+                                                                mac))
+    network_spec = vim.vm.device.VirtualDeviceSpec()
+    network_spec.device = _create_adapter_type(network_spec.device, adapter_type,
+                                               network_adapter_label=network_adapter_label)
+    network_spec.device.deviceInfo = vim.Description()
+    if operation == 'add':
+        network_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+    elif operation == 'edit':
+        network_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+    if switch_type and network_name:
+        network_spec.device.backing = _create_network_backing(network_name, switch_type, parent)
+        network_spec.device.deviceInfo.summary = network_name
+    if key:
+        # random negative integer for creations, concrete device key for updates
+        network_spec.device.key = key
+    if network_adapter_label:
+        network_spec.device.deviceInfo.label = network_adapter_label
+    if mac:
+        network_spec.device.macAddress = mac
+        network_spec.device.addressType = 'Manual'
+    network_spec.device.wakeOnLanEnabled = True
+    if connectable:
+        network_spec.device.connectable = vim.vm.device.VirtualDevice.ConnectInfo()
+        network_spec.device.connectable.startConnected = connectable['start_connected']
+        network_spec.device.connectable.allowGuestControl = connectable['allow_guest_control']
+    return network_spec
+
+
+def _apply_scsi_controller(adapter, adapter_type, bus_sharing, key, bus_number, operation):
+    '''
+    Returns a vim.vm.device.VirtualDeviceSpec object specifying to add/edit a SCSI controller
+
+    adapter
+        SCSI controller adapter name
+
+    adapter_type
+        SCSI controller adapter type eg. paravirtual
+
+    bus_sharing
+         SCSI controller bus sharing eg. virtual_sharing
+
+    key
+        SCSI controller unique key
+
+    bus_number
+        Device bus number property
+
+    operation
+        Describes the operation which should be done on the object,
+        the possibles values: 'add' and 'edit', the default value is 'add'
+
+    .. code-block: bash
+
+        scsi:
+          adapter: 'SCSI controller 0'
+          type: paravirtual or lsilogic or lsilogic_sas
+          bus_sharing: 'no_sharing' or 'virtual_sharing' or 'physical_sharing'
+    '''
+    log.trace('Configuring scsi controller adapter={0} adapter_type={1} bus_sharing={2} '
+              'key={3} bus_number={4}'.format(adapter, adapter_type, bus_sharing, key, bus_number))
+    scsi_spec = vim.vm.device.VirtualDeviceSpec()
+    if adapter_type == 'lsilogic':
+        summary = 'LSI Logic'
+        scsi_spec.device = vim.vm.device.VirtualLsiLogicController()
+    elif adapter_type == 'lsilogic_sas':
+        summary = 'LSI Logic Sas'
+        scsi_spec.device = vim.vm.device.VirtualLsiLogicSASController()
+    elif adapter_type == 'paravirtual':
+        summary = 'VMware paravirtual SCSI'
+        scsi_spec.device = vim.vm.device.ParaVirtualSCSIController()
+    elif adapter_type == 'buslogic':
+        summary = 'Bus Logic'
+        scsi_spec.device = vim.vm.device.VirtualBusLogicController()
+    if operation == 'add':
+        scsi_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+    elif operation == 'edit':
+        scsi_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+    scsi_spec.device.key = key
+    scsi_spec.device.busNumber = bus_number
+    scsi_spec.device.deviceInfo = vim.Description()
+    scsi_spec.device.deviceInfo.label = adapter
+    scsi_spec.device.deviceInfo.summary = summary
+    if bus_sharing == 'virtual_sharing':
+        # Virtual disks can be shared between virtual machines on the same server
+        scsi_spec.device.sharedBus = vim.vm.device.VirtualSCSIController.Sharing.virtualSharing
+    elif bus_sharing == 'physical_sharing':
+        # Virtual disks can be shared between virtual machines on any server
+        scsi_spec.device.sharedBus = vim.vm.device.VirtualSCSIController.Sharing.physicalSharing
+    elif bus_sharing == 'no_sharing':
+        # Virtual disks cannot be shared between virtual machines
+        scsi_spec.device.sharedBus = vim.vm.device.VirtualSCSIController.Sharing.noSharing
+    return scsi_spec
+
+
+def _create_ide_controllers(ide_controllers):
+    '''
+    Returns a list of vim.vm.device.VirtualDeviceSpec objects representing IDE controllers
+
+    ide_controllers
+        IDE properties
+    '''
+    ide_ctrls = []
+    keys = range(-200, -250, -1)
+    log.trace(
+        'Creating IDE controllers {0}'.format([ide['adapter'] for ide in ide_controllers])) if ide_controllers else None
+    for ide, key in zip(ide_controllers, keys):
+        ide_ctrls.append(_apply_ide_controller_config(ide['adapter'], 'add', key, abs(key + 200)))
+    return ide_ctrls
+
+
+def _apply_ide_controller_config(ide_controller_label, operation, key, bus_number=0):
+    '''
+    Returns a vim.vm.device.VirtualDeviceSpec object specifying to add/edit an IDE controller
+
+    ide_controller_label
+        Controller label of the IDE adapter
+
+    operation
+        Type of operation: add or edit
+
+    key
+        Unique key of the device
+
+    bus_number
+        Device bus number property
+    '''
+    log.trace('Configuring IDE controller ide_controller_label={0}'.format(ide_controller_label))
+    ide_spec = vim.vm.device.VirtualDeviceSpec()
+    ide_spec.device = vim.vm.device.VirtualIDEController()
+    if operation == 'add':
+        ide_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+    if operation == 'edit':
+        ide_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+    ide_spec.device.key = key
+    ide_spec.device.busNumber = bus_number
+    if ide_controller_label:
+        ide_spec.device.deviceInfo = vim.Description()
+        ide_spec.device.deviceInfo.label = ide_controller_label
+        ide_spec.device.deviceInfo.summary = ide_controller_label
+    return ide_spec
+
+
+def _create_sata_controllers(sata_controllers):
+    '''
+    Returns a list of vim.vm.device.VirtualDeviceSpec objects representing SATA controllers
+
+    sata_controllers
+        SATA properties
+    '''
+    sata_ctrls = []
+    keys = range(-15000, -15050, -1)
+    log.trace('Creating SATA controllers {0}'.format(
+        [sata['adapter'] for sata in sata_controllers])) if sata_controllers else None
+    for sata, key in zip(sata_controllers, keys):
+        sata_ctrls.append(_apply_sata_controller_config(sata['adapter'], 'add', key, sata['bus_number']))
+    return sata_ctrls
+
+
+def _apply_sata_controller_config(sata_controller_label, operation, key, bus_number=0):
+    '''
+    Returns a vim.vm.device.VirtualDeviceSpec object specifying to add/edit a SATA controller
+
+    sata_controller_label
+        Controller label of the SATA adapter
+
+    operation
+        Type of operation: add or edit
+
+    key
+        Unique key of the device
+
+    bus_number
+        Device bus number property
+    '''
+    log.trace('Configuring SATA controller sata_controller_label={0}'.format(sata_controller_label))
+    sata_spec = vim.vm.device.VirtualDeviceSpec()
+    sata_spec.device = vim.vm.device.VirtualAHCIController()
+    if operation == 'add':
+        sata_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+    elif operation == 'edit':
+        sata_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+    sata_spec.device.key = key
+    sata_spec.device.controllerKey = 100
+    sata_spec.device.busNumber = bus_number
+    if sata_controller_label:
+        sata_spec.device.deviceInfo = vim.Description()
+        sata_spec.device.deviceInfo.label = sata_controller_label
+        sata_spec.device.deviceInfo.summary = sata_controller_label
+    return sata_spec
+
+
+def _apply_cd_drive(drive_label, key, device_type, operation, client_device=None,
+                    datastore_iso_file=None, connectable=None, controller_key=200, parent_ref=None):
+    '''
+    Returns a vim.vm.device.VirtualDeviceSpec object specifying to add/edit a CD/DVD drive
+
+    drive_label
+        Leble of the CD/DVD drive
+
+    key
+        Unique key of the device
+
+    device_type
+        Type of the device: client or iso
+
+    operation
+        Type of operation: add or edit
+
+    client_device
+        Client device properties
+
+    datastore_iso_file
+        ISO properties
+
+    connectable
+        Connection info for the device
+
+    controller_key
+        Controller unique identifier to which we will attach this device
+
+    parent_ref
+        Parent object
+
+    .. code-block: bash
+
+        cd:
+            adapter: "CD/DVD drive 1"
+            device_type: datastore_iso_file or client_device
+            client_device:
+              mode: atapi or passthrough
+            datastore_iso_file:
+              path: "[share] iso/disk.iso"
+            connectable:
+              start_connected: True
+              allow_guest_control:
+    '''
+    log.trace('Configuring CD/DVD drive drive_label={0} device_type={1} client_device={2} '
+              'datastore_iso_file={3}'.format(drive_label, device_type,
+                                              client_device, datastore_iso_file))
+    drive_spec = vim.vm.device.VirtualDeviceSpec()
+    drive_spec.device = vim.vm.device.VirtualCdrom()
+    drive_spec.device.deviceInfo = vim.Description()
+    if operation == 'add':
+        drive_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+    elif operation == 'edit':
+        drive_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+    if device_type == 'datastore_iso_file':
+        drive_spec.device.backing = vim.vm.device.VirtualCdrom.IsoBackingInfo()
+        drive_spec.device.backing.fileName = datastore_iso_file['path']
+        datastore = datastore_iso_file['path'].partition('[')[-1].rpartition(']')[0]
+        datastore_object = salt.utils.vmware.get_datastores(
+            salt.utils.vmware.get_service_instance_from_managed_object(parent_ref),
+            parent_ref, datastore_names=[datastore])[0]
+        if datastore_object:
+            drive_spec.device.backing.datastore = datastore_object
+        drive_spec.device.deviceInfo.summary = '{0}'.format(datastore_iso_file['path'])
+    elif device_type == 'client_device':
+        if client_device['mode'] == 'passthrough':
+            drive_spec.device.backing = vim.vm.device.VirtualCdrom.RemotePassthroughBackingInfo()
+        elif client_device['mode'] == 'atapi':
+            drive_spec.device.backing = vim.vm.device.VirtualCdrom.RemoteAtapiBackingInfo()
+    drive_spec.device.key = key
+    drive_spec.device.deviceInfo.label = drive_label
+    drive_spec.device.controllerKey = controller_key
+    drive_spec.device.connectable = vim.vm.device.VirtualDevice.ConnectInfo()
+    if connectable:
+        drive_spec.device.connectable.startConnected = connectable['start_connected']
+        drive_spec.device.connectable.allowGuestControl = connectable['allow_guest_control']
+    return drive_spec
+
+
+def _set_network_adapter_mapping(domain, gateway, ip_addr, subnet_mask, mac):
+    '''
+    Returns a vim.vm.customization.AdapterMapping object containing the IP properties of a network adapter card
+
+    domain
+        Domain of the host
+
+    gateway
+        Gateway address
+
+    ip_addr
+        IP address
+
+    subnet_mask
+        Subnet mask
+
+    mac
+        MAC address of the guest
+    '''
+    adapter_mapping = vim.vm.customization.AdapterMapping()
+    adapter_mapping.macAddress = mac
+    adapter_mapping.adapter = vim.vm.customization.IPSettings()
+    if domain:
+        adapter_mapping.adapter.dnsDomain = domain
+    if gateway:
+        adapter_mapping.adapter.gateway = gateway
+    if ip_addr:
+        adapter_mapping.adapter.ip = vim.vm.customization.FixedIp(ipAddress=ip_addr)
+        adapter_mapping.adapter.subnetMask = subnet_mask
+    else:
+        adapter_mapping.adapter.ip = vim.vm.customization.DhcpIpGenerator()
+    return adapter_mapping
+
+
+def _apply_serial_port(serial_device_spec, key, operation='add'):
+    '''
+    Returns a vim.vm.device.VirtualSerialPort representing a serial port component
+
+    serial_device_spec
+        Serial device properties
+
+    key
+        Unique key of the device
+
+    operation
+        Add or edit the given device
+
+    .. code-block:: bash
+
+        serial_ports:
+            adapter: 'Serial port 1'
+            backing:
+              type: uri
+              uri: 'telnet://something:port'
+              direction: <client|server>
+              filename: 'service_uri'
+            connectable:
+              allow_guest_control: True
+              start_connected: True
+            yield: False
+    '''
+    log.trace('Creating serial port adapter={0} type={1} connectable={2} yield={3}'.format(
+        serial_device_spec['adapter'], serial_device_spec['type'], serial_device_spec['connectable'],
+        serial_device_spec['yield']))
+    device_spec = vim.vm.device.VirtualDeviceSpec()
+    device_spec.device = vim.vm.device.VirtualSerialPort()
+    if operation == 'add':
+        device_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+    elif operation == 'edit':
+        device_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+    connect_info = vim.vm.device.VirtualDevice.ConnectInfo()
+    type_backing = None
+
+    if serial_device_spec['type'] == 'network':
+        type_backing = vim.vm.device.VirtualSerialPort.URIBackingInfo()
+        if 'uri' not in serial_device_spec['backing'].keys():
+            raise ValueError('vSPC proxy URI not specified in config')
+        if 'uri' not in serial_device_spec['backing'].keys():
+            raise ValueError('vSPC Direction not specified in config')
+        if 'filename' not in serial_device_spec['backing'].keys():
+            raise ValueError('vSPC Filename not specified in config')
+        type_backing.proxyURI = serial_device_spec['backing']['uri']
+        type_backing.direction = serial_device_spec['backing']['direction']
+        type_backing.serviceURI = serial_device_spec['backing']['filename']
+    if serial_device_spec['type'] == 'pipe':
+        type_backing = vim.vm.device.VirtualSerialPort.PipeBackingInfo()
+    if serial_device_spec['type'] == 'file':
+        type_backing = vim.vm.device.VirtualSerialPort.FileBackingInfo()
+    if serial_device_spec['type'] == 'device':
+        type_backing = vim.vm.device.VirtualSerialPort.DeviceBackingInfo()
+    connect_info.allowGuestControl = serial_device_spec['connectable']['allow_guest_control']
+    connect_info.startConnected = serial_device_spec['connectable']['start_connected']
+    device_spec.device.backing = type_backing
+    device_spec.device.connectable = connect_info
+    device_spec.device.unitNumber = 1
+    device_spec.device.key = key
+    device_spec.device.yieldOnPoll = serial_device_spec['yield']
+
+    return device_spec
+
+
+def _create_disks(service_instance, disks, scsi_controllers=None, parent=None):
+    '''
+    Returns a list of disk specs representing the disks to be created for a virtual machine
+
+    service_instance
+        Service instance (vim.ServiceInstance) of the vCenter.
+        Default is None.
+
+    disks
+        List of disks with properties
+
+    scsi_controllers
+        List of SCSI controllers
+
+    parent
+        Parent object reference
+
+    .. code-block: bash
+
+        disk:
+          adapter: 'Hard disk 1'
+          size: 16
+          unit: GB
+          address: '0:0'
+          controller: 'SCSI controller 0'
+          thin_provision: False
+          eagerly_scrub: False
+          datastore: 'myshare'
+          filename: 'vm/mydisk.vmdk'
+    '''
+    disk_specs = []
+    keys = range(-2000, -2050, -1)
+    log.trace('Creating disks {0}'.format([disk['adapter'] for disk in disks])) if disks else None
+    for disk, key in zip(disks, keys):
+        # create the disk
+        filename, datastore, datastore_ref = None, None, None
+        size = float(disk['size'])
+        # when creating both SCSI controller and Hard disk at the same time we need the randomly
+        # assigned (temporary) key of the newly created SCSI controller
+        controller_key = 1000  # Default is the first SCSI controller
+        if 'address' in disk:  # 0:0
+            controller_bus_number, unit_number = disk['address'].split(':')
+            controller_bus_number = int(controller_bus_number)
+            unit_number = int(unit_number)
+            controller_key = _get_scsi_controller_key(controller_bus_number, scsi_ctrls=scsi_controllers)
+        elif 'controller' in disk:
+            for contr in scsi_controllers:
+                if contr['label'] == disk['controller']:
+                    controller_key = contr['key']
+                    break
+            else:
+                raise salt.exceptions.VmwareNotFoundError('The given controller does not exist: {0}'.format(disk['controller']))
+        if 'datastore' in disk:
+            datastore_ref = \
+                salt.utils.vmware.get_datastores(service_instance, parent, datastore_names=[disk['datastore']])[0]
+            datastore = disk['datastore']
+        if 'filename' in disk:
+            filename = disk['filename']
+        # XOR filename, datastore
+        if (not filename and datastore) or (filename and not datastore):
+            raise salt.exceptions.ArgumentValueError(
+                'You must specify both filename and datastore attributes'
+                ' to place your disk to a specific datastore {0}, {1}'.format(datastore, filename))
+        disk_spec = _apply_hard_disk(unit_number, key, disk_label=disk['adapter'], size=size, unit=disk['unit'],
+                                     controller_key=controller_key,
+                                     operation='add', thin_provision=disk['thin_provision'],
+                                     eagerly_scrub=disk['eagerly_scrub'] if 'eagerly_scrub' in disk else None,
+                                     datastore=datastore_ref, filename=filename)
+        disk_specs.append(disk_spec)
+        unit_number += 1
+    return disk_specs
+
+
+def _create_scsi_devices(scsi_devices):
+    '''
+    Returns a list of vim.vm.device.VirtualDeviceSpec objects representing SCSI controllers
+
+    scsi_devices:
+        List of SCSI device properties
+    '''
+    keys = range(-1000, -1050, -1)
+    log.trace('Creating SCSI devices {0}'.format([scsi['adapter'] for scsi in scsi_devices])) if scsi_devices else None
+    # unitNumber for disk attachment, 0:0 1st 0 is the controller busNumber, 2nd is the unitNumber
+    scsi_specs = []
+    for (key, scsi_controller) in zip(keys, scsi_devices):
+        # create the SCSI controller
+        scsi_spec = _apply_scsi_controller(scsi_controller['adapter'],
+                                           scsi_controller['type'],
+                                           scsi_controller['bus_sharing'],
+                                           key, scsi_controller['bus_number'], 'add')
+        scsi_specs.append(scsi_spec)
+    return scsi_specs
+
+
+def _create_network_adapters(network_interfaces, parent=None):
+    '''
+    Returns a list of vim.vm.device.VirtualDeviceSpec objects representing the interfaces to be created for a virtual machine
+
+    network_interfaces
+        List of network interfaces and properties
+
+    parent
+        Parent object reference
+
+    .. code-block: bash
+
+        interfaces:
+          adapter: 'Network adapter 1'
+          name: vlan100
+          switch_type: distributed or standard
+          adapter_type: vmxnet3 or vmxnet, vmxnet2, vmxnet3, e1000, e1000e
+          mac: '00:11:22:33:44:55'
+    '''
+    network_specs = []
+    nics_settings = []
+    keys = range(-4000, -4050, -1)
+    log.trace('Creating network interfaces {0}'.format(
+        [inter['adapter'] for inter in network_interfaces])) if network_interfaces else None
+    for interface, key in zip(network_interfaces, keys):
+        network_spec = _apply_network_adapter_config(key, interface['name'],
+                                                     interface['adapter_type'],
+                                                     interface['switch_type'],
+                                                     network_adapter_label=interface['adapter'],
+                                                     operation='add',
+                                                     connectable=interface[
+                                                         'connectable'] if 'connectable' in interface else None,
+                                                     mac=interface['mac'], parent=parent)
+        network_specs.append(network_spec)
+        if 'mapping' in interface:
+            adapter_mapping = _set_network_adapter_mapping(interface['mapping']['domain'],
+                                                           interface['mapping']['gateway'],
+                                                           interface['mapping']['ip_addr'],
+                                                           interface['mapping']['subnet_mask'],
+                                                           interface['mac'])
+            nics_settings.append(adapter_mapping)
+    return (network_specs, nics_settings)
+
+
+def _create_serial_ports(serial_ports):
+    '''
+    Returns a list of vim.vm.device.VirtualDeviceSpec objects representing the serial ports to be created for a virtual machine
+
+    serial_ports
+        Serial port properties
+    '''
+    ports = []
+    keys = range(-9000, -9050, -1)
+    log.trace(
+        'Creating serial ports {0}'.format([serial['adapter'] for serial in serial_ports])) if serial_ports else None
+    for port, key in zip(serial_ports, keys):
+        serial_port_device = _apply_serial_port(port, key, 'add')
+        ports.append(serial_port_device)
+    return ports
+
+
+def _create_cd_drives(cd_drives, controllers=None, parent_ref=None):
+    '''
+    Returns a list of vim.vm.device.VirtualDeviceSpec objects representing the CD/DVD dirves to be created for a virtual machine
+
+    cd_drives
+        CD/DVD drive properties
+
+    controllers
+        CD/DVD drive controllers (IDE, SATA)
+
+    parent_ref
+        Parent object reference
+    '''
+    cd_drive_specs = []
+    keys = range(-3000, -3050, -1)
+    log.trace('Creating cd/dvd drives {0}'.format([dvd['adapter'] for dvd in cd_drives])) if cd_drives else None
+    for drive, key in zip(cd_drives, keys):
+        # if a controller is not available/cannot be created we should use the one which is available by default, this is 'IDE 0'
+        controller_key = 200
+        if controllers:
+            controller = _get_device_by_label(controllers, drive['controller'])
+            controller_key = controller.key
+        cd_drive_specs.append(_apply_cd_drive(drive['adapter'], key, drive['device_type'], 'add',
+                                              client_device=drive[
+                                                  'client_device'] if 'client_device' in drive else None,
+                                              datastore_iso_file=drive[
+                                                  'datastore_iso_file'] if 'datastore_iso_file' in drive else None,
+                                              connectable=drive['connectable'] if 'connectable' in drive else None,
+                                              controller_key=controller_key,
+                                              parent_ref=parent_ref))
+
+    return cd_drive_specs
+
+
+@depends(HAS_PYVMOMI)
+@supports_proxies('esxvm')
+@gets_service_instance_via_proxy
+def create_vm(vm_name, cpu, memory, image, version, datacenter, datastore, placement,
+              interfaces, disks, scsi_devices, serial_ports=None, ide_controllers=None,
+              sata_controllers=None, cd_drives=None, advanced_configs=None, service_instance=None):
+    '''
+    Creates a virtual machine container.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt vm_minion vsphere.create_vm vm_name=vmname cpu='{count: 2, nested: True}' ...
+
+    vm_name
+        Name of the virtual machine
+
+    cpu
+        Properties of CPUs for freshly created machines
+
+    memory
+        Memory size for freshly created machines
+
+    image
+        Virtual machine guest OS version identifier
+        VirtualMachineGuestOsIdentifier
+
+    version
+        Virtual machine container hardware version
+
+    datacenter
+        Datacenter where the virtual machine will be deployed (mandatory)
+
+    datastore
+        Datastore where the virtual machine files will be placed
+
+    placement
+        Resource pool or cluster or host or folder where the virtual machine will be deployed
+
+    devices
+        interfaces
+        .. code-block:: bash
+            interfaces:
+              adapter: 'Network adapter 1'
+              name: vlan100
+              switch_type: distributed or standard
+              adapter_type: vmxnet3 or vmxnet, vmxnet2, vmxnet3, e1000, e1000e
+              mac: '00:11:22:33:44:55'
+
+        disks
+        .. code-block:: bash
+            disks:
+              adapter: 'Hard disk 1'
+              size: 16
+              unit: GB
+              address: '0:0'
+              controller: 'SCSI controller 0'
+              thin_provision: False
+              eagerly_scrub: False
+              datastore: 'myshare'
+              filename: 'vm/mydisk.vmdk'
+
+        scsi_devices
+        .. code-block:: bash
+            scsi_devices:
+              controller: 'SCSI controller 0'
+              type: paravirtual
+              bus_sharing: no_sharing
+
+        serial_ports
+        .. code-block:: bash
+            serial_ports:
+              adapter: 'Serial port 1'
+              type: network
+              backing:
+                uri: 'telnet://something:port'
+                direction: <client|server>
+                filename: 'service_uri'
+              connectable:
+                allow_guest_control: True
+                start_connected: True
+              yield: False
+
+        cd_drives
+        .. code-block:: bash
+            cd_drives:
+              adapter: 'CD/DVD drive 0'
+              controller: 'IDE 0'
+              device_type: datastore_iso_file
+              datastore_iso_file:
+                path: path_to_iso
+              connectable:
+                allow_guest_control: True
+                start_connected: True
+
+    advanced_config
+        Advanced config parameters to be set for the virtual machine
+    '''
+    # If datacenter is specified, set the container reference to start search from it instead
+    container_object = salt.utils.vmware.get_datacenter(service_instance, datacenter)
+    (resourcepool_object, placement_object) = salt.utils.vmware.get_placement(service_instance, datacenter,
+                                                                              placement=placement)
+    folder_object = salt.utils.vmware.get_folder(service_instance, datacenter, placement)
+    # Create the config specs
+    config_spec = vim.vm.ConfigSpec()
+    config_spec.name = vm_name
+    config_spec.guestId = image
+    config_spec.files = vim.vm.FileInfo()
+
+    # For VSAN disks we need to specify a different vm path name, the vm file full path cannot be used
+    datastore_object = \
+        salt.utils.vmware.get_datastores(service_instance, placement_object, datastore_names=[datastore])[0]
+    if not datastore_object:
+        raise salt.exceptions.ArgumentValueError('Specified datastore: \'{0}\' does not exist.'.format(datastore))
+    try:
+        ds_summary = salt.utils.vmware.get_properties_of_managed_object(datastore_object, 'summary.type')
+        if 'summary.type' in ds_summary and ds_summary['summary.type'] == 'vsan':
+            log.trace('The vmPathName should be the datastore name if the datastore type is vsan')
+            config_spec.files.vmPathName = '[{0}]'.format(datastore)
+        else:
+            config_spec.files.vmPathName = '[{0}] {1}/{1}.vmx'.format(datastore, vm_name)
+    except salt.exceptions.VMwareApiError:
+        config_spec.files.vmPathName = '[{0}] {1}/{1}.vmx'.format(datastore, vm_name)
+
+    cd_controllers = []
+    if version:
+        _apply_hardware_version(version, config_spec, 'add')
+    if cpu:
+        _apply_cpu_config(config_spec, cpu)
+    if memory:
+        _apply_memory_config(config_spec, memory)
+    if scsi_devices:
+        scsi_specs = _create_scsi_devices(scsi_devices)
+        config_spec.deviceChange.extend(scsi_specs)
+    if disks:
+        scsi_controllers = [spec.device for spec in scsi_specs]
+        disk_specs = _create_disks(service_instance, disks, scsi_controllers=scsi_controllers, parent=container_object)
+        config_spec.deviceChange.extend(disk_specs)
+    if interfaces:
+        (interface_specs, nic_settings) = _create_network_adapters(interfaces, parent=container_object)
+        config_spec.deviceChange.extend(interface_specs)
+    if serial_ports:
+        serial_port_specs = _create_serial_ports(serial_ports)
+        config_spec.deviceChange.extend(serial_port_specs)
+    if ide_controllers:
+        ide_specs = _create_ide_controllers(ide_controllers)
+        config_spec.deviceChange.extend(ide_specs)
+        cd_controllers.extend(ide_specs)
+    if sata_controllers:
+        sata_specs = _create_sata_controllers(sata_controllers)
+        config_spec.deviceChange.extend(sata_specs)
+        cd_controllers.extend(sata_specs)
+    if cd_drives:
+        cd_drive_specs = _create_cd_drives(cd_drives, controllers=cd_controllers, parent_ref=container_object)
+        config_spec.deviceChange.extend(cd_drive_specs)
+    if advanced_configs:
+        _apply_advanced_config(config_spec, advanced_configs)
+    salt.utils.vmware.create_vm(vm_name, config_spec, folder_object, resourcepool_object, placement_object)
+
+    return {'create_vm': True}
+
+
+def _get_device_by_key(devices, key):
+    '''
+    Returns the device with the given key, raises error if the device is not found.
+
+    devices
+        list of vim.vm.device.VirtualDevice objects
+
+    key
+        Unique key of device
+    '''
+    for device in devices:
+        if device.key == key:
+            return device
+    else:
+        raise salt.exceptions.VmwareNotFoundError('Virtual machine device with unique key {0} does not exist'.format(key))
+
+
+def _get_device_by_label(devices, label):
+    '''
+    Returns the device with the given label, raises error if the device is not found.
+
+    devices
+        list of vim.vm.device.VirtualDevice objects
+
+    key
+        Unique key of device
+    '''
+    for device in devices:
+        if device.deviceInfo.label == label:
+            return device
+    else:
+        raise ValueError('Virtual machine device with label {0} does not exist'.format(label))
+
+
+def _convert_units(devices):
+    '''
+    Updates the size and unit dictionary values with the new unit values
+
+    devices
+        List of device data objects
+    '''
+    for device in devices:
+        if 'unit' in device and 'size' in device:
+            device.update(salt.utils.vmware.convert_to_kb(device['unit'], device['size']))
+    else:
+        return False
+    return True
+
+
+def compare_vm_configs(new_config, current_config):
+    '''
+    Compares virtual machine current and new configuration, the current is the one which
+    is deployed now, and the new is the target config. Returns the differences between
+    the objects in a dictionary, the keys are the configuration parameter keys and the
+    values are differences objects: either list or recursive difference
+
+    new_config:
+        New config dictionary with every available parameter
+
+    current_config
+        Currently deployed configuration
+    '''
+    diffs = {}
+    keys = set(new_config.keys())
+
+    # These values identify the virtual machine, comparison is unnecessary
+    keys.discard('name')
+    keys.discard('datacenter')
+    keys.discard('datastore')
+    for property_key in ('version', 'image'):
+        if property_key in keys:
+            single_value_diff = recursive_diff({property_key: new_config[property_key]},
+                                               {property_key: current_config[property_key]})
+            if single_value_diff.diffs:
+                diffs[property_key] = single_value_diff
+            keys.discard(property_key)
+
+    if 'cpu' in keys:
+        keys.remove('cpu')
+        cpu_diff = recursive_diff(new_config['cpu'], current_config['cpu'])
+        if cpu_diff.diffs:
+            diffs['cpu'] = cpu_diff
+
+    if 'memory' in keys:
+        keys.remove('memory')
+        _convert_units([current_config['memory']])
+        _convert_units([new_config['memory']])
+        memory_diff = recursive_diff(new_config['memory'], current_config['memory'])
+        if memory_diff.diffs:
+            diffs['memory'] = memory_diff
+
+    if 'advanced_configs' in keys:
+        keys.remove('advanced_configs')
+        key = 'advanced_configs'
+        advanced_diff = recursive_diff(new_config[key], current_config[key])
+        if advanced_diff.diffs:
+            diffs[key] = advanced_diff
+
+    if 'disks' in keys:
+        keys.remove('disks')
+        _convert_units(current_config['disks'])
+        _convert_units(new_config['disks'])
+        disk_diffs = list_diff(current_config['disks'], new_config['disks'], 'address')
+        ## REMOVE UNSUPPORTED DIFFERENCES/CHANGES
+        # If the disk already exist, the backing properties like eagerly scrub and thin provisioning
+        # cannot be updated, and should not be identified as differences
+        disk_diffs.remove_diff(diff_key='eagerly_scrub')
+        # Filename updates are not supported yet, on VSAN datastores the backing.fileName points to a uid + the vmdk name
+        disk_diffs.remove_diff(diff_key='filename')
+        # The adapter name shouldn't be changed
+        disk_diffs.remove_diff(diff_key='adapter')
+        if disk_diffs.diffs:
+            diffs['disks'] = disk_diffs
+
+    if 'interfaces' in keys:
+        keys.remove('interfaces')
+        interface_diffs = list_diff(current_config['interfaces'], new_config['interfaces'], 'mac')
+        # The adapter name shouldn't be changed
+        interface_diffs.remove_diff(diff_key='adapter')
+        if interface_diffs.diffs:
+            diffs['interfaces'] = interface_diffs
+
+    # For general items where the identification can be done by adapter
+    for key in keys:
+        if key not in current_config or key not in new_config:
+            raise ValueError('A general device {0} configuration was not supplied '
+                             'or it was not retrieved from remote configuration'.format(key))
+        device_diffs = list_diff(current_config[key], new_config[key], 'adapter')
+        if device_diffs.diffs:
+            diffs[key] = device_diffs
+
+    return diffs
+
+
+@gets_service_instance_via_proxy
+def get_vm_config(name, datacenter=None, objects=True, service_instance=None):
+    '''
+    Queries and converts the virtual machine properties to the available format from the schema. If the objects
+    attribute is True the config objects will have extra properties, like 'object' which will include the
+    vim.vm.device.VirtualDevice, this is necessary for deletion and update actions.
+
+    name
+        Name of the virtual machine
+
+    datacenter
+        Datacenter's name where the virtual machine is available
+
+    objects
+        Indicates whether to return the vmware object properties (eg. object, key)
+        or just the properties which can be set
+
+    service_instance
+        vCenter service instance for connection and configuration
+    '''
+    properties = ['config.hardware.device', 'config.hardware.numCPU', 'config.hardware.numCoresPerSocket',
+                  'config.nestedHVEnabled', 'config.cpuHotAddEnabled', 'config.cpuHotRemoveEnabled',
+                  'config.hardware.memoryMB', 'config.memoryReservationLockedToMax',
+                  'config.memoryHotAddEnabled', 'config.version', 'config.guestId', 'config.extraConfig',
+                  'name']
+    virtual_machine = salt.utils.vmware.get_vm_by_property(service_instance,
+                                                           name, vm_properties=properties,
+                                                           datacenter=datacenter)
+    parent_ref = salt.utils.vmware.get_datacenter(service_instance=service_instance, datacenter_name=datacenter)
+    current_config = {'name': name}
+    current_config['cpu'] = {'count': virtual_machine['config.hardware.numCPU'],
+                             'cores_per_socket': virtual_machine['config.hardware.numCoresPerSocket'],
+                             'nested': virtual_machine['config.nestedHVEnabled'],
+                             'hotadd': virtual_machine['config.cpuHotAddEnabled'],
+                             'hotremove': virtual_machine['config.cpuHotRemoveEnabled']}
+
+    current_config['memory'] = {'size': virtual_machine['config.hardware.memoryMB'],
+                                'unit': 'MB',
+                                'reservation_max': virtual_machine['config.memoryReservationLockedToMax'],
+                                'hotadd': virtual_machine['config.memoryHotAddEnabled']}
+    current_config['image'] = virtual_machine['config.guestId']
+    current_config['version'] = virtual_machine['config.version']
+    current_config['advanced_configs'] = {}
+    for extra_conf in virtual_machine['config.extraConfig']:
+        current_config['advanced_configs'][extra_conf.key] = extra_conf.value
+
+    current_config['disks'] = []
+    current_config['scsi_devices'] = []
+    current_config['interfaces'] = []
+    current_config['serial_ports'] = []
+    current_config['cd_drives'] = []
+    current_config['sata_controllers'] = []
+
+    for device in virtual_machine['config.hardware.device']:
+        if isinstance(device, vim.vm.device.VirtualSCSIController):
+            controller = {}
+            controller['adapter'] = device.deviceInfo.label
+            controller['bus_number'] = device.busNumber
+            bus_sharing = device.sharedBus
+            if bus_sharing == 'noSharing':
+                controller['bus_sharing'] = 'no_sharing'
+            elif bus_sharing == 'virtualSharing':
+                controller['bus_sharing'] = 'virtual_sharing'
+            elif bus_sharing == 'physicalSharing':
+                controller['bus_sharing'] = 'physical_sharing'
+            if isinstance(device, vim.vm.device.ParaVirtualSCSIController):
+                controller['type'] = 'paravirtual'
+            elif isinstance(device, vim.vm.device.VirtualBusLogicController):
+                controller['type'] = 'buslogic'
+            elif isinstance(device, vim.vm.device.VirtualLsiLogicController):
+                controller['type'] = 'lsilogic'
+            elif isinstance(device, vim.vm.device.VirtualLsiLogicSASController):
+                controller['type'] = 'lsilogic_sas'
+            if objects:
+                controller[
+                    'device'] = device.device  # int list, stores the keys of the disks which are attached to this controller
+                controller['key'] = device.key
+                controller['object'] = device
+            current_config['scsi_devices'].append(controller)
+        if isinstance(device, vim.vm.device.VirtualDisk):
+            disk = {}
+            disk['adapter'] = device.deviceInfo.label
+            disk['size'] = device.capacityInKB
+            disk['unit'] = 'KB'
+            controller = _get_device_by_key(virtual_machine['config.hardware.device'], device.controllerKey)
+            disk['controller'] = controller.deviceInfo.label
+            disk['address'] = str(controller.busNumber) + ':' + str(device.unitNumber)
+            disk['datastore'] = salt.utils.vmware.get_managed_object_name(device.backing.datastore)
+            disk['thin_provision'] = device.backing.thinProvisioned
+            disk['eagerly_scrub'] = device.backing.eagerlyScrub
+            if objects:
+                disk['key'] = device.key
+                disk['unit_number'] = device.unitNumber
+                disk['bus_number'] = controller.busNumber
+                disk['controller_key'] = device.controllerKey
+                disk['object'] = device
+            current_config['disks'].append(disk)
+        if isinstance(device, vim.vm.device.VirtualEthernetCard):
+            interface = {}
+            interface['adapter'] = device.deviceInfo.label
+            interface['adapter_type'] = salt.utils.vmware.get_network_adapter_object_type(device)
+            interface['connectable'] = {'allow_guest_control': device.connectable.allowGuestControl,
+                                        'start_connected': device.connectable.startConnected}
+            interface['mac'] = device.macAddress
+            if isinstance(device.backing, vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo):
+                interface['switch_type'] = 'distributed'
+                pg_key = device.backing.port.portgroupKey
+                network_ref = salt.utils.vmware.get_mor_by_property(service_instance,
+                                                                    vim.DistributedVirtualPortgroup,
+                                                                    pg_key,
+                                                                    property_name='key',
+                                                                    container_ref=parent_ref)
+            elif isinstance(device.backing, vim.vm.device.VirtualEthernetCard.NetworkBackingInfo):
+                interface['switch_type'] = 'standard'
+                network_ref = device.backing.network
+            interface['name'] = salt.utils.vmware.get_managed_object_name(network_ref)
+            if objects:
+                interface['key'] = device.key
+                interface['object'] = device
+            current_config['interfaces'].append(interface)
+        if isinstance(device, vim.vm.device.VirtualCdrom):
+            drive = {}
+            drive['adapter'] = device.deviceInfo.label
+            controller = _get_device_by_key(virtual_machine['config.hardware.device'], device.controllerKey)
+            drive['controller'] = controller.deviceInfo.label
+            if isinstance(device.backing, vim.vm.device.VirtualCdrom.RemotePassthroughBackingInfo):
+                drive['device_type'] = 'client_device'
+                drive['client_device'] = {'mode': 'passthrough'}
+            if isinstance(device.backing, vim.vm.device.VirtualCdrom.RemoteAtapiBackingInfo):
+                drive['device_type'] = 'client_device'
+                drive['client_device'] = {'mode': 'atapi'}
+            if isinstance(device.backing, vim.vm.device.VirtualCdrom.IsoBackingInfo):
+                drive['device_type'] = 'datastore_iso_file'
+                drive['datastore_iso_file'] = {'path': device.backing.fileName}
+            drive['connectable'] = {'allow_guest_control': device.connectable.allowGuestControl,
+                                    'start_connected': device.connectable.startConnected}
+            if objects:
+                drive['key'] = device.key
+                drive['controller_key'] = device.controllerKey
+                drive['object'] = device
+            current_config['cd_drives'].append(drive)
+        if isinstance(device, vim.vm.device.VirtualSerialPort):
+            port = {}
+            port['adapter'] = device.deviceInfo.label
+            if isinstance(device.backing, vim.vm.device.VirtualSerialPort.URIBackingInfo):
+                port['type'] = 'network'
+                port['backing'] = {'uri': device.backing.proxyURI,
+                                   'direction': device.backing.direction,
+                                   'filename': device.backing.serviceURI}
+            if isinstance(device.backing, vim.vm.device.VirtualSerialPort.PipeBackingInfo):
+                port['type'] = 'pipe'
+            if isinstance(device.backing, vim.vm.device.VirtualSerialPort.FileBackingInfo):
+                port['type'] = 'file'
+            if isinstance(device.backing, vim.vm.device.VirtualSerialPort.DeviceBackingInfo):
+                port['type'] = 'device'
+            port['yield'] = device.yieldOnPoll
+            port['connectable'] = {'allow_guest_control': device.connectable.allowGuestControl,
+                                   'start_connected': device.connectable.startConnected}
+            if objects:
+                port['key'] = device.key
+                port['object'] = device
+            current_config['serial_ports'].append(port)
+        if isinstance(device, vim.vm.device.VirtualSATAController):
+            sata = {}
+            sata['adapter'] = device.deviceInfo.label
+            sata['bus_number'] = device.busNumber
+            if objects:
+                sata['device'] = device.device # keys of the connected devices
+                sata['key'] = device.key
+                sata['object'] = device
+            current_config['sata_controllers'].append(sata)
+
+    return current_config
+
+
+def _update_disks(disks_old_new):
+    '''
+    Changes the disk size and returns the config spec objects in a list. The controller property
+    cannot be updated, because controller address identifies the disk by the unit and
+    bus number properties.
+
+    disks_diffs
+        List of old and new disk properties, the properties are dictionary objects
+    '''
+    disk_changes = []
+    log.trace('Updating disks {0}'.format(
+        [disk['old']['address'] for disk in disks_old_new])) if disks_old_new else None
+    for item in disks_old_new:
+        current_disk = item['old']
+        next_disk = item['new']
+        difference = recursive_diff(next_disk, current_disk)
+        difference.ignore_unset_values = False
+        if difference.changed():
+            if next_disk['size'] < current_disk['size']:
+                raise salt.exceptions.VMwareSaltError('Disk cannot be downsized '
+                                           'size={0} unit={1} controller_key={2} '
+                                           'unit_number={3}'.format(next_disk['size'],
+                                                                    next_disk['unit'],
+                                                                    current_disk['controller_key'],
+                                                                    current_disk['unit_number']))
+            log.trace('Virtual machine disk will be updated '
+                      'size={0} unit={1} controller_key={2} '
+                      'unit_number={3}'.format(next_disk['size'],
+                                               next_disk['unit'],
+                                               current_disk['controller_key'],
+                                               current_disk['unit_number']))
+            device_config_spec = _apply_hard_disk(current_disk['unit_number'],
+                                                  current_disk['key'], 'edit',
+                                                  size=next_disk['size'],
+                                                  unit=next_disk['unit'],
+                                                  controller_key=current_disk['controller_key'])
+            # The backing didn't change and we must supply one for reconfigure
+            device_config_spec.device.backing = current_disk['object'].backing
+            disk_changes.append(device_config_spec)
+
+    return disk_changes
+
+
+def _update_scsi_devices(scsis_old_new, current_disks):
+    '''
+    Returns a list of vim.vm.device.VirtualDeviceSpec specifying  the scsi properties
+    as input the old and new configs are defined in a dictionary.
+
+    scsi_diffs
+        List of old and new scsi properties
+    '''
+    device_config_specs = []
+    log.trace('Updating SCSI controllers {0}'.format(
+        [scsi['old']['adapter'] for scsi in scsis_old_new])) if scsis_old_new else None
+    for item in scsis_old_new:
+        next_scsi = item['new']
+        current_scsi = item['old']
+        difference = recursive_diff(next_scsi, current_scsi)
+        difference.ignore_unset_values = False
+        if difference.changed():
+            log.trace('Virtual machine scsi device will be updated '
+                      'key={0} bus_number={1} type={2} bus_sharing={3}'.format(current_scsi['key'],
+                                                                               current_scsi['bus_number'],
+                                                                               next_scsi['type'],
+                                                                               next_scsi['bus_sharing']))
+            # The sharedBus property is not optional
+            # The type can only be updated if we delete the original controller, create a new one with the
+            # properties and then attach the disk object to the newly created controller, even though the
+            # controller key stays the same the last step is mandatory
+            if next_scsi['type'] != current_scsi['type']:
+                device_config_specs.append(_delete_device(current_scsi['object']))
+                device_config_specs.append(_apply_scsi_controller(current_scsi['adapter'],
+                                                                  next_scsi['type'],
+                                                                  next_scsi['bus_sharing'],
+                                                                  current_scsi['key'],
+                                                                  current_scsi['bus_number'], 'add'))
+                disks_to_update = []
+                for disk_key in current_scsi['device']:
+                    disk_objects = [disk['object'] for disk in current_disks]
+                    disks_to_update.append(_get_device_by_key(disk_objects, disk_key))
+                for current_disk in disks_to_update:
+                    disk_spec = vim.vm.device.VirtualDeviceSpec()
+                    disk_spec.device = current_disk
+                    disk_spec.operation = 'edit'
+                    device_config_specs.append(disk_spec)
+            else:
+                device_config_specs.append(_apply_scsi_controller(current_scsi['adapter'],
+                                                                  current_scsi['type'],
+                                                                  next_scsi['bus_sharing'],
+                                                                  current_scsi['key'],
+                                                                  current_scsi['bus_number'], 'edit'))
+    return device_config_specs
+
+
+def _update_network_adapters(interface_old_new, parent):
+    '''
+    Returns a list of vim.vm.device.VirtualDeviceSpec specifying configuration(s) for
+    changed network adapters, the adapter type cannot be changed, as input the old and
+    new configs are defined in a dictionary.
+
+    interface_old_new
+        Dictionary with old and new keys which contains the current and the next config for a network device
+
+    parent
+        Parent managed object reference
+    '''
+    network_changes = []
+    log.trace('Updating network interfaces {0}'.format(
+        [inter['old']['mac'] for inter in interface_old_new])) if interface_old_new else None
+    for item in interface_old_new:
+        current_interface = item['old']
+        next_interface = item['new']
+        difference = recursive_diff(next_interface, current_interface)
+        difference.ignore_unset_values = False
+        if difference.changed():
+            log.trace('Virtual machine network adapter will be updated switch_type={0} name={1} '
+                      'adapter_type={2} mac={3}'.format(next_interface['switch_type'],
+                                                        next_interface['name'],
+                                                        current_interface['adapter_type'],
+                                                        current_interface['mac']))
+            device_config_spec = _apply_network_adapter_config(current_interface['key'],
+                                                               next_interface['name'],
+                                                               current_interface['adapter_type'],
+                                                               next_interface['switch_type'],
+                                                               operation='edit',
+                                                               mac=current_interface['mac'],
+                                                               parent=parent)
+            network_changes.append(device_config_spec)
+    return network_changes
+
+
+def _update_serial_ports(serial_old_new):
+    '''
+    Returns a list of vim.vm.device.VirtualDeviceSpec specifying to edit a deployed
+    serial port configuration to the new given config
+
+    serial_old_new
+         Dictionary with old and new keys which contains the current and the next config for a serial port device
+    '''
+    serial_changes = []
+    log.trace('Updating serial ports {0}'.format(
+        [serial['old']['adapter'] for serial in serial_old_new])) if serial_old_new else None
+    for item in serial_old_new:
+        current_serial = item['old']
+        next_serial = item['new']
+        difference = recursive_diff(next_serial, current_serial)
+        difference.ignore_unset_values = False
+        if difference.changed():
+            serial_changes.append(_apply_serial_port(next_serial, current_serial['key'], 'edit'))
+    return serial_changes
+
+
+def _update_cd_drives(drives_old_new, controllers=[], parent=None):
+    '''
+    Returns a list of vim.vm.device.VirtualDeviceSpec specifying to edit a deployed
+    cd drive configuration to the new given config
+
+    drives_old_new
+        Dictionary with old and new keys which contains the current and the next config for a cd drive
+
+    controllers
+        Controller device list
+
+    parent
+        Managed object reference of the parent object
+    '''
+    cd_changes = []
+    log.trace('Updating cd/dvd drives {0}'.format(
+        [drive['old']['adapter'] for drive in drives_old_new])) if drives_old_new else None
+    for item in drives_old_new:
+        current_drive = item['old']
+        new_drive = item['new']
+        difference = recursive_diff(new_drive, current_drive)
+        difference.ignore_unset_values = False
+        if difference.changed():
+            if controllers:
+                controller = _get_device_by_label(controllers, new_drive['controller'])
+                controller_key = controller.key
+            else:
+                controller_key = current_drive['controller_key']
+            cd_changes.append(_apply_cd_drive(current_drive['adapter'],
+                                              current_drive['key'],
+                                              new_drive['device_type'], 'edit',
+                                              client_device=new_drive['client_device'] if 'client_device' in new_drive else None,
+                                              datastore_iso_file=new_drive['datastore_iso_file'] if 'datastore_iso_file' in new_drive else None,
+                                              connectable=new_drive['connectable'],
+                                              controller_key=controller_key,
+                                              parent_ref=parent))
+    return cd_changes
+
+
+def _delete_device(device):
+    '''
+    Returns a vim.vm.device.VirtualDeviceSpec specifying to remove a virtual machine device
+
+    device
+        Device data type object
+    '''
+    log.trace('Deleting device with type {0}'.format(type(device)))
+    device_spec = vim.vm.device.VirtualDeviceSpec()
+    device_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.remove
+    device_spec.device = device
+    return device_spec
+
+
+@gets_service_instance_via_proxy
+def update_vm(vm_name, cpu=None, memory=None, image=None, version=None, interfaces=None, disks=None,
+              scsi_devices=None, serial_ports=None, datacenter=None, datastore=None,
+              cd_dvd_drives=None, sata_controllers=None, advanced_configs=None, service_instance=None):
+    '''
+    Updates the configuration of the virtual machine if the config differs
+
+    vm_name
+        Virtual Machine name to be updated
+
+    cpu
+        CPU configuration options
+
+    memory
+        Memory configuration options
+
+    version
+        Virtual machine container hardware version
+
+    image
+        Virtual machine guest OS version identifier
+        VirtualMachineGuestOsIdentifier
+
+    interfaces
+        Network interfaces configuration options
+
+    disks
+        Disks configuration options
+
+    scsi_devices
+        SCSI devices configuration options
+
+    serial_ports
+        Serial ports configuration options
+
+    datacenter
+        Datacenter where the virtual machine is available
+
+    datastore
+        Datastore where the virtual machine config files are available
+
+    cd_dvd_drives
+        CD/DVD drives configuration options
+
+    advanced_config
+        Advanced config parameters to be set for the virtual machine
+
+    service_instance
+        vCenter service instance for connection and configuration
+    '''
+    current_config = get_vm_config(vm_name,
+                                   datacenter=datacenter,
+                                   objects=True,
+                                   service_instance=service_instance)
+    diffs = compare_vm_configs({'name': vm_name,
+                                'cpu': cpu,
+                                'memory': memory,
+                                'image': image,
+                                'version': version,
+                                'interfaces': interfaces,
+                                'disks': disks,
+                                'scsi_devices': scsi_devices,
+                                'serial_ports': serial_ports,
+                                'datacenter': datacenter,
+                                'datastore': datastore,
+                                'cd_drives': cd_dvd_drives,
+                                'sata_controllers': sata_controllers,
+                                'advanced_configs': advanced_configs},
+                               current_config)
+    config_spec = vim.vm.ConfigSpec()
+    datacenter_ref = salt.utils.vmware.get_datacenter(service_instance, datacenter)
+    vm_ref = salt.utils.vmware.get_mor_by_property(service_instance,
+                                                   vim.VirtualMachine,
+                                                   vm_name,
+                                                   property_name='name',
+                                                   container_ref=datacenter_ref)
+
+    difference_keys = diffs.keys()
+    if 'cpu' in difference_keys:
+        if diffs['cpu'].changed() != set():
+            _apply_cpu_config(config_spec, diffs['cpu'].current_dict)
+    if 'memory' in difference_keys:
+        if diffs['memory'].changed() != set():
+            _apply_memory_config(config_spec, diffs['memory'].current_dict)
+    if 'advanced_configs' in difference_keys:
+        _apply_advanced_config(config_spec, diffs['advanced_configs'].new_values)
+    if 'version' in difference_keys:
+        _apply_hardware_version(version, config_spec, 'edit')
+    if 'image' in difference_keys:
+        config_spec.guestId = image
+    new_scsi_devices = []
+    if 'scsi_devices' in difference_keys and 'disks' in current_config:
+        scsi_changes = []
+        scsi_changes.extend(_update_scsi_devices(diffs['scsi_devices'].intersect, current_config['disks']))
+        for item in diffs['scsi_devices'].removed:
+            scsi_changes.append(_delete_device(item['object']))
+        new_scsi_devices = _create_scsi_devices(diffs['scsi_devices'].added)
+        scsi_changes.extend(new_scsi_devices)
+        config_spec.deviceChange.extend(scsi_changes)
+    if 'disks' in difference_keys:
+        disk_changes = []
+        disk_changes.extend(_update_disks(diffs['disks'].intersect))
+        for item in diffs['disks'].removed:
+            disk_changes.append(_delete_device(item['object']))
+        # We will need the existing and new controllers as well
+        scsi_controllers = [dev['object'] for dev in current_config['scsi_devices']]
+        scsi_controllers.extend([device_spec.device for device_spec in new_scsi_devices])
+        disk_changes.extend(_create_disks(service_instance, diffs['disks'].added,
+                                          scsi_controllers=scsi_controllers,
+                                          parent=datacenter_ref))
+        config_spec.deviceChange.extend(disk_changes)
+    if 'interfaces' in difference_keys:
+        network_changes = []
+        network_changes.extend(_update_network_adapters(diffs['interfaces'].intersect, datacenter_ref))
+        for item in diffs['interfaces'].removed:
+            network_changes.append(_delete_device(item['object']))
+        (adapters, nics) = _create_network_adapters(diffs['interfaces'].added, datacenter_ref)
+        network_changes.extend(adapters)
+        config_spec.deviceChange.extend(network_changes)
+    if 'serial_ports' in difference_keys:
+        serial_changes = []
+        serial_changes.extend(_update_serial_ports(diffs['serial_ports'].intersect))
+        for item in diffs['serial_ports'].removed:
+            serial_changes.append(_delete_device(item['object']))
+        serial_changes.extend(_create_serial_ports(diffs['serial_ports'].added))
+        config_spec.deviceChange.extend(serial_changes)
+    new_controllers = []
+    if 'sata_controllers' in difference_keys:
+        # SATA controllers don't have many properties, it does not make sense to update them
+        sata_specs = _create_sata_controllers(diffs['sata_controllers'].added)
+        for item in diffs['sata_controllers'].removed:
+            sata_specs.append(_delete_device(item['object']))
+        new_controllers.extend(sata_specs)
+        config_spec.deviceChange.extend(sata_specs)
+    if 'cd_drives' in difference_keys:
+        cd_changes = []
+        controllers = [dev['object'] for dev in current_config['sata_controllers']]
+        controllers.extend([device_spec.device for device_spec in new_controllers])
+        cd_changes.extend(_update_cd_drives(diffs['cd_drives'].intersect,
+                                            controllers=controllers,
+                                            parent=datacenter_ref))
+        for item in diffs['cd_drives'].removed:
+            cd_changes.append(_delete_device(item['object']))
+        cd_changes.extend(_create_cd_drives(diffs['cd_drives'].added,
+                                            controllers=controllers,
+                                            parent_ref=datacenter_ref))
+        config_spec.deviceChange.extend(cd_changes)
+
+    if difference_keys:
+        salt.utils.vmware.update_vm(vm_ref, config_spec)
+    changes = {}
+    for key, properties in six.iteritems(diffs):
+        # We can't display object, although we will need them for delete and update actions,
+        # we will need to delete these before we summarize the changes for the users
+        if isinstance(properties, salt.utils.listdiffer.ListDictDiffer):
+            properties.remove_diff(diff_key='object', diff_list='intersect')
+            properties.remove_diff(diff_key='key', diff_list='intersect')
+            properties.remove_diff(diff_key='object', diff_list='removed')
+            properties.remove_diff(diff_key='key', diff_list='removed')
+        changes[key] = properties.diffs
+
+    return changes
+
+
+def _remove_vm(name, datacenter, service_instance, placement=None, power_off=None):
+    '''
+    Helper function to remove a virtual machine
+
+    name
+        Name of the virtual machine
+
+    service_instance
+        vCenter service instance for connection and configuration
+
+    datacenter
+        Datacenter of the virtual machine
+
+    placement
+        Placement information of the virtual machine
+    '''
+    results = {}
+    if placement:
+        (resourcepool_object, placement_object) = salt.utils.vmware.get_placement(service_instance,
+                                                                                  datacenter,
+                                                                                  placement)
+    else:
+        placement_object = salt.utils.vmware.get_datacenter(service_instance, datacenter)
+    if power_off:
+        power_off_vm(name, datacenter, service_instance)
+        results['powered_off'] = True
+    vm_ref = salt.utils.vmware.get_mor_by_property(service_instance,
+                                                   vim.VirtualMachine,
+                                                   name,
+                                                   property_name='name',
+                                                   container_ref=placement_object)
+    if not vm_ref:
+        raise salt.exceptions.VMwareObjectRetrievalError('The virtual machine object {0} in '
+                                              'datacenter {1} was not found'.format(name, datacenter))
+    return results, vm_ref
+
+
+@depends(HAS_PYVMOMI)
+@supports_proxies('esxvm', 'esxcluster', 'esxdatacenter')
+@gets_service_instance_via_proxy
+def delete_vm(name, datacenter, placement=None, power_off=False, service_instance=None):
+    '''
+    Deletes a virtual machine defined by name and placement
+
+    name
+        Name of the virtual machine
+
+    datacenter
+        Datacenter of the virtual machine
+
+    placement
+        Placement information of the virtual machine
+
+    service_instance
+        vCenter service instance for connection and configuration
+    '''
+    results = {}
+    schema = ESXVirtualMachineDeleteSchema.serialize()
+    try:
+        jsonschema.validate({'name': name,
+                             'datacenter': datacenter,
+                             'placement': placement},
+                            schema)
+    except jsonschema.exceptions.ValidationError as exc:
+        raise salt.exceptions.InvalidESXVmPayloadError(exc)
+    (results, vm_ref) = _remove_vm(name, datacenter, service_instance=service_instance,
+                                   placement=placement, power_off=power_off)
+    salt.utils.vmware.delete_vm(vm_ref)
+    results['deleted_vm'] = True
+    return results
+
+
+@depends(HAS_PYVMOMI)
+@supports_proxies('esxvm', 'esxcluster', 'esxdatacenter')
+@gets_service_instance_via_proxy
+def unregister_vm(name, datacenter, placement=None, power_off=False, service_instance=None):
+    '''
+    Unregisters a virtual machine defined by name and placement
+
+    name
+        Name of the virtual machine
+
+    datacenter
+        Datacenter of the virtual machine
+
+    placement
+        Placement information of the virtual machine
+
+    service_instance
+        vCenter service instance for connection and configuration
+    '''
+    results = {}
+    schema = ESXVirtualMachineUnregisterSchema.serialize()
+    try:
+        jsonschema.validate({'name': name,
+                             'datacenter': datacenter,
+                             'placement': placement},
+                            schema)
+    except jsonschema.exceptions.ValidationError as exc:
+        raise salt.exceptions.InvalidESXVmPayloadError(exc)
+    (results, vm_ref) = _remove_vm(name, datacenter, service_instance=service_instance,
+                                   placement=placement, power_off=power_off)
+    salt.utils.vmware.unregister_vm(vm_ref)
+    results['unregistered_vm'] = True
+    return results
+

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -188,7 +188,8 @@ from salt.config.schemas.esxcluster import ESXClusterConfigSchema, \
 from salt.config.schemas.vcenter import VCenterEntitySchema
 from salt.config.schemas.esxi import DiskGroupsDiskIdSchema, \
         VmfsDatastoreSchema, SimpleHostCacheSchema
-from salt.config.schemas.esxvm import ESXVirtualMachineDeleteSchema
+from salt.config.schemas.esxvm import ESXVirtualMachineDeleteSchema, \
+        ESXVirtualMachineUnregisterSchema
 
 
 log = logging.getLogger(__name__)
@@ -8794,7 +8795,10 @@ def get_vm_config(name, datacenter=None, objects=True, service_instance=None):
     current_config['version'] = virtual_machine['config.version']
     current_config['advanced_configs'] = {}
     for extra_conf in virtual_machine['config.extraConfig']:
-        current_config['advanced_configs'][extra_conf.key] = extra_conf.value
+        try:
+            current_config['advanced_configs'][extra_conf.key] = int(extra_conf.value)
+        except ValueError as exc:
+            current_config['advanced_configs'][extra_conf.key] = extra_conf.value
 
     current_config['disks'] = []
     current_config['scsi_devices'] = []
@@ -9404,4 +9408,3 @@ def unregister_vm(name, datacenter, placement=None, power_off=False, service_ins
     salt.utils.vmware.unregister_vm(vm_ref)
     results['unregistered_vm'] = True
     return results
-

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -9514,6 +9514,11 @@ def power_on_vm(name, datacenter=None, service_instance=None):
     service_instance
         Service instance (vim.ServiceInstance) of the vCenter.
         Default is None.
+
+    .. code-block:: bash
+
+        salt '*' vsphere.power_on_vm name=my_vm
+
     '''
     log.trace('Powering on virtual machine {0}'.format(name))
     vm_properties = [
@@ -9551,6 +9556,11 @@ def power_off_vm(name, datacenter=None, service_instance=None):
     service_instance
         Service instance (vim.ServiceInstance) of the vCenter.
         Default is None.
+
+    .. code-block:: bash
+
+        salt '*' vsphere.power_off_vm name=my_vm
+
     '''
     log.trace('Powering off virtual machine {0}'.format(name))
     vm_properties = [
@@ -9633,6 +9643,11 @@ def delete_vm(name, datacenter, placement=None, power_off=False,
 
     service_instance
         vCenter service instance for connection and configuration
+
+    .. code-block:: bash
+
+        salt '*' vsphere.delete_vm name=my_vm datacenter=my_datacenter
+
     '''
     results = {}
     schema = ESXVirtualMachineDeleteSchema.serialize()
@@ -9672,6 +9687,11 @@ def unregister_vm(name, datacenter, placement=None, power_off=False,
 
     service_instance
         vCenter service instance for connection and configuration
+
+    .. code-block:: bash
+
+        salt '*' vsphere.unregister_vm name=my_vm datacenter=my_datacenter
+
     '''
     results = {}
     schema = ESXVirtualMachineUnregisterSchema.serialize()

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -7550,9 +7550,10 @@ def _apply_advanced_config(config_spec, advanced_config, vm_extra_config=None):
         raise salt.exceptions.ArgumentValueError('The specified \'advanced_configs\' configuration'
                                       ' option cannot be parsed, please check the parameters')
     for key, value in six.iteritems(advanced_config):
-        for option in vm_extra_config:
-            if option.key == key and option.value == str(value):
-                continue
+        if vm_extra_config:
+            for option in vm_extra_config:
+                if option.key == key and option.value == str(value):
+                    continue
         else:
             option = vim.option.OptionValue(key=key, value=value)
             config_spec.extraConfig.append(option)
@@ -8495,6 +8496,10 @@ def create_vm(vm_name, cpu, memory, image, version, datacenter, datastore, place
               switch_type: distributed or standard
               adapter_type: vmxnet3 or vmxnet, vmxnet2, vmxnet3, e1000, e1000e
               mac: '00:11:22:33:44:55'
+              connectable:
+                allow_guest_control: True
+                connected: True
+                start_connected: True
 
         disks
         .. code-block:: bash
@@ -8527,6 +8532,7 @@ def create_vm(vm_name, cpu, memory, image, version, datacenter, datastore, place
                 filename: 'service_uri'
               connectable:
                 allow_guest_control: True
+                connected: True
                 start_connected: True
               yield: False
 
@@ -8540,6 +8546,7 @@ def create_vm(vm_name, cpu, memory, image, version, datacenter, datastore, place
                 path: path_to_iso
               connectable:
                 allow_guest_control: True
+                connected: True
                 start_connected: True
 
     advanced_config
@@ -8845,6 +8852,7 @@ def get_vm_config(name, datacenter=None, objects=True, service_instance=None):
             interface['adapter'] = device.deviceInfo.label
             interface['adapter_type'] = salt.utils.vmware.get_network_adapter_object_type(device)
             interface['connectable'] = {'allow_guest_control': device.connectable.allowGuestControl,
+                                        'connected': device.connectable.connected,
                                         'start_connected': device.connectable.startConnected}
             interface['mac'] = device.macAddress
             if isinstance(device.backing, vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo):
@@ -8878,6 +8886,7 @@ def get_vm_config(name, datacenter=None, objects=True, service_instance=None):
                 drive['device_type'] = 'datastore_iso_file'
                 drive['datastore_iso_file'] = {'path': device.backing.fileName}
             drive['connectable'] = {'allow_guest_control': device.connectable.allowGuestControl,
+                                    'connected': device.connectable.connected,
                                     'start_connected': device.connectable.startConnected}
             if objects:
                 drive['key'] = device.key
@@ -8900,6 +8909,7 @@ def get_vm_config(name, datacenter=None, objects=True, service_instance=None):
                 port['type'] = 'device'
             port['yield'] = device.yieldOnPoll
             port['connectable'] = {'allow_guest_control': device.connectable.allowGuestControl,
+                                   'connected': device.connectable.connected,
                                    'start_connected': device.connectable.startConnected}
             if objects:
                 port['key'] = device.key

--- a/salt/proxy/esxvm.py
+++ b/salt/proxy/esxvm.py
@@ -199,18 +199,18 @@ def init(opts):
             raise excs.InvalidProxyInputError(
                 'Mechanism is set to \'userpass\' , but no '
                 '\'username\' key found in pillar for this proxy.')
-        if not 'passwords' in proxy_conf:
+        if 'passwords' not in proxy_conf:
             raise excs.InvalidProxyInputError(
                 'Mechanism is set to \'userpass\' , but no '
                 '\'passwords\' key found in pillar for this proxy.')
         for key in ('username', 'passwords'):
             DETAILS[key] = proxy_conf[key]
     else:
-        if not 'domain' in proxy_conf:
+        if 'domain' not in proxy_conf:
             raise excs.InvalidProxyInputError(
                 'Mechanism is set to \'sspi\' , but no '
                 '\'domain\' key found in pillar for this proxy.')
-        if not 'principal' in proxy_conf:
+        if 'principal' not in proxy_conf:
             raise excs.InvalidProxyInputError(
                 'Mechanism is set to \'sspi\' , but no '
                 '\'principal\' key found in pillar for this proxy.')
@@ -237,7 +237,7 @@ def init(opts):
 
 def ping():
     '''
-    Returns True. 
+    Returns True.
 
     CLI Example:
 
@@ -285,4 +285,3 @@ def get_details():
     Function that returns the cached details
     '''
     return DETAILS
-

--- a/salt/proxy/esxvm.py
+++ b/salt/proxy/esxvm.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+'''
+TODO Add and review comments
+
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import logging
+import os
+
+# Import Salt Libs
+import salt.exceptions as excs
+from salt.utils.dictupdate import merge
+
+# This must be present or the Salt loader won't load this module.
+__proxyenabled__ = ['esxvm']
+
+
+# Variables are scoped to this module so we can have persistent data
+# across calls to fns in here.
+GRAINS_CACHE = {}
+DETAILS = {}
+
+
+# Set up logging
+log = logging.getLogger(__name__)
+# Define the module's virtual name
+__virtualname__ = 'esxvm'
+
+
+def __virtual__():
+    '''
+    Only load if the vsphere execution module is available.
+    '''
+    return __virtualname__
+
+
+def init(opts):
+    '''
+    This function gets called when the proxy starts up. For
+    login the protocol and port are cached.
+    '''
+    log.debug('Initting esxvm proxy module in process '
+              '{}'.format(os.getpid()))
+    log.debug('Validating esxvm proxy input')
+    proxy_conf = merge(opts.get('proxy', {}), __pillar__.get('proxy', {}))
+    log.trace('proxy_conf = {0}'.format(proxy_conf))
+    # TODO json schema validation
+
+    # Save mandatory fields in cache
+    for key in ('vcenter', 'datacenter', 'mechanism'):
+        DETAILS[key] = proxy_conf[key]
+
+    # Additional validation
+    if DETAILS['mechanism'] == 'userpass':
+        if 'username' not in proxy_conf:
+            raise excs.InvalidProxyInputError(
+                'Mechanism is set to \'userpass\' , but no '
+                '\'username\' key found in pillar for this proxy.')
+        if not 'passwords' in proxy_conf:
+            raise excs.InvalidProxyInputError(
+                'Mechanism is set to \'userpass\' , but no '
+                '\'passwords\' key found in pillar for this proxy.')
+        for key in ('username', 'passwords'):
+            DETAILS[key] = proxy_conf[key]
+    else:
+        if not 'domain' in proxy_conf:
+            raise excs.InvalidProxyInputError(
+                'Mechanism is set to \'sspi\' , but no '
+                '\'domain\' key found in pillar for this proxy.')
+        if not 'principal' in proxy_conf:
+            raise excs.InvalidProxyInputError(
+                'Mechanism is set to \'sspi\' , but no '
+                '\'principal\' key found in pillar for this proxy.')
+        for key in ('domain', 'principal'):
+            DETAILS[key] = proxy_conf[key]
+
+    # Save optional
+    DETAILS['protocol'] = proxy_conf.get('protocol')
+    DETAILS['port'] = proxy_conf.get('port')
+
+    # Test connection
+    if DETAILS['mechanism'] == 'userpass':
+        # Get the correct login details
+        log.debug('Retrieving credentials and testing vCenter connection for '
+                  'mehchanism \'userpass\'')
+        try:
+            username, password = find_credentials()
+            DETAILS['password'] = password
+        except excs.SaltSystemExit as err:
+            log.critical('Error: {0}'.format(err))
+            return False
+    return True
+
+
+def ping():
+    '''
+    Returns True. 
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt esx-vm test.ping
+    '''
+    return True
+
+
+def shutdown():
+    '''
+    Shutdown the connection to the proxy device. For this proxy,
+    shutdown is a no-op.
+    '''
+    log.debug('ESX vm proxy shutdown() called...')
+
+
+def find_credentials():
+    '''
+    Cycle through all the possible credentials and return the first one that
+    works.
+    '''
+
+    # if the username and password were already found don't go through the
+    # connection process again
+    if 'username' in DETAILS and 'password' in DETAILS:
+        return DETAILS['username'], DETAILS['password']
+
+    passwords = __pillar__['proxy']['passwords']
+    for password in passwords:
+        DETAILS['password'] = password
+        if not __salt__['vsphere.test_vcenter_connection']():
+            # We are unable to authenticate
+            continue
+        # If we have data returned from above, we've successfully authenticated.
+        return DETAILS['username'], password
+    # We've reached the end of the list without successfully authenticating.
+    raise excs.VMwareConnectionError('Cannot complete login due to '
+                                     'incorrect credentials.')
+
+
+def get_details():
+    '''
+    Function that returns the cached details
+    '''
+    return DETAILS
+

--- a/salt/proxy/esxvm.py
+++ b/salt/proxy/esxvm.py
@@ -1,7 +1,148 @@
 # -*- coding: utf-8 -*-
 '''
-TODO Add and review comments
+Proxy Minion interface module for managing VMWare ESXi virtual machines.
 
+Dependencies
+============
+
+- pyVmomi
+- jsonschema
+
+Configuration
+=============
+To use this integration proxy module, please configure the following:
+
+Pillar
+------
+
+Proxy minions get their configuration from Salt's Pillar. This can now happen
+from the proxy's configuration file.
+
+Example pillars:
+
+``userpass`` mechanism:
+
+.. code-block:: yaml
+
+    proxy:
+      proxytype: esxvm
+      datacenter: <datacenter name>
+      vcenter: <ip or dns name of parent vcenter>
+      mechanism: userpass
+      username: <vCenter username>
+      passwords: (required if userpass is used)
+        - first_password
+        - second_password
+        - third_password
+
+``sspi`` mechanism:
+
+.. code-block:: yaml
+
+    proxy:
+      proxytype: esxvm
+      datacenter: <datacenter name>
+      vcenter: <ip or dns name of parent vcenter>
+      mechanism: sspi
+      domain: <user domain>
+      principal: <host kerberos principal>
+
+proxytype
+^^^^^^^^^
+To use this Proxy Module, set this to ``esxvm``.
+
+datacenter
+^^^^^^^^^^
+Name of the datacenter where the virtual machine should be deployed. Required.
+
+vcenter
+^^^^^^^
+The location of the VMware vCenter server (host of ip) where the virtual
+machine should be managed. Required.
+
+mechanism
+^^^^^^^^^
+The mechanism used to connect to the vCenter server. Supported values are
+``userpass`` and ``sspi``. Required.
+
+Note:
+    Connections are attempted using all (``username``, ``password``)
+    combinations on proxy startup.
+
+username
+^^^^^^^^
+The username used to login to the host, such as ``root``. Required if mechanism
+is ``userpass``.
+
+passwords
+^^^^^^^^^
+A list of passwords to be used to try and login to the vCenter server. At least
+one password in this list is required if mechanism is ``userpass``.  When the
+proxy comes up, it will try the passwords listed in order.
+
+domain
+^^^^^^
+User realm domain. Required if mechanism is ``sspi``.
+
+principal
+^^^^^^^^
+Kerberos principal. Rquired if mechanism is ``sspi``.
+
+protocol
+^^^^^^^^
+If the ESXi host is not using the default protocol, set this value to an
+alternate protocol. Default is ``https``.
+
+port
+^^^^
+If the ESXi host is not using the default port, set this value to an
+alternate port. Default is ``443``.
+
+Salt Proxy
+----------
+
+After your pillar is in place, you can test the proxy. The proxy can run on
+any machine that has network connectivity to your Salt Master and to the
+vCenter server in the pillar. SaltStack recommends that the machine running the
+salt-proxy process also run a regular minion, though it is not strictly
+necessary.
+
+To start a proxy minion one needs to establish its identity <id>:
+
+.. code-block:: bash
+
+    salt-proxy --proxyid <proxy_id>
+
+On the machine that will run the proxy, make sure there is a configuration file
+present. By default this is ``/etc/salt/proxy``. If in a different location, the
+``<configuration_folder>`` has to be specified when running the proxy:
+file with at least the following in it:
+
+.. code-block:: bash
+
+    salt-proxy --proxyid <proxy_id> -c <configuration_folder>
+
+Commands
+--------
+
+Once the proxy is running it will connect back to the specified master and
+individual commands can be runs against it:
+
+.. code-block:: bash
+
+    # Master - minion communication
+    salt <proxy_id> test.ping
+
+    # Test vcenter connection
+    salt <proxy_id> vsphere.test_vcenter_connection
+
+States
+------
+
+Associated states are documented in
+:mod:`salt.states.esxvm </ref/states/all/salt.states.esxvm>`.
+Look there to find an example structure for Pillar as well as an example
+``.sls`` file for configuring an ESX virtual machine from scratch.
 '''
 
 # Import Python Libs

--- a/salt/states/esxvm.py
+++ b/salt/states/esxvm.py
@@ -1,12 +1,144 @@
 # -*- coding: utf-8 -*-
 '''
-Manage VMware ESXi Virtual Machines.
+Salt state to create, update VMware ESXi Virtual Machines.
+
+:codeauthor: :email:`Agnes Tevesz <agnes.tevesz@morganstaley.com>`
 
 Dependencies
 ============
 
-- pyVmomi Python Module
+- pyVmomi
+- jsonschema
 
+States
+======
+
+vm_configured
+-------------
+
+Enforces correct virtual machine configuration. Creates, updates and registers
+a virtual machine.
+
+This state identifies the action which should be taken for the virtual machine
+and applies that action via the create, update, register state functions.
+
+Supported proxies: esxvm
+
+
+Example:
+
+1. Get the virtual machine ``my_vm`` status with an ``esxvm`` proxy:
+
+Proxy minion configuration for ``esxvm`` proxy:
+
+.. code-block:: yaml
+
+    proxy:
+      proxytype: esxvm
+      datacenter: my_dc
+      vcenter: vcenter.fake.com
+      mechanism: sspi
+      domain: fake.com
+      principal: host
+
+State configuration:
+
+.. code-block:: yaml
+
+      myvm_state:
+        esxvm.vm_configured:
+        - vm_name: my_vm
+        - cpu: {{ {'count': 4, 'cores_per_socket': 2} }}
+        - memory: {{ {'size': 16384, 'unit': 'MB'} }}
+        - image: rhel7_64Guest
+        - version: vmx-12
+        - interfaces: {{ [{
+                           'adapter': 'Network adapter 1',
+                           'name': 'my_pg1',
+                           'switch_type': 'distributed',
+                           'adapter_type': 'vmxnet3',
+                           'mac': '00:50:56:00:01:02,
+                           'connectable': { 'start_connected': true,
+                                            'allow_guest_control': true,
+                                            'connected': true}},
+                           {
+                           'adapter': 'Network adapter 2',
+                           'name': 'my_pg2',
+                           'switch_type': 'distributed',
+                           'adapter_type': 'vmxnet3',
+                           'mac': '00:50:56:00:01:03',
+                           'connectable': { 'start_connected': true,
+                                            'allow_guest_control': true,
+                                            'connected': true}}
+                      ] }}
+        - disks: {{ [{
+                      'adapter': 'Hard disk 1',
+                      'unit': 'MB',
+                      'size': 51200,
+                      'filename': 'my_vm/sda.vmdk',
+                      'datastore': 'my_datastore',
+                      'address': '0:0',
+                      'thin_provision': true,
+                      'eagerly_scrub': false,
+                      'controller': 'SCSI controller 0'},
+                      {
+                      'adapter': 'Hard disk 2',
+                      'unit': 'MB',
+                      'size': 10240,
+                      'filename': 'my_vm/sdb.vmdk',
+                      'datastore': 'my_datastore',
+                      'address': '0:1',
+                      'thin_provision': true,
+                      'eagerly_scrub': false,
+                      'controller': 'SCSI controller 0'}
+                ] }}
+        - scsi_devices: {{ [{
+                             'adapter': 'SCSI controller 0',
+                             'type': 'paravirtual',
+                             'bus_sharing': 'no_sharing',
+                             'bus_number': 0}
+                            ] }}
+        - serial_ports: {{ [{
+                             'adapter': 'Serial port 1',
+                             'type': 'network',
+                             'yield': false,
+                             'backing': {
+                                         'uri': 'my_uri',
+                                         'direction': 'server',
+                                         'filename': 'my_file'},
+                              'connectable': {
+                                              'start_connected': true,
+                                              'allow_guest_control': true,
+                                              'connected': true}}
+                             ] }}
+        - datacenter: {{ 'my_dc' }}
+        - datastore: 'my_datastore'
+        - placement: {{ {'cluster': 'my_cluster'} }}
+        - cd_dvd_drives: {{ [] }}
+        - advanced_configs: {{ {'my_param': '1'} }}
+        - template: false
+        - tools: false
+        - power_on: false
+        - deploy: false
+
+
+vm_updated
+----------
+
+Updates a virtual machine to a given configuration.
+
+vm_created
+----------
+
+Creates a virtual machine with a given configuration.
+
+vm_registered
+-------------
+
+Registers a virtual machine with it's configuration file path.
+
+Dependencies
+============
 
 pyVmomi
 -------
@@ -19,12 +151,13 @@ PyVmomi can be installed via pip:
 
 .. note::
 
-    Version 6.0 of pyVmomi has some problems with SSL error handling on certain
-    versions of Python. If using version 6.0 of pyVmomi, Python 2.6,
-    Python 2.7.9, or newer must be present. This is due to an upstream dependency
-    in pyVmomi 6.0 that is not supported in Python versions 2.7 to 2.7.8. If the
-    version of Python is not in the supported range, you will need to install an
-    earlier version of pyVmomi. See `Issue #29537`_ for more information.
+    Version 6.0 of pyVmomi has some problems with SSL error handling on
+    certain versions of Python. If using version 6.0 of pyVmomi, Python 2.6,
+    Python 2.7.9, or newer must be present. This is due to an upstream
+    dependency in pyVmomi 6.0 that is not supported in Python versions
+    2.7 to 2.7.8. If the version of Python is not in the supported range,
+    you will need to install an earlier version of pyVmomi.
+    See `Issue #29537`_ for more information.
 
 .. _Issue #29537: https://github.com/saltstack/salt/issues/29537
 
@@ -33,13 +166,12 @@ version currently listed in PyPi, run the following:
 
 .. code-block:: bash
 
-    pip install pyVmomi==5.5.0.2014.1.1
+    pip install pyVmomi==6.0.0.2016.4
 
 The 5.5.0.2014.1.1 is a known stable version that this original ESXi State
-Module was developed against.
-
-To be able to connect through SSPI you must use pyvmomi 6.0.0.2016.4 or above.
-The ESXVM State Module was tested with this version.
+Module was developed against. To be able to connect through SSPI you must
+use pyvmomi 6.0.0.2016.4 or above. The ESXVM State Module was tested with
+this version.
 
 About
 -----
@@ -50,10 +182,10 @@ This state module was written to be used in conjunction with Salt's
 
 # Import Python libs
 from __future__ import absolute_import
-
+import sys
 import logging
 
-import salt.exceptions as exceptions
+import salt.exceptions
 import salt.ext.six as six
 from salt.config.schemas.esxvm import ESXVirtualMachineConfigSchema
 
@@ -64,20 +196,39 @@ try:
 except ImportError:
     HAS_JSONSCHEMA = False
 
+try:
+    from pyVmomi import VmomiSupport
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
 log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    return 'esxvm.get_details' in __salt__
+    if not HAS_JSONSCHEMA:
+        return False, 'State module did not load: jsonschema not found'
+    if not HAS_PYVMOMI:
+        return False, 'State module did not load: pyVmomi not found'
+
+    # We check the supported vim versions to infer the pyVmomi version
+    if 'vim25/6.0' in VmomiSupport.versionMap and \
+        sys.version_info > (2, 7) and sys.version_info < (2, 7, 9):
+
+        return False, ('State module did not load: Incompatible versions '
+                       'of Python and pyVmomi present. See Issue #29537.')
+    return True
 
 
-def vm_configured(name, vm_name, cpu, memory, image, version, interfaces, disks, scsi_devices,
-                  serial_ports, datacenter, datastore, placement, cd_dvd_drives=None,
-                  sata_controllers=None, advanced_configs=None, template=None,
-                  tools=True, power_on=False, deploy=False):
+def vm_configured(name, vm_name, cpu, memory, image, version, interfaces,
+                  disks, scsi_devices, serial_ports, datacenter, datastore,
+                  placement, cd_dvd_drives=None, sata_controllers=None,
+                  advanced_configs=None, template=None, tools=True,
+                  power_on=False, deploy=False):
     '''
-    Selects the correct operation to be executed on a virtual machine, non existing machines
-    will be created, existing ones will be updated if the config differs.
+    Selects the correct operation to be executed on a virtual machine, non
+    existing machines will be created, existing ones will be updated if the
+    config differs.
     '''
     result = {'name': name,
               'result': None,
@@ -88,49 +239,69 @@ def vm_configured(name, vm_name, cpu, memory, image, version, interfaces, disks,
     schema = ESXVirtualMachineConfigSchema.serialize()
     log.trace('schema = {}'.format(schema))
     try:
-        jsonschema.validate({'vm_name': vm_name, 'cpu': cpu, 'memory': memory,
-                             'image': image, 'version': version, 'interfaces': interfaces,
-                             'disks': disks, 'scsi_devices': scsi_devices,
-                             'serial_ports': serial_ports, 'cd_dvd_drives': cd_dvd_drives,
+        jsonschema.validate({'vm_name': vm_name,
+                             'cpu': cpu,
+                             'memory': memory,
+                             'image': image,
+                             'version': version,
+                             'interfaces': interfaces,
+                             'disks': disks,
+                             'scsi_devices': scsi_devices,
+                             'serial_ports': serial_ports,
+                             'cd_dvd_drives': cd_dvd_drives,
                              'sata_controllers': sata_controllers,
-                             'datacenter': datacenter, 'datastore': datastore,
-                             'placement': placement, 'template': template, 'tools': tools,
-                             'power_on': power_on, 'deploy': deploy}, schema)
+                             'datacenter': datacenter,
+                             'datastore': datastore,
+                             'placement': placement,
+                             'template': template,
+                             'tools': tools,
+                             'power_on': power_on,
+                             'deploy': deploy}, schema)
     except jsonschema.exceptions.ValidationError as exc:
-        raise exceptions.InvalidConfigError(exc)
+        raise salt.exceptions.InvalidConfigError(exc)
 
     service_instance = __salt__['vsphere.get_service_instance_via_proxy']()
     try:
-        __salt__['vsphere.get_vm'](vm_name, vm_properties=['name'], service_instance=service_instance)
-    except exceptions.VMwareObjectRetrievalException:
-        vm_file = __salt__['vsphere.get_vm_config_file'](vm_name, datacenter,
-                                                         placement, datastore,
-                                                         service_instance=service_instance)
+        __salt__['vsphere.get_vm'](vm_name, vm_properties=['name'],
+                                   service_instance=service_instance)
+    except salt.exceptions.VMwareObjectRetrievalException:
+        vm_file = __salt__['vsphere.get_vm_config_file'](
+            vm_name, datacenter,
+            placement, datastore,
+            service_instance=service_instance)
         if vm_file:
             if __opts__['test']:
-                result.update({'comment': 'The virtual machine {0}'
+                result.update({'comment': 'The virtual machine {0}' \
                                           ' will be registered.'.format(vm_name)})
+                __salt__['vsphere.disconnect'](service_instance)
                 return result
-            result = vm_registered(vm_name, datacenter, placement, vm_file, power_on=power_on)
+            result = vm_registered(vm_name, datacenter, placement,
+                                   vm_file, power_on=power_on)
             return result
         else:
             if __opts__['test']:
-                result.update({'comment': 'The virtual machine {0}'
+                result.update({'comment': 'The virtual machine {0}' \
                                           ' will be created.'.format(vm_name)})
+                __salt__['vsphere.disconnect'](service_instance)
                 return result
             if template:
                 result = vm_cloned(name)
             else:
-                result = vm_created(name, vm_name, cpu, memory, image, version, interfaces, disks,
-                                    scsi_devices, serial_ports, datacenter, datastore, placement,
-                                    cd_dvd_drives=cd_dvd_drives, advanced_configs=advanced_configs,
+                result = vm_created(name, vm_name, cpu, memory, image, version,
+                                    interfaces, disks, scsi_devices,
+                                    serial_ports, datacenter, datastore,
+                                    placement, cd_dvd_drives=cd_dvd_drives,
+                                    advanced_configs=advanced_configs,
                                     power_on=power_on)
             return result
 
-    result = vm_updated(name, vm_name, cpu, memory, image, version, interfaces, disks,
-                        scsi_devices, serial_ports, datacenter, datastore,
-                        cd_dvd_drives=cd_dvd_drives, sata_controllers=sata_controllers,
-                        advanced_configs=advanced_configs, power_on=power_on)
+    result = vm_updated(name, vm_name, cpu, memory, image, version,
+                        interfaces, disks, scsi_devices,
+                        serial_ports, datacenter, datastore,
+                        cd_dvd_drives=cd_dvd_drives,
+                        sata_controllers=sata_controllers,
+                        advanced_configs=advanced_configs,
+                        power_on=power_on)
     __salt__['vsphere.disconnect'](service_instance)
 
     log.trace(result)
@@ -139,8 +310,8 @@ def vm_configured(name, vm_name, cpu, memory, image, version, interfaces, disks,
 
 def vm_cloned(name):
     '''
-    Clones a virtual machine from a template virtual machine if it doesn't exist and a template
-    is defined.
+    Clones a virtual machine from a template virtual machine if it doesn't
+    exist and a template is defined.
     '''
     result = {'name': name,
               'result': True,
@@ -150,45 +321,46 @@ def vm_cloned(name):
     return result
 
 
-def vm_updated(name, vm_name, cpu, memory, image, version, interfaces, disks,
-               scsi_devices, serial_ports, datacenter, datastore,
-               cd_dvd_drives=None, sata_controllers=None, advanced_configs=None,
-               power_on=False):
+def vm_updated(name, vm_name, cpu, memory, image, version, interfaces,
+               disks, scsi_devices, serial_ports, datacenter, datastore,
+               cd_dvd_drives=None, sata_controllers=None,
+               advanced_configs=None, power_on=False):
     '''
-    Updates a virtual machine configuration if there is a difference between the given and
-    deployed configuration.
+    Updates a virtual machine configuration if there is a difference between
+    the given and deployed configuration.
     '''
     result = {'name': name,
               'result': None,
               'changes': {},
               'comment': ''}
-    comment = []
 
     service_instance = __salt__['vsphere.get_service_instance_via_proxy']()
-    current_config = __salt__['vsphere.get_vm_config'](vm_name,
-                                                       datacenter=datacenter,
-                                                       objects=False,
-                                                       service_instance=service_instance)
+    current_config = __salt__['vsphere.get_vm_config'](
+        vm_name,
+        datacenter=datacenter,
+        objects=False,
+        service_instance=service_instance)
 
-    diffs = __salt__['vsphere.compare_vm_configs']({'name': vm_name,
-                                                    'cpu': cpu,
-                                                    'memory': memory,
-                                                    'image': image,
-                                                    'version': version,
-                                                    'interfaces': interfaces,
-                                                    'disks': disks,
-                                                    'scsi_devices': scsi_devices,
-                                                    'serial_ports': serial_ports,
-                                                    'datacenter': datacenter,
-                                                    'datastore': datastore,
-                                                    'cd_drives': cd_dvd_drives,
-                                                    'sata_controllers': sata_controllers,
-                                                    'advanced_configs': advanced_configs},
-                                                   current_config)
+    diffs = __salt__['vsphere.compare_vm_configs'](
+        {'name': vm_name,
+         'cpu': cpu,
+         'memory': memory,
+         'image': image,
+         'version': version,
+         'interfaces': interfaces,
+         'disks': disks,
+         'scsi_devices': scsi_devices,
+         'serial_ports': serial_ports,
+         'datacenter': datacenter,
+         'datastore': datastore,
+         'cd_drives': cd_dvd_drives,
+         'sata_controllers': sata_controllers,
+         'advanced_configs': advanced_configs},
+         current_config)
     if not diffs:
         result.update({
             'result': True,
-            'changes': None,
+            'changes': {},
             'comment': 'Virtual machine {0} is already up to date'.format(vm_name)})
         return result
 
@@ -197,19 +369,23 @@ def vm_updated(name, vm_name, cpu, memory, image, version, interfaces, disks,
                   'in datacenter \'{1}\':\n{2}'.format(
             vm_name,
             datacenter,
-            '\n'.join([ ':\n'.join([key, difference.changes_str]) for key, difference in six.iteritems(diffs)]))
+            '\n'.join([':\n'.join([key, difference.changes_str]) \
+                       for key, difference in six.iteritems(diffs)]))
         result.update({'result': None,
                        'comment': comment})
+        __salt__['vsphere.disconnect'](service_instance)
         return result
 
     try:
-        changes = __salt__['vsphere.update_vm'](vm_name, cpu, memory, image, version, interfaces,
-                                                disks, scsi_devices, serial_ports, datacenter,
-                                                datastore, cd_dvd_drives=cd_dvd_drives,
+        changes = __salt__['vsphere.update_vm'](vm_name, cpu, memory, image,
+                                                version, interfaces, disks,
+                                                scsi_devices, serial_ports,
+                                                datacenter, datastore,
+                                                cd_dvd_drives=cd_dvd_drives,
                                                 sata_controllers=sata_controllers,
                                                 advanced_configs=advanced_configs,
                                                 service_instance=service_instance)
-    except exceptions.CommandExecutionError as exc:
+    except salt.exceptions.CommandExecutionError as exc:
         log.error('Error: {}'.format(str(exc)))
         if service_instance:
             __salt__['vsphere.disconnect'](service_instance)
@@ -221,9 +397,9 @@ def vm_updated(name, vm_name, cpu, memory, image, version, interfaces, disks,
     if power_on:
         try:
             __salt__['vsphere.power_on_vm'](vm_name, datacenter)
-        except exceptions.VMwarePowerOnException:
+        except salt.exceptions.VMwarePowerOnException:
             pass
-        except exceptions.VMwarePowerOnError as exc:
+        except salt.exceptions.VMwarePowerOnError as exc:
             log.error('Error: {}'.format(exc))
             if service_instance:
                 __salt__['vsphere.disconnect'](service_instance)
@@ -238,14 +414,16 @@ def vm_updated(name, vm_name, cpu, memory, image, version, interfaces, disks,
     result = {'name': name,
               'result': True,
               'changes': changes,
-              'comment': 'Virtual machine {0} was updated successfully'.format(vm_name)}
+              'comment': 'Virtual machine ' \
+                         '{0} was updated successfully'.format(vm_name)}
 
     return result
 
 
-def vm_created(name, vm_name, cpu, memory, image, version, interfaces, disks, scsi_devices,
-               serial_ports, datacenter, datastore, placement, ide_controllers=None,
-               sata_controllers=None, cd_dvd_drives=None, advanced_configs=None, power_on=False):
+def vm_created(name, vm_name, cpu, memory, image, version, interfaces,
+               disks, scsi_devices, serial_ports, datacenter, datastore,
+               placement, ide_controllers=None, sata_controllers=None,
+               cd_dvd_drives=None, advanced_configs=None, power_on=False):
     '''
     Creates a virtual machine with the given properties if it doesn't exist.
     '''
@@ -257,21 +435,23 @@ def vm_created(name, vm_name, cpu, memory, image, version, interfaces, disks, sc
     if __opts__['test']:
         result.update({'result': None,
                        'changes': None,
-                       'comment': 'Virtual machine {0} will be created'.format(vm_name)})
+                       'comment': 'Virtual machine ' \
+                                  '{0} will be created'.format(vm_name)})
         return result
 
     service_instance = __salt__['vsphere.get_service_instance_via_proxy']()
     try:
-        info = __salt__['vsphere.create_vm'](vm_name, cpu, memory, image, version,
-                                             datacenter, datastore, placement,
-                                             interfaces, disks, scsi_devices,
+        info = __salt__['vsphere.create_vm'](vm_name, cpu, memory, image,
+                                             version, datacenter, datastore,
+                                             placement, interfaces, disks,
+                                             scsi_devices,
                                              serial_ports=serial_ports,
                                              ide_controllers=ide_controllers,
                                              sata_controllers=sata_controllers,
                                              cd_drives=cd_dvd_drives,
                                              advanced_configs=advanced_configs,
                                              service_instance=service_instance)
-    except exceptions.CommandExecutionError as exc:
+    except salt.exceptions.CommandExecutionError as exc:
         log.error('Error: {0}'.format(str(exc)))
         if service_instance:
             __salt__['vsphere.disconnect'](service_instance)
@@ -282,10 +462,11 @@ def vm_created(name, vm_name, cpu, memory, image, version, interfaces, disks, sc
 
     if power_on:
         try:
-            __salt__['vsphere.power_on_vm'](vm_name, datacenter, service_instance=service_instance)
-        except exceptions.VMwarePowerOnException:
+            __salt__['vsphere.power_on_vm'](vm_name, datacenter,
+                                            service_instance=service_instance)
+        except salt.exceptions.VMwarePowerOnException:
             pass
-        except exceptions.VMwarePowerOnError as exc:
+        except salt.exceptions.VMwarePowerOnError as exc:
             log.error('Error: {0}'.format(exc))
             if service_instance:
                 __salt__['vsphere.disconnect'](service_instance)
@@ -300,14 +481,16 @@ def vm_created(name, vm_name, cpu, memory, image, version, interfaces, disks, sc
     result = {'name': name,
               'result': True,
               'changes': changes,
-              'comment': 'Virtual machine {0} created successfully'.format(vm_name)}
+              'comment': 'Virtual machine ' \
+                         '{0} created successfully'.format(vm_name)}
 
     return result
 
 
 def vm_registered(vm_name, datacenter, placement, vm_file, power_on=False):
     '''
-    Registers a virtual machine if the machine files are available on the main datastore.
+    Registers a virtual machine if the machine files are available on
+    the main datastore.
     '''
     result = {'name': vm_name,
               'result': None,
@@ -318,15 +501,17 @@ def vm_registered(vm_name, datacenter, placement, vm_file, power_on=False):
     log.trace('Registering virtual machine with vmx file: {0}'.format(vmx_path))
     service_instance = __salt__['vsphere.get_service_instance_via_proxy']()
     try:
-        __salt__['vsphere.register_vm'](vm_name, datacenter, placement, vmx_path, service_instance=service_instance)
-    except exceptions.VMwareObjectDuplicateException as exc:
+        __salt__['vsphere.register_vm'](vm_name, datacenter,
+                                        placement, vmx_path,
+                                        service_instance=service_instance)
+    except salt.exceptions.VMwareObjectDuplicateException as exc:
         log.error('Error: {0}'.format(str(exc)))
         if service_instance:
             __salt__['vsphere.disconnect'](service_instance)
         result.update({'result': False,
                        'comment': str(exc)})
         return result
-    except exceptions.VMwareVmRegisterError as exc:
+    except salt.exceptions.VMwareVmRegisterError as exc:
         log.error('Error: {0}'.format(exc))
         if service_instance:
             __salt__['vsphere.disconnect'](service_instance)
@@ -336,10 +521,11 @@ def vm_registered(vm_name, datacenter, placement, vm_file, power_on=False):
 
     if power_on:
         try:
-            __salt__['vsphere.power_on_vm'](vm_name, datacenter, service_instance=service_instance)
-        except exceptions.VMwarePowerOnException:
+            __salt__['vsphere.power_on_vm'](vm_name, datacenter,
+                                            service_instance=service_instance)
+        except salt.exceptions.VMwarePowerOnException:
             pass
-        except exceptions.VMwarePowerOnError as exc:
+        except salt.exceptions.VMwarePowerOnError as exc:
             log.error('Error: {0}'.format(exc))
             if service_instance:
                 __salt__['vsphere.disconnect'](service_instance)
@@ -350,6 +536,7 @@ def vm_registered(vm_name, datacenter, placement, vm_file, power_on=False):
     __salt__['vsphere.disconnect'](service_instance)
     result.update({'result': True,
                    'changes': {'name': vm_name, 'power_on': power_on},
-                   'comment': 'Virtual machine {0} registered successfully'.format(vm_name)})
+                   'comment': 'Virtual machine ' \
+                              '{0} registered successfully'.format(vm_name)})
 
     return result

--- a/salt/states/esxvm.py
+++ b/salt/states/esxvm.py
@@ -237,7 +237,7 @@ def vm_configured(name, vm_name, cpu, memory, image, version, interfaces,
 
     log.trace('Validating virtual machine configuration')
     schema = ESXVirtualMachineConfigSchema.serialize()
-    log.trace('schema = {}'.format(schema))
+    log.trace('schema = {0}'.format(schema))
     try:
         jsonschema.validate({'vm_name': vm_name,
                              'cpu': cpu,
@@ -264,7 +264,7 @@ def vm_configured(name, vm_name, cpu, memory, image, version, interfaces,
     try:
         __salt__['vsphere.get_vm'](vm_name, vm_properties=['name'],
                                    service_instance=service_instance)
-    except salt.exceptions.VMwareObjectRetrievalException:
+    except salt.exceptions.VMwareObjectRetrievalError:
         vm_file = __salt__['vsphere.get_vm_config_file'](
             vm_name, datacenter,
             placement, datastore,
@@ -356,7 +356,7 @@ def vm_updated(name, vm_name, cpu, memory, image, version, interfaces,
          'cd_drives': cd_dvd_drives,
          'sata_controllers': sata_controllers,
          'advanced_configs': advanced_configs},
-         current_config)
+        current_config)
     if not diffs:
         result.update({
             'result': True,
@@ -366,11 +366,10 @@ def vm_updated(name, vm_name, cpu, memory, image, version, interfaces,
 
     if __opts__['test']:
         comment = 'State vm_updated will update virtual machine \'{0}\' ' \
-                  'in datacenter \'{1}\':\n{2}'.format(
-            vm_name,
-            datacenter,
-            '\n'.join([':\n'.join([key, difference.changes_str]) \
-                       for key, difference in six.iteritems(diffs)]))
+                  'in datacenter \'{1}\':\n{2}'.format(vm_name,
+                                                       datacenter,
+                  '\n'.join([':\n'.join([key, difference.changes_str]) \
+                      for key, difference in six.iteritems(diffs)]))
         result.update({'result': None,
                        'comment': comment})
         __salt__['vsphere.disconnect'](service_instance)
@@ -397,7 +396,7 @@ def vm_updated(name, vm_name, cpu, memory, image, version, interfaces,
     if power_on:
         try:
             __salt__['vsphere.power_on_vm'](vm_name, datacenter)
-        except salt.exceptions.VMwarePowerOnException:
+        except salt.exceptions.VMwarePowerOnError:
             pass
         except salt.exceptions.VMwarePowerOnError as exc:
             log.error('Error: {}'.format(exc))
@@ -464,7 +463,7 @@ def vm_created(name, vm_name, cpu, memory, image, version, interfaces,
         try:
             __salt__['vsphere.power_on_vm'](vm_name, datacenter,
                                             service_instance=service_instance)
-        except salt.exceptions.VMwarePowerOnException:
+        except salt.exceptions.VMwarePowerOnError:
             pass
         except salt.exceptions.VMwarePowerOnError as exc:
             log.error('Error: {0}'.format(exc))
@@ -504,7 +503,7 @@ def vm_registered(vm_name, datacenter, placement, vm_file, power_on=False):
         __salt__['vsphere.register_vm'](vm_name, datacenter,
                                         placement, vmx_path,
                                         service_instance=service_instance)
-    except salt.exceptions.VMwareObjectDuplicateException as exc:
+    except salt.exceptions.VMwareMultipleObjectsError as exc:
         log.error('Error: {0}'.format(str(exc)))
         if service_instance:
             __salt__['vsphere.disconnect'](service_instance)
@@ -523,7 +522,7 @@ def vm_registered(vm_name, datacenter, placement, vm_file, power_on=False):
         try:
             __salt__['vsphere.power_on_vm'](vm_name, datacenter,
                                             service_instance=service_instance)
-        except salt.exceptions.VMwarePowerOnException:
+        except salt.exceptions.VMwarePowerOnError:
             pass
         except salt.exceptions.VMwarePowerOnError as exc:
             log.error('Error: {0}'.format(exc))

--- a/salt/states/esxvm.py
+++ b/salt/states/esxvm.py
@@ -2,8 +2,6 @@
 '''
 Salt state to create, update VMware ESXi Virtual Machines.
 
-:codeauthor: :email:`Agnes Tevesz <agnes.tevesz@morganstaley.com>`
-
 Dependencies
 ============
 

--- a/salt/states/esxvm.py
+++ b/salt/states/esxvm.py
@@ -1,0 +1,355 @@
+# -*- coding: utf-8 -*-
+'''
+Manage VMware ESXi Virtual Machines.
+
+Dependencies
+============
+
+- pyVmomi Python Module
+
+
+pyVmomi
+-------
+
+PyVmomi can be installed via pip:
+
+.. code-block:: bash
+
+    pip install pyVmomi
+
+.. note::
+
+    Version 6.0 of pyVmomi has some problems with SSL error handling on certain
+    versions of Python. If using version 6.0 of pyVmomi, Python 2.6,
+    Python 2.7.9, or newer must be present. This is due to an upstream dependency
+    in pyVmomi 6.0 that is not supported in Python versions 2.7 to 2.7.8. If the
+    version of Python is not in the supported range, you will need to install an
+    earlier version of pyVmomi. See `Issue #29537`_ for more information.
+
+.. _Issue #29537: https://github.com/saltstack/salt/issues/29537
+
+Based on the note above, to install an earlier version of pyVmomi than the
+version currently listed in PyPi, run the following:
+
+.. code-block:: bash
+
+    pip install pyVmomi==5.5.0.2014.1.1
+
+The 5.5.0.2014.1.1 is a known stable version that this original ESXi State
+Module was developed against.
+
+To be able to connect through SSPI you must use pyvmomi 6.0.0.2016.4 or above.
+The ESXVM State Module was tested with this version.
+
+About
+-----
+
+This state module was written to be used in conjunction with Salt's
+:doc:`ESXi Proxy Minion Tutorial </topics/tutorials/esxi_proxy_minion>`
+'''
+
+# Import Python libs
+from __future__ import absolute_import
+
+import logging
+
+import salt.exceptions as exceptions
+import salt.ext.six as six
+from salt.config.schemas.esxvm import ESXVirtualMachineConfigSchema
+
+# External libraries
+try:
+    import jsonschema
+    HAS_JSONSCHEMA = True
+except ImportError:
+    HAS_JSONSCHEMA = False
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    return 'esxvm.get_details' in __salt__
+
+
+def vm_configured(name, vm_name, cpu, memory, image, version, interfaces, disks, scsi_devices,
+                  serial_ports, datacenter, datastore, placement, cd_dvd_drives=None,
+                  sata_controllers=None, advanced_configs=None, template=None,
+                  tools=True, power_on=False, deploy=False):
+    '''
+    Selects the correct operation to be executed on a virtual machine, non existing machines
+    will be created, existing ones will be updated if the config differs.
+    '''
+    result = {'name': name,
+              'result': None,
+              'changes': {},
+              'comment': ''}
+
+    log.trace('Validating virtual machine configuration')
+    schema = ESXVirtualMachineConfigSchema.serialize()
+    log.trace('schema = {}'.format(schema))
+    try:
+        jsonschema.validate({'vm_name': vm_name, 'cpu': cpu, 'memory': memory,
+                             'image': image, 'version': version, 'interfaces': interfaces,
+                             'disks': disks, 'scsi_devices': scsi_devices,
+                             'serial_ports': serial_ports, 'cd_dvd_drives': cd_dvd_drives,
+                             'sata_controllers': sata_controllers,
+                             'datacenter': datacenter, 'datastore': datastore,
+                             'placement': placement, 'template': template, 'tools': tools,
+                             'power_on': power_on, 'deploy': deploy}, schema)
+    except jsonschema.exceptions.ValidationError as exc:
+        raise exceptions.InvalidConfigError(exc)
+
+    service_instance = __salt__['vsphere.get_service_instance_via_proxy']()
+    try:
+        __salt__['vsphere.get_vm'](vm_name, vm_properties=['name'], service_instance=service_instance)
+    except exceptions.VMwareObjectRetrievalException:
+        vm_file = __salt__['vsphere.get_vm_config_file'](vm_name, datacenter,
+                                                         placement, datastore,
+                                                         service_instance=service_instance)
+        if vm_file:
+            if __opts__['test']:
+                result.update({'comment': 'The virtual machine {0}'
+                                          ' will be registered.'.format(vm_name)})
+                return result
+            result = vm_registered(vm_name, datacenter, placement, vm_file, power_on=power_on)
+            return result
+        else:
+            if __opts__['test']:
+                result.update({'comment': 'The virtual machine {0}'
+                                          ' will be created.'.format(vm_name)})
+                return result
+            if template:
+                result = vm_cloned(name)
+            else:
+                result = vm_created(name, vm_name, cpu, memory, image, version, interfaces, disks,
+                                    scsi_devices, serial_ports, datacenter, datastore, placement,
+                                    cd_dvd_drives=cd_dvd_drives, advanced_configs=advanced_configs,
+                                    power_on=power_on)
+            return result
+
+    result = vm_updated(name, vm_name, cpu, memory, image, version, interfaces, disks,
+                        scsi_devices, serial_ports, datacenter, datastore,
+                        cd_dvd_drives=cd_dvd_drives, sata_controllers=sata_controllers,
+                        advanced_configs=advanced_configs, power_on=power_on)
+    __salt__['vsphere.disconnect'](service_instance)
+
+    log.trace(result)
+    return result
+
+
+def vm_cloned(name):
+    '''
+    Clones a virtual machine from a template virtual machine if it doesn't exist and a template
+    is defined.
+    '''
+    result = {'name': name,
+              'result': True,
+              'changes': {},
+              'comment': ''}
+
+    return result
+
+
+def vm_updated(name, vm_name, cpu, memory, image, version, interfaces, disks,
+               scsi_devices, serial_ports, datacenter, datastore,
+               cd_dvd_drives=None, sata_controllers=None, advanced_configs=None,
+               power_on=False):
+    '''
+    Updates a virtual machine configuration if there is a difference between the given and
+    deployed configuration.
+    '''
+    result = {'name': name,
+              'result': None,
+              'changes': {},
+              'comment': ''}
+    comment = []
+
+    service_instance = __salt__['vsphere.get_service_instance_via_proxy']()
+    current_config = __salt__['vsphere.get_vm_config'](vm_name,
+                                                       datacenter=datacenter,
+                                                       objects=False,
+                                                       service_instance=service_instance)
+
+    diffs = __salt__['vsphere.compare_vm_configs']({'name': vm_name,
+                                                    'cpu': cpu,
+                                                    'memory': memory,
+                                                    'image': image,
+                                                    'version': version,
+                                                    'interfaces': interfaces,
+                                                    'disks': disks,
+                                                    'scsi_devices': scsi_devices,
+                                                    'serial_ports': serial_ports,
+                                                    'datacenter': datacenter,
+                                                    'datastore': datastore,
+                                                    'cd_drives': cd_dvd_drives,
+                                                    'sata_controllers': sata_controllers,
+                                                    'advanced_configs': advanced_configs},
+                                                   current_config)
+    if not diffs:
+        result.update({
+            'result': True,
+            'changes': None,
+            'comment': 'Virtual machine {0} is already up to date'.format(vm_name)})
+        return result
+
+    if __opts__['test']:
+        comment = 'State vm_updated will update virtual machine \'{0}\' ' \
+                  'in datacenter \'{1}\':\n{2}'.format(
+            vm_name,
+            datacenter,
+            '\n'.join([ ':\n'.join([key, difference.changes_str]) for key, difference in six.iteritems(diffs)]))
+        result.update({'result': None,
+                       'comment': comment})
+        return result
+
+    try:
+        changes = __salt__['vsphere.update_vm'](vm_name, cpu, memory, image, version, interfaces,
+                                                disks, scsi_devices, serial_ports, datacenter,
+                                                datastore, cd_dvd_drives=cd_dvd_drives,
+                                                sata_controllers=sata_controllers,
+                                                advanced_configs=advanced_configs,
+                                                service_instance=service_instance)
+    except exceptions.CommandExecutionError as exc:
+        log.error('Error: {}'.format(str(exc)))
+        if service_instance:
+            __salt__['vsphere.disconnect'](service_instance)
+        result.update({
+            'result': False,
+            'comment': str(exc)})
+        return result
+
+    if power_on:
+        try:
+            __salt__['vsphere.power_on_vm'](vm_name, datacenter)
+        except exceptions.VMwarePowerOnException:
+            pass
+        except exceptions.VMwarePowerOnError as exc:
+            log.error('Error: {}'.format(exc))
+            if service_instance:
+                __salt__['vsphere.disconnect'](service_instance)
+            result.update({
+                'result': False,
+                'comment': str(exc)})
+            return result
+        changes.update({'power_on': True})
+
+    __salt__['vsphere.disconnect'](service_instance)
+
+    result = {'name': name,
+              'result': True,
+              'changes': changes,
+              'comment': 'Virtual machine {0} was updated successfully'.format(vm_name)}
+
+    return result
+
+
+def vm_created(name, vm_name, cpu, memory, image, version, interfaces, disks, scsi_devices,
+               serial_ports, datacenter, datastore, placement, ide_controllers=None,
+               sata_controllers=None, cd_dvd_drives=None, advanced_configs=None, power_on=False):
+    '''
+    Creates a virtual machine with the given properties if it doesn't exist.
+    '''
+    result = {'name': name,
+              'result': None,
+              'changes': {},
+              'comment': ''}
+
+    if __opts__['test']:
+        result.update({'result': None,
+                       'changes': None,
+                       'comment': 'Virtual machine {0} will be created'.format(vm_name)})
+        return result
+
+    service_instance = __salt__['vsphere.get_service_instance_via_proxy']()
+    try:
+        info = __salt__['vsphere.create_vm'](vm_name, cpu, memory, image, version,
+                                             datacenter, datastore, placement,
+                                             interfaces, disks, scsi_devices,
+                                             serial_ports=serial_ports,
+                                             ide_controllers=ide_controllers,
+                                             sata_controllers=sata_controllers,
+                                             cd_drives=cd_dvd_drives,
+                                             advanced_configs=advanced_configs,
+                                             service_instance=service_instance)
+    except exceptions.CommandExecutionError as exc:
+        log.error('Error: {0}'.format(str(exc)))
+        if service_instance:
+            __salt__['vsphere.disconnect'](service_instance)
+        result.update({
+            'result': False,
+            'comment': str(exc)})
+        return result
+
+    if power_on:
+        try:
+            __salt__['vsphere.power_on_vm'](vm_name, datacenter, service_instance=service_instance)
+        except exceptions.VMwarePowerOnException:
+            pass
+        except exceptions.VMwarePowerOnError as exc:
+            log.error('Error: {0}'.format(exc))
+            if service_instance:
+                __salt__['vsphere.disconnect'](service_instance)
+            result.update({
+                'result': False,
+                'comment': str(exc)})
+            return result
+        info['power_on'] = power_on
+
+    changes = {'name': vm_name, 'info': info}
+    __salt__['vsphere.disconnect'](service_instance)
+    result = {'name': name,
+              'result': True,
+              'changes': changes,
+              'comment': 'Virtual machine {0} created successfully'.format(vm_name)}
+
+    return result
+
+
+def vm_registered(vm_name, datacenter, placement, vm_file, power_on=False):
+    '''
+    Registers a virtual machine if the machine files are available on the main datastore.
+    '''
+    result = {'name': vm_name,
+              'result': None,
+              'changes': {},
+              'comment': ''}
+
+    vmx_path = '{0}{1}'.format(vm_file.folderPath, vm_file.file[0].path)
+    log.trace('Registering virtual machine with vmx file: {0}'.format(vmx_path))
+    service_instance = __salt__['vsphere.get_service_instance_via_proxy']()
+    try:
+        __salt__['vsphere.register_vm'](vm_name, datacenter, placement, vmx_path, service_instance=service_instance)
+    except exceptions.VMwareObjectDuplicateException as exc:
+        log.error('Error: {0}'.format(str(exc)))
+        if service_instance:
+            __salt__['vsphere.disconnect'](service_instance)
+        result.update({'result': False,
+                       'comment': str(exc)})
+        return result
+    except exceptions.VMwareVmRegisterError as exc:
+        log.error('Error: {0}'.format(exc))
+        if service_instance:
+            __salt__['vsphere.disconnect'](service_instance)
+        result.update({'result': False,
+                       'comment': str(exc)})
+        return result
+
+    if power_on:
+        try:
+            __salt__['vsphere.power_on_vm'](vm_name, datacenter, service_instance=service_instance)
+        except exceptions.VMwarePowerOnException:
+            pass
+        except exceptions.VMwarePowerOnError as exc:
+            log.error('Error: {0}'.format(exc))
+            if service_instance:
+                __salt__['vsphere.disconnect'](service_instance)
+            result.update({
+                'result': False,
+                'comment': str(exc)})
+            return result
+    __salt__['vsphere.disconnect'](service_instance)
+    result.update({'result': True,
+                   'changes': {'name': vm_name, 'power_on': power_on},
+                   'comment': 'Virtual machine {0} registered successfully'.format(vm_name)})
+
+    return result

--- a/salt/states/esxvm.py
+++ b/salt/states/esxvm.py
@@ -175,7 +175,12 @@ About
 -----
 
 This state module was written to be used in conjunction with Salt's
-:doc:`ESXi Proxy Minion Tutorial </topics/tutorials/esxi_proxy_minion>`
+:mod:`ESXi Proxy Minion <salt.proxy.esxi>` For a tutorial on how to use Salt's
+ESXi Proxy Minion, please refer to the
+:ref:`ESXi Proxy Minion Tutorial <tutorial-esxi-proxy>` for
+configuration examples, dependency installation instructions, how to run remote
+execution functions against ESXi hosts via a Salt Proxy Minion, and a larger state
+example.
 '''
 
 # Import Python libs
@@ -269,7 +274,7 @@ def vm_configured(name, vm_name, cpu, memory, image, version, interfaces,
             service_instance=service_instance)
         if vm_file:
             if __opts__['test']:
-                result.update({'comment': 'The virtual machine {0}' \
+                result.update({'comment': 'The virtual machine {0}'
                                           ' will be registered.'.format(vm_name)})
                 __salt__['vsphere.disconnect'](service_instance)
                 return result
@@ -278,7 +283,7 @@ def vm_configured(name, vm_name, cpu, memory, image, version, interfaces,
             return result
         else:
             if __opts__['test']:
-                result.update({'comment': 'The virtual machine {0}' \
+                result.update({'comment': 'The virtual machine {0}'
                                           ' will be created.'.format(vm_name)})
                 __salt__['vsphere.disconnect'](service_instance)
                 return result
@@ -366,7 +371,7 @@ def vm_updated(name, vm_name, cpu, memory, image, version, interfaces,
         comment = 'State vm_updated will update virtual machine \'{0}\' ' \
                   'in datacenter \'{1}\':\n{2}'.format(vm_name,
                                                        datacenter,
-                  '\n'.join([':\n'.join([key, difference.changes_str]) \
+                  '\n'.join([':\n'.join([key, difference.changes_str])
                       for key, difference in six.iteritems(diffs)]))
         result.update({'result': None,
                        'comment': comment})
@@ -394,8 +399,6 @@ def vm_updated(name, vm_name, cpu, memory, image, version, interfaces,
     if power_on:
         try:
             __salt__['vsphere.power_on_vm'](vm_name, datacenter)
-        except salt.exceptions.VMwarePowerOnError:
-            pass
         except salt.exceptions.VMwarePowerOnError as exc:
             log.error('Error: {}'.format(exc))
             if service_instance:
@@ -411,7 +414,7 @@ def vm_updated(name, vm_name, cpu, memory, image, version, interfaces,
     result = {'name': name,
               'result': True,
               'changes': changes,
-              'comment': 'Virtual machine ' \
+              'comment': 'Virtual machine '
                          '{0} was updated successfully'.format(vm_name)}
 
     return result
@@ -432,7 +435,7 @@ def vm_created(name, vm_name, cpu, memory, image, version, interfaces,
     if __opts__['test']:
         result.update({'result': None,
                        'changes': None,
-                       'comment': 'Virtual machine ' \
+                       'comment': 'Virtual machine '
                                   '{0} will be created'.format(vm_name)})
         return result
 
@@ -461,8 +464,6 @@ def vm_created(name, vm_name, cpu, memory, image, version, interfaces,
         try:
             __salt__['vsphere.power_on_vm'](vm_name, datacenter,
                                             service_instance=service_instance)
-        except salt.exceptions.VMwarePowerOnError:
-            pass
         except salt.exceptions.VMwarePowerOnError as exc:
             log.error('Error: {0}'.format(exc))
             if service_instance:
@@ -478,7 +479,7 @@ def vm_created(name, vm_name, cpu, memory, image, version, interfaces,
     result = {'name': name,
               'result': True,
               'changes': changes,
-              'comment': 'Virtual machine ' \
+              'comment': 'Virtual machine '
                          '{0} created successfully'.format(vm_name)}
 
     return result
@@ -520,8 +521,6 @@ def vm_registered(vm_name, datacenter, placement, vm_file, power_on=False):
         try:
             __salt__['vsphere.power_on_vm'](vm_name, datacenter,
                                             service_instance=service_instance)
-        except salt.exceptions.VMwarePowerOnError:
-            pass
         except salt.exceptions.VMwarePowerOnError as exc:
             log.error('Error: {0}'.format(exc))
             if service_instance:
@@ -533,7 +532,7 @@ def vm_registered(vm_name, datacenter, placement, vm_file, power_on=False):
     __salt__['vsphere.disconnect'](service_instance)
     result.update({'result': True,
                    'changes': {'name': vm_name, 'power_on': power_on},
-                   'comment': 'Virtual machine ' \
+                   'comment': 'Virtual machine '
                               '{0} registered successfully'.format(vm_name)})
 
     return result

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -1027,6 +1027,25 @@ def get_network_adapter_type(adapter_type):
         return vim.vm.device.VirtualE1000e()
 
 
+def get_network_adapter_object_type(adapter_object):
+    '''
+    Returns the network adapter type.
+
+    adapter_object
+        The adapter object from which to obtain the network adapter type.
+    '''
+    if isinstance(adapter_object, vim.vm.device.VirtualVmxnet2):
+        return 'vmxnet2'
+    if isinstance(adapter_object, vim.vm.device.VirtualVmxnet3):
+        return 'vmxnet3'
+    if isinstance(adapter_object, vim.vm.device.VirtualVmxnet):
+        return 'vmxnet'
+    if isinstance(adapter_object, vim.vm.device.VirtualE1000e):
+        return 'e1000e'
+    if isinstance(adapter_object, vim.vm.device.VirtualE1000):
+        return 'e1000'
+
+
 def get_dvss(dc_ref, dvs_names=None, get_all_dvss=False):
     '''
     Returns distributed virtual switches (DVSs) in a datacenter.

--- a/tests/unit/modules/test_vsphere.py
+++ b/tests/unit/modules/test_vsphere.py
@@ -916,7 +916,7 @@ class GetServiceInstanceViaProxyTestCase(TestCase, LoaderModuleMockMixin):
         }
 
     def test_supported_proxies(self):
-        supported_proxies = ['esxi', 'esxcluster', 'esxdatacenter', 'vcenter']
+        supported_proxies = ['esxi', 'esxcluster', 'esxdatacenter', 'vcenter', 'esxvm']
         for proxy_type in supported_proxies:
             with patch('salt.modules.vsphere.get_proxy_type',
                        MagicMock(return_value=proxy_type)):
@@ -959,7 +959,7 @@ class DisconnectTestCase(TestCase, LoaderModuleMockMixin):
         }
 
     def test_supported_proxies(self):
-        supported_proxies = ['esxi', 'esxcluster', 'esxdatacenter', 'vcenter']
+        supported_proxies = ['esxi', 'esxcluster', 'esxdatacenter', 'vcenter', 'esxvm']
         for proxy_type in supported_proxies:
             with patch('salt.modules.vsphere.get_proxy_type',
                        MagicMock(return_value=proxy_type)):
@@ -1000,7 +1000,7 @@ class TestVcenterConnectionTestCase(TestCase, LoaderModuleMockMixin):
         }
 
     def test_supported_proxies(self):
-        supported_proxies = ['esxi', 'esxcluster', 'esxdatacenter', 'vcenter']
+        supported_proxies = ['esxi', 'esxcluster', 'esxdatacenter', 'vcenter', 'esxvm']
         for proxy_type in supported_proxies:
             with patch('salt.modules.vsphere.get_proxy_type',
                        MagicMock(return_value=proxy_type)):
@@ -1076,7 +1076,7 @@ class ListDatacentersViaProxyTestCase(TestCase, LoaderModuleMockMixin):
         }
 
     def test_supported_proxies(self):
-        supported_proxies = ['esxcluster', 'esxdatacenter', 'vcenter']
+        supported_proxies = ['esxcluster', 'esxdatacenter', 'vcenter', 'esxvm']
         for proxy_type in supported_proxies:
             with patch('salt.modules.vsphere.get_proxy_type',
                        MagicMock(return_value=proxy_type)):

--- a/tests/unit/utils/vmware/test_vm.py
+++ b/tests/unit/utils/vmware/test_vm.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+'''
+:codeauthor: :email:`Agnes Tevesz <agnes.tevesz@morganstanley.com>`
+
+Tests for virtual machine related functions in salt.utils.vmware
+'''
+
+# Import python libraries
+from __future__ import absolute_import
+import logging
+
+# Import Salt testing libraries
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import NO_MOCK, NO_MOCK_REASON, patch, MagicMock
+
+from salt.exceptions import VMwareRuntimeError, VMwareApiError, ArgumentValueError
+
+# Import Salt libraries
+import salt.utils.vmware as vmware
+
+# Import Third Party Libs
+try:
+    from pyVmomi import vim, vmodl
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+# Get Logging Started
+log = logging.getLogger(__name__)
+
+# Get Logging Started
+log = logging.getLogger(__name__)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class ConvertToKbTestCase(TestCase):
+    '''Tests for converting units'''
+
+    def setUp(self):
+        pass
+
+    def test_gb_conversion_call(self):
+        self.assertEqual(vmware.convert_to_kb('Gb', 10), {'size': 10485760L, 'unit': 'KB'})
+
+    def test_mb_conversion_call(self):
+        self.assertEqual(vmware.convert_to_kb('Mb', 10), {'size': 10240L, 'unit': 'KB'})
+
+    def test_kb_conversion_call(self):
+        self.assertEqual(vmware.convert_to_kb('Kb', 10), {'size': 10L, 'unit': 'KB'})
+
+    def test_conversion_bad_input_argument_fault(self):
+        self.assertRaises(ArgumentValueError, vmware.convert_to_kb, 'test', 10)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
+@patch('salt.utils.vmware.get_managed_object_name', MagicMock())
+@patch('salt.utils.vmware.wait_for_task', MagicMock())
+class UpdateVirtualMachineTestCase(TestCase):
+    '''Tests for salt.utils.vmware.update_vm'''
+
+    def setUp(self):
+        self.mock_task = MagicMock()
+        self.mock_config_spec = MagicMock()
+        self.mock_vm_update_task = MagicMock(return_value=self.mock_task)
+        self.mock_vm_ref = MagicMock(ReconfigVM_Task=self.mock_vm_update_task)
+
+    def test_update_vm_task_call(self):
+        vmware.update_vm(self.mock_vm_ref, self.mock_config_spec)
+        self.mock_vm_update_task.assert_called_once()
+
+    def test_update_vm_raise_vim_fault(self):
+        exception = vim.fault.VimFault()
+        exception.msg = 'vim.fault.VimFault'
+        self.mock_vm_ref.ReconfigVM_Task = MagicMock(side_effect=exception)
+        with self.assertRaises(VMwareApiError) as exc:
+            vmware.update_vm(self.mock_vm_ref, self.mock_config_spec)
+        self.assertEqual(exc.exception.strerror, 'vim.fault.VimFault')
+
+    def test_destroy_vm_raise_runtime_fault(self):
+        exception = vmodl.RuntimeFault()
+        exception.msg = 'vmodl.RuntimeFault'
+        self.mock_vm_ref.ReconfigVM_Task = MagicMock(side_effect=exception)
+        with self.assertRaises(VMwareRuntimeError) as exc:
+            vmware.update_vm(self.mock_vm_ref, self.mock_config_spec)
+        self.assertEqual(exc.exception.strerror, 'vmodl.RuntimeFault')
+
+    def test_update_vm_wait_for_task(self):
+        mock_wait_for_task = MagicMock()
+        with patch('salt.utils.vmware.get_managed_object_name',
+                   MagicMock(return_value='my_vm')):
+            with patch('salt.utils.vmware.wait_for_task', mock_wait_for_task):
+                vmware.update_vm(self.mock_vm_ref, self.mock_config_spec)
+        mock_wait_for_task.assert_called_once_with(
+            self.mock_task, 'my_vm', 'ReconfigureVM Task')
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
+@patch('salt.utils.vmware.get_managed_object_name', MagicMock())
+@patch('salt.utils.vmware.wait_for_task', MagicMock())
+class DeleteVirtualMachineTestCase(TestCase):
+    '''Tests for salt.utils.vmware.delete_vm'''
+
+    def setUp(self):
+        self.mock_task = MagicMock()
+        self.mock_vm_destroy_task = MagicMock(return_value=self.mock_task)
+        self.mock_vm_ref = MagicMock(Destroy_Task=self.mock_vm_destroy_task)
+
+    def test_destroy_vm_task_call(self):
+        vmware.delete_vm(self.mock_vm_ref)
+        self.mock_vm_destroy_task.assert_called_once()
+
+    def test_destroy_vm_raise_vim_fault(self):
+        exception = vim.fault.VimFault()
+        exception.msg = 'vim.fault.VimFault'
+        self.mock_vm_ref.Destroy_Task = MagicMock(side_effect=exception)
+        with self.assertRaises(VMwareApiError) as exc:
+            vmware.delete_vm(self.mock_vm_ref)
+        self.assertEqual(exc.exception.strerror, 'vim.fault.VimFault')
+
+    def test_destroy_vm_raise_runtime_fault(self):
+        exception = vmodl.RuntimeFault()
+        exception.msg = 'vmodl.RuntimeFault'
+        self.mock_vm_ref.Destroy_Task = MagicMock(side_effect=exception)
+        with self.assertRaises(VMwareRuntimeError) as exc:
+            vmware.delete_vm(self.mock_vm_ref)
+        self.assertEqual(exc.exception.strerror, 'vmodl.RuntimeFault')
+
+    def test_destroy_vm_wait_for_task(self):
+        mock_wait_for_task = MagicMock()
+        with patch('salt.utils.vmware.get_managed_object_name',
+                   MagicMock(return_value='my_vm')):
+            with patch('salt.utils.vmware.wait_for_task', mock_wait_for_task):
+                vmware.delete_vm(self.mock_vm_ref)
+        mock_wait_for_task.assert_called_once_with(
+            self.mock_task, 'my_vm', 'Destroy Task')
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(not HAS_PYVMOMI, 'The \'pyvmomi\' library is missing')
+@patch('salt.utils.vmware.get_managed_object_name', MagicMock())
+class UnregisterVirtualMachineTestCase(TestCase):
+    '''Tests for salt.utils.vmware.unregister_vm'''
+
+    def setUp(self):
+        self.mock_vm_unregister = MagicMock()
+        self.mock_vm_ref = MagicMock(UnregisterVM=self.mock_vm_unregister)
+
+    def test_unregister_vm_task_call(self):
+        vmware.unregister_vm(self.mock_vm_ref)
+        self.mock_vm_unregister.assert_called_once()
+
+    def test_unregister_vm_raise_vim_fault(self):
+        exception = vim.fault.VimFault()
+        exception.msg = 'vim.fault.VimFault'
+        self.mock_vm_ref.UnregisterVM = MagicMock(side_effect=exception)
+        with self.assertRaises(VMwareApiError) as exc:
+            vmware.unregister_vm(self.mock_vm_ref)
+        self.assertEqual(exc.exception.strerror, 'vim.fault.VimFault')
+
+    def test_unregister_vm_raise_runtime_fault(self):
+        exception = vmodl.RuntimeFault()
+        exception.msg = 'vmodl.RuntimeFault'
+        self.mock_vm_ref.UnregisterVM = MagicMock(side_effect=exception)
+        with self.assertRaises(VMwareRuntimeError) as exc:
+            vmware.unregister_vm(self.mock_vm_ref)
+        self.assertEqual(exc.exception.strerror, 'vmodl.RuntimeFault')

--- a/tests/unit/utils/vmware/test_vm.py
+++ b/tests/unit/utils/vmware/test_vm.py
@@ -37,13 +37,13 @@ class ConvertToKbTestCase(TestCase):
         pass
 
     def test_gb_conversion_call(self):
-        self.assertEqual(vmware.convert_to_kb('Gb', 10), {'size': 10485760L, 'unit': 'KB'})
+        self.assertEqual(vmware.convert_to_kb('Gb', 10), {'size': int(10485760), 'unit': 'KB'})
 
     def test_mb_conversion_call(self):
-        self.assertEqual(vmware.convert_to_kb('Mb', 10), {'size': 10240L, 'unit': 'KB'})
+        self.assertEqual(vmware.convert_to_kb('Mb', 10), {'size': int(10240), 'unit': 'KB'})
 
     def test_kb_conversion_call(self):
-        self.assertEqual(vmware.convert_to_kb('Kb', 10), {'size': 10L, 'unit': 'KB'})
+        self.assertEqual(vmware.convert_to_kb('Kb', 10), {'size': int(10), 'unit': 'KB'})
 
     def test_conversion_bad_input_argument_fault(self):
         self.assertRaises(ArgumentValueError, vmware.convert_to_kb, 'test', 10)
@@ -110,7 +110,7 @@ class CreateVirtualMachineTestCase(TestCase):
             vmware.create_vm(self.vm_name, self.mock_config_spec,
                              self.mock_folder_object, self.mock_resourcepool_object)
         mock_wait_for_task.assert_called_once_with(
-            self.mock_task, self.vm_name,  'CreateVM Task', 10, 'info')
+            self.mock_task, self.vm_name, 'CreateVM Task', 10, 'info')
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)


### PR DESCRIPTION
### What does this PR do?
Adds Vmware ESXi virtual machine management capability with state module, you can create, update and register a machine through a vCenter server. Also a new proxy minion type: esxvm got introduced. Based on a state file now you are able to provision a vm with given parameters and with an esxvm proxy you are able to manage a vm through a full life cycle. 

### What issues does this PR fix or reference?
None

### Previous Behavior
Virtual machine creation was only available with a cloud module.

### New Behavior
With states you can provision your vm with an esxvm proxy minion. You can also delete and remove it from the vCenter inventory.

### Tests written?

Yes, but just partial coverage is available

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
