### PR TITLE
[develop] Various updates to the scheduler

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2067,12 +2067,16 @@ class Minion(MinionBase):
             self.schedule.run_job(name)
         elif func == u'disable_job':
             self.schedule.disable_job(name, persist)
+        elif func == u'postpone_job':
+            self.schedule.postpone_job(name, data)
         elif func == u'reload':
             self.schedule.reload(schedule)
         elif func == u'list':
             self.schedule.list(where)
         elif func == u'save_schedule':
             self.schedule.save_schedule()
+        elif func == u'get_next_fire_time':
+            self.schedule.get_next_fire_time(name)
 
     def manage_beacons(self, tag, data):
         '''

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -58,7 +58,7 @@ SCHEDULE_CONF = [
         'return_config',
         'return_kwargs',
         'run_on_start'
-        'not_during_range',
+        'skip_during_range',
 ]
 
 
@@ -354,7 +354,7 @@ def build_schedule_item(name, **kwargs):
 
     for item in ['range', 'when', 'once', 'once_fmt', 'cron',
                  'returner', 'after', 'return_config', 'return_kwargs',
-                 'until', 'run_on_start', 'not_during_range']:
+                 'until', 'run_on_start', 'skip_during_range']:
         if item in kwargs:
             schedule[name][item] = kwargs[item]
 

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -975,14 +975,27 @@ def postpone_job(name, current_time, new_time, **kwargs):
     if not name:
         ret['comment'] = 'Job name is required.'
         ret['result'] = False
+        return ret
 
     if not current_time:
         ret['comment'] = 'Job current time is required.'
         ret['result'] = False
+        return ret
+    else:
+        if not isinstance(current_time, six.integer_types):
+            ret['comment'] = 'Job current time must be an integer.'
+            ret['result'] = False
+            return ret
 
     if not new_time:
         ret['comment'] = 'Job new_time is required.'
         ret['result'] = False
+        return ret
+    else:
+        if not isinstance(new_time, six.integer_types):
+            ret['comment'] = 'Job new time must be an integer.'
+            ret['result'] = False
+            return ret
 
     if 'test' in __opts__ and __opts__['test']:
         ret['comment'] = 'Job: {0} would be postponed in schedule.'.format(name)

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -58,6 +58,7 @@ SCHEDULE_CONF = [
         'return_config',
         'return_kwargs',
         'run_on_start'
+        'not_during_range',
 ]
 
 
@@ -353,7 +354,7 @@ def build_schedule_item(name, **kwargs):
 
     for item in ['range', 'when', 'once', 'once_fmt', 'cron',
                  'returner', 'after', 'return_config', 'return_kwargs',
-                 'until', 'run_on_start']:
+                 'until', 'run_on_start', 'not_during_range']:
         if item in kwargs:
             schedule[name][item] = kwargs[item]
 

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1322,6 +1322,37 @@ class Schedule(object):
                                      Ignoring job {0}.'.format(job))
                             continue
 
+                if 'not_during_range' in data:
+                    if not _RANGE_SUPPORTED:
+                        log.error('Missing python-dateutil. Ignoring job {0}'.format(job))
+                        continue
+                    else:
+                        if isinstance(data['not_during_range'], dict):
+                            try:
+                                start = int(time.mktime(dateutil_parser.parse(data['not_during_range']['start']).timetuple()))
+                            except ValueError:
+                                log.error('Invalid date string for start in not_during_range. Ignoring job {0}.'.format(job))
+                                continue
+                            try:
+                                end = int(time.mktime(dateutil_parser.parse(data['not_during_range']['end']).timetuple()))
+                            except ValueError:
+                                log.error('Invalid date string for end in not_during_range. Ignoring job {0}.'.format(job))
+                                log.error(data)
+                                continue
+                            if end > start:
+                                if start <= now <= end:
+                                    run = False
+                                else:
+                                    run = True
+                            else:
+                                log.error('schedule.handle_func: Invalid range, end must be larger than start. \
+                                         Ignoring job {0}.'.format(job))
+                                continue
+                        else:
+                            log.error('schedule.handle_func: Invalid, range must be specified as a dictionary. \
+                                     Ignoring job {0}.'.format(job))
+                            continue
+
             if not run:
                 continue
 

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1173,7 +1173,7 @@ class Schedule(object):
                             _run_explicit.remove(i)
 
                 if _run_explicit:
-                    if _run_explicit[0] <= now <= (_run_explicit[0] + self.opts['loop_interval']):
+                    if _run_explicit[0] <= now < (_run_explicit[0] + self.opts['loop_interval']):
                         run = True
                         data['_next_fire_time'] = _run_explicit[0]
 

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1036,6 +1036,9 @@ class Schedule(object):
     def eval(self, now=None):
         '''
         Evaluate and execute the schedule
+
+        :param int now: Override current time with a Unix timestamp``
+
         '''
 
         log.trace('==== evaluating schedule =====')
@@ -1292,19 +1295,16 @@ class Schedule(object):
                 else:
                     if ('pillar' in self.opts and 'whens' in self.opts['pillar'] and
                             data['when'] in self.opts['pillar']['whens']):
-                        log.debug('=== whens found in pillar ===')
                         if not isinstance(self.opts['pillar']['whens'], dict):
                             log.error('Pillar item "whens" must be dict.'
                                       'Ignoring')
                             continue
                         _when = self.opts['pillar']['whens'][data['when']]
-                        log.debug('=== _when {} ==='.format(_when))
                         try:
                             when__ = dateutil_parser.parse(_when)
                         except ValueError:
                             log.error('Invalid date string. Ignoring')
                             continue
-                        log.debug('=== __when {} ==='.format(__when))
                     elif ('whens' in self.opts['grains'] and
                           data['when'] in self.opts['grains']['whens']):
                         if not isinstance(self.opts['grains']['whens'], dict):


### PR DESCRIPTION
### What does this PR do?
* Adding not_during_range to schedule
* Renaming not_during_range to skip_during_range, adding now as a parameter for eval to override the current time.  
* Adding skip_explicit to include an explicitly list of times in UNIX time stamp format when jobs should be skipped.  
* Adding ability to include a function that should be run if jobs are to be skipped.
* Adding ability to postpone jobs using a simple, initial postpone function.  The postpone function adds the current job time to a skip_explicit list and adds the new run time to a run_explicit list.
* Adding a simple function to skip jobs at specified times.  
* Adding versionadded tags to new functions.  
* Updating parameters for postpone function to ensure it's more clear.  
* Adding documentation for `whens` which was implemented awhile ago but never documented.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
None of the above functionality existed.

### New Behavior
Adding new functionality

### Tests written?
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
