### PR TITLE
pop None for runas and runas_password

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1878,8 +1878,8 @@ class State(object):
                 sys.modules[self.states[cdata['full']].__module__].__opts__[
                     'test'] = test
 
-            self.state_con.pop('runas')
-            self.state_con.pop('runas_password')
+            self.state_con.pop('runas', None)
+            self.state_con.pop('runas_password', None)
 
         # If format_call got any warnings, let's show them to the user
         if 'warnings' in cdata:


### PR DESCRIPTION
### What does this PR do?
We don't want to error here, so if for some reason the key is not populated,
just return a None instead of erroring.

### What issues does this PR fix or reference?
Fixes #44136

### Tests written?

No

### Commits signed with GPG?

Yes