### PR TITLE
Fix state absent in ipset broken by ipset-add-new-options

### DIFF
--- a/salt/states/ipset.py
+++ b/salt/states/ipset.py
@@ -293,7 +293,7 @@ def absent(name, entry=None, entries=None, family='ipv4', **kwargs):
                     kwargs['set_name'],
                     family)
             else:
-                command = __salt__['ipset.delete'](kwargs['set_name'], _entry, family, **kwargs)
+                command = __salt__['ipset.delete'](kwargs['set_name'], entry, family, **kwargs)
                 if 'Error' not in command:
                     ret['changes'] = {'locale': name}
                     ret['result'] = True


### PR DESCRIPTION
### What does this PR do?
Fixes problem with #44592 in state absent with entry options
### What issues does this PR fix or reference?
Fixes state absent in ipset with options:
```
test_entries_absent:
  ipset.absent:
    - set_name: test_setname
    - entry:
        - 192.168.1.1 comment "Test2"
        - 192.168.1.13
        - 192.168.1.14 skbprio 1:10
```
### Tests written?

No

### Commits signed with GPG?

No
