### PR TITLE
Fix inet_pton for Windows on Py3

### DIFF
--- a/salt/ext/win_inet_pton.py
+++ b/salt/ext/win_inet_pton.py
@@ -10,6 +10,7 @@ import socket
 import ctypes
 import os
 import ipaddress
+import six
 
 
 class sockaddr(ctypes.Structure):
@@ -36,7 +37,7 @@ def inet_pton(address_family, ip_string):
     # This will catch IP Addresses such as 10.1.2
     if address_family == socket.AF_INET:
         try:
-            ipaddress.ip_address(ip_string.encode().decode())
+            ipaddress.ip_address(six.u(ip_string))
         except ValueError:
             raise socket.error('illegal IP address string passed to inet_pton')
         return socket.inet_aton(ip_string)

--- a/salt/ext/win_inet_pton.py
+++ b/salt/ext/win_inet_pton.py
@@ -10,7 +10,7 @@ import socket
 import ctypes
 import os
 import ipaddress
-import six
+import salt.ext.six as six
 
 
 class sockaddr(ctypes.Structure):

--- a/salt/ext/win_inet_pton.py
+++ b/salt/ext/win_inet_pton.py
@@ -36,7 +36,7 @@ def inet_pton(address_family, ip_string):
     # This will catch IP Addresses such as 10.1.2
     if address_family == socket.AF_INET:
         try:
-            ipaddress.ip_address(ip_string.decode())
+            ipaddress.ip_address(ip_string.encode().decode())
         except ValueError:
             raise socket.error('illegal IP address string passed to inet_pton')
         return socket.inet_aton(ip_string)


### PR DESCRIPTION
### What does this PR do?
Fixes issue with unicode values in Py3. There may be a better cross-platform way to do this. This is the only thing I could get to work.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/44687

### Previous Behavior
inet_pton function would fail with str has no decode

### New Behavior
inet_pton function works on Py2 and Py3

### Tests written?
N/A

### Commits signed with GPG?
Yes