### PR TITLE
Include failed state/function orchestration results in changes dict

### DIFF
--- a/doc/topics/orchestrate/orchestrate_runner.rst
+++ b/doc/topics/orchestrate/orchestrate_runner.rst
@@ -258,6 +258,7 @@ To execute with pillar data.
     salt-run state.orch orch.deploy pillar='{"servers": "newsystem1",
     "master": "mymaster"}'
 
+.. _orchestrate-runner-return-codes-runner-wheel:
 
 Return Codes in Runner/Wheel Jobs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -591,9 +592,10 @@ loadable and parsable format:
 
 
 The Oxygen release includes a couple fixes to make parsing this data easier and
-more accurate. The first is the ability to set a return code in a custom runner
-or wheel function, as noted above. The second is a change to how failures are
-included in the return data. Prior to the Oxygen release, minions that failed a
+more accurate. The first is the ability to set a :ref:`return code
+<orchestrate-runner-return-codes-runner-wheel>` in a custom runner or wheel
+function, as noted above. The second is a change to how failures are included
+in the return data. Prior to the Oxygen release, minions that failed a
 ``salt.state`` orchestration job would show up in the ``comment`` field of the
 return data, in a human-readable string that was not easily parsed. They are
 now included in the ``changes`` dictionary alongside the minions that

--- a/doc/topics/orchestrate/orchestrate_runner.rst
+++ b/doc/topics/orchestrate/orchestrate_runner.rst
@@ -137,6 +137,43 @@ can specify the "name" argument to avoid conflicting IDs:
         - kwarg:
             remove_existing: true
 
+.. _orchestrate-runner-fail-functions:
+
+Fail Functions
+**************
+
+When running a remote execution function in orchestration, certain return
+values for those functions may indicate failure, while the function itself
+doesn't set a return code. For those circumstances, using a "fail function"
+allows for a more flexible means of assessing success or failure.
+
+A fail function can be written as part of a :ref:`custom execution module
+<writing-execution-modules>`. The function should accept one argument, and
+return a boolean result. For example:
+
+.. code-block:: python
+
+    def check_func_result(retval):
+        if some_condition:
+            return True
+        else:
+            return False
+
+
+The function can then be referenced in orchestration SLS like so:
+
+.. code-block:: yaml
+
+    do_stuff:
+      salt.function:
+        - name: modname.funcname
+        - tgt: '*'
+        - fail_function: mymod.check_func_result
+
+.. important::
+    Fail functions run *on the master*, so they must be synced using ``salt-run
+    saltutil.sync_modules``.
+
 State
 ^^^^^
 
@@ -298,3 +335,269 @@ Given the above setup, the orchestration will be carried out as follows:
 .. note::
 
     Remember, salt-run is always executed on the master.
