### PR TITLE
Fix the grains.setvals execution function when working with proxy minions

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -229,20 +229,44 @@ def setvals(grains, destructive=False):
         raise SaltException('setvals grains must be a dictionary.')
     grains = {}
     if os.path.isfile(__opts__['conf_file']):
-        gfn = os.path.join(
-            os.path.dirname(__opts__['conf_file']),
-            'grains'
-        )
+        if salt.utils.is_proxy():
+            gfn = os.path.join(
+                os.path.dirname(__opts__['conf_file']),
+                'proxy.d',
+                __opts__['id'],
+                'grains'
+            )
+        else:
+            gfn = os.path.join(
+                os.path.dirname(__opts__['conf_file']),
+                'grains'
+            )
     elif os.path.isdir(__opts__['conf_file']):
-        gfn = os.path.join(
-            __opts__['conf_file'],
-            'grains'
-        )
+        if salt.utils.is_proxy():
+            gfn = os.path.join(
+                __opts__['conf_file'],
+                'proxy.d',
+                __opts__['id'],
+                'grains'
+            )
+        else:
+            gfn = os.path.join(
+                __opts__['conf_file'],
+                'grains'
+            )
     else:
-        gfn = os.path.join(
-            os.path.dirname(__opts__['conf_file']),
-            'grains'
-        )
+        if salt.utils.is_proxy():
+            gfn = os.path.join(
+                os.path.dirname(__opts__['conf_file']),
+                'proxy.d',
+                __opts__['id'],
+                'grains'
+            )
+        else:
+            gfn = os.path.join(
+                os.path.dirname(__opts__['conf_file']),
+                'grains'
+            )
 
     if os.path.isfile(gfn):
         with salt.utils.fopen(gfn, 'rb') as fp_:

--- a/salt/proxy/dummy.py
+++ b/salt/proxy/dummy.py
@@ -48,7 +48,7 @@ def _load_state():
         pck = open(FILENAME, 'r')  # pylint: disable=W8470
         DETAILS = pickle.load(pck)
         pck.close()
-    except IOError:
+    except EOFError:
         DETAILS = {}
         DETAILS['initialized'] = False
         _save_state(DETAILS)


### PR DESCRIPTION
### What does this PR do?

Similarly to the changes from #44549, we need to look under in a different
location when saving the static grains, so the grain file is, e.g.,
`/etc/salt/proxy.d/{id}/grains`.
Not related to this, I have also solved a small issue with the dummy proxy module.

### What issues does this PR fix or reference?

#42300

### Previous Behavior

Unable to use `grains.setval`, `grains.setvals` and the `grains.present` state.

### Tests written?

No

### Commits signed with GPG?

Yes