### PR TITLE
Update salt-cloud lxc driver behavior when target unavailable , fix #44651

### DIFF
--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -560,9 +560,10 @@ def get_configured_provider(vm_=None):
     # in all cases, verify that the linked saltmaster is alive.
     if data:
         ret = _salt('test.ping', salt_target=data['target'])
-        if not ret:
-            raise SaltCloudSystemExit(
+        if ret:
+            return data
+        else:
+            log.error(
                 'Configured provider {0} minion: {1} is unreachable'.format(
                     __active_provider_name__, data['target']))
-        return data
     return False


### PR DESCRIPTION
  **now salt-cloud lxc driver won't  exit if provider target unavalible

### What does this PR do?
Update salt-cloud lxc driver behavior when target unavailable 
### What issues does this PR fix or reference?
fix #44651
### Previous Behavior
```
# salt-cloud -Q
Error: ('Configured provider lab-deb9-cloud02:lxc minion: lab-deb9-cloud02 is unreachable',)
```
### New Behavior
print error message and continue to query other providers
```
# salt-cloud -Q 
[ERROR   ] Configured provider lab-deb9-cloud02:lxc minion: lab-deb9-cloud02 is unreachable
[WARNING ] The cloud driver, 'lxc', configured under the 'lab-deb9-cloud02' cloud provider alias is not properly configured. Removing it from the available providers list.
lab-deb9-cloud01:
    ----------
    lxc:
        ----------
        test-container01:
            ----------
            id:
                test-container01
            image:
                None
            name:
                test-container01
            private_ips:
                - fe80::aede:48ff:fe2f:7d96
                - 127.0.0.1
                - ::1
            public_ips:
            size:
                10278752
            state:
                running

``` 

### Tests written?

No
I checked on my local env

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