+
+.. _orchestrate-runner-parsing-results-programatically:
+
+Parsing Results Programatically
+-------------------------------
+
+Orchestration jobs return output in a specific data structure. That data
+structure is represented differently depending on the outputter used. With the
+default outputter for orchestration, you get a nice human-readable output.
+Assume the following orchestration SLS:
+
+.. code-block:: yaml
+
+    good_state:
+      salt.state:
+        - tgt: myminion
+        - sls:
+        - succeed_with_changes
+
+    bad_state:
+      salt.state:
+        - tgt: myminion
+        - sls:
+        - fail_with_changes
+
+    mymod.myfunc:
+      salt.function:
+        - tgt: myminion
+
+    mymod.myfunc_false_result:
+      salt.function:
+        - tgt: myminion
+
+
+Running this using the default outputter would produce output which looks like
+this:
+
+.. code-block:: text
+
+    fa5944a73aa8_master:
+    ----------
+              ID: good_state
+        Function: salt.state
+          Result: True
+         Comment: States ran successfully. Updating myminion.
+         Started: 21:08:02.681604
+        Duration: 265.565 ms
+         Changes:
+                  myminion:
+                  ----------
+                            ID: test succeed with changes
+                      Function: test.succeed_with_changes
+                        Result: True
+                       Comment: Success!
+                       Started: 21:08:02.835893
+                      Duration: 0.375 ms
+                       Changes:
+                                ----------
+                                testing:
+                                    ----------
+                                    new:
+                                        Something pretended to change
+                                    old:
+                                        Unchanged
+
+                  Summary for myminion
+                  ------------
+                  Succeeded: 1 (changed=1)
+                  Failed:    0
+                  ------------
+                  Total states run:     1
+                  Total run time:   0.375 ms
+    ----------
+              ID: bad_state
+        Function: salt.state
+          Result: False
+         Comment: Run failed on minions: myminion
+         Started: 21:08:02.947702
+        Duration: 177.01 ms
+         Changes:
+                  myminion:
+                  ----------
+                            ID: test fail with changes
+                      Function: test.fail_with_changes
+                        Result: False
+                       Comment: Failure!
+                       Started: 21:08:03.116634
+                      Duration: 0.502 ms
+                       Changes:
+                                ----------
+                                testing:
+                                    ----------
+                                    new:
+                                        Something pretended to change
+                                    old:
+                                        Unchanged
+
+                  Summary for myminion
+                  ------------
+                  Succeeded: 0 (changed=1)
+                  Failed:    1
+                  ------------
+                  Total states run:     1
+                  Total run time:   0.502 ms
+    ----------
+              ID: mymod.myfunc
+        Function: salt.function
+          Result: True
+         Comment: Function ran successfully. Function mymod.myfunc ran on myminion.
+         Started: 21:08:03.125011
+        Duration: 159.488 ms
+         Changes:
+                  myminion:
+                      True
+    ----------
+              ID: mymod.myfunc_false_result
+        Function: salt.function
+          Result: False
+         Comment: Running function mymod.myfunc_false_result failed on minions: myminion. Function mymod.myfunc_false_result ran on myminion.
+         Started: 21:08:03.285148
+        Duration: 176.787 ms
+         Changes:
+                  myminion:
+                      False
+
+    Summary for fa5944a73aa8_master
+    ------------
+    Succeeded: 2 (changed=4)
+    Failed:    2
+    ------------
+    Total states run:     4
+    Total run time: 778.850 ms
+
+
+However, using the ``json`` outputter, you can get the output in an easily
+loadable and parsable format:
+
+.. code-block:: bash
+
+    salt-run state.orchestrate test --out=json
+
+.. code-block:: json
+
+    {
+        "outputter": "highstate",
+        "data": {
+            "fa5944a73aa8_master": {
+                "salt_|-good_state_|-good_state_|-state": {
+                    "comment": "States ran successfully. Updating myminion.",
+                    "name": "good_state",
+                    "start_time": "21:35:16.868345",
+                    "result": true,
+                    "duration": 267.299,
+                    "__run_num__": 0,
+                    "__jid__": "20171130213516897392",
+                    "__sls__": "test",
+                    "changes": {
+                        "ret": {
+                            "myminion": {
+                                "test_|-test succeed with changes_|-test succeed with changes_|-succeed_with_changes": {
+                                    "comment": "Success!",
+                                    "name": "test succeed with changes",
+                                    "start_time": "21:35:17.022592",
+                                    "result": true,
+                                    "duration": 0.362,
+                                    "__run_num__": 0,
+                                    "__sls__": "succeed_with_changes",
+                                    "changes": {
+                                        "testing": {
+                                            "new": "Something pretended to change",
+                                            "old": "Unchanged"
+                                        }
+                                    },
+                                    "__id__": "test succeed with changes"
+                                }
+                            }
+                        },
+                        "out": "highstate"
+                    },
+                    "__id__": "good_state"
+                },
+                "salt_|-bad_state_|-bad_state_|-state": {
+                    "comment": "Run failed on minions: test",
+                    "name": "bad_state",
+                    "start_time": "21:35:17.136511",
+                    "result": false,
+                    "duration": 197.635,
+                    "__run_num__": 1,
+                    "__jid__": "20171130213517202203",
+                    "__sls__": "test",
+                    "changes": {
+                        "ret": {
+                            "myminion": {
+                                "test_|-test fail with changes_|-test fail with changes_|-fail_with_changes": {
+                                    "comment": "Failure!",
+                                    "name": "test fail with changes",
+                                    "start_time": "21:35:17.326268",
+                                    "result": false,
+                                    "duration": 0.509,
+                                    "__run_num__": 0,
+                                    "__sls__": "fail_with_changes",
+                                    "changes": {
+                                        "testing": {
+                                            "new": "Something pretended to change",
+                                            "old": "Unchanged"
+                                        }
+                                    },
+                                    "__id__": "test fail with changes"
+                                }
+                            }
+                        },
+                        "out": "highstate"
+                    },
+                    "__id__": "bad_state"
+                },
+                "salt_|-mymod.myfunc_|-mymod.myfunc_|-function": {
+                    "comment": "Function ran successfully. Function mymod.myfunc ran on myminion.",
+                    "name": "mymod.myfunc",
+                    "start_time": "21:35:17.334373",
+                    "result": true,
+                    "duration": 151.716,
+                    "__run_num__": 2,
+                    "__jid__": "20171130213517361706",
+                    "__sls__": "test",
+                    "changes": {
+                        "ret": {
+                            "myminion": true
+                        },
+                        "out": "highstate"
+                    },
+                    "__id__": "mymod.myfunc"
+                },
+                "salt_|-mymod.myfunc_false_result-mymod.myfunc_false_result-function": {
+                    "comment": "Running function mymod.myfunc_false_result failed on minions: myminion. Function mymod.myfunc_false_result ran on myminion.",
+                    "name": "mymod.myfunc_false_result",
+                    "start_time": "21:35:17.486625",
+                    "result": false,
+                    "duration": 174.241,
+                    "__run_num__": 3,
+                    "__jid__": "20171130213517536270",
+                    "__sls__": "test",
+                    "changes": {
+                        "ret": {
+                            "myminion": false
+                        },
+                        "out": "highstate"
+                    },
+                    "__id__": "mymod.myfunc_false_result"
+                }
+            }
+        },
+        "retcode": 1
+    }
+
+
+The Oxygen release includes a couple fixes to make parsing this data easier and
+more accurate. The first is the ability to set a return code in a custom runner
+or wheel function, as noted above. The second is a change to how failures are
+included in the return data. Prior to the Oxygen release, minions that failed a
+``salt.state`` orchestration job would show up in the ``comment`` field of the
+return data, in a human-readable string that was not easily parsed. They are
+now included in the ``changes`` dictionary alongside the minions that
+succeeded. In addition, ``salt.function`` jobs which failed because the
+:ref:`fail function <orchestrate-runner-fail-functions>` returned ``False``
+used to handle their failures in the same way ``salt.state`` jobs did, and this
+has likewise been corrected.

