### PR TITLE
DoubleBugfix: a) errors in external pillar causes crash, b) highstate crashes on certain SLS scenarios

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1006,7 +1006,6 @@ def highstate(test=None, queue=False, **kwargs):
     if 'pillarenv' in kwargs:
         opts['pillarenv'] = kwargs['pillarenv']
 
-    pillar = kwargs.get('pillar')
     pillar_override = kwargs.get('pillar')
     pillar_enc = kwargs.get('pillar_enc')
     if pillar_enc is None \
@@ -1057,13 +1056,13 @@ def highstate(test=None, queue=False, **kwargs):
             kwargs.get('terse')):
         ret = _filter_running(ret)
 
-    serial = salt.payload.Serial(__opts__)
-    cache_file = os.path.join(__opts__['cachedir'], 'highstate.p')
     _set_retcode(ret, highstate=st_.building_highstate)
+    _snapper_post(opts, kwargs.get('__pub_jid', 'called localy'), snapper_pre)
+
     # Work around Windows multiprocessing bug, set __opts__['test'] back to
     # value from before this function was run.
-    _snapper_post(opts, kwargs.get('__pub_jid', 'called localy'), snapper_pre)
     __opts__['test'] = orig_test
+
     return ret
 
 

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -991,10 +991,9 @@ def highstate(test=None, queue=False, **kwargs):
     conflict = _check_queue(queue, kwargs)
     if conflict is not None:
         return conflict
+
     orig_test = __opts__.get('test', None)
-
     opts = salt.utils.state.get_sls_opts(__opts__, **kwargs)
-
     opts['test'] = _get_test_value(test, **kwargs)
 
     if 'env' in kwargs:

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1041,7 +1041,6 @@ def highstate(test=None, queue=False, **kwargs):
         return ['Pillar failed to render with the following messages:'] + errors
 
     st_.push_active()
-    ret = {}
     orchestration_jid = kwargs.get('orchestration_jid')
     snapper_pre = _snapper_pre(opts, kwargs.get('__pub_jid', 'called localy'))
     try:

--- a/salt/state.py
+++ b/salt/state.py
@@ -1049,66 +1049,6 @@ class State(object):
         elif data['state'] in ('pkg', 'ports'):
             self.module_refresh()
 
