### PR TITLE
Virtualbox API had small change, and add trap for int conversion error, and add arg to bootstrap call

### DIFF
--- a/salt/cloud/clouds/virtualbox.py
+++ b/salt/cloud/clouds/virtualbox.py
@@ -173,7 +173,7 @@ def create(vm_info):
                 vm_info['key_filename'] = key_filename
                 vm_info['ssh_host'] = ip
 
-                res = __utils__['cloud.bootstrap'](vm_info)
+                res = __utils__['cloud.bootstrap'](vm_info, __opts__)
                 vm_result.update(res)
 
     __utils__['cloud.fire_event'](

--- a/salt/utils/virtualbox.py
+++ b/salt/utils/virtualbox.py
@@ -19,7 +19,9 @@ from salt.utils.timeout import wait_for
 log = logging.getLogger(__name__)
 
 # Import 3rd-party libs
+from salt.ext import six
 from salt.ext.six.moves import range
+
 # Import virtualbox libs
 HAS_LIBS = False
 try:
@@ -146,7 +148,7 @@ def vb_get_box():
     @rtype: IVirtualBox
     '''
     vb_get_manager()
-    vbox = _virtualboxManager.vbox
+    vbox = _virtualboxManager.getVirtualBox()
     return vbox
 
 


### PR DESCRIPTION
### What does this PR do?

When testing I found an int(conversion) failed when the host interface was not ready, and the bootstrap constructor was missing an argument, and the more recent version of virtualbox, like 5.2 and later 5.1 versions, no longer have virtualbox.vbox.

### What issues does this PR fix or reference?

Catch on empty Virtualbox network addr #43427 (ticket looks to be fixed already but not evident)
bootstrap can come from dunders #43278 - (same)

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
