### PR TITLE
Master/Minion auto-discovery

### DIFF
--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -222,6 +222,62 @@ The new grains added are:
 * ``iscsi_iqn``: Show the iSCSI IQN name for a host
 * ``swap_total``: Show the configured swap_total for Linux, *BSD, OS X and Solaris/SunOS
 
+Salt Minion Autodiscovery
+------------------------
+
+Salt Minion now no longer need to be configured against a specifig DNS name or IP address of a Master.
+
+For this feature Salt Master is now require port 4520 for UDP broadcast packet to be opened
+and Salt Minion is expected to be able to send to the same port UDP packets.
+
+Connection to a type instead of DNS
+===================================
+
+By now each Minion was connecting to a Master by DNS or IP address. From now on it is possible
+also to connect to a _type_ of a Master. For example, in the network there are three different
+Masters, each corresponds for a particular niche or environment or specific role etc. Minion
+supposed to connect only to one of those Masters that is described approriately.
+
+To achieve such effect, each `/etc/salt/master` configuration should have a `discovery` option,
+which should have `mapping` element with arbitrary key/value pairs. The same configuration shoul
+be on the Minion, so then when mapping matches, Minion recognises Master as its connection target.
+
+Example for Master configuration (`/etc/salt/master`):
+
+.. code-block:: yaml
+
+       discovery:
+         mapping:
+           description: SES 5.0
+           node: 1
+
+The example above describes a system that is running a particular product, where `description` is
+an arbitrary key and `SES 5.0` is just a string. In order to match exactly this Master, the
+following configuration at Minion should be present:
+
+.. code-block:: yaml
+
+       discovery:
+         match: all  # Can be "all" or "any"
+         mapping:
+           description: SES 5.0
+           node: 1
+
+Notice `match` criteria is set to `all`. This would mean that from all found Masters select only
+that, which `description` is set to `SES 5.0` _and_ `node` is set to `1`. All other Masters will
+be ignored.
+
+
+Limitations
+===========
+
+This feature has a couple of _temporary_ limitations that are subject to change in nearest future:
+
+- Only one Master on the network is supported
+- Minions will accept _any_ master that matches connection criteria without any particular
+  security applied (priv/pub key check, signature, fingerprint etc). That implies that administrator
+  is expected to know his network and make sure it is clean.
+
 Grains Changes
 --------------
 

--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -273,7 +273,8 @@ Limitations
 
 This feature has a couple of _temporary_ limitations that are subject to change in nearest future:
 
-- Only one Master on the network is supported
+- Only one Master on the network is supported. Currently Minion cannot select which Master
+  out of few the same to choose. This will change to choosing Master that is least loaded.
 - Minions will accept _any_ master that matches connection criteria without any particular
   security applied (priv/pub key check, signature, fingerprint etc). That implies that administrator
   is expected to know his network and make sure it is clean.

--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -227,19 +227,19 @@ Salt Minion Autodiscovery
 
 Salt Minion now no longer need to be configured against a specifig DNS name or IP address of a Master.
 
-For this feature Salt Master is now require port 4520 for UDP broadcast packet to be opened
-and Salt Minion is expected to be able to send to the same port UDP packets.
+For this feature Salt Master now requires port 4520 for UDP broadcast packets to be opened
+and the Salt Minion be able to send UDP packets to the same port.
 
 Connection to a type instead of DNS
 ===================================
 
 By now each Minion was connecting to a Master by DNS or IP address. From now on it is possible
-also to connect to a _type_ of a Master. For example, in the network there are three different
-Masters, each corresponds for a particular niche or environment or specific role etc. Minion
-supposed to connect only to one of those Masters that is described approriately.
+also to connect to a _type_ of a Master. For example, in a network there are three different
+Masters, each corresponds for a particular niche or environment or specific role etc. The Minion
+is supposed to connect only to one of those Masters that is described approriately.
 
-To achieve such effect, each `/etc/salt/master` configuration should have a `discovery` option,
-which should have `mapping` element with arbitrary key/value pairs. The same configuration shoul
+To achieve such an effect, each `/etc/salt/master` configuration should have a `discovery` option,
+which should have a `mapping` element with arbitrary key/value pairs. The same configuration shoul
 be on the Minion, so then when mapping matches, Minion recognises Master as its connection target.
 
 Example for Master configuration (`/etc/salt/master`):
