### PR TITLE
Fix acme.cert to run certbot non-interactively

### DIFF
--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -125,8 +125,7 @@ def cert(name,
         salt 'gitlab.example.com' acme.cert dev.example.com "[gitlab.example.com]" test_cert=True renew=14 webroot=/opt/gitlab/embedded/service/gitlab-rails/public
     '''
 
-    # cmd = [LEA, 'certonly', '--quiet']
-    cmd = [LEA, 'certonly']
+    cmd = [LEA, 'certonly', '--non-interactive']
 
     cert_file = _cert_file(name, 'cert')
     if not __salt__['file.file_exists'](cert_file):


### PR DESCRIPTION
### What does this PR do?

Certbot should never be running interactively when executed via Salt, so
this patch adds an argument to certbot which informs it to not run
interactively.

### What issues does this PR fix or reference?

#42763 

### Previous Behavior

Certbot would run interactively and in some instances cause salt to malfunction when it prompting for a response.

### New Behavior

Certbot no longer runs interactively.

### Tests written?

No

### Commits signed with GPG?

Yes
