### PR TITLE
if gateway is not specified use iface

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -1070,8 +1070,8 @@ def build_routes(iface, **settings):
     log.debug("IPv4 routes:\n{0}".format(opts4))
     log.debug("IPv6 routes:\n{0}".format(opts6))
 
-    routecfg = template.render(routes=opts4)
-    routecfg6 = template.render(routes=opts6)
+    routecfg = template.render(routes=opts4, iface=iface)
+    routecfg6 = template.render(routes=opts6, iface=iface)
 
     if settings['test']:
         routes = _read_temp(routecfg)

--- a/salt/templates/rh_ip/rh6_route_eth.jinja
+++ b/salt/templates/rh_ip/rh6_route_eth.jinja
@@ -5,5 +5,6 @@
 /{{route.netmask}}
 {%- endif -%}
 {%- if route.gateway %} via {{route.gateway}}
+{%- else %} dev {{iface}}
 {%- endif %}
 {% endfor -%}


### PR DESCRIPTION
### What does this PR do?
This will allow for the route to be applied to drop the packets on that
interface.

### What issues does this PR fix or reference?
Fixes #44730

### Previous Behavior
route-eth0 looks like
```
# cat /etc/sysconfig/network-scripts/route-eth0
8.8.8.0/255.255.255.0
```
Which is invalid if networkmanager is not running

### New Behavior
route-eth0 will look like

```
# cat /etc/sysconfig/network-scripts/route-eth0
8.8.8.0/255.255.255.0 dev eth0
```

Which is valid for network manager and just the regular network startup.

### Tests written?

No

### Commits signed with GPG?

Yes