### PR TITLE
Add ability to reset file permissions on Windows

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4920,7 +4920,7 @@ def manage_file(name,
         if salt.utils.is_windows():
             # This function resides in win_file.py and will be available
             # on Windows. The local function will be overridden
-            # pylint: disable=E1121
+            # pylint: disable=E1120,E1121,E1123
             ret = check_perms(
                 path=name,
                 ret=ret,
@@ -4929,7 +4929,7 @@ def manage_file(name,
                 deny_perms=kwargs.get('win_deny_perms'),
                 inheritance=kwargs.get('win_inheritance', True),
                 reset=kwargs.get('win_perms_reset', False))
-            # pylint: enable=E1121
+            # pylint: enable=E1120,E1121,E1123
         else:
             ret, _ = check_perms(name, ret, user, group, mode, follow_symlinks)
 
@@ -4968,7 +4968,7 @@ def manage_file(name,
             if salt.utils.is_windows():
                 # This function resides in win_file.py and will be available
                 # on Windows. The local function will be overridden
-                # pylint: disable=E1121
+                # pylint: disable=E1120,E1121,E1123
                 makedirs_(
                     path=name,
                     owner=kwargs.get('win_owner'),
@@ -4976,7 +4976,7 @@ def manage_file(name,
                     deny_perms=kwargs.get('win_deny_perms'),
                     inheritance=kwargs.get('win_inheritance', True),
                     reset=kwargs.get('win_perms_reset', False))
-                # pylint: enable=E1121
+                # pylint: enable=E1120,E1121,E1123
             else:
                 makedirs_(name, user=user, group=group, mode=dir_mode)
 
@@ -5091,7 +5091,7 @@ def manage_file(name,
         if salt.utils.is_windows():
             # This function resides in win_file.py and will be available
             # on Windows. The local function will be overridden
-            # pylint: disable=E1121
+            # pylint: disable=E1120,E1121,E1123
             ret = check_perms(
                 path=name,
                 ret=ret,
@@ -5100,7 +5100,7 @@ def manage_file(name,
                 deny_perms=kwargs.get('win_deny_perms'),
                 inheritance=kwargs.get('win_inheritance', True),
                 reset=kwargs.get('win_perms_reset', False))
-            # pylint: enable=E1121
+            # pylint: enable=E1120,E1121,E1123
         else:
             ret, _ = check_perms(name, ret, user, group, mode)
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4927,8 +4927,8 @@ def manage_file(name,
                 owner=kwargs.get('win_owner'),
                 grant_perms=kwargs.get('win_perms'),
                 deny_perms=kwargs.get('win_deny_perms'),
-                inheritance=kwargs.get('win_inheritance'),
-                reset=kwargs.get('win_perms_reset'))
+                inheritance=kwargs.get('win_inheritance', True),
+                reset=kwargs.get('win_perms_reset', False))
             # pylint: enable=E1121
         else:
             ret, _ = check_perms(name, ret, user, group, mode, follow_symlinks)
@@ -4974,8 +4974,8 @@ def manage_file(name,
                     owner=kwargs.get('win_owner'),
                     grant_perms=kwargs.get('win_perms'),
                     deny_perms=kwargs.get('win_deny_perms'),
-                    inheritance=kwargs.get('win_inheritance'),
-                    reset=kwargs.get('win_perms_reset'))
+                    inheritance=kwargs.get('win_inheritance', True),
+                    reset=kwargs.get('win_perms_reset', False))
                 # pylint: enable=E1121
             else:
                 makedirs_(name, user=user, group=group, mode=dir_mode)
@@ -5098,8 +5098,8 @@ def manage_file(name,
                 owner=kwargs.get('win_owner'),
                 grant_perms=kwargs.get('win_perms'),
                 deny_perms=kwargs.get('win_deny_perms'),
-                inheritance=kwargs.get('win_inheritance'),
-                reset=kwargs.get('win_perms_reset'))
+                inheritance=kwargs.get('win_inheritance', True),
+                reset=kwargs.get('win_perms_reset', False))
             # pylint: enable=E1121
         else:
             ret, _ = check_perms(name, ret, user, group, mode)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4922,7 +4922,7 @@ def manage_file(name,
             # on Windows. The local function will be overridden
             # pylint: disable=E1121
             ret = check_perms(
-                name=name,
+                path=name,
                 ret=ret,
                 owner=kwargs.get('win_owner'),
                 grant_perms=kwargs.get('win_perms'),

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4918,12 +4918,18 @@ def manage_file(name,
                 'Replace symbolic link with regular file'
 
         if salt.utils.is_windows():
-            ret = check_perms(name,
-                              ret,
-                              kwargs.get('win_owner'),
-                              kwargs.get('win_perms'),
-                              kwargs.get('win_deny_perms'),
-                              kwargs.get('win_inheritance'))
+            # This function resides in win_file.py and will be available
+            # on Windows. The local function will be overridden
+            # pylint: disable=E1121
+            ret = check_perms(
+                name=name,
+                ret=ret,
+                owner=kwargs.get('win_owner'),
+                grant_perms=kwargs.get('win_perms'),
+                deny_perms=kwargs.get('win_deny_perms'),
+                inheritance=kwargs.get('win_inheritance'),
+                reset=kwargs.get('win_perms_reset'))
+            # pylint: enable=E1121
         else:
             ret, _ = check_perms(name, ret, user, group, mode, follow_symlinks)
 
@@ -4963,11 +4969,13 @@ def manage_file(name,
                 # This function resides in win_file.py and will be available
                 # on Windows. The local function will be overridden
                 # pylint: disable=E1121
-                makedirs_(name,
-                          kwargs.get('win_owner'),
-                          kwargs.get('win_perms'),
-                          kwargs.get('win_deny_perms'),
-                          kwargs.get('win_inheritance'))
+                makedirs_(
+                    path=name,
+                    owner=kwargs.get('win_owner'),
+                    grant_perms=kwargs.get('win_perms'),
+                    deny_perms=kwargs.get('win_deny_perms'),
+                    inheritance=kwargs.get('win_inheritance'),
+                    reset=kwargs.get('win_perms_reset'))
                 # pylint: enable=E1121
             else:
                 makedirs_(name, user=user, group=group, mode=dir_mode)
@@ -5081,12 +5089,18 @@ def manage_file(name,
             mode = oct((0o777 ^ mask) & 0o666)
 
         if salt.utils.is_windows():
-            ret = check_perms(name,
-                              ret,
-                              kwargs.get('win_owner'),
-                              kwargs.get('win_perms'),
-                              kwargs.get('win_deny_perms'),
-                              kwargs.get('win_inheritance'))
+            # This function resides in win_file.py and will be available
+            # on Windows. The local function will be overridden
+            # pylint: disable=E1121
+            ret = check_perms(
+                path=name,
+                ret=ret,
+                owner=kwargs.get('win_owner'),
+                grant_perms=kwargs.get('win_perms'),
+                deny_perms=kwargs.get('win_deny_perms'),
+                inheritance=kwargs.get('win_inheritance'),
+                reset=kwargs.get('win_perms_reset'))
+            # pylint: enable=E1121
         else:
             ret, _ = check_perms(name, ret, user, group, mode)
 

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1452,7 +1452,7 @@ def makedirs_perms(path,
                    grant_perms=None,
                    deny_perms=None,
                    inheritance=True,
-                   reset=True):
+                   reset=False):
     '''
     Set owner and permissions for each directory created.
 

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1877,8 +1877,18 @@ def check_perms(path,
     # If reset=True, which users will be removed as a result
     if reset:
         for user_name in cur_perms:
-            if not any(user_name in perms for perms in (grant_perms, deny_perms)):
-                ret['changes']['remove_perms'].update({user_name: cur_perms[user_name]})
+            if user_name not in grant_perms:
+                if 'grant' in cur_perms[user_name] and not cur_perms[user_name]['grant']['inherited']:
+                    if 'remove_perms' not in ret['changes']:
+                        ret['changes']['remove_perms'] = {}
+                    salt.utils.win_dacl.rm_permissions(obj_name=path, principal=user_name, ace_type='grant')
+                    ret['changes']['remove_perms'].update({user_name: cur_perms[user_name]})
+            if user_name not in deny_perms:
+                if 'deny' in cur_perms[user_name] and not cur_perms[user_name]['deny']['inherited']:
+                    if 'remove_perms' not in ret['changes']:
+                        ret['changes']['remove_perms'] = {}
+                    salt.utils.win_dacl.rm_permissions(obj_name=path, principal=user_name, ace_type='deny')
+                    ret['changes']['remove_perms'].update({user_name: cur_perms[user_name]})
 
     # Re-add the Original Comment if defined
     if isinstance(orig_comment, six.string_types):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -751,7 +751,8 @@ def _check_directory_win(name,
                          win_owner,
                          win_perms=None,
                          win_deny_perms=None,
-                         win_inheritance=None):
+                         win_inheritance=None,
+                         win_perms_reset=None):
     '''
     Check what changes need to be made on a directory
     '''
@@ -868,6 +869,12 @@ def _check_directory_win(name,
         if win_inheritance is not None:
             if not win_inheritance == salt.utils.win_dacl.get_inheritance(name):
                 changes['inheritance'] = win_inheritance
+
+        # Check reset
+        if win_perms_reset:
+            for user_name in perms:
+                if not any(user_name in perms for perms in (win_perms, win_deny_perms)):
+                    changes['remove_perms'].update({user_name: perms[user_name]})
 
     if changes:
         return None, 'The directory "{0}" will be changed'.format(name), changes
@@ -1549,6 +1556,7 @@ def managed(name,
             win_perms=None,
             win_deny_perms=None,
             win_inheritance=True,
+            win_perms_reset=False,
             **kwargs):
     r'''
     Manage a given file, this function allows for a file to be downloaded from
@@ -2043,6 +2051,13 @@ def managed(name,
 
         .. versionadded:: 2017.7.0
 
+    win_perms_reset : False
+        If ``True`` the existing DACL will be cleared and replaced with the
+        settings defined in this function. If ``False``, new entries will be
+        appended to the existing DACL. Default is ``False``.
+
+        .. versionadded:: 2017.7.3
+
     Here's an example using the above ``win_*`` parameters:
 
     .. code-block:: yaml
@@ -2287,8 +2302,13 @@ def managed(name,
         # Check and set the permissions if necessary
         if salt.utils.is_windows():
             ret = __salt__['file.check_perms'](
-                name, ret, win_owner, win_perms, win_deny_perms,
-                win_inheritance)
+                name=name,
+                ret=ret,
+                owner=win_owner,
+                grant_perms=win_perms,
+                deny_perms=win_deny_perms,
+                inheritance=win_inheritance,
+                reset=win_perms_reset)
         else:
             ret, _ = __salt__['file.check_perms'](
                 name, ret, user, group, mode, follow_symlinks)
@@ -2328,8 +2348,13 @@ def managed(name,
 
                 if salt.utils.is_windows():
                     ret = __salt__['file.check_perms'](
-                        name, ret, win_owner, win_perms, win_deny_perms,
-                        win_inheritance)
+                        name=name,
+                        ret=ret,
+                        owner=win_owner,
+                        grant_perms=win_perms,
+                        deny_perms=win_deny_perms,
+                        inheritance=win_inheritance,
+                        reset=win_perms_reset)
 
             if isinstance(ret['pchanges'], tuple):
                 ret['result'], ret['comment'] = ret['pchanges']
@@ -2420,6 +2445,7 @@ def managed(name,
                 win_perms=win_perms,
                 win_deny_perms=win_deny_perms,
                 win_inheritance=win_inheritance,
+                win_perms_reset=win_perms_reset,
                 encoding=encoding,
                 encoding_errors=encoding_errors,
                 **kwargs)
@@ -2488,6 +2514,7 @@ def managed(name,
                 win_perms=win_perms,
                 win_deny_perms=win_deny_perms,
                 win_inheritance=win_inheritance,
+                win_perms_reset=win_perms_reset,
                 encoding=encoding,
                 encoding_errors=encoding_errors,
                 **kwargs)
@@ -2561,6 +2588,7 @@ def directory(name,
               win_perms=None,
               win_deny_perms=None,
               win_inheritance=True,
+              win_perms_reset=False,
               **kwargs):
     r'''
     Ensure that a named directory is present and has the right perms
@@ -2722,6 +2750,13 @@ def directory(name,
 
         .. versionadded:: 2017.7.0
 
+    win_perms_reset : False
+        If ``True`` the existing DACL will be cleared and replaced with the
+        settings defined in this function. If ``False``, new entries will be
+        appended to the existing DACL. Default is ``False``.
+
+        .. versionadded:: 2017.7.3
+
     Here's an example using the above ``win_*`` parameters:
 
     .. code-block:: yaml
@@ -2846,7 +2881,12 @@ def directory(name,
     # Check directory?
     if salt.utils.is_windows():
         presult, pcomment, ret['pchanges'] = _check_directory_win(
-            name, win_owner, win_perms, win_deny_perms, win_inheritance)
+            name=name,
+            win_owner=win_owner,
+            win_perms=win_perms,
+            win_deny_perms=win_deny_perms,
+            win_inheritance=win_inheritance,
+            win_perms_reset=win_perms_reset)
     else:
         presult, pcomment, ret['pchanges'] = _check_directory(
             name, user, group, recurse or [], dir_mode, clean, require,
@@ -2871,8 +2911,13 @@ def directory(name,
                     if not os.path.isdir(drive):
                         return _error(
                             ret, 'Drive {0} is not mapped'.format(drive))
-                    __salt__['file.makedirs'](name, win_owner, win_perms,
-                                              win_deny_perms, win_inheritance)
+                    __salt__['file.makedirs'](
+                        path=name,
+                        owner=win_owner,
+                        grant_perms=win_perms,
+                        deny_perms=win_deny_perms,
+                        inheritance=win_inheritance,
+                        reset=win_perms_reset)
                 else:
                     __salt__['file.makedirs'](name, user=user, group=group,
                                               mode=dir_mode)
@@ -2881,8 +2926,13 @@ def directory(name,
                     ret, 'No directory to create {0} in'.format(name))
 
         if salt.utils.is_windows():
-            __salt__['file.mkdir'](name, win_owner, win_perms, win_deny_perms,
-                                   win_inheritance)
+            __salt__['file.mkdir'](
+                path=name,
+                owner=win_owner,
+                grant_perms=win_perms,
+                deny_perms=win_deny_perms,
+                inheritance=win_inheritance,
+                reset=win_perms_reset)
         else:
             __salt__['file.mkdir'](name, user=user, group=group, mode=dir_mode)
 
@@ -2896,7 +2946,13 @@ def directory(name,
     if not children_only:
         if salt.utils.is_windows():
             ret = __salt__['file.check_perms'](
-                name, ret, win_owner, win_perms, win_deny_perms, win_inheritance)
+                path=name,
+                ret=ret,
+                owner=win_owner,
+                grant_perms=win_perms,
+                deny_perms=win_deny_perms,
+                inheritance=win_inheritance,
+                reset=win_perms_reset)
         else:
             ret, perms = __salt__['file.check_perms'](
                 name, ret, user, group, dir_mode, follow_symlinks)
@@ -2967,8 +3023,13 @@ def directory(name,
                     try:
                         if salt.utils.is_windows():
                             ret = __salt__['file.check_perms'](
-                                full, ret, win_owner, win_perms, win_deny_perms,
-                                win_inheritance)
+                                path=full,
+                                ret=ret,
+                                owner=win_owner,
+                                grant_perms=win_perms,
+                                deny_perms=win_deny_perms,
+                                inheritance=win_inheritance,
+                                reset=win_perms_reset)
                         else:
                             ret, _ = __salt__['file.check_perms'](
                                 full, ret, user, group, file_mode, follow_symlinks)
@@ -2982,8 +3043,13 @@ def directory(name,
                     try:
                         if salt.utils.is_windows():
                             ret = __salt__['file.check_perms'](
-                                full, ret, win_owner, win_perms, win_deny_perms,
-                                win_inheritance)
+                                path=full,
+                                ret=ret,
+                                owner=win_owner,
+                                grant_perms=win_perms,
+                                deny_perms=win_deny_perms,
+                                inheritance=win_inheritance,
+                                reset=win_perms_reset)
                         else:
                             ret, _ = __salt__['file.check_perms'](
                                 full, ret, user, group, dir_mode, follow_symlinks)

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -841,6 +841,11 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                                                  ret)
 
                         recurse = ['ignore_files', 'ignore_dirs']
+                        ret.update({'comment': 'Must not specify "recurse" '
+                                               'options "ignore_files" and '
+                                               '"ignore_dirs" at the same '
+                                               'time.',
+                                    'pchanges': {}})
                         with patch.object(os.path, 'isdir', mock_t):
                             self.assertDictEqual(filestate.directory
                                                  (name, user=user,

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -815,7 +815,7 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                             'comment': comt,
                             'result': None,
                             'pchanges': p_chg,
-                            'changes': {'/etc/grub.conf': {'directory': 'new'}}
+                            'changes': {}
                         })
                         self.assertDictEqual(filestate.directory(name,
                                                                  user=user,


### PR DESCRIPTION
### What does this PR do?
Adds the ability to set the DACL of a file or directory object to be exactly what is specified in the CLI call or the state.

Adds the `reset` option to the following execution module functions in `win_file.py`:
- `mkdir`
- `makedirs_`
- `makedirs_perms`
- `check_perms`
- `set_perms`

Adds the `win_perms_reset` option to the following state module functions in `file.py`:
- `managed`
- `directory`
- `_check_directory_win`

Fixes some documentation issues (copy & paste errors that were not corrected)

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44460

### Previous Behavior
Could only add/remove entries to the DACL. Could not pass a list of permissions and say... Make these the permissions

### New Behavior
Now you can explicitly define the permissions for a file system object

### Tests written?
Yes

### Commits signed with GPG?
Yes