### PR TITLE
Backported issue #42713 to 2017.7

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -586,7 +586,18 @@ class RemoteFuncs(object):
         ret = {}
         if not salt.utils.verify.valid_id(self.opts, load['id']):
             return ret
-        match_type = load.get('tgt_type', 'glob')
+        expr_form = load.get('expr_form')
+        if expr_form is not None and 'tgt_type' not in load:
+            salt.utils.warn_until(
+                u'Neon',
+                u'_mine_get: minion {0} uses pre-Nitrogen API key '
+                u'"expr_form". Accepting for backwards compatibility '
+                u'but this is not guaranteed '
+                u'after the Neon release'.format(load['id'])
+            )
+            match_type = expr_form
+        else:
+            match_type = load.get('tgt_type', 'glob')
         if match_type.lower() == 'pillar':
             match_type = 'pillar_exact'
         if match_type.lower() == 'compound':

--- a/tests/unit/daemons/test_masterapi.py
+++ b/tests/unit/daemons/test_masterapi.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+
+# Import Salt libs
+import salt.config
+import salt.daemons.masterapi as masterapi
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase
+from tests.support.mock import (
+    patch,
+    MagicMock,
+)
+
+
+class FakeCache(object):
+
+    def __init__(self):
+        self.data = {}
+
+    def store(self, bank, key, value):
+        self.data[bank, key] = value
+
+    def fetch(self, bank, key):
+        return self.data[bank, key]
+
+
+class RemoteFuncsTestCase(TestCase):
+    '''
+    TestCase for salt.daemons.masterapi.RemoteFuncs class
+    '''
+
+    def setUp(self):
+        opts = salt.config.master_config(None)
+        self.funcs = masterapi.RemoteFuncs(opts)
+        self.funcs.cache = FakeCache()
+
+    def test_mine_get(self, tgt_type_key='tgt_type'):
+        '''
+        Asserts that ``mine_get`` gives the expected results.
+
+        Actually this only tests that:
+
+        - the correct check minions method is called
+        - the correct cache key is subsequently used
+        '''
+        self.funcs.cache.store('minions/webserver', 'mine',
+                               dict(ip_addr='2001:db8::1:3'))
+        with patch('salt.utils.minions.CkMinions._check_compound_minions',
+                   MagicMock(return_value=['webserver'])):
+            ret = self.funcs._mine_get(
+                {
+                    'id': 'requester_minion',
+                    'tgt': 'G@roles:web',
+                    'fun': 'ip_addr',
+                    tgt_type_key: 'compound',
+                }
+            )
+        self.assertDictEqual(ret, dict(webserver='2001:db8::1:3'))
+
+    def test_mine_get_pre_nitrogen_compat(self):
+        '''
+        Asserts that pre-Nitrogen API key ``expr_form`` is still accepted.
+
+        This is what minions before Nitrogen would issue.
+        '''
+        self.test_mine_get(tgt_type_key='expr_form')


### PR DESCRIPTION
Cherry-picked and squashed the two commits from the develop branch

The unit test module didn't exist at all on 2017.7, hence a conflict during
cherry picking, resolved by introducing only the new tests (the other ones
don't pass as is on 2017.7).

I'm thinking of taking a look at the other tests, in case they can easily be backported in a subsequent PR.

See the commit message for more technical details.

The commit is signed, I get an unchangeed pylint core on dameons/masterapi.py (9.37/10)



