### PR TITLE
Allow for omission of HWADDR from ifcfg-* file

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -643,12 +643,18 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
                 result[opt] = opts[opt]
 
     if iface_type not in ['bond', 'vlan', 'bridge', 'ipip']:
+        auto_addr = False
         if 'addr' in opts:
             if salt.utils.validate.net.mac(opts['addr']):
                 result['addr'] = opts['addr']
-            else:
-                _raise_error_iface(iface, opts['addr'], ['AA:BB:CC:DD:EE:FF'])
+            elif opts['addr'] == 'auto':
+                auto_addr = True
+            elif opts['addr'] != 'none':
+                _raise_error_iface(iface, opts['addr'], ['AA:BB:CC:DD:EE:FF', 'auto', 'none'])
         else:
+            auto_addr = True
+
+        if auto_addr:
             # If interface type is slave for bond, not setting hwaddr
             if iface_type != 'slave':
                 ifaces = __salt__['network.interfaces']()


### PR DESCRIPTION
Allow
  - addr: none

in network.managed to omit the HWADDR from the generated ifcfg-* file.

For the sake of completeness, also accept

  - addr: auto

to explicitly request the default behaviour with no "addr" specified.

### What does this PR do?

This allows to manage interfaces solely by their name, keeping their
configuration over MAC changes.

### Previous Behavior

There was no way to not write an HWADDR setting to ifcfg-* for ethernet interfaces

### New Behavior

This is now possible by specifying
- addr: none
### Tests written?

No

### Commits signed with GPG?

No
