### PR TITLE
Just a small improvement to the Thorium documentation

### DIFF
--- a/doc/topics/thorium/index.rst
+++ b/doc/topics/thorium/index.rst
@@ -59,6 +59,14 @@ Like some other Salt subsystems, Thorium uses its own directory structure. The
 default location for this structure is ``/srv/thorium/``, but it can be changed
 using the ``thorium_roots`` setting in the ``master`` configuration file.
 
+Example ``thorium_roots`` configuration:
+
+.. code-block:: yaml
+
+    thorium_roots:
+      base:
+        - /etc/salt/thorium
+
 
 The Thorium top.sls File
 ------------------------

--- a/doc/topics/thorium/index.rst
+++ b/doc/topics/thorium/index.rst
@@ -57,7 +57,7 @@ Writing Thorium Formulas
 ========================
 Like some other Salt subsystems, Thorium uses its own directory structure. The
 default location for this structure is ``/srv/thorium/``, but it can be changed
-using the ``thorium_roots_dir`` setting in the ``master`` configuration file.
+using the ``thorium_roots`` setting in the ``master`` configuration file.
 
 
 The Thorium top.sls File


### PR DESCRIPTION
### What does this PR do?

I was playing again with Thorium and couldn't figure out why I wasn't able to start although I was following the docs, and this error message wasn't really helpful:

```python
[DEBUG   ] Started 'salt.engines.Engine' with pid 19696
[DEBUG   ] LazyLoaded thorium.start
[DEBUG   ] LazyLoaded roots.envs
[DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
[DEBUG   ] Updating roots fileserver cache
[CRITICAL] Engine <salt.loader.LazyLoader object at 0x7f5dc1435f10> could not be started! Error: 'str' object has no attribute 'iteritems'
[INFO    ] Process <class 'salt.engines.Engine'> (19696) died with exit status 0, restarting...
```

The Thorium documentation needs much more work, this is just a quick patch to help new users.