-    @staticmethod
-    def verify_ret(ret):
-        '''
-        Perform basic verification of the raw state return data
-        '''
-        if not isinstance(ret, dict):
-            raise SaltException(
-                'Malformed state return, return must be a dict'
-            )
-        bad = []
-        for val in ['name', 'result', 'changes', 'comment']:
-            if val not in ret:
-                bad.append(val)
-        if bad:
-            m = 'The following keys were not present in the state return: {0}'
-            raise SaltException(m.format(','.join(bad)))
-
-    @staticmethod
-    def munge_ret_for_export(ret):
-        '''
-        Process raw state return data to make it suitable for export,
-        to ensure consistency of the data format seen by external systems
-        '''
-        # We support lists of strings for ret['comment'] internal
-        # to the state system for improved ergonomics.
-        # However, to maintain backwards compatability with external tools,
-        # the list representation is not allowed to leave the state system,
-        # and should be converted like this at external boundaries.
-        if isinstance(ret['comment'], list):
-            ret['comment'] = '\n'.join(ret['comment'])
-
-    @staticmethod
-    def verify_ret_for_export(ret):
-        '''
-        Verify the state return data for export outside the state system
-        '''
-        State.verify_ret(ret)
-
-        for key in ['name', 'comment']:
-            if not isinstance(ret[key], six.string_types):
-                msg = (
-                    'The value for the {0} key in the state return '
-                    'must be a string, found {1}'
-                )
-                raise SaltException(msg.format(key, repr(ret[key])))
-
-        if ret['result'] not in [True, False, None]:
-            msg = (
-                'The value for the result key in the state return '
-                'must be True, False, or None, found {0}'
-            )
-            raise SaltException(msg.format(repr(ret['result'])))
-
-        if not isinstance(ret['changes'], dict):
-            msg = (
-                'The value for the changes key in the state return '
-                'must be a dict, found {0}'
-            )
-            raise SaltException(msg.format(repr(ret['changes'])))
-
     def verify_data(self, data):
         '''
         Verify the data, return an error statement if something is wrong
@@ -1996,8 +1936,6 @@ class State(object):
                 self.states.inject_globals = {}
             if 'check_cmd' in low and '{0[state]}.mod_run_check_cmd'.format(low) not in self.states:
                 ret.update(self._run_check_cmd(low))
-            self.verify_ret(ret)
-            self.munge_ret_for_export(ret)
         except Exception:
             trb = traceback.format_exc()
             # There are a number of possibilities to not have the cdata

--- a/salt/state.py
+++ b/salt/state.py
@@ -676,6 +676,39 @@ class Compiler(object):
         return high
 
 
+def state_output_check(func):
+    '''
+    Checks for specific types in the state output.
+    Raises an Exception in case particular rule is broken.
+
+    :param func:
+    :return:
+    '''
+    def _func(*args, **kwargs):
+        '''
+        Ruleset.
+        '''
+        err_msg = []
+        result = func(*args, **kwargs)
+        if not isinstance(result, dict):
+            err_msg.append('Malformed state return, return must be a dict.')
+        if not isinstance(result.get('changes'), dict):
+            err_msg.append("'Changes' should be a dictionary.")
+
+        missing = []
+        for val in ['name', 'result', 'changes', 'comment']:
+            if val not in result:
+                missing.append(val)
+        if missing:
+            err_msg.append('The following keys were not present in the state return: {0}.'.format(', '.join(missing)))
+
+        if err_msg:
+            raise SaltException(' '.join(err_msg))
+        return result
+
+    return _func
+
+
 def state_output_unificator(func):
     '''
     While comments as a list are allowed,

--- a/salt/state.py
+++ b/salt/state.py
@@ -1864,6 +1864,8 @@ class State(object):
                 'proc': proc}
         return ret
 
+    @state_output_check
+    @state_output_unificator
     def call(self, low, chunks=None, running=None, retries=1):
         '''
         Call a state directly with the low data structure, verify data

--- a/salt/state.py
+++ b/salt/state.py
@@ -1874,7 +1874,7 @@ class State(object):
                     else:
                         self.format_slots(cdata)
                         ret = self.states[cdata['full']](*cdata['args'],
-                                                          **cdata['kwargs'])
+                                                         **cdata['kwargs'])
                 self.states.inject_globals = {}
             if 'check_cmd' in low and '{0[state]}.mod_run_check_cmd'.format(low) not in self.states:
                 ret.update(self._run_check_cmd(low))

--- a/salt/state.py
+++ b/salt/state.py
@@ -676,6 +676,31 @@ class Compiler(object):
         return high
 
 
+def state_output_unificator(func):
+    '''
+    While comments as a list are allowed,
+    comments needs to be strings for backward compatibility.
+    See such claim here: https://github.com/saltstack/salt/pull/43070
+
+    Rules applied:
+      - 'comment' is joined into a multi-line string, in case the value is a list.
+      - 'result' should be always either True, False or None.
+
+    :param func: module function
+    :return: Joins 'comment' list into a multi-line string
+    '''
+    def _func(*args, **kwargs):
+        result = func(*args, **kwargs)
+        if isinstance(result.get('comment'), list):
+            result['comment'] = '\n'.join([str(elm) for elm in result['comment']])
+        if result.get('result') is not None:
+            result['result'] = bool(result['result'])
+
+        return result
+
+    return _func
+
+
 class State(object):
     '''
     Class used to execute salt states

--- a/salt/state.py
+++ b/salt/state.py
@@ -1746,8 +1746,6 @@ class State(object):
                 'proc': proc}
         return ret
 
