### PR TITLE
Sort the show_top results for test_state_show_top test

### DIFF
--- a/tests/integration/ssh/test_state.py
+++ b/tests/integration/ssh/test_state.py
@@ -57,7 +57,7 @@ class SSHStateTest(SSHCase):
         test state.show_top with salt-ssh
         '''
         ret = self.run_function('state.show_top')
-        self.assertEqual(sorted(ret['base']), ['core', 'master_tops_test'])
+        self.assertEqual(ret, {u'base': list(set([u'master_tops_test']).union([u'core']))})
 
     def test_state_single(self):
         '''

--- a/tests/integration/ssh/test_state.py
+++ b/tests/integration/ssh/test_state.py
@@ -57,7 +57,7 @@ class SSHStateTest(SSHCase):
         test state.show_top with salt-ssh
         '''
         ret = self.run_function('state.show_top')
-        self.assertEqual(ret, {u'base': [u'master_tops_test', u'core']})
+        self.assertEqual(sorted(ret['base']), ['core', 'master_tops_test'])
 
     def test_state_single(self):
         '''


### PR DESCRIPTION
### What does this PR do?
This test was previously failing sometimes because the order would change. Looking at the debug logs during rendering of show_top I see:

```
[DEBUG   ] Results of YAML rendering: 
OrderedDict([('base', OrderedDict([('*', ['test', 'core'])]))])
```

Since that list is not ordered the test just needs to be changed to make sure we sort it ourselves and make sure the expected states in the top file show up.