### PR TITLE
Implements #9183

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -278,6 +278,7 @@ import time
 import traceback
 from collections import Iterable, Mapping, defaultdict
 from datetime import datetime   # python3 problem in the making?
+from glob import iglob
 
 # Import salt libs
 import salt.loader
@@ -1200,6 +1201,50 @@ def _shortcut_check(name,
                        'should be. Did you mean to use force?'.format(name)), pchanges
 
 
+def _resolve_glob(func):
+    '''
+    Decorator that enables glob filename matching for the wrapped function.
+    Calls the wrapped function for every file that matches the glob pattern
+    specified by parameter ``name`` if parameter ``resolve_glob`` is set True.
+    If any file matches the glob pattern, this makes the wrapped function return
+    ``result`` as True only if the returning value of ``result`` of every
+    matching file is True, and also makes the values of ``changes``,
+    ``pchanges`` and ``comment`` of each matching file as dicts, indexed by the
+    matching file names, so that they can be individually tracked.
+    '''
+    def wrapper(name, *args, **kwargs):
+        combined_ret = {
+            'name': name,
+            'changes': {},
+            'result': True,
+            'comment': '',
+            'pchanges': {}
+        }
+        if not name:
+            return _error(combined_ret, 'Must provide name to file.{0}'.format(func.__name__))
+        if not os.path.isabs(name):
+            return _error(
+                combined_ret, 'Specified file {0} is not an absolute path'.format(name)
+            )
+        found = False
+        if kwargs.pop('resolve_glob', False):
+            for resolved_name in iglob(name):
+                found = True
+                ret = func(resolved_name, *args, **kwargs)
+                for key in ret:
+                    if key == 'result':
+                        combined_ret[key] = combined_ret[key] and ret[key]
+                    elif key != 'name':
+                        if type(combined_ret[key]) is not dict:
+                            combined_ret[key] = {}
+                        combined_ret[key][resolved_name] = ret[key]
+        if not found:
+            return func(name, *args, **kwargs)
+        combined_ret['name'] = name
+        return combined_ret
+    return wrapper
+
+
 def symlink(
         name,
         target,
@@ -1417,6 +1462,7 @@ def symlink(
     return ret
 
 
+@_resolve_glob
 def absent(name,
            **kwargs):
     '''
@@ -1426,20 +1472,16 @@ def absent(name,
 
     name
         The path which should be deleted
-    '''
-    name = os.path.expanduser(name)
 
+    resolve_glob
+        If True, resolve name as a glob pattern and delete all matching files
+        and/or directories.
+    '''
     ret = {'name': name,
            'changes': {},
            'pchanges': {},
            'result': True,
            'comment': ''}
-    if not name:
-        return _error(ret, 'Must provide name to file.absent')
-    if not os.path.isabs(name):
-        return _error(
-            ret, 'Specified file {0} is not an absolute path'.format(name)
-        )
     if name == '/':
         return _error(ret, 'Refusing to make "/" absent')
     if os.path.isfile(name) or os.path.islink(name):


### PR DESCRIPTION
Support glob pattern in file.absent state as requested in issue #9183.

Currently file.absent can only remove one specific file or directory at a time. This PR will enable file.absent to remove all files matching a given glob pattern.

The way I implemented it is with a decorator that wraps any existing function in states/file.py and makes it accept an addition keyword argument of resolve_glob such that when it is set True, the decorator will treat the given file name as a glob pattern and calls the wrapped function for each file that matches the glob pattern, and for the returning dict, the result will only be True if every call to the wrapped function returns result as True, and changes, pchanges and comment will all be made into dicts indexed by matching file names, with values set to those of the corresponding values returned by the individual calls to the wrapped function, so that the changes and comments for each matching file can be individually tracked in case they're different. And if resolve_glob is set False or if no file is found, the decorator will simply call the wrapped function directly for its original behavior.