### PR TITLE
Fix calls to verify_env

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -161,7 +161,6 @@ class Master(salt.utils.parsers.MasterOptionParser, DaemonsMixin):  # pylint: di
                     v_dirs,
                     self.config['user'],
                     permissive=self.config['permissive_pki_access'],
-                    pki_dir=self.config['pki_dir'],
                     root_dir=self.config['root_dir'],
                     sensitive_dirs=[self.config['pki_dir'], self.config['key_dir']],
                 )
@@ -283,7 +282,6 @@ class Minion(salt.utils.parsers.MinionOptionParser, DaemonsMixin):  # pylint: di
                     v_dirs,
                     self.config['user'],
                     permissive=self.config['permissive_pki_access'],
-                    pki_dir=self.config['pki_dir'],
                     root_dir=self.config['root_dir'],
                     sensitive_dirs=[self.config['pki_dir']],
                 )
@@ -472,7 +470,6 @@ class ProxyMinion(salt.utils.parsers.ProxyMinionOptionParser, DaemonsMixin):  # 
                     v_dirs,
                     self.config['user'],
                     permissive=self.config['permissive_pki_access'],
-                    pki_dir=self.config['pki_dir'],
                     root_dir=self.config['root_dir'],
                     sensitive_dirs=[self.config['pki_dir']],
                 )
@@ -582,7 +579,6 @@ class Syndic(salt.utils.parsers.SyndicOptionParser, DaemonsMixin):  # pylint: di
                     ],
                     self.config['user'],
                     permissive=self.config['permissive_pki_access'],
-                    pki_dir=self.config['pki_dir'],
                     root_dir=self.config['root_dir'],
                     sensitive_dirs=[self.config['pki_dir']],
                 )


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/44584 deprecated pki_dir but left several references. These lines can be safely removed since sensitive_dirs is already being used in each of these refs.

CC: @rallytime