### PR TITLE
Update notes around grains topic, and salt.modules.grains and salt.state.grains

### DIFF
--- a/doc/topics/grains/index.rst
+++ b/doc/topics/grains/index.rst
@@ -80,7 +80,7 @@ same way as in the above example, only without a top-level ``grains:`` key:
 
 .. note::
 
-    The content of ``/etc/salt/grains`` is ignored if you specify grains in the minion config.
+    Grains in ``/etc/salt/grains`` are ignored if you specify the same grains in the minion config.
 
 .. note::
 

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -1,6 +1,13 @@
 # -*- coding: utf-8 -*-
 '''
 Return/control aspects of the grains data
+
+Grains set or altered this way are stored in the 'grains'
+file on the minions, by default at: ``/etc/salt/grains``
+
+.. Note::
+
+   This does **NOT** override any grains set in the minion file.
 '''
 
 # Import python libs

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -2,12 +2,12 @@
 '''
 Return/control aspects of the grains data
 
-Grains set or altered this way are stored in the 'grains'
-file on the minions, by default at: ``/etc/salt/grains``
+Grains set or altered with this module are stored in the 'grains'
+file on the minions. By default, this file is located at: ``/etc/salt/grains``
 
 .. Note::
 
-   This does **NOT** override any grains set in the minion file.
+   This does **NOT** override any grains set in the minion config file.
 '''
 
 # Import python libs

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -4,12 +4,13 @@ Manage grains on the minion
 ===========================
 
 This state allows for grains to be set.
-Grains set or altered this way are stored in the 'grains'
-file on the minions, by default at: ``/etc/salt/grains``
+
+Grains set or altered with this module are stored in the 'grains'
+file on the minions, By default, this file is located at: ``/etc/salt/grains``
 
 .. Note::
-    
-   This does **NOT** override any grains set in the minion file.
+
+   This does **NOT** override any grains set in the minion config file.
 '''
 
 # Import Python libs

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -5,9 +5,11 @@ Manage grains on the minion
 
 This state allows for grains to be set.
 Grains set or altered this way are stored in the 'grains'
-file on the minions, by default at: /etc/salt/grains
+file on the minions, by default at: ``/etc/salt/grains``
 
-Note: This does NOT override any grains set in the minion file.
+.. Note::
+    
+   This does **NOT** override any grains set in the minion file.
 '''
 
 # Import Python libs


### PR DESCRIPTION
### What does this PR do?

Updates the documentation. coping the header from salt.states.grains that mention the /etc/salt/grains behavior mentioned in #33957 to salt.modules.grains. as well as cleans it up a little to stand out better.

Also tweaks the wording of the first note of [grains in /etc/salt/grains](http://localhost:8000/topics/grains/#grains-in-etc-salt-grains) to reflect that not all grains are ignored if a grain is included in the minion config. only those that are included in the minion config. Which is my understanding from the notes in #33957

### What issues does this PR fix or reference?

See above. 

### Tests written?

No - Documentation

### Commits signed with GPG?

Yes