-    @salt.utils.decorators.state.state_output_check
-    @salt.utils.decorators.state.state_output_unifier
     def call(self, low, chunks=None, running=None, retries=1):
         '''
         Call a state directly with the low data structure, verify data

--- a/salt/state.py
+++ b/salt/state.py
@@ -1905,6 +1905,9 @@ class State(object):
             self.state_con.pop('runas', None)
             self.state_con.pop('runas_password', None)
 
+        if not isinstance(ret, dict):
+            return ret
+
         # If format_call got any warnings, let's show them to the user
         if 'warnings' in cdata:
             ret.setdefault('warnings', []).extend(cdata['warnings'])

--- a/salt/state.py
+++ b/salt/state.py
@@ -33,6 +33,7 @@ import salt.pillar
 import salt.fileclient
 import salt.utils.args
 import salt.utils.crypt
+import salt.utils.decorators.state
 import salt.utils.dictupdate
 import salt.utils.event
 import salt.utils.files
@@ -1746,8 +1747,8 @@ class State(object):
                 'proc': proc}
         return ret
 
-    @state_output_check
-    @state_output_unificator
+    @salt.utils.decorators.state.state_output_check
+    @salt.utils.decorators.state.state_output_unificator
     def call(self, low, chunks=None, running=None, retries=1):
         '''
         Call a state directly with the low data structure, verify data

--- a/salt/state.py
+++ b/salt/state.py
@@ -44,7 +44,6 @@ import salt.utils.url
 import salt.syspaths as syspaths
 from salt.template import compile_template, compile_template_str
 from salt.exceptions import (
-    SaltException,
     SaltRenderError,
     SaltReqTimeoutError
 )

--- a/salt/state.py
+++ b/salt/state.py
@@ -1747,7 +1747,7 @@ class State(object):
         return ret
 
     @salt.utils.decorators.state.state_output_check
-    @salt.utils.decorators.state.state_output_unificator
+    @salt.utils.decorators.state.state_output_unifier
     def call(self, low, chunks=None, running=None, retries=1):
         '''
         Call a state directly with the low data structure, verify data

--- a/salt/state.py
+++ b/salt/state.py
@@ -676,64 +676,6 @@ class Compiler(object):
         return high
 
 
-def state_output_check(func):
-    '''
-    Checks for specific types in the state output.
-    Raises an Exception in case particular rule is broken.
-
-    :param func:
-    :return:
-    '''
-    def _func(*args, **kwargs):
-        '''
-        Ruleset.
-        '''
-        err_msg = []
-        result = func(*args, **kwargs)
-        if not isinstance(result, dict):
-            err_msg.append('Malformed state return, return must be a dict.')
-        if not isinstance(result.get('changes'), dict):
-            err_msg.append("'Changes' should be a dictionary.")
-
-        missing = []
-        for val in ['name', 'result', 'changes', 'comment']:
-            if val not in result:
-                missing.append(val)
-        if missing:
-            err_msg.append('The following keys were not present in the state return: {0}.'.format(', '.join(missing)))
-
-        if err_msg:
-            raise SaltException(' '.join(err_msg))
-        return result
-
-    return _func
-
-
-def state_output_unificator(func):
-    '''
-    While comments as a list are allowed,
-    comments needs to be strings for backward compatibility.
-    See such claim here: https://github.com/saltstack/salt/pull/43070
-
-    Rules applied:
-      - 'comment' is joined into a multi-line string, in case the value is a list.
-      - 'result' should be always either True, False or None.
-
-    :param func: module function
-    :return: Joins 'comment' list into a multi-line string
-    '''
-    def _func(*args, **kwargs):
-        result = func(*args, **kwargs)
-        if isinstance(result.get('comment'), list):
-            result['comment'] = '\n'.join([str(elm) for elm in result['comment']])
-        if result.get('result') is not None:
-            result['result'] = bool(result['result'])
-
-        return result
-
-    return _func
-
-
 class State(object):
     '''
     Class used to execute salt states

--- a/salt/state.py
+++ b/salt/state.py
@@ -1900,8 +1900,7 @@ class State(object):
             }
         finally:
             if low.get('__prereq__'):
