### PR TITLE
Bugfix: iscsi initiator check causes crash

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2476,7 +2476,7 @@ def _linux_iqn():
         with salt.utils.files.fopen(initiator, 'r') as _iscsi:
             for line in _iscsi.readlines():
                 if line.startswith('InitiatorName') and '=' in line:
-                    ret.extend([line.split('=', 1)[-1].strip()])
+                    ret.append(line.split('=', 1)[-1].strip())
     return ret
 
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2474,11 +2474,9 @@ def _linux_iqn():
 
     if os.path.isfile(initiator):
         with salt.utils.files.fopen(initiator, 'r') as _iscsi:
-            for line in _iscsi:
-                if line.find('InitiatorName') != -1:
-                    iqn = line.split('=')
-                    final_iqn = iqn[1].rstrip()
-                    ret.extend([final_iqn])
+            for line in _iscsi.readlines():
+                if line.startswith('InitiatorName') and '=' in line:
+                    ret.extend([line.split('=', 1)[-1].strip()])
     return ret
 
 

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -625,7 +625,7 @@ class CoreGrainsUtilityFunctionsTestCase(TestCase):
     grains.core has helper utilities. This is test class for them
     '''
     def test_linux_iqn_iscsi_initiator(self):
-        data='''##
+        data = '''##
 ## /etc/iscsi/iscsi.initiatorname
 ##
 ## Default iSCSI Initiatorname.

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -618,3 +618,28 @@ SwapTotal:       4789244 kB'''
 
         self.assertEqual(os_grains.get('mem_total'), 2023)
         self.assertEqual(os_grains.get('swap_total'), 400)
+
+
+class CoreGrainsUtilityFunctionsTestCase(TestCase):
+    '''
+    grains.core has helper utilities. This is test class for them
+    '''
+    def test_linux_iqn_iscsi_initiator(self):
+        data='''##
+## /etc/iscsi/iscsi.initiatorname
+##
+## Default iSCSI Initiatorname.
+##
+## DO NOT EDIT OR REMOVE THIS FILE!
+## If you remove this file, the iSCSI daemon will not start.
+## If you change the InitiatorName, existing access control lists
+## may reject this initiator.  The InitiatorName must be unique
+## for each iSCSI initiator.  Do NOT duplicate iSCSI InitiatorNames.
+InitiatorName=iqn.1996-04.de.suse:01:56f083eae28
+'''
+        with patch('os.path.isfile', MagicMock(return_value=True)):
+            with patch('salt.utils.files.fopen', mock_open(read_data=data)):
+                iqn = core._linux_iqn()
+                assert type(iqn) == list
+                assert len(iqn) == 1
+                assert iqn[0] == 'iqn.1996-04.de.suse:01:56f083eae28'


### PR DESCRIPTION
### What does this PR do?

Fixes this (affects Salt SSH and anywhere iSCSI initiator is configured):
```
    stderr:
        Traceback (most recent call last):
          File "/var/tmp/.root_26386f_salt/salt-call", line 15, in <module>
            salt_call()
          File "/var/tmp/.root_26386f_salt/py2/salt/scripts.py", line 395, in salt_call
            client.run()
          File "/var/tmp/.root_26386f_salt/py2/salt/cli/call.py", line 47, in run
            caller = salt.cli.caller.Caller.factory(self.config)
          File "/var/tmp/.root_26386f_salt/py2/salt/cli/caller.py", line 79, in factory
            return ZeroMQCaller(opts, **kwargs)
          File "/var/tmp/.root_26386f_salt/py2/salt/cli/caller.py", line 289, in __init__
            super(ZeroMQCaller, self).__init__(opts)
          File "/var/tmp/.root_26386f_salt/py2/salt/cli/caller.py", line 102, in __init__
            self.minion = salt.minion.SMinion(opts)
          File "/var/tmp/.root_26386f_salt/py2/salt/minion.py", line 716, in __init__
            opts[u'grains'] = salt.loader.grains(opts)
          File "/var/tmp/.root_26386f_salt/py2/salt/loader.py", line 729, in grains
            ret = funcs[key]()
          File "/var/tmp/.root_26386f_salt/py2/salt/grains/core.py", line 2459, in iscsi_iqn
            grains['iscsi_iqn'] = _linux_iqn()
          File "/var/tmp/.root_26386f_salt/py2/salt/grains/core.py", line 2480, in _linux_iqn
            final_iqn = iqn[1].rstrip()
        IndexError: list index out of range
    stdout:
```

### Tests written?

Yes