--- a/doc/topics/releases/oxygen.rst
+++ b/doc/topics/releases/oxygen.rst
@@ -84,6 +84,18 @@ If set to ``True``, this option will prevent a minion from allowing the
 ``saltenv`` argument to override the value set in :conf_minion:`saltenv` when
 running states.
 
+Failed Minions for State/Function Orchestration Jobs Added to Changes Dictionary
+--------------------------------------------------------------------------------
+
+For orchestration jobs which run states (or run remote execution functions and
+also use a :ref:`fail function <orchestrate-runner-fail-functions>` to indicate
+success or failure), minions which have ``False`` results were previously
+included as a formatted string in the comment field of the return for that
+orchestration job. This made the failed returns difficult to :ref:`parse
+programatically <orchestrate-runner-parsing-results-programatically>`. The
+failed returns in these cases are now included in the changes dictionary,
+making for much easier parsing.
+
 New Grains
 ----------
 

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -351,7 +351,6 @@ def state(name,
 
     changes = {}
     fail = set()
-    failures = {}
     no_change = set()
 
     if fail_minions is None:
@@ -393,7 +392,7 @@ def state(name,
         if not m_state:
             if minion not in fail_minions:
                 fail.add(minion)
-            failures[minion] = m_ret or 'Minion did not respond'
+            changes[minion] = m_ret
             continue
         try:
             for state_item in six.itervalues(m_ret):
@@ -418,18 +417,6 @@ def state(name,
             state_ret['comment'] += ' Updating {0}.'.format(', '.join(changes))
         if no_change:
             state_ret['comment'] += ' No changes made to {0}.'.format(', '.join(no_change))
-    if failures:
-        state_ret['comment'] += '\nFailures:\n'
-        for minion, failure in six.iteritems(failures):
-            state_ret['comment'] += '\n'.join(
-                    (' ' * 4 + l)
-                    for l in salt.output.out_format(
-                        {minion: failure},
-                        'highstate',
-                        __opts__,
-                        ).splitlines()
-                    )
-            state_ret['comment'] += '\n'
     if test or __opts__.get('test'):
         if state_ret['changes'] and state_ret['result'] is True:
             # Test mode with changes is the only case where result should ever be none
@@ -570,7 +557,6 @@ def function(
 
     changes = {}
     fail = set()
-    failures = {}
 
     if fail_minions is None:
         fail_minions = ()
@@ -598,7 +584,7 @@ def function(
         if not m_func:
             if minion not in fail_minions:
                 fail.add(minion)
-            failures[minion] = m_ret and m_ret or 'Minion did not respond'
+            changes[minion] = m_ret
             continue
         changes[minion] = m_ret
     if not cmd_ret:
@@ -614,18 +600,6 @@ def function(
             func_ret['comment'] = 'Function ran successfully.'
         if changes:
             func_ret['comment'] += ' Function {0} ran on {1}.'.format(name, ', '.join(changes))
-        if failures:
-            func_ret['comment'] += '\nFailures:\n'
-            for minion, failure in six.iteritems(failures):
-                func_ret['comment'] += '\n'.join(
-                        (' ' * 4 + l)
-                        for l in salt.output.out_format(
-                            {minion: failure},
-                            'highstate',
-                            __opts__,
-                            ).splitlines()
-                        )
-                func_ret['comment'] += '\n'
     return func_ret
 
 

--- a/tests/integration/files/file/base/_modules/runtests_helpers.py
+++ b/tests/integration/files/file/base/_modules/runtests_helpers.py
@@ -125,3 +125,26 @@ def modules_available(*names):
         if not fnmatch.filter(list(__salt__), name):
             not_found.append(name)
     return not_found
+
+
+def nonzero_retcode_return_true():
+    '''
+    Sets a nonzero retcode before returning. Designed to test orchestration.
+    '''
+    __context__['retcode'] = 1
+    return True
+
+
+def nonzero_retcode_return_false():
+    '''
+    Sets a nonzero retcode before returning. Designed to test orchestration.
+    '''
+    __context__['retcode'] = 1
+    return False
+
+
+def fail_function(*args, **kwargs):  # pylint: disable=unused-argument
+    '''
+    Return False no matter what is passed to it
+    '''
+    return False

--- a/tests/integration/files/file/base/orch/issue43204/fail_with_changes.sls
+++ b/tests/integration/files/file/base/orch/issue43204/fail_with_changes.sls
@@ -1,0 +1,2 @@
+test fail with changes:
+  test.fail_with_changes

--- a/tests/integration/files/file/base/orch/issue43204/init.sls
+++ b/tests/integration/files/file/base/orch/issue43204/init.sls
@@ -1,0 +1,11 @@
+Step01:
+  salt.state:
+    - tgt: 'minion'
+    - sls:
+      - orch.issue43204.fail_with_changes
+
+Step02:
+  salt.function:
+    - name: runtests_helpers.nonzero_retcode_return_false
+    - tgt: 'minion'
+    - fail_function: runtests_helpers.fail_function


### PR DESCRIPTION
### What does this PR do?

Gets rid of logic that dumped failures into the comment field in the orchestration return, and places failures directly into the changes dict.

### What issues does this PR fix or reference?

Fixes #43204

Failed state returns (in addition to failed remote exec returns, when `fail_function` is used) would invoke the highstate outputter to include formatted info about the failures in the comment field. This would convert the failures into a string, making them extremely difficult to programatically analyze. Annoyingly, it would also log the failures at the `error` loglevel, meaning that they'd show up twice on the CLI.

### Setup

The below examples use Docker image **terminalmage/issues:43204**. Run the commands from the root of a git checkout of Salt. Running against the head of the develop branch will allow you to replicate the bug, and running against the fixed code from the PR will reproduce the fix. Use [this walkthrough](https://help.github.com/articles/checking-out-pull-requests-locally/) to check out this PR locally.

```
% docker run --rm -it -v $PWD:/testing terminalmage/issues:43204 cat /srv/salt/test.sls
good_state:
  salt.state:
    - tgt: test
    - sls:
      - succeed_with_changes

bad_state:
  salt.state:
    - tgt: test
    - sls:
      - fail_with_changes

orchtest.zero_retcode_return_true:
  salt.function:
    - tgt: test

orchtest.nonzero_retcode_return_false:
  salt.function:
    - tgt: test
    - fail_function: orchtest.fail_function
% docker run --rm -it -v $PWD:/testing terminalmage/issues:43204 cat /srv/salt/_modules/orchtest.py
def nonzero_retcode_return_true():
    __context__['retcode'] = 1
    return True


def nonzero_retcode_return_false():
    __context__['retcode'] = 1
    return False


def zero_retcode_return_true():
    __context__['retcode'] = 0
    return True


def zero_retcode_return_false():
    __context__['retcode'] = 0
    return False


def fail_function(*args, **kwargs):
    return False
```

### Previous Behavior

```
% docker run --rm -it -v $PWD:/testing terminalmage/issues:43204 sh -c "salt-master -d; salt-minion -d; sleep 10; salt-run state.orch test"
/testing/salt/utils/verify.py:215: DeprecationWarning: Use of 'pki_dir' was detected: 'pki_dir' has been deprecated in favor of 'sensitive_dirs'. Support for 'pki_dir' will be removed in Salt Neon.
/testing/salt/utils/verify.py:215: DeprecationWarning: Use of 'pki_dir' was detected: 'pki_dir' has been deprecated in favor of 'sensitive_dirs'. Support for 'pki_dir' will be removed in Salt Neon.
[ERROR   ] Run failed on minions: test
Failures:
    test:
    ----------
              ID: test fail with changes
        Function: test.fail_with_changes
          Result: False
         Comment: Failure!
         Started: 21:08:25.105596
        Duration: 0.501 ms
         Changes:
                  ----------
                  testing:
                      ----------
                      new:
                          Something pretended to change
                      old:
                          Unchanged

    Summary for test
    ------------
    Succeeded: 0 (changed=1)
    Failed:    1
    ------------
    Total states run:     1
    Total run time:   0.501 ms

[ERROR   ] Running function orchtest.nonzero_retcode_return_false failed on minions: test
Failures:
    test:
        Minion did not respond

fa5944a73aa8_master:
----------
          ID: good_state
    Function: salt.state
      Result: True
     Comment: States ran successfully. Updating test.
     Started: 21:08:24.589104
    Duration: 269.236 ms
     Changes:
              test:
              ----------
                        ID: test succeed with changes
                  Function: test.succeed_with_changes
                    Result: True
                   Comment: Success!
                   Started: 21:08:24.746596
                  Duration: 0.364 ms
                   Changes:
                            ----------
                            testing:
                                ----------
                                new:
                                    Something pretended to change
                                old:
                                    Unchanged

              Summary for test
              ------------
              Succeeded: 1 (changed=1)
              Failed:    0
              ------------
              Total states run:     1
              Total run time:   0.364 ms
----------
          ID: bad_state
    Function: salt.state
      Result: False
     Comment: Run failed on minions: test
              Failures:
                  test:
                  ----------
                            ID: test fail with changes
                      Function: test.fail_with_changes
                        Result: False
                       Comment: Failure!
                       Started: 21:08:25.105596
                      Duration: 0.501 ms
                       Changes:
                                ----------
                                testing:
                                    ----------
                                    new:
                                        Something pretended to change
                                    old:
                                        Unchanged

                  Summary for test
                  ------------
                  Succeeded: 0 (changed=1)
                  Failed:    1
                  ------------
                  Total states run:     1
                  Total run time:   0.501 ms
     Started: 21:08:24.858925
    Duration: 258.492 ms
     Changes:
----------
          ID: orchtest.zero_retcode_return_true
    Function: salt.function
      Result: True
     Comment: Function ran successfully. Function orchtest.zero_retcode_return_true ran on test.
     Started: 21:08:25.117678
    Duration: 159.217 ms
     Changes:
              test:
                  True
----------
          ID: orchtest.nonzero_retcode_return_false
    Function: salt.function
      Result: False
     Comment: Running function orchtest.nonzero_retcode_return_false failed on minions: test
              Failures:
                  test:
                      Minion did not respond
     Started: 21:08:25.277442
    Duration: 177.192 ms
     Changes:

Summary for fa5944a73aa8_master
------------
Succeeded: 2 (changed=2)
Failed:    2
------------
Total states run:     4
Total run time: 864.137 ms
```

### New Behavior

```
% docker run --rm -it -v $PWD:/testing terminalmage/issues:43204 sh -c "salt-master -d; salt-minion -d; sleep 10; salt-run state.orch test"
/testing/salt/utils/verify.py:215: DeprecationWarning: Use of 'pki_dir' was detected: 'pki_dir' has been deprecated in favor of 'sensitive_dirs'. Support for 'pki_dir' will be removed in Salt Neon.
/testing/salt/utils/verify.py:215: DeprecationWarning: Use of 'pki_dir' was detected: 'pki_dir' has been deprecated in favor of 'sensitive_dirs'. Support for 'pki_dir' will be removed in Salt Neon.
[ERROR   ] {'ret': {'test': {'test_|-test fail with changes_|-test fail with changes_|-fail_with_changes': {'comment': 'Failure!', 'name': 'test fail with changes', 'start_time': '21:08:03.116634', 'result': False, 'duration': 0.502, '__run_num__': 0, '__sls__': 'fail_with_changes', 'changes': {'testing': {'new': 'Something pretended to change', 'old': 'Unchanged'}}, '__id__': 'test fail with changes'}}}, 'out': 'highstate'}
[ERROR   ] {'ret': {'test': False}, 'out': 'highstate'}
fa5944a73aa8_master:
----------
          ID: good_state
    Function: salt.state
      Result: True
     Comment: States ran successfully. Updating test.
     Started: 21:08:02.681604
    Duration: 265.565 ms
     Changes:
              test:
              ----------
                        ID: test succeed with changes
                  Function: test.succeed_with_changes
                    Result: True
                   Comment: Success!
                   Started: 21:08:02.835893
                  Duration: 0.375 ms
                   Changes:
                            ----------
                            testing:
                                ----------
                                new:
                                    Something pretended to change
                                old:
                                    Unchanged

              Summary for test
              ------------
              Succeeded: 1 (changed=1)
              Failed:    0
              ------------
              Total states run:     1
              Total run time:   0.375 ms
----------
          ID: bad_state
    Function: salt.state
      Result: False
     Comment: Run failed on minions: test
     Started: 21:08:02.947702
    Duration: 177.01 ms
     Changes:
              test:
              ----------
                        ID: test fail with changes
                  Function: test.fail_with_changes
                    Result: False
                   Comment: Failure!
                   Started: 21:08:03.116634
                  Duration: 0.502 ms
                   Changes:
                            ----------
                            testing:
                                ----------
                                new:
                                    Something pretended to change
                                old:
                                    Unchanged

              Summary for test
              ------------
              Succeeded: 0 (changed=1)
              Failed:    1
              ------------
              Total states run:     1
              Total run time:   0.502 ms
----------
          ID: orchtest.zero_retcode_return_true
    Function: salt.function
      Result: True
     Comment: Function ran successfully. Function orchtest.zero_retcode_return_true ran on test.
     Started: 21:08:03.125011
    Duration: 159.488 ms
     Changes:
              test:
                  True
----------
          ID: orchtest.nonzero_retcode_return_false
    Function: salt.function
      Result: False
     Comment: Running function orchtest.nonzero_retcode_return_false failed on minions: test Function orchtest.nonzero_retcode_return_false ran on test.
     Started: 21:08:03.285148
    Duration: 176.787 ms
     Changes:
              test:
                  False

Summary for fa5944a73aa8_master
------------
Succeeded: 2 (changed=4)
Failed:    2
------------
Total states run:     4
Total run time: 778.850 ms
```

### Tests written?

```
% docker run --rm -it -v $PWD:/testing terminalmage/issues:43204 python /testing/tests/runtests.py -n integration.runners.test_state.StateRunnerTest.test_orchestrate_state_and_function_failure
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Python Version: 2.7.5 (default, Nov 6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
 * Transplanting configuration files to '/tmp/salt-tests-tmpdir/config'
 * Current Directory: /testing
 * Test suite is running under PID 1
 * Logging tests on /tmp/salt-runtests.log
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Setting up Salt daemons to execute tests
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Starting salt-master ... STARTED!
 * Starting salt-minion ... STARTED!
 * Starting sub salt-minion ... STARTED!
 * Starting syndic salt-master ... STARTED!
 * Starting salt-syndic ... STARTED!
===================================================================================
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Starting integration.runners.test_state.StateRunnerTest.test_orchestrate_state_and_function_failure Tests
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ERROR   ] {'ret': {'minion': {'test_|-test fail with changes_|-test fail with changes_|-fail_with_changes': {'comment': 'Failure!', 'name': 'test fail with changes', 'start_time': '21:21:43.966815', 'result': False, 'duration': 0.935, '__run_num__': 0, '__sls__': 'orch.issue43204.fail_with_changes', 'changes': {'testing': {'new': 'Something pretended to change', 'old': 'Unchanged'}}, '__id__': 'test fail with changes'}}}, 'out': 'highstate'}
[ERROR   ] {'ret': {'minion': False}, 'out': 'highstate'}
.
----------------------------------------------------------------------
Ran 1 test in 8.067s

OK

=============================  Overall Tests Report  ==============================
***  No Problems Found While Running Tests  ***************************************
===================================================================================
OK (total=1, skipped=0, passed=1, failures=0, errors=0)
=============================  Overall Tests Report  ==============================
```

### Commits signed with GPG?

Yes