### PR TITLE
Bump some deprecation warnings from Oxygen to Fluorine

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -237,7 +237,7 @@ class SyncClientMixin(object):
 
     def low(self, fun, low, print_event=True, full_return=False):
         '''
-        Check for deprecated usage and allow until Salt Oxygen.
+        Check for deprecated usage and allow until Salt Fluorine.
         '''
         msg = []
         if 'args' in low:
@@ -248,7 +248,7 @@ class SyncClientMixin(object):
             low['kwarg'] = low.pop('kwargs')
 
         if msg:
-            salt.utils.warn_until('Oxygen', ' '.join(msg))
+            salt.utils.warn_until('Fluorine', ' '.join(msg))
 
         return self._low(fun, low, print_event=print_event, full_return=full_return)
 

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -696,7 +696,7 @@ def edited_conf(name, lxc_conf=None, lxc_conf_unset=None):
     # to keep this function around and cannot officially remove it. Progress of
     # the new function will be tracked in https://github.com/saltstack/salt/issues/35523
     salt.utils.warn_until(
-        'Oxygen',
+        'Fluorine',
         'This state is unsuitable for setting parameters that appear more '
         'than once in an LXC config file, or parameters which must appear in '
         'a certain order (such as when configuring more than one network '

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1115,10 +1115,10 @@ def format_call(fun,
             continue
         extra[key] = copy.deepcopy(value)
 
-    # We'll be showing errors to the users until Salt Oxygen comes out, after
+    # We'll be showing errors to the users until Salt Fluorine comes out, after
     # which, errors will be raised instead.
     warn_until(
-        'Oxygen',
+        'Fluorine',
         'It\'s time to start raising `SaltInvocationError` instead of '
         'returning warnings',
         # Let's not show the deprecation warning on the console, there's no
@@ -1155,7 +1155,7 @@ def format_call(fun,
             '{0}. If you were trying to pass additional data to be used '
             'in a template context, please populate \'context\' with '
             '\'key: value\' pairs. Your approach will work until Salt '
-            'Oxygen is out.{1}'.format(
+            'Fluorine is out.{1}'.format(
                 msg,
                 '' if 'full' not in ret else ' Please update your state files.'
             )


### PR DESCRIPTION
### What does this PR do?
The following files had deprecation warnings for "Oxygen" that should be handled in the next feature release (Fluorine):

- salt/client/mixins.py
- salt/states/lxc.py
- salt/utils/__init__.py

### What issues does this PR fix or reference?
#35523 and #35777

### Tests written?
No

### Commits signed with GPG?

Yes
