### PR TITLE
Add __context__ to RunnerClient and WheelClient

### DIFF
--- a/doc/ref/states/writing.rst
+++ b/doc/ref/states/writing.rst
@@ -111,6 +111,8 @@ This code will call the `managed` function in the :mod:`file
 <salt.states.file>` state module and pass the arguments ``name`` and ``source``
 to it.
 
+.. _state-return-data:
+
 Return Data
 ===========
 

--- a/doc/topics/orchestrate/orchestrate_runner.rst
+++ b/doc/topics/orchestrate/orchestrate_runner.rst
@@ -5,10 +5,10 @@ Orchestrate Runner
 ==================
 
 Executing states or highstate on a minion is perfect when you want to ensure that
-minion configured and running the way you want. Sometimes however you want to 
+minion configured and running the way you want. Sometimes however you want to
 configure a set of minions all at once.
 
-For example, if you want to set up a load balancer in front of a cluster of web 
+For example, if you want to set up a load balancer in front of a cluster of web
 servers you can ensure the load balancer is set up first, and then the same
 matching configuration is applied consistently across the whole cluster.
 
@@ -220,6 +220,34 @@ To execute with pillar data.
 
     salt-run state.orch orch.deploy pillar='{"servers": "newsystem1",
     "master": "mymaster"}'
+
+
+Return Codes in Runner/Wheel Jobs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: Oxygen
+
+State (``salt.state``) jobs are able to report failure via the :ref:`state
+return dictionary <state-return-data>`. Remote execution (``salt.function``)
+jobs are able to report failure by setting a ``retcode`` key in the
+``__context__`` dictionary. However, runner (``salt.runner``) and wheel
+(``salt.wheel``) jobs would only report a ``False`` result when the
+runner/wheel function raised an exception. As of the Oxygen release, it is now
+possible to set a retcode in runner and wheel functions just as you can do in
+remote execution functions. Here is some example pseudocode:
+
+.. code-block:: python
+
+    def myrunner():
+        ...
+        do stuff
+        ...
+        if some_error_condition:
+            __context__['retcode'] = 1
+        return result
+
+This allows a custom runner/wheel function to report its failure so that
+requisites can accurately tell that a job has failed.
 
 
 More Complex Orchestration

--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -25,6 +25,25 @@ by any master tops matches that are not matched via a top file.
 To make master tops matches execute first, followed by top file matches, set
 the new :conf_minion:`master_tops_first` minion config option to ``True``.
 
+Return Codes for Runner/Wheel Functions
+---------------------------------------
+
+When using :ref:`orchestration <orchestrate-runner>`, runner and wheel
+functions used to report a ``True`` result if the function ran to completion
+without raising an exception. It is now possible to set a return code in the
+``__context__`` dictionary, allowing runner and wheel functions to report that
+they failed. Here's some example pseudocode:
+
+.. code-block:: python
+
+    def myrunner():
+        ...
+        do stuff
+        ...
+        if some_error_condition:
+            __context__['retcode'] = 1
+        return result
+
 LDAP via External Authentication Changes
 ----------------------------------------
 In this release of Salt, if LDAP Bind Credentials are supplied, then

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -385,7 +385,11 @@ class SyncClientMixin(object):
             # Initialize a context for executing the method.
             with tornado.stack_context.StackContext(self.functions.context_dict.clone):
                 data[u'return'] = self.functions[fun](*args, **kwargs)
-                data[u'success'] = True
+                try:
+                    data[u'success'] = self.context.get(u'retcode', 0) == 0
+                except AttributeError:
+                    # Assume a True result if no context attribute
+                    data[u'success'] = True
                 if isinstance(data[u'return'], dict) and u'data' in data[u'return']:
                     # some functions can return boolean values
                     data[u'success'] = salt.utils.state.check_result(data[u'return'][u'data'])

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -372,15 +372,18 @@ def tops(opts):
     return FilterDictWrapper(ret, u'.top')
 
 
-def wheels(opts, whitelist=None):
+def wheels(opts, whitelist=None, context=None):
     '''
     Returns the wheels modules
     '''
+    if context is None:
+        context = {}
     return LazyLoader(
         _module_dirs(opts, u'wheel'),
         opts,
         tag=u'wheel',
         whitelist=whitelist,
+        pack={u'__context__': context},
     )
 
 
@@ -836,17 +839,19 @@ def call(fun, **kwargs):
     return funcs[fun](*args)
 
 
-def runner(opts, utils=None):
+def runner(opts, utils=None, context=None):
     '''
     Directly call a function inside a loader directory
     '''
     if utils is None:
         utils = {}
