### PR TITLE
Fix invocation of cron.file with when run with test=True

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -392,9 +392,9 @@ def absent(name,
         The special keyword used in the job (eg. @reboot, @hourly...).
         Quotes must be used, otherwise PyYAML will strip the '@' sign.
     '''
-    ### NOTE: The keyword arguments in **kwargs are ignored in this state, but
-    ###       cannot be removed from the function definition, otherwise the use
-    ###       of unsupported arguments will result in a traceback.
+    # NOTE: The keyword arguments in **kwargs are ignored in this state, but
+    #       cannot be removed from the function definition, otherwise the use
+    #       of unsupported arguments will result in a traceback.
 
     name = name.strip()
     if identifier is False:
@@ -566,6 +566,7 @@ def file(name,
                                              user,
                                              group,
                                              mode,
+                                             [],  # no special attrs for cron
                                              template,
                                              context,
                                              defaults,


### PR DESCRIPTION
### What does this PR do?

Fix invocation of `file.check_managed` when testing for cron file changes. For example:

    root_tasks:
      cron.file:
        - name: salt://t420s/root.cron
        - source_hash: md5=189ceaa871306656312f39a0482c28a1


### Previous Behavior

Remove this section if not relevant

    (saltenv) $ sudo salt-call --local --file-root=$PWD state.sls_id root_tasks test test=True
    [ERROR   ] An exception occurred in this state: Traceback (most recent call last):
      File "/home/eradman/local/saltenv/lib/python2.7/site-packages/salt/state.py", line 1927, in call
        **cdata[u'kwargs'])
      File "/home/eradman/local/saltenv/lib/python2.7/site-packages/salt/loader.py", line 1794, in wrapper
        return f(*args, **kwargs)
      File "/home/eradman/local/saltenv/lib/python2.7/site-packages/salt/states/cron.py", line 573, in file
        **kwargs
    TypeError: check_managed() takes at least 12 arguments (11 given)

### New Behavior

    (saltenv) $ sudo salt-call --local --file-root=$PWD state.sls_id root_tasks test test=True
    local:
    ----------
              ID: root_tasks
        Function: cron.file
            Name: salt://t420s/root.cron
          Result: None
         Comment: The following values are set to be changed:
                  <diff>
         Started: 18:22:59.756001
        Duration: 99.766 ms
         Changes:
    
    Summary for local
    ------------
    Succeeded: 1 (unchanged=1)
    Failed:    0

