### PR TITLE
Add phusion container initd detection

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1476,6 +1476,9 @@ def os_data():
                         grains['init'] = 'supervisord'
                     elif init_cmdline == ['runit']:
                         grains['init'] = 'runit'
+                    elif '/sbin/my_init' in init_cmdline:
+                        #Phusion Base docker container use runit for srv mgmt, but my_init as pid1
+                        grains['init'] = 'runit'
                     else:
                         log.info(
                             'Could not determine init system from command line: ({0})'


### PR DESCRIPTION
### What does this PR do?
Add support for initd detection in Phusion Base docker containers

### What issues does this PR fix or reference?
(none opened)

### Previous Behavior
- Running salt-minion inside a Phusion Base docker container and using the service module lead to duplicate services as salt didn't detect that a service was already running. (same for stopping,enabling,...)
- salt(-master,-minion) complained that it wasn't able to determine the init system in such a setup

### New Behavior
- Salt doesn't complain about being unable to determine the init system on such containers
- Salt uses the runit service module for service management if the init process is /sbin/my_init (as used in phusion docker containers)

### Tests written?

No (manually tested using phusion/baseimage:0.9.22)

### Commits signed with GPG?

No