-                sys.modules[self.states[cdata['full']].__module__].__opts__[
-                    'test'] = test
+                sys.modules[self.states[cdata['full']].__module__].__opts__['test'] = test
 
             self.state_con.pop('runas', None)
             self.state_con.pop('runas_password', None)

--- a/salt/state.py
+++ b/salt/state.py
@@ -1905,7 +1905,6 @@ class State(object):
 
             self.state_con.pop('runas', None)
             self.state_con.pop('runas_password', None)
-            self.verify_ret_for_export(ret)
 
         # If format_call got any warnings, let's show them to the user
         if 'warnings' in cdata:

--- a/salt/state.py
+++ b/salt/state.py
@@ -1746,6 +1746,7 @@ class State(object):
                 'proc': proc}
         return ret
 
+    @salt.utils.decorators.state.OutputUnifier('content_check', 'unify')
     def call(self, low, chunks=None, running=None, retries=1):
         '''
         Call a state directly with the low data structure, verify data

--- a/salt/utils/decorators/state.py
+++ b/salt/utils/decorators/state.py
@@ -43,7 +43,7 @@ def state_output_check(func):
     return _func
 
 
-def state_output_unificator(func):
+def state_output_unifier(func):
     '''
     While comments as a list are allowed,
     comments needs to be strings for backward compatibility.

--- a/salt/utils/decorators/state.py
+++ b/salt/utils/decorators/state.py
@@ -5,6 +5,7 @@ Decorators for salt.state
 :codeauthor: :email:`Bo Maryniuk (bo@suse.de)`
 '''
 
+from __future__ import absolute_import
 from salt.exceptions import SaltException
 
 

--- a/salt/utils/decorators/state.py
+++ b/salt/utils/decorators/state.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+'''
+Decorators for salt.state
+
+:codeauthor: :email:`Bo Maryniuk (bo@suse.de)`
+'''
+
+from salt.exceptions import SaltException
+
+
+def state_output_check(func):
+    '''
+    Checks for specific types in the state output.
+    Raises an Exception in case particular rule is broken.
+
+    :param func:
+    :return:
+    '''
+    def _func(*args, **kwargs):
+        '''
+        Ruleset.
+        '''
+        result = func(*args, **kwargs)
+        print('is instance of dict:', isinstance(result, dict), 'result:', result)
+
+        if not isinstance(result, dict):
+            err_msg = 'Malformed state return, return must be a dict.'
+        elif not isinstance(result.get('changes'), dict):
+            err_msg = "'Changes' should be a dictionary."
+        else:
+            missing = []
+            for val in ['name', 'result', 'changes', 'comment']:
+                if val not in result:
+                    missing.append(val)
+            if missing:
+                err_msg = 'The following keys were not present in the state return: {0}.'.format(', '.join(missing))
+            else:
+                err_msg = None
+
+        if err_msg:
+            raise SaltException(err_msg)
+        return result
+
+    return _func
+
+
+def state_output_unificator(func):
+    '''
+    While comments as a list are allowed,
+    comments needs to be strings for backward compatibility.
+    See such claim here: https://github.com/saltstack/salt/pull/43070
+
+    Rules applied:
+      - 'comment' is joined into a multi-line string, in case the value is a list.
+      - 'result' should be always either True, False or None.
+
+    :param func: module function
+    :return: Joins 'comment' list into a multi-line string
+    '''
+    def _func(*args, **kwargs):
+        result = func(*args, **kwargs)
+        if isinstance(result.get('comment'), list):
+            result['comment'] = '\n'.join([str(elm) for elm in result['comment']])
+        if result.get('result') is not None:
+            result['result'] = bool(result['result'])
+
+        return result
+
+    return _func

--- a/salt/utils/decorators/state.py
+++ b/salt/utils/decorators/state.py
@@ -5,7 +5,7 @@ Decorators for salt.state
 :codeauthor: :email:`Bo Maryniuk (bo@suse.de)`
 '''
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 from salt.exceptions import SaltException
 
 

