### PR TITLE
[develop] Bump deprecation notice in utils/args from Oxygen to Fluorine

### DIFF
--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -451,10 +451,10 @@ def format_call(fun,
             continue
         extra[key] = copy.deepcopy(value)
 
-    # We'll be showing errors to the users until Salt Oxygen comes out, after
+    # We'll be showing errors to the users until Salt Fluorine comes out, after
     # which, errors will be raised instead.
     salt.utils.versions.warn_until(
-        'Oxygen',
+        'Fluorine',
         'It\'s time to start raising `SaltInvocationError` instead of '
         'returning warnings',
         # Let's not show the deprecation warning on the console, there's no
@@ -491,7 +491,7 @@ def format_call(fun,
             '{0}. If you were trying to pass additional data to be used '
             'in a template context, please populate \'context\' with '
             '\'key: value\' pairs. Your approach will work until Salt '
-            'Oxygen is out.{1}'.format(
+            'Fluorine is out.{1}'.format(
                 msg,
                 '' if 'full' not in ret else ' Please update your state files.'
             )


### PR DESCRIPTION
### What does this PR do?
This is the same fix for the `utils/__init__.py` in PR #44738, but since the `format_call` function has been moved to `salt.utils.args.py` in `develop`, we need to bump the version in that file as well.

### What issues does this PR fix or reference?
Refs #35777

### Tests written?

No

### Commits signed with GPG?

Yes