### PR TITLE
[develop] Updates to scheduler to deal with loop_interval

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -953,6 +953,8 @@ class Schedule(object):
         Evaluate and execute the schedule
         '''
 
+        log.trace('==== evaluating schedule =====')
+
         def _splay(splaytime):
             '''
             Calculate splaytime
@@ -1011,6 +1013,7 @@ class Schedule(object):
                     '_run_on_start' not in data:
                 data['_run_on_start'] = True
 
+            # Current time
             now = int(time.time())
 
             if 'until' in data:
@@ -1153,10 +1156,11 @@ class Schedule(object):
 
                     # Copy the list so we can loop through it
                     for i in copy.deepcopy(_when):
-                        if i < now and len(_when) > 1:
-                            # Remove all missed schedules except the latest one.
-                            # We need it to detect if it was triggered previously.
-                            _when.remove(i)
+                        if len(_when) > 1:
+                            if i < now - self.opts['loop_interval']:
+                                # Remove all missed schedules except the latest one.
+                                # We need it to detect if it was triggered previously.
+                                _when.remove(i)
 
                     if _when:
                         # Grab the first element, which is the next run time or
@@ -1258,19 +1262,21 @@ class Schedule(object):
             seconds = data['_next_fire_time'] - now
             if data['_splay']:
                 seconds = data['_splay'] - now
-            if seconds <= 0:
-                if '_seconds' in data:
+            if '_seconds' in data:
+                if seconds <= 0:
                     run = True
-                elif 'when' in data and data['_run']:
+            elif 'when' in data and data['_run']:
+                if data['_next_fire_time'] <= now <= (data['_next_fire_time'] + self.opts['loop_interval']):
                     data['_run'] = False
                     run = True
-                elif 'cron' in data:
-                    # Reset next scheduled time because it is in the past now,
-                    # and we should trigger the job run, then wait for the next one.
+            elif 'cron' in data:
+                # Reset next scheduled time because it is in the past now,
+                # and we should trigger the job run, then wait for the next one.
+                if seconds <= 0:
                     data['_next_fire_time'] = None
                     run = True
-                elif seconds == 0:
-                    run = True
+            elif seconds == 0:
+                run = True
 
             if '_run_on_start' in data and data['_run_on_start']:
                 run = True
@@ -1374,6 +1380,7 @@ class Schedule(object):
             finally:
                 if '_seconds' in data:
                     data['_next_fire_time'] = now + data['_seconds']
+                data['_last_run'] = now
                 data['_splay'] = None
             if salt.utils.platform.is_windows():
                 # Restore our function references.


### PR DESCRIPTION
### What does this PR do?
Updating scheduler options such as when to account for situations when the loop_interval is not 1 second, eg. when running on the master.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Previously if a job was scheduled using the when argument and the loop_interval was anything but 1 second then the job would not fire unless the particular daemon, eg. the master, was started exactly on the hour.

### New Behavior
When a job is scheduled using the when argument we look at a time range starting at when the job should fire and that time plus the loop_interval, if the current time fails into that range then the job will fire.

### Tests written?
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