--- a/salt/utils/decorators/state.py
+++ b/salt/utils/decorators/state.py
@@ -22,8 +22,6 @@ def state_output_check(func):
         Ruleset.
         '''
         result = func(*args, **kwargs)
-        print('is instance of dict:', isinstance(result, dict), 'result:', result)
-
         if not isinstance(result, dict):
             err_msg = 'Malformed state return, return must be a dict.'
         elif not isinstance(result.get('changes'), dict):

--- a/tests/integration/states/test_handle_error.py
+++ b/tests/integration/states/test_handle_error.py
@@ -4,7 +4,7 @@ tests for host state
 '''
 
 # Import Python libs
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
@@ -14,14 +14,11 @@ class HandleErrorTest(ModuleCase):
     '''
     Validate that ordering works correctly
     '''
-    def test_handle_error(self):
+    def test_function_do_not_return_dictionary_type(self):
         '''
-        Test how an error can be recovered
+        Handling a case when function returns anything but a dictionary type
         '''
-        # without sync_states, the custom state may not be installed
-        # (resulting in :
-        # State salttest.hello found in sls issue-... is unavailable
         ret = self.run_function('state.sls', ['issue-9983-handleerror'])
-        self.assertTrue(
-            'An exception occurred in this state: Traceback'
-            in ret[[a for a in ret][0]]['comment'])
+        self.assertTrue('Data must be a dictionary type' in ret[[a for a in ret][0]]['comment'])
+        self.assertTrue(not ret[[a for a in ret][0]]['result'])
+        self.assertTrue(ret[[a for a in ret][0]]['changes'] == {})

--- a/tests/unit/modules/test_state.py
+++ b/tests/unit/modules/test_state.py
@@ -1034,6 +1034,11 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                     self.assertEqual(state.pkg(tar_file, 0, "md5"), True)
 
                 MockTarFile.path = ""
+<<<<<<< HEAD
+=======
+                MockJson.flag = False
+
+>>>>>>> Add unit test for _get_pillar_errors when external and internal pillars are clean
                 if six.PY2:
                     with patch('salt.utils.files.fopen', mock_open()), \
                             patch.dict(state.__utils__, {'state.check_result': MagicMock(return_value=True)}):

--- a/tests/unit/modules/test_state.py
+++ b/tests/unit/modules/test_state.py
@@ -1034,11 +1034,6 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
                     self.assertEqual(state.pkg(tar_file, 0, "md5"), True)
 
                 MockTarFile.path = ""
-<<<<<<< HEAD
-=======
-                MockJson.flag = False
-
->>>>>>> Add unit test for _get_pillar_errors when external and internal pillars are clean
                 if six.PY2:
                     with patch('salt.utils.files.fopen', mock_open()), \
                             patch.dict(state.__utils__, {'state.check_result': MagicMock(return_value=True)}):

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -21,7 +21,6 @@ from tests.support.mixins import AdaptedConfigurationTestCaseMixin
 
 # Import Salt libs
 import salt.exceptions
-from salt.ext import six
 import salt.state
 from salt.utils.odict import OrderedDict, DefaultOrderedDict
 from salt.utils.decorators import state as statedecorators

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -534,6 +534,14 @@ class StateReturnsTestCase(TestCase):
         expected = 'data\nin\nthe\nlist'
         assert statedecorators.state_output_unificator(lambda: data)()['comment'] == expected
 
+    def test_state_output_unificator_result_converted_to_true(self):
+        '''
+        Test for output is unified so the comment is converted to a multi-line string
+        :return:
+        '''
+        data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': 'Fantastic'}
+        assert statedecorators.state_output_unificator(lambda: data)()['result'] is True
+
 
 class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     '''

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -533,6 +533,15 @@ class StateReturnsTestCase(TestCase):
             statedecorators.state_output_check(lambda: data)()
         assert ' The following keys were not present in the state return: name, result, comment' in str(err)
 
+    def test_state_output_unificator_comment_is_not_list(self):
+        '''
+        Test that changes key contains a dictionary.
+        :return:
+        '''
+        data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': 'fantastic!'}
+        expected = {'comment': 'data\nin\nthe\nlist', 'changes': {}, 'name': None, 'result': True}
+        assert statedecorators.state_output_unificator(lambda: data)() == expected
+
 
 class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     '''

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -24,7 +24,12 @@ import salt.exceptions
 from salt.ext import six
 import salt.state
 from salt.utils.odict import OrderedDict, DefaultOrderedDict