+    if context is None:
+        context = {}
     ret = LazyLoader(
         _module_dirs(opts, u'runners', u'runner', ext_type_dirs=u'runner_dirs'),
         opts,
         tag=u'runners',
-        pack={u'__utils__': utils},
+        pack={u'__utils__': utils, u'__context__': context},
     )
     # TODO: change from __salt__ to something else, we overload __salt__ too much
     ret.pack[u'__salt__'] = ret

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -43,6 +43,7 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
 
     def __init__(self, opts):
         self.opts = opts
+        self.context = {}
 
     @property
     def functions(self):
@@ -51,11 +52,13 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
                 self.utils = salt.loader.utils(self.opts)
             # Must be self.functions for mixin to work correctly :-/
             try:
-                self._functions = salt.loader.runner(self.opts, utils=self.utils)
+                self._functions = salt.loader.runner(
+                    self.opts, utils=self.utils, context=self.context)
             except AttributeError:
                 # Just in case self.utils is still not present (perhaps due to
                 # problems with the loader), load the runner funcs without them
-                self._functions = salt.loader.runner(self.opts)
+                self._functions = salt.loader.runner(
+                    self.opts, context=self.context)
 
         return self._functions
 

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -787,28 +787,16 @@ def runner(name, **kwargs):
     runner_return = out.get('return')
     if isinstance(runner_return, dict) and 'Error' in runner_return:
         out['success'] = False
-    if not out.get('success', True):
-        cmt = "Runner function '{0}' failed{1}.".format(
+
+    success = out.get('success', True)
+    ret = {'name': name,
+           'changes': {},
+           'result': success}
+    ret['comment'] = "Runner function '{0}' {1}{2}.".format(
             name,
+            'executed' if success else 'failed',
             ' with return {0}'.format(runner_return) if runner_return else '',
         )
-        ret = {
-            'name': name,
-            'result': False,
-            'changes': {},
-            'comment': cmt,
-        }
-    else:
-        cmt = "Runner function '{0}' executed{1}.".format(
-            name,
-            ' with return {0}'.format(runner_return) if runner_return else '',
-        )
-        ret = {
-            'name': name,
-            'result': True,
-            'changes': {},
-            'comment': cmt,
-        }
 
     ret['__orchestration__'] = True
     if 'jid' in out:
@@ -1039,15 +1027,22 @@ def wheel(name, **kwargs):
                                      __env__=__env__,
                                      **kwargs)
 
-    ret['result'] = True
+    wheel_return = out.get('return')
+    if isinstance(wheel_return, dict) and 'Error' in wheel_return:
+        out['success'] = False
+
+    success = out.get('success', True)
+    ret = {'name': name,
+           'changes': {},
+           'result': success}
+    ret['comment'] = "Wheel function '{0}' {1}{2}.".format(
+            name,
+            'executed' if success else 'failed',
+            ' with return {0}'.format(wheel_return) if wheel_return else '',
+        )
+
     ret['__orchestration__'] = True
     if 'jid' in out:
         ret['__jid__'] = out['jid']
-
-    runner_return = out.get('return')
-    ret['comment'] = "Wheel function '{0}' executed{1}.".format(
-        name,
-        ' with return {0}'.format(runner_return) if runner_return else '',
-    )
 
     return ret

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -790,13 +790,12 @@ def runner(name, **kwargs):
 
     success = out.get('success', True)
     ret = {'name': name,
-           'changes': {},
+           'changes': {'return': runner_return},
            'result': success}
-    ret['comment'] = "Runner function '{0}' {1}{2}.".format(
-            name,
-            'executed' if success else 'failed',
-            ' with return {0}'.format(runner_return) if runner_return else '',
-        )
+    ret['comment'] = "Runner function '{0}' {1}.".format(
+        name,
+        'executed' if success else 'failed',
+    )
 
     ret['__orchestration__'] = True
     if 'jid' in out:
@@ -1033,13 +1032,12 @@ def wheel(name, **kwargs):
 
     success = out.get('success', True)
     ret = {'name': name,
-           'changes': {},
+           'changes': {'return': wheel_return},
            'result': success}
