### PR TITLE
document note suggesting systemd-run --scope with cmd.run_bg

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -3127,6 +3127,12 @@ def run_bg(cmd,
     Note that ``env`` represents the environment variables for the command, and
     should be formatted as a dict, or a YAML string which resolves to a dict.
 
+    .. note::
+
+        If the init system is systemd and the backgrounded task should run even if the salt-minion process
+        is restarted, prepend ``systemd-run --scope`` to the command.  This will reparent the process in its
+        own scope separate from salt-minion, and will not be affected by restarting the minion service.
+
     :param str cmd: The command to run. ex: 'ls -lart /home'
 
     :param str cwd: The current working directory to execute the command in.


### PR DESCRIPTION
### What does this PR do?

adds a quick note about using `systemd-run --scope` with cmd.run_bg if using systemd and want the process to stay around after restarting salt-minion. 

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/22993

### Tests written?

No - Documentation

### Commits signed with GPG?

Yes