+from salt.utils.decorators import state as statedecorators
 
+try:
+    import pytest
+except ImportError as err:
+    pytest = None
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
@@ -479,6 +484,8 @@ class TopFileMergeTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         self.assertEqual(merged_tops, expected_merge)
 
 
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(pytest is None, 'PyTest is missing')
 class StateReturnsTestCase(TestCase):
     '''
     TestCase for code handling state returns.

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -521,7 +521,7 @@ class StateReturnsTestCase(TestCase):
             statedecorators.state_output_check(lambda: data)()
         assert ' The following keys were not present in the state return: name, result, comment' in str(err)
 
-    def test_state_output_unificator_comment_is_not_list(self):
+    def test_state_output_unifier_comment_is_not_list(self):
         '''
         Test for output is unified so the comment is converted to a multi-line string
         :return:
@@ -532,23 +532,23 @@ class StateReturnsTestCase(TestCase):
 
         data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': None}
         expected = 'data\nin\nthe\nlist'
-        assert statedecorators.state_output_unificator(lambda: data)()['comment'] == expected
+        assert statedecorators.state_output_unifier(lambda: data)()['comment'] == expected
 
-    def test_state_output_unificator_result_converted_to_true(self):
+    def test_state_output_unifier_result_converted_to_true(self):
         '''
         Test for output is unified so the result is converted to True
         :return:
         '''
         data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': 'Fantastic'}
-        assert statedecorators.state_output_unificator(lambda: data)()['result'] is True
+        assert statedecorators.state_output_unifier(lambda: data)()['result'] is True
 
-    def test_state_output_unificator_result_converted_to_false(self):
+    def test_state_output_unifier_result_converted_to_false(self):
         '''
         Test for output is unified so the result is converted to False
         :return:
         '''
         data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': ''}
-        assert statedecorators.state_output_unificator(lambda: data)()['result'] is False
+        assert statedecorators.state_output_unifier(lambda: data)()['result'] is False
 
 
 class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -542,6 +542,14 @@ class StateReturnsTestCase(TestCase):
         data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': 'Fantastic'}
         assert statedecorators.state_output_unificator(lambda: data)()['result'] is True
 
+    def test_state_output_unificator_result_converted_to_false(self):
+        '''
+        Test for output is unified so the result is converted to False
+        :return:
+        '''
+        data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': ''}
+        assert statedecorators.state_output_unificator(lambda: data)()['result'] is False
+
 
 class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     '''

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -530,6 +530,10 @@ class StateReturnsTestCase(TestCase):
         expected = {'comment': 'data\nin\nthe\nlist', 'changes': {}, 'name': None, 'result': True}
         assert statedecorators.state_output_unificator(lambda: data)() == expected
 
+        data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': None}
+        expected = 'data\nin\nthe\nlist'
+        assert statedecorators.state_output_unificator(lambda: data)()['comment'] == expected
+
 
 class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     '''

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -536,7 +536,7 @@ class StateReturnsTestCase(TestCase):
 
     def test_state_output_unificator_result_converted_to_true(self):
         '''
-        Test for output is unified so the comment is converted to a multi-line string
+        Test for output is unified so the result is converted to True
         :return:
         '''
         data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': 'Fantastic'}

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -523,6 +523,16 @@ class StateReturnsTestCase(TestCase):
             statedecorators.state_output_check(lambda: data)()
         assert 'Malformed state return, return must be a dict' in str(err)
 