@@ -271,10 +271,10 @@ be ignored.
 Limitations
 ===========
 
-This feature has a couple of _temporary_ limitations that are subject to change in nearest future:
+This feature has a couple of _temporary_ limitations that are subject to change in the future:
 
-- Only one Master on the network is supported. Currently Minion cannot select which Master
-  out of few the same to choose. This will change to choosing Master that is least loaded.
+- Only one Master on the network is supported. Currently the Minion cannot select which Master
+  out of few the same to choose. This will change to choosing the Master that is least loaded.
 - Minions will accept _any_ master that matches connection criteria without any particular
   security applied (priv/pub key check, signature, fingerprint etc). That implies that administrator
   is expected to know his network and make sure it is clean.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1771,6 +1771,10 @@ DEFAULT_MASTER_OPTS = {
     'salt_cp_chunk_size': 98304,
     'require_minion_sign_messages': False,
     'drop_messages_signature_fail': False,
+    'discovery': {
+        'port': 4520,
+        'mapping': {},
+    },
 }
 
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1457,6 +1457,10 @@ DEFAULT_MINION_OPTS = {
         'static': ['Aliases', 'Links', 'IPAMConfig'],
         'automatic': ['IPAddress', 'Gateway',
                       'GlobalIPv6Address', 'IPv6Gateway'],
+    'discovery': {
+        'port': 4520,
+        'match': 'any',
+        'mapping': {},
     },
 }
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1464,6 +1464,8 @@ DEFAULT_MINION_OPTS = {
         'automatic': ['IPAddress', 'Gateway',
                       'GlobalIPv6Address', 'IPv6Gateway'],
     'discovery': {
+        'attempts': 3,
+        'pause': 5,
         'port': 4520,
         'match': 'any',
         'mapping': {},

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1167,6 +1167,11 @@ VALID_OPTS = {
     # especially when masters are not related to each other.
     'mapping': dict,
 
+    # SSDP discovery mapping matcher policy
+    # Values: "any" where at least one key/value pair should be found or
+    # "all", where every key/value should be identical
+    'match': str,
+
     # Port definition.
     'port': int,
 }

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1174,6 +1174,12 @@ VALID_OPTS = {
 
     # Port definition.
     'port': int,
+
+    # SSDP discovery attempts to send query to the Universe
+    'attempts': int,
+
+    # SSDP discovery pause between the attempts
+    'pause': int,
 }
 
 # default configurations

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1156,6 +1156,19 @@ VALID_OPTS = {
 
     # Used by salt.modules.dockermod.compare_container_networks to specify which keys are compared
     'docker.compare_container_networks': dict,
+
+    # SSDP discovery publisher description.
+    # Contains publisher configuration and minion mapping.
+    # Setting it to False disables discovery
+    'discovery': (dict, bool),
+
+    # SSDP discovery mapping
+    # Defines arbitrary data for description and grouping minions across various types of masters,
+    # especially when masters are not related to each other.
+    'mapping': dict,
+
+    # Port definition.
+    'port': int,
 }
 
 # default configurations

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1463,6 +1463,7 @@ DEFAULT_MINION_OPTS = {
         'static': ['Aliases', 'Links', 'IPAMConfig'],
         'automatic': ['IPAddress', 'Gateway',
                       'GlobalIPv6Address', 'IPv6Gateway'],
+    },
     'discovery': {
         'attempts': 3,
         'pause': 5,

--- a/salt/master.py
+++ b/salt/master.py
@@ -607,11 +607,16 @@ class Master(SMaster):
                 name='ReqServer')
 
             # Fire up SSDP discovery publisher
-            if self.opts[u'discovery'] is not False:
-                self.process_manager.add_process(salt.utils.ssdp.SSDPDiscoveryServer(
-                    port=self.opts[u'discovery'].get(u'port', DEFAULT_MASTER_OPTS[u'discovery'][u'port']),
-                    listen_ip=self.opts[u'interface'],
-                    answer={u'mapping': self.opts[u'discovery'].get(u'mapping', {})}).run)
+            if self.opts[u'discovery']:
+                if salt.utils.ssdp.SSDPDiscoveryServer.is_available():
+                    self.process_manager.add_process(salt.utils.ssdp.SSDPDiscoveryServer(
+                        port=self.opts[u'discovery'].get(u'port', DEFAULT_MASTER_OPTS[u'discovery'][u'port']),
+                        listen_ip=self.opts[u'interface'],
+                        answer={u'mapping': self.opts[u'discovery'].get(u'mapping', {})}).run)
+                else:
+                    log.error(u'Unable to load SSDP: asynchronous IO is not available.')
+                    if sys.version_info.major == 2:
+                        log.error(u'You are using Python 2, please install "trollius" module to enable SSDP discovery.')
 
         # Install the SIGINT/SIGTERM handlers if not done so far
         if signal.getsignal(signal.SIGINT) is signal.SIG_DFL:

--- a/salt/master.py
+++ b/salt/master.py
@@ -82,6 +82,7 @@ import salt.utils.verify
 import salt.utils.zeromq
 import salt.utils.ssdp
 from salt.defaults import DEFAULT_TARGET_DELIM
+from salt.config import DEFAULT_MASTER_OPTS
 from salt.exceptions import FileserverConfigError
 from salt.transport import iter_transport_opts
 from salt.utils.debug import (
@@ -606,7 +607,11 @@ class Master(SMaster):
                 name='ReqServer')
 
             # Fire up SSDP discovery publisher
-            self.process_manager.add_process(salt.utils.ssdp.SSDPDiscoveryServer(answer={}).run)
+            if self.opts[u'discovery'] is not False:
+                self.process_manager.add_process(salt.utils.ssdp.SSDPDiscoveryServer(
+                    port=self.opts[u'discovery'].get(u'port', DEFAULT_MASTER_OPTS[u'discovery'][u'port']),
+                    listen_ip=self.opts[u'interface'],
+                    answer={u'mapping': self.opts[u'discovery'].get(u'mapping', {})}).run)
 
         # Install the SIGINT/SIGTERM handlers if not done so far
         if signal.getsignal(signal.SIGINT) is signal.SIG_DFL:

--- a/salt/master.py
+++ b/salt/master.py
@@ -80,6 +80,7 @@ import salt.utils.schedule
 import salt.utils.user
 import salt.utils.verify
 import salt.utils.zeromq
+import salt.utils.ssdp
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.exceptions import FileserverConfigError
 from salt.transport import iter_transport_opts
@@ -603,6 +604,9 @@ class Master(SMaster):
                 args=(self.opts, self.key, self.master_key),
                 kwargs=kwargs,
                 name='ReqServer')
+
+            # Fire up SSDP discovery publisher
+            self.process_manager.add_process(salt.utils.ssdp.SSDPDiscoveryServer(answer={}).run)
 
         # Install the SIGINT/SIGTERM handlers if not done so far
         if signal.getsignal(signal.SIGINT) is signal.SIG_DFL:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -483,8 +483,13 @@ class MinionBase(object):
             log.warning('Master is set to disable, skipping connection')
             self.connected = False
             raise tornado.gen.Return((None, None))
+
+        # Run masters discovery over SSDP. This may modify the whole configuration,
+        # depending of the networking and sets of masters.
+        self._discover_masters(opts)
+
         # check if master_type was altered from its default
-        elif opts['master_type'] != 'str' and opts['__role'] != 'syndic':
+        if opts[u'master_type'] != u'str' and opts[u'__role'] != u'syndic':
             # check for a valid keyword
             if opts['master_type'] == 'func':
                 eval_master_func(opts)
@@ -661,7 +666,6 @@ class MinionBase(object):
 
         # single master sign in
         else:
-            self._discover_masters(opts)
             if opts[u'random_master']:
                 log.warning(u'random_master is True but there is only one master specified. Ignoring.')
             while True:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -486,7 +486,7 @@ class MinionBase(object):
 
         # Run masters discovery over SSDP. This may modify the whole configuration,
         # depending of the networking and sets of masters.
-        self._discover_masters(opts)
+        self._discover_masters()
 
         # check if master_type was altered from its default
         if opts[u'master_type'] != u'str' and opts[u'__role'] != u'syndic':
@@ -711,12 +711,13 @@ class MinionBase(object):
                         self.connected = False
                         raise exc
 
-    def _discover_masters(self, opts):
+    def _discover_masters(self):
         '''
         Discover master(s) and decide where to connect, if SSDP is around.
+        This modifies the configuration on the fly.
         :return:
         '''
-        if opts['master'] == DEFAULT_MINION_OPTS['master'] and opts['discovery'] is not False:
+        if self.opts['master'] == DEFAULT_MINION_OPTS['master'] and self.opts['discovery'] is not False:
             master_discovery_client = salt.utils.ssdp.SSDPDiscoveryClient()
             try:
                 proto_data, ssdp_addr = master_discovery_client.discover()
@@ -733,7 +734,7 @@ class MinionBase(object):
 
                 cnt = len([key for key, value in mapping.items() if proto_data.get('mapping', {}).get(key) == value])
                 if policy == 'any' and bool(cnt) or cnt == len(mapping):
-                    opts['master'] = proto_data['master']
+                    self.opts['master'] = proto_data['master']
 
     def _return_retry_timer(self):
         '''

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -489,7 +489,7 @@ class MinionBase(object):
         self._discover_masters()
 
         # check if master_type was altered from its default
-        if opts[u'master_type'] != u'str' and opts[u'__role'] != u'syndic':
+        if opts['master_type'] != 'str' and opts['__role'] != 'syndic':
             # check for a valid keyword
             if opts['master_type'] == 'func':
                 eval_master_func(opts)
@@ -666,8 +666,8 @@ class MinionBase(object):
 
         # single master sign in
         else:
-            if opts[u'random_master']:
-                log.warning(u'random_master is True but there is only one master specified. Ignoring.')
+            if opts['random_master']:
+                log.warning('random_master is True but there is only one master specified. Ignoring.')
             while True:
                 if attempts != 0:
                     # Give up a little time between connection attempts

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -263,9 +263,13 @@ class SSDPDiscoveryServer(SSDPBase):
         listen_ip = self._config.get(self.LISTEN_IP, self.DEFAULTS[self.LISTEN_IP])
         port = self._config.get(self.PORT, self.DEFAULTS[self.PORT])
         loop = asyncio.get_event_loop()
-        transport, protocol = loop.run_until_complete(
-            loop.create_datagram_endpoint(SSDPFactory(answer=self._config[self.ANSWER]),
-                                          local_addr=(listen_ip, port), allow_broadcast=True))
+        protocol = SSDPFactory(answer=self._config[self.ANSWER])
+        if asyncio.ported:
+            transport, protocol = loop.run_until_complete(
+                SSDPDiscoveryServer.create_datagram_endpoint(loop, protocol, local_addr=(listen_ip, port)))
+        else:
+            transport, protocol = loop.run_until_complete(
+                loop.create_datagram_endpoint(protocol, local_addr=(listen_ip, port), allow_broadcast=True))
         try:
             loop.run_forever()
         except KeyboardInterrupt:

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -335,6 +335,25 @@ class SSDPDiscoveryClient(SSDPBase):
 
         return query
 
+    def _collect_masters_map(self, response):
+        '''
+        Collect masters map from the network.
+        :return:
+        '''
+        while True:
+            try:
+                data, addr = self._socket.recvfrom(0x400)
+                if data:
+                    if addr not in response:
+                        response[addr] = []
+                    response[addr].append(data)
+                else:
+                    break
+            except socket.timeout:
+                break
+            except socket.error as err:
+                self.log.error('Error ocurred while discovering masters from the network: {0}'.format(err))
+
     def discover(self):
         '''
         Gather the information of currently declared servers.

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -198,7 +198,13 @@ class SSDPDiscoveryServer(SSDPBase):
     Discovery service publisher.
 
     '''
-    is_available = SSDPBase._is_available
+    @staticmethod
+    def is_available():
+        '''
+        Return availability of the Server.
+        :return:
+        '''
+        return SSDPBase._is_available()
 
     def __init__(self, **config):
         '''
@@ -309,7 +315,13 @@ class SSDPDiscoveryClient(SSDPBase):
     '''
     Class to discover Salt Master via UDP broadcast.
     '''
-    is_available = SSDPBase._is_available
+    @staticmethod
+    def is_available():
+        '''
+        Return availability of the Client
+        :return:
+        '''
+        return SSDPBase._is_available()
 
     def __init__(self, **config):
         '''

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -100,7 +100,7 @@ class SSDPFactory(SSDPBase):
         self.disable_hidden = False
         self.transport = None
         self.my_ip = socket.gethostbyname(socket.gethostname())
-        self.DEFAULTS[self.ANSWER] = '{}'
+        self.DEFAULTS[self.ANSWER] = {}
 
     def __call__(self, *args, **kwargs):
         '''
@@ -145,7 +145,8 @@ class SSDPFactory(SSDPBase):
                 return
 
             self.log.debug('Received %r from %s' % (message, "%s:%s" % addr))
-            self.transport.sendto('{0}#OK#{1}'.format(self.signature, self.answer), addr)
+            self.transport.sendto('{0}#OK#{1}'.format(self.signature,
+                                                      json.dumps(self.answer)), addr)
         else:
             if self.disable_hidden:
                 self.transport.sendto('{0}#ERROR#{1}'.format(self.signature,

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -272,8 +272,6 @@ class SSDPDiscoveryServer(SSDPBase):
                 loop.create_datagram_endpoint(protocol, local_addr=(listen_ip, port), allow_broadcast=True))
         try:
             loop.run_forever()
-        except KeyboardInterrupt:
-            pass
         finally:
             self.log.info('Removing SSDP publisher')
             transport.close()

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -359,4 +359,8 @@ class SSDPDiscoveryClient(SSDPBase):
                 if "timestamp" in err:
                     raise TimeStampException(err)
             else:
-                return json.loads(msg.split(':@:')[-1]), "%s:%s" % addr
+                data, addr, attempt = json.loads(msg.split(':@:')[-1]), "%s:%s" % addr, True
+        else:
+            data, addr, attempt = {}, '', False
+
+        return data, addr, attempt

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -279,7 +279,7 @@ class SSDPDiscoveryServer(SSDPBase):
             loop.close()
 
 
-class SSPDiscoveryClient(SSDPBase):
+class SSDPDiscoveryClient(SSDPBase):
     '''
     Class to discover Salt Master via UDP broadcast.
     '''

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -176,21 +176,21 @@ class SSDPFactory(SSDPBase):
             except TypeError:
                 self.log.debug('Received invalid timestamp in package from %s' % ("%s:%s" % addr))
                 if self.disable_hidden:
-                    self._sendto('{0}#ERROR#{1}'.format(self.signature, 'Invalid timestamp'), addr)
+                    self._sendto('{0}:E:{1}'.format(self.signature, 'Invalid timestamp'), addr)
                 return
 
             if datetime.datetime.fromtimestamp(timestamp) < (datetime.datetime.now() - datetime.timedelta(seconds=20)):
                 if self.disable_hidden:
-                    self._sendto('{0}#ERROR#{1}'.format(self.signature, 'Timestamp is too old'), addr)
+                    self._sendto('{0}:E:{1}'.format(self.signature, 'Timestamp is too old'), addr)
                 self.log.debug('Received outdated package from %s' % ("%s:%s" % addr))
                 return
 
             self.log.debug('Received %r from %s' % (message, "%s:%s" % addr))
-            self._sendto('{0}#OK#{1}'.format(self.signature,
+            self._sendto('{0}:@:{1}'.format(self.signature,
                                                       json.dumps(self.answer)), addr)
         else:
             if self.disable_hidden:
-                self._sendto('{0}#ERROR#{1}'.format(self.signature,
+                self._sendto('{0}:E:{1}'.format(self.signature,
                                                              'Invalid packet signature').encode(), addr)
             self.log.debug('Received bad signature from %s:%s' % addr)
 
@@ -353,10 +353,10 @@ class SSDPDiscoveryClient(SSDPBase):
         if msg.startswith(self.signature):
             msg = msg.split(self.signature)[-1]
             self.log.debug("Service announcement at '{0}'. Response: '{1}'".format("%s:%s" % addr, msg))
-            if '#ERROR#' in msg:
-                err = msg.split('#ERROR#')[-1]
+            if ':E:' in msg:
+                err = msg.split(':E:')[-1]
                 self.log.debug('Error response from the service publisher: {0}'.format(err))
                 if "timestamp" in err:
                     raise TimeStampException(err)
             else:
-                return json.loads(msg.split('#OK#')[-1]), "%s:%s" % addr
+                return json.loads(msg.split(':@:')[-1]), "%s:%s" % addr

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -21,6 +21,7 @@ JSON-based service discovery protocol, used by minions to find running Master.
 '''
 
 import datetime
+import time
 import logging
 import socket
 from collections import OrderedDict
@@ -302,7 +303,7 @@ class SSDPDiscoveryClient(SSDPBase):
         Query the broadcast for defined services.
         :return:
         '''
-        query = "%s%s" % (self.signature, datetime.datetime.now().timestamp())
+        query = "%s%s" % (self.signature, time.time())
         self._socket.sendto(query.encode(), ('<broadcast>', self.port))
 
         return query

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -20,7 +20,10 @@ Salt Service Discovery Protocol.
 JSON-based service discovery protocol, used by minions to find running Master.
 '''
 
+import socket
 import logging
+import datetime
+
 try:
     import asyncio
 except ImportError:
@@ -37,10 +40,36 @@ class SSDPBase(object):
     '''
     log = logging.getLogger(__name__)
 
+    # Fields
+    SIGNATURE = 'signature'
+    ANSWER = 'answer'
+
+    # Default values
+    DEFAULTS = {
+        SIGNATURE: '__salt_master_service'
+    }
+
     @staticmethod
-    def is_available():
+    def _is_available():
         '''
         Return True if the USSDP dependencies are satisfied.
         :return:
         '''
         return bool(asyncio)
+
+    @staticmethod
+    def get_self_ip():
+        '''
+        Find out localhost outside IP.
+
+        :return:
+        '''
+        sck = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            sck.connect(('1.255.255.255', 1))  # Does not needs to be reachable
+            ip_addr = sck.getsockname()[0]
+        except Exception:
+            ip_addr = socket.gethostbyname(socket.gethostname())
+        finally:
+            sck.close()
+        return ip_addr

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -20,9 +20,14 @@ Salt Service Discovery Protocol.
 JSON-based service discovery protocol, used by minions to find running Master.
 '''
 
-import socket
-import logging
 import datetime
+import logging
+import socket
+
+from salt.utils import json
+json = json.import_json()
+if not hasattr(json, 'dumps'):
+    json = None
 
 try:
     import asyncio

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -174,7 +174,7 @@ class SSDPFactory(SSDPBase):
             try:
                 timestamp = float(message[len(self.signature):])
             except TypeError:
-                self.log.debug('Received invalid timestamp in package from %s' % ("%s:%s" % addr))
+                self.log.debug('Received invalid timestamp in package from {}'.format("{}:{}".format(*addr)))
                 if self.disable_hidden:
                     self._sendto('{0}:E:{1}'.format(self.signature, 'Invalid timestamp'), addr)
                 return
@@ -182,17 +182,15 @@ class SSDPFactory(SSDPBase):
             if datetime.datetime.fromtimestamp(timestamp) < (datetime.datetime.now() - datetime.timedelta(seconds=20)):
                 if self.disable_hidden:
                     self._sendto('{0}:E:{1}'.format(self.signature, 'Timestamp is too old'), addr)
-                self.log.debug('Received outdated package from %s' % ("%s:%s" % addr))
+                self.log.debug('Received outdated package from {}'.format("{}:{}".format(*addr)))
                 return
 
-            self.log.debug('Received %r from %s' % (message, "%s:%s" % addr))
-            self._sendto('{0}:@:{1}'.format(self.signature,
-                                                      json.dumps(self.answer)), addr)
+            self.log.debug('Received "{}" from {}'.format(message, "{}:{}".format(*addr)))
+            self._sendto('{0}:@:{1}'.format(self.signature, json.dumps(self.answer)), addr)
         else:
             if self.disable_hidden:
-                self._sendto('{0}:E:{1}'.format(self.signature,
-                                                             'Invalid packet signature').encode(), addr)
-            self.log.debug('Received bad signature from %s:%s' % addr)
+                self._sendto('{0}:E:{1}'.format(self.signature, 'Invalid packet signature').encode(), addr)
+            self.log.debug('Received bad signature from {}:{}'.format(*addr))
 
 
 class SSDPDiscoveryServer(SSDPBase):
@@ -330,7 +328,7 @@ class SSDPDiscoveryClient(SSDPBase):
         Query the broadcast for defined services.
         :return:
         '''
-        query = "%s%s" % (self.signature, time.time())
+        query = "{}{}".format(self.signature, time.time())
         self._socket.sendto(query.encode(), ('<broadcast>', self.port))
 
         return query
@@ -374,7 +372,7 @@ class SSDPDiscoveryClient(SSDPBase):
                 msg = data.decode()
                 if msg.startswith(self.signature):
                     msg = msg.split(self.signature)[-1]
-                    self.log.debug("Service announcement at '{0}'. Response: '{1}'".format("%s:%s" % addr, msg))
+                    self.log.debug("Service announcement at '{0}'. Response: '{1}'".format("{}:{}".format(*addr), msg))
                     if ':E:' in msg:
                         err = msg.split(':E:')[-1]
                         self.log.error('Error response from the service publisher at {0}: {1}'.format(addr, err))

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -19,7 +19,7 @@
 Salt Service Discovery Protocol.
 JSON-based service discovery protocol, used by minions to find running Master.
 '''
-
+from __future__ import absolute_import, print_function
 import datetime
 import time
 import logging

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Author: Bo Maryniuk <bo@suse.de>
+#
+# Copyright 2017 SUSE LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Salt Service Discovery Protocol.
+JSON-based service discovery protocol, used by minions to find running Master.
+'''
+
+import logging
+try:
+    import asyncio
+except ImportError:
+    try:
+        # Python 2 doesn't have asyncio
+        import trollius as asyncio
+    except ImportError:
+        asyncio = None
+
+
+class SSDPBase(object):
+    '''
+    Salt Service Discovery Protocol.
+    '''
+    log = logging.getLogger(__name__)
+
+    @staticmethod
+    def is_available():
+        '''
+        Return True if the USSDP dependencies are satisfied.
+        :return:
+        '''
+        return bool(asyncio)

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -262,6 +262,7 @@ class SSDPDiscoveryServer(SSDPBase):
         '''
         listen_ip = self._config.get(self.LISTEN_IP, self.DEFAULTS[self.LISTEN_IP])
         port = self._config.get(self.PORT, self.DEFAULTS[self.PORT])
+        self.log.info('Starting service discovery listener on udp://{0}:{1}'.format(listen_ip, port))
         loop = asyncio.get_event_loop()
         protocol = SSDPFactory(answer=self._config[self.ANSWER])
         if asyncio.ported:
@@ -273,7 +274,7 @@ class SSDPDiscoveryServer(SSDPBase):
         try:
             loop.run_forever()
         finally:
-            self.log.info('Removing SSDP publisher')
+            self.log.info('Stopping service discovery listener.')
             transport.close()
             loop.close()
 

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -23,6 +23,7 @@ JSON-based service discovery protocol, used by minions to find running Master.
 import datetime
 import logging
 import socket
+from collections import OrderedDict
 
 from salt.utils import json
 json = json.import_json()
@@ -31,10 +32,12 @@ if not hasattr(json, 'dumps'):
 
 try:
     import asyncio
+    asyncio.ported = False
 except ImportError:
     try:
         # Python 2 doesn't have asyncio
         import trollius as asyncio
+        asyncio.ported = True
     except ImportError:
         asyncio = None
 

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -67,7 +67,7 @@ class SSDPBase(object):
     # Default values
     DEFAULTS = {
         SIGNATURE: '__salt_master_service',
-        PORT: 30777,
+        PORT: 4520,
         LISTEN_IP: '0.0.0.0',
         TIMEOUT: 3,
         ANSWER: {},

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -317,7 +317,7 @@ class SSDPDiscoveryClient(SSDPBase):
         self.log.info("Looking for a server discovery")
         try:
             self._query()
-            data, addr = self._socket.recvfrom(1024)  # wait for a packet
+            data, addr = self._socket.recvfrom(0x400)  # wait for a packet
         except socket.timeout:
             msg = 'No master has been discovered.'
             self.log.info(msg)

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -48,10 +48,14 @@ class SSDPBase(object):
     # Fields
     SIGNATURE = 'signature'
     ANSWER = 'answer'
+    PORT = 'port'
+    LISTEN_IP = 'listen_ip'
 
     # Default values
     DEFAULTS = {
-        SIGNATURE: '__salt_master_service'
+        SIGNATURE: '__salt_master_service',
+        PORT: 30777,
+        LISTEN_IP: '0.0.0.0',
     }
 
     @staticmethod
@@ -60,7 +64,7 @@ class SSDPBase(object):
         Return True if the USSDP dependencies are satisfied.
         :return:
         '''
-        return bool(asyncio)
+        return bool(asyncio and json)
 
     @staticmethod
     def get_self_ip():

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -293,10 +293,10 @@ class SSDPDiscoveryClient(SSDPBase):
         self._config = config
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        self._socket.settimeout(self._config.get(self.TIMEOUT, self.DEFAUTS[self.TIMEOUT]))
+        self._socket.settimeout(self._config.get(self.TIMEOUT, self.DEFAULTS[self.TIMEOUT]))
 
         for attr in [self.SIGNATURE, self.TIMEOUT, self.PORT]:
-            setattr(self, attr, self._config.get(attr, self.DEFAUTS[attr]))
+            setattr(self, attr, self._config.get(attr, self.DEFAULTS[attr]))
 
     def _query(self):
         '''

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -198,6 +198,6 @@ class SSDPDiscoveryServer(SSDPBase):
         except KeyboardInterrupt:
             pass
         finally:
-            log.info("Shutdown server")
+            self.log.info('Removing SSDP publisher')
             transport.close()
             loop.close()

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -165,7 +165,7 @@ class SSDPFactory(SSDPBase):
             if self.disable_hidden:
                 self.transport.sendto('{0}#ERROR#{1}'.format(self.signature,
                                                              'Invalid packet signature').encode(), addr)
-            self.log.debug('Received bad magic or password from %s:%s' % addr)
+            self.log.debug('Received bad signature from %s:%s' % addr)
 
 
 class SSDPDiscoveryServer(SSDPBase):

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -39,6 +39,14 @@ except ImportError:
         asyncio = None
 
 
+class TimeOutException(Exception):
+    pass
+
+
+class TimeStampException(Exception):
+    pass
+
+
 class SSDPBase(object):
     '''
     Salt Service Discovery Protocol.

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -150,7 +150,7 @@ class SSDPFactory(SSDPBase):
         tries = 0
         slp_time = lambda: 0.5 / random.randint(10, 30)
         slp = slp_time()
-        while tries < 3:
+        while tries < attempts:
             try:
                 self.transport.sendto(data, addr=addr)
                 self.log.debug('Sent successfully')

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -58,12 +58,15 @@ class SSDPBase(object):
     ANSWER = 'answer'
     PORT = 'port'
     LISTEN_IP = 'listen_ip'
+    TIMEOUT = 'timeout'
 
     # Default values
     DEFAULTS = {
         SIGNATURE: '__salt_master_service',
         PORT: 30777,
         LISTEN_IP: '0.0.0.0',
+        TIMEOUT: 3,
+        ANSWER: {},
     }
 
     @staticmethod
@@ -108,7 +111,6 @@ class SSDPFactory(SSDPBase):
         self.disable_hidden = False
         self.transport = None
         self.my_ip = socket.gethostbyname(socket.gethostname())
-        self.DEFAULTS[self.ANSWER] = {}
 
     def __call__(self, *args, **kwargs):
         '''
@@ -175,10 +177,6 @@ class SSDPDiscoveryServer(SSDPBase):
 
         :param config:
         '''
-        self.DEFAULTS = {
-            self.ANSWER: {},
-        }
-
         self._config = config.copy()
         if self.ANSWER not in self._config:
             self._config[self.ANSWER] = {}


### PR DESCRIPTION
### What does this PR do?

Allows your Minion find out Master(s) without configuration, automatically finding them out on the network.

### Previous Behavior

Typical Salt Minion configuration required:
```
master: your.master.somewhere
```

### New Behavior
Possible configuration on Salt Minion:
```
```

:wink: 

### Additional Features

Suppose you have three Masters, but all of them are serving for different isolated segments in parallel. They are dockers or temporary VMs. And your network is entirely dynamic, so you don't know what IP will appear on what docker or VM for your masters after their restart. But you still want to _segregate_ these Masters the way Minions find their "home" again, after restart all that. So your Minion is connecting not to a specific IP or DNS, but to a _description_. An example of such configuration as follows:

Configuration on Master: `/etc/salt/master`:
```yaml
discovery:
  mapping:
    product: SUSE Manager
```

Configuration on Minion: `/etc/salt/minion`:
```yaml
discovery:
  match: all
  mapping:
    product: SUSE Manager
```

In this case a key `product` matches string `SUSE Manager`. The `mapping` is just merely a key/value pair of _absolutely anything_ you want. It can be `name: Steven` or `fruit: grapes` or whatever you want.

### ToDO (right next)

Right now Minion connects to a several same Masters (multi-master) by random factor. How about found list of valid masters would report their load/numbers of minions, so minion choses the least loaded one?


### Tests written?

Yes

@thatch45 @cachedout @gtmanfred Merry Christmas! :wink: 