### PR TITLE
Allow --static option to display state runs with highstate output

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -142,6 +142,17 @@ def get_printout(out, opts=None, **kwargs):
         # See Issue #29796 for more information.
         out = opts['output']
 
+    # Handle setting the output when --static is passed.
+    if not out and opts.get('static'):
+        if opts.get('output'):
+            out = opts['output']
+        elif opts.get('fun', '').split('.')[0] == 'state':
+            # --static doesn't have an output set at this point, but if we're
+            # running a state function and "out" hasn't already been set, we
+            # should set the out variable to "highstate". Otherwise state runs
+            # are set to "nested" below. See Issue #44556 for more information.
+            out = 'highstate'
+
     if out == 'text':
         out = 'txt'
     elif out is None or out == '':

--- a/tests/integration/output/output.py
+++ b/tests/integration/output/output.py
@@ -106,6 +106,62 @@ class OutputReturnTest(integration.ShellCase):
             trace = traceback.format_exc()
             self.assertEqual(trace, '')
 
+    def test_output_highstate(self):
+        '''
+        Regression tests for the highstate outputter. Calls a basic state with various
+        flags. Each comparison should be identical when successful.
+        '''
+        # Test basic highstate output. No frills.
+        expected = ['minion:', '          ID: simple-ping', '    Function: module.run',
+                    '        Name: test.ping', '      Result: True',
+                    '     Comment: Module function test.ping executed',
+                    '     Changes:   ', '              ret:', '                  True',
+                    'Summary for minion', 'Succeeded: 1 (changed=1)', 'Failed:    0',
+                    'Total states run:     1']
+        state_run = self.run_salt('"minion" state.sls simple-ping')
+
+        for expected_item in expected:
+            self.assertIn(expected_item, state_run)
+
+        # Test highstate output while also passing --out=highstate.
+        # This is a regression test for Issue #29796
+        state_run = self.run_salt('"minion" state.sls simple-ping --out=highstate')
+
+        for expected_item in expected:
+            self.assertIn(expected_item, state_run)
+
+        # Test highstate output when passing --static and running a state function.
+        # See Issue #44556.
+        state_run = self.run_salt('"minion" state.sls simple-ping --static')
+
+        for expected_item in expected:
+            self.assertIn(expected_item, state_run)
+
+        # Test highstate output when passing --static and --out=highstate.
+        # See Issue #44556.
+        state_run = self.run_salt('"minion" state.sls simple-ping --static --out=highstate')
+
+        for expected_item in expected:
+            self.assertIn(expected_item, state_run)
+
+    def test_output_highstate_falls_back_nested(self):
+        '''
+        Tests outputter when passing --out=highstate with a non-state call. This should
+        fall back to "nested" output.
+        '''
+        expected = ['minion:', '    True']
+        ret = self.run_salt('"minion" test.ping --out=highstate')
+        self.assertEqual(ret, expected)
+
+    def test_static_simple(self):
+        '''
+        Tests passing the --static option with a basic test.ping command. This
+        should be the "nested" output.
+        '''
+        expected = ['minion:', '    True']
+        ret = self.run_salt('"minion" test.ping --static')
+        self.assertEqual(ret, expected)
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where `state.*` functions called with the `--static` flag would display with the "nested" outputter instead of the "highstate" outputter.

I also added several regression tests to ensure these changes didn't break expected output functionality and ensures the new functionality works:

- simple state == highstate output
- simple state with `--out=highstate` == highstate output
- simple state with `--static` == highstate output
- simple state with `--static` and `--out=highstate` == highstate output
- `test.ping` with `--static` == defaults to nested output
- `test.ping` with `--out=highstate` == falls back to nested output

### What issues does this PR fix or reference?
Fixes #44556

### Previous Behavior
When passing `--static` on state runs, the output would default to "nested" like so:
```
# salt rallytime state.sls test --static
rallytime:
    ----------
    retcode:
        0
    test_|-always-changes-and-succeeds_|-foo_|-succeed_with_changes:
        ----------
        __id__:
            always-changes-and-succeeds
        __run_num__:
            0
        __sls__:
            test
        changes:
            ----------
            testing:
                ----------
                new:
                    Something pretended to change
                old:
                    Unchanged
        comment:
            Success!
        duration:
            0.856
        name:
            foo
        result:
            True
        start_time:
            18:13:09.870478
```

### New Behavior
The same state run with `--static` uses the "highstate" outputter:
```
# salt rallytime state.sls test --static
rallytime:
----------
          ID: always-changes-and-succeeds
    Function: test.succeed_with_changes
        Name: foo
      Result: True
     Comment: Success!
     Started: 18:15:05.171211
    Duration: 0.696 ms
     Changes:
              ----------
              testing:
                  ----------
                  new:
                      Something pretended to change
                  old:
                      Unchanged

Summary for rallytime
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:   0.696 ms
```

### Tests written?

Yes 

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