-    ret['comment'] = "Wheel function '{0}' {1}{2}.".format(
-            name,
-            'executed' if success else 'failed',
-            ' with return {0}'.format(wheel_return) if wheel_return else '',
-        )
+    ret['comment'] = "Wheel function '{0}' {1}.".format(
+        name,
+        'executed' if success else 'failed',
+    )
 
     ret['__orchestration__'] = True
     if 'jid' in out:

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -43,7 +43,8 @@ class WheelClient(salt.client.mixins.SyncClientMixin,
 
     def __init__(self, opts=None):
         self.opts = opts
-        self.functions = salt.loader.wheels(opts)
+        self.context = {}
+        self.functions = salt.loader.wheels(opts, context=self.context)
 
     # TODO: remove/deprecate
     def call_func(self, fun, **kwargs):

--- a/tests/integration/files/file/base/_runners/runtests_helpers.py
+++ b/tests/integration/files/file/base/_runners/runtests_helpers.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+'''
+Runner functions for integration tests
+'''
+
+# Import python libs
+from __future__ import absolute_import
+
+
+def failure():
+    __context__['retcode'] = 1
+    return False
+
+
+def success():
+    return True

--- a/tests/integration/files/file/base/_wheel/runtests_helpers.py
+++ b/tests/integration/files/file/base/_wheel/runtests_helpers.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+'''
+Wheel functions for integration tests
+'''
+
+# Import python libs
+from __future__ import absolute_import
+
+
+def failure():
+    __context__['retcode'] = 1
+    return False
+
+
+def success():
+    return True

--- a/tests/integration/files/file/base/orch/retcode.sls
+++ b/tests/integration/files/file/base/orch/retcode.sls
@@ -1,0 +1,15 @@
+test_runner_success:
+  salt.runner:
+    - name: runtests_helpers.success
+
+test_runner_failure:
+  salt.runner:
+    - name: runtests_helpers.failure
+
+test_wheel_success:
+  salt.wheel:
+    - name: runtests_helpers.success
+
+test_wheel_failure:
+  salt.wheel:
+    - name: runtests_helpers.failure

--- a/tests/integration/runners/test_state.py
+++ b/tests/integration/runners/test_state.py
@@ -106,6 +106,35 @@ class StateRunnerTest(ShellCase):
             for item in out:
                 self.assertIn(item, ret)
 
+    def test_orchestrate_retcode(self):
+        '''
+        Test orchestration with nonzero retcode set in __context__
+        '''
+        self.run_run('saltutil.sync_runners')
+        self.run_run('saltutil.sync_wheel')
+        ret = '\n'.join(self.run_run('state.orchestrate orch.retcode'))
+
+        for result in ('          ID: test_runner_success\n'
+                       '    Function: salt.runner\n'
+                       '        Name: runtests_helpers.success\n'
+                       '      Result: True',
+
+                       '          ID: test_runner_failure\n'
+                       '    Function: salt.runner\n'
+                       '        Name: runtests_helpers.failure\n'
+                       '      Result: False',
+
+                       '          ID: test_wheel_success\n'
+                       '    Function: salt.wheel\n'
+                       '        Name: runtests_helpers.success\n'
+                       '      Result: True',
+
+                       '          ID: test_wheel_failure\n'
+                       '    Function: salt.wheel\n'
+                       '        Name: runtests_helpers.failure\n'
+                       '      Result: False'):
+            self.assertIn(result, ret)
+
     def test_orchestrate_target_doesnt_exists(self):
         '''
         test orchestration when target doesnt exist

--- a/tests/unit/states/test_saltmod.py
+++ b/tests/unit/states/test_saltmod.py
@@ -258,8 +258,8 @@ class SaltmodTestCase(TestCase, LoaderModuleMockMixin):
         '''
         name = 'state'
 
-        ret = {'changes': {}, 'name': 'state', 'result': True,
-               'comment': 'Runner function \'state\' executed with return True.',
+        ret = {'changes': {'return': True}, 'name': 'state', 'result': True,
+               'comment': 'Runner function \'state\' executed.',
                '__orchestration__': True}
         runner_mock = MagicMock(return_value={'return': True})
 
@@ -274,8 +274,8 @@ class SaltmodTestCase(TestCase, LoaderModuleMockMixin):
         '''
         name = 'state'
 
-        ret = {'changes': {}, 'name': 'state', 'result': True,
-               'comment': 'Wheel function \'state\' executed with return True.',
+        ret = {'changes': {'return': True}, 'name': 'state', 'result': True,
+               'comment': 'Wheel function \'state\' executed.',
                '__orchestration__': True}
         wheel_mock = MagicMock(return_value={'return': True})
 


### PR DESCRIPTION
### What does this PR do?

Allows for a retcode to be set via `__context__`. Example pseudocode:

```python
def my_runner_func():
    ...
    do stuff
    ...
    if error_detected:
        __context__['retcode'] = 1
    return result
```

Orchestration will use a nonzero retcode to assume a False result for the runner/wheel orchestration job.

### What issues does this PR fix or reference?

#42188

### Testing/Replication

I've created a Docker image for this. When the Docker commands below are run from the root of a git clone of Salt, they will run Salt from the git checkout. Use [this walkthrough](https://help.github.com/articles/checking-out-pull-requests-locally/) for information on checking out a pull request locally if you would like to confirm this fix.

```
% docker run --rm -it -v $PWD:/testing terminalmage/issues:42188 cat /srv/salt/test.sls
runner_succeeded:
  salt.runner:
    - name: runnertest.succeeded

runner_failed:
  salt.runner:
    - name: runnertest.failed
% docker run --rm -it -v $PWD:/testing terminalmage/issues:42188 cat /srv/salt/_runners/runnertest.py
def succeeded():
    return True

def foo():
    return 'foo'

def failed():
    __context__['retcode'] = 1
    return False
```

### Previous Behavior

The result would be considered `True` if the runner/wheel function ran to completion without raising an exception.

```
% docker run --rm -it -v $PWD:/testing terminalmage/issues:42188 sh -c "salt-master -d; salt-run state.orch test"/testing/salt/utils/verify.py:215: DeprecationWarning: Use of 'pki_dir' was detected: 'pki_dir' has been deprecated in favor of 'sensitive_dirs'. Support for 'pki_dir' will be removed in Salt Neon.
1357e28844f9_master:
----------
          ID: runner_succeeded
    Function: salt.runner
        Name: runnertest.succeeded
      Result: True
     Comment: Runner function 'runnertest.succeeded' executed with return True.
     Started: 04:11:37.892796
    Duration: 6704.284 ms
     Changes:
----------
          ID: runner_failed
    Function: salt.runner
        Name: runnertest.failed
      Result: True
     Comment: Runner function 'runnertest.failed' executed.
     Started: 04:11:44.597303
    Duration: 6331.277 ms
     Changes:

Summary for 1357e28844f9_master
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2
Total run time:  13.036 s
```

### New Behavior

Runner and wheel functions can now report to the orchestration runner that they did not succeed.

```
% docker run --rm -it -v $PWD:/testing terminalmage/issues:42188 sh -c "salt-master -d; salt-run state.orch test"
/testing/salt/utils/verify.py:215: DeprecationWarning: Use of 'pki_dir' was detected: 'pki_dir' has been deprecated in favor of 'sensitive_dirs'. Support for 'pki_dir' will be removed in Salt Neon.
[ERROR   ] Runner function 'runnertest.failed' failed.
01ba31422c95_master:
----------
          ID: runner_succeeded
    Function: salt.runner
        Name: runnertest.succeeded
      Result: True
     Comment: Runner function 'runnertest.succeeded' executed with return True.
     Started: 03:59:53.176967
    Duration: 6909.516 ms
     Changes:
----------
          ID: runner_failed
    Function: salt.runner
        Name: runnertest.failed
      Result: False
     Comment: Runner function 'runnertest.failed' failed.
     Started: 04:00:00.086712
    Duration: 5995.296 ms
     Changes:

Summary for 01ba31422c95_master
------------
Succeeded: 1
Failed:    1
------------
Total states run:     2
Total run time:  12.905 s
```

### Tests written?

Yes

```
% docker run --rm -it -v $PWD:/testing terminalmage/issues:42188 python /testing/tests/runtests.py -n integration.runners.test_state.StateRunnerTest.test_orchestrate_retcode
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Python Version: 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
 * Transplanting configuration files to '/tmp/salt-tests-tmpdir/config'
 * Current Directory: /testing
 * Test suite is running under PID 1
 * Logging tests on /tmp/salt-runtests.log
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Setting up Salt daemons to execute tests
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Starting salt-master ... STARTED!
 * Starting salt-minion ... STARTED!
 * Starting sub salt-minion ... STARTED!
 * Starting syndic salt-master ... STARTED!
 * Starting salt-syndic ... STARTED!
===================================================================================
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Starting integration.runners.test_state.StateRunnerTest.test_orchestrate_retcode Tests
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ERROR   ] Runner function 'runtests_helpers.failure' failed.
[ERROR   ] Wheel function 'runtests_helpers.failure' failed.
.
----------------------------------------------------------------------
Ran 1 test in 26.578s

OK

=============================  Overall Tests Report  ==============================
***  No Problems Found While Running Tests  ***************************************
===================================================================================
OK (total=1, skipped=0, passed=1, failures=0, errors=0)
=============================  Overall Tests Report  ==============================
```

### Commits signed with GPG?

Yes