### PR TITLE
utils/files.py remove temp file upon move failure

### DIFF
--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -26,6 +26,16 @@ REMOTE_PROTOS = ('http', 'https', 'ftp', 'swift', 's3')
 VALID_PROTOS = ('salt', 'file') + REMOTE_PROTOS
 
 
+def __clean_tmp(tmp):
+    '''
+    Remove temporary files
+    '''
+    try:
+        salt.utils.rm_rf(tmp)
+    except Exception:
+        pass
+
+
 def guess_archive_type(name):
     '''
     Guess an archive type (tar, zip, or rar) by its file extension
@@ -93,7 +103,15 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
             fstat = os.stat(dest)
         except OSError:
             pass
-    shutil.move(tgt, dest)
+
+    # The move could fail if the dest has xattr protections, so delete the
+    # temp file in this case
+    try:
+        shutil.move(tgt, dest)
+    except Exception:
+        __clean_tmp(tgt)
+        raise
+
     if fstat is not None:
         os.chown(dest, fstat.st_uid, fstat.st_gid)
         os.chmod(dest, fstat.st_mode)
@@ -111,10 +129,7 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
                 subprocess.call(cmd, stdout=dev_null, stderr=dev_null)
     if os.path.isfile(tgt):
         # The temp file failed to move
-        try:
-            os.remove(tgt)
-        except Exception:
-            pass
+        __clean_tmp(tgt)
 
 
 def rename(src, dst):


### PR DESCRIPTION
### What does this PR do?

Delete temp file if replacement fails in `salt.utils.files.copyfile`.  For example, when using the `file.managed` state, the state will fail and the temp file will remain if the named file has `xattr +i` protection.

I also considered removing the state `changes` when this happens, but the `try`/`except` blocks in the `file.manage_file` exec mod function seem like they may handle more generic contexts, so I was unsure about clearing `changes` upon failure there.  The question for this is: if a file state fails, should failure imply that there are no changes?  Should any failed state report changes?

It seems that changes should be reported if changes were made which is not necessarily true if a state fails.  There was no easy way to separate an error due to xattrs without adding xattr-aware code, which seemed like a hack, so the `changes` remain.

```sls
# touch /tmp/file && chattr +i /tmp/file
# salt-call --local state.single file.managed name=/tmp/file contents=test
[ERROR   ] File changed:
--- 
+++ 
@@ -0,0 +1 @@
+test

local:
----------
          ID: /tmp/file
    Function: file.managed
      Result: False
     Comment: Failed to commit change: [Errno 1] Operation not permitted: '/tmp/file'
     Started: 12:41:19.566720
    Duration: 52.778 ms
     Changes:   
              ----------
              diff:   
                  --- 
                  +++ 
                  @@ -0,0 +1 @@
                  +test

Summary for local
------------
Succeeded: 0 (changed=1)
Failed:    1
------------
Total states run:     1
Total run time:  52.778 ms
```

### What issues does this PR fix or reference?

#31405

### Previous Behavior

```bash
# ls -lh /tmp/file*
-rw-r--r-- 1 root root 0 Nov 27 12:41 /tmp/file
-rw------- 1 root root 5 Nov 27 12:42 /tmp/fileWkKZTa
```

### New Behavior

```bash
# ls -lh /tmp/file*
-rw-r--r-- 1 root root 0 Nov 27 12:41 /tmp/file
```

### Tests written?

No

### Commits signed with GPG?

Yes