### PR TITLE
use a copy so roster_defaults doesn't mangle

### DIFF
--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -77,7 +77,7 @@ class RosterMatcher(object):
             if fnmatch.fnmatch(minion, self.tgt):
                 data = self.get_data(minion)
                 if data:
-                    minions[minion] = data
+                    minions[minion] = data.copy()
         return minions
 
     def ret_pcre_minions(self):
@@ -89,7 +89,7 @@ class RosterMatcher(object):
             if re.match(self.tgt, minion):
                 data = self.get_data(minion)
                 if data:
-                    minions[minion] = data
+                    minions[minion] = data.copy()
         return minions
 
     def ret_list_minions(self):
@@ -103,7 +103,7 @@ class RosterMatcher(object):
             if minion in self.tgt:
                 data = self.get_data(minion)
                 if data:
-                    minions[minion] = data
+                    minions[minion] = data.copy()
         return minions
 
     def ret_nodegroup_minions(self):
@@ -119,7 +119,7 @@ class RosterMatcher(object):
             if minion in nodegroup:
                 data = self.get_data(minion)
                 if data:
-                    minions[minion] = data
+                    minions[minion] = data.copy()
         return minions
 
     def ret_range_minions(self):
@@ -136,7 +136,7 @@ class RosterMatcher(object):
             if minion in range_hosts:
                 data = self.get_data(minion)
                 if data:
-                    minions[minion] = data
+                    minions[minion] = data.copy()
         return minions
 
     def get_data(self, minion):

--- a/tests/unit/ssh/test_roster_defaults.py
+++ b/tests/unit/ssh/test_roster_defaults.py
@@ -1,0 +1,70 @@
+
+# -*- coding: utf-8 -*-
+'''
+Test roster default rendering
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import os
+import shutil
+import tempfile
+import yaml
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase
+from tests.support.mock import MagicMock, patch
+from tests.support.paths import TMP
+
+# Import Salt libs
+import salt.roster
+import salt.config
+import salt.utils
+
+ROSTER = '''
+localhost:
+  host: 127.0.0.1
+  port: 2827
+self:
+  host: 0.0.0.0
+  port: 42
+'''
+
+
+class SSHRosterDefaults(TestCase):
+    def test_roster_defaults_flat(self):
+        '''
+        Test Roster Defaults on the flat roster
+        '''
+        tempdir = tempfile.mkdtemp(dir=TMP)
+        expected = {
+            'self': {
+                'host': '0.0.0.0',
+                'user': 'daniel',
+                'port': 42,
+            },
+            'localhost': {
+                'host': '127.0.0.1',
+                'user': 'daniel',
+                'port': 2827,
+            },
+        }
+        try:
+            root_dir = os.path.join(tempdir, 'foo', 'bar')
+            os.makedirs(root_dir)
+            fpath = os.path.join(root_dir, 'config')
+            with salt.utils.fopen(fpath, 'w') as fp_:
+                fp_.write(
+                    '''
+                    roster_defaults:
+                      user: daniel
+                    '''
+                )
+            opts = salt.config.master_config(fpath)
+            with patch('salt.roster.get_roster_file', MagicMock(return_value=ROSTER)):
+                with patch('salt.template.compile_template', MagicMock(return_value=yaml.load(ROSTER))):
+                    roster = salt.roster.Roster(opts=opts)
+                    self.assertEqual(roster.targets('*', 'glob'), expected)
+        finally:
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)


### PR DESCRIPTION
### What does this PR do?
The minion information is getting mangled if the roster_defaults is set

### What issues does this PR fix or reference?
Fixes #44744

### Tests written?

Yes

### Commits signed with GPG?

Yes