+    def test_state_output_check_return_is_dict(self):
+        '''
+        Test that changes key contains a dictionary.
+        :return:
+        '''
+        data = {'arbitrary': 'data', 'changes': {}}
+        with pytest.raises(salt.exceptions.SaltException) as err:
+            statedecorators.state_output_check(lambda: data)()
+        assert ' The following keys were not present in the state return: name, result, comment' in str(err)
+
 
 class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     '''

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -511,7 +511,7 @@ class StateReturnsTestCase(TestCase):
             statedecorators.state_output_check(lambda: data)()
         assert 'Malformed state return, return must be a dict' in str(err)
 
-    def test_state_output_check_return_is_dict(self):
+    def test_state_output_check_return_has_nrc(self):
         '''
         Test for name/result/comment keys are inside the return.
         :return:

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -497,9 +497,9 @@ class StateReturnsTestCase(TestCase):
         :return:
         '''
         data = {'changes': []}
-        with pytest.raises(salt.exceptions.SaltException) as err:
-            statedecorators.state_output_check(lambda: data)()
-        assert "'Changes' should be a dictionary" in str(err)
+        out = statedecorators.OutputUnifier('content_check')(lambda: data)()
+        assert "'Changes' should be a dictionary" in out['comment']
+        assert not out['result']
 
     def test_state_output_check_return_is_dict(self):
         '''
@@ -507,9 +507,9 @@ class StateReturnsTestCase(TestCase):
         :return:
         '''
         data = ['whatever']
-        with pytest.raises(salt.exceptions.SaltException) as err:
-            statedecorators.state_output_check(lambda: data)()
-        assert 'Malformed state return, return must be a dict' in str(err)
+        out = statedecorators.OutputUnifier('content_check')(lambda: data)()
+        assert 'Malformed state return. Data must be a dictionary type' in out['comment']
+        assert not out['result']
 
     def test_state_output_check_return_has_nrc(self):
         '''
@@ -517,9 +517,9 @@ class StateReturnsTestCase(TestCase):
         :return:
         '''
         data = {'arbitrary': 'data', 'changes': {}}
-        with pytest.raises(salt.exceptions.SaltException) as err:
-            statedecorators.state_output_check(lambda: data)()
-        assert ' The following keys were not present in the state return: name, result, comment' in str(err)
+        out = statedecorators.OutputUnifier('content_check')(lambda: data)()
+        assert ' The following keys were not present in the state return: name, result, comment' in out['comment']
+        assert not out['result']
 
     def test_state_output_unifier_comment_is_not_list(self):
         '''
@@ -528,11 +528,11 @@ class StateReturnsTestCase(TestCase):
         '''
         data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': 'fantastic!'}
         expected = {'comment': 'data\nin\nthe\nlist', 'changes': {}, 'name': None, 'result': True}
-        assert statedecorators.state_output_unifier(lambda: data)() == expected
+        assert statedecorators.OutputUnifier('unify')(lambda: data)() == expected
 
         data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': None}
         expected = 'data\nin\nthe\nlist'
-        assert statedecorators.state_output_unifier(lambda: data)()['comment'] == expected
+        assert statedecorators.OutputUnifier('unify')(lambda: data)()['comment'] == expected
 
     def test_state_output_unifier_result_converted_to_true(self):
         '''
@@ -540,7 +540,7 @@ class StateReturnsTestCase(TestCase):
         :return:
         '''
         data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': 'Fantastic'}
-        assert statedecorators.state_output_unifier(lambda: data)()['result'] is True
+        assert statedecorators.OutputUnifier('unify')(lambda: data)()['result'] is True
 
     def test_state_output_unifier_result_converted_to_false(self):
         '''
@@ -548,7 +548,7 @@ class StateReturnsTestCase(TestCase):
         :return:
         '''
         data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': ''}
-        assert statedecorators.state_output_unifier(lambda: data)()['result'] is False
+        assert statedecorators.OutputUnifier('unify')(lambda: data)()['result'] is False
 
 
 class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -491,18 +491,6 @@ class StateReturnsTestCase(TestCase):
     TestCase for code handling state returns.
     '''
 
