### PR TITLE
Skip `unit.transport.test_ipc` for Windows

### DIFF
--- a/tests/unit/transport/test_ipc.py
+++ b/tests/unit/transport/test_ipc.py
@@ -26,10 +26,12 @@ from salt.ext.six.moves import range
 # Import Salt Testing libs
 from tests.support.mock import MagicMock
 from tests.support.paths import TMP
+from tests.support.unit import skipIf
 
 log = logging.getLogger(__name__)
 
 
+@skipIf(salt.utils.is_windows(), 'Windows does not support Posix IPC')
 class BaseIPCReqCase(tornado.testing.AsyncTestCase):
     '''
     Test the req server/client pair


### PR DESCRIPTION
### What does this PR do?
Skips the IPC transport tests in Windows. Windows does not support Posix IPC sockets.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/issues/439

### Tests written?
No

### Commits signed with GPG?
Yes