### PR TITLE
Fix ssh state.show_top integration test (develop branch)

### DIFF
--- a/tests/integration/ssh/test_state.py
+++ b/tests/integration/ssh/test_state.py
@@ -57,7 +57,7 @@ class SSHStateTest(SSHCase):
         test state.show_top with salt-ssh
         '''
         ret = self.run_function('state.show_top')
-        self.assertEqual(ret, {u'base': [u'master_tops_test', u'core']})
+        self.assertEqual(ret, {u'base': [u'core', u'master_tops_test']})
 
     def test_state_single(self):
         '''


### PR DESCRIPTION
63823f3 changed how we handle cases where master_tops and top file matches both exist in a given environment. This updates the test to reflect the correct behavior in develop based on the fact that the `master_tops_first` config option is set to False.

See: https://github.com/saltstack/salt/pull/44697#issuecomment-347373412 and the subsequent comments in that pull request.