-    def test_comment_lists_are_converted_to_string(self):
-        '''
-        Tests that states returning a list of comments
-        have that converted to a single string
-        '''
-        ret = {
-            'name': 'myresource',
-            'result': True,
-            'comment': ['comment 1', 'comment 2'],
-            'changes': {},
-        }
-
     def test_state_output_check_changes_is_dict(self):
         '''
         Test that changes key contains a dictionary.

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -528,7 +528,7 @@ class StateReturnsTestCase(TestCase):
         '''
         data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': 'fantastic!'}
         expected = {'comment': 'data\nin\nthe\nlist', 'changes': {}, 'name': None, 'result': True}
-        assert statedecorators.state_output_unificator(lambda: data)() == expected
+        assert statedecorators.state_output_unifier(lambda: data)() == expected
 
         data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': None}
         expected = 'data\nin\nthe\nlist'

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -513,6 +513,16 @@ class StateReturnsTestCase(TestCase):
             statedecorators.state_output_check(lambda: data)()
         assert "'Changes' should be a dictionary" in str(err)
 
+    def test_state_output_check_return_is_dict(self):
+        '''
+        Test that changes key contains a dictionary.
+        :return:
+        '''
+        data = ['whatever']
+        with pytest.raises(salt.exceptions.SaltException) as err:
+            statedecorators.state_output_check(lambda: data)()
+        assert 'Malformed state return, return must be a dict' in str(err)
+
 
 class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     '''

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -503,6 +503,16 @@ class StateReturnsTestCase(TestCase):
             'changes': {},
         }
 
+    def test_state_output_check_changes_is_dict(self):
+        '''
+        Test that changes key contains a dictionary.
+        :return:
+        '''
+        data = {'changes': []}
+        with pytest.raises(salt.exceptions.SaltException) as err:
+            statedecorators.state_output_check(lambda: data)()
+        assert "'Changes' should be a dictionary" in str(err)
+
 
 class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     '''

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -503,7 +503,7 @@ class StateReturnsTestCase(TestCase):
 
     def test_state_output_check_return_is_dict(self):
         '''
-        Test that changes key contains a dictionary.
+        Test for the entire return is a dictionary
         :return:
         '''
         data = ['whatever']
@@ -513,7 +513,7 @@ class StateReturnsTestCase(TestCase):
 
     def test_state_output_check_return_is_dict(self):
         '''
-        Test that changes key contains a dictionary.
+        Test for name/result/comment keys are inside the return.
         :return:
         '''
         data = {'arbitrary': 'data', 'changes': {}}
@@ -523,7 +523,7 @@ class StateReturnsTestCase(TestCase):
 
     def test_state_output_unificator_comment_is_not_list(self):
         '''
-        Test that changes key contains a dictionary.
+        Test for output is unified so the comment is converted to a multi-line string
         :return:
         '''
         data = {'comment': ['data', 'in', 'the', 'list'], 'changes': {}, 'name': None, 'result': 'fantastic!'}

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -502,13 +502,6 @@ class StateReturnsTestCase(TestCase):
             'comment': ['comment 1', 'comment 2'],
             'changes': {},
         }
-        salt.state.State.verify_ret(ret)  # sanity check
-        with self.assertRaises(salt.exceptions.SaltException):
-            # Not suitable for export as is
-            salt.state.State.verify_ret_for_export(ret)
-        salt.state.State.munge_ret_for_export(ret)
-        self.assertIsInstance(ret['comment'], six.string_types)
-        salt.state.State.verify_ret_for_export(ret)
 
 
 class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -30,6 +30,7 @@ try:
 except ImportError as err:
     pytest = None
 
+
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     '''


### PR DESCRIPTION
### What does this PR do?

- ~Back~forwardports https://github.com/saltstack/salt/pull/44621
- Fixes state module that breaks highstate in some cases general by [this pull request](https://github.com/saltstack/salt/pull/43070)
- Re-implements mentioned above PR, so everybody are happy

### Tests written?

:ok: Yes

### Notes

http://bugzilla.suse.com/1068446
