### PR TITLE
[2017.7] Fixes to at module

### DIFF
--- a/salt/modules/at.py
+++ b/salt/modules/at.py
@@ -178,7 +178,7 @@ def atrm(*args):
             ret = {'jobs': {'removed': opts, 'tag': None}}
     else:
         opts = list(list(map(str, [i['job'] for i in atq()['jobs']
-            if i['job'] in args])))
+            if str(i['job']) in args])))
         ret = {'jobs': {'removed': opts, 'tag': None}}
 
     # Shim to produce output similar to what __virtual__() should do

--- a/salt/modules/at.py
+++ b/salt/modules/at.py
@@ -162,9 +162,6 @@ def atrm(*args):
         salt '*' at.atrm all [tag]
     '''
 
-    import logging
-    log = logging.getLogger(__name__)
-    log.debug('args {}'.format(args))
     # Need to do this here also since we use atq()
     if not salt.utils.which('at'):
         return '\'at.atrm\' is not available.'

--- a/salt/modules/at.py
+++ b/salt/modules/at.py
@@ -162,12 +162,18 @@ def atrm(*args):
         salt '*' at.atrm all [tag]
     '''
 
+    import logging
+    log = logging.getLogger(__name__)
+    log.debug('args {}'.format(args))
     # Need to do this here also since we use atq()
     if not salt.utils.which('at'):
         return '\'at.atrm\' is not available.'
 
     if not args:
         return {'jobs': {'removed': [], 'tag': None}}
+
+    # Convert all to strings
+    args = [str(arg) for arg in args]
 
     if args[0] == 'all':
         if len(args) > 1:


### PR DESCRIPTION
### What does this PR do?
When looking for job ids to remove based on the tag_name the comparison was comparing an `int` to a string, so the correct job id was not being returned.

### What issues does this PR fix or reference?
#44694 

### Previous Behavior
When looking for job ids to remove based on the tag_name the comparison was comparing an `int` to a string, so the correct job id was not being returned.

### New Behavior
Convert the `int` to a `str` when comparing.

### Tests written?